### PR TITLE
fix(web): keep the package-switch confirm safe and faithful to the mock

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.stories.tsx
@@ -149,3 +149,24 @@ export const NoTargetPackage: Story = {
     targetPackage: null,
   },
 };
+
+/**
+ * A name wider than the `size="sm"` card's title column wraps onto the second
+ * line the header already allows, rather than ellipsizing.
+ */
+export const LongPackageName: Story = {
+  args: {
+    relation: "upgrade",
+    packageName: "Ultra Enterprise Performance",
+    targetPackage: proPackage({
+      key: "ultra-enterprise",
+      name: "Ultra Enterprise Performance",
+      description:
+        "Large machine, 120 GB of storage, and $115 in monthly credits.",
+      machine_size: "large",
+      storage_gib: 120,
+      credits_usd: 115,
+      total_price_cents: 24900,
+    }),
+  },
+};

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
@@ -128,6 +128,76 @@ describe("PackageSwitchConfirmModal", () => {
     );
   });
 
+  test("a downgrade swaps the avatar for a warning glyph and drops the gains framing", () => {
+    const { getByTestId, queryByTestId, getByText, queryByText } = renderModal({
+      relation: "downgrade",
+    });
+
+    getByTestId("package-switch-warning-tile");
+    expect(queryByTestId("assistant-avatar-tile")).toBeNull();
+    getByText("Your plan will include");
+    expect(queryByText("The plan includes")).toBeNull();
+  });
+
+  test("an upgrade keeps the friendly avatar header", () => {
+    const { getByTestId, queryByTestId, getByText } = renderModal();
+
+    getByTestId("assistant-avatar-tile");
+    expect(queryByTestId("package-switch-warning-tile")).toBeNull();
+    getByText("The plan includes");
+  });
+
+  test("the dialog opens focused on Cancel, not on the confirm", () => {
+    const { getByRole, getByTestId } = renderModal({ relation: "downgrade" });
+
+    expect(document.activeElement).toBe(
+      getByRole("button", { name: "Cancel" }),
+    );
+    expect(document.activeElement).not.toBe(
+      getByTestId("confirm-package-switch-button"),
+    );
+
+    cleanup();
+
+    const upgrade = renderModal();
+    expect(document.activeElement).toBe(
+      upgrade.getByRole("button", { name: "Cancel" }),
+    );
+  });
+
+  test("a package with no tier copy describes itself from the catalog", () => {
+    const { getByRole, getByText } = renderModal({
+      packageName: "Mega",
+      targetPackage: proPackage({ key: "mega", name: "Mega" }),
+    });
+
+    const describedBy = getByRole("dialog").getAttribute("aria-describedby");
+    expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+      "Small machine, 15 GB of storage, and $25 in monthly credits.",
+    );
+    getByText("Small machine, 15 GB of storage, and $25 in monthly credits.");
+  });
+
+  test("with nothing to describe the dialog carries no aria-describedby", () => {
+    const { getByRole } = renderModal({
+      packageName: "",
+      targetPackage: null,
+    });
+
+    expect(getByRole("dialog").hasAttribute("aria-describedby")).toBe(false);
+  });
+
+  test("the downgrade safeguard note survives an unresolved target", () => {
+    const { getByText, queryByText } = renderModal({
+      relation: "downgrade",
+      packageName: "Mighty",
+      targetPackage: null,
+    });
+
+    getByText(DOWNGRADE_NOTE);
+    expect(queryByText("Your plan will include")).toBeNull();
+  });
+
   test("a direction-neutral switch names both proration outcomes", () => {
     const { getByText, getByRole, getByTestId, queryByText } = renderModal({
       relation: "switch",

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -1,4 +1,5 @@
-import { CircleCheck } from "lucide-react";
+import { AlertTriangle, CircleCheck } from "lucide-react";
+import { useRef } from "react";
 
 import { AssistantAvatarTile } from "@/domains/settings/billing/assistant-avatar-tile";
 import type {
@@ -9,6 +10,7 @@ import { packageHighlights } from "@/domains/settings/billing/plan-spec";
 import { packageSwitchCopy } from "@/domains/settings/billing/plans/package-switch-copy";
 import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
 import { formatMonthly } from "@/domains/settings/components/tier-pricing";
+import { cn } from "@/utils/misc";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -37,11 +39,12 @@ export interface PackageSwitchConfirmModalProps {
 
 /**
  * Reconfirm dialog for a one-click Pro package switch. A downgrade gets the
- * danger confirm plus its safeguard note; an upgrade and a direction-neutral
- * switch get a lighter primary confirm. Layout-only for the mutation — the
- * parent owns `change-package` — but it does read the assistant avatar through
- * `AssistantAvatarTile`, so both call sites get the header glyph without
- * duplicating that wiring.
+ * warning glyph, loss-framed checklist copy, neutral spec markers, the danger
+ * confirm and its safeguard note; an upgrade and a direction-neutral switch get
+ * the assistant avatar and a lighter primary confirm. Layout-only for the
+ * mutation — the parent owns `change-package` — but it does read the assistant
+ * avatar through `AssistantAvatarTile`, so both call sites get the header glyph
+ * without duplicating that wiring.
  */
 export function PackageSwitchConfirmModal({
   open,
@@ -52,11 +55,17 @@ export function PackageSwitchConfirmModal({
   onCancel,
   onConfirm,
 }: PackageSwitchConfirmModalProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
   const copy = packageSwitchCopy(
     relation,
     packageName,
     targetPackage?.key ?? null,
   );
+  // The catalog is server-driven and can ship a package this bundle has no tier
+  // copy for, so fall back to the package's own blurb — without it the
+  // description element disappears while Radix still points
+  // `aria-describedby` at its id.
+  const description = copy.subtitle || targetPackage?.description || "";
   // Everything below the header describes one concrete package, so it all
   // resolves — or doesn't — together.
   const details = targetPackage
@@ -68,6 +77,12 @@ export function PackageSwitchConfirmModal({
         ),
       }
     : null;
+  // A green check reads as a win; on a downgrade the rows describe a smaller
+  // machine, so the same glyph goes neutral. An empty marker would instead read
+  // as "not included".
+  const highlightIconColor = copy.destructive
+    ? "text-[var(--content-tertiary)]"
+    : "text-[var(--system-positive-strong)]";
 
   return (
     <Modal.Root
@@ -78,16 +93,46 @@ export function PackageSwitchConfirmModal({
         }
       }}
     >
-      <Modal.Content size="sm" hideCloseButton className="gap-6 p-4">
-        <Modal.Header className="flex-row items-center gap-3 p-0">
-          <AssistantAvatarTile />
+      <Modal.Content
+        size="sm"
+        hideCloseButton
+        className="gap-4 p-4"
+        // The confirm sits above Cancel to match the mock, which puts it first
+        // in the DOM too — and with no close button it is the first tabbable
+        // node, so Radix's mount autofocus would arm Enter on an immediate,
+        // unrefundable package change. Every relation opens on Cancel instead.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          cancelRef.current?.focus();
+        }}
+        // Radix stamps `aria-describedby` whether or not a description renders.
+        {...(description ? {} : { "aria-describedby": undefined })}
+      >
+        {/* 8px here plus the 16px content gap makes the mock's 24px under the
+            header, while that gap stays 16px between the checklist and the
+            actions. */}
+        <Modal.Header className="flex-row items-center gap-3 p-0 pb-2">
+          {copy.destructive ? (
+            <div
+              aria-hidden
+              data-testid="package-switch-warning-tile"
+              className="flex size-[52px] shrink-0 items-center justify-center rounded-xl bg-[var(--system-negative-weak)]"
+            >
+              <AlertTriangle className="size-6 text-[var(--system-negative-strong)]" />
+            </div>
+          ) : (
+            <AssistantAvatarTile />
+          )}
           <div className="flex min-w-0 flex-1 flex-col gap-1">
-            <Modal.Title className="text-title-small text-[var(--content-emphasised)]">
+            {/* A catalog or custom package name can outrun the 304px of title
+                width a `size="sm"` card leaves, and the header column already
+                allows a second line. */}
+            <Modal.Title className="text-title-small text-[var(--content-emphasised)] [&>span]:whitespace-normal">
               {copy.title}
             </Modal.Title>
-            {copy.subtitle ? (
+            {description ? (
               <Modal.Description className="mt-0 text-body-medium-default text-[var(--content-tertiary)]">
-                {copy.subtitle}
+                {description}
               </Modal.Description>
             ) : null}
           </div>
@@ -117,13 +162,13 @@ export function PackageSwitchConfirmModal({
               variant="body-small-default"
               className="text-[var(--content-tertiary)]"
             >
-              The plan includes
+              {copy.checklistHeading}
             </Typography>
             <ul className="flex flex-col gap-2">
               {details.highlights.map((row) => (
-                <li key={row} className="flex items-center gap-1.5">
+                <li key={row} className="flex items-center gap-1">
                   <CircleCheck
-                    className="size-4 shrink-0 text-[var(--system-positive-strong)]"
+                    className={cn("size-4 shrink-0", highlightIconColor)}
                     aria-hidden
                   />
                   <Typography
@@ -136,18 +181,20 @@ export function PackageSwitchConfirmModal({
                 </li>
               ))}
             </ul>
-            {copy.note ? (
-              <Typography
-                as="p"
-                variant="body-medium-default"
-                className="text-[var(--content-secondary)]"
-              >
-                {copy.note}
-              </Typography>
-            ) : null}
           </Modal.Body>
         ) : null}
-        <Modal.Footer className="flex-col gap-2 p-0">
+        {/* Outside the details gate: the note comes from the relation alone, and
+            an unresolved target still offers the danger confirm. */}
+        {copy.note ? (
+          <Typography
+            as="p"
+            variant="body-medium-default"
+            className="text-[var(--content-secondary)]"
+          >
+            {copy.note}
+          </Typography>
+        ) : null}
+        <Modal.Footer className="flex-col gap-4 p-0">
           <Button
             fullWidth
             variant={copy.destructive ? "danger" : "primary"}
@@ -158,6 +205,7 @@ export function PackageSwitchConfirmModal({
             {copy.confirmLabel}
           </Button>
           <Button
+            ref={cancelRef}
             fullWidth
             variant="ghost"
             onClick={onCancel}

--- a/clients/web/src/domains/settings/billing/plans/package-switch-copy.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-copy.test.ts
@@ -17,6 +17,7 @@ describe("packageSwitchCopy", () => {
       title: "Upgrade to Super",
       subtitle: PLAN_TIER_COPY.super.tagline,
       priceCaption: "Billed monthly · prorated difference charged today",
+      checklistHeading: "The plan includes",
       note: "",
       confirmLabel: "Continue",
       destructive: false,
@@ -29,6 +30,7 @@ describe("packageSwitchCopy", () => {
       subtitle: PLAN_TIER_COPY.ultra.tagline,
       priceCaption:
         "Billed monthly · prorated difference charged today or credited next invoice",
+      checklistHeading: "The plan includes",
       note: "",
       confirmLabel: "Continue",
       destructive: false,
@@ -40,6 +42,7 @@ describe("packageSwitchCopy", () => {
       title: "Downgrade to Mighty",
       subtitle: PLAN_TIER_COPY.mighty.tagline,
       priceCaption: "Billed monthly · prorated credit on your next invoice",
+      checklistHeading: "Your plan will include",
       note: "Your machine downsizes now and your storage stays. No refund.",
       confirmLabel: "Downgrade to Mighty",
       destructive: true,
@@ -79,6 +82,18 @@ describe("packageSwitchCopy", () => {
     );
     expect(packageSwitchCopy("upgrade", "Mighty", "mighty").note).toBe("");
     expect(packageSwitchCopy("switch", "Mighty", "mighty").note).toBe("");
+  });
+
+  test("only a downgrade frames the checklist as what is left", () => {
+    expect(
+      packageSwitchCopy("downgrade", "Mighty", "mighty").checklistHeading,
+    ).toBe("Your plan will include");
+    expect(
+      packageSwitchCopy("upgrade", "Mighty", "mighty").checklistHeading,
+    ).toBe("The plan includes");
+    expect(
+      packageSwitchCopy("switch", "Mighty", "mighty").checklistHeading,
+    ).toBe("The plan includes");
   });
 
   test("subtitle is empty for an unknown or absent tier key", () => {

--- a/clients/web/src/domains/settings/billing/plans/package-switch-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-copy.ts
@@ -19,6 +19,8 @@ export interface PackageSwitchCopy {
   subtitle: string;
   /** Caption under the price — where the money actually lands. */
   priceCaption: string;
+  /** Heading above the target package's spec rows. */
+  checklistHeading: string;
   /** Extra safeguard prose shown below the checklist; empty when none. */
   note: string;
   /** Full-width primary CTA label. */
@@ -41,6 +43,11 @@ const DOWNGRADE_CAPTION =
 const DOWNGRADE_NOTE =
   "Your machine downsizes now and your storage stays. No refund.";
 const CONTINUE_LABEL = "Continue";
+const CHECKLIST_HEADING = "The plan includes";
+// The rows enumerate the *lower* package on a downgrade, so a present-tense
+// "The plan includes" reads as a list of gains. Future tense keeps it a
+// statement of what is left, not what is won.
+const DOWNGRADE_CHECKLIST_HEADING = "Your plan will include";
 
 /** Every string the confirm modal renders for one target package. */
 export function packageSwitchCopy(
@@ -56,6 +63,7 @@ export function packageSwitchCopy(
         title: `Downgrade to ${packageName}`,
         subtitle,
         priceCaption: DOWNGRADE_CAPTION,
+        checklistHeading: DOWNGRADE_CHECKLIST_HEADING,
         note: DOWNGRADE_NOTE,
         confirmLabel: downgradeLabel(packageName),
         destructive: true,
@@ -65,6 +73,7 @@ export function packageSwitchCopy(
         title: `Switch to ${packageName}`,
         subtitle,
         priceCaption: SWITCH_CAPTION,
+        checklistHeading: CHECKLIST_HEADING,
         note: "",
         confirmLabel: CONTINUE_LABEL,
         destructive: false,
@@ -74,6 +83,7 @@ export function packageSwitchCopy(
         title: `Upgrade to ${packageName}`,
         subtitle,
         priceCaption: UPGRADE_CAPTION,
+        checklistHeading: CHECKLIST_HEADING,
         note: "",
         confirmLabel: CONTINUE_LABEL,
         destructive: false,


### PR DESCRIPTION
## Summary
- Mount focus no longer lands on the confirm button, so Enter immediately after the dialog opens can no longer commit an irreversible downgrade.
- The downgrade variant regains a distinct warning treatment and no longer frames the lower package's specs as green-checked gains.
- Fixes a dangling `aria-describedby` for catalog packages with no client-side tier copy, and hoists the downgrade safeguard note out of the price/checklist gate.
- Corrects three spacings against the Figma node and lets long plan names wrap instead of ellipsizing.

Fixes gaps found during plan self-review for package-switch-modal-redesign.md.