### PR TITLE
fix(heartbeat): stop rendering scheduler bookkeeping rows as heartbeat runs

### DIFF
--- a/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
+++ b/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
@@ -26,6 +26,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   countCompletedHeartbeatRuns: mock(() => 10),
   countCompletedRunsToday: mock(() => 0),
   countRecentConsecutiveRuns: mock(() => 0),
+  getLastHeartbeatRunAt: mock(() => null),
 }));
 
 mock.module("../schedule/recurrence-engine.js", () => ({

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -34,6 +34,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   countCompletedHeartbeatRuns: mockCountCompletedHeartbeatRuns,
   countCompletedRunsToday: mock(() => 0),
   countRecentConsecutiveRuns: mock(() => 0),
+  getLastHeartbeatRunAt: mock(() => null),
 }));
 
 // ── Heartbeat config seeding ────────────────────────────────────────

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -43,6 +43,7 @@ import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import {
   insertPendingHeartbeatRun,
   startHeartbeatRun,
+  supersedePendingRun,
 } from "../heartbeat/heartbeat-run-store.js";
 import {
   archiveConversation,
@@ -845,6 +846,38 @@ describe("schedule and heartbeat run metadata", () => {
     };
 
     expect(result.runs[0].estimatedCostUsd).toBeCloseTo(0.02);
+  });
+
+  test("heartbeat runs omit bookkeeping rows so timer resets don't render as runs", () => {
+    const now = Date.now();
+
+    // Timer resets (e.g. guardian messages) supersede the pending row and
+    // schedule a new one an interval into the future.
+    for (let i = 0; i < 3; i++) {
+      supersedePendingRun(insertPendingHeartbeatRun(now + 60 * 60 * 1000 + i));
+    }
+    // The next scheduled run, not yet fired.
+    insertPendingHeartbeatRun(now + 60 * 60 * 1000 + 10);
+
+    // The one run that actually executed.
+    const okId = insertPendingHeartbeatRun(now - 1000);
+    startHeartbeatRun(okId);
+    rawRun(
+      "test:setHeartbeatRunOk",
+      "UPDATE heartbeat_runs SET status = 'ok', finished_at = ?, duration_ms = ? WHERE id = ?",
+      now,
+      1000,
+      okId,
+    );
+
+    const route = findHeartbeatRoute("heartbeat/runs", "GET");
+    const result = route.handler({}) as {
+      runs: Array<{ id: string; status: string }>;
+    };
+
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0].id).toBe(okId);
+    expect(result.runs[0].status).toBe("ok");
   });
 });
 

--- a/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
@@ -4,9 +4,11 @@ import { sql } from "drizzle-orm";
 
 import { getDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
+import { heartbeatRuns } from "../../persistence/schema/index.js";
 import {
   completeHeartbeatRun,
   countCompletedHeartbeatRuns,
+  getLastHeartbeatRunAt,
   insertPendingHeartbeatRun,
   listHeartbeatRuns,
   markStaleRunningAsError,
@@ -17,6 +19,19 @@ import {
 } from "../heartbeat-run-store.js";
 
 await initializeDb();
+
+/**
+ * Raw read-back of every row (any status). `listHeartbeatRuns` serves run
+ * history and hides bookkeeping rows (pending/superseded), so tests that
+ * assert on those statuses read the table directly.
+ */
+function allRuns() {
+  return getDb()
+    .select()
+    .from(heartbeatRuns)
+    .orderBy(sql`${heartbeatRuns.scheduledFor} DESC`)
+    .all();
+}
 
 describe("heartbeat-run-store", () => {
   beforeEach(() => {
@@ -29,7 +44,7 @@ describe("heartbeat-run-store", () => {
     const id = insertPendingHeartbeatRun(scheduledFor);
     expect(id).toBeTruthy();
 
-    const rows = listHeartbeatRuns();
+    const rows = allRuns();
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toBe(id);
     expect(rows[0].status).toBe("pending");
@@ -134,7 +149,7 @@ describe("heartbeat-run-store", () => {
     const ok = supersedePendingRun(id);
     expect(ok).toBe(true);
 
-    const rows = listHeartbeatRuns();
+    const rows = allRuns();
     expect(rows[0].status).toBe("superseded");
   });
 
@@ -156,7 +171,7 @@ describe("heartbeat-run-store", () => {
     const count = markStaleRunsAsMissed(5 * 60 * 1000);
     expect(count).toBe(2);
 
-    const rows = listHeartbeatRuns();
+    const rows = allRuns();
     const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
     expect(byId[id1].status).toBe("missed");
     expect(byId[id2].status).toBe("missed");
@@ -185,9 +200,9 @@ describe("heartbeat-run-store", () => {
 
   test("listHeartbeatRuns returns rows ordered by scheduledFor desc", () => {
     const now = Date.now();
-    insertPendingHeartbeatRun(now - 2000);
-    insertPendingHeartbeatRun(now);
-    insertPendingHeartbeatRun(now - 1000);
+    skipHeartbeatRun(insertPendingHeartbeatRun(now - 2000), "overlap");
+    skipHeartbeatRun(insertPendingHeartbeatRun(now), "overlap");
+    skipHeartbeatRun(insertPendingHeartbeatRun(now - 1000), "overlap");
 
     const rows = listHeartbeatRuns();
     expect(rows).toHaveLength(3);
@@ -199,11 +214,46 @@ describe("heartbeat-run-store", () => {
   test("listHeartbeatRuns respects limit", () => {
     const now = Date.now();
     for (let i = 0; i < 5; i++) {
-      insertPendingHeartbeatRun(now + i);
+      skipHeartbeatRun(insertPendingHeartbeatRun(now + i), "overlap");
     }
 
     const rows = listHeartbeatRuns(3);
     expect(rows).toHaveLength(3);
+  });
+
+  test("listHeartbeatRuns hides bookkeeping rows (pending, superseded)", () => {
+    const now = Date.now();
+
+    // Superseded rows: pending runs replaced by timer resets, scheduled in
+    // the future at insert time — never ran.
+    for (let i = 0; i < 3; i++) {
+      supersedePendingRun(insertPendingHeartbeatRun(now + 60 * 60 * 1000 + i));
+    }
+    // The not-yet-fired next scheduled run.
+    insertPendingHeartbeatRun(now + 60 * 60 * 1000 + 10);
+
+    // Real history: a completed run, a skipped run, a missed run, and one
+    // in flight.
+    const okId = insertPendingHeartbeatRun(now - 3000);
+    startHeartbeatRun(okId);
+    completeHeartbeatRun(okId, { status: "ok", conversationId: "conv-1" });
+    const skippedId = insertPendingHeartbeatRun(now - 2000);
+    skipHeartbeatRun(skippedId, "outside_active_hours");
+    const missedId = insertPendingHeartbeatRun(now - 10 * 60 * 1000);
+    markStaleRunsAsMissed(5 * 60 * 1000);
+    const runningId = insertPendingHeartbeatRun(now - 1000);
+    startHeartbeatRun(runningId);
+
+    const rows = listHeartbeatRuns();
+    expect(rows.map((r) => r.id).sort()).toEqual(
+      [okId, skippedId, missedId, runningId].sort(),
+    );
+
+    // The pagination cursor path applies the same filter.
+    const paged = listHeartbeatRuns(10, now + 2 * 60 * 60 * 1000);
+    expect(paged.map((r) => r.id).sort()).toEqual(
+      [okId, skippedId, missedId, runningId].sort(),
+    );
   });
 
   test("countCompletedHeartbeatRuns counts only ok rows", () => {
@@ -239,5 +289,48 @@ describe("heartbeat-run-store", () => {
     skipHeartbeatRun(id2, "outside_active_hours");
 
     expect(countCompletedHeartbeatRuns()).toBe(0);
+  });
+
+  test("getLastHeartbeatRunAt returns the newest executed-run timestamp", () => {
+    const now = Date.now();
+
+    const oldId = insertPendingHeartbeatRun(now - 5000);
+    startHeartbeatRun(oldId);
+    completeHeartbeatRun(oldId, { status: "ok", conversationId: "conv-1" });
+
+    const newId = insertPendingHeartbeatRun(now - 1000);
+    startHeartbeatRun(newId);
+    completeHeartbeatRun(newId, { status: "error", error: "fail" });
+
+    // Non-executed rows never contribute, even when newer.
+    skipHeartbeatRun(insertPendingHeartbeatRun(now), "outside_active_hours");
+    insertPendingHeartbeatRun(now + 60 * 60 * 1000);
+
+    const newRow = allRuns().find((r) => r.id === newId);
+    expect(getLastHeartbeatRunAt()).toBe(newRow!.finishedAt!);
+  });
+
+  test("getLastHeartbeatRunAt falls back to startedAt when finishedAt is null", () => {
+    const now = Date.now();
+    const id = insertPendingHeartbeatRun(now - 60 * 60 * 1000);
+    startHeartbeatRun(id);
+    const db = getDb();
+    const backdatedStartedAt = now - 60 * 60 * 1000;
+    db.run(
+      sql`UPDATE heartbeat_runs SET started_at = ${backdatedStartedAt} WHERE id = ${id}`,
+    );
+    // Crash sweep finalizes the row as error without a finishedAt.
+    markStaleRunningAsError(45 * 60 * 1000);
+
+    expect(getLastHeartbeatRunAt()).toBe(backdatedStartedAt);
+  });
+
+  test("getLastHeartbeatRunAt returns null when no run ever executed", () => {
+    expect(getLastHeartbeatRunAt()).toBeNull();
+
+    skipHeartbeatRun(insertPendingHeartbeatRun(Date.now()), "disabled");
+    supersedePendingRun(insertPendingHeartbeatRun(Date.now() + 1));
+
+    expect(getLastHeartbeatRunAt()).toBeNull();
   });
 });

--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -178,6 +178,7 @@ mock.module("../../credential-health/credential-health-service.js", () => ({
 // Stub the heartbeat-run-store so the tests don't need a populated SQLite
 // schema. Each function is a no-op that returns sensible defaults.
 let heartbeatRunIdCounter = 0;
+let lastRunAtFromHistory: number | null = null;
 const skipHeartbeatRunCalls: Array<{ runId: string; reason: string }> = [];
 mock.module("../heartbeat-run-store.js", () => ({
   insertPendingHeartbeatRun: () => `heartbeat-run-${++heartbeatRunIdCounter}`,
@@ -192,6 +193,7 @@ mock.module("../heartbeat-run-store.js", () => ({
   countCompletedHeartbeatRuns: () => 10,
   countCompletedRunsToday: () => 0,
   countRecentConsecutiveRuns: () => 0,
+  getLastHeartbeatRunAt: () => lastRunAtFromHistory,
 }));
 
 // Stub the pre-first-message gate so tests can flip it on/off without
@@ -225,6 +227,7 @@ beforeEach(() => {
   onBroadcast = null;
   runBackgroundJobCalls.length = 0;
   skipHeartbeatRunCalls.length = 0;
+  lastRunAtFromHistory = null;
   preFirstMessageGateOpen = true;
   seedHeartbeat();
   runBackgroundJobImpl = async () => ({
@@ -268,6 +271,24 @@ describe("HeartbeatService", () => {
     });
     expect(call.prompt).toContain("<heartbeat-checklist>");
     expect(call.prompt).toContain("<heartbeat-disposition>");
+  });
+
+  test("lastRunAt rehydrates from run history when unset in memory", async () => {
+    const historicalRunAt = Date.now() - 60 * 60 * 1000;
+    lastRunAtFromHistory = historicalRunAt;
+
+    const service = new HeartbeatService();
+    expect(service.lastRunAt).toBe(historicalRunAt);
+
+    // An in-process run takes over from the rehydrated value.
+    await service.runOnce({ force: true });
+    expect(service.lastRunAt).toBeGreaterThan(historicalRunAt);
+  });
+
+  test("lastRunAt is null when no run has ever executed", () => {
+    lastRunAtFromHistory = null;
+    const service = new HeartbeatService();
+    expect(service.lastRunAt).toBeNull();
   });
 
   test("fires onConversationCreated synchronously via the runner BEFORE the runner returns", async () => {

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -1,4 +1,14 @@
-import { and, desc, eq, gt, isNotNull, lt, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  lt,
+  notInArray,
+  sql,
+} from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../persistence/db-connection.js";
@@ -272,7 +282,19 @@ export function countRecentConsecutiveRuns(maxToCheck: number): number {
 }
 
 /**
- * List heartbeat runs ordered by `scheduledFor` descending.
+ * Statuses excluded from run history: scheduler bookkeeping rows, not runs.
+ * `pending` is the not-yet-fired next scheduled run (surfaced separately as
+ * "next run"), and `superseded` rows are pending rows replaced by a timer
+ * reset — a guardian message resets the heartbeat timer, so an active chat
+ * day leaves dozens of them behind without a single heartbeat firing.
+ */
+const BOOKKEEPING_STATUSES: HeartbeatRunStatus[] = ["pending", "superseded"];
+
+/**
+ * List heartbeat run history ordered by `scheduledFor` descending.
+ * Bookkeeping rows ({@link BOOKKEEPING_STATUSES}) are excluded — every
+ * returned row is a run that executed, was skipped by a guard (with its
+ * `skipReason`), or was missed while the daemon was down.
  * When `before` is set, only runs with `scheduledFor` strictly older than it
  * are returned (cursor for paginating into history).
  */
@@ -281,14 +303,42 @@ export function listHeartbeatRuns(
   before?: number,
 ): HeartbeatRunRecord[] {
   const db = getDb();
+  const historyOnly = notInArray(heartbeatRuns.status, BOOKKEEPING_STATUSES);
   const rows = db
     .select()
     .from(heartbeatRuns)
-    .where(before != null ? lt(heartbeatRuns.scheduledFor, before) : undefined)
+    .where(
+      before != null
+        ? and(lt(heartbeatRuns.scheduledFor, before), historyOnly)
+        : historyOnly,
+    )
     .orderBy(desc(heartbeatRuns.scheduledFor))
     .limit(limit)
     .all();
   return rows.map(parseRow);
+}
+
+/** Terminal statuses of runs that actually executed. */
+const EXECUTED_STATUSES: HeartbeatRunStatus[] = ["ok", "error", "timeout"];
+
+/**
+ * Epoch-ms timestamp of the most recent heartbeat run that actually executed
+ * (reached `ok`, `error`, or `timeout`), or null when none exists. Uses
+ * `finishedAt`, falling back to `startedAt` for rows finalized by a crash
+ * sweep without one.
+ */
+export function getLastHeartbeatRunAt(): number | null {
+  const db = getDb();
+  const row = db
+    .select({
+      lastRunAt: sql<
+        number | null
+      >`max(coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.startedAt}))`,
+    })
+    .from(heartbeatRuns)
+    .where(inArray(heartbeatRuns.status, EXECUTED_STATUSES))
+    .get();
+  return row?.lastRunAt ?? null;
 }
 
 /**

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -30,6 +30,7 @@ import {
   countCompletedHeartbeatRuns,
   countCompletedRunsToday,
   countRecentConsecutiveRuns,
+  getLastHeartbeatRunAt,
   insertPendingHeartbeatRun,
   markStaleRunningAsError,
   markStaleRunsAsMissed,
@@ -169,8 +170,23 @@ export class HeartbeatService {
     HeartbeatService.instance = this;
   }
 
-  /** Epoch-ms timestamp of the last completed heartbeat run. */
+  /**
+   * Epoch-ms timestamp of the last completed heartbeat run. The in-memory
+   * field only covers runs completed in this process's lifetime, so when it
+   * is unset the value is rehydrated from run history — a daemon restart
+   * must not blank "last run" while completed runs exist in the database.
+   */
   get lastRunAt(): number | null {
+    if (this._lastRunAt == null) {
+      try {
+        this._lastRunAt = getLastHeartbeatRunAt();
+      } catch (err) {
+        // DB unavailable (e.g. migrations still settling) — report unknown
+        // and retry on the next read.
+        log.debug({ err }, "Failed to read last heartbeat run from history");
+        return null;
+      }
+    }
     return this._lastRunAt;
   }
 

--- a/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
@@ -13,6 +13,8 @@ import {
   flattenRunPages,
   formatTimestamp,
   heartbeatSubtitle,
+  isBookkeepingRun,
+  isExecutedRun,
   RETROSPECTIVE_SUBTITLE,
 } from "@/domains/settings/utils/schedule-formatters";
 import { toScheduleRun } from "@/domains/settings/utils/system-task-run-transforms";
@@ -163,9 +165,23 @@ export function SystemTaskDetailPanel({
     });
   const runs = flattenRunPages(
     data?.pages.map((page) => ({
-      runs: page.runs.map((run) => toScheduleRun(run, kind)),
+      runs: page.runs
+        .filter((run) => !isBookkeepingRun(run))
+        .map((run) => toScheduleRun(run, kind)),
     })),
   );
+
+  // The config endpoint reports lastRunAt from daemon-process state, which
+  // can lag the run history (e.g. right after a restart on older daemons).
+  // Fall back to the newest completed run so completed runs never show "—".
+  const newestCompletedRun = runs?.find(
+    (run) => isExecutedRun(run) && run.status !== "running",
+  );
+  const lastRunAtDisplay =
+    lastRunAt ??
+    newestCompletedRun?.finishedAt ??
+    newestCompletedRun?.startedAt ??
+    null;
 
   return (
     <div
@@ -241,7 +257,7 @@ export function SystemTaskDetailPanel({
             <div className="flex items-center justify-between gap-4">
               <span className="text-[var(--content-secondary)]">Last run</span>
               <span className="text-[var(--content-default)]">
-                {formatTimestamp(lastRunAt)}
+                {formatTimestamp(lastRunAtDisplay)}
               </span>
             </div>
           </div>

--- a/clients/web/src/domains/settings/components/recent-runs-card.tsx
+++ b/clients/web/src/domains/settings/components/recent-runs-card.tsx
@@ -40,6 +40,28 @@ export function RecentRunsCard({
   const navigate = useNavigate();
   const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
 
+  // Rendered in the empty state too: a page can filter down to nothing
+  // (e.g. bookkeeping-only pages from daemons that still send them) while
+  // older pages hold real runs, so pagination must stay reachable.
+  const loadMoreControl =
+    hasMore && onLoadMore ? (
+      <div className="flex justify-center pt-3">
+        <Button
+          variant="outlined"
+          size="compact"
+          onClick={onLoadMore}
+          disabled={isLoadingMore}
+          leftIcon={
+            isLoadingMore ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : undefined
+          }
+        >
+          {isLoadingMore ? "Loading…" : "Load more"}
+        </Button>
+      </div>
+    ) : null;
+
   return (
     <DetailCard title="Recent runs">
       {isLoading ? (
@@ -47,9 +69,12 @@ export function RecentRunsCard({
           <Loader2 className="h-5 w-5 animate-spin text-stone-400" />
         </div>
       ) : !runs || runs.length === 0 ? (
-        <p className="py-4 text-center text-body-medium-lighter text-[var(--content-tertiary)] italic">
-          {emptyMessage}
-        </p>
+        <>
+          <p className="py-4 text-center text-body-medium-lighter text-[var(--content-tertiary)] italic">
+            {emptyMessage}
+          </p>
+          {loadMoreControl}
+        </>
       ) : (
         <div className="divide-y divide-[var(--border-base)]">
           {runs.map((run, index) => {
@@ -157,23 +182,7 @@ export function RecentRunsCard({
               </div>
             );
           })}
-          {hasMore && onLoadMore ? (
-            <div className="flex justify-center pt-3">
-              <Button
-                variant="outlined"
-                size="compact"
-                onClick={onLoadMore}
-                disabled={isLoadingMore}
-                leftIcon={
-                  isLoadingMore ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : undefined
-                }
-              >
-                {isLoadingMore ? "Loading…" : "Load more"}
-              </Button>
-            </div>
-          ) : null}
+          {loadMoreControl}
         </div>
       )}
     </DetailCard>

--- a/clients/web/src/domains/settings/components/recent-runs-card.tsx
+++ b/clients/web/src/domains/settings/components/recent-runs-card.tsx
@@ -56,7 +56,13 @@ export function RecentRunsCard({
             const conversationId = getOpenableScheduleRunConversationId(run);
             const hasOutput = hasRunText(run.output);
             const hasError = hasRunText(run.error);
-            const hasLocalDetails = !conversationId && (hasOutput || hasError);
+            // Runs that never executed (skipped by a guard, missed while the
+            // daemon was down) have no duration or cost; their detail line is
+            // the reason text instead, so no expandable details either.
+            const isUnexecuted =
+              run.status === "skipped" || run.status === "missed";
+            const hasLocalDetails =
+              !conversationId && !isUnexecuted && (hasOutput || hasError);
             const isExpanded = expandedRunId === run.id;
             const detailsId = `schedule-run-details-${index}`;
             return (
@@ -78,8 +84,20 @@ export function RecentRunsCard({
                           {hasRunText(run.title)
                             ? `${formatTimestamp(run.startedAt)} · `
                             : ""}
-                          {formatDuration(run.durationMs)} ·{" "}
-                          {formatScheduleCost(run.estimatedCostUsd)}
+                          {isUnexecuted ? (
+                            <>
+                              {hasOutput
+                                ? run.output
+                                : run.status === "missed"
+                                  ? "Missed"
+                                  : "Skipped"}
+                            </>
+                          ) : (
+                            <>
+                              {formatDuration(run.durationMs)} ·{" "}
+                              {formatScheduleCost(run.estimatedCostUsd)}
+                            </>
+                          )}
                           {run.status === "error" && run.error && (
                             <span className="ml-2 text-[var(--system-negative-strong)]">
                               {run.error.slice(0, 80)}

--- a/clients/web/src/domains/settings/components/schedule-components.test.ts
+++ b/clients/web/src/domains/settings/components/schedule-components.test.ts
@@ -68,6 +68,7 @@ const {
   formatTimestamp,
   groupSchedules,
   pastOneTimeStatus,
+  summarizeRunsForUsage,
   SYSTEM_TASK_URL_IDS,
   systemTaskKindFromUrlId,
 } = await import("@/domains/settings/utils/schedule-formatters");
@@ -438,6 +439,91 @@ describe("RecentRunsCard", () => {
     expect(document.body.textContent).toContain("local output");
     expect(document.body.textContent).not.toContain("Run details");
     expect(document.body.textContent).not.toContain("Back to runs");
+  });
+
+  test("skipped runs show the skip reason inline instead of duration and cost", () => {
+    render(
+      createElement(RecentRunsCard, {
+        runs: [
+          run({
+            id: "run-skipped",
+            conversationId: null,
+            status: "skipped",
+            startedAt: 1_761_792_000_000,
+            durationMs: null,
+            estimatedCostUsd: 0,
+            output: "Skipped — outside active hours",
+          }),
+        ],
+        isLoading: false,
+      }),
+    );
+
+    expect(document.body.textContent).toContain(
+      "Skipped — outside active hours",
+    );
+    expect(document.body.textContent).not.toContain("$0.00");
+    // The reason is already inline — no expandable details affordance, so
+    // the row renders non-interactive.
+    expect(document.querySelector('[role="button"]')).toBeNull();
+  });
+
+  test("missed runs without stored output fall back to a Missed label", () => {
+    render(
+      createElement(RecentRunsCard, {
+        runs: [
+          run({
+            id: "run-missed",
+            conversationId: null,
+            status: "missed",
+            startedAt: 1_761_792_000_000,
+            durationMs: null,
+            estimatedCostUsd: 0,
+            output: null,
+          }),
+        ],
+        isLoading: false,
+      }),
+    );
+
+    expect(document.body.textContent).toContain("Missed");
+    expect(document.body.textContent).not.toContain("$0.00");
+  });
+});
+
+describe("summarizeRunsForUsage", () => {
+  test("counts only executed runs, not skipped/missed/bookkeeping rows", () => {
+    const runs = [
+      run({ id: "r-ok", status: "ok", startedAt: 1_000, estimatedCostUsd: 0.1 }),
+      run({
+        id: "r-error",
+        status: "error",
+        startedAt: 1_100,
+        estimatedCostUsd: 0.05,
+      }),
+      run({ id: "r-skip", status: "skipped", startedAt: 1_200, estimatedCostUsd: 0 }),
+      run({ id: "r-miss", status: "missed", startedAt: 1_300, estimatedCostUsd: 0 }),
+      run({
+        id: "r-pending",
+        status: "pending",
+        startedAt: 1_400,
+        estimatedCostUsd: 0,
+      }),
+      run({
+        id: "r-superseded",
+        status: "superseded",
+        startedAt: 1_500,
+        estimatedCostUsd: 0,
+      }),
+    ];
+
+    const summary = summarizeRunsForUsage("system-heartbeat", runs, {
+      from: 0,
+      to: 2_000,
+    });
+
+    expect(summary.runCount).toBe(2);
+    expect(summary.totalEstimatedCostUsd).toBeCloseTo(0.15);
   });
 });
 

--- a/clients/web/src/domains/settings/components/schedule-components.test.ts
+++ b/clients/web/src/domains/settings/components/schedule-components.test.ts
@@ -489,6 +489,25 @@ describe("RecentRunsCard", () => {
     expect(document.body.textContent).toContain("Missed");
     expect(document.body.textContent).not.toContain("$0.00");
   });
+
+  test("empty page with more history keeps the Load more control reachable", () => {
+    const onLoadMore = mock(() => {});
+    render(
+      createElement(RecentRunsCard, {
+        // A page can filter down to nothing (bookkeeping-only rows from an
+        // older daemon) while real runs sit on older pages.
+        runs: [],
+        isLoading: false,
+        hasMore: true,
+        onLoadMore,
+      }),
+    );
+
+    expect(document.body.textContent).toContain("No runs yet.");
+    const loadMore = screen.getByRole("button", { name: "Load more" });
+    fireEvent.click(loadMore);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("summarizeRunsForUsage", () => {

--- a/clients/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/clients/web/src/domains/settings/utils/schedule-formatters.ts
@@ -134,6 +134,27 @@ export function hasRunText(value: string | null | undefined): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
+/**
+ * Scheduler bookkeeping rows: the not-yet-fired `pending` row for the next
+ * scheduled run, and `superseded` rows a timer reset leaves behind when it
+ * replaces that pending row. They describe scheduling state, not runs — a
+ * heartbeat daemon excludes them from run history, but daemons predating
+ * that exclusion still send them, so run lists filter them here as well.
+ */
+export function isBookkeepingRun(run: Pick<ScheduleRun, "status">): boolean {
+  return run.status === "pending" || run.status === "superseded";
+}
+
+/**
+ * Whether the run actually executed, as opposed to being skipped by a guard,
+ * missed while the daemon was down, or a bookkeeping row.
+ */
+export function isExecutedRun(run: Pick<ScheduleRun, "status">): boolean {
+  return (
+    run.status !== "skipped" && run.status !== "missed" && !isBookkeepingRun(run)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // System task helpers
 // ---------------------------------------------------------------------------
@@ -336,9 +357,11 @@ export function summarizeRunsForUsage(
   runs: ScheduleRun[] | undefined,
   range: { from: number; to: number },
 ): ScheduleUsageSummary {
+  // Only executed runs count — skipped/missed/bookkeeping rows would inflate
+  // the run count without representing anything that ran or cost money.
   const runsInRange = (runs ?? []).filter((run) => {
     const startedAt = run.startedAt ?? run.createdAt;
-    return startedAt >= range.from && startedAt <= range.to;
+    return isExecutedRun(run) && startedAt >= range.from && startedAt <= range.to;
   });
 
   return {

--- a/clients/web/src/domains/settings/utils/system-task-run-transforms.test.ts
+++ b/clients/web/src/domains/settings/utils/system-task-run-transforms.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  selectHeartbeatRuns,
+  toScheduleRun,
+  type AnySystemTaskRun,
+} from "@/domains/settings/utils/system-task-run-transforms";
+
+import type { HeartbeatRunsGetResponse } from "@/generated/daemon/types.gen";
+
+type HeartbeatRun = HeartbeatRunsGetResponse["runs"][number];
+
+function heartbeatRun(overrides: Partial<HeartbeatRun> = {}): HeartbeatRun {
+  return {
+    id: "run-1",
+    scheduledFor: 1_000,
+    startedAt: 1_000,
+    finishedAt: 2_000,
+    durationMs: 1_000,
+    status: "ok",
+    skipReason: null,
+    error: null,
+    conversationId: null,
+    conversationExists: false,
+    conversationArchivedAt: null,
+    estimatedCostUsd: 0,
+    createdAt: 1_000,
+    ...overrides,
+  };
+}
+
+describe("toScheduleRun", () => {
+  test("skipped runs carry a human-readable skip reason", () => {
+    const mapped = toScheduleRun(
+      heartbeatRun({
+        status: "skipped",
+        skipReason: "outside_active_hours",
+        startedAt: null,
+        finishedAt: null,
+        durationMs: null,
+      }),
+      "heartbeat",
+    );
+
+    expect(mapped.output).toBe("Skipped — outside active hours");
+  });
+
+  test("unknown skip reasons fall back to the raw code", () => {
+    const mapped = toScheduleRun(
+      heartbeatRun({ status: "skipped", skipReason: "future_reason" }),
+      "heartbeat",
+    );
+
+    expect(mapped.output).toBe("Skipped — future_reason");
+  });
+
+  test("missed runs explain the gap", () => {
+    const mapped = toScheduleRun(
+      heartbeatRun({
+        status: "missed",
+        startedAt: null,
+        finishedAt: null,
+        durationMs: null,
+      }),
+      "heartbeat",
+    );
+
+    expect(mapped.output).toBe("Missed while the assistant was offline");
+  });
+
+  test("executed runs have no unexecuted-run text", () => {
+    const mapped = toScheduleRun(
+      heartbeatRun({ status: "ok" }) as AnySystemTaskRun,
+      "heartbeat",
+    );
+
+    expect(mapped.output).toBeNull();
+  });
+});
+
+describe("selectHeartbeatRuns", () => {
+  test("hides bookkeeping rows (pending, superseded) sent by older daemons", () => {
+    const response: HeartbeatRunsGetResponse = {
+      nextCursor: null,
+      runs: [
+        heartbeatRun({
+          id: "next-scheduled",
+          status: "pending",
+          scheduledFor: 10_000,
+          startedAt: null,
+          finishedAt: null,
+        }),
+        heartbeatRun({
+          id: "timer-reset",
+          status: "superseded",
+          scheduledFor: 9_000,
+          startedAt: null,
+          finishedAt: null,
+        }),
+        heartbeatRun({ id: "real-run", status: "ok" }),
+        heartbeatRun({
+          id: "skipped-run",
+          status: "skipped",
+          skipReason: "max_consecutive_runs",
+        }),
+      ],
+    };
+
+    expect(selectHeartbeatRuns(response).map((r) => r.id)).toEqual([
+      "real-run",
+      "skipped-run",
+    ]);
+  });
+});

--- a/clients/web/src/domains/settings/utils/system-task-run-transforms.ts
+++ b/clients/web/src/domains/settings/utils/system-task-run-transforms.ts
@@ -4,6 +4,8 @@ import type {
   RetrospectiveRunsGetResponse,
 } from "@/generated/daemon/types.gen";
 
+import { isBookkeepingRun } from "@/domains/settings/utils/schedule-formatters";
+
 import type {
   ScheduleRun,
   SystemTaskKind,
@@ -15,6 +17,32 @@ type RetrospectiveRun = RetrospectiveRunsGetResponse["runs"][number];
 
 /** Union of all raw system-task run types from the daemon SDK. */
 export type AnySystemTaskRun = HeartbeatRun | ConsolidationRun | RetrospectiveRun;
+
+/** Human-readable labels for heartbeat `skip_reason` codes. */
+const SKIP_REASON_LABELS: Record<string, string> = {
+  disabled: "heartbeat is disabled",
+  outside_active_hours: "outside active hours",
+  overlap: "previous run was still active",
+  pre_first_user_message: "waiting for the first conversation",
+  max_consecutive_runs: "consecutive-run cap reached",
+  max_daily_runs: "daily run cap reached",
+  quiesced: "assistant was shutting down",
+};
+
+/**
+ * Detail text for runs that never executed: skipped runs surface why the
+ * guard skipped them, missed runs explain the gap. Executed runs return null
+ * — their detail line is duration and cost.
+ */
+function unexecutedRunText(run: AnySystemTaskRun): string | null {
+  if (run.status === "missed") {
+    return "Missed while the assistant was offline";
+  }
+  if ("skipReason" in run && run.skipReason) {
+    return `Skipped — ${SKIP_REASON_LABELS[run.skipReason] ?? run.skipReason}`;
+  }
+  return null;
+}
 
 /**
  * Maps a raw system-task run from the daemon SDK into the shared
@@ -51,10 +79,7 @@ export function toScheduleRun(
     startedAt: run.startedAt ?? run.scheduledFor,
     finishedAt: run.finishedAt,
     durationMs: run.durationMs,
-    output:
-      "skipReason" in run && run.skipReason
-        ? `Skipped: ${run.skipReason}`
-        : null,
+    output: unexecutedRunText(run),
     error: run.error,
     conversationId: run.conversationId,
     conversationExists: run.conversationExists,
@@ -69,7 +94,9 @@ export function toScheduleRun(
 export function selectHeartbeatRuns(
   data: HeartbeatRunsGetResponse,
 ): ScheduleRun[] {
-  return data.runs.map((r) => toScheduleRun(r, "heartbeat"));
+  return data.runs
+    .filter((r) => !isBookkeepingRun(r))
+    .map((r) => toScheduleRun(r, "heartbeat"));
 }
 
 /** Select transform: extracts `ScheduleRun[]` from a consolidation runs response. */


### PR DESCRIPTION
## Prompt / plan

Fixes [LUM-2840](https://linear.app/vellum/issue/LUM-2840/schedules-page-renders-superseded-heartbeat-rows-as-dollar000-runs) — the Schedules page made a healthy heartbeat look like a crash loop.

## Why this is needed

Every guardian message resets the heartbeat timer. The reset supersedes the pending `heartbeat_runs` row and inserts a new one for now+interval, so an active chat day produces ~90 `superseded` bookkeeping rows (93 on Jul 27 in the reported case). `/v1/heartbeat/runs` returned every row, so the panel rendered them as a rapid-fire list of `— · $0.00` "runs" with future (`scheduled_for`) timestamps — on a heartbeat configured to run hourly. At the same time, "Last run" showed "—" after any daemon restart because `HeartbeatService._lastRunAt` lives only in memory.

Net effect: a perfectly healthy heartbeat read as "firing every minute, dying instantly, never completing." It already triggered one wasted debugging session that ended in "working as designed"; anyone monitoring their assistant's background health through this page would draw the same wrong conclusion.

## What changes for the user

| Panel element | Before | After |
|---|---|---|
| Recent runs list | Dozens of `— · $0.00` entries, 1–2 min apart, with future timestamps (superseded timer resets + the pending next run) | Only actual history: executed runs with real duration and cost, skipped runs, missed runs |
| Skipped runs | `— · $0.00`, reason hidden behind an expand chevron as `Skipped: max_consecutive_runs` | Inline reason: "Skipped — consecutive-run cap reached", "Skipped — outside active hours", etc. |
| Missed runs | `— · $0.00` | "Missed while the assistant was offline" |
| Last run | "—" after every daemon restart, even with completed runs in the DB | Timestamp of the most recent completed run, surviving restarts |
| List-row usage ("N runs · $X") | Run count inflated by bookkeeping and skip rows (the "93 runs · $0.00" crash-loop look) | Counts executed runs only, matching the cost figure |
| Next run | Unchanged — still shown from config | Unchanged |

A user can now tell "healthy but idle" (skips explain why it didn't fire) apart from "broken" (error rows with messages).

## Why this is safe

- **No schema or data changes.** Rows are still written exactly as before — `pending`/`superseded` bookkeeping stays in the table (it feeds startup recovery and the consecutive-run counter); it's only excluded from the run-history read path. Nothing is deleted, so this is trivially revertible.
- **The API shape is unchanged.** Same response schema, same pagination contract; the filter is applied in SQL before the `limit + 1` fetch, so cursors stay correct. No OpenAPI regeneration needed.
- **Consumer audit:** `listHeartbeatRuns` has exactly one caller (the runs route), and `HeartbeatService.lastRunAt` is read only by the heartbeat config routes. The other run-store readers (startup recovery sweeps, `listRunningHeartbeatRuns` used by CLI drain, consecutive/daily-run counters) are untouched.
- **`lastRunAt` rehydration is read-only, lazy, and fault-tolerant**: it runs on first read (route handlers are already DB-readiness gated), memoizes, returns null if the DB isn't available, and is immediately overwritten by real in-process runs. Semantics match the in-memory field (last executed run: `ok`/`error`/`timeout`).
- **Version skew is handled both ways.** New web + old daemon: the client filters bookkeeping rows itself and derives "Last run" from the loaded history. Old web + new daemon: it simply receives a cleaner list.
- **Blast radius on shared UI is nil**: `RecentRunsCard` is rendered only by the system-task detail panel, and user-schedule runs never carry `skipped`/`missed` statuses, so their rendering is unchanged.

## Test plan

- `assistant`: `bun test src/heartbeat/__tests__/heartbeat-run-store.test.ts` (20 pass — bookkeeping exclusion incl. the pagination-cursor path; `getLastHeartbeatRunAt` newest/fallback/null cases), `bun test src/heartbeat/__tests__/heartbeat-service.test.ts` (17 pass — `lastRunAt` rehydration + in-process takeover), `bun test src/__tests__/schedule-routes.test.ts` (51 pass — route-level regression: superseded/pending rows never reach the response), plus `src/__tests__/heartbeat-service.test.ts` and `heartbeat-disk-pressure.test.ts`.
- `clients/web`: `bun test src/domains/settings/utils/system-task-run-transforms.test.ts src/domains/settings/components/schedule-components.test.ts` (29 pass — skip-reason labels, client-side bookkeeping filter, executed-only usage counting, skipped/missed row rendering).
- Type checks pass in both packages (`tsgo`/`tsc --noEmit`); pre-commit hook ran format, lint, and openapi regeneration checks clean.

## CLI verb checklist

No new routes added — the existing `listHeartbeatRuns` route changed behavior only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tnsFqADjMWd3wHfFsvn1M