### PR TITLE
test(web): make the Pro package fixtures match the real catalog

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -38,6 +38,7 @@ import type {
   ProPackage,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
+import { makeProPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
 
@@ -138,24 +139,7 @@ mock.module(
 
 const { PlansPage } = await import("./plans-page");
 
-const MIGHTY: ProPackage = {
-  key: "mighty",
-  name: "Mighty",
-  description: "",
-  version: 1,
-  machine_tier: null,
-  storage_tier: "xs",
-  credit_tier: "credits_25",
-  machine_size: null,
-  storage_gib: 10,
-  credits_usd: 25,
-  include_platform_fee: false,
-  base_price_cents: 0,
-  machine_price_cents: 0,
-  storage_price_cents: 0,
-  credit_price_cents: 0,
-  total_price_cents: 3000,
-};
+const MIGHTY: ProPackage = makeProPackage();
 
 function fullCatalog(): PlanListResponse {
   return {

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.stories.tsx
@@ -3,7 +3,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useLayoutEffect } from "react";
 
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
-import { makeProPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
+import {
+  makeProPackage,
+  makeSuperPackage,
+  makeUltraPackage,
+} from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
@@ -23,15 +27,7 @@ for (const supportsManifest of [false, true]) {
   );
 }
 
-const SUPER_PACKAGE = makeProPackage({
-  key: "super",
-  name: "Super",
-  description: "Medium machine, 30 GB of storage, and $45 in monthly credits.",
-  machine_size: "medium",
-  storage_gib: 30,
-  credits_usd: 45,
-  total_price_cents: 12400,
-});
+const SUPER_PACKAGE = makeSuperPackage();
 
 const meta: Meta<typeof PackageSwitchConfirmModal> = {
   title: "Settings/Billing/PackageSwitchConfirmModal",
@@ -142,21 +138,23 @@ export const NoTargetPackage: Story = {
 
 /**
  * A name wider than the `size="sm"` card's title column wraps onto the second
- * line the header already allows, rather than ellipsizing.
+ * line the header already allows, rather than ellipsizing. No such package
+ * exists — it is Ultra on the 120 GB (`l`) storage tier, priced off the real
+ * tier table, so only the name is invented.
  */
 export const LongPackageName: Story = {
   args: {
     relation: "upgrade",
     packageName: "Ultra Enterprise Performance",
-    targetPackage: makeProPackage({
+    targetPackage: makeUltraPackage({
       key: "ultra-enterprise",
       name: "Ultra Enterprise Performance",
       description:
         "Large machine, 120 GB of storage, and $115 in monthly credits.",
-      machine_size: "large",
+      storage_tier: "l",
       storage_gib: 120,
-      credits_usd: 115,
-      total_price_cents: 24900,
+      storage_price_cents: 3000,
+      total_price_cents: 21500,
     }),
   },
 };

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
@@ -25,7 +25,10 @@ import {
   PLAN_TIER_COPY,
   downgradeLabel,
 } from "@/domains/settings/billing/plans/plans-copy";
-import { makeProPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
+import {
+  makeProPackage,
+  makeSuperPackage,
+} from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /** The package's own catalog blurb — never the dialog's description. */
@@ -72,11 +75,11 @@ describe("PackageSwitchConfirmModal", () => {
     const { getByText, getByRole, getByTestId } = renderModal();
 
     getByRole("heading", { name: "Upgrade to Mighty" });
-    getByText("$50/mo");
+    getByText("$30/mo");
     getByText(UPGRADE_CAPTION);
     getByText(CHECKLIST_HEADING);
     getByText("Small machine (2 vCPU, 3 GiB)");
-    getByText("15 GB storage");
+    getByText("10 GB storage");
     getByText("$25 of bundled credits");
     expect(getByTestId("confirm-package-switch-button").textContent).toBe(
       CONTINUE_LABEL,
@@ -129,7 +132,7 @@ describe("PackageSwitchConfirmModal", () => {
     const downgrade = renderModal({ relation: "downgrade" });
     expect(downgrade.queryByText(CATALOG_BLURB)).toBeNull();
     expect(downgrade.queryByText(PLAN_TIER_COPY.mighty.tagline)).toBeNull();
-    downgrade.getByText("15 GB storage");
+    downgrade.getByText("10 GB storage");
 
     cleanup();
 
@@ -139,7 +142,7 @@ describe("PackageSwitchConfirmModal", () => {
       targetPackage: UNKNOWN_TIER_PACKAGE,
     });
     expect(unknownTier.queryByText(CATALOG_BLURB)).toBeNull();
-    unknownTier.getByText("15 GB storage");
+    unknownTier.getByText("10 GB storage");
   });
 
   test("an upgrade with tier copy is described by its tagline", () => {
@@ -260,14 +263,7 @@ describe("PackageSwitchConfirmModal", () => {
   test("tier copy with extra features appends them after the derived rows", () => {
     const { getByText, getAllByRole } = renderModal({
       packageName: "Super",
-      targetPackage: makeProPackage({
-        key: "super",
-        name: "Super",
-        machine_size: "medium",
-        storage_gib: 30,
-        credits_usd: 45,
-        total_price_cents: 10000,
-      }),
+      targetPackage: makeSuperPackage(),
     });
 
     getByText("$100/mo");
@@ -289,7 +285,7 @@ describe("PackageSwitchConfirmModal", () => {
     getByTestId("assistant-avatar-tile");
     expect(queryByText(CHECKLIST_HEADING)).toBeNull();
     expect(queryByText(UPGRADE_CAPTION)).toBeNull();
-    expect(queryByText("15 GB storage")).toBeNull();
+    expect(queryByText("10 GB storage")).toBeNull();
     getByTestId("confirm-package-switch-button");
     getByText("Cancel");
   });

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -14,12 +14,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 
@@ -32,10 +27,14 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
   PlanListResponse,
-  ProPackage,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
+import {
+  makeProPackage,
+  makeSuperPackage,
+  makeUltraPackage,
+} from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
 
@@ -90,45 +89,11 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 
 const { PlansPage } = await import("./plans-page");
 
-function makePackage(overrides: Partial<ProPackage>): ProPackage {
-  return {
-    key: "mighty",
-    name: "Mighty",
-    description: "",
-    version: 1,
-    machine_tier: null,
-    storage_tier: "xs",
-    credit_tier: "credits_25",
-    machine_size: null,
-    storage_gib: 10,
-    credits_usd: 25,
-    include_platform_fee: false,
-    base_price_cents: 0,
-    machine_price_cents: 0,
-    storage_price_cents: 0,
-    credit_price_cents: 0,
-    total_price_cents: 3000,
-    ...overrides,
-  };
-}
-
-const MIGHTY = makePackage({});
-const SUPER = makePackage({
-  key: "super",
-  name: "Super",
-  machine_size: "medium",
-  storage_gib: 25,
-  credits_usd: 50,
-  total_price_cents: 10000,
-});
-const ULTRA = makePackage({
-  key: "ultra",
-  name: "Ultra",
-  machine_size: "large",
-  storage_gib: 50,
-  credits_usd: 100,
-  total_price_cents: 20000,
-});
+// These tests only need the three catalog keys to exist and render their CTAs,
+// so the packages come straight from the shared fixtures.
+const MIGHTY = makeProPackage();
+const SUPER = makeSuperPackage();
+const ULTRA = makeUltraPackage();
 
 function fullCatalog(): PlanListResponse {
   return {
@@ -193,7 +158,10 @@ function renderPage(subscription: SubscriptionResponse) {
     organizationsBillingSubscriptionRetrieveQueryKey(),
     subscription,
   );
-  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), fullCatalog());
+  client.setQueryData(
+    organizationsBillingPlansRetrieveQueryKey(),
+    fullCatalog(),
+  );
   return render(
     <MemoryRouter initialEntries={["/assistant/plans"]}>
       <QueryClientProvider client={client}>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -42,7 +42,11 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { ProPackage } from "@/domains/settings/billing/package-types";
 import { SWITCH_CAPTION } from "@/domains/settings/billing/plans/package-switch-copy";
-import { makeProPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
+import {
+  makeProPackage,
+  makeSuperPackage,
+  makeUltraPackage,
+} from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 import type {
   OnboardingStateResponse,
   PackageChangeResponse,
@@ -212,29 +216,12 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 const { PlansPage } = await import("./plans-page");
 const { getPlanTierCopy } = await import("./plans-copy");
 
-// This page's assertions key off the storage/credit/price rows, so each tier
-// pins whatever it has to differ on and inherits the rest of the Mighty shape;
-// the fixture's tier keys and component prices are read by nothing under test.
-const MIGHTY = makeProPackage({
-  storage_gib: 10,
-  total_price_cents: 3000,
-});
-const SUPER = makeProPackage({
-  key: "super",
-  name: "Super",
-  machine_size: "medium",
-  storage_gib: 25,
-  credits_usd: 50,
-  total_price_cents: 10000,
-});
-const ULTRA = makeProPackage({
-  key: "ultra",
-  name: "Ultra",
-  machine_size: "large",
-  storage_gib: 50,
-  credits_usd: 100,
-  total_price_cents: 20000,
-});
+// This page's assertions key off the storage/credit/price rows, so the three
+// tiers come straight from the catalog fixtures rather than being re-specced
+// here.
+const MIGHTY = makeProPackage();
+const SUPER = makeSuperPackage();
+const ULTRA = makeUltraPackage();
 
 function plansWith(packages: ProPackage[]): PlanListResponse {
   return {
@@ -363,8 +350,8 @@ describe("PlansPage — full catalog render", () => {
     const html = renderStatic(freeSubscription(), fullCatalog());
     // Storage rows.
     expect(html).toContain("10 GB Storage");
-    expect(html).toContain("25 GB Storage");
-    expect(html).toContain("50 GB Storage");
+    expect(html).toContain("30 GB Storage");
+    expect(html).toContain("60 GB Storage");
     // Free plan's baseline storage (FREE_STORAGE_GIB).
     expect(html).toContain("4 GB Storage");
     // Credits row, formatted from credits_usd.

--- a/clients/web/src/domains/settings/billing/plans/pro-package-test-fixtures.ts
+++ b/clients/web/src/domains/settings/billing/plans/pro-package-test-fixtures.ts
@@ -1,39 +1,95 @@
 /**
- * Shared `ProPackage` factory for the plan/package suites and the
+ * Shared `ProPackage` fixtures for the plan/package suites and the
  * package-switch story file.
  *
- * The defaults are the Mighty catalog shape; pass overrides for another tier.
- * One factory keeps the three surfaces from drifting into subtly different
- * "typical package" shapes — and from disagreeing on where `ProPackage` is
- * imported from.
+ * Source of truth: `PRO_PACKAGES` (with `PRO_MACHINE_TIERS`,
+ * `PRO_STORAGE_TIERS`, `PRO_CREDIT_TIERS` and `PRO_BASE_PRICE_USD`) in the
+ * platform repo's `django/app/domain_models/constants.py`, priced by
+ * `_build_packages` in `django/app/billing/plan_views.py`: the total is
+ * `base + machine + storage + credits`, and `base` is zero unless the package
+ * carries the platform fee. Re-check both when a package changes — a value
+ * here the catalog does not have is a bug in the fixture, not a scenario.
+ *
+ * One factory per catalog package keeps the surfaces from drifting into subtly
+ * different "typical package" shapes — and from disagreeing on where
+ * `ProPackage` is imported from.
  */
 
 import type { ProPackage } from "@/domains/settings/billing/package-types";
 
-/** A fully-typed Pro package with Mighty defaults; override per tier. */
+/** The catalog's Mighty package; override per scenario. */
 export function makeProPackage(
   overrides: Partial<ProPackage> = {},
 ): ProPackage {
   return {
     key: "mighty",
     name: "Mighty",
-    // Deliberately spec-free. The real catalog blurbs are the machine/storage/
-    // credits sentence, and every caller overrides some of those numbers — a
-    // default quoting them would decorate a package it contradicts.
-    description: "A Pro package.",
+    description:
+      "10 GB of storage and $25 in monthly credits on the standard machine.",
     version: 1,
     machine_tier: null,
-    storage_tier: "s",
+    storage_tier: "xs",
     credit_tier: "credits_25",
     machine_size: null,
-    storage_gib: 15,
+    storage_gib: 10,
     credits_usd: 25,
-    include_platform_fee: true,
-    base_price_cents: 2000,
+    // Mighty is the one package that skips the base platform fee.
+    include_platform_fee: false,
+    base_price_cents: 0,
     machine_price_cents: 0,
     storage_price_cents: 500,
     credit_price_cents: 2500,
-    total_price_cents: 5000,
+    total_price_cents: 3000,
     ...overrides,
   };
+}
+
+/** The catalog's Super package; override per scenario. */
+export function makeSuperPackage(
+  overrides: Partial<ProPackage> = {},
+): ProPackage {
+  return makeProPackage({
+    key: "super",
+    name: "Super",
+    description:
+      "Medium machine, 30 GB of storage, and $45 in monthly credits.",
+    machine_tier: "medium",
+    storage_tier: "s",
+    credit_tier: "credits_45",
+    machine_size: "medium",
+    storage_gib: 30,
+    credits_usd: 45,
+    include_platform_fee: true,
+    base_price_cents: 1000,
+    machine_price_cents: 3500,
+    storage_price_cents: 1000,
+    credit_price_cents: 4500,
+    total_price_cents: 10000,
+    ...overrides,
+  });
+}
+
+/** The catalog's Ultra package; override per scenario. */
+export function makeUltraPackage(
+  overrides: Partial<ProPackage> = {},
+): ProPackage {
+  return makeProPackage({
+    key: "ultra",
+    name: "Ultra",
+    description:
+      "Large machine, 60 GB of storage, and $115 in monthly credits.",
+    machine_tier: "large",
+    storage_tier: "m",
+    credit_tier: "credits_115",
+    machine_size: "large",
+    storage_gib: 60,
+    credits_usd: 115,
+    include_platform_fee: true,
+    base_price_cents: 1000,
+    machine_price_cents: 6000,
+    storage_price_cents: 1500,
+    credit_price_cents: 11500,
+    total_price_cents: 20000,
+    ...overrides,
+  });
 }

--- a/clients/web/src/domains/settings/components/plan-card-checkout.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-checkout.test.tsx
@@ -33,6 +33,7 @@ import {
   readCheckoutIntent,
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
+import { makeProPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
 
@@ -92,26 +93,7 @@ function plansResponse(): PlanListResponse {
         included_features: [],
         machine_tiers: [],
         storage_tiers: [],
-        packages: [
-          {
-            key: "mighty",
-            name: "Mighty",
-            description: "",
-            version: 1,
-            machine_tier: null,
-            storage_tier: "xs",
-            credit_tier: "credits_25",
-            machine_size: null,
-            storage_gib: 10,
-            credits_usd: 25,
-            include_platform_fee: false,
-            base_price_cents: 0,
-            machine_price_cents: 0,
-            storage_price_cents: 0,
-            credit_price_cents: 0,
-            total_price_cents: 3000,
-          },
-        ],
+        packages: [makeProPackage()],
       },
     ],
   };

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -40,6 +40,11 @@ import * as runtimeBrowser from "@/runtime/browser";
 import * as toastModule from "@vellumai/design-library/components/toast";
 import { UPGRADE_CAPTION } from "@/domains/settings/billing/plans/package-switch-copy";
 import { PLAN_TIER_COPY } from "@/domains/settings/billing/plans/plans-copy";
+import {
+  makeProPackage,
+  makeSuperPackage,
+  makeUltraPackage,
+} from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 import { routes } from "@/utils/routes";
 
 // Capture navigate() targets so the action-button wiring can be asserted
@@ -173,27 +178,7 @@ function basePlansResponse(): PlanListResponse {
         included_features: [],
         machine_tiers: [],
         storage_tiers: [],
-        packages: [
-          {
-            key: "mighty",
-            name: "Mighty",
-            description:
-              "10 GB of storage and $25 in monthly credits on the standard machine.",
-            version: 1,
-            machine_tier: null,
-            storage_tier: "xs",
-            credit_tier: "credits_25",
-            machine_size: null,
-            storage_gib: 10,
-            credits_usd: 25,
-            include_platform_fee: false,
-            base_price_cents: 4000,
-            machine_price_cents: 0,
-            storage_price_cents: 0,
-            credit_price_cents: 0,
-            total_price_cents: 4000,
-          },
-        ],
+        packages: [makeProPackage()],
       },
     ],
   };
@@ -216,25 +201,7 @@ function plansWithSuper(): PlanListResponse {
   const plans = basePlansResponse();
   const pro = plans.plans.find((p) => p.id === "pro");
   if (pro && "packages" in pro && pro.packages) {
-    pro.packages.push({
-      key: "super",
-      name: "Super",
-      description:
-        "Medium machine, 30 GB of storage, and $45 in monthly credits.",
-      version: 1,
-      machine_tier: "medium",
-      storage_tier: "s",
-      credit_tier: "credits_45",
-      machine_size: "medium",
-      storage_gib: 30,
-      credits_usd: 45,
-      include_platform_fee: true,
-      base_price_cents: 1000,
-      machine_price_cents: 3500,
-      storage_price_cents: 1000,
-      credit_price_cents: 4500,
-      total_price_cents: 10000,
-    });
+    pro.packages.push(makeSuperPackage());
   }
   return plans;
 }
@@ -258,25 +225,7 @@ function plansWithUltra(): PlanListResponse {
   const plans = plansWithSuper();
   const pro = plans.plans.find((p) => p.id === "pro");
   if (pro && "packages" in pro && pro.packages) {
-    pro.packages.push({
-      key: "ultra",
-      name: "Ultra",
-      description:
-        "Large machine, 60 GB of storage, and $115 in monthly credits.",
-      version: 1,
-      machine_tier: "large",
-      storage_tier: "l",
-      credit_tier: "credits_115",
-      machine_size: "large",
-      storage_gib: 60,
-      credits_usd: 115,
-      include_platform_fee: true,
-      base_price_cents: 1000,
-      machine_price_cents: 7000,
-      storage_price_cents: 2000,
-      credit_price_cents: 11500,
-      total_price_cents: 20000,
-    });
+    pro.packages.push(makeUltraPackage());
   }
   return plans;
 }


### PR DESCRIPTION
## Summary
- The shared `ProPackage` fixture and the confirm-modal stories carried invented numbers (Mighty at 15 GB / $50, Super at $124, Ultra at 120 GB / $249). Production is unaffected — it reads the live catalog — but fixtures that disagree with the catalog let a future test lock in wrong behaviour and still pass.
- Defaults now mirror `PRO_PACKAGES` in the platform's `domain_models/constants.py`, with component prices that sum to the documented total, and catalog-accurate Super and Ultra fixtures so suites stop hand-rolling their own.

Fixtures, stories and test expectations only — no production source changed.