### PR TITLE
fix(ios): call the now-parameterized voice deep-link URL builder

### DIFF
--- a/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
@@ -31,7 +31,7 @@ struct VoiceSessionLiveActivity: Widget {
                 assistantName: context.attributes.assistantName,
                 state: context.state
             )
-            .widgetURL(VoiceModeDeepLink.resume.url)
+            .widgetURL(VoiceModeDeepLink.resume.url())
         } dynamicIsland: { context in
             let state = context.state
             return DynamicIsland {
@@ -64,7 +64,7 @@ struct VoiceSessionLiveActivity: Widget {
             } minimal: {
                 VoiceAccentGlyph(accent: state.accentColor, scale: .small)
             }
-            .widgetURL(VoiceModeDeepLink.resume.url)
+            .widgetURL(VoiceModeDeepLink.resume.url())
             .keylineTint(state.accentColor)
         }
     }


### PR DESCRIPTION
## Summary
Fixes a broken `App Dev` build on the feature branch.

Two PRs landed in parallel and collided on `VoiceModeDeepLink`:
- #39279 deleted the extension's local `VoiceSessionDeepLink` and pointed the island's two `widgetURL` call sites at `VoiceModeDeepLink.resume.url`, which was a **property**.
- #39281 added an optional prompt parameter, turning `url` into a **function**, `url(prompt:)`.

Neither PR was wrong in isolation and neither diff touched the other's line, so the conflict was invisible to git — it only surfaced at compile time as `function produces expected type 'URL?'` at `VoiceSessionLiveActivity.swift:34` and `:67`.

Call sites now use `url()`, taking the parameter's `nil` default: an island tap resumes an existing session and carries no prompt, which is the intended behavior.

## Verification
`xcodebuild -target "VoiceActivity Dev" -sdk iphonesimulator -configuration Release` — **BUILD SUCCEEDED** locally. CI's `PR iOS Checks` gates the three app schemes.

Part of plan: first-class-ios-voice-mode.md (fix)