### PR TITLE
feat(web): voice room minimize — visibility honors roomMinimized, Escape minimizes

### DIFF
--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -13,14 +13,17 @@
  *
  * Visibility is the exact complement of the owning-composer voice surface — the
  * one the full-screen voice room also renders against — so that in the main
- * window, for any active session, exactly one of {room, pill} renders. Both
- * derive from the shared {@link useOwningComposerSurfaceVisible} predicate
- * (session active AND the on-screen composer owns it): the pill shows when a
- * session is active and it is `false`, the room when it is `true` and this is
- * the main window. Because the pill keys off that popout-free primitive (not
- * the room's own `!isPopout` gate), a headerless pop-out's standalone pill
- * still hides while the composer's voice bar owns the session — no double
- * control. Concretely, the pill shows when:
+ * window, for any active session, exactly one of {room, voice bar, pill} is
+ * the visible control. The room and the pill both derive from the shared
+ * {@link useOwningComposerSurfaceVisible} predicate (session active AND the
+ * on-screen composer owns it): the pill shows when a session is active and it
+ * is `false`; the room when it is `true`, this is the main window, and the
+ * room is not minimized. Because the pill keys off that primitive alone — not
+ * the room's own `!isPopout` / `!roomMinimized` gates — a headerless
+ * pop-out's standalone pill still hides while the composer's voice bar owns
+ * the session, and minimizing the room on the owning thread hands control to
+ * the voice bar underneath, not the pill — no double control. Concretely, the
+ * pill shows when:
  *
  * - the user is viewing a different conversation than the session's,
  * - the user is off the chat routes entirely (Home, Library, …) or on a

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
@@ -4,13 +4,20 @@
  *
  * The room is the owning-composer's voice surface: it shows exactly when a
  * session is active AND the composer currently on screen owns it AND this is
- * the main window (never a pop-out — see below). It is a full-app takeover —
- * there is no minimize: the room stays up for the whole session and ending the
- * session (the room's ✕) is the only way out. Its popout-free core,
- * {@link useOwningComposerSurfaceVisible}, is the precise complement of the
- * title-bar session pill, whose host consumes that primitive's negation
- * (`sessionActive && !owningSurfaceVisible`) so the two surfaces can never
- * both render — or both hide — for an active owned session.
+ * the main window (never a pop-out — see below) AND the room is not
+ * minimized. Minimizing (the room's − control, Escape, or an
+ * assistant-driven `minimize_room` frame) dismisses the room while the
+ * session stays live: the composer's voice bar covers the session on the
+ * owning thread and the title-bar pill everywhere else, per the complement
+ * rules below. Its popout-free core, {@link useOwningComposerSurfaceVisible},
+ * is the precise complement of the title-bar session pill, whose host
+ * consumes that primitive's negation (`sessionActive &&
+ * !owningSurfaceVisible`) so the two surfaces can never both render — or both
+ * hide — for an active owned session. `roomMinimized` deliberately stays OUT
+ * of that shared primitive: with the owning composer on screen and the room
+ * minimized, the composer's voice bar (not the pill) is the session control —
+ * the same complement a pop-out uses — so folding the minimize gate into the
+ * primitive would wrongly summon the pill on top of the voice bar.
  *
  * The inputs mirror {@link VoiceSessionPillHost} one-for-one:
  * - `composerOnScreen` — shared via {@link useComposerOnScreen}: a conversation
@@ -68,11 +75,12 @@ export function useOwningComposerSurfaceVisible(): boolean {
 
 /**
  * Whether the voice room should render. See the module docstring for the
- * complement contract with the title-bar session pill and the pop-out
- * exclusion.
+ * complement contract with the title-bar session pill, the pop-out
+ * exclusion, and the minimize gate.
  */
 export function useIsVoiceRoomVisible(): boolean {
   const owningSurfaceVisible = useOwningComposerSurfaceVisible();
+  const roomMinimized = useLiveVoiceStore.use.roomMinimized();
   const location = useLocation();
   // Capture pop-out mode once at mount: pop-out URLs carry `?popout=1` only on
   // the window's initial load (in-window navigation drops the query), and this
@@ -80,5 +88,5 @@ export function useIsVoiceRoomVisible(): boolean {
   // window's lifetime value — mirroring `ChatLayout`'s own capture.
   const [isPopout] = useState(() => isPopoutWindow(location.search));
 
-  return owningSurfaceVisible && !isPopout;
+  return owningSurfaceVisible && !isPopout && !roomMinimized;
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -9,10 +9,11 @@
  * assistant-avatar React Query graph — irrelevant to room chrome, and stubbed
  * so the exit control's independence from avatar readiness is testable).
  *
- * Exit is the load-bearing behavior: the room is a full-app takeover with no
- * minimize — ending the session is the only way out, via the ✕ control (which
- * renders even with no assistant resolved) or Escape, and the key listener is
- * removed on unmount (no leaks).
+ * Dismissal is the load-bearing behavior: the ✕ control (which renders even
+ * with no assistant resolved) ends the session; the minimize control and
+ * Escape dismiss the room while the session keeps running (`roomMinimized`
+ * flips, session state untouched); and the key listener is removed on
+ * unmount (no leaks).
  */
 
 import { type ReactNode } from "react";
@@ -381,6 +382,16 @@ describe("VoiceRoom — visibility", () => {
     render(<VoiceRoom />);
     expect(roomDialog()).toBeNull();
   });
+
+  test("renders nothing while the room is minimized, even on the owning composer", () => {
+    // Minimized, the composer's voice bar underneath is the session control —
+    // the session itself stays live.
+    startOwnedSession("listening");
+    useLiveVoiceStore.getState().setRoomMinimized(true);
+    render(<VoiceRoom />);
+    expect(roomDialog()).toBeNull();
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+  });
 });
 
 describe("VoiceRoom — listening waves", () => {
@@ -425,25 +436,31 @@ describe("VoiceRoom — exit", () => {
   });
 });
 
-describe("VoiceRoom — no way out but ending the session", () => {
-  test("no minimize control renders", () => {
+describe("VoiceRoom — minimize (session keeps running)", () => {
+  const minimizeButton = () =>
+    screen.queryByRole("button", { name: "Minimize voice room" });
+
+  test("the minimize control dismisses the room without ending the session", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
-    expect(
-      screen.queryByRole("button", { name: "Minimize voice room" }),
-    ).toBeNull();
+    fireEvent.click(minimizeButton()!);
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(controls.stop).not.toHaveBeenCalled();
   });
 
-  test("Escape ends the session, same as ✕", () => {
+  test("Escape minimizes instead of ending the session", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     act(() => {
       window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     });
-    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(controls.stop).not.toHaveBeenCalled();
   });
 
-  test("Escape ends the session even when an editable element holds focus (global key)", () => {
+  test("Escape minimizes even when an editable element holds focus (global key)", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     // The room can open while the composer textarea still owns focus; the key
@@ -455,7 +472,8 @@ describe("VoiceRoom — no way out but ending the session", () => {
         new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
       );
     });
-    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expect(controls.stop).not.toHaveBeenCalled();
     input.remove();
   });
 
@@ -464,6 +482,7 @@ describe("VoiceRoom — no way out but ending the session", () => {
     const { unmount } = render(<VoiceRoom />);
     unmount();
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
     expect(controls.stop).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -19,29 +19,31 @@
  *
  * The room is a full-app takeover on every platform — `fixed inset-0`, modal,
  * covering the header and sidebar, with safe-area padding for notched iOS
- * shells. A voice session IS the room: there is no minimize and no way to
- * leave it while the session runs — ending the session (the ✕ control) is the
- * only way out.
+ * shells. It is not exit-only: minimizing (the − control or Escape) dismisses
+ * the room while the session keeps running — the composer's voice bar / the
+ * title-bar pill become the session surfaces — and ending the session (the ✕
+ * control) tears the whole call down.
  *
  * Visibility is a pure function of {@link useIsVoiceRoomVisible} — active
- * session, owned by the on-screen composer, main window. Any session end
- * (user exit, `failed`, conversation timeout, stop from elsewhere) flips that
- * predicate false and unmounts the room; a `failed` session surfaces through
- * the existing composer Notice / pill failure chip, never a dead room.
+ * session, owned by the on-screen composer, main window, not minimized. Any
+ * session end (user exit, `failed`, conversation timeout, stop from
+ * elsewhere) flips that predicate false and unmounts the room; a `failed`
+ * session surfaces through the existing composer Notice / pill failure chip,
+ * never a dead room.
  *
  * Sessions are hands-free (server-VAD): the user just speaks, so there is no
  * push-to-talk control. Bottom-center carries the session controls in the
  * call-app idiom: a mic mute toggle (always) and, while the assistant speaks
  * hands-free, a turn-scoped ■ stop. Exit is first-class: the persistent
- * ✕ control (always rendered, even while the avatar/assistant data is loading
- * or failed) and Escape both end the session — the room is modal with no
- * lesser dismissal, so the platform "leave" key maps to the only exit there
- * is. The key handler attaches only while the room is mounted.
+ * ✕ control ends the session, always rendered even while the avatar/assistant
+ * data is loading or failed. Escape maps to the lesser dismissal — it
+ * minimizes the room, same as the − control, leaving the call live. The key
+ * handler attaches only while the room is mounted.
  */
 
 import { useEffect, useState, type CSSProperties } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { Mic, MicOff, Square, X } from "lucide-react";
+import { Mic, MicOff, Minus, Square, X } from "lucide-react";
 
 import { Tooltip, cn } from "@vellumai/design-library";
 
@@ -50,6 +52,7 @@ import {
   getLiveVoiceInputAmplitude,
   getLiveVoiceOutputAmplitude,
   liveVoiceStateLabel,
+  minimizeVoiceRoom,
   setLiveVoiceMuted,
   stopLiveVoiceResponse,
   useLiveVoiceStore,
@@ -188,16 +191,17 @@ function VoiceRoomOverlay() {
     "--room-bubble-fg": tone?.bubbleFg ?? "#FFFFFF",
   } as CSSProperties;
 
-  // Global Escape, live only while the room is mounted: ends the session,
-  // same as the ✕ — the room is modal with no lesser dismissal, so the
-  // platform "leave" key maps to the only exit there is. It fires even when
-  // the composer textarea (or any other focused element) still holds focus as
-  // the room opens, so it is intentionally not guarded by the event target.
+  // Global Escape, live only while the room is mounted: minimizes the room,
+  // same as the − control — the platform "leave the overlay" key dismisses
+  // the surface without hanging up the call (✕ is the end-session control).
+  // It fires even when the composer textarea (or any other focused element)
+  // still holds focus as the room opens, so it is intentionally not guarded
+  // by the event target.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
-        endLiveVoiceSession();
+        minimizeVoiceRoom();
       }
     }
     window.addEventListener("keydown", onKeyDown);
@@ -317,9 +321,9 @@ function VoiceRoomOverlay() {
         ) : null}
       </AnimatePresence>
 
-      {/* Room controls — captions toggle and the persistent exit. Rendered
-          above all room chrome; ✕ is never gated behind avatar readiness, so
-          ending works even mid-load / on failure. */}
+      {/* Room controls — captions toggle, minimize, and the persistent exit.
+          Rendered above all room chrome; ✕ is never gated behind avatar
+          readiness, so ending works even mid-load / on failure. */}
       <div
         // Absolute position is relative to the padding box, so the overlay's
         // safe-area padding does not shift this — inset it from the notch /
@@ -334,7 +338,17 @@ function VoiceRoomOverlay() {
           triggerClassName={ROOM_CONTROL_CLASS}
           assistantId={assistantId}
         />
-        <Tooltip content="End voice session (Esc)">
+        <Tooltip content="Minimize — session keeps going">
+          <button
+            type="button"
+            onClick={minimizeVoiceRoom}
+            aria-label="Minimize voice room"
+            className={ROOM_CONTROL_CLASS}
+          >
+            <Minus className="size-5" />
+          </button>
+        </Tooltip>
+        <Tooltip content="End voice session">
           <button
             type="button"
             onClick={endLiveVoiceSession}


### PR DESCRIPTION
## Summary
- `useIsVoiceRoomVisible` now ANDs `!roomMinimized`; shared owning-surface primitive untouched
- Minimize control beside ✕; Escape now minimizes (✕ still ends the session)
- Docstring contracts updated (room / visibility hook / pill host)

Part of plan: voice-room-minimize.md (PR 2 of 9)