### PR TITLE
fix(calls): strip the [-1] minimize marker from persisted voice transcript rows

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1325,7 +1325,7 @@ describe("cutFrontDoorContentAtVerdict", () => {
   });
 });
 
-describe("front-door transcript hygiene (teardown pass)", () => {
+describe("transcript hygiene (teardown pass)", () => {
   beforeEach(resetCrudLog);
 
   function makeRow(text: string) {
@@ -1415,16 +1415,48 @@ describe("front-door transcript hygiene (teardown pass)", () => {
     expect(events).not.toContain("loadFromDb");
   });
 
-  test("a non-routed leg never runs the hygiene pass", async () => {
-    makeReservedRowConversation();
+  test("a non-routed leg leaves verdict-token content untouched (verdict cutting is front-door-only)", async () => {
+    const { events } = makeReservedRowConversation();
     getMessageByIdImpl = () => makeRow("[1] Anything at all");
 
     await startVoiceTurn(makeTurnOptions());
     await flushMicrotasks();
 
-    expect(crudLog.reads).toHaveLength(0);
+    expect(crudLog.reads).toEqual(["assistant-row-1"]);
     expect(crudLog.updates).toHaveLength(0);
     expect(crudLog.deletes).toHaveLength(0);
+    expect(events).not.toContain("loadFromDb");
+  });
+
+  test("a main-leg row containing the minimize marker persists with the marker stripped", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => makeRow("Done, take a look [-1]");
+
+    await startVoiceTurn(makeTurnOptions());
+    await flushMicrotasks();
+
+    expect(crudLog.updates).toEqual([
+      {
+        messageId: "assistant-row-1",
+        content: JSON.stringify([{ type: "text", text: "Done, take a look" }]),
+      },
+    ]);
+    expect(crudLog.deletes).toHaveLength(0);
+    // The clean row must reach in-memory history and sync consumers.
+    expect(events).toContain("loadFromDb");
+  });
+
+  test("a main-leg row without the minimize marker is never rewritten", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => makeRow("Done, take a look.");
+
+    await startVoiceTurn(makeTurnOptions());
+    await flushMicrotasks();
+
+    expect(crudLog.reads).toEqual(["assistant-row-1"]);
+    expect(crudLog.updates).toHaveLength(0);
+    expect(crudLog.deletes).toHaveLength(0);
+    expect(events).not.toContain("loadFromDb");
   });
 
   test("a discarded speculative leg deletes its reserved assistant row at teardown", async () => {

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1446,6 +1446,43 @@ describe("transcript hygiene (teardown pass)", () => {
     expect(events).toContain("loadFromDb");
   });
 
+  test("a marker-only main-leg row is deleted, not persisted as an empty bubble", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => makeRow("[-1]");
+
+    await startVoiceTurn(makeTurnOptions());
+    await flushMicrotasks();
+
+    expect(crudLog.updates).toHaveLength(0);
+    expect(crudLog.deletes).toEqual(["assistant-row-1"]);
+    expect(events).toContain("loadFromDb");
+  });
+
+  test("a marker-only row with a surviving non-text block is rewritten, never deleted", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => ({
+      ...makeRow("[-1]"),
+      content: [
+        { type: "text", text: "[-1]" },
+        { type: "tool_use", id: "tool-1", name: "app_create", input: {} },
+      ],
+    });
+
+    await startVoiceTurn(makeTurnOptions());
+    await flushMicrotasks();
+
+    expect(crudLog.deletes).toHaveLength(0);
+    expect(crudLog.updates).toEqual([
+      {
+        messageId: "assistant-row-1",
+        content: JSON.stringify([
+          { type: "tool_use", id: "tool-1", name: "app_create", input: {} },
+        ]),
+      },
+    ]);
+    expect(events).toContain("loadFromDb");
+  });
+
   test("a main-leg row without the minimize marker is never rewritten", async () => {
     const { events } = makeReservedRowConversation();
     getMessageByIdImpl = () => makeRow("Done, take a look.");

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1266,13 +1266,23 @@ export async function startVoiceTurn(
         } else if (
           joinedTextOfBlocks(row.content).includes(MINIMIZE_ROOM_MARKER)
         ) {
-          updateMessageContent(
-            reservedAssistantRowId,
-            JSON.stringify(
-              trimOuterTextEdges(stripMarkersFromBlocks(row.content)),
-            ),
+          const cleaned = trimOuterTextEdges(
+            stripMarkersFromBlocks(row.content),
           );
-          action = "strip_minimize_marker";
+          // A marker-only reply (the model said nothing beyond "[-1]") strips
+          // to nothing at all; keeping the row would render a blank assistant
+          // bubble, so delete it like the front-door empty case. Any surviving
+          // block — including non-text blocks like tool_use — keeps the row.
+          if (cleaned.length === 0) {
+            deleteMessageById(reservedAssistantRowId);
+            action = "delete_empty";
+          } else {
+            updateMessageContent(
+              reservedAssistantRowId,
+              JSON.stringify(cleaned),
+            );
+            action = "strip_minimize_marker";
+          }
         }
       }
       // Main legs run the pass on every voice turn; keep the no-op case

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -43,6 +43,7 @@ import {
   CALL_VERIFICATION_COMPLETE_MARKER,
   ESCALATE_VERDICT_TOKEN,
   HOLD_VERDICT_TOKEN,
+  MINIMIZE_ROOM_MARKER,
   stripInternalSpeechMarkers,
 } from "./voice-control-protocol.js";
 import {
@@ -481,8 +482,59 @@ function buildVoiceCallControlPrompt(opts: {
 }
 
 // ---------------------------------------------------------------------------
-// Front-door transcript hygiene
+// Transcript hygiene
 // ---------------------------------------------------------------------------
+
+/** The concatenated text of a row's text blocks. */
+function joinedTextOfBlocks(blocks: ContentBlock[]): string {
+  return blocks
+    .map((block) => (block.type === "text" ? block.text : ""))
+    .join("");
+}
+
+/**
+ * Strip internal speech markers from every text block, dropping text blocks
+ * the strip leaves empty; non-text blocks pass through untouched. Shared by
+ * the front-door stray-token rewrite and the main-leg minimize-marker
+ * rewrite.
+ */
+function stripMarkersFromBlocks(blocks: ContentBlock[]): ContentBlock[] {
+  const kept: ContentBlock[] = [];
+  for (const block of blocks) {
+    if (block.type !== "text") {
+      kept.push(block);
+      continue;
+    }
+    const cleaned = stripInternalSpeechMarkers(block.text);
+    if (cleaned.trim().length > 0) {
+      kept.push({ ...block, text: cleaned });
+    }
+  }
+  return kept;
+}
+
+/**
+ * Trim whitespace stranded at a rewritten row's outer edges by a stripped
+ * edge marker (e.g. "Done, take a look [-1]"), leaving inter-block spacing
+ * untouched.
+ */
+function trimOuterTextEdges(blocks: ContentBlock[]): ContentBlock[] {
+  const result = blocks.map((block) => ({ ...block }));
+  for (const block of result) {
+    if (block.type === "text") {
+      block.text = block.text.trimStart();
+      break;
+    }
+  }
+  for (let i = result.length - 1; i >= 0; i--) {
+    const block = result[i]!;
+    if (block.type === "text") {
+      block.text = block.text.trimEnd();
+      break;
+    }
+  }
+  return result;
+}
 
 /**
  * Reduce a front-door leg's persisted content to what was actually spoken
@@ -500,9 +552,7 @@ function buildVoiceCallControlPrompt(opts: {
 export function cutFrontDoorContentAtVerdict(
   blocks: ContentBlock[],
 ): { blocks: ContentBlock[]; spokenText: string } | null {
-  const joinedText = blocks
-    .map((block) => (block.type === "text" ? block.text : ""))
-    .join("");
+  const joinedText = joinedTextOfBlocks(blocks);
   if (joinedText.trimStart().startsWith(ESCALATE_VERDICT_TOKEN)) {
     const spokenText = spokenBridgeText(joinedText);
     return {
@@ -516,21 +566,8 @@ export function cutFrontDoorContentAtVerdict(
   ) {
     return null;
   }
-  const kept: ContentBlock[] = [];
-  for (const block of blocks) {
-    if (block.type !== "text") {
-      kept.push(block);
-      continue;
-    }
-    const cleaned = stripInternalSpeechMarkers(block.text);
-    if (cleaned.trim().length > 0) {
-      kept.push({ ...block, text: cleaned });
-    }
-  }
-  const spokenText = kept
-    .map((block) => (block.type === "text" ? block.text : ""))
-    .join("")
-    .trim();
+  const kept = stripMarkersFromBlocks(blocks);
+  const spokenText = joinedTextOfBlocks(kept).trim();
   return { blocks: kept, spokenText };
 }
 
@@ -1178,6 +1215,11 @@ export async function startVoiceTurn(
    *   never the verdict token or the text streamed past the cap (issue
    *   #37850). A row with no spoken bridge (canned-fallback case — that
    *   bridge is audio-only) is deleted.
+   * - Any other leg whose row carries the `[-1]` minimize marker (swallowed
+   *   before TTS on the live path) has its text blocks rewritten through
+   *   `stripInternalSpeechMarkers` so the marker never renders in the chat
+   *   transcript. Deliberately scoped to that marker: rows without it
+   *   persist byte-identical.
    *
    * After a rewrite, in-memory history is reloaded from the clean DB before
    * the escalated leg — blocked on this turn's teardown — snapshots it, so
@@ -1198,9 +1240,6 @@ export async function startVoiceTurn(
       }
       return;
     }
-    if (!discarded && opts.routingLeg !== "front-door") {
-      return;
-    }
     try {
       let action = "none";
       if (discarded) {
@@ -1208,32 +1247,50 @@ export async function startVoiceTurn(
         action = "delete_discarded";
       } else {
         const row = getMessageById(reservedAssistantRowId, opts.conversationId);
-        const cut = row ? cutFrontDoorContentAtVerdict(row.content) : null;
-        if (cut) {
-          if (cut.spokenText.length > 0) {
-            updateMessageContent(
-              reservedAssistantRowId,
-              JSON.stringify(cut.blocks),
-            );
-            action = "rewrite_spoken";
-          } else {
-            deleteMessageById(reservedAssistantRowId);
-            action = "delete_empty";
-          }
-        } else if (!row) {
+        if (!row) {
           action = "row_missing";
+        } else if (opts.routingLeg === "front-door") {
+          const cut = cutFrontDoorContentAtVerdict(row.content);
+          if (cut) {
+            if (cut.spokenText.length > 0) {
+              updateMessageContent(
+                reservedAssistantRowId,
+                JSON.stringify(cut.blocks),
+              );
+              action = "rewrite_spoken";
+            } else {
+              deleteMessageById(reservedAssistantRowId);
+              action = "delete_empty";
+            }
+          }
+        } else if (
+          joinedTextOfBlocks(row.content).includes(MINIMIZE_ROOM_MARKER)
+        ) {
+          updateMessageContent(
+            reservedAssistantRowId,
+            JSON.stringify(
+              trimOuterTextEdges(stripMarkersFromBlocks(row.content)),
+            ),
+          );
+          action = "strip_minimize_marker";
         }
       }
-      log.info(
-        {
-          turnId,
-          messageId: reservedAssistantRowId,
-          routingLeg: opts.routingLeg ?? null,
-          discarded,
-          action,
-        },
-        "Voice leg transcript hygiene",
-      );
+      // Main legs run the pass on every voice turn; keep the no-op case
+      // out of the logs.
+      const isMainLegNoOp =
+        action === "none" && !discarded && opts.routingLeg !== "front-door";
+      if (!isMainLegNoOp) {
+        log.info(
+          {
+            turnId,
+            messageId: reservedAssistantRowId,
+            routingLeg: opts.routingLeg ?? null,
+            discarded,
+            action,
+          },
+          "Voice leg transcript hygiene",
+        );
+      }
       if (action !== "none" && action !== "row_missing") {
         await conversation.loadFromDb();
         publishConversationMessagesChanged(opts.conversationId);


### PR DESCRIPTION
## Summary
- Teardown transcript-hygiene pass now rewrites main-leg rows containing `[-1]` through `stripInternalSpeechMarkers`
- Scoped to the minimize marker; broader all-marker stripping noted as follow-up

Part of plan: voice-room-minimize.md (PR 9 of 9)