### PR TITLE
feat(ios): expose voice mode to Siri and the Action Button

### DIFF
--- a/clients/ios/App/App/Intents/StartVoiceModeIntent.swift
+++ b/clients/ios/App/App/Intents/StartVoiceModeIntent.swift
@@ -10,8 +10,8 @@ import AppIntents
 /// one is the natural Siri target ("talk to Vellum" should rejoin a call in
 /// progress); the other is the natural Action Button target.
 ///
-/// No `AppShortcutsProvider` accompanies these yet, so they surface in the
-/// Shortcuts app but not in Siri, Spotlight, or the Action Button picker.
+/// `VoiceAppShortcuts` carries both intents into Siri, Spotlight, and the
+/// Action Button picker; add any new phrase there rather than here.
 struct StartVoiceModeIntent: AppIntent {
     static var title: LocalizedStringResource = "Start voice mode"
     static var description = IntentDescription(

--- a/clients/ios/App/App/Intents/VoiceAppShortcuts.swift
+++ b/clients/ios/App/App/Intents/VoiceAppShortcuts.swift
@@ -1,0 +1,43 @@
+import AppIntents
+
+/// Publishes the voice intents to every system surface that consumes App
+/// Shortcuts: Siri, Spotlight, the Shortcuts app gallery, and the Action Button
+/// picker in Settings.
+///
+/// Declaring the provider is the whole of the work — none of those surfaces has
+/// an API of its own. The Action Button in particular offers any `AppShortcut`
+/// under Settings → Action Button → Shortcut → the app's name, so a shortcut
+/// listed here is bindable to it with no further code.
+///
+/// Every phrase must interpolate `\(.applicationName)`. App Intents drops the
+/// ones that omit it, and the drop is silent at runtime — the shortcut still
+/// appears in the Shortcuts app while Siri never matches a word of it. The
+/// token resolves to `CFBundleDisplayName`, which each environment's xcconfig
+/// sets via `BUNDLE_DISPLAY_NAME`: "Vellum", "Vellum Staging", "Vellum Dev".
+/// All three are pronounceable, so one phrase list serves every build.
+///
+/// Translations go in `Intents/en.lproj/AppShortcuts.strings` and its siblings
+/// — the filename App Intents looks for — keyed by the literals below.
+struct VoiceAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: StartVoiceModeIntent(),
+            phrases: [
+                "Talk to \(.applicationName)",
+                "Start voice mode in \(.applicationName)",
+                "Voice mode in \(.applicationName)",
+            ],
+            shortTitle: "Voice mode",
+            systemImageName: "waveform"
+        )
+        AppShortcut(
+            intent: StartNewVoiceConversationIntent(),
+            phrases: [
+                "New voice conversation in \(.applicationName)",
+                "Start a new voice chat in \(.applicationName)",
+            ],
+            shortTitle: "New voice conversation",
+            systemImageName: "waveform.badge.plus"
+        )
+    }
+}

--- a/clients/ios/App/App/Intents/en.lproj/AppShortcuts.strings
+++ b/clients/ios/App/App/Intents/en.lproj/AppShortcuts.strings
@@ -1,0 +1,18 @@
+/* Siri phrases for the App Shortcuts declared in VoiceAppShortcuts.swift.
+
+   Keys are the English phrases exactly as written there, with the Swift
+   interpolation `\(.applicationName)` spelled `${applicationName}` — the token
+   App Intents substitutes in a strings file. Every phrase in every locale must
+   keep it; see VoiceAppShortcuts.swift for what happens otherwise.
+
+   A translation should be what someone would actually say, not a literal
+   rendering, and a locale may carry more or fewer phrases than English. */
+
+/* Rejoins a voice conversation already in progress, or starts one. */
+"Talk to ${applicationName}" = "Talk to ${applicationName}";
+"Start voice mode in ${applicationName}" = "Start voice mode in ${applicationName}";
+"Voice mode in ${applicationName}" = "Voice mode in ${applicationName}";
+
+/* Always starts a fresh voice conversation. */
+"New voice conversation in ${applicationName}" = "New voice conversation in ${applicationName}";
+"Start a new voice chat in ${applicationName}" = "Start a new voice chat in ${applicationName}";


### PR DESCRIPTION
Declares `VoiceAppShortcuts: AppShortcutsProvider` so the two App Intents merged in #39263 stop being Shortcuts-app-only and light up Siri, Spotlight, the Shortcuts gallery, and the Action Button picker.

## What's here

- **`clients/ios/App/App/Intents/VoiceAppShortcuts.swift`** (new) — one `AppShortcut` per intent, each with a `shortTitle` and a `systemImageName` (both surface in the Shortcuts app and the Action Button picker):

  | Intent | `shortTitle` | Symbol | Phrases |
  |---|---|---|---|
  | `StartVoiceModeIntent` | Voice mode | `waveform` | "Talk to \(.applicationName)" · "Start voice mode in \(.applicationName)" · "Voice mode in \(.applicationName)" |
  | `StartNewVoiceConversationIntent` | New voice conversation | `waveform.badge.plus` | "New voice conversation in \(.applicationName)" · "Start a new voice chat in \(.applicationName)" |

- **`clients/ios/App/App/Intents/en.lproj/AppShortcuts.strings`** (new) — the English source strings, keyed by the Swift literals with `\(.applicationName)` spelled `${applicationName}`. `AppShortcuts.strings` is the exact filename App Intents looks for; putting it in `en.lproj/` now means adding a locale later is a new `.lproj` directory and nothing else.

No API is needed for the Action Button beyond the provider itself, and no Control Center control is added here — that is a separate PR.

## Every phrase carries `\(.applicationName)`

App Intents discards phrases that omit the token, and the discard is **silent at runtime**: the shortcut still looks healthy in the Shortcuts app while Siri never matches a word of it. The token resolves to `CFBundleDisplayName`, set per environment in the xcconfigs via `BUNDLE_DISPLAY_NAME`:

| Target | `BUNDLE_DISPLAY_NAME` | `\(.applicationName)` resolves to | Sample phrase |
|---|---|---|---|
| `App` | `Vellum` | **Vellum** | "Talk to Vellum" |
| `App Staging` | `Vellum Staging` | **Vellum Staging** | "Talk to Vellum Staging" |
| `App Dev` | `Vellum Dev` | **Vellum Dev** | "Talk to Vellum Dev" |

All three are things a person can actually say, so one phrase list serves every build. Worth noting for anyone touching the xcconfigs: `CFBundleName` is `$(PRODUCT_NAME)` = `$(TARGET_NAME)` = "App"/"App Staging"/"App Dev". If `CFBundleDisplayName` were ever dropped, the token would fall back to "App" and every phrase would become "Talk to App".

## Action Button binding path

This is the path user docs and support will need to quote, on iPhone 15 Pro or newer:

**Settings → Action Button → Shortcut → (tap the shortcut chooser) → Vellum → "New voice conversation"**

The chooser lists app shortcuts by their `shortTitle`, which is why both shortcuts carry one. `StartVoiceModeIntent` ("Voice mode") is bindable the same way, but "New voice conversation" is the intended target — a physical button should do the same thing on every press, which is exactly the split the two intents exist for.

## `project.yml` unchanged

The plan flagged a possible explicit resource entry. Not needed, and this was checked rather than assumed: `xcodegen generate` was run against the modified tree, and the generated `project.pbxproj` shows the `AppShortcuts.strings` variant group in the Resources build phase of all three app targets, with `en` added to `knownRegions`. The `AppEnvironment` template's blanket `App` source path already sweeps a nested `.lproj`. (The generated project is gitignored and was deleted again; nothing from it is in this diff.)

## Verified

- `xcrun -sdk iphoneos swiftc -typecheck -target arm64-apple-ios17.0` over `App/Intents/*.swift` + `App/Shared/*.swift` (with a stub `AppDelegate`, since `Capacitor` is not resolvable outside a full build) — clean.
- `plutil -lint` on the strings file — OK.
- `xcodegen generate` — succeeds; wiring confirmed as above.
- Every phrase literal contains `\(.applicationName)` — checked mechanically over the file.

The full-app `xcodebuild` cannot run locally (Capacitor SPM `IONFilesystemLib` resolution failure, pre-existing and reproduced on an unmodified baseline), so **`PR iOS Checks` on CI is the build gate** — including the App Intents metadata processor, which is what actually validates the phrase list at compile time.

## Unverified

**No device was available for this PR.** Nothing below was performed; none of it should be read as verified.

Needs **physical hardware**:
- Saying each of the five phrases to Siri and having it launch the app and start/resume a voice session.
- Action Button binding on iPhone 15 Pro or newer, and a press starting a new voice session. The Simulator has no Action Button at all.
- Apple Intelligence routing — requires a device where Apple Intelligence is available and enabled.
- Any timing claim about how long a surface takes to pick the shortcut up after install (device-side donation and indexing can lag by minutes).

Coverable on the **Simulator**, but not yet run:
- Both shortcuts appearing in the Shortcuts app with the correct icon and short title.
- Running each shortcut from the Shortcuts app and confirming it starts/resumes a session (the Simulator does execute intents from Shortcuts).
- Spotlight surfacing — searchable in the Simulator, though indexing behaviour there is not a faithful stand-in for a device.
- That the Dev and Staging builds show "Vellum Dev" / "Vellum Staging" in the shortcut tiles.

The plan's PR 16 acceptance criteria that depend on the four hardware items above remain open and should be closed out on device before this is called done.