### PR TITLE
build(ios): add VoiceActivity widget extension targets for all three environments

### DIFF
--- a/clients/ios/App/App/Config/Extension-Base.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Base.xcconfig
@@ -1,0 +1,48 @@
+// Extension-Base.xcconfig — shared build settings for the three
+// VoiceActivity widget extension targets. Per-target xcconfigs #include
+// this file, then override the one key that differs: the bundle ID,
+// which iOS requires to be prefixed by its containing app's ID. That
+// prefix rule is the whole reason there are three extension targets
+// rather than one shared appex.
+//
+// This deliberately does NOT #include Base.xcconfig. That file carries
+// app-only settings — CODE_SIGN_ENTITLEMENTS, the app's INFOPLIST_FILE,
+// BUNDLE_URL_SCHEME, ASSOCIATED_DOMAIN — that are wrong or actively
+// harmful on an appex. The cost is that the handful of genuinely shared
+// values below are restated: keep DEVELOPMENT_TEAM, SWIFT_VERSION,
+// TARGETED_DEVICE_FAMILY and especially IPHONEOS_DEPLOYMENT_TARGET in
+// sync with Base.xcconfig. An extension whose deployment target is
+// higher than its host app's fails to install on the OS versions the
+// app still claims to support.
+//
+// The extension ships no entitlements file at all: no App Group
+// (ContentState carries only primitives across the ActivityKit
+// boundary, so there is nothing to share through a container) and no
+// push. An unused entitlement is a provisioning failure waiting to
+// happen.
+//
+// MARKETING_VERSION and CURRENT_PROJECT_VERSION are intentionally not
+// set here, for the same reason as in Base.xcconfig: release builds
+// inject them as xcodebuild CLI overrides at archive time (see
+// .github/workflows/release-ios.yaml). Because that override applies to
+// every target in the archive, the extension's CFBundleVersion always
+// matches its containing app's — which App Store validation requires.
+
+CODE_SIGN_STYLE = Automatic
+DEVELOPMENT_TEAM = 7FZDXZR8P5
+INFOPLIST_FILE = VoiceActivity/Info.plist
+IPHONEOS_DEPLOYMENT_TARGET = 17.0
+
+// PRODUCT_NAME is deliberately left at XcodeGen's $(TARGET_NAME)
+// default, matching the app targets (which already ship "App
+// Staging.app"). Do not pin it to a fixed name: XcodeGen derives each
+// product file reference from the target name, and the app's embed
+// phase looks the appex up by that reference — a PRODUCT_NAME that
+// disagrees with the target name makes the copy fail on a missing file.
+
+// Required for an embedded extension: the appex is copied into the app
+// bundle by the embed phase, and must not also be installed at the
+// archive root.
+SKIP_INSTALL = YES
+SWIFT_VERSION = 5.0
+TARGETED_DEVICE_FAMILY = 1,2

--- a/clients/ios/App/App/Config/Extension-Dev.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Dev.xcconfig
@@ -1,0 +1,6 @@
+// Extension-Dev.xcconfig — dev VoiceActivity extension overrides.
+// The bundle ID must stay prefixed by App-Dev.xcconfig's.
+
+#include "Extension-Base.xcconfig"
+
+PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity

--- a/clients/ios/App/App/Config/Extension-Staging.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Staging.xcconfig
@@ -1,0 +1,6 @@
+// Extension-Staging.xcconfig — staging VoiceActivity extension overrides.
+// The bundle ID must stay prefixed by App-Staging.xcconfig's.
+
+#include "Extension-Base.xcconfig"
+
+PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity

--- a/clients/ios/App/App/Config/Extension.xcconfig
+++ b/clients/ios/App/App/Config/Extension.xcconfig
@@ -1,0 +1,6 @@
+// Extension.xcconfig — production VoiceActivity extension overrides.
+// The bundle ID must stay prefixed by App.xcconfig's.
+
+#include "Extension-Base.xcconfig"
+
+PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.VoiceActivity

--- a/clients/ios/App/VoiceActivity/Info.plist
+++ b/clients/ios/App/VoiceActivity/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
+++ b/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
@@ -1,0 +1,44 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+/// Widget bundle entry point for the VoiceActivity extension.
+///
+/// The bundle currently hosts a single placeholder Live Activity. It exists so
+/// the extension targets, their bundle IDs, and the embed wiring can be proven
+/// green on their own — a build failure here is a *target* problem, not a
+/// SwiftUI one. The real Dynamic Island and Lock Screen presentations replace
+/// ``VoiceSessionLiveActivity`` in a follow-up.
+@main
+struct VoiceActivityBundle: WidgetBundle {
+    var body: some Widget {
+        VoiceSessionLiveActivity()
+    }
+}
+
+/// Placeholder rendering of a running live-voice session.
+///
+/// Every presentation shows `context.state.label` verbatim. That is not just
+/// placeholder laziness — it is the contract the real UI keeps too: the web
+/// side owns all user-facing phase copy (`LIVE_VOICE_STATE_LABELS` in
+/// `clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts`), because
+/// this shell ships on App Store cadence while that copy deploys continuously.
+struct VoiceSessionLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: VoiceSessionAttributes.self) { context in
+            Text(context.state.label)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.state.label)
+                }
+            } compactLeading: {
+                Text(context.state.label)
+            } compactTrailing: {
+                Text(context.state.label)
+            } minimal: {
+                Text(context.state.label)
+            }
+        }
+    }
+}

--- a/clients/ios/App/project.yml
+++ b/clients/ios/App/project.yml
@@ -94,7 +94,9 @@ targetTemplates:
     # by `xcodegen generate`.
     scheme:
       configVariants: []
-    preBuildScripts:
+    # Anchored so `ExtensionEnvironment` can alias the identical guard
+    # instead of carrying a second copy that could drift.
+    preBuildScripts: &projectSpecFreshnessGuard
       # Fails the Xcode build with a clear, actionable error if the
       # generated project is older than the source-of-truth spec
       # (`clients/ios/App/project.yml`). This catches the case where a
@@ -118,6 +120,34 @@ targetTemplates:
             exit 1
           fi
 
+  # WidgetKit extension hosting the live-voice Live Activity. One per
+  # environment, so each app embeds an extension whose bundle ID is
+  # prefixed by its own — iOS requires that, and it is why there are
+  # three of these rather than one shared appex.
+  ExtensionEnvironment:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: VoiceActivity
+        excludes:
+          - "Info.plist"
+      # `VoiceSessionAttributes` is the ActivityKit wire model. The app
+      # targets already sweep it up via `AppEnvironment`'s `App` source
+      # path; pointing at the same directory here compiles it into the
+      # extension from that one copy on disk, rather than duplicating a
+      # file whose two halves would drift into a decode mismatch.
+      - path: App/Shared
+    settings:
+      configs:
+        Debug:
+          OTHER_SWIFT_FLAGS: '$(inherited) "-DDEBUG"'
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
+        Release:
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: ""
+    # No `scheme:` — extensions build as embedded dependencies of the app
+    # targets, so the three app schemes are the only ones worth having.
+    preBuildScripts: *projectSpecFreshnessGuard
+
 targets:
   App:
     templates: [AppEnvironment]
@@ -126,6 +156,9 @@ targets:
     configFiles:
       Debug: App/Config/App.xcconfig
       Release: App/Config/App.xcconfig
+    dependencies:
+      - target: VoiceActivity
+        embed: true
 
   "App Staging":
     templates: [AppEnvironment]
@@ -134,6 +167,9 @@ targets:
     configFiles:
       Debug: App/Config/App-Staging.xcconfig
       Release: App/Config/App-Staging.xcconfig
+    dependencies:
+      - target: "VoiceActivity Staging"
+        embed: true
 
   "App Dev":
     templates: [AppEnvironment]
@@ -142,3 +178,24 @@ targets:
     configFiles:
       Debug: App/Config/App-Dev.xcconfig
       Release: App/Config/App-Dev.xcconfig
+    dependencies:
+      - target: "VoiceActivity Dev"
+        embed: true
+
+  VoiceActivity:
+    templates: [ExtensionEnvironment]
+    configFiles:
+      Debug: App/Config/Extension.xcconfig
+      Release: App/Config/Extension.xcconfig
+
+  "VoiceActivity Staging":
+    templates: [ExtensionEnvironment]
+    configFiles:
+      Debug: App/Config/Extension-Staging.xcconfig
+      Release: App/Config/Extension-Staging.xcconfig
+
+  "VoiceActivity Dev":
+    templates: [ExtensionEnvironment]
+    configFiles:
+      Debug: App/Config/Extension-Dev.xcconfig
+      Release: App/Config/Extension-Dev.xcconfig


### PR DESCRIPTION
Structural only. This adds three WidgetKit extension targets — one per environment — carrying a **placeholder** Live Activity. The real Dynamic Island / Lock Screen UI lands in a follow-up, deliberately: a build or signing problem here stays isolated from a SwiftUI problem there.

## What's here

- **`project.yml`** — a new `ExtensionEnvironment` target template (`type: app-extension`) mirroring the `AppEnvironment` shape, plus three targets (`VoiceActivity`, `VoiceActivity Staging`, `VoiceActivity Dev`). Each app target gains a `dependencies: [{ target: <ext>, embed: true }]` entry pointing at its own environment's extension.
- **`VoiceActivity/VoiceActivityBundle.swift`** — `@main WidgetBundle` with one `ActivityConfiguration` for `VoiceSessionAttributes` that renders `Text(context.state.label)` in every presentation.
- **`VoiceActivity/Info.plist`** — `NSExtensionPointIdentifier = com.apple.widgetkit-extension`.
- **`App/Config/Extension-Base.xcconfig`** + three per-environment files that `#include` it and set only `PRODUCT_BUNDLE_IDENTIFIER`.

`VoiceSessionAttributes.swift` compiles into both the app and the extension **from one copy on disk** — `ExtensionEnvironment` points its sources at the same `App/Shared` directory the app targets already sweep, so there is no duplicated file to drift into a decode mismatch.

## ⚠️ NOT release-ready — needs Apple Developer portal work first

**This PR creates three new bundle IDs**, which need portal registration and three new distribution provisioning profiles before a release build can be signed:

| Environment | New extension bundle ID |
|---|---|
| Production | `ai.vocify-inc.vellum-assistant-ios.VoiceActivity` |
| Staging | `ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity` |
| Dev | `ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity` |

`release-ios.yaml` today installs exactly **one** profile and writes an `ExportOptions.plist` with a single `provisioningProfiles` entry keyed on the app's bundle ID. It also passes `PROVISIONING_PROFILE_SPECIFIER=<app profile>` as an `xcodebuild archive` CLI override, which applies to *every* target in the archive — including the new appex, whose bundle ID that profile does not cover. A later PR handles the pipeline. **Do not assume this is release-ready.**

`pr-ios.yaml` is unaffected: it builds with `CODE_SIGNING_ALLOWED=NO`.

## Verification

`bun run ios:setup` produces **six** targets — three apps, three extensions:

- Bundle IDs verified via `xcodebuild -showBuildSettings` — each exactly `<app-bundle-id>.VoiceActivity`, all at `IPHONEOS_DEPLOYMENT_TARGET = 17.0`, no `CODE_SIGN_ENTITLEMENTS`.
- Embed wiring verified by parsing the generated `project.pbxproj`: each app has a `PBXCopyFilesBuildPhase` (`dstSubfolderSpec 13` / PlugIns) containing exactly its matching environment's `.appex`, and a target dependency on it — no cross-environment mismatch.
- `VoiceSessionAttributes.swift` appears in the sources phase of all six targets from a single file reference.
- The extension target builds clean against the real iOS SDK in both Debug and Release (`xcodebuild -target VoiceActivity -sdk iphonesimulator`). The built `.appex` carries the right `CFBundleIdentifier`, `CFBundlePackageType = XPC!`, `MinimumOSVersion = 17.0`, and the `NSExtension` dictionary.
- CI's `PR iOS Checks` is the real gate for the full app-scheme build. A local full-app `xcodebuild` cannot resolve the Capacitor SPM plugin graph on this machine (`unable to resolve module dependency: 'IONFilesystemLib'`) — confirmed pre-existing by reproducing it on the unmodified base.

## Notes for review

- **No entitlements file for the extension**, by design — no App Group (`ContentState` carries only primitives) and no push. An unused entitlement is a provisioning failure waiting to happen.
- `Extension-Base.xcconfig` intentionally does *not* `#include Base.xcconfig`, which carries app-only settings (`CODE_SIGN_ENTITLEMENTS`, the app's `INFOPLIST_FILE`, `BUNDLE_URL_SCHEME`, `ASSOCIATED_DOMAIN`) that would be wrong on an appex. The handful of genuinely shared values are restated with a comment flagging the sync requirement.
- `PRODUCT_NAME` is deliberately left at `$(TARGET_NAME)`. Pinning it to a fixed `VoiceActivity` breaks the embed phase: XcodeGen derives each product file reference from the *target* name, so the copy phase then looks for a file the build never produces. Caught during verification.
- The `project.yml` freshness guard is shared with the app targets via a YAML anchor/alias rather than a second copy of the script.
- `CapApp-SPM/Package.swift` is unmodified and `App.xcodeproj/` is not committed (both confirmed via `git status`).