### PR TITLE
feat(followups,calls,acp): zod-parse three small skill families (LUM-2856)

### DIFF
--- a/assistant/src/__tests__/call-start-guardian-guard.test.ts
+++ b/assistant/src/__tests__/call-start-guardian-guard.test.ts
@@ -111,3 +111,30 @@ describe("call_start guardian verification guard", () => {
     expect(startCallInputs.length).toBe(1);
   });
 });
+
+describe("call tools — model-input schema validation (LUM-2856)", () => {
+  test("call_start rejects a non-string phone_number before reaching startCall", async () => {
+    const before = startCallInputs.length;
+    const result = await executeCallStart(
+      { phone_number: 4155550100, task: "call someone" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "call_start"');
+    expect(result.content).toContain("phone_number");
+    expect(startCallInputs.length).toBe(before);
+  });
+
+  test("call_start rejects an unknown caller_identity_mode", async () => {
+    const result = await executeCallStart(
+      {
+        phone_number: "+14155550100",
+        task: "call someone",
+        caller_identity_mode: "spoofed",
+      },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("caller_identity_mode");
+  });
+});

--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -308,3 +308,61 @@ describe("followup_resolve tool", () => {
     );
   });
 });
+
+// ── model-input schema validation (LUM-2856) ────────────────────────
+
+describe("followup tools — model-input schema validation", () => {
+  test("followup_create rejects a non-string contact_id", async () => {
+    const result = await executeFollowupCreate(
+      { channel: "email", conversation_id: "conv-1", contact_id: 42 },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "followup_create"',
+    );
+    expect(result.content).toContain("contact_id");
+  });
+
+  test("followup_create keeps the bespoke positive-number error for expected_response_hours", async () => {
+    const result = await executeFollowupCreate(
+      {
+        channel: "email",
+        conversation_id: "conv-1",
+        expected_response_hours: "soon",
+      },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      "expected_response_hours must be a positive number",
+    );
+  });
+
+  test("followup_create treats explicit null channel as missing (bespoke error)", async () => {
+    const result = await executeFollowupCreate(
+      { channel: null, conversation_id: "conv-1" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("channel is required");
+  });
+
+  test("followup_list rejects a non-boolean overdue_only but keeps the bespoke status error", async () => {
+    const bad = await executeFollowupList({ overdue_only: "yes" }, ctx);
+    expect(bad.isError).toBe(true);
+    expect(bad.content).toContain('Invalid input for tool "followup_list"');
+
+    const status = await executeFollowupList({ status: 42 }, ctx);
+    expect(status.isError).toBe(true);
+    expect(status.content).toContain("Invalid status");
+  });
+
+  test("followup_resolve rejects a non-string id", async () => {
+    const result = await executeFollowupResolve({ id: 42 }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "followup_resolve"',
+    );
+  });
+});

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1986,3 +1986,67 @@ describe("Advisor role is tool-less", () => {
     ).toBe(0);
   });
 });
+
+// ── model-input schema validation (LUM-2855) ────────────────────────
+
+describe("subagent tools — model-input schema validation", () => {
+  test("spawn rejects a non-string label instead of spawning with it", async () => {
+    const result = await executeSubagentSpawn(
+      { label: 42, objective: "do something" },
+      makeContext("sess-schema", { sendToClient: () => {} }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "subagent_spawn"');
+    expect(result.content).toContain("label");
+  });
+
+  test("spawn treats explicit null label as missing (bespoke required error)", async () => {
+    const result = await executeSubagentSpawn(
+      { label: null, objective: "do something" },
+      makeContext("sess-schema", { sendToClient: () => {} }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("required");
+  });
+
+  test("status rejects a non-string subagent_id", async () => {
+    const result = await executeSubagentStatus(
+      { subagent_id: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "subagent_status"',
+    );
+  });
+
+  test("message rejects a non-string content", async () => {
+    const result = await executeSubagentMessage(
+      { subagent_id: "some-id", content: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "subagent_message"',
+    );
+    expect(result.content).toContain("content");
+  });
+
+  test("read rejects a non-string label but passes malformed last_n through", async () => {
+    const bad = await executeSubagentRead(
+      { label: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(bad.isError).toBe(true);
+    expect(bad.content).toContain('Invalid input for tool "subagent_read"');
+
+    // last_n is loose passthrough — a malformed value is ignored, so the call
+    // reaches the bespoke "required" check instead of failing validation.
+    const passthrough = await executeSubagentRead(
+      { last_n: "five" },
+      makeContext("sess-schema"),
+    );
+    expect(passthrough.isError).toBe(true);
+    expect(passthrough.content).toContain("required");
+  });
+});

--- a/assistant/src/tools/__tests__/followup-call-acp-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/followup-call-acp-tool-input-schemas.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test } from "bun:test";
+
+import type { z } from "zod";
+
+import { acpAbortInputSchema } from "../acp/abort.js";
+import { acpSpawnInputSchema } from "../acp/spawn.js";
+import { acpStatusInputSchema } from "../acp/status.js";
+import { acpSteerInputSchema } from "../acp/steer.js";
+import { callEndInputSchema } from "../calls/call-end.js";
+import { callStartInputSchema } from "../calls/call-start.js";
+import { callStatusInputSchema } from "../calls/call-status.js";
+import { followupCreateInputSchema } from "../followups/followup_create.js";
+import { followupListInputSchema } from "../followups/followup_list.js";
+import { followupResolveInputSchema } from "../followups/followup_resolve.js";
+import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+import { expectNoSchemaDrift } from "./tool-schema-drift-harness.js";
+
+/**
+ * Drift guard between the followups / phone-calls / acp skills' hand-written
+ * `TOOLS.json` `input_schema`s (the advertised contract) and the executors'
+ * runtime Zod schemas. See `tool-schema-drift-harness.ts` for what is (and
+ * deliberately is not) compared. `acp_list_agents` takes no input and has no
+ * runtime schema, so it has no entry here.
+ */
+
+function loadToolsJson(
+  skill: string,
+): Parameters<typeof expectNoSchemaDrift>[1] {
+  return JSON.parse(
+    readFileSync(
+      join(import.meta.dir, `../../config/bundled-skills/${skill}/TOOLS.json`),
+      "utf8",
+    ),
+  ) as Parameters<typeof expectNoSchemaDrift>[1];
+}
+
+const CASES: {
+  skill: string;
+  name: string;
+  schema: z.ZodType;
+  advertiseRequired?: string[];
+  passthrough?: Record<string, string>;
+}[] = [
+  {
+    skill: "followups",
+    name: "followup_create",
+    schema: followupCreateInputSchema,
+    advertiseRequired: ["channel", "conversation_id"],
+    passthrough: {
+      expected_response_hours:
+        "bespoke positive-number check owns the error message for every malformed shape (per LUM-2856)",
+    },
+  },
+  {
+    skill: "followups",
+    name: "followup_list",
+    schema: followupListInputSchema,
+    passthrough: {
+      status:
+        "bespoke VALID_STATUSES check owns the 'Invalid status' error (test-asserted)",
+    },
+  },
+  {
+    skill: "followups",
+    name: "followup_resolve",
+    schema: followupResolveInputSchema,
+  },
+  {
+    skill: "phone-calls",
+    name: "call_start",
+    schema: callStartInputSchema,
+    passthrough: {
+      skip_disclosure: "deliberate `=== true` coercion owns malformed values",
+    },
+  },
+  {
+    skill: "phone-calls",
+    name: "call_status",
+    schema: callStatusInputSchema,
+  },
+  {
+    skill: "phone-calls",
+    name: "call_end",
+    schema: callEndInputSchema,
+    advertiseRequired: ["call_session_id"],
+  },
+  {
+    skill: "acp",
+    name: "acp_spawn",
+    schema: acpSpawnInputSchema,
+    advertiseRequired: ["task"],
+  },
+  { skill: "acp", name: "acp_status", schema: acpStatusInputSchema },
+  {
+    skill: "acp",
+    name: "acp_abort",
+    schema: acpAbortInputSchema,
+    advertiseRequired: ["acp_session_id"],
+  },
+  {
+    skill: "acp",
+    name: "acp_steer",
+    schema: acpSteerInputSchema,
+    advertiseRequired: ["acp_session_id", "instruction"],
+  },
+];
+
+describe("followups + phone-calls + acp TOOLS.json ↔ runtime Zod schema drift guard", () => {
+  for (const c of CASES) {
+    test(`${c.skill}:${c.name}`, () => {
+      expectNoSchemaDrift(
+        {
+          name: c.name,
+          derived: toToolInputSchema(c.schema, {
+            advertiseRequired: c.advertiseRequired,
+          }),
+          passthrough: c.passthrough,
+        },
+        loadToolsJson(c.skill),
+      );
+    });
+  }
+});

--- a/assistant/src/tools/__tests__/subagent-workflow-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/subagent-workflow-tool-input-schemas.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test } from "bun:test";
+
+import type { z } from "zod";
+
+import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+import { subagentAbortInputSchema } from "../subagent/abort.js";
+import { subagentMessageInputSchema } from "../subagent/message.js";
+import { subagentReadInputSchema } from "../subagent/read.js";
+import { subagentSpawnInputSchema } from "../subagent/spawn.js";
+import { subagentStatusInputSchema } from "../subagent/status.js";
+import { manageWorkflowsInputSchema } from "../workflows/manage-workflows.js";
+import { runWorkflowInputSchema } from "../workflows/run-workflow.js";
+import { expectNoSchemaDrift } from "./tool-schema-drift-harness.js";
+
+/**
+ * Drift guard between the subagent and workflows skills' hand-written
+ * `TOOLS.json` `input_schema`s (the advertised contract) and the executors'
+ * runtime Zod schemas. See `tool-schema-drift-harness.ts` for what is (and
+ * deliberately is not) compared.
+ */
+
+function loadToolsJson(
+  skill: string,
+): Parameters<typeof expectNoSchemaDrift>[1] {
+  return JSON.parse(
+    readFileSync(
+      join(import.meta.dir, `../../config/bundled-skills/${skill}/TOOLS.json`),
+      "utf8",
+    ),
+  ) as Parameters<typeof expectNoSchemaDrift>[1];
+}
+
+const CASES: {
+  skill: string;
+  name: string;
+  schema: z.ZodType;
+  advertiseRequired?: string[];
+  passthrough?: Record<string, string>;
+}[] = [
+  {
+    skill: "subagent",
+    name: "subagent_spawn",
+    schema: subagentSpawnInputSchema,
+    advertiseRequired: ["label", "objective"],
+    passthrough: {
+      fork: "deliberate `=== true` coercion owns malformed values",
+      send_result_to_user:
+        "deliberate `=== true` / `!== false` coercions own malformed values",
+      role: "SubagentManager.spawn's 'Invalid subagent role' error (test-asserted) owns non-enum values",
+    },
+  },
+  {
+    skill: "subagent",
+    name: "subagent_status",
+    schema: subagentStatusInputSchema,
+  },
+  {
+    skill: "subagent",
+    name: "subagent_abort",
+    schema: subagentAbortInputSchema,
+  },
+  {
+    skill: "subagent",
+    name: "subagent_message",
+    schema: subagentMessageInputSchema,
+    advertiseRequired: ["content"],
+  },
+  {
+    skill: "subagent",
+    name: "subagent_read",
+    schema: subagentReadInputSchema,
+    passthrough: {
+      last_n:
+        "typeof-guarded read ignores malformed values (including non-integer numbers the advertised type wouldn't admit)",
+    },
+  },
+  {
+    skill: "workflows",
+    name: "run_workflow",
+    schema: runWorkflowInputSchema,
+    passthrough: {
+      args: "workflow runtime accepts any JSON value as args",
+      capabilities:
+        "CapabilityManifestSchema is the single validation authority; executor.ts reads it pre-execution for the requireFreshApproval promotion",
+    },
+  },
+  {
+    skill: "workflows",
+    name: "manage_workflows",
+    schema: manageWorkflowsInputSchema,
+    advertiseRequired: ["action"],
+    passthrough: {
+      action:
+        "switch default owns the unknown-action error; executor.ts reads it pre-execution for the requireFreshApproval promotion",
+    },
+  },
+];
+
+describe("subagent + workflows TOOLS.json ↔ runtime Zod schema drift guard", () => {
+  for (const c of CASES) {
+    test(`${c.skill}:${c.name}`, () => {
+      expectNoSchemaDrift(
+        {
+          name: c.name,
+          derived: toToolInputSchema(c.schema, {
+            advertiseRequired: c.advertiseRequired,
+          }),
+          passthrough: c.passthrough,
+        },
+        loadToolsJson(c.skill),
+      );
+    });
+  }
+});

--- a/assistant/src/tools/acp/abort.ts
+++ b/assistant/src/tools/acp/abort.ts
@@ -1,11 +1,31 @@
+import { z } from "zod";
+
 import { getAcpSessionManager } from "../../acp/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeAcpAbort}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools. The bespoke required check keeps its message for the
+ * missing/null/empty cases.
+ */
+export const acpAbortInputSchema = z.looseObject({
+  acp_session_id: nullAsOmitted(z.string()),
+});
 
 export async function executeAcpAbort(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acpSessionId = input.acp_session_id as string;
+  const parsedInput = acpAbortInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("acp_abort", parsedInput.error);
+  }
+  const acpSessionId = parsedInput.data.acp_session_id;
   if (!acpSessionId) {
     return { content: '"acp_session_id" is required.', isError: true };
   }

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -49,7 +49,9 @@ mock.module("../credentials/metadata-store.js", () => ({
   getCredentialMetadata: (service: string, field: string) => {
     const key = `${service}/${field}`;
     const entry = metadataStore.get(key);
-    if (!entry) return undefined;
+    if (!entry) {
+      return undefined;
+    }
     return {
       credentialId: `cred-${key}`,
       service,
@@ -278,8 +280,12 @@ describe("executeAcpSpawn: sandboxed bun auto-install on missing binary", () => 
     // successful global install that links the adapter bin onto PATH.
     let binaryOnPath = false;
     which.setWhich((cmd) => {
-      if (cmd === "bun") return BUN_BIN;
-      if (binaryOnPath) return `/usr/local/bin/${cmd}`;
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (binaryOnPath) {
+        return `/usr/local/bin/${cmd}`;
+      }
       return null;
     });
     execScripts.set(BUN_ADD_KEY, {
@@ -326,8 +332,12 @@ describe("executeAcpSpawn: sandboxed bun auto-install on missing binary", () => 
   test("the installer cwd is a temp dir (not the project cwd) with secrets stripped", async () => {
     let binaryOnPath = false;
     which.setWhich((cmd) => {
-      if (cmd === "bun") return BUN_BIN;
-      if (binaryOnPath) return `/usr/local/bin/${cmd}`;
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (binaryOnPath) {
+        return `/usr/local/bin/${cmd}`;
+      }
       return null;
     });
     execScripts.set(BUN_ADD_KEY, {

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -1,5 +1,7 @@
 import { basename } from "node:path";
 
+import { z } from "zod";
+
 import { markAcpConnectCardRaised } from "../../acp/acp-connect-card-state.js";
 import { resolveAgentWithAutoInstall } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
@@ -10,8 +12,25 @@ import {
 import { formatResolveFailure } from "../../acp/resolve-agent.js";
 import { claudeResumeHint } from "../../acp/resume-hint.js";
 import { FailedDependencyError } from "../../runtime/routes/errors.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { getSendToClient } from "./context.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeAcpSpawn}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework. The bespoke '"task" is required.' check keeps its message for
+ * the missing/null/empty cases.
+ */
+export const acpSpawnInputSchema = z.looseObject({
+  agent: nullAsOmitted(z.string()),
+  task: nullAsOmitted(z.string()),
+  cwd: nullAsOmitted(z.string()),
+});
 
 /**
  * Recover the stable `acp_claude_oauth_missing` marker off a `prepareAgentEnv`
@@ -34,8 +53,12 @@ export async function executeAcpSpawn(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const agent = (input.agent as string) || "claude";
-  const task = input.task as string;
+  const parsedInput = acpSpawnInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("acp_spawn", parsedInput.error);
+  }
+  const agent = parsedInput.data.agent || "claude";
+  const task = parsedInput.data.task;
 
   if (!task) {
     return { content: '"task" is required.', isError: true };
@@ -87,7 +110,7 @@ export async function executeAcpSpawn(
 
   try {
     const manager = getAcpSessionManager();
-    const cwd = (input.cwd as string) || context.workingDir;
+    const cwd = parsedInput.data.cwd || context.workingDir;
     const { acpSessionId, protocolSessionId } = await manager.spawn(
       agent,
       agentConfig,

--- a/assistant/src/tools/acp/status.ts
+++ b/assistant/src/tools/acp/status.ts
@@ -1,11 +1,30 @@
+import { z } from "zod";
+
 import { getAcpSessionManager } from "../../acp/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeAcpStatus}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools.
+ */
+export const acpStatusInputSchema = z.looseObject({
+  acp_session_id: nullAsOmitted(z.string()),
+});
 
 export async function executeAcpStatus(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acpSessionId = input.acp_session_id as string | undefined;
+  const parsedInput = acpStatusInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("acp_status", parsedInput.error);
+  }
+  const acpSessionId = parsedInput.data.acp_session_id;
   const manager = getAcpSessionManager();
 
   try {

--- a/assistant/src/tools/acp/steer.test.ts
+++ b/assistant/src/tools/acp/steer.test.ts
@@ -195,3 +195,23 @@ describe("executeAcpSteer", () => {
     expect(result.content).toContain("is not running");
   });
 });
+
+describe("acp tools — model-input schema validation (LUM-2856)", () => {
+  test("steer rejects a non-string acp_session_id", async () => {
+    const result = await executeAcpSteer(
+      { acp_session_id: 42, instruction: "redirect" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "acp_steer"');
+  });
+
+  test("steer treats explicit null instruction as missing (bespoke error)", async () => {
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-1", instruction: null },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"instruction" is required');
+  });
+});

--- a/assistant/src/tools/acp/steer.ts
+++ b/assistant/src/tools/acp/steer.ts
@@ -1,17 +1,38 @@
+import { z } from "zod";
+
 import { getAcpSessionManager } from "../../acp/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { getSendToClient } from "./context.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeAcpSteer}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools. The bespoke required checks keep their (test-asserted) messages for
+ * the missing/null/empty cases.
+ */
+export const acpSteerInputSchema = z.looseObject({
+  acp_session_id: nullAsOmitted(z.string()),
+  instruction: nullAsOmitted(z.string()),
+});
 
 export async function executeAcpSteer(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acpSessionId = input.acp_session_id as string;
+  const parsedInput = acpSteerInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("acp_steer", parsedInput.error);
+  }
+  const acpSessionId = parsedInput.data.acp_session_id;
   if (!acpSessionId) {
     return { content: '"acp_session_id" is required.', isError: true };
   }
 
-  const instruction = input.instruction as string;
+  const instruction = parsedInput.data.instruction;
   if (!instruction) {
     return { content: '"instruction" is required.', isError: true };
   }

--- a/assistant/src/tools/calls/call-end.ts
+++ b/assistant/src/tools/calls/call-end.ts
@@ -1,19 +1,40 @@
+import { z } from "zod";
+
 import { cancelCall } from "../../calls/call-domain.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeCallEnd}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools. The bespoke required check below keeps its error message for the
+ * missing/null/empty cases.
+ */
+export const callEndInputSchema = z.looseObject({
+  call_session_id: nullAsOmitted(z.string()),
+  end_reason: nullAsOmitted(z.string()),
+});
 
 export async function executeCallEnd(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const callSessionId = input.call_session_id as string | undefined;
-  if (!callSessionId || typeof callSessionId !== "string") {
+  const parsedInput = callEndInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("call_end", parsedInput.error);
+  }
+  const callSessionId = parsedInput.data.call_session_id;
+  if (!callSessionId) {
     return {
       content: "Error: call_session_id is required and must be a string",
       isError: true,
     };
   }
 
-  const reason = input.end_reason as string | undefined;
+  const reason = parsedInput.data.end_reason;
 
   const result = await cancelCall({ callSessionId, reason });
 

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -14,10 +14,10 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
  * Model-input schema, `safeParse`d at the top of {@link executeCallStart}.
  * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
  * tools — see the schema block in `tools/document/document-tool.ts` for the
- * framework. This executor had no input validation of its own (a missing or
- * mistyped `phone_number`/`task` flowed straight into `startCall`), so the
- * advertised-required fields are simply required here. `skip_disclosure`
- * (deliberate `=== true` coercion) is UNDECLARED — loose passthrough.
+ * framework. The advertised-required fields are required here — schema
+ * rejection is the only guard between a mistyped `phone_number`/`task` and
+ * `startCall`. `skip_disclosure` (deliberate `=== true` coercion) is
+ * UNDECLARED — loose passthrough.
  */
 export const callStartInputSchema = z.looseObject({
   phone_number: z.string(),

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -1,8 +1,32 @@
+import { z } from "zod";
+
 import { startCall } from "../../calls/call-domain.js";
 import { findActiveSession } from "../../channels/gateway-verification-sessions.js";
 import { getConfig } from "../../config/loader.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeCallStart}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework. This executor had no input validation of its own (a missing or
+ * mistyped `phone_number`/`task` flowed straight into `startCall`), so the
+ * advertised-required fields are simply required here. `skip_disclosure`
+ * (deliberate `=== true` coercion) is UNDECLARED — loose passthrough.
+ */
+export const callStartInputSchema = z.looseObject({
+  phone_number: z.string(),
+  task: z.string(),
+  context: nullAsOmitted(z.string()),
+  caller_identity_mode: nullAsOmitted(
+    z.enum(["assistant_number", "user_number"]),
+  ),
+});
 
 export async function executeCallStart(
   input: Record<string, unknown>,
@@ -16,10 +40,13 @@ export async function executeCallStart(
     };
   }
 
-  const requestedPhone =
-    typeof input.phone_number === "string"
-      ? normalizePhoneNumber(input.phone_number)
-      : null;
+  const parsedInput = callStartInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("call_start", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const requestedPhone = normalizePhoneNumber(parsed.phone_number);
   if (requestedPhone) {
     const activeVoiceVerification = await findActiveSession("phone");
     const verificationDestination =
@@ -37,15 +64,12 @@ export async function executeCallStart(
   }
 
   const result = await startCall({
-    phoneNumber: input.phone_number as string,
-    task: input.task as string,
-    context: input.context as string | undefined,
+    phoneNumber: parsed.phone_number,
+    task: parsed.task,
+    context: parsed.context,
     conversationId: context.conversationId,
     assistantId: context.assistantId,
-    callerIdentityMode: input.caller_identity_mode as
-      | "assistant_number"
-      | "user_number"
-      | undefined,
+    callerIdentityMode: parsed.caller_identity_mode,
     skipDisclosure: input.skip_disclosure === true,
   });
 

--- a/assistant/src/tools/calls/call-status.ts
+++ b/assistant/src/tools/calls/call-status.ts
@@ -1,11 +1,30 @@
+import { z } from "zod";
+
 import { getCallStatus } from "../../calls/call-domain.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeCallStatus}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools.
+ */
+export const callStatusInputSchema = z.looseObject({
+  call_session_id: nullAsOmitted(z.string()),
+});
 
 export async function executeCallStatus(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const callSessionId = input.call_session_id as string | undefined;
+  const parsedInput = callStatusInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("call_status", parsedInput.error);
+  }
+  const callSessionId = parsedInput.data.call_session_id;
 
   const result = getCallStatus(callSessionId, context.conversationId);
 

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -1,7 +1,29 @@
+import { z } from "zod";
+
 import { getContact } from "../../contacts/contact-store.js";
 import { createFollowUp } from "../../followups/followup-store.js";
 import type { FollowUp } from "../../followups/types.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeFollowupCreate}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework. The bespoke non-empty (trim) checks keep their current error
+ * semantics; `expected_response_hours` is deliberately UNDECLARED (loose
+ * passthrough) so its bespoke positive-number check owns the error message
+ * for every malformed shape, exactly as before.
+ */
+export const followupCreateInputSchema = z.looseObject({
+  channel: nullAsOmitted(z.string()),
+  conversation_id: nullAsOmitted(z.string()),
+  contact_id: nullAsOmitted(z.string()),
+  reminder_schedule_id: nullAsOmitted(z.string()),
+});
 
 function formatFollowUp(f: FollowUp): string {
   const lines = [
@@ -11,14 +33,17 @@ function formatFollowUp(f: FollowUp): string {
     `  Status: ${f.status}`,
     `  Sent at: ${new Date(f.sentAt).toISOString()}`,
   ];
-  if (f.contactId) lines.push(`  Contact ID: ${f.contactId}`);
+  if (f.contactId) {
+    lines.push(`  Contact ID: ${f.contactId}`);
+  }
   if (f.expectedResponseBy) {
     lines.push(
       `  Expected response by: ${new Date(f.expectedResponseBy).toISOString()}`,
     );
   }
-  if (f.reminderScheduleId)
+  if (f.reminderScheduleId) {
     lines.push(`  Reminder schedule: ${f.reminderScheduleId}`);
+  }
   return lines.join("\n");
 }
 
@@ -26,20 +51,22 @@ export async function executeFollowupCreate(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const channel = input.channel as string | undefined;
-  if (!channel || typeof channel !== "string" || channel.trim().length === 0) {
+  const parsedInput = followupCreateInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("followup_create", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const channel = parsed.channel;
+  if (!channel || channel.trim().length === 0) {
     return {
       content: "Error: channel is required and must be a non-empty string",
       isError: true,
     };
   }
 
-  const conversationId = input.conversation_id as string | undefined;
-  if (
-    !conversationId ||
-    typeof conversationId !== "string" ||
-    conversationId.trim().length === 0
-  ) {
+  const conversationId = parsed.conversation_id;
+  if (!conversationId || conversationId.trim().length === 0) {
     return {
       content:
         "Error: conversation_id is required and must be a non-empty string",
@@ -47,11 +74,13 @@ export async function executeFollowupCreate(
     };
   }
 
-  const contactId = input.contact_id as string | undefined;
+  const contactId = parsed.contact_id;
+  // Loose passthrough (see schema doc comment) — the bespoke check below
+  // owns every malformed shape.
   const expectedResponseHours = input.expected_response_hours as
     | number
     | undefined;
-  const reminderScheduleId = input.reminder_schedule_id as string | undefined;
+  const reminderScheduleId = parsed.reminder_schedule_id;
 
   // Validate contact exists if provided
   if (contactId) {

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -16,7 +16,7 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
  * framework. The bespoke non-empty (trim) checks keep their current error
  * semantics; `expected_response_hours` is deliberately UNDECLARED (loose
  * passthrough) so its bespoke positive-number check owns the error message
- * for every malformed shape, exactly as before.
+ * for every malformed shape.
  */
 export const followupCreateInputSchema = z.looseObject({
   channel: nullAsOmitted(z.string()),

--- a/assistant/src/tools/followups/followup_list.ts
+++ b/assistant/src/tools/followups/followup_list.ts
@@ -1,11 +1,29 @@
+import { z } from "zod";
+
 import {
   getOverdueFollowUps,
   listFollowUps,
 } from "../../followups/followup-store.js";
 import type { FollowUp, FollowUpStatus } from "../../followups/types.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 const VALID_STATUSES = ["pending", "resolved", "overdue", "nudged"] as const;
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeFollowupList}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools. `status` is deliberately UNDECLARED (loose passthrough): the bespoke
+ * `VALID_STATUSES` check owns the "Invalid status" error (test-asserted).
+ */
+export const followupListInputSchema = z.looseObject({
+  channel: nullAsOmitted(z.string()),
+  contact_id: nullAsOmitted(z.string()),
+  overdue_only: nullAsOmitted(z.boolean()),
+});
 
 function formatFollowUpSummary(f: FollowUp): string {
   const parts = [
@@ -14,7 +32,9 @@ function formatFollowUpSummary(f: FollowUp): string {
   parts.push(
     `  Status: ${f.status} | Sent: ${new Date(f.sentAt).toISOString()}`,
   );
-  if (f.contactId) parts.push(`  Contact: ${f.contactId}`);
+  if (f.contactId) {
+    parts.push(`  Contact: ${f.contactId}`);
+  }
   if (f.expectedResponseBy) {
     const deadline = new Date(f.expectedResponseBy);
     const isOverdue = f.status === "pending" && deadline.getTime() < Date.now();
@@ -29,10 +49,14 @@ export async function executeFollowupList(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const parsedInput = followupListInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("followup_list", parsedInput.error);
+  }
   const status = input.status as FollowUpStatus | undefined;
-  const channel = input.channel as string | undefined;
-  const contactId = input.contact_id as string | undefined;
-  const overdueOnly = input.overdue_only as boolean | undefined;
+  const channel = parsedInput.data.channel;
+  const contactId = parsedInput.data.contact_id;
+  const overdueOnly = parsedInput.data.overdue_only;
 
   if (
     status &&
@@ -51,8 +75,12 @@ export async function executeFollowupList(
 
     if (overdueOnly || status === "overdue") {
       results = getOverdueFollowUps();
-      if (channel) results = results.filter((f) => f.channel === channel);
-      if (contactId) results = results.filter((f) => f.contactId === contactId);
+      if (channel) {
+        results = results.filter((f) => f.channel === channel);
+      }
+      if (contactId) {
+        results = results.filter((f) => f.contactId === contactId);
+      }
     } else {
       results = listFollowUps({ status, channel, contactId });
     }

--- a/assistant/src/tools/followups/followup_resolve.ts
+++ b/assistant/src/tools/followups/followup_resolve.ts
@@ -1,9 +1,27 @@
+import { z } from "zod";
+
 import {
   resolveByConversation,
   resolveFollowUp,
 } from "../../followups/followup-store.js";
 import type { FollowUp } from "../../followups/types.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of
+ * {@link executeFollowupResolve}. Same in-tool pattern and TOOLS.json drift
+ * guard as the other bundled-skill tools. The bespoke either-or check below
+ * keeps its error message.
+ */
+export const followupResolveInputSchema = z.looseObject({
+  id: nullAsOmitted(z.string()),
+  channel: nullAsOmitted(z.string()),
+  conversation_id: nullAsOmitted(z.string()),
+});
 
 function formatFollowUp(f: FollowUp): string {
   const lines = [
@@ -12,7 +30,9 @@ function formatFollowUp(f: FollowUp): string {
     `  Conversation: ${f.conversationId}`,
     `  Status: ${f.status}`,
   ];
-  if (f.contactId) lines.push(`  Contact ID: ${f.contactId}`);
+  if (f.contactId) {
+    lines.push(`  Contact ID: ${f.contactId}`);
+  }
   return lines.join("\n");
 }
 
@@ -20,9 +40,11 @@ export async function executeFollowupResolve(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const id = input.id as string | undefined;
-  const channel = input.channel as string | undefined;
-  const conversationId = input.conversation_id as string | undefined;
+  const parsedInput = followupResolveInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("followup_resolve", parsedInput.error);
+  }
+  const { id, channel, conversation_id: conversationId } = parsedInput.data;
 
   if (!id && !(channel && conversationId)) {
     return {

--- a/assistant/src/tools/subagent/abort.ts
+++ b/assistant/src/tools/subagent/abort.ts
@@ -1,15 +1,23 @@
 import { getSubagentManager } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentAbortInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentAbort(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  if (!subagentId && input.label) {
+  const parsedInput = subagentAbortInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_abort", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/consult-deadline.ts
+++ b/assistant/src/tools/subagent/consult-deadline.ts
@@ -29,8 +29,12 @@ export function createConsultDeadline(opts: {
 
   const recordProgress = (): void => {
     // Once aborted, don't re-arm — the consult is already being torn down.
-    if (controller.signal.aborted) return;
-    if (idleTimer) clearTimeout(idleTimer);
+    if (controller.signal.aborted) {
+      return;
+    }
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
     idleTimer = setTimeout(() => controller.abort(), opts.idleMs);
   };
 
@@ -41,7 +45,9 @@ export function createConsultDeadline(opts: {
   recordProgress();
 
   const dispose = (): void => {
-    if (idleTimer) clearTimeout(idleTimer);
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
     clearTimeout(maxTimer);
   };
 

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -1,17 +1,33 @@
+import { z } from "zod";
+
 import { getSubagentManager } from "../../subagent/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentMessageInputSchema = z.looseObject({
+  ...subagentRefInputSchema.shape,
+  content: nullAsOmitted(z.string()),
+});
 
 export async function executeSubagentMessage(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  const content = input.content as string;
+  const parsedInput = subagentMessageInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_message", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  const content = parsed.content;
 
-  if (!subagentId && input.label) {
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -1,17 +1,28 @@
 import { getMessages } from "../../persistence/conversation-crud.js";
 import { extractTextFromStoredMessageContent } from "../../persistence/message-content.js";
 import { getSubagentManager, TERMINAL_STATUSES } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+// `last_n` is deliberately UNDECLARED (loose passthrough): the executor's
+// typeof-guarded read below ignores it when malformed — including non-integer
+// numbers the advertised `integer` type wouldn't admit — and always has.
+export const subagentReadInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentRead(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  if (!subagentId && input.label) {
+  const parsedInput = subagentReadInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_read", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -7,7 +7,7 @@ import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
 
 // `last_n` is deliberately UNDECLARED (loose passthrough): the executor's
 // typeof-guarded read below ignores it when malformed — including non-integer
-// numbers the advertised `integer` type wouldn't admit — and always has.
+// numbers the advertised `integer` type wouldn't admit.
 export const subagentReadInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentRead(

--- a/assistant/src/tools/subagent/resolve.ts
+++ b/assistant/src/tools/subagent/resolve.ts
@@ -1,18 +1,40 @@
+import { z } from "zod";
+
 import { getSubagentManager } from "../../subagent/index.js";
+import { nullAsOmitted } from "../shared/zod-tool-schema.js";
 import type { ToolContext } from "../types.js";
 
 /**
- * Resolve a subagent ID from tool input.
+ * Shared model-input schema for the subagent tools that address an existing
+ * subagent by `subagent_id` or `label` (`subagent_status` / `subagent_abort`,
+ * extended by `subagent_message` / `subagent_read`). Same in-tool pattern and
+ * TOOLS.json drift guard as the other bundled-skill tools — see
+ * `subagent-tool-input-schemas.test.ts` and the schema block in
+ * `tools/document/document-tool.ts` for the framework. The
+ * '"subagent_id" or "label" is required' / not-found error messages stay
+ * bespoke in each executor.
+ */
+export const subagentRefInputSchema = z.looseObject({
+  subagent_id: nullAsOmitted(z.string()),
+  label: nullAsOmitted(z.string()),
+});
+
+export type SubagentRefInput = z.infer<typeof subagentRefInputSchema>;
+
+/**
+ * Resolve a subagent ID from parsed tool input.
  * Accepts either `subagent_id` (direct UUID) or `label` (case-insensitive lookup).
  */
 export function resolveSubagentId(
-  input: Record<string, unknown>,
+  input: SubagentRefInput,
   context: ToolContext,
 ): string | undefined {
-  if (input.subagent_id) return input.subagent_id as string;
+  if (input.subagent_id) {
+    return input.subagent_id;
+  }
   if (input.label) {
     const state = getSubagentManager().getByLabel(
-      input.label as string,
+      input.label,
       context.conversationId,
     );
     return state?.config.id;

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { AssistantEvent } from "../../api/index.js";
 import { validateInferenceProfileKey } from "../../config/inference-profile-validation.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
@@ -19,6 +21,10 @@ import {
 } from "../../subagent/index.js";
 import type { SubagentRole } from "../../subagent/types.js";
 import { getLogger } from "../../util/logger.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { createConsultDeadline } from "./consult-deadline.js";
 
@@ -42,16 +48,40 @@ const ADVISOR_IDLE_TIMEOUT_MS = 60_000;
  */
 const ADVISOR_MAX_TIMEOUT_MS = 300_000;
 
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeSubagentSpawn}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework.
+ *
+ * `fork` / `send_result_to_user` (deliberate `=== true` / `!== false`
+ * coercions) and `role` (SubagentManager.spawn's "Invalid subagent role"
+ * error, asserted by tests, owns non-enum values) are deliberately
+ * UNDECLARED — loose passthrough.
+ */
+export const subagentSpawnInputSchema = z.looseObject({
+  label: nullAsOmitted(z.string()),
+  objective: nullAsOmitted(z.string()),
+  context: nullAsOmitted(z.string()),
+  inference_profile: z.string().optional(),
+});
+
 export async function executeSubagentSpawn(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const label = input.label as string;
-  const objective = input.objective as string;
-  const extraContext = input.context as string | undefined;
+  const parsedInput = subagentSpawnInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_spawn", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const label = parsed.label;
+  const objective = parsed.objective;
+  const extraContext = parsed.context;
   const fork = input.fork === true;
   const role = (input.role as string | undefined) ?? undefined;
-  const inferenceProfile = input.inference_profile;
+  const inferenceProfile = parsed.inference_profile;
 
   // For fork mode, sendResultToUser defaults to false unless explicitly set to true.
   // For regular mode, sendResultToUser defaults to true (existing behavior).
@@ -69,12 +99,6 @@ export async function executeSubagentSpawn(
   let requestedOverrideProfile: string | undefined;
   let forceOverrideProfile = false;
   if (inferenceProfile !== undefined) {
-    if (typeof inferenceProfile !== "string") {
-      return {
-        content: "Error: inference_profile must be a string",
-        isError: true,
-      };
-    }
     const profileError = validateInferenceProfileKey(inferenceProfile);
     if (profileError) {
       return {

--- a/assistant/src/tools/subagent/status.ts
+++ b/assistant/src/tools/subagent/status.ts
@@ -1,19 +1,27 @@
 import { getSubagentManager } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentStatusInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentStatus(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
+  const parsedInput = subagentStatusInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_status", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
   const manager = getSubagentManager();
 
   // If a label was provided but didn't resolve, that's an error — don't fall
   // through to the "list all" path.
-  if (!subagentId && input.label) {
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -13,19 +13,45 @@
  * by the type checker.
  */
 
+import { z } from "zod";
+
 import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of
+ * {@link executeManageWorkflows}. Same in-tool pattern and TOOLS.json drift
+ * guard as the other bundled-skill tools — see the schema block in
+ * `tools/document/document-tool.ts` for the framework.
+ *
+ * `action` is deliberately UNDECLARED (loose passthrough): the switch's
+ * default case owns the unknown-action error, and `executor.ts` reads
+ * `input.action` / `input.run_id` pre-execution for the requireFreshApproval
+ * promotion (those reads are already defensive and see the raw input either
+ * way).
+ */
+export const manageWorkflowsInputSchema = z.looseObject({
+  run_id: nullAsOmitted(z.string()),
+});
 
 export async function executeManageWorkflows(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const parsedInput = manageWorkflowsInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("manage_workflows", parsedInput.error);
+  }
   const action = input.action as string | undefined;
-  const runId = input.run_id as string | undefined;
+  const runId = parsedInput.data.run_id;
   const manager = getWorkflowRunManager();
 
   // Authorization scope ({@link callerOwnsWorkflowRun}, shared with the
@@ -104,7 +130,9 @@ export async function executeManageWorkflows(
       // Only signal a run the caller owns. A non-owned (or absent) run is a
       // no-op with the same response shape, so existence is never revealed.
       const run = manager.status(runId);
-      if (run && ownsRun(run)) manager.abort(runId);
+      if (run && ownsRun(run)) {
+        manager.abort(runId);
+      }
       return {
         content: JSON.stringify({
           runId,

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -27,7 +27,9 @@ mock.module("../../daemon/conversation-registry.js", () => ({
 let lastStartArgs: Record<string, unknown> | null = null;
 let startThrows: Error | null = null;
 const startMock = mock((opts: Record<string, unknown>) => {
-  if (startThrows) throw startThrows;
+  if (startThrows) {
+    throw startThrows;
+  }
   lastStartArgs = opts;
   return { runId: "run-123" };
 });
@@ -36,7 +38,9 @@ const abortMock = mock(() => {});
 const listMock = mock(() => [] as unknown[]);
 let resumeThrows: Error | null = null;
 const resumeMock = mock((runId: string) => {
-  if (resumeThrows) throw resumeThrows;
+  if (resumeThrows) {
+    throw resumeThrows;
+  }
   return { runId };
 });
 
@@ -419,5 +423,53 @@ describe("manage_workflows", () => {
       contactContext(),
     );
     expect(abortMock).toHaveBeenCalledWith("mine");
+  });
+});
+
+// ── model-input schema validation (LUM-2855) ────────────────────────
+
+describe("workflow tools — model-input schema validation", () => {
+  test("run_workflow rejects a non-string script", async () => {
+    const result = await executeRunWorkflow({ script: 42 }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "run_workflow"');
+    expect(result.content).toContain("script");
+    expect(startMock).not.toHaveBeenCalled();
+  });
+
+  test("run_workflow treats explicit null script/name as omitted (bespoke exactly-one error)", async () => {
+    const result = await executeRunWorkflow(
+      { script: null, name: null },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("exactly one");
+  });
+
+  test("run_workflow passes args through unvalidated (workflow runtime accepts any JSON)", async () => {
+    const result = await executeRunWorkflow(
+      { script: "export const meta = {}", args: ["positional"] },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(lastStartArgs?.args).toEqual(["positional"]);
+  });
+
+  test("manage_workflows rejects a non-string run_id", async () => {
+    const result = await executeManageWorkflows(
+      { action: "status", run_id: 42 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "manage_workflows"',
+    );
+    expect(result.content).toContain("run_id");
+  });
+
+  test("manage_workflows keeps the bespoke unknown-action error", async () => {
+    const result = await executeManageWorkflows({ action: 42 }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unknown action");
   });
 });

--- a/assistant/src/tools/workflows/run-workflow.ts
+++ b/assistant/src/tools/workflows/run-workflow.ts
@@ -15,12 +15,36 @@
  * of truth the model reads when generating the `script`.
  */
 
+import { z } from "zod";
+
 import { findConversation } from "../../daemon/conversation-registry.js";
 import { FALLBACK_TURN_TRUST } from "../../daemon/trust-context.js";
 import type { TrustContext } from "../../daemon/trust-context-types.js";
 import { CapabilityManifestSchema } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeRunWorkflow}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework.
+ *
+ * `args` (the workflow runtime accepts any JSON value) and `capabilities`
+ * (`CapabilityManifestSchema` is the single validation authority, and
+ * `executor.ts` reads it pre-execution for the requireFreshApproval
+ * promotion) are deliberately UNDECLARED — loose passthrough. The
+ * exactly-one-of script/name rule stays a bespoke check below.
+ */
+export const runWorkflowInputSchema = z.looseObject({
+  script: nullAsOmitted(z.string()),
+  name: nullAsOmitted(z.string()),
+  label: nullAsOmitted(z.string()),
+});
 
 /**
  * Resolve the {@link TrustContext} to forward to the run's leaves. Prefer the
@@ -33,7 +57,9 @@ function resolveTrustContext(context: ToolContext): TrustContext {
   const conversation = findConversation(context.conversationId);
   const fromConversation =
     conversation?.currentTurnTrustContext ?? conversation?.trustContext;
-  if (fromConversation) return fromConversation;
+  if (fromConversation) {
+    return fromConversation;
+  }
   return { ...FALLBACK_TURN_TRUST, trustClass: context.trustClass };
 }
 
@@ -41,8 +67,11 @@ export async function executeRunWorkflow(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const script = input.script as string | undefined;
-  const name = input.name as string | undefined;
+  const parsedInput = runWorkflowInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("run_workflow", parsedInput.error);
+  }
+  const { script, name, label } = parsedInput.data;
 
   // Exactly one of script/name is required.
   if ((script == null) === (name == null)) {
@@ -54,7 +83,6 @@ export async function executeRunWorkflow(
   }
 
   const args = (input.args as Record<string, unknown> | undefined) ?? {};
-  const label = input.label as string | undefined;
   const trustContext = resolveTrustContext(context);
 
   try {


### PR DESCRIPTION
> **Stacked on #39290 (LUM-2855)** → #39285 → #39283. Merge in order; GitHub retargets as each base merges. Only the last commit is new here.

## Summary

Fifth tranche of [LUM-2797](https://linear.app/vellum/issue/LUM-2797) ([LUM-2856](https://linear.app/vellum/issue/LUM-2856)): the followups (`followup_create`/`followup_list`/`followup_resolve`), phone-calls (`call_start`/`call_end`/`call_status`), and ACP (`acp_spawn`/`acp_steer`/`acp_status`/`acp_abort`) executors now `safeParse` tolerant Zod schemas and return `invalidToolInputResult(...)` on failure, replacing ~24 naked casts across three small flat-shape skill families.

## Implementation

Same in-tool pattern and drift-guard decision as the earlier tranches; new `followup-call-acp-tool-input-schemas.test.ts` covers all three skills' TOOLS.json via the shared harness. `acp_list_agents` takes no input, so it has no runtime schema or guard entry.

## Key technical choices — tolerance preserved

- Per the ticket's explicit note, the followups executors' **trim / positive-number checks keep their current error semantics**: `expected_response_hours` is loose passthrough (its bespoke `"must be a positive number"` message owns every malformed shape — covered by a new test), and `followup_list.status` keeps its test-asserted `VALID_STATUSES` "Invalid status" error.
- `call_start` had **no input validation at all** — a missing or mistyped `phone_number`/`task` flowed straight into `startCall`. Its advertised-required fields are now runtime-required, and `caller_identity_mode` is validated against the advertised enum (previously an unchecked cast into the call domain). `skip_disclosure` keeps its deliberate `=== true` coercion as passthrough.
- The ACP tools' bespoke `'"task" is required.'` / `'"acp_session_id" is required.'` / `'"instruction" is required.'` messages (test-asserted in steer.test.ts) stay the contract for missing/null/empty cases via `nullAsOmitted`; only genuinely mistyped values (numbers, objects) hit the new schema rejection.
- `call_end`/`call_status`/`followup_resolve`/`acp_status` follow the same shape: `nullAsOmitted` strings, bespoke required/either-or checks untouched.

## Testing

- `bun test src/__tests__/followup-tools.test.ts` — 24 pass (5 new validation tests)
- `bun test src/__tests__/call-start-guardian-guard.test.ts` — 4 pass (2 new)
- `bun test src/tools/acp/steer.test.ts` — 10 pass (2 new); `spawn.test.ts`, `list-agents.test.ts` pass unchanged
- `bun test src/tools/__tests__/followup-call-acp-tool-input-schemas.test.ts` — 10 pass (new drift guard)
- `bunx tsc --noEmit` clean; eslint + prettier clean; `lint:circular` unchanged (201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Latent prod bugs fixed (tracking)

Live, reachable paths in production code — any malformed model call could trigger them; fixed by this PR's validation:

1. **`call_start` had no input validation at all** — the standout of the batch: a missing or mistyped `phone_number`/`task` flowed straight into `startCall` as `undefined`/garbage, and `caller_identity_mode` was cast to the `"assistant_number" | "user_number"` union without any check, so an arbitrary string (e.g. `"spoofed"`) entered the call domain unchecked.
2. **`followup_create` raw persistence** — the `contact_id` / `reminder_schedule_id` casts flowed non-strings toward `createFollowUp` (`contact_id` was only existence-checked when truthy, so `42` went to `getContact(42)`).
3. **`acp_spawn` `agent: 42`** — truthy past `|| "claude"`, so a number reached agent resolution instead of the default.
