### PR TITLE
feat(ios): render the voice session in the Dynamic Island and Lock Screen

### DIFF
--- a/clients/ios/App/App/Config/Extension-Base.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Base.xcconfig
@@ -7,13 +7,21 @@
 //
 // This deliberately does NOT #include Base.xcconfig. That file carries
 // app-only settings — CODE_SIGN_ENTITLEMENTS, the app's INFOPLIST_FILE,
-// BUNDLE_URL_SCHEME, ASSOCIATED_DOMAIN — that are wrong or actively
-// harmful on an appex. The cost is that the handful of genuinely shared
-// values below are restated: keep DEVELOPMENT_TEAM, SWIFT_VERSION,
+// ASSOCIATED_DOMAIN — that are wrong or actively harmful on an appex.
+// The cost is that the handful of genuinely shared values below are
+// restated: keep DEVELOPMENT_TEAM, SWIFT_VERSION,
 // TARGETED_DEVICE_FAMILY and especially IPHONEOS_DEPLOYMENT_TARGET in
 // sync with Base.xcconfig. An extension whose deployment target is
 // higher than its host app's fails to install on the OS versions the
 // app still claims to support.
+//
+// BUNDLE_URL_SCHEME is the one app-target variable each per-environment
+// extension xcconfig does restate. The Live Activity's widgetURL has to
+// deep-link into its *own* containing app, so the value must be copied
+// verbatim from the matching App*.xcconfig — a mismatch sends a Dev
+// build's island tap into the production app. It reaches Swift as the
+// VellumURLScheme Info.plist key, never as CFBundleURLTypes: an appex
+// must not register a URL type.
 //
 // The extension ships no entitlements file at all: no App Group
 // (ContentState carries only primitives across the ActivityKit

--- a/clients/ios/App/App/Config/Extension-Dev.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Dev.xcconfig
@@ -1,6 +1,9 @@
 // Extension-Dev.xcconfig — dev VoiceActivity extension overrides.
-// The bundle ID must stay prefixed by App-Dev.xcconfig's.
+// The bundle ID must stay prefixed by App-Dev.xcconfig's, and the URL
+// scheme must match App-Dev.xcconfig's exactly or the island deep-links
+// into the production app when it happens to be installed.
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_URL_SCHEME = vellum-assistant-dev
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity

--- a/clients/ios/App/App/Config/Extension-Staging.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Staging.xcconfig
@@ -1,6 +1,9 @@
 // Extension-Staging.xcconfig — staging VoiceActivity extension overrides.
-// The bundle ID must stay prefixed by App-Staging.xcconfig's.
+// The bundle ID must stay prefixed by App-Staging.xcconfig's, and the URL
+// scheme must match App-Staging.xcconfig's exactly or the island deep-links
+// into the production app when it happens to be installed.
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_URL_SCHEME = vellum-assistant-staging
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity

--- a/clients/ios/App/App/Config/Extension.xcconfig
+++ b/clients/ios/App/App/Config/Extension.xcconfig
@@ -1,6 +1,8 @@
 // Extension.xcconfig — production VoiceActivity extension overrides.
-// The bundle ID must stay prefixed by App.xcconfig's.
+// The bundle ID must stay prefixed by App.xcconfig's, and the URL scheme
+// must match App.xcconfig's exactly or the island deep-links elsewhere.
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_URL_SCHEME = vellum-assistant
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.VoiceActivity

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -577,36 +577,3 @@ private final class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
         delegate?.userContentController(userContentController, didReceive: message)
     }
 }
-
-// MARK: - CSS hex color parsing
-
-extension UIColor {
-    /// Parse a CSS hex color string (`#RGB`, `#RRGGBB`, or `#RRGGBBAA`) as
-    /// reported by `getComputedStyle().getPropertyValue()` for the web theme's
-    /// `--surface-overlay` token. Returns `nil` for any unrecognised format so
-    /// the caller can fall back to the asset-catalog color.
-    convenience init?(cssHex: String) {
-        var s = cssHex.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard s.hasPrefix("#") else { return nil }
-        s.removeFirst()
-        if s.count == 3 {
-            s = s.map { "\($0)\($0)" }.joined()
-        }
-        guard s.count == 6 || s.count == 8,
-              let value = UInt64(s, radix: 16)
-        else { return nil }
-        let r, g, b, a: CGFloat
-        if s.count == 8 {
-            r = CGFloat((value & 0xFF00_0000) >> 24) / 255
-            g = CGFloat((value & 0x00FF_0000) >> 16) / 255
-            b = CGFloat((value & 0x0000_FF00) >> 8) / 255
-            a = CGFloat(value & 0x0000_00FF) / 255
-        } else {
-            r = CGFloat((value & 0xFF0000) >> 16) / 255
-            g = CGFloat((value & 0x00FF00) >> 8) / 255
-            b = CGFloat(value & 0x0000FF) / 255
-            a = 1
-        }
-        self.init(red: r, green: g, blue: b, alpha: a)
-    }
-}

--- a/clients/ios/App/App/NativeAuthPlugin.swift
+++ b/clients/ios/App/App/NativeAuthPlugin.swift
@@ -41,22 +41,10 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
     /// on the plugin instance for the duration of the flow.
     private var authSession: ASWebAuthenticationSession?
 
-    /// Read the URL scheme from the bundle's CFBundleURLTypes rather than
-    /// hardcoding it. Each build target (App, App Dev, App Staging) sets
-    /// BUNDLE_URL_SCHEME in its xcconfig, which is baked into Info.plist's
-    /// CFBundleURLSchemes at build time. Falls back to "vellum-assistant"
-    /// if the plist entry is missing or un-substituted.
-    private static let callbackScheme: String = {
-        guard let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
-              let schemes = urlTypes.first?["CFBundleURLSchemes"] as? [String],
-              let scheme = schemes.first,
-              !scheme.isEmpty,
-              !scheme.contains("$")
-        else {
-            return "vellum-assistant"
-        }
-        return scheme
-    }()
+    /// The OAuth callback scheme, read from this build's own bundle rather
+    /// than hardcoded — see ``BundleURLScheme``, which the widget extension
+    /// shares.
+    private static let callbackScheme: String = BundleURLScheme.current
 
     /// The host this build target is allowed to authenticate against,
     /// read from the `VellumAssociatedDomain` Info.plist key (set per

--- a/clients/ios/App/App/Shared/BundleURLScheme.swift
+++ b/clients/ios/App/App/Shared/BundleURLScheme.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// The custom URL scheme this build target speaks, resolved from its own
+/// bundle rather than hardcoded.
+///
+/// Each environment sets `BUNDLE_URL_SCHEME` in its xcconfig
+/// (`vellum-assistant`, `vellum-assistant-staging`, `vellum-assistant-dev`), so
+/// a hardcoded literal would make a Dev or Staging build hand out production
+/// links — and if the production app happens to be installed, iOS would open
+/// *that* app instead.
+///
+/// Shared by the app target and the VoiceActivity widget extension so there is
+/// one implementation. The two read different keys because they play different
+/// roles:
+///
+/// - The **app** *registers* the scheme in `CFBundleURLTypes`, which is what
+///   iOS actually routes on. That registration is authoritative, so it is read
+///   first.
+/// - An **appex registers nothing** — a widget extension must not claim a URL
+///   type — so it carries the scheme as the plain ``infoPlistKey`` string,
+///   populated from the very same `$(BUNDLE_URL_SCHEME)` variable. It only
+///   needs to *build* a link, never to receive one.
+enum BundleURLScheme {
+    /// Info.plist key carrying the scheme where `CFBundleURLTypes` is absent.
+    static let infoPlistKey = "VellumURLScheme"
+
+    /// Used when the plist entry is missing or left un-substituted, which is
+    /// only reachable via a misconfigured build.
+    static let fallback = "vellum-assistant"
+
+    /// The scheme for the currently running bundle.
+    static let current: String = resolve(in: .main)
+
+    static func resolve(in bundle: Bundle) -> String {
+        let info = bundle.infoDictionary
+        if let urlTypes = info?["CFBundleURLTypes"] as? [[String: Any]],
+           let schemes = urlTypes.first?["CFBundleURLSchemes"] as? [String],
+           let scheme = schemes.first.flatMap(substituted) {
+            return scheme
+        }
+        if let scheme = (info?[infoPlistKey] as? String).flatMap(substituted) {
+            return scheme
+        }
+        return fallback
+    }
+
+    /// Rejects an empty value and one Xcode never expanded (`$(BUNDLE_URL_SCHEME)`),
+    /// both of which would otherwise produce an unopenable URL.
+    private static func substituted(_ raw: String) -> String? {
+        guard !raw.isEmpty, !raw.contains("$") else { return nil }
+        return raw
+    }
+}

--- a/clients/ios/App/App/Shared/CSSHexColor.swift
+++ b/clients/ios/App/App/Shared/CSSHexColor.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import UIKit
+
+/// CSS hex color parsing, shared by the app target and the VoiceActivity
+/// widget extension.
+///
+/// This is the single native parser for the `#RGB` / `#RRGGBB` / `#RRGGBBAA`
+/// strings the web side hands across (`--surface-overlay` for the shell
+/// background, `accentHex` for the Live Activity). `VoiceSessionAttributes`'s
+/// `canonicalAccentHex` validates against exactly this grammar, so a
+/// canonicalized accent always parses here.
+extension UIColor {
+    /// Parse a CSS hex color string (`#RGB`, `#RRGGBB`, or `#RRGGBBAA`) as
+    /// reported by `getComputedStyle().getPropertyValue()`. Returns `nil` for
+    /// any unrecognised format so the caller can fall back.
+    convenience init?(cssHex: String) {
+        var s = cssHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard s.hasPrefix("#") else { return nil }
+        s.removeFirst()
+        if s.count == 3 {
+            s = s.map { "\($0)\($0)" }.joined()
+        }
+        guard s.count == 6 || s.count == 8,
+              let value = UInt64(s, radix: 16)
+        else { return nil }
+        let r, g, b, a: CGFloat
+        if s.count == 8 {
+            r = CGFloat((value & 0xFF00_0000) >> 24) / 255
+            g = CGFloat((value & 0x00FF_0000) >> 16) / 255
+            b = CGFloat((value & 0x0000_FF00) >> 8) / 255
+            a = CGFloat(value & 0x0000_00FF) / 255
+        } else {
+            r = CGFloat((value & 0xFF0000) >> 16) / 255
+            g = CGFloat((value & 0x00FF00) >> 8) / 255
+            b = CGFloat(value & 0x0000FF) / 255
+            a = 1
+        }
+        self.init(red: r, green: g, blue: b, alpha: a)
+    }
+
+    /// `.black` or `.white`, whichever has the higher WCAG contrast ratio
+    /// against the receiver.
+    ///
+    /// Used where content sits *on* a web-supplied color, which may be any
+    /// brightness — a fixed foreground would be unreadable for half the
+    /// palette. Only the receiver's own brightness matters, so the result is
+    /// independent of light/dark appearance.
+    var contrastingForeground: UIColor {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        guard getRed(&r, green: &g, blue: &b, alpha: &a) else { return .white }
+        // WCAG relative luminance; the 0.179 threshold is where contrast
+        // against black and against white are equal.
+        let channels = [r, g, b].map { channel -> CGFloat in
+            channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+        }
+        let luminance = 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+        return luminance > 0.179 ? .black : .white
+    }
+}
+
+extension Color {
+    /// SwiftUI wrapper over ``UIColor/init(cssHex:)`` so SwiftUI surfaces do
+    /// not grow a second parser.
+    init?(cssHex: String) {
+        guard let color = UIColor(cssHex: cssHex) else { return nil }
+        self.init(uiColor: color)
+    }
+
+    /// See ``UIColor/contrastingForeground``.
+    var contrastingForeground: Color {
+        Color(uiColor: UIColor(self).contrastingForeground)
+    }
+}

--- a/clients/ios/App/VoiceActivity/Info.plist
+++ b/clients/ios/App/VoiceActivity/Info.plist
@@ -23,5 +23,12 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<!-- The containing app's URL scheme, so the Live Activity's widgetURL
+	     deep-links back into the app this appex is embedded in. Deliberately
+	     NOT CFBundleURLTypes: an appex must not register a URL type (it can
+	     never be the target of one) — this only lets the extension *build* a
+	     link. Read via BundleURLScheme. -->
+	<key>VellumURLScheme</key>
+	<string>$(BUNDLE_URL_SCHEME)</string>
 </dict>
 </plist>

--- a/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
+++ b/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
@@ -1,44 +1,15 @@
-import ActivityKit
 import SwiftUI
 import WidgetKit
 
 /// Widget bundle entry point for the VoiceActivity extension.
 ///
-/// The bundle currently hosts a single placeholder Live Activity. It exists so
-/// the extension targets, their bundle IDs, and the embed wiring can be proven
-/// green on their own — a build failure here is a *target* problem, not a
-/// SwiftUI one. The real Dynamic Island and Lock Screen presentations replace
-/// ``VoiceSessionLiveActivity`` in a follow-up.
+/// One member today: the live-voice Live Activity, defined in
+/// `VoiceSessionLiveActivity.swift`. A `WidgetBundle` can hold home-screen
+/// widgets and controls alongside it, so anything added later joins this list
+/// rather than needing another extension target.
 @main
 struct VoiceActivityBundle: WidgetBundle {
     var body: some Widget {
         VoiceSessionLiveActivity()
-    }
-}
-
-/// Placeholder rendering of a running live-voice session.
-///
-/// Every presentation shows `context.state.label` verbatim. That is not just
-/// placeholder laziness — it is the contract the real UI keeps too: the web
-/// side owns all user-facing phase copy (`LIVE_VOICE_STATE_LABELS` in
-/// `clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts`), because
-/// this shell ships on App Store cadence while that copy deploys continuously.
-struct VoiceSessionLiveActivity: Widget {
-    var body: some WidgetConfiguration {
-        ActivityConfiguration(for: VoiceSessionAttributes.self) { context in
-            Text(context.state.label)
-        } dynamicIsland: { context in
-            DynamicIsland {
-                DynamicIslandExpandedRegion(.center) {
-                    Text(context.state.label)
-                }
-            } compactLeading: {
-                Text(context.state.label)
-            } compactTrailing: {
-                Text(context.state.label)
-            } minimal: {
-                Text(context.state.label)
-            }
-        }
     }
 }

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+// Shared building blocks for the live-voice Live Activity.
+//
+// The Lock Screen, expanded, compact and minimal presentations are four
+// separately-sized renderings of the *same* three facts — accent, phase
+// label, assistant name — so they compose from these primitives rather than
+// each growing its own copy that drifts.
+//
+// Two rules run through all of them:
+//
+// 1. **No native phase copy.** Every user-facing string here is either
+//    `ContentState.label` or `VoiceSessionAttributes.assistantName`, both
+//    passed through from the web side. `LIVE_VOICE_STATE_LABELS` /
+//    `liveVoiceStateLabel` in `live-voice-store.ts` own the wording — this
+//    shell ships on App Store cadence while that copy deploys continuously,
+//    so a native `switch` over `phase` would fossilize old strings. Tight
+//    slots truncate the passed label; they never substitute a shorter native
+//    one.
+// 2. **Accent is decoration, never the carrier.** `accentHex` is the user's
+//    avatar color and can be any brightness, while the Lock Screen renders
+//    over a wallpaper in either appearance. Text is therefore always
+//    `.primary`/`.secondary`, which adapts; the accent only fills shapes that
+//    carry a hairline `.primary` border so their edge stays visible whatever
+//    is behind them.
+
+extension VoiceSessionAttributes.ContentState {
+    /// The avatar accent as a SwiftUI color.
+    ///
+    /// `accentHex` is canonicalized on the way in — including through
+    /// `init(from:)`, so it survives decoding into this extension — to a form
+    /// `UIColor(cssHex:)` accepts. The final fallback is unreachable in
+    /// practice and exists only so this stays non-optional.
+    var accentColor: Color {
+        Color(cssHex: accentHex)
+            ?? Color(cssHex: Self.neutralAccentHex)
+            ?? .secondary
+    }
+}
+
+/// Deep link back into the running session.
+///
+/// `mode=resume` is the web-side contract: it foregrounds the app into the
+/// live voice room, falling through to starting a fresh session if the app was
+/// killed and the session no longer exists.
+enum VoiceSessionDeepLink {
+    /// Built from *this* build's own scheme, so a Dev island opens the Dev app
+    /// even with production installed.
+    static let resume = URL(string: "\(BundleURLScheme.current)://voice?mode=resume")
+}
+
+/// The accent-tinted state indicator: a waveform, tinted with the avatar
+/// accent. Small enough to be the entire content of the minimal presentation
+/// and of the compact leading slot.
+struct VoiceAccentGlyph: View {
+    let accent: Color
+    var scale: Image.Scale = .medium
+
+    var body: some View {
+        Image(systemName: "waveform")
+            .imageScale(scale)
+            .foregroundStyle(accent)
+            .accessibilityHidden(true)
+    }
+}
+
+/// The accent glyph as a filled badge, for the roomier Lock Screen and
+/// expanded layouts.
+///
+/// The glyph is black or white by the accent's own luminance so it is legible
+/// on any avatar color, and the hairline border is `.primary` so the badge's
+/// edge reads against a light *and* a dark Lock Screen.
+struct VoiceAccentBadge: View {
+    let accent: Color
+
+    var body: some View {
+        VoiceAccentGlyph(accent: accent.contrastingForeground)
+            .frame(width: 34, height: 34)
+            .background(accent, in: Circle())
+            .overlay(Circle().strokeBorder(Color.primary.opacity(0.2), lineWidth: 1))
+    }
+}
+
+/// Mute indicator, shown only while the session is muted. Not accent-tinted:
+/// this is a status the user must be able to read at a glance regardless of
+/// their avatar color.
+struct VoiceMuteGlyph: View {
+    var body: some View {
+        Image(systemName: "mic.slash.fill")
+            .imageScale(.small)
+            .foregroundStyle(.secondary)
+            .accessibilityLabel("Muted")
+    }
+}
+
+/// The one text primitive: a single passed-through line — the phase label or
+/// the assistant name — sized for whichever slot it lands in.
+///
+/// Always one line with a tail ellipsis. The web side decides how long the
+/// string is, so the tight slots shorten what they were given instead of
+/// substituting a native string of their own.
+///
+/// Empty text renders nothing at all rather than an empty `Text` that still
+/// claims layout space: `LIVE_VOICE_STATE_LABELS` maps `failed` to `""`, and a
+/// blank line would leave a lopsided gap.
+struct VoiceSessionText: View {
+    let text: String
+    var font: Font = .subheadline
+    var color: HierarchicalShapeStyle = .primary
+
+    var body: some View {
+        if !text.isEmpty {
+            Text(text)
+                .font(font)
+                .foregroundStyle(color)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+    }
+}
+
+/// Lock Screen and notification-banner presentation: badge, assistant name,
+/// phase label, and a mute glyph while muted.
+///
+/// No `activityBackgroundTint` — the system background already adapts to the
+/// Lock Screen's appearance, and tinting it with an arbitrary avatar color is
+/// exactly how the label text stops being readable in one of the two modes.
+struct VoiceSessionLockScreenView: View {
+    let assistantName: String
+    let state: VoiceSessionAttributes.ContentState
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VoiceAccentBadge(accent: state.accentColor)
+            VStack(alignment: .leading, spacing: 2) {
+                VoiceSessionText(text: assistantName, font: .headline)
+                VoiceSessionText(text: state.label, color: .secondary)
+            }
+            Spacer(minLength: 0)
+            if state.muted {
+                VoiceMuteGlyph()
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}

--- a/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
@@ -1,0 +1,62 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+/// The live-voice session, rendered on the Lock Screen and in the Dynamic
+/// Island.
+///
+/// All four presentations are the same three facts at four sizes, composed
+/// from the primitives in `VoiceSessionIslandViews.swift`; see that file for
+/// the two rules they share (no native phase copy, accent as decoration only).
+///
+/// **There are no interactive controls, by design.** An in-island end button
+/// would need a `LiveActivityIntent` plus a signalling path into the running
+/// app, and it contradicts the voice room's established invariant that the
+/// room is a full-app takeover whose ✕ is the only exit. Tap-to-return is the
+/// single affordance, so both halves of "look at it" and "act on it" resolve
+/// to the same place: the room.
+struct VoiceSessionLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: VoiceSessionAttributes.self) { context in
+            VoiceSessionLockScreenView(
+                assistantName: context.attributes.assistantName,
+                state: context.state
+            )
+            .widgetURL(VoiceSessionDeepLink.resume)
+        } dynamicIsland: { context in
+            let state = context.state
+            return DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    VoiceAccentBadge(accent: state.accentColor)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    // Nothing to say when unmuted: an always-present mic glyph
+                    // would read as a control, and there are none here.
+                    if state.muted {
+                        VoiceMuteGlyph()
+                    }
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    VoiceSessionText(text: state.label, font: .headline)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    VoiceSessionText(
+                        text: context.attributes.assistantName,
+                        color: .secondary
+                    )
+                }
+            } compactLeading: {
+                VoiceAccentGlyph(accent: state.accentColor, scale: .small)
+            } compactTrailing: {
+                // The tightest slot there is. It still shows the passed label,
+                // truncated — substituting a shorter native string here is
+                // precisely the fossilization this design avoids.
+                VoiceSessionText(text: state.label, font: .caption2, color: .secondary)
+            } minimal: {
+                VoiceAccentGlyph(accent: state.accentColor, scale: .small)
+            }
+            .widgetURL(VoiceSessionDeepLink.resume)
+            .keylineTint(state.accentColor)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder `ActivityConfiguration` with the real live-voice Live Activity: all four presentations (Lock Screen / banner, Dynamic Island expanded, compact, minimal), composed from one set of primitives.

- `VoiceSessionIslandViews.swift` — the shared pieces: `VoiceAccentGlyph`, `VoiceAccentBadge`, `VoiceMuteGlyph`, the single `VoiceSessionText` line primitive, and `VoiceSessionLockScreenView`. Four presentations, one set of parts.
- `VoiceSessionLiveActivity.swift` — the configuration. Expanded is `.leading` accent badge / `.trailing` mute glyph while muted / `.center` phase label / `.bottom` assistant name; compact is accent glyph + truncated label; minimal is the glyph alone.
- `VoiceActivityBundle.swift` — now just the bundle.

**All copy is passed through.** Every user-facing string is `ContentState.label` or `assistantName`. There is no native `switch` over `phase` anywhere, so the web side's `LIVE_VOICE_STATE_LABELS` / `liveVoiceStateLabel` (including "Reconnecting…") stays the only source of wording — this shell ships on App Store cadence while that copy deploys continuously. Tight slots truncate with `.lineLimit(1)` + `.truncationMode(.tail)` rather than substituting a shorter native string. `failed` maps to `""` on the web side, so `VoiceSessionText` renders nothing at all for an empty string instead of an empty `Text` that would still claim layout space.

**No interactive controls, per the plan's scope decision.** Tap-to-return is the only affordance — an in-island end button needs a `LiveActivityIntent` plus a signalling path into the app, and conflicts with the voice room's invariant that it is a full-app takeover whose ✕ is the only exit.

### Per-environment deep link

`widgetURL` is set on the Lock Screen and expanded presentations to `<scheme>://voice?mode=resume`, with the scheme read from the extension's own bundle. Rather than hand-rolling a second reader, this adds a shared `App/Shared/BundleURLScheme.swift` and moves `NativeAuthPlugin`'s inline copy onto it. The app reads `CFBundleURLTypes` (its real registration, tried first); the appex — which must not register a URL type — carries the same `$(BUNDLE_URL_SCHEME)` value as a plain `VellumURLScheme` Info.plist key, populated from a `BUNDLE_URL_SCHEME` line added to each per-environment `Extension*.xcconfig`.

Verified by building the extension targets and reading the baked plists: `VoiceActivity.appex` → `vellum-assistant`, `VoiceActivity Dev.appex` → `vellum-assistant-dev`.

### One color parser, not three

`UIColor(cssHex:)` moves out of `MyViewController.swift` into a shared `App/Shared/CSSHexColor.swift` (unchanged logic) so the extension reuses it via a thin `Color(cssHex:)` wrapper instead of adding a third parser next to it and `VoiceSessionAttributes.canonicalAccentHex`. Also adds `contrastingForeground` (WCAG relative luminance → black or white), used so the badge glyph is legible on any avatar accent.

Contrast approach: text is always `.primary`/`.secondary`, which adapts to light and dark; the accent only fills shapes, and the badge carries a hairline `Color.primary` border so its edge reads against either Lock Screen appearance. No `activityBackgroundTint` — tinting the background with an arbitrary avatar color is exactly how label text stops being readable in one of the two modes.

## Verification performed

- `xcrun -sdk iphoneos swiftc -typecheck` over the extension's full source set: clean.
- `xcodebuild -target VoiceActivity` and `-target "VoiceActivity Dev"` (Release, simulator SDK): **BUILD SUCCEEDED**, no warnings. The extension has no Capacitor dependency, so it builds locally even though the full app does not.
- `xcodegen generate` regenerates cleanly; the new shared files land in all six targets. `App.xcodeproj/` is gitignored and not committed.
- No `#Preview` / `PreviewProvider` blocks.

## Unverified

No physical device was available, so **nothing below was observed at runtime**. Every claim about how this looks or behaves on device is a design intent, not an observation:

- All four presentations rendering for each of the seven phases (`connecting`, `listening`, `transcribing`, `thinking`, `speaking`, `ending`, `failed`) — no layout breakage, no truncation artifacts. In particular: how much of "Transcribing…" actually survives the compact trailing slot, and whether the expanded `.center` and `.bottom` regions look right when `failed` supplies an empty label.
- Tap-to-return: that tapping the Lock Screen or expanded presentation opens the app at all (end-to-end resume behavior is PR 14's; even the bare "does the widgetURL fire" leg is unobserved here).
- That a Dev build's island tap lands in the Dev app rather than a co-installed production app. The baked plist value is confirmed; the routing is not.
- Light/dark Lock Screen contrast, including a very light and a very dark avatar accent against a busy wallpaper, and whether the hairline border does the job it is there to do.
- Whether the `waveform` glyph reads as intended at compact/minimal sizes.
- `keylineTint` behavior on a real update.