### PR TITLE
docs(ios): document the native voice bridge, background audio, and intents

### DIFF
--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -4,6 +4,19 @@ Native iOS wrapper built with [Capacitor](https://capacitorjs.com/).
 This is _not_ a port of the web app — it's a thin `WKWebView` shell in
 `server.url` mode that loads the live web app directly over HTTPS.
 
+**Minimum iOS version: 17.0.** Set in `App/App/Config/Base.xcconfig`
+(`IPHONEOS_DEPLOYMENT_TARGET`) and `App/project.yml`
+(`options.deploymentTarget.iOS`) — both, because the xcconfig wins for
+targets that carry one and the `project.yml` value covers those that
+don't. Do not lower it: Live Activities need 16.1, interactive Live
+Activity content 17.0, and the Action Button 17.1. The Control Center
+control needs 18.0 and is therefore `@available`-gated rather than
+holding the whole app back.
+
+**Native voice mode** — the Live Activity, App Intents, Siri phrases, the
+Action Button, and the `<scheme>://voice` deep-link contract — is
+documented in [`docs/NATIVE_VOICE.md`](docs/NATIVE_VOICE.md).
+
 ## Web content delivery
 
 **What:** The iOS app loads the web UI live over HTTPS from the deployed
@@ -228,8 +241,10 @@ breakpoint.
 > **Web-side conventions for iOS code paths**: any change to the web app
 > that might run inside this WKWebView shell needs to follow the patterns
 > in [`clients/web/docs/CAPACITOR.md`](../web/docs/CAPACITOR.md) — Capacitor plugin
-> lazy imports, native auth, deep links, autogrowing textareas,
-> streaming watchdogs, OS permission UI, etc.
+> lazy imports, native auth, deep links, the native voice bridge,
+> autogrowing textareas, streaming watchdogs, OS permission UI, etc.
+> For the native half of voice mode, see
+> [`docs/NATIVE_VOICE.md`](docs/NATIVE_VOICE.md).
 
 ### `server.url` mode, not static export
 
@@ -252,9 +267,15 @@ experience works. Do not enable it.
 
 ### Targets and environments
 
-The Xcode project has three targets — one per environment. Each has its own
+The Xcode project has three _app_ targets — one per environment. Each has its own
 bundle ID, display name, and icon colour so they can be installed side by
-side on the same device.
+side on the same device. Each also embeds its own `VoiceActivity` widget
+extension target (`<app bundle id>.VoiceActivity`), so `xcodegen generate`
+produces six targets in total; only the three app schemes are worth
+building, since the extensions build as embedded dependencies. See
+[`docs/NATIVE_VOICE.md`](docs/NATIVE_VOICE.md) for what the extension
+contains and [Signing: two profiles per environment](#signing-two-profiles-per-environment)
+for what it costs at release time.
 
 | Target | Bundle ID | Display Name | Icon | Server |
 |--------|-----------|-------------|------|--------|
@@ -641,6 +662,8 @@ clients/
 └── ios/
     ├── .gitignore                    # Ignores Pods, DerivedData, xcuserdata,
     │                                 # generated capacitor.config.json, etc.
+    ├── docs/
+    │   └── NATIVE_VOICE.md           # Live Activity, App Intents, deep links
     ├── App/
     │   ├── App.xcodeproj/            # Open this in Xcode
     │   │   └── xcshareddata/xcschemes/  # Shared schemes for all 3 targets
@@ -657,8 +680,11 @@ clients/
     │   │   ├── NativeBiometricPlugin.swift # Face ID / Touch ID Keychain
     │   │   ├── VoiceAudioSessionPlugin.swift # AVAudioSession for live voice
     │   │   ├── VoiceLiveActivityPlugin.swift # Dynamic Island for live voice
-    │   │   ├── Shared/                   # Compiled into app + widget extension
+    │   │   ├── Intents/              # App Intents + AppShortcutsProvider
+    │   │   ├── Shared/               # Compiled into app + widget extension
     │   │   └── Info.plist
+    │   ├── VoiceActivity/            # WidgetKit extension: Live Activity
+    │   │                             # presentations + Control Center control
     │   └── CapApp-SPM/               # SPM local package: pulls in @capacitor/ios
     │                                 # and any Capacitor plugin native deps
     └── debug.xcconfig                # Sets CAPACITOR_DEBUG for Debug builds

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -1,0 +1,503 @@
+# Native voice mode
+
+How a live-voice session — which runs entirely in the web layer — reaches the
+Dynamic Island, the Lock Screen, Siri, Spotlight, the Action Button, and
+Control Center.
+
+Read [`clients/web/docs/CAPACITOR.md` § Native voice bridge](../../web/docs/CAPACITOR.md#native-voice-bridge)
+first if you are touching the web half. That document owns the skew rule; this
+one owns the native contracts.
+
+---
+
+## What is native and what is not
+
+Nothing about the *conversation* is native. Mic capture (`getUserMedia` →
+AudioWorklet → PCM), the velay WebSocket, TTS playback, turn state, and every
+user-facing string all live under
+`clients/web/src/domains/chat/voice/live-voice/`. The native side contributes
+exactly four things:
+
+| Native surface | What it is |
+| --- | --- |
+| `VoiceAudioSessionPlugin` | Owns `AVAudioSession` for the duration of a session (`.playAndRecord` / `.voiceChat`), and reports interruptions and route changes |
+| `VoiceLiveActivityPlugin` | Requests, updates, and ends the one ActivityKit activity mirroring the session |
+| `VoiceActivity` widget extension | Renders that activity on the Lock Screen and in the Dynamic Island, plus the Control Center control |
+| App Intents + `AppShortcutsProvider` | Turn a Siri phrase, a Spotlight hit, an Action Button press, or a control tap into a `<scheme>://voice` URL |
+
+Everything native is *additive*. Remove all of it and voice still works — that
+property is load-bearing, because the shell ships on App Store review cadence
+while the web bundle it hosts deploys continuously.
+
+## Architecture
+
+One direction of data (web → native) and one of commands (native → web).
+
+**State, web → island:**
+
+```
+live-voice-store.ts            zustand store; `state`, `muted`, `reconnecting`
+        │  useLiveVoiceStore.subscribe (inside an effect, never a selector)
+        ▼
+use-live-activity-mirror.ts    diffs the four ContentState fields, drops no-op pushes
+        │  startVoiceLiveActivity / updateVoiceLiveActivity / endVoiceLiveActivity
+        ▼
+runtime/native-live-activity.ts   every call wrapped in callNativeVoice
+        │  Capacitor bridge
+        ▼
+VoiceLiveActivityPlugin.swift  holds at most one Activity handle
+        │  ActivityKit
+        ▼
+VoiceActivity.appex            VoiceSessionLiveActivity + VoiceSessionIslandViews
+```
+
+The mirror is mounted by `use-live-voice-session-controller.ts` (at `ChatLayout`
+scope), so its lifetime is exactly the session's. It is a separate module from
+the controller on purpose: the controller owns session lifecycle, the mirror owns
+an optional platform flourish, and conflating them makes both harder to test.
+
+**Commands, native → web:**
+
+```
+Siri phrase / Spotlight / Action Button   →  StartVoiceModeIntent
+                                             StartNewVoiceConversationIntent
+                                             AskVellumIntent
+Control Center / Lock Screen control      →  StartNewVoiceConversationIntent
+Dynamic Island / Lock Screen tap          →  .widgetURL(VoiceModeDeepLink.resume.url())
+Safari, a test link, another app          →  application(_:open:) / launchOptions[.url]
+        │                        all of them produce  <scheme>://voice?mode=…
+        ▼
+AppDelegate.deliverVoiceCommand(_:)  →  ApplicationDelegateProxy  →  Capacitor `appUrlOpen`
+        ▼
+capacitor-deep-links.ts  →  parseStartVoiceDeepLink  →  bus `deeplink.startVoice`
+        ▼
+use-global-deep-link-consumer.ts  →  navigate + the live-voice `starter`
+```
+
+## The two enums that must change together
+
+`LiveVoiceSessionState` in
+[`live-voice-store.ts`](../../web/src/domains/chat/voice/live-voice/live-voice-store.ts)
+is the source of truth:
+
+```
+idle | connecting | listening | transcribing | thinking | speaking | ending | failed
+```
+
+`VoiceSessionAttributes.ContentState.Phase` in
+[`App/App/Shared/VoiceSessionAttributes.swift`](../App/App/Shared/VoiceSessionAttributes.swift)
+declares the same cases **minus `idle`**, with raw values that string-match. The
+web side sends those raw strings across the Capacitor bridge and
+`VoiceLiveActivityPlugin.contentState(from:)` decodes them with
+`Phase(rawValue:)`, so a case added or renamed on one side without the other
+fails to decode and the plugin rejects the call. The TypeScript type is
+`Exclude<LiveVoiceSessionState, "idle">` — derived, not restated — so a web-side
+rename is a compile error on the web and a silent decode failure natively. **The
+native enum is the half that has to be remembered.**
+
+`idle` is absent because an idle session has no Live Activity; a case for it
+would be unreachable state the island UI would still have to handle.
+
+One asymmetry worth knowing: `Phase.failed` exists but the mirror never sends
+it. `isLiveVoiceSessionActive()` excludes `failed` as well as `idle`, so
+`toActivityContent()` returns `null` and the mirror *ends* the activity on a
+failure — the failure is surfaced in the app, where it can be dismissed, and an
+island the user cannot act on is worse than none. The case is kept so the wire
+model stays a faithful mirror of the web enum rather than a filtered one.
+
+### Why label copy comes from the web
+
+`ContentState.label` is a string passed through from
+`liveVoiceStateLabel(state, reconnecting)`. The native side never switches on
+`phase` to produce wording — not in the expanded island, not in the compact
+slots, not on the Lock Screen. Three reasons, in order of importance:
+
+1. **Cadence.** `LIVE_VOICE_STATE_LABELS` deploys continuously; this shell ships
+   on App Store review. A native `switch` would fossilize whatever wording was
+   current at submission and drift silently from the room the user is looking at.
+2. **One relabel rule.** `liveVoiceStateLabel` maps `connecting` +
+   `reconnecting` to "Reconnecting…". Reproducing that natively means shipping
+   `reconnecting` across the bridge and duplicating the rule.
+3. **Localization.** The web layer already owns user-facing copy.
+
+The compact trailing slot is very tight. It *truncates* the passed label
+(`.lineLimit(1)` + `.truncationMode(.tail)` in `VoiceSessionText`); it does not
+substitute a shorter native string. `LIVE_VOICE_STATE_LABELS` maps `failed` to
+`""`, so `VoiceSessionText` renders nothing at all for an empty string rather
+than an empty `Text` that still claims layout space.
+
+## The deep-link contract
+
+```
+<scheme>://voice?mode=new|resume[&prompt=<percent-encoded text>]
+```
+
+- `<scheme>` is the running build's own: `vellum-assistant`,
+  `vellum-assistant-staging`, or `vellum-assistant-dev`, set per environment as
+  `BUNDLE_URL_SCHEME` in `App/App/Config/App*.xcconfig`.
+- `mode` defaults to `new` for anything that is not exactly `resume`.
+- `resume` puts a running session back on screen; with nothing running it
+  degrades to `new`.
+- `prompt` is optional free-form text (`AskVellumIntent`). The **web parser**
+  bounds and sanitizes it — 2000 characters max, control characters rejected —
+  because a deep link is reachable from any app or web page that can open a URL.
+  A rejected prompt does not reject the link: the session still starts.
+
+Native producers build the URL through `VoiceModeDeepLink.url(prompt:)`
+([`App/App/Shared/VoiceModeDeepLink.swift`](../App/App/Shared/VoiceModeDeepLink.swift)),
+never by hand. That function assigns through `percentEncodedQueryItems` with
+`&=+?#` removed from the allowed set, because `URLComponents.queryItems` encodes
+with `urlQueryAllowed`, which permits those sub-delimiters — correct for a whole
+query string, wrong for a single value inside one. A spoken "Ben & Jerry's" would
+otherwise arrive as a `prompt` of `Ben ` plus a stray parameter.
+
+### Producers
+
+| Producer | Mode | Where |
+| --- | --- | --- |
+| `StartVoiceModeIntent` (Siri: "Talk to Vellum") | `resume` | `App/App/Intents/` |
+| `StartNewVoiceConversationIntent` (Action Button, Control Center) | `new` | `App/App/Shared/` |
+| `AskVellumIntent` (Siri collects the question) | `new` + `prompt` | `App/App/Intents/` |
+| Live Activity `widgetURL` (island / Lock Screen tap) | `resume` | `App/VoiceActivity/VoiceSessionLiveActivity.swift` |
+| Safari, a note, another app, a test link | either | — |
+
+### Delivery paths, and the one that used to drop
+
+Intents run **in the app process** and never pass through
+`application(_:open:)`, so `VoiceModeDeepLink.route()` hands the URL directly to
+`AppDelegate.deliverVoiceCommand(_:)`. That method stashes the URL and replays it
+through `ApplicationDelegateProxy` — the exact channel a warm open uses — once
+the bridge web view exists, so the URL surfaces to JS as Capacitor's `appUrlOpen`
+and needs no new web code. `AppPlugin` posts that event with
+`retainUntilConsumed: true`, so a command delivered before the SPA registers its
+listener is replayed rather than lost.
+
+A **terminated** launch is the case that needs care.
+`didFinishLaunchingWithOptions` receives the URL in `launchOptions[.url]` and
+does *not* forward to `ApplicationDelegateProxy`; before this feature it only
+tried `handleConnectDeepLink`, which returns `false` for any host that is not
+`connect` and takes no other action — so a `voice` URL from Siri, the Action
+Button, or Safari was silently discarded before the web view existed. It now
+stashes any non-`connect` launch URL as `pendingVoiceCommandURL` and delivers it
+from `MyViewController.viewDidAppear`.
+
+There are **two** independent cold-launch races and both fixes are required:
+
+- **Native**: the URL never reaches the web layer (fixed above).
+- **Web**: the URL arrives before `ChatLayout` registers the live-voice
+  `starter`. `start-voice-deep-link.ts` parks the request and
+  `use-live-voice-session-controller.ts` drains it when the starter registers.
+
+Neither can cover for the other.
+
+## App Intents: the availability duplication is load-bearing
+
+Every voice intent declares **both**:
+
+```swift
+@available(iOS 26.0, *)
+static var supportedModes: IntentModes { .foreground(.immediate) }
+
+static var openAppWhenRun: Bool { true }
+```
+
+This is not leftover. iOS 26 soft-deprecated `openAppWhenRun` in favor of
+`supportedModes`, but `supportedModes` is itself iOS 26.0+ while this app
+deploys to **17.0**. Drop `openAppWhenRun` and every intent stops launching the
+app on 17.0–25.x; drop `supportedModes` and you are shipping a deprecated
+declaration on the current OS. `.foreground(.immediate)` is the documented exact
+equivalent of `openAppWhenRun = true`, so the two agree.
+
+**Do not "clean this up".** It reads like a redundant pair and is not. The
+duplication can go away only when the deployment target reaches 26.0.
+
+Neither alternative fits: `OpenIntent` needs a `target` `AppEntity` and SwiftUI's
+`onAppIntentExecution` (there is no entity to open), and iOS 26 snippet intents
+render a result in place, which is the opposite of launching the app.
+
+`perform()` returns immediately — App Intents run under a short execution budget,
+so it hands off rather than waiting for a session to start.
+
+## `\(.applicationName)` — silent failure in two directions
+
+Every phrase in `VoiceAppShortcuts.swift` must interpolate `\(.applicationName)`:
+
+```swift
+"Talk to \(.applicationName)"
+```
+
+App Intents **drops** phrases that omit the token, and the drop is silent at
+runtime: the shortcut still appears in the Shortcuts app, so it looks registered
+— Siri simply never matches a word of it. There is no build error and no log.
+
+The token resolves from **`CFBundleDisplayName`**, which `App/Info.plist` sets to
+`$(BUNDLE_DISPLAY_NAME)` and each environment's xcconfig supplies: "Vellum",
+"Vellum Staging", "Vellum Dev". All three are pronounceable, which is why one
+phrase list serves every build. If `BUNDLE_DISPLAY_NAME` were ever dropped from
+an xcconfig, `CFBundleDisplayName` would expand to an empty string and the token
+would fall back to `CFBundleName` — which is `$(PRODUCT_NAME)`, itself
+XcodeGen's `$(TARGET_NAME)` default, so **"App"** / "App Staging" / "App Dev" —
+and every phrase would silently stop matching while still appearing correct
+everywhere you would think to look.
+
+**No test can catch either failure.** Phrase registration happens in the system's
+App Intents database at install time, outside the app's process. Verification is
+manual: install, wait for indexing, and say each phrase to Siri.
+
+Translations live in `App/App/Intents/en.lproj/AppShortcuts.strings` (and
+siblings), keyed by the English phrase with the token spelled
+`${applicationName}` — the strings-file form of the same token. Every phrase in
+every locale must keep it.
+
+## `VOICE_ACTIVITY_EXTENSION` — what compiles out of the appex
+
+`App/App/Shared/` is compiled into the app targets *and* the three
+`VoiceActivity` extension targets from one copy on disk. The extension targets
+set `SWIFT_ACTIVE_COMPILATION_CONDITIONS = … VOICE_ACTIVITY_EXTENSION` (see
+`project.yml`'s `ExtensionEnvironment` template), and exactly one body is guarded
+by it: `VoiceModeDeepLink.route()`.
+
+```swift
+#if VOICE_ACTIVITY_EXTENSION
+assertionFailure("Voice intents are performed in the app process, not the appex")
+#else
+(UIApplication.shared.delegate as? AppDelegate)?.deliverVoiceCommand(url)
+#endif
+```
+
+Two things make the body impossible to compile into the appex:
+
+- **`UIApplication.shared` is unavailable under
+  `APPLICATION_EXTENSION_API_ONLY`**, which Xcode sets for app extensions. It is
+  a hard compile error, not a warning.
+- **`AppDelegate` links Capacitor**, which the appex does not — and must not.
+
+The signature stays, so callers compile on both sides. That matters because
+`StartNewVoiceConversationIntent` lives in `Shared/`: `StartVoiceControl` builds
+a `ControlWidgetButton` around that exact type, and a control is code in the
+appex, so the appex needs the intent *type* to exist. It never runs it — both
+intents declare `openAppWhenRun` / `.foreground(.immediate)`, so the system
+performs them in the app process even when the tap came from Control Center.
+Sharing one intent type is what makes Control Center, the Action Button, and Siri
+the same action rather than three lookalikes; compiling the body out is what
+keeps that safe.
+
+`import UIKit` at the top of the file is guarded the same way.
+
+## `BundleURLScheme.current` is deliberately optional
+
+[`App/App/Shared/BundleURLScheme.swift`](../App/App/Shared/BundleURLScheme.swift)
+resolves the running bundle's scheme and returns `String?` with **no universal
+fallback**. Substituting the production scheme on a misconfigured Dev or Staging
+build is precisely the cross-environment mis-routing the type exists to prevent:
+if the production app happens to be installed, iOS opens *that* one.
+
+Each caller decides:
+
+- **Auth** (`NativeAuthPlugin`) falls back to the production scheme. An OAuth
+  callback is not a cross-app launch, and a sign-in that reaches a working
+  callback beats one that fails outright.
+- **Voice deep links** do **not** fall back. `VoiceModeDeepLink.url()` returns
+  `nil`, `route()` logs and drops, and `.widgetURL(_:)` — which takes an optional
+  — leaves the presentation untappable. **An untappable island beats one that
+  opens the wrong app.**
+
+The app and the appex read different keys, because they play different roles. The
+app *registers* the scheme in `CFBundleURLTypes`, which is what iOS routes on, so
+that is read first. An appex registers nothing — a widget extension must not
+claim a URL type — so it carries the scheme as the plain `VellumURLScheme`
+Info.plist string, populated from the same `$(BUNDLE_URL_SCHEME)` variable. Both
+reject an empty value and one Xcode never expanded (`$(BUNDLE_URL_SCHEME)`
+verbatim), either of which would produce an unopenable URL.
+
+**The `BUNDLE_URL_SCHEME` value is restated in each `Extension-*.xcconfig` and
+must match its `App-*.xcconfig` character for character.** A mismatch sends a Dev
+island's tap into the production app.
+
+## v1 scope decisions
+
+Three things were deliberately left out. Each is listed with what would have to
+change to revisit it.
+
+### 1. Live Activity updates are local, not push
+
+The app process issues every `Activity.update`. There is no APNs
+`liveactivity` push involved.
+
+*Why:* the platform's device-token API (`DevicePushTokenUpsertRequest`:
+`token` / `platform` / `bundle_id` / `apns_environment`) has no concept of a Live
+Activity push token, so push-to-update needs a platform API change before any
+client work.
+
+*To revisit:* extend the platform token model to carry Live Activity push tokens,
+add APNs `liveactivity` push-type support server-side, then have the plugin
+register for `activity.pushTokenUpdates` and forward. The client half is small;
+the platform half is not. Worth doing only if the session needs to update while
+the app is suspended — which is not the case today, because the web layer that
+drives the phase is suspended at the same time.
+
+### 2. No App Group
+
+`ContentState` carries only primitives: `phase`, `label`, `accentHex`, `muted`,
+plus `assistantName` on the attributes. The extension ships **no entitlements
+file at all**.
+
+*Why:* an App Group is only needed to share *files* — the obvious candidate being
+a user's custom avatar image in the island. A hex accent gets most of the visual
+identity for none of the plumbing, and no entitlement means one less Apple
+Developer portal capability to keep in sync (an entitlement enabled in the portal
+but not satisfiable by the build is a provisioning failure waiting to happen).
+
+*To revisit:* enable an App Group capability on all six App IDs (three apps,
+three extensions), add entitlements files, regenerate all six profiles, write the
+avatar into the shared container on the app side, and read it in
+`VoiceSessionIslandViews`. Note that the container write has to happen before the
+activity starts, so it also needs an avatar-caching path.
+
+### 3. The island is tap-to-return only — no interactive End button
+
+`VoiceSessionLiveActivity` has no buttons. The only affordance is
+`.widgetURL(VoiceModeDeepLink.resume.url())`.
+
+*Why:* two reasons. Mechanically, an in-island control needs a
+`LiveActivityIntent` plus a signalling path into the running app (the appex
+cannot reach the session). Product-wise, it contradicts the voice room's
+established invariant that the room is a full-app takeover whose ✕ is the only
+exit — tapping the island returns to the room, where ✕ already ends the session,
+so "look at it" and "act on it" resolve to the same place.
+
+*To revisit:* decide the invariant question first — it is a product decision, not
+an engineering one. Then add a `LiveActivityIntent` in `Shared/` and a way for it
+to reach the web layer; the existing deep-link channel is the natural candidate
+(an `<scheme>://voice?mode=end`), which would keep it to one command surface.
+
+## Background audio: what is known and what is not
+
+`UIBackgroundModes: audio` (in `App/Info.plist`) plus an active
+`.playAndRecord` / `.voiceChat` session buys the *audio* half: the app keeps its
+audio session and its route while backgrounded or locked, output goes to the
+loudspeaker rather than the earpiece via `.defaultToSpeaker`, and hardware echo
+cancellation and AGC are engaged.
+
+It does **not** buy the *web* half. WebKit throttles and eventually suspends JS
+timers and main-thread work in a backgrounded web process. The AudioWorklet runs
+on the audio render thread, but the velay socket send happens on the main JS
+thread.
+
+**Whether a WKWebView voice session actually survives lock is empirically
+unknown.** The device spike that was meant to answer it was never run, and no
+findings document exists. The background/foreground hardening that was planned on
+top of it — `AudioContext` resume on `app.resume`, a socket-liveness probe, a
+bounded background grace period — was never implemented either. Do not assume
+coverage that is not there. Anyone picking this up should measure, on a physical
+device, whether `getUserMedia` keeps producing PCM and whether the socket keeps
+pumping once the app is backgrounded and once the screen is locked, and for how
+long.
+
+If that measurement says "must move native", capture and the socket move to
+`AVAudioEngine` + `URLSessionWebSocketTask` and `VoiceAudioSessionPlugin` becomes
+the audio-session half of that path rather than a hint to the webview.
+Everything in this document above that line — the Live Activity, the deep-link
+contract, the intents — is unaffected either way: it consumes store state and a
+URL contract, not the audio transport.
+
+A related open item: `.voiceChat` adds hardware AEC, which changes the
+assumptions the software echo-adaptive barge-in gate was tuned against. Worth
+measuring on device; deliberately not tuned as part of this work, so the gate's
+behavior can be compared against a stable baseline.
+
+## Testing
+
+### Simulator-coverable
+
+An iPhone 17 Pro simulator on the iOS 26.2 runtime covers more than you would
+expect.
+
+| What | How |
+| --- | --- |
+| Deep-link contract, both modes | `xcrun simctl openurl booted "vellum-assistant-dev://voice?mode=new"` — and `…?mode=resume`, and a `&prompt=` variant with `&`, `#`, and emoji to check the round trip |
+| Terminated-launch delivery | Force-quit the app in the simulator first, then `openurl`. This is the path that used to drop; a warm-open pass proves nothing about it |
+| Scheme isolation | Open a `vellum-assistant://` link with only the Dev build installed — nothing should happen |
+| Live Activity presentations | Start a session; the Lock Screen presentation renders in the simulator. Check both appearances (Features → Toggle Appearance) — the accent is an arbitrary avatar color over a wallpaper |
+| App Intents in the Shortcuts app | The three intents appear under the app with their icons and short titles |
+| Control Center control | Add "New voice conversation" from the gallery and tap it |
+| Extension builds | `cd clients/ios/App && xcodebuild -project App.xcodeproj -target "VoiceActivity Dev" -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO` after `bun run ios:setup` |
+
+Note on local builds: a full-app local build has been failing while resolving the
+Capacitor SPM graph (`IONFilesystemLib`), which is environmental and pre-existing
+— unrelated to anything here. **CI is the app-build gate**: `pr-ios.yaml` builds
+the `App Dev` scheme unsigned on every PR touching `clients/ios/**`, and the
+extension is embedded, so it builds too. Do not treat a green extension-only
+build as a green app build.
+
+### Device-only
+
+The Simulator does not faithfully reproduce any of these.
+
+| What | Why the simulator can't |
+| --- | --- |
+| Dynamic Island (compact / expanded / minimal) | No island hardware; only the Lock Screen presentation renders |
+| Backgrounded and locked audio | The simulator does not suspend the web process the way real iOS does — this is exactly the measurement the missing spike needs |
+| Siri phrase matching | Needs the on-device App Intents index and real speech. Allow a few minutes after install before the phrases resolve |
+| Action Button | iPhone 15 Pro or newer. Settings → Action Button → Shortcut → Vellum → "New voice conversation" |
+| Spotlight surfacing | Device-side indexing, which lags install |
+| Apple Intelligence routing | Requires a device where Apple Intelligence is available |
+| `.notifyOthersOnDeactivation` | Start music, run a voice session, end it, confirm the music resumes |
+| Interruption handling | Take a real phone call mid-session; the session should end, not keep "listening" into a dead mic |
+| Bluetooth / AirPods routing | `.voiceChat` HFP routing needs real hardware |
+| No stranded island | Force-quit mid-session and confirm the island disappears; then crash-and-relaunch and confirm `load()`'s sweep clears anything left over |
+
+## Shipping prerequisites
+
+Each app target embeds a `VoiceActivity` extension whose bundle ID is prefixed by
+its host app's, and Apple treats that appex as its own App ID with its own
+provisioning profile. **Every environment signs with two profiles, not one.**
+Three extension bundle IDs, three distribution profiles, and three
+`IOS_PROVISIONING_PROFILE_EXT*` GitHub secrets have to exist before a release
+build of that environment can archive and export.
+
+None of it is created by any script. The full step-by-step checklist — exact
+bundle IDs, exact profile names, secret names, and how to verify the signature on
+the exported appex — is in
+[`clients/ios/README.md` § Manual Apple Developer portal setup](../README.md#manual-apple-developer-portal-setup).
+It is not duplicated here; a second copy would go stale and the names have to
+agree character for character across the portal, the xcconfigs, and
+`release-ios.yaml`.
+
+## File map
+
+| Path | Role |
+| --- | --- |
+| `App/App/VoiceAudioSessionPlugin.swift` | `AVAudioSession` ownership, interruption and route-change events |
+| `App/App/VoiceLiveActivityPlugin.swift` | ActivityKit lifecycle, at most one activity |
+| `App/App/MyViewController.swift` | Registers all four plugins in `capacitorDidLoad()` |
+| `App/App/AppDelegate.swift` | Voice command stash + replay; `applicationWillTerminate` island teardown |
+| `App/App/Shared/VoiceSessionAttributes.swift` | The ActivityKit wire model (app + appex) |
+| `App/App/Shared/VoiceModeDeepLink.swift` | The one URL builder + the app-only `route()` |
+| `App/App/Shared/BundleURLScheme.swift` | Per-build scheme resolution, deliberately optional |
+| `App/App/Shared/CSSHexColor.swift` | `UIColor`/`Color` from a CSS hex, plus contrast-picking |
+| `App/App/Shared/StartNewVoiceConversationIntent.swift` | In `Shared/` because the Control Center control needs the type |
+| `App/App/Intents/` | The other two intents, `VoiceAppShortcuts`, `en.lproj/AppShortcuts.strings` |
+| `App/VoiceActivity/` | Widget extension: bundle, Live Activity, island views, Control Center control |
+| `App/App/Config/Extension*.xcconfig` | Extension build settings; bundle IDs, schemes, profile specifiers |
+| `App/project.yml` | Six targets, `VOICE_ACTIVITY_EXTENSION`, embed relationships |
+
+Web-side counterparts:
+
+| Path | Role |
+| --- | --- |
+| `clients/web/src/runtime/native-voice.ts` | `callNativeVoice` — the skew-safe seam |
+| `clients/web/src/runtime/native-audio-session.ts` | `VoiceAudioSession` bridge |
+| `clients/web/src/runtime/native-live-activity.ts` | `VoiceLiveActivity` bridge |
+| `clients/web/src/runtime/native-deep-link.ts` | `parseStartVoiceDeepLink` and prompt sanitization |
+| `clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts` | Store → island mirror |
+| `clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts` | Mounts the mirror and the audio-session lifecycle |
+| `clients/web/src/hooks/use-global-deep-link-consumer.ts` | `deeplink.startVoice` consumer |
+
+## See also
+
+- [`clients/ios/README.md`](../README.md) — shell setup, targets, release pipeline, portal checklist.
+- [`clients/web/docs/CAPACITOR.md`](../../web/docs/CAPACITOR.md) — the web-side rules, including the skew rule.
+- [Apple — ActivityKit](https://developer.apple.com/documentation/activitykit)
+- [Apple — App Intents](https://developer.apple.com/documentation/appintents)
+- [Apple — `AVAudioSession`](https://developer.apple.com/documentation/avfaudio/avaudiosession)

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -116,11 +116,86 @@ Native OAuth completion auto-dismisses `SFSafariViewController` by redirecting t
 - **Parse via `parseOAuthCompleteDeepLink()`.** It exact-matches the scheme against the apex allow-list, rejects look-alikes (e.g. `vellum-assistant-evil://`), requires the `oauth-complete` host, and enforces a non-empty `requestId`. Adding a new scheme means adding it to the allow-list — do not loosen the matcher to a `startsWith` check.
 - **Consume via a typed window-event listener hook** that registers for the `"vellum:oauth-complete-deeplink"` event and cleans up on unmount.
 - **Pair the deep-link listener with a `browserFinished` poll fallback** when the consumer must work on builds where the listener doesn't fire (e.g. iOS dispatch hiccups, user-cancel paths). Today's UX must remain the worst case in every failure mode.
+- **`<scheme>://voice?mode=new|resume[&prompt=…]`** is the start-voice contract (`parseStartVoiceDeepLink` → `deeplink.startVoice`). Siri, the Action Button, Control Center, the Live Activity's `widgetURL`, and a link typed into Safari all converge on it — see [`clients/ios/docs/NATIVE_VOICE.md` § The deep-link contract](../../../clients/ios/docs/NATIVE_VOICE.md#the-deep-link-contract). `prompt` is untrusted free-form text and is bounded and sanitized *in the parser*, not at the consumer.
 
 References:
 - Apple — [`SFSafariViewControllerDelegate.safariViewController(_:initialLoadDidRedirectTo:)`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontrollerdelegate/safariviewcontroller(_:initialloaddidredirectto:)) — custom URL scheme dismissal is the recommended pattern.
 - Capacitor — [`App` plugin · `appUrlOpen`](https://capacitorjs.com/docs/apis/app#addlistenerappurlopen).
 - Apple HIG — [Supporting universal links and custom URL schemes](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content).
+
+---
+
+## Native voice bridge
+
+Live voice is a web feature with native accessories. The session — mic capture, the velay socket, TTS playback, every user-facing string — lives entirely under `src/domains/chat/voice/live-voice/`. The iOS shell adds an `AVAudioSession`, a Dynamic Island / Lock Screen presence, and a set of App Intents on top of it.
+
+The shell registers **four** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) — count them there, not from prose:
+
+| Plugin | Web module | What it does |
+| --- | --- | --- |
+| `NativeAuth` | [`src/runtime/native-auth.ts`](../src/runtime/native-auth.ts) | `ASWebAuthenticationSession` OIDC flow |
+| `NativeBiometric` | [`src/runtime/native-biometric.ts`](../src/runtime/native-biometric.ts) | Face ID / Touch ID Keychain |
+| `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | `.playAndRecord` / `.voiceChat` session + interruption and route-change events |
+| `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | The one ActivityKit activity mirroring a session |
+
+The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
+
+### The skew rule
+
+**A native voice call may always be absent. A missing plugin must degrade to a working voice session, never to an error.**
+
+This is a rule, not a caveat. The iOS app is a `server.url` shell: it bundles no web assets and navigates `WKWebView` straight at the deployed origin at launch (see [`clients/ios/README.md` § Web content delivery](../../../clients/ios/README.md#web-content-delivery)). So this bundle is live for every iOS user on their next app load, while the shell hosting it only changes after an App Store review cycle. At any moment an arbitrarily old shell can be running an arbitrarily new bundle. There is no build flag that tells you which.
+
+**Route every JS → native voice call through `callNativeVoice`** ([`src/runtime/native-voice.ts`](../src/runtime/native-voice.ts)). It returns the fallback off-iOS and on any bridge failure, and never throws:
+
+```ts
+export async function callNativeVoice<T>(
+  invoke: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  if (!isNativeIOS()) {
+    return fallback;
+  }
+  try {
+    return await invoke();
+  } catch (err) {
+    // `console.debug`, not `captureError`: an older App Store shell without the
+    // plugin is an expected state on every web deploy, not a fault, and
+    // reporting it would spam Sentry once per skewed install.
+    console.debug("[native-voice] bridge call unavailable:", err);
+    return fallback;
+  }
+}
+```
+
+Three things follow from the rule:
+
+- **Pick a fallback the caller can proceed with.** `activateVoiceAudioSession()` resolves `false`, `endVoiceLiveActivity()` resolves `undefined`. There is no error branch to write, and no call site may treat a `false` as a reason not to start a session.
+- **Fire and forget at the call site.** Use `fireAndForgetNativeVoice()` from the same module. `callNativeVoice` already swallows failures, so this is belt-and-braces — but it keeps "a hung or failed bridge call must never delay a voice session" a property each call site owns locally, and it makes the call site testable against a bridge that rejects outright.
+- **Destructure the plugin inline inside `invoke`.** The lazy-import rule at the top of this document applies verbatim: only the *result* may cross the `async` boundary, never the plugin Proxy.
+
+A capability probe is not a substitute. `VoiceLiveActivity.isAvailable()` exists (it also reports whether the user has disabled Live Activities in Settings), but the mirror does not consult it — `start` resolving `false` already covers every case, and a probe that can itself be absent just moves the problem. `VoiceAudioSessionPlugin` has an `isAvailable` method too, and the web module deliberately does not expose it: `activateVoiceAudioSession()` resolving `false` *is* the probe, and it is the only answer a caller can act on.
+
+### The background-audio contract
+
+`UIBackgroundModes: audio` in `clients/ios/App/App/Info.plist`, plus an active `.playAndRecord` / `.voiceChat` session, buys:
+
+- audio keeps playing while the app is backgrounded or the screen is locked;
+- the mic route survives backgrounding;
+- output goes to the loudspeaker rather than the earpiece (`.defaultToSpeaker`);
+- hardware echo cancellation, AGC, and AirPods/Bluetooth-HFP routing (`.voiceChat`);
+- other apps' audio resumes on `deactivate` (`.notifyOthersOnDeactivation`).
+
+It does **not** buy a running web layer. WebKit throttles and eventually suspends JS timers and main-thread work in a backgrounded web process. The AudioWorklet runs on the audio render thread, but the socket send happens on the main JS thread — so "audio is allowed in the background" and "this voice session keeps working in the background" are different claims.
+
+**The second claim is unverified.** The device spike that was meant to measure whether a WKWebView voice session survives lock — does `getUserMedia` keep producing PCM, does the velay socket keep pumping, and for how long — was never run, and there is no findings document. The background/foreground hardening that was planned on top of it (`AudioContext.resume()` on `app.resume`, a socket-liveness probe, a bounded background grace period) was never implemented. **Do not assume coverage that does not exist**: if you are about to rely on a session surviving a lock, measure it on a physical device first.
+
+For the native side of all of this — the enum-parity rule, the deep-link contract, the App Intents availability duplication, the extension compilation condition, and the v1 scope decisions — see [`clients/ios/docs/NATIVE_VOICE.md`](../../../clients/ios/docs/NATIVE_VOICE.md).
+
+References:
+- Apple — [Playing audio in the background](https://developer.apple.com/documentation/avfaudio/audio_session/enabling_background_audio).
+- Apple — [`AVAudioSession.Mode.voiceChat`](https://developer.apple.com/documentation/avfaudio/avaudiosession/mode/voicechat).
+- Apple — [ActivityKit](https://developer.apple.com/documentation/activitykit).
 
 ---
 
@@ -194,3 +269,4 @@ References:
 - [`STATE_MANAGEMENT.md`](./STATE_MANAGEMENT.md) — Zustand stores, atomic selectors, TanStack Query.
 - [`STYLE_GUIDE.md`](./STYLE_GUIDE.md) — naming, imports, TypeScript, component authoring.
 - [`clients/ios/README.md`](../../../clients/ios/README.md) — Capacitor iOS shell setup, Xcode targets, release pipeline.
+- [`clients/ios/docs/NATIVE_VOICE.md`](../../../clients/ios/docs/NATIVE_VOICE.md) — the native voice surfaces: Live Activity, App Intents, the deep-link contract, and the v1 scope decisions.


### PR DESCRIPTION
Closes out the first-class iOS voice mode feature branch with the documentation for what actually shipped.

## `clients/web/docs/CAPACITOR.md` — new "Native voice bridge" section

- The **four** plugins the shell registers in `MyViewController.capacitorDidLoad()` (`NativeAuth`, `NativeBiometric`, `VoiceAudioSession`, `VoiceLiveActivity`), each mapped to its web module.
- **The skew rule, stated as a rule**: a native voice call may always be absent, and a missing plugin must degrade to a working voice session, never to an error. Includes the `callNativeVoice` snippet and the three consequences (pick a proceedable fallback, fire-and-forget at the call site, destructure the plugin inside `invoke`).
- The background-audio contract: what `UIBackgroundModes: audio` + `.playAndRecord`/`.voiceChat` buys, and what it explicitly does not — a running web layer.
- A `<scheme>://voice` bullet in the existing deep-links section.

## `clients/ios/docs/NATIVE_VOICE.md` (new)

Prose architecture (store → mirror hook → plugin → ActivityKit → appex, plus the reverse command path), then the contracts that are easy to break silently:

- **Enum parity** — `LiveVoiceSessionState` ↔ `VoiceSessionAttributes.ContentState.Phase`, why the native half is the one that has to be remembered, and why label copy is passed from web rather than derived natively.
- **The deep-link contract** and all five producer classes.
- **The App Intents availability duplication** — both `supportedModes` (26+) and `openAppWhenRun` (17.0–25.x) are declared, this is load-bearing, do not clean it up.
- **`VOICE_ACTIVITY_EXTENSION`** — why `VoiceModeDeepLink.route()`'s body compiles out of the appex.
- **`\(.applicationName)` fragility** — silent in two directions, no test can catch either.
- **`BundleURLScheme.current` is deliberately optional** — auth falls back to production, voice deep links do not.
- **The three v1 scope decisions** (local not push, no App Group, no interactive island button), each with what would have to change to revisit it.
- Testing split into **Simulator-coverable vs device-only**, and a cross-reference to the portal checklist already in the README.

## `clients/ios/README.md`

Minimum iOS version (17.0, and why), a link to `NATIVE_VOICE.md` from the header and the conventions callout, the three-app-targets-plus-three-extensions correction, and `Intents/` / `VoiceActivity/` / `docs/` in the structure tree. The plugin count already read "four" and is correct.

## Where the docs describe reality rather than the plan

Verified against source, not the plan:

- **The background-audio spike (plan PR 1) was never run and PR 8 was never implemented.** Both documents say so plainly rather than implying coverage: whether a WKWebView voice session survives lock is empirically unknown, and there is no `background-audio-findings.md` to point at. No cross-reference to that non-existent file.
- **`native-audio-session.ts` exposes no `isAvailable`**, despite the plugin having the method — `activate` resolving `false` is the probe.
- **`Phase.failed` is unreachable via the mirror**: `isLiveVoiceSessionActive()` excludes `failed` as well as `idle`, so the mirror *ends* the activity on failure instead of pushing that phase.
- **The Live Activity mirror never consults `isVoiceLiveActivityAvailable()`.**
- **`StartNewVoiceConversationIntent` lives in `Shared/`, not `Intents/`**, because the Control Center control needs the type in the appex.
- **A Control Center control shipped** (plan PR 20, which was conditional), `@available(iOS 18.0, *)`-gated inside the same extension.
- **The start-voice deep link carries a `prompt`** and the resume branch navigates off `conversationId` (there is no `startedConversationId` in the store).

Docs only — no code changes.