### PR TITLE
feat(web): activate the native audio session for the duration of a voice session

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -26,6 +26,37 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
   ),
 }));
 
+// The iOS audio-session bridge. Stubbed at the module boundary (rather than by
+// faking `isNativeIOS`) so the controller's lifecycle wiring is asserted
+// directly; the bridge's own off-native/skew behavior is pinned by
+// `runtime/native-audio-session.test.ts`.
+type InterruptionEvent = { type: "began" | "ended"; shouldResume: boolean };
+const activateVoiceAudioSession = mock(async () => true);
+const deactivateVoiceAudioSession = mock(async () => undefined);
+const unsubscribeInterruptions = mock(() => undefined);
+let interruptionHandlers: ((event: InterruptionEvent) => void)[] = [];
+
+mock.module("@/runtime/native-audio-session", () => ({
+  activateVoiceAudioSession,
+  deactivateVoiceAudioSession,
+  subscribeVoiceAudioInterruptions: (
+    handler: (event: InterruptionEvent) => void,
+  ) => {
+    interruptionHandlers.push(handler);
+    return () => {
+      unsubscribeInterruptions();
+      interruptionHandlers = interruptionHandlers.filter((h) => h !== handler);
+    };
+  },
+}));
+
+/** Deliver a native `AVAudioSession` interruption to every live subscriber. */
+function emitInterruption(event: InterruptionEvent): void {
+  for (const handler of interruptionHandlers) {
+    handler(event);
+  }
+}
+
 import type { LiveVoiceChannelClient } from "@/domains/chat/voice/live-voice/live-voice-client";
 import type { LiveVoiceAudioCapture } from "@/domains/chat/voice/live-voice/pcm-capture";
 import type { LiveVoiceAudioPlayer } from "@/domains/chat/voice/live-voice/tts-playback";
@@ -60,7 +91,10 @@ function renderPersistentController() {
   const captures: FakeCapture[] = [];
   const player = new FakePlayer();
 
-  const view = renderHook(() =>
+  let renderCount = 0;
+
+  const view = renderHook(() => {
+    renderCount += 1;
     useLiveVoiceSessionController({
       createClient: () => {
         const client = new FakeClient();
@@ -73,8 +107,8 @@ function renderPersistentController() {
         captures.push(capture);
         return capture as unknown as LiveVoiceAudioCapture;
       },
-    }),
-  );
+    });
+  });
 
   return {
     view,
@@ -83,6 +117,7 @@ function renderPersistentController() {
     captures,
     lastClient: () => clients[clients.length - 1]!,
     lastCapture: () => captures[captures.length - 1]!,
+    renderCount: () => renderCount,
   };
 }
 
@@ -123,6 +158,12 @@ beforeEach(() => {
   __resetPendingDeepLinkForTesting();
   useAssistantIdentityStore.setState({ assistantId: null, version: null });
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  interruptionHandlers = [];
+  activateVoiceAudioSession.mockClear();
+  activateVoiceAudioSession.mockImplementation(async () => true);
+  deactivateVoiceAudioSession.mockClear();
+  deactivateVoiceAudioSession.mockImplementation(async () => undefined);
+  unsubscribeInterruptions.mockClear();
 });
 
 afterEach(() => {
@@ -274,5 +315,162 @@ describe("session lifetime", () => {
     expect(h.lastCapture().shutdownCount).toBe(1);
     expect(useLiveVoiceStore.getState().state).toBe("idle");
     expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Native audio session — held for exactly the span of a voice session
+// ---------------------------------------------------------------------------
+
+describe("native audio session", () => {
+  test("activates once per session, not once per phase change", async () => {
+    const h = renderPersistentController();
+    expect(activateVoiceAudioSession).not.toHaveBeenCalled();
+
+    await startListeningViaStarter(h);
+    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
+
+    // The churn a real turn produces. The audio session is already held; none
+    // of this may re-activate it.
+    act(() => {
+      useLiveVoiceStore.getState().setState("thinking");
+      useLiveVoiceStore.getState().setState("speaking");
+      useLiveVoiceStore.getState().setState("listening");
+    });
+    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
+    expect(deactivateVoiceAudioSession).not.toHaveBeenCalled();
+  });
+
+  test("deactivates when the session reaches idle", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    await act(async () => {
+      useLiveVoiceStore.getState().controls?.stop();
+      await Promise.resolve();
+    });
+
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("deactivates when the session fails", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    act(() => {
+      useLiveVoiceStore.getState().fail("velay unreachable");
+    });
+
+    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("deactivates on unmount and drops the interruption listener", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    // Exactly one release, whichever order the controller's own teardown and
+    // this cleanup happen to run in.
+    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
+    expect(unsubscribeInterruptions).toHaveBeenCalledTimes(1);
+  });
+
+  test("unmounting without a session deactivates nothing", () => {
+    const h = renderPersistentController();
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    expect(activateVoiceAudioSession).not.toHaveBeenCalled();
+    expect(deactivateVoiceAudioSession).not.toHaveBeenCalled();
+  });
+
+  test("an interruption ends the active session", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    await act(async () => {
+      emitInterruption({ type: "began", shouldResume: true });
+      await Promise.resolve();
+    });
+
+    // A phone call took the mic; the session ends rather than listening into
+    // a dead input.
+    expect(h.lastClient().ended).toBe(true);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("an interruption ending does not resume or disturb the session", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    await act(async () => {
+      emitInterruption({ type: "ended", shouldResume: true });
+      await Promise.resolve();
+    });
+
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(h.lastClient().closed).toBe(false);
+    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("an interruption with no session running is a no-op", async () => {
+    const h = renderPersistentController();
+
+    await act(async () => {
+      emitInterruption({ type: "began", shouldResume: false });
+      await Promise.resolve();
+    });
+
+    expect(h.clients).toHaveLength(0);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+  });
+
+  // The skew case: an App Store shell older than the `VoiceAudioSession`
+  // plugin. Voice must behave exactly as it does today.
+  test("a failing bridge neither blocks nor breaks a session", async () => {
+    activateVoiceAudioSession.mockImplementation(async () => {
+      throw new Error("VoiceAudioSession does not have web implementation.");
+    });
+    deactivateVoiceAudioSession.mockImplementation(async () => {
+      throw new Error("VoiceAudioSession does not have web implementation.");
+    });
+
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+
+    await act(async () => {
+      useLiveVoiceStore.getState().controls?.stop();
+      await Promise.resolve();
+    });
+
+    expect(h.lastClient().ended).toBe(true);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+  });
+
+  test("amplitude and transcript churn never re-renders the controller's host", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+    const renders = h.renderCount();
+
+    // The `observeAudioState: false` contract. The audio-session lifecycle
+    // reads `state` through `useLiveVoiceStore.subscribe` inside an effect,
+    // never a reactive selector, so the per-frame amplitude and transcript
+    // deltas a live session emits stay free for the mounting layout.
+    act(() => {
+      const store = useLiveVoiceStore.getState();
+      store.setInputAmplitude(0.4);
+      store.setPartialTranscript("hello");
+      store.appendAssistantTranscript("hi");
+    });
+
+    expect(h.renderCount()).toBe(renders);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -24,6 +24,9 @@
  * - `controls` (stop/release/interrupt) — registered per-session by
  *   {@link useLiveVoice} itself.
  * - `state`/`error`/transcripts/amplitude — observable session state.
+ *
+ * It is also where the iOS native audio session is bound to the session
+ * lifecycle — see {@link useNativeAudioSessionLifecycle}.
  */
 
 import { useEffect } from "react";
@@ -32,14 +35,106 @@ import {
   useLiveVoice,
   type UseLiveVoiceOptions,
 } from "@/domains/chat/voice/live-voice/use-live-voice";
-import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  endLiveVoiceSession,
+  isLiveVoiceSessionActive,
+  useLiveVoiceStore,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { drainPendingVoiceStartDeepLink } from "@/domains/chat/voice/live-voice/start-voice-deep-link";
+import {
+  activateVoiceAudioSession,
+  deactivateVoiceAudioSession,
+  subscribeVoiceAudioInterruptions,
+} from "@/runtime/native-audio-session";
 
 /** Injectable primitive factories, for tests. */
 export type UseLiveVoiceSessionControllerOptions = Pick<
   UseLiveVoiceOptions,
   "createClient" | "createCapture" | "createPlayer"
 >;
+
+/**
+ * Fire-and-forget a native bridge call. The bridge already swallows its own
+ * failures (`callNativeVoice`), but keeping the catch here makes "a hung or
+ * failed bridge call must never delay or block a voice session" a local,
+ * testable property of this hook rather than one inherited from a distant
+ * module.
+ */
+function fireAndForget(call: Promise<unknown>): void {
+  void call.catch(() => undefined);
+}
+
+/**
+ * Hold the native iOS audio session open for exactly as long as a live-voice
+ * session is running.
+ *
+ * Driven off store *phase transitions* rather than off the `starter`, so
+ * sessions begun from any surface — the composer mic, a start-voice deep link,
+ * a reconnect — are covered symmetrically, and so `failed` releases the audio
+ * session just as `idle` does.
+ *
+ * Everything runs through `useLiveVoiceStore.subscribe` inside an effect, never
+ * a reactive selector in a render body: the controller sets
+ * `observeAudioState: false` precisely so high-frequency amplitude/transcript
+ * updates do not re-render the mounting layout, and reading `state` reactively
+ * here would subscribe the layout to session churn all over again.
+ *
+ * Off the iOS shell every call is a no-op (see `runtime/native-audio-session`),
+ * so this is inert in the browser and on Electron.
+ */
+function useNativeAudioSessionLifecycle(): void {
+  useEffect(() => {
+    // Mirrors whether we currently hold the native audio session, so activate
+    // fires once per session — not once per `listening`/`thinking`/`speaking`
+    // transition — and deactivate never double-fires.
+    let holdingAudioSession = false;
+
+    const sync = (state: LiveVoiceSessionState): void => {
+      const active = isLiveVoiceSessionActive(state);
+      if (active === holdingAudioSession) {
+        return;
+      }
+      holdingAudioSession = active;
+      fireAndForget(
+        active ? activateVoiceAudioSession() : deactivateVoiceAudioSession(),
+      );
+    };
+
+    // A session can already be running when this mounts (the controller
+    // remounts across layout-level route changes while the store persists).
+    sync(useLiveVoiceStore.getState().state);
+    const unsubscribeStore = useLiveVoiceStore.subscribe((s) => sync(s.state));
+
+    const unsubscribeInterruptions = subscribeVoiceAudioInterruptions(
+      (event) => {
+        // A phone call or Siri has taken the mic. End the session rather than
+        // leave it "listening" into a dead input. No auto-resume on `ended` —
+        // the user restarts explicitly.
+        if (event.type !== "began") {
+          return;
+        }
+        if (!isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
+          return;
+        }
+        endLiveVoiceSession();
+      },
+    );
+
+    return () => {
+      unsubscribeStore();
+      unsubscribeInterruptions();
+      // A live audio session must never outlive its controller. Usually the
+      // sibling teardown in `useLiveVoice` has already reset the store to
+      // `idle` (which `sync` observed), leaving this a no-op; it covers the
+      // orders where it has not.
+      if (holdingAudioSession) {
+        holdingAudioSession = false;
+        fireAndForget(deactivateVoiceAudioSession());
+      }
+    };
+  }, []);
+}
 
 export function useLiveVoiceSessionController(
   options: UseLiveVoiceSessionControllerOptions = {},
@@ -70,4 +165,6 @@ export function useLiveVoiceSessionController(
       useLiveVoiceStore.getState().setStarter(null);
     };
   }, [start]);
+
+  useNativeAudioSessionLifecycle();
 }

--- a/clients/web/src/runtime/native-audio-session.test.ts
+++ b/clients/web/src/runtime/native-audio-session.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the `VoiceAudioSession` bridge.
+ *
+ * The contract under test is skew-safety: the iOS shell ships through App Store
+ * review while this bundle deploys continuously, so an arbitrarily old shell
+ * can host it with no such plugin compiled in. Every exported function must
+ * therefore resolve — never reject, never hang — whether the plugin answers,
+ * rejects, or does not exist, and must not touch the bridge at all off iOS.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { PluginListenerHandle } from "@capacitor/core";
+
+import type { VoiceAudioInterruptionEvent } from "@/runtime/native-audio-session";
+
+let onNativeIOS = false;
+
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => onNativeIOS,
+}));
+
+type Handler = (event: VoiceAudioInterruptionEvent) => void;
+
+/** Handlers the module registered, so tests can emit native events. */
+let handlers: Handler[] = [];
+
+const activate = mock(async () => ({ activated: true }));
+const deactivate = mock(async () => undefined);
+const remove = mock(async () => undefined);
+
+// Registration is async on the real bridge, so the handle only lands a
+// microtask later — the window the unsubscribe race lives in.
+const defaultAddListener = (
+  _event: string,
+  handler: Handler,
+): Promise<PluginListenerHandle> => {
+  handlers.push(handler);
+  return Promise.resolve({ remove });
+};
+const addListener = mock(defaultAddListener);
+
+mock.module("@capacitor/core", () => ({
+  registerPlugin: () => ({ activate, deactivate, addListener }),
+}));
+
+const {
+  activateVoiceAudioSession,
+  deactivateVoiceAudioSession,
+  subscribeVoiceAudioInterruptions,
+} = await import("@/runtime/native-audio-session");
+
+beforeEach(() => {
+  onNativeIOS = true;
+  handlers = [];
+  activate.mockClear();
+  activate.mockImplementation(async () => ({ activated: true }));
+  deactivate.mockClear();
+  deactivate.mockImplementation(async () => undefined);
+  remove.mockClear();
+  addListener.mockClear();
+  addListener.mockImplementation(defaultAddListener);
+});
+
+// ---------------------------------------------------------------------------
+// Off-native — the browser and Electron paths
+// ---------------------------------------------------------------------------
+
+describe("off the iOS shell", () => {
+  beforeEach(() => {
+    onNativeIOS = false;
+  });
+
+  test("activate resolves false without touching the bridge", async () => {
+    expect(await activateVoiceAudioSession()).toBe(false);
+    expect(activate).not.toHaveBeenCalled();
+  });
+
+  test("deactivate resolves without touching the bridge", async () => {
+    expect(await deactivateVoiceAudioSession()).toBeUndefined();
+    expect(deactivate).not.toHaveBeenCalled();
+  });
+
+  test("subscribing registers nothing and unsubscribing is safe", () => {
+    const unsubscribe = subscribeVoiceAudioInterruptions(() => undefined);
+    expect(addListener).not.toHaveBeenCalled();
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// On the iOS shell, plugin present
+// ---------------------------------------------------------------------------
+
+describe("with the plugin present", () => {
+  test("activate reports whether the native side took the session", async () => {
+    expect(await activateVoiceAudioSession()).toBe(true);
+    expect(activate).toHaveBeenCalledTimes(1);
+
+    activate.mockImplementation(async () => ({ activated: false }));
+    expect(await activateVoiceAudioSession()).toBe(false);
+  });
+
+  test("deactivate calls through", async () => {
+    await deactivateVoiceAudioSession();
+    expect(deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  test("interruption events reach the handler until unsubscribed", async () => {
+    const handler = mock((_event: VoiceAudioInterruptionEvent) => undefined);
+    const unsubscribe = subscribeVoiceAudioInterruptions(handler);
+    expect(addListener).toHaveBeenCalledWith(
+      "voiceAudioInterruption",
+      expect.any(Function),
+    );
+
+    handlers[0]?.({ type: "began", shouldResume: false });
+    expect(handler).toHaveBeenCalledWith({
+      type: "began",
+      shouldResume: false,
+    });
+
+    // Let the registration settle so the handle is held, then release it.
+    await Promise.resolve();
+    unsubscribe();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribing before registration settles still removes the listener", async () => {
+    const unsubscribe = subscribeVoiceAudioInterruptions(() => undefined);
+    // Unsubscribe while `addListener` is still in flight — the pending
+    // registration must be torn down on arrival, not leaked.
+    unsubscribe();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// On the iOS shell, older shell without the plugin — the skew case
+// ---------------------------------------------------------------------------
+
+describe("with an older shell that has no plugin", () => {
+  // What `registerPlugin` produces for a plugin the shell never registered:
+  // every method rejects rather than being absent.
+  const notImplemented = async (): Promise<never> => {
+    throw new Error("VoiceAudioSession does not have web implementation.");
+  };
+
+  beforeEach(() => {
+    activate.mockImplementation(notImplemented);
+    deactivate.mockImplementation(notImplemented);
+  });
+
+  test("activate resolves false instead of rejecting", async () => {
+    expect(await activateVoiceAudioSession()).toBe(false);
+  });
+
+  test("deactivate resolves instead of rejecting", async () => {
+    expect(await deactivateVoiceAudioSession()).toBeUndefined();
+  });
+
+  test("a rejecting addListener never surfaces to the caller", async () => {
+    addListener.mockImplementation(() =>
+      Promise.reject(new Error("no plugin")),
+    );
+
+    let unsubscribe: (() => void) | undefined;
+    expect(() => {
+      unsubscribe = subscribeVoiceAudioInterruptions(() => undefined);
+    }).not.toThrow();
+    await Promise.resolve();
+    expect(() => unsubscribe?.()).not.toThrow();
+    expect(remove).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/native-audio-session.ts
+++ b/clients/web/src/runtime/native-audio-session.ts
@@ -1,0 +1,156 @@
+/**
+ * JS ↔ native bridge for the `VoiceAudioSession` Capacitor plugin registered by
+ * `clients/ios/App/App/MyViewController.swift` +
+ * `clients/ios/App/App/VoiceAudioSessionPlugin.swift`.
+ *
+ * The plugin owns the app's `AVAudioSession` for the duration of a live-voice
+ * session: `.playAndRecord` / `.voiceChat` (hardware echo cancellation, AGC,
+ * correct AirPods/Bluetooth-HFP routing) plus the `audio` background mode, so
+ * TTS keeps playing and the mic keeps its route while the app is backgrounded
+ * or the screen is locked. Deactivating passes `.notifyOthersOnDeactivation`
+ * so whatever the user was listening to before resumes.
+ *
+ * **Skew contract.** The iOS shell ships through App Store review while this
+ * bundle deploys continuously (`clients/ios/README.md` § "Web content
+ * delivery"), so an arbitrarily old shell may host this bundle with no such
+ * plugin compiled in. Every call therefore goes through
+ * {@link callNativeVoice}, which returns the fallback off-iOS and on any bridge
+ * failure: without the plugin a voice session behaves exactly as it does today,
+ * losing only the background/route niceties. Nothing here may throw, and
+ * nothing here may block a session.
+ *
+ * There is no separate `isAvailable` probe: {@link activateVoiceAudioSession}
+ * resolving `false` *is* the probe, and it is the only answer a caller can act
+ * on anyway.
+ *
+ * References:
+ * - https://developer.apple.com/documentation/avfaudio/avaudiosession
+ * - https://developer.apple.com/documentation/avfaudio/avaudiosession/mode/1616455-voicechat
+ */
+
+import { registerPlugin } from "@capacitor/core";
+import type { PluginListenerHandle } from "@capacitor/core";
+
+import { callNativeVoice } from "@/runtime/native-voice";
+import { isNativeIOS } from "@/runtime/platform-detection";
+
+/**
+ * An `AVAudioSession` interruption — something else took the audio hardware.
+ *
+ * - `began` — a phone call, a Siri invocation, or another app grabbed the mic.
+ * - `ended` — the interrupting activity finished. `shouldResume` mirrors
+ *   Apple's `.shouldResume` option; we deliberately do not act on it (see
+ *   {@link subscribeVoiceAudioInterruptions}).
+ */
+export interface VoiceAudioInterruptionEvent {
+  type: "began" | "ended";
+  shouldResume: boolean;
+}
+
+/**
+ * An `AVAudioSession` route change (AirPods connected/removed, …). The plugin
+ * emits these; nothing consumes them yet, so no subscriber is exported.
+ */
+interface VoiceAudioRouteChangeEvent {
+  reason: string;
+}
+
+interface VoiceAudioSessionPlugin {
+  activate(): Promise<{ activated: boolean }>;
+  deactivate(): Promise<void>;
+  addListener(
+    eventName: "voiceAudioInterruption",
+    handler: (event: VoiceAudioInterruptionEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "voiceAudioRouteChange",
+    handler: (event: VoiceAudioRouteChangeEvent) => void,
+  ): Promise<PluginListenerHandle>;
+}
+
+const VoiceAudioSession =
+  registerPlugin<VoiceAudioSessionPlugin>("VoiceAudioSession");
+
+/**
+ * Configure and activate the audio session for a live-voice session. Resolves
+ * `true` when the native side took over, `false` on every other platform and
+ * on any bridge failure (an older shell without the plugin).
+ *
+ * Call it when a session becomes active, and pair every call with
+ * {@link deactivateVoiceAudioSession} — an audio session that outlives its
+ * voice session holds the mic route and keeps other apps' audio ducked.
+ */
+export async function activateVoiceAudioSession(): Promise<boolean> {
+  return callNativeVoice(async () => {
+    // Only the result crosses this `async` boundary, never `VoiceAudioSession`
+    // itself: per `docs/CAPACITOR.md` § "Capacitor plugins must be destructured
+    // inline", a plugin Proxy in a Promise-resolution context dispatches a
+    // native `then()` that never resolves and hangs the caller forever.
+    const { activated } = await VoiceAudioSession.activate();
+    // Normalized rather than returned raw — the bridge payload is untyped at
+    // runtime, and a shell that answers `{}` must read as "not activated".
+    return activated === true;
+  }, false);
+}
+
+/**
+ * Release the audio session at the end of a live-voice session. No-op off-iOS
+ * and on an older shell. Never throws.
+ */
+export async function deactivateVoiceAudioSession(): Promise<void> {
+  return callNativeVoice(async () => {
+    await VoiceAudioSession.deactivate();
+  }, undefined);
+}
+
+/**
+ * Subscribe to `AVAudioSession` interruptions, returning an unsubscribe.
+ *
+ * Consumers should end the voice session on `type: "began"` — the mic is gone,
+ * and a session that silently keeps "listening" into a dead input is worse than
+ * one that ends. Do NOT auto-resume on `ended`: the user restarts explicitly.
+ *
+ * `addListener` is one of the few property names the Capacitor plugin Proxy
+ * does *not* trap into a fabricated native method, so calling it on a plugin
+ * the shell never registered is safe — it simply never fires. The
+ * `isNativeIOS()` guard still short-circuits everywhere else for the same
+ * reason as {@link callNativeVoice}: off the iOS shell there is no native side
+ * to listen to.
+ *
+ * Registration is asynchronous, so an unsubscribe that beats it removes the
+ * handle on arrival rather than leaking it. This deliberately does not reuse
+ * `subscribeCapacitorListener`: that scaffold reports failures through
+ * `captureError`, and a missing plugin on a skewed shell is an expected state
+ * on every web deploy, not a fault worth a Sentry event.
+ */
+export function subscribeVoiceAudioInterruptions(
+  handler: (event: VoiceAudioInterruptionEvent) => void,
+): () => void {
+  if (!isNativeIOS()) {
+    return () => undefined;
+  }
+
+  let handle: PluginListenerHandle | null = null;
+  let cancelled = false;
+
+  VoiceAudioSession.addListener("voiceAudioInterruption", handler)
+    .then((registered) => {
+      if (cancelled) {
+        void registered.remove();
+        return;
+      }
+      handle = registered;
+    })
+    .catch((err: unknown) => {
+      console.debug(
+        "[native-audio-session] interruption listener failed:",
+        err,
+      );
+    });
+
+  return () => {
+    cancelled = true;
+    void handle?.remove();
+    handle = null;
+  };
+}


### PR DESCRIPTION
Binds the iOS `VoiceAudioSession` Capacitor plugin to the live-voice session lifecycle, so an active voice session holds a correctly configured `AVAudioSession` (`.playAndRecord` / `.voiceChat` + the `audio` background mode) and releases it the moment the session ends.

## Skew-safety (the top review criterion)

This merges safely ahead of the native plugin reaching the App Store. Every bridge call goes through `callNativeVoice`, so on an older shell — or in a browser, or on Electron — all of this no-ops and voice behaves exactly as it does today. `native-audio-session.test.ts` proves it with a suite where every plugin method (`activate`, `deactivate`, `addListener`) rejects, plus a controller test where the bridge functions themselves reject and the session still starts, runs, and ends normally.

The plugin Proxy never crosses an `async` return (`docs/CAPACITOR.md` lazy-import rule) — only destructured results do.

## What it does

`runtime/native-audio-session.ts` (new)
- `registerPlugin<VoiceAudioSessionPlugin>("VoiceAudioSession")` at module scope, matching `native-biometric.ts`.
- `activateVoiceAudioSession(): Promise<boolean>` / `deactivateVoiceAudioSession(): Promise<void>`, both wrapped in `callNativeVoice` with `false` / `undefined` fallbacks. No separate `isAvailable` probe — `activate` resolving `false` *is* the probe.
- `subscribeVoiceAudioInterruptions(handler)` wrapping `addListener` (one of the few properties the plugin Proxy does not trap), guarded by `isNativeIOS()`, with unsubscribe-before-registration race handling. Deliberately does not reuse `subscribeCapacitorListener`: that scaffold reports through `captureError`, and a missing plugin on a skewed shell is an expected state on every web deploy, not a Sentry event.

`use-live-voice-session-controller.ts`
- A new `useNativeAudioSessionLifecycle()` drives the audio session off store **phase transitions**, not off the starter — so deep-link starts, reconnects, and failures are all covered symmetrically. Out of `idle`/`failed` into any active phase → activate; into `idle` or `failed` → deactivate; unmount with a session held → deactivate.
- A held-flag means activate fires **once per session**, not once per `listening`→`thinking`→`speaking` transition.
- On `voiceAudioInterruption { type: "began" }` while active, it ends the session via the shared `endLiveVoiceSession()`. A phone call or Siri has taken the mic; a session that silently keeps "listening" into a dead input is worse than one that ends. No auto-resume on `ended` — the user restarts explicitly.
- Every call is fire-and-forget: a hung or failed bridge call can never delay or block a voice session.
- **The `observeAudioState: false` contract is preserved.** `state` is read via `useLiveVoiceStore.subscribe` inside an effect, never a reactive selector in a render body, so per-frame amplitude/transcript deltas still cost the mounting layout nothing. Pinned by a new render-count test.

## Tests

29 tests across the two files, covering: activate exactly once per session and not on phase churn; deactivate on `idle`, on `failed`, and on unmount; interruption `began` ends the session while `ended` does not disturb it; an interruption with no session is a no-op; every path no-ops off-iOS; and the rejecting-bridge skew case.

`bun test` green for both files (run separately), `bun run typecheck` green, `eslint` clean.