### PR TITLE
feat(schedule): zod-parse schedule tool input in the executors (LUM-2853)

### DIFF
--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -2023,3 +2023,193 @@ describe("script handoff validation", () => {
     expect(row.skill_version_hash).toBeNull();
   });
 });
+
+// ── model-input schema validation (LUM-2853) ────────────────────────
+
+describe("schedule tools — model-input schema validation", () => {
+  beforeEach(() => {
+    getRawDb().run("DELETE FROM cron_runs");
+    getRawDb().run("DELETE FROM cron_jobs");
+  });
+
+  test("schedule_create rejects a mistyped field instead of persisting it", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Bad timezone",
+        expression: "0 9 * * *",
+        message: "hi",
+        timezone: 42,
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "schedule_create"',
+    );
+    expect(result.content).toContain("timezone");
+    const count = getRawDb()
+      .query("SELECT COUNT(*) as n FROM cron_jobs")
+      .get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+
+  test("schedule_create rejects a non-integer retry policy", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Bad retries",
+        expression: "0 9 * * *",
+        message: "hi",
+        max_retries: "five",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("max_retries");
+  });
+
+  test("schedule_create rejects an unknown syntax value instead of persisting it", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Bad syntax",
+        expression: "0 9 * * *",
+        syntax: "daily",
+        message: "hi",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("syntax");
+  });
+
+  test("schedule_create treats explicit null as an omitted optional", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Null tolerance",
+        expression: "0 9 * * *",
+        message: "hi",
+        timezone: null,
+        enabled: null,
+        quiet: null,
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain("Enabled: true");
+  });
+
+  test("schedule_create still silently ignores a malformed skill_id", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Ignored skill_id",
+        expression: "0 9 * * *",
+        message: "hi",
+        skill_id: 42,
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  test("schedule_create keeps the bespoke error for a non-string mode", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Bad mode",
+        expression: "0 9 * * *",
+        message: "hi",
+        mode: 42,
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("mode must be one of");
+  });
+
+  test("schedule_create passes unknown keys through (loose schema)", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Loose keys",
+        expression: "0 9 * * *",
+        message: "hi",
+        activity: "creating a schedule",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  test("schedule_update rejects a mistyped field", async () => {
+    const create = await executeScheduleCreate(
+      { name: "To update", expression: "0 9 * * *", message: "hi" },
+      ctx,
+    );
+    expect(create.isError).toBeFalsy();
+    const jobId = (
+      getRawDb().query("SELECT id FROM cron_jobs").get() as { id: string }
+    ).id;
+
+    const result = await executeScheduleUpdate(
+      { job_id: jobId, max_retries: 2.5 },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "schedule_update"',
+    );
+    expect(result.content).toContain("max_retries");
+  });
+
+  test("schedule_update still clears timezone with an explicit null", async () => {
+    const create = await executeScheduleCreate(
+      {
+        name: "Tz clear",
+        expression: "0 9 * * *",
+        message: "hi",
+        timezone: "America/Los_Angeles",
+      },
+      ctx,
+    );
+    expect(create.isError).toBeFalsy();
+    const jobId = (
+      getRawDb().query("SELECT id FROM cron_jobs").get() as { id: string }
+    ).id;
+
+    const result = await executeScheduleUpdate(
+      { job_id: jobId, timezone: null },
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const row = getRawDb()
+      .query("SELECT timezone FROM cron_jobs WHERE id = ?")
+      .get(jobId) as { timezone: string | null };
+    expect(row.timezone).toBeNull();
+  });
+
+  test("schedule_list rejects a mistyped enabled_only and tolerates null", async () => {
+    const bad = await executeScheduleList({ enabled_only: "yes" }, ctx);
+    expect(bad.isError).toBe(true);
+    expect(bad.content).toContain('Invalid input for tool "schedule_list"');
+
+    const ok = await executeScheduleList(
+      { enabled_only: null, job_id: null },
+      ctx,
+    );
+    expect(ok.isError).toBeFalsy();
+  });
+
+  test("schedule_delete rejects a mistyped job_id", async () => {
+    const result = await executeScheduleDelete({ job_id: 42 }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "schedule_delete"',
+    );
+  });
+});

--- a/assistant/src/tools/__tests__/schedule-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/schedule-tool-input-schemas.test.ts
@@ -1,0 +1,187 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import type { z } from "zod";
+
+import { scheduleCreateInputSchema } from "../schedule/create.js";
+import { scheduleDeleteInputSchema } from "../schedule/delete.js";
+import { scheduleListInputSchema } from "../schedule/list.js";
+import { scheduleUpdateInputSchema } from "../schedule/update.js";
+import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+
+/**
+ * Drift guard between the schedule skill's hand-written `TOOLS.json`
+ * `input_schema`s (the advertised contract) and the executors' runtime Zod
+ * schemas. Skill-owned tools are skipped by the central `TOOL_INPUT_SCHEMAS`
+ * gate, so the two halves live in different files — this test pins their
+ * STRUCTURE (property names, types, enums, required lists) together so a
+ * field added or retyped on one side cannot silently diverge on the other.
+ *
+ * What is deliberately NOT compared:
+ *
+ * - `description` strings — advertised prose is TOOLS.json-owned; the
+ *   runtime schema never reads it.
+ * - PASSTHROUGH fields — advertised in TOOLS.json but undeclared in the Zod
+ *   schema (loose passthrough), because the executor's bespoke handling is
+ *   the validation contract. Each entry documents why. The guard still
+ *   asserts they exist in TOOLS.json, so a rename breaks this test.
+ * - NULLABLE_AT_RUNTIME fields — declared `.nullable()` in the Zod schema
+ *   though advertised non-null, because `updateSchedule` treats null as
+ *   "clear this field" and always has. The guard compares them with the
+ *   null branch stripped.
+ */
+
+type JsonSchema = Record<string, unknown>;
+
+const TOOLS_JSON = JSON.parse(
+  readFileSync(
+    join(import.meta.dir, "../../config/bundled-skills/schedule/TOOLS.json"),
+    "utf8",
+  ),
+) as { tools: { name: string; input_schema: JsonSchema }[] };
+
+const CASES: {
+  name: string;
+  schema: z.ZodType;
+  advertiseRequired?: string[];
+  /** Advertised fields the runtime schema passes through unvalidated. */
+  passthrough?: Record<string, string>;
+  /** Declared fields that additionally accept null at runtime. */
+  nullableAtRuntime?: string[];
+}[] = [
+  {
+    name: "schedule_create",
+    schema: scheduleCreateInputSchema,
+    advertiseRequired: ["name", "description"],
+    passthrough: {
+      mode: "bespoke VALID_MODES check owns the error semantics",
+      routing_intent: "bespoke VALID_ROUTING_INTENTS check owns the error",
+      capabilities:
+        "CapabilityManifestSchema is the single validation authority; must reach the executor (and the requireFreshApproval promotion) unaltered",
+      workflow_args: "workflow runtime accepts any JSON value as args",
+    },
+  },
+  {
+    name: "schedule_update",
+    schema: scheduleUpdateInputSchema,
+    advertiseRequired: ["job_id"],
+    passthrough: {
+      mode: "bespoke VALID_MODES check owns the error semantics",
+      routing_intent: "bespoke VALID_ROUTING_INTENTS check owns the error",
+      then_execute:
+        "resolveScheduleBindingUpdate's `=== true` coercion owns it",
+      skill_id: "typeof-guarded null fallback + empty-string unbind semantics",
+      workflow_name: "typeof-guarded null fallback (non-string clears)",
+      workflow_args: "workflow runtime accepts any JSON value as args",
+    },
+    nullableAtRuntime: ["timezone", "script", "routing_hints"],
+  },
+  { name: "schedule_list", schema: scheduleListInputSchema },
+  {
+    name: "schedule_delete",
+    schema: scheduleDeleteInputSchema,
+    advertiseRequired: ["job_id"],
+  },
+];
+
+/** Strip `description` keys recursively — prose is TOOLS.json-owned. */
+function structural(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(structural);
+  }
+  if (node === null || typeof node !== "object") {
+    return node;
+  }
+  const out: JsonSchema = {};
+  for (const [key, value] of Object.entries(node as JsonSchema)) {
+    if (key === "description") {
+      continue;
+    }
+    out[key] = structural(value);
+  }
+  return out;
+}
+
+/**
+ * Canonicalize a derived property schema for comparison with TOOLS.json's
+ * hand-written form:
+ *
+ * - drop the safe-integer `minimum`/`maximum` bounds `z.int()` emits;
+ * - collapse `anyOf: [X, {type: "null"}]` (Zod's nullable encoding) into
+ *   TOOLS.json's `type: [t, "null"]` array form;
+ * - when `stripNull` is set (NULLABLE_AT_RUNTIME fields), drop the null
+ *   branch entirely so the runtime-only null tolerance is not advertised.
+ */
+function canonicalize(prop: JsonSchema, stripNull: boolean): JsonSchema {
+  const out = { ...prop };
+  if (out.minimum === -(2 ** 53 - 1)) {
+    delete out.minimum;
+  }
+  if (out.maximum === 2 ** 53 - 1) {
+    delete out.maximum;
+  }
+  // `z.looseObject({})` (an "any object" passthrough) emits an empty
+  // `properties` block TOOLS.json's bare `{type: "object"}` doesn't carry.
+  if (
+    typeof out.properties === "object" &&
+    out.properties !== null &&
+    Object.keys(out.properties).length === 0
+  ) {
+    delete out.properties;
+  }
+  const anyOf = out.anyOf;
+  if (Array.isArray(anyOf) && anyOf.length === 2) {
+    const nullIdx = anyOf.findIndex(
+      (entry) => (entry as JsonSchema).type === "null",
+    );
+    if (nullIdx !== -1) {
+      const base = canonicalize(anyOf[1 - nullIdx] as JsonSchema, false);
+      delete out.anyOf;
+      Object.assign(out, base);
+      if (!stripNull && typeof base.type === "string") {
+        out.type = [base.type, "null"];
+      }
+    }
+  }
+  return out;
+}
+
+describe("schedule TOOLS.json ↔ runtime Zod schema drift guard", () => {
+  for (const c of CASES) {
+    test(c.name, () => {
+      const entry = TOOLS_JSON.tools.find((t) => t.name === c.name);
+      expect(entry).toBeDefined();
+      const advertised = structural(entry!.input_schema) as JsonSchema;
+      const derived = structural(
+        toToolInputSchema(c.schema, { advertiseRequired: c.advertiseRequired }),
+      ) as JsonSchema;
+
+      const advertisedProps = { ...(advertised.properties as JsonSchema) };
+      const derivedProps = { ...(derived.properties as JsonSchema) };
+
+      for (const field of Object.keys(c.passthrough ?? {})) {
+        expect(advertisedProps[field]).toBeDefined();
+        expect(derivedProps[field]).toBeUndefined();
+        delete advertisedProps[field];
+      }
+
+      for (const [field, prop] of Object.entries(derivedProps)) {
+        derivedProps[field] = canonicalize(
+          prop as JsonSchema,
+          c.nullableAtRuntime?.includes(field) ?? false,
+        );
+      }
+
+      expect(Object.keys(derivedProps).sort()).toEqual(
+        Object.keys(advertisedProps).sort(),
+      );
+      expect(derivedProps).toEqual(advertisedProps);
+      expect(
+        [...((derived.required as string[] | undefined) ?? [])].sort(),
+      ).toEqual(
+        [...((advertised.required as string[] | undefined) ?? [])].sort(),
+      );
+    });
+  }
+});

--- a/assistant/src/tools/__tests__/schedule-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/schedule-tool-input-schemas.test.ts
@@ -28,7 +28,7 @@ import { toToolInputSchema } from "../shared/zod-tool-schema.js";
  *   asserts they exist in TOOLS.json, so a rename breaks this test.
  * - NULLABLE_AT_RUNTIME fields — declared `.nullable()` in the Zod schema
  *   though advertised non-null, because `updateSchedule` treats null as
- *   "clear this field" and always has. The guard compares them with the
+ *   "clear this field". The guard compares them with the
  *   null branch stripped.
  */
 

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -42,11 +42,11 @@ const VALID_ROUTING_INTENTS: RoutingIntent[] = [
  * `TOOLS.json`, and `schedule-tool-input-schemas.test.ts` guards the two
  * against structural drift.
  *
- * Tolerance mirrors what the executor always accepted — this schema only
- * rejects values that previously flowed into the store as corruption:
+ * Tolerance matches the executor's own reads — this schema only rejects
+ * values the executor would otherwise pass into the store unchecked:
  *
- * - `nullAsOmitted` on optionals read via `?? fallback`, where null always
- *   behaved as absent.
+ * - `nullAsOmitted` on optionals read via `?? fallback`, where null and
+ *   absent are equivalent.
  * - `.catch(undefined)` on `skill_id` / `workflow_name`, which the executor
  *   silently coerces to null when malformed.
  * - `mode`, `routing_intent`, `capabilities`, and `workflow_args` are

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { resolveCapabilities } from "../../runtime/capabilities.js";
 import { validateScheduleInferenceProfile } from "../../schedule/inference-profile.js";
 import { formatIntegrationSummary } from "../../schedule/integration-status.js";
@@ -19,6 +21,10 @@ import {
   CapabilityManifestSchema,
   resolveCapabilities as resolveWorkflowCapabilities,
 } from "../../workflows/capabilities.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 const VALID_MODES: ScheduleMode[] = ["notify", "execute", "script", "workflow"];
@@ -27,6 +33,50 @@ const VALID_ROUTING_INTENTS: RoutingIntent[] = [
   "multi_channel",
   "all_channels",
 ];
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeScheduleCreate}.
+ * Skill-owned tools are skipped by the central `TOOL_INPUT_SCHEMAS` gate, so
+ * validation lives in the executor (`ask_question` pre-registry precedent);
+ * the advertised `input_schema` stays hand-written in the schedule skill's
+ * `TOOLS.json`, and `schedule-tool-input-schemas.test.ts` guards the two
+ * against structural drift.
+ *
+ * Tolerance mirrors what the executor always accepted — this schema only
+ * rejects values that previously flowed into the store as corruption:
+ *
+ * - `nullAsOmitted` on optionals read via `?? fallback`, where null always
+ *   behaved as absent.
+ * - `.catch(undefined)` on `skill_id` / `workflow_name`, which the executor
+ *   silently coerces to null when malformed.
+ * - `mode`, `routing_intent`, `capabilities`, and `workflow_args` are
+ *   deliberately UNDECLARED (loose passthrough): the first two keep their
+ *   bespoke `VALID_*` error messages, `capabilities` must reach
+ *   `CapabilityManifestSchema` (and the `requireFreshApproval` promotion in
+ *   `executor.ts`) unaltered, and `workflow_args` accepts any JSON value the
+ *   workflow runtime accepts.
+ */
+export const scheduleCreateInputSchema = z.looseObject({
+  name: nullAsOmitted(z.string()),
+  description: nullAsOmitted(z.string()),
+  syntax: nullAsOmitted(z.enum(["cron", "rrule"])),
+  expression: nullAsOmitted(z.string()),
+  fire_at: nullAsOmitted(z.string()),
+  timezone: nullAsOmitted(z.string()),
+  message: nullAsOmitted(z.string()),
+  script: nullAsOmitted(z.string()),
+  then_execute: nullAsOmitted(z.boolean()),
+  skill_id: z.string().optional().catch(undefined),
+  enabled: nullAsOmitted(z.boolean()),
+  workflow_name: z.string().optional().catch(undefined),
+  routing_hints: nullAsOmitted(z.looseObject({})),
+  quiet: nullAsOmitted(z.boolean()),
+  reuse_conversation: nullAsOmitted(z.boolean()),
+  max_retries: nullAsOmitted(z.int()),
+  retry_backoff_ms: nullAsOmitted(z.int()),
+  timeout_ms: z.int().optional(),
+  inference_profile: z.string().optional(),
+});
 
 export async function executeScheduleCreate(
   input: Record<string, unknown>,
@@ -39,30 +89,34 @@ export async function executeScheduleCreate(
       isError: true,
     };
   }
-  const name = input.name as string;
-  const description = input.description as string | undefined;
-  const timezone = (input.timezone as string) ?? null;
-  const message = (input.message as string) ?? "";
-  const script = (input.script as string) ?? null;
-  const enabled = (input.enabled as boolean) ?? true;
-  const fireAt = input.fire_at as string | undefined;
+  const parsedInput = scheduleCreateInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("schedule_create", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const name = parsed.name;
+  const description = parsed.description;
+  const timezone = parsed.timezone ?? null;
+  const message = parsed.message ?? "";
+  const script = parsed.script ?? null;
+  const enabled = parsed.enabled ?? true;
+  const fireAt = parsed.fire_at;
+  // mode / routing_intent / workflow_args (and capabilities, read below) stay
+  // raw-input reads: they are undeclared in the schema (see its doc comment).
   const mode = (input.mode as ScheduleMode | undefined) ?? "execute";
   const routingIntent = input.routing_intent as string | undefined;
-  const routingHints = input.routing_hints as
-    | Record<string, unknown>
-    | undefined;
-  const quiet = (input.quiet as boolean) ?? false;
-  const reuseConversation = input.reuse_conversation as boolean | undefined;
-  const maxRetries = input.max_retries as number | undefined;
-  const retryBackoffMs = input.retry_backoff_ms as number | undefined;
-  const timeoutMs = input.timeout_ms as number | undefined;
-  const workflowName =
-    typeof input.workflow_name === "string" ? input.workflow_name.trim() : null;
+  const routingHints = parsed.routing_hints;
+  const quiet = parsed.quiet ?? false;
+  const reuseConversation = parsed.reuse_conversation;
+  const maxRetries = parsed.max_retries;
+  const retryBackoffMs = parsed.retry_backoff_ms;
+  const timeoutMs = parsed.timeout_ms;
+  const workflowName = parsed.workflow_name?.trim() ?? null;
   const workflowArgs = input.workflow_args;
-  const inferenceProfile = input.inference_profile as string | undefined;
-  const thenExecute = (input.then_execute as boolean) ?? false;
-  const skillId =
-    typeof input.skill_id === "string" ? input.skill_id.trim() : null;
+  const inferenceProfile = parsed.inference_profile;
+  const thenExecute = parsed.then_execute ?? false;
+  const skillId = parsed.skill_id?.trim() ?? null;
 
   // Validated workflow capability manifest, resolved only for workflow mode.
   // Left null for non-workflow modes so `createSchedule` persists no manifest.
@@ -85,30 +139,20 @@ export async function executeScheduleCreate(
   }
 
   if (inferenceProfile !== undefined) {
-    if (typeof inferenceProfile !== "string") {
-      return {
-        content: "Error: inference_profile must be a string",
-        isError: true,
-      };
-    }
     const profileError = validateScheduleInferenceProfile(inferenceProfile);
     if (profileError) {
       return { content: `Error: ${profileError}`, isError: true };
     }
   }
 
-  if (!name || typeof name !== "string") {
+  if (!name) {
     return {
       content: "Error: name is required and must be a string",
       isError: true,
     };
   }
 
-  if (
-    !description ||
-    typeof description !== "string" ||
-    description.trim().length === 0
-  ) {
+  if (!description || description.trim().length === 0) {
     return {
       content: "Error: description is required and must be a non-empty string",
       isError: true,
@@ -125,7 +169,7 @@ export async function executeScheduleCreate(
 
   // Mode-specific field validation
   if (mode === "script") {
-    if (!script || typeof script !== "string") {
+    if (!script) {
       return {
         content:
           "Error: script is required for script mode and must be a non-empty string",
@@ -274,8 +318,8 @@ export async function executeScheduleCreate(
 
   // ── Recurring schedule (expression) ──────────────────────────────
   const resolved = normalizeScheduleSyntax({
-    syntax: input.syntax as "cron" | "rrule" | undefined,
-    expression: input.expression as string | undefined,
+    syntax: parsed.syntax,
+    expression: parsed.expression,
   });
 
   if (!resolved) {

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -1,12 +1,31 @@
+import { z } from "zod";
+
 import { deleteSchedule, getSchedule } from "../../schedule/schedule-store.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeScheduleDelete}.
+ * Same in-tool pattern and drift guard as {@link scheduleCreateInputSchema}
+ * in `create.ts` — see that schema's doc comment for the framework.
+ */
+export const scheduleDeleteInputSchema = z.looseObject({
+  job_id: nullAsOmitted(z.string()),
+});
 
 export async function executeScheduleDelete(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const jobId = input.job_id as string;
-  if (!jobId || typeof jobId !== "string") {
+  const parsedInput = scheduleDeleteInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("schedule_delete", parsedInput.error);
+  }
+  const jobId = parsedInput.data.job_id;
+  if (!jobId) {
     return { content: "Error: job_id is required", isError: true };
   }
 

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { hasSetConstructs } from "../../schedule/recurrence-engine.js";
 import {
   describeCronExpression,
@@ -6,6 +8,10 @@ import {
   getScheduleRuns,
   listSchedules,
 } from "../../schedule/schedule-store.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 function describeSchedule(job: {
@@ -13,7 +19,9 @@ function describeSchedule(job: {
   expression: string | null;
   cronExpression: string | null;
 }): string {
-  if (job.expression == null) return "One-time";
+  if (job.expression == null) {
+    return "One-time";
+  }
   if (job.syntax === "rrule") {
     const label = hasSetConstructs(job.expression) ? "[RRULE set] " : "";
     return `${label}${job.expression}`;
@@ -29,12 +37,26 @@ function describeAuthoredPurpose(job: { description: string }): string {
   return job.description || "(none)";
 }
 
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeScheduleList}.
+ * Same in-tool pattern and drift guard as {@link scheduleCreateInputSchema}
+ * in `create.ts` — see that schema's doc comment for the framework.
+ */
+export const scheduleListInputSchema = z.looseObject({
+  enabled_only: nullAsOmitted(z.boolean()),
+  job_id: nullAsOmitted(z.string()),
+});
+
 export async function executeScheduleList(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const jobId = input.job_id as string | undefined;
-  const enabledOnly = (input.enabled_only as boolean) ?? false;
+  const parsedInput = scheduleListInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("schedule_list", parsedInput.error);
+  }
+  const jobId = parsedInput.data.job_id;
+  const enabledOnly = parsedInput.data.enabled_only ?? false;
 
   // Detail mode for a specific job
   if (jobId) {

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { resolveCapabilities } from "../../runtime/capabilities.js";
 import { validateScheduleInferenceProfile } from "../../schedule/inference-profile.js";
 import { validateRruleSetLines } from "../../schedule/recurrence-engine.js";
@@ -18,6 +20,10 @@ import {
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { resolveScheduleBindingUpdate } from "../../schedule/skill-binding.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 const VALID_MODES: ScheduleMode[] = ["notify", "execute", "script", "workflow"];
@@ -26,6 +32,48 @@ const VALID_ROUTING_INTENTS: RoutingIntent[] = [
   "multi_channel",
   "all_channels",
 ];
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeScheduleUpdate}.
+ * Same in-tool pattern and drift guard as {@link scheduleCreateInputSchema}
+ * in `create.ts` — see that schema's doc comment for the framework.
+ *
+ * Update-specific tolerance notes:
+ *
+ * - Presence semantics matter here (`input.x !== undefined` gates every
+ *   update), so fields are plain `.optional()` — no null-to-omitted
+ *   preprocessing that would silently turn an explicit update into a no-op.
+ * - `timezone` and `script` are nullable at runtime though advertised as
+ *   plain strings: `updateSchedule` persists null as "clear this field" and
+ *   that has always worked.
+ * - `timeout_ms` / `inference_profile` advertise null (it reverts to the
+ *   default); the executor's bespoke handling stays.
+ * - `mode`, `routing_intent`, `then_execute`, `skill_id`, `workflow_name`,
+ *   and `workflow_args` are deliberately UNDECLARED (loose passthrough):
+ *   the first two keep bespoke `VALID_*` errors; the binding fields
+ *   (`then_execute`, `skill_id`) and `workflow_name` have bespoke coercion
+ *   semantics (`=== true`, typeof-guarded null fallbacks, empty-string
+ *   unbind) inside `resolveScheduleBindingUpdate` and the workflow-name
+ *   resolution below; `workflow_args` accepts any JSON value.
+ */
+export const scheduleUpdateInputSchema = z.looseObject({
+  job_id: nullAsOmitted(z.string()),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  syntax: z.enum(["cron", "rrule"]).optional(),
+  expression: z.string().optional(),
+  timezone: z.string().nullable().optional(),
+  message: z.string().optional(),
+  script: z.string().nullable().optional(),
+  enabled: z.boolean().optional(),
+  routing_hints: z.looseObject({}).nullable().optional(),
+  quiet: z.boolean().optional(),
+  reuse_conversation: z.boolean().optional(),
+  max_retries: z.int().optional(),
+  retry_backoff_ms: z.int().optional(),
+  timeout_ms: z.int().nullable().optional(),
+  inference_profile: z.string().nullable().optional(),
+});
 
 export async function executeScheduleUpdate(
   input: Record<string, unknown>,
@@ -38,19 +86,26 @@ export async function executeScheduleUpdate(
       isError: true,
     };
   }
-  const jobId = input.job_id as string;
-  if (!jobId || typeof jobId !== "string") {
+  const parsedInput = scheduleUpdateInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("schedule_update", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const jobId = parsed.job_id;
+  if (!jobId) {
     return { content: "Error: job_id is required", isError: true };
   }
 
-  // Prevent changing a one-shot to recurring or vice versa
-  if (input.expression !== undefined || input.fire_at !== undefined) {
+  // Prevent changing a one-shot to recurring or vice versa. (`fire_at` is
+  // not an advertised update field, so it stays a raw-input read.)
+  if (parsed.expression !== undefined || input.fire_at !== undefined) {
     const existing = getSchedule(jobId);
     if (!existing) {
       return { content: `Error: Schedule not found: ${jobId}`, isError: true };
     }
     const isExistingOneShot = existing.expression == null;
-    if (isExistingOneShot && input.expression !== undefined) {
+    if (isExistingOneShot && parsed.expression !== undefined) {
       return {
         content:
           "Error: Cannot change a one-shot schedule to recurring. Delete and recreate instead.",
@@ -67,10 +122,12 @@ export async function executeScheduleUpdate(
   }
 
   const updates: Record<string, unknown> = {};
-  if (input.name !== undefined) updates.name = input.name;
-  if (input.description !== undefined) {
-    const description = input.description as string;
-    if (typeof description !== "string" || description.trim().length === 0) {
+  if (parsed.name !== undefined) {
+    updates.name = parsed.name;
+  }
+  if (parsed.description !== undefined) {
+    const description = parsed.description;
+    if (description.trim().length === 0) {
       return {
         content: "Error: description must be a non-empty string when provided",
         isError: true,
@@ -78,10 +135,18 @@ export async function executeScheduleUpdate(
     }
     updates.description = description;
   }
-  if (input.timezone !== undefined) updates.timezone = input.timezone;
-  if (input.message !== undefined) updates.message = input.message;
-  if (input.script !== undefined) updates.script = input.script;
-  if (input.enabled !== undefined) updates.enabled = input.enabled;
+  if (parsed.timezone !== undefined) {
+    updates.timezone = parsed.timezone;
+  }
+  if (parsed.message !== undefined) {
+    updates.message = parsed.message;
+  }
+  if (parsed.script !== undefined) {
+    updates.script = parsed.script;
+  }
+  if (parsed.enabled !== undefined) {
+    updates.enabled = parsed.enabled;
+  }
 
   // Validate the handoff whenever the toggle or the action prompt moves.
   // `message` matters because it becomes the handoff's trusted postamble:
@@ -90,7 +155,7 @@ export async function executeScheduleUpdate(
   if (
     input.then_execute !== undefined ||
     input.skill_id !== undefined ||
-    input.message !== undefined
+    parsed.message !== undefined
   ) {
     const existing = getSchedule(jobId);
     if (!existing) {
@@ -107,7 +172,7 @@ export async function executeScheduleUpdate(
             skillId: typeof input.skill_id === "string" ? input.skill_id : null,
           }
         : {}),
-      ...(typeof input.message === "string" ? { message: input.message } : {}),
+      ...(parsed.message !== undefined ? { message: parsed.message } : {}),
     });
     if (!binding.ok) {
       return { content: `Error: ${binding.error}`, isError: true };
@@ -151,81 +216,77 @@ export async function executeScheduleUpdate(
   }
 
   // Routing hints pass-through
-  if (input.routing_hints !== undefined) {
-    updates.routingHints = input.routing_hints;
+  if (parsed.routing_hints !== undefined) {
+    updates.routingHints = parsed.routing_hints;
   }
 
   // Quiet mode
-  if (input.quiet !== undefined) {
-    updates.quiet = input.quiet;
+  if (parsed.quiet !== undefined) {
+    updates.quiet = parsed.quiet;
   }
 
   // Conversation reuse
-  if (input.reuse_conversation !== undefined) {
-    updates.reuseConversation = input.reuse_conversation;
+  if (parsed.reuse_conversation !== undefined) {
+    updates.reuseConversation = parsed.reuse_conversation;
   }
 
   // Retry policy
-  if (input.max_retries !== undefined) {
-    updates.maxRetries = input.max_retries;
+  if (parsed.max_retries !== undefined) {
+    updates.maxRetries = parsed.max_retries;
   }
-  if (input.retry_backoff_ms !== undefined) {
-    updates.retryBackoffMs = input.retry_backoff_ms;
+  if (parsed.retry_backoff_ms !== undefined) {
+    updates.retryBackoffMs = parsed.retry_backoff_ms;
   }
 
   // Inference profile override (null clears it, reverting to the default
   // main-agent model selection)
-  if (input.inference_profile !== undefined) {
-    if (input.inference_profile === null) {
+  if (parsed.inference_profile !== undefined) {
+    if (parsed.inference_profile === null) {
       updates.inferenceProfile = null;
     } else {
-      const inferenceProfile = input.inference_profile;
-      if (typeof inferenceProfile !== "string") {
-        return {
-          content: "Error: inference_profile must be a string or null",
-          isError: true,
-        };
-      }
-      const profileError = validateScheduleInferenceProfile(inferenceProfile);
+      const profileError = validateScheduleInferenceProfile(
+        parsed.inference_profile,
+      );
       if (profileError) {
         return { content: `Error: ${profileError}`, isError: true };
       }
-      updates.inferenceProfile = inferenceProfile;
+      updates.inferenceProfile = parsed.inference_profile;
     }
   }
 
   // Script execution timeout override (null clears it, reverting to default)
-  if (input.timeout_ms !== undefined) {
-    if (input.timeout_ms === null) {
+  if (parsed.timeout_ms !== undefined) {
+    if (parsed.timeout_ms === null) {
       updates.timeoutMs = null;
     } else {
-      const timeoutMs = input.timeout_ms as number;
-      const timeoutError = validateScriptTimeoutMs(timeoutMs);
+      const timeoutError = validateScriptTimeoutMs(parsed.timeout_ms);
       if (timeoutError) {
         return { content: `Error: ${timeoutError}`, isError: true };
       }
-      updates.timeoutMs = timeoutMs;
+      updates.timeoutMs = parsed.timeout_ms;
     }
   }
 
   // Auto-detect syntax when expression changes without explicit syntax
-  if (input.expression !== undefined || input.syntax !== undefined) {
+  if (parsed.expression !== undefined || parsed.syntax !== undefined) {
     const resolved = normalizeScheduleSyntax({
-      syntax: input.syntax as "cron" | "rrule" | undefined,
-      expression: input.expression as string | undefined,
+      syntax: parsed.syntax,
+      expression: parsed.expression,
     });
     if (resolved) {
       updates.syntax = resolved.syntax;
       updates.expression = resolved.expression;
-    } else if (input.expression !== undefined) {
-      updates.expression = input.expression;
-      const detected = detectScheduleSyntax(input.expression as string);
-      if (detected) updates.syntax = detected;
+    } else if (parsed.expression !== undefined) {
+      updates.expression = parsed.expression;
+      const detected = detectScheduleSyntax(parsed.expression);
+      if (detected) {
+        updates.syntax = detected;
+      }
     }
     // When only syntax is provided (no expression), normalizeScheduleSyntax returns null
     // but we still need to persist the explicit syntax value.
-    if (input.syntax !== undefined && updates.syntax === undefined) {
-      updates.syntax = input.syntax;
+    if (parsed.syntax !== undefined && updates.syntax === undefined) {
+      updates.syntax = parsed.syntax;
     }
   }
 

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -44,8 +44,7 @@ const VALID_ROUTING_INTENTS: RoutingIntent[] = [
  *   update), so fields are plain `.optional()` — no null-to-omitted
  *   preprocessing that would silently turn an explicit update into a no-op.
  * - `timezone` and `script` are nullable at runtime though advertised as
- *   plain strings: `updateSchedule` persists null as "clear this field" and
- *   that has always worked.
+ *   plain strings: `updateSchedule` persists null as "clear this field".
  * - `timeout_ms` / `inference_profile` advertise null (it reverts to the
  *   default); the executor's bespoke handling stays.
  * - `mode`, `routing_intent`, `then_execute`, `skill_id`, `workflow_name`,

--- a/assistant/src/tools/shared/zod-tool-schema.ts
+++ b/assistant/src/tools/shared/zod-tool-schema.ts
@@ -81,10 +81,10 @@ function stripPermissiveAdditionalProperties(node: unknown): void {
 /**
  * Wrap an optional field's schema so an explicit `null` parses as "omitted"
  * (`undefined`). Models routinely send `null` for optional fields they mean
- * to skip, and executors that read fields with `input.x ?? fallback` have
- * always treated null exactly like absent — validation must not start
- * rejecting that. The derived JSON Schema is the inner schema's (the
- * null-tolerance is runtime slack, not advertised contract).
+ * to skip, and executors read such fields via `input.x ?? fallback`, where
+ * null and absent are equivalent — validation must not reject null there.
+ * The derived JSON Schema is the inner schema's (the null-tolerance is
+ * runtime slack, not advertised contract).
  */
 export function nullAsOmitted<T extends z.ZodType>(schema: T) {
   return z.preprocess((value) => value ?? undefined, schema.optional());

--- a/assistant/src/tools/shared/zod-tool-schema.ts
+++ b/assistant/src/tools/shared/zod-tool-schema.ts
@@ -79,6 +79,18 @@ function stripPermissiveAdditionalProperties(node: unknown): void {
 }
 
 /**
+ * Wrap an optional field's schema so an explicit `null` parses as "omitted"
+ * (`undefined`). Models routinely send `null` for optional fields they mean
+ * to skip, and executors that read fields with `input.x ?? fallback` have
+ * always treated null exactly like absent — validation must not start
+ * rejecting that. The derived JSON Schema is the inner schema's (the
+ * null-tolerance is runtime slack, not advertised contract).
+ */
+export function nullAsOmitted<T extends z.ZodType>(schema: T) {
+  return z.preprocess((value) => value ?? undefined, schema.optional());
+}
+
+/**
  * Render a failed tool-input parse as a compact `field: message` summary the
  * model can correct from. Mirrors `runtime/routes/parse-body.ts`.
  */


### PR DESCRIPTION
## Summary

Second tranche of [LUM-2797](https://linear.app/vellum/issue/LUM-2797) ([LUM-2853](https://linear.app/vellum/issue/LUM-2853)): the four schedule executors (`schedule_create` / `schedule_update` / `schedule_list` / `schedule_delete`) held the biggest remaining concentration of naked `input.<field> as T` casts (28), so a mistyped model field — `timezone: 42`, `max_retries: "five"`, `syntax: "daily"` — flowed straight into the `cron_jobs` store as corruption. Each executor now `safeParse`s a tolerant Zod schema at the top and returns `invalidToolInputResult(...)` (same model-correctable error format as the central gate) before any field is read.

## Implementation

These are **skill-owned** tools, which the central `TOOL_INPUT_SCHEMAS` gate in `checkPreExecutionGates` deliberately skips, so validation lives in-tool (the `ask_question` pre-registry precedent). The advertised `input_schema` stays hand-written in the schedule skill's `TOOLS.json`.

**Drift decision (per the ticket's decide-in-implementation note): guard test, not gate extension.** In-tool `safeParse` runs on every invocation path, and extending the executor gate would have required new owner-kind plumbing to distinguish first-party bundled skills from user/workspace skills while still leaving TOOLS.json ungoverned. The new `schedule-tool-input-schemas.test.ts` pins the **structural** contract (property names, types, enums, required lists) between TOOLS.json and the runtime schemas; `description` prose stays TOOLS.json-owned and is not compared. Later skill tranches (LUM-2854–2856) will follow the same shape.

## Key technical choices — tolerance is preserved, never tightened

- **`nullAsOmitted` helper** (new in `shared/zod-tool-schema.ts`): models routinely send explicit `null` for optionals they mean to skip, and the executors' `?? fallback` reads always treated null as absent. The helper preprocesses `null → undefined` so that keeps working, while the derived JSON stays the inner schema's.
- **`.catch(undefined)`** only on fields the executors already silently ignore when malformed (`skill_id`, `workflow_name` in create).
- **Loose passthrough (undeclared in the schema)** for fields whose bespoke executor handling *is* the contract, each documented in the schema doc comments and asserted in the guard's exception list:
  - `mode` / `routing_intent`: bespoke `VALID_*` error messages preserved verbatim (existing tests assert them).
  - `capabilities`: `CapabilityManifestSchema` remains the single validation authority, and the value must reach `executor.ts`'s `requireFreshApproval` promotion unaltered.
  - `workflow_args`: the workflow runtime accepts any JSON value as `args`.
  - update's `then_execute` / `skill_id` / `workflow_name`: `=== true` coercion, typeof-guarded null fallbacks, and empty-string unbind semantics stay in `resolveScheduleBindingUpdate`.
- **Nullable at runtime, advertised non-null** (update's `timezone` / `script` / `routing_hints`): `updateSchedule` persists null as "clear this field" and always has; the guard compares these with the null branch stripped so the runtime-only slack is not advertised.
- **Update fields use plain `.optional()`, not `nullAsOmitted`** — presence (`!== undefined`) gates every update, and null-to-omitted preprocessing would silently turn an explicit update into a no-op.
- All bespoke validation with test-asserted messages (`name is required`, `mode must be one of`, `timeout_ms must be between`, `job_id is required`, …) is untouched; only type-guard branches the schema now guarantees were removed.

## Files changed

- `assistant/src/tools/schedule/{create,update,list,delete}.ts` — exported input schemas + safeParse; casts replaced with typed reads
- `assistant/src/tools/shared/zod-tool-schema.ts` — `nullAsOmitted` helper
- `assistant/src/tools/__tests__/schedule-tool-input-schemas.test.ts` — new TOOLS.json ↔ Zod structural drift guard
- `assistant/src/__tests__/schedule-tools.test.ts` — new validation describe block (rejection, null tolerance, ignored-field tolerance, loose passthrough, bespoke-message preservation)

## Testing

- `bun test src/__tests__/schedule-tools.test.ts` — 98 pass (87 pre-existing unchanged, 11 new)
- `bun test src/tools/__tests__/schedule-tool-input-schemas.test.ts` — 4 pass
- `bun test src/tools/__tests__/tool-input-schemas.test.ts` — 13 pass
- `bunx tsc --noEmit` clean; eslint + prettier clean on changed files; `lint:circular` count unchanged vs main (201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Latent prod bugs fixed (tracking)

Live, reachable paths in production code — any malformed model call could trigger them; fixed by this PR's validation:

1. **Invalid `syntax` persisted verbatim** — `schedule_create` with `syntax: "daily"` + an expression short-circuited `normalizeScheduleSyntax`'s auto-detection and persisted the bogus syntax into `cron_jobs`; `schedule_update` assigned `updates.syntax = input.syntax` with no check at all. Result: a schedule the recurrence engine cannot interpret (wedged/never fires). Note: this prevents **new** corruption only — long-lived DBs may still hold bad rows.
2. **Unvalidated numeric retry/timing fields** — `schedule_update` persisted `max_retries: "five"` / `retry_backoff_ms` garbage raw; retry arithmetic on those yields NaN backoff timing. `schedule_create`'s casts flowed the same fields unchecked into `createSchedule`.
3. **`expression: null` on update flips schedule type** — persisted a null expression, which is exactly the field used to distinguish recurring from one-shot (`expression == null`), silently converting the row's type.
4. **Raw passthrough of mistyped `timezone` / `message` / `script` / booleans** into the store on both create and update (e.g. `timezone: 42` persisted).
