### PR TITLE
feat(web): restore-to-room affordance on the voice composer bar

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -175,6 +175,9 @@ mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
 const navigateSpy = mock((_to: string) => {});
 mock.module("react-router", () => ({
   useNavigate: () => navigateSpy,
+  // The composer captures pop-out mode once at mount from the URL search
+  // string; a plain window (no `?popout=1`) is the default test context.
+  useLocation: () => ({ search: "" }),
 }));
 
 // Flush the microtask/timer queue so the composer's awaited preflight

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -11,7 +11,7 @@ import {
     useState,
 } from "react";
 import { flushSync } from "react-dom";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import {
     AttachFileButton,
@@ -41,6 +41,7 @@ import {
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
     releaseLiveVoiceTurn,
+    restoreVoiceRoom,
     setLiveVoiceEntryOrigin,
     setLiveVoiceMuted,
     stopLiveVoiceResponse,
@@ -54,6 +55,7 @@ import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-sto
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
+import { isPopoutWindow } from "@/runtime/popout-window";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { isNativeIOS } from "@/runtime/platform-detection";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -338,6 +340,12 @@ export function ChatComposer({
   // the first-run card path defers the actual start to its own handler.
   const liveVoiceEntryOriginRef = useRef<{ x: number; y: number } | null>(null);
   const navigate = useNavigate();
+  const location = useLocation();
+  // Captured once at mount, mirroring `ChatLayout` / `useIsVoiceRoomVisible`:
+  // pop-out URLs carry `?popout=1` only on the window's initial load. Pop-outs
+  // never render the voice room, so the bar's expand-to-room control is
+  // omitted there (the mount-time value gates it below).
+  const [isPopout] = useState(() => isPopoutWindow(location.search));
   // "Configure voice" copy surfaced when the pre-open preflight returns
   // `not-ready` — the daemon's human-readable `userMessage`. Non-null renders
   // the notice below (with a deep-link to voice settings) and the room stays
@@ -878,6 +886,10 @@ export function ChatComposer({
                 // Turn-scoped stop is hands-free-only; a manual session's
                 // interrupt ends the whole session (✕ owns that).
                 onStop={liveVoiceHandsFree ? stopLiveVoiceResponse : undefined}
+                // Expand back to the full-screen room — omitted in pop-out
+                // windows, where the room never renders (the standalone pill
+                // is their only session surface).
+                onExpand={isPopout ? undefined : restoreVoiceRoom}
               />
             ) : (
               <div className="flex items-center justify-between gap-1 px-2 pb-2">

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -26,6 +26,7 @@ function renderBar(state: LiveVoiceSessionState, overrides?: {
   onEnd?: () => void;
   onSend?: () => void;
   onStop?: () => void;
+  onExpand?: () => void;
 }) {
   return render(
     <VoiceComposerBar
@@ -36,6 +37,7 @@ function renderBar(state: LiveVoiceSessionState, overrides?: {
       onEnd={overrides?.onEnd ?? (() => {})}
       onSend={overrides?.onSend ?? (() => {})}
       onStop={overrides?.onStop}
+      onExpand={overrides?.onExpand}
     />,
   );
 }
@@ -158,6 +160,22 @@ describe("VoiceComposerBar — stop response", () => {
     renderBar("speaking");
     expect(
       screen.queryByRole("button", { name: "Stop assistant response" }),
+    ).toBeNull();
+  });
+});
+
+describe("VoiceComposerBar — expand to room", () => {
+  test("renders with onExpand wired and fires it", () => {
+    const onExpand = mock(() => {});
+    renderBar("listening", { onExpand });
+    fireEvent.click(screen.getByRole("button", { name: "Open voice room" }));
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  test("absent without onExpand (pop-out windows)", () => {
+    renderBar("listening");
+    expect(
+      screen.queryByRole("button", { name: "Open voice room" }),
     ).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -3,7 +3,8 @@
  * active the composer's action row is replaced by this bar — a mic mute
  * toggle and muted state label on the left, the dotted timeline waveform
  * filling the middle, and the session controls on the right: optional
- * ■ stop-response (while the assistant speaks), end (✕), and send-now (↑).
+ * ■ stop-response (while the assistant speaks), optional expand back to the
+ * voice room, end (✕), and send-now (↑).
  *
  * Purely presentational: the composer observes the live-voice store and
  * wires `state`, an amplitude poll function, and the callbacks. The green ↑
@@ -15,7 +16,7 @@
  * layout shift.
  */
 
-import { ArrowUp, Mic, MicOff, Square, X } from "lucide-react";
+import { ArrowUp, Maximize2, Mic, MicOff, Square, X } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
@@ -44,6 +45,12 @@ export interface VoiceComposerBarProps {
    * hands-free sessions, where the interrupt is turn-scoped.
    */
   onStop?: () => void;
+  /**
+   * Return to the full-screen voice room. The composer passes it only where
+   * the room can render (never in pop-out windows), so the control never
+   * ships dead.
+   */
+  onExpand?: () => void;
 }
 
 export function VoiceComposerBar({
@@ -54,6 +61,7 @@ export function VoiceComposerBar({
   onEnd,
   onSend,
   onStop,
+  onExpand,
 }: VoiceComposerBarProps) {
   return (
     <div
@@ -101,6 +109,15 @@ export function VoiceComposerBar({
             onClick={onStop}
             aria-label="Stop assistant response"
             tooltip="Stop assistant response"
+          />
+        ) : null}
+        {onExpand ? (
+          <Button
+            variant="ghost"
+            iconOnly={<Maximize2 className="h-4 w-4" />}
+            onClick={onExpand}
+            aria-label="Open voice room"
+            tooltip="Open voice room"
           />
         ) : null}
         <Button


### PR DESCRIPTION
## Summary
- Optional `onExpand` on VoiceComposerBar (Maximize2 ghost button, presentational)
- chat-composer wires it to `restoreVoiceRoom`, omitted in pop-out windows

Part of plan: voice-room-minimize.md (PR 3 of 9)