### PR TITLE
feat(subagent,workflows): zod-parse subagent + workflow tool input (LUM-2855)

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1986,3 +1986,67 @@ describe("Advisor role is tool-less", () => {
     ).toBe(0);
   });
 });
+
+// ── model-input schema validation (LUM-2855) ────────────────────────
+
+describe("subagent tools — model-input schema validation", () => {
+  test("spawn rejects a non-string label instead of spawning with it", async () => {
+    const result = await executeSubagentSpawn(
+      { label: 42, objective: "do something" },
+      makeContext("sess-schema", { sendToClient: () => {} }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "subagent_spawn"');
+    expect(result.content).toContain("label");
+  });
+
+  test("spawn treats explicit null label as missing (bespoke required error)", async () => {
+    const result = await executeSubagentSpawn(
+      { label: null, objective: "do something" },
+      makeContext("sess-schema", { sendToClient: () => {} }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("required");
+  });
+
+  test("status rejects a non-string subagent_id", async () => {
+    const result = await executeSubagentStatus(
+      { subagent_id: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "subagent_status"',
+    );
+  });
+
+  test("message rejects a non-string content", async () => {
+    const result = await executeSubagentMessage(
+      { subagent_id: "some-id", content: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "subagent_message"',
+    );
+    expect(result.content).toContain("content");
+  });
+
+  test("read rejects a non-string label but passes malformed last_n through", async () => {
+    const bad = await executeSubagentRead(
+      { label: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(bad.isError).toBe(true);
+    expect(bad.content).toContain('Invalid input for tool "subagent_read"');
+
+    // last_n is loose passthrough — a malformed value is ignored, so the call
+    // reaches the bespoke "required" check instead of failing validation.
+    const passthrough = await executeSubagentRead(
+      { last_n: "five" },
+      makeContext("sess-schema"),
+    );
+    expect(passthrough.isError).toBe(true);
+    expect(passthrough.content).toContain("required");
+  });
+});

--- a/assistant/src/tools/__tests__/subagent-workflow-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/subagent-workflow-tool-input-schemas.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test } from "bun:test";
+
+import type { z } from "zod";
+
+import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+import { subagentAbortInputSchema } from "../subagent/abort.js";
+import { subagentMessageInputSchema } from "../subagent/message.js";
+import { subagentReadInputSchema } from "../subagent/read.js";
+import { subagentSpawnInputSchema } from "../subagent/spawn.js";
+import { subagentStatusInputSchema } from "../subagent/status.js";
+import { manageWorkflowsInputSchema } from "../workflows/manage-workflows.js";
+import { runWorkflowInputSchema } from "../workflows/run-workflow.js";
+import { expectNoSchemaDrift } from "./tool-schema-drift-harness.js";
+
+/**
+ * Drift guard between the subagent and workflows skills' hand-written
+ * `TOOLS.json` `input_schema`s (the advertised contract) and the executors'
+ * runtime Zod schemas. See `tool-schema-drift-harness.ts` for what is (and
+ * deliberately is not) compared.
+ */
+
+function loadToolsJson(
+  skill: string,
+): Parameters<typeof expectNoSchemaDrift>[1] {
+  return JSON.parse(
+    readFileSync(
+      join(import.meta.dir, `../../config/bundled-skills/${skill}/TOOLS.json`),
+      "utf8",
+    ),
+  ) as Parameters<typeof expectNoSchemaDrift>[1];
+}
+
+const CASES: {
+  skill: string;
+  name: string;
+  schema: z.ZodType;
+  advertiseRequired?: string[];
+  passthrough?: Record<string, string>;
+}[] = [
+  {
+    skill: "subagent",
+    name: "subagent_spawn",
+    schema: subagentSpawnInputSchema,
+    advertiseRequired: ["label", "objective"],
+    passthrough: {
+      fork: "deliberate `=== true` coercion owns malformed values",
+      send_result_to_user:
+        "deliberate `=== true` / `!== false` coercions own malformed values",
+      role: "SubagentManager.spawn's 'Invalid subagent role' error (test-asserted) owns non-enum values",
+    },
+  },
+  {
+    skill: "subagent",
+    name: "subagent_status",
+    schema: subagentStatusInputSchema,
+  },
+  {
+    skill: "subagent",
+    name: "subagent_abort",
+    schema: subagentAbortInputSchema,
+  },
+  {
+    skill: "subagent",
+    name: "subagent_message",
+    schema: subagentMessageInputSchema,
+    advertiseRequired: ["content"],
+  },
+  {
+    skill: "subagent",
+    name: "subagent_read",
+    schema: subagentReadInputSchema,
+    passthrough: {
+      last_n:
+        "typeof-guarded read ignores malformed values (including non-integer numbers the advertised type wouldn't admit)",
+    },
+  },
+  {
+    skill: "workflows",
+    name: "run_workflow",
+    schema: runWorkflowInputSchema,
+    passthrough: {
+      args: "workflow runtime accepts any JSON value as args",
+      capabilities:
+        "CapabilityManifestSchema is the single validation authority; executor.ts reads it pre-execution for the requireFreshApproval promotion",
+    },
+  },
+  {
+    skill: "workflows",
+    name: "manage_workflows",
+    schema: manageWorkflowsInputSchema,
+    advertiseRequired: ["action"],
+    passthrough: {
+      action:
+        "switch default owns the unknown-action error; executor.ts reads it pre-execution for the requireFreshApproval promotion",
+    },
+  },
+];
+
+describe("subagent + workflows TOOLS.json ↔ runtime Zod schema drift guard", () => {
+  for (const c of CASES) {
+    test(`${c.skill}:${c.name}`, () => {
+      expectNoSchemaDrift(
+        {
+          name: c.name,
+          derived: toToolInputSchema(c.schema, {
+            advertiseRequired: c.advertiseRequired,
+          }),
+          passthrough: c.passthrough,
+        },
+        loadToolsJson(c.skill),
+      );
+    });
+  }
+});

--- a/assistant/src/tools/subagent/abort.ts
+++ b/assistant/src/tools/subagent/abort.ts
@@ -1,15 +1,23 @@
 import { getSubagentManager } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentAbortInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentAbort(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  if (!subagentId && input.label) {
+  const parsedInput = subagentAbortInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_abort", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/consult-deadline.ts
+++ b/assistant/src/tools/subagent/consult-deadline.ts
@@ -29,8 +29,12 @@ export function createConsultDeadline(opts: {
 
   const recordProgress = (): void => {
     // Once aborted, don't re-arm — the consult is already being torn down.
-    if (controller.signal.aborted) return;
-    if (idleTimer) clearTimeout(idleTimer);
+    if (controller.signal.aborted) {
+      return;
+    }
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
     idleTimer = setTimeout(() => controller.abort(), opts.idleMs);
   };
 
@@ -41,7 +45,9 @@ export function createConsultDeadline(opts: {
   recordProgress();
 
   const dispose = (): void => {
-    if (idleTimer) clearTimeout(idleTimer);
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
     clearTimeout(maxTimer);
   };
 

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -1,17 +1,33 @@
+import { z } from "zod";
+
 import { getSubagentManager } from "../../subagent/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentMessageInputSchema = z.looseObject({
+  ...subagentRefInputSchema.shape,
+  content: nullAsOmitted(z.string()),
+});
 
 export async function executeSubagentMessage(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  const content = input.content as string;
+  const parsedInput = subagentMessageInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_message", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  const content = parsed.content;
 
-  if (!subagentId && input.label) {
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -1,17 +1,28 @@
 import { getMessages } from "../../persistence/conversation-crud.js";
 import { extractTextFromStoredMessageContent } from "../../persistence/message-content.js";
 import { getSubagentManager, TERMINAL_STATUSES } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+// `last_n` is deliberately UNDECLARED (loose passthrough): the executor's
+// typeof-guarded read below ignores it when malformed — including non-integer
+// numbers the advertised `integer` type wouldn't admit — and always has.
+export const subagentReadInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentRead(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  if (!subagentId && input.label) {
+  const parsedInput = subagentReadInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_read", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -7,7 +7,7 @@ import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
 
 // `last_n` is deliberately UNDECLARED (loose passthrough): the executor's
 // typeof-guarded read below ignores it when malformed — including non-integer
-// numbers the advertised `integer` type wouldn't admit — and always has.
+// numbers the advertised `integer` type wouldn't admit.
 export const subagentReadInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentRead(

--- a/assistant/src/tools/subagent/resolve.ts
+++ b/assistant/src/tools/subagent/resolve.ts
@@ -1,18 +1,40 @@
+import { z } from "zod";
+
 import { getSubagentManager } from "../../subagent/index.js";
+import { nullAsOmitted } from "../shared/zod-tool-schema.js";
 import type { ToolContext } from "../types.js";
 
 /**
- * Resolve a subagent ID from tool input.
+ * Shared model-input schema for the subagent tools that address an existing
+ * subagent by `subagent_id` or `label` (`subagent_status` / `subagent_abort`,
+ * extended by `subagent_message` / `subagent_read`). Same in-tool pattern and
+ * TOOLS.json drift guard as the other bundled-skill tools — see
+ * `subagent-tool-input-schemas.test.ts` and the schema block in
+ * `tools/document/document-tool.ts` for the framework. The
+ * '"subagent_id" or "label" is required' / not-found error messages stay
+ * bespoke in each executor.
+ */
+export const subagentRefInputSchema = z.looseObject({
+  subagent_id: nullAsOmitted(z.string()),
+  label: nullAsOmitted(z.string()),
+});
+
+export type SubagentRefInput = z.infer<typeof subagentRefInputSchema>;
+
+/**
+ * Resolve a subagent ID from parsed tool input.
  * Accepts either `subagent_id` (direct UUID) or `label` (case-insensitive lookup).
  */
 export function resolveSubagentId(
-  input: Record<string, unknown>,
+  input: SubagentRefInput,
   context: ToolContext,
 ): string | undefined {
-  if (input.subagent_id) return input.subagent_id as string;
+  if (input.subagent_id) {
+    return input.subagent_id;
+  }
   if (input.label) {
     const state = getSubagentManager().getByLabel(
-      input.label as string,
+      input.label,
       context.conversationId,
     );
     return state?.config.id;

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { AssistantEvent } from "../../api/index.js";
 import { validateInferenceProfileKey } from "../../config/inference-profile-validation.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
@@ -19,6 +21,10 @@ import {
 } from "../../subagent/index.js";
 import type { SubagentRole } from "../../subagent/types.js";
 import { getLogger } from "../../util/logger.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { createConsultDeadline } from "./consult-deadline.js";
 
@@ -42,16 +48,40 @@ const ADVISOR_IDLE_TIMEOUT_MS = 60_000;
  */
 const ADVISOR_MAX_TIMEOUT_MS = 300_000;
 
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeSubagentSpawn}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework.
+ *
+ * `fork` / `send_result_to_user` (deliberate `=== true` / `!== false`
+ * coercions) and `role` (SubagentManager.spawn's "Invalid subagent role"
+ * error, asserted by tests, owns non-enum values) are deliberately
+ * UNDECLARED — loose passthrough.
+ */
+export const subagentSpawnInputSchema = z.looseObject({
+  label: nullAsOmitted(z.string()),
+  objective: nullAsOmitted(z.string()),
+  context: nullAsOmitted(z.string()),
+  inference_profile: z.string().optional(),
+});
+
 export async function executeSubagentSpawn(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const label = input.label as string;
-  const objective = input.objective as string;
-  const extraContext = input.context as string | undefined;
+  const parsedInput = subagentSpawnInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_spawn", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const label = parsed.label;
+  const objective = parsed.objective;
+  const extraContext = parsed.context;
   const fork = input.fork === true;
   const role = (input.role as string | undefined) ?? undefined;
-  const inferenceProfile = input.inference_profile;
+  const inferenceProfile = parsed.inference_profile;
 
   // For fork mode, sendResultToUser defaults to false unless explicitly set to true.
   // For regular mode, sendResultToUser defaults to true (existing behavior).
@@ -69,12 +99,6 @@ export async function executeSubagentSpawn(
   let requestedOverrideProfile: string | undefined;
   let forceOverrideProfile = false;
   if (inferenceProfile !== undefined) {
-    if (typeof inferenceProfile !== "string") {
-      return {
-        content: "Error: inference_profile must be a string",
-        isError: true,
-      };
-    }
     const profileError = validateInferenceProfileKey(inferenceProfile);
     if (profileError) {
       return {

--- a/assistant/src/tools/subagent/status.ts
+++ b/assistant/src/tools/subagent/status.ts
@@ -1,19 +1,27 @@
 import { getSubagentManager } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentStatusInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentStatus(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
+  const parsedInput = subagentStatusInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_status", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
   const manager = getSubagentManager();
 
   // If a label was provided but didn't resolve, that's an error — don't fall
   // through to the "list all" path.
-  if (!subagentId && input.label) {
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -13,19 +13,45 @@
  * by the type checker.
  */
 
+import { z } from "zod";
+
 import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of
+ * {@link executeManageWorkflows}. Same in-tool pattern and TOOLS.json drift
+ * guard as the other bundled-skill tools — see the schema block in
+ * `tools/document/document-tool.ts` for the framework.
+ *
+ * `action` is deliberately UNDECLARED (loose passthrough): the switch's
+ * default case owns the unknown-action error, and `executor.ts` reads
+ * `input.action` / `input.run_id` pre-execution for the requireFreshApproval
+ * promotion (those reads are already defensive and see the raw input either
+ * way).
+ */
+export const manageWorkflowsInputSchema = z.looseObject({
+  run_id: nullAsOmitted(z.string()),
+});
 
 export async function executeManageWorkflows(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const parsedInput = manageWorkflowsInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("manage_workflows", parsedInput.error);
+  }
   const action = input.action as string | undefined;
-  const runId = input.run_id as string | undefined;
+  const runId = parsedInput.data.run_id;
   const manager = getWorkflowRunManager();
 
   // Authorization scope ({@link callerOwnsWorkflowRun}, shared with the
@@ -104,7 +130,9 @@ export async function executeManageWorkflows(
       // Only signal a run the caller owns. A non-owned (or absent) run is a
       // no-op with the same response shape, so existence is never revealed.
       const run = manager.status(runId);
-      if (run && ownsRun(run)) manager.abort(runId);
+      if (run && ownsRun(run)) {
+        manager.abort(runId);
+      }
       return {
         content: JSON.stringify({
           runId,

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -27,7 +27,9 @@ mock.module("../../daemon/conversation-registry.js", () => ({
 let lastStartArgs: Record<string, unknown> | null = null;
 let startThrows: Error | null = null;
 const startMock = mock((opts: Record<string, unknown>) => {
-  if (startThrows) throw startThrows;
+  if (startThrows) {
+    throw startThrows;
+  }
   lastStartArgs = opts;
   return { runId: "run-123" };
 });
@@ -36,7 +38,9 @@ const abortMock = mock(() => {});
 const listMock = mock(() => [] as unknown[]);
 let resumeThrows: Error | null = null;
 const resumeMock = mock((runId: string) => {
-  if (resumeThrows) throw resumeThrows;
+  if (resumeThrows) {
+    throw resumeThrows;
+  }
   return { runId };
 });
 
@@ -419,5 +423,53 @@ describe("manage_workflows", () => {
       contactContext(),
     );
     expect(abortMock).toHaveBeenCalledWith("mine");
+  });
+});
+
+// ── model-input schema validation (LUM-2855) ────────────────────────
+
+describe("workflow tools — model-input schema validation", () => {
+  test("run_workflow rejects a non-string script", async () => {
+    const result = await executeRunWorkflow({ script: 42 }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "run_workflow"');
+    expect(result.content).toContain("script");
+    expect(startMock).not.toHaveBeenCalled();
+  });
+
+  test("run_workflow treats explicit null script/name as omitted (bespoke exactly-one error)", async () => {
+    const result = await executeRunWorkflow(
+      { script: null, name: null },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("exactly one");
+  });
+
+  test("run_workflow passes args through unvalidated (workflow runtime accepts any JSON)", async () => {
+    const result = await executeRunWorkflow(
+      { script: "export const meta = {}", args: ["positional"] },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(lastStartArgs?.args).toEqual(["positional"]);
+  });
+
+  test("manage_workflows rejects a non-string run_id", async () => {
+    const result = await executeManageWorkflows(
+      { action: "status", run_id: 42 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "manage_workflows"',
+    );
+    expect(result.content).toContain("run_id");
+  });
+
+  test("manage_workflows keeps the bespoke unknown-action error", async () => {
+    const result = await executeManageWorkflows({ action: 42 }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unknown action");
   });
 });

--- a/assistant/src/tools/workflows/run-workflow.ts
+++ b/assistant/src/tools/workflows/run-workflow.ts
@@ -15,12 +15,36 @@
  * of truth the model reads when generating the `script`.
  */
 
+import { z } from "zod";
+
 import { findConversation } from "../../daemon/conversation-registry.js";
 import { FALLBACK_TURN_TRUST } from "../../daemon/trust-context.js";
 import type { TrustContext } from "../../daemon/trust-context-types.js";
 import { CapabilityManifestSchema } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeRunWorkflow}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework.
+ *
+ * `args` (the workflow runtime accepts any JSON value) and `capabilities`
+ * (`CapabilityManifestSchema` is the single validation authority, and
+ * `executor.ts` reads it pre-execution for the requireFreshApproval
+ * promotion) are deliberately UNDECLARED — loose passthrough. The
+ * exactly-one-of script/name rule stays a bespoke check below.
+ */
+export const runWorkflowInputSchema = z.looseObject({
+  script: nullAsOmitted(z.string()),
+  name: nullAsOmitted(z.string()),
+  label: nullAsOmitted(z.string()),
+});
 
 /**
  * Resolve the {@link TrustContext} to forward to the run's leaves. Prefer the
@@ -33,7 +57,9 @@ function resolveTrustContext(context: ToolContext): TrustContext {
   const conversation = findConversation(context.conversationId);
   const fromConversation =
     conversation?.currentTurnTrustContext ?? conversation?.trustContext;
-  if (fromConversation) return fromConversation;
+  if (fromConversation) {
+    return fromConversation;
+  }
   return { ...FALLBACK_TURN_TRUST, trustClass: context.trustClass };
 }
 
@@ -41,8 +67,11 @@ export async function executeRunWorkflow(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const script = input.script as string | undefined;
-  const name = input.name as string | undefined;
+  const parsedInput = runWorkflowInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("run_workflow", parsedInput.error);
+  }
+  const { script, name, label } = parsedInput.data;
 
   // Exactly one of script/name is required.
   if ((script == null) === (name == null)) {
@@ -54,7 +83,6 @@ export async function executeRunWorkflow(
   }
 
   const args = (input.args as Record<string, unknown> | undefined) ?? {};
-  const label = input.label as string | undefined;
   const trustContext = resolveTrustContext(context);
 
   try {


### PR DESCRIPTION
> **Stacked on #39285 (LUM-2854)**, which stacks on #39283 (LUM-2853). Merge in order; GitHub retargets as each base merges. Only the last commit is new here.

## Summary

Fourth tranche of [LUM-2797](https://linear.app/vellum/issue/LUM-2797) ([LUM-2855](https://linear.app/vellum/issue/LUM-2855)): the subagent skill's five tools (`subagent_spawn` / `subagent_message` / `subagent_read` / `subagent_status` / `subagent_abort`) and the workflows skill's two (`run_workflow` / `manage_workflows`) now `safeParse` tolerant Zod schemas at the top of each executor and return `invalidToolInputResult(...)` on failure, replacing ~15 naked casts.

## Implementation

Same in-tool pattern and drift-guard decision as the earlier tranches. New `subagent-workflow-tool-input-schemas.test.ts` covers both skills' TOOLS.json via the shared harness. Per the ticket, `resolveSubagentId` now takes the **parsed** `subagent_id`/`label` — the shared `subagentRefInputSchema` lives beside it in `resolve.ts` and is reused/extended by all four ref-addressing tools.

## Key technical choices — tolerance preserved

- `nullAsOmitted` on all declared optionals; bespoke error messages (`'Both "label" and "objective" are required.'`, `'"run_id" is required for action …'`, exactly-one-of script/name) all stay — the existing suites assert them and pass unchanged.
- **Passthrough fields** (documented in the guard's exception lists):
  - `subagent_spawn.fork` / `send_result_to_user`: deliberate `=== true` / `!== false` coercions.
  - `subagent_spawn.role`: `SubagentManager.spawn`'s `"Invalid subagent role … Must be one of …"` error is test-asserted and owns non-enum values.
  - `subagent_read.last_n`: typeof-guarded read ignores malformed values, including non-integer numbers the advertised `integer` type wouldn't admit.
  - `run_workflow.args`: the workflow runtime accepts any JSON value (covered by a new test asserting array args still start the run).
  - `run_workflow.capabilities` / `manage_workflows.action`+`run_id` pre-execution reads: per the ticket's caution, `executor.ts` reads these raw before execution for the requireFreshApproval promotions — in-tool parsing cannot change what those defensive reads see, and `capabilities` still flows to `CapabilityManifestSchema` unaltered.
  - `manage_workflows.action`: the switch's default case owns the unknown-action error (test-asserted).
- `subagent_spawn.inference_profile` is schema-typed; the now-dead bespoke typeof branch was removed (`validateInferenceProfileKey` still owns semantic validation).

## Testing

- `bun test src/__tests__/subagent-tools.test.ts` — 89 pass (5 new validation tests)
- `bun test src/tools/workflows/run-workflow.test.ts` — 23 pass (5 new)
- `bun test src/tools/__tests__/subagent-workflow-tool-input-schemas.test.ts` — 7 pass (new drift guard)
- `subagent-spawn-tool-fork`, `agent-loop-override-profile` suites pass unchanged
- `bunx tsc --noEmit` clean; eslint + prettier clean; `lint:circular` unchanged (201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Latent prod bugs fixed (tracking)

Live, reachable paths in production code — any malformed model call could trigger them; fixed by this PR's validation:

1. **`subagent_spawn` label/objective corruption** — the `!label || !objective` truthy check passed `label: 42`, which then entered the subagent config (rendered in UI, used for `getByLabel` lookups → type-confused lookup path); `objective: 42` flowed into the spawn prompt path the same way.
2. **`run_workflow` non-string `name`/`label`** flowed unchecked into the run manager (`name as string` after only an xor-presence check), landing garbage in the run record / saved-workflow lookup.
3. **`subagent_message` / shared `resolveSubagentId` non-string `subagent_id`** passed the truthy check and reached `getState`/`getByLabel` as a number.
