### PR TITLE
test(web): assert the widened startVoice payload shape

### DIFF
--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
@@ -185,7 +185,7 @@ describe("publishCapacitorDeepLinksSource", () => {
 
       urlOpenHandler!({ url: "vellum-assistant://voice?mode=resume" });
 
-      expect(starts).toEqual([{ mode: "resume" }]);
+      expect(starts).toEqual([{ mode: "resume", prompt: null }]);
       expect(unknowns).toEqual([]);
     } finally {
       unsubStart();


### PR DESCRIPTION
## Summary
Fixes a failing test on the feature branch.

#39281 added an optional `prompt` to the start-voice deep link, widening the `deeplink.startVoice` bus payload from `{ mode }` to `{ mode, prompt }`. It updated `native-deep-link.test.ts` and `use-global-deep-link-consumer.test.tsx`, but not `capacitor-deep-links.test.ts`, whose `toEqual` is exact and so began failing on `{ mode: "resume" }` vs `{ mode: "resume", prompt: null }`.

Worth noting how it stayed hidden: every PR merged between #39281 and now was iOS-only, and the web `Test` job is path-filtered. The first PR since then to touch `clients/web/**` was a docs-only change, which is where it surfaced — the failure was never that PR's fault.

## Verification
`bun test src/runtime/event-sources/capacitor-deep-links.test.ts` — 10 pass, 0 fail.

Part of plan: first-class-ios-voice-mode.md (fix)