### PR TITLE
ci(ios): provision and export the VoiceActivity extension

### DIFF
--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -45,6 +45,12 @@ jobs:
           fi
           echo "Building iOS $ENVIRONMENT release, version $VERSION"
 
+      # Every environment resolves two bundle IDs and two provisioning
+      # profiles: the app's, and the VoiceActivity extension embedded inside
+      # it. The profile names must match character for character both the
+      # Apple Developer portal and the `PROVISIONING_PROFILE_SPECIFIER_Manual`
+      # values in `clients/ios/App/App/Config/*.xcconfig`. See "Signing: two
+      # profiles per environment" in `clients/ios/README.md`.
       - name: Resolve environment config
         id: config
         env:
@@ -56,6 +62,9 @@ jobs:
               echo "bundle_id=ai.vocify-inc.vellum-assistant-ios" >> "$GITHUB_OUTPUT"
               echo "profile_key=IOS_PROVISIONING_PROFILE" >> "$GITHUB_OUTPUT"
               echo "profile_name=Vellum Assistant iOS Distribution" >> "$GITHUB_OUTPUT"
+              echo "ext_bundle_id=ai.vocify-inc.vellum-assistant-ios.VoiceActivity" >> "$GITHUB_OUTPUT"
+              echo "ext_profile_key=IOS_PROVISIONING_PROFILE_EXT" >> "$GITHUB_OUTPUT"
+              echo "ext_profile_name=Vellum Assistant iOS VoiceActivity Distribution" >> "$GITHUB_OUTPUT"
               echo "apple_app_id_key=APPLE_APP_ID_PROD" >> "$GITHUB_OUTPUT"
               echo "vellum_env=production" >> "$GITHUB_OUTPUT"
               echo "testflight_internal=false" >> "$GITHUB_OUTPUT"
@@ -65,6 +74,9 @@ jobs:
               echo "bundle_id=ai.vocify-inc.vellum-assistant-ios.staging" >> "$GITHUB_OUTPUT"
               echo "profile_key=IOS_PROVISIONING_PROFILE_STAGING" >> "$GITHUB_OUTPUT"
               echo "profile_name=Vellum Assistant iOS Staging Distribution" >> "$GITHUB_OUTPUT"
+              echo "ext_bundle_id=ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity" >> "$GITHUB_OUTPUT"
+              echo "ext_profile_key=IOS_PROVISIONING_PROFILE_EXT_STAGING" >> "$GITHUB_OUTPUT"
+              echo "ext_profile_name=Vellum Assistant iOS Staging VoiceActivity Distribution" >> "$GITHUB_OUTPUT"
               echo "apple_app_id_key=APPLE_APP_ID_STAGING" >> "$GITHUB_OUTPUT"
               echo "vellum_env=staging" >> "$GITHUB_OUTPUT"
               echo "testflight_internal=true" >> "$GITHUB_OUTPUT"
@@ -74,6 +86,9 @@ jobs:
               echo "bundle_id=ai.vocify-inc.vellum-assistant-ios.dev" >> "$GITHUB_OUTPUT"
               echo "profile_key=IOS_PROVISIONING_PROFILE_DEV" >> "$GITHUB_OUTPUT"
               echo "profile_name=Vellum Assistant iOS Dev Distribution" >> "$GITHUB_OUTPUT"
+              echo "ext_bundle_id=ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity" >> "$GITHUB_OUTPUT"
+              echo "ext_profile_key=IOS_PROVISIONING_PROFILE_EXT_DEV" >> "$GITHUB_OUTPUT"
+              echo "ext_profile_name=Vellum Assistant iOS Dev VoiceActivity Distribution" >> "$GITHUB_OUTPUT"
               echo "apple_app_id_key=APPLE_APP_ID_DEV" >> "$GITHUB_OUTPUT"
               echo "vellum_env=dev" >> "$GITHUB_OUTPUT"
               echo "testflight_internal=true" >> "$GITHUB_OUTPUT"
@@ -148,22 +163,36 @@ jobs:
           security find-identity -v -p codesigning | grep -q "Apple Distribution" \
             || { echo "::error::Apple Distribution identity not found in keychain."; exit 1; }
 
-      - name: Install provisioning profile
+      - name: Install provisioning profiles
         env:
           IOS_PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE }}
           IOS_PROVISIONING_PROFILE_STAGING: ${{ secrets.IOS_PROVISIONING_PROFILE_STAGING }}
           IOS_PROVISIONING_PROFILE_DEV: ${{ secrets.IOS_PROVISIONING_PROFILE_DEV }}
+          IOS_PROVISIONING_PROFILE_EXT: ${{ secrets.IOS_PROVISIONING_PROFILE_EXT }}
+          IOS_PROVISIONING_PROFILE_EXT_STAGING: ${{ secrets.IOS_PROVISIONING_PROFILE_EXT_STAGING }}
+          IOS_PROVISIONING_PROFILE_EXT_DEV: ${{ secrets.IOS_PROVISIONING_PROFILE_EXT_DEV }}
         run: |
-          PROFILE_KEY="${{ steps.config.outputs.profile_key }}"
-          PROFILE_B64="${!PROFILE_KEY}"
-          if [ -z "$PROFILE_B64" ]; then
-            echo "::error::Provisioning profile secret $PROFILE_KEY is empty"
-            exit 1
-          fi
           PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$PROFILE_DIR"
-          echo "$PROFILE_B64" | base64 -D > "$PROFILE_DIR/ios_distribution.mobileprovision"
-          echo "Provisioning profile installed from $PROFILE_KEY"
+
+          # Both profiles are required. The archive embeds the VoiceActivity
+          # appex, and neither `xcodebuild archive` nor `-exportArchive` can
+          # sign a bundle whose profile is absent. The filenames must differ:
+          # a second write to the same name silently clobbers the first, and
+          # the failure surfaces much later as an opaque export error.
+          install_profile() {
+            local key="$1" filename="$2"
+            local b64="${!key}"
+            if [ -z "$b64" ]; then
+              echo "::error::Provisioning profile secret $key is empty"
+              exit 1
+            fi
+            echo "$b64" | base64 -D > "$PROFILE_DIR/$filename"
+            echo "Provisioning profile installed from $key"
+          }
+
+          install_profile "${{ steps.config.outputs.profile_key }}" ios_distribution.mobileprovision
+          install_profile "${{ steps.config.outputs.ext_profile_key }}" ios_distribution_ext.mobileprovision
 
       - name: Set version
         id: version
@@ -180,11 +209,16 @@ jobs:
           echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
           echo "Display version: $DISPLAY_VERSION (from $VERSION) / Build version: $BUILD_VERSION"
 
+      # `provisioningProfiles` needs one entry per signed bundle, not just the
+      # app: `-exportArchive` fails when an embedded extension has no entry,
+      # and its error does not name the offending extension.
       - name: Generate ExportOptions.plist
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           BUNDLE_ID: ${{ steps.config.outputs.bundle_id }}
           PROFILE_NAME: ${{ steps.config.outputs.profile_name }}
+          EXT_BUNDLE_ID: ${{ steps.config.outputs.ext_bundle_id }}
+          EXT_PROFILE_NAME: ${{ steps.config.outputs.ext_profile_name }}
           TESTFLIGHT_INTERNAL: ${{ steps.config.outputs.testflight_internal }}
         run: |
           INTERNAL_ENTRY=""
@@ -207,12 +241,23 @@ jobs:
               <dict>
                   <key>$BUNDLE_ID</key>
                   <string>$PROFILE_NAME</string>
+                  <key>$EXT_BUNDLE_ID</key>
+                  <string>$EXT_PROFILE_NAME</string>
               </dict>
               $INTERNAL_ENTRY
           </dict>
           </plist>
           EOF
 
+      # PROVISIONING_PROFILE_SPECIFIER is deliberately NOT passed here. An
+      # xcodebuild CLI override applies to every target in the archive, so a
+      # single specifier would push the app profile onto the embedded
+      # VoiceActivity appex, which it does not cover. The per-target mapping
+      # lives in `clients/ios/App/App/Config/*.xcconfig` instead, next to the
+      # per-target bundle IDs it has to agree with. Those xcconfigs key the
+      # specifier off CODE_SIGN_STYLE, so the `CODE_SIGN_STYLE=Manual`
+      # override below is what activates it — local Xcode builds stay on
+      # automatic signing and pick up no specifier at all.
       - name: Archive
         working-directory: clients/ios/App
         run: |
@@ -223,7 +268,6 @@ jobs:
             -destination 'generic/platform=iOS' \
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Apple Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="${{ steps.config.outputs.profile_name }}" \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
             MARKETING_VERSION="${{ steps.version.outputs.display_version }}" \
             CURRENT_PROJECT_VERSION="${{ steps.version.outputs.build_version }}"

--- a/clients/ios/App/App/Config/App-Dev.xcconfig
+++ b/clients/ios/App/App/Config/App-Dev.xcconfig
@@ -8,3 +8,6 @@ BUNDLE_DISPLAY_NAME = Vellum Dev
 BUNDLE_URL_SCHEME = vellum-assistant-dev
 CODE_SIGN_ENTITLEMENTS = App/App-Dev.entitlements
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.dev
+
+// Exact portal profile name; must equal release-ios.yaml's `profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS Dev Distribution

--- a/clients/ios/App/App/Config/App-Staging.xcconfig
+++ b/clients/ios/App/App/Config/App-Staging.xcconfig
@@ -7,3 +7,6 @@ ASSOCIATED_DOMAIN = staging-assistant.vellum.ai
 BUNDLE_DISPLAY_NAME = Vellum Staging
 BUNDLE_URL_SCHEME = vellum-assistant-staging
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.staging
+
+// Exact portal profile name; must equal release-ios.yaml's `profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS Staging Distribution

--- a/clients/ios/App/App/Config/App.xcconfig
+++ b/clients/ios/App/App/Config/App.xcconfig
@@ -7,3 +7,6 @@ ASSOCIATED_DOMAIN = www.vellum.ai
 BUNDLE_DISPLAY_NAME = Vellum
 BUNDLE_URL_SCHEME = vellum-assistant
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios
+
+// Exact portal profile name; must equal release-ios.yaml's `profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS Distribution

--- a/clients/ios/App/App/Config/Base.xcconfig
+++ b/clients/ios/App/App/Config/Base.xcconfig
@@ -16,5 +16,24 @@ INFOPLIST_FILE = App/Info.plist
 IPHONEOS_DEPLOYMENT_TARGET = 17.0
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks
 PRODUCT_NAME = $(TARGET_NAME)
+
+// Manual-signing provisioning profile, resolved per target.
+//
+// Release builds sign manually (the workflow passes CODE_SIGN_STYLE=Manual
+// on the xcodebuild command line) and need a profile name per target: the
+// app targets and the VoiceActivity extension targets have different bundle
+// IDs and therefore different profiles. An xcodebuild CLI override cannot
+// express that — it applies to every target in the archive — so the mapping
+// lives in the per-target xcconfigs alongside the PRODUCT_BUNDLE_IDENTIFIER
+// it has to agree with. Each of them sets
+// PROVISIONING_PROFILE_SPECIFIER_Manual.
+//
+// The indirection through CODE_SIGN_STYLE keeps local development working:
+// under the Automatic default above, PROVISIONING_PROFILE_SPECIFIER_Automatic
+// is undefined, so the specifier resolves to empty and Xcode manages signing
+// itself. Setting the specifier unconditionally would break every local
+// build, because the distribution profiles are not on developer machines.
+PROVISIONING_PROFILE_SPECIFIER = $(PROVISIONING_PROFILE_SPECIFIER_$(CODE_SIGN_STYLE))
+
 SWIFT_VERSION = 5.0
 TARGETED_DEVICE_FAMILY = 1,2

--- a/clients/ios/App/App/Config/Extension-Base.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Base.xcconfig
@@ -40,6 +40,15 @@ IPHONEOS_DEPLOYMENT_TARGET = 17.0
 // phase looks the appex up by that reference — a PRODUCT_NAME that
 // disagrees with the target name makes the copy fail on a missing file.
 
+// Manual-signing provisioning profile, resolved per target. Restated here
+// rather than inherited, for the same reason as the settings above: this
+// file deliberately does not #include Base.xcconfig. Each per-target
+// xcconfig sets PROVISIONING_PROFILE_SPECIFIER_Manual to the extension
+// profile for its environment — the appex has its own bundle ID, so the
+// app's profile does not cover it. See the comment in Base.xcconfig for why
+// the value is keyed off CODE_SIGN_STYLE.
+PROVISIONING_PROFILE_SPECIFIER = $(PROVISIONING_PROFILE_SPECIFIER_$(CODE_SIGN_STYLE))
+
 // Required for an embedded extension: the appex is copied into the app
 // bundle by the embed phase, and must not also be installed at the
 // archive root.

--- a/clients/ios/App/App/Config/Extension-Dev.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Dev.xcconfig
@@ -4,3 +4,6 @@
 #include "Extension-Base.xcconfig"
 
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity
+
+// Exact portal profile name; must equal release-ios.yaml's `ext_profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS Dev VoiceActivity Distribution

--- a/clients/ios/App/App/Config/Extension-Staging.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Staging.xcconfig
@@ -4,3 +4,6 @@
 #include "Extension-Base.xcconfig"
 
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity
+
+// Exact portal profile name; must equal release-ios.yaml's `ext_profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS Staging VoiceActivity Distribution

--- a/clients/ios/App/App/Config/Extension.xcconfig
+++ b/clients/ios/App/App/Config/Extension.xcconfig
@@ -4,3 +4,6 @@
 #include "Extension-Base.xcconfig"
 
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.VoiceActivity
+
+// Exact portal profile name; must equal release-ios.yaml's `ext_profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS VoiceActivity Distribution

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -512,6 +512,103 @@ workflow called from the release pipelines — it intentionally has no
 extracted into their own reusable workflow because it's the only iOS
 workflow.
 
+### Signing: two profiles per environment
+
+Each app target embeds a `VoiceActivity` widget extension whose bundle ID
+is prefixed by its host app's (`<app bundle id>.VoiceActivity`). Apple
+treats that appex as its own App ID with its own provisioning profile, so
+**every environment signs with two profiles, not one**: the app's and the
+extension's.
+
+That has three consequences in the pipeline:
+
+- The **install step** writes both profiles into
+  `~/Library/MobileDevice/Provisioning Profiles/` under distinct
+  filenames (`ios_distribution.mobileprovision` and
+  `ios_distribution_ext.mobileprovision`). Writing both to one name
+  silently clobbers the first.
+- **`ExportOptions.plist`** carries a `provisioningProfiles` entry for
+  each bundle ID. `xcodebuild -exportArchive` fails when an embedded
+  extension has no entry, and the error does not name the extension.
+- **`PROVISIONING_PROFILE_SPECIFIER` is not an `xcodebuild` CLI
+  override.** A CLI override applies to every target in the archive,
+  which would push the app profile onto the appex it does not cover.
+  Instead each target's specifier lives in its own xcconfig
+  (`App/App/Config/App*.xcconfig` and `Extension*.xcconfig`), next to the
+  `PRODUCT_BUNDLE_IDENTIFIER` it has to agree with. Those files set
+  `PROVISIONING_PROFILE_SPECIFIER_Manual` and resolve
+  `PROVISIONING_PROFILE_SPECIFIER =
+  $(PROVISIONING_PROFILE_SPECIFIER_$(CODE_SIGN_STYLE))`, so the specifier
+  applies only under the workflow's `CODE_SIGN_STYLE=Manual` override —
+  local Xcode builds stay on automatic signing and see no specifier,
+  which matters because the distribution profiles are not on developer
+  machines.
+
+Profile names are therefore written down in three places that must agree
+character for character: the Apple Developer portal, the xcconfig, and
+the `profile_name` / `ext_profile_name` outputs of the `config` step in
+`release-ios.yaml`. A mismatch fails the build with an unhelpful message.
+
+### Manual Apple Developer portal setup
+
+The extension App IDs and profiles are **not** created by any script —
+an Apple Developer team admin (Vocify, Inc., team `7FZDXZR8P5`) has to
+register them by hand. Until all three environments are done, a release
+build of the affected environment fails while signing or exporting.
+
+| Environment | Extension bundle ID | Profile name (exact) | GitHub secret |
+|-------------|---------------------|----------------------|---------------|
+| production | `ai.vocify-inc.vellum-assistant-ios.VoiceActivity` | `Vellum Assistant iOS VoiceActivity Distribution` | `IOS_PROVISIONING_PROFILE_EXT` |
+| staging | `ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity` | `Vellum Assistant iOS Staging VoiceActivity Distribution` | `IOS_PROVISIONING_PROFILE_EXT_STAGING` |
+| dev | `ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity` | `Vellum Assistant iOS Dev VoiceActivity Distribution` | `IOS_PROVISIONING_PROFILE_EXT_DEV` |
+
+Repeat these steps once per row (start with **dev** — it is the only
+track that releases hourly, so it is the fastest way to prove the setup):
+
+1. **Register the App ID.** [Certificates, Identifiers &
+   Profiles](https://developer.apple.com/account/resources/identifiers/list)
+   → **Identifiers** → **+** → **App IDs** → **App**. Set
+   **Bundle ID** to **Explicit** and paste the exact string from the
+   table. Description can be anything descriptive
+   (e.g. "Vellum Assistant iOS Dev VoiceActivity"). **Enable no
+   capabilities** — the extension deliberately ships no entitlements
+   file (no App Group, no push; see the comment at the top of
+   `App/App/Config/Extension-Base.xcconfig`), and a capability enabled
+   here produces a profile the build cannot satisfy. **Register**.
+2. **Create the distribution profile.** **Profiles** → **+** →
+   **Distribution → App Store Connect** → pick the App ID from step 1 →
+   pick the Apple Distribution certificate that matches the
+   `DIST_CERTIFICATE_P12` secret → **Provisioning Profile Name**: type
+   the profile name from the table exactly, including capitalisation and
+   spacing → **Generate** → **Download**.
+3. **Base64-encode it**, matching how the existing profile secrets are
+   stored (the workflow pipes the secret through `base64 -D`):
+
+   ```bash
+   base64 -i ~/Downloads/<downloaded>.mobileprovision | pbcopy
+   ```
+
+4. **Add the GitHub secret.** Repo **Settings → Secrets and variables →
+   Actions → New repository secret**. Name it exactly as in the table,
+   paste the clipboard contents. Use the same scope as the existing
+   `IOS_PROVISIONING_PROFILE*` secrets.
+5. **Nothing to do in App Store Connect.** The extension ships inside
+   its host app's record — it gets no app record and no
+   `APPLE_APP_ID_*` of its own.
+
+Once all three rows are done, verify end to end by dispatching
+`dev-release.yaml`, downloading the `ios-ipa-dev` artifact, and checking
+that the appex is signed with the *extension* profile:
+
+```bash
+unzip -q ios-ipa-dev.zip && unzip -q *.ipa
+codesign -dvvv "Payload/App Dev.app/PlugIns/VoiceActivity Dev.appex" 2>&1 | grep -i profile
+```
+
+> **Profiles expire after one year.** Renewal is the same loop:
+> regenerate in the portal under the identical name, re-encode, update
+> the secret. Nothing in the repo changes.
+
 ### Secrets (GitHub Actions)
 
 All iOS signing secrets are stored as GitHub Actions secrets:
@@ -521,6 +618,7 @@ All iOS signing secrets are stored as GitHub Actions secrets:
 - `ASC_KEY_P8` (base64-encoded) / `ASC_KEY_ID` / `ASC_ISSUER_ID` — App Store Connect API key for [`xcrun altool`](https://keith.github.io/xcode-man-pages/altool.1.html) uploads. The workflow `base64 -D` decodes `ASC_KEY_P8` before writing the `.p8` file.
 - `IOS_PROVISIONING_PROFILE` — Production provisioning profile (App Store Distribution)
 - `IOS_PROVISIONING_PROFILE_STAGING` / `_DEV` — Per-environment profiles
+- `IOS_PROVISIONING_PROFILE_EXT` / `_EXT_STAGING` / `_EXT_DEV` — Per-environment profiles for the embedded `VoiceActivity` widget extension. See [Manual Apple Developer portal setup](#manual-apple-developer-portal-setup).
 - `APPLE_APP_ID_PROD` / `_STAGING` / `_DEV` — Numeric App Store Connect app IDs (e.g. `123456789`), passed as `--apple-id` to [`xcrun altool --upload-package`](https://keith.github.io/xcode-man-pages/altool.7.html). Each environment has its own ASC app record with its own ID.
 - `SLACK_WEBHOOK_URL` — Slack incoming webhook for `#build-alerts` notifications
 


### PR DESCRIPTION
> ## ⚠️ UNVERIFIABLE UNTIL THE APPLE DEVELOPER PORTAL WORK LANDS — DO NOT MERGE TO MAIN AS IF PROVEN
>
> The three `VoiceActivity` extension bundle IDs are **not** registered in the
> Apple Developer portal, and the three distribution profiles / GitHub secrets
> (`IOS_PROVISIONING_PROFILE_EXT`, `_EXT_STAGING`, `_EXT_DEV`) **do not exist**.
> No release run can exercise this pipeline until a human completes the portal
> checklist below. The end-to-end Dev release, the exported IPA, and
> `codesign -dvvv` on the `.appex` are all **unverified**.
>
> The practical deliverable of this PR is the manual checklist in
> `clients/ios/README.md`.

## Summary

The release pipeline signs and exports exactly one bundle. Now that each app
target embeds a `VoiceActivity` widget extension with its own bundle ID, every
environment needs **two** profiles. This wires that through end to end.

Three separate blockers, all fixed:

1. **Only one profile installed.** The install step now writes both, to
   distinct filenames (`ios_distribution.mobileprovision` and
   `ios_distribution_ext.mobileprovision`) — a second write to the fixed name
   would have silently clobbered the first. The two installs share one
   `install_profile` shell helper rather than being copy-pasted.
2. **`ExportOptions.plist` had one `provisioningProfiles` entry.** It now has
   the extension's too. `xcodebuild -exportArchive` fails on a missing profile
   for any embedded extension and its error does not name the extension.
3. **`PROVISIONING_PROFILE_SPECIFIER` was a global `xcodebuild` CLI override**,
   which applies to *every* target in the archive — it would have pushed the
   app profile onto the `.appex` it does not cover. This was a second, separate
   blocker beyond the ExportOptions gap.

## Why `clients/ios/App/App/Config/*.xcconfig` is in this diff

Blocker 3 is fixed the xcconfig way rather than with target-qualified YAML, so
the per-target profile mapping lives in the same committed files that already
own per-target identity, right next to the `PRODUCT_BUNDLE_IDENTIFIER` it has
to agree with. The `PROVISIONING_PROFILE_SPECIFIER` CLI override is deleted
from the `archive` step; each xcconfig sets
`PROVISIONING_PROFILE_SPECIFIER_Manual` instead and the two base xcconfigs
resolve:

```
PROVISIONING_PROFILE_SPECIFIER = $(PROVISIONING_PROFILE_SPECIFIER_$(CODE_SIGN_STYLE))
```

The indirection through `CODE_SIGN_STYLE` is what keeps local development
working. The distribution profiles are not on developer machines, so an
unconditional specifier would break every local build; under the xcconfigs'
`Automatic` default `PROVISIONING_PROFILE_SPECIFIER_Automatic` is undefined and
the specifier resolves to empty. The workflow's existing
`CODE_SIGN_STYLE=Manual` override is what activates it in CI.

## Manual Apple Developer portal setup — required before this can work

An Apple Developer team admin (Vocify, Inc., `7FZDXZR8P5`) must do this by
hand, once per environment. Full step-by-step is in `clients/ios/README.md`
under "Manual Apple Developer portal setup".

| Environment | Register this bundle ID | Create this profile (exact name) | Populate this secret |
|-------------|-------------------------|----------------------------------|----------------------|
| production | `ai.vocify-inc.vellum-assistant-ios.VoiceActivity` | `Vellum Assistant iOS VoiceActivity Distribution` | `IOS_PROVISIONING_PROFILE_EXT` |
| staging | `ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity` | `Vellum Assistant iOS Staging VoiceActivity Distribution` | `IOS_PROVISIONING_PROFILE_EXT_STAGING` |
| dev | `ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity` | `Vellum Assistant iOS Dev VoiceActivity Distribution` | `IOS_PROVISIONING_PROFILE_EXT_DEV` |

Per row: register an **Explicit** App ID with **no capabilities enabled** (the
extension ships no entitlements file — an enabled capability produces a profile
the build cannot satisfy), create an **App Store Connect** distribution profile
against the Apple Distribution cert matching `DIST_CERTIFICATE_P12`, name it
*exactly* as above, download, `base64 -i <file> | pbcopy`, and add it as the
named repository secret. Nothing to do in App Store Connect — the extension
ships inside its host app's record.

Profile names are written down in three places that must agree character for
character: the portal, the xcconfig, and the `config` step's `profile_name` /
`ext_profile_name` outputs.

## What was verified

- `xcodebuild -showBuildSettings` on the regenerated project resolves the
  correct, distinct specifier for all six targets under
  `CODE_SIGN_STYLE=Manual`, and resolves to **empty** for all six under the
  `Automatic` default (local dev unaffected).
- The generated `ExportOptions.plist` passes `plutil -lint` and contains both
  `provisioningProfiles` entries.
- The `install_profile` helper smoke-tested against fake secrets: two distinct
  files written, empty-secret case fails loudly.
- Workflow YAML parses; all `uses:` pins unchanged and still 40-char SHAs.
- Appex embed destination confirmed as `PlugIns/` (`dstSubfolderSpec = 13`), so
  the README's `codesign` verification path is right.

## What was NOT verified (cannot be, yet)

- A Dev release run archiving, exporting, and uploading to TestFlight.
- That the exported IPA contains a correctly-signed `VoiceActivity Dev.appex`.
- `codesign -dvvv` confirming the extension profile rather than the app profile.