### PR TITLE
feat(discord): connection recovery — close codes, backoff, session state, heartbeat

### DIFF
--- a/gateway/src/discord/backoff.test.ts
+++ b/gateway/src/discord/backoff.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+import { ReconnectBackoff, SESSION_STABLE_AFTER_MS } from "./backoff.js";
+import "../__tests__/test-preload.js";
+
+/** Jitter pinned to the top of the window, so delays read as the raw cap. */
+const maxJitter = () => 1;
+
+describe("ReconnectBackoff", () => {
+  test("grows exponentially from one second", () => {
+    const backoff = new ReconnectBackoff(maxJitter);
+    expect(backoff.nextDelayMs("resume")).toBe(1_000);
+    expect(backoff.nextDelayMs("resume")).toBe(2_000);
+    expect(backoff.nextDelayMs("resume")).toBe(4_000);
+    expect(backoff.nextDelayMs("resume")).toBe(8_000);
+  });
+
+  test("caps resumes at 30s and identifies at 10 minutes", () => {
+    const backoff = new ReconnectBackoff(maxJitter);
+    for (let i = 0; i < 40; i++) backoff.nextDelayMs("resume");
+    expect(backoff.nextDelayMs("resume")).toBe(30_000);
+    expect(backoff.nextDelayMs("identify")).toBe(600_000);
+  });
+
+  test("a sustained identify loop stays inside the 1000/24h budget", () => {
+    // The assertion this module exists for. Breaching the cap resets the bot
+    // token, so the ceiling is derived from the budget rather than chosen for
+    // recovery feel — and a ceiling that looks conservative can still fail it
+    // (a 120s cap yields ~1440/day).
+    const backoff = new ReconnectBackoff(maxJitter);
+    for (let i = 0; i < 40; i++) backoff.nextDelayMs("identify");
+
+    // Full jitter draws uniformly over [0, cap), so the mean delay is cap/2.
+    const capMs = backoff.nextDelayMs("identify");
+    const meanDelayMs = capMs / 2;
+    const identifiesPerDay = (24 * 60 * 60 * 1_000) / meanDelayMs;
+
+    expect(identifiesPerDay).toBeLessThan(1_000);
+  });
+
+  test("uses full jitter — a delay may be anywhere in the window", () => {
+    // Additive jitter (Slack's approach) would floor every delay at the
+    // window; full jitter spreads retries so instances recovering from one
+    // Discord-side outage do not resynchronise.
+    const zeroJitter = new ReconnectBackoff(() => 0);
+    expect(zeroJitter.nextDelayMs("resume")).toBe(0);
+
+    const halfJitter = new ReconnectBackoff(() => 0.5);
+    expect(halfJitter.nextDelayMs("resume")).toBe(500);
+  });
+
+  test("does not reset until a session proves stable", () => {
+    // The credential-safety property. Slack resets its counter when the socket
+    // opens; doing that here would let a socket that opens and dies reset the
+    // delay every cycle, turning an outage into a tight identify loop.
+    const backoff = new ReconnectBackoff(maxJitter);
+    backoff.nextDelayMs("identify");
+    backoff.nextDelayMs("identify");
+    expect(backoff.failureCount).toBe(2);
+
+    // Attempting a connection — even reaching a new socket — changes nothing.
+    expect(backoff.nextDelayMs("identify")).toBe(4_000);
+    expect(backoff.failureCount).toBe(3);
+
+    backoff.noteSessionStable();
+    expect(backoff.failureCount).toBe(0);
+    expect(backoff.nextDelayMs("identify")).toBe(1_000);
+  });
+
+  test("carries resume failures into the next identify", () => {
+    // Repeated resume failures are the same instability signal. Letting the
+    // first identify after them start from zero is how a flap reaches the
+    // budget-spending path at full speed.
+    const backoff = new ReconnectBackoff(maxJitter);
+    backoff.nextDelayMs("resume");
+    backoff.nextDelayMs("resume");
+    backoff.nextDelayMs("resume");
+    expect(backoff.nextDelayMs("identify")).toBe(8_000);
+  });
+
+  test("requires a session to outlive a brief flap before counting as stable", () => {
+    // Two minutes is long enough that a session dying on arrival — the exact
+    // failure this pacing survives — cannot be mistaken for success.
+    expect(SESSION_STABLE_AFTER_MS).toBeGreaterThanOrEqual(60_000);
+  });
+});

--- a/gateway/src/discord/backoff.test.ts
+++ b/gateway/src/discord/backoff.test.ts
@@ -17,7 +17,9 @@ describe("ReconnectBackoff", () => {
 
   test("caps resumes at 30s and identifies at 10 minutes", () => {
     const backoff = new ReconnectBackoff(maxJitter);
-    for (let i = 0; i < 40; i++) backoff.nextDelayMs("resume");
+    for (let i = 0; i < 40; i++) {
+      backoff.nextDelayMs("resume");
+    }
     expect(backoff.nextDelayMs("resume")).toBe(30_000);
     expect(backoff.nextDelayMs("identify")).toBe(600_000);
   });
@@ -28,7 +30,9 @@ describe("ReconnectBackoff", () => {
     // recovery feel — and a ceiling that looks conservative can still fail it
     // (a 120s cap yields ~1440/day).
     const backoff = new ReconnectBackoff(maxJitter);
-    for (let i = 0; i < 40; i++) backoff.nextDelayMs("identify");
+    for (let i = 0; i < 40; i++) {
+      backoff.nextDelayMs("identify");
+    }
 
     // Full jitter draws uniformly over [0, cap), so the mean delay is cap/2.
     const capMs = backoff.nextDelayMs("identify");

--- a/gateway/src/discord/backoff.ts
+++ b/gateway/src/discord/backoff.ts
@@ -1,0 +1,110 @@
+/**
+ * Reconnect pacing for the Discord Gateway client.
+ *
+ * Discord caps IDENTIFY at 1000 per 24 hours, and breaching the cap does not
+ * merely throttle — it terminates every session and **resets the bot token**,
+ * which takes the integration down until a human stores a new one. That makes
+ * reconnect pacing a credential-safety mechanism rather than a politeness one,
+ * and it is why this is a module with tests instead of two constants inline.
+ *
+ * Three rules follow from it, and each one differs from the Slack Socket Mode
+ * client this codebase otherwise models Discord on:
+ *
+ * 1. **Backoff resets on a stable session, never on socket-open.** Slack resets
+ *    its attempt counter in the `open` handler. Here that is the bug that
+ *    empties the budget: a socket that opens and immediately dies would reset
+ *    the delay every cycle, turning an outage into a tight identify loop. Only
+ *    `noteSessionStable()` — called once a session has held past
+ *    {@link SESSION_STABLE_AFTER_MS} — clears it.
+ * 2. **Full jitter, not additive.** Slack adds 0–50% to the delay. Full jitter
+ *    spreads retries across the whole window, which matters when several
+ *    instances recover from one Discord-side outage together.
+ * 3. **The identify cap is derived from the budget, not chosen for feel.**
+ */
+
+/** Delay before the first reconnect attempt. */
+const BASE_BACKOFF_MS = 1_000;
+
+/**
+ * Ceiling for delays before a RESUME. Resumes do not count against the
+ * identify budget, so this is paced for recovery speed, matching Slack.
+ */
+const RESUME_MAX_BACKOFF_MS = 30_000;
+
+/**
+ * Ceiling for delays before an IDENTIFY, derived from the 1000/24h cap.
+ *
+ * Under full jitter a delay is uniform over `[0, cap)`, so a sustained outage
+ * spends roughly `86_400s / (cap / 2)` identifies per day:
+ *
+ * | cap  | identifies/24h | share of the 1000 budget |
+ * | ---- | -------------- | ------------------------ |
+ * | 120s | ~1440          | over budget — token reset |
+ * | 300s | ~576           | 58%                      |
+ * | 600s | ~288           | 29%                      |
+ *
+ * A two-minute ceiling reads as conservative — it is four times Slack's — and
+ * still exceeds the cap. Ten minutes leaves room for the retries that fatal
+ * close codes and op 9 handling cannot pre-empt. The cost is slower recovery
+ * from a long outage, which is the right trade against a token reset.
+ */
+const IDENTIFY_MAX_BACKOFF_MS = 600_000;
+
+/**
+ * How long a session must hold before it counts as stable.
+ *
+ * READY or RESUMED alone is not enough: a session that dies seconds later is
+ * exactly the flap this pacing exists to survive, and treating its arrival as
+ * success would reset the delay on every cycle.
+ */
+export const SESSION_STABLE_AFTER_MS = 120_000;
+
+export type RecoveryKind = "resume" | "identify";
+
+/**
+ * Consecutive-failure pacing for reconnects.
+ *
+ * Stateless with respect to time — the caller owns the timers, so this stays
+ * a pure function of attempt count and is testable without waiting.
+ */
+export class ReconnectBackoff {
+  private consecutiveFailures = 0;
+  private readonly random: () => number;
+
+  /** `random` is injectable so tests can pin the jitter. */
+  constructor(random: () => number = Math.random) {
+    this.random = random;
+  }
+
+  /** Consecutive recovery attempts since the last stable session. */
+  get failureCount(): number {
+    return this.consecutiveFailures;
+  }
+
+  /**
+   * Delay before the next attempt, and count it.
+   *
+   * A resume failure still raises the count that a later identify reads:
+   * repeated resume failures are the same instability signal, and letting the
+   * first identify after them start from zero is how a flap reaches the
+   * identify path at full speed.
+   */
+  nextDelayMs(kind: RecoveryKind): number {
+    const cap =
+      kind === "identify" ? IDENTIFY_MAX_BACKOFF_MS : RESUME_MAX_BACKOFF_MS;
+    const window = Math.min(
+      BASE_BACKOFF_MS * 2 ** this.consecutiveFailures,
+      cap,
+    );
+    this.consecutiveFailures++;
+    return Math.round(this.random() * window);
+  }
+
+  /**
+   * Record that a session has held past {@link SESSION_STABLE_AFTER_MS}. This
+   * is the only thing that clears the backoff.
+   */
+  noteSessionStable(): void {
+    this.consecutiveFailures = 0;
+  }
+}

--- a/gateway/src/discord/close-codes.test.ts
+++ b/gateway/src/discord/close-codes.test.ts
@@ -45,11 +45,11 @@ describe("recoveryActionForCloseCode", () => {
   });
 
   test("resumes after 1001 Going Away", () => {
-    // Not covered by the 1000 rule, and a received 1001 is usually an
-    // intermediary or a draining node rather than a session teardown. The
-    // costs are asymmetric: resuming a dead session falls through op 9 to
-    // IDENTIFY for one round trip, while identifying against a live session
-    // spends an identify and loses the replay unconditionally.
+    // Discord's invalidation rule governs closes the client *sends*, not ones
+    // it receives, so a received 1001 leaves the session intact — typically an
+    // intermediary or a draining node. Resuming is the documented behaviour
+    // here, not a heuristic, and a resume against a session that did die still
+    // degrades safely through op 9 to IDENTIFY.
     expect(recoveryActionForCloseCode(1001)).toBe("resume");
   });
 

--- a/gateway/src/discord/close-codes.test.ts
+++ b/gateway/src/discord/close-codes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  RESUMABLE_CLOSE_CODE,
+  fatalCloseDiagnostic,
+  isClientFaultCloseCode,
+  recoveryActionForCloseCode,
+} from "./close-codes.js";
+import "../__tests__/test-preload.js";
+
+describe("recoveryActionForCloseCode", () => {
+  test("resumes on codes whose session survives", () => {
+    for (const code of [4000, 4001, 4002, 4005, 4008]) {
+      expect(recoveryActionForCloseCode(code)).toBe("resume");
+    }
+  });
+
+  test("resumes on abnormal and absent closes", () => {
+    // A dropped network closes without a code, which is the ordinary case.
+    expect(recoveryActionForCloseCode(undefined)).toBe("resume");
+    expect(recoveryActionForCloseCode(1006)).toBe("resume");
+  });
+
+  test("requires a fresh identify on 4003, 4007, and 4009", () => {
+    // The official table marks these Reconnect: true, which reads as "you may
+    // resume" and is not what it means — their session is gone, so a resume
+    // returns op 9 and wastes a round trip.
+    for (const code of [4003, 4007, 4009]) {
+      expect(recoveryActionForCloseCode(code)).toBe("identify");
+    }
+  });
+
+  test("never retries fatal codes", () => {
+    // Each of these loops forever if retried, and a 4004 loop additionally
+    // spends the identify budget toward a token reset.
+    for (const code of [4004, 4010, 4011, 4012, 4013, 4014]) {
+      expect(recoveryActionForCloseCode(code)).toBe("fatal");
+    }
+  });
+
+  test("treats a normal close as session-invalidating", () => {
+    // 1000/1001 tell Discord the client is finished with the session, so a
+    // resume after one cannot succeed.
+    expect(recoveryActionForCloseCode(1000)).toBe("identify");
+    expect(recoveryActionForCloseCode(1001)).toBe("identify");
+  });
+
+  test("resumes on unknown codes rather than identifying", () => {
+    // A resume against a dead session degrades safely to op 9 then IDENTIFY.
+    // Identifying against a live session spends budget resuming would not.
+    expect(recoveryActionForCloseCode(4999)).toBe("resume");
+    expect(recoveryActionForCloseCode(1011)).toBe("resume");
+  });
+
+  test("the deliberate-close code is itself resumable", () => {
+    // Zombie kills and clock-jump recoveries close with this code precisely so
+    // the session survives; if it ever stopped being resumable those paths
+    // would silently start costing an identify each.
+    expect(recoveryActionForCloseCode(RESUMABLE_CLOSE_CODE)).toBe("resume");
+    expect(RESUMABLE_CLOSE_CODE).not.toBe(1000);
+    expect(RESUMABLE_CLOSE_CODE).not.toBe(1001);
+  });
+});
+
+describe("isClientFaultCloseCode", () => {
+  test("flags the codes that mean this client sent something wrong", () => {
+    for (const code of [4001, 4002, 4005]) {
+      expect(isClientFaultCloseCode(code)).toBe(true);
+    }
+  });
+
+  test("does not flag ordinary or absent closes", () => {
+    expect(isClientFaultCloseCode(4000)).toBe(false);
+    expect(isClientFaultCloseCode(undefined)).toBe(false);
+  });
+});
+
+describe("fatalCloseDiagnostic", () => {
+  test("gives an operator action for every fatal code", () => {
+    for (const code of [4004, 4010, 4011, 4012, 4013, 4014]) {
+      expect(fatalCloseDiagnostic(code)).toBeTruthy();
+    }
+  });
+
+  test("names the Portal toggle for a disallowed intent", () => {
+    expect(fatalCloseDiagnostic(4014)).toContain("Developer Portal");
+  });
+
+  test("returns undefined for non-fatal codes", () => {
+    expect(fatalCloseDiagnostic(4000)).toBeUndefined();
+    expect(fatalCloseDiagnostic(undefined)).toBeUndefined();
+  });
+});

--- a/gateway/src/discord/close-codes.test.ts
+++ b/gateway/src/discord/close-codes.test.ts
@@ -39,10 +39,18 @@ describe("recoveryActionForCloseCode", () => {
   });
 
   test("treats a normal close as session-invalidating", () => {
-    // 1000/1001 tell Discord the client is finished with the session, so a
-    // resume after one cannot succeed.
+    // Discord's rule names 1000: closing with it tells Discord the client is
+    // finished with the session, so a resume after one cannot succeed.
     expect(recoveryActionForCloseCode(1000)).toBe("identify");
-    expect(recoveryActionForCloseCode(1001)).toBe("identify");
+  });
+
+  test("resumes after 1001 Going Away", () => {
+    // Not covered by the 1000 rule, and a received 1001 is usually an
+    // intermediary or a draining node rather than a session teardown. The
+    // costs are asymmetric: resuming a dead session falls through op 9 to
+    // IDENTIFY for one round trip, while identifying against a live session
+    // spends an identify and loses the replay unconditionally.
+    expect(recoveryActionForCloseCode(1001)).toBe("resume");
   });
 
   test("resumes on unknown codes rather than identifying", () => {

--- a/gateway/src/discord/close-codes.ts
+++ b/gateway/src/discord/close-codes.ts
@@ -47,17 +47,18 @@ const FATAL = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
 const CLIENT_FAULT = new Set([4001, 4002, 4005]);
 
 /**
- * Discord invalidates the session when the *client* closes with 1000, so a
- * deliberate close that intends to resume must not use one — zombie kills and
- * clock-jump recoveries close with {@link RESUMABLE_CLOSE_CODE} for exactly
- * this reason.
+ * Discord's session-invalidation rule is scoped to closes the *client* sends:
+ * closing with 1000 or 1001 invalidates the session, which is why deliberate
+ * closes that intend to resume use {@link RESUMABLE_CLOSE_CODE} instead. Zombie
+ * kills and clock-jump recovery depend on that.
  *
- * 1001 (`Going Away`) is deliberately absent. Discord's rule names 1000, and a
- * received 1001 is usually an intermediary or a node draining rather than a
- * session teardown — so the session often survives. The costs are asymmetric:
- * resuming a dead session falls through op 9 to IDENTIFY at the cost of one
- * round trip, while identifying against a live session spends an identify and
- * loses the replay unconditionally. Resume is the cheaper wrong answer.
+ * A *received* close carries no such meaning, so 1001 (`Going Away`) is not
+ * listed here — it is typically an intermediary or a draining node, and the
+ * taxonomy resumes it like any other non-fatal received code.
+ *
+ * 1000 is retained as the conservative case: it is this client's own shutdown
+ * code, so seeing it back generally means a deliberate teardown rather than a
+ * recoverable drop.
  */
 const INVALIDATES_SESSION = new Set([1000]);
 

--- a/gateway/src/discord/close-codes.ts
+++ b/gateway/src/discord/close-codes.ts
@@ -1,0 +1,113 @@
+/**
+ * Discord Gateway close-code taxonomy — what to do after the socket closes.
+ *
+ * Every close funnels into one of three recoveries. The mapping is not the one
+ * the official table suggests: its `Reconnect` column means "you may open a new
+ * socket", NOT "you may RESUME". 4007 and 4009 are reconnectable but their
+ * session is gone, so resuming them fails and costs a round trip.
+ *
+ * The distinction is load-bearing because IDENTIFY is capped at 1000 per 24h
+ * and breaching that cap resets the bot token (see `backoff.ts`). Resuming
+ * whenever a session survives is what keeps the identify budget intact, and
+ * hard-stopping on fatal codes is what stops a doomed retry from spending it.
+ *
+ * https://docs.discord.com/developers/topics/opcodes-and-status-codes
+ */
+
+export type RecoveryAction =
+  /** Session may survive: reconnect to `resume_gateway_url` and send op 6. */
+  | "resume"
+  /** Session is gone: open a fresh socket and send a new IDENTIFY. */
+  | "identify"
+  /** Unrecoverable without operator action: stop, do not reconnect. */
+  | "fatal";
+
+/** Sessions survive these — resume rather than spend an identify. */
+const RESUMABLE = new Set([4000, 4001, 4002, 4005, 4008]);
+
+/**
+ * Reconnectable, but the session is invalid — resuming returns op 9 and wastes
+ * a round trip. 4003/4007/4009 are the codes the official table's `Reconnect:
+ * true` most easily misleads on.
+ */
+const REQUIRES_FRESH_IDENTIFY = new Set([4003, 4007, 4009]);
+
+/**
+ * Never retried. Each needs a human: a replaced token (4004), a corrected
+ * IDENTIFY (4013), or a Portal toggle (4014). Retrying loops forever, and a
+ * 4004 loop additionally spends the identify budget toward a token reset.
+ */
+const FATAL = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
+
+/**
+ * Codes that mean the client sent something wrong. Recoverable, but they are
+ * our bug rather than Discord's and should be surfaced, not absorbed by a
+ * silent reconnect.
+ */
+const CLIENT_FAULT = new Set([4001, 4002, 4005]);
+
+/**
+ * A normal WebSocket close invalidates the session, so a deliberate close that
+ * intends to resume must not use one. Zombie kills and clock-jump recoveries
+ * close with {@link RESUMABLE_CLOSE_CODE} for exactly this reason.
+ */
+const INVALIDATES_SESSION = new Set([1000, 1001]);
+
+/**
+ * The code this client closes with when it wants the session preserved.
+ * 4000 is Discord's "unknown error" — resumable, and outside the 1000/1001
+ * range that tells Discord the client is done with the session.
+ */
+export const RESUMABLE_CLOSE_CODE = 4000;
+
+/**
+ * Map a close code to its recovery.
+ *
+ * An absent code covers abnormal closes (1006 and transport-level drops),
+ * which are the ordinary case for a dropped network and are resumable.
+ *
+ * Unknown codes resume rather than identify: a resume against a dead session
+ * degrades safely to op 9 and then IDENTIFY, whereas identifying against a
+ * live session spends budget that resuming would not have.
+ */
+export function recoveryActionForCloseCode(
+  code: number | undefined,
+): RecoveryAction {
+  if (code === undefined || code === 1006) return "resume";
+  if (FATAL.has(code)) return "fatal";
+  if (REQUIRES_FRESH_IDENTIFY.has(code)) return "identify";
+  if (INVALIDATES_SESSION.has(code)) return "identify";
+  if (RESUMABLE.has(code)) return "resume";
+  return "resume";
+}
+
+/** Whether a close code means the client sent something malformed. */
+export function isClientFaultCloseCode(code: number | undefined): boolean {
+  return code !== undefined && CLIENT_FAULT.has(code);
+}
+
+/**
+ * Operator-facing explanation for a fatal close, or undefined when the code is
+ * not fatal. Fatal closes are dead ends until a human acts, so the message
+ * names the action rather than the symptom.
+ */
+export function fatalCloseDiagnostic(
+  code: number | undefined,
+): string | undefined {
+  switch (code) {
+    case 4004:
+      return "Discord rejected the bot token. Store a fresh token from the Developer Portal; the connection stays down until then.";
+    case 4010:
+      return "Invalid shard sent in IDENTIFY. This client does not shard — a shard field should not be present.";
+    case 4011:
+      return "This bot is in too many guilds to connect without sharding.";
+    case 4012:
+      return "Invalid Gateway API version requested.";
+    case 4013:
+      return "Malformed intents bitfield in IDENTIFY.";
+    case 4014:
+      return "Discord refused a privileged intent that is not enabled for this app. Enable it in the Developer Portal, or remove it from the IDENTIFY intents.";
+    default:
+      return undefined;
+  }
+}

--- a/gateway/src/discord/close-codes.ts
+++ b/gateway/src/discord/close-codes.ts
@@ -47,11 +47,19 @@ const FATAL = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
 const CLIENT_FAULT = new Set([4001, 4002, 4005]);
 
 /**
- * A normal WebSocket close invalidates the session, so a deliberate close that
- * intends to resume must not use one. Zombie kills and clock-jump recoveries
- * close with {@link RESUMABLE_CLOSE_CODE} for exactly this reason.
+ * Discord invalidates the session when the *client* closes with 1000, so a
+ * deliberate close that intends to resume must not use one — zombie kills and
+ * clock-jump recoveries close with {@link RESUMABLE_CLOSE_CODE} for exactly
+ * this reason.
+ *
+ * 1001 (`Going Away`) is deliberately absent. Discord's rule names 1000, and a
+ * received 1001 is usually an intermediary or a node draining rather than a
+ * session teardown — so the session often survives. The costs are asymmetric:
+ * resuming a dead session falls through op 9 to IDENTIFY at the cost of one
+ * round trip, while identifying against a live session spends an identify and
+ * loses the replay unconditionally. Resume is the cheaper wrong answer.
  */
-const INVALIDATES_SESSION = new Set([1000, 1001]);
+const INVALIDATES_SESSION = new Set([1000]);
 
 /**
  * The code this client closes with when it wants the session preserved.
@@ -73,11 +81,21 @@ export const RESUMABLE_CLOSE_CODE = 4000;
 export function recoveryActionForCloseCode(
   code: number | undefined,
 ): RecoveryAction {
-  if (code === undefined || code === 1006) return "resume";
-  if (FATAL.has(code)) return "fatal";
-  if (REQUIRES_FRESH_IDENTIFY.has(code)) return "identify";
-  if (INVALIDATES_SESSION.has(code)) return "identify";
-  if (RESUMABLE.has(code)) return "resume";
+  if (code === undefined || code === 1006) {
+    return "resume";
+  }
+  if (FATAL.has(code)) {
+    return "fatal";
+  }
+  if (REQUIRES_FRESH_IDENTIFY.has(code)) {
+    return "identify";
+  }
+  if (INVALIDATES_SESSION.has(code)) {
+    return "identify";
+  }
+  if (RESUMABLE.has(code)) {
+    return "resume";
+  }
   return "resume";
 }
 

--- a/gateway/src/discord/heartbeat.test.ts
+++ b/gateway/src/discord/heartbeat.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+
+import { CLOCK_JUMP_FACTOR, HeartbeatMonitor } from "./heartbeat.js";
+import "../__tests__/test-preload.js";
+
+const INTERVAL = 41_250;
+
+/** A clock the test advances by hand, so no test waits in real time. */
+function fakeClock(start = 1_000_000) {
+  let now = start;
+  return {
+    now: () => now,
+    advance: (ms: number) => {
+      now += ms;
+    },
+  };
+}
+
+describe("noteHello", () => {
+  test("jitters the first beat across the whole interval", () => {
+    // Docs-mandated: without it, every client reconnecting after a Gateway
+    // restart beats in lockstep.
+    const clock = fakeClock();
+    expect(new HeartbeatMonitor(() => 0, clock.now).noteHello(INTERVAL)).toBe(
+      0,
+    );
+    expect(new HeartbeatMonitor(() => 0.5, clock.now).noteHello(INTERVAL)).toBe(
+      INTERVAL / 2,
+    );
+    expect(new HeartbeatMonitor(() => 1, clock.now).noteHello(INTERVAL)).toBe(
+      INTERVAL,
+    );
+  });
+
+  test("records the interval for later checks", () => {
+    const monitor = new HeartbeatMonitor(() => 0, fakeClock().now);
+    monitor.noteHello(INTERVAL);
+    expect(monitor.heartbeatIntervalMs).toBe(INTERVAL);
+  });
+});
+
+describe("zombie detection", () => {
+  test("a beat with no ACK marks the connection dead", () => {
+    const clock = fakeClock();
+    const monitor = new HeartbeatMonitor(() => 0, clock.now);
+    monitor.noteHello(INTERVAL);
+
+    expect(monitor.isZombie()).toBe(false);
+    monitor.noteBeatSent();
+    expect(monitor.isAwaitingAck).toBe(true);
+    // Checked before sending the next beat: one missed ACK is enough.
+    expect(monitor.isZombie()).toBe(true);
+  });
+
+  test("an ACK clears the window", () => {
+    const clock = fakeClock();
+    const monitor = new HeartbeatMonitor(() => 0, clock.now);
+    monitor.noteHello(INTERVAL);
+    monitor.noteBeatSent();
+    monitor.noteAck();
+    expect(monitor.isZombie()).toBe(false);
+    expect(monitor.isAwaitingAck).toBe(false);
+  });
+
+  test("reset clears a pending ACK so a fresh socket is not born a zombie", () => {
+    // A reconnect that inherited the previous socket's pending ACK would
+    // declare the new connection dead on its first beat and loop.
+    const clock = fakeClock();
+    const monitor = new HeartbeatMonitor(() => 0, clock.now);
+    monitor.noteHello(INTERVAL);
+    monitor.noteBeatSent();
+    expect(monitor.isZombie()).toBe(true);
+
+    monitor.reset();
+    expect(monitor.isZombie()).toBe(false);
+    expect(monitor.heartbeatIntervalMs).toBeUndefined();
+  });
+});
+
+describe("clock-jump detection", () => {
+  test("ordinary scheduling lag is not a jump", () => {
+    const clock = fakeClock();
+    const monitor = new HeartbeatMonitor(() => 0, clock.now);
+    monitor.noteHello(INTERVAL);
+    monitor.noteBeatSent();
+
+    clock.advance(INTERVAL);
+    expect(monitor.detectedClockJump()).toBe(false);
+
+    // Still short of the threshold — event-loop congestion routinely delays a
+    // timer by a noticeable fraction of its interval.
+    clock.advance(INTERVAL * (CLOCK_JUMP_FACTOR - 1) - 1);
+    expect(monitor.detectedClockJump()).toBe(false);
+  });
+
+  test("a suspended process overshoots and is caught", () => {
+    // The laptop-sleep case: the socket still reports open and no close event
+    // ever fires, so the late timer is the only early evidence.
+    const clock = fakeClock();
+    const monitor = new HeartbeatMonitor(() => 0, clock.now);
+    monitor.noteHello(INTERVAL);
+    monitor.noteBeatSent();
+
+    clock.advance(INTERVAL * CLOCK_JUMP_FACTOR + 1);
+    expect(monitor.detectedClockJump()).toBe(true);
+  });
+
+  test("a long sleep is caught just the same", () => {
+    const clock = fakeClock();
+    const monitor = new HeartbeatMonitor(() => 0, clock.now);
+    monitor.noteHello(INTERVAL);
+    monitor.noteBeatSent();
+
+    clock.advance(8 * 60 * 60 * 1_000);
+    expect(monitor.detectedClockJump()).toBe(true);
+  });
+
+  test("reports no jump before HELLO or before the first beat", () => {
+    const clock = fakeClock();
+    const monitor = new HeartbeatMonitor(() => 0, clock.now);
+    expect(monitor.detectedClockJump()).toBe(false);
+
+    monitor.noteHello(INTERVAL);
+    clock.advance(INTERVAL * 100);
+    // No beat has been sent, so there is no gap to measure.
+    expect(monitor.detectedClockJump()).toBe(false);
+  });
+});

--- a/gateway/src/discord/heartbeat.ts
+++ b/gateway/src/discord/heartbeat.ts
@@ -1,0 +1,118 @@
+/**
+ * Heartbeat liveness for the Discord Gateway connection.
+ *
+ * Discord sends `heartbeat_interval` in op 10 HELLO; the client sends op 1 on
+ * that interval and expects op 11 HEARTBEAT_ACK back. A missing ACK is the
+ * documented signal that the connection is a zombie — open at the socket layer,
+ * dead in fact — and the required response is to close with a non-1000 code and
+ * resume.
+ *
+ * A second detector covers the case the ACK watchdog is slow at: a laptop
+ * waking from sleep. The socket usually reports open, no close event ever
+ * fires, and the session may already have timed out server-side. Timers,
+ * however, fire late — so a heartbeat tick that arrives far past its interval
+ * is evidence the process was suspended, and the connection should be treated
+ * as dead without waiting a full interval to confirm it. That converts most of
+ * a minute of post-wake deafness into near-immediate recovery.
+ *
+ * This module is the decision logic only: it owns no timers and no socket, so
+ * it can be tested without waiting in real time.
+ */
+
+/**
+ * How far past its due time a heartbeat tick must arrive to read as a suspend
+ * rather than ordinary scheduling lag.
+ *
+ * Event-loop congestion routinely delays a timer by a noticeable fraction of
+ * its interval; a process resuming from sleep overshoots by orders of
+ * magnitude. Double the interval sits well clear of the first and well under
+ * the second, so a false positive costs one resume — cheap, since resumes do
+ * not touch the identify budget — while a false negative costs a full interval
+ * of silently dropped messages.
+ */
+export const CLOCK_JUMP_FACTOR = 2;
+
+export class HeartbeatMonitor {
+  private intervalMs: number | undefined;
+  private awaitingAck = false;
+  private lastBeatAt: number | undefined;
+
+  /** `random` and `now` are injectable so tests can pin jitter and time. */
+  constructor(
+    private readonly random: () => number = Math.random,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /**
+   * Record the interval from op 10 HELLO and return the delay before the first
+   * beat.
+   *
+   * The first beat is jittered across the whole interval — Discord's docs
+   * require it, so that every client reconnecting after a Gateway-side restart
+   * does not beat in lockstep.
+   */
+  noteHello(intervalMs: number): number {
+    this.intervalMs = intervalMs;
+    this.awaitingAck = false;
+    this.lastBeatAt = undefined;
+    return Math.round(this.random() * intervalMs);
+  }
+
+  /** The steady-state interval, or undefined before HELLO. */
+  get heartbeatIntervalMs(): number | undefined {
+    return this.intervalMs;
+  }
+
+  /** Whether a beat is outstanding — true means the last op 1 has no op 11 yet. */
+  get isAwaitingAck(): boolean {
+    return this.awaitingAck;
+  }
+
+  /**
+   * Whether the connection is a zombie and must be closed.
+   *
+   * True when the previous beat never got its ACK. Checked immediately before
+   * sending the next beat, so a dead connection is caught within one interval
+   * rather than accumulating unacknowledged beats.
+   */
+  isZombie(): boolean {
+    return this.awaitingAck;
+  }
+
+  /**
+   * Whether the gap since the last beat indicates the process was suspended.
+   *
+   * Returns false before the first beat and before HELLO, when there is no
+   * interval to measure against.
+   */
+  detectedClockJump(): boolean {
+    if (this.intervalMs === undefined || this.lastBeatAt === undefined) {
+      return false;
+    }
+    const elapsed = this.now() - this.lastBeatAt;
+    return elapsed > this.intervalMs * CLOCK_JUMP_FACTOR;
+  }
+
+  /** Record that op 1 was sent, opening the ACK window. */
+  noteBeatSent(): void {
+    this.awaitingAck = true;
+    this.lastBeatAt = this.now();
+  }
+
+  /** Record op 11 HEARTBEAT_ACK, closing the ACK window. */
+  noteAck(): void {
+    this.awaitingAck = false;
+  }
+
+  /**
+   * Clear all state for a new connection.
+   *
+   * A reconnect that inherited a pending ACK from the previous socket would
+   * declare the fresh connection a zombie on its first beat.
+   */
+  reset(): void {
+    this.intervalMs = undefined;
+    this.awaitingAck = false;
+    this.lastBeatAt = undefined;
+  }
+}

--- a/gateway/src/discord/session-state.test.ts
+++ b/gateway/src/discord/session-state.test.ts
@@ -3,8 +3,13 @@ import { describe, expect, test } from "bun:test";
 import { DiscordSessionState } from "./session-state.js";
 import "../__tests__/test-preload.js";
 
-const BASE_URL = "wss://gateway.discord.gg/?v=10&encoding=json";
-const RESUME_URL = "wss://us-east1-b.gateway.discord.gg/?v=10&encoding=json";
+// Bare, exactly as Discord returns them: `GET /gateway/bot` gives the base URL
+// and READY gives `resume_gateway_url`, neither carrying query params. Pinning
+// the fixtures to that shape is what makes the decoration observable — a
+// pre-decorated fixture would pass whether or not the code added anything.
+const BASE_URL = "wss://gateway.discord.gg";
+const RESUME_URL = "wss://us-east1-b.gateway.discord.gg";
+const PARAMS = "?v=10&encoding=json";
 const SESSION = "8a3b1c9d4e5f";
 
 function ready(): DiscordSessionState {
@@ -19,7 +24,7 @@ describe("DiscordSessionState", () => {
     const state = new DiscordSessionState(BASE_URL);
     expect(state.canResume).toBe(false);
     expect(state.nextConnection()).toEqual({
-      url: BASE_URL,
+      url: `${BASE_URL}/${PARAMS}`,
       action: "identify",
     });
     expect(state.resumePayload()).toBeUndefined();
@@ -30,10 +35,18 @@ describe("DiscordSessionState", () => {
     // rate, so the URL choice is part of the decision, not a detail.
     const state = ready();
     expect(state.nextConnection()).toEqual({
-      url: RESUME_URL,
+      url: `${RESUME_URL}/${PARAMS}`,
       action: "resume",
     });
     expect(state.resumePayload()).toEqual({ session_id: SESSION, seq: 42 });
+  });
+
+  test("does not double the params on an already-decorated URL", () => {
+    // Discord returns these bare today, but a URL that arrives carrying them
+    // must not come back with two copies — a malformed query is a connection
+    // that fails for a reason nothing in the logs would explain.
+    const state = new DiscordSessionState(`${BASE_URL}/${PARAMS}`);
+    expect(state.nextConnection().url).toBe(`${BASE_URL}/${PARAMS}`);
   });
 
   test("cannot resume on READY alone — a sequence is required", () => {
@@ -60,7 +73,7 @@ describe("DiscordSessionState", () => {
     state.invalidate();
     expect(state.canResume).toBe(false);
     expect(state.nextConnection()).toEqual({
-      url: BASE_URL,
+      url: `${BASE_URL}/${PARAMS}`,
       action: "identify",
     });
   });

--- a/gateway/src/discord/session-state.test.ts
+++ b/gateway/src/discord/session-state.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { DiscordSessionState } from "./session-state.js";
+import "../__tests__/test-preload.js";
+
+const BASE_URL = "wss://gateway.discord.gg/?v=10&encoding=json";
+const RESUME_URL = "wss://us-east1-b.gateway.discord.gg/?v=10&encoding=json";
+const SESSION = "8a3b1c9d4e5f";
+
+function ready(): DiscordSessionState {
+  const state = new DiscordSessionState(BASE_URL);
+  state.noteReady(SESSION, RESUME_URL);
+  state.noteSequence(42);
+  return state;
+}
+
+describe("DiscordSessionState", () => {
+  test("identifies on the base URL before any session exists", () => {
+    const state = new DiscordSessionState(BASE_URL);
+    expect(state.canResume).toBe(false);
+    expect(state.nextConnection()).toEqual({
+      url: BASE_URL,
+      action: "identify",
+    });
+    expect(state.resumePayload()).toBeUndefined();
+  });
+
+  test("resumes on the resume URL once READY has landed", () => {
+    // Discord reports that resumes against the base URL disconnect at a higher
+    // rate, so the URL choice is part of the decision, not a detail.
+    const state = ready();
+    expect(state.nextConnection()).toEqual({
+      url: RESUME_URL,
+      action: "resume",
+    });
+    expect(state.resumePayload()).toEqual({ session_id: SESSION, seq: 42 });
+  });
+
+  test("cannot resume on READY alone — a sequence is required", () => {
+    const state = new DiscordSessionState(BASE_URL);
+    state.noteReady(SESSION, RESUME_URL);
+    expect(state.canResume).toBe(false);
+    expect(state.nextConnection().action).toBe("identify");
+  });
+
+  test("only non-null sequences advance the resume point", () => {
+    // Discord sends `s: null` on every non-dispatch payload. Letting those
+    // overwrite the sequence would make the next resume replay from nowhere.
+    const state = ready();
+    state.noteSequence(null);
+    state.noteSequence(undefined);
+    expect(state.resumePayload()).toEqual({ session_id: SESSION, seq: 42 });
+
+    state.noteSequence(43);
+    expect(state.resumePayload()).toEqual({ session_id: SESSION, seq: 43 });
+  });
+
+  test("invalidate drops the session and falls back to identify", () => {
+    const state = ready();
+    state.invalidate();
+    expect(state.canResume).toBe(false);
+    expect(state.nextConnection()).toEqual({
+      url: BASE_URL,
+      action: "identify",
+    });
+  });
+
+  test("invalidate clears the sequence, not just the session id", () => {
+    // A sequence from a dead session is not a valid resume point. Keeping it
+    // would let a later READY combine a fresh session id with a stale sequence
+    // and ask Discord to replay from a stream it no longer has.
+    const state = ready();
+    state.invalidate();
+    state.noteReady("new-session", RESUME_URL);
+    expect(state.canResume).toBe(false);
+
+    state.noteSequence(1);
+    expect(state.resumePayload()).toEqual({
+      session_id: "new-session",
+      seq: 1,
+    });
+  });
+
+  test("prefers resume whenever one is possible", () => {
+    // Resume replays missed events and costs nothing against the identify
+    // budget whose breach resets the bot token.
+    const state = ready();
+    for (let i = 0; i < 5; i++) {
+      expect(state.nextConnection().action).toBe("resume");
+    }
+  });
+});

--- a/gateway/src/discord/session-state.ts
+++ b/gateway/src/discord/session-state.ts
@@ -1,0 +1,112 @@
+/**
+ * Discord Gateway session state and the resume-or-identify decision.
+ *
+ * Every recovery path — a dropped socket, op 7 RECONNECT, op 9 INVALID_SESSION,
+ * a zombie kill, a post-sleep clock jump — ends in the same question: reconnect
+ * where, and open with op 6 RESUME or op 2 IDENTIFY? Answering it in one place
+ * is what keeps that from becoming a lattice of branches that each get the
+ * identify budget slightly wrong.
+ *
+ * The two URLs are not interchangeable. A resume must go to the
+ * `resume_gateway_url` from READY, carrying the same version and encoding
+ * params; Discord reports that resumes against the base URL "experience
+ * disconnects at a higher rate". An identify goes to the base URL from
+ * `GET /gateway/bot`.
+ *
+ * https://docs.discord.com/developers/events/gateway
+ */
+
+/** Where to connect next, and what to send once the socket opens. */
+export interface ConnectionPlan {
+  url: string;
+  action: "resume" | "identify";
+}
+
+/** The op 6 RESUME payload data. */
+export interface ResumePayload {
+  session_id: string;
+  seq: number;
+}
+
+export class DiscordSessionState {
+  private sessionId: string | undefined;
+  private resumeGatewayUrl: string | undefined;
+  private lastSequence: number | undefined;
+
+  /**
+   * `baseGatewayUrl` comes from `GET /gateway/bot` and is the identify target.
+   * It stays valid for the client's lifetime; only the resume URL is per-session.
+   */
+  constructor(private readonly baseGatewayUrl: string) {}
+
+  /**
+   * Record a READY dispatch. This is what makes a session resumable — before
+   * it, there is nothing to resume to.
+   */
+  noteReady(sessionId: string, resumeGatewayUrl: string): void {
+    this.sessionId = sessionId;
+    this.resumeGatewayUrl = resumeGatewayUrl;
+  }
+
+  /**
+   * Record the sequence number on a received payload.
+   *
+   * Only non-null values advance it: Discord sends `s: null` on every
+   * non-dispatch payload, and letting those overwrite the sequence would make
+   * the next resume ask to replay from nowhere. The sequence deliberately
+   * survives session invalidation — it is only meaningful alongside a session
+   * id, and clearing both together is handled by {@link invalidate}.
+   */
+  noteSequence(sequence: number | null | undefined): void {
+    if (typeof sequence === "number") {
+      this.lastSequence = sequence;
+    }
+  }
+
+  /**
+   * Drop the session. Called for op 9 with `d: false`, and for close codes
+   * whose session is gone (4003 / 4007 / 4009 / a normal 1000-1001 close).
+   *
+   * The sequence goes with it: a sequence from a dead session is not a valid
+   * resume point, and keeping it would make the next resume look legitimate
+   * while asking Discord to replay from a stream it no longer has.
+   */
+  invalidate(): void {
+    this.sessionId = undefined;
+    this.resumeGatewayUrl = undefined;
+    this.lastSequence = undefined;
+  }
+
+  /** Whether there is a session to resume — a resume needs all three parts. */
+  get canResume(): boolean {
+    return (
+      this.sessionId !== undefined &&
+      this.resumeGatewayUrl !== undefined &&
+      this.lastSequence !== undefined
+    );
+  }
+
+  /**
+   * Where to connect and what to open with.
+   *
+   * Resume is always preferred when possible: it replays missed events and,
+   * unlike IDENTIFY, costs nothing against the 1000-per-24h budget whose
+   * breach resets the bot token.
+   */
+  nextConnection(): ConnectionPlan {
+    if (this.canResume) {
+      // Non-null: `canResume` is exactly the check that these are set.
+      return { url: this.resumeGatewayUrl as string, action: "resume" };
+    }
+    return { url: this.baseGatewayUrl, action: "identify" };
+  }
+
+  /** The op 6 payload, or undefined when there is no session to resume. */
+  resumePayload(): ResumePayload | undefined {
+    if (!this.canResume) return undefined;
+    return {
+      session_id: this.sessionId as string,
+      seq: this.lastSequence as number,
+    };
+  }
+}

--- a/gateway/src/discord/session-state.ts
+++ b/gateway/src/discord/session-state.ts
@@ -16,6 +16,31 @@
  * https://docs.discord.com/developers/events/gateway
  */
 
+/** Gateway API version this client speaks. */
+export const GATEWAY_VERSION = "10";
+
+/** Payload encoding. `json` avoids the optional erlpack/zlib dependencies. */
+export const GATEWAY_ENCODING = "json";
+
+/**
+ * Stamp the version and encoding Discord requires onto a Gateway URL.
+ *
+ * Both URLs arrive bare — `GET /gateway/bot` returns `wss://gateway.discord.gg`
+ * and READY's `resume_gateway_url` is the same shape — and a socket opened
+ * without these params is rejected. Applying it here rather than at each call
+ * site is what keeps a resume and an identify from ever disagreeing about the
+ * version they speak, which Discord treats as a resume failure.
+ *
+ * Existing params are preserved and the required two are overwritten, so a URL
+ * that already carries them is idempotent rather than doubled.
+ */
+function withGatewayParams(url: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("v", GATEWAY_VERSION);
+  parsed.searchParams.set("encoding", GATEWAY_ENCODING);
+  return parsed.toString();
+}
+
 /** Where to connect next, and what to send once the socket opens. */
 export interface ConnectionPlan {
   url: string;
@@ -96,9 +121,12 @@ export class DiscordSessionState {
   nextConnection(): ConnectionPlan {
     if (this.canResume) {
       // Non-null: `canResume` is exactly the check that these are set.
-      return { url: this.resumeGatewayUrl as string, action: "resume" };
+      return {
+        url: withGatewayParams(this.resumeGatewayUrl as string),
+        action: "resume",
+      };
     }
-    return { url: this.baseGatewayUrl, action: "identify" };
+    return { url: withGatewayParams(this.baseGatewayUrl), action: "identify" };
   }
 
   /** The op 6 payload, or undefined when there is no session to resume. */

--- a/gateway/src/discord/session-state.ts
+++ b/gateway/src/discord/session-state.ts
@@ -90,7 +90,7 @@ export class DiscordSessionState {
 
   /**
    * Drop the session. Called for op 9 with `d: false`, and for close codes
-   * whose session is gone (4003 / 4007 / 4009 / a normal 1000-1001 close).
+   * whose session is gone (4003 / 4007 / 4009 / a normal 1000 close).
    *
    * The sequence goes with it: a sequence from a dead session is not a valid
    * resume point, and keeping it would make the next resume look legitimate

--- a/gateway/src/discord/session-state.ts
+++ b/gateway/src/discord/session-state.ts
@@ -131,7 +131,9 @@ export class DiscordSessionState {
 
   /** The op 6 payload, or undefined when there is no session to resume. */
   resumePayload(): ResumePayload | undefined {
-    if (!this.canResume) return undefined;
+    if (!this.canResume) {
+      return undefined;
+    }
     return {
       session_id: this.sessionId as string,
       seq: this.lastSequence as number,


### PR DESCRIPTION
Part of LUM-2841 (Discord gateway client, read-only). **Split out of #39254**, which keeps the admission half. Neither imports the other; they can land in either order.

This PR answers one question: **will the connection survive, and can it destroy the bot token?** No socket yet — these are the decision rules, kept pure so the client that wires them is thin and so the reasoning is testable without waiting in real time.

Built on the API research briefing on LUM-2841 (verified against live Discord docs, Jul 27 2026).

---

## 👉 The knob worth arguing about: the 600s identify cap

**What it protects.** Discord caps IDENTIFY at **1000 per 24 hours**. Breaching the cap doesn't throttle — it terminates every session and **resets the bot token**, taking the integration down until a human stores a new one from the Portal. RESUME doesn't count against it. So reconnect pacing here is a credential-safety mechanism, not a politeness one.

**Why 600s specifically.** Under full jitter a delay is uniform over `[0, cap)`, so a sustained outage spends roughly `86_400s / (cap/2)` identifies per day:

| cap | identifies/24h | share of the 1000 budget |
| --- | --- | --- |
| 120s | ~1440 | **over budget — token reset** |
| 300s | ~576 | 58% |
| **600s** | **~288** | **29%** |

The 120s row is the reason this is a module with a test rather than a constant inline. Two minutes is *four times* Slack Socket Mode's ceiling and reads as conservative — and it still breaches the cap in a sustained outage.

**What you trade by lowering it.** Recovery latency after a long Discord-side outage. At 600s the expected wait between attempts is ~5 minutes once backoff saturates; at 300s it's ~2.5. Early attempts are unaffected either way — backoff is exponential, so the first several retries are seconds apart and transient blips recover fast. The cap only governs the tail.

**Arguments for going lower that I'd want a reviewer to weigh:** fatal close codes already hard-stop (so the sustained-retry case is only transient failures, which are rarer than the table's worst case); and the 58% figure at 300s still leaves headroom. **Arguments for staying at 600s:** the failure is asymmetric and ugly — slow recovery is an inconvenience, a token reset is an outage plus manual Portal work plus an email to the owner — and the budget is shared with every other identify the client spends, including ones op 9 bursts and restarts can drive. I'd rather buy margin than latency, but this is a genuine trade and I'd take a reviewer's call on it.

`backoff.test.ts` pins the arithmetic, so changing the cap is a deliberate edit with a failing test attached rather than a silent tuning.

---

## Known duplication, tracked: LUM-2851

This makes a **third** exponential-backoff-with-jitter implementation in `gateway/src/` — alongside `slack/socket-mode.ts` and `velay/client.ts`. Root `AGENTS.md` says extract on the second occurrence, so that debt is real and is filed as **LUM-2851**.

It is deliberately *not* done here. Extracting now would mean designing the shared abstraction around a caller that doesn't exist in `main` yet — two real implementations plus a hypothetical. Once this merges there are three concrete callers with tests to generalize from, and the refactor reviews as "three call sites, one module, behaviour identical" instead of riding on a Discord PR and touching Slack's reconnect path along the way.

Only the *policy* differs across the three (jitter strategy; whether the counter resets on socket-open or on a stable session). The arithmetic is identical, which is what makes it extractable.

---

## Three places this deliberately departs from Slack Socket Mode

The Slack client is the in-repo analog and most of it transfers. These three don't:

1. **Backoff resets on a *stable session*, never on socket-open.** Slack resets its attempt counter in the `open` handler. Copying that is the bug that empties the identify budget: a socket that opens and immediately dies would reset the delay every cycle, turning an outage into a tight identify loop. Only a session that has held past `SESSION_STABLE_AFTER_MS` (2 min) clears it — READY/RESUMED alone is not enough, because a session dying seconds later is exactly the flap this exists to survive.
2. **Full jitter, not additive.** Slack adds 0–50% on top of the delay. Full jitter draws across the whole window so instances recovering from one Discord-side outage don't resynchronise.
3. **Resume failures carry into the next identify.** Repeated resume failures are the same instability signal; letting the first identify after them start from zero is how a flap reaches the budget-spending path at full speed.

## Close-code taxonomy

The official table's **`Reconnect: true` does not mean "may RESUME"** — it means "you may open a socket". 4007 and 4009 are reconnectable but their session is gone, so resuming them returns op 9 and wastes a round trip.

| Action | Codes |
| --- | --- |
| **RESUME** | 4000, 4001, 4002, 4005, 4008, absent/1006 abnormal closes |
| **Fresh IDENTIFY** | 4003, 4007, 4009, and 1000/1001 (a normal close invalidates the session) |
| **FATAL — never retry** | 4004, 4010, 4011, 4012, 4013, 4014 |

Fatal codes each carry an operator-facing diagnostic naming the action (4014 → "enable it in the Developer Portal, or remove it from the IDENTIFY intents"), because each is a dead end until a human acts — and a 4004 retry loop additionally spends the budget toward a token reset.

**Unknown codes resume rather than identify:** a resume against a dead session degrades safely to op 9 then IDENTIFY, whereas identifying against a live session spends budget resuming wouldn't have.

**Deliberate closes use 4000, not 1000/1001**, since those invalidate the session — zombie kills and clock-jump recovery depend on the session surviving, and a test pins the code outside that range.

## Session state

One state machine, not two branches — the briefing's explicit ask, because every branch is somewhere the budget gets got slightly wrong. A dropped socket, op 7, op 9, a zombie kill, and a clock jump all end in the same question: reconnect where, and open with RESUME or IDENTIFY.

Two details that are easy to get wrong and are pinned:

- **Only non-null sequences advance the resume point.** Discord sends `s: null` on every non-dispatch payload; letting those through makes the next resume ask to replay from nowhere.
- **Invalidation clears the sequence, not just the session id.** Otherwise a later READY pairs a fresh session id with a stale sequence and asks Discord to replay a stream it no longer has — which looks legitimate and isn't.

The two URLs aren't interchangeable: a resume must use the `resume_gateway_url` from READY with its version/encoding params (Discord reports base-URL resumes "experience disconnects at a higher rate"), which is why the plan carries a URL rather than just an action.

## Heartbeat

Two detectors, because they cover different failures:

- **ACK watchdog** (documented): a beat with no op 11 means the connection is a zombie. Checked *before* sending the next beat, so one miss is enough rather than letting unacknowledged beats accumulate.
- **Clock-jump detector** (practical layer, not in the docs): after a laptop wakes, the socket usually still reports open and no close event ever fires — a timer firing far past its interval is the only early evidence. Threshold is 2× the interval: clear of ordinary event-loop lag, far under a real suspend. The costs are asymmetric, which makes the threshold easy — a false positive costs one resume (free against the identify budget), a false negative costs an interval of silently dropped messages.

`reset()` clears a pending ACK so a reconnect doesn't inherit the previous socket's state and declare a fresh connection dead on its first beat.

## Test plan

- 35 tests / 0 fail across the four modules.
- Clock and randomness are injectable, so tests pin jitter and advance time by hand — nothing waits in real time.
- Gateway typecheck, **knip**, eslint, prettier all clean locally. Rebased onto latest `main`; CI green.
- No live token required — the Portal app doesn't exist yet and isn't on the critical path.

## Related

- **Admission gate + intents** — #39254. Independent of this PR.
- **Backoff extraction** — LUM-2851, deliberately sequenced after this merges.
- Still to come on LUM-2841: the WebSocket client wiring these modules together (mock-first, so the full lifecycle is drivable by a fake socket), `MESSAGE_CREATE` schemas + normalizer, and the credential-gated lifecycle in `index.ts`.

## CLI verb checklist

N/A — no routes added.