### PR TITLE
feat(web): honor the minimize_room frame in the live-voice client wiring

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -47,7 +47,7 @@ import {
 // static import graph.
 const { useLiveVoice } =
   await import("@/domains/chat/voice/live-voice/use-live-voice");
-const { useLiveVoiceStore, getLiveVoicePlaybackProgress } =
+const { useLiveVoiceStore, getLiveVoicePlaybackProgress, restoreVoiceRoom } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 
@@ -874,6 +874,56 @@ describe("hands-free mode", () => {
   // "hands-free session controls" suite below: it sends ptt_release (the
   // daemon honors it as a manual VAD override) while leaving forwarding and
   // local state untouched.
+});
+
+// ---------------------------------------------------------------------------
+// minimize_room (assistant-requested room dismissal)
+// ---------------------------------------------------------------------------
+
+describe("minimize_room", () => {
+  test("emitting minimizeRoom sets roomMinimized on the store", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
+
+    act(() => {
+      h.client.emit("minimizeRoom", {
+        type: "minimize_room",
+        seq: 2,
+        turnId: "t1",
+      });
+    });
+
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    // Advisory frame: the session itself is untouched.
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+  });
+
+  test("a repeat frame while already minimized stays minimized, and restore still works", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("minimizeRoom", {
+        type: "minimize_room",
+        seq: 2,
+        turnId: "t1",
+      });
+      h.client.emit("minimizeRoom", {
+        type: "minimize_room",
+        seq: 3,
+        turnId: "t2",
+      });
+    });
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+
+    // The user can still bring the room back after a server-driven minimize.
+    act(() => {
+      restoreVoiceRoom();
+    });
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -47,7 +47,12 @@ import {
 // static import graph.
 const { useLiveVoice } =
   await import("@/domains/chat/voice/live-voice/use-live-voice");
-const { useLiveVoiceStore, getLiveVoicePlaybackProgress, restoreVoiceRoom } =
+const {
+  useLiveVoiceStore,
+  getLiveVoicePlaybackProgress,
+  minimizeVoiceRoom,
+  restoreVoiceRoom,
+} =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 
@@ -1148,6 +1153,37 @@ describe("hands-free session controls (send now / stop response / mute)", () => 
     });
     expect(h.view.result.current.state).toBe("listening");
     expect(useLiveVoiceStore.getState().muted).toBe(true);
+  });
+
+  test("a minimized room stays minimized across a retryable reconnect", async () => {
+    const h = renderController({ reconnectBackoffMs: [10] });
+    await startListening(h, { handsFree: true });
+    act(() => minimizeVoiceRoom());
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+
+    await act(async () => {
+      h.client.emit("closed", {
+        code: 1013,
+        reason: "assistant tunnel disconnected",
+      });
+    });
+    await act(async () => {
+      await sleep(40);
+    });
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s2",
+        conversationId: "conv-1",
+        turnDetection: "server_vad",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    // The same logical session is continuing — the room must not remount
+    // over whatever the user minimized it to look at.
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
   });
 
   test("publishes handsFree to the store, downgraded on the version-skew fallback", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -95,6 +95,7 @@ import {
 } from "@/domains/chat/voice/live-voice/tts-playback";
 import {
   isLiveVoiceSessionActive,
+  minimizeVoiceRoom,
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -824,6 +825,12 @@ export function useLiveVoice(
         client.on("ttsDone", () => {
           if (!live()) return;
           void finishResponseAfterPlayback(session, teardown);
+        }),
+        client.on("minimizeRoom", () => {
+          // Assistant asked to reveal the screen behind the room. Advisory: if
+          // the room isn't up (already minimized, pop-out, other route) this is
+          // a no-op — minimizeVoiceRoom() is an idempotent store write.
+          minimizeVoiceRoom();
         }),
         client.on("turnCancelled", () => {
           if (!live() || !session.handsFree) return;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -560,6 +560,11 @@ export function useLiveVoice(
       // composer just before start) also lives in the session state the reset
       // below clears — carry it across so the room's entrance grows from it.
       const entryOrigin = store.entryOrigin;
+      // A minimized room must stay minimized across a transient reconnect —
+      // the same logical session is continuing, and remounting the full-screen
+      // room would cover whatever the user minimized it to look at. A fresh
+      // start (attempt 0) always reopens in the room.
+      const wasRoomMinimized = store.roomMinimized;
       store.reset();
       store.setState("connecting");
       // A retry re-enters here via the backoff timer with `reconnectAttemptRef`
@@ -571,6 +576,7 @@ export function useLiveVoice(
       store.setSessionContext(assistantId, conversationId ?? null);
       store.setEntryOrigin(entryOrigin);
       if (isReconnect && wasMuted) store.setMuted(true);
+      if (isReconnect && wasRoomMinimized) store.setRoomMinimized(true);
       store.setHandsFree(startOptions.handsFree === true);
       // Registered here (not on `ready`) so a globally mounted surface can
       // drive the session from the moment it exists; cleared by the store


### PR DESCRIPTION
## Summary
- `minimizeRoom` client event → `minimizeVoiceRoom()` (idempotent, advisory)

Part of plan: voice-room-minimize.md (PR 7 of 9)