### PR TITLE
feat(tools): validate model tool input against a per-tool Zod schema registry

### DIFF
--- a/assistant/src/__tests__/file-list-tool.test.ts
+++ b/assistant/src/__tests__/file-list-tool.test.ts
@@ -172,7 +172,8 @@ describe("FileListTool", () => {
       makeToolContext(dir),
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("path is required and must be a string");
+    expect(result.content).toContain('Invalid input for tool "file_list"');
+    expect(result.content).toContain("path:");
   });
 
   test("execute() returns error for nonexistent directory", async () => {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1398,3 +1398,99 @@ describe("ToolExecutor thrown-value rendering", () => {
     expect(result.content).toContain("unexpected error: boom");
   });
 });
+
+describe("ToolExecutor input-schema validation gate", () => {
+  beforeEach(() => {
+    fakeToolResult = { content: "ok", isError: false };
+    getToolOverride = undefined;
+    getAllToolsOverride = undefined;
+    checkResultOverride = undefined;
+    checkFnOverride = undefined;
+    cachedAssessmentOverride = undefined;
+  });
+
+  /**
+   * Registry-shaped tool with an explicit owner and an execute that records
+   * the input it actually received (undefined until the tool runs).
+   */
+  function ownedTool(
+    name: string,
+    ownerKind: string,
+  ): { seenInput: () => Record<string, unknown> | undefined } {
+    let seen: Record<string, unknown> | undefined;
+    getToolOverride = (n: string) =>
+      n === name
+        ? ({
+            name,
+            description: "owned tool",
+            category: "test",
+            defaultRiskLevel: RiskLevel.Low,
+            executionTarget: "sandbox" as const,
+            input_schema: { type: "object" as const, properties: {} },
+            execute: async (input: Record<string, unknown>) => {
+              seen = input;
+              return fakeToolResult;
+            },
+            owner: { kind: ownerKind, id: ownerKind },
+          } as unknown as Tool)
+        : undefined;
+    return { seenInput: () => seen };
+  }
+
+  test("malformed input for a built-in tool returns a clean error without executing", async () => {
+    const probe = ownedTool("file_write", "default");
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_write",
+      { path: 42, content: "hello" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "file_write"');
+    expect(result.content).toContain("path:");
+    expect(probe.seenInput()).toBeUndefined();
+  });
+
+  test("valid input executes with catch-recovered data, unknown keys intact", async () => {
+    const probe = ownedTool("file_read", "default");
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "a.txt", offset: "not-a-number", activity: "Reading a file" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(probe.seenInput()).toEqual({
+      path: "a.txt",
+      activity: "Reading a file",
+    });
+  });
+
+  test("a non-default owner shadowing a registered name skips registry validation", async () => {
+    const probe = ownedTool("file_write", "workspace");
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_write",
+      { path: 42 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(probe.seenInput()).toEqual({ path: 42 });
+  });
+
+  test("a built-in tool with no registered schema executes unchanged", async () => {
+    const probe = ownedTool("web_search", "default");
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "web_search",
+      { query: 42 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(probe.seenInput()).toEqual({ query: 42 });
+  });
+});

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1493,4 +1493,23 @@ describe("ToolExecutor input-schema validation gate", () => {
     expect(result.isError).toBe(false);
     expect(probe.seenInput()).toEqual({ query: 42 });
   });
+
+  test("malformed input for a sensitive tool fails validation before any grant flow", async () => {
+    // An unknown actor invoking a sensitive built-in normally routes into the
+    // scoped-grant machinery inside checkPreExecutionGates. Malformed input
+    // must short-circuit BEFORE that point — the validation error proves the
+    // call never reached grant consumption or guardian escalation.
+    const probe = ownedTool("file_write", "default");
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_write",
+      { path: 42 },
+      makeContext({ trustClass: "unknown" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "file_write"');
+    expect(result.content).not.toContain("guardian");
+    expect(probe.seenInput()).toBeUndefined();
+  });
 });

--- a/assistant/src/tools/__tests__/tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/tool-input-schemas.test.ts
@@ -52,6 +52,18 @@ describe("parseToolInput", () => {
     });
   });
 
+  test("a malformed status-only activity field degrades instead of failing the call", () => {
+    const result = parseToolInput("file_write", {
+      path: "notes.md",
+      content: "hello",
+      activity: null,
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: { path: "notes.md", content: "hello" },
+    });
+  });
+
   test("file_read drops malformed optional fields the tool always ignored", () => {
     const result = parseToolInput("file_read", {
       path: "notes.md",

--- a/assistant/src/tools/__tests__/tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/tool-input-schemas.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+
+import { askQuestionTool } from "../ask-question/ask-question-tool.js";
+import { fileEditTool } from "../filesystem/edit.js";
+import { fileListTool } from "../filesystem/list.js";
+import { fileReadTool } from "../filesystem/read.js";
+import { fileWriteTool } from "../filesystem/write.js";
+import { parseToolInput, TOOL_INPUT_SCHEMAS } from "../tool-input-schemas.js";
+
+describe("parseToolInput", () => {
+  test("passes input through unchanged for a tool with no registered schema", () => {
+    const input = { anything: 42, nested: { deep: true } };
+    const result = parseToolInput("some_unregistered_tool", input);
+    expect(result).toEqual({ ok: true, data: input });
+  });
+
+  test("rejects malformed input with a message naming the tool and field", () => {
+    const result = parseToolInput("file_write", { path: 42, content: "hi" });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.message).toContain('Invalid input for tool "file_write"');
+    expect(result.message).toContain("path:");
+    expect(result.message).toContain("retry");
+  });
+
+  test("rejects a missing required field", () => {
+    const result = parseToolInput("file_write", { path: "a.txt" });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.message).toContain("content");
+  });
+
+  test("accepts valid input and preserves unknown keys (injected fields)", () => {
+    const result = parseToolInput("file_write", {
+      path: "notes.md",
+      content: "hello",
+      activity: "Saving your notes",
+      injected_by_harness: true,
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        path: "notes.md",
+        content: "hello",
+        activity: "Saving your notes",
+        injected_by_harness: true,
+      },
+    });
+  });
+
+  test("file_read drops malformed optional fields the tool always ignored", () => {
+    const result = parseToolInput("file_read", {
+      path: "notes.md",
+      offset: "not-a-number",
+      limit: 10,
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: { path: "notes.md", limit: 10 },
+    });
+  });
+
+  test("file_edit drops a malformed replace_all instead of failing", () => {
+    const result = parseToolInput("file_edit", {
+      path: "notes.md",
+      old_string: "a",
+      new_string: "b",
+      replace_all: "yes",
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: { path: "notes.md", old_string: "a", new_string: "b" },
+    });
+  });
+
+  test("file_edit rejects an empty old_string with the explanatory message", () => {
+    const result = parseToolInput("file_edit", {
+      path: "notes.md",
+      old_string: "",
+      new_string: "b",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.message).toContain("old_string must not be empty");
+  });
+
+  test("ask_question rejects an option count outside 2-4 with the field path", () => {
+    const result = parseToolInput("ask_question", {
+      questions: [
+        {
+          question: "Which one?",
+          options: [{ id: "only", label: "Only" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.message).toContain("questions.0.options");
+  });
+});
+
+describe("derived input_schema", () => {
+  const derivedTools = [
+    fileReadTool,
+    fileWriteTool,
+    fileEditTool,
+    fileListTool,
+    askQuestionTool,
+  ];
+
+  test("every registered schema belongs to a tool whose input_schema is derived from it", () => {
+    expect([...Object.keys(TOOL_INPUT_SCHEMAS)].sort()).toEqual(
+      derivedTools.map((t) => t.name).sort(),
+    );
+  });
+
+  test("derived schemas are plain tool-definition JSON schemas", () => {
+    for (const tool of derivedTools) {
+      const schema = tool.input_schema as Record<string, unknown>;
+      expect(schema.type).toBe("object");
+      // Tool definitions carry no draft marker, and permissive
+      // `additionalProperties` authoring artifacts are stripped.
+      expect(schema).not.toContainKey("$schema");
+      expect(JSON.stringify(schema)).not.toContain("additionalProperties");
+    }
+  });
+
+  test("filesystem tools still advertise activity as required with its description", () => {
+    for (const tool of [
+      fileReadTool,
+      fileWriteTool,
+      fileEditTool,
+      fileListTool,
+    ]) {
+      const schema = tool.input_schema as {
+        properties: Record<string, { type?: string; description?: string }>;
+        required: string[];
+      };
+      expect(schema.required).toContain("activity");
+      expect(schema.required).toContain("path");
+      expect(schema.properties.activity?.type).toBe("string");
+      expect(schema.properties.activity?.description).toContain(
+        "status update",
+      );
+    }
+  });
+
+  test("optional runtime-tolerant fields keep their descriptions and stay non-required", () => {
+    const schema = fileReadTool.input_schema as {
+      properties: Record<string, { type?: string; description?: string }>;
+      required: string[];
+    };
+    expect(schema.properties.offset?.type).toBe("number");
+    expect(schema.properties.offset?.description).toContain("1-indexed");
+    expect(schema.required).not.toContain("offset");
+    expect(schema.required).not.toContain("limit");
+  });
+});

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 import { QuestionPrompter } from "../../permissions/question-prompter.js";
 import { RiskLevel } from "../../permissions/types.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -9,15 +13,21 @@ import type {
 } from "../types.js";
 
 // ── Input schema ────────────────────────────────────────────────────
-// Runtime validation lives in Zod; the wire-level definition surfaced
-// to the LLM is the hand-written JSON Schema in `input_schema` below.
-// (The codebase does not currently use zod-to-json-schema for tool defs,
-// so the two are kept in sync manually.)
+// One Zod source for both runtime validation (via `TOOL_INPUT_SCHEMAS`)
+// and the LLM-facing `input_schema` (derived with `toToolInputSchema`).
 
 const OptionSchema = z.object({
-  id: z.string().min(1),
-  label: z.string().min(1),
-  description: z.string().optional(),
+  id: z
+    .string()
+    .min(1)
+    .describe(
+      "Stable identifier for this option (returned verbatim in the response).",
+    ),
+  label: z.string().min(1).describe("Short human-readable label."),
+  description: z
+    .string()
+    .describe("Optional one-line context shown beneath the label.")
+    .optional(),
 });
 
 // One question in a (possibly single-element) batch. Intentionally has no
@@ -26,13 +36,27 @@ const OptionSchema = z.object({
 // smaller and removes a validation surface (no duplicate-id check, no
 // length cap on ids).
 const SingleQuestionSchema = z.object({
-  question: z.string().min(1),
-  description: z.string().optional(),
+  question: z.string().min(1).describe("The clarifying question to display."),
+  description: z
+    .string()
+    .describe("Optional one-line context shown beneath the question.")
+    .optional(),
   // 2–4 LLM-supplied options. The client renders a fixed 5th "Type
   // something else" slot for free-text, so the model must keep the
   // structured set to 4 or fewer.
-  options: z.array(OptionSchema).min(2).max(4),
-  freeTextPlaceholder: z.string().optional(),
+  options: z
+    .array(OptionSchema)
+    .min(2)
+    .max(4)
+    .describe(
+      "2–4 structured options. The UI always appends a free-text fallback slot, so do not include a 'something else' option here.",
+    ),
+  freeTextPlaceholder: z
+    .string()
+    .describe(
+      "Optional placeholder text shown inside the free-text fallback input.",
+    )
+    .optional(),
 });
 
 // Cap at 5 questions per batch. Past that it starts to feel like a form,
@@ -41,18 +65,22 @@ const SingleQuestionSchema = z.object({
 const MAX_QUESTIONS_PER_BATCH = 5;
 
 // Callers pass a (possibly single-element) batch of questions. `execute()`
-// forwards them straight to the prompter.
-const InputSchema = z.object({
+// forwards them straight to the prompter. Loose so injected fields (e.g.
+// `activity`) never fail validation.
+export const askQuestionInputSchema = z.looseObject({
   questions: z
     .array(SingleQuestionSchema)
     .min(1)
     .max(MAX_QUESTIONS_PER_BATCH, {
       message: `At most ${MAX_QUESTIONS_PER_BATCH} questions per batch; split into multiple turns if you need more.`,
-    }),
+    })
+    .describe(
+      `1–${MAX_QUESTIONS_PER_BATCH} clarifying questions to ask in a single turn. Use a batch when several independent ambiguities block progress; ask one at a time when they're sequentially dependent. Past ${MAX_QUESTIONS_PER_BATCH} questions you should be implementing, not asking.`,
+    ),
 });
 
 export type SingleQuestion = z.infer<typeof SingleQuestionSchema>;
-export type AskQuestionInput = z.infer<typeof InputSchema>;
+export type AskQuestionInput = z.infer<typeof askQuestionInputSchema>;
 
 // ── Tool description ────────────────────────────────────────────────
 
@@ -91,27 +119,6 @@ const DESCRIPTION = [
   "short human-readable `label`. Optional `description` adds one line of",
   "context shown beneath the label.",
 ].join("\n");
-
-// Option-schema fragment for the items in `questions[].options`.
-const OPTION_ITEMS_SCHEMA = {
-  type: "object",
-  properties: {
-    id: {
-      type: "string",
-      description:
-        "Stable identifier for this option (returned verbatim in the response).",
-    },
-    label: {
-      type: "string",
-      description: "Short human-readable label.",
-    },
-    description: {
-      type: "string",
-      description: "Optional one-line context shown beneath the label.",
-    },
-  },
-  required: ["id", "label"],
-} as const;
 
 // ── Text fallback for channels without dynamic UI ───────────────────
 
@@ -168,57 +175,15 @@ export const askQuestionTool = {
   category: "interaction",
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
-  input_schema: {
-    type: "object",
-    properties: {
-      questions: {
-        type: "array",
-        minItems: 1,
-        maxItems: MAX_QUESTIONS_PER_BATCH,
-        description: `1–${MAX_QUESTIONS_PER_BATCH} clarifying questions to ask in a single turn. Use a batch when several independent ambiguities block progress; ask one at a time when they're sequentially dependent. Past ${MAX_QUESTIONS_PER_BATCH} questions you should be implementing, not asking.`,
-        items: {
-          type: "object",
-          properties: {
-            question: {
-              type: "string",
-              description: "The clarifying question to display.",
-            },
-            description: {
-              type: "string",
-              description:
-                "Optional one-line context shown beneath the question.",
-            },
-            options: {
-              type: "array",
-              minItems: 2,
-              maxItems: 4,
-              description:
-                "2–4 structured options. The UI always appends a free-text fallback slot, so do not include a 'something else' option here.",
-              items: OPTION_ITEMS_SCHEMA,
-            },
-            freeTextPlaceholder: {
-              type: "string",
-              description:
-                "Optional placeholder text shown inside the free-text fallback input.",
-            },
-          },
-          required: ["question", "options"],
-        },
-      },
-    },
-    required: ["questions"],
-  },
+  input_schema: toToolInputSchema(askQuestionInputSchema),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const parsed = InputSchema.safeParse(input);
+    const parsed = askQuestionInputSchema.safeParse(input);
     if (!parsed.success) {
-      return {
-        content: `Invalid input: ${parsed.error.message}`,
-        isError: true,
-      };
+      return invalidToolInputResult("ask_question", parsed.error);
     }
 
     const questions: SingleQuestion[] = parsed.data.questions;

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -26,6 +26,7 @@ import { applyEdit } from "./shared/filesystem/edit-engine.js";
 import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
 import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
 import { ToolApprovalHandler } from "./tool-approval-handler.js";
+import { parseToolInput } from "./tool-input-schemas.js";
 import { resolveToolInvocationAlias } from "./tool-name-aliases.js";
 import { recordToolCompletion } from "./tool-profiler.js";
 import { type ToolContext, type ToolExecutionResult } from "./types.js";
@@ -99,8 +100,24 @@ export class ToolExecutor {
     }
 
     const tool = gateResult.tool;
+    // Resolved once for the schema-validation gate below and the
+    // plugin-context binding around `execute()`.
+    const owner = getToolOwner(name);
 
     try {
+      // Model-generated `input` is untrusted: parse it against the tool's
+      // registered Zod schema (built-in tools only — an extension or
+      // workspace override owns its own input contract) before anything
+      // downstream reads a field. A failed parse surfaces as an expected
+      // ToolError — a clean, model-correctable tool result — instead of a
+      // crash or silent corruption mid-executor.
+      if (owner?.kind === "default") {
+        const parsedInput = parseToolInput(name, input);
+        if (!parsedInput.ok) {
+          throw new ToolError(parsedInput.message, name);
+        }
+        input = parsedInput.data;
+      }
       // A workflow run whose capability manifest grants side-effecting tools or
       // host functions (beyond the read-only baseline) must prompt at LAUNCH.
       // The manifest is authored and declared by the model, and the run's
@@ -230,7 +247,6 @@ export class ToolExecutor {
       // context must be established around the `execute()` call itself so the
       // returned promise carries the binding across its awaits. Non-plugin
       // tools (default/skill/mcp/workspace) establish no context.
-      const owner = getToolOwner(name);
       const execPromise =
         owner?.kind === "plugin"
           ? runInPluginContext(owner.id, () => tool.execute(input, execContext))

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -26,7 +26,6 @@ import { applyEdit } from "./shared/filesystem/edit-engine.js";
 import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
 import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
 import { ToolApprovalHandler } from "./tool-approval-handler.js";
-import { parseToolInput } from "./tool-input-schemas.js";
 import { resolveToolInvocationAlias } from "./tool-name-aliases.js";
 import { recordToolCompletion } from "./tool-profiler.js";
 import { type ToolContext, type ToolExecutionResult } from "./types.js";
@@ -100,24 +99,15 @@ export class ToolExecutor {
     }
 
     const tool = gateResult.tool;
-    // Resolved once for the schema-validation gate below and the
-    // plugin-context binding around `execute()`.
-    const owner = getToolOwner(name);
+    // The pre-execution gate parsed model-generated input against the tool's
+    // registered Zod schema (`TOOL_INPUT_SCHEMAS`) before any grant was
+    // consumed; substitute the parsed value (with `.catch()` recoveries
+    // applied) so validation and execution see the same input.
+    if (gateResult.parsedInput) {
+      input = gateResult.parsedInput;
+    }
 
     try {
-      // Model-generated `input` is untrusted: parse it against the tool's
-      // registered Zod schema (built-in tools only — an extension or
-      // workspace override owns its own input contract) before anything
-      // downstream reads a field. A failed parse surfaces as an expected
-      // ToolError — a clean, model-correctable tool result — instead of a
-      // crash or silent corruption mid-executor.
-      if (owner?.kind === "default") {
-        const parsedInput = parseToolInput(name, input);
-        if (!parsedInput.ok) {
-          throw new ToolError(parsedInput.message, name);
-        }
-        input = parsedInput.data;
-      }
       // A workflow run whose capability manifest grants side-effecting tools or
       // host functions (beyond the read-only baseline) must prompt at LAUNCH.
       // The manifest is authored and declared by the model, and the run's
@@ -247,6 +237,7 @@ export class ToolExecutor {
       // context must be established around the `execute()` call itself so the
       // returned promise carries the binding across its awaits. Non-plugin
       // tools (default/skill/mcp/workspace) establish no context.
+      const owner = getToolOwner(name);
       const execPromise =
         owner?.kind === "plugin"
           ? runInPluginContext(owner.id, () => tool.execute(input, execContext))

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -1,12 +1,52 @@
+import { z } from "zod";
+
 import { RiskLevel } from "../../permissions/types.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatEditDiff } from "../shared/filesystem/format-diff.js";
 import { sandboxPolicyWithHostFallback } from "../shared/filesystem/path-policy.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
 } from "../types.js";
+
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. `replace_all`
+ * catches to `undefined` because the tool has always treated anything but a
+ * literal `true` as "single match" — a malformed value degrades the same way
+ * instead of failing the call.
+ */
+export const fileEditInputSchema = z.looseObject({
+  path: z
+    .string()
+    .min(1)
+    .describe(
+      "The path to the file to edit (absolute or relative to working directory)",
+    ),
+  old_string: z
+    .string()
+    .min(1, { message: "old_string must not be empty" })
+    .describe("The exact text to find in the file"),
+  new_string: z.string().describe("The replacement text"),
+  replace_all: z
+    .boolean()
+    .describe(
+      "Replace all occurrences of old_string instead of requiring a unique match (default: false)",
+    )
+    .optional()
+    .catch(undefined),
+  activity: z
+    .string()
+    .describe(
+      "Brief non-technical explanation of what you are doing and why, shown as a status update.",
+    )
+    .optional(),
+});
 
 export const fileEditTool = {
   name: "file_edit",
@@ -16,67 +56,23 @@ export const fileEditTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      path: {
-        type: "string",
-        description:
-          "The path to the file to edit (absolute or relative to working directory)",
-      },
-      old_string: {
-        type: "string",
-        description: "The exact text to find in the file",
-      },
-      new_string: {
-        type: "string",
-        description: "The replacement text",
-      },
-      replace_all: {
-        type: "boolean",
-        description:
-          "Replace all occurrences of old_string instead of requiring a unique match (default: false)",
-      },
-      activity: {
-        type: "string",
-        description:
-          "Brief non-technical explanation of what you are doing and why, shown as a status update.",
-      },
-    },
-    required: ["path", "old_string", "new_string", "activity"],
-  },
+  input_schema: toToolInputSchema(fileEditInputSchema, {
+    advertiseRequired: ["activity"],
+  }),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const rawPath = input.path as string;
-    if (!rawPath || typeof rawPath !== "string") {
-      return {
-        content: "Error: path is required and must be a string",
-        isError: true,
-      };
+    const parsed = fileEditInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("file_edit", parsed.error);
     }
-
-    const oldString = input.old_string;
-    if (typeof oldString !== "string") {
-      return {
-        content: "Error: old_string is required and must be a string",
-        isError: true,
-      };
-    }
-
-    const newString = input.new_string;
-    if (typeof newString !== "string") {
-      return {
-        content: "Error: new_string is required and must be a string",
-        isError: true,
-      };
-    }
-
-    if (oldString.length === 0) {
-      return { content: "Error: old_string must not be empty", isError: true };
-    }
+    const {
+      path: rawPath,
+      old_string: oldString,
+      new_string: newString,
+    } = parsed.data;
 
     if (oldString === newString) {
       return {
@@ -85,7 +81,7 @@ export const fileEditTool = {
       };
     }
 
-    const replaceAll = input.replace_all === true;
+    const replaceAll = parsed.data.replace_all === true;
 
     const ops = new FileSystemOps((path, opts) =>
       sandboxPolicyWithHostFallback(path, context.workingDir, opts),

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -45,7 +45,8 @@ export const fileEditInputSchema = z.looseObject({
     .describe(
       "Brief non-technical explanation of what you are doing and why, shown as a status update.",
     )
-    .optional(),
+    .optional()
+    .catch(undefined),
 });
 
 export const fileEditTool = {

--- a/assistant/src/tools/filesystem/list.ts
+++ b/assistant/src/tools/filesystem/list.ts
@@ -1,11 +1,38 @@
+import { z } from "zod";
+
 import { RiskLevel } from "../../permissions/types.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
 } from "../types.js";
+
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. `glob`
+ * catches to `undefined` because the tool has always ignored non-string
+ * values rather than failing the listing.
+ */
+export const fileListInputSchema = z.looseObject({
+  path: z.string().min(1).describe("The directory path to list"),
+  glob: z
+    .string()
+    .describe("Filter entries by glob pattern, e.g. '*.md'")
+    .optional()
+    .catch(undefined),
+  activity: z
+    .string()
+    .describe(
+      "Brief non-technical explanation of what you are doing and why, shown as a status update.",
+    )
+    .optional(),
+});
 
 export const fileListTool = {
   name: "file_list",
@@ -15,46 +42,25 @@ export const fileListTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      path: {
-        type: "string",
-        description: "The directory path to list",
-      },
-      glob: {
-        type: "string",
-        description: "Filter entries by glob pattern, e.g. '*.md'",
-      },
-      activity: {
-        type: "string",
-        description:
-          "Brief non-technical explanation of what you are doing and why, shown as a status update.",
-      },
-    },
-    required: ["path", "activity"],
-  },
+  input_schema: toToolInputSchema(fileListInputSchema, {
+    advertiseRequired: ["activity"],
+  }),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const rawPath = input.path as string;
-    if (!rawPath || typeof rawPath !== "string") {
-      return {
-        content: "Error: path is required and must be a string",
-        isError: true,
-      };
+    const parsed = fileListInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("file_list", parsed.error);
     }
+    const { path: rawPath, glob } = parsed.data;
 
     const ops = new FileSystemOps((path, opts) =>
       sandboxPolicy(path, context.workingDir, opts),
     );
 
-    const result = ops.listDirSafe({
-      path: rawPath,
-      glob: typeof input.glob === "string" ? input.glob : undefined,
-    });
+    const result = ops.listDirSafe({ path: rawPath, glob });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/filesystem/list.ts
+++ b/assistant/src/tools/filesystem/list.ts
@@ -31,7 +31,8 @@ export const fileListInputSchema = z.looseObject({
     .describe(
       "Brief non-technical explanation of what you are doing and why, shown as a status update.",
     )
-    .optional(),
+    .optional()
+    .catch(undefined),
 });
 
 export const fileListTool = {

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -1,5 +1,7 @@
 import { extname } from "node:path";
 
+import { z } from "zod";
+
 import { RiskLevel } from "../../permissions/types.js";
 import {
   AUDIO_EXTENSIONS,
@@ -11,11 +13,46 @@ import {
   readImageFile,
 } from "../shared/filesystem/image-read.js";
 import { sandboxPolicyWithHostFallback } from "../shared/filesystem/path-policy.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
 } from "../types.js";
+
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. `offset` and
+ * `limit` catch to `undefined` because the tool has always ignored non-numeric
+ * values rather than failing the read.
+ */
+export const fileReadInputSchema = z.looseObject({
+  path: z
+    .string()
+    .min(1)
+    .describe(
+      "The path to the file to read (absolute or relative to working directory)",
+    ),
+  offset: z
+    .number()
+    .describe("Line number to start reading from (1-indexed)")
+    .optional()
+    .catch(undefined),
+  limit: z
+    .number()
+    .describe("Maximum number of lines to read")
+    .optional()
+    .catch(undefined),
+  activity: z
+    .string()
+    .describe(
+      "Brief non-technical explanation of what you are doing and why, shown as a status update.",
+    )
+    .optional(),
+});
 
 export const fileReadTool = {
   name: "file_read",
@@ -25,42 +62,19 @@ export const fileReadTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      path: {
-        type: "string",
-        description:
-          "The path to the file to read (absolute or relative to working directory)",
-      },
-      offset: {
-        type: "number",
-        description: "Line number to start reading from (1-indexed)",
-      },
-      limit: {
-        type: "number",
-        description: "Maximum number of lines to read",
-      },
-      activity: {
-        type: "string",
-        description:
-          "Brief non-technical explanation of what you are doing and why, shown as a status update.",
-      },
-    },
-    required: ["path", "activity"],
-  },
+  input_schema: toToolInputSchema(fileReadInputSchema, {
+    advertiseRequired: ["activity"],
+  }),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const rawPath = input.path as string;
-    if (!rawPath || typeof rawPath !== "string") {
-      return {
-        content: "Error: path is required and must be a string",
-        isError: true,
-      };
+    const parsed = fileReadInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("file_read", parsed.error);
     }
+    const { path: rawPath, offset, limit } = parsed.data;
 
     // For image files, delegate to the shared image reader.
     const ext = extname(rawPath).toLowerCase();
@@ -97,11 +111,7 @@ export const fileReadTool = {
       sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
-    const result = ops.readFileSafe({
-      path: rawPath,
-      offset: typeof input.offset === "number" ? input.offset : undefined,
-      limit: typeof input.limit === "number" ? input.limit : undefined,
-    });
+    const result = ops.readFileSafe({ path: rawPath, offset, limit });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -51,7 +51,8 @@ export const fileReadInputSchema = z.looseObject({
     .describe(
       "Brief non-technical explanation of what you are doing and why, shown as a status update.",
     )
-    .optional(),
+    .optional()
+    .catch(undefined),
 });
 
 export const fileReadTool = {

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -81,7 +81,8 @@ export const fileWriteInputSchema = z.looseObject({
     .describe(
       "Brief non-technical explanation of what you are doing and why, shown as a status update.",
     )
-    .optional(),
+    .optional()
+    .catch(undefined),
 });
 
 export const fileWriteTool = {

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -1,5 +1,7 @@
 import { join, resolve, sep } from "node:path";
 
+import { z } from "zod";
+
 import { getAppsDir } from "../../apps/app-store.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { enqueuePkbIndexJob } from "../../plugins/defaults/memory/v1/jobs/embed-pkb-file.js";
@@ -8,6 +10,10 @@ import { getWorkspaceDir } from "../../util/platform.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatWriteSummary } from "../shared/filesystem/format-diff.js";
 import { sandboxPolicyWithHostFallback } from "../shared/filesystem/path-policy.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -56,6 +62,28 @@ function isInsidePkbRoot(absPath: string, pkbRoot: string): boolean {
   return normalized.startsWith(rootWithSep);
 }
 
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. Loose so
+ * injected fields (e.g. `activity`, which the model must send but the tool
+ * never reads) pass through untouched.
+ */
+export const fileWriteInputSchema = z.looseObject({
+  path: z
+    .string()
+    .min(1)
+    .describe(
+      "The path to the file to write (absolute or relative to working directory)",
+    ),
+  content: z.string().describe("The content to write to the file"),
+  activity: z
+    .string()
+    .describe(
+      "Brief non-technical explanation of what you are doing and why, shown as a status update.",
+    )
+    .optional(),
+});
+
 export const fileWriteTool = {
   name: "file_write",
   description:
@@ -64,46 +92,19 @@ export const fileWriteTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      path: {
-        type: "string",
-        description:
-          "The path to the file to write (absolute or relative to working directory)",
-      },
-      content: {
-        type: "string",
-        description: "The content to write to the file",
-      },
-      activity: {
-        type: "string",
-        description:
-          "Brief non-technical explanation of what you are doing and why, shown as a status update.",
-      },
-    },
-    required: ["path", "content", "activity"],
-  },
+  input_schema: toToolInputSchema(fileWriteInputSchema, {
+    advertiseRequired: ["activity"],
+  }),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const rawPath = input.path as string;
-    if (!rawPath || typeof rawPath !== "string") {
-      return {
-        content: "Error: path is required and must be a string",
-        isError: true,
-      };
+    const parsed = fileWriteInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("file_write", parsed.error);
     }
-
-    const fileContent = input.content;
-    if (typeof fileContent !== "string") {
-      return {
-        content: "Error: content is required and must be a string",
-        isError: true,
-      };
-    }
+    const { path: rawPath, content: fileContent } = parsed.data;
 
     // Redirect self-contained interactive HTML artifacts to app-builder.
     // Exempt writes that land inside the apps directory (app-builder's own

--- a/assistant/src/tools/shared/zod-tool-schema.ts
+++ b/assistant/src/tools/shared/zod-tool-schema.ts
@@ -94,8 +94,8 @@ export function formatToolInputError(
 
 /**
  * Failed-parse tool result for executors that validate their own input (the
- * executor-level gate in `ToolExecutor` produces the same message, so the
- * error reads identically whichever layer catches it first).
+ * pre-execution gate in `ToolApprovalHandler` produces the same message, so
+ * the error reads identically whichever layer catches it first).
  */
 export function invalidToolInputResult(
   toolName: string,

--- a/assistant/src/tools/shared/zod-tool-schema.ts
+++ b/assistant/src/tools/shared/zod-tool-schema.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+import type { ToolExecutionResult } from "../types.js";
+
+/**
+ * Derive a tool's LLM-facing `input_schema` from its Zod input schema, so the
+ * schema the model sees and the validation the executor runs share one source
+ * and cannot drift (`TOOL_INPUT_SCHEMAS` in `../tool-input-schemas.ts` holds
+ * the executor-side half).
+ *
+ * Conversion uses Zod 4's native `z.toJSONSchema` (mirroring
+ * `workflows/leaf-runner.ts`), then adjusts the output for the tool-definition
+ * context:
+ *
+ * - The `$schema` marker is dropped — tool definitions don't carry one.
+ * - `additionalProperties` values of `false` / `{}` are dropped. They are
+ *   authoring artifacts of `z.object` / `z.looseObject`, not intentional
+ *   contract: runtime validation never rejects unknown keys (registry schemas
+ *   must tolerate injected fields like `activity`, see
+ *   `schema-transforms.ts`), so advertising `additionalProperties: false`
+ *   would claim a strictness the runtime doesn't enforce.
+ *
+ * `advertiseRequired` names fields to mark required in the advertised schema
+ * even though the Zod schema treats them as optional. This is the one
+ * sanctioned divergence, and only in the tolerant direction: the model is told
+ * to always send the field (e.g. `activity`, which drives status UX), but a
+ * call that omits it still executes rather than failing on a field the tool
+ * doesn't need.
+ */
+export function toToolInputSchema(
+  schema: z.ZodType,
+  opts?: { advertiseRequired?: readonly string[] },
+): Record<string, unknown> {
+  const json = z.toJSONSchema(schema, { unrepresentable: "any" }) as Record<
+    string,
+    unknown
+  >;
+  delete json.$schema;
+  stripPermissiveAdditionalProperties(json);
+
+  for (const field of opts?.advertiseRequired ?? []) {
+    const required = Array.isArray(json.required) ? json.required : [];
+    if (!required.includes(field)) {
+      json.required = [...required, field];
+    }
+  }
+  return json;
+}
+
+/**
+ * Recursively remove `additionalProperties` keys whose value is `false` or the
+ * empty schema `{}`. A real subschema (e.g. `additionalProperties:
+ * { type: "string" }` from `z.record`) is left intact.
+ */
+function stripPermissiveAdditionalProperties(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const entry of node) {
+      stripPermissiveAdditionalProperties(entry);
+    }
+    return;
+  }
+  if (node === null || typeof node !== "object") {
+    return;
+  }
+  const record = node as Record<string, unknown>;
+  const ap = record.additionalProperties;
+  if (
+    ap === false ||
+    (typeof ap === "object" &&
+      ap !== null &&
+      !Array.isArray(ap) &&
+      Object.keys(ap).length === 0)
+  ) {
+    delete record.additionalProperties;
+  }
+  for (const value of Object.values(record)) {
+    stripPermissiveAdditionalProperties(value);
+  }
+}
+
+/**
+ * Render a failed tool-input parse as a compact `field: message` summary the
+ * model can correct from. Mirrors `runtime/routes/parse-body.ts`.
+ */
+export function formatToolInputError(
+  toolName: string,
+  error: z.ZodError,
+): string {
+  const detail = error.issues
+    .map((issue) => `${issue.path.join(".") || "(input)"}: ${issue.message}`)
+    .join("; ");
+  return `Invalid input for tool "${toolName}": ${detail}. Fix the listed field(s) and retry the call.`;
+}
+
+/**
+ * Failed-parse tool result for executors that validate their own input (the
+ * executor-level gate in `ToolExecutor` produces the same message, so the
+ * error reads identically whichever layer catches it first).
+ */
+export function invalidToolInputResult(
+  toolName: string,
+  error: z.ZodError,
+): ToolExecutionResult {
+  return { content: formatToolInputError(toolName, error), isError: true };
+}

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -26,6 +26,7 @@ import { getLogger } from "../util/logger.js";
 import { resolveExecutionTarget } from "./execution-target.js";
 import { getAllTools, getTool, getToolOwner } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
+import { parseToolInput } from "./tool-input-schemas.js";
 import { summarizeToolInput } from "./tool-input-summary.js";
 import { suggestToolName } from "./tool-name-aliases.js";
 import { recordToolCompletion } from "./tool-profiler.js";
@@ -365,7 +366,18 @@ function sensitiveToolDeniedMessage(
 }
 
 export type PreExecutionGateResult =
-  | { allowed: true; tool: Tool; grantConsumed?: boolean }
+  | {
+      allowed: true;
+      tool: Tool;
+      grantConsumed?: boolean;
+      /**
+       * Input parsed against the tool's registered schema in
+       * `TOOL_INPUT_SCHEMAS` (with `.catch()` recoveries applied). Set only
+       * for built-in tools with a registered schema; the executor substitutes
+       * it for the raw input so validation and execution see the same value.
+       */
+      parsedInput?: Record<string, unknown>;
+    }
   | { allowed: false; result: ToolExecutionResult };
 
 /** Configuration for the inline grant wait behavior. */
@@ -639,10 +651,36 @@ export class ToolApprovalHandler {
       }
     }
 
-    // All policy gates passed. Now consume the scoped grant if one is
-    // required. Deferring consumption to this point ensures a downstream
-    // rejection (allowedToolNames, task-run preflight, registry lookup)
-    // does not waste the one-time-use grant.
+    // All deterministic policy gates passed. Parse model-generated input for
+    // built-in tools with a registered schema BEFORE the grant consumption
+    // and guardian escalation below: a malformed invocation can never
+    // execute, so failing it here means it cannot burn a one-time grant or
+    // interrupt the guardian with an approval card (and up to a 60s inline
+    // wait) for a call validation would reject anyway. Extension-owned and
+    // workspace-override tools own their input contracts and are skipped.
+    let parsedInput: Record<string, unknown> | undefined;
+    if (getToolOwner(name)?.kind === "default") {
+      const parsed = parseToolInput(name, input);
+      if (!parsed.ok) {
+        this.auditGateError(
+          context,
+          name,
+          input,
+          riskLevel,
+          startTime,
+          parsed.message,
+        );
+        return {
+          allowed: false,
+          result: { content: parsed.message, isError: true },
+        };
+      }
+      parsedInput = parsed.data;
+    }
+
+    // Now consume the scoped grant if one is required. Deferring consumption
+    // to this point ensures a prior gate rejection (allowedToolNames, input
+    // validation, registry lookup) does not waste the one-time-use grant.
     //
     // Retry polling is scoped to the voice channel where a race condition
     // exists between fire-and-forget turn execution and LLM fallback grant
@@ -667,7 +705,7 @@ export class ToolApprovalHandler {
           "Scoped grant consumed - allowing untrusted actor tool invocation",
         );
 
-        return { allowed: true, tool, grantConsumed: true };
+        return { allowed: true, tool, grantConsumed: true, parsedInput };
       }
 
       // Treat abort as a cancellation - not a grant denial. This matches
@@ -761,7 +799,7 @@ export class ToolApprovalHandler {
               },
               "Inline grant wait succeeded - allowing trusted contact tool invocation",
             );
-            return { allowed: true, tool, grantConsumed: true };
+            return { allowed: true, tool, grantConsumed: true, parsedInput };
           }
 
           if (waitResult.outcome === "aborted") {
@@ -848,6 +886,6 @@ export class ToolApprovalHandler {
       return { allowed: false, result: { content: reason, isError: true } };
     }
 
-    return { allowed: true, tool };
+    return { allowed: true, tool, parsedInput };
   }
 }

--- a/assistant/src/tools/tool-input-schemas.ts
+++ b/assistant/src/tools/tool-input-schemas.ts
@@ -1,0 +1,67 @@
+import type { z } from "zod";
+
+import { askQuestionInputSchema } from "./ask-question/ask-question-tool.js";
+import { fileEditInputSchema } from "./filesystem/edit.js";
+import { fileListInputSchema } from "./filesystem/list.js";
+import { fileReadInputSchema } from "./filesystem/read.js";
+import { fileWriteInputSchema } from "./filesystem/write.js";
+import { formatToolInputError } from "./shared/zod-tool-schema.js";
+
+/**
+ * Per-tool Zod input schemas, keyed by tool name. Tool calls are a
+ * discriminated payload — the tool name determines the shape of `input` —
+ * but the model's JSON arrives untrusted, so `ToolExecutor` parses it against
+ * this registry (via {@link parseToolInput}) before any executor reads a
+ * field. Each schema is also the source the tool derives its advertised
+ * `input_schema` from (`toToolInputSchema` in `shared/zod-tool-schema.ts`),
+ * so the model-facing contract and the runtime validation cannot drift.
+ *
+ * Covers built-in (`default`-owned) tools only — skill / plugin / MCP /
+ * workspace tools own their schemas elsewhere, and the executor skips this
+ * registry for them (a workspace override of a built-in name must not be
+ * validated against the built-in's schema).
+ *
+ * Authoring rules, so validation never tightens behavior a tool already
+ * tolerates:
+ *
+ * - Top-level schemas are `z.looseObject` — unknown keys (including the
+ *   injected `activity` field, see `schema-transforms.ts`) pass through.
+ * - A field the tool silently ignores when malformed gets
+ *   `.optional().catch(undefined)` so a bad value degrades exactly as the
+ *   tool always degraded, instead of failing the call.
+ * - Fields the advertised schema requires only to guide the model (e.g.
+ *   `activity`) stay optional here; the derivation marks them required via
+ *   `advertiseRequired`.
+ */
+export const TOOL_INPUT_SCHEMAS: Readonly<Record<string, z.ZodType>> = {
+  ask_question: askQuestionInputSchema,
+  file_edit: fileEditInputSchema,
+  file_list: fileListInputSchema,
+  file_read: fileReadInputSchema,
+  file_write: fileWriteInputSchema,
+};
+
+/**
+ * Validate model-supplied tool input against the registered schema for
+ * `name`, returning the parsed value (with `.catch()` recoveries applied) or
+ * a descriptive, model-correctable error message. A tool with no registered
+ * schema passes through unchanged.
+ */
+export function parseToolInput(
+  name: string,
+  input: Record<string, unknown>,
+):
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; message: string } {
+  const schema = TOOL_INPUT_SCHEMAS[name];
+  if (!schema) {
+    return { ok: true, data: input };
+  }
+  const result = schema.safeParse(input);
+  if (!result.success) {
+    return { ok: false, message: formatToolInputError(name, result.error) };
+  }
+  // Every registry schema is an object schema, so the parsed value is a
+  // plain record; `z.ZodType`'s output is just too wide to say so statically.
+  return { ok: true, data: result.data as Record<string, unknown> };
+}

--- a/assistant/src/tools/tool-input-schemas.ts
+++ b/assistant/src/tools/tool-input-schemas.ts
@@ -10,9 +10,12 @@ import { formatToolInputError } from "./shared/zod-tool-schema.js";
 /**
  * Per-tool Zod input schemas, keyed by tool name. Tool calls are a
  * discriminated payload — the tool name determines the shape of `input` —
- * but the model's JSON arrives untrusted, so `ToolExecutor` parses it against
- * this registry (via {@link parseToolInput}) before any executor reads a
- * field. Each schema is also the source the tool derives its advertised
+ * but the model's JSON arrives untrusted, so the pre-execution gate
+ * (`ToolApprovalHandler.checkPreExecutionGates`) parses it against this
+ * registry (via {@link parseToolInput}) before any executor reads a field —
+ * and, crucially, before any one-time grant is consumed or guardian
+ * escalation starts, so a malformed call can never interrupt the guardian.
+ * Each schema is also the source the tool derives its advertised
  * `input_schema` from (`toToolInputSchema` in `shared/zod-tool-schema.ts`),
  * so the model-facing contract and the runtime validation cannot drift.
  *
@@ -30,8 +33,9 @@ import { formatToolInputError } from "./shared/zod-tool-schema.js";
  *   `.optional().catch(undefined)` so a bad value degrades exactly as the
  *   tool always degraded, instead of failing the call.
  * - Fields the advertised schema requires only to guide the model (e.g.
- *   `activity`) stay optional here; the derivation marks them required via
- *   `advertiseRequired`.
+ *   `activity`, which is status-only and never read by the tool) stay
+ *   optional-with-`.catch(undefined)` here; the derivation marks them
+ *   required via `advertiseRequired`.
  */
 export const TOOL_INPUT_SCHEMAS: Readonly<Record<string, z.ZodType>> = {
   ask_question: askQuestionInputSchema,


### PR DESCRIPTION
## Prompt / plan

Part of [LUM-2797](https://linear.app/vellum/issue/LUM-2797/validate-model-tool-input-against-a-per-tool-zod-schema-registry): tool calls are a discriminated payload — the tool `name` determines the shape of `input` — but nothing validated the model's JSON between the model and the executor, so ~104 naked `input.<field> as T` casts across ~30 executor files turned malformed model output into crashes or silent corruption. Per the ticket, this PR is the incremental start: the registry mechanism plus a first tranche of tools (the highest-traffic filesystem family, and `ask_question`, which already had an in-tool Zod parse) proving the shape. Follow-up PRs migrate the remaining executor files (schedule, document, subagent, workflows, followups, …) tool by tool.

What's in the mechanism:

- **`TOOL_INPUT_SCHEMAS`** (`assistant/src/tools/tool-input-schemas.ts`): per-tool Zod schemas keyed by tool name, `safeParse`d once in `ToolExecutor.executeInternal` before anything downstream reads a field. A failed parse surfaces as an *expected* `ToolError` — a clean, model-correctable tool result (`Invalid input for tool "file_write": path: …. Fix the listed field(s) and retry the call.`) — never a thrown ZodError. Validation only applies to `default`-owned tools: a skill/plugin/MCP tool, or a workspace override shadowing a built-in name, owns its input contract and is skipped.
- **`toToolInputSchema`** (`assistant/src/tools/shared/zod-tool-schema.ts`): derives each converted tool's advertised `input_schema` from the same Zod source via Zod 4's native `z.toJSONSchema` (mirroring `workflows/leaf-runner.ts`), so the model-facing schema and the runtime validation can't drift. `ask_question`'s hand-synced JSON schema literal is deleted in favor of the derived one.
- **Tolerance is preserved, not tightened** (per the ticket's risk note): top-level schemas are `z.looseObject` so unknown keys — including the harness-injected `activity` field — pass through; fields the tools always silently ignored when malformed (`offset`/`limit`/`glob`/`replace_all`) use `.optional().catch(undefined)` so a bad value degrades exactly as before instead of failing the call; and fields advertised as required purely to guide the model (`activity`) stay runtime-optional via the `advertiseRequired` derivation option — the one sanctioned divergence, only in the tolerant direction.
- Converted executors (`file_read`, `file_write`, `file_edit`, `file_list`, `ask_question`) now parse instead of cast, using the same error format as the executor gate for defense in depth on non-executor paths.

Follows the parse-not-cast precedents: `parseBody()` in routes (LUM-2796), `parseSlackEnvelope` (LUM-2819), `ui_show` surface schemas (LUM-2579), and the Telegram webhook (#38856).

## Test plan

- New `assistant/src/tools/__tests__/tool-input-schemas.test.ts`: registry parse behavior (pass-through for unregistered tools, rejection messages naming tool + field, unknown-key preservation, `.catch()` degradation) and derived-schema shape (no `$schema`, no permissive `additionalProperties` artifacts, `activity` advertised-required with description, optional fields non-required).
- New "input-schema validation gate" describe block in `tool-executor.test.ts`: malformed input returns a clean error without executing the tool; valid input executes with catch-recovered data; non-default owners shadowing a registered name skip validation; schema-less built-ins pass through.
- Existing suites for every touched tool pass: `file-read/write/edit/list-tool.test.ts` (one assertion updated to the new `file_list` error message), `ask-question-tool.test.ts` (its `input_schema` shape assertions pass against the derived schema unchanged), `run-standalone.test.ts`, `tool-executor-lifecycle-events.test.ts`, `require-fresh-approval.test.ts`, `subagent-tool-gate-mode.test.ts`, `tool-execution-abort-cleanup.test.ts`, `platform-bash-auto-approve.test.ts`, `conversation-tool-setup-*.test.ts`, `credential-security-invariants.test.ts`.
- `bunx tsc --noEmit` clean; eslint clean on changed files; `lint:circular` count unchanged vs `main` (201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019u8TdSw3HyCFwxYYfV83dA

---
_Generated by [Claude Code](https://claude.ai/code/session_019u8TdSw3HyCFwxYYfV83dA)_