### PR TITLE
feat(live-voice): teach the voice legs the [-1] room-minimize marker

### DIFF
--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -296,6 +296,6 @@ export function escalatedContinuationRule(spokenBridge?: string): string {
     'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that holding phrase —',
     'opening with another "Let me check", "One moment", or any restatement of what you are about to do sounds broken, because the caller just heard that.',
     "Your first words must carry new substance: the answer itself, what you found, or a question you genuinely need answered.",
-    `Never output ${ESCALATE_VERDICT_TOKEN} or any other verdict token — you are the model that finishes the answer.`,
+    `Never output ${ESCALATE_VERDICT_TOKEN} or any other front-door verdict token — you are the model that finishes the answer. (The [-1] room-minimize marker from your call instructions is not a verdict token and stays allowed.)`,
   ].join(" ");
 }

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -253,11 +253,13 @@ describe("LiveVoiceSession archive and metrics events", () => {
       assistantMessageChannel: "vellum",
       userMessageInterface: "macos",
       assistantMessageInterface: "macos",
-      // Pins the full production control prompt, including the no-UI rule
-      // (voice turns are non-interactive — everything is conveyed in speech)
-      // and the shared no-setup-flows rule (no OAuth/browser flows mid-call).
+      // Pins the full production control prompt: the no-UI rule (voice turns
+      // are non-interactive — everything is conveyed in speech), the [-1]
+      // room-minimize marker teaching, and the shared no-setup-flows rule
+      // (no OAuth/browser flows mid-call).
       voiceControlPrompt:
         "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech. " +
+        "The call renders as a full-screen overlay covering the app. If this reply created or changed something on screen worth looking at (an app, a page, a document), you may end the reply with the marker [-1]: after you finish speaking, the overlay minimizes so the user can see the screen while the call continues. Use it at most once per reply, only when there is genuinely something new to show, never speak the marker aloud or mention it, and never emit any other bracketed marker. " +
         VOICE_NO_SETUP_FLOWS_RULE,
     });
     callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -569,8 +569,17 @@ function createControlMarkerHoldback(
 // barge-in, the interruption merge note is appended to it (see
 // buildInterruptionMergeNote) so the model reconciles the interrupted request
 // with the new utterance.
+//
+// The MINIMIZE_ROOM_MARKER teaching deliberately keeps the no-interactive-UI
+// rule intact (live-voice turns are non-interactive, JARVIS-1291): the marker
+// does not render UI — it asks the client to reveal the screen the call
+// overlay covers. The gate in createControlMarkerHoldback strips it from
+// speech, and completeTtsForTurn sends the minimize_room frame only after the
+// reply's TTS drains, so "end your reply with it" is the whole contract the
+// model needs.
 const LIVE_VOICE_CONTROL_PROMPT =
   "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech. " +
+  "The call renders as a full-screen overlay covering the app. If this reply created or changed something on screen worth looking at (an app, a page, a document), you may end the reply with the marker [-1]: after you finish speaking, the overlay minimizes so the user can see the screen while the call continues. Use it at most once per reply, only when there is genuinely something new to show, never speak the marker aloud or mention it, and never emit any other bracketed marker. " +
   VOICE_NO_SETUP_FLOWS_RULE;
 
 // System-level guidance appended to a barge-in turn's control prompt so the


### PR DESCRIPTION
## Summary
- `LIVE_VOICE_CONTROL_PROMPT` teaches the end-of-reply `[-1]` marker (at most once, only when there is something new to show) while keeping the JARVIS-1291 no-interactive-UI and no-setup-flows rules intact
- Escalated-leg preamble carves the marker out of its no-verdict-token rule
- Pinned-prompt test updated

Part of plan: voice-room-minimize.md (PR 8 of 9)