### PR TITLE
fix(web): match the switch-modal to the mock and stop the downgrade repeating itself

### DIFF
--- a/clients/web/src/domains/settings/billing/assistant-avatar-tile.tsx
+++ b/clients/web/src/domains/settings/billing/assistant-avatar-tile.tsx
@@ -1,12 +1,10 @@
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { DialogHeaderTile } from "@/domains/settings/billing/dialog-header-tile";
 import { useTakeoverSurface } from "@/domains/settings/billing/pro-onboarding/use-takeover-surface";
-import { cn } from "@/utils/misc";
 
-export interface AssistantAvatarTileProps {
-  /** Avatar diameter in px, inside the tile's padding. */
-  size?: number;
-  className?: string;
-}
+// The mock places the creature at 32 × 26 inside the 52px tile — wider than the
+// tile's nominal padding, which is how the art is drawn there.
+const AVATAR_SIZE = 32;
 
 /**
  * The assistant's avatar on a rounded neutral tile — the header glyph of the
@@ -15,29 +13,22 @@ export interface AssistantAvatarTileProps {
  * `ChatAvatar` synthesizes fallback traits, so drawing early would flash the
  * bundled green and then jump to the real color.
  */
-export function AssistantAvatarTile({
-  size = 24,
-  className,
-}: AssistantAvatarTileProps) {
+export function AssistantAvatarTile() {
   const { ready, avatar } = useTakeoverSurface();
 
   return (
-    <div
-      aria-hidden
+    <DialogHeaderTile
       data-testid="assistant-avatar-tile"
-      className={cn(
-        "flex size-[52px] shrink-0 items-center justify-center rounded-xl bg-[var(--surface-active)]",
-        className,
-      )}
+      className="bg-[var(--surface-active)]"
     >
       {ready ? (
         <ChatAvatar
           components={avatar.components}
           traits={avatar.traits}
           customImageUrl={avatar.customImageUrl}
-          size={size}
+          size={AVATAR_SIZE}
         />
       ) : null}
-    </div>
+    </DialogHeaderTile>
   );
 }

--- a/clients/web/src/domains/settings/billing/dialog-header-tile.tsx
+++ b/clients/web/src/domains/settings/billing/dialog-header-tile.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/utils/misc";
+
+export interface DialogHeaderTileProps {
+  /** The tile's fill, e.g. `bg-[var(--surface-active)]`. */
+  className?: string;
+  /** Test hook naming which glyph the header resolved to. */
+  "data-testid"?: string;
+  children?: ReactNode;
+}
+
+/**
+ * The 52px rounded square behind the package-switch confirm dialog's header
+ * glyph — the assistant avatar on the way up, a warning triangle on the way
+ * down. One owner for the geometry so the two variants cannot drift; only the
+ * fill differs. Decorative: the title beside it carries the meaning.
+ */
+export function DialogHeaderTile({
+  className,
+  "data-testid": testId,
+  children,
+}: DialogHeaderTileProps) {
+  return (
+    <div
+      aria-hidden
+      data-testid={testId}
+      className={cn(
+        "flex size-[52px] shrink-0 items-center justify-center rounded-xl",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -56,6 +56,15 @@ describe("packageSpecs", () => {
     } as ProPackage);
     expect(specs[1].label).toBe("$0 credits");
   });
+
+  test("formats a sub-dollar credit amount cents-aware", () => {
+    const specs = packageSpecs({
+      machine_size: "small",
+      credits_usd: 0.5,
+      storage_gib: 8,
+    } as ProPackage);
+    expect(specs[1].label).toBe("$0.50 credits");
+  });
 });
 
 describe("packageHighlights", () => {
@@ -95,16 +104,6 @@ describe("packageHighlights", () => {
     ]);
   });
 
-  test("formats a sub-dollar credit amount cents-aware", () => {
-    expect(
-      packageHighlights({
-        machine_size: "small",
-        credits_usd: 0.5,
-        storage_gib: 8,
-      } as ProPackage)[2],
-    ).toBe("$0.50 of bundled credits");
-  });
-
   test("appends extra rows in order after the derived rows", () => {
     expect(
       packageHighlights(
@@ -128,12 +127,6 @@ describe("packageHighlights", () => {
     expect(
       packageHighlights({ machine_size: "gigantic" } as ProPackage)[0],
     ).toBe("gigantic machine");
-  });
-
-  test("appends nothing when extra is omitted", () => {
-    expect(
-      packageHighlights({ machine_size: "small" } as ProPackage),
-    ).toHaveLength(3);
   });
 });
 

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -7,6 +7,7 @@ import {
 import type { ProPackage } from "@/domains/settings/billing/package-types";
 import {
   creditRowLabel,
+  formatDollars,
   storageRowLabel,
 } from "@/domains/settings/components/tier-pricing";
 import type { MachineSizeEnum } from "@/generated/api/types.gen";
@@ -44,7 +45,9 @@ export function packageSpecs(pkg: ProPackage | null): PlanSpec[] {
   const storage = pkg?.storage_gib ?? FREE_STORAGE_GIB;
   return [
     { icon: Computer, label: `${machineLabel(pkg)} Machine` },
-    { icon: Coins, label: `$${credits} credits` },
+    // Cents-aware like every other price on these surfaces, so a sub-dollar
+    // bundle reads "$0.50 credits" rather than "$0.5 credits".
+    { icon: Coins, label: `${formatDollars(credits * 100)} credits` },
     { icon: HardDrive, label: `${storage} GB` },
   ];
 }

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.stories.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useLayoutEffect } from "react";
 
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { makeProPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
@@ -54,10 +55,22 @@ const meta: Meta<typeof PackageSwitchConfirmModal> = {
   decorators: [
     (Story) => {
       // The avatar tile resolves its assistant from the active id, and holds an
-      // empty square while that is null.
-      useResolvedAssistantsStore.setState({
-        activeAssistantId: STORY_ASSISTANT_ID,
-      });
+      // empty square while that is null. Writing the store during render would
+      // update the subscribed tile mid-render on every control change, and the
+      // fake id would outlive these stories — so seed it in an effect and hand
+      // the previous value back on unmount.
+      useLayoutEffect(() => {
+        const previous =
+          useResolvedAssistantsStore.getState().activeAssistantId;
+        useResolvedAssistantsStore.setState({
+          activeAssistantId: STORY_ASSISTANT_ID,
+        });
+        return () => {
+          useResolvedAssistantsStore.setState({
+            activeAssistantId: previous,
+          });
+        };
+      }, []);
       return (
         <QueryClientProvider client={queryClient}>
           <Story />

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
@@ -1,8 +1,7 @@
 /**
  * Tests for `PackageSwitchConfirmModal`. The dialog is pure layout over three
- * pure helpers, so the harness only has to mock the assistant-avatar query at
- * its module boundary — the header tile pulls it in transitively and there is
- * no active assistant to resolve in a test.
+ * pure helpers, and the header tile draws nothing without an active assistant,
+ * so the harness only has to leave that store empty.
  *
  * Radix portals the dialog, so queries come off `render`'s `baseElement`
  * (document.body), not the mount container.
@@ -12,31 +11,27 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import type { ComponentProps } from "react";
 
+import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import {
+  CHECKLIST_HEADING,
+  CONTINUE_LABEL,
   DOWNGRADE_CAPTION,
+  DOWNGRADE_CHECKLIST_HEADING,
   DOWNGRADE_NOTE,
   SWITCH_CAPTION,
   UPGRADE_CAPTION,
 } from "@/domains/settings/billing/plans/package-switch-copy";
-import { PLAN_TIER_COPY } from "@/domains/settings/billing/plans/plans-copy";
+import {
+  PLAN_TIER_COPY,
+  downgradeLabel,
+} from "@/domains/settings/billing/plans/plans-copy";
 import { makeProPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
-mock.module("@/hooks/use-assistant-avatar", () => ({
-  useAssistantAvatar: () => ({
-    components: null,
-    traits: null,
-    customImageUrl: null,
-    isLoading: false,
-    invalidate: () => {},
-  }),
-}));
-
-const { PackageSwitchConfirmModal } =
-  await import("./package-switch-confirm-modal");
-
-const MIGHTY_DESCRIPTION =
-  "Small machine, 15 GB of storage, and $25 in monthly credits.";
+/** The package's own catalog blurb — never the dialog's description. */
+const CATALOG_BLURB = makeProPackage().description;
+/** A server-shipped package this bundle has no tier copy for. */
+const UNKNOWN_TIER_PACKAGE = makeProPackage({ key: "mega", name: "Mega" });
 
 let onCancel = mock(() => {});
 let onConfirm = mock(() => {});
@@ -77,20 +72,14 @@ describe("PackageSwitchConfirmModal", () => {
     const { getByText, getByRole, getByTestId } = renderModal();
 
     getByRole("heading", { name: "Upgrade to Mighty" });
-    // Moving up, the tagline renders as the dialog's description, so it is what
-    // `aria-describedby` points at.
-    const describedBy = getByRole("dialog").getAttribute("aria-describedby");
-    expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
-      PLAN_TIER_COPY.mighty.tagline,
-    );
     getByText("$50/mo");
     getByText(UPGRADE_CAPTION);
-    getByText("The plan includes");
+    getByText(CHECKLIST_HEADING);
     getByText("Small machine (2 vCPU, 3 GiB)");
     getByText("15 GB storage");
     getByText("$25 of bundled credits");
     expect(getByTestId("confirm-package-switch-button").textContent).toBe(
-      "Continue",
+      CONTINUE_LABEL,
     );
   });
 
@@ -99,31 +88,27 @@ describe("PackageSwitchConfirmModal", () => {
       relation: "downgrade",
     });
 
-    getByRole("heading", { name: "Downgrade to Mighty" });
+    getByRole("heading", { name: downgradeLabel("Mighty") });
     getByText(DOWNGRADE_CAPTION);
     getByText(DOWNGRADE_NOTE);
     expect(getByTestId("confirm-package-switch-button").textContent).toBe(
-      "Downgrade to Mighty",
+      downgradeLabel("Mighty"),
     );
   });
 
-  test("a downgrade swaps the avatar for a warning glyph and drops the gains framing", () => {
-    const { getByTestId, queryByTestId, getByText, queryByText } = renderModal({
-      relation: "downgrade",
-    });
+  test("the header glyph and the checklist framing track the direction", () => {
+    const upgrade = renderModal();
+    upgrade.getByTestId("assistant-avatar-tile");
+    expect(upgrade.queryByTestId("package-switch-warning-tile")).toBeNull();
+    upgrade.getByText(CHECKLIST_HEADING);
 
-    getByTestId("package-switch-warning-tile");
-    expect(queryByTestId("assistant-avatar-tile")).toBeNull();
-    getByText("Your plan will include");
-    expect(queryByText("The plan includes")).toBeNull();
-  });
+    cleanup();
 
-  test("an upgrade keeps the friendly avatar header", () => {
-    const { getByTestId, queryByTestId, getByText } = renderModal();
-
-    getByTestId("assistant-avatar-tile");
-    expect(queryByTestId("package-switch-warning-tile")).toBeNull();
-    getByText("The plan includes");
+    const downgrade = renderModal({ relation: "downgrade" });
+    downgrade.getByTestId("package-switch-warning-tile");
+    expect(downgrade.queryByTestId("assistant-avatar-tile")).toBeNull();
+    downgrade.getByText(DOWNGRADE_CHECKLIST_HEADING);
+    expect(downgrade.queryByText(CHECKLIST_HEADING)).toBeNull();
   });
 
   test("the dialog opens focused on Cancel, not on the confirm", () => {
@@ -135,52 +120,118 @@ describe("PackageSwitchConfirmModal", () => {
     expect(document.activeElement).not.toBe(
       getByTestId("confirm-package-switch-button"),
     );
+  });
+
+  test("the checklist owns the specs — the catalog blurb never doubles them", () => {
+    // The real blurbs are the checklist in sentence form ("Medium machine,
+    // 30 GB of storage, and $45 in monthly credits."), so quoting one in the
+    // header would state the same three facts twice, 40px apart.
+    const downgrade = renderModal({ relation: "downgrade" });
+    expect(downgrade.queryByText(CATALOG_BLURB)).toBeNull();
+    expect(downgrade.queryByText(PLAN_TIER_COPY.mighty.tagline)).toBeNull();
+    downgrade.getByText("15 GB storage");
 
     cleanup();
 
-    const upgrade = renderModal();
-    expect(document.activeElement).toBe(
-      upgrade.getByRole("button", { name: "Cancel" }),
-    );
-  });
-
-  test("a package with no tier copy describes itself from the catalog", () => {
-    const { getByRole, getByText } = renderModal({
+    // Same for a tier this bundle has no tagline for: title-only header.
+    const unknownTier = renderModal({
       packageName: "Mega",
-      targetPackage: makeProPackage({ key: "mega", name: "Mega" }),
+      targetPackage: UNKNOWN_TIER_PACKAGE,
     });
-
-    const describedBy = getByRole("dialog").getAttribute("aria-describedby");
-    expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
-      MIGHTY_DESCRIPTION,
-    );
-    getByText(MIGHTY_DESCRIPTION);
+    expect(unknownTier.queryByText(CATALOG_BLURB)).toBeNull();
+    unknownTier.getByText("15 GB storage");
   });
 
-  test("a downgrade describes the target factually, never with its sales tagline", () => {
-    const { getByRole, getByText, queryByText } = renderModal({
-      relation: "downgrade",
-    });
+  test("an upgrade with tier copy is described by its tagline", () => {
+    const { getByRole, getByText } = renderModal();
 
-    // "Downgrade to Mighty" over "More capacity for consistent use." pitches the
-    // tier the user is leaving. The catalog blurb states what they land on, and
-    // still anchors `aria-describedby`.
-    expect(queryByText(PLAN_TIER_COPY.mighty.tagline)).toBeNull();
-    getByText(MIGHTY_DESCRIPTION);
+    getByText(PLAN_TIER_COPY.mighty.tagline);
     const describedBy = getByRole("dialog").getAttribute("aria-describedby");
     expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
-      MIGHTY_DESCRIPTION,
+      PLAN_TIER_COPY.mighty.tagline,
     );
   });
 
-  test("with nothing to describe the dialog carries no aria-describedby", () => {
-    const { getByRole } = renderModal({
-      packageName: "",
-      targetPackage: null,
-    });
+  // Radix stamps `aria-describedby` at `Modal.Description`'s id whether or not
+  // that element renders, so every relation × catalog combination has to land
+  // on an element that exists — or on no attribute at all. A destructive switch
+  // is described by its safeguard, never by a spec line.
+  const DESCRIBED_BY_CASES: {
+    label: string;
+    props: Partial<ComponentProps<typeof PackageSwitchConfirmModal>>;
+    /** Expected description text, or null for no `aria-describedby`. */
+    text: string | null;
+  }[] = [
+    {
+      label: "upgrade, known tier",
+      props: {},
+      text: PLAN_TIER_COPY.mighty.tagline,
+    },
+    {
+      label: "upgrade, unknown tier",
+      props: { packageName: "Mega", targetPackage: UNKNOWN_TIER_PACKAGE },
+      text: null,
+    },
+    {
+      label: "upgrade, no target",
+      props: { packageName: "", targetPackage: null },
+      text: null,
+    },
+    {
+      label: "switch, known tier",
+      props: { relation: "switch" },
+      text: PLAN_TIER_COPY.mighty.tagline,
+    },
+    {
+      label: "switch, unknown tier",
+      props: {
+        relation: "switch",
+        packageName: "Mega",
+        targetPackage: UNKNOWN_TIER_PACKAGE,
+      },
+      text: null,
+    },
+    {
+      label: "switch, no target",
+      props: { relation: "switch", packageName: "", targetPackage: null },
+      text: null,
+    },
+    {
+      label: "downgrade, known tier",
+      props: { relation: "downgrade" },
+      text: DOWNGRADE_NOTE,
+    },
+    {
+      label: "downgrade, unknown tier",
+      props: {
+        relation: "downgrade",
+        packageName: "Mega",
+        targetPackage: UNKNOWN_TIER_PACKAGE,
+      },
+      text: DOWNGRADE_NOTE,
+    },
+    {
+      label: "downgrade, no target",
+      props: { relation: "downgrade", packageName: "", targetPackage: null },
+      text: DOWNGRADE_NOTE,
+    },
+  ];
 
-    expect(getByRole("dialog").hasAttribute("aria-describedby")).toBe(false);
-  });
+  for (const { label, props, text } of DESCRIBED_BY_CASES) {
+    test(`aria-describedby resolves to a rendered element — ${label}`, () => {
+      const { getByRole } = renderModal(props);
+      const dialog = getByRole("dialog");
+
+      if (text === null) {
+        expect(dialog.hasAttribute("aria-describedby")).toBe(false);
+        return;
+      }
+      const describedBy = dialog.getAttribute("aria-describedby");
+      expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+        text,
+      );
+    });
+  }
 
   test("the downgrade safeguard note survives an unresolved target", () => {
     const { getByText, queryByText } = renderModal({
@@ -190,7 +241,7 @@ describe("PackageSwitchConfirmModal", () => {
     });
 
     getByText(DOWNGRADE_NOTE);
-    expect(queryByText("Your plan will include")).toBeNull();
+    expect(queryByText(DOWNGRADE_CHECKLIST_HEADING)).toBeNull();
   });
 
   test("a direction-neutral switch names both proration outcomes", () => {
@@ -202,7 +253,7 @@ describe("PackageSwitchConfirmModal", () => {
     getByText(SWITCH_CAPTION);
     expect(queryByText(DOWNGRADE_NOTE)).toBeNull();
     expect(getByTestId("confirm-package-switch-button").textContent).toBe(
-      "Continue",
+      CONTINUE_LABEL,
     );
   });
 
@@ -236,7 +287,7 @@ describe("PackageSwitchConfirmModal", () => {
 
     getByRole("heading", { name: "Upgrade to" });
     getByTestId("assistant-avatar-tile");
-    expect(queryByText("The plan includes")).toBeNull();
+    expect(queryByText(CHECKLIST_HEADING)).toBeNull();
     expect(queryByText(UPGRADE_CAPTION)).toBeNull();
     expect(queryByText("15 GB storage")).toBeNull();
     getByTestId("confirm-package-switch-button");

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -1,7 +1,8 @@
 import { AlertTriangle, CircleCheck } from "lucide-react";
-import { useRef } from "react";
+import { useId, useRef } from "react";
 
 import { AssistantAvatarTile } from "@/domains/settings/billing/assistant-avatar-tile";
+import { DialogHeaderTile } from "@/domains/settings/billing/dialog-header-tile";
 import type {
   ProPackage,
   SwitchRelation,
@@ -10,7 +11,6 @@ import { packageHighlights } from "@/domains/settings/billing/plan-spec";
 import { packageSwitchCopy } from "@/domains/settings/billing/plans/package-switch-copy";
 import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
 import { formatMonthly } from "@/domains/settings/components/tier-pricing";
-import { cn } from "@/utils/misc";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -39,10 +39,10 @@ export interface PackageSwitchConfirmModalProps {
 
 /**
  * Reconfirm dialog for a one-click Pro package switch. A downgrade gets the
- * warning glyph, loss-framed checklist copy, neutral spec markers, the danger
- * confirm and its safeguard note; an upgrade and a direction-neutral switch get
- * the assistant avatar and a lighter primary confirm. Layout-only for the
- * mutation — the parent owns `change-package`.
+ * warning glyph, loss-framed checklist copy, the danger confirm and its
+ * safeguard note; an upgrade and a direction-neutral switch get the assistant
+ * avatar and a lighter primary confirm. Layout-only for the mutation — the
+ * parent owns `change-package`.
  */
 export function PackageSwitchConfirmModal({
   open,
@@ -54,16 +54,12 @@ export function PackageSwitchConfirmModal({
   onConfirm,
 }: PackageSwitchConfirmModalProps) {
   const cancelRef = useRef<HTMLButtonElement>(null);
+  const noteId = useId();
   const copy = packageSwitchCopy(
     relation,
     packageName,
     targetPackage?.key ?? null,
   );
-  // A downgrade withholds the tagline outright, and the server-driven catalog
-  // can ship a package this bundle has no tier copy for; either way the
-  // package's own factual blurb takes over — without it the description element
-  // disappears while Radix still points `aria-describedby` at its id.
-  const description = copy.subtitle || targetPackage?.description || "";
   // Everything below the header describes one concrete package, so it all
   // resolves — or doesn't — together.
   const details = targetPackage
@@ -75,12 +71,22 @@ export function PackageSwitchConfirmModal({
         ),
       }
     : null;
-  // A green check reads as a win; on a downgrade the rows describe a smaller
-  // machine, so the same glyph goes neutral. An empty marker would instead read
-  // as "not included".
-  const highlightIconColor = copy.destructive
-    ? "text-[var(--content-tertiary)]"
-    : "text-[var(--system-positive-strong)]";
+  // The header's second line, and only ever the tier's tagline. The package's
+  // own catalog blurb is the checklist in sentence form ("Medium machine, 30 GB
+  // of storage, and $45 in monthly credits."), and that checklist renders for
+  // every package there is a blurb to read — so falling back to it would state
+  // the same three facts twice, 40px apart. A relation that withholds the
+  // tagline (a downgrade) simply gets a title-only header.
+  const description = copy.subtitle;
+  // Radix stamps `aria-describedby` at `Modal.Description`'s id whether or not
+  // that element renders, so the dialog owns the attribute outright: a
+  // destructive switch is described by its no-refund safeguard rather than by a
+  // spec line, and a dialog with neither carries no attribute at all.
+  const describedBy = copy.note
+    ? { "aria-describedby": noteId }
+    : description
+      ? {}
+      : { "aria-describedby": undefined };
 
   return (
     <Modal.Root
@@ -94,7 +100,10 @@ export function PackageSwitchConfirmModal({
       <Modal.Content
         size="sm"
         hideCloseButton
-        className="gap-4 p-4"
+        // The mock's card is 421 wide — a 389px content column inside 16px of
+        // padding — where `size="sm"` caps at 400. Overridden here rather than
+        // in the shared Modal, which every other dialog sizes off.
+        className="gap-4 p-4 max-w-[421px]"
         // The confirm sits above Cancel to match the mock, which puts it first
         // in the DOM too — and with no close button it is the first tabbable
         // node, so Radix's mount autofocus would arm Enter on an immediate,
@@ -103,21 +112,19 @@ export function PackageSwitchConfirmModal({
           event.preventDefault();
           cancelRef.current?.focus();
         }}
-        // Radix stamps `aria-describedby` whether or not a description renders.
-        {...(description ? {} : { "aria-describedby": undefined })}
+        {...describedBy}
       >
         {/* 8px here plus the 16px content gap makes the mock's 24px under the
             header, while that gap stays 16px between the checklist and the
             actions. */}
         <Modal.Header className="flex-row items-center gap-3 p-0 pb-2">
           {copy.destructive ? (
-            <div
-              aria-hidden
+            <DialogHeaderTile
               data-testid="package-switch-warning-tile"
-              className="flex size-[52px] shrink-0 items-center justify-center rounded-xl bg-[var(--system-negative-weak)]"
+              className="bg-[var(--system-negative-weak)]"
             >
               <AlertTriangle className="size-6 text-[var(--system-negative-strong)]" />
-            </div>
+            </DialogHeaderTile>
           ) : (
             <AssistantAvatarTile />
           )}
@@ -165,8 +172,12 @@ export function PackageSwitchConfirmModal({
             <ul className="flex flex-col gap-2">
               {details.highlights.map((row) => (
                 <li key={row} className="flex items-center gap-1">
+                  {/* Not --system-positive-strong: velvet restyles that token
+                      to its pink accent, so a check would read as an error.
+                      The plans takeover's checklist is neutral for the same
+                      reason. */}
                   <CircleCheck
-                    className={cn("size-4 shrink-0", highlightIconColor)}
+                    className="size-4 shrink-0 text-[var(--content-secondary)]"
                     aria-hidden
                   />
                   <Typography
@@ -185,6 +196,7 @@ export function PackageSwitchConfirmModal({
             an unresolved target still offers the danger confirm. */}
         {copy.note ? (
           <Typography
+            id={noteId}
             as="p"
             variant="body-medium-default"
             className="text-[var(--content-secondary)]"

--- a/clients/web/src/domains/settings/billing/plans/package-switch-copy.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-copy.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit tests for the relation-keyed package-switch confirm copy.
  *
- * The three `toEqual` cases pin every field of every relation, so the extra
- * tests below only earn their place by covering inputs those three don't:
- * an unknown tier key, and the same tier key read across two relations.
+ * The three `toEqual` cases pin every field of every relation, so the one extra
+ * test below only earns its place by covering an input those three don't: a
+ * tier key the bundle has no copy for.
  *
  * The downgrade variant carries the safeguards: an explicit destructive CTA
  * label (never a neutral "Continue"), the "machine downsizes now / no refund"
@@ -53,20 +53,6 @@ describe("packageSwitchCopy", () => {
       confirmLabel: "Downgrade to Mighty",
       destructive: true,
     });
-  });
-
-  test("a downgrade withholds the tagline the same tier gets on the way up", () => {
-    // The tagline is a pitch. Under "Downgrade to Mighty" it sells the tier the
-    // user is leaving, so only the upward directions may quote it.
-    expect(packageSwitchCopy("downgrade", "Mighty", "mighty").subtitle).toBe(
-      "",
-    );
-    expect(packageSwitchCopy("upgrade", "Mighty", "mighty").subtitle).toBe(
-      PLAN_TIER_COPY.mighty.tagline,
-    );
-    expect(packageSwitchCopy("switch", "Mighty", "mighty").subtitle).toBe(
-      PLAN_TIER_COPY.mighty.tagline,
-    );
   });
 
   test("subtitle is empty for an unknown or absent tier key", () => {

--- a/clients/web/src/domains/settings/billing/plans/package-switch-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-copy.ts
@@ -17,8 +17,8 @@ export interface PackageSwitchCopy {
   title: string;
   /**
    * Tier tagline under the title. Empty on a downgrade, and whenever the
-   * catalog key has no copy — the modal then falls back to the package's own
-   * factual blurb.
+   * catalog key has no copy — the modal then renders a title-only header and
+   * lets the checklist state the specs.
    */
   subtitle: string;
   /** Caption under the price — where the money actually lands. */
@@ -50,12 +50,12 @@ export const DOWNGRADE_CAPTION =
   "Billed monthly · prorated credit on your next invoice";
 export const DOWNGRADE_NOTE =
   "Your machine downsizes now and your storage stays. No refund.";
-const CONTINUE_LABEL = "Continue";
-const CHECKLIST_HEADING = "The plan includes";
+export const CONTINUE_LABEL = "Continue";
+export const CHECKLIST_HEADING = "The plan includes";
 // The rows enumerate the *lower* package on a downgrade, so a present-tense
 // "The plan includes" reads as a list of gains. Future tense keeps it a
 // statement of what is left, not what is won.
-const DOWNGRADE_CHECKLIST_HEADING = "Your plan will include";
+export const DOWNGRADE_CHECKLIST_HEADING = "Your plan will include";
 
 /** Every string the confirm modal renders for one target package. */
 export function packageSwitchCopy(
@@ -72,8 +72,8 @@ export function packageSwitchCopy(
         // arms cannot name different packages.
         title: downgradeLabel(packageName),
         // The tagline sells the tier — quoting it under "Downgrade to X" pitches
-        // a plan the user is stepping down from. Empty hands the modal its
-        // factual catalog blurb instead.
+        // a plan the user is stepping down from. Empty leaves the header to the
+        // title, with the checklist below stating what the plan will include.
         subtitle: "",
         priceCaption: DOWNGRADE_CAPTION,
         checklistHeading: DOWNGRADE_CHECKLIST_HEADING,

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -212,11 +212,10 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 const { PlansPage } = await import("./plans-page");
 const { getPlanTierCopy } = await import("./plans-copy");
 
-// This page's assertions key off the storage/credit/price rows, so the three
-// tiers pin those explicitly; the fixture's remaining defaults (component
-// prices, platform fee) are read by nothing under test.
+// This page's assertions key off the storage/credit/price rows, so each tier
+// pins whatever it has to differ on and inherits the rest of the Mighty shape;
+// the fixture's tier keys and component prices are read by nothing under test.
 const MIGHTY = makeProPackage({
-  storage_tier: "xs",
   storage_gib: 10,
   total_price_cents: 3000,
 });

--- a/clients/web/src/domains/settings/billing/plans/pro-package-test-fixtures.ts
+++ b/clients/web/src/domains/settings/billing/plans/pro-package-test-fixtures.ts
@@ -17,7 +17,10 @@ export function makeProPackage(
   return {
     key: "mighty",
     name: "Mighty",
-    description: "Small machine, 15 GB of storage, and $25 in monthly credits.",
+    // Deliberately spec-free. The real catalog blurbs are the machine/storage/
+    // credits sentence, and every caller overrides some of those numbers — a
+    // default quoting them would decorate a package it contradicts.
+    description: "A Pro package.",
     version: 1,
     machine_tier: null,
     storage_tier: "s",


### PR DESCRIPTION
## Summary
- Corrects two mock-fidelity misses: the avatar art now draws at the mock's 32px, and the card at its 421px width.
- A downgrade no longer states the same three facts twice, and its accessible description now points at the no-refund safeguard rather than a spec blurb.
- Check icons no longer resolve to velvet's pink accent, matching the plans takeover's own checklist.
- Deduplicates the 52px header-tile geometry, removes a dead test mock and subsumed tests, and fixes a fixture default that contradicted its own package.

Final self-review round for package-switch-modal-redesign.md.