### PR TITLE
fix(daemon): recover streamed assistant text the finalized snapshot dropped

### DIFF
--- a/assistant/src/__tests__/recover-streamed-text.test.ts
+++ b/assistant/src/__tests__/recover-streamed-text.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for `recoverStreamedTextMissingFromFinal` — the finalize-time guard
+ * that re-inserts streamed assistant text the provider's accumulated final
+ * snapshot dropped (the interleaved-thinking `thinking → text → thinking →
+ * tool_use` shape, LUM-2847 / JARVIS-1324). The streamed mirror is the
+ * recovery source; the finalized content stays authoritative whenever it
+ * carries visible text of its own.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import { recoverStreamedTextMissingFromFinal } from "../daemon/conversation-agent-loop-handlers.js";
+import type { ContentBlock } from "../providers/types.js";
+
+const thinking = (text: string): ContentBlock => ({
+  type: "thinking",
+  thinking: text,
+  signature: "sig",
+});
+const text = (t: string): ContentBlock => ({ type: "text", text: t });
+const toolUse = (id: string): ContentBlock => ({
+  type: "tool_use",
+  id,
+  name: "remember",
+  input: { content: "note", finish_turn: true },
+});
+
+describe("recoverStreamedTextMissingFromFinal", () => {
+  test("re-inserts text dropped between two thinking blocks at its stream position", () => {
+    const final = [thinking("A"), thinking("B"), toolUse("t1")];
+    const streamed = [thinking("A"), text("the reply"), thinking("B")];
+
+    const result = recoverStreamedTextMissingFromFinal(final, streamed);
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toEqual([
+      thinking("A"),
+      text("the reply"),
+      thinking("B"),
+      toolUse("t1"),
+    ]);
+    expect(result!.recoveredChars).toBe("the reply".length);
+  });
+
+  test("returns null when the finalized content already carries visible text", () => {
+    const final = [thinking("A"), text("kept reply"), toolUse("t1")];
+    const streamed = [thinking("A"), text("kept reply")];
+
+    expect(recoverStreamedTextMissingFromFinal(final, streamed)).toBeNull();
+  });
+
+  test("returns null for a tool-only call that streamed no text", () => {
+    const final = [thinking("A"), toolUse("t1")];
+    const streamed = [thinking("A")];
+
+    expect(recoverStreamedTextMissingFromFinal(final, streamed)).toBeNull();
+  });
+
+  test("ignores whitespace-only streamed text", () => {
+    const final = [thinking("A"), toolUse("t1")];
+    const streamed = [thinking("A"), text("  \n ")];
+
+    expect(recoverStreamedTextMissingFromFinal(final, streamed)).toBeNull();
+  });
+
+  test("without streamed thinking to anchor on, text lands before the first tool call", () => {
+    const final = [thinking("A"), thinking("B"), toolUse("t1")];
+    const streamed = [text("the reply")];
+
+    const result = recoverStreamedTextMissingFromFinal(final, streamed);
+
+    expect(result!.content).toEqual([
+      thinking("A"),
+      thinking("B"),
+      text("the reply"),
+      toolUse("t1"),
+    ]);
+  });
+
+  test("without thinking or tool blocks in the final content, text appends at the end", () => {
+    const final: ContentBlock[] = [];
+    const streamed = [text("the reply")];
+
+    const result = recoverStreamedTextMissingFromFinal(final, streamed);
+
+    expect(result!.content).toEqual([text("the reply")]);
+  });
+
+  test("multiple interleaved text segments keep their stream order", () => {
+    const final = [thinking("A"), thinking("B"), toolUse("t1")];
+    const streamed = [
+      thinking("A"),
+      text("first part"),
+      thinking("B"),
+      text("second part"),
+    ];
+
+    const result = recoverStreamedTextMissingFromFinal(final, streamed);
+
+    expect(result!.content).toEqual([
+      thinking("A"),
+      text("first part"),
+      thinking("B"),
+      text("second part"),
+      toolUse("t1"),
+    ]);
+    expect(result!.recoveredChars).toBe(
+      "first part".length + "second part".length,
+    );
+  });
+
+  test("text streamed before any thinking is restored ahead of the first thinking block", () => {
+    const final = [thinking("A"), toolUse("t1")];
+    const streamed = [text("preamble"), thinking("A")];
+
+    const result = recoverStreamedTextMissingFromFinal(final, streamed);
+
+    expect(result!.content).toEqual([
+      text("preamble"),
+      thinking("A"),
+      toolUse("t1"),
+    ]);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -891,6 +891,106 @@ export function stampThinkingTiming(
   });
 }
 
+/**
+ * Recover streamed assistant text that is missing from the finalized provider
+ * content.
+ *
+ * The provider SDK's accumulated final snapshot can silently drop a text block
+ * that streamed between two thinking blocks (`thinking → text → thinking →
+ * tool_use`): the deltas reach the client live, but `finalMessage()` returns
+ * only `[thinking, thinking, tool_use]`. Persisting that snapshot verbatim
+ * rewrites the row without the reply the user watched stream — the transcript
+ * body vanishes at the turn-end reseed, and directive extraction (vellum://
+ * attachment links) runs on text-less content (LUM-2847 / JARVIS-1324).
+ *
+ * The streamed mirror (`state.currentMessageContent`) holds exactly what was
+ * emitted as deltas this call, so it is the recovery source: when the mirror
+ * carries non-empty text and the finalized content carries none, the mirror's
+ * text blocks are re-inserted — each after the same number of thinking blocks
+ * that preceded it in the stream, or before the first tool call when the
+ * mirror has no thinking blocks to anchor on (thinking streaming disabled).
+ * The persisted record must never be a subset of what the user watched stream.
+ *
+ * Returns `null` when the finalized content already has visible text (it is
+ * authoritative — a post-model-call hook may have rewritten it) or the mirror
+ * has nothing to recover.
+ */
+export function recoverStreamedTextMissingFromFinal(
+  finalContent: readonly ContentBlock[],
+  streamedContent: readonly ContentBlock[],
+): { content: ContentBlock[]; recoveredChars: number } | null {
+  const finalHasText = finalContent.some(
+    (block) => block.type === "text" && block.text.trim().length > 0,
+  );
+  if (finalHasText) {
+    return null;
+  }
+
+  const streamedThinkingTotal = streamedContent.filter(
+    (block) => block.type === "thinking",
+  ).length;
+
+  const pending: {
+    afterThinking: number;
+    block: Extract<ContentBlock, { type: "text" }>;
+  }[] = [];
+  let thinkingBefore = 0;
+  for (const block of streamedContent) {
+    if (block.type === "thinking") {
+      thinkingBefore++;
+      continue;
+    }
+    if (block.type === "text" && block.text.trim().length > 0) {
+      pending.push({
+        afterThinking:
+          streamedThinkingTotal === 0
+            ? Number.POSITIVE_INFINITY
+            : thinkingBefore,
+        block: { type: "text", text: block.text },
+      });
+    }
+  }
+  if (pending.length === 0) {
+    return null;
+  }
+
+  const recovered: ContentBlock[] = [];
+  let thinkingSeen = 0;
+  let next = 0;
+  for (const block of finalContent) {
+    if (block.type === "thinking" || block.type === "redacted_thinking") {
+      while (
+        next < pending.length &&
+        pending[next]!.afterThinking <= thinkingSeen
+      ) {
+        recovered.push(pending[next]!.block);
+        next++;
+      }
+      recovered.push(block);
+      thinkingSeen++;
+      continue;
+    }
+    if (block.type === "tool_use" || block.type === "server_tool_use") {
+      // Reply text always precedes the call that ends the turn — flush any
+      // remaining streamed text before the first tool block.
+      while (next < pending.length) {
+        recovered.push(pending[next]!.block);
+        next++;
+      }
+    }
+    recovered.push(block);
+  }
+  while (next < pending.length) {
+    recovered.push(pending[next]!.block);
+    next++;
+  }
+
+  return {
+    content: recovered,
+    recoveredChars: pending.reduce((n, p) => n + p.block.text.length, 0),
+  };
+}
+
 /** Append a streamed text chunk to `state.currentMessageContent`, fusing into tail text block. */
 function appendTextToCurrentMessage(
   state: EventHandlerState,
@@ -2732,11 +2832,39 @@ export async function handleMessageComplete(
     // reconnecting client applying `seq > snapshot.seq` would append the
     // tail a second time.
     state.lastStreamedContentSeq = getCurrentSeq();
+    // Mirror the raw tail like the text-delta path mirrors consumed bytes, so
+    // the streamed mirror holds the complete streamed text — the recovery
+    // comparison below must see everything that reached the client.
+    appendTextToCurrentMessage(state, trailingLiveText);
     if (deps.shouldGenerateTitle) {
       state.firstAssistantText += state.pendingDirectiveDisplayBuffer;
     }
     state.pendingDirectiveDisplayBuffer = "";
     state.pendingSentinelGuardBuffer = "";
+  }
+
+  // The finalized snapshot can arrive without the text that streamed live
+  // this call (interleaved-thinking snapshot drop — see
+  // {@link recoverStreamedTextMissingFromFinal}). Recover the mirrored
+  // streamed text before directive extraction and persistence, so the durable
+  // row — and the vellum:// directives inside the text — match what the user
+  // watched stream.
+  let finalContentBlocks = event.message.content as ContentBlock[];
+  const textRecovery = recoverStreamedTextMissingFromFinal(
+    finalContentBlocks,
+    state.currentMessageContent,
+  );
+  if (textRecovery) {
+    deps.rlog.error(
+      {
+        conversationId: deps.ctx.conversationId,
+        messageId: state.lastAssistantMessageId,
+        recoveredChars: textRecovery.recoveredChars,
+        finalBlockTypes: finalContentBlocks.map((block) => block.type),
+      },
+      "Finalized assistant content is missing text that streamed live; recovering it from the streamed mirror (LUM-2847 / JARVIS-1324)",
+    );
+    finalContentBlocks = textRecovery.content;
   }
 
   // Finalize the grouped tool-result row. Each result was persisted into this
@@ -2757,7 +2885,7 @@ export async function handleMessageComplete(
   // side-effects local to this handler while letting the shared helper
   // own the persisted-content shape.
   const { directives: msgDirectives, warnings: msgWarnings } =
-    cleanAssistantContent(event.message.content);
+    cleanAssistantContent(finalContentBlocks);
   state.accumulatedDirectives.push(...msgDirectives);
   state.directiveWarnings.push(...msgWarnings);
   if (msgDirectives.length > 0) {
@@ -2786,7 +2914,7 @@ export async function handleMessageComplete(
   const finalRevealCandidates = await chatRevealCandidates(state);
   const contentForPersistence = stampThinkingTiming(
     buildPersistedAssistantContent(
-      event.message.content as ContentBlock[],
+      finalContentBlocks,
       deps.ctx.currentTurnSurfaces,
       state.toolActivityMetadata,
       finalRevealCandidates,


### PR DESCRIPTION
## Prompt / plan

Investigation of [LUM-2847](https://linear.app/vellum/issue/LUM-2847/web-assistant-reply-text-swallowed-when-turn-ends-on-rememberfinish) — on web, assistant reply text is swallowed when the turn ends on `remember(finish_turn: true)`.

Traced the full pipeline (web reducer → SSE handlers → turn-end reseed → `/messages` projection → daemon finalize). The web client is a faithful consumer; the loss happens upstream, and [JARVIS-1324](https://linear.app/vellum/issue/JARVIS-1324) has the diagnosis: for content shaped `thinking → text → thinking → tool_use`, the provider SDK's accumulated final snapshot silently drops the text block (a misindexed `content_block_start` makes every subsequent `text_delta` land on a mismatched-type block and get discarded), while the same stream's `text` events fire and reach the client live. At `message_complete` the daemon persists that authoritative-but-text-less snapshot, overwriting the streamed content — so the web's turn-end reseed replaces the visible reply with a row that has no body. Ending the turn on `remember(finish_turn: true)` makes it user-visible because no follow-up LLM call ever restates the reply: the swallowed text *was* the reply, and the guardian sees tool activity with no message body.

This PR implements the defense-in-depth JARVIS-1324 recommends at the finalize seam: the persisted record must never be a subset of what the user watched stream.

- `recoverStreamedTextMissingFromFinal()` — when the streamed mirror (`state.currentMessageContent`) carries visible text and the finalized content carries none, re-insert the mirror's text blocks: each after the same number of thinking blocks that preceded it in the stream, or before the first tool call when thinking streaming is disabled (no anchor). When the finalized content has any visible text of its own it stays authoritative (a `post-model-call` hook may have rewritten it) and nothing changes.
- `handleMessageComplete` runs the recovery before directive extraction and `buildPersistedAssistantContent`, and logs at error level with `recoveredChars` + the finalized block shape so occurrences are measurable.
- The trailing sentinel-guard/directive buffer flush now also mirrors its raw tail into `state.currentMessageContent`, matching the text-delta path's raw-bytes mirror convention, so the recovery comparison sees everything that reached the client.

The recovered text flows through the existing persistence pipeline (redaction, thinking-timing stamps, surfaces), so `vellum://` directive extraction also recovers — the dead-attachment-link symptom from JARVIS-1324 is covered for these turns too. The gateway/SDK indexing root cause is out of this repo's reach and stays tracked on JARVIS-1324.

Fixes LUM-2847
Related to JARVIS-1324

## Test plan

- New unit tests: `assistant/src/__tests__/recover-streamed-text.test.ts` (8 cases) covering the `thinking → text → thinking → tool_use` loss shape, the authoritative-final guard, tool-only calls, whitespace-only mirrors, anchor-less placement, multi-segment ordering, and text-before-thinking streams.
- `bun test src/__tests__/conversation-agent-loop.test.ts` (66 pass), `build-persisted-content.test.ts` (11 pass), `server-history-render.test.ts` (60 pass), `annotate-activity-metadata.test.ts` (3 pass).
- `bun run typecheck:fast` clean; lint/format via pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FE38g2Jj4gssBK3qJwVnbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FE38g2Jj4gssBK3qJwVnbT)_