### PR TITLE
feat(ios): add a Control Center control for starting voice mode

### DIFF
--- a/clients/ios/App/App/Shared/BundleURLScheme.swift
+++ b/clients/ios/App/App/Shared/BundleURLScheme.swift
@@ -29,9 +29,9 @@ import Foundation
 /// - **Auth** (`NativeAuthPlugin`) falls back to the production scheme: the
 ///   OAuth callback is not a cross-app launch, and a sign-in that reaches a
 ///   working callback beats one that fails outright.
-/// - **Voice deep links** (`VoiceModeDeepLink`, ``VoiceSessionDeepLink``) do
-///   *not* fall back. Emitting no link is strictly better than launching voice
-///   mode in the wrong app.
+/// - **Voice deep links** (``VoiceModeDeepLink``, shared by the App Intents
+///   and the Live Activity's `widgetURL`) do *not* fall back. Emitting no link
+///   is strictly better than launching voice mode in the wrong app.
 enum BundleURLScheme {
     /// Info.plist key carrying the scheme where `CFBundleURLTypes` is absent.
     static let infoPlistKey = "VellumURLScheme"

--- a/clients/ios/App/App/Shared/StartNewVoiceConversationIntent.swift
+++ b/clients/ios/App/App/Shared/StartNewVoiceConversationIntent.swift
@@ -6,6 +6,15 @@ import AppIntents
 /// The Action Button target: a physical button press should do the same thing
 /// every time. See `StartVoiceModeIntent` for why this is a second intent
 /// rather than a `mode` parameter, and for the launch-mode declaration below.
+///
+/// Lives in `Shared/` — compiled into the app *and* the VoiceActivity
+/// extension — rather than beside its sibling in `Intents/`, because
+/// `StartVoiceControl` builds a `ControlWidgetButton` around this exact type
+/// and a control is code in the appex. Sharing one type is what makes the
+/// Control Center control, the Action Button and Siri the same action rather
+/// than three lookalikes. The launch-mode declaration below is what keeps that
+/// safe: the system performs the intent in the app process, so the appex's
+/// copy of `perform()` never runs.
 struct StartNewVoiceConversationIntent: AppIntent {
     static var title: LocalizedStringResource = "New voice conversation"
     static var description = IntentDescription(

--- a/clients/ios/App/App/Shared/VoiceModeDeepLink.swift
+++ b/clients/ios/App/App/Shared/VoiceModeDeepLink.swift
@@ -1,13 +1,21 @@
 import Foundation
+#if !VOICE_ACTIVITY_EXTENSION
 import UIKit
+#endif
 
 /// The `<scheme>://voice?mode=…` command an App Intent hands to the web layer.
 ///
 /// This is deliberately the *same* URL contract the SPA already parses
 /// (`parseStartVoiceDeepLink` in `clients/web/src/runtime/native-deep-link.ts`,
 /// routed by `runtime/event-sources/capacitor-deep-links.ts`), so the intents
-/// add no second command channel: Siri, the Action Button, the Live Activity's
-/// `widgetURL`, and a link typed into Safari all converge on one parser.
+/// add no second command channel: Siri, the Action Button, the Control Center
+/// control, the Live Activity's `widgetURL`, and a link typed into Safari all
+/// converge on one parser.
+///
+/// Lives in `Shared/` because the VoiceActivity extension needs it too. The
+/// Live Activity's `widgetURL` builds ``resume``'s URL, and the Control Center
+/// control needs `StartNewVoiceConversationIntent` — defined in terms of this
+/// type — to compile. ``route()`` is the one app-only piece; see its docs.
 enum VoiceModeDeepLink: String {
     /// Start a fresh live-voice session.
     case new
@@ -34,12 +42,25 @@ enum VoiceModeDeepLink: String {
     /// Hand this command to the shell. Returns immediately — App Intents run
     /// under a short execution budget, so `perform()` must hand off rather than
     /// wait for a session to actually start.
+    ///
+    /// The body is compiled out of the VoiceActivity extension, which defines
+    /// `VOICE_ACTIVITY_EXTENSION`. Both callers declare `openAppWhenRun` /
+    /// `.foreground(.immediate)`, so the system performs them in the *app*
+    /// process even when the tap came from the extension's Control Center
+    /// control — the appex needs the intent type to exist, never to run it.
+    /// Compiling the body out keeps `UIApplication.shared` (unavailable to app
+    /// extensions) and `AppDelegate` (which links Capacitor, which the appex
+    /// does not) out of the appex binary.
     @MainActor
     func route() {
+        #if VOICE_ACTIVITY_EXTENSION
+        assertionFailure("Voice intents are performed in the app process, not the appex")
+        #else
         guard let url else {
             NSLog("[voice] No bundle URL scheme; dropping voice command")
             return
         }
         (UIApplication.shared.delegate as? AppDelegate)?.deliverVoiceCommand(url)
+        #endif
     }
 }

--- a/clients/ios/App/VoiceActivity/StartVoiceControl.swift
+++ b/clients/ios/App/VoiceActivity/StartVoiceControl.swift
@@ -1,0 +1,46 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+/// One-tap "New voice conversation" for Control Center and the Lock Screen.
+///
+/// A `ControlWidget` in this bundle is offered in the Control Center gallery
+/// and, on hardware with a customizable Lock Screen control slot, as a Lock
+/// Screen control — one declaration, both placements.
+///
+/// The action is `StartNewVoiceConversationIntent` verbatim, the same type Siri
+/// and the Action Button run, so every surface starts a session through the one
+/// `<scheme>://voice?mode=new` contract instead of growing a second route to
+/// keep in sync. It is deliberately the *new*-conversation intent rather than
+/// `StartVoiceModeIntent`: a control, like a physical button, should do the
+/// same thing every time it is pressed.
+///
+/// Its title and gallery copy are read off that intent rather than restated, so
+/// the action cannot drift into reading like a different feature in Control
+/// Center than it does in Siri. `waveform` matches the Live Activity's accent
+/// glyph (`VoiceAccentGlyph`), tying the control to the island that follows it.
+///
+/// **iOS 18+.** `ControlWidget` did not exist before then and the app deploys
+/// to 17.0, so this is availability-gated: on 17.x the app installs and its
+/// Live Activity behaves exactly as before, there is simply no control in the
+/// gallery.
+@available(iOS 18.0, *)
+struct StartVoiceControl: ControlWidget {
+    /// Stable identity for this control. iOS keys a user's placements off it,
+    /// so changing it orphans every control the user has already placed.
+    private static let kind = "new-voice-conversation"
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: Self.kind) {
+            ControlWidgetButton(action: StartNewVoiceConversationIntent()) {
+                Label {
+                    Text(StartNewVoiceConversationIntent.title)
+                } icon: {
+                    Image(systemName: "waveform")
+                }
+            }
+        }
+        .displayName(StartNewVoiceConversationIntent.title)
+        .description(StartNewVoiceConversationIntent.description.descriptionText)
+    }
+}

--- a/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
+++ b/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
@@ -3,13 +3,24 @@ import WidgetKit
 
 /// Widget bundle entry point for the VoiceActivity extension.
 ///
-/// One member today: the live-voice Live Activity, defined in
-/// `VoiceSessionLiveActivity.swift`. A `WidgetBundle` can hold home-screen
-/// widgets and controls alongside it, so anything added later joins this list
-/// rather than needing another extension target.
+/// Two members: the live-voice Live Activity (`VoiceSessionLiveActivity.swift`)
+/// and the Control Center / Lock Screen control (`StartVoiceControl.swift`). A
+/// `WidgetBundle` can hold home-screen widgets alongside them, so anything
+/// added later joins this list rather than needing another extension target.
+///
+/// The control is `@available(iOS 18.0, *)` while the app deploys to 17.0, so
+/// it is listed under an `#available` check — the one shape that works here.
+/// `WidgetBundleBuilder.buildOptional` is `@available(*, unavailable)` for a
+/// plain `if`, and its overload accepting a `ControlWidget` exists only on
+/// iOS 18+, so an `#available` block is what routes the control through it.
+/// Listing the control unconditionally would not compile, and annotating the
+/// *bundle* instead would drag the Live Activity up to iOS 18 with it.
 @main
 struct VoiceActivityBundle: WidgetBundle {
     var body: some Widget {
         VoiceSessionLiveActivity()
+        if #available(iOS 18.0, *) {
+            StartVoiceControl()
+        }
     }
 }

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -38,31 +38,6 @@ extension VoiceSessionAttributes.ContentState {
     }
 }
 
-/// Deep link back into the running session.
-///
-/// `mode=resume` is the web-side contract: it foregrounds the app into the
-/// live voice room, falling through to starting a fresh session if the app was
-/// killed and the session no longer exists.
-enum VoiceSessionDeepLink {
-    /// Built from *this* build's own scheme, so a Dev island opens the Dev app
-    /// even with production installed.
-    ///
-    /// `nil` when the appex declares no scheme — a misconfigured build. The
-    /// island then carries no tap target, which is the correct failure: a
-    /// production-scheme fallback would make a Dev island foreground the
-    /// *production* app, the exact mis-routing this indirection prevents. The
-    /// `.widgetURL(_:)` modifier already accepts an optional, so nil simply
-    /// leaves the presentation untappable.
-    static let resume: URL? = {
-        guard let scheme = BundleURLScheme.current else { return nil }
-        var components = URLComponents()
-        components.scheme = scheme
-        components.host = "voice"
-        components.queryItems = [URLQueryItem(name: "mode", value: "resume")]
-        return components.url
-    }()
-}
-
 /// The accent-tinted state indicator: a waveform, tinted with the avatar
 /// accent. Small enough to be the entire content of the minimal presentation
 /// and of the compact leading slot.

--- a/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
@@ -15,6 +15,15 @@ import WidgetKit
 /// room is a full-app takeover whose ✕ is the only exit. Tap-to-return is the
 /// single affordance, so both halves of "look at it" and "act on it" resolve
 /// to the same place: the room.
+///
+/// The tap target is `VoiceModeDeepLink.resume`, the same shared contract the
+/// App Intents use: it foregrounds the app into the live voice room, falling
+/// through to a fresh session if the app was killed and the session is gone.
+/// Its URL is built from *this* build's own scheme, so a Dev island opens the
+/// Dev app even with production installed — and is `nil` on a build that
+/// declares no scheme, which correctly leaves the presentation untappable
+/// (`.widgetURL(_:)` takes an optional) rather than sending a Dev island into
+/// the production app.
 struct VoiceSessionLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: VoiceSessionAttributes.self) { context in
@@ -22,7 +31,7 @@ struct VoiceSessionLiveActivity: Widget {
                 assistantName: context.attributes.assistantName,
                 state: context.state
             )
-            .widgetURL(VoiceSessionDeepLink.resume)
+            .widgetURL(VoiceModeDeepLink.resume.url)
         } dynamicIsland: { context in
             let state = context.state
             return DynamicIsland {
@@ -55,7 +64,7 @@ struct VoiceSessionLiveActivity: Widget {
             } minimal: {
                 VoiceAccentGlyph(accent: state.accentColor, scale: .small)
             }
-            .widgetURL(VoiceSessionDeepLink.resume)
+            .widgetURL(VoiceModeDeepLink.resume.url)
             .keylineTint(state.accentColor)
         }
     }

--- a/clients/ios/App/project.yml
+++ b/clients/ios/App/project.yml
@@ -131,19 +131,26 @@ targetTemplates:
       - path: VoiceActivity
         excludes:
           - "Info.plist"
-      # `VoiceSessionAttributes` is the ActivityKit wire model. The app
-      # targets already sweep it up via `AppEnvironment`'s `App` source
-      # path; pointing at the same directory here compiles it into the
-      # extension from that one copy on disk, rather than duplicating a
-      # file whose two halves would drift into a decode mismatch.
+      # `App/Shared` holds everything both sides need, from one copy on
+      # disk rather than duplicated files whose halves drift apart: the
+      # ActivityKit wire model, the URL-scheme and color helpers, and —
+      # because a Control Center control is code in the appex — the deep
+      # link plus the App Intent that control invokes. The app targets
+      # already sweep the same directory up via `AppEnvironment`'s `App`
+      # source path.
       - path: App/Shared
     settings:
       configs:
         Debug:
           OTHER_SWIFT_FLAGS: '$(inherited) "-DDEBUG"'
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
+          # VOICE_ACTIVITY_EXTENSION marks "this is the appex" for the
+          # `App/Shared` sources compiled into both sides.
+          # `VoiceModeDeepLink.route()` uses it to compile its
+          # `UIApplication`/`AppDelegate` body — extension-unsafe API the
+          # appex never reaches — out of the extension binary.
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG VOICE_ACTIVITY_EXTENSION
         Release:
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: ""
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: VOICE_ACTIVITY_EXTENSION
     # No `scheme:` — extensions build as embedded dependencies of the app
     # targets, so the three app schemes are the only ones worth having.
     preBuildScripts: *projectSpecFreshnessGuard


### PR DESCRIPTION
Adds a Control Center control that starts a new live-voice conversation, as a
second member of the existing `VoiceActivity` widget bundle. No fourth target:
a `WidgetBundle` holds the Live Activity and the control side by side.

## Both placements, one declaration

A `ControlWidget` in a widget bundle is offered in the **Control Center
gallery** and — on hardware with a customizable Lock Screen control slot —
as a **Lock Screen control**. There is nothing extra to declare for the second
placement; it falls out of the same type. (The Action Button is a third
surface, but it binds a Shortcuts action rather than a control, so it comes
from the intent directly and needs nothing here.)

## The action is the existing intent, not a new one

The control's button runs `StartNewVoiceConversationIntent` verbatim — the same
type Siri and the Action Button run — so every surface starts a session through
the one `<scheme>://voice?mode=new` contract. The control's title and gallery
description are read off that intent (`.title`, `.description.descriptionText`)
rather than restated, so the action cannot drift into reading like a different
feature in Control Center than it does in Siri. Its symbol is `waveform`, which
is also the Live Activity's accent glyph.

It is deliberately the *new*-conversation intent rather than
`StartVoiceModeIntent`: a control, like a physical button, should do the same
thing every time it is pressed.

## The intent had to move to `App/Shared/` — here is exactly why

A control is code in the app extension, so the extension has to *see* the
intent type to compile a `ControlWidgetButton` around it. `App/Shared/` is the
directory `project.yml` already compiles into both the app targets and the
extension targets from one copy on disk, so `StartNewVoiceConversationIntent`
and `VoiceModeDeepLink` (which it is defined in terms of) moved there. Pure
moves — neither type's behavior changed. `StartVoiceModeIntent` stays in
`App/Intents/`; nothing in the extension references it, and its metadata
correctly does not appear in the appex.

One thing did have to change, and it is worth reading carefully.
`VoiceModeDeepLink.route()` hands the URL to the app through
`UIApplication.shared.delegate as? AppDelegate`. Both halves of that are
unavailable to the extension: XcodeGen sets `APPLICATION_EXTENSION_API_ONLY =
YES` on the appex (verified via `-showBuildSettings`), and `AppDelegate` links
Capacitor, which the appex does not. Compiling the file into the extension
unmodified fails outright — confirmed locally: `error: cannot find type
'AppDelegate' in scope`.

So the three extension targets now define a `VOICE_ACTIVITY_EXTENSION`
compilation condition, and `route()`'s body is compiled out of the appex. That
is sound because both intents declare `openAppWhenRun` / `.foreground(.immediate)`:
the system performs them **in the app process** even when the tap came from the
extension's control, so the appex only ever needs the type to exist, never to
run it. The compiled-out branch carries an `assertionFailure` so a wrong
assumption here surfaces loudly in a debug build rather than silently doing
nothing. The app's code path is byte-for-byte unchanged, and extension-unsafe
UIKit API stays out of the appex binary.

## Availability gating at deployment target 17.0

`ControlWidget` is iOS 18+; the deployment target stays at **17.0** (unchanged).
`StartVoiceControl` is therefore `@available(iOS 18.0, *)` and the bundle lists
it under an `#available` check:

```swift
var body: some Widget {
    VoiceSessionLiveActivity()
    if #available(iOS 18.0, *) {
        StartVoiceControl()
    }
}
```

That exact shape is load-bearing and it is the only one that works. Checking
the SwiftUI interface for the SDK in use: `WidgetBundleBuilder.buildOptional`
is `@available(*, unavailable, message: "if statements in a WidgetBundleBuilder
can only be used with #available clauses")` for a plain `if`, and the
`buildLimitedAvailability` overload that accepts a `ControlWidget` lives in an
`@available(iOS 18.0, *)` extension — so an `#available` block is precisely
what routes the control through it. Listing the control unconditionally does
not compile. Annotating the *bundle* with `@available(iOS 18.0, *)` instead
would drag the Live Activity up to iOS 18 with it, breaking the thing that
already works. The Live Activity itself is untouched: it stays the
unconditional first member, and on 17.x it is the only member.

## Drive-by simplification

`VoiceModeDeepLink` landing in `Shared/` made the extension's local
`VoiceSessionDeepLink` a second builder of the identical
`<scheme>://voice?mode=resume` URL in the same target, so it is deleted and the
two `widgetURL` call sites use `VoiceModeDeepLink.resume.url`. Its reasoning
about why a nil URL is the correct failure moved into
`VoiceSessionLiveActivity`'s docstring.

## Verification performed

- All three extension targets build clean from a cold build directory, zero
  warnings: `xcodebuild -project App.xcodeproj -target "VoiceActivity{, Staging,
  Dev}" -sdk iphonesimulator -configuration Release build`.
- The appex's emitted `Metadata.appintents/extract.actionsdata` contains exactly
  `StartNewVoiceConversationIntent` with `openAppWhenRun: true`, and does not
  contain `StartVoiceModeIntent`.
- `-showBuildSettings` confirms `SWIFT_ACTIVE_COMPILATION_CONDITIONS` carries
  `VOICE_ACTIVITY_EXTENSION` on the extension targets and not on the app
  targets, and that `IPHONEOS_DEPLOYMENT_TARGET` is still `17.0` everywhere.
- Removing the `#if` reproduces the compile failure quoted above, so the gate
  is required rather than decorative.
- No `#Preview` / `PreviewProvider` blocks. `App.xcodeproj/` is not committed.
  `CapApp-SPM/Package.swift` is unmodified (`cap sync` was not run).

## Unverified

Device and Simulator verification is deferred. Nothing below was performed.

**A full-app build could not be run locally.** `xcodebuild -target "App Dev"`
fails in `CapApp-SPM` dependency resolution (`unable to resolve module
dependency: 'IONFilesystemLib'` from `@capacitor/filesystem`) — pre-existing and
environmental, unrelated to this change. **CI is the gate for all three app
schemes.** Everything below depends on getting an app build first.

Coverable on the **iPhone 17 Pro Simulator (iOS 26.2 runtime, installed here)**
once the app builds:

- The control appears in the Control Center gallery under this app.
- Tapping it opens the app and starts a *new* voice session (the end-to-end
  path through `openAppWhenRun` → app-process `perform()` → `deliverVoiceCommand`
  → `appUrlOpen` → the SPA's `mode=new` consumer). This also settles the one
  real assumption in the design above.
- Whether the intent now shows **twice** in the Shortcuts app. The appex's
  metadata marks it `isDiscoverable: true`, same as the app's copy, so a
  duplicate "New voice conversation" row is possible. If it happens, the fix is
  one line — a `#if VOICE_ACTIVITY_EXTENSION` override of `isDiscoverable` on
  the appex copy — deliberately not applied pre-emptively, because guessing
  wrong there could hide the intent from the control itself.
- Whether the app build emits any App Intents metadata warning about the type
  being declared in both the app and the appex.

Needs **real hardware**:

- Placing the control on the Lock Screen. Simulator does not faithfully
  reproduce the Lock Screen control slots.
- Control Center behavior from a cold (terminated) app, where the launch URL
  takes the `launchOptions[.url]` path.

Needs an **iOS 17.x device or runtime** (only the iOS 26.2 runtime is installed
on this machine, so this could not be checked even in Simulator):

- A 17.x device installs and runs the app, shows Live Activities normally, and
  simply does not offer the control.