### PR TITLE
feat(live-voice): give the duplex-handoff continuation full subagent abilities (JARVIS-1354)

### DIFF
--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -44,7 +44,13 @@ const capturedParentIds: string[] = [];
 // Live subagent conversations, keyed by conversationId. notifyParentFromChild
 // routes to the parent recorded here (the non-writable in-process source), so
 // tests register a child before expecting a notification to route.
-const liveSubagents = new Map<string, { parentConversationId: string }>();
+const liveSubagents = new Map<
+  string,
+  {
+    parentConversationId: string;
+    subagentSuppressParentNotifications?: boolean;
+  }
+>();
 
 mock.module("../daemon/conversation-registry.js", () => ({
   findConversation: (id: string) => {
@@ -60,9 +66,7 @@ mock.module("../daemon/conversation-registry.js", () => ({
   },
   findConversationOrSubagent: (id: string) => {
     const live = liveSubagents.get(id);
-    return live
-      ? { parentConversationId: live.parentConversationId }
-      : undefined;
+    return live ? { ...live } : undefined;
   },
 }));
 
@@ -319,6 +323,23 @@ describe("notifyParentFromChild", () => {
       true,
     );
     expect(lastCapturedMessage()).toContain("Test message");
+  });
+
+  test("returns false for a synchronous child that suppresses parent notifications", () => {
+    clearCaptured();
+    const conversationId = "conv-suppressed-1";
+    seedSubagent(conversationId);
+    // spawnAndAwait children carry this flag: the awaiting caller is their
+    // only parent channel, so a mid-run injection must not reach the parent.
+    const live = liveSubagents.get(conversationId);
+    if (live) {
+      live.subagentSuppressParentNotifications = true;
+    }
+
+    expect(
+      notifyParentFromChild(conversationId, "Should not arrive", "info"),
+    ).toBe(false);
+    expect(capturedMessages).toHaveLength(0);
   });
 
   test("labels forks as Fork", () => {

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -59,6 +59,8 @@ let lastDenySideEffects: boolean | undefined;
  * FakeConversation.
  */
 let lastSuppressParentNotifications: boolean | undefined;
+/** Records `setTrustContext` on the most recent FakeConversation. */
+let lastTrustContext: unknown;
 /** Options the most recent `bootstrapConversation` call received. */
 let lastBootstrapOptions: Record<string, unknown> | undefined;
 
@@ -93,7 +95,9 @@ class FakeConversation {
     this.sendToClient = sendToClient;
   }
 
-  setTrustContext() {}
+  setTrustContext(ctx: unknown) {
+    lastTrustContext = ctx;
+  }
   setAuthContext() {}
   getAuthContext() {
     return undefined;
@@ -239,6 +243,7 @@ describe("SubagentManager.spawnAndAwait", () => {
   beforeEach(() => {
     lastDenySideEffects = undefined;
     lastSuppressParentNotifications = undefined;
+    lastTrustContext = undefined;
   });
 
   test("wires denySideEffectTools onto the subagent conversation (read-only)", async () => {
@@ -260,6 +265,27 @@ describe("SubagentManager.spawnAndAwait", () => {
     await manager.spawnAndAwait(makeConfig(), () => {});
 
     expect(lastDenySideEffects).toBeUndefined();
+  });
+
+  test("an explicit config trustContext lands on the subagent conversation", async () => {
+    nextConversationConfig = {};
+
+    const manager = new SubagentManager();
+    // No parent conversation is registered here, so inheritance would leave
+    // trust unset — the explicit config value must be applied regardless (the
+    // live-voice continuation path, where the parent's per-turn trust has
+    // already been cleared at spawn time).
+    await manager.spawnAndAwait(
+      makeConfig({
+        trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+      }),
+      () => {},
+    );
+
+    expect(lastTrustContext).toMatchObject({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    });
   });
 
   test("suppresses mid-run parent notifications on the synchronous path", async () => {

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -54,6 +54,11 @@ let runLoopInvoked = false;
 let lastPersistedUserMessage: string | undefined;
 /** Records `setSubagentDenySideEffects` on the most recent FakeConversation. */
 let lastDenySideEffects: boolean | undefined;
+/**
+ * Records `setSubagentSuppressParentNotifications` on the most recent
+ * FakeConversation.
+ */
+let lastSuppressParentNotifications: boolean | undefined;
 /** Options the most recent `bootstrapConversation` call received. */
 let lastBootstrapOptions: Record<string, unknown> | undefined;
 
@@ -99,6 +104,9 @@ class FakeConversation {
   setSubagentDenySideEffects(deny: boolean) {
     lastDenySideEffects = deny;
   }
+  setSubagentSuppressParentNotifications(suppress: boolean) {
+    lastSuppressParentNotifications = suppress;
+  }
   setPreactivatedSkillIds() {}
   getCurrentSystemPrompt() {
     return "system";
@@ -125,7 +133,9 @@ class FakeConversation {
           this.resolveAbort = resolve;
         });
       }
-      if (this.cfg.resolveOnAbort) {return;}
+      if (this.cfg.resolveOnAbort) {
+        return;
+      }
       throw new Error("aborted");
     }
     if (this.cfg.runError) {
@@ -228,6 +238,7 @@ describe("SubagentManager.spawnAndAwait", () => {
   // `undefined` across the opaque spawnAndAwait call.
   beforeEach(() => {
     lastDenySideEffects = undefined;
+    lastSuppressParentNotifications = undefined;
   });
 
   test("wires denySideEffectTools onto the subagent conversation (read-only)", async () => {
@@ -249,6 +260,17 @@ describe("SubagentManager.spawnAndAwait", () => {
     await manager.spawnAndAwait(makeConfig(), () => {});
 
     expect(lastDenySideEffects).toBeUndefined();
+  });
+
+  test("suppresses mid-run parent notifications on the synchronous path", async () => {
+    nextConversationConfig = {};
+
+    const manager = new SubagentManager();
+    await manager.spawnAndAwait(makeConfig(), () => {});
+
+    // The awaiting caller is the child's only parent channel: notify_parent
+    // must not inject a user-role turn into the live parent mid-await.
+    expect(lastSuppressParentNotifications).toBe(true);
   });
 
   test("stamps the parent conversation id on the subagent's conversation", async () => {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -180,8 +180,8 @@ export function getEffectiveEnabledPluginSet(conv: {
 // ── read-only pass classification ────────────────────────────────────
 
 /**
- * The ONLY tools allowed in a read-only subagent pass (the live-voice background
- * continuation, `subagentDenySideEffects`). This is a strict fail-safe allowlist
+ * The ONLY tools allowed in a read-only subagent pass
+ * (`subagentDenySideEffects`). This is a strict fail-safe allowlist
  * of tools known to be read-only. Everything else is refused, because:
  * - A side-effect denylist is inherently incomplete — low-risk core mutators
  *   (`remember`, `notify_parent`, `computer_use_*`, `delete_memory_page`, …) are

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -164,10 +164,7 @@ import { canonicalizeTimeZone } from "./date-context.js";
 import { HostAppControlProxy } from "./host-app-control-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import { shouldAttachHostProxyForCapability } from "./host-proxy-preactivation.js";
-import type {
-  SurfaceType,
-  UsageStats,
-} from "./message-protocol.js";
+import type { SurfaceType, UsageStats } from "./message-protocol.js";
 import { filterMessagesForUntrustedActor } from "./message-provenance.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import { isHostProxyTransport } from "./message-types/conversations.js";
@@ -345,6 +342,15 @@ export class Conversation {
    * @internal
    */
   subagentDenySideEffects?: boolean;
+  /**
+   * When true, mid-run subagent → parent notifications (`notify_parent`) are
+   * suppressed for this child. Set on synchronous (spawnAndAwait) subagents:
+   * the awaiting caller is their only parent channel, so injecting a
+   * user-role turn into the live parent mid-await would start an unsolicited
+   * parent run. Checked in `notifyParentFromChild`.
+   * @internal
+   */
+  subagentSuppressParentNotifications?: boolean;
   /**
    * Tool names a subagent attempted but that its role allowlist
    * ({@link subagentAllowedTools}) denied. Recorded by the tool executor;
@@ -1463,6 +1469,10 @@ export class Conversation {
 
   setSubagentDenySideEffects(deny: boolean): void {
     this.subagentDenySideEffects = deny;
+  }
+
+  setSubagentSuppressParentNotifications(suppress: boolean): void {
+    this.subagentSuppressParentNotifications = suppress;
   }
 
   /**

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 
 import type { TurnDetectorConfig } from "../../calls/media-turn-detector.js";
 import type {
@@ -19,6 +19,7 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+import { __resetRegistryForTesting } from "../../tools/registry.js";
 import type { VoiceFrontDecider } from "../front-decision.js";
 import type { LiveVoiceAudioArchiveResult } from "../live-voice-archive.js";
 import {
@@ -311,6 +312,11 @@ async function flushAsyncCallbacks(): Promise<void> {
 }
 
 describe("LiveVoiceSession server VAD", () => {
+  // The foreground-wins classification consults the tool registry's owner map
+  // (a tool is only provably read-only when it is the trusted built-in);
+  // register the core baseline so built-in names resolve like in the daemon.
+  beforeAll(() => __resetRegistryForTesting());
+
   // The voice-duplex-handoff flag is toggled via the override cache in a few
   // tests below; reset it so it never leaks into the flag-off default cases.
   afterEach(() => clearCachedOverrides());
@@ -1412,10 +1418,10 @@ describe("LiveVoiceSession server VAD", () => {
     resolvers[1]?.("");
   });
 
-  test("voice-duplex-handoff on: a foreground side-effecting tool start aborts an in-flight continuation", async () => {
+  test("voice-duplex-handoff on: a foreground consequential tool start aborts an in-flight continuation", async () => {
     setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
     // Hang the continuation so it is still running when the follow-up turn
-    // starts writing; resolve it when its signal aborts.
+    // starts mutating; resolve it when its signal aborts.
     const spawnBackgroundContinuation = mock(
       (args: {
         parentConversationId: string;
@@ -1458,17 +1464,19 @@ describe("LiveVoiceSession server VAD", () => {
     const signal = spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal;
     expect(signal?.aborted).toBe(false);
 
-    // The follow-up turn starts a side-effecting tool: foreground wins the
+    // The follow-up turn starts a consequential tool: foreground wins the
     // workspace, so the still-running continuation is aborted before the two
-    // can race on writes.
+    // can race on writes. `remember` is deliberately NOT on the core
+    // side-effect name list — the classification must fail closed on any
+    // tool that is not provably read-only, not just named writers.
     const followUp = calls.find((c) => c.content === "second question");
-    followUp?.callbacks?.tool_use_start?.("file_write", {
+    followUp?.callbacks?.tool_use_start?.("remember", {
       toolUseId: "tool-1",
     });
     expect(signal?.aborted).toBe(true);
   });
 
-  test("voice-duplex-handoff on: a foreground read-only tool start leaves the continuation running", async () => {
+  test("voice-duplex-handoff on: a read-only built-in leaves the continuation running; an unclassified tool fails closed", async () => {
     setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
     let abortListenerArmed = false;
     const spawnBackgroundContinuation = mock(
@@ -1508,15 +1516,20 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => abortListenerArmed);
     await waitFor(() => calls.some((c) => c.content === "second question"));
 
-    // A read-only tool cannot contend on the workspace: the continuation
-    // survives (this is the topic-change case the handoff exists for).
+    // A provably read-only built-in cannot contend on the workspace: the
+    // continuation survives (this is the topic-change case the handoff
+    // exists for).
     const followUp = calls.find((c) => c.content === "second question");
     followUp?.callbacks?.tool_use_start?.("file_read", { toolUseId: "tool-1" });
     const signal = spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal;
     expect(signal?.aborted).toBe(false);
 
-    // Cleanup: the interrupt aborts the still-pending continuation.
-    await session.handleClientFrame({ type: "interrupt" });
+    // A tool the registry does not know (e.g. an MCP or plugin tool) is not
+    // provably read-only: fail closed and abort.
+    followUp?.callbacks?.tool_use_start?.("calendar_lookup", {
+      toolUseId: "tool-2",
+    });
+    expect(signal?.aborted).toBe(true);
   });
 
   test("voice-duplex-handoff on: a foreground-wins abort keeps an already-stashed continuation result", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1412,6 +1412,173 @@ describe("LiveVoiceSession server VAD", () => {
     resolvers[1]?.("");
   });
 
+  test("voice-duplex-handoff on: a foreground side-effecting tool start aborts an in-flight continuation", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    // Hang the continuation so it is still running when the follow-up turn
+    // starts writing; resolve it when its signal aborts.
+    const spawnBackgroundContinuation = mock(
+      (args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          args.signal.addEventListener("abort", () => resolve(""), {
+            once: true,
+          });
+        }),
+    );
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge in during thinking: the continuation detaches, the follow-up turn
+    // launches while it is still in flight.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => spawnBackgroundContinuation.mock.calls.length === 1);
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+
+    const signal = spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal;
+    expect(signal?.aborted).toBe(false);
+
+    // The follow-up turn starts a side-effecting tool: foreground wins the
+    // workspace, so the still-running continuation is aborted before the two
+    // can race on writes.
+    const followUp = calls.find((c) => c.content === "second question");
+    followUp?.callbacks?.tool_use_start?.("file_write", {
+      toolUseId: "tool-1",
+    });
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("voice-duplex-handoff on: a foreground read-only tool start leaves the continuation running", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    let abortListenerArmed = false;
+    const spawnBackgroundContinuation = mock(
+      (args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          abortListenerArmed = true;
+          args.signal.addEventListener("abort", () => resolve(""), {
+            once: true,
+          });
+        }),
+    );
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => abortListenerArmed);
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+
+    // A read-only tool cannot contend on the workspace: the continuation
+    // survives (this is the topic-change case the handoff exists for).
+    const followUp = calls.find((c) => c.content === "second question");
+    followUp?.callbacks?.tool_use_start?.("file_read", { toolUseId: "tool-1" });
+    const signal = spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal;
+    expect(signal?.aborted).toBe(false);
+
+    // Cleanup: the interrupt aborts the still-pending continuation.
+    await session.handleClientFrame({ type: "interrupt" });
+  });
+
+  test("voice-duplex-handoff on: a foreground-wins abort keeps an already-stashed continuation result", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    let resolveContinuation: ((result: string) => void) | undefined;
+    const spawnBackgroundContinuation = mock(
+      (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          resolveContinuation = resolve;
+        }),
+    );
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question", "third question"],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge in; the follow-up turn launches, then the continuation finishes
+    // and stashes its answer for the NEXT turn while the follow-up still runs.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => resolveContinuation !== undefined);
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+    resolveContinuation?.("THE_RESULT");
+    await flushAsyncCallbacks();
+
+    // The follow-up turn starts writing: the foreground-wins abort fires, but
+    // a completed continuation's stashed answer cannot race anything and is
+    // kept.
+    const followUp = calls.find((c) => c.content === "second question");
+    followUp?.callbacks?.tool_use_start?.("file_write", {
+      toolUseId: "tool-1",
+    });
+    followUp?.callbacks?.assistant_text_delta?.(makeTextDelta("ok"));
+    followUp?.callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The next turn still folds the stashed answer in as context.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const resurfaced = calls.find((c) => c.content === "third question");
+    expect(resurfaced?.voiceControlPrompt).toContain("THE_RESULT");
+  });
+
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1533,10 +1533,18 @@ describe("LiveVoiceSession server VAD", () => {
     const signal = spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal;
     expect(signal?.aborted).toBe(false);
 
+    // skill_load is non-contending too: it only registers tool definitions,
+    // and it is the first call of a follow-up turn that re-enters the skill
+    // the interrupted turn was using — it must not kill the continuation.
+    followUp?.callbacks?.tool_use_start?.("skill_load", {
+      toolUseId: "tool-2",
+    });
+    expect(signal?.aborted).toBe(false);
+
     // A tool the registry does not know (e.g. an MCP or plugin tool) is not
     // provably read-only: fail closed and abort.
     followUp?.callbacks?.tool_use_start?.("calendar_lookup", {
-      toolUseId: "tool-2",
+      toolUseId: "tool-3",
     });
     expect(signal?.aborted).toBe(true);
   });

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1328,8 +1328,13 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => calls.some((c) => c.content === "second question"));
     // Barge #2 is a rapid second interruption: it bumps the sequence
     // synchronously, so A is invalidated even before barge #2's own async detach
-    // runs.
+    // runs — and A's run itself is ABORTED, so a still-writing older
+    // continuation can never overlap the newer full-ability one.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () =>
+        spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal.aborted === true,
+    );
     // A finishes AFTER barge #2 and must be rejected. The newer continuation is
     // left pending so it can't mask the bug by superseding A itself.
     resolvers[0]?.("OLDER_RESULT");
@@ -1345,8 +1350,12 @@ describe("LiveVoiceSession server VAD", () => {
       "background you finished",
     );
 
-    // Cleanup the still-pending newer continuation.
+    // The newer continuation was not collateral damage of superseding A.
     await waitFor(() => resolvers.length === 2);
+    expect(spawnBackgroundContinuation.mock.calls[1]?.[0]?.signal.aborted).toBe(
+      false,
+    );
+    // Cleanup the still-pending newer continuation.
     resolvers[1]?.("");
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1541,10 +1541,20 @@ describe("LiveVoiceSession server VAD", () => {
     });
     expect(signal?.aborted).toBe(false);
 
-    // A tool the registry does not know (e.g. an MCP or plugin tool) is not
-    // provably read-only: fail closed and abort.
-    followUp?.callbacks?.tool_use_start?.("calendar_lookup", {
+    // web_fetch is a network read: it cannot corrupt local state, so it does
+    // not contend even though it is on the core SIDE_EFFECT_TOOLS list (which
+    // exists for a permission question, not a contention one). This is the
+    // canonical topic-change case — "what's the weather?" over a running
+    // build — and it is exactly what the handoff exists to keep alive.
+    followUp?.callbacks?.tool_use_start?.("web_fetch", {
       toolUseId: "tool-3",
+    });
+    expect(signal?.aborted).toBe(false);
+
+    // A tool the registry does not know (e.g. an MCP or plugin tool) is not
+    // provably non-contending: fail closed and abort.
+    followUp?.callbacks?.tool_use_start?.("calendar_lookup", {
+      toolUseId: "tool-4",
     });
     expect(signal?.aborted).toBe(true);
   });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1509,7 +1509,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // result is dropped with them so the barge-in follow-up (or any later)
     // turn can't consume an older answer before this barge-in's own
     // continuation completes. This barge-in's detach snapshots the stop
-    // generation AFTER this bump (below), so it is unaffected.
+    // generation AFTER this bump (below), so it is unaffected. The abort is
+    // signal-level, with the same accepted residual as the foreground-wins
+    // gate (see the tool_use_start handler): a tool call already executing in
+    // the superseded run is not awaited. The replacement's detach still waits
+    // out the interrupted TURN's teardown before forking, which bounds the
+    // overlap to that one abandoned call.
     this.abortDetachedRuns();
     // Order this barge-in among concurrent detaches SYNCHRONOUSLY, in barge
     // order — the actual detach runs after an async teardown chain, and those

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2933,6 +2933,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // drops a best-effort salvage; under-aborting risks a write race.
             // An already-completed continuation's stashed answer is kept — it
             // cannot race anything.
+            //
+            // Accepted residual: the abort is signal-level. A tool call
+            // already executing inside the continuation is not awaited (the
+            // agent loop abandons the in-flight promise on cancellation), so
+            // that one call can briefly overlap the foreground tool. Closing
+            // it would take a cross-conversation execution lock that the
+            // subagent model deliberately does not have — parallel subagents
+            // share the workspace with the parent everywhere — and awaiting
+            // background teardown here would stall the live call's turn.
+            // This gate already makes voice stricter than that baseline; the
+            // residual is bounded to one in-flight call at barge-over time.
             if (
               toolName === "skill_execute" ||
               isRefusedInReadOnlyPass(toolName, getToolOwner(toolName)?.kind)

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -665,14 +665,24 @@ function buildDuplexContinuationObjective(interruptedRequest: string): string {
 // re-enters the skill the interrupted turn was using, so counting it as
 // consequential would kill nearly every continuation doing skill-based work
 // at the moment it matters most.
+// `web_fetch` sits on the core SIDE_EFFECT_TOOLS list because an UNATTENDED
+// run firing off external requests is a permission concern — a different
+// question from this gate's, which is only "can these two writers corrupt the
+// same local state?". A network read cannot, so it does not contend.
 const FOREGROUND_NON_CONTENDING_TOOLS: ReadonlySet<string> = new Set([
   "skill_load",
+  "web_fetch",
 ]);
 
 // Foreground-wins classification: does this foreground tool start force the
-// running continuations to be aborted? Fail closed — anything that is not a
-// provably read-only or non-contending BUILT-IN contends. `skill_execute`
-// always contends: it is a dispatcher whose resolved inner tool can mutate.
+// running continuations to be aborted? The question is LOCAL-STATE
+// CONTENTION ("could these two writers corrupt the same workspace, host, or
+// extension state?"), NOT permission — this gate never affects what a tool is
+// allowed to do. Fail closed anyway: anything that is not a provably
+// non-contending BUILT-IN contends, because skill/plugin/MCP/workspace tools
+// carry no "writes local state" metadata and some of them (app_*, document_*)
+// very much do. `skill_execute` always contends: it is a dispatcher whose
+// resolved inner tool can mutate.
 function foregroundToolContendsWithContinuation(toolName: string): boolean {
   if (toolName === "skill_execute") {
     return true;
@@ -1012,7 +1022,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.turnDetector?.dispose();
     this.clearEndpointExtensionTimer();
     this.stopSessionTranscriber();
-    this.abortDetachedRuns();
+    this.abortDetachedRuns({ reason: "session_closed" });
     await this.cancelAssistantTurn("session_closed");
     if (shouldEmitSessionEndMetrics) {
       await this.emitSessionEndMetrics();
@@ -1543,7 +1553,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // the superseded run is not awaited. The replacement's detach still waits
     // out the interrupted TURN's teardown before forking, which bounds the
     // overlap to that one abandoned call.
-    this.abortDetachedRuns();
+    this.abortDetachedRuns({ reason: "superseded_by_new_barge_in" });
     // Order this barge-in among concurrent detaches SYNCHRONOUSLY, in barge
     // order — the actual detach runs after an async teardown chain, and those
     // chains can interleave, so bumping there could assign sequences out of
@@ -1569,6 +1579,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Snapshot the stop generation before the async teardown: a stop that lands
     // during it must cancel the pending detach (checked in detachInterruptedTurn).
     const stopGeneration = this.detachStopGeneration;
+    log.info(
+      {
+        turnId: turn.turnId,
+        detachSeq,
+        // The two facts that decide whether a continuation is even eligible.
+        assistantCompleted: turn.assistantCompleted,
+        hasTeardownWait: teardownWait !== undefined,
+      },
+      "Voice barge-in cancelled a turn",
+    );
     void (async () => {
       await this.finishMetricsTurn(
         turn.utterance,
@@ -1604,18 +1624,41 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     detachSeq: number,
   ): void {
     const spawn = this.spawnBackgroundContinuation;
-    if (
-      !spawn ||
-      this.isClosed ||
-      // The model already finished generating (barge-in during TTS playback of a
-      // complete reply): there is nothing to continue, so a continuation would
-      // just re-do a finished answer.
-      turn.assistantCompleted ||
-      // A stop (interrupt/close) landed during the barge-in teardown: honor it
-      // and do not start the continuation.
-      this.detachStopGeneration !== stopGeneration ||
-      !isAssistantFeatureFlagEnabled("voice-duplex-handoff", getConfig())
-    ) {
+    // Every skip is logged with its reason — the handoff is silent by design,
+    // so without this a dropped continuation is indistinguishable from a
+    // never-attempted one (tail with: grep -i "voice duplex").
+    const skipReason = !spawn
+      ? "no_spawner"
+      : this.isClosed
+        ? "session_closed"
+        : // The model already finished generating (barge-in during TTS playback
+          // of a complete reply): there is nothing to continue, so a
+          // continuation would just re-do a finished answer.
+          turn.assistantCompleted
+          ? "assistant_already_completed"
+          : // A stop (interrupt/close) or a superseding invalidation landed
+            // during the barge-in teardown: honor it.
+            this.detachStopGeneration !== stopGeneration
+            ? "invalidated_during_barge_teardown"
+            : !isAssistantFeatureFlagEnabled(
+                  "voice-duplex-handoff",
+                  getConfig(),
+                )
+              ? "flag_disabled"
+              : null;
+    if (skipReason !== null || !spawn) {
+      // debug for the always-off configurations, info for the dynamic skips.
+      if (skipReason === "flag_disabled" || skipReason === "no_spawner") {
+        log.debug(
+          { turnId: turn.turnId, skipReason },
+          "Voice duplex continuation skipped",
+        );
+      } else {
+        log.info(
+          { turnId: turn.turnId, skipReason },
+          "Voice duplex continuation skipped",
+        );
+      }
       return;
     }
     // Embed the interrupted request in the objective so the continuation knows
@@ -1629,6 +1672,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // controller.abort(), which the spawn's signal wiring honors).
     const controller = new AbortController();
     this.detachControllers.add(controller);
+    const detachStartedAtMs = Date.now();
     void (async () => {
       try {
         // Wait for the interrupted turn's teardown to settle its partial into
@@ -1656,12 +1700,41 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           // The continuation is best-effort, so a rare dropped one is the safe
           // trade.
           if (!settled) {
+            log.info(
+              {
+                turnId: turn.turnId,
+                skipReason: controller.signal.aborted
+                  ? "invalidated_during_teardown_wait"
+                  : "teardown_settle_timeout",
+                waitedMs: Date.now() - detachStartedAtMs,
+                timeoutMs: this.detachTeardownSettleTimeoutMs,
+              },
+              "Voice duplex continuation skipped",
+            );
             return;
           }
         }
         if (controller.signal.aborted || this.isClosed) {
+          log.info(
+            {
+              turnId: turn.turnId,
+              skipReason: this.isClosed
+                ? "session_closed"
+                : "invalidated_before_spawn",
+              waitedMs: Date.now() - detachStartedAtMs,
+            },
+            "Voice duplex continuation skipped",
+          );
           return;
         }
+        log.info(
+          {
+            turnId: turn.turnId,
+            teardownWaitMs: Date.now() - detachStartedAtMs,
+            interruptedRequest,
+          },
+          "Voice duplex continuation starting",
+        );
         const resultText = await spawn({
           parentConversationId: this.conversationId,
           objective: buildDuplexContinuationObjective(interruptedRequest),
@@ -1675,20 +1748,37 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // barge-in has started, an older continuation completing (before or
         // after it, empty or not) can't surface a stale answer. Only non-empty
         // text is actually surfaced.
-        if (
+        const stillCurrent =
           !controller.signal.aborted &&
           !this.isClosed &&
           this.detachStopGeneration === stopGeneration &&
-          detachSeq === this.detachSequence
-        ) {
+          detachSeq === this.detachSequence;
+        if (stillCurrent) {
           const answer = resultText.trim();
           this.pendingContinuationResult = answer.length > 0 ? answer : null;
         }
+        log.info(
+          {
+            turnId: turn.turnId,
+            ranMs: Date.now() - detachStartedAtMs,
+            resultChars: resultText.trim().length,
+            // false = it finished, but a stop/interrupt or a newer barge-in
+            // landed while it ran, so its answer is dropped rather than
+            // folded into the next turn.
+            resultStashed: stillCurrent && resultText.trim().length > 0,
+          },
+          "Voice duplex continuation finished",
+        );
       } catch (err) {
         // A stop/interrupt aborts via the signal; that rejection is expected.
-        if (!controller.signal.aborted) {
+        if (controller.signal.aborted) {
+          log.info(
+            { turnId: turn.turnId, ranMs: Date.now() - detachStartedAtMs },
+            "Voice duplex continuation aborted mid-run",
+          );
+        } else {
           log.warn(
-            { err, turnId: turn.turnId },
+            { err, turnId: turn.turnId, ranMs: Date.now() - detachStartedAtMs },
             "Voice duplex handoff continuation failed",
           );
         }
@@ -1707,7 +1797,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // detaches must be skipped), but an already-completed continuation's stashed
   // answer stays — it cannot race anything, and the next turn's "use only if
   // relevant" framing makes a stale one harmless.
-  private abortDetachedRuns(opts?: { keepPendingResult?: boolean }): void {
+  private abortDetachedRuns(opts?: {
+    keepPendingResult?: boolean;
+    // Why the runs are being invalidated, for the log line below. Every
+    // caller passes one: an unexplained dead continuation is the single
+    // hardest thing to debug about this feature.
+    reason?: string;
+    // The foreground tool whose start tripped the contention gate, if any.
+    toolName?: string;
+  }): void {
+    const aborted = this.detachControllers.size;
+    const hadPendingResult = this.pendingContinuationResult !== null;
+    if (aborted > 0 || hadPendingResult) {
+      log.info(
+        {
+          conversationId: this.conversationId,
+          reason: opts?.reason ?? "unspecified",
+          ...(opts?.toolName ? { toolName: opts.toolName } : {}),
+          abortedRuns: aborted,
+          droppedPendingResult: hadPendingResult && !opts?.keepPendingResult,
+        },
+        "Voice duplex continuations invalidated",
+      );
+    }
     // Bump the generation so a barge-in whose async teardown is still in flight
     // (its detach not yet spawned) sees the stop and skips the continuation.
     this.detachStopGeneration += 1;
@@ -2439,7 +2551,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // without ever reaching finalizePendingUtterance).
     this.pendingInterruptedRequest = null;
     // ...and it hard-stops any detached background continuations.
-    this.abortDetachedRuns();
+    this.abortDetachedRuns({ reason: "client_interrupt" });
     const utterance = this.currentUtterance;
     this.stopSessionTranscriber();
     if (utterance) {
@@ -2985,7 +3097,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // This gate already makes voice stricter than that baseline; the
             // residual is bounded to one in-flight call at barge-over time.
             if (foregroundToolContendsWithContinuation(toolName)) {
-              this.abortDetachedRuns({ keepPendingResult: true });
+              this.abortDetachedRuns({
+                keepPendingResult: true,
+                reason: "foreground_tool_contends",
+                toolName,
+              });
             }
             // The op counts toward the narration threshold on start (not
             // completion) so a burst of slow tools still trips the ops

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -39,6 +39,7 @@ import {
 } from "../config/schemas/live-voice.js";
 import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { findConversation } from "../daemon/conversation-registry.js";
+import { isRefusedInReadOnlyPass } from "../daemon/conversation-tool-setup.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
@@ -54,7 +55,7 @@ import type {
   SttStreamServerEvent,
 } from "../stt/types.js";
 import { getSubagentManager } from "../subagent/index.js";
-import { isSideEffectTool } from "../tools/side-effects.js";
+import { getToolOwner } from "../tools/registry.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
@@ -2920,13 +2921,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             current.toolUseStarted = true;
             // Foreground wins the workspace: the continuation runs with full
             // subagent abilities (it can write files, run commands), so the
-            // moment a live turn starts a side-effecting tool the two could
-            // race on the same workspace. Kill running continuations and skip
-            // pending detaches; a continuation only survives while foreground
-            // turns stay read-only (the topic-change case it exists for). An
-            // already-completed continuation's stashed answer is kept — it
+            // moment a live turn starts a consequential tool the two could
+            // race on the same workspace, host, or extension state. Kill
+            // running continuations and skip pending detaches; a continuation
+            // only survives while foreground turns stay provably read-only
+            // (the topic-change case it exists for). Fail closed: only the
+            // built-in read-only allowlist keeps a continuation alive — a
+            // name-based side-effect denylist misses mutators like plugin/
+            // MCP/skill tools — and `skill_execute` counts as consequential
+            // because its resolved inner tool can mutate. Over-aborting only
+            // drops a best-effort salvage; under-aborting risks a write race.
+            // An already-completed continuation's stashed answer is kept — it
             // cannot race anything.
-            if (isSideEffectTool(toolName)) {
+            if (
+              toolName === "skill_execute" ||
+              isRefusedInReadOnlyPass(toolName, getToolOwner(toolName)?.kind)
+            ) {
               this.abortDetachedRuns({ keepPendingResult: true });
             }
             // The op counts toward the narration threshold on start (not

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -38,7 +38,6 @@ import {
   LiveVoiceFrontModelConfigSchema,
 } from "../config/schemas/live-voice.js";
 import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
-import { findConversation } from "../daemon/conversation-registry.js";
 import { isRefusedInReadOnlyPass } from "../daemon/conversation-tool-setup.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
@@ -657,6 +656,35 @@ function buildDuplexContinuationObjective(interruptedRequest: string): string {
   return interruptedRequest.length > 0
     ? `${base} Their request was: "${interruptedRequest}".`
     : base;
+}
+
+// Built-ins beyond the strict read-only allowlist that cannot contend with a
+// background continuation's writes: they touch no workspace, host, or
+// extension state. `skill_load` reads skill files and registers tool
+// definitions — and it is the FIRST call of a barge-in follow-up that
+// re-enters the skill the interrupted turn was using, so counting it as
+// consequential would kill nearly every continuation doing skill-based work
+// at the moment it matters most.
+const FOREGROUND_NON_CONTENDING_TOOLS: ReadonlySet<string> = new Set([
+  "skill_load",
+]);
+
+// Foreground-wins classification: does this foreground tool start force the
+// running continuations to be aborted? Fail closed — anything that is not a
+// provably read-only or non-contending BUILT-IN contends. `skill_execute`
+// always contends: it is a dispatcher whose resolved inner tool can mutate.
+function foregroundToolContendsWithContinuation(toolName: string): boolean {
+  if (toolName === "skill_execute") {
+    return true;
+  }
+  const ownerKind = getToolOwner(toolName)?.kind;
+  if (
+    FOREGROUND_NON_CONTENDING_TOOLS.has(toolName) &&
+    ownerKind === "default"
+  ) {
+    return false;
+  }
+  return isRefusedInReadOnlyPass(toolName, ownerKind);
 }
 
 // Upper bound on how long a barge-in waits for the interrupted turn's teardown
@@ -2937,12 +2965,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // race on the same workspace, host, or extension state. Kill
             // running continuations and skip pending detaches; a continuation
             // only survives while foreground turns stay provably read-only
-            // (the topic-change case it exists for). Fail closed: only the
-            // built-in read-only allowlist keeps a continuation alive — a
-            // name-based side-effect denylist misses mutators like plugin/
-            // MCP/skill tools — and `skill_execute` counts as consequential
-            // because its resolved inner tool can mutate. Over-aborting only
-            // drops a best-effort salvage; under-aborting risks a write race.
+            // (the topic-change case it exists for). Fail closed: only
+            // provably non-contending built-ins keep a continuation alive
+            // (see foregroundToolContendsWithContinuation) — a name-based
+            // side-effect denylist misses mutators like plugin/MCP/skill
+            // tools. Over-aborting only drops a best-effort salvage;
+            // under-aborting risks a write race.
             // An already-completed continuation's stashed answer is kept — it
             // cannot race anything.
             //
@@ -2956,10 +2984,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // background teardown here would stall the live call's turn.
             // This gate already makes voice stricter than that baseline; the
             // residual is bounded to one in-flight call at barge-over time.
-            if (
-              toolName === "skill_execute" ||
-              isRefusedInReadOnlyPass(toolName, getToolOwner(toolName)?.kind)
-            ) {
+            if (foregroundToolContendsWithContinuation(toolName)) {
               this.abortDetachedRuns({ keepPendingResult: true });
             }
             // The op counts toward the narration threshold on start (not
@@ -4503,12 +4528,32 @@ async function defaultSpawnBackgroundContinuation(args: {
   label: string;
   signal: AbortSignal;
 }): Promise<string> {
-  const parentConversation = findConversation(args.parentConversationId);
-  if (!parentConversation) {
-    throw new Error(
-      `Cannot detach interrupted voice turn: conversation ${args.parentConversationId} is not resident.`,
-    );
+  // getOrCreateConversation (not a raw registry read): it rebuilds a stale
+  // instance and awaits loadFromDb, so the snapshot below sees the persisted
+  // history. A raw findConversation can return a cold instance whose in-memory
+  // `messages` is empty, which silently forks a continuation with no context.
+  const { getOrCreateConversation } =
+    await import("../daemon/conversation-store.js");
+  const parentConversation = await getOrCreateConversation(
+    args.parentConversationId,
+  );
+  // Belt-and-suspenders for a resident-but-unhydrated instance: the teardown
+  // settle that gated this spawn guarantees the interrupted turn's partial is
+  // persisted, so an empty in-memory history on a conversation that has rows
+  // means the instance is cold — hydrate before snapshotting. A genuinely new
+  // conversation loads zero rows; harmless.
+  if (parentConversation.getMessages().length === 0) {
+    await parentConversation.loadFromDb();
   }
+  // The bridge stamps trust per-turn and clears it at teardown, which has
+  // settled by now — inheriting from the parent would read the cleared window
+  // and run the continuation fail-closed as `unknown`, denying every
+  // consequential tool. Resolve the same guardian trust the foreground turn
+  // ran under and pass it explicitly (resolution itself stays fail-closed:
+  // on a miss the continuation runs as `unknown`, exactly as before).
+  const trustContext = await resolveLocalLiveVoiceTrustContext(
+    args.parentConversationId,
+  );
   return await getSubagentManager().spawnAndAwait(
     {
       parentConversationId: args.parentConversationId,
@@ -4519,14 +4564,15 @@ async function defaultSpawnBackgroundContinuation(args: {
       // Full subagent abilities: the continuation runs like any other
       // background subagent, so it can genuinely finish build-shaped work
       // (JARVIS-1354). Side effects are governed by the standard
-      // non-interactive permission path via the inherited trust context —
-      // auto-approved up to the background risk threshold, auto-denied above
-      // it — the same policy the foreground voice turn it continues ran
-      // under. Workspace write races with the user's next foreground turn
-      // are prevented by the session's foreground-wins abort (a
-      // side-effecting tool start on a live turn aborts running
+      // non-interactive permission path under the explicit trust context
+      // resolved above — auto-approved up to the background risk threshold,
+      // auto-denied above it — the same policy the foreground voice turn it
+      // continues ran under. Workspace write races with the user's next
+      // foreground turn are prevented by the session's foreground-wins abort
+      // (a side-effecting tool start on a live turn aborts running
       // continuations; see the tool_use_start handler).
-      parentMessages: [...parentConversation.messages],
+      ...(trustContext ? { trustContext } : {}),
+      parentMessages: [...parentConversation.getMessages()],
       parentSystemPrompt: parentConversation.getCurrentSystemPrompt(),
     },
     // No client-facing events: the continuation is silent; its result is folded

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -693,9 +693,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // synchronously before its spawn, so interrupt()/close() abort a continuation
   // even if a stop lands while it is still spawning.
   private readonly detachControllers = new Set<AbortController>();
-  // Bumped whenever a stop (interrupt/close) fires. A barge-in captures this
-  // before its async teardown; if it has changed by the time the detach would
-  // spawn, a stop landed during the gap and the continuation is not started.
+  // Bumped whenever detached runs are invalidated: a stop (interrupt/close),
+  // a newer barge-in superseding them, or a foreground-wins abort. A barge-in
+  // captures this (after its own bump) before its async teardown; if it has
+  // changed by the time the detach would spawn, an invalidation landed during
+  // the gap and the continuation is not started.
   private detachStopGeneration = 0;
   // Bumped SYNCHRONOUSLY at each barge-in (in barge order), before the async
   // detach runs. Only the latest-started detach (detachSeq === detachSequence)
@@ -1500,11 +1502,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       .trim();
     this.pendingInterruptedRequest =
       interruptedRequest.length > 0 ? interruptedRequest : null;
-    // A fresh interruption supersedes any already-stashed continuation result:
-    // drop it synchronously here so the barge-in follow-up (or any later) turn
-    // can't consume an older answer before this barge-in's own continuation
-    // completes. Cleared even when no continuation ultimately detaches.
-    this.pendingContinuationResult = null;
+    // A fresh interruption supersedes every earlier detached run, not just its
+    // stashed result: abort still-running continuations (and skip pending
+    // detaches) before this barge-in's own continuation can launch, so two
+    // full-ability background writers never share the workspace. The stashed
+    // result is dropped with them so the barge-in follow-up (or any later)
+    // turn can't consume an older answer before this barge-in's own
+    // continuation completes. This barge-in's detach snapshots the stop
+    // generation AFTER this bump (below), so it is unaffected.
+    this.abortDetachedRuns();
     // Order this barge-in among concurrent detaches SYNCHRONOUSLY, in barge
     // order — the actual detach runs after an async teardown chain, and those
     // chains can interleave, so bumping there could assign sequences out of
@@ -1660,8 +1666,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   // Abort every background continuation this session started and drop its
-  // handle. A client interrupt or session close is a hard stop for detached
-  // work; the continuation's own `.finally` removes it from the set too.
+  // handle. Called on a hard stop (client interrupt / session close), when a
+  // newer barge-in supersedes the detached runs, and on a foreground-wins
+  // abort; the continuation's own `.finally` removes it from the set too.
   // `keepPendingResult` is the foreground-wins variant: the foreground turn is
   // claiming the workspace, so running continuations must die (and pending
   // detaches must be skipped), but an already-completed continuation's stashed

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -46,6 +46,7 @@ import {
   supportsBoundary,
 } from "../providers/speech-to-text/provider-catalog.js";
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { publishConversationListAndMetadataChanged } from "../runtime/sync/resource-sync-events.js";
 import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
 import type {
@@ -483,6 +484,10 @@ interface ActiveAssistantTurn {
   // or reference it in reply to the user, without ever speaking it unprompted.
   // Null when no continuation result is pending for this turn.
   continuationResult: string | null;
+  // Set when a barge-in handed the interrupted work to a background subagent:
+  // that request's transcript, so the model can tell the user the work is
+  // still running instead of appearing to have dropped it.
+  handedOffRequest: string | null;
   // The agent run started a definitive tool use this turn — tool use implies
   // a guaranteed-slow turn, so acknowledgment logic can key off this.
   toolUseStarted: boolean;
@@ -621,6 +626,18 @@ function buildResurfaceContextNote(continuationResult: string): string {
   return `Earlier the user interrupted you, and in the background you finished the reply they cut off. What you worked out was: "${continuationResult}". If their current message relates to it, use it to answer; otherwise you may briefly offer it or leave it aside, and do not repeat it verbatim if it no longer fits.`;
 }
 
+// Appended to the turn that follows a barge-in whose interrupted work was
+// handed to a background subagent. Without this the assistant simply stops
+// talking about the request it was mid-way through, and the user has no way to
+// know the work survived — it reads as dropped. The model decides whether to
+// mention it, because only it can tell "keep working on that" (the foreground
+// turn continues the same work, so announcing a background copy would be
+// confusing) from a genuine topic change (where "I'm still working on that in
+// the background" is exactly what the user needs to hear).
+function buildHandoffAnnouncementNote(handedOffRequest: string): string {
+  return `You handed your unfinished work on "${handedOffRequest}" to a background task, which is still running. If the user has moved to a different topic, briefly let them know you are still working on it in the background before answering them. If they are asking you to continue that same work, just continue and do not mention the background task.`;
+}
+
 // Assemble a leg's model-facing control prompt: the base live-voice rules,
 // the [-1] minimize teaching (withheld from the front-door leg — see
 // LIVE_VOICE_MINIMIZE_MARKER_TEACHING), the shared no-setup-flows rule, plus
@@ -641,7 +658,26 @@ function buildVoiceControlPrompt(
   if (turn.continuationResult) {
     prompt = `${prompt}\n\n${buildResurfaceContextNote(turn.continuationResult)}`;
   }
+  if (turn.handedOffRequest) {
+    prompt = `${prompt}\n\n${buildHandoffAnnouncementNote(turn.handedOffRequest)}`;
+  }
   return prompt;
+}
+
+// Delivered into the conversation when a continuation finishes AFTER the voice
+// session ended. There is no next voice turn to fold into, so this lands as a
+// normal turn in the thread — where the user actually goes looking for the
+// work. Framed as a system-style report rather than a user request so the
+// reply reads as "here is what I finished", not a fresh instruction.
+function buildClosedSessionDeliveryPrompt(
+  interruptedRequest: string,
+  answer: string,
+): string {
+  const what =
+    interruptedRequest.length > 0
+      ? `their earlier request ("${interruptedRequest}")`
+      : "their earlier request";
+  return `[Background work finished] The voice call ended while you were still finishing ${what} in the background. You have now finished it. Tell the user briefly that it is done and give them the result. Do not re-run any tool calls; the work is already complete. What you produced was:\n\n${answer}`;
 }
 
 // Objective handed to the background subagent that continues a barged-in turn.
@@ -798,6 +834,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // starts as context. Consumed (and cleared) when that turn launches; cleared
   // on a hard stop (abortDetachedRuns) so a stale result never surfaces later.
   private pendingContinuationResult: string | null = null;
+  // Set when a continuation actually spawns: the request it took over, so the
+  // NEXT turn can tell the user the work is still running. Consumed by that
+  // turn; cleared when the continuation finishes (by then the result note
+  // takes over and "still running" would be stale).
+  private pendingHandoffRequest: string | null = null;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -1022,7 +1063,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.turnDetector?.dispose();
     this.clearEndpointExtensionTimer();
     this.stopSessionTranscriber();
-    this.abortDetachedRuns({ reason: "session_closed" });
+    // Deliberately NOT aborting detached continuations: outliving the call is
+    // the entire premise of the handoff. Hanging up used to destroy the work
+    // the user had just asked to keep — and the natural test sequence (barge
+    // in, hear the answer, close the room, go look for the result) hit that
+    // every time. A deliberate `interrupt()` still aborts; ending the session
+    // does not. With no next voice turn to fold into, a continuation that
+    // finishes after this point delivers into the conversation instead (see
+    // the completion handler in detachInterruptedTurn).
     await this.cancelAssistantTurn("session_closed");
     if (shouldEmitSessionEndMetrics) {
       await this.emitSessionEndMetrics();
@@ -1714,13 +1762,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             return;
           }
         }
-        if (controller.signal.aborted || this.isClosed) {
+        // A closed session is NOT a reason to skip: the work outlives the
+        // call, and its result is delivered into the conversation below.
+        // Only an explicit invalidation (stop/interrupt/supersede) stops it.
+        if (controller.signal.aborted) {
           log.info(
             {
               turnId: turn.turnId,
-              skipReason: this.isClosed
-                ? "session_closed"
-                : "invalidated_before_spawn",
+              skipReason: "invalidated_before_spawn",
               waitedMs: Date.now() - detachStartedAtMs,
             },
             "Voice duplex continuation skipped",
@@ -1735,6 +1784,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           },
           "Voice duplex continuation starting",
         );
+        // The next turn tells the user this is still running. Set before the
+        // await so a follow-up turn launching during the run picks it up.
+        this.pendingHandoffRequest =
+          interruptedRequest.length > 0 ? interruptedRequest : null;
         const resultText = await spawn({
           parentConversationId: this.conversationId,
           objective: buildDuplexContinuationObjective(interruptedRequest),
@@ -1748,24 +1801,46 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // barge-in has started, an older continuation completing (before or
         // after it, empty or not) can't surface a stale answer. Only non-empty
         // text is actually surfaced.
-        const stillCurrent =
+        this.pendingHandoffRequest = null;
+        const answer = resultText.trim();
+        const notInvalidated =
           !controller.signal.aborted &&
-          !this.isClosed &&
           this.detachStopGeneration === stopGeneration &&
           detachSeq === this.detachSequence;
-        if (stillCurrent) {
-          const answer = resultText.trim();
+        // Two destinations, decided by whether a next voice turn still exists.
+        // Live session: stash for that turn's control prompt (never spoken
+        // unprompted). Session closed: there is no next turn, so deliver into
+        // the conversation — the call is over, nobody is being talked over,
+        // and the thread is exactly where the user goes looking for the work.
+        const deliverToConversation =
+          notInvalidated && this.isClosed && answer.length > 0;
+        if (notInvalidated && !this.isClosed) {
           this.pendingContinuationResult = answer.length > 0 ? answer : null;
+        }
+        if (deliverToConversation) {
+          const { injectMessageIntoParent } =
+            await import("../subagent/notify.js");
+          injectMessageIntoParent(
+            this.conversationId,
+            buildClosedSessionDeliveryPrompt(interruptedRequest, answer),
+          );
         }
         log.info(
           {
             turnId: turn.turnId,
             ranMs: Date.now() - detachStartedAtMs,
-            resultChars: resultText.trim().length,
-            // false = it finished, but a stop/interrupt or a newer barge-in
-            // landed while it ran, so its answer is dropped rather than
-            // folded into the next turn.
-            resultStashed: stillCurrent && resultText.trim().length > 0,
+            resultChars: answer.length,
+            // Where the answer went. "stashed" = folded into the next voice
+            // turn; "conversation" = the call had ended, so it was delivered
+            // into the thread; "dropped" = a stop/interrupt or a newer
+            // barge-in landed while it ran.
+            resultDestination: !notInvalidated
+              ? "dropped"
+              : answer.length === 0
+                ? "empty"
+                : this.isClosed
+                  ? "conversation"
+                  : "stashed",
           },
           "Voice duplex continuation finished",
         );
@@ -2657,9 +2732,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.pendingInterruptedRequest = null;
     const continuationResult = this.pendingContinuationResult;
     this.pendingContinuationResult = null;
+    const handedOffRequest = this.pendingHandoffRequest;
+    this.pendingHandoffRequest = null;
     await this.launchAssistantTurn(utterance, content, {
       interruptedRequest,
       continuationResult,
+      handedOffRequest,
     });
   }
 
@@ -2675,6 +2753,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Set when a background continuation finished the interrupted reply: its
       // answer, appended to the turn's control prompt as context.
       continuationResult?: string | null;
+      // Set when a barge-in handed this request's work to a background
+      // subagent, so the model can say it is still running.
+      handedOffRequest?: string | null;
       // Unified front-door: dispatch without releasing the utterance. The
       // thinking frame and floor-holding timers are deferred until the leg's
       // leading verdict commits the turn (see commitSpeculativeTurn); a hold
@@ -2725,6 +2806,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       speculativeBuffer: "",
       interruptedRequest: opts?.interruptedRequest ?? null,
       continuationResult: opts?.continuationResult ?? null,
+      handedOffRequest: opts?.handedOffRequest ?? null,
       toolUseStarted: false,
       firstDeltaSeen: false,
       deltaEpoch: 0,
@@ -4691,9 +4773,20 @@ async function defaultSpawnBackgroundContinuation(args: {
       parentMessages: [...parentConversation.getMessages()],
       parentSystemPrompt: parentConversation.getCurrentSystemPrompt(),
     },
-    // No client-facing events: the continuation is silent; its result is folded
-    // into the next user turn as context, never spoken on its own.
-    () => {},
+    // Broadcast subagent events to clients attached to this conversation so
+    // the continuation appears in the UI like any other handoff — a background
+    // run the user cannot see reads as the assistant silently dropping their
+    // work. "Silent" means never SPOKEN unprompted (live-voice has no unbidden
+    // TTS); it was never meant to mean invisible.
+    //
+    // NOT the conversation's own sender: the voice bridge resets that to a
+    // no-op at turn teardown (see voice-session-bridge's clientCallbackInstalled
+    // reset), and the detach deliberately waits for that teardown before
+    // spawning — so a sender-based route is guaranteed to be dead by the time
+    // these events fire. `broadcastMessage` is the same path the bridge itself
+    // uses to reach an attached web client. The subagent events carry
+    // `parentConversationId`, not `conversationId`, so scope explicitly.
+    (msg) => broadcastMessage(msg, args.parentConversationId),
     { signal: args.signal },
   );
 }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -54,6 +54,7 @@ import type {
   SttStreamServerEvent,
 } from "../stt/types.js";
 import { getSubagentManager } from "../subagent/index.js";
+import { isSideEffectTool } from "../tools/side-effects.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
@@ -651,7 +652,7 @@ function buildVoiceControlPrompt(
 // the forked history.
 function buildDuplexContinuationObjective(interruptedRequest: string): string {
   const base =
-    "You were in the middle of responding to the user's most recent request when they interrupted you. Finish that response now. Do not repeat any tool calls whose results are already present in the conversation. You are running unattended in the background with a read-only toolset: you cannot send, write, delete, purchase, or otherwise change anything, and most tools (including memory writes and any that take an action) are unavailable here. Do the read-only work you can. If finishing the request needs an action or a tool you do not have, do not attempt it; instead say plainly what you would do, so the user can approve it on their next turn.";
+    "You were in the middle of responding to the user's most recent request when they interrupted you. Finish that response now. Do not repeat any tool calls whose results are already present in the conversation. You are running unattended in the background: permission policy may auto-deny higher-risk actions with no one to approve them. If an action you need is denied, do not retry it; finish what you can and say plainly what remains, so the user can trigger it on their next turn.";
   return interruptedRequest.length > 0
     ? `${base} Their request was: "${interruptedRequest}".`
     : base;
@@ -1550,8 +1551,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // settle before forking, so its partial — including any completed tool calls —
   // is already in the conversation the subagent forks from and a side-effecting
   // continuation cannot repeat a call the interrupted turn already ran.
-  // Resurfacing the subagent's result is a follow-up; for now it runs silently
-  // and a later stop/interrupt aborts it.
+  // The continuation runs with full subagent abilities under the standard
+  // non-interactive permission policy; if a foreground turn starts its own
+  // side-effecting tool, the foreground-wins abort in the tool_use_start
+  // handler kills the continuation before the two can race on the workspace.
+  // The run stays silent (never spoken unprompted) and a later stop/interrupt
+  // aborts it.
   private detachInterruptedTurn(
     turn: ActiveAssistantTurn,
     stopGeneration: number,
@@ -1656,7 +1661,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Abort every background continuation this session started and drop its
   // handle. A client interrupt or session close is a hard stop for detached
   // work; the continuation's own `.finally` removes it from the set too.
-  private abortDetachedRuns(): void {
+  // `keepPendingResult` is the foreground-wins variant: the foreground turn is
+  // claiming the workspace, so running continuations must die (and pending
+  // detaches must be skipped), but an already-completed continuation's stashed
+  // answer stays — it cannot race anything, and the next turn's "use only if
+  // relevant" framing makes a stale one harmless.
+  private abortDetachedRuns(opts?: { keepPendingResult?: boolean }): void {
     // Bump the generation so a barge-in whose async teardown is still in flight
     // (its detach not yet spawned) sees the stop and skips the continuation.
     this.detachStopGeneration += 1;
@@ -1666,7 +1676,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.detachControllers.clear();
     // A hard stop also drops any completed continuation's result still waiting
     // to fold into the next turn, so it can't surface after the user reset.
-    this.pendingContinuationResult = null;
+    if (!opts?.keepPendingResult) {
+      this.pendingContinuationResult = null;
+    }
   }
 
   // VAD closed the utterance — the analog of ptt_release: emit
@@ -2906,6 +2918,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               return;
             }
             current.toolUseStarted = true;
+            // Foreground wins the workspace: the continuation runs with full
+            // subagent abilities (it can write files, run commands), so the
+            // moment a live turn starts a side-effecting tool the two could
+            // race on the same workspace. Kill running continuations and skip
+            // pending detaches; a continuation only survives while foreground
+            // turns stay read-only (the topic-change case it exists for). An
+            // already-completed continuation's stashed answer is kept — it
+            // cannot race anything.
+            if (isSideEffectTool(toolName)) {
+              this.abortDetachedRuns({ keepPendingResult: true });
+            }
             // The op counts toward the narration threshold on start (not
             // completion) so a burst of slow tools still trips the ops
             // trigger while they run.
@@ -4460,12 +4483,16 @@ async function defaultSpawnBackgroundContinuation(args: {
       objective: args.objective,
       fork: true,
       sendResultToUser: false,
-      // Read-only: the continuation runs unattended while the user talks to the
-      // live session, so it must never take an unapproved side effect. Any
-      // side-effecting tool is refused; the continuation surfaces the intended
-      // action for the user to approve on their next turn (via the resurface
-      // context) instead.
-      denySideEffectTools: true,
+      // Full subagent abilities: the continuation runs like any other
+      // background subagent, so it can genuinely finish build-shaped work
+      // (JARVIS-1354). Side effects are governed by the standard
+      // non-interactive permission path via the inherited trust context —
+      // auto-approved up to the background risk threshold, auto-denied above
+      // it — the same policy the foreground voice turn it continues ran
+      // under. Workspace write races with the user's next foreground turn
+      // are prevented by the session's foreground-wins abort (a
+      // side-effecting tool start on a live turn aborts running
+      // continuations; see the tool_use_start handler).
       parentMessages: [...parentConversation.messages],
       parentSystemPrompt: parentConversation.getCurrentSystemPrompt(),
     },

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -574,6 +574,15 @@ export class SubagentManager {
       conversation.setSubagentDenySideEffects(true);
     }
 
+    // A synchronous child's only parent channel is the awaiting caller: a
+    // mid-run notify_parent would inject a user-role turn into the live
+    // parent conversation (starting an unsolicited parent run) instead of
+    // reaching that caller, so suppress it — the same reason runSubagent
+    // skips the terminal parent-injection on this path.
+    if (opts?.synchronous) {
+      conversation.setSubagentSuppressParentNotifications(true);
+    }
+
     // Pre-activate skills defined by the role config, merged with any caller-provided skill IDs.
     const mergedSkillIds = mergeSkillIds(
       roleConfig.skillIds,

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -567,8 +567,8 @@ export class SubagentManager {
       conversation.setSubagentAllowedTools(new Set(roleConfig.allowedTools));
     }
 
-    // A read-only subagent (e.g. the live-voice background continuation) refuses
-    // side-effecting tools regardless of trust class; the executor gate rejects
+    // A read-only subagent refuses side-effecting tools regardless of trust
+    // class; the executor gate rejects
     // any such dispatch and they are kept off the model's tool surface.
     if (config.denySideEffectTools) {
       conversation.setSubagentDenySideEffects(true);

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -528,8 +528,13 @@ export class SubagentManager {
     // Subagents execute as background child conversations, but their tool
     // permissions must still be scoped to the actor that spawned them. Without
     // this, tool execution falls back to `unknown` trust and guardian-owned
-    // desktop turns get denied as unverified.
-    if (parentConversation?.trustContext) {
+    // desktop turns get denied as unverified. An explicit config trust context
+    // wins over parent inheritance: a parent that stamps trust per-turn (the
+    // live-voice bridge) has already cleared it by the time a detached spawn
+    // reads it, so its spawner resolves trust itself.
+    if (config.trustContext) {
+      conversation.setTrustContext({ ...config.trustContext });
+    } else if (parentConversation?.trustContext) {
       conversation.setTrustContext({ ...parentConversation.trustContext });
     }
     const parentAuthContext = parentConversation?.getAuthContext();

--- a/assistant/src/subagent/notify.ts
+++ b/assistant/src/subagent/notify.ts
@@ -86,6 +86,14 @@ export function notifyParentFromChild(
     return false;
   }
 
+  // A synchronous (spawnAndAwait) child's only parent channel is the awaiting
+  // caller: injecting a user-role turn into the live parent mid-await would
+  // start an unsolicited parent run (e.g. unprompted activity on a live voice
+  // call whose continuation is meant to stay silent until resurfaced).
+  if (child?.subagentSuppressParentNotifications) {
+    return false;
+  }
+
   // Cosmetic metadata only — a tampered record can at most mislabel a
   // notification to the child's own (routing is fixed to the live parent above).
   const record = getSubagentRecordByConversationId(childConversationId);

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -52,9 +52,9 @@ export interface SubagentConfig {
    * When true, side-effecting tools (send/write/delete/purchase, host commands)
    * are refused for this subagent regardless of trust class — the executor
    * rejects any such dispatch and the tool is kept off the model's tool surface.
-   * Used for the read-only live-voice background continuation, which must never
-   * take an unapproved action while the user isn't watching; it surfaces the
-   * intended action for the user to approve on their next turn instead.
+   * For unattended passes that must never take an unapproved action while the
+   * user isn't watching; the subagent surfaces the intended action for the
+   * user to approve instead.
    */
   denySideEffectTools?: boolean;
   /**

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { UsageStats } from "../daemon/message-protocol.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 import type { Message } from "../providers/types.js";
 
 // ── Status ──────────────────────────────────────────────────────────────
@@ -57,6 +58,15 @@ export interface SubagentConfig {
    * user to approve instead.
    */
   denySideEffectTools?: boolean;
+  /**
+   * Explicit trust context for the subagent. When set, it wins over the
+   * default inheritance from the parent conversation's live `trustContext`.
+   * For spawners whose parent stamps trust per-turn and clears it at teardown
+   * (the live-voice bridge), inheritance reads the cleared window and the
+   * child would run fail-closed as `unknown`; the caller resolves trust
+   * itself and passes it here instead.
+   */
+  trustContext?: TrustContext;
   /**
    * When true, the sub-agent inherits the parent's full context instead of
    * receiving only the objective + context fields.


### PR DESCRIPTION
## Summary
- Drop `denySideEffectTools` from the voice-duplex-handoff background continuation so it runs with full subagent abilities under the standard non-interactive permission policy (auto-approve up to the background risk threshold, auto-deny above), matching the foreground voice turn it continues; rewrite the continuation objective accordingly.
- Add a foreground-wins rule: a side-effecting `tool_use_start` on a live voice turn aborts running continuations and skips pending detaches so the two can never race on workspace writes; read-only foreground tool use leaves continuations running, and an already-completed continuation's stashed answer is kept.
- Keep the read-only subagent machinery (`subagentDenySideEffects`) intact for other unattended passes; generalize two comments that named the live-voice continuation as its consumer. New VAD tests cover the abort, the read-only non-abort, and stash retention.

## Original prompt
While reviewing the voice-duplex-handoff feature we established that the barge-in continuation's fail-closed read-only toolset means build-shaped work (like an app-builder turn) can't actually finish in the background — it degrades to a planning pass, which defeats the point of the handoff. Alex decided the continuation should run with full subagent abilities, the way ordinary spawned subagents already do (side effects governed by the background auto-approve threshold rather than a hard gate). The agreed scope: drop the read-only gate, rewrite the objective, add foreground-wins contention handling so the continuation and the user's next turn can't race on workspace writes, and keep the read-only machinery for other callers. Tracked as JARVIS-1354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)