### PR TITLE
feat(ios): add App Intents to start a voice session

### DIFF
--- a/clients/ios/App/App/AppDelegate.swift
+++ b/clients/ios/App/App/AppDelegate.swift
@@ -10,8 +10,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // A QR scan that launches the terminated app delivers the connect URL
         // here, not through `application(_:open:)` (which only covers warm
         // opens). Persist the origin now so the bridge boots to it.
-        if let url = launchOptions?[.url] as? URL {
-            _ = handleConnectDeepLink(url)
+        if let url = launchOptions?[.url] as? URL, !handleConnectDeepLink(url) {
+            // Every *other* custom-scheme launch URL — a `voice` link from an
+            // App Intent, the Live Activity, or Safari — would otherwise be
+            // dropped on the floor. Unlike the warm-open `application(_:open:)`
+            // path, this one never reaches `ApplicationDelegateProxy`, and the
+            // bridge web view does not exist yet, so there is nothing to
+            // forward to. Stash it and replay it once the web view is live.
+            pendingVoiceCommandURL = url
         }
         return true
     }
@@ -150,6 +156,50 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let encodedCode = deviceCode.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? deviceCode
         components.percentEncodedFragment = "device_code=\(encodedCode)"
         return components.url
+    }
+
+    // MARK: - Voice command deep links
+
+    /// A `<scheme>://voice?mode=…` command (or any other non-`connect` launch
+    /// URL) waiting for the bridge web view to come up, mirroring
+    /// `pendingConnectPairURL` above. Only the most recent one is kept — a
+    /// superseded command is stale by definition.
+    private var pendingVoiceCommandURL: URL?
+
+    /// Hand a voice command to the web layer, deferring until the bridge web
+    /// view exists.
+    ///
+    /// Called by the App Intents (`StartVoiceModeIntent` /
+    /// `StartNewVoiceConversationIntent`), which run in-process and therefore
+    /// never pass through `application(_:open:)`, and by the terminated-launch
+    /// path in `didFinishLaunchingWithOptions`.
+    func deliverVoiceCommand(_ url: URL) {
+        pendingVoiceCommandURL = url
+        deliverPendingVoiceCommand()
+    }
+
+    /// Replay a stashed voice command once the bridge web view is live. Safe to
+    /// call before the view controller exists (a cold launch defers to the first
+    /// `viewDidAppear`) and idempotent once delivered.
+    ///
+    /// Delivery goes through `ApplicationDelegateProxy`, the exact channel a
+    /// warm `application(_:open:)` uses, so the URL surfaces to JS as Capacitor's
+    /// `appUrlOpen` and `capacitor-deep-links.ts` handles it with no new web
+    /// code. `AppPlugin` posts that event with `retainUntilConsumed: true`, so a
+    /// command delivered before the SPA has registered its listener is replayed
+    /// rather than lost.
+    func deliverPendingVoiceCommand() {
+        guard let url = pendingVoiceCommandURL,
+              currentBridgeViewController()?.webView != nil
+        else {
+            return
+        }
+        pendingVoiceCommandURL = nil
+        _ = ApplicationDelegateProxy.shared.application(
+            UIApplication.shared,
+            open: url,
+            options: [:]
+        )
     }
 
     // MARK: - Web view navigation

--- a/clients/ios/App/App/BundleURLScheme.swift
+++ b/clients/ios/App/App/BundleURLScheme.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// The custom URL scheme this build registers, read from the bundle rather than
+/// hardcoded.
+///
+/// The three targets ship three schemes — `vellum-assistant`,
+/// `vellum-assistant-staging`, `vellum-assistant-dev` — each injected as
+/// `$(BUNDLE_URL_SCHEME)` from `App/Config/*.xcconfig` into `Info.plist`'s
+/// `CFBundleURLSchemes`. Hardcoding the production scheme would make a Dev or
+/// Staging build hand its deep links to the production app whenever both are
+/// installed.
+enum BundleURLScheme {
+    /// `nil` when the plist entry is missing, empty, or left un-substituted
+    /// (a literal `$(BUNDLE_URL_SCHEME)`, which happens when a target is built
+    /// without its xcconfig). Callers decide whether to fall back or bail.
+    static let current: String? = {
+        guard let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
+              let schemes = urlTypes.first?["CFBundleURLSchemes"] as? [String],
+              let scheme = schemes.first,
+              !scheme.isEmpty,
+              !scheme.contains("$")
+        else {
+            return nil
+        }
+        return scheme
+    }()
+}

--- a/clients/ios/App/App/Intents/StartNewVoiceConversationIntent.swift
+++ b/clients/ios/App/App/Intents/StartNewVoiceConversationIntent.swift
@@ -1,0 +1,25 @@
+import AppIntents
+
+/// "New voice conversation" — always start a clean live-voice session, never
+/// rejoin one in progress.
+///
+/// The Action Button target: a physical button press should do the same thing
+/// every time. See `StartVoiceModeIntent` for why this is a second intent
+/// rather than a `mode` parameter, and for the launch-mode declaration below.
+struct StartNewVoiceConversationIntent: AppIntent {
+    static var title: LocalizedStringResource = "New voice conversation"
+    static var description = IntentDescription(
+        "Open Vellum and start a brand-new voice conversation."
+    )
+
+    @available(iOS 26.0, *)
+    static var supportedModes: IntentModes { .foreground(.immediate) }
+
+    static var openAppWhenRun: Bool { true }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        VoiceModeDeepLink.new.route()
+        return .result()
+    }
+}

--- a/clients/ios/App/App/Intents/StartVoiceModeIntent.swift
+++ b/clients/ios/App/App/Intents/StartVoiceModeIntent.swift
@@ -1,0 +1,38 @@
+import AppIntents
+
+/// "Start voice mode" — bring the user into a live-voice conversation, joining
+/// one already in flight when there is one.
+///
+/// Paired with `StartNewVoiceConversationIntent`, which always starts fresh.
+/// Two intents rather than one intent with a `mode` parameter because the
+/// Action Button picker in Settings binds a shortcut, not a shortcut plus an
+/// argument — a parameterized intent would leave that binding ambiguous. This
+/// one is the natural Siri target ("talk to Vellum" should rejoin a call in
+/// progress); the other is the natural Action Button target.
+///
+/// No `AppShortcutsProvider` accompanies these yet, so they surface in the
+/// Shortcuts app but not in Siri, Spotlight, or the Action Button picker.
+struct StartVoiceModeIntent: AppIntent {
+    static var title: LocalizedStringResource = "Start voice mode"
+    static var description = IntentDescription(
+        "Open Vellum and start talking, picking up a voice conversation already in progress."
+    )
+
+    // iOS 26 soft-deprecated `openAppWhenRun` in favor of `supportedModes`, but
+    // `supportedModes` is itself iOS 26.0+ while this app deploys to 17.0 — so
+    // both are declared, and `.foreground(.immediate)` is the documented exact
+    // equivalent of `openAppWhenRun = true`. Neither `OpenIntent` (which needs a
+    // `target` AppEntity and SwiftUI's `onAppIntentExecution`) nor the iOS 26
+    // snippet intents fit: there is no entity to open, and the whole point is to
+    // launch rather than render a result in place.
+    @available(iOS 26.0, *)
+    static var supportedModes: IntentModes { .foreground(.immediate) }
+
+    static var openAppWhenRun: Bool { true }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        VoiceModeDeepLink.resume.route()
+        return .result()
+    }
+}

--- a/clients/ios/App/App/Intents/VoiceModeDeepLink.swift
+++ b/clients/ios/App/App/Intents/VoiceModeDeepLink.swift
@@ -1,0 +1,45 @@
+import Foundation
+import UIKit
+
+/// The `<scheme>://voice?mode=…` command an App Intent hands to the web layer.
+///
+/// This is deliberately the *same* URL contract the SPA already parses
+/// (`parseStartVoiceDeepLink` in `clients/web/src/runtime/native-deep-link.ts`,
+/// routed by `runtime/event-sources/capacitor-deep-links.ts`), so the intents
+/// add no second command channel: Siri, the Action Button, the Live Activity's
+/// `widgetURL`, and a link typed into Safari all converge on one parser.
+enum VoiceModeDeepLink: String {
+    /// Start a fresh live-voice session.
+    case new
+    /// Bring an already-running session back on screen; the web consumer falls
+    /// back to `new` when nothing is running.
+    case resume
+
+    /// Host segment shared with `START_VOICE_DEEP_LINK_HOST` on the web side.
+    private static let host = "voice"
+
+    /// The command URL for the *running build*, or `nil` when the bundle
+    /// declares no usable scheme. Unlike sign-in, there is no safe fallback
+    /// here: defaulting to the production scheme would make a Dev build launch
+    /// voice mode in the production app.
+    var url: URL? {
+        guard let scheme = BundleURLScheme.current else { return nil }
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = Self.host
+        components.queryItems = [URLQueryItem(name: "mode", value: rawValue)]
+        return components.url
+    }
+
+    /// Hand this command to the shell. Returns immediately — App Intents run
+    /// under a short execution budget, so `perform()` must hand off rather than
+    /// wait for a session to actually start.
+    @MainActor
+    func route() {
+        guard let url else {
+            NSLog("[voice] No bundle URL scheme; dropping voice command")
+            return
+        }
+        (UIApplication.shared.delegate as? AppDelegate)?.deliverVoiceCommand(url)
+    }
+}

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -183,12 +183,17 @@ class MyViewController: CAPBridgeViewController {
         webView?.load(URLRequest(url: destination))
     }
 
-    /// Apply any connect deep link that arrived before the web view was ready.
-    /// A cold launch stashes the pair-page navigation in `AppDelegate` and it is
-    /// delivered here, once the bridge web view is live and on screen.
+    /// Apply any deep link that arrived before the web view was ready. A cold
+    /// launch stashes the connect pair-page navigation and any voice command in
+    /// `AppDelegate`; both are delivered here, once the bridge web view is live
+    /// and on screen. Connect goes first: it can swap the origin out from under
+    /// the web view, and the voice command survives that reload because
+    /// Capacitor retains `appUrlOpen` until a JS listener consumes it.
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        (UIApplication.shared.delegate as? AppDelegate)?.deliverPendingConnectNavigation()
+        let appDelegate = UIApplication.shared.delegate as? AppDelegate
+        appDelegate?.deliverPendingConnectNavigation()
+        appDelegate?.deliverPendingVoiceCommand()
     }
 
     /// Bind foreground change detection to the currently-configured self-hosted

--- a/clients/ios/App/App/NativeAuthPlugin.swift
+++ b/clients/ios/App/App/NativeAuthPlugin.swift
@@ -41,22 +41,10 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
     /// on the plugin instance for the duration of the flow.
     private var authSession: ASWebAuthenticationSession?
 
-    /// Read the URL scheme from the bundle's CFBundleURLTypes rather than
-    /// hardcoding it. Each build target (App, App Dev, App Staging) sets
-    /// BUNDLE_URL_SCHEME in its xcconfig, which is baked into Info.plist's
-    /// CFBundleURLSchemes at build time. Falls back to "vellum-assistant"
-    /// if the plist entry is missing or un-substituted.
-    private static let callbackScheme: String = {
-        guard let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
-              let schemes = urlTypes.first?["CFBundleURLSchemes"] as? [String],
-              let scheme = schemes.first,
-              !scheme.isEmpty,
-              !scheme.contains("$")
-        else {
-            return "vellum-assistant"
-        }
-        return scheme
-    }()
+    /// The OAuth redirect scheme for this build target. Falls back to the
+    /// production scheme when the bundle declares none, so a misconfigured
+    /// build still reaches a working callback rather than failing sign-in.
+    private static let callbackScheme: String = BundleURLScheme.current ?? "vellum-assistant"
 
     /// The host this build target is allowed to authenticate against,
     /// read from the `VellumAssociatedDomain` Info.plist key (set per


### PR DESCRIPTION
Adds two App Intents that launch the iOS shell straight into live voice, routed through the already-merged `<scheme>://voice?mode=…` deep-link contract so no new web code is needed.

- `StartVoiceModeIntent` — "Start voice mode", routes `mode=resume` (the web consumer rejoins a live session, else starts fresh). The natural Siri target.
- `StartNewVoiceConversationIntent` — "New voice conversation", routes `mode=new`. The natural Action Button target.

Two intents rather than one with a `mode` parameter: the Settings → Action Button picker binds a shortcut, not a shortcut plus an argument, so a parameterized intent would leave that binding ambiguous.

**No `AppShortcutsProvider` here** — Siri phrases / Action Button / Spotlight surfacing is the next PR, deliberately kept separate so a phrase-matching problem stays isolated from an intent-plumbing problem. Until then these are reachable from the Shortcuts app only.

App Intents declared in the app target are discovered from the app binary via Xcode's App Intents metadata extraction — **no separate extension target is required**.

## ⚠️ Step 0 findings: `openAppWhenRun` is soft-deprecated in iOS 26 — approach adjusted

The plan's `openAppWhenRun = true` approach was designed against the pre-iOS-26 shape. Verified against the installed iOS 26.5 SDK (Xcode 26.6) by reading `AppIntents.swiftinterface` directly:

```swift
@available(iOS, deprecated: 26.0, message: "Please provide 'supportedModes' instead")
static var openAppWhenRun: Swift.Bool { get }

@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
static var supportedModes: AppIntents.IntentModes { get }
```

So: **`openAppWhenRun` is soft-deprecated (not removed) in iOS 26.0, and its replacement `supportedModes` is iOS 26.0+ only** — while this app deploys to 17.0. Neither alone is sufficient.

**Adjustment:** both intents declare *both*, with `supportedModes` availability-gated:

```swift
@available(iOS 26.0, *)
static var supportedModes: IntentModes { .foreground(.immediate) }

static var openAppWhenRun: Bool { true }
```

`.foreground(.immediate)` is the documented exact equivalent of `openAppWhenRun = true`. Verified this compiles clean — **zero warnings, no deprecation diagnostic** — with `swiftc -target arm64-apple-ios17.0` against the iOS 26.5 SDK. (Declaring a witness for a deprecated protocol requirement does not itself warn; only *referencing* it does.)

Two alternatives considered and **rejected**, with reasons:

- **`OpenIntent`** (which some iOS 26 write-ups recommend as the modern app-launching pattern) does not fit. Its protocol requires `var target: Self.Value where Value: AppValue` — it models "open *this entity*", and the current pattern pairs it with SwiftUI's `onAppIntentExecution` modifier. We have no entity to open, and this is a UIKit/WKWebView Capacitor shell with no SwiftUI view tree to attach that modifier to.
- **Snippet-based intents** (`_SnippetIntentContainer`, interactive snippets, new in iOS 26) are for rendering a result *in place without launching* — the exact opposite of the requirement here.

Conclusion: URL handoff + foreground launch remains correct. App Intents has never offered a "navigate my app" API for non-SwiftUI hosts.

## Terminated-launch URL drop (Codex P1 from #39243) — fixed

`didFinishLaunchingWithOptions` previously did only:

```swift
if let url = launchOptions?[.url] as? URL { _ = handleConnectDeepLink(url) }
```

`handleConnectDeepLink` returns `false` for any non-`connect` host and takes no other action, and — unlike the warm-open `application(_:open:)` — this path never forwards to `ApplicationDelegateProxy`. So on a **terminated** app, a `vellum-assistant://voice?…` URL from Siri, the Action Button, Safari, or a manual test link was silently discarded before the web view existed. That is the headline Action Button case.

Now any non-`connect` launch URL is stashed in `pendingVoiceCommandURL` and replayed once the bridge web view is live. Scoped to launch URLs generally, not just intent-generated ones — Safari and manual test links hit the identical native path.

This composes with, and does not replace, the merged web-side cold-launch parking: that solves a different race (link arrives before `ChatLayout` registers the live-voice `starter`). Here the URL never reached the web layer at all. Both are required.

### Why the `connect` QR flow does not regress

This is the highest-risk part of the change, so, precisely:

```diff
-if let url = launchOptions?[.url] as? URL {
-    _ = handleConnectDeepLink(url)
+if let url = launchOptions?[.url] as? URL, !handleConnectDeepLink(url) {
+    pendingVoiceCommandURL = url
 }
```

- `handleConnectDeepLink(url)` is still evaluated **exactly once**, with identical arguments and identical side effects (`SelfHostedServer.store`, `pendingConnectPairURL`, `deliverPendingConnectNavigation`). Swift's `&&`-style short-circuiting in an `if let … , cond` clause cannot skip it, because it is the *last* condition.
- It returns `true` for **every** `connect`-host URL — both well-formed and malformed (the malformed branch logs and returns `true` deliberately, so a connect link is never re-routed to the OAuth/unknown handler). `!true` is `false`, so a connect URL is never stashed and never forwarded to the web layer. Behavior is bit-for-bit what it was.
- The only behavior change is for URLs where it returned `false`, i.e. non-`connect` hosts, which previously fell through to nothing at all.
- On the delivery side, `deliverPendingConnectNavigation()` runs *before* `deliverPendingVoiceCommand()` in `viewDidAppear`. Connect can swap the origin out from under the web view with a `webView.load(...)`; a voice command survives that reload because Capacitor's `AppPlugin` posts `appUrlOpen` with `retainUntilConsumed: true` and replays it to the first JS listener that registers.

An unknown-host launch URL is now stashed and forwarded to `appUrlOpen`, where the merged `capacitor-deep-links.ts` publishes `deeplink.unknown` (query/fragment stripped). No crash, and it matches what a warm open already did.

## Delivery channel

`deliverVoiceCommand(_:)` forwards through `ApplicationDelegateProxy.shared.application(_:open:options:)` — the exact channel a warm `application(_:open:)` uses. It posts `.capacitorOpenURL`, which `@capacitor/app`'s `AppPlugin` (eagerly instantiated by `CapacitorBridge.registerPlugins()` at bridge init, well before `viewDidAppear`) turns into the `appUrlOpen` JS event the merged web consumer already handles. Zero new web code.

## Files

| File | |
|---|---|
| `clients/ios/App/App/Intents/StartVoiceModeIntent.swift` | new |
| `clients/ios/App/App/Intents/StartNewVoiceConversationIntent.swift` | new |
| `clients/ios/App/App/Intents/VoiceModeDeepLink.swift` | new — shared URL construction + routing for both intents |
| `clients/ios/App/App/BundleURLScheme.swift` | new — see below |
| `clients/ios/App/App/AppDelegate.swift` | `deliverVoiceCommand` / `deliverPendingVoiceCommand` + the terminated-launch fix |
| `clients/ios/App/App/MyViewController.swift` | drain the pending voice command from `viewDidAppear`, mirroring the connect pair URL |
| `clients/ios/App/App/NativeAuthPlugin.swift` | de-duplicated onto `BundleURLScheme` (see below) |

Beyond the planned three files:

- `VoiceModeDeepLink.swift` keeps URL construction in one place instead of duplicating it across two intents.
- `MyViewController.swift` is where `viewDidAppear` lives, so the cold-launch drain has to go there.
- `BundleURLScheme.swift` + `NativeAuthPlugin.swift`: `NativeAuthPlugin` already had bundle-scheme lookup, including an un-substituted-`$(BUNDLE_URL_SCHEME)` guard that a fresh copy would have missed. Extracted to one shared lazily-computed value. Behavior-preserving: `NativeAuthPlugin` keeps its `?? "vellum-assistant"` fallback (a broken sign-in callback is worse than the wrong scheme), while the voice path deliberately has **no** fallback — defaulting to the production scheme would make a Dev build launch voice mode in the production app.

`bun run ios:setup` regenerates cleanly; all three targets pick up `App/Intents/` automatically (the `App` source path sweeps subdirectories). `CapApp-SPM/Package.swift` is unmodified.

## Unverified

Local `xcodebuild` cannot run: Xcode 26.6 has the iOS 26.5 SDK but not the installed iOS platform components, so `generic/platform=iOS` and `generic/platform=iOS Simulator` both resolve zero destinations. Pre-existing and environmental. **CI's `PR iOS Checks` is the real build gate for this PR.** As a partial local substitute, all new Swift sources type-check clean (zero warnings) via `swiftc -typecheck -target arm64-apple-ios17.0` against the iOS 26.5 SDK.

**No physical device was available, so every runtime acceptance criterion below is code-reasoned only and needs a device pass:**

- [ ] Both intents appear in the Shortcuts app after install.
- [ ] Running each intent with the app **terminated** launches it and starts/resumes a voice session.
- [ ] Running each intent with the app **backgrounded** foregrounds it and starts/resumes a session.
- [ ] A terminated-launch `vellum-assistant://voice?mode=new` URL (e.g. typed into Safari) reaches the web layer and starts a session.
- [ ] **Highest risk — no regression to the QR pairing flow:** a terminated-launch `vellum-assistant://connect?url=…&code=…` still pairs. Reasoned about in detail above and I believe it is airtight, but it is the one path where a mistake silently breaks an existing shipped feature, so it should be exercised on device before this reaches TestFlight.
- [ ] An unknown-host terminated-launch URL (`vellum-assistant://nonsense`) does not crash.
- [ ] Each build's intent uses its own scheme — install Dev alongside Prod and confirm the Dev intent opens Dev.
- [ ] The exact ordering of `perform()` vs. `viewDidAppear` on a cold intent launch. Both orderings are handled (immediate delivery when the web view exists, stash-and-replay when it does not), but which one actually occurs is worth observing.

Timing note: `perform()` hands off and returns immediately; it never waits for a session to start, per the App Intents execution budget.