### PR TITLE
fix(voice): strip a trailing [-1] minimize marker from front-door answer rows

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1502,6 +1502,47 @@ describe("transcript hygiene (teardown pass)", () => {
     expect(events).toContain("loadFromDb");
   });
 
+  test("a terminal marker split across text blocks is stripped whole", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => ({
+      ...makeRow(""),
+      content: [
+        { type: "text", text: "Done, take a look [-" },
+        { type: "text", text: "1]" },
+      ],
+    });
+
+    await startVoiceTurn(makeTurnOptions());
+    await flushMicrotasks();
+
+    expect(crudLog.updates).toEqual([
+      {
+        messageId: "assistant-row-1",
+        content: JSON.stringify([{ type: "text", text: "Done, take a look" }]),
+      },
+    ]);
+    expect(crudLog.deletes).toHaveLength(0);
+    expect(events).toContain("loadFromDb");
+  });
+
+  test("a marker-only row split across text blocks is deleted", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => ({
+      ...makeRow(""),
+      content: [
+        { type: "text", text: "[-" },
+        { type: "text", text: "1]" },
+      ],
+    });
+
+    await startVoiceTurn(makeTurnOptions());
+    await flushMicrotasks();
+
+    expect(crudLog.updates).toHaveLength(0);
+    expect(crudLog.deletes).toEqual(["assistant-row-1"]);
+    expect(events).toContain("loadFromDb");
+  });
+
   test("a marker-only row with a surviving non-text block is rewritten, never deleted", async () => {
     const { events } = makeReservedRowConversation();
     getMessageByIdImpl = () => ({

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1415,6 +1415,37 @@ describe("transcript hygiene (teardown pass)", () => {
     expect(events).not.toContain("loadFromDb");
   });
 
+  test("a front-door answer ending with the minimize marker has the marker stripped", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => makeRow("Here we go, watch the overlay. [-1]");
+
+    await startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" });
+    await flushMicrotasks();
+
+    expect(crudLog.updates).toEqual([
+      {
+        messageId: "assistant-row-1",
+        content: JSON.stringify([
+          { type: "text", text: "Here we go, watch the overlay." },
+        ]),
+      },
+    ]);
+    expect(crudLog.deletes).toHaveLength(0);
+    expect(events).toContain("loadFromDb");
+  });
+
+  test("a marker-only front-door answer row is deleted", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => makeRow("[-1]");
+
+    await startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" });
+    await flushMicrotasks();
+
+    expect(crudLog.updates).toHaveLength(0);
+    expect(crudLog.deletes).toEqual(["assistant-row-1"]);
+    expect(events).toContain("loadFromDb");
+  });
+
   test("a non-routed leg leaves verdict-token content untouched (verdict cutting is front-door-only)", async () => {
     const { events } = makeReservedRowConversation();
     getMessageByIdImpl = () => makeRow("[1] Anything at all");

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -507,6 +507,31 @@ function stripMarkersFromBlocks(blocks: ContentBlock[]): ContentBlock[] {
 }
 
 /**
+ * Remove the terminal MINIMIZE_ROOM_MARKER from the end of a row's text,
+ * walking text blocks from the last one backward so a marker split across
+ * block boundaries (e.g. `"Done [-"` + `"1]"`) is removed whole — the
+ * per-block strip in {@link stripMarkersFromBlocks} only sees fragments and
+ * would leave both halves in place. Callers must have established that the
+ * row's joined text ends with the marker after trimming trailing whitespace.
+ */
+function stripTerminalMinimizeMarker(blocks: ContentBlock[]): ContentBlock[] {
+  const result = blocks.map((block) => ({ ...block }));
+  const joined = joinedTextOfBlocks(result);
+  const cutAt = joined.trimEnd().length - MINIMIZE_ROOM_MARKER.length;
+  let blockEnd = joined.length;
+  for (let i = result.length - 1; i >= 0 && blockEnd > cutAt; i--) {
+    const block = result[i]!;
+    if (block.type !== "text") {
+      continue;
+    }
+    const blockStart = blockEnd - block.text.length;
+    block.text = block.text.slice(0, Math.max(0, cutAt - blockStart));
+    blockEnd = blockStart;
+  }
+  return result;
+}
+
+/**
  * Trim whitespace stranded at a rewritten row's outer edges by a stripped
  * edge marker (e.g. "Done, take a look [-1]"), leaving inter-block spacing
  * untouched.
@@ -1270,8 +1295,10 @@ export async function startVoiceTurn(
             .trimEnd()
             .endsWith(MINIMIZE_ROOM_MARKER)
         ) {
+          // Terminal marker first (boundary-aware — it may span text blocks),
+          // then the per-block strip for any interior complete markers.
           const cleaned = trimOuterTextEdges(
-            stripMarkersFromBlocks(row.content),
+            stripMarkersFromBlocks(stripTerminalMinimizeMarker(row.content)),
           );
           // A marker-only reply (the model said nothing beyond "[-1]") strips
           // to nothing at all; keeping the row would render a blank assistant

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1208,10 +1208,13 @@ export async function startVoiceTurn(
    *   never the verdict token or the text streamed past the cap (issue
    *   #37850). A row with no spoken bridge (canned-fallback case — that
    *   bridge is audio-only) is deleted.
-   * - Any other leg whose row carries the `[-1]` minimize marker (swallowed
+   * - Any leg whose row ENDS with the `[-1]` minimize marker (swallowed
    *   before TTS on the live path) has its text blocks rewritten through
    *   `stripInternalSpeechMarkers` so the marker never renders in the chat
-   *   transcript. Deliberately scoped to that marker: rows without it
+   *   transcript. This covers front-door answers too: that leg is never
+   *   taught the marker, but it can parrot one from visible conversation
+   *   history, and the parroted marker is never spoken and never minimizes
+   *   the room. Deliberately scoped to that marker: rows without it
    *   persist byte-identical.
    *
    * After a rewrite, in-memory history is reloaded from the clean DB before
@@ -1240,27 +1243,29 @@ export async function startVoiceTurn(
         action = "delete_discarded";
       } else {
         const row = getMessageById(reservedAssistantRowId, opts.conversationId);
+        const cut =
+          row && opts.routingLeg === "front-door"
+            ? cutFrontDoorContentAtVerdict(row.content)
+            : null;
         if (!row) {
           action = "row_missing";
-        } else if (opts.routingLeg === "front-door") {
-          const cut = cutFrontDoorContentAtVerdict(row.content);
-          if (cut) {
-            if (cut.spokenText.length > 0) {
-              updateMessageContent(
-                reservedAssistantRowId,
-                JSON.stringify(cut.blocks),
-              );
-              action = "rewrite_spoken";
-            } else {
-              deleteMessageById(reservedAssistantRowId);
-              action = "delete_empty";
-            }
+        } else if (cut) {
+          if (cut.spokenText.length > 0) {
+            updateMessageContent(
+              reservedAssistantRowId,
+              JSON.stringify(cut.blocks),
+            );
+            action = "rewrite_spoken";
+          } else {
+            deleteMessageById(reservedAssistantRowId);
+            action = "delete_empty";
           }
         } else if (
           // Terminal position only — mirrors the live latch in
           // createControlMarkerHoldback: a reply whose CONTENT contains
           // "[-1]" mid-text never minimized the room, so its transcript
-          // keeps that content untouched too.
+          // keeps that content untouched too. Front-door answer rows (no
+          // verdict token to cut) take this branch as well.
           joinedTextOfBlocks(row.content)
             .trimEnd()
             .endsWith(MINIMIZE_ROOM_MARKER)


### PR DESCRIPTION
## Summary

The live-voice teardown transcript-hygiene pass (`finalizeVoiceLegTranscript`) ran only the verdict cut for front-door legs. A committed front-door **answer** (no verdict token) that parrots the `[-1]` minimize marker from visible conversation history therefore kept the trailing marker in the chat transcript — even though the marker is never spoken (the live holdback strips it) and a front-door leg never latches a minimize (it never force-flushes).

- The terminal-position `[-1]` strip now covers any leg row the verdict cut leaves untouched, front-door answers included.
- A marker-only front-door answer row deletes instead of rendering an empty assistant bubble, matching the main-leg case.
- Mid-text `[-1]` (content, not command) still persists byte-identical for every leg.

## Testing

- Two new regression tests in `voice-session-bridge.test.ts` (front-door answer with trailing marker → stripped; marker-only front-door answer → deleted); all 53 bridge tests pass.

Part of JARVIS-1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)