### PR TITLE
fix(subagent): keep completed subagents readable when the parent survives

### DIFF
--- a/assistant/src/__tests__/conversation-evictor.test.ts
+++ b/assistant/src/__tests__/conversation-evictor.test.ts
@@ -19,11 +19,15 @@ import {
 
 function createMockSession(
   processing = false,
+  queued = false,
 ): EvictableConversation & { disposed: boolean } {
   return {
     disposed: false,
     isProcessing() {
       return processing;
+    },
+    hasQueuedMessages() {
+      return queued;
     },
     dispose() {
       this.disposed = true;
@@ -98,6 +102,21 @@ describe("ConversationEvictor", () => {
       expect(sessions.has("a")).toBe(true);
       expect(s1.disposed).toBe(false);
     });
+
+    test("skips sessions with queued messages even when not processing", () => {
+      // Models the gap between a turn's `finally` and the async queue-drain
+      // dispatch: isProcessing() is false but a queued turn (e.g. a subagent
+      // completion wake) is still pending.
+      const s1 = createMockSession(false, true);
+      sessions.set("a", s1);
+
+      const result = evictor.sweep();
+
+      expect(result.ttlEvicted).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(sessions.has("a")).toBe(true);
+      expect(s1.disposed).toBe(false);
+    });
   });
 
   describe("LRU eviction", () => {
@@ -130,6 +149,36 @@ describe("ConversationEvictor", () => {
       expect(sessions.has("s2")).toBe(true);
       expect(sessions.has("s3")).toBe(true);
       expect(sessions.has("s4")).toBe(true);
+    });
+
+    test("skips sessions with queued messages during LRU eviction", () => {
+      // maxConversations = 3, add 4 sessions; the LRU one has a queued turn.
+      const s0 = createMockSession(false, true); // queued — should not be evicted
+      const s1 = createMockSession();
+      const s2 = createMockSession();
+      const s3 = createMockSession();
+      sessions.set("s0", s0);
+      sessions.set("s1", s1);
+      sessions.set("s2", s2);
+      sessions.set("s3", s3);
+
+      const now = Date.now();
+      const lastAccess = (
+        evictor as unknown as { lastAccess: Map<string, number> }
+      ).lastAccess;
+      lastAccess.set("s0", now - 50); // old but has queued messages
+      lastAccess.set("s1", now - 40);
+      lastAccess.set("s2", now);
+      lastAccess.set("s3", now);
+
+      const result = evictor.sweep();
+
+      // s1 is the LRU evictable session, gets evicted
+      expect(result.lruEvicted).toBe(1);
+      expect(sessions.has("s0")).toBe(true); // kept: queued messages
+      expect(sessions.has("s1")).toBe(false); // evicted: LRU
+      expect(s0.disposed).toBe(false);
+      expect(s1.disposed).toBe(true);
     });
 
     test("skips processing sessions during LRU eviction", () => {

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -34,6 +34,7 @@ interface FakeManagedSubagent {
 interface ManagerInternals {
   subagents: Map<string, FakeManagedSubagent>;
   parentToChildren: Map<string, Set<string>>;
+  labelIndex: Map<string, string>;
   runSubagent: (subagentId: string, objective: string) => Promise<void>;
   sweepTerminal: () => void;
   stopSweep: () => void;
@@ -77,6 +78,10 @@ function injectFakeSubagent(
     internals.parentToChildren.set(parentId, new Set());
   }
   internals.parentToChildren.get(parentId)!.add(subagentId);
+  internals.labelIndex.set(
+    `${parentId}:${state.config.label.toLowerCase().trim()}`,
+    subagentId,
+  );
 }
 
 function makeState(
@@ -210,10 +215,34 @@ describe("SubagentManager terminal disposal", () => {
     expect(manager.getState("sub-1")).toBeDefined();
 
     // Parent disposal should remove it.
-    manager.abortAllForParent("parent-sess-1");
+    manager.disposeAllForParent("parent-sess-1");
 
     expect(manager.getState("sub-1")).toBeUndefined();
     expect(manager.getChildrenOf("parent-sess-1")).toHaveLength(0);
+  });
+
+  test("parent cancel keeps a completed child readable within its retention window", () => {
+    const manager = new SubagentManager();
+    injectFakeSubagent(
+      manager,
+      "sub-done",
+      makeState("sub-done", { status: "completed" }),
+      undefined,
+      null, // conversation released, metadata retained
+    );
+    asInternals(manager).subagents.get("sub-done")!.retainedUntil =
+      Date.now() + 60_000;
+
+    // A user stop / idle eviction aborts in-flight children only.
+    manager.abortAllForParent("parent-sess-1");
+
+    // The completed child's result must remain resolvable by id and by label
+    // so the parent can still subagent_read it after the cancel.
+    expect(manager.getState("sub-done")?.status).toBe("completed");
+    expect(
+      manager.getByLabel("Test subagent", "parent-sess-1")?.config.id,
+    ).toBe("sub-done");
+    expect(manager.getChildrenOf("parent-sess-1")).toHaveLength(1);
   });
 
   test("TTL sweep removes expired terminal entries but not active subagents", () => {

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -444,6 +444,37 @@ describe("SubagentManager disposeAllForParent", () => {
   });
 });
 
+describe("SubagentManager disposeAllForAllParents", () => {
+  test("removes retained children across every parent — clear-all semantics", () => {
+    clearCaptured();
+    const manager = new SubagentManager();
+    // Two parents; only one would appear in the in-memory conversation store
+    // during a clear-all — the other models an evicted parent whose terminal
+    // children are still retained.
+    injectFakeSubagent(manager, "sub-a", makeState("sub-a"));
+    injectFakeSubagent(
+      manager,
+      "sub-b",
+      makeState("sub-b", {
+        config: {
+          id: "sub-b",
+          parentConversationId: "parent-evicted",
+          label: "Evicted parent child",
+          objective: "Do something",
+        },
+        status: "completed",
+      }),
+    );
+
+    manager.disposeAllForAllParents();
+
+    expect(manager.getState("sub-a")).toBeUndefined();
+    expect(manager.getState("sub-b")).toBeUndefined();
+    expect(manager.getChildrenOf("parent-sess-1")).toHaveLength(0);
+    expect(manager.getChildrenOf("parent-evicted")).toHaveLength(0);
+  });
+});
+
 describe("SubagentManager sharedRequestTimestamps", () => {
   test("defaults to an empty array", () => {
     const manager = new SubagentManager();

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -386,7 +386,7 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
 });
 
 describe("SubagentManager abortAllForParent", () => {
-  test("aborts all active children of a parent", () => {
+  test("aborts active children but keeps every child's state readable", () => {
     clearCaptured();
     const manager = new SubagentManager();
     injectFakeSubagent(manager, "sub-1", makeState("sub-1"));
@@ -402,16 +402,44 @@ describe("SubagentManager abortAllForParent", () => {
     expect(count).toBe(2); // sub-1 and sub-2, not sub-3 (already completed)
     expect(capturedNotifications).toHaveLength(2);
 
-    // All children should be disposed — parent is going away.
-    expect(manager.getState("sub-1")).toBeUndefined();
-    expect(manager.getState("sub-2")).toBeUndefined();
-    expect(manager.getState("sub-3")).toBeUndefined();
-    expect(manager.getChildrenOf("parent-sess-1")).toHaveLength(0);
+    // The parent conversation lives on (stop/eviction/rebuild), so every
+    // child stays tracked: aborted ones as terminal metadata, and the
+    // completed one still readable via subagent_read.
+    expect(manager.getState("sub-1")?.status).toBe("aborted");
+    expect(manager.getState("sub-2")?.status).toBe("aborted");
+    expect(manager.getState("sub-3")?.status).toBe("completed");
+    expect(manager.getChildrenOf("parent-sess-1")).toHaveLength(3);
   });
 
   test("returns 0 for unknown parent", () => {
     const manager = new SubagentManager();
     const count = manager.abortAllForParent("nonexistent");
+    expect(count).toBe(0);
+  });
+});
+
+describe("SubagentManager disposeAllForParent", () => {
+  test("aborts and removes all children — parent data is going away", () => {
+    clearCaptured();
+    const manager = new SubagentManager();
+    injectFakeSubagent(manager, "sub-1", makeState("sub-1"));
+    injectFakeSubagent(
+      manager,
+      "sub-2",
+      makeState("sub-2", { status: "completed" }),
+    );
+
+    const count = manager.disposeAllForParent("parent-sess-1", () => {});
+
+    expect(count).toBe(1); // only sub-1 was still in flight
+    expect(manager.getState("sub-1")).toBeUndefined();
+    expect(manager.getState("sub-2")).toBeUndefined();
+    expect(manager.getChildrenOf("parent-sess-1")).toHaveLength(0);
+  });
+
+  test("returns 0 for unknown parent", () => {
+    const manager = new SubagentManager();
+    const count = manager.disposeAllForParent("nonexistent");
     expect(count).toBe(0);
   });
 });

--- a/assistant/src/daemon/conversation-evictor.ts
+++ b/assistant/src/daemon/conversation-evictor.ts
@@ -7,6 +7,7 @@ const log = getLogger("conversation-evictor");
 /** Minimal interface a conversation must satisfy to be evictable. */
 export interface EvictableConversation {
   isProcessing(): boolean;
+  hasQueuedMessages(): boolean;
   dispose(): void;
 }
 
@@ -63,7 +64,12 @@ export class ConversationEvictor {
       options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
   }
 
-  /** Abort any subagents belonging to a conversation as it's evicted. */
+  /**
+   * Abort any in-flight subagents belonging to a conversation as it's evicted.
+   * Terminal subagent metadata is left readable — an evicted conversation is
+   * resumable from the database, and its next turn may still `subagent_read` a
+   * completed child's result.
+   */
   onEvict(conversationId: string): void {
     getSubagentManager().abortAllForParent(conversationId);
   }
@@ -125,10 +131,19 @@ export class ConversationEvictor {
     };
 
     // Phase 1: TTL eviction — remove conversations idle longer than ttlMs.
+    // A conversation with queued messages is not idle: the queue drains via an
+    // async dispatch after the current turn's `finally`, so `isProcessing()`
+    // can read false while a queued turn (e.g. a subagent completion wake) is
+    // still pending. Disposing in that gap would silently drop the queued
+    // messages.
     for (const [id, conversation] of this.conversations) {
       const lastAccessTime = this.lastAccess.get(id) ?? 0;
       if (now - lastAccessTime < this.ttlMs) continue;
-      if (conversation.isProcessing() || this.shouldProtect(id)) {
+      if (
+        conversation.isProcessing() ||
+        conversation.hasQueuedMessages() ||
+        this.shouldProtect(id)
+      ) {
         result.skipped++;
         continue;
       }
@@ -202,8 +217,15 @@ export class ConversationEvictor {
   private idleConversationsByLru(): Array<[string, EvictableConversation]> {
     const idle: Array<[string, EvictableConversation, number]> = [];
     for (const [id, conversation] of this.conversations) {
-      if (conversation.isProcessing()) continue;
-      if (this.shouldProtect(id)) continue;
+      if (conversation.isProcessing()) {
+        continue;
+      }
+      if (conversation.hasQueuedMessages()) {
+        continue;
+      }
+      if (this.shouldProtect(id)) {
+        continue;
+      }
       idle.push([id, conversation, this.lastAccess.get(id) ?? 0]);
     }
     idle.sort((a, b) => a[2] - b[2]);

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -250,12 +250,15 @@ export async function getOrCreateConversation(
  * deleted conversation and trip FK constraints.
  */
 export function destroyActiveConversation(conversationId: string): void {
+  // Subagent teardown is keyed by parent id, not the live instance — an
+  // evicted parent still retains its terminal children, and deleting the
+  // conversation must take their records with it.
+  getSubagentManager().disposeAllForParent(conversationId);
   const conversation = findConversation(conversationId);
   if (!conversation) {
     return;
   }
   removeFromEvictor(conversationId);
-  getSubagentManager().disposeAllForParent(conversationId);
   conversation.dispose();
   deleteConversation(conversationId);
   deleteConversationOptions(conversationId);
@@ -280,10 +283,12 @@ export function stopConversations(): void {
  */
 export function clearAllActiveConversations(): number {
   const count = conversationCount();
-  const subagentManager = getSubagentManager();
+  // Dispose subagents across ALL parents, not just the in-memory ones — an
+  // evicted parent still retains its terminal children, and clear-all must
+  // take their records with it.
+  getSubagentManager().disposeAllForAllParents();
   for (const id of conversationIds()) {
     removeFromEvictor(id);
-    subagentManager.disposeAllForParent(id);
   }
   for (const conversation of allConversations()) {
     conversation.dispose();

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -118,6 +118,9 @@ export async function getOrCreateConversation(
     (conversation.isStale() && !conversation.isProcessing())
   ) {
     if (conversation) {
+      // Stale rebuild: the conversation id lives on, so abort in-flight
+      // children but keep terminal subagent results readable for the
+      // retention window.
       getSubagentManager().abortAllForParent(conversationId);
       conversation.dispose();
     }
@@ -252,7 +255,7 @@ export function destroyActiveConversation(conversationId: string): void {
     return;
   }
   removeFromEvictor(conversationId);
-  getSubagentManager().abortAllForParent(conversationId);
+  getSubagentManager().disposeAllForParent(conversationId);
   conversation.dispose();
   deleteConversation(conversationId);
   deleteConversationOptions(conversationId);
@@ -280,7 +283,7 @@ export function clearAllActiveConversations(): number {
   const subagentManager = getSubagentManager();
   for (const id of conversationIds()) {
     removeFromEvictor(id);
-    subagentManager.abortAllForParent(id);
+    subagentManager.disposeAllForParent(id);
   }
   for (const conversation of allConversations()) {
     conversation.dispose();

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -103,10 +103,12 @@ export function cancelGeneration(conversationId: string): boolean {
   conversation.abort(
     createAbortReason("user_cancel", "cancelGeneration", conversationId),
   );
-  // Also abort any child subagents spawned by this conversation.
+  // Also abort any in-flight child subagents spawned by this conversation.
   // Omit sendToClient to suppress parent notifications — the parent is
   // being cancelled, so enqueuing synthetic messages would trigger
-  // unwanted model activity after the user pressed stop.
+  // unwanted model activity after the user pressed stop. Terminal children
+  // stay readable: the conversation survives the stop, and its next turn may
+  // still `subagent_read` a completed child's result.
   getSubagentManager().abortAllForParent(conversationId);
   // Cancel any in-flight ACP agent sessions this conversation spawned, for the
   // same reason: a backgrounded ACP prompt would otherwise keep running (and

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -3197,6 +3197,10 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM tool_invocations");
   await runOrThrow("DELETE FROM messages");
   await runOrThrow("DELETE FROM conversations");
+  // Subagent lifecycle records reference conversations by id without an FK
+  // cascade; wipe them explicitly so labels/objectives don't survive (or
+  // rehydrate after) a clear-all.
+  await runOrThrow("DELETE FROM subagents");
 
   // The memory feature's relocated conversation-keyed tables lost their main-DB
   // cascade. Signal the wipe through the hook rather than reaching into the

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -960,8 +960,14 @@ export class SubagentManager {
   }
 
   /**
-   * Abort all subagents belonging to a parent conversation.
-   * Called when the parent conversation is aborted or evicted.
+   * Abort all in-flight subagents belonging to a parent conversation, keeping
+   * every child's metadata (and durable record) readable for the normal
+   * terminal-retention window. Called when the parent conversation stops or is
+   * released from memory but its id lives on — user cancel, idle eviction,
+   * config-reload rebuild — so a completed child's result stays retrievable via
+   * `subagent_read` afterwards. Aborted children release their live
+   * conversations through the run's own teardown and are swept on the TTL like
+   * any other terminal entry.
    */
   abortAllForParent(
     parentConversationId: string,
@@ -979,10 +985,29 @@ export class SubagentManager {
       }
     }
 
-    // Dispose all children — the parent conversation is going away so nobody
-    // will call subagent_read.  Use snapshot since dispose mutates the set.
-    for (const childId of [...children]) {
-      this.dispose(childId);
+    return count;
+  }
+
+  /**
+   * Abort and fully dispose all subagents belonging to a parent conversation,
+   * deleting their durable records. Only for parents whose conversation data is
+   * going away (deletion, clear-all) — nobody will call subagent_read.
+   */
+  disposeAllForParent(
+    parentConversationId: string,
+    parentSendToClient?: (msg: AssistantEvent) => void,
+  ): number {
+    const count = this.abortAllForParent(
+      parentConversationId,
+      parentSendToClient,
+    );
+
+    const children = this.parentToChildren.get(parentConversationId);
+    if (children) {
+      // Use snapshot since dispose mutates the set.
+      for (const childId of [...children]) {
+        this.dispose(childId);
+      }
     }
 
     return count;

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -989,6 +989,18 @@ export class SubagentManager {
   }
 
   /**
+   * Abort and fully dispose every subagent across all parents, deleting their
+   * durable records. For clear-all: every conversation's data is going away,
+   * including retained children of parents that are no longer in the in-memory
+   * conversation store.
+   */
+  disposeAllForAllParents(): void {
+    for (const parentId of [...this.parentToChildren.keys()]) {
+      this.disposeAllForParent(parentId);
+    }
+  }
+
+  /**
    * Abort and fully dispose all subagents belonging to a parent conversation,
    * deleting their durable records. Only for parents whose conversation data is
    * going away (deletion, clear-all) — nobody will call subagent_read.


### PR DESCRIPTION
## Prompt / plan

Investigated [LUM-2846](https://linear.app/vellum/issue/LUM-2846/completed-subagents-vanish-from-registry-between-final-notification): completed subagents vanished from the registry between sending their final `notify_parent` notification and delivering their completion wake — `subagent_read` by label and by ID returned "not found", and only the condensed notification survived.

Root cause: `SubagentManager.abortAllForParent` didn't just abort running children — it **disposed every child**, deleting the in-memory registry entry *and* the durable `subagents` row. That is correct when the parent conversation's data is going away, but the method is also called on paths where the parent lives on:

- `cancelGeneration` (user presses stop) and the CLI cancel signal (`signals/cancel.ts`)
- idle/LRU/memory-pressure eviction (`ConversationEvictor.onEvict`) — the conversation is resumable from the DB
- the stale-rebuild branch of `getOrCreateConversation` after a config reload

Any of these firing inside a completed child's 30-minute retention window destroyed the finished result. A completion wake queued on a busy parent died with it (conversation dispose / abort clears the queue), so the parent saw the teaser notification and could never retrieve the result.

A second contributing defect: the evictor considered a conversation idle whenever `isProcessing()` was false, but there is a documented gap between a turn's `finally` and the async queue-drain dispatch where `isProcessing()` is false while queued turns (such as a subagent completion wake) are still pending. Evicting in that gap silently dropped the queued wake.

Fix:

- `abortAllForParent` now only aborts in-flight children; every child's metadata and durable record stay readable for the normal terminal-retention window (TTL sweep cleans up as before).
- New `disposeAllForParent` carries the full teardown, used by `destroyActiveConversation` and `clearAllActiveConversations` — the paths where the parent's data is actually deleted.
- `EvictableConversation` gains `hasQueuedMessages()`, and the evictor skips conversations with queued messages in the TTL and LRU/memory-pressure phases.

## Test plan

- New unit tests:
  - `abortAllForParent` keeps aborted and completed children tracked and resolvable (`getState`, `getByLabel`, `getChildrenOf`); `disposeAllForParent` removes everything.
  - A completed child inside its retention window survives a parent cancel (the LUM-2846 regression).
  - Evictor skips sessions with queued messages during TTL and LRU eviction.
- `bun test src/__tests__/conversation-evictor.test.ts src/__tests__/subagent-disposal.test.ts src/__tests__/subagent-manager-notify.test.ts` — 45 pass.
- Related suites (`subagent-persistence`, `subagent-tools`, `subagent-fork-notifications`, `subagent-notify-parent`, `injector-chain`, `subagent-spawn-and-await`, `agent-wake`, `voice-session-bridge`, `conversation-retry-route`) pass; one pre-existing multi-file mock-interference failure in `subagent-spawn-and-await` reproduces identically on the base commit.
- `bun run typecheck:fast` clean; lint clean on changed files (remaining `curly` warnings are pre-existing lines this PR doesn't touch).

Part of LUM-2846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X5APyA5ZAxWYbY3dRNnAE

---
_Generated by [Claude Code](https://claude.ai/code/session_019X5APyA5ZAxWYbY3dRNnAE)_