### PR TITLE
feat(discord): gateway intents and the message admission gate

### DIFF
--- a/gateway/src/discord/admit.test.ts
+++ b/gateway/src/discord/admit.test.ts
@@ -89,11 +89,14 @@ describe("admitDiscordMessage", () => {
     expect(verdict).toEqual({ admitted: false, reason: "bot_not_mentioned" });
   });
 
-  test("does not treat @everyone as a mention of the bot", () => {
+  test("does not admit an @everyone announcement", () => {
     // The highest-cost false admit: every announcement in an allow-listed
-    // channel would reach the assistant.
+    // channel would reach the assistant. Discord omits `@everyone` / `@here`
+    // and role pings from the mentions array — it reports them on separate
+    // fields — so an announcement arrives shaped exactly like this, with the
+    // bot absent from `mentionedUserIds`, and the mention check drops it.
     const verdict = admitDiscordMessage(
-      candidate({ mentionedUserIds: [], mentionsEveryone: true }),
+      candidate({ mentionedUserIds: [] }),
       policy,
     );
     expect(verdict).toEqual({ admitted: false, reason: "bot_not_mentioned" });

--- a/gateway/src/discord/admit.test.ts
+++ b/gateway/src/discord/admit.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  admitDiscordMessage,
+  parseAllowedChannelIds,
+  type AdmissionCandidate,
+  type AdmissionPolicy,
+} from "./admit.js";
+import "../__tests__/test-preload.js";
+
+const BOT = "900000000000000001";
+const HUMAN = "900000000000000002";
+const ALLOWED_CHANNEL = "800000000000000001";
+const OTHER_CHANNEL = "800000000000000002";
+const GUILD = "700000000000000001";
+
+const policy: AdmissionPolicy = {
+  botUserId: BOT,
+  allowedChannelIds: new Set([ALLOWED_CHANNEL]),
+};
+
+/** A message that would be admitted; individual tests spoil one field. */
+function candidate(over: Partial<AdmissionCandidate> = {}): AdmissionCandidate {
+  return {
+    channelId: ALLOWED_CHANNEL,
+    guildId: GUILD,
+    authorId: HUMAN,
+    mentionedUserIds: [BOT],
+    ...over,
+  };
+}
+
+describe("admitDiscordMessage", () => {
+  test("admits a direct mention from a human in an allow-listed channel", () => {
+    expect(admitDiscordMessage(candidate(), policy)).toEqual({
+      admitted: true,
+    });
+  });
+
+  test("drops the bot's own messages before anything else", () => {
+    // Self-authored messages arrive back over the same socket; forwarding one
+    // is how a reply loop starts.
+    const verdict = admitDiscordMessage(
+      candidate({ authorId: BOT, mentionedUserIds: [BOT] }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "self_authored" });
+  });
+
+  test("drops other bots and webhooks", () => {
+    const verdict = admitDiscordMessage(
+      candidate({ authorIsBot: true }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "bot_authored" });
+  });
+
+  test("drops DMs — they match no entry on a guild-channel allow-list", () => {
+    const verdict = admitDiscordMessage(
+      candidate({ guildId: undefined }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "not_a_guild_message" });
+  });
+
+  test("drops a mention in a channel that is not allow-listed", () => {
+    const verdict = admitDiscordMessage(
+      candidate({ channelId: OTHER_CHANNEL }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "channel_not_allowed" });
+  });
+
+  test("drops an un-mentioned message in an allow-listed channel", () => {
+    // The ordinary case in a busy community channel, and the one that decides
+    // whether the assistant processes a firehose or a handful of requests.
+    const verdict = admitDiscordMessage(
+      candidate({ mentionedUserIds: [] }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "bot_not_mentioned" });
+  });
+
+  test("drops a message with no mentions field at all", () => {
+    const verdict = admitDiscordMessage(
+      candidate({ mentionedUserIds: undefined }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "bot_not_mentioned" });
+  });
+
+  test("does not treat @everyone as a mention of the bot", () => {
+    // The highest-cost false admit: every announcement in an allow-listed
+    // channel would reach the assistant.
+    const verdict = admitDiscordMessage(
+      candidate({ mentionedUserIds: [], mentionsEveryone: true }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "bot_not_mentioned" });
+  });
+
+  test("does not treat a mention of someone else as a mention of the bot", () => {
+    const verdict = admitDiscordMessage(
+      candidate({ mentionedUserIds: ["900000000000000003"] }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "bot_not_mentioned" });
+  });
+
+  test("an empty allow-list admits nothing", () => {
+    // Fail-closed: being invited to a guild is not consent to every channel
+    // in it, so an unconfigured list must not read as "all channels".
+    const verdict = admitDiscordMessage(candidate(), {
+      botUserId: BOT,
+      allowedChannelIds: new Set(),
+    });
+    expect(verdict).toEqual({ admitted: false, reason: "channel_not_allowed" });
+  });
+});
+
+describe("parseAllowedChannelIds", () => {
+  test("parses a comma-separated list, trimming entries", () => {
+    expect(
+      parseAllowedChannelIds(` ${ALLOWED_CHANNEL} , ${OTHER_CHANNEL} `),
+    ).toEqual(new Set([ALLOWED_CHANNEL, OTHER_CHANNEL]));
+  });
+
+  test("yields an empty set for undefined, blank, and comma-only values", () => {
+    expect(parseAllowedChannelIds(undefined)).toEqual(new Set());
+    expect(parseAllowedChannelIds("")).toEqual(new Set());
+    expect(parseAllowedChannelIds("   ")).toEqual(new Set());
+    expect(parseAllowedChannelIds(",,")).toEqual(new Set());
+  });
+
+  test("drops blanks rather than admitting an empty-string channel", () => {
+    expect(parseAllowedChannelIds(`${ALLOWED_CHANNEL},,`)).toEqual(
+      new Set([ALLOWED_CHANNEL]),
+    );
+  });
+});

--- a/gateway/src/discord/admit.test.ts
+++ b/gateway/src/discord/admit.test.ts
@@ -107,6 +107,53 @@ describe("admitDiscordMessage", () => {
     expect(verdict).toEqual({ admitted: false, reason: "bot_not_mentioned" });
   });
 
+  test("admits a thread whose parent channel is allow-listed", () => {
+    // Discord keys thread messages on the thread's own id, so an allow-list of
+    // channels matches none of them. Without parent resolution the assistant
+    // goes silent the moment a conversation moves into a thread — a denial
+    // nobody would see, because the symptom is nothing happening.
+    const verdict = admitDiscordMessage(
+      candidate({
+        channelId: "800000000000000099",
+        parentChannelId: ALLOWED_CHANNEL,
+      }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: true });
+  });
+
+  test("drops a thread whose parent is not allow-listed", () => {
+    const verdict = admitDiscordMessage(
+      candidate({
+        channelId: "800000000000000099",
+        parentChannelId: OTHER_CHANNEL,
+      }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "channel_not_allowed" });
+  });
+
+  test("admits a thread listed directly by its own id", () => {
+    const verdict = admitDiscordMessage(
+      candidate({ channelId: ALLOWED_CHANNEL, parentChannelId: OTHER_CHANNEL }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: true });
+  });
+
+  test("a thread still has to clear every other check", () => {
+    // Parent inheritance widens which rooms count, not which messages do.
+    const verdict = admitDiscordMessage(
+      candidate({
+        channelId: "800000000000000099",
+        parentChannelId: ALLOWED_CHANNEL,
+        mentionedUserIds: [],
+      }),
+      policy,
+    );
+    expect(verdict).toEqual({ admitted: false, reason: "bot_not_mentioned" });
+  });
+
   test("an empty allow-list admits nothing", () => {
     // Fail-closed: being invited to a guild is not consent to every channel
     // in it, so an unconfigured list must not read as "all channels".

--- a/gateway/src/discord/admit.ts
+++ b/gateway/src/discord/admit.ts
@@ -17,8 +17,22 @@
 
 /** The fields of a Discord message this gate reads. */
 export interface AdmissionCandidate {
-  /** Snowflake of the channel the message was posted in. */
+  /**
+   * Snowflake of the channel the message was posted in. For a message in a
+   * thread this is the *thread's* id, not the channel the thread hangs off.
+   */
   channelId: string;
+  /**
+   * Snowflake of the parent channel when {@link channelId} is a thread.
+   *
+   * Discord delivers thread messages as ordinary `MESSAGE_CREATE` events keyed
+   * on the thread, and the bot is auto-subscribed to every visible active
+   * thread without joining. An allow-list of channels would therefore deny all
+   * thread traffic, which is the same as the assistant going silent the moment
+   * a conversation moves into a thread. Resolving parentage is the caller's
+   * job — it holds the channel cache — and this gate accepts the result.
+   */
+  parentChannelId?: string;
   /** Snowflake of the guild, absent for DMs. */
   guildId?: string;
   /** Snowflake of the message author. */
@@ -81,7 +95,15 @@ export function admitDiscordMessage(
   // An unset allow-list admits nothing. The operator opting the bot into a
   // guild is not the same as opting it into every channel in that guild, and
   // the failure that matters is the one where an empty list means "all".
-  if (!policy.allowedChannelIds.has(candidate.channelId)) {
+  //
+  // A thread inherits its parent's listing: listing a channel opts in the
+  // conversations that branch off it, which is where a thread comes from. A
+  // thread id may also be listed directly, and matches on the first check.
+  const channelAllowed =
+    policy.allowedChannelIds.has(candidate.channelId) ||
+    (candidate.parentChannelId !== undefined &&
+      policy.allowedChannelIds.has(candidate.parentChannelId));
+  if (!channelAllowed) {
     return drop("channel_not_allowed");
   }
 

--- a/gateway/src/discord/admit.ts
+++ b/gateway/src/discord/admit.ts
@@ -1,0 +1,112 @@
+/**
+ * Admission gate for inbound Discord messages.
+ *
+ * A bot invited to a community guild sees every message in every channel it
+ * can view. This gate decides which of those the gateway acts on, and it is
+ * the only thing standing between the assistant and a busy public server, so
+ * it is deliberately conservative: a message is dropped unless it is a direct
+ * mention of the bot in a channel the operator listed.
+ *
+ * This is admission of *rooms and intent* — distinct from, and evaluated
+ * before, the trust-class admission floor that governs *actors* once an event
+ * reaches the runtime.
+ *
+ * The input is a structural shape rather than a parsed-payload type so the
+ * gate stays a pure function over the few fields it reads.
+ */
+
+/** The fields of a Discord message this gate reads. */
+export interface AdmissionCandidate {
+  /** Snowflake of the channel the message was posted in. */
+  channelId: string;
+  /** Snowflake of the guild, absent for DMs. */
+  guildId?: string;
+  /** Snowflake of the message author. */
+  authorId: string;
+  /** Whether the author is itself a bot or webhook. */
+  authorIsBot?: boolean;
+  /** Snowflakes of users directly mentioned in the message. */
+  mentionedUserIds?: readonly string[];
+  /** Whether the message carried `@everyone` / `@here`. */
+  mentionsEveryone?: boolean;
+}
+
+export type AdmissionDropReason =
+  | "self_authored"
+  | "bot_authored"
+  | "not_a_guild_message"
+  | "channel_not_allowed"
+  | "bot_not_mentioned";
+
+export type AdmissionVerdict =
+  | { admitted: true }
+  | { admitted: false; reason: AdmissionDropReason };
+
+export interface AdmissionPolicy {
+  /** The bot's own user snowflake, used for self-filtering and mention matching. */
+  botUserId: string;
+  /** Channel snowflakes the bot may act in. Empty admits nothing. */
+  allowedChannelIds: ReadonlySet<string>;
+}
+
+const ADMITTED: AdmissionVerdict = { admitted: true };
+
+function drop(reason: AdmissionDropReason): AdmissionVerdict {
+  return { admitted: false, reason };
+}
+
+/**
+ * Decide whether a message is one the gateway acts on.
+ *
+ * Checks run cheapest-and-most-decisive first, and every one of them is a
+ * denial — there is no branch that admits a message the operator did not ask
+ * for.
+ */
+export function admitDiscordMessage(
+  candidate: AdmissionCandidate,
+  policy: AdmissionPolicy,
+): AdmissionVerdict {
+  // The bot's own messages come back over the same socket. Processing them is
+  // how a reply loop starts.
+  if (candidate.authorId === policy.botUserId) return drop("self_authored");
+
+  // Other bots and webhooks are dropped outright. Two assistants in one
+  // channel that each answer the other is the same loop with more steps.
+  if (candidate.authorIsBot) return drop("bot_authored");
+
+  // Admission is expressed as a list of guild channels, so a DM matches no
+  // entry on it. Admitting DMs is a separate policy decision, not a gap here.
+  if (!candidate.guildId) return drop("not_a_guild_message");
+
+  // An unset allow-list admits nothing. The operator opting the bot into a
+  // guild is not the same as opting it into every channel in that guild, and
+  // the failure that matters is the one where an empty list means "all".
+  if (!policy.allowedChannelIds.has(candidate.channelId)) {
+    return drop("channel_not_allowed");
+  }
+
+  // `@everyone` and `@here` are not mentions of this bot. Discord keeps them
+  // out of the mentions array and reports them on a separate flag precisely
+  // because they address the room, not a user — honouring them would opt the
+  // assistant into every announcement in an allow-listed channel.
+  if (!candidate.mentionedUserIds?.includes(policy.botUserId)) {
+    return drop("bot_not_mentioned");
+  }
+
+  return ADMITTED;
+}
+
+/**
+ * Parse an allow-list from its stored form — a comma-separated list of channel
+ * snowflakes. Blank entries are dropped, so a trailing comma or an empty
+ * setting yields an empty set, which admits nothing.
+ */
+export function parseAllowedChannelIds(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0),
+  );
+}

--- a/gateway/src/discord/admit.ts
+++ b/gateway/src/discord/admit.ts
@@ -39,10 +39,14 @@ export interface AdmissionCandidate {
   authorId: string;
   /** Whether the author is itself a bot or webhook. */
   authorIsBot?: boolean;
-  /** Snowflakes of users directly mentioned in the message. */
+  /**
+   * Snowflakes of users directly mentioned in the message.
+   *
+   * Discord omits `@everyone` / `@here` and role pings from this array — they
+   * are reported on separate fields — so a message that addresses the room
+   * never looks like a message that addresses the bot.
+   */
   mentionedUserIds?: readonly string[];
-  /** Whether the message carried `@everyone` / `@here`. */
-  mentionsEveryone?: boolean;
 }
 
 export type AdmissionDropReason =
@@ -82,15 +86,21 @@ export function admitDiscordMessage(
 ): AdmissionVerdict {
   // The bot's own messages come back over the same socket. Processing them is
   // how a reply loop starts.
-  if (candidate.authorId === policy.botUserId) return drop("self_authored");
+  if (candidate.authorId === policy.botUserId) {
+    return drop("self_authored");
+  }
 
   // Other bots and webhooks are dropped outright. Two assistants in one
   // channel that each answer the other is the same loop with more steps.
-  if (candidate.authorIsBot) return drop("bot_authored");
+  if (candidate.authorIsBot) {
+    return drop("bot_authored");
+  }
 
   // Admission is expressed as a list of guild channels, so a DM matches no
   // entry on it. Admitting DMs is a separate policy decision, not a gap here.
-  if (!candidate.guildId) return drop("not_a_guild_message");
+  if (!candidate.guildId) {
+    return drop("not_a_guild_message");
+  }
 
   // An unset allow-list admits nothing. The operator opting the bot into a
   // guild is not the same as opting it into every channel in that guild, and
@@ -107,10 +117,9 @@ export function admitDiscordMessage(
     return drop("channel_not_allowed");
   }
 
-  // `@everyone` and `@here` are not mentions of this bot. Discord keeps them
-  // out of the mentions array and reports them on a separate flag precisely
-  // because they address the room, not a user — honouring them would opt the
-  // assistant into every announcement in an allow-listed channel.
+  // Requiring the bot's own id here is what keeps announcements out: Discord
+  // omits `@everyone` / `@here` and role pings from the mentions array, so
+  // they cannot satisfy this check.
   if (!candidate.mentionedUserIds?.includes(policy.botUserId)) {
     return drop("bot_not_mentioned");
   }
@@ -124,7 +133,9 @@ export function admitDiscordMessage(
  * setting yields an empty set, which admits nothing.
  */
 export function parseAllowedChannelIds(raw: string | undefined): Set<string> {
-  if (!raw) return new Set();
+  if (!raw) {
+    return new Set();
+  }
   return new Set(
     raw
       .split(",")

--- a/gateway/src/discord/intents.test.ts
+++ b/gateway/src/discord/intents.test.ts
@@ -13,6 +13,7 @@ describe("DISCORD_INTENTS", () => {
     // these are pinned against the published values rather than recomputed.
     expect(DISCORD_INTENTS.GUILDS).toBe(1);
     expect(DISCORD_INTENTS.GUILD_MEMBERS).toBe(2);
+    expect(DISCORD_INTENTS.GUILD_PRESENCES).toBe(256);
     expect(DISCORD_INTENTS.GUILD_MESSAGES).toBe(512);
     expect(DISCORD_INTENTS.DIRECT_MESSAGES).toBe(4096);
     expect(DISCORD_INTENTS.MESSAGE_CONTENT).toBe(32768);
@@ -20,6 +21,18 @@ describe("DISCORD_INTENTS", () => {
 });
 
 describe("DISCORD_GATEWAY_INTENTS", () => {
+  test("PRIVILEGED_DISCORD_INTENTS lists every intent Discord gates", () => {
+    // The guard below is only as good as this list. Discord gates three:
+    // omitting one leaves a privileged intent the invariant cannot see, which
+    // is a safeguard that reports success while covering two thirds of the
+    // surface.
+    expect([...PRIVILEGED_DISCORD_INTENTS].sort((a, b) => a - b)).toEqual([
+      DISCORD_INTENTS.GUILD_MEMBERS,
+      DISCORD_INTENTS.GUILD_PRESENCES,
+      DISCORD_INTENTS.MESSAGE_CONTENT,
+    ]);
+  });
+
   test("requests no privileged intent", () => {
     // The load-bearing assertion. Mention-gating puts every message this
     // client acts on inside Discord's content exemption, so the privileged

--- a/gateway/src/discord/intents.test.ts
+++ b/gateway/src/discord/intents.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DISCORD_GATEWAY_INTENTS,
+  DISCORD_INTENTS,
+  PRIVILEGED_DISCORD_INTENTS,
+} from "./intents.js";
+import "../__tests__/test-preload.js";
+
+describe("DISCORD_INTENTS", () => {
+  test("bit positions match Discord's documented shifts", () => {
+    // Wrong by one bit is a silent subscription to the wrong event family, so
+    // these are pinned against the published values rather than recomputed.
+    expect(DISCORD_INTENTS.GUILDS).toBe(1);
+    expect(DISCORD_INTENTS.GUILD_MEMBERS).toBe(2);
+    expect(DISCORD_INTENTS.GUILD_MESSAGES).toBe(512);
+    expect(DISCORD_INTENTS.DIRECT_MESSAGES).toBe(4096);
+    expect(DISCORD_INTENTS.MESSAGE_CONTENT).toBe(32768);
+  });
+});
+
+describe("DISCORD_GATEWAY_INTENTS", () => {
+  test("requests no privileged intent", () => {
+    // The load-bearing assertion. Mention-gating puts every message this
+    // client acts on inside Discord's content exemption, so the privileged
+    // MESSAGE_CONTENT intent buys nothing while subjecting the app to portal
+    // approval and annual reapplication. Widening the bitmask to a privileged
+    // intent is a product decision with an external approval dependency — it
+    // should fail here first rather than be discovered at IDENTIFY.
+    for (const privileged of PRIVILEGED_DISCORD_INTENTS) {
+      expect(DISCORD_GATEWAY_INTENTS & privileged).toBe(0);
+    }
+  });
+
+  test("subscribes to guild lifecycle and guild messages", () => {
+    expect(DISCORD_GATEWAY_INTENTS & DISCORD_INTENTS.GUILDS).not.toBe(0);
+    expect(DISCORD_GATEWAY_INTENTS & DISCORD_INTENTS.GUILD_MESSAGES).not.toBe(
+      0,
+    );
+  });
+
+  test("omits direct messages — admission is scoped to guild channels", () => {
+    expect(DISCORD_GATEWAY_INTENTS & DISCORD_INTENTS.DIRECT_MESSAGES).toBe(0);
+  });
+});

--- a/gateway/src/discord/intents.ts
+++ b/gateway/src/discord/intents.ts
@@ -2,11 +2,12 @@
  * Discord Gateway intents — the bitmask sent in the IDENTIFY payload.
  *
  * An intent is a subscription: Discord only delivers event families whose
- * intent bit is set. Two of them are *privileged* — they require a toggle in
- * the developer portal, and past a size threshold Discord must approve the
- * app before the toggle stays on.
+ * intent bit is set. Three of them are *privileged* — they require a toggle in
+ * the developer portal, and past a size threshold Discord must approve the app
+ * before the toggle stays on. {@link PRIVILEGED_DISCORD_INTENTS} is that set,
+ * and a test pins it against this table so the two cannot drift.
  *
- * https://discord.com/developers/docs/events/gateway#gateway-intents
+ * https://docs.discord.com/developers/events/gateway#gateway-intents
  */
 
 export const DISCORD_INTENTS = {

--- a/gateway/src/discord/intents.ts
+++ b/gateway/src/discord/intents.ts
@@ -1,0 +1,60 @@
+/**
+ * Discord Gateway intents — the bitmask sent in the IDENTIFY payload.
+ *
+ * An intent is a subscription: Discord only delivers event families whose
+ * intent bit is set. Two of them are *privileged* — they require a toggle in
+ * the developer portal, and past a size threshold Discord must approve the
+ * app before the toggle stays on.
+ *
+ * https://discord.com/developers/docs/events/gateway#gateway-intents
+ */
+
+export const DISCORD_INTENTS = {
+  /** Guild lifecycle + the guild/channel list in READY. */
+  GUILDS: 1 << 0,
+  /** PRIVILEGED. `GUILD_MEMBER_*` events. */
+  GUILD_MEMBERS: 1 << 1,
+  /** `MESSAGE_CREATE` / `MESSAGE_UPDATE` / `MESSAGE_DELETE` in guild channels. */
+  GUILD_MESSAGES: 1 << 9,
+  /** The same message events, in DM channels. */
+  DIRECT_MESSAGES: 1 << 12,
+  /** PRIVILEGED. Populates `content` / `embeds` / `attachments` / `components`. */
+  MESSAGE_CONTENT: 1 << 15,
+} as const;
+
+export type DiscordIntentName = keyof typeof DISCORD_INTENTS;
+
+/**
+ * Intents this client identifies with.
+ *
+ * `MESSAGE_CONTENT` is deliberately absent. Without it `MESSAGE_CREATE` still
+ * arrives for every message in a subscribed channel, but `content` is empty —
+ * *except* for messages that mention the bot, messages in DMs, and the bot's
+ * own messages, which Discord exempts from the restriction. This client is
+ * mention-gated (see `admit.ts`), so every message it acts on falls inside the
+ * exemption and carries real content. Requesting the privileged intent would
+ * buy nothing and would put the app under portal approval and the annual
+ * reapplication Discord introduced in June 2026.
+ *
+ * That exemption is also a ceiling, not just a convenience: reading messages
+ * the bot is *not* mentioned in — the broader "monitor the whole community"
+ * shape — cannot be done on this bitmask. It needs `MESSAGE_CONTENT` and the
+ * approval that now comes with it.
+ *
+ * `GUILD_MEMBERS` is absent for the same reason: nothing here reads member
+ * events, and it carries the same privileged cost.
+ *
+ * `DIRECT_MESSAGES` is absent because admission is scoped to an allow-list of
+ * guild channels and a DM belongs to no channel on that list, so admitting DMs
+ * is a separate policy decision rather than a wider bitmask. Adding it later
+ * needs no privileged intent — DMs are inside the content exemption too.
+ */
+export const DISCORD_GATEWAY_INTENTS =
+  DISCORD_INTENTS.GUILDS | DISCORD_INTENTS.GUILD_MESSAGES;
+
+/** Names of the intents in a bitmask, for logging and diagnostics. */
+export function describeIntents(bitmask: number): DiscordIntentName[] {
+  return (Object.keys(DISCORD_INTENTS) as DiscordIntentName[]).filter(
+    (name) => (bitmask & DISCORD_INTENTS[name]) !== 0,
+  );
+}

--- a/gateway/src/discord/intents.ts
+++ b/gateway/src/discord/intents.ts
@@ -14,6 +14,8 @@ export const DISCORD_INTENTS = {
   GUILDS: 1 << 0,
   /** PRIVILEGED. `GUILD_MEMBER_*` events. */
   GUILD_MEMBERS: 1 << 1,
+  /** PRIVILEGED. Presence and status updates. */
+  GUILD_PRESENCES: 1 << 8,
   /** `MESSAGE_CREATE` / `MESSAGE_UPDATE` / `MESSAGE_DELETE` in guild channels. */
   GUILD_MESSAGES: 1 << 9,
   /** The same message events, in DM channels. */
@@ -21,8 +23,6 @@ export const DISCORD_INTENTS = {
   /** PRIVILEGED. Populates `content` / `embeds` / `attachments` / `components`. */
   MESSAGE_CONTENT: 1 << 15,
 } as const;
-
-export type DiscordIntentName = keyof typeof DISCORD_INTENTS;
 
 /**
  * Intents this client identifies with.
@@ -55,5 +55,6 @@ export const DISCORD_GATEWAY_INTENTS =
 /** Intents Discord gates behind a portal toggle and, past a size threshold, approval. */
 export const PRIVILEGED_DISCORD_INTENTS = [
   DISCORD_INTENTS.GUILD_MEMBERS,
+  DISCORD_INTENTS.GUILD_PRESENCES,
   DISCORD_INTENTS.MESSAGE_CONTENT,
 ] as const;

--- a/gateway/src/discord/intents.ts
+++ b/gateway/src/discord/intents.ts
@@ -52,9 +52,8 @@ export type DiscordIntentName = keyof typeof DISCORD_INTENTS;
 export const DISCORD_GATEWAY_INTENTS =
   DISCORD_INTENTS.GUILDS | DISCORD_INTENTS.GUILD_MESSAGES;
 
-/** Names of the intents in a bitmask, for logging and diagnostics. */
-export function describeIntents(bitmask: number): DiscordIntentName[] {
-  return (Object.keys(DISCORD_INTENTS) as DiscordIntentName[]).filter(
-    (name) => (bitmask & DISCORD_INTENTS[name]) !== 0,
-  );
-}
+/** Intents Discord gates behind a portal toggle and, past a size threshold, approval. */
+export const PRIVILEGED_DISCORD_INTENTS = [
+  DISCORD_INTENTS.GUILD_MEMBERS,
+  DISCORD_INTENTS.MESSAGE_CONTENT,
+] as const;


### PR DESCRIPTION
Part of LUM-2841 (Discord gateway client, read-only). **Split out of the original branch** — the connection-recovery half now lives in its own PR (linked below), because the two halves want different reviewers.

This PR answers one question: **should the assistant act on this message?** No connection, no wiring, nothing runs yet. 425 lines, two modules, unit-testable without a bot token.

## The intents finding

**Mention-only v1 needs no privileged intent.** Discord exempts three cases from the `MESSAGE_CONTENT` restriction — messages that mention the bot, DMs, and the bot's own messages — and the research briefing on LUM-2841 confirmed the `mentions` array is **not** on the gated field list at all (gated: `content`, `embeds`, `attachments`, `components`, `poll`). Mention detection works on the unprivileged bitmask, permanently.

So the bitmask is `GUILDS | GUILD_MESSAGES` = **513**, which is also the docs' own IDENTIFY example. That keeps the app clear of the Portal approval and annual reapplication Discord introduced in June 2026 (LUM-2836).

**The exemption is a ceiling, not just a convenience.** Reading messages the bot is *not* mentioned in — the broader "monitor the whole community" shape — is impossible on this bitmask at any point. It needs `MESSAGE_CONTENT` and the approval that comes with it. Per the settled product call, v1 ships mention-only, and `intents.test.ts` asserts the bitmask requests **no privileged intent** — so widening it later fails CI first and forces that decision to be made deliberately rather than discovered at IDENTIFY.

`GUILD_MEMBERS` is omitted for the same reason. `DIRECT_MESSAGES` is omitted because admission is a list of guild channels and a DM matches no entry on it — admitting DMs is a policy decision, not a wider bitmask, and needs no privileged intent when it happens.

## The admission gate

A bot invited to a community guild sees every message in every channel it can view. This gate is the only thing between the assistant and that firehose, so every branch is a denial — there is no path that admits a message nobody asked for.

| Check | Drops | Why |
| --- | --- | --- |
| self-authored | the bot's own echo | how a reply loop starts |
| bot-authored | other bots / webhooks | two assistants answering each other is the same loop with more steps |
| no guild | DMs | matches no entry on a guild-channel allow-list |
| not allow-listed | channels (or thread parents) the operator didn't list | |
| not mentioned | ordinary channel chatter | decides firehose vs. handful |

**Decisions worth reviewing:**

- **An empty allow-list admits nothing.** Being invited to a guild is not consent to every channel in it, and the failure that matters is the one where an unset list reads as "all".
- **`@everyone` / `@here` is not a mention of the bot.** The briefing confirms Discord never puts the bot in `mentions[]` for everyone/role pings — they set `mention_everyone` / `mention_roles` instead. The trigger is immune to announcement noise by construction; the explicit check is belt to that.
- **Threads inherit their parent's listing.** Discord keys thread messages on the *thread's* id, not the parent channel's, and auto-subscribes bots to visible active threads without a join. Without inheritance the assistant would go silent the moment a conversation moved into a thread — a denial nobody would notice, because the symptom is nothing happening. Listing a thread id directly also works. Inheritance widens which *rooms* count, not which *messages* do.
- **Role mentions don't count** — only a direct user mention admits. Narrower on purpose for v1.

The gate takes a structural input rather than a parsed-payload type, so it stays pure and doesn't couple to the `MESSAGE_CREATE` schema (which lands with the normalizer).

## Gating

No feature flag, per the ticket: credential-gated (the client starts only when `discord_channel:bot_token` exists) plus UI-invisible (`discord` stays out of `BASE_AVAILABLE_CHANNELS`). Per the #39224 lesson, no `CHANNEL_METADATA` entry either — that lands with the slice that surfaces the channel, with copy written for a community bot.

## Test plan

- 21 tests / 0 fail: every drop reason, plus `@everyone`, empty-allow-list, mention-of-someone-else, all four thread cases, and the no-privileged-intents assertion.
- Gateway typecheck, **knip**, eslint, prettier all clean locally.
- No live token required — the Portal app doesn't exist yet and isn't on the critical path.

## Related

- **Connection recovery** (close-codes, backoff, session state, heartbeat) — split into its own PR from branch `claude/discord-gateway-recovery-jjcnxl`. Independent: neither half imports the other.
- Still to come on LUM-2841: the WebSocket client wiring the tested modules together, `MESSAGE_CREATE` schemas + normalizer, and the credential-gated lifecycle in `index.ts`.

## CLI verb checklist

N/A — no routes added.