### PR TITLE
fix: self-review gaps — front-door prompt scope, popout capture, live() guard

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -222,6 +222,28 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(escalated?.content).toBe(ESCALATION_CONTINUATION_CONTENT);
   });
 
+  test("the [-1] teaching reaches the escalated leg's prompt but never the front-door leg's", async () => {
+    enableVoiceMode();
+    const { starter } = scriptedStartVoiceTurn({
+      frontDoor: ["[1] ", "Let me think about that."],
+      escalated: ["The detailed answer is 42."],
+    });
+    const { frames, session } = createHarness(starter);
+
+    await driveTurn(session);
+    await waitFor(() => starter.mock.calls.length >= 2);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    const frontDoorPrompt =
+      starter.mock.calls[0]?.[0]?.voiceControlPrompt ?? "";
+    const escalatedPrompt =
+      starter.mock.calls[1]?.[0]?.voiceControlPrompt ?? "";
+    // The toolless fast leg has nothing to show and its decision rule promises
+    // verbatim speech — it must never learn the marker.
+    expect(frontDoorPrompt).not.toContain("[-1]");
+    expect(escalatedPrompt).toContain("[-1]");
+  });
+
   test("the verdict token and any text past the bridge cap never reach the transcript", async () => {
     enableVoiceMode();
     const { starter } = scriptedStartVoiceTurn({

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -569,18 +569,25 @@ function createControlMarkerHoldback(
 // barge-in, the interruption merge note is appended to it (see
 // buildInterruptionMergeNote) so the model reconciles the interrupted request
 // with the new utterance.
+const LIVE_VOICE_CONTROL_PROMPT_BASE =
+  "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech. ";
+
+// MINIMIZE_ROOM_MARKER teaching, appended for the legs that can actually put
+// something on screen — the main leg and the escalated leg. The front-door
+// (fast) leg never receives it: that leg is toolless, so it has nothing to
+// show, and its decision rule promises that apart from a leading verdict
+// token every character is spoken verbatim — teaching it the marker would
+// contradict that rule and could only produce spurious minimizes.
 //
-// The MINIMIZE_ROOM_MARKER teaching deliberately keeps the no-interactive-UI
-// rule intact (live-voice turns are non-interactive, JARVIS-1291): the marker
-// does not render UI — it asks the client to reveal the screen the call
-// overlay covers. The gate in createControlMarkerHoldback strips it from
-// speech, and completeTtsForTurn sends the minimize_room frame only after the
-// reply's TTS drains, so "end your reply with it" is the whole contract the
-// model needs.
-const LIVE_VOICE_CONTROL_PROMPT =
-  "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech. " +
-  "The call renders as a full-screen overlay covering the app. If this reply created or changed something on screen worth looking at (an app, a page, a document), you may end the reply with the marker [-1]: after you finish speaking, the overlay minimizes so the user can see the screen while the call continues. Use it at most once per reply, only when there is genuinely something new to show, never speak the marker aloud or mention it, and never emit any other bracketed marker. " +
-  VOICE_NO_SETUP_FLOWS_RULE;
+// The teaching deliberately keeps the no-interactive-UI rule intact
+// (live-voice turns are non-interactive, JARVIS-1291): the marker does not
+// render UI — it asks the client to reveal the screen the call overlay
+// covers. The gate in createControlMarkerHoldback strips it from speech, and
+// completeTtsForTurn sends the minimize_room frame only after the reply's
+// TTS drains, so "end your reply with it" is the whole contract the model
+// needs.
+const LIVE_VOICE_MINIMIZE_MARKER_TEACHING =
+  "The call renders as a full-screen overlay covering the app. If this reply created or changed something on screen worth looking at (an app, a page, a document), you may end the reply with the marker [-1]: after you finish speaking, the overlay minimizes so the user can see the screen while the call continues. Use it at most once per reply, only when there is genuinely something new to show, never speak the marker aloud or mention it, and never emit any other bracketed marker. ";
 
 // System-level guidance appended to a barge-in turn's control prompt so the
 // model treats the new utterance as a continuation of the request it was cut
@@ -600,12 +607,20 @@ function buildResurfaceContextNote(continuationResult: string): string {
   return `Earlier the user interrupted you, and in the background you finished the reply they cut off. What you worked out was: "${continuationResult}". If their current message relates to it, use it to answer; otherwise you may briefly offer it or leave it aside, and do not repeat it verbatim if it no longer fits.`;
 }
 
-// Assemble a turn's model-facing control prompt: the base live-voice rules plus
+// Assemble a leg's model-facing control prompt: the base live-voice rules,
+// the [-1] minimize teaching (withheld from the front-door leg — see
+// LIVE_VOICE_MINIMIZE_MARKER_TEACHING), the shared no-setup-flows rule, plus
 // any pending barge-in merge context and/or completed-continuation context. A
-// turn can carry both (a barge-in follow-up that also has a continuation result
-// waiting); the notes are model-only and never render as user bubbles.
-function buildVoiceControlPrompt(turn: ActiveAssistantTurn): string {
-  let prompt = LIVE_VOICE_CONTROL_PROMPT;
+// turn can carry both (a barge-in follow-up that also has a continuation
+// result waiting); the notes are model-only and never render as user bubbles.
+function buildVoiceControlPrompt(
+  turn: ActiveAssistantTurn,
+  leg: { frontDoor?: boolean },
+): string {
+  let prompt =
+    LIVE_VOICE_CONTROL_PROMPT_BASE +
+    (leg.frontDoor === true ? "" : LIVE_VOICE_MINIMIZE_MARKER_TEACHING) +
+    VOICE_NO_SETUP_FLOWS_RULE;
   if (turn.interruptedRequest) {
     prompt = `${prompt}\n\n${buildInterruptionMergeNote(turn.interruptedRequest)}`;
   }
@@ -2825,7 +2840,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         assistantMessageChannel: "vellum",
         userMessageInterface: "macos",
         assistantMessageInterface: "macos",
-        voiceControlPrompt: buildVoiceControlPrompt(activeTurn),
+        voiceControlPrompt: buildVoiceControlPrompt(activeTurn, {
+          ...(leg.frontDoor !== undefined ? { frontDoor: leg.frontDoor } : {}),
+        }),
         content: leg.content,
         isInbound: true,
         launchedAtMs: activeTurn.launchedAtMs,

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -252,9 +252,7 @@ export function ChatLayout({
   const headerControlsHidden = useInChatOnboardingStore(
     selectHeaderControlsHidden,
   );
-  const headerCenterHidden = useInChatOnboardingStore(
-    selectHeaderCenterHidden,
-  );
+  const headerCenterHidden = useInChatOnboardingStore(selectHeaderCenterHidden);
   const navTourActive = useInChatOnboardingStore.use.navTourActive();
   const tourActive = useInChatOnboardingStore(selectTourActive);
 
@@ -363,7 +361,8 @@ export function ChatLayout({
 
   // Voice-room visibility. The room is a full-viewport takeover on every
   // platform (mounted at layout scope below): it covers the header and
-  // sidebar, and ending the session is the only way out of it.
+  // sidebar until the session ends or the room is minimized (the session
+  // then continues behind the composer voice bar / title-bar pill).
   const voiceRoomVisible = useIsVoiceRoomVisible();
 
   const drawerVisible = isMobile && drawerOpen;
@@ -426,7 +425,10 @@ export function ChatLayout({
   useEdgeSwipeDrawer({
     panelRef: drawerRef,
     enabled:
-      isMobile && !drawerOpen && backSwipeOwnerCount === 0 && openRowCount === 0,
+      isMobile &&
+      !drawerOpen &&
+      backSwipeOwnerCount === 0 &&
+      openRowCount === 0,
     onDragStart: () => setDrawerDragging(true),
     onOpen: () => {
       // Same as the button path: swiping the drawer in over a focused
@@ -798,9 +800,10 @@ export function ChatLayout({
       // Hidden during the avatar tour for the same reason (plus noise) —
       // the tour owns the sidebar's attention.
       tipCard={
-        (args.variant === "overlay" && !drawerOpen) || navTourActive
-          ? undefined
-          : <SidebarTipCard />
+        (args.variant === "overlay" && !drawerOpen) ||
+        navTourActive ? undefined : (
+          <SidebarTipCard />
+        )
       }
       onClose={args.onClose}
     />
@@ -942,7 +945,11 @@ export function ChatLayout({
             // Hiding eases smoothly; revealing uses a back-ease so the rail
             // lands with a slight bounce (the tour's takeover moment).
             style={{
-              width: chatFocusActive ? 0 : effectiveCollapsed ? 48 : sidebarWidth,
+              width: chatFocusActive
+                ? 0
+                : effectiveCollapsed
+                  ? 48
+                  : sidebarWidth,
               opacity: chatFocusActive ? 0 : 1,
               marginRight: chatFocusActive ? -16 : 0,
               transition: chatFocusActive

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -1,27 +1,27 @@
 import { ArrowUp, Square } from "lucide-react";
 import {
-    type FormEvent,
-    type ReactNode,
-    type RefObject,
-    useCallback,
-    useEffect,
-    useLayoutEffect,
-    useMemo,
-    useRef,
-    useState,
+  type FormEvent,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
 import { flushSync } from "react-dom";
-import { useLocation, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 
 import {
-    AttachFileButton,
-    ChatAttachmentsStrip,
+  AttachFileButton,
+  ChatAttachmentsStrip,
 } from "@/domains/chat/components/chat-attachments/chat-attachments";
 import {
-    selectPathReferencePaths,
-    selectUploadedIds,
-    selectUploadingCount,
-    useComposerStore,
+  selectPathReferencePaths,
+  selectUploadedIds,
+  selectUploadingCount,
+  useComposerStore,
 } from "@/domains/chat/composer-store";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
@@ -31,22 +31,22 @@ import { VoiceLiveTranscript } from "@/domains/chat/components/chat-composer/voi
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import {
-    VoiceInputButton,
-    type VoiceInputButtonHandle,
+  VoiceInputButton,
+  type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
-    dismissLiveVoiceFailure,
-    endLiveVoiceSession,
-    getLiveVoiceInputAmplitude,
-    isLiveVoiceSessionActive,
-    releaseLiveVoiceTurn,
-    restoreVoiceRoom,
-    setLiveVoiceEntryOrigin,
-    setLiveVoiceMuted,
-    stopLiveVoiceResponse,
-    useIsLiveVoiceSessionOwnedBy,
-    useLiveVoiceStore,
+  dismissLiveVoiceFailure,
+  endLiveVoiceSession,
+  getLiveVoiceInputAmplitude,
+  isLiveVoiceSessionActive,
+  releaseLiveVoiceTurn,
+  restoreVoiceRoom,
+  setLiveVoiceEntryOrigin,
+  setLiveVoiceMuted,
+  stopLiveVoiceResponse,
+  useIsLiveVoiceSessionOwnedBy,
+  useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { preflightLiveVoice } from "@/domains/chat/voice/live-voice/live-voice-preflight-api";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
@@ -55,7 +55,7 @@ import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-sto
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
-import { isPopoutWindow } from "@/runtime/popout-window";
+import { isPopoutWindowLifetime } from "@/runtime/popout-window";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { isNativeIOS } from "@/runtime/platform-detection";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -63,20 +63,25 @@ import { routes } from "@/utils/routes";
 import { Button, Notice, Popover } from "@vellumai/design-library";
 
 import {
-    computeGhostSuffix,
-    shouldSubmitOnEnter,
+  computeGhostSuffix,
+  shouldSubmitOnEnter,
 } from "@/domains/chat/components/chat-composer/chat-composer-utils";
-import { EMOJI_MIN_FILTER_LENGTH, EMOJI_TRIGGER_RE, type EmojiEntry, useEmojiSearch } from "@/domains/chat/components/chat-composer/emoji-catalog";
+import {
+  EMOJI_MIN_FILTER_LENGTH,
+  EMOJI_TRIGGER_RE,
+  type EmojiEntry,
+  useEmojiSearch,
+} from "@/domains/chat/components/chat-composer/emoji-catalog";
 import { EmojiPickerPopup } from "@/domains/chat/components/chat-composer/emoji-picker-popup";
 import {
-    applyMarkdownFormatting,
-    matchFormattingShortcut,
+  applyMarkdownFormatting,
+  matchFormattingShortcut,
 } from "@/domains/chat/components/chat-composer/markdown-formatting";
 import {
-    SLASH_PREFIX_RE,
-    type SlashCommand,
-    filteredCommands,
-    selectedInputText,
+  SLASH_PREFIX_RE,
+  type SlashCommand,
+  filteredCommands,
+  selectedInputText,
 } from "@/domains/chat/components/chat-composer/slash-command-catalog";
 import { SlashCommandPopup } from "@/domains/chat/components/chat-composer/slash-command-popup";
 import { useTextPopup } from "@/domains/chat/components/chat-composer/use-text-popup";
@@ -239,7 +244,8 @@ export function ChatComposer({
       selectPathReferencePaths(attachments).length > 0);
 
   const voicePhase = useVoiceRecordingStore.use.phase();
-  const isVoiceActive = voicePhase === "recording" || voicePhase === "processing";
+  const isVoiceActive =
+    voicePhase === "recording" || voicePhase === "processing";
   // Holds the MediaStream opened by VoiceInputButton so we can reuse it for
   // amplitude analysis rather than opening a second getUserMedia request.
   const voiceStreamRef = useRef<MediaStream | null>(null);
@@ -305,8 +311,8 @@ export function ChatComposer({
   // by `VoiceLiveTranscript`, which subscribes to the store on its own,
   // keeping the composer's deliberate opt-out of high-frequency live-voice
   // updates (amplitude ticks, transcript deltas) intact.
-  const hasLiveVoiceTranscript = useLiveVoiceStore(
-    (s) => Boolean(s.partialTranscript || s.finalTranscript),
+  const hasLiveVoiceTranscript = useLiveVoiceStore((s) =>
+    Boolean(s.partialTranscript || s.finalTranscript),
   );
   // The in-composer transcript shows the *user's* own speech, so it must
   // honor the "Show the words you say" voice preference (default OFF). When
@@ -340,12 +346,11 @@ export function ChatComposer({
   // the first-run card path defers the actual start to its own handler.
   const liveVoiceEntryOriginRef = useRef<{ x: number; y: number } | null>(null);
   const navigate = useNavigate();
-  const location = useLocation();
-  // Captured once at mount, mirroring `ChatLayout` / `useIsVoiceRoomVisible`:
-  // pop-out URLs carry `?popout=1` only on the window's initial load. Pop-outs
-  // never render the voice room, so the bar's expand-to-room control is
-  // omitted there (the mount-time value gates it below).
-  const [isPopout] = useState(() => isPopoutWindow(location.search));
+  // Window-lifetime, not mount-time: the composer is a per-route component
+  // that can remount after an in-window navigation has dropped `?popout=1`,
+  // so a mount-time capture could misread a pop-out as a main window and ship
+  // a dead expand-to-room control (pop-outs never render the voice room).
+  const isPopout = isPopoutWindowLifetime();
   // "Configure voice" copy surfaced when the pre-open preflight returns
   // `not-ready` — the daemon's human-readable `userMessage`. Non-null renders
   // the notice below (with a deep-link to voice settings) and the room stays
@@ -524,10 +529,8 @@ export function ChatComposer({
     phase === "queued" || phase === "thinking" || phase === "streaming";
   const showInlineVoicePreview =
     isVoiceActive && !isLocallyGenerating && !isElectronHost;
-  const hideTextareaForVoice =
-    isNative && showInlineVoicePreview;
-  const hasStagedQuotes =
-    useQuoteReplyStore.use.stagedQuotes().length > 0;
+  const hideTextareaForVoice = isNative && showInlineVoicePreview;
+  const hasStagedQuotes = useQuoteReplyStore.use.stagedQuotes().length > 0;
   const canSendMessageContent =
     Boolean(input.trim()) || canSendAttachments || hasStagedQuotes;
   // Voice mode occupies the send slot while there is nothing to send: the
@@ -537,7 +540,10 @@ export function ChatComposer({
   // send arrow — byte-identical to before — whenever voice mode is unavailable.
   const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
   const showVoiceModeInSendSlot =
-    showVoiceInput && Boolean(assistantId) && voiceMode && !canSendMessageContent;
+    showVoiceInput &&
+    Boolean(assistantId) &&
+    voiceMode &&
+    !canSendMessageContent;
 
   const ghostSuffix = useMemo(
     () =>
@@ -669,7 +675,10 @@ export function ChatComposer({
                   // restored draft — retire the "draft restored" marker (and its
                   // notice). Keeps `restoredDraftConversationId` an accurate
                   // signal for "unedited restored draft" (see use-deep-link-consumer).
-                  if (useComposerStore.getState().restoredDraftConversationId !== null) {
+                  if (
+                    useComposerStore.getState().restoredDraftConversationId !==
+                    null
+                  ) {
                     useComposerStore.getState().clearRestoredDraftNotice();
                   }
                 }}
@@ -848,7 +857,9 @@ export function ChatComposer({
               // overlay bridge no-ops there.
               <div
                 className={hideTextareaForVoice ? "px-2 pt-3" : "px-2"}
-                aria-label={voicePhase === "processing" ? "Transcribing" : "Recording"}
+                aria-label={
+                  voicePhase === "processing" ? "Transcribing" : "Recording"
+                }
                 aria-live="polite"
               >
                 <StreamingWaveform
@@ -919,7 +930,9 @@ export function ChatComposer({
                             <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
                           }
                           type="submit"
-                          disabled={sendDisabled || attachmentsUploadingCount > 0}
+                          disabled={
+                            sendDisabled || attachmentsUploadingCount > 0
+                          }
                           title={
                             sendDisabled
                               ? "Type a message to send"

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -833,6 +833,7 @@ export function useLiveVoice(
           void finishResponseAfterPlayback(session, teardown);
         }),
         client.on("minimizeRoom", () => {
+          if (!live()) return;
           // Assistant asked to reveal the screen behind the room. Advisory: if
           // the room isn't up (already minimized, pop-out, other route) this is
           // a no-op — minimizeVoiceRoom() is an idempotent store write.

--- a/clients/web/src/runtime/popout-window.ts
+++ b/clients/web/src/runtime/popout-window.ts
@@ -12,6 +12,24 @@ export function isPopoutWindow(search: string): boolean {
   return search.includes("popout=1");
 }
 
+// Captured at module load, while the initial URL still carries `?popout=1`
+// (in-window navigations drop the query). `typeof window` guard keeps the
+// module importable under SSR/tooling contexts with no window.
+const INITIAL_LOAD_IS_POPOUT =
+  typeof window !== "undefined" && isPopoutWindow(window.location.search);
+
+/**
+ * Whether THIS window is an Electron pop-out thread window, valid for the
+ * window's whole lifetime. Unlike `isPopoutWindow(location.search)` — which
+ * per-route components can only trust at their own mount time, and which
+ * reads false after an in-window navigation drops the query — this is the
+ * initial-load answer, so components that remount mid-lifetime (e.g. the
+ * composer) get the correct window-lifetime value.
+ */
+export function isPopoutWindowLifetime(): boolean {
+  return INITIAL_LOAD_IS_POPOUT;
+}
+
 /**
  * Request the Electron host to open (or focus) a pop-out window for the given
  * conversation. No-ops on web and Capacitor iOS where pop-out windows don't


### PR DESCRIPTION
## Summary
Fixes the four gaps from the plan self-review for voice-room-minimize.md:
- **Front-door leg no longer taught `[-1]`** — the teaching moved out of the shared prompt into a leg-scoped append (front-door legs are toolless and promise verbatim speech); test pins the split
- **Expand-to-room gate uses a window-lifetime pop-out capture** (`isPopoutWindowLifetime`) instead of a per-route mount-time read that can misread after in-window navigation
- **`minimizeRoom` handler gains the file-standard `live()` guard** against stale-session frames
- **chat-layout's stale "only way out" docstring updated** for minimize

Part of plan: voice-room-minimize.md (self-review round 1)