### PR TITLE
feat(web): route an island tap back into the running voice room

### DIFF
--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -13,10 +13,24 @@ import {
 } from "@/stores/pending-deep-link-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useViewerStore } from "@/stores/viewer-store";
+import { routes } from "@/utils/routes";
 
-const navigateMock = mock((_to: string) => undefined);
+/**
+ * Location the app is "on", advanced by the consumer's own `navigate` calls.
+ * The voice-room predicate reads `useLocation`, so driving it from
+ * `navigateMock` lets the resume tests assert the room is visible *at the
+ * route the deep link actually landed on* rather than at a hand-written path.
+ */
+let mockPathname: string = routes.assistant;
+const navigateMock = mock((to: string) => {
+  mockPathname = to.split("?")[0] ?? to;
+  return undefined;
+});
 mock.module("react-router", () => ({
   useNavigate: () => navigateMock,
+  // Empty `search` is the main window — the room's pop-out gate
+  // (`isPopoutWindow`) looks for `popout=1`.
+  useLocation: () => ({ pathname: mockPathname, search: "" }),
 }));
 
 const ensureMainWindowVisibleMock = mock(async () => undefined);
@@ -37,6 +51,9 @@ const { useGlobalDeepLinkConsumer } =
   await import("./use-global-deep-link-consumer");
 const { drainPendingVoiceStartDeepLink } =
   await import("@/domains/chat/voice/live-voice/start-voice-deep-link");
+const { useIsVoiceRoomVisible } = await import(
+  "@/domains/chat/voice/voice-room/use-is-voice-room-visible"
+);
 
 const resetStores = () => {
   useViewerStore.setState({ mainView: "chat" });
@@ -61,6 +78,7 @@ const seedEligibleAssistant = (version = "0.10.12") => {
 beforeEach(() => {
   __resetForTesting();
   __resetPendingDeepLinkForTesting();
+  mockPathname = routes.assistant;
   navigateMock.mockClear();
   ensureMainWindowVisibleMock.mockClear();
   sentryBreadcrumbMock.mockClear();
@@ -200,6 +218,18 @@ describe("deeplink.startVoice", () => {
     });
   };
 
+  /**
+   * The real room predicate, evaluated at wherever the consumer just
+   * navigated (`navigateMock` advances the mocked location).
+   *
+   * `useIsVoiceRoomVisible` is what decides room-vs-title-bar-pill, so this is
+   * the assertion the whole resume path exists to satisfy: a resume that
+   * navigates must land somewhere the room actually renders. Asserting the
+   * navigation target alone would pass while the user stares at a pill.
+   */
+  const isVoiceRoomVisible = (): boolean =>
+    renderHook(() => useIsVoiceRoomVisible()).result.current;
+
   test("mode=new starts a session on the draft composer — no conversation, so the server assigns one", async () => {
     seedEligibleAssistant();
     const starter = mock((_a: string, _c: string | null) => undefined);
@@ -276,6 +306,7 @@ describe("deeplink.startVoice", () => {
       "/assistant/conversations/conv-9",
     );
     expect(starter).not.toHaveBeenCalled();
+    expect(isVoiceRoomVisible()).toBe(true);
   });
 
   test("mode=resume with nothing running falls through to a new session", async () => {
@@ -291,6 +322,107 @@ describe("deeplink.startVoice", () => {
 
     expect(navigateMock).toHaveBeenCalledWith("/assistant");
     expect(starter).toHaveBeenCalledWith("assistant-1", null);
+  });
+
+  // -------------------------------------------------------------------------
+  // The island tap: `mode=resume` must land on the composer that OWNS the
+  // session, or the room stays hidden and the user gets the title-bar pill on
+  // some unrelated chat instead of the room they tapped into.
+  //
+  // Ownership (`isLiveVoiceSessionOwnedBy`) accepts either the session's
+  // `startedConversationId` or its server-assigned `conversationId`, so each
+  // case below asserts the *predicate*, not just the navigation target.
+  // -------------------------------------------------------------------------
+
+  test("mode=resume prefers startedConversationId — the id the owning composer is bound to", async () => {
+    // A composer-started session: the composer passed its routing-truth id (a
+    // client-side draft id) and the server republished its own on `ready`.
+    // `startedConversationId` is the one still on screen.
+    seedEligibleAssistant();
+    const starter = mock((_a: string, _c: string | null) => undefined);
+    useLiveVoiceStore.getState().setStarter(starter);
+    useLiveVoiceStore.getState().setState("listening");
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "draft-1");
+    useLiveVoiceStore.getState().setConversationId("conv-7");
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.startVoice", { mode: "resume", prompt: null });
+    });
+    await flush();
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/assistant/conversations/draft-1",
+    );
+    expect(starter).not.toHaveBeenCalled();
+    expect(isVoiceRoomVisible()).toBe(true);
+  });
+
+  test("mode=resume falls back to conversationId for a session started without one", async () => {
+    // The `mode=new` deep-link shape: started with `null`, so the server's
+    // `ready` id is the only conversation there is.
+    seedEligibleAssistant();
+    const starter = mock((_a: string, _c: string | null) => undefined);
+    useLiveVoiceStore.getState().setStarter(starter);
+    useLiveVoiceStore.getState().setState("listening");
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", null);
+    useLiveVoiceStore.getState().setConversationId("conv-7");
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.startVoice", { mode: "resume", prompt: null });
+    });
+    await flush();
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/assistant/conversations/conv-7",
+    );
+    expect(starter).not.toHaveBeenCalled();
+    expect(isVoiceRoomVisible()).toBe(true);
+  });
+
+  test("mode=resume falls back to /assistant when the session has no conversation at all", async () => {
+    // Pre-`ready` window of a deep-link-started session: both ids are still
+    // `null`, so the draft composer — bound to no conversation — owns it.
+    seedEligibleAssistant();
+    const starter = mock((_a: string, _c: string | null) => undefined);
+    useLiveVoiceStore.getState().setStarter(starter);
+    useLiveVoiceStore.getState().setState("connecting");
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", null);
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.startVoice", { mode: "resume", prompt: null });
+    });
+    await flush();
+
+    expect(navigateMock).toHaveBeenCalledWith("/assistant");
+    expect(starter).not.toHaveBeenCalled();
+    expect(useConversationStore.getState().activeConversationId).toBe(null);
+    expect(isVoiceRoomVisible()).toBe(true);
+  });
+
+  test("tapping the island for a killed app starts a fresh session instead of an empty room", async () => {
+    // Force-quit: the Live Activity outlives the session it described, so the
+    // tap arrives with an idle store. Degrading to `new` is the only sane
+    // landing — resuming would show a room with nothing behind it.
+    seedEligibleAssistant();
+    const starter = mock((_a: string, _c: string | null) => undefined);
+    useLiveVoiceStore.getState().setStarter(starter);
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    // Nothing survived the force-quit — the branch condition the tap hits.
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+
+    act(() => {
+      publish("deeplink.startVoice", { mode: "resume", prompt: null });
+    });
+    await flush();
+
+    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    // No session yet, so no room — the room appears once the starter's session
+    // reaches an active phase, exactly as it does for a `mode=new` link.
+    expect(isVoiceRoomVisible()).toBe(false);
   });
 
   test("a prompt is parked in the composer inbox and the session starts as for mode=new", async () => {

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -113,8 +113,18 @@ export function useGlobalDeepLinkConsumer(): void {
     // on the right conversation is the whole job. With nothing running, resume
     // degrades to `new`.
     if (mode === "resume" && isLiveVoiceSessionActive(session.state)) {
-      if (session.conversationId !== null) {
-        openThread(session.conversationId);
+      // `startedConversationId` first — ownership is a *composer binding*, not
+      // wire identity, and this is the id the owning composer is bound to. A
+      // composer that started the session on a client-side draft id keeps that
+      // id here while `conversationId` becomes the server's, so landing on the
+      // latter would navigate away from the composer that owns the session.
+      // (`use-live-voice`'s reconnect paths take the opposite precedence: they
+      // need the conversation the *transport* reattaches to.) `conversationId`
+      // is the fallback for a session started without one, where `ready`
+      // assigns it and `startedConversationId` stays `null`.
+      const target = session.startedConversationId ?? session.conversationId;
+      if (target !== null) {
+        openThread(target);
       } else {
         // Pre-`ready` draft session — the draft composer owns it.
         navigateRef.current(routes.assistant);


### PR DESCRIPTION
PR 5 defined `mode=resume` and PR 11 wired the Live Activity's `widgetURL` to it. This closes the loop: it makes a resume tap land on the composer that actually **owns** the session, and proves the end-to-end path — which could not be tested until both halves existed.

## The invariant

`useIsVoiceRoomVisible` requires session active AND the on-screen composer owns the session AND not a pop-out. So a resume deep link that navigates to the wrong conversation doesn't fail loudly — it silently drops the user on a chat showing the title-bar **pill** instead of the room they tapped into.

## What changed

**Resolution order** (`use-global-deep-link-consumer.ts`) — one line:

```ts
const target = session.startedConversationId ?? session.conversationId;
```

It previously read `conversationId` only. These diverge for a **composer-started** session: the composer passes its routing-truth id (a client-side draft id, per `chat-route-content.tsx`'s `conversationId={activeConversationId}`), and the server republishes its own id on `ready` via `setConversationId`. `startedConversationId` is deliberately left at its start-time value precisely so the owning composer keeps matching it — so it, not the server's id, is the route that still has that composer on screen.

Note this is the *opposite* precedence from `use-live-voice.ts`'s reconnect paths, which want the conversation the **transport** reattaches to. Different question, so no shared helper; the comment cross-references it.

Both ids `null` (pre-`ready` window of a deep-link-started session) still falls back to `routes.assistant`, and an inactive session still falls through to starting a fresh one — both pre-existing, both now covered by tests.

## Tests

The point of the PR is asserting the predicate, not the navigation target — so the tests render the **real** `useIsVoiceRoomVisible` at wherever the consumer navigated, with the mocked `useLocation` driven by `navigateMock` itself:

- resume → `startedConversationId` when the two diverge
- resume → `conversationId` when the session started without one
- resume → `routes.assistant` when both are `null`
- killed app (idle store) → starts a fresh session, no empty room
- **room visible in all three navigated cases**, not visible in the killed-app case

Verified the assertions bite: pointing `target` at an unrelated conversation fails 5 tests on the room predicate alone.

`use-is-voice-room-visible.ts` is untouched — the invariant holds, it needed no change.

## Unverified

**No device or Simulator run was performed.** Everything above is static analysis plus the unit tests.

A Simulator pass would cover most of this and is worth doing — an iPhone 17 Pro sim with iOS 26.2 is installed on this machine:

```
xcrun simctl openurl booted "vellum-assistant://voice?mode=resume"
```

That exercises the parse → consumer → navigate → room path for every case above. What it does **not** cover is a real Dynamic Island / Lock Screen tap delivering the `widgetURL`, which needs the full app running with a live session and a physical device. The plan's first two acceptance criteria (physical-device island tap, same from the Lock Screen) remain unverified.

**One honest caveat found while tracing, not fixed here.** In the both-`null` case the room predicate holds only if the on-screen composer is bound to no conversation. In the real app, navigating to `/assistant` runs `use-conversation-loader`'s bootstrap effect, which resolves a landing conversation (preferring the currently-active id) and redirects — so `activeConversationId` is realistically never `null` there, and the room may not appear until `ready` assigns a conversation. This window is ~1s and the behavior is shared with `mode=new` (pre-existing, not introduced here), so it's out of scope for this PR — but it's the one case where "a resume that navigates always satisfies the predicate" is true in the ownership model and shaky in practice.