### PR TITLE
feat(ios): add the VoiceLiveActivity Capacitor plugin

### DIFF
--- a/clients/ios/App/App/AppDelegate.swift
+++ b/clients/ios/App/App/AppDelegate.swift
@@ -20,7 +20,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(_ application: UIApplication) {}
     func applicationWillEnterForeground(_ application: UIApplication) {}
     func applicationDidBecomeActive(_ application: UIApplication) {}
-    func applicationWillTerminate(_ application: UIApplication) {}
+    /// A backgrounded voice session keeps the app alive (the `audio` background
+    /// mode), so swiping it away in the app switcher terminates a *running*
+    /// process and lands here. Its Live Activity outlives the process unless it
+    /// is ended, which would strand an island the user cannot dismiss.
+    func applicationWillTerminate(_ application: UIApplication) {
+        VoiceLiveActivityPlugin.endRunningActivityBeforeTermination()
+    }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         if handleConnectDeepLink(url) {

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -4,10 +4,10 @@ import WebKit
 
 /// Custom `CAPBridgeViewController` subclass that:
 ///
-/// 1. Registers `NativeAuthPlugin`, `NativeBiometricPlugin`, and
-///    `VoiceAudioSessionPlugin` as local plugin instances at bridge init
-///    time. These plugins live inside the App target (no SPM module) so the
-///    bridge won't discover them automatically.
+/// 1. Registers `NativeAuthPlugin`, `NativeBiometricPlugin`,
+///    `VoiceAudioSessionPlugin`, and `VoiceLiveActivityPlugin` as local plugin
+///    instances at bridge init time. These plugins live inside the App target
+///    (no SPM module) so the bridge won't discover them automatically.
 ///
 /// 2. Injects `WKUserScript`s at `.atDocumentEnd` to:
 ///    a) Pin focusable fields to a minimum 16px font-size, preventing the
@@ -145,6 +145,7 @@ class MyViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(NativeAuthPlugin())
         bridge?.registerPluginInstance(NativeBiometricPlugin())
         bridge?.registerPluginInstance(VoiceAudioSessionPlugin())
+        bridge?.registerPluginInstance(VoiceLiveActivityPlugin())
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()

--- a/clients/ios/App/App/VoiceLiveActivityPlugin.swift
+++ b/clients/ios/App/App/VoiceLiveActivityPlugin.swift
@@ -1,0 +1,251 @@
+import ActivityKit
+import Capacitor
+import Foundation
+
+/// Capacitor plugin that owns the ActivityKit Live Activity mirroring a running
+/// live-voice session — the Dynamic Island / Lock Screen presence for a session
+/// that otherwise lives entirely in the web layer.
+///
+/// ## The wire contract
+///
+/// The web half is `clients/web/src/runtime/native-live-activity.ts`; the two
+/// files are a pair and must change together. The activity's shape is
+/// `VoiceSessionAttributes` (`App/Shared/VoiceSessionAttributes.swift`), which
+/// is also compiled into the widget extension that renders it. This plugin only
+/// *requests* activities — ActivityKit's request API is typed on the attributes,
+/// not on the presentation, so this compiles and runs with or without the
+/// extension. Without it, iOS simply has nothing to draw.
+///
+/// All user-facing copy (`label`) is passed through from the web side. The
+/// native side never derives phase wording — see `VoiceSessionAttributes` for
+/// why.
+///
+/// ## At most one activity, ever
+///
+/// The plugin holds a single handle. `start` while one is already running
+/// updates it rather than requesting a second: ActivityKit will happily create
+/// a duplicate, and two islands for one voice session is a visible bug with no
+/// way for the user to dismiss the stale one.
+///
+/// ## Nothing here may break a voice session
+///
+/// Every ActivityKit call is wrapped and rejects with the stable
+/// ``failureCode``; the web side treats every method as best-effort and
+/// swallows failures through `callNativeVoice`. A Live Activity is a flourish —
+/// a session must run identically without it.
+///
+/// `isAvailable` is both the shell-version probe (an older App Store shell
+/// rejects the call with Capacitor's "not implemented") *and* the user-
+/// preference probe: Live Activities can be switched off per-app in Settings,
+/// which must read as `false`, never as an error.
+///
+/// ## No stranded islands
+///
+/// An island outlives its process unless something ends it, so teardown is
+/// belt-and-braces: ``load()`` ends anything left over by a previous launch
+/// (the crash case, where neither hook below runs), `applicationWillTerminate`
+/// ends the running activity when the user force-quits a backgrounded voice
+/// session, and `deinit` covers bridge teardown.
+///
+/// References:
+/// - https://developer.apple.com/documentation/activitykit/activity
+/// - https://developer.apple.com/documentation/activitykit/activityauthorizationinfo
+@objc(VoiceLiveActivityPlugin)
+public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "VoiceLiveActivityPlugin"
+    public let jsName = "VoiceLiveActivity"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "isAvailable", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "start", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "update", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "end", returnType: CAPPluginReturnPromise),
+    ]
+
+    /// Stable rejection code for every ActivityKit failure, so the web side can
+    /// branch on it without matching against a localized message.
+    private static let failureCode = "LIVE_ACTIVITY_FAILED"
+
+    /// How long `applicationWillTerminate` may block the main thread waiting for
+    /// the activity to actually end. iOS allows roughly five seconds before it
+    /// kills the process; ending is asynchronous, so without a bounded wait the
+    /// app can die first and strand the island.
+    private static let terminationEndTimeout: DispatchTimeInterval = .milliseconds(1500)
+
+    /// The live plugin instance, so `AppDelegate.applicationWillTerminate` can
+    /// reach it. Weak: the bridge owns the plugin's lifetime, not this.
+    private static weak var registered: VoiceLiveActivityPlugin?
+
+    /// The one activity this plugin may have running, or `nil`.
+    ///
+    /// Touched only from the main thread: every mutation happens inside a
+    /// `@MainActor` task, and both teardown hooks run on the main thread. That
+    /// discipline — not a lock — is what makes "at most one" hold when `start`
+    /// and `end` race.
+    private var activity: Activity<VoiceSessionAttributes>?
+
+    // MARK: - Lifecycle
+
+    override public func load() {
+        Self.registered = self
+        Self.endActivitiesStrandedByAPreviousLaunch()
+    }
+
+    deinit {
+        guard let activity else { return }
+        Task { await activity.end(nil, dismissalPolicy: .immediate) }
+    }
+
+    // MARK: - isAvailable
+
+    /// Capability probe: `false` when the user has turned Live Activities off
+    /// for this app in Settings, and a rejection (which the web side reads as
+    /// `false`) on a shell that predates this plugin.
+    @objc public func isAvailable(_ call: CAPPluginCall) {
+        call.resolve(["available": ActivityAuthorizationInfo().areActivitiesEnabled])
+    }
+
+    // MARK: - start
+
+    /// Begin mirroring a voice session, resolving `{ started: Bool }`.
+    ///
+    /// Expects `{ assistantName, phase, label, accentHex, muted }`. Resolves
+    /// `started: false` — rather than rejecting — when Live Activities are
+    /// disabled in Settings, because that is a user preference and not a fault.
+    /// Calling it while an activity is already running updates that activity and
+    /// resolves `started: true`; it never requests a second one.
+    @objc public func start(_ call: CAPPluginCall) {
+        guard let assistantName = call.getString("assistantName"), !assistantName.isEmpty else {
+            call.reject("Missing required option: assistantName", Self.failureCode)
+            return
+        }
+        guard let state = Self.contentState(from: call) else {
+            call.reject("Missing or unrecognized option: phase", Self.failureCode)
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else {
+                call.resolve(["started": false])
+                return
+            }
+            if let running = self.activity {
+                await running.update(ActivityContent(state: state, staleDate: nil))
+                call.resolve(["started": true])
+                return
+            }
+            guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+                call.resolve(["started": false])
+                return
+            }
+            do {
+                self.activity = try Activity.request(
+                    attributes: VoiceSessionAttributes(assistantName: assistantName),
+                    content: ActivityContent(state: state, staleDate: nil)
+                )
+                call.resolve(["started": true])
+            } catch {
+                call.reject(
+                    "Failed to start the voice Live Activity: \(error.localizedDescription)",
+                    Self.failureCode,
+                    error
+                )
+            }
+        }
+    }
+
+    // MARK: - update
+
+    /// Push new content to the running activity. Expects
+    /// `{ phase, label, accentHex, muted }`. A no-op resolve when no activity is
+    /// running — the web side mirrors store state and must not have to know
+    /// whether the request ever succeeded.
+    @objc public func update(_ call: CAPPluginCall) {
+        guard let state = Self.contentState(from: call) else {
+            call.reject("Missing or unrecognized option: phase", Self.failureCode)
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let running = self?.activity else {
+                call.resolve()
+                return
+            }
+            await running.update(ActivityContent(state: state, staleDate: nil))
+            call.resolve()
+        }
+    }
+
+    // MARK: - end
+
+    /// Dismiss the running activity immediately — the session is over, so
+    /// leaving the island up for ActivityKit's default grace period would show a
+    /// stale state. A no-op resolve when nothing is running.
+    @objc public func end(_ call: CAPPluginCall) {
+        Task { @MainActor [weak self] in
+            guard let self, let running = self.activity else {
+                call.resolve()
+                return
+            }
+            // Cleared before awaiting so a `start` that lands during teardown
+            // requests a fresh activity instead of updating a dying one.
+            self.activity = nil
+            await running.end(nil, dismissalPolicy: .immediate)
+            call.resolve()
+        }
+    }
+
+    // MARK: - Teardown
+
+    /// End the running activity as the app terminates. Called from
+    /// `AppDelegate.applicationWillTerminate`, which is what a user swiping away
+    /// a backgrounded voice session triggers.
+    ///
+    /// Blocks the main thread for at most ``terminationEndTimeout``: the process
+    /// is about to go away, so fire-and-forget would lose the race and leave the
+    /// island on screen with no owner. A launch-time sweep (``load()``) is the
+    /// backstop for the paths this cannot cover, such as a crash.
+    static func endRunningActivityBeforeTermination() {
+        guard let activity = registered?.activity else { return }
+        // Cleared so the `deinit` that follows during teardown does not fire a
+        // second end at an activity already on its way out.
+        registered?.activity = nil
+        let ended = DispatchSemaphore(value: 0)
+        Task {
+            await activity.end(nil, dismissalPolicy: .immediate)
+            ended.signal()
+        }
+        _ = ended.wait(timeout: .now() + terminationEndTimeout)
+    }
+
+    /// Dismiss any voice activity still on screen from a previous process. A
+    /// crash ends the session without running either teardown hook, and the
+    /// island would otherwise sit there indefinitely showing a phase nothing is
+    /// driving. Nothing can legitimately be running at plugin-load time, so
+    /// everything found here is stale.
+    private static func endActivitiesStrandedByAPreviousLaunch() {
+        for stranded in Activity<VoiceSessionAttributes>.activities {
+            Task { await stranded.end(nil, dismissalPolicy: .immediate) }
+        }
+    }
+
+    // MARK: - Payload
+
+    /// Read the four `ContentState` fields off a bridge call. `phase` is
+    /// required and must decode; the rest degrade to harmless defaults rather
+    /// than failing a best-effort call. `accentHex` is canonicalized by
+    /// `ContentState.init`, so an unparseable color lands as the neutral accent.
+    private static func contentState(from call: CAPPluginCall) -> VoiceSessionAttributes.ContentState? {
+        guard let rawPhase = call.getString("phase"),
+              let phase = VoiceSessionAttributes.ContentState.Phase(rawValue: rawPhase)
+        else {
+            return nil
+        }
+        return VoiceSessionAttributes.ContentState(
+            phase: phase,
+            label: call.getString("label") ?? "",
+            accentHex: call.getString("accentHex")
+                ?? VoiceSessionAttributes.ContentState.neutralAccentHex,
+            muted: call.getBool("muted") ?? false
+        )
+    }
+}

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -30,8 +30,9 @@ which URL is baked into the build.
   process. With `server.url`, only native shell changes (Swift code,
   entitlements, Capacitor plugin updates) require a store submission.
 - **Thin native surface** — the IPC bridge between the WKWebView and
-  native code is minimal (three plugins: `NativeAuthPlugin`,
-  `NativeBiometricPlugin`, and `VoiceAudioSessionPlugin`), so version
+  native code is minimal (four plugins: `NativeAuthPlugin`,
+  `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`, and
+  `VoiceLiveActivityPlugin`), so version
   skew risk between the web app and native shell is low. Every plugin
   call from the web side must still be capability-probed, because a new
   web bundle always ships ahead of the shell that hosts it. Contrast
@@ -136,7 +137,7 @@ Apple's reference for the toolbar controls:
 
 The app has two layers — the **WKWebView contents** (the React app loaded
 from the configured server URL) and the **native Swift shell** (Capacitor
-bridge, `MyViewController`, the three native plugins). Each has its own
+bridge, `MyViewController`, the four native plugins). Each has its own
 debugger.
 
 ### Safari Web Inspector — for the web side (JS / CSS / network / `console.log`)
@@ -183,8 +184,9 @@ For a **physical iPhone**:
 
 ⌘R runs with `lldb` already attached. Click in the gutter next to any
 line in `AppDelegate.swift`, `MyViewController.swift`,
-`NativeAuthPlugin.swift`, `NativeBiometricPlugin.swift`, or
-`VoiceAudioSessionPlugin.swift` to set a breakpoint.
+`NativeAuthPlugin.swift`, `NativeBiometricPlugin.swift`,
+`VoiceAudioSessionPlugin.swift`, or `VoiceLiveActivityPlugin.swift` to set a
+breakpoint.
 
 - **Console / log output**: View → Debug Area → Activate Console (⇧⌘Y),
   or click the bottom-right console toggle. `print()` and `NSLog()` from
@@ -203,7 +205,7 @@ line in `AppDelegate.swift`, `MyViewController.swift`,
 ### Common debugging recipes
 
 - **A native plugin call (`NativeAuth`, `NativeBiometric`,
-  `VoiceAudioSession`) seems broken**:
+  `VoiceAudioSession`, `VoiceLiveActivity`) seems broken**:
   set a Swift breakpoint in the relevant `@objc func` inside the plugin
   file and trigger the action from the web app. If the breakpoint never
   hits, the JS-side `Capacitor.Plugins.NativeAuth` lookup is wrong (check
@@ -556,6 +558,8 @@ clients/
     │   │   ├── NativeAuthPlugin.swift  # ASWebAuthenticationSession OIDC flow
     │   │   ├── NativeBiometricPlugin.swift # Face ID / Touch ID Keychain
     │   │   ├── VoiceAudioSessionPlugin.swift # AVAudioSession for live voice
+    │   │   ├── VoiceLiveActivityPlugin.swift # Dynamic Island for live voice
+    │   │   ├── Shared/                   # Compiled into app + widget extension
     │   │   └── Info.plist
     │   └── CapApp-SPM/               # SPM local package: pulls in @capacitor/ios
     │                                 # and any Capacitor plugin native deps

--- a/clients/web/src/runtime/native-live-activity.test.ts
+++ b/clients/web/src/runtime/native-live-activity.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the `VoiceLiveActivity` bridge.
+ *
+ * The contract under test is skew-safety: the iOS shell ships through App Store
+ * review while this bundle deploys continuously, so an arbitrarily old shell
+ * can host it with no such plugin compiled in. Every exported function must
+ * therefore resolve — never reject, never hang — whether the plugin answers,
+ * rejects, or does not exist, and must not touch the bridge at all off iOS.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceLiveActivityContent,
+  VoiceLiveActivityStart,
+} from "@/runtime/native-live-activity";
+
+let onNativeIOS = false;
+
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => onNativeIOS,
+}));
+
+const isAvailable = mock(async () => ({ available: true }));
+const start = mock(async () => ({ started: true }));
+const update = mock(async () => undefined);
+const end = mock(async () => undefined);
+
+mock.module("@capacitor/core", () => ({
+  registerPlugin: () => ({ isAvailable, start, update, end }),
+}));
+
+const {
+  isVoiceLiveActivityAvailable,
+  startVoiceLiveActivity,
+  updateVoiceLiveActivity,
+  endVoiceLiveActivity,
+} = await import("@/runtime/native-live-activity");
+
+const content: VoiceLiveActivityContent = {
+  phase: "listening",
+  label: "Listening…",
+  accentHex: "#7C3AED",
+  muted: false,
+};
+const startOptions: VoiceLiveActivityStart = {
+  ...content,
+  phase: "connecting",
+  label: "Connecting…",
+  assistantName: "Vellum",
+};
+
+beforeEach(() => {
+  onNativeIOS = true;
+  isAvailable.mockClear();
+  isAvailable.mockImplementation(async () => ({ available: true }));
+  start.mockClear();
+  start.mockImplementation(async () => ({ started: true }));
+  update.mockClear();
+  update.mockImplementation(async () => undefined);
+  end.mockClear();
+  end.mockImplementation(async () => undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Off-native — the browser and Electron paths
+// ---------------------------------------------------------------------------
+
+describe("off the iOS shell", () => {
+  beforeEach(() => {
+    onNativeIOS = false;
+  });
+
+  test("availability reports false without touching the bridge", async () => {
+    expect(await isVoiceLiveActivityAvailable()).toBe(false);
+    expect(isAvailable).not.toHaveBeenCalled();
+  });
+
+  test("start resolves false without touching the bridge", async () => {
+    expect(await startVoiceLiveActivity(startOptions)).toBe(false);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  test("update resolves without touching the bridge", async () => {
+    expect(await updateVoiceLiveActivity(content)).toBeUndefined();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("end resolves without touching the bridge", async () => {
+    expect(await endVoiceLiveActivity()).toBeUndefined();
+    expect(end).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// On the iOS shell, plugin present
+// ---------------------------------------------------------------------------
+
+describe("with the plugin present", () => {
+  test("availability tracks the native answer", async () => {
+    expect(await isVoiceLiveActivityAvailable()).toBe(true);
+    expect(isAvailable).toHaveBeenCalledTimes(1);
+
+    // Live Activities switched off for the app in iOS Settings.
+    isAvailable.mockImplementation(async () => ({ available: false }));
+    expect(await isVoiceLiveActivityAvailable()).toBe(false);
+  });
+
+  test("start forwards the payload and reports whether one is running", async () => {
+    expect(await startVoiceLiveActivity(startOptions)).toBe(true);
+    expect(start).toHaveBeenCalledWith(startOptions);
+
+    start.mockImplementation(async () => ({ started: false }));
+    expect(await startVoiceLiveActivity(startOptions)).toBe(false);
+  });
+
+  test("update and end call through", async () => {
+    await updateVoiceLiveActivity(content);
+    expect(update).toHaveBeenCalledWith(content);
+
+    await endVoiceLiveActivity();
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  test("a payload missing the expected shape reads as not running", async () => {
+    // A shell that answers `{}` must not read as success.
+    isAvailable.mockImplementation(async () => ({}) as { available: boolean });
+    start.mockImplementation(async () => ({}) as { started: boolean });
+    expect(await isVoiceLiveActivityAvailable()).toBe(false);
+    expect(await startVoiceLiveActivity(startOptions)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// On the iOS shell, older shell without the plugin — the skew case
+// ---------------------------------------------------------------------------
+
+describe("with an older shell that has no plugin", () => {
+  // What `registerPlugin` produces for a plugin the shell never registered:
+  // every method rejects rather than being absent.
+  const notImplemented = async (): Promise<never> => {
+    throw new Error("VoiceLiveActivity does not have web implementation.");
+  };
+
+  beforeEach(() => {
+    isAvailable.mockImplementation(notImplemented);
+    start.mockImplementation(notImplemented);
+    update.mockImplementation(notImplemented);
+    end.mockImplementation(notImplemented);
+  });
+
+  test("every export swallows the rejection and returns its fallback", async () => {
+    expect(await isVoiceLiveActivityAvailable()).toBe(false);
+    expect(await startVoiceLiveActivity(startOptions)).toBe(false);
+    expect(await updateVoiceLiveActivity(content)).toBeUndefined();
+    expect(await endVoiceLiveActivity()).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire contract with the Swift side
+// ---------------------------------------------------------------------------
+
+describe("phase typing", () => {
+  test("rejects idle at compile time", () => {
+    // `VoiceSessionAttributes.ContentState.Phase` has no `idle` case: an idle
+    // session has no Live Activity, so this must not typecheck. The assertion
+    // is the `@ts-expect-error` itself — `bun run typecheck` fails if the
+    // union ever admits `"idle"`.
+    // @ts-expect-error — "idle" is not a Live Activity phase.
+    const idle: VoiceLiveActivityContent = { ...content, phase: "idle" };
+    expect(idle).toBeDefined();
+  });
+});

--- a/clients/web/src/runtime/native-live-activity.ts
+++ b/clients/web/src/runtime/native-live-activity.ts
@@ -1,0 +1,142 @@
+/**
+ * JS ↔ native bridge for the `VoiceLiveActivity` Capacitor plugin registered by
+ * `clients/ios/App/App/MyViewController.swift` +
+ * `clients/ios/App/App/VoiceLiveActivityPlugin.swift`.
+ *
+ * The plugin mirrors a running live-voice session into an ActivityKit Live
+ * Activity — the Dynamic Island and Lock Screen presence for a session that
+ * otherwise lives entirely in the web layer. It holds at most one activity, so
+ * calling {@link startVoiceLiveActivity} twice updates the running one instead
+ * of stacking a second island.
+ *
+ * **Skew contract.** The iOS shell ships through App Store review while this
+ * bundle deploys continuously (`clients/ios/README.md` § "Web content
+ * delivery"), so an arbitrarily old shell may host this bundle with no such
+ * plugin compiled in. Every call therefore goes through {@link callNativeVoice},
+ * which returns the fallback off-iOS and on any bridge failure. A Live Activity
+ * is a flourish: nothing here may throw, block, or otherwise reach a voice
+ * session.
+ *
+ * That fallback also covers the case where the user has turned Live Activities
+ * off for the app in iOS Settings — the plugin reports that as
+ * {@link isVoiceLiveActivityAvailable} resolving `false` and
+ * {@link startVoiceLiveActivity} resolving `false`, never as an error.
+ *
+ * Reference: https://developer.apple.com/documentation/activitykit/activity
+ */
+
+import { registerPlugin } from "@capacitor/core";
+
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { callNativeVoice } from "@/runtime/native-voice";
+
+/**
+ * Session phase the island renders. Exactly the non-`idle`
+ * {@link LiveVoiceSessionState} values, derived rather than restated so the two
+ * cannot drift.
+ *
+ * `idle` is excluded because an idle session has no Live Activity at all — the
+ * mirror ends the activity instead of pushing an idle phase.
+ *
+ * These raw strings cross the bridge and are decoded by
+ * `VoiceSessionAttributes.ContentState.Phase` in
+ * `clients/ios/App/App/Shared/VoiceSessionAttributes.swift`. **The two must
+ * change together**: a value added or renamed here without a matching Swift
+ * case fails to decode on the native side.
+ */
+export type VoiceLiveActivityPhase = Exclude<LiveVoiceSessionState, "idle">;
+
+/** The mutable half of the activity — everything that can change mid-session. */
+export interface VoiceLiveActivityContent {
+  phase: VoiceLiveActivityPhase;
+  /**
+   * User-facing activity copy. Pass `liveVoiceStateLabel(state, reconnecting)`
+   * so the island shows exactly what the voice room shows; the native side
+   * deliberately owns no phase wording of its own.
+   */
+  label: string;
+  /** Avatar accent as `#RRGGBB`. Unparseable values fall back to a neutral gray natively. */
+  accentHex: string;
+  muted: boolean;
+}
+
+/** {@link VoiceLiveActivityContent} plus the fields fixed for the activity's lifetime. */
+export interface VoiceLiveActivityStart extends VoiceLiveActivityContent {
+  assistantName: string;
+}
+
+interface VoiceLiveActivityPlugin {
+  isAvailable(): Promise<{ available: boolean }>;
+  start(options: VoiceLiveActivityStart): Promise<{ started: boolean }>;
+  update(content: VoiceLiveActivityContent): Promise<void>;
+  end(): Promise<void>;
+}
+
+const VoiceLiveActivity =
+  registerPlugin<VoiceLiveActivityPlugin>("VoiceLiveActivity");
+
+/**
+ * Whether this device can show a voice Live Activity right now — `false`
+ * off-iOS, on a shell without the plugin, and when the user has disabled Live
+ * Activities for the app in Settings.
+ *
+ * Callers do not need this to be safe: {@link startVoiceLiveActivity} already
+ * resolves `false` in every one of those cases. It exists for surfaces that
+ * want to know before they ask.
+ */
+export async function isVoiceLiveActivityAvailable(): Promise<boolean> {
+  return callNativeVoice(async () => {
+    // Only the result crosses this `async` boundary, never `VoiceLiveActivity`
+    // itself: per `docs/CAPACITOR.md` § "Capacitor plugins must be destructured
+    // inline", a plugin Proxy in a Promise-resolution context dispatches a
+    // native `then()` that never resolves and hangs the caller forever.
+    const { available } = await VoiceLiveActivity.isAvailable();
+    // Normalized rather than returned raw — the bridge payload is untyped at
+    // runtime, and a shell that answers `{}` must read as "not available".
+    return available === true;
+  }, false);
+}
+
+/**
+ * Show a Live Activity for a session that just became active. Resolves whether
+ * one is now running.
+ *
+ * Safe to call when one is already running: the plugin updates it rather than
+ * requesting a second island. Pair every call with {@link endVoiceLiveActivity}
+ * — an activity that outlives its session sits on the Lock Screen showing a
+ * phase nothing is driving.
+ */
+export async function startVoiceLiveActivity(
+  options: VoiceLiveActivityStart,
+): Promise<boolean> {
+  return callNativeVoice(async () => {
+    const { started } = await VoiceLiveActivity.start(options);
+    return started === true;
+  }, false);
+}
+
+/**
+ * Push new content to the running activity. A no-op when none is running, and
+ * off-iOS, and on an older shell. Never throws.
+ *
+ * ActivityKit rate-limits updates, so callers must push only on an actual
+ * {@link VoiceLiveActivityContent} change — never on high-frequency store
+ * fields such as input amplitude.
+ */
+export async function updateVoiceLiveActivity(
+  content: VoiceLiveActivityContent,
+): Promise<void> {
+  return callNativeVoice(async () => {
+    await VoiceLiveActivity.update(content);
+  }, undefined);
+}
+
+/**
+ * Dismiss the Live Activity at the end of a session. A no-op when none is
+ * running, and off-iOS, and on an older shell. Never throws.
+ */
+export async function endVoiceLiveActivity(): Promise<void> {
+  return callNativeVoice(async () => {
+    await VoiceLiveActivity.end();
+  }, undefined);
+}


### PR DESCRIPTION
## Summary
- Adds `VoiceLiveActivityPlugin` (Swift) with `isAvailable` / `start` / `update` / `end`, holding at most one `Activity<VoiceSessionAttributes>` handle so a second `start` updates rather than duplicating the island
- Adds the matching `clients/web/src/runtime/native-live-activity.ts` bridge, every call routed through `callNativeVoice` so an older App Store shell degrades silently instead of breaking a voice session
- Ends any running activity on `applicationWillTerminate` and plugin deinit, so a force-quit cannot strand an island on the user's screen
- `isAvailable` reads `ActivityAuthorizationInfo().areActivitiesEnabled`, so it doubles as the user-preference probe: Live Activities disabled in Settings returns `false` rather than erroring

## Validation
- `bun test src/runtime/native-live-activity.test.ts` — 10 pass, 0 fail (single-file run). The `error:` lines in output are `callNativeVoice`'s specified `console.debug` on caught rejections, not failures.
- `bun run typecheck` — exit 0.
- `CapApp-SPM/Package.swift` unmodified; `App.xcodeproj/` not committed.

## Unverified — needs a physical-device pass
- The Live Activity actually appearing in the Dynamic Island / Lock Screen on `start`.
- Force-quitting with a session running leaving no orphaned island.
- The Settings-disabled path returning `available: false` on a real device.
- Skew fallback against a shell without the plugin.

Note: this PR was shipped by the run-plan lead after the implementing agent terminated on a repeated API error at the ship step. All work is the agent's; the lead independently re-ran the validation above before pushing.

Part of plan: first-class-ios-voice-mode.md (PR 12 of 20)