### PR TITLE
fix(web): funnel a post-checkout return with no assistant into provisioning

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -145,6 +145,7 @@ mock.module("@/domains/onboarding/prefs", () => ({
 }));
 
 mock.module("@/lib/navigation/navigation-resolver", () => ({
+  POST_CHECKOUT_HATCH_PARAM: "post_checkout",
   resolveNavigation: () => ({ action: "allow" }),
 }));
 

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -130,12 +130,21 @@ const hatchAssistantMock = mock(async () => ({
 // queued" / network blip under throwOnError:false — before one succeeds. 0 =
 // always succeed. Infinity = never succeeds.
 let ensureProvisionedFailFirstN = 0;
+// How many leading reconcile calls answer with the `no_active_pro` entitlement
+// race: a 200 body that queues nothing because the platform cannot see the
+// entitlement yet.
+let ensureProvisionedRaceFirstN = 0;
 let ensureProvisionedCallCount = 0;
 
 const ensureProvisionedMock = mock(async () => {
   ensureProvisionedCallCount += 1;
   if (ensureProvisionedCallCount <= ensureProvisionedFailFirstN) {
     return { data: undefined };
+  }
+  if (ensureProvisionedCallCount <= ensureProvisionedRaceFirstN) {
+    return {
+      data: { state: "not_applicable", reason: "no_active_pro", targets: {} },
+    };
   }
   return { data: { state: "started", reason: null, targets: {} } };
 });
@@ -283,6 +292,7 @@ mock.module("@/lib/self-hosted/connection", () => ({
 }));
 
 mock.module("@/lib/navigation/navigation-resolver", () => ({
+  POST_CHECKOUT_HATCH_PARAM: "post_checkout",
   resolveNavigation: () => ({ action: "proceed" }),
 }));
 
@@ -408,6 +418,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     subscriptionCallCount = 0;
     subscriptionPollClockStepMs = 0;
     ensureProvisionedFailFirstN = 0;
+    ensureProvisionedRaceFirstN = 0;
     ensureProvisionedCallCount = 0;
     onboardingThrows = false;
     onboardingData = null;
@@ -916,4 +927,143 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     // teardown must not have run ahead of it.
     expect(setSelfHostedConnectionMock).not.toHaveBeenCalled();
   });
+
+  // -- post-checkout return -----------------------------------------------
+  //
+  // Stripe redirects the moment payment succeeds, which can beat the subscribe
+  // webhook that flips the org to Pro. On the return leg of a completed
+  // checkout — marked by `post_checkout=1`, set only by the funnel — a
+  // still-base plan read means the webhook is lagging, not that the org is
+  // free. `hosting=vellum-cloud` alone never carries that meaning: it is a
+  // hosting choice a free user can make.
+
+  const POST_CHECKOUT_PARAMS = "hosting=vellum-cloud&post_checkout=1";
+
+  test(
+    "a post-checkout return whose plan still reads base waits, then applies the purchased targets",
+    async () => {
+      searchParams = new URLSearchParams(POST_CHECKOUT_PARAMS);
+      // The webhook has not landed: the org still reports its pre-checkout plan
+      // with no targets, and the assistant sits at the warm-pool baseline.
+      subscriptionPlanId = "base";
+      onboardingData = null;
+
+      render(<HatchingScreen />);
+
+      // The subscription is re-read rather than accepted as a free entitlement.
+      await waitFor(
+        () =>
+          expect(
+            subscriptionRetrieveMock.mock.calls.length,
+          ).toBeGreaterThanOrEqual(2),
+        { timeout: 15000 },
+      );
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      // The webhook lands, carrying the purchased ceiling.
+      subscriptionPlanId = "pro";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+
+      await waitFor(() => expect(screen.getByText(RESIZE_LABEL)).toBeTruthy(), {
+        timeout: 15000,
+      });
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      // The resize lands and the screen completes at the purchased size.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+    },
+    30000,
+  );
+
+  test(
+    "a post-checkout return whose plan never flips still completes at the hard cap",
+    async () => {
+      searchParams = new URLSearchParams(POST_CHECKOUT_PARAMS);
+      subscriptionPlanId = "base";
+      onboardingData = null;
+      // The subscription loop's poll jumps the clock past RESIZE_WAIT_MAX_MS so
+      // the cap fires without a real 90s wait.
+      subscriptionPollClockStepMs = 91_000;
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+      // The cap released it at baseline: the resize phase was never entered.
+      expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
+    },
+    20000,
+  );
+
+  test("a hatch with no post-checkout marker completes on the first non-pro read", async () => {
+    // The free path is untouched — one subscription read, no resize phase, no
+    // added poll — even with a stale onboarding ceiling on record.
+    subscriptionPlanId = "base";
+    onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+
+    render(<HatchingScreen />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
+    expect(subscriptionRetrieveMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
+  });
+
+  test("a managed hatch without the post-checkout marker completes on the first non-pro read", async () => {
+    // Picking Vellum Cloud is not a purchase: a free managed hatch must never
+    // be parked on the post-checkout wait.
+    isLocalModeValue = true;
+    searchParams = new URLSearchParams("hosting=vellum-cloud");
+    subscriptionPlanId = "base";
+    onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+
+    render(<HatchingScreen />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
+    expect(subscriptionRetrieveMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
+  });
+
+  test(
+    "a no_active_pro reconcile is re-fired on a later poll instead of consuming the fire-once guard",
+    async () => {
+      // The entitlement race answers with a 200 body but queues nothing.
+      // Consuming the guard on it would spend the nudge for the whole hatch, so
+      // the purchased resize would land only if the webhook's own resize did.
+      subscriptionPlanId = "pro";
+      onboardingData = null;
+      ensureProvisionedRaceFirstN = 1;
+      // Actuals already sit at the eventual ceiling so completion is prompt
+      // once the targets land.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+
+      render(<HatchingScreen />);
+
+      await waitFor(
+        () =>
+          expect(
+            ensureProvisionedMock.mock.calls.length,
+          ).toBeGreaterThanOrEqual(2),
+        { timeout: 15000 },
+      );
+
+      // The entitlement becomes visible and provisioning converges.
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+    },
+    20000,
+  );
 });

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -49,12 +49,19 @@ let opStatusNoData = false;
 // Whether the no-id pre-flight getAssistant resolves an already-active
 // assistant (the reload path, Fix 3).
 let preflightActive = false;
+// Whether the no-id pre-flight resolves the SELECTED LOCKFILE assistant, which
+// is what `getAssistant()` answers with under gateway auth in a local-mode
+// build: always `status: "active", is_local: true`.
+let preflightGatewaySelectedLocal = false;
+
+const GATEWAY_SELECTED_LOCAL_ID = "local-selected-1";
 
 interface AssistantShape {
   id: string;
   status: string;
   machine_size: string | null;
   provisioned_storage_gib: number | null;
+  is_local?: boolean;
 }
 let currentAssistant: AssistantShape;
 
@@ -80,6 +87,19 @@ let onboardingThrows = false;
 
 const getAssistantMock = mock(async (id?: string) => {
   if (!id) {
+    if (preflightGatewaySelectedLocal) {
+      return {
+        ok: true as const,
+        status: 200,
+        data: {
+          id: GATEWAY_SELECTED_LOCAL_ID,
+          status: "active",
+          is_local: true,
+          machine_size: null,
+          provisioned_storage_gib: null,
+        },
+      };
+    }
     if (preflightActive) {
       // Reload onto an already-active assistant.
       return { ok: true as const, status: 200, data: { ...currentAssistant } };
@@ -158,6 +178,12 @@ const hatchLocalAssistantMock = mock(async () => ({
   assistantId: "local-1",
 }));
 
+const saveLockfileAssistantMock = mock(
+  async (_entry: { assistantId: string; cloud: string }) => {},
+);
+const clearGatewayTokenMock = mock(() => {});
+const setSelfHostedConnectionMock = mock((_connection: unknown) => {});
+
 mock.module("react-router", () => ({
   useNavigate: () => navigateMock,
   useSearchParams: () => [searchParams],
@@ -201,10 +227,12 @@ mock.module("@/assistant/lifecycle", () => ({
   resolveAssistantLifecycleState: (result: {
     ok?: boolean;
     status?: number;
-    data?: { status?: string };
+    data?: { status?: string; is_local?: boolean };
   }) => {
     if (result?.ok && result.data?.status === "active") {
-      return { kind: "active" };
+      // Mirrors the real projection: an active assistant flagged `is_local`
+      // is self-hosted, never the managed `active` the hatch is waiting for.
+      return result.data.is_local ? { kind: "self_hosted" } : { kind: "active" };
     }
     if (!result?.ok && result.status === 404) {
       return { kind: "auto_hatch" };
@@ -243,11 +271,15 @@ mock.module("@/lib/local-mode", () => ({
   loadLockfile: async () => {},
   primeLocalGatewayConnection: async () => {},
   probeLocalGatewayReady: async () => true,
-  saveLockfileAssistant: async () => {},
+  saveLockfileAssistant: saveLockfileAssistantMock,
 }));
 
 mock.module("@/lib/auth/gateway-session", () => ({
-  clearGatewayToken: () => {},
+  clearGatewayToken: clearGatewayTokenMock,
+}));
+
+mock.module("@/lib/self-hosted/connection", () => ({
+  setSelfHostedConnection: setSelfHostedConnectionMock,
 }));
 
 mock.module("@/lib/navigation/navigation-resolver", () => ({
@@ -359,6 +391,9 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     subscriptionRetrieveMock.mockClear();
     operationalStatusReadMock.mockClear();
     hatchLocalAssistantMock.mockClear();
+    saveLockfileAssistantMock.mockClear();
+    clearGatewayTokenMock.mockClear();
+    setSelfHostedConnectionMock.mockClear();
     searchParams = new URLSearchParams();
     isLocalModeValue = false;
     subscriptionPlanId = "base";
@@ -367,6 +402,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     opStatusInFlight = false;
     opStatusNoData = false;
     preflightActive = false;
+    preflightGatewaySelectedLocal = false;
     idPollCount = 0;
     resizePollClockStepMs = 0;
     subscriptionCallCount = 0;
@@ -786,11 +822,10 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
   });
 
   test("a local-mode preflight-active reload completes without provisioning", async () => {
-    // A local-mode session with no hosting param (or hosting=vellum-cloud) makes
-    // useLocalHatch false, so a reload onto an already-active assistant flows
-    // through the platform preflight path into finishActiveHatch. The
-    // provisioning wait must still short-circuit for local mode — no billing
-    // reads, no resize wait — so local hatching stays byte-identical.
+    // A local-mode session with no hosting param makes useLocalHatch false, so
+    // a reload onto an already-active assistant flows through the platform
+    // preflight path into finishActiveHatch. Without the managed marker the
+    // provisioning wait short-circuits — no billing reads, no resize wait.
     isLocalModeValue = true;
     preflightActive = true;
 
@@ -803,5 +838,82 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     expect(subscriptionRetrieveMock).not.toHaveBeenCalled();
     expect(onboardingRetrieveMock).not.toHaveBeenCalled();
     expect(operationalStatusReadMock).not.toHaveBeenCalled();
+  });
+
+  // -- managed hatch in a local-mode build --------------------------------
+  //
+  // The post-checkout funnel sends a local-mode client here with
+  // `hosting=vellum-cloud`: the plan was bought for a managed assistant the
+  // org does not have yet, so the assistant is provisioned on the platform and
+  // the purchased machine and storage must land before the screen completes.
+
+  test(
+    "a managed hatch in local mode waits for the purchased provisioning",
+    async () => {
+      isLocalModeValue = true;
+      searchParams = new URLSearchParams("hosting=vellum-cloud");
+      subscriptionPlanId = "pro";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+
+      render(<HatchingScreen />);
+
+      // The purchased ceiling is read and held for, exactly as in platform mode.
+      await waitFor(() => expect(screen.getByText(RESIZE_LABEL)).toBeTruthy());
+      expect(ensureProvisionedMock).toHaveBeenCalled();
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+    },
+    20000,
+  );
+
+  test(
+    "a managed hatch never adopts or reclassifies the gateway-selected local assistant",
+    async () => {
+      // Under gateway auth `getAssistant()` answers from the selected lockfile
+      // entry. That entry is self-hosted, so it is never mistaken for the
+      // managed assistant being hatched: the hatch still runs, and the only
+      // lockfile write names the managed id.
+      isLocalModeValue = true;
+      searchParams = new URLSearchParams("hosting=vellum-cloud");
+      preflightGatewaySelectedLocal = true;
+      subscriptionPlanId = "base";
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 5000,
+      });
+
+      expect(hatchAssistantMock).toHaveBeenCalled();
+      const savedIds = saveLockfileAssistantMock.mock.calls.map(
+        ([entry]) => entry.assistantId,
+      );
+      expect(savedIds).not.toContain(GATEWAY_SELECTED_LOCAL_ID);
+      expect(savedIds).toEqual(["asst-1"]);
+      // The local gateway is dropped up front so the hatch, its polls and its
+      // healthz probes address the platform.
+      expect(clearGatewayTokenMock).toHaveBeenCalled();
+      expect(setSelfHostedConnectionMock).toHaveBeenCalledWith(null);
+    },
+  );
+
+  test("a local hatch keeps its gateway session", async () => {
+    isLocalModeValue = true;
+    searchParams = new URLSearchParams("hosting=docker");
+
+    render(<HatchingScreen />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
+    // The local hatch's own handoff re-primes the connection; the managed
+    // teardown must not have run ahead of it.
+    expect(setSelfHostedConnectionMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/generated/api/sdk.gen";
 import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
 import {
+    isEntitlementRaceVerdict,
     isResizeOperationInFlight,
     targetsMet,
     type ProvisioningDimensions,
@@ -35,7 +36,10 @@ import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution
 import { getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
-import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
+import {
+    POST_CHECKOUT_HATCH_PARAM,
+    resolveNavigation,
+} from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { hatchLocalAssistant } from "@/runtime/local-mode-host";
 import { isElectron } from "@/runtime/is-electron";
@@ -149,6 +153,12 @@ export function HatchingScreen() {
   // (see `adopt-existing-assistant`): the assistant is provisioned on the
   // platform, so its purchased machine and storage are waited for.
   const managedHatch = hostingParam === "vellum-cloud";
+  // This hatch is the return leg of a completed checkout — only the
+  // post-checkout funnel sets the param, and only for a billing landing
+  // carrying Stripe's `session_id`. `managedHatch` is NOT a substitute: it
+  // names a hosting choice a free user can make too.
+  const postCheckoutReturn =
+    searchParams.get(POST_CHECKOUT_HATCH_PARAM) === "1";
   const sessionStatus = useAuthStore.use.sessionStatus();
   // Local hatches drive `sessionStatus` themselves (`connectLocalAssistant`
   // below flips it mid-handoff), so they gate on settled-ness to keep that flip
@@ -538,11 +548,12 @@ export function HatchingScreen() {
       }
       // Fire the idempotent grow-only reconcile — the same resize the subscribe
       // webhook triggers — covering a webhook that never fired or whose resize
-      // was lost. It is marked done only when it SUCCEEDS: a 503 ("nothing
-      // queued"), a network error, or a pre-org-hydration mount leaves the guard
-      // unset so a later poll iteration re-fires the nudge. It never blocks
-      // completion (which keys off targets + op-status); the re-fires stay
-      // bounded by the RESIZE_WAIT_MAX_MS cap below.
+      // was lost. It is marked done only when it RECONCILES: a 503 ("nothing
+      // queued"), a network error, a pre-org-hydration mount, or the
+      // entitlement race leaves the guard unset so a later poll iteration
+      // re-fires the nudge. It never blocks completion (which keys off targets
+      // + op-status); the re-fires stay bounded by the RESIZE_WAIT_MAX_MS cap
+      // below.
       const fireProvisioningReconcile = (): void => {
         if (provisioningReconcileFiredRef.current) {
           return;
@@ -552,8 +563,13 @@ export function HatchingScreen() {
         })
           .then((result) => {
             // Success carries a body; a 503/5xx resolves with no data under
-            // throwOnError:false. Only a real success consumes the guard.
-            if (result.data != null) {
+            // throwOnError:false. A `no_active_pro` body is the entitlement
+            // race, not an answer — nothing was queued, so it must not consume
+            // the guard or the nudge is lost for the whole hatch.
+            if (
+              result.data != null &&
+              !isEntitlementRaceVerdict(result.data)
+            ) {
               provisioningReconcileFiredRef.current = true;
             }
           })
@@ -624,9 +640,13 @@ export function HatchingScreen() {
           targets != null &&
           (targets.machineSize != null || targets.storageGib != null);
 
-        // Confirmed non-Pro — genuinely free. Complete exactly as a
-        // non-provisioned hatch does today.
-        if (subscriptionState === "non_pro") {
+        // Confirmed non-Pro on an ordinary hatch — genuinely free. Complete
+        // exactly as a non-provisioned hatch does today, with no added poll.
+        // On a post-checkout return the same read is not an answer: Stripe
+        // redirects before the subscribe webhook updates the org, so the plan
+        // still reads at its pre-checkout base. That case falls through to the
+        // capped wait below.
+        if (subscriptionState === "non_pro" && !postCheckoutReturn) {
           return;
         }
         // Confirmed Pro with a purchased ceiling to wait on: hold for the resize
@@ -634,10 +654,11 @@ export function HatchingScreen() {
         if (subscriptionState === "pro" && hasTargets) {
           break;
         }
-        // Pro with targets not yet visible, or an unknown/errored subscription
-        // read: keep polling within the cap rather than completing at baseline
-        // onto an unprovisioned assistant. The cap is the ultimate escape so a
-        // persistently-erroring subscription endpoint still completes.
+        // Pro with targets not yet visible, a still-base read on a paid return,
+        // or an unknown/errored subscription read: keep polling within the cap
+        // rather than completing at baseline onto an unprovisioned assistant.
+        // The cap is the ultimate escape, so a subscription that never flips —
+        // a persistently-erroring endpoint, a lost webhook — still completes.
         if (Date.now() >= resizeDeadline) {
           return;
         }
@@ -860,6 +881,7 @@ export function HatchingScreen() {
     failParam,
     hatchTraits,
     managedHatch,
+    postCheckoutReturn,
     sessionGateKey,
     navigate,
     queryClient,

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -34,6 +34,7 @@ import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
 import { getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
+import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { hatchLocalAssistant } from "@/runtime/local-mode-host";
@@ -144,6 +145,10 @@ export function HatchingScreen() {
   const pluginParam = searchParams.get(ATTRIBUTED_PLUGIN_PARAM);
   const electron = isElectron();
   const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
+  // `hosting=vellum-cloud` names a managed hatch even in a local-mode build
+  // (see `adopt-existing-assistant`): the assistant is provisioned on the
+  // platform, so its purchased machine and storage are waited for.
+  const managedHatch = hostingParam === "vellum-cloud";
   const sessionStatus = useAuthStore.use.sessionStatus();
   // Local hatches drive `sessionStatus` themselves (`connectLocalAssistant`
   // below flips it mid-handoff), so they gate on settled-ness to keep that flip
@@ -205,6 +210,17 @@ export function HatchingScreen() {
       return;
     }
     if (decision.kind === "wait") return;
+
+    // A managed hatch in a local-mode build must address the platform, not the
+    // machine's own gateway: `getAssistant()` answers from the selected
+    // lockfile entry while a gateway token is held, and daemon SDK calls (the
+    // healthz probes below) rewrite to the local gateway while a self-hosted
+    // connection is primed. Dropping both is the same handoff the hosting
+    // screen performs for its Vellum Cloud choice.
+    if (managedHatch && isLocalMode()) {
+      clearGatewayToken();
+      setSelfHostedConnection(null);
+    }
 
     setPlatformHostedDisabled(false);
 
@@ -513,11 +529,11 @@ export function HatchingScreen() {
     const awaitPurchasedProvisioning = async (
       assistantId: string,
     ): Promise<void> => {
-      // Local hatches never provision purchased specs — a self-hosted daemon has
-      // no billing surface to read. Short-circuit so a local-mode reload that
-      // falls through the platform preflight path (hosting=vellum-cloud or no
-      // param, where useLocalHatch is false) stays byte-identical to today.
-      if (isLocalMode()) {
+      // Purchased specs live on the platform, so only a managed hatch reads
+      // them. A local-mode run without the managed marker can reach here off a
+      // preflight that resolved the lockfile assistant, which has no billing
+      // surface — short-circuit there.
+      if (isLocalMode() && !managedHatch) {
         return;
       }
       // Fire the idempotent grow-only reconcile — the same resize the subscribe
@@ -843,6 +859,7 @@ export function HatchingScreen() {
     attempt,
     failParam,
     hatchTraits,
+    managedHatch,
     sessionGateKey,
     navigate,
     queryClient,

--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -74,12 +74,19 @@ mock.module("@/generated/api/sdk.gen", () => ({
     },
 }));
 
-// Force the platform-hosted gate open so BillingTab mounts its plan-management
-// body instead of the login notice / unavailable states.
+// Drives the active assistant's hosting. Platform-hosted by default so
+// BillingTab mounts its plan-management body instead of the login notice /
+// unavailable states; flipped to model an org holding both hosting types with
+// the self-hosted one selected, where `platformHostedOnly` surfaces gate off.
+let activeAssistantIsPlatformHosted = true;
+
 mock.module("@/hooks/use-platform-gate", () => ({
     ...platformGate,
-    usePlatformGate: () => "full",
-    useActiveAssistantIsPlatformHosted: () => true,
+    usePlatformGate: (options?: { platformHostedOnly?: boolean }) =>
+        options?.platformHostedOnly === true && !activeAssistantIsPlatformHosted
+            ? "gated"
+            : "full",
+    useActiveAssistantIsPlatformHosted: () => activeAssistantIsPlatformHosted,
     useActiveAssistantLifecycleIsLoading: () => false,
 }));
 
@@ -220,6 +227,7 @@ beforeEach(() => {
     domainsCalls = 0;
     domainsListPaths = [];
     orgReady = true;
+    activeAssistantIsPlatformHosted = true;
 });
 
 afterEach(() => {
@@ -242,6 +250,63 @@ describe("BillingTab ?pro_onboarding param", () => {
         expect(getByTestId("loc").textContent).toBe(
             "/assistant/settings/usage?tab=billing",
         );
+    });
+});
+
+describe("BillingTab post-checkout return", () => {
+    // The pro onboarding wizard reads the org's subscription and its
+    // `primary_assistant_id`, so a completed checkout is consumable whichever
+    // assistant is selected. Gating its mount on the active assistant's hosting
+    // would drop `session_id` for an org holding both hosting types.
+
+    test("opens the wizard on session_id", async () => {
+        const { getByTestId } = renderPage("?tab=billing&session_id=cs_test_123");
+
+        await waitFor(() =>
+            expect(
+                getByTestId("onboarding-modal").getAttribute("data-open"),
+            ).toBe("true"),
+        );
+    });
+
+    test("opens the wizard on session_id while a self-hosted assistant is active", async () => {
+        activeAssistantIsPlatformHosted = false;
+        const { getByTestId, queryByTestId } = renderPage(
+            "?tab=billing&session_id=cs_test_123",
+        );
+
+        await waitFor(() =>
+            expect(
+                getByTestId("onboarding-modal").getAttribute("data-open"),
+            ).toBe("true"),
+        );
+        // Plan management still reads the active assistant, so it stays gated.
+        expect(queryByTestId("plan-card-tier-upgraded")).toBeNull();
+        expect(queryByTestId("resize-onboarding-modal")).toBeNull();
+        expect(queryByTestId("finish-pro-setup-notice")).toBeNull();
+    });
+
+    test("opens the wizard on ?pro_onboarding while a self-hosted assistant is active", async () => {
+        activeAssistantIsPlatformHosted = false;
+        const { getByTestId } = renderPage("?tab=billing&pro_onboarding");
+
+        await waitFor(() =>
+            expect(
+                getByTestId("onboarding-modal").getAttribute("data-open"),
+            ).toBe("true"),
+        );
+        expect(getByTestId("loc").textContent).toBe(
+            "/assistant/settings/usage?tab=billing",
+        );
+    });
+
+    test("mounts no wizard for a self-hosted assistant with no billing intent", async () => {
+        activeAssistantIsPlatformHosted = false;
+        const { queryByTestId } = renderPage();
+
+        await waitFor(() => expect(queryByTestId("loc")).toBeTruthy());
+        expect(queryByTestId("onboarding-modal")).toBeNull();
+        expect(queryByTestId("resize-onboarding-modal")).toBeNull();
     });
 });
 

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -207,6 +207,16 @@ function BillingTab() {
     }
 
     const showPlanManagement = isPlatformHosted;
+    // The pro onboarding wizard is organization-scoped — `useProProvisioning`
+    // targets the subscription's `primary_assistant_id` and falls back to the
+    // active assistant only when the payload names none — so it is gated on the
+    // organization rather than on the active assistant's hosting. An
+    // organization holding both hosting types would otherwise drop a completed
+    // checkout's `session_id` whenever a self-hosted assistant is selected.
+    // Every other surface below reads the active assistant and stays gated on
+    // `showPlanManagement`.
+    const showProOnboarding =
+        showPlanManagement || hasSessionId || proOnboardingOpen;
 
     if (!isPlatformHosted && platformGate !== "gated") {
         return (
@@ -240,7 +250,7 @@ function BillingTab() {
             <Suspense fallback={null}>
                 <InvoicesTable />
             </Suspense>
-            {showPlanManagement && (
+            {showProOnboarding && (
                 <BillingOnboardingModal
                     open={hasSessionId || proOnboardingOpen}
                     onClose={closeOnboarding}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -41,7 +41,10 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
-import { isResizeOperationInFlight } from "@/lib/billing/provisioning-targets";
+import {
+  isEntitlementRaceVerdict,
+  isResizeOperationInFlight,
+} from "@/lib/billing/provisioning-targets";
 import { useOrganizationStore } from "@/stores/organization-store";
 
 import {
@@ -301,15 +304,11 @@ export function useProProvisioning({
               return;
             }
             setEnsureError(null);
-            // `not_applicable` + `no_active_pro` is the subscription-flipped-
-            // but-entitlement-not-yet-visible race, not an answer: adopting it
-            // would park the wizard in a terminal state with an unprovisioned
-            // assistant. Leave the verdict null (pure inference keeps running)
-            // and re-ask once — the race resolves in a beat.
-            if (
-              data.state === "not_applicable" &&
-              data.reason === "no_active_pro"
-            ) {
+            // The entitlement race is not an answer: adopting it would park the
+            // wizard in a terminal state with an unprovisioned assistant. Leave
+            // the verdict null (pure inference keeps running) and re-ask once —
+            // the race resolves in a beat.
+            if (isEntitlementRaceVerdict(data)) {
               if (!ensureRaceRetriedRef.current) {
                 ensureRaceRetriedRef.current = true;
                 setRaceRetryScheduled(true);

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -64,6 +64,13 @@ mock.module("@/utils/when-store-state", () => ({
     })) as typeof whenStoreStateReal,
 }));
 
+// The guard re-runs itself through the router when a timed-out probe reports
+// late; stub the route tree so the assertion is on the re-run, not on routing.
+const revalidateMock = mock(() => Promise.resolve());
+mock.module("@/routes", () => ({
+  router: { revalidate: revalidateMock },
+}));
+
 import { authMiddleware } from "./auth-middleware";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
@@ -135,12 +142,17 @@ beforeEach(() => {
   mockSelectedAssistant = undefined;
   mockGatewayTokenPresent = false;
   mockGatewayAuthMode = false;
+  revalidateMock.mockClear();
   useAuthStore.setState(initialAuthState, true);
   useResolvedAssistantsStore.setState({ assistants: [], activeAssistantId: null });
   useAssistantLifecycleStore.setState({ assistantState: { kind: "error", message: "no assistant" } });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Settle the probe so a re-run armed by a timed-out wait fires and detaches
+  // here instead of in the next test, then drain its lazy router import.
+  useAuthStore.setState({ platformSession: "absent" });
+  await tick();
   useAuthStore.setState(initialAuthState, true);
 });
 
@@ -469,6 +481,45 @@ describe("authMiddleware — local-mode post-checkout platform probe", () => {
     // billing, whose login notice carries `session_id` through sign-in.
     const outcome = await runMiddlewareOutcome(postCheckoutBilling);
     expect(outcome.admitted).toBe(true);
+  });
+
+  test("a probe that succeeds after the timeout re-runs the guard", async () => {
+    makeSelfHostedLocalReturn();
+
+    // The probe outruns the (clamped) wait, so the guard decides on the forced
+    // "absent" and admits the return to billing.
+    const outcome = await runMiddlewareOutcome(postCheckoutBilling);
+    expect(outcome.admitted).toBe(true);
+    expect(revalidateMock).not.toHaveBeenCalled();
+
+    // The probe lands "present" afterwards. Nothing else re-runs route
+    // middleware on a store change, so without this the paid return is stranded
+    // on billing with no managed assistant to apply the purchase to.
+    useAuthStore.setState({ platformSession: "present" });
+    await tick();
+    expect(revalidateMock).toHaveBeenCalledTimes(1);
+
+    // The re-run reads the settled session and funnels the return.
+    const redirected = await runMiddleware(postCheckoutBilling);
+    expect(redirected.status).toBe(302);
+    expect(redirected.headers.get("Location")).toBe(managedFunnel);
+  });
+
+  test("the re-run is armed once and fires once", async () => {
+    makeSelfHostedLocalReturn();
+
+    await runMiddlewareOutcome(postCheckoutBilling);
+    await runMiddlewareOutcome(postCheckoutBilling);
+
+    useAuthStore.setState({ platformSession: "present" });
+    await tick();
+    expect(revalidateMock).toHaveBeenCalledTimes(1);
+
+    // A settled probe never reopens "unknown", so no later change re-triggers
+    // the re-run — the correction cannot loop.
+    useAuthStore.setState({ platformSession: "absent" });
+    await tick();
+    expect(revalidateMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -309,7 +309,35 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
     expect(res.headers.get("Location")).toBe(routes.onboarding.hatching);
   });
 
-  test("admits the return once an assistant exists", async () => {
+  // A local assistant satisfies `hasAssistants`, so the gateway-auth bypass
+  // would admit the return — but `BillingTab` gates the Pro onboarding wizard
+  // on a platform-hosted assistant, so the purchase would apply to nothing.
+  // Provision the managed assistant instead; the lockfile entry is untouched.
+  test("funnels a local-mode return whose only assistant is self-hosted", async () => {
+    makePaidPlatformReturn();
+    isLocalModeMock.mockImplementation(() => true);
+    mockGatewayAuthMode = true;
+    mockSelectedAssistant = localAssistant;
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: localAssistant.assistantId,
+          isLocal: true,
+          isPlatformHosted: false,
+        },
+      ],
+      assistantsHydrated: true,
+    });
+    useAssistantLifecycleStore.setState({
+      assistantState: { kind: "active", isLocal: true },
+    });
+
+    const res = await runMiddleware(postCheckoutBilling);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(routes.onboarding.hatching);
+  });
+
+  test("admits the return once a platform-hosted assistant exists", async () => {
     makePaidPlatformReturn();
     useResolvedAssistantsStore.setState({
       assistants: [{ id: "a-1", isLocal: false, isPlatformHosted: true }],

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -306,7 +306,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
   // The funnel entry carries the managed-hatch marker so a local-mode client
   // provisions on the platform rather than letting its own gateway answer for
   // the assistant.
-  const managedFunnel = `${routes.onboarding.hatching}?hosting=vellum-cloud`;
+  const managedFunnel = `${routes.onboarding.hatching}?hosting=vellum-cloud&post_checkout=1`;
 
   function makePaidPlatformReturn(): void {
     isLocalModeMock.mockImplementation(() => false);
@@ -408,7 +408,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
 
 describe("authMiddleware — local-mode post-checkout platform probe", () => {
   const postCheckoutBilling = `${routes.settings.root}/billing?session_id=cs_test_123`;
-  const managedFunnel = `${routes.onboarding.hatching}?hosting=vellum-cloud`;
+  const managedFunnel = `${routes.onboarding.hatching}?hosting=vellum-cloud&post_checkout=1`;
 
   // A checkout return on a local-mode client whose lockfile already holds a
   // self-hosted assistant. `hasAssistants()` is true, so the cold-boot probe

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -27,11 +27,12 @@ mock.module("@/lib/local-mode", () => ({
 
 // Drive the non-reactive gateway token off a flag.
 let mockGatewayTokenPresent = false;
+let mockGatewayAuthMode = false;
 const gatewaySessionActual = await import("@/lib/auth/gateway-session");
 mock.module("@/lib/auth/gateway-session", () => ({
   ...gatewaySessionActual,
   getGatewayToken: () => (mockGatewayTokenPresent ? "gw-token" : null),
-  isGatewayAuthMode: () => false,
+  isGatewayAuthMode: () => mockGatewayAuthMode,
 }));
 
 // Consent prefs are read by buildNavigationState; pin them current so the
@@ -133,6 +134,7 @@ beforeEach(() => {
   hasAssistantsMock.mockImplementation(() => false);
   mockSelectedAssistant = undefined;
   mockGatewayTokenPresent = false;
+  mockGatewayAuthMode = false;
   useAuthStore.setState(initialAuthState, true);
   useResolvedAssistantsStore.setState({ assistants: [], activeAssistantId: null });
   useAssistantLifecycleStore.setState({ assistantState: { kind: "error", message: "no assistant" } });
@@ -265,6 +267,59 @@ describe("authMiddleware — app-access admit gate", () => {
         `${routes.account.login}?returnTo=${encodeURIComponent("/assistant/home")}`,
       );
     }
+  });
+});
+
+describe("authMiddleware — post-checkout return with nothing provisioned", () => {
+  // The platform hardcodes the non-native Stripe `success_url` to this path,
+  // and the pricing funnel has a brand-new user pay before an assistant
+  // exists. Billing lives under `ActiveAssistantGate`, so admitting the return
+  // strands the (paying) user on "Connecting to your assistant…" forever.
+  const postCheckoutBilling = `${routes.settings.root}/billing?session_id=cs_test_123`;
+
+  function makePaidPlatformReturn(): void {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    useOnboardingStore.setState({ consentHydrated: true });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: true,
+    });
+  }
+
+  test("funnels the paid return into hatching", async () => {
+    makePaidPlatformReturn();
+
+    const res = await runMiddleware(postCheckoutBilling);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(routes.onboarding.hatching);
+  });
+
+  test("funnels it under a gateway session too, which otherwise bypasses the pipeline", async () => {
+    makePaidPlatformReturn();
+    isLocalModeMock.mockImplementation(() => true);
+    mockGatewayAuthMode = true;
+
+    const res = await runMiddleware(postCheckoutBilling);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(routes.onboarding.hatching);
+  });
+
+  test("admits the return once an assistant exists", async () => {
+    makePaidPlatformReturn();
+    useResolvedAssistantsStore.setState({
+      assistants: [{ id: "a-1", isLocal: false, isPlatformHosted: true }],
+    });
+    useAssistantLifecycleStore.setState({
+      assistantState: { kind: "active", isLocal: false },
+    });
+
+    const outcome = await runMiddlewareOutcome(postCheckoutBilling);
+    expect(outcome.admitted).toBe(true);
   });
 });
 

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -183,6 +183,20 @@ describe("authMiddleware — local-mode onboarding fork", () => {
     expect(res.headers.get("Location")).toBe(routes.welcome);
   });
 
+  test("a probe that never settles routes to welcome instead of looping", async () => {
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "unknown",
+    });
+
+    // The probe stays "unknown" for the whole (clamped) wait, so the guard
+    // decides on a settled-absent session rather than re-entering the wait.
+    const res = await runMiddleware(routes.home);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(routes.welcome);
+  });
+
   test("routes to hosting when a resolved platform session exists", async () => {
     useAuthStore.setState({
       sessionStatus: "authenticated",
@@ -375,6 +389,84 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
       assistantState: { kind: "active", isLocal: false },
     });
 
+    const outcome = await runMiddlewareOutcome(postCheckoutBilling);
+    expect(outcome.admitted).toBe(true);
+  });
+});
+
+describe("authMiddleware — local-mode post-checkout platform probe", () => {
+  const postCheckoutBilling = `${routes.settings.root}/billing?session_id=cs_test_123`;
+  const managedFunnel = `${routes.onboarding.hatching}?hosting=vellum-cloud`;
+
+  // A checkout return on a local-mode client whose lockfile already holds a
+  // self-hosted assistant. `hasAssistants()` is true, so the cold-boot probe
+  // wait does not apply, yet the funnel decision still hangs on the probe.
+  function makeSelfHostedLocalReturn(): void {
+    isLocalModeMock.mockImplementation(() => true);
+    hasAssistantsMock.mockImplementation(() => true);
+    mockGatewayAuthMode = true;
+    mockSelectedAssistant = localAssistant;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "unknown",
+    });
+    useOnboardingStore.setState({ consentHydrated: true });
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: localAssistant.assistantId,
+          isLocal: true,
+          isPlatformHosted: false,
+        },
+      ] as never[],
+      assistantsHydrated: true,
+    });
+  }
+
+  test("holds the return until the probe settles, then funnels it", async () => {
+    makeSelfHostedLocalReturn();
+
+    let settled: Response | null = null;
+    const pending = runMiddleware(postCheckoutBilling).then((res) => {
+      settled = res;
+    });
+
+    // Probe still in flight: deciding now would strand the purchase on a
+    // billing page with nothing to apply it to.
+    await tick();
+    expect(settled).toBeNull();
+
+    useAuthStore.setState({ platformSession: "present" });
+    await pending;
+
+    expect(settled).not.toBeNull();
+    expect(settled!.status).toBe(302);
+    expect(settled!.headers.get("Location")).toBe(managedFunnel);
+  });
+
+  test("leaves the return on billing once the probe settles absent", async () => {
+    makeSelfHostedLocalReturn();
+
+    let decided = false;
+    const pending = runMiddlewareOutcome(postCheckoutBilling).then((res) => {
+      decided = true;
+      return res;
+    });
+
+    await tick();
+    expect(decided).toBe(false);
+
+    useAuthStore.setState({ platformSession: "absent" });
+    expect((await pending).admitted).toBe(true);
+  });
+
+  test("a probe that never settles degrades to a decision instead of looping", async () => {
+    makeSelfHostedLocalReturn();
+
+    // The probe stays "unknown", so the wait runs out its (clamped) timeout and
+    // the guard decides on a settled-absent session: the return stays on
+    // billing, whose login notice carries `session_id` through sign-in.
     const outcome = await runMiddlewareOutcome(postCheckoutBilling);
     expect(outcome.admitted).toBe(true);
   });

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -277,6 +277,11 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
   // strands the (paying) user on "Connecting to your assistant…" forever.
   const postCheckoutBilling = `${routes.settings.root}/billing?session_id=cs_test_123`;
 
+  // The funnel entry carries the managed-hatch marker so a local-mode client
+  // provisions on the platform rather than letting its own gateway answer for
+  // the assistant.
+  const managedFunnel = `${routes.onboarding.hatching}?hosting=vellum-cloud`;
+
   function makePaidPlatformReturn(): void {
     isLocalModeMock.mockImplementation(() => false);
     useAuthStore.setState({
@@ -296,7 +301,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
 
     const res = await runMiddleware(postCheckoutBilling);
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe(routes.onboarding.hatching);
+    expect(res.headers.get("Location")).toBe(managedFunnel);
   });
 
   test("funnels it under a gateway session too, which otherwise bypasses the pipeline", async () => {
@@ -306,7 +311,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
 
     const res = await runMiddleware(postCheckoutBilling);
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe(routes.onboarding.hatching);
+    expect(res.headers.get("Location")).toBe(managedFunnel);
   });
 
   // A local assistant satisfies `hasAssistants`, so the gateway-auth bypass
@@ -334,7 +339,31 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
 
     const res = await runMiddleware(postCheckoutBilling);
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe(routes.onboarding.hatching);
+    expect(res.headers.get("Location")).toBe(managedFunnel);
+  });
+
+  // A local-mode client is "authenticated" on its gateway session alone. With
+  // no platform session there is no account to provision into, so the return
+  // stays on billing, whose login notice carries `session_id` through sign-in.
+  test("admits a local-mode return with no platform session", async () => {
+    makePaidPlatformReturn();
+    isLocalModeMock.mockImplementation(() => true);
+    mockGatewayAuthMode = true;
+    mockSelectedAssistant = localAssistant;
+    useAuthStore.setState({ platformSession: "absent" });
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: localAssistant.assistantId,
+          isLocal: true,
+          isPlatformHosted: false,
+        },
+      ],
+      assistantsHydrated: true,
+    });
+
+    const outcome = await runMiddlewareOutcome(postCheckoutBilling);
+    expect(outcome.admitted).toBe(true);
   });
 
   test("admits the return once a platform-hosted assistant exists", async () => {

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -310,9 +310,9 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
   });
 
   // A local assistant satisfies `hasAssistants`, so the gateway-auth bypass
-  // would admit the return — but `BillingTab` gates the Pro onboarding wizard
-  // on a platform-hosted assistant, so the purchase would apply to nothing.
-  // Provision the managed assistant instead; the lockfile entry is untouched.
+  // admits the return — but a managed plan has no target in an org whose only
+  // entries are self-hosted. Provision the managed assistant; the lockfile
+  // entry is untouched.
   test("funnels a local-mode return whose only assistant is self-hosted", async () => {
     makePaidPlatformReturn();
     isLocalModeMock.mockImplementation(() => true);

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -19,24 +19,30 @@ const PLATFORM_SESSION_PROBE_TIMEOUT_MS = 5_000;
 const STATE_HYDRATION_TIMEOUT_MS = 5_000;
 
 export const authMiddleware: MiddlewareFunction = (args, next) =>
-  resolveWithGuard(args, next, false);
+  resolveWithGuard(args, next, false, false);
 
 const resolveWithGuard = async (
   { request, context }: Parameters<MiddlewareFunction>[0],
   next: Parameters<MiddlewareFunction>[1],
   hydrationTimedOut: boolean,
+  platformProbeTimedOut: boolean,
 ): Promise<Awaited<ReturnType<MiddlewareFunction>>> => {
   const url = new URL(request.url);
 
   // After a timed-out hydration wait, force the hydration flags so the
   // resolver decides on whatever state exists instead of returning another
   // "wait" — a fetch that hangs (never reaching any settle path) must degrade
-  // to a decision, not loop navigation in timeout-sized chunks.
-  const state = buildNavigationState(
-    hydrationTimedOut
+  // to a decision, not loop navigation in timeout-sized chunks. A platform
+  // probe that never settles degrades the same way, to `"absent"`: every step
+  // that reads the probe treats an unsettled session as "no decision yet" and
+  // a settled-absent one as "no platform account", so forcing it can only turn
+  // a non-decision into that documented fallback.
+  const state = buildNavigationState({
+    ...(hydrationTimedOut
       ? { consentHydrated: true, assistantsHydrated: true }
-      : undefined,
-  );
+      : {}),
+    ...(platformProbeTimedOut ? { platformSession: "absent" as const } : {}),
+  });
 
   const decision = resolveNavigation(state, {
     kind: "route-guard",
@@ -45,12 +51,23 @@ const resolveWithGuard = async (
 
   if (decision.action === "wait") {
     await whenStoreState(useAuthStore, (s) => isSessionSettled(s.sessionStatus));
-    if (isLocalMode() && !hasAssistants()) {
+    // Two local-mode cases hang on the platform probe: the cold boot with an
+    // empty lockfile, and any step that names the signal on its wait — a
+    // checkout return whose org already has a self-hosted assistant reaches
+    // the latter with `hasAssistants()` already true.
+    let platformProbeStillUnknown = false;
+    if (
+      !platformProbeTimedOut &&
+      isLocalMode() &&
+      (!hasAssistants() || decision.waitFor === "platform-session")
+    ) {
       await whenStoreState(
         useAuthStore,
         (s) => s.platformSession !== "unknown",
         { timeoutMs: PLATFORM_SESSION_PROBE_TIMEOUT_MS },
       );
+      platformProbeStillUnknown =
+        useAuthStore.getState().platformSession === "unknown";
     }
     // Platform mode also waits for consent and the assistants list to hydrate
     // — the resolver defers to them, and deciding on their boot defaults would
@@ -81,6 +98,7 @@ const resolveWithGuard = async (
       { request, context } as Parameters<MiddlewareFunction>[0],
       next,
       hydrationTimedOut || hydrationStillPending,
+      platformProbeTimedOut || platformProbeStillUnknown,
     );
   }
 

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -9,6 +9,7 @@ import { isAuthenticated, isSessionSettled } from "@/stores/session-status";
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
+import { captureError } from "@/lib/sentry/capture-error";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { whenStoreState } from "@/utils/when-store-state";
@@ -17,6 +18,47 @@ export const authUserContext = createRouterContext<AuthUser | null>(null);
 
 const PLATFORM_SESSION_PROBE_TIMEOUT_MS = 5_000;
 const STATE_HYDRATION_TIMEOUT_MS = 5_000;
+
+/** Whether a late probe result already has a guard re-run waiting on it. */
+let probeRevalidationPending = false;
+
+/**
+ * Re-run the route guard once a timed-out platform probe reports its result.
+ *
+ * The timeout decides on a forced `"absent"`, which is the right fallback for
+ * an org with no platform account and the wrong one for an org whose probe was
+ * merely slow — a paid checkout return is then admitted to billing, which has
+ * no managed assistant to apply the purchase to and no way out. Nothing else
+ * re-runs middleware on a store change, so the correction has to be driven
+ * from here.
+ *
+ * `platformSession` leaves `"unknown"` at most once (re-probes keep the last
+ * settled value), the subscription is one-shot, and the re-run reads a settled
+ * session — so it never waits on the probe, never times out, and never arms
+ * another re-run.
+ */
+function revalidateWhenPlatformProbeSettles(): void {
+  if (probeRevalidationPending) {
+    return;
+  }
+  probeRevalidationPending = true;
+  const unsubscribe = useAuthStore.subscribe((state) => {
+    if (state.platformSession === "unknown") {
+      return;
+    }
+    unsubscribe();
+    probeRevalidationPending = false;
+    // Lazily imported: `@/routes` builds the router out of this middleware, so
+    // a static import is a cycle.
+    void import("@/routes")
+      .then(({ router }) => router.revalidate())
+      .catch((error: unknown) => {
+        captureError(error, {
+          context: "authMiddleware.platformProbeRevalidation",
+        });
+      });
+  });
+}
 
 export const authMiddleware: MiddlewareFunction = (args, next) =>
   resolveWithGuard(args, next, false, false);
@@ -33,10 +75,12 @@ const resolveWithGuard = async (
   // resolver decides on whatever state exists instead of returning another
   // "wait" — a fetch that hangs (never reaching any settle path) must degrade
   // to a decision, not loop navigation in timeout-sized chunks. A platform
-  // probe that never settles degrades the same way, to `"absent"`: every step
+  // probe that outran its wait degrades the same way, to `"absent"`: every step
   // that reads the probe treats an unsettled session as "no decision yet" and
   // a settled-absent one as "no platform account", so forcing it can only turn
-  // a non-decision into that documented fallback.
+  // a non-decision into that documented fallback. A result that lands after the
+  // timeout re-runs the guard (see `revalidateWhenPlatformProbeSettles`), so a
+  // slow-but-successful probe still reaches its platform-session destination.
   const state = buildNavigationState({
     ...(hydrationTimedOut
       ? { consentHydrated: true, assistantsHydrated: true }
@@ -68,6 +112,9 @@ const resolveWithGuard = async (
       );
       platformProbeStillUnknown =
         useAuthStore.getState().platformSession === "unknown";
+      if (platformProbeStillUnknown) {
+        revalidateWhenPlatformProbeSettles();
+      }
     }
     // Platform mode also waits for consent and the assistants list to hydrate
     // — the resolver defers to them, and deciding on their boot defaults would

--- a/clients/web/src/lib/billing/provisioning-targets.ts
+++ b/clients/web/src/lib/billing/provisioning-targets.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  EnsureProvisionedResponse,
   MachineSizeEnum,
   OperationalStatus,
 } from "@/generated/api/types.gen";
@@ -62,4 +63,19 @@ export function isResizeOperationInFlight(
   }
   const operation = status.active_operation?.operation;
   return typeof operation === "string" && operation.startsWith("resize");
+}
+
+/**
+ * Whether an ensure-provisioned reply is the entitlement race rather than an
+ * answer: the subscription has flipped to Pro but the platform cannot see the
+ * entitlement yet, so nothing was queued and no target is known. Callers must
+ * re-ask instead of adopting it — treating it as a verdict strands them on an
+ * unprovisioned assistant.
+ */
+export function isEntitlementRaceVerdict(
+  response: Pick<EnsureProvisionedResponse, "state" | "reason">,
+): boolean {
+  return (
+    response.state === "not_applicable" && response.reason === "no_active_pro"
+  );
 }

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -30,6 +30,7 @@ mock.module("@/domains/onboarding/prefs", () => ({
 
 const { buildNavigationState } = await import("./build-state");
 const { useAuthStore } = await import("@/stores/auth-store");
+const { useOrganizationStore } = await import("@/stores/organization-store");
 const { useResolvedAssistantsStore } = await import(
   "@/stores/resolved-assistants-store"
 );
@@ -40,6 +41,8 @@ beforeEach(() => {
   mockIsLocalMode = true;
   mockIsRemoteGatewayMode = false;
   useAuthStore.setState(initialAuthState, true);
+  useOrganizationStore.setState({ currentOrganizationId: null });
+  globalThis.sessionStorage?.clear();
   useResolvedAssistantsStore.setState({
     assistants: [],
     activeAssistantId: null,
@@ -105,5 +108,80 @@ describe("buildNavigationState — isAuthenticated mirrors sessionStatus", () =>
     });
 
     expect(buildNavigationState().platformSession).toBe("unknown");
+  });
+});
+
+describe("buildNavigationState — hasPlatformHostedAssistant", () => {
+  // The post-checkout provisioning funnel asks a narrower question than
+  // `hasAssistants`: does the ACTIVE ORG have an assistant a managed plan can
+  // apply to? Local, Docker, and other-organization entries do not qualify.
+
+  const ORG_A = "org-a";
+  const ORG_B = "org-b";
+
+  const local = { id: "local-1", isLocal: true, isPlatformHosted: false };
+  const docker = { id: "docker-1", isLocal: false, isPlatformHosted: false };
+  const managedInOrgA = {
+    id: "managed-a",
+    isLocal: false,
+    isPlatformHosted: true,
+    organizationId: ORG_A,
+  };
+  // API-sourced entries carry no org — the platform list is already org-scoped.
+  const managedNoOrg = {
+    id: "managed-api",
+    isLocal: false,
+    isPlatformHosted: true,
+  };
+
+  test("false with nothing resolved", () => {
+    expect(buildNavigationState().hasPlatformHostedAssistant).toBe(false);
+  });
+
+  test("false when every entry is self-hosted", () => {
+    useResolvedAssistantsStore.setState({ assistants: [local, docker] });
+
+    const state = buildNavigationState();
+    expect(state.hasAssistants).toBe(true);
+    expect(state.hasPlatformHostedAssistant).toBe(false);
+  });
+
+  test("true for an org-scoped API entry that names no org", () => {
+    useResolvedAssistantsStore.setState({ assistants: [managedNoOrg] });
+    useOrganizationStore.setState({ currentOrganizationId: ORG_A });
+
+    expect(buildNavigationState().hasPlatformHostedAssistant).toBe(true);
+  });
+
+  test("true for a lockfile entry owned by the active org", () => {
+    useResolvedAssistantsStore.setState({ assistants: [local, managedInOrgA] });
+    useOrganizationStore.setState({ currentOrganizationId: ORG_A });
+
+    expect(buildNavigationState().hasPlatformHostedAssistant).toBe(true);
+  });
+
+  test("false when the only managed entry belongs to another org", () => {
+    useResolvedAssistantsStore.setState({ assistants: [managedInOrgA] });
+    useOrganizationStore.setState({ currentOrganizationId: ORG_B });
+
+    const state = buildNavigationState();
+    expect(state.hasAssistants).toBe(true);
+    expect(state.hasPlatformHostedAssistant).toBe(false);
+  });
+
+  // The org resolves asynchronously. Narrowing against an unresolved org would
+  // read an established user's own managed assistant as absent and funnel them
+  // out of their billing page.
+  test("does not narrow by org until the org resolves", () => {
+    useResolvedAssistantsStore.setState({ assistants: [managedInOrgA] });
+
+    expect(buildNavigationState().hasPlatformHostedAssistant).toBe(true);
+  });
+
+  test("falls back to the persisted org id when the store has not hydrated", () => {
+    useResolvedAssistantsStore.setState({ assistants: [managedInOrgA] });
+    globalThis.sessionStorage.setItem("vellum_active_organization_id", ORG_B);
+
+    expect(buildNavigationState().hasPlatformHostedAssistant).toBe(false);
   });
 });

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -14,8 +14,32 @@ import {
   readDiagnosticsConsentCurrent,
   readConsentHydrated,
 } from "@/domains/onboarding/prefs";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
+import {
+  assistantsValidForOrg,
+  useResolvedAssistantsStore,
+  type ResolvedAssistant,
+} from "@/stores/resolved-assistants-store";
 import type { NavigationState } from "./navigation-resolver";
+
+/**
+ * Whether the active organization has a platform-hosted assistant — the only
+ * kind a managed plan can apply to.
+ *
+ * The org narrows the list only once it resolves. Before that every resolved
+ * assistant counts: narrowing against an unresolved org would read an
+ * established user's own managed assistant as absent (lockfile entries carry
+ * an `organizationId`, and `assistantsValidForOrg` drops those that name a
+ * different one).
+ */
+function hasPlatformHostedAssistant(assistants: ResolvedAssistant[]): boolean {
+  const activeOrganizationId = getActiveOrganizationIdForRequests();
+  const scoped =
+    activeOrganizationId == null
+      ? assistants
+      : assistantsValidForOrg(assistants, activeOrganizationId);
+  return scoped.some((assistant) => assistant.isPlatformHosted);
+}
 
 export function buildNavigationState(
   overrides?: Partial<NavigationState>,
@@ -33,6 +57,7 @@ export function buildNavigationState(
       : "",
     isGatewayAuth: isGatewayAuthMode(),
     hasAssistants: assistants.length > 0,
+    hasPlatformHostedAssistant: hasPlatformHostedAssistant(assistants),
     sessionSettled: isSessionSettled(sessionStatus),
     // `isAuthenticated` mirrors `sessionStatus`. The local gateway is the sole
     // session authority (#35152), so a reachable local user is already

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -578,6 +578,14 @@ describe("resolveNavigation", () => {
     const POST_CHECKOUT_BILLING =
       "/assistant/settings/billing?session_id=cs_test_123";
 
+    // The funnel entry carries the managed-hatch marker, so a local-mode
+    // client provisions on the platform instead of letting its own gateway
+    // answer for the assistant and skipping the purchased-provisioning wait.
+    const MANAGED_FUNNEL: NavigationDecision = {
+      action: "redirect",
+      to: "/assistant/onboarding/hatching?hosting=vellum-cloud",
+    };
+
     // A brand-new org: nothing resolved at all.
     const EMPTY_ORG = {
       hasAssistants: false,
@@ -593,25 +601,23 @@ describe("resolveNavigation", () => {
     } as const;
 
     test("funnels a no-assistant post-checkout return into hatching", () => {
-      expect(guard(s(EMPTY_ORG), POST_CHECKOUT_BILLING)).toEqual({
-        action: "redirect",
-        to: "/assistant/onboarding/hatching",
-      });
+      expect(guard(s(EMPTY_ORG), POST_CHECKOUT_BILLING)).toEqual(
+        MANAGED_FUNNEL,
+      );
     });
 
     // The decision is "does a managed plan have a target", not "is the list
     // empty": in a self-hosted-only org the purchase has nothing to apply to.
     test("funnels a return whose only assistants are self-hosted", () => {
-      expect(guard(s(NO_MANAGED_ASSISTANT), POST_CHECKOUT_BILLING)).toEqual({
-        action: "redirect",
-        to: "/assistant/onboarding/hatching",
-      });
+      expect(guard(s(NO_MANAGED_ASSISTANT), POST_CHECKOUT_BILLING)).toEqual(
+        MANAGED_FUNNEL,
+      );
       expect(
         guard(
           s(NO_MANAGED_ASSISTANT),
           "/assistant/settings/usage?tab=billing&session_id=cs_test_123",
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+      ).toEqual(MANAGED_FUNNEL);
     });
 
     test("leaves an existing-assistant post-checkout return on billing", () => {
@@ -635,7 +641,7 @@ describe("resolveNavigation", () => {
           s({ isGatewayAuth: true, isLocalMode: true, ...EMPTY_ORG }),
           POST_CHECKOUT_BILLING,
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+      ).toEqual(MANAGED_FUNNEL);
     });
 
     // The Electron desktop case: gateway auth against a local assistant, so
@@ -646,7 +652,41 @@ describe("resolveNavigation", () => {
           s({ isGatewayAuth: true, isLocalMode: true, ...NO_MANAGED_ASSISTANT }),
           POST_CHECKOUT_BILLING,
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+      ).toEqual(MANAGED_FUNNEL);
+    });
+
+    // A local-mode client is "authenticated" on its gateway session alone, so
+    // the platform session is decided separately — and the managed hatch the
+    // funnel starts needs one. The probe boots "unknown".
+    test("waits for the local-mode platform-session probe before funneling", () => {
+      expect(
+        guard(
+          s({
+            isGatewayAuth: true,
+            isLocalMode: true,
+            platformSession: "unknown",
+            ...NO_MANAGED_ASSISTANT,
+          }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual(WAIT);
+    });
+
+    // Signed out of the platform there is no account to provision into. The
+    // return stays on billing, whose login notice carries `session_id` through
+    // sign-in and lands back here.
+    test("leaves a local-mode return with no platform session on billing", () => {
+      expect(
+        guard(
+          s({
+            isGatewayAuth: true,
+            isLocalMode: true,
+            platformSession: "absent",
+            ...NO_MANAGED_ASSISTANT,
+          }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual(ALLOW);
     });
 
     test("keeps the gateway-auth bypass for every other case", () => {
@@ -737,7 +777,7 @@ describe("resolveNavigation", () => {
           }),
           POST_CHECKOUT_BILLING,
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+      ).toEqual(MANAGED_FUNNEL);
     });
 
     // Consent is enforced at the destination, not skipped: the funnel entry is
@@ -748,11 +788,11 @@ describe("resolveNavigation", () => {
           s({ ...EMPTY_ORG, tosAccepted: false, privacyConsent: false }),
           POST_CHECKOUT_BILLING,
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+      ).toEqual(MANAGED_FUNNEL);
       expect(
         guard(
           s({ ...EMPTY_ORG, tosAccepted: false, privacyConsent: false }),
-          "/assistant/onboarding/hatching",
+          "/assistant/onboarding/hatching?hosting=vellum-cloud",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -20,6 +20,7 @@ const base: NavigationState = {
   remoteGatewayPublicPathPrefix: "",
   isGatewayAuth: false,
   hasAssistants: true,
+  hasPlatformHostedAssistant: true,
   sessionSettled: true,
   isAuthenticated: true,
   platformSession: "present",
@@ -565,7 +566,7 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
     });
 
-    // -- post-checkout return with nothing provisioned yet -----------------
+    // -- post-checkout return with nothing the plan can apply to -----------
     //
     // The marketing pricing funnel has a brand-new user pay BEFORE an
     // assistant exists, and the platform hardcodes the non-native Stripe
@@ -577,20 +578,50 @@ describe("resolveNavigation", () => {
     const POST_CHECKOUT_BILLING =
       "/assistant/settings/billing?session_id=cs_test_123";
 
+    // A brand-new org: nothing resolved at all.
+    const EMPTY_ORG = {
+      hasAssistants: false,
+      hasPlatformHostedAssistant: false,
+    } as const;
+
+    // An org whose resolved entries are all local / Docker / another
+    // organization's. `hasAssistants` is satisfied; a managed plan still has
+    // no target.
+    const NO_MANAGED_ASSISTANT = {
+      hasAssistants: true,
+      hasPlatformHostedAssistant: false,
+    } as const;
+
     test("funnels a no-assistant post-checkout return into hatching", () => {
-      expect(guard(s({ hasAssistants: false }), POST_CHECKOUT_BILLING)).toEqual({
+      expect(guard(s(EMPTY_ORG), POST_CHECKOUT_BILLING)).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/hatching",
       });
     });
 
-    test("leaves an existing-assistant post-checkout return on billing", () => {
-      expect(guard(s({ hasAssistants: true }), POST_CHECKOUT_BILLING)).toEqual(
-        ALLOW,
-      );
+    // The decision is "does a managed plan have a target", not "is the list
+    // empty": a self-hosted-only org lands on billing with the Pro onboarding
+    // wizard gated off, so the purchase would apply to nothing.
+    test("funnels a return whose only assistants are self-hosted", () => {
+      expect(guard(s(NO_MANAGED_ASSISTANT), POST_CHECKOUT_BILLING)).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/hatching",
+      });
       expect(
         guard(
-          s({ hasAssistants: true }),
+          s(NO_MANAGED_ASSISTANT),
+          "/assistant/settings/usage?tab=billing&session_id=cs_test_123",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+    });
+
+    test("leaves an existing-assistant post-checkout return on billing", () => {
+      expect(
+        guard(s({ hasPlatformHostedAssistant: true }), POST_CHECKOUT_BILLING),
+      ).toEqual(ALLOW);
+      expect(
+        guard(
+          s({ hasPlatformHostedAssistant: true }),
           "/assistant/settings/usage?tab=billing&session_id=cs_test_123",
         ),
       ).toEqual(ALLOW);
@@ -602,7 +633,18 @@ describe("resolveNavigation", () => {
     test("funnels a no-assistant post-checkout return even under gateway auth", () => {
       expect(
         guard(
-          s({ isGatewayAuth: true, isLocalMode: true, hasAssistants: false }),
+          s({ isGatewayAuth: true, isLocalMode: true, ...EMPTY_ORG }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+    });
+
+    // The Electron desktop case: gateway auth against a local assistant, so
+    // `hasAssistants` is true and `requireAssistant` never runs.
+    test("funnels a self-hosted-only return under gateway auth", () => {
+      expect(
+        guard(
+          s({ isGatewayAuth: true, isLocalMode: true, ...NO_MANAGED_ASSISTANT }),
           POST_CHECKOUT_BILLING,
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
@@ -611,13 +653,23 @@ describe("resolveNavigation", () => {
     test("keeps the gateway-auth bypass for every other case", () => {
       expect(
         guard(
-          s({ isGatewayAuth: true, isLocalMode: true, hasAssistants: true }),
+          s({
+            isGatewayAuth: true,
+            isLocalMode: true,
+            hasPlatformHostedAssistant: true,
+          }),
           POST_CHECKOUT_BILLING,
         ),
       ).toEqual(ALLOW);
       expect(
         guard(
-          s({ isGatewayAuth: true, isLocalMode: true, hasAssistants: false }),
+          s({ isGatewayAuth: true, isLocalMode: true, ...EMPTY_ORG }),
+          "/assistant/settings/billing",
+        ),
+      ).toEqual(ALLOW);
+      expect(
+        guard(
+          s({ isGatewayAuth: true, isLocalMode: true, ...NO_MANAGED_ASSISTANT }),
           "/assistant/settings/billing",
         ),
       ).toEqual(ALLOW);
@@ -627,22 +679,33 @@ describe("resolveNavigation", () => {
     // whatever `requireAssistant` already decided for it.
     test("leaves a billing URL without session_id on its existing path", () => {
       expect(
-        guard(s({ hasAssistants: false }), "/assistant/settings/billing"),
+        guard(s(EMPTY_ORG), "/assistant/settings/billing"),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
       expect(
         guard(
-          s({ hasAssistants: false, tosAccepted: false, privacyConsent: false }),
+          s({ ...EMPTY_ORG, tosAccepted: false, privacyConsent: false }),
           "/assistant/settings/billing",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+      // `requireAssistant` reads `hasAssistants`, which the narrower
+      // post-checkout predicate must not disturb.
+      expect(
+        guard(s(NO_MANAGED_ASSISTANT), "/assistant/settings/billing"),
+      ).toEqual(ALLOW);
     });
 
     // Signed out, the return must still reach login with `session_id` intact,
     // so the decision is retaken once the session lands.
     test("sends a signed-out post-checkout return to login with session_id preserved", () => {
       expect(
+        guard(s({ ...EMPTY_ORG, isAuthenticated: false }), POST_CHECKOUT_BILLING),
+      ).toEqual({
+        action: "redirect",
+        to: "/account/login?returnTo=%2Fassistant%2Fsettings%2Fbilling%3Fsession_id%3Dcs_test_123",
+      });
+      expect(
         guard(
-          s({ hasAssistants: false, isAuthenticated: false }),
+          s({ ...NO_MANAGED_ASSISTANT, isAuthenticated: false }),
           POST_CHECKOUT_BILLING,
         ),
       ).toEqual({
@@ -655,8 +718,11 @@ describe("resolveNavigation", () => {
     // would funnel an established user out of their own billing page.
     test("waits for the platform assistants list before funneling", () => {
       expect(
+        guard(s({ ...EMPTY_ORG, assistantsHydrated: false }), POST_CHECKOUT_BILLING),
+      ).toEqual(WAIT);
+      expect(
         guard(
-          s({ hasAssistants: false, assistantsHydrated: false }),
+          s({ ...NO_MANAGED_ASSISTANT, assistantsHydrated: false }),
           POST_CHECKOUT_BILLING,
         ),
       ).toEqual(WAIT);
@@ -667,7 +733,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isLocalMode: true,
-            hasAssistants: false,
+            ...EMPTY_ORG,
             assistantsHydrated: false,
           }),
           POST_CHECKOUT_BILLING,
@@ -680,13 +746,13 @@ describe("resolveNavigation", () => {
     test("consent is still enforced once the funnel destination is resolved", () => {
       expect(
         guard(
-          s({ hasAssistants: false, tosAccepted: false, privacyConsent: false }),
+          s({ ...EMPTY_ORG, tosAccepted: false, privacyConsent: false }),
           POST_CHECKOUT_BILLING,
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
       expect(
         guard(
-          s({ hasAssistants: false, tosAccepted: false, privacyConsent: false }),
+          s({ ...EMPTY_ORG, tosAccepted: false, privacyConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
@@ -697,7 +763,7 @@ describe("resolveNavigation", () => {
     test("the funnel destination is not treated as a post-checkout return", () => {
       expect(
         guard(
-          s({ hasAssistants: false }),
+          s(EMPTY_ORG),
           "/assistant/onboarding/hatching?session_id=cs_test_123",
         ),
       ).toEqual(ALLOW);

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -586,10 +586,12 @@ describe("resolveNavigation", () => {
 
     // The funnel entry carries the managed-hatch marker, so a local-mode
     // client provisions on the platform instead of letting its own gateway
-    // answer for the assistant and skipping the purchased-provisioning wait.
+    // answer for the assistant and skipping the purchased-provisioning wait,
+    // plus the post-checkout marker that tells the hatching screen a
+    // still-base subscription read is a lagging webhook, not a free org.
     const MANAGED_FUNNEL: NavigationDecision = {
       action: "redirect",
-      to: "/assistant/onboarding/hatching?hosting=vellum-cloud",
+      to: "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1",
     };
 
     // A brand-new org: nothing resolved at all.
@@ -800,7 +802,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({ ...EMPTY_ORG, tosAccepted: false, privacyConsent: false }),
-          "/assistant/onboarding/hatching?hosting=vellum-cloud",
+          "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -565,6 +565,144 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
     });
 
+    // -- post-checkout return with nothing provisioned yet -----------------
+    //
+    // The marketing pricing funnel has a brand-new user pay BEFORE an
+    // assistant exists, and the platform hardcodes the non-native Stripe
+    // `success_url` to `/assistant/settings/billing?session_id=…`. Every
+    // billing surface mounts under `ActiveAssistantGate`, which spins on
+    // "Connecting to your assistant…" forever for a no-assistant org — so the
+    // paid return must be funneled into provisioning first.
+
+    const POST_CHECKOUT_BILLING =
+      "/assistant/settings/billing?session_id=cs_test_123";
+
+    test("funnels a no-assistant post-checkout return into hatching", () => {
+      expect(guard(s({ hasAssistants: false }), POST_CHECKOUT_BILLING)).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/hatching",
+      });
+    });
+
+    test("leaves an existing-assistant post-checkout return on billing", () => {
+      expect(guard(s({ hasAssistants: true }), POST_CHECKOUT_BILLING)).toEqual(
+        ALLOW,
+      );
+      expect(
+        guard(
+          s({ hasAssistants: true }),
+          "/assistant/settings/usage?tab=billing&session_id=cs_test_123",
+        ),
+      ).toEqual(ALLOW);
+    });
+
+    // A gateway session normally short-circuits the whole pipeline to "allow",
+    // which is exactly how the dead-end is reached in Electron / local-mode
+    // web. The paid return is the one path that must still be funneled.
+    test("funnels a no-assistant post-checkout return even under gateway auth", () => {
+      expect(
+        guard(
+          s({ isGatewayAuth: true, isLocalMode: true, hasAssistants: false }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+    });
+
+    test("keeps the gateway-auth bypass for every other case", () => {
+      expect(
+        guard(
+          s({ isGatewayAuth: true, isLocalMode: true, hasAssistants: true }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual(ALLOW);
+      expect(
+        guard(
+          s({ isGatewayAuth: true, isLocalMode: true, hasAssistants: false }),
+          "/assistant/settings/billing",
+        ),
+      ).toEqual(ALLOW);
+    });
+
+    // A billing URL without `session_id` is not a checkout return, so it keeps
+    // whatever `requireAssistant` already decided for it.
+    test("leaves a billing URL without session_id on its existing path", () => {
+      expect(
+        guard(s({ hasAssistants: false }), "/assistant/settings/billing"),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+      expect(
+        guard(
+          s({ hasAssistants: false, tosAccepted: false, privacyConsent: false }),
+          "/assistant/settings/billing",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
+    // Signed out, the return must still reach login with `session_id` intact,
+    // so the decision is retaken once the session lands.
+    test("sends a signed-out post-checkout return to login with session_id preserved", () => {
+      expect(
+        guard(
+          s({ hasAssistants: false, isAuthenticated: false }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: "/account/login?returnTo=%2Fassistant%2Fsettings%2Fbilling%3Fsession_id%3Dcs_test_123",
+      });
+    });
+
+    // The platform assistants list boots empty, so deciding before it hydrates
+    // would funnel an established user out of their own billing page.
+    test("waits for the platform assistants list before funneling", () => {
+      expect(
+        guard(
+          s({ hasAssistants: false, assistantsHydrated: false }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual(WAIT);
+    });
+
+    test("does not wait on hydration in local mode (lockfile-driven list)", () => {
+      expect(
+        guard(
+          s({
+            isLocalMode: true,
+            hasAssistants: false,
+            assistantsHydrated: false,
+          }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+    });
+
+    // Consent is enforced at the destination, not skipped: the funnel entry is
+    // an onboarding path, and re-resolving it bounces an unconsented user on.
+    test("consent is still enforced once the funnel destination is resolved", () => {
+      expect(
+        guard(
+          s({ hasAssistants: false, tosAccepted: false, privacyConsent: false }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+      expect(
+        guard(
+          s({ hasAssistants: false, tosAccepted: false, privacyConsent: false }),
+          "/assistant/onboarding/hatching",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
+    // The funnel destination must not itself read as a checkout return, or the
+    // redirect would loop.
+    test("the funnel destination is not treated as a post-checkout return", () => {
+      expect(
+        guard(
+          s({ hasAssistants: false }),
+          "/assistant/onboarding/hatching?session_id=cs_test_123",
+        ),
+      ).toEqual(ALLOW);
+    });
+
     test("redirects brand-new platform user with no assistant to privacy, unaffected by stale-toggle gate", () => {
       expect(
         guard(

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -40,6 +40,12 @@ function s(overrides: Partial<NavigationState>): NavigationState {
 
 const ALLOW: NavigationDecision = { action: "allow" };
 const WAIT: NavigationDecision = { action: "wait" };
+// The auth middleware awaits the probe only for a wait that names it, so the
+// tag is part of the contract, not a label.
+const WAIT_FOR_PLATFORM_SESSION: NavigationDecision = {
+  action: "wait",
+  waitFor: "platform-session",
+};
 
 describe("resolveNavigation", () => {
   // -----------------------------------------------------------------------
@@ -272,7 +278,7 @@ describe("resolveNavigation", () => {
     test("waits for platform probe in local mode with no assistants", () => {
       expect(
         guard(s({ isLocalMode: true, hasAssistants: false, platformSession: "unknown" })),
-      ).toEqual(WAIT);
+      ).toEqual(WAIT_FOR_PLATFORM_SESSION);
     });
 
     test("redirects to hosting when local mode + platform session present", () => {
@@ -657,7 +663,9 @@ describe("resolveNavigation", () => {
 
     // A local-mode client is "authenticated" on its gateway session alone, so
     // the platform session is decided separately — and the managed hatch the
-    // funnel starts needs one. The probe boots "unknown".
+    // funnel starts needs one. The probe boots "unknown". The wait names the
+    // probe because the org already has an assistant here, so nothing else
+    // tells the middleware to await it.
     test("waits for the local-mode platform-session probe before funneling", () => {
       expect(
         guard(
@@ -669,7 +677,7 @@ describe("resolveNavigation", () => {
           }),
           POST_CHECKOUT_BILLING,
         ),
-      ).toEqual(WAIT);
+      ).toEqual(WAIT_FOR_PLATFORM_SESSION);
     });
 
     // Signed out of the platform there is no account to provision into. The

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -600,8 +600,7 @@ describe("resolveNavigation", () => {
     });
 
     // The decision is "does a managed plan have a target", not "is the list
-    // empty": a self-hosted-only org lands on billing with the Pro onboarding
-    // wizard gated off, so the purchase would apply to nothing.
+    // empty": in a self-hosted-only org the purchase has nothing to apply to.
     test("funnels a return whose only assistants are self-hosted", () => {
       expect(guard(s(NO_MANAGED_ASSISTANT), POST_CHECKOUT_BILLING)).toEqual({
         action: "redirect",

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -145,6 +145,18 @@ function isPostCheckoutReturn(
 }
 
 /**
+ * The hatching-screen query param naming a hatch that is the return leg of a
+ * completed Stripe Checkout. Only {@link MANAGED_PROVISIONING_DESTINATION} sets
+ * it, and only for a billing landing carrying Stripe's `session_id`.
+ *
+ * Deliberately separate from `hosting=vellum-cloud`, which says only that the
+ * hatch is managed — a hosting choice a free user can make too. The hatching
+ * screen holds for a lagging subscription webhook on this param alone, so
+ * conflating the two would park every free managed hatch on a spinner.
+ */
+export const POST_CHECKOUT_HATCH_PARAM = "post_checkout";
+
+/**
  * The provisioning funnel entry for a purchase with no managed assistant to
  * apply to.
  *
@@ -152,8 +164,12 @@ function isPostCheckoutReturn(
  * `adopt-existing-assistant`): it names a managed hatch even in a local-mode
  * build, where the hatching screen would otherwise let the local gateway answer
  * for the assistant and skip the purchased-provisioning wait.
+ *
+ * {@link POST_CHECKOUT_HATCH_PARAM} adds the narrower fact that money has
+ * already changed hands, which is what lets the hatching screen treat a
+ * still-base subscription read as a pending webhook rather than a free org.
  */
-const MANAGED_PROVISIONING_DESTINATION = `${routes.onboarding.hatching}?hosting=vellum-cloud`;
+const MANAGED_PROVISIONING_DESTINATION = `${routes.onboarding.hatching}?hosting=vellum-cloud&${POST_CHECKOUT_HATCH_PARAM}=1`;
 
 function extractPathname(destination: string): string {
   if (

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -124,9 +124,13 @@ function isPostCheckoutReturn(
   path: string,
   pathnameWithSearch: string,
 ): boolean {
-  if (!POST_CHECKOUT_LANDING_PATHS.has(path)) return false;
+  if (!POST_CHECKOUT_LANDING_PATHS.has(path)) {
+    return false;
+  }
   const qIdx = pathnameWithSearch.indexOf("?");
-  if (qIdx < 0) return false;
+  if (qIdx < 0) {
+    return false;
+  }
   return new URLSearchParams(pathnameWithSearch.slice(qIdx + 1)).has(
     "session_id",
   );
@@ -289,12 +293,18 @@ function requirePostCheckoutProvisioning(
   // An org with a platform-hosted assistant has a target for the purchase, so
   // the return stays on billing and the pro onboarding wizard consumes
   // `session_id` there.
-  if (state.hasPlatformHostedAssistant) return null;
-  if (!isPostCheckoutReturn(path, pathnameWithSearch)) return null;
+  if (state.hasPlatformHostedAssistant) {
+    return null;
+  }
+  if (!isPostCheckoutReturn(path, pathnameWithSearch)) {
+    return null;
+  }
   // Not signed in yet: fall through so `requireAuth` sends the user to login
   // with a `returnTo` that still carries `session_id`, and this step decides
   // again on the way back.
-  if (!state.isAuthenticated) return null;
+  if (!state.isAuthenticated) {
+    return null;
+  }
   // The platform assistants list boots empty and loads asynchronously, so
   // deciding on that default would funnel an established user out of their own
   // billing page. Local mode is excluded for the same reason as in

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -108,11 +108,10 @@ function onboardingEntrypoint(isLocalMode: boolean): string {
 }
 
 /**
- * The two paths a finished Stripe Checkout can land on: the legacy
- * `/assistant/settings/billing` (hardcoded as the platform's non-native
- * `success_url`, and forwarded by `BillingRedirectPage`) and the Billing tab's
- * real home, which the native deep-link return and `usageBillingCheckout()`
- * build directly.
+ * The two paths a finished Stripe Checkout can land on: the platform's
+ * hardcoded non-native `success_url` (`/assistant/settings/billing`, which
+ * `BillingRedirectPage` forwards) and the Billing tab's own path, which the
+ * native deep-link return and `usageBillingCheckout()` build directly.
  */
 const POST_CHECKOUT_LANDING_PATHS: Set<string> = new Set([
   `${routes.settings.root}/billing`,

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -135,6 +135,17 @@ function isPostCheckoutReturn(
   );
 }
 
+/**
+ * The provisioning funnel entry for a purchase with no managed assistant to
+ * apply to.
+ *
+ * `hosting=vellum-cloud` is the onboarding flow's managed-hatch marker (see
+ * `adopt-existing-assistant`): it names a managed hatch even in a local-mode
+ * build, where the hatching screen would otherwise let the local gateway answer
+ * for the assistant and skip the purchased-provisioning wait.
+ */
+const MANAGED_PROVISIONING_DESTINATION = `${routes.onboarding.hatching}?hosting=vellum-cloud`;
+
 function extractPathname(destination: string): string {
   if (
     destination.startsWith("http://") ||
@@ -256,6 +267,11 @@ function waitForSession(state: NavigationState): NavigationDecision | null {
  * into the hatching funnel instead, which provisions the assistant and applies
  * the purchased specs.
  *
+ * The destination is {@link MANAGED_PROVISIONING_DESTINATION}: the marker is
+ * what makes a local-mode client provision on the platform and hold for the
+ * purchased machine and storage instead of letting its own gateway answer for
+ * the assistant.
+ *
  * The decision is `hasPlatformHostedAssistant`, not `hasAssistants`: a managed
  * plan is only expressible on a platform-hosted assistant, so an org whose
  * only entries are local, Docker, or another organization's needs the same
@@ -311,7 +327,21 @@ function requirePostCheckoutProvisioning(
   if (!state.isLocalMode && !state.assistantsHydrated) {
     return { action: "wait" };
   }
-  return { action: "redirect", to: routes.onboarding.hatching };
+  // A local-mode client reaches "authenticated" on its gateway session alone,
+  // so the platform session is a separate question — and the managed hatch this
+  // redirect starts needs one for the org header and the purchased ceiling. The
+  // probe boots `"unknown"`, so hold until it settles. When it settles absent
+  // there is no account to provision into: fall through to billing, whose login
+  // notice carries `session_id` through sign-in and lands back here.
+  if (state.isLocalMode) {
+    if (state.platformSession === "unknown") {
+      return { action: "wait" };
+    }
+    if (state.platformSession !== "present") {
+      return null;
+    }
+  }
+  return { action: "redirect", to: MANAGED_PROVISIONING_DESTINATION };
 }
 
 function allowGatewayAuth(state: NavigationState): NavigationDecision | null {

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -64,7 +64,16 @@ export type NavigationQuery =
 export type NavigationDecision =
   | { action: "allow" }
   | { action: "redirect"; to: string }
-  | { action: "wait" };
+  /**
+   * State the decision depends on has not settled yet.
+   *
+   * `waitFor` names the signal when it is one the caller has to block on
+   * beyond the session itself, so a caller that can await it (the auth
+   * middleware) awaits exactly that signal instead of guessing from the
+   * surrounding state — guessing wrong re-resolves on unchanged state and
+   * spins.
+   */
+  | { action: "wait"; waitFor?: "platform-session" };
 
 // ---------------------------------------------------------------------------
 // Shared predicates & helpers
@@ -335,7 +344,7 @@ function requirePostCheckoutProvisioning(
   // notice carries `session_id` through sign-in and lands back here.
   if (state.isLocalMode) {
     if (state.platformSession === "unknown") {
-      return { action: "wait" };
+      return { action: "wait", waitFor: "platform-session" };
     }
     if (state.platformSession !== "present") {
       return null;
@@ -453,7 +462,9 @@ function requireAssistant(
   if (path === routes.checkout) return null;
 
   if (state.isLocalMode) {
-    if (state.platformSession === "unknown") return { action: "wait" };
+    if (state.platformSession === "unknown") {
+      return { action: "wait", waitFor: "platform-session" };
+    }
     if (state.platformSession === "present") {
       return { action: "redirect", to: routes.onboarding.hosting };
     }

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -97,6 +97,31 @@ function onboardingEntrypoint(isLocalMode: boolean): string {
   return isLocalMode ? routes.welcome : routes.onboarding.privacy;
 }
 
+/**
+ * The two paths a finished Stripe Checkout can land on: the legacy
+ * `/assistant/settings/billing` (hardcoded as the platform's non-native
+ * `success_url`, and forwarded by `BillingRedirectPage`) and the Billing tab's
+ * real home, which the native deep-link return and `usageBillingCheckout()`
+ * build directly.
+ */
+const POST_CHECKOUT_LANDING_PATHS: Set<string> = new Set([
+  `${routes.settings.root}/billing`,
+  routes.settings.usage,
+]);
+
+/** Whether `pathnameWithSearch` is a billing landing carrying Stripe's `session_id`. */
+function isPostCheckoutReturn(
+  path: string,
+  pathnameWithSearch: string,
+): boolean {
+  if (!POST_CHECKOUT_LANDING_PATHS.has(path)) return false;
+  const qIdx = pathnameWithSearch.indexOf("?");
+  if (qIdx < 0) return false;
+  return new URLSearchParams(pathnameWithSearch.slice(qIdx + 1)).has(
+    "session_id",
+  );
+}
+
 function extractPathname(destination: string): string {
   if (
     destination.startsWith("http://") ||
@@ -162,12 +187,13 @@ export function resolveNavigation(
 //
 // Conceptual layers:
 //   1. Readiness          — is the session ready?
-//   2. Bypass             — gateway auth skips everything
-//   3. Identity           — is the user authenticated?
-//   4. Mode boundary      — is this path valid for the user's mode?
-//   5. Setup exemptions   — onboarding/consent paths are always reachable
-//   6. Assistant required  — user needs at least one assistant
-//   7. Consent required   — platform users must accept TOS
+//   2. Paid return        — a checkout return with nothing provisioned yet
+//   3. Bypass             — gateway auth skips everything
+//   4. Identity           — is the user authenticated?
+//   5. Mode boundary      — is this path valid for the user's mode?
+//   6. Setup exemptions   — onboarding/consent paths are always reachable
+//   7. Assistant required  — user needs at least one assistant
+//   8. Consent required   — platform users must accept TOS
 
 type RouteGuardStep = (
   state: NavigationState,
@@ -177,6 +203,7 @@ type RouteGuardStep = (
 
 const ROUTE_GUARD_PIPELINE: RouteGuardStep[] = [
   waitForSession,
+  requirePostCheckoutProvisioning,
   allowGatewayAuth,
   requireRemoteGatewayPairing,
   requireAuth,
@@ -202,6 +229,51 @@ function resolveRouteGuard(
 
 function waitForSession(state: NavigationState): NavigationDecision | null {
   return state.sessionSettled ? null : { action: "wait" };
+}
+
+/**
+ * A finished Stripe Checkout returning to an org that has no assistant yet.
+ *
+ * The marketing pricing funnel has a brand-new user pay BEFORE anything is
+ * provisioned, and the platform hardcodes the non-native `success_url` to the
+ * billing landing. Every billing surface mounts under `ActiveAssistantGate`,
+ * which renders a "Connecting to your assistant…" placeholder for as long as
+ * no assistant resolves — so the paid return dead-ends on a spinner. Send it
+ * into the hatching funnel instead, which provisions the assistant and applies
+ * the purchased specs.
+ *
+ * `session_id` is deliberately dropped: the hatch reads the purchased ceiling
+ * from the subscription server-side (`awaitPurchasedProvisioning`), so nothing
+ * downstream of this redirect consumes the Stripe session.
+ *
+ * Runs before `allowGatewayAuth` because that step short-circuits the whole
+ * pipeline to "allow" for a gateway session — which is how the dead-end is
+ * reached in Electron / local-mode web, where `requireAssistant` never runs.
+ * Consent is still enforced: the destination is an onboarding path, and
+ * `onboardingCompletedMiddleware` re-runs this pipeline there, where
+ * `allowSetupRoutes` bounces an unconsented user to the privacy screen.
+ */
+function requirePostCheckoutProvisioning(
+  state: NavigationState,
+  path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
+  // An org that already has an assistant lands on billing as before, where
+  // `session_id` opens the Pro onboarding wizard.
+  if (state.hasAssistants) return null;
+  if (!isPostCheckoutReturn(path, pathnameWithSearch)) return null;
+  // Not signed in yet: fall through so `requireAuth` sends the user to login
+  // with a `returnTo` that still carries `session_id`, and this step decides
+  // again on the way back.
+  if (!state.isAuthenticated) return null;
+  // The platform assistants list boots empty and loads asynchronously, so
+  // deciding on that default would funnel an established user out of their own
+  // billing page. Local mode is excluded for the same reason as in
+  // `requireAssistant` — its list is lockfile-driven.
+  if (!state.isLocalMode && !state.assistantsHydrated) {
+    return { action: "wait" };
+  }
+  return { action: "redirect", to: routes.onboarding.hatching };
 }
 
 function allowGatewayAuth(state: NavigationState): NavigationDecision | null {

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -258,10 +258,13 @@ function waitForSession(state: NavigationState): NavigationDecision | null {
  * only entries are local, Docker, or another organization's needs the same
  * provisioning funnel. Hatching is additive — the lockfile keeps every
  * existing entry and they stay reachable from the assistant switcher — so a
- * self-hosted user who buys managed hosting gains a managed assistant rather
- * than losing the one they had. Landing them on billing instead drops the
- * purchase silently: `BillingTab` gates the whole Pro onboarding wizard on the
- * active assistant being platform-hosted, so `session_id` is ignored.
+ * self-hosted user who buys managed hosting ends up holding both.
+ *
+ * The predicate is org membership rather than the active assistant because the
+ * purchase applies to the org: `BillingTab` opens the org-scoped pro onboarding
+ * wizard on `session_id` whichever assistant is selected, and hatching a second
+ * managed assistant for an org that already has one provisions a machine nobody
+ * bought.
  *
  * `session_id` is deliberately dropped: the hatch reads the purchased ceiling
  * from the subscription server-side (`awaitPurchasedProvisioning`), so nothing
@@ -283,8 +286,9 @@ function requirePostCheckoutProvisioning(
   path: string,
   pathnameWithSearch: string,
 ): NavigationDecision | null {
-  // An org that already has a platform-hosted assistant lands on billing as
-  // before, where `session_id` opens the Pro onboarding wizard.
+  // An org with a platform-hosted assistant has a target for the purchase, so
+  // the return stays on billing and the pro onboarding wizard consumes
+  // `session_id` there.
   if (state.hasPlatformHostedAssistant) return null;
   if (!isPostCheckoutReturn(path, pathnameWithSearch)) return null;
   // Not signed in yet: fall through so `requireAuth` sends the user to login

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -14,6 +14,16 @@ export interface NavigationState {
   remoteGatewayPublicPathPrefix: string;
   isGatewayAuth: boolean;
   hasAssistants: boolean;
+  /**
+   * Whether the active organization has a **platform-hosted** assistant — the
+   * only kind a managed plan can apply to.
+   *
+   * Strictly narrower than `hasAssistants`, which counts every resolved entry
+   * regardless of hosting or owning org: a local, Docker, or
+   * other-organization assistant satisfies `hasAssistants` while leaving this
+   * org with nothing the purchased plan can be applied to.
+   */
+  hasPlatformHostedAssistant: boolean;
   sessionSettled: boolean;
   isAuthenticated: boolean;
   platformSession: PlatformSessionStatus;
@@ -232,7 +242,8 @@ function waitForSession(state: NavigationState): NavigationDecision | null {
 }
 
 /**
- * A finished Stripe Checkout returning to an org that has no assistant yet.
+ * A finished Stripe Checkout returning to an org with nothing the purchased
+ * plan can apply to.
  *
  * The marketing pricing funnel has a brand-new user pay BEFORE anything is
  * provisioned, and the platform hardcodes the non-native `success_url` to the
@@ -242,13 +253,27 @@ function waitForSession(state: NavigationState): NavigationDecision | null {
  * into the hatching funnel instead, which provisions the assistant and applies
  * the purchased specs.
  *
+ * The decision is `hasPlatformHostedAssistant`, not `hasAssistants`: a managed
+ * plan is only expressible on a platform-hosted assistant, so an org whose
+ * only entries are local, Docker, or another organization's needs the same
+ * provisioning funnel. Hatching is additive — the lockfile keeps every
+ * existing entry and they stay reachable from the assistant switcher — so a
+ * self-hosted user who buys managed hosting gains a managed assistant rather
+ * than losing the one they had. Landing them on billing instead drops the
+ * purchase silently: `BillingTab` gates the whole Pro onboarding wizard on the
+ * active assistant being platform-hosted, so `session_id` is ignored.
+ *
  * `session_id` is deliberately dropped: the hatch reads the purchased ceiling
  * from the subscription server-side (`awaitPurchasedProvisioning`), so nothing
- * downstream of this redirect consumes the Stripe session.
+ * downstream of this redirect consumes the Stripe session. Credit top-ups
+ * return with `billing_status`, never `session_id`, so they never reach here.
  *
  * Runs before `allowGatewayAuth` because that step short-circuits the whole
  * pipeline to "allow" for a gateway session — which is how the dead-end is
  * reached in Electron / local-mode web, where `requireAssistant` never runs.
+ * Electron takes the `"native"` checkout return, but its deep-link handler
+ * lands on the same in-app billing path carrying `session_id`, so it resolves
+ * through this pipeline too.
  * Consent is still enforced: the destination is an onboarding path, and
  * `onboardingCompletedMiddleware` re-runs this pipeline there, where
  * `allowSetupRoutes` bounces an unconsented user to the privacy screen.
@@ -258,9 +283,9 @@ function requirePostCheckoutProvisioning(
   path: string,
   pathnameWithSearch: string,
 ): NavigationDecision | null {
-  // An org that already has an assistant lands on billing as before, where
-  // `session_id` opens the Pro onboarding wizard.
-  if (state.hasAssistants) return null;
+  // An org that already has a platform-hosted assistant lands on billing as
+  // before, where `session_id` opens the Pro onboarding wizard.
+  if (state.hasPlatformHostedAssistant) return null;
   if (!isPostCheckoutReturn(path, pathnameWithSearch)) return null;
   // Not signed in yet: fall through so `requireAuth` sends the user to login
   // with a `returnTo` that still carries `session_id`, and this step decides


### PR DESCRIPTION
## Problem

A brand-new user coming from the marketing pricing funnel pays **before** an assistant exists — that ordering is deliberate. The platform hardcodes the non-native Stripe `success_url` (`django/app/billing/subscription_views.py:313`):

```python
success_url = f"{base_url}/assistant/settings/billing?session_id={{CHECKOUT_SESSION_ID}}"
```

`return_target` only accepts `native` / `web`, and the web checkout page sends `web`. So Stripe returns the user to `/assistant/settings/billing?session_id=…` while `GET /v1/assistants/` returns `{"count":0,"results":[]}`.

Every billing surface — including the `/assistant/settings/billing` redirect page — mounts under `ActiveAssistantGate` (`routes.tsx`), which renders a "Connecting to your assistant…" placeholder with a Log Out button for as long as no assistant resolves. No hatch is ever kicked off. The one user who has already paid is the one who gets stranded.

## What actually lets it through

I probed the real `authMiddleware` for the post-checkout URL across modes. Two holes:

| mode | before |
|---|---|
| platform web, hydrated + consented | `redirect → /assistant/onboarding/hatching` (incidental — `requireAssistant`'s generic no-assistant fallback) |
| platform web, consent hydration times out | `redirect → /assistant/onboarding/privacy` — a paying user re-asked to consent, purchase invisible |
| **gateway auth (Electron / local-mode web)** | **`ADMITTED`** → `ActiveAssistantGate` → spinner forever |

`allowGatewayAuth` is step 2 of the pipeline and short-circuits everything to `allow`, so `requireAssistant` never runs there. That is the exact reported symptom.

## Fix

A dedicated `requirePostCheckoutProvisioning` step in `ROUTE_GUARD_PIPELINE`, placed **before** `allowGatewayAuth`: a no-assistant org landing on a billing path that carries `session_id` is redirected into `/assistant/onboarding/hatching`, which provisions the assistant and applies the purchased specs via the existing `awaitPurchasedProvisioning` wait.

It runs before render (guard pipeline, not a component effect), so the gate placeholder can never flash.

### `session_id` is deliberately dropped

`awaitPurchasedProvisioning` reads the purchased ceiling from the subscription server-side (`organizationsBillingSubscriptionRetrieve` / `...OnboardingRetrieve` / `...EnsureProvisionedCreate`). Nothing downstream of this redirect consumes the Stripe session — the only reader of `session_id` is the Billing page's Pro onboarding wizard, which is on the *has-assistant* path we don't touch. Carrying it would just park a Stripe session id in the funnel URL and history for no consumer.

### Checkout-intent stash — left alone, deliberately

- **No loop back into checkout.** `PrivacyScreen` resumes only a stash marked `resumeAfterOnboarding: true`. `CheckoutPage` overwrites the marked signup stash with an **unmarked** one at the same key immediately before the Stripe redirect (`checkout-page.tsx:68`), so by the time Stripe returns the marker is already gone.
- **Nothing resurfaces.** The stash's only reader is `billing-onboarding-modal`, reachable only once an assistant exists — at which point rendering the purchased package is correct. It self-clears at `step === "complete"` and otherwise expires on its 30-minute TTL.
- Clearing it from a route-guard step would put a side effect on a hot path for no benefit.

### Existing-user path verified unchanged

An org that already has an assistant falls through on the first line (`if (state.hasAssistants) return null`) and still lands on billing with the `session_id`-driven Pro onboarding modal. Covered by both a resolver test and an end-to-end middleware test.

## Not in scope

Adding a third `return_target` so the platform can land the funnel case directly on onboarding is the durable server-side fix; this PR is the client-side guard.

## Tests

`navigation-resolver.test.ts` (+10 cases) and `auth-middleware.test.ts` (+3 end-to-end cases):

- zero-assistant + `session_id` → hatching (both landing paths, and under gateway auth)
- has-assistant + `session_id` → billing settings, unchanged (plain and gateway auth)
- zero-assistant **without** `session_id` → existing behavior preserved (hatching, or privacy when unconsented)
- signed-out return → login with `session_id` preserved in `returnTo`
- platform list not yet hydrated → `wait` (never funnel an established user off their own billing page); local mode decides immediately (lockfile-driven)
- the funnel destination is not itself read as a checkout return (no redirect loop)
- gateway-auth bypass intact for every other case

```
bun run test:ci   → 725 passed, 0 failed (725 test files)
bunx tsc --noEmit → clean
bun run lint      → 0 errors (2826 pre-existing warnings, repo-wide)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)