### PR TITLE
feat(document): zod-parse document-editor tool input in the executors (LUM-2854)

### DIFF
--- a/assistant/src/__tests__/document-tool-security.test.ts
+++ b/assistant/src/__tests__/document-tool-security.test.ts
@@ -3,9 +3,12 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { getDocumentById } from "../documents/document-store.js";
 import { getSqlite } from "../persistence/db-connection.js";
 import {
+  executeDocumentCreate,
   executeDocumentDelete,
+  executeDocumentFind,
   executeDocumentList,
   executeDocumentRead,
+  executeDocumentReplaceText,
   executeDocumentUpdate,
 } from "../tools/document/document-tool.js";
 import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
@@ -336,5 +339,97 @@ describe("executeDocumentUpdate — input validation", () => {
     expect(result.isError).toBe(true);
     const body = parseResult<{ error: string }>(result);
     expect(body.error).toContain("Invalid input: surface_id is required");
+  });
+});
+
+// ── model-input schema validation (LUM-2854) ─────────────────────────
+
+describe("document tools — model-input schema validation", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+    seedFixtureDocuments();
+  });
+
+  test("document_find rejects a non-string query instead of crashing downstream", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-current", query: 42 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "document_find"');
+    expect(result.content).toContain("query");
+  });
+
+  test("document_find rejects a missing query cleanly", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-current" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "document_find"');
+  });
+
+  test("document_find treats null option flags as omitted", () => {
+    const result = executeDocumentFind(
+      {
+        surface_id: "doc-current",
+        query: "current",
+        regex: null,
+        case_sensitive: null,
+      },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ total_matches: number }>(result);
+    expect(body.total_matches).toBe(1);
+  });
+
+  test("document_create rejects a non-string title instead of persisting it", () => {
+    const result = executeDocumentCreate(
+      { title: 42, initial_content: "hello" },
+      makeContext({ conversationId: "conv-current" }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "document_create"',
+    );
+    expect(result.content).toContain("title");
+  });
+
+  test("document_update rejects a non-string content before the bespoke checks", () => {
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-current", content: 42 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "document_update"',
+    );
+  });
+
+  test("document_list still silently ignores a malformed query", () => {
+    const result = executeDocumentList({ query: 42 }, makeContext());
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ documents: Array<{ surface_id: string }> }>(
+      result,
+    );
+    expect(body.documents.map((d) => d.surface_id)).toEqual(["doc-current"]);
+  });
+
+  test("document_replace_text rejects a non-number max_replacements", () => {
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-current",
+        find: "current",
+        replace: "new",
+        max_replacements: "3",
+      },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "document_replace_text"',
+    );
+    expect(result.content).toContain("max_replacements");
   });
 });

--- a/assistant/src/tools/__tests__/document-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/document-tool-input-schemas.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test } from "bun:test";
+
+import type { z } from "zod";
+
+import {
+  commentListInputSchema,
+  commentReplyInputSchema,
+  commentResolveInputSchema,
+} from "../document/document-comment-tool.js";
+import {
+  documentCreateInputSchema,
+  documentDeleteInputSchema,
+  documentFindInputSchema,
+  documentListInputSchema,
+  documentOpenInputSchema,
+  documentReadInputSchema,
+  documentReplaceTextInputSchema,
+  documentUpdateInputSchema,
+} from "../document/document-tool.js";
+import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+import { expectNoSchemaDrift } from "./tool-schema-drift-harness.js";
+
+/**
+ * Drift guard between the document-editor skill's hand-written `TOOLS.json`
+ * `input_schema`s (the advertised contract) and the executors' runtime Zod
+ * schemas. See `tool-schema-drift-harness.ts` for what is (and deliberately
+ * is not) compared.
+ */
+
+const TOOLS_JSON = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dir,
+      "../../config/bundled-skills/document-editor/TOOLS.json",
+    ),
+    "utf8",
+  ),
+) as Parameters<typeof expectNoSchemaDrift>[1];
+
+const CASES: {
+  name: string;
+  schema: z.ZodType;
+  advertiseRequired?: string[];
+  passthrough?: Record<string, string>;
+}[] = [
+  {
+    name: "document_open",
+    schema: documentOpenInputSchema,
+    advertiseRequired: ["surface_id"],
+  },
+  { name: "document_create", schema: documentCreateInputSchema },
+  {
+    name: "document_update",
+    schema: documentUpdateInputSchema,
+    advertiseRequired: ["content"],
+    passthrough: {
+      mode: "bespoke check owns the error message and the { mode: null } tolerance that mirrors validateInputAgainstSchema",
+    },
+  },
+  {
+    name: "document_read",
+    schema: documentReadInputSchema,
+    advertiseRequired: ["surface_id"],
+  },
+  { name: "document_list", schema: documentListInputSchema },
+  {
+    name: "document_delete",
+    schema: documentDeleteInputSchema,
+    advertiseRequired: ["surface_id"],
+  },
+  {
+    name: "document_find",
+    schema: documentFindInputSchema,
+    advertiseRequired: ["surface_id"],
+  },
+  {
+    name: "document_replace_text",
+    schema: documentReplaceTextInputSchema,
+    advertiseRequired: ["surface_id", "replace"],
+  },
+  { name: "comment_list", schema: commentListInputSchema },
+  { name: "comment_resolve", schema: commentResolveInputSchema },
+  { name: "comment_reply", schema: commentReplyInputSchema },
+];
+
+describe("document-editor TOOLS.json ↔ runtime Zod schema drift guard", () => {
+  for (const c of CASES) {
+    test(c.name, () => {
+      expectNoSchemaDrift(
+        {
+          name: c.name,
+          derived: toToolInputSchema(c.schema, {
+            advertiseRequired: c.advertiseRequired,
+          }),
+          passthrough: c.passthrough,
+        },
+        TOOLS_JSON,
+      );
+    });
+  }
+});

--- a/assistant/src/tools/__tests__/schedule-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/schedule-tool-input-schemas.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
+import { describe, test } from "bun:test";
 
 import type { z } from "zod";
 
@@ -9,45 +9,27 @@ import { scheduleDeleteInputSchema } from "../schedule/delete.js";
 import { scheduleListInputSchema } from "../schedule/list.js";
 import { scheduleUpdateInputSchema } from "../schedule/update.js";
 import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+import { expectNoSchemaDrift } from "./tool-schema-drift-harness.js";
 
 /**
  * Drift guard between the schedule skill's hand-written `TOOLS.json`
  * `input_schema`s (the advertised contract) and the executors' runtime Zod
- * schemas. Skill-owned tools are skipped by the central `TOOL_INPUT_SCHEMAS`
- * gate, so the two halves live in different files — this test pins their
- * STRUCTURE (property names, types, enums, required lists) together so a
- * field added or retyped on one side cannot silently diverge on the other.
- *
- * What is deliberately NOT compared:
- *
- * - `description` strings — advertised prose is TOOLS.json-owned; the
- *   runtime schema never reads it.
- * - PASSTHROUGH fields — advertised in TOOLS.json but undeclared in the Zod
- *   schema (loose passthrough), because the executor's bespoke handling is
- *   the validation contract. Each entry documents why. The guard still
- *   asserts they exist in TOOLS.json, so a rename breaks this test.
- * - NULLABLE_AT_RUNTIME fields — declared `.nullable()` in the Zod schema
- *   though advertised non-null, because `updateSchedule` treats null as
- *   "clear this field". The guard compares them with the
- *   null branch stripped.
+ * schemas. See `tool-schema-drift-harness.ts` for what is (and deliberately
+ * is not) compared.
  */
-
-type JsonSchema = Record<string, unknown>;
 
 const TOOLS_JSON = JSON.parse(
   readFileSync(
     join(import.meta.dir, "../../config/bundled-skills/schedule/TOOLS.json"),
     "utf8",
   ),
-) as { tools: { name: string; input_schema: JsonSchema }[] };
+) as Parameters<typeof expectNoSchemaDrift>[1];
 
 const CASES: {
   name: string;
   schema: z.ZodType;
   advertiseRequired?: string[];
-  /** Advertised fields the runtime schema passes through unvalidated. */
   passthrough?: Record<string, string>;
-  /** Declared fields that additionally accept null at runtime. */
   nullableAtRuntime?: string[];
 }[] = [
   {
@@ -85,102 +67,19 @@ const CASES: {
   },
 ];
 
-/** Strip `description` keys recursively — prose is TOOLS.json-owned. */
-function structural(node: unknown): unknown {
-  if (Array.isArray(node)) {
-    return node.map(structural);
-  }
-  if (node === null || typeof node !== "object") {
-    return node;
-  }
-  const out: JsonSchema = {};
-  for (const [key, value] of Object.entries(node as JsonSchema)) {
-    if (key === "description") {
-      continue;
-    }
-    out[key] = structural(value);
-  }
-  return out;
-}
-
-/**
- * Canonicalize a derived property schema for comparison with TOOLS.json's
- * hand-written form:
- *
- * - drop the safe-integer `minimum`/`maximum` bounds `z.int()` emits;
- * - collapse `anyOf: [X, {type: "null"}]` (Zod's nullable encoding) into
- *   TOOLS.json's `type: [t, "null"]` array form;
- * - when `stripNull` is set (NULLABLE_AT_RUNTIME fields), drop the null
- *   branch entirely so the runtime-only null tolerance is not advertised.
- */
-function canonicalize(prop: JsonSchema, stripNull: boolean): JsonSchema {
-  const out = { ...prop };
-  if (out.minimum === -(2 ** 53 - 1)) {
-    delete out.minimum;
-  }
-  if (out.maximum === 2 ** 53 - 1) {
-    delete out.maximum;
-  }
-  // `z.looseObject({})` (an "any object" passthrough) emits an empty
-  // `properties` block TOOLS.json's bare `{type: "object"}` doesn't carry.
-  if (
-    typeof out.properties === "object" &&
-    out.properties !== null &&
-    Object.keys(out.properties).length === 0
-  ) {
-    delete out.properties;
-  }
-  const anyOf = out.anyOf;
-  if (Array.isArray(anyOf) && anyOf.length === 2) {
-    const nullIdx = anyOf.findIndex(
-      (entry) => (entry as JsonSchema).type === "null",
-    );
-    if (nullIdx !== -1) {
-      const base = canonicalize(anyOf[1 - nullIdx] as JsonSchema, false);
-      delete out.anyOf;
-      Object.assign(out, base);
-      if (!stripNull && typeof base.type === "string") {
-        out.type = [base.type, "null"];
-      }
-    }
-  }
-  return out;
-}
-
 describe("schedule TOOLS.json ↔ runtime Zod schema drift guard", () => {
   for (const c of CASES) {
     test(c.name, () => {
-      const entry = TOOLS_JSON.tools.find((t) => t.name === c.name);
-      expect(entry).toBeDefined();
-      const advertised = structural(entry!.input_schema) as JsonSchema;
-      const derived = structural(
-        toToolInputSchema(c.schema, { advertiseRequired: c.advertiseRequired }),
-      ) as JsonSchema;
-
-      const advertisedProps = { ...(advertised.properties as JsonSchema) };
-      const derivedProps = { ...(derived.properties as JsonSchema) };
-
-      for (const field of Object.keys(c.passthrough ?? {})) {
-        expect(advertisedProps[field]).toBeDefined();
-        expect(derivedProps[field]).toBeUndefined();
-        delete advertisedProps[field];
-      }
-
-      for (const [field, prop] of Object.entries(derivedProps)) {
-        derivedProps[field] = canonicalize(
-          prop as JsonSchema,
-          c.nullableAtRuntime?.includes(field) ?? false,
-        );
-      }
-
-      expect(Object.keys(derivedProps).sort()).toEqual(
-        Object.keys(advertisedProps).sort(),
-      );
-      expect(derivedProps).toEqual(advertisedProps);
-      expect(
-        [...((derived.required as string[] | undefined) ?? [])].sort(),
-      ).toEqual(
-        [...((advertised.required as string[] | undefined) ?? [])].sort(),
+      expectNoSchemaDrift(
+        {
+          name: c.name,
+          derived: toToolInputSchema(c.schema, {
+            advertiseRequired: c.advertiseRequired,
+          }),
+          passthrough: c.passthrough,
+          nullableAtRuntime: c.nullableAtRuntime,
+        },
+        TOOLS_JSON,
       );
     });
   }

--- a/assistant/src/tools/__tests__/tool-schema-drift-harness.ts
+++ b/assistant/src/tools/__tests__/tool-schema-drift-harness.ts
@@ -1,0 +1,142 @@
+import { expect } from "bun:test";
+
+/**
+ * Shared assertion harness for the per-skill TOOLS.json ↔ runtime Zod schema
+ * drift guards (`schedule-tool-input-schemas.test.ts`,
+ * `document-tool-input-schemas.test.ts`, …). Skill-owned tools are skipped by
+ * the central `TOOL_INPUT_SCHEMAS` gate, so the advertised contract
+ * (hand-written TOOLS.json) and the runtime validation (Zod schema in the
+ * executor module) live in different files; these helpers pin their STRUCTURE
+ * (property names, types, enums, required lists) together so a field added or
+ * retyped on one side cannot silently diverge on the other.
+ *
+ * What is deliberately NOT compared:
+ *
+ * - `description` strings — advertised prose is TOOLS.json-owned; the runtime
+ *   schema never reads it.
+ * - `passthrough` fields — advertised in TOOLS.json but undeclared in the Zod
+ *   schema (loose passthrough), because the executor's bespoke handling is the
+ *   validation contract. Each entry documents why. The harness still asserts
+ *   they exist in TOOLS.json (and are absent from the derived schema), so a
+ *   rename breaks the test.
+ * - `nullableAtRuntime` fields — declared `.nullable()` in the Zod schema
+ *   though advertised non-null (runtime-only tolerance); compared with the
+ *   null branch stripped so the slack is not advertised.
+ *
+ * This file is imported by test files at test time (after the preload's
+ * workspace override), and deliberately imports nothing from `src/` — callers
+ * pass in the already-derived JSON schema.
+ */
+
+export type JsonSchema = Record<string, unknown>;
+
+export interface DriftCase {
+  /** Tool name, matched against the TOOLS.json `tools[].name`. */
+  name: string;
+  /** `toToolInputSchema(...)` output for the tool's runtime Zod schema. */
+  derived: JsonSchema;
+  /** Advertised fields the runtime schema passes through unvalidated. */
+  passthrough?: Record<string, string>;
+  /** Declared fields that additionally accept null at runtime. */
+  nullableAtRuntime?: string[];
+}
+
+/** Strip `description` keys recursively — prose is TOOLS.json-owned. */
+function structural(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(structural);
+  }
+  if (node === null || typeof node !== "object") {
+    return node;
+  }
+  const out: JsonSchema = {};
+  for (const [key, value] of Object.entries(node as JsonSchema)) {
+    if (key === "description") {
+      continue;
+    }
+    out[key] = structural(value);
+  }
+  return out;
+}
+
+/**
+ * Canonicalize a derived property schema for comparison with TOOLS.json's
+ * hand-written form:
+ *
+ * - drop the safe-integer `minimum`/`maximum` bounds `z.int()` emits;
+ * - drop the empty `properties` block `z.looseObject({})` (an "any object"
+ *   passthrough) emits that TOOLS.json's bare `{type: "object"}` doesn't;
+ * - collapse `anyOf: [X, {type: "null"}]` (Zod's nullable encoding) into
+ *   TOOLS.json's `type: [t, "null"]` array form;
+ * - when `stripNull` is set (`nullableAtRuntime` fields), drop the null
+ *   branch entirely so the runtime-only null tolerance is not advertised.
+ */
+function canonicalize(prop: JsonSchema, stripNull: boolean): JsonSchema {
+  const out = { ...prop };
+  if (out.minimum === -(2 ** 53 - 1)) {
+    delete out.minimum;
+  }
+  if (out.maximum === 2 ** 53 - 1) {
+    delete out.maximum;
+  }
+  if (
+    typeof out.properties === "object" &&
+    out.properties !== null &&
+    Object.keys(out.properties).length === 0
+  ) {
+    delete out.properties;
+  }
+  const anyOf = out.anyOf;
+  if (Array.isArray(anyOf) && anyOf.length === 2) {
+    const nullIdx = anyOf.findIndex(
+      (entry) => (entry as JsonSchema).type === "null",
+    );
+    if (nullIdx !== -1) {
+      const base = canonicalize(anyOf[1 - nullIdx] as JsonSchema, false);
+      delete out.anyOf;
+      Object.assign(out, base);
+      if (!stripNull && typeof base.type === "string") {
+        out.type = [base.type, "null"];
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Assert one tool's derived runtime schema structurally matches its advertised
+ * TOOLS.json `input_schema`, modulo the documented exceptions above.
+ */
+export function expectNoSchemaDrift(
+  c: DriftCase,
+  toolsJson: { tools: { name: string; input_schema: JsonSchema }[] },
+): void {
+  const entry = toolsJson.tools.find((t) => t.name === c.name);
+  expect(entry).toBeDefined();
+  const advertised = structural(entry!.input_schema) as JsonSchema;
+  const derived = structural(c.derived) as JsonSchema;
+
+  const advertisedProps = { ...(advertised.properties as JsonSchema) };
+  const derivedProps = { ...(derived.properties as JsonSchema) };
+
+  for (const field of Object.keys(c.passthrough ?? {})) {
+    expect(advertisedProps[field]).toBeDefined();
+    expect(derivedProps[field]).toBeUndefined();
+    delete advertisedProps[field];
+  }
+
+  for (const [field, prop] of Object.entries(derivedProps)) {
+    derivedProps[field] = canonicalize(
+      prop as JsonSchema,
+      c.nullableAtRuntime?.includes(field) ?? false,
+    );
+  }
+
+  expect(Object.keys(derivedProps).sort()).toEqual(
+    Object.keys(advertisedProps).sort(),
+  );
+  expect(derivedProps).toEqual(advertisedProps);
+  expect(
+    [...((derived.required as string[] | undefined) ?? [])].sort(),
+  ).toEqual([...((advertised.required as string[] | undefined) ?? [])].sort());
+}

--- a/assistant/src/tools/document/document-comment-tool.test.ts
+++ b/assistant/src/tools/document/document-comment-tool.test.ts
@@ -375,3 +375,52 @@ describe("executeCommentReply", () => {
     expect(body.comment.content).toBe("Answer");
   });
 });
+
+// ── model-input schema validation (LUM-2854) ────────────────────────
+
+describe("comment tools — model-input schema validation", () => {
+  test("comment_list rejects a missing surface_id instead of 'Document not found'", () => {
+    const result = executeCommentList({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "comment_list"');
+    expect(result.content).toContain("surface_id");
+  });
+
+  test("comment_resolve rejects a non-string comment_id", () => {
+    const result = executeCommentResolve(
+      { surface_id: SURFACE_ID, comment_id: 42 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "comment_resolve"',
+    );
+    expect(result.content).toContain("comment_id");
+  });
+
+  test("comment_reply rejects a non-string content instead of persisting it", () => {
+    const parent = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user",
+      content: "Question",
+    });
+
+    const result = executeCommentReply(
+      { surface_id: SURFACE_ID, comment_id: parent.id, content: 42 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "comment_reply"');
+    expect(result.content).toContain("content");
+    expect(listComments(SURFACE_ID, {}).length).toBe(1);
+  });
+
+  test("comment tools pass unknown keys through (loose schema)", () => {
+    const result = executeCommentList(
+      { surface_id: SURFACE_ID, activity: "checking comments" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+  });
+});

--- a/assistant/src/tools/document/document-comment-tool.ts
+++ b/assistant/src/tools/document/document-comment-tool.ts
@@ -14,10 +14,9 @@ import { canAccessDocument, documentNotFound } from "./document-tool.js";
 //
 // `safeParse`d at the top of each `execute*` — same in-tool pattern and
 // drift guard as `document-tool.ts` (see the schema block there for the
-// framework). Unlike the document tools, these executors had no bespoke
-// input validation at all (a missing/mistyped field fell through to a
-// misleading "Document not found"), so every advertised-required field is
-// simply required here too.
+// framework). Every advertised-required field is required here; without
+// schema rejection a missing/mistyped field would fall through to a
+// misleading "Document not found".
 
 export const commentListInputSchema = z.looseObject({
   surface_id: z.string(),

--- a/assistant/src/tools/document/document-comment-tool.ts
+++ b/assistant/src/tools/document/document-comment-tool.ts
@@ -1,11 +1,38 @@
+import { z } from "zod";
+
 import {
   createComment,
   getComment,
   listComments,
   resolveComment,
 } from "../../documents/document-comments-store.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { canAccessDocument, documentNotFound } from "./document-tool.js";
+
+// ── Model-input schemas ────────────────────────────────────────────────
+//
+// `safeParse`d at the top of each `execute*` — same in-tool pattern and
+// drift guard as `document-tool.ts` (see the schema block there for the
+// framework). Unlike the document tools, these executors had no bespoke
+// input validation at all (a missing/mistyped field fell through to a
+// misleading "Document not found"), so every advertised-required field is
+// simply required here too.
+
+export const commentListInputSchema = z.looseObject({
+  surface_id: z.string(),
+});
+
+export const commentResolveInputSchema = z.looseObject({
+  surface_id: z.string(),
+  comment_id: z.string(),
+});
+
+export const commentReplyInputSchema = z.looseObject({
+  surface_id: z.string(),
+  comment_id: z.string(),
+  content: z.string(),
+});
 
 // ── Exported execute functions ─────────────────────────────────────────
 
@@ -13,7 +40,11 @@ export function executeCommentList(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
+  const parsedInput = commentListInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("comment_list", parsedInput.error);
+  }
+  const surfaceId = parsedInput.data.surface_id;
 
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
@@ -46,8 +77,11 @@ export function executeCommentResolve(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
-  const commentId = input.comment_id as string;
+  const parsedInput = commentResolveInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("comment_resolve", parsedInput.error);
+  }
+  const { surface_id: surfaceId, comment_id: commentId } = parsedInput.data;
 
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
@@ -91,9 +125,15 @@ export function executeCommentReply(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceId = input.surface_id as string;
-  const commentId = input.comment_id as string;
-  const content = input.content as string;
+  const parsedInput = commentReplyInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("comment_reply", parsedInput.error);
+  }
+  const {
+    surface_id: surfaceId,
+    comment_id: commentId,
+    content,
+  } = parsedInput.data;
 
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -78,15 +78,15 @@ function validateSurfaceId(
 // `document-tool-input-schemas.test.ts` guards the two against structural
 // drift.
 //
-// Tolerance mirrors what the executors always accepted — the schemas only
-// reject values that previously crashed downstream (`document_find`'s
-// `query` reaching `.toLowerCase()` as a number) or were persisted as
-// corruption (`document_create`'s `title`):
+// Tolerance matches the executors' own reads — the schemas only reject
+// values the executors would otherwise pass downstream unchecked
+// (`document_find`'s `query` reaching `.toLowerCase()` as a non-string) or
+// persist unvalidated (`document_create`'s `title`):
 //
-// - `nullAsOmitted` on optionals whose falsy/`??` fallbacks treated null as
-//   absent — including `surface_id`, whose bespoke `validateSurfaceId` /
-//   `resolveUpdateSurfaceId` error messages stay the contract for the
-//   missing/empty cases.
+// - `nullAsOmitted` on optionals where null and absent are equivalent under
+//   the falsy/`??` reads — including `surface_id`, whose bespoke
+//   `validateSurfaceId` / `resolveUpdateSurfaceId` error messages stay the
+//   contract for the missing/empty cases.
 // - `.catch(undefined)` on `document_list`'s `query`, which the executor
 //   silently ignores when malformed (falls back to the conversation list).
 // - `document_update`'s `mode` is deliberately UNDECLARED (loose

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 
+import { z } from "zod";
+
 import {
   addDocumentConversation,
   deleteDocument,
@@ -14,6 +16,10 @@ import {
   updateDocumentContent,
 } from "../../documents/document-store.js";
 import { canActOnPrivilegedDocuments } from "../../runtime/effective-capabilities.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 function isPrivilegedDocumentActor(context: ToolContext): boolean {
@@ -62,14 +68,83 @@ function validateSurfaceId(
   return input.surface_id;
 }
 
+// ── Model-input schemas ─────────────────────────────────────────────
+//
+// One schema per tool entry point, `safeParse`d at the top of each
+// `execute*`. Skill-owned tools are skipped by the central
+// `TOOL_INPUT_SCHEMAS` gate, so validation lives in the executor
+// (`ask_question` pre-registry precedent); the advertised `input_schema`
+// stays hand-written in the document-editor skill's `TOOLS.json`, and
+// `document-tool-input-schemas.test.ts` guards the two against structural
+// drift.
+//
+// Tolerance mirrors what the executors always accepted — the schemas only
+// reject values that previously crashed downstream (`document_find`'s
+// `query` reaching `.toLowerCase()` as a number) or were persisted as
+// corruption (`document_create`'s `title`):
+//
+// - `nullAsOmitted` on optionals whose falsy/`??` fallbacks treated null as
+//   absent — including `surface_id`, whose bespoke `validateSurfaceId` /
+//   `resolveUpdateSurfaceId` error messages stay the contract for the
+//   missing/empty cases.
+// - `.catch(undefined)` on `document_list`'s `query`, which the executor
+//   silently ignores when malformed (falls back to the conversation list).
+// - `document_update`'s `mode` is deliberately UNDECLARED (loose
+//   passthrough): its bespoke check owns the error message and the
+//   `{ mode: null }` tolerance that mirrors `validateInputAgainstSchema`.
+
+export const documentOpenInputSchema = z.looseObject({
+  surface_id: nullAsOmitted(z.string()),
+});
+
+export const documentCreateInputSchema = z.looseObject({
+  title: nullAsOmitted(z.string()),
+  initial_content: nullAsOmitted(z.string()),
+});
+
+export const documentUpdateInputSchema = z.looseObject({
+  surface_id: nullAsOmitted(z.string()),
+  content: nullAsOmitted(z.string()),
+});
+
+export const documentReadInputSchema = documentOpenInputSchema;
+
+export const documentListInputSchema = z.looseObject({
+  query: z.string().optional().catch(undefined),
+});
+
+export const documentDeleteInputSchema = documentOpenInputSchema;
+
+export const documentFindInputSchema = z.looseObject({
+  surface_id: nullAsOmitted(z.string()),
+  query: z.string(),
+  regex: nullAsOmitted(z.boolean()),
+  case_sensitive: nullAsOmitted(z.boolean()),
+});
+
+export const documentReplaceTextInputSchema = z.looseObject({
+  surface_id: nullAsOmitted(z.string()),
+  find: z.string(),
+  replace: nullAsOmitted(z.string()),
+  regex: nullAsOmitted(z.boolean()),
+  case_sensitive: nullAsOmitted(z.boolean()),
+  max_replacements: nullAsOmitted(z.number()),
+});
+
 // ── Exported execute functions ──────────────────────────────────────
 
 export function executeDocumentOpen(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
+  const parsedInput = documentOpenInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("document_open", parsedInput.error);
+  }
   const surfaceIdOrError = validateSurfaceId(input);
-  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  if (typeof surfaceIdOrError !== "string") {
+    return surfaceIdOrError;
+  }
   const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
@@ -140,17 +215,23 @@ function maybeReuseEmptyDocument(
   initialContent: string,
   context: ToolContext,
 ): ToolExecutionResult | null {
-  if (initialContent.length === 0) return null;
+  if (initialContent.length === 0) {
+    return null;
+  }
   const existing = findRecentEmptyDocumentByTitle(
     context.conversationId,
     title,
     EMPTY_DOCUMENT_DEDUPE_WINDOW_MS,
   );
-  if (!existing) return null;
+  if (!existing) {
+    return null;
+  }
 
   const surfaceId = existing.surfaceId;
   const update = updateDocumentContent(surfaceId, initialContent, "replace");
-  if (!update.success) return null;
+  if (!update.success) {
+    return null;
+  }
 
   // Defensive idempotent insert (saveDocument from the create-new path already
   // ran addDocumentConversation; INSERT OR IGNORE makes this a safe no-op).
@@ -200,11 +281,17 @@ export function executeDocumentCreate(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const title = (input.title as string | undefined) || "Untitled Document";
-  const initialContent = (input.initial_content as string | undefined) || "";
+  const parsedInput = documentCreateInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("document_create", parsedInput.error);
+  }
+  const title = parsedInput.data.title || "Untitled Document";
+  const initialContent = parsedInput.data.initial_content || "";
 
   const reused = maybeReuseEmptyDocument(title, initialContent, context);
-  if (reused) return reused;
+  if (reused) {
+    return reused;
+  }
 
   const surfaceId = `doc-${randomUUID()}`;
 
@@ -298,11 +385,17 @@ export function executeDocumentUpdate(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
+  const parsedInput = documentUpdateInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("document_update", parsedInput.error);
+  }
   if (typeof input.content !== "string") {
     return invalidInput("content is required and must be a string");
   }
   const surfaceIdOrError = resolveUpdateSurfaceId(input, context);
-  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  if (typeof surfaceIdOrError !== "string") {
+    return surfaceIdOrError;
+  }
   const surfaceId = surfaceIdOrError;
   // Loose `!= null` to match validateInputAgainstSchema, which treats null as
   // "absent" for enum checks — without this, { mode: null } passes the
@@ -368,8 +461,14 @@ export function executeDocumentRead(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
+  const parsedInput = documentReadInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("document_read", parsedInput.error);
+  }
   const surfaceIdOrError = validateSurfaceId(input);
-  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  if (typeof surfaceIdOrError !== "string") {
+    return surfaceIdOrError;
+  }
   const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
@@ -396,10 +495,11 @@ export function executeDocumentList(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const query =
-    typeof input.query === "string" && input.query.trim().length > 0
-      ? input.query.trim()
-      : undefined;
+  const parsedInput = documentListInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("document_list", parsedInput.error);
+  }
+  const query = parsedInput.data.query?.trim() || undefined;
   const docs = query
     ? searchDocumentsByTitle(
         query,
@@ -427,8 +527,14 @@ export function executeDocumentDelete(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
+  const parsedInput = documentDeleteInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("document_delete", parsedInput.error);
+  }
   const surfaceIdOrError = validateSurfaceId(input);
-  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  if (typeof surfaceIdOrError !== "string") {
+    return surfaceIdOrError;
+  }
   const surfaceId = surfaceIdOrError;
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
@@ -452,12 +558,18 @@ export function executeDocumentFind(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
+  const parsedInput = documentFindInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("document_find", parsedInput.error);
+  }
   const surfaceIdOrError = validateSurfaceId(input);
-  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  if (typeof surfaceIdOrError !== "string") {
+    return surfaceIdOrError;
+  }
   const surfaceId = surfaceIdOrError;
-  const query = input.query as string;
-  const regex = (input.regex as boolean | undefined) ?? false;
-  const caseSensitive = (input.case_sensitive as boolean | undefined) ?? false;
+  const query = parsedInput.data.query;
+  const regex = parsedInput.data.regex ?? false;
+  const caseSensitive = parsedInput.data.case_sensitive ?? false;
 
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
@@ -505,14 +617,20 @@ export function executeDocumentReplaceText(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
+  const parsedInput = documentReplaceTextInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("document_replace_text", parsedInput.error);
+  }
   const surfaceIdOrError = validateSurfaceId(input);
-  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  if (typeof surfaceIdOrError !== "string") {
+    return surfaceIdOrError;
+  }
   const surfaceId = surfaceIdOrError;
-  const find = input.find as string;
-  const replace = (input.replace as string) ?? "";
-  const regex = (input.regex as boolean | undefined) ?? false;
-  const caseSensitive = (input.case_sensitive as boolean | undefined) ?? false;
-  const maxReplacements = input.max_replacements as number | undefined;
+  const find = parsedInput.data.find;
+  const replace = parsedInput.data.replace ?? "";
+  const regex = parsedInput.data.regex ?? false;
+  const caseSensitive = parsedInput.data.case_sensitive ?? false;
+  const maxReplacements = parsedInput.data.max_replacements;
 
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);


### PR DESCRIPTION
> **Stacked on #39283 (LUM-2853)** — merge that first; GitHub will retarget this PR to `main` when the base branch merges. Only the last commit is new here.

## Summary

Third tranche of [LUM-2797](https://linear.app/vellum/issue/LUM-2797) ([LUM-2854](https://linear.app/vellum/issue/LUM-2854)): the document-editor skill's 11 tool entry points (`document-tool.ts` + `document-comment-tool.ts`, 17 casts) now `safeParse` tolerant Zod schemas at the top and return `invalidToolInputResult(...)` on failure. This includes the initiative's representative smell — `document_find`'s `const query = input.query as string`, where a non-string model value became a lie that crashed later at `.toLowerCase()`.

## Implementation

Same in-tool pattern and drift-guard decision as LUM-2853 (skill-owned tools, central gate skips them; TOOLS.json stays the hand-written advertised contract). One schema per tool entry point, exported from the executor module.

The LUM-2853 drift guard is generalized into a shared harness — `tool-schema-drift-harness.ts` — now that it has two consumers. Per the test-machinery isolation rule it imports nothing from `src/`; test files derive the JSON themselves via `toToolInputSchema` and pass it in. The schedule drift test is refactored onto the harness with identical coverage.

## Key technical choices — tolerance preserved

- `nullAsOmitted` on optionals read via falsy/`??` fallbacks (`surface_id`, `title`, `initial_content`, `content`, `regex`, `case_sensitive`, `replace`, `max_replacements`) — explicit null keeps behaving as absent, and the bespoke `validateSurfaceId` / `content is required` JSON error messages (test-asserted) stay the contract for the missing/empty cases.
- `document_list.query` keeps `.catch(undefined)` — the executor silently falls back to the conversation list when query is malformed, and always has.
- `document_update.mode` is loose passthrough (guard exception): its bespoke check owns the `'mode must be "replace" or "append"'` message and the `{ mode: null }` tolerance mirroring `validateInputAgainstSchema` (both test-asserted).
- Runtime-required only where advertised-required AND previously crash/garbage: `document_find.query`, `document_replace_text.find`, and all comment-tool fields (`comment_reply.content: 42` was previously **persisted**; a missing `surface_id` fell through to a misleading "Document not found").
- `document_replace_text.replace` is advertised-required but runtime-optional via `advertiseRequired` (the executor's `?? ""` always tolerated omission) — same sanctioned divergence as `activity` in #39272.

## Testing

- `bun test src/__tests__/document-tool-security.test.ts` — 19 pass (7 new validation tests)
- `bun test src/tools/document/document-comment-tool.test.ts` — 14 pass (4 new)
- `bun test src/tools/__tests__/document-tool-input-schemas.test.ts` — 11 pass (new drift guard)
- `bun test src/tools/__tests__/schedule-tool-input-schemas.test.ts` — 4 pass (refactored onto harness)
- `document-find-replace`, `document-update-default-surface`, `document-create-dedupe`, `schedule-tools` suites — all pass unchanged
- `bunx tsc --noEmit` clean; eslint + prettier clean; `lint:circular` unchanged (201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Latent prod bugs fixed (tracking)

Live, reachable paths in production code — any malformed model call could trigger them; fixed by this PR's validation:

1. **`document_find` crash** (the initiative's poster child) — `input.query as string` let a non-string reach `.toLowerCase()` and throw; `document_replace_text`'s `find` had the same shape.
2. **`document_create` title corruption** — `(input.title as string | undefined) || "Untitled Document"`: a number `42` is truthy, so it bypassed the fallback and was persisted as the document title.
3. **`comment_reply` content corruption** — `input.content as string` persisted non-string content into the comments store verbatim.
4. **Misleading comment-tool errors** — a missing/mistyped `surface_id` fell through to `canAccessDocument(undefined)` → "Document not found", sending the model chasing the wrong problem instead of fixing its call.
