### PR TITLE
feat(live-voice): main-leg control-marker hygiene + drain-scoped minimize_room emission

### DIFF
--- a/assistant/src/calls/__tests__/voice-control-protocol.test.ts
+++ b/assistant/src/calls/__tests__/voice-control-protocol.test.ts
@@ -4,6 +4,7 @@ import {
   couldBeControlMarker,
   ESCALATE_VERDICT_TOKEN,
   HOLD_VERDICT_TOKEN,
+  isIncompleteControlMarkerTail,
   MINIMIZE_ROOM_MARKER,
   stripInternalSpeechMarkers,
 } from "../voice-control-protocol.js";
@@ -67,5 +68,38 @@ describe("minimize-room marker", () => {
 
   test("a bracket prefix that disproves the marker is not held", () => {
     expect(couldBeControlMarker("[- something else")).toBe(false);
+  });
+});
+
+describe("isIncompleteControlMarkerTail", () => {
+  test("strict prefixes of any marker are incomplete", () => {
+    for (const tail of ["[", "[-", "[-1", "[END_CAL", "[ASK_GUARDIAN_APPRO"]) {
+      expect(isIncompleteControlMarkerTail(tail)).toBe(true);
+    }
+  });
+
+  test("complete literal markers are not held", () => {
+    for (const tail of ["[-1]", "[END_CALL]", "[0] answer", "[-1] look here"]) {
+      expect(isIncompleteControlMarkerTail(tail)).toBe(false);
+    }
+  });
+
+  test("guardian-approval is judged by the balanced parser, not the first bracket", () => {
+    const streaming =
+      '[ASK_GUARDIAN_APPROVAL: {"question": "ok]?", "options": ["a", "b"';
+    expect(isIncompleteControlMarkerTail(streaming)).toBe(true);
+    expect(isIncompleteControlMarkerTail(`${streaming}]}]`)).toBe(false);
+  });
+
+  test("colon-style markers terminate at their first bracket", () => {
+    expect(isIncompleteControlMarkerTail("[ASK_GUARDIAN: may I")).toBe(true);
+    expect(isIncompleteControlMarkerTail("[ASK_GUARDIAN: may I?]")).toBe(false);
+    expect(isIncompleteControlMarkerTail("[USER_ANSWERED: yes")).toBe(true);
+  });
+
+  test("non-marker bracket text is not held", () => {
+    for (const tail of ["[- something else", "[sic]", '["a", "b"]']) {
+      expect(isIncompleteControlMarkerTail(tail)).toBe(false);
+    }
   });
 });

--- a/assistant/src/calls/voice-control-protocol.ts
+++ b/assistant/src/calls/voice-control-protocol.ts
@@ -215,3 +215,47 @@ export function couldBeControlMarker(text: string): boolean {
     (marker) => marker.startsWith(text) || text.startsWith(marker),
   );
 }
+
+// Colon-style markers whose bodies terminate at the first "]" — their strip
+// regexes are non-greedy (`.+?\]`), so the first bracket IS the terminator.
+// ASK_GUARDIAN_APPROVAL is deliberately absent: its balanced-JSON body may
+// itself contain "]" (arrays, string values), so only the balanced parser can
+// judge it complete.
+const FIRST_BRACKET_TERMINATED_PREFIXES = [
+  "[ASK_GUARDIAN:",
+  "[USER_ANSWERED:",
+  "[USER_INSTRUCTION:",
+];
+
+const GUARDIAN_APPROVAL_PREFIX = "[ASK_GUARDIAN_APPROVAL:";
+
+/**
+ * Whether `tail` (a buffer starting at a `[`) is a control marker that is
+ * still streaming — i.e. holding it back is required because
+ * {@link stripInternalSpeechMarkers} cannot yet remove it. Returns false for
+ * complete markers (safe to flush: stripping removes them) and for text that
+ * is not a marker at all (safe to flush: it is speech).
+ *
+ * Completion is judged per marker family: a strict prefix of any known
+ * marker string is always incomplete; an ASK_GUARDIAN_APPROVAL body is
+ * complete only when {@link extractBalancedJson} finds the balanced JSON and
+ * its closing bracket (a bare "]" inside the JSON does NOT terminate it);
+ * the other colon-style markers terminate at their first "]"; the fixed
+ * literal markers are complete the moment they match.
+ */
+export function isIncompleteControlMarkerTail(tail: string): boolean {
+  if (
+    CONTROL_MARKER_STRINGS.some(
+      (marker) => marker.length > tail.length && marker.startsWith(tail),
+    )
+  ) {
+    return true;
+  }
+  if (tail.startsWith(GUARDIAN_APPROVAL_PREFIX)) {
+    return extractBalancedJson(tail) === null;
+  }
+  if (FIRST_BRACKET_TERMINATED_PREFIXES.some((p) => tail.startsWith(p))) {
+    return !tail.includes("]");
+  }
+  return false;
+}

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -706,4 +706,27 @@ describe("LiveVoiceSession minimize-room marker", () => {
     expect(assistantDeltaTexts(frames).join("")).toBe("Score was [-");
     expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
   });
+
+  test("holds a guardian-approval marker whose JSON body contains brackets, then strips it whole", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    // The JSON body carries both a "]" inside a string value and a nested
+    // array — neither may terminate the hold or mask the marker's start.
+    emitTextDelta(
+      getCallbacks,
+      'Hold on. [ASK_GUARDIAN_APPROVAL: {"question": "ok]?", "options": ["a", "b"',
+    );
+    await flushAsyncCallbacks();
+    expect(assistantDeltaTexts(frames).join("")).toBe("Hold on. ");
+
+    emitTextDelta(getCallbacks, "]}] Anything else?");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    const joined = assistantDeltaTexts(frames).join("");
+    expect(joined).not.toContain("ASK_GUARDIAN_APPROVAL");
+    expect(joined).toContain("Anything else?");
+    expect(ttsTexts.join(" ")).not.toContain("ASK_GUARDIAN_APPROVAL");
+  });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -144,10 +144,78 @@ async function waitFor(
   message = "Timed out waiting for live voice assistant turn condition",
 ): Promise<void> {
   for (let attempt = 0; attempt < 40; attempt += 1) {
-    if (predicate()) return;
+    if (predicate()) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error(message);
+}
+
+function createCapturingTurnStarter(): {
+  startVoiceTurn: LiveVoiceTurnStarter;
+  getCallbacks: () => VoiceTurnCallbacks | undefined;
+} {
+  let callbacks: VoiceTurnCallbacks | undefined;
+  const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+    callbacks = options.callbacks;
+    return { turnId: "bridge-turn-1", abort: mock() };
+  });
+  return { startVoiceTurn, getCallbacks: () => callbacks };
+}
+
+function createRecordingTtsStreamer(): {
+  streamTtsAudio: LiveVoiceTtsStreamer;
+  ttsTexts: string[];
+} {
+  const ttsTexts: string[] = [];
+  const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+    ttsTexts.push(options.text);
+    return {
+      provider: "fish-audio" as const,
+      contentType: "audio/pcm",
+      sampleRate: 24_000,
+      chunks: 1,
+      bytes: Buffer.byteLength(options.text),
+    };
+  });
+  return { streamTtsAudio, ttsTexts };
+}
+
+function emitTextDelta(
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+  text: string,
+): void {
+  getCallbacks()?.assistant_text_delta?.({
+    type: "assistant_text_delta",
+    text,
+    conversationId: "conversation-123",
+  });
+}
+
+function emitMessageComplete(
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+): void {
+  getCallbacks()?.message_complete?.({
+    type: "message_complete",
+    conversationId: "conversation-123",
+    messageId: "assistant-message-123",
+  });
+}
+
+async function startReleasedTurn(
+  session: LiveVoiceSession,
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+): Promise<void> {
+  await session.start();
+  await session.handleClientFrame({ type: "ptt_release" });
+  await waitFor(() => getCallbacks() !== undefined);
+}
+
+function assistantDeltaTexts(frames: LiveVoiceServerFrame[]): string[] {
+  return frames.flatMap((frame) =>
+    frame.type === "assistant_text_delta" ? [frame.text] : [],
+  );
 }
 
 describe("LiveVoiceSession assistant turn", () => {
@@ -464,57 +532,6 @@ describe("LiveVoiceSession tool-use spoken ack", () => {
     pickAckPhrase("first_delta", 0),
   ).trim();
 
-  function createCapturingTurnStarter(): {
-    startVoiceTurn: LiveVoiceTurnStarter;
-    getCallbacks: () => VoiceTurnCallbacks | undefined;
-  } {
-    let callbacks: VoiceTurnCallbacks | undefined;
-    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
-      callbacks = options.callbacks;
-      return { turnId: "bridge-turn-1", abort: mock() };
-    });
-    return { startVoiceTurn, getCallbacks: () => callbacks };
-  }
-
-  function createRecordingTtsStreamer(): {
-    streamTtsAudio: LiveVoiceTtsStreamer;
-    ttsTexts: string[];
-  } {
-    const ttsTexts: string[] = [];
-    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
-      ttsTexts.push(options.text);
-      return {
-        provider: "fish-audio" as const,
-        contentType: "audio/pcm",
-        sampleRate: 24_000,
-        chunks: 1,
-        bytes: Buffer.byteLength(options.text),
-      };
-    });
-    return { streamTtsAudio, ttsTexts };
-  }
-
-  function emitTextDelta(
-    getCallbacks: () => VoiceTurnCallbacks | undefined,
-    text: string,
-  ): void {
-    getCallbacks()?.assistant_text_delta?.({
-      type: "assistant_text_delta",
-      text,
-      conversationId: "conversation-123",
-    });
-  }
-
-  function emitMessageComplete(
-    getCallbacks: () => VoiceTurnCallbacks | undefined,
-  ): void {
-    getCallbacks()?.message_complete?.({
-      type: "message_complete",
-      conversationId: "conversation-123",
-      messageId: "assistant-message-123",
-    });
-  }
-
   function createAckHarness() {
     const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
     const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
@@ -524,15 +541,6 @@ describe("LiveVoiceSession tool-use spoken ack", () => {
       frontModelConfig: { ackFirstDeltaTimeoutMs: ACK_TIMEOUT_MS },
     });
     return { ...harness, getCallbacks, ttsTexts };
-  }
-
-  async function startReleasedTurn(
-    session: LiveVoiceSession,
-    getCallbacks: () => VoiceTurnCallbacks | undefined,
-  ): Promise<void> {
-    await session.start();
-    await session.handleClientFrame({ type: "ptt_release" });
-    await waitFor(() => getCallbacks() !== undefined);
   }
 
   test("tool_use_start before any delta speaks an immediate tool ack and cancels the timer", async () => {
@@ -588,5 +596,114 @@ describe("LiveVoiceSession tool-use spoken ack", () => {
     emitMessageComplete(getCallbacks);
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     expect(ttsTexts).toEqual([EXPECTED_FIRST_DELTA_ACK, "Hello there."]);
+  });
+});
+
+describe("LiveVoiceSession minimize-room marker", () => {
+  function createMarkerHarness() {
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const harness = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      // Deltas are emitted immediately in these runs; a long ack budget keeps
+      // filler phrases out of the recorded TTS text.
+      frontModelConfig: { ackFirstDeltaTimeoutMs: 10_000 },
+    });
+    return { ...harness, getCallbacks, ttsTexts };
+  }
+
+  test("strips [-1] from deltas and TTS and emits minimize_room after tts_done", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    emitTextDelta(getCallbacks, "hello [-1] world.");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
+
+    expect(assistantDeltaTexts(frames).join("")).toBe("hello  world.");
+    expect(ttsTexts.join(" ")).not.toContain("[-1]");
+    const ttsDoneIndex = frames.findIndex((frame) => frame.type === "tts_done");
+    const minimizeIndex = frames.findIndex(
+      (frame) => frame.type === "minimize_room",
+    );
+    expect(ttsDoneIndex).toBeGreaterThanOrEqual(0);
+    expect(minimizeIndex).toBeGreaterThan(ttsDoneIndex);
+    expect(frames[minimizeIndex]).toMatchObject({
+      type: "minimize_room",
+      turnId: "live-turn-1",
+    });
+    expect(
+      frames.filter((frame) => frame.type === "minimize_room"),
+    ).toHaveLength(1);
+  });
+
+  test("holds a marker split across deltas, never leaks the partial, and still emits", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    emitTextDelta(getCallbacks, "One sec. [-");
+    await flushAsyncCallbacks();
+    expect(assistantDeltaTexts(frames).join("")).toBe("One sec. ");
+
+    emitTextDelta(getCallbacks, "1] done.");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
+
+    const joined = assistantDeltaTexts(frames).join("");
+    expect(joined).toBe("One sec.  done.");
+    expect(joined).not.toContain("[-");
+    expect(ttsTexts.join(" ")).not.toContain("[-");
+  });
+
+  test("does not emit minimize_room when the turn is interrupted before drain", async () => {
+    const { frames, session, getCallbacks } = createMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    emitTextDelta(getCallbacks, "Minimizing now. [-1]");
+    await flushAsyncCallbacks();
+
+    await session.handleClientFrame({ type: "interrupt" });
+    emitMessageComplete(getCallbacks);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
+  });
+
+  test("a turn without the marker emits no minimize_room frame", async () => {
+    const { frames, session, getCallbacks } = createMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    emitTextDelta(getCallbacks, "Hello there.");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(assistantDeltaTexts(frames).join("")).toBe("Hello there.");
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
+  });
+
+  test("strips a stray [END_CALL] from main-leg deltas and TTS", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    emitTextDelta(getCallbacks, "Bye now. [END_CALL]");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(assistantDeltaTexts(frames).join("")).toBe("Bye now. ");
+    expect(ttsTexts.join(" ")).not.toContain("[END_CALL]");
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
+  });
+
+  test("a held marker-like tail that never completes is emitted at completion", async () => {
+    const { frames, session, getCallbacks } = createMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    emitTextDelta(getCallbacks, "Score was [-");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(assistantDeltaTexts(frames).join("")).toBe("Score was [-");
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
   });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -8,6 +8,7 @@ import {
 import { sanitizeForTts } from "../calls/tts-text-sanitizer.js";
 import {
   couldBeControlMarker,
+  MINIMIZE_ROOM_MARKER,
   stripInternalSpeechMarkers,
 } from "../calls/voice-control-protocol.js";
 import type {
@@ -428,6 +429,9 @@ interface ActiveAssistantTurn {
   progress: TurnProgressState;
   assistantCompleted: boolean;
   ttsDone: boolean;
+  // Latched when the leg's stream contains MINIMIZE_ROOM_MARKER; consumed
+  // once at TTS drain, where the minimize_room frame goes out after tts_done.
+  minimizeRequested: boolean;
   // A tts_audio frame actually went out to the client — latches on the first
   // forwarded chunk so the firstTtsAudio metric is marked exactly once per turn.
   ttsAudioStarted: boolean;
@@ -514,6 +518,44 @@ interface ActiveAssistantTurn {
   assistantAudioChunks: Buffer[];
   assistantAudioMimeType: string;
   assistantAudioSampleRate?: number;
+}
+
+/**
+ * Control-marker hygiene for one model leg's delta stream, shared by the
+ * front-door answer stage and the default/escalated leg. The returned flush
+ * forwards the stripped (stripInternalSpeechMarkers) prefix of `raw` that has
+ * not been emitted yet and can no longer become a control marker: a trailing
+ * "[…"-tail that could still complete one (couldBeControlMarker) is held back
+ * until a later delta disproves it, and `force` (leg completion) emits the
+ * held tail so real text that merely resembles a marker prefix is not
+ * dropped. As a side effect the flush latches the turn's `minimizeRequested`
+ * once the raw stream contains MINIMIZE_ROOM_MARKER — the marker itself is
+ * stripped, so the latch is the only observable.
+ */
+function createControlMarkerHoldback(
+  turn: ActiveAssistantTurn,
+  emit: (chunk: string) => void,
+): (raw: string, opts?: { force?: boolean }) => void {
+  let emitted = 0;
+  return (raw, opts) => {
+    if (!turn.minimizeRequested && raw.includes(MINIMIZE_ROOM_MARKER)) {
+      turn.minimizeRequested = true;
+    }
+    let safeEnd = raw.length;
+    if (opts?.force !== true) {
+      const lastOpen = raw.lastIndexOf("[");
+      if (lastOpen >= emitted) {
+        const tail = raw.slice(lastOpen);
+        if (!tail.includes("]") && couldBeControlMarker(tail)) {
+          safeEnd = lastOpen;
+        }
+      }
+    }
+    if (safeEnd > emitted) {
+      emit(stripInternalSpeechMarkers(raw.slice(emitted, safeEnd)));
+      emitted = safeEnd;
+    }
+  };
 }
 
 // Base control prompt for every live-voice turn. When a turn starts from a
@@ -2569,6 +2611,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       },
       assistantCompleted: false,
       ttsDone: false,
+      minimizeRequested: false,
       ttsAudioStarted: false,
       finalized: false,
       speculativePending: opts?.speculative === true,
@@ -2710,29 +2753,32 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     const { token, utterance, turnId } = activeTurn;
 
-    // Front-door verdict gate (verdict-first protocol — see
-    // voice-triage-escalate.ts). `rawText` accumulates this leg's full
-    // stream; the leg starts in `deciding` until its leading tokens
-    // classify as hold / escalate / answer. An answer flushes through
-    // `flushFrontDoor` (with `frontDoorEmitted` tracking what has been
-    // forwarded); an escalation buffers the post-verdict stream into
-    // `bridgeRaw` until the bridge is complete, then hands off.
+    // `rawText` accumulates this leg's full stream. A front-door leg starts
+    // in `deciding` until its leading tokens classify as hold / escalate /
+    // answer: an answer flushes through the shared marker holdback, while an
+    // escalation buffers the post-verdict stream into `bridgeRaw` until the
+    // bridge is complete, then hands off. A default/escalated leg flushes
+    // every delta through the same holdback, so a stray control marker from
+    // the main model is stripped instead of spoken.
     let rawText = "";
-    let frontDoorEmitted = 0;
     let frontDoorStage: "deciding" | "answer" | "bridging" | "handedOff" =
       "deciding";
     let bridgeRaw = "";
 
-    const emitFrontDoor = (chunk: string): void => {
+    const emitLegText = (chunk: string): void => {
       if (chunk.length === 0) {
         return;
       }
       this.markFirstAssistantDelta(utterance, turnId);
       this.markFirstDeltaForAck(activeTurn);
-      // Same send-time abort gate as the default-leg delta path: a front-door
-      // delta queued behind a backed-up outbound frame must not be written
-      // once barge-in aborts the turn. Escalation aborts the front-door handle,
-      // not this turn's controller, so legitimate front-door text still sends.
+      // Send-time abort gate: a delta queued behind a backed-up outbound
+      // frame must not be written once barge-in aborts the turn, or the
+      // cancelled reply's text leaks ahead of turn_cancelled. Key off this
+      // turn's own abort signal — a normal message_complete finalizes and
+      // clears activeAssistantTurn while trailing deltas may still be
+      // draining, so an activeAssistantTurn-based guard would drop them.
+      // Escalation aborts the front-door handle, not this turn's controller,
+      // so legitimate front-door text still sends.
       void this.sendFrame(
         { type: "assistant_text_delta", text: chunk },
         () => !activeTurn.abortController.signal.aborted && !this.isClosed,
@@ -2740,26 +2786,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.bufferAssistantTextForTts(token, chunk);
     };
 
-    // Forward the stripped, non-partial-marker prefix that has not been
-    // emitted yet (answer stage only). A trailing "[…" that could still
-    // become a control marker is held back until a later delta disproves
-    // it; a real partial that never completes is simply never spoken.
-    const flushFrontDoor = (): void => {
-      let safeEnd = rawText.length;
-      const lastOpen = rawText.lastIndexOf("[");
-      if (lastOpen >= frontDoorEmitted) {
-        const tail = rawText.slice(lastOpen);
-        if (!tail.includes("]") && couldBeControlMarker(tail)) {
-          safeEnd = lastOpen;
-        }
-      }
-      if (safeEnd > frontDoorEmitted) {
-        emitFrontDoor(
-          stripInternalSpeechMarkers(rawText.slice(frontDoorEmitted, safeEnd)),
-        );
-        frontDoorEmitted = safeEnd;
-      }
-    };
+    const flushLegText = createControlMarkerHoldback(activeTurn, emitLegText);
 
     // Hand off once enough of the post-verdict stream has arrived to cap
     // the bridge (sentence terminator or hard cap). Until then nothing is
@@ -2856,7 +2883,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                 }
                 frontDoorStage = "answer";
               }
-              flushFrontDoor();
+              flushLegText(rawText);
               return;
             }
             // Defensive: speculative legs are always front-door today, but a
@@ -2871,24 +2898,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                 return;
               }
             }
-            this.markFirstAssistantDelta(utterance, turnId);
-            this.markFirstDeltaForAck(activeTurn);
-            void this.sendFrame(
-              {
-                type: "assistant_text_delta",
-                text: msg.text,
-              },
-              // Re-check at send time (mirrors the tts_audio path): a delta
-              // already queued behind a backed-up outbound frame must not be
-              // written once barge-in has aborted the turn, or the cancelled
-              // reply's text leaks ahead of turn_cancelled. Key off this turn's
-              // own abort signal — a normal message_complete finalizes and
-              // clears activeAssistantTurn while trailing deltas may still be
-              // draining, so an activeAssistantTurn-based guard would drop them.
-              () =>
-                !activeTurn.abortController.signal.aborted && !this.isClosed,
-            );
-            this.bufferAssistantTextForTts(token, msg.text);
+            rawText += msg.text;
+            flushLegText(rawText);
           },
           message_complete: (msg) => {
             const current = this.activeAssistantTurn;
@@ -2929,6 +2940,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // (including the generation_cancelled from its abort) is a no-op.
             if (leg.frontDoor && current.escalationHandedOff) {
               return;
+            }
+            // A held "[…"-tail that never completed a marker is real text —
+            // force-flush it before assistantCompleted closes the TTS buffer
+            // and completeTtsForTurn signals the drain, so it is spoken and
+            // emitted rather than dropped.
+            if (!leg.frontDoor && msg.type === "message_complete") {
+              flushLegText(rawText, { force: true });
             }
             current.assistantCompleted = true;
             if (msg.type === "generation_cancelled") {
@@ -3663,6 +3681,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             currentTurn.finalized &&
             !this.isClosed,
         );
+
+        // Drain-scoped minimize: the latched marker is consumed here, after
+        // the turn's speech has fully drained — never mid-speech, never for
+        // a barged-in turn, at most once per turn.
+        if (
+          currentTurn.minimizeRequested &&
+          !currentTurn.abortController.signal.aborted
+        ) {
+          currentTurn.minimizeRequested = false;
+          await this.sendFrame(
+            { type: "minimize_room", turnId: currentTurn.turnId },
+            () => !this.isClosed,
+          );
+        }
 
         if (this.activeAssistantTurn?.token === token) {
           if (currentTurn.handle && currentTurn.finalized) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -7,7 +7,7 @@ import {
 } from "../calls/media-turn-detector.js";
 import { sanitizeForTts } from "../calls/tts-text-sanitizer.js";
 import {
-  couldBeControlMarker,
+  isIncompleteControlMarkerTail,
   MINIMIZE_ROOM_MARKER,
   stripInternalSpeechMarkers,
 } from "../calls/voice-control-protocol.js";
@@ -524,13 +524,17 @@ interface ActiveAssistantTurn {
  * Control-marker hygiene for one model leg's delta stream, shared by the
  * front-door answer stage and the default/escalated leg. The returned flush
  * forwards the stripped (stripInternalSpeechMarkers) prefix of `raw` that has
- * not been emitted yet and can no longer become a control marker: a trailing
- * "[…"-tail that could still complete one (couldBeControlMarker) is held back
- * until a later delta disproves it, and `force` (leg completion) emits the
- * held tail so real text that merely resembles a marker prefix is not
- * dropped. As a side effect the flush latches the turn's `minimizeRequested`
- * once the raw stream contains MINIMIZE_ROOM_MARKER — the marker itself is
- * stripped, so the latch is the only observable.
+ * not been emitted yet and cannot contain a still-streaming control marker:
+ * the flush stops at the first "[" whose tail is an incomplete marker
+ * (isIncompleteControlMarkerTail) and holds from there until a later delta
+ * completes or disproves it; `force` (leg completion) emits the held tail so
+ * real text that merely resembles a marker prefix is not dropped. The scan
+ * runs forward from the emitted boundary — not from the last "[" — so
+ * brackets INSIDE a streaming marker body (a JSON array or "]"-bearing string
+ * in ASK_GUARDIAN_APPROVAL) can neither mask the marker's start nor pass as
+ * its terminator. As a side effect the flush latches the turn's
+ * `minimizeRequested` once the raw stream contains MINIMIZE_ROOM_MARKER —
+ * the marker itself is stripped, so the latch is the only observable.
  */
 function createControlMarkerHoldback(
   turn: ActiveAssistantTurn,
@@ -543,11 +547,14 @@ function createControlMarkerHoldback(
     }
     let safeEnd = raw.length;
     if (opts?.force !== true) {
-      const lastOpen = raw.lastIndexOf("[");
-      if (lastOpen >= emitted) {
-        const tail = raw.slice(lastOpen);
-        if (!tail.includes("]") && couldBeControlMarker(tail)) {
-          safeEnd = lastOpen;
+      for (
+        let i = raw.indexOf("[", emitted);
+        i !== -1;
+        i = raw.indexOf("[", i + 1)
+      ) {
+        if (isIncompleteControlMarkerTail(raw.slice(i))) {
+          safeEnd = i;
+          break;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Main-leg deltas now share the front-door holdback/strip hygiene (stray control markers no longer spoken)
- `[-1]` latches `minimizeRequested`; `minimize_room` frame sent once after `tts_done`, never on cancelled turns

Part of plan: voice-room-minimize.md (PR 6 of 9)