### PR TITLE
feat(tools): register remaining built-ins in TOOL_INPUT_SCHEMAS (LUM-2857)

### DIFF
--- a/assistant/src/__tests__/call-start-guardian-guard.test.ts
+++ b/assistant/src/__tests__/call-start-guardian-guard.test.ts
@@ -111,3 +111,30 @@ describe("call_start guardian verification guard", () => {
     expect(startCallInputs.length).toBe(1);
   });
 });
+
+describe("call tools — model-input schema validation (LUM-2856)", () => {
+  test("call_start rejects a non-string phone_number before reaching startCall", async () => {
+    const before = startCallInputs.length;
+    const result = await executeCallStart(
+      { phone_number: 4155550100, task: "call someone" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "call_start"');
+    expect(result.content).toContain("phone_number");
+    expect(startCallInputs.length).toBe(before);
+  });
+
+  test("call_start rejects an unknown caller_identity_mode", async () => {
+    const result = await executeCallStart(
+      {
+        phone_number: "+14155550100",
+        task: "call someone",
+        caller_identity_mode: "spoofed",
+      },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("caller_identity_mode");
+  });
+});

--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -308,3 +308,61 @@ describe("followup_resolve tool", () => {
     );
   });
 });
+
+// ── model-input schema validation (LUM-2856) ────────────────────────
+
+describe("followup tools — model-input schema validation", () => {
+  test("followup_create rejects a non-string contact_id", async () => {
+    const result = await executeFollowupCreate(
+      { channel: "email", conversation_id: "conv-1", contact_id: 42 },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "followup_create"',
+    );
+    expect(result.content).toContain("contact_id");
+  });
+
+  test("followup_create keeps the bespoke positive-number error for expected_response_hours", async () => {
+    const result = await executeFollowupCreate(
+      {
+        channel: "email",
+        conversation_id: "conv-1",
+        expected_response_hours: "soon",
+      },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      "expected_response_hours must be a positive number",
+    );
+  });
+
+  test("followup_create treats explicit null channel as missing (bespoke error)", async () => {
+    const result = await executeFollowupCreate(
+      { channel: null, conversation_id: "conv-1" },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("channel is required");
+  });
+
+  test("followup_list rejects a non-boolean overdue_only but keeps the bespoke status error", async () => {
+    const bad = await executeFollowupList({ overdue_only: "yes" }, ctx);
+    expect(bad.isError).toBe(true);
+    expect(bad.content).toContain('Invalid input for tool "followup_list"');
+
+    const status = await executeFollowupList({ status: 42 }, ctx);
+    expect(status.isError).toBe(true);
+    expect(status.content).toContain("Invalid status");
+  });
+
+  test("followup_resolve rejects a non-string id", async () => {
+    const result = await executeFollowupResolve({ id: 42 }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "followup_resolve"',
+    );
+  });
+});

--- a/assistant/src/__tests__/host-file-edit-tool.test.ts
+++ b/assistant/src/__tests__/host-file-edit-tool.test.ts
@@ -152,7 +152,7 @@ describe("host_file_edit tool", () => {
       makeContext(),
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("path is required");
+    expect(result.content).toContain('Invalid input for tool "host_file_edit"');
   });
 
   test("rejects non-string old_string", async () => {
@@ -170,7 +170,7 @@ describe("host_file_edit tool", () => {
       makeContext(),
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("old_string is required");
+    expect(result.content).toContain('Invalid input for tool "host_file_edit"');
   });
 
   test("rejects non-string new_string", async () => {
@@ -188,7 +188,7 @@ describe("host_file_edit tool", () => {
       makeContext(),
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("new_string is required");
+    expect(result.content).toContain('Invalid input for tool "host_file_edit"');
   });
 
   test("rejects empty old_string", async () => {

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -118,13 +118,13 @@ describe("host_file_read tool", () => {
   test("rejects missing path parameter", async () => {
     const result = await hostFileReadTool.execute({}, makeContext());
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("path is required");
+    expect(result.content).toContain('Invalid input for tool "host_file_read"');
   });
 
   test("rejects non-string path", async () => {
     const result = await hostFileReadTool.execute({ path: 42 }, makeContext());
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("path is required and must be a string");
+    expect(result.content).toContain('Invalid input for tool "host_file_read"');
   });
 
   test("reads entire file when no offset or limit specified", async () => {

--- a/assistant/src/__tests__/host-file-write-tool.test.ts
+++ b/assistant/src/__tests__/host-file-write-tool.test.ts
@@ -69,7 +69,7 @@ describe("host_file_write tool", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain(
-      "content is required and must be a string",
+      'Invalid input for tool "host_file_write"',
     );
   });
 
@@ -124,7 +124,9 @@ describe("host_file_write tool", () => {
       makeContext(),
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("path is required");
+    expect(result.content).toContain(
+      'Invalid input for tool "host_file_write"',
+    );
   });
 
   test("rejects non-string path", async () => {
@@ -133,7 +135,9 @@ describe("host_file_write tool", () => {
       makeContext(),
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("path is required and must be a string");
+    expect(result.content).toContain(
+      'Invalid input for tool "host_file_write"',
+    );
   });
 
   test("success message contains the file path", async () => {

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -404,6 +404,20 @@ describe("host_bash — environment setup", () => {
     expect(result.content.trim()).toBe(realpathSync(homedir()));
   });
 
+  test("treats an explicit null working_dir as omitted (runs from home)", async () => {
+    const { homedir } = await import("node:os");
+    const result = await hostShellTool.execute(
+      {
+        command: "pwd",
+        working_dir: null,
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content.trim()).toBe(realpathSync(homedir()));
+  });
+
   test("PATH includes ~/.local/bin and ~/.bun/bin", async () => {
     const { homedir } = await import("node:os");
     const home = homedir();

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -357,7 +357,7 @@ describe("host_bash — input validation", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("command is required");
+    expect(result.content).toContain('Invalid input for tool "host_bash"');
   });
 
   test("rejects non-string command", async () => {
@@ -369,9 +369,7 @@ describe("host_bash — input validation", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain(
-      "command is required and must be a string",
-    );
+    expect(result.content).toContain('Invalid input for tool "host_bash"');
   });
 
   test("rejects non-string working_dir", async () => {
@@ -384,7 +382,7 @@ describe("host_bash — input validation", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("working_dir must be a string");
+    expect(result.content).toContain('Invalid input for tool "host_bash"');
   });
 });
 

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -349,3 +349,26 @@ describe("notifyParentFromChild", () => {
     expect(capturedParentIds).not.toContain("victim-conversation");
   });
 });
+
+describe("notify_parent — model-input schema validation (LUM-2857)", () => {
+  test("rejects a non-string message", async () => {
+    const result = await executeSubagentNotifyParent(
+      { message: 42 },
+      makeContext("conv-notify-schema-1"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "notify_parent"');
+  });
+
+  test("degrades a malformed urgency to info instead of forwarding it", async () => {
+    const conversationId = "conv-notify-schema-2";
+    seedSubagent(conversationId);
+    const result = await executeSubagentNotifyParent(
+      { message: "found something", urgency: 42 },
+      makeContext(conversationId),
+    );
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content) as { urgency: string };
+    expect(parsed.urgency).toBe("info");
+  });
+});

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1986,3 +1986,67 @@ describe("Advisor role is tool-less", () => {
     ).toBe(0);
   });
 });
+
+// ── model-input schema validation (LUM-2855) ────────────────────────
+
+describe("subagent tools — model-input schema validation", () => {
+  test("spawn rejects a non-string label instead of spawning with it", async () => {
+    const result = await executeSubagentSpawn(
+      { label: 42, objective: "do something" },
+      makeContext("sess-schema", { sendToClient: () => {} }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "subagent_spawn"');
+    expect(result.content).toContain("label");
+  });
+
+  test("spawn treats explicit null label as missing (bespoke required error)", async () => {
+    const result = await executeSubagentSpawn(
+      { label: null, objective: "do something" },
+      makeContext("sess-schema", { sendToClient: () => {} }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("required");
+  });
+
+  test("status rejects a non-string subagent_id", async () => {
+    const result = await executeSubagentStatus(
+      { subagent_id: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "subagent_status"',
+    );
+  });
+
+  test("message rejects a non-string content", async () => {
+    const result = await executeSubagentMessage(
+      { subagent_id: "some-id", content: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "subagent_message"',
+    );
+    expect(result.content).toContain("content");
+  });
+
+  test("read rejects a non-string label but passes malformed last_n through", async () => {
+    const bad = await executeSubagentRead(
+      { label: 42 },
+      makeContext("sess-schema"),
+    );
+    expect(bad.isError).toBe(true);
+    expect(bad.content).toContain('Invalid input for tool "subagent_read"');
+
+    // last_n is loose passthrough — a malformed value is ignored, so the call
+    // reaches the bespoke "required" check instead of failing validation.
+    const passthrough = await executeSubagentRead(
+      { last_n: "five" },
+      makeContext("sess-schema"),
+    );
+    expect(passthrough.isError).toBe(true);
+    expect(passthrough.content).toContain("required");
+  });
+});

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -219,7 +219,10 @@ describe("Shell tool input validation", () => {
       baseContext,
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("command is required");
+    expect(result.content).toContain('Invalid input for tool "bash"');
+    expect(result.content).toContain(
+      "command: Too small: expected string to have >=1 characters",
+    );
   });
 
   test("rejects non-string command", async () => {
@@ -228,7 +231,10 @@ describe("Shell tool input validation", () => {
       baseContext,
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("command is required");
+    expect(result.content).toContain('Invalid input for tool "bash"');
+    expect(result.content).toContain(
+      "command: Invalid input: expected string, received number",
+    );
   });
 
   test("rejects command with null bytes", async () => {
@@ -243,7 +249,10 @@ describe("Shell tool input validation", () => {
   test("rejects missing command", async () => {
     const result = await shellTool.execute({ reason: "test" }, baseContext);
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("command is required");
+    expect(result.content).toContain('Invalid input for tool "bash"');
+    expect(result.content).toContain(
+      "command: Invalid input: expected string, received undefined",
+    );
   });
 
   test("executes simple command successfully", async () => {

--- a/assistant/src/tools/__tests__/followup-call-acp-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/followup-call-acp-tool-input-schemas.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test } from "bun:test";
+
+import type { z } from "zod";
+
+import { acpAbortInputSchema } from "../acp/abort.js";
+import { acpSpawnInputSchema } from "../acp/spawn.js";
+import { acpStatusInputSchema } from "../acp/status.js";
+import { acpSteerInputSchema } from "../acp/steer.js";
+import { callEndInputSchema } from "../calls/call-end.js";
+import { callStartInputSchema } from "../calls/call-start.js";
+import { callStatusInputSchema } from "../calls/call-status.js";
+import { followupCreateInputSchema } from "../followups/followup_create.js";
+import { followupListInputSchema } from "../followups/followup_list.js";
+import { followupResolveInputSchema } from "../followups/followup_resolve.js";
+import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+import { expectNoSchemaDrift } from "./tool-schema-drift-harness.js";
+
+/**
+ * Drift guard between the followups / phone-calls / acp skills' hand-written
+ * `TOOLS.json` `input_schema`s (the advertised contract) and the executors'
+ * runtime Zod schemas. See `tool-schema-drift-harness.ts` for what is (and
+ * deliberately is not) compared. `acp_list_agents` takes no input and has no
+ * runtime schema, so it has no entry here.
+ */
+
+function loadToolsJson(
+  skill: string,
+): Parameters<typeof expectNoSchemaDrift>[1] {
+  return JSON.parse(
+    readFileSync(
+      join(import.meta.dir, `../../config/bundled-skills/${skill}/TOOLS.json`),
+      "utf8",
+    ),
+  ) as Parameters<typeof expectNoSchemaDrift>[1];
+}
+
+const CASES: {
+  skill: string;
+  name: string;
+  schema: z.ZodType;
+  advertiseRequired?: string[];
+  passthrough?: Record<string, string>;
+}[] = [
+  {
+    skill: "followups",
+    name: "followup_create",
+    schema: followupCreateInputSchema,
+    advertiseRequired: ["channel", "conversation_id"],
+    passthrough: {
+      expected_response_hours:
+        "bespoke positive-number check owns the error message for every malformed shape (per LUM-2856)",
+    },
+  },
+  {
+    skill: "followups",
+    name: "followup_list",
+    schema: followupListInputSchema,
+    passthrough: {
+      status:
+        "bespoke VALID_STATUSES check owns the 'Invalid status' error (test-asserted)",
+    },
+  },
+  {
+    skill: "followups",
+    name: "followup_resolve",
+    schema: followupResolveInputSchema,
+  },
+  {
+    skill: "phone-calls",
+    name: "call_start",
+    schema: callStartInputSchema,
+    passthrough: {
+      skip_disclosure: "deliberate `=== true` coercion owns malformed values",
+    },
+  },
+  {
+    skill: "phone-calls",
+    name: "call_status",
+    schema: callStatusInputSchema,
+  },
+  {
+    skill: "phone-calls",
+    name: "call_end",
+    schema: callEndInputSchema,
+    advertiseRequired: ["call_session_id"],
+  },
+  {
+    skill: "acp",
+    name: "acp_spawn",
+    schema: acpSpawnInputSchema,
+    advertiseRequired: ["task"],
+  },
+  { skill: "acp", name: "acp_status", schema: acpStatusInputSchema },
+  {
+    skill: "acp",
+    name: "acp_abort",
+    schema: acpAbortInputSchema,
+    advertiseRequired: ["acp_session_id"],
+  },
+  {
+    skill: "acp",
+    name: "acp_steer",
+    schema: acpSteerInputSchema,
+    advertiseRequired: ["acp_session_id", "instruction"],
+  },
+];
+
+describe("followups + phone-calls + acp TOOLS.json ↔ runtime Zod schema drift guard", () => {
+  for (const c of CASES) {
+    test(`${c.skill}:${c.name}`, () => {
+      expectNoSchemaDrift(
+        {
+          name: c.name,
+          derived: toToolInputSchema(c.schema, {
+            advertiseRequired: c.advertiseRequired,
+          }),
+          passthrough: c.passthrough,
+        },
+        loadToolsJson(c.skill),
+      );
+    });
+  }
+});

--- a/assistant/src/tools/__tests__/subagent-workflow-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/subagent-workflow-tool-input-schemas.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test } from "bun:test";
+
+import type { z } from "zod";
+
+import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+import { subagentAbortInputSchema } from "../subagent/abort.js";
+import { subagentMessageInputSchema } from "../subagent/message.js";
+import { subagentReadInputSchema } from "../subagent/read.js";
+import { subagentSpawnInputSchema } from "../subagent/spawn.js";
+import { subagentStatusInputSchema } from "../subagent/status.js";
+import { manageWorkflowsInputSchema } from "../workflows/manage-workflows.js";
+import { runWorkflowInputSchema } from "../workflows/run-workflow.js";
+import { expectNoSchemaDrift } from "./tool-schema-drift-harness.js";
+
+/**
+ * Drift guard between the subagent and workflows skills' hand-written
+ * `TOOLS.json` `input_schema`s (the advertised contract) and the executors'
+ * runtime Zod schemas. See `tool-schema-drift-harness.ts` for what is (and
+ * deliberately is not) compared.
+ */
+
+function loadToolsJson(
+  skill: string,
+): Parameters<typeof expectNoSchemaDrift>[1] {
+  return JSON.parse(
+    readFileSync(
+      join(import.meta.dir, `../../config/bundled-skills/${skill}/TOOLS.json`),
+      "utf8",
+    ),
+  ) as Parameters<typeof expectNoSchemaDrift>[1];
+}
+
+const CASES: {
+  skill: string;
+  name: string;
+  schema: z.ZodType;
+  advertiseRequired?: string[];
+  passthrough?: Record<string, string>;
+}[] = [
+  {
+    skill: "subagent",
+    name: "subagent_spawn",
+    schema: subagentSpawnInputSchema,
+    advertiseRequired: ["label", "objective"],
+    passthrough: {
+      fork: "deliberate `=== true` coercion owns malformed values",
+      send_result_to_user:
+        "deliberate `=== true` / `!== false` coercions own malformed values",
+      role: "SubagentManager.spawn's 'Invalid subagent role' error (test-asserted) owns non-enum values",
+    },
+  },
+  {
+    skill: "subagent",
+    name: "subagent_status",
+    schema: subagentStatusInputSchema,
+  },
+  {
+    skill: "subagent",
+    name: "subagent_abort",
+    schema: subagentAbortInputSchema,
+  },
+  {
+    skill: "subagent",
+    name: "subagent_message",
+    schema: subagentMessageInputSchema,
+    advertiseRequired: ["content"],
+  },
+  {
+    skill: "subagent",
+    name: "subagent_read",
+    schema: subagentReadInputSchema,
+    passthrough: {
+      last_n:
+        "typeof-guarded read ignores malformed values (including non-integer numbers the advertised type wouldn't admit)",
+    },
+  },
+  {
+    skill: "workflows",
+    name: "run_workflow",
+    schema: runWorkflowInputSchema,
+    passthrough: {
+      args: "workflow runtime accepts any JSON value as args",
+      capabilities:
+        "CapabilityManifestSchema is the single validation authority; executor.ts reads it pre-execution for the requireFreshApproval promotion",
+    },
+  },
+  {
+    skill: "workflows",
+    name: "manage_workflows",
+    schema: manageWorkflowsInputSchema,
+    advertiseRequired: ["action"],
+    passthrough: {
+      action:
+        "switch default owns the unknown-action error; executor.ts reads it pre-execution for the requireFreshApproval promotion",
+    },
+  },
+];
+
+describe("subagent + workflows TOOLS.json ↔ runtime Zod schema drift guard", () => {
+  for (const c of CASES) {
+    test(`${c.skill}:${c.name}`, () => {
+      expectNoSchemaDrift(
+        {
+          name: c.name,
+          derived: toToolInputSchema(c.schema, {
+            advertiseRequired: c.advertiseRequired,
+          }),
+          passthrough: c.passthrough,
+        },
+        loadToolsJson(c.skill),
+      );
+    });
+  }
+});

--- a/assistant/src/tools/__tests__/tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/tool-input-schemas.test.ts
@@ -5,6 +5,13 @@ import { fileEditTool } from "../filesystem/edit.js";
 import { fileListTool } from "../filesystem/list.js";
 import { fileReadTool } from "../filesystem/read.js";
 import { fileWriteTool } from "../filesystem/write.js";
+import { hostFileEditTool } from "../host-filesystem/edit.js";
+import { hostFileReadTool } from "../host-filesystem/read.js";
+import { hostFileWriteTool } from "../host-filesystem/write.js";
+import { hostShellTool } from "../host-terminal/host-shell.js";
+import { notifyParentTool } from "../subagent/notify-parent.js";
+import { requestSystemPermissionTool } from "../system/request-permission.js";
+import { shellTool } from "../terminal/shell.js";
 import { parseToolInput, TOOL_INPUT_SCHEMAS } from "../tool-input-schemas.js";
 
 describe("parseToolInput", () => {
@@ -126,6 +133,13 @@ describe("derived input_schema", () => {
     fileEditTool,
     fileListTool,
     askQuestionTool,
+    hostFileReadTool,
+    hostFileWriteTool,
+    hostFileEditTool,
+    shellTool,
+    hostShellTool,
+    requestSystemPermissionTool,
+    notifyParentTool,
   ];
 
   test("every registered schema belongs to a tool whose input_schema is derived from it", () => {

--- a/assistant/src/tools/acp/abort.ts
+++ b/assistant/src/tools/acp/abort.ts
@@ -1,11 +1,31 @@
+import { z } from "zod";
+
 import { getAcpSessionManager } from "../../acp/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeAcpAbort}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools. The bespoke required check keeps its message for the
+ * missing/null/empty cases.
+ */
+export const acpAbortInputSchema = z.looseObject({
+  acp_session_id: nullAsOmitted(z.string()),
+});
 
 export async function executeAcpAbort(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acpSessionId = input.acp_session_id as string;
+  const parsedInput = acpAbortInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("acp_abort", parsedInput.error);
+  }
+  const acpSessionId = parsedInput.data.acp_session_id;
   if (!acpSessionId) {
     return { content: '"acp_session_id" is required.', isError: true };
   }

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -49,7 +49,9 @@ mock.module("../credentials/metadata-store.js", () => ({
   getCredentialMetadata: (service: string, field: string) => {
     const key = `${service}/${field}`;
     const entry = metadataStore.get(key);
-    if (!entry) return undefined;
+    if (!entry) {
+      return undefined;
+    }
     return {
       credentialId: `cred-${key}`,
       service,
@@ -278,8 +280,12 @@ describe("executeAcpSpawn: sandboxed bun auto-install on missing binary", () => 
     // successful global install that links the adapter bin onto PATH.
     let binaryOnPath = false;
     which.setWhich((cmd) => {
-      if (cmd === "bun") return BUN_BIN;
-      if (binaryOnPath) return `/usr/local/bin/${cmd}`;
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (binaryOnPath) {
+        return `/usr/local/bin/${cmd}`;
+      }
       return null;
     });
     execScripts.set(BUN_ADD_KEY, {
@@ -326,8 +332,12 @@ describe("executeAcpSpawn: sandboxed bun auto-install on missing binary", () => 
   test("the installer cwd is a temp dir (not the project cwd) with secrets stripped", async () => {
     let binaryOnPath = false;
     which.setWhich((cmd) => {
-      if (cmd === "bun") return BUN_BIN;
-      if (binaryOnPath) return `/usr/local/bin/${cmd}`;
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (binaryOnPath) {
+        return `/usr/local/bin/${cmd}`;
+      }
       return null;
     });
     execScripts.set(BUN_ADD_KEY, {

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -1,5 +1,7 @@
 import { basename } from "node:path";
 
+import { z } from "zod";
+
 import { markAcpConnectCardRaised } from "../../acp/acp-connect-card-state.js";
 import { resolveAgentWithAutoInstall } from "../../acp/auto-install.js";
 import { getAcpSessionManager } from "../../acp/index.js";
@@ -10,8 +12,25 @@ import {
 import { formatResolveFailure } from "../../acp/resolve-agent.js";
 import { claudeResumeHint } from "../../acp/resume-hint.js";
 import { FailedDependencyError } from "../../runtime/routes/errors.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { getSendToClient } from "./context.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeAcpSpawn}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework. The bespoke '"task" is required.' check keeps its message for
+ * the missing/null/empty cases.
+ */
+export const acpSpawnInputSchema = z.looseObject({
+  agent: nullAsOmitted(z.string()),
+  task: nullAsOmitted(z.string()),
+  cwd: nullAsOmitted(z.string()),
+});
 
 /**
  * Recover the stable `acp_claude_oauth_missing` marker off a `prepareAgentEnv`
@@ -34,8 +53,12 @@ export async function executeAcpSpawn(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const agent = (input.agent as string) || "claude";
-  const task = input.task as string;
+  const parsedInput = acpSpawnInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("acp_spawn", parsedInput.error);
+  }
+  const agent = parsedInput.data.agent || "claude";
+  const task = parsedInput.data.task;
 
   if (!task) {
     return { content: '"task" is required.', isError: true };
@@ -87,7 +110,7 @@ export async function executeAcpSpawn(
 
   try {
     const manager = getAcpSessionManager();
-    const cwd = (input.cwd as string) || context.workingDir;
+    const cwd = parsedInput.data.cwd || context.workingDir;
     const { acpSessionId, protocolSessionId } = await manager.spawn(
       agent,
       agentConfig,

--- a/assistant/src/tools/acp/status.ts
+++ b/assistant/src/tools/acp/status.ts
@@ -1,11 +1,30 @@
+import { z } from "zod";
+
 import { getAcpSessionManager } from "../../acp/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeAcpStatus}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools.
+ */
+export const acpStatusInputSchema = z.looseObject({
+  acp_session_id: nullAsOmitted(z.string()),
+});
 
 export async function executeAcpStatus(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acpSessionId = input.acp_session_id as string | undefined;
+  const parsedInput = acpStatusInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("acp_status", parsedInput.error);
+  }
+  const acpSessionId = parsedInput.data.acp_session_id;
   const manager = getAcpSessionManager();
 
   try {

--- a/assistant/src/tools/acp/steer.test.ts
+++ b/assistant/src/tools/acp/steer.test.ts
@@ -195,3 +195,23 @@ describe("executeAcpSteer", () => {
     expect(result.content).toContain("is not running");
   });
 });
+
+describe("acp tools — model-input schema validation (LUM-2856)", () => {
+  test("steer rejects a non-string acp_session_id", async () => {
+    const result = await executeAcpSteer(
+      { acp_session_id: 42, instruction: "redirect" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "acp_steer"');
+  });
+
+  test("steer treats explicit null instruction as missing (bespoke error)", async () => {
+    const result = await executeAcpSteer(
+      { acp_session_id: "acp-1", instruction: null },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"instruction" is required');
+  });
+});

--- a/assistant/src/tools/acp/steer.ts
+++ b/assistant/src/tools/acp/steer.ts
@@ -1,17 +1,38 @@
+import { z } from "zod";
+
 import { getAcpSessionManager } from "../../acp/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { getSendToClient } from "./context.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeAcpSteer}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools. The bespoke required checks keep their (test-asserted) messages for
+ * the missing/null/empty cases.
+ */
+export const acpSteerInputSchema = z.looseObject({
+  acp_session_id: nullAsOmitted(z.string()),
+  instruction: nullAsOmitted(z.string()),
+});
 
 export async function executeAcpSteer(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acpSessionId = input.acp_session_id as string;
+  const parsedInput = acpSteerInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("acp_steer", parsedInput.error);
+  }
+  const acpSessionId = parsedInput.data.acp_session_id;
   if (!acpSessionId) {
     return { content: '"acp_session_id" is required.', isError: true };
   }
 
-  const instruction = input.instruction as string;
+  const instruction = parsedInput.data.instruction;
   if (!instruction) {
     return { content: '"instruction" is required.', isError: true };
   }

--- a/assistant/src/tools/calls/call-end.ts
+++ b/assistant/src/tools/calls/call-end.ts
@@ -1,19 +1,40 @@
+import { z } from "zod";
+
 import { cancelCall } from "../../calls/call-domain.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeCallEnd}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools. The bespoke required check below keeps its error message for the
+ * missing/null/empty cases.
+ */
+export const callEndInputSchema = z.looseObject({
+  call_session_id: nullAsOmitted(z.string()),
+  end_reason: nullAsOmitted(z.string()),
+});
 
 export async function executeCallEnd(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const callSessionId = input.call_session_id as string | undefined;
-  if (!callSessionId || typeof callSessionId !== "string") {
+  const parsedInput = callEndInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("call_end", parsedInput.error);
+  }
+  const callSessionId = parsedInput.data.call_session_id;
+  if (!callSessionId) {
     return {
       content: "Error: call_session_id is required and must be a string",
       isError: true,
     };
   }
 
-  const reason = input.end_reason as string | undefined;
+  const reason = parsedInput.data.end_reason;
 
   const result = await cancelCall({ callSessionId, reason });
 

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -14,10 +14,10 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
  * Model-input schema, `safeParse`d at the top of {@link executeCallStart}.
  * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
  * tools — see the schema block in `tools/document/document-tool.ts` for the
- * framework. This executor had no input validation of its own (a missing or
- * mistyped `phone_number`/`task` flowed straight into `startCall`), so the
- * advertised-required fields are simply required here. `skip_disclosure`
- * (deliberate `=== true` coercion) is UNDECLARED — loose passthrough.
+ * framework. The advertised-required fields are required here — schema
+ * rejection is the only guard between a mistyped `phone_number`/`task` and
+ * `startCall`. `skip_disclosure` (deliberate `=== true` coercion) is
+ * UNDECLARED — loose passthrough.
  */
 export const callStartInputSchema = z.looseObject({
   phone_number: z.string(),

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -1,8 +1,32 @@
+import { z } from "zod";
+
 import { startCall } from "../../calls/call-domain.js";
 import { findActiveSession } from "../../channels/gateway-verification-sessions.js";
 import { getConfig } from "../../config/loader.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeCallStart}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework. This executor had no input validation of its own (a missing or
+ * mistyped `phone_number`/`task` flowed straight into `startCall`), so the
+ * advertised-required fields are simply required here. `skip_disclosure`
+ * (deliberate `=== true` coercion) is UNDECLARED — loose passthrough.
+ */
+export const callStartInputSchema = z.looseObject({
+  phone_number: z.string(),
+  task: z.string(),
+  context: nullAsOmitted(z.string()),
+  caller_identity_mode: nullAsOmitted(
+    z.enum(["assistant_number", "user_number"]),
+  ),
+});
 
 export async function executeCallStart(
   input: Record<string, unknown>,
@@ -16,10 +40,13 @@ export async function executeCallStart(
     };
   }
 
-  const requestedPhone =
-    typeof input.phone_number === "string"
-      ? normalizePhoneNumber(input.phone_number)
-      : null;
+  const parsedInput = callStartInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("call_start", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const requestedPhone = normalizePhoneNumber(parsed.phone_number);
   if (requestedPhone) {
     const activeVoiceVerification = await findActiveSession("phone");
     const verificationDestination =
@@ -37,15 +64,12 @@ export async function executeCallStart(
   }
 
   const result = await startCall({
-    phoneNumber: input.phone_number as string,
-    task: input.task as string,
-    context: input.context as string | undefined,
+    phoneNumber: parsed.phone_number,
+    task: parsed.task,
+    context: parsed.context,
     conversationId: context.conversationId,
     assistantId: context.assistantId,
-    callerIdentityMode: input.caller_identity_mode as
-      | "assistant_number"
-      | "user_number"
-      | undefined,
+    callerIdentityMode: parsed.caller_identity_mode,
     skipDisclosure: input.skip_disclosure === true,
   });
 

--- a/assistant/src/tools/calls/call-status.ts
+++ b/assistant/src/tools/calls/call-status.ts
@@ -1,11 +1,30 @@
+import { z } from "zod";
+
 import { getCallStatus } from "../../calls/call-domain.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeCallStatus}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools.
+ */
+export const callStatusInputSchema = z.looseObject({
+  call_session_id: nullAsOmitted(z.string()),
+});
 
 export async function executeCallStatus(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const callSessionId = input.call_session_id as string | undefined;
+  const parsedInput = callStatusInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("call_status", parsedInput.error);
+  }
+  const callSessionId = parsedInput.data.call_session_id;
 
   const result = getCallStatus(callSessionId, context.conversationId);
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -19,6 +19,8 @@ import {
 } from "../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { executeWithTimeout, safeTimeoutMs } from "./execution-timeout.js";
+import { fileEditInputSchema } from "./filesystem/edit.js";
+import { fileWriteInputSchema } from "./filesystem/write.js";
 import { PermissionChecker } from "./permission-checker.js";
 import { getToolOwner } from "./registry.js";
 import { extractAndSanitize } from "./sensitive-output-placeholders.js";
@@ -496,11 +498,13 @@ function computePreviewDiff(
   | undefined {
   try {
     if (toolName === "file_write") {
-      const rawPath = input.path as string;
-      const content = input.content as string;
-      if (!rawPath || typeof content !== "string") {
+      // Parse with the tool's own schema so the preview reads the same shape
+      // the executor will (a call the schema rejects gets no preview).
+      const parsed = fileWriteInputSchema.safeParse(input);
+      if (!parsed.success) {
         return undefined;
       }
+      const { path: rawPath, content } = parsed.data;
       const pathCheck = sandboxPolicy(rawPath, workingDir, {
         mustExist: false,
       });
@@ -520,17 +524,15 @@ function computePreviewDiff(
     }
 
     if (toolName === "file_edit") {
-      const rawPath = input.path as string;
-      const oldString = input.old_string as string;
-      const newString = input.new_string as string;
-      if (
-        !rawPath ||
-        typeof oldString !== "string" ||
-        typeof newString !== "string" ||
-        oldString.length === 0
-      ) {
+      const parsed = fileEditInputSchema.safeParse(input);
+      if (!parsed.success) {
         return undefined;
       }
+      const {
+        path: rawPath,
+        old_string: oldString,
+        new_string: newString,
+      } = parsed.data;
       const pathCheck = sandboxPolicy(rawPath, workingDir);
       if (!pathCheck.ok) {
         return undefined;
@@ -544,7 +546,7 @@ function computePreviewDiff(
         return undefined;
       }
       const content = readFileSync(filePath, "utf-8");
-      const replaceAll = input.replace_all === true;
+      const replaceAll = parsed.data.replace_all === true;
       const result = applyEdit(content, oldString, newString, replaceAll);
       if (!result.ok) {
         return undefined;

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -1,7 +1,29 @@
+import { z } from "zod";
+
 import { getContact } from "../../contacts/contact-store.js";
 import { createFollowUp } from "../../followups/followup-store.js";
 import type { FollowUp } from "../../followups/types.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeFollowupCreate}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework. The bespoke non-empty (trim) checks keep their current error
+ * semantics; `expected_response_hours` is deliberately UNDECLARED (loose
+ * passthrough) so its bespoke positive-number check owns the error message
+ * for every malformed shape, exactly as before.
+ */
+export const followupCreateInputSchema = z.looseObject({
+  channel: nullAsOmitted(z.string()),
+  conversation_id: nullAsOmitted(z.string()),
+  contact_id: nullAsOmitted(z.string()),
+  reminder_schedule_id: nullAsOmitted(z.string()),
+});
 
 function formatFollowUp(f: FollowUp): string {
   const lines = [
@@ -11,14 +33,17 @@ function formatFollowUp(f: FollowUp): string {
     `  Status: ${f.status}`,
     `  Sent at: ${new Date(f.sentAt).toISOString()}`,
   ];
-  if (f.contactId) lines.push(`  Contact ID: ${f.contactId}`);
+  if (f.contactId) {
+    lines.push(`  Contact ID: ${f.contactId}`);
+  }
   if (f.expectedResponseBy) {
     lines.push(
       `  Expected response by: ${new Date(f.expectedResponseBy).toISOString()}`,
     );
   }
-  if (f.reminderScheduleId)
+  if (f.reminderScheduleId) {
     lines.push(`  Reminder schedule: ${f.reminderScheduleId}`);
+  }
   return lines.join("\n");
 }
 
@@ -26,20 +51,22 @@ export async function executeFollowupCreate(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const channel = input.channel as string | undefined;
-  if (!channel || typeof channel !== "string" || channel.trim().length === 0) {
+  const parsedInput = followupCreateInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("followup_create", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const channel = parsed.channel;
+  if (!channel || channel.trim().length === 0) {
     return {
       content: "Error: channel is required and must be a non-empty string",
       isError: true,
     };
   }
 
-  const conversationId = input.conversation_id as string | undefined;
-  if (
-    !conversationId ||
-    typeof conversationId !== "string" ||
-    conversationId.trim().length === 0
-  ) {
+  const conversationId = parsed.conversation_id;
+  if (!conversationId || conversationId.trim().length === 0) {
     return {
       content:
         "Error: conversation_id is required and must be a non-empty string",
@@ -47,11 +74,13 @@ export async function executeFollowupCreate(
     };
   }
 
-  const contactId = input.contact_id as string | undefined;
+  const contactId = parsed.contact_id;
+  // Loose passthrough (see schema doc comment) — the bespoke check below
+  // owns every malformed shape.
   const expectedResponseHours = input.expected_response_hours as
     | number
     | undefined;
-  const reminderScheduleId = input.reminder_schedule_id as string | undefined;
+  const reminderScheduleId = parsed.reminder_schedule_id;
 
   // Validate contact exists if provided
   if (contactId) {

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -16,7 +16,7 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
  * framework. The bespoke non-empty (trim) checks keep their current error
  * semantics; `expected_response_hours` is deliberately UNDECLARED (loose
  * passthrough) so its bespoke positive-number check owns the error message
- * for every malformed shape, exactly as before.
+ * for every malformed shape.
  */
 export const followupCreateInputSchema = z.looseObject({
   channel: nullAsOmitted(z.string()),

--- a/assistant/src/tools/followups/followup_list.ts
+++ b/assistant/src/tools/followups/followup_list.ts
@@ -1,11 +1,29 @@
+import { z } from "zod";
+
 import {
   getOverdueFollowUps,
   listFollowUps,
 } from "../../followups/followup-store.js";
 import type { FollowUp, FollowUpStatus } from "../../followups/types.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 const VALID_STATUSES = ["pending", "resolved", "overdue", "nudged"] as const;
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeFollowupList}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools. `status` is deliberately UNDECLARED (loose passthrough): the bespoke
+ * `VALID_STATUSES` check owns the "Invalid status" error (test-asserted).
+ */
+export const followupListInputSchema = z.looseObject({
+  channel: nullAsOmitted(z.string()),
+  contact_id: nullAsOmitted(z.string()),
+  overdue_only: nullAsOmitted(z.boolean()),
+});
 
 function formatFollowUpSummary(f: FollowUp): string {
   const parts = [
@@ -14,7 +32,9 @@ function formatFollowUpSummary(f: FollowUp): string {
   parts.push(
     `  Status: ${f.status} | Sent: ${new Date(f.sentAt).toISOString()}`,
   );
-  if (f.contactId) parts.push(`  Contact: ${f.contactId}`);
+  if (f.contactId) {
+    parts.push(`  Contact: ${f.contactId}`);
+  }
   if (f.expectedResponseBy) {
     const deadline = new Date(f.expectedResponseBy);
     const isOverdue = f.status === "pending" && deadline.getTime() < Date.now();
@@ -29,10 +49,14 @@ export async function executeFollowupList(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const parsedInput = followupListInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("followup_list", parsedInput.error);
+  }
   const status = input.status as FollowUpStatus | undefined;
-  const channel = input.channel as string | undefined;
-  const contactId = input.contact_id as string | undefined;
-  const overdueOnly = input.overdue_only as boolean | undefined;
+  const channel = parsedInput.data.channel;
+  const contactId = parsedInput.data.contact_id;
+  const overdueOnly = parsedInput.data.overdue_only;
 
   if (
     status &&
@@ -51,8 +75,12 @@ export async function executeFollowupList(
 
     if (overdueOnly || status === "overdue") {
       results = getOverdueFollowUps();
-      if (channel) results = results.filter((f) => f.channel === channel);
-      if (contactId) results = results.filter((f) => f.contactId === contactId);
+      if (channel) {
+        results = results.filter((f) => f.channel === channel);
+      }
+      if (contactId) {
+        results = results.filter((f) => f.contactId === contactId);
+      }
     } else {
       results = listFollowUps({ status, channel, contactId });
     }

--- a/assistant/src/tools/followups/followup_resolve.ts
+++ b/assistant/src/tools/followups/followup_resolve.ts
@@ -1,9 +1,27 @@
+import { z } from "zod";
+
 import {
   resolveByConversation,
   resolveFollowUp,
 } from "../../followups/followup-store.js";
 import type { FollowUp } from "../../followups/types.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of
+ * {@link executeFollowupResolve}. Same in-tool pattern and TOOLS.json drift
+ * guard as the other bundled-skill tools. The bespoke either-or check below
+ * keeps its error message.
+ */
+export const followupResolveInputSchema = z.looseObject({
+  id: nullAsOmitted(z.string()),
+  channel: nullAsOmitted(z.string()),
+  conversation_id: nullAsOmitted(z.string()),
+});
 
 function formatFollowUp(f: FollowUp): string {
   const lines = [
@@ -12,7 +30,9 @@ function formatFollowUp(f: FollowUp): string {
     `  Conversation: ${f.conversationId}`,
     `  Status: ${f.status}`,
   ];
-  if (f.contactId) lines.push(`  Contact ID: ${f.contactId}`);
+  if (f.contactId) {
+    lines.push(`  Contact ID: ${f.contactId}`);
+  }
   return lines.join("\n");
 }
 
@@ -20,9 +40,11 @@ export async function executeFollowupResolve(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const id = input.id as string | undefined;
-  const channel = input.channel as string | undefined;
-  const conversationId = input.conversation_id as string | undefined;
+  const parsedInput = followupResolveInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("followup_resolve", parsedInput.error);
+  }
+  const { id, channel, conversation_id: conversationId } = parsedInput.data;
 
   if (!id && !(channel && conversationId)) {
     return {

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { supportsHostProxy } from "../../channels/types.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
@@ -5,11 +7,46 @@ import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatEditDiff } from "../shared/filesystem/format-diff.js";
 import { hostPolicy } from "../shared/filesystem/path-policy.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
 } from "../types.js";
+
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below — mirrors
+ * `filesystem/edit.ts`. `replace_all` catches to `undefined` because the
+ * tool has always treated anything but a literal `true` as "single match";
+ * `target_client_id` catches because a non-string (or empty) value has
+ * always meant "untargeted".
+ */
+export const hostFileEditInputSchema = z.looseObject({
+  path: z.string().min(1).describe("Absolute host path to the file to edit"),
+  old_string: z
+    .string()
+    .min(1, { message: "old_string must not be empty" })
+    .describe("The exact text to find in the file"),
+  new_string: z.string().describe("The replacement text"),
+  replace_all: z
+    .boolean()
+    .describe(
+      "Replace all occurrences instead of requiring a unique match (default: false)",
+    )
+    .optional()
+    .catch(undefined),
+  target_client_id: z
+    .string()
+    .describe(
+      "ID of the specific client to execute this on. Required when multiple clients support host_file; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_file`.",
+    )
+    .optional()
+    .catch(undefined),
+});
 
 export const hostFileEditTool = {
   name: "host_file_edit",
@@ -19,66 +56,21 @@ export const hostFileEditTool = {
   executionTarget: "host",
   defaultRiskLevel: RiskLevel.Medium,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      path: {
-        type: "string",
-        description: "Absolute host path to the file to edit",
-      },
-      old_string: {
-        type: "string",
-        description: "The exact text to find in the file",
-      },
-      new_string: {
-        type: "string",
-        description: "The replacement text",
-      },
-      replace_all: {
-        type: "boolean",
-        description:
-          "Replace all occurrences instead of requiring a unique match (default: false)",
-      },
-      target_client_id: {
-        type: "string",
-        description:
-          "ID of the specific client to execute this on. Required when multiple clients support host_file; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_file`.",
-      },
-    },
-    required: ["path", "old_string", "new_string"],
-  },
+  input_schema: toToolInputSchema(hostFileEditInputSchema),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const rawPath = input.path as string;
-    if (!rawPath || typeof rawPath !== "string") {
-      return {
-        content: "Error: path is required and must be a string",
-        isError: true,
-      };
+    const parsed = hostFileEditInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("host_file_edit", parsed.error);
     }
-
-    const oldString = input.old_string;
-    if (typeof oldString !== "string") {
-      return {
-        content: "Error: old_string is required and must be a string",
-        isError: true,
-      };
-    }
-
-    const newString = input.new_string;
-    if (typeof newString !== "string") {
-      return {
-        content: "Error: new_string is required and must be a string",
-        isError: true,
-      };
-    }
-
-    if (oldString.length === 0) {
-      return { content: "Error: old_string must not be empty", isError: true };
-    }
+    const {
+      path: rawPath,
+      old_string: oldString,
+      new_string: newString,
+    } = parsed.data;
 
     if (oldString === newString) {
       return {
@@ -87,12 +79,11 @@ export const hostFileEditTool = {
       };
     }
 
-    const replaceAll = input.replace_all === true;
+    const replaceAll = parsed.data.replace_all === true;
 
     const targetClientId =
-      typeof input.target_client_id === "string" &&
-      input.target_client_id !== ""
-        ? input.target_client_id
+      parsed.data.target_client_id !== ""
+        ? parsed.data.target_client_id
         : undefined;
 
     const transportInterface = context.transportInterface;
@@ -154,8 +145,8 @@ export const hostFileEditTool = {
         {
           operation: "edit",
           path: rawPath,
-          old_string: oldString as string,
-          new_string: newString as string,
+          old_string: oldString,
+          new_string: newString,
           replace_all: replaceAll,
           targetClientId,
         },

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -20,10 +20,9 @@ import type {
 /**
  * Model-input schema, the single source for both runtime validation (via
  * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below — mirrors
- * `filesystem/edit.ts`. `replace_all` catches to `undefined` because the
- * tool has always treated anything but a literal `true` as "single match";
- * `target_client_id` catches because a non-string (or empty) value has
- * always meant "untargeted".
+ * `filesystem/edit.ts`. `replace_all` catches to `undefined` — anything
+ * but a literal `true` means "single match"; `target_client_id` catches so
+ * a non-string (or empty) value means "untargeted".
  */
 export const hostFileEditInputSchema = z.looseObject({
   path: z.string().min(1).describe("Absolute host path to the file to edit"),

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -1,5 +1,7 @@
 import { extname } from "node:path";
 
+import { z } from "zod";
+
 import { supportsHostProxy } from "../../channels/types.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
@@ -14,11 +16,44 @@ import {
   readImageFile,
 } from "../shared/filesystem/image-read.js";
 import { hostPolicy } from "../shared/filesystem/path-policy.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
 } from "../types.js";
+
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below — mirrors
+ * `filesystem/read.ts`. `offset`/`limit` catch to `undefined` because the
+ * tool has always ignored non-numeric values; `target_client_id` catches
+ * because the tool has always treated a non-string (or empty) value as
+ * "untargeted".
+ */
+export const hostFileReadInputSchema = z.looseObject({
+  path: z.string().min(1).describe("Absolute path to the host file to read"),
+  offset: z
+    .number()
+    .describe("Line number to start reading from (1-indexed)")
+    .optional()
+    .catch(undefined),
+  limit: z
+    .number()
+    .describe("Maximum number of lines to read")
+    .optional()
+    .catch(undefined),
+  target_client_id: z
+    .string()
+    .describe(
+      "ID of the specific client to execute this on. Required when multiple clients support host_file; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_file`.",
+    )
+    .optional()
+    .catch(undefined),
+});
 
 export const hostFileReadTool = {
   name: "host_file_read",
@@ -28,46 +63,21 @@ export const hostFileReadTool = {
   executionTarget: "host",
   defaultRiskLevel: RiskLevel.Medium,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      path: {
-        type: "string",
-        description: "Absolute path to the host file to read",
-      },
-      offset: {
-        type: "number",
-        description: "Line number to start reading from (1-indexed)",
-      },
-      limit: {
-        type: "number",
-        description: "Maximum number of lines to read",
-      },
-      target_client_id: {
-        type: "string",
-        description:
-          "ID of the specific client to execute this on. Required when multiple clients support host_file; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_file`.",
-      },
-    },
-    required: ["path"],
-  },
+  input_schema: toToolInputSchema(hostFileReadInputSchema),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const rawPath = input.path as string;
-    if (!rawPath || typeof rawPath !== "string") {
-      return {
-        content: "Error: path is required and must be a string",
-        isError: true,
-      };
+    const parsed = hostFileReadInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("host_file_read", parsed.error);
     }
+    const { path: rawPath, offset, limit } = parsed.data;
 
     const targetClientId =
-      typeof input.target_client_id === "string" &&
-      input.target_client_id !== ""
-        ? input.target_client_id
+      parsed.data.target_client_id !== ""
+        ? parsed.data.target_client_id
         : undefined;
 
     const transportInterface = context.transportInterface;
@@ -130,8 +140,8 @@ export const hostFileReadTool = {
         {
           operation: "read",
           path: rawPath,
-          offset: typeof input.offset === "number" ? input.offset : undefined,
-          limit: typeof input.limit === "number" ? input.limit : undefined,
+          offset,
+          limit,
           targetClientId,
         },
         context.conversationId,
@@ -160,11 +170,7 @@ export const hostFileReadTool = {
 
     const ops = new FileSystemOps(hostPolicy);
 
-    const result = ops.readFileSafe({
-      path: rawPath,
-      offset: typeof input.offset === "number" ? input.offset : undefined,
-      limit: typeof input.limit === "number" ? input.limit : undefined,
-    });
+    const result = ops.readFileSafe({ path: rawPath, offset, limit });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -29,9 +29,9 @@ import type {
 /**
  * Model-input schema, the single source for both runtime validation (via
  * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below — mirrors
- * `filesystem/read.ts`. `offset`/`limit` catch to `undefined` because the
- * tool has always ignored non-numeric values; `target_client_id` catches
- * because the tool has always treated a non-string (or empty) value as
+ * `filesystem/read.ts`. `offset`/`limit` catch to `undefined` so a
+ * non-numeric value reads the whole file instead of failing the call;
+ * `target_client_id` catches so a non-string (or empty) value means
  * "untargeted".
  */
 export const hostFileReadInputSchema = z.looseObject({

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -20,8 +20,8 @@ import type {
 /**
  * Model-input schema, the single source for both runtime validation (via
  * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below — mirrors
- * `filesystem/write.ts`. `target_client_id` catches to `undefined` because
- * the tool has always treated a non-string (or empty) value as "untargeted".
+ * `filesystem/write.ts`. `target_client_id` catches to `undefined` so a
+ * non-string (or empty) value means "untargeted".
  */
 export const hostFileWriteInputSchema = z.looseObject({
   path: z.string().min(1).describe("Absolute host path to the file to write"),

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { supportsHostProxy } from "../../channels/types.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
@@ -5,11 +7,33 @@ import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatWriteSummary } from "../shared/filesystem/format-diff.js";
 import { hostPolicy } from "../shared/filesystem/path-policy.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
 } from "../types.js";
+
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below — mirrors
+ * `filesystem/write.ts`. `target_client_id` catches to `undefined` because
+ * the tool has always treated a non-string (or empty) value as "untargeted".
+ */
+export const hostFileWriteInputSchema = z.looseObject({
+  path: z.string().min(1).describe("Absolute host path to the file to write"),
+  content: z.string().describe("The content to write to the file"),
+  target_client_id: z
+    .string()
+    .describe(
+      "ID of the specific client to execute this on. Required when multiple clients support host_file; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_file`.",
+    )
+    .optional()
+    .catch(undefined),
+});
 
 export const hostFileWriteTool = {
   name: "host_file_write",
@@ -19,50 +43,21 @@ export const hostFileWriteTool = {
   executionTarget: "host",
   defaultRiskLevel: RiskLevel.Medium,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      path: {
-        type: "string",
-        description: "Absolute host path to the file to write",
-      },
-      content: {
-        type: "string",
-        description: "The content to write to the file",
-      },
-      target_client_id: {
-        type: "string",
-        description:
-          "ID of the specific client to execute this on. Required when multiple clients support host_file; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_file`.",
-      },
-    },
-    required: ["path", "content"],
-  },
+  input_schema: toToolInputSchema(hostFileWriteInputSchema),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const rawPath = input.path as string;
-    if (!rawPath || typeof rawPath !== "string") {
-      return {
-        content: "Error: path is required and must be a string",
-        isError: true,
-      };
+    const parsed = hostFileWriteInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("host_file_write", parsed.error);
     }
-
-    const fileContent = input.content;
-    if (typeof fileContent !== "string") {
-      return {
-        content: "Error: content is required and must be a string",
-        isError: true,
-      };
-    }
+    const { path: rawPath, content: fileContent } = parsed.data;
 
     const targetClientId =
-      typeof input.target_client_id === "string" &&
-      input.target_client_id !== ""
-        ? input.target_client_id
+      parsed.data.target_client_id !== ""
+        ? parsed.data.target_client_id
         : undefined;
 
     const transportInterface = context.transportInterface;

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -40,6 +40,7 @@ import {
 } from "../shared/shell-output.js";
 import {
   invalidToolInputResult,
+  nullAsOmitted,
   toToolInputSchema,
 } from "../shared/zod-tool-schema.js";
 import { buildSanitizedEnv } from "../terminal/safe-env.js";
@@ -100,11 +101,12 @@ function buildHostBashProxyEnv(conversationId: string): Record<string, string> {
  * Model-input schema, the single source for both runtime validation (via
  * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below.
  * `timeout_seconds` / `background` / `target_client_id` / `activity` catch
- * to `undefined` because the tool has always degraded a malformed value to
- * its default (configured timeout, foreground, untargeted, status-only);
- * `working_dir` does NOT catch — the tool has always rejected a malformed
- * working directory rather than silently running in the wrong place, and its
- * null-byte / absolute-path checks stay bespoke below.
+ * to `undefined` so a malformed value degrades to its default (configured
+ * timeout, foreground, untargeted, status-only). `working_dir` treats an
+ * explicit null as omitted (the run defaults to the user home) but does NOT
+ * catch — a malformed working directory fails the parse rather than
+ * silently running in the wrong place, and the null-byte / absolute-path
+ * checks stay bespoke below.
  */
 export const hostShellInputSchema = z.looseObject({
   command: z.string().min(1).describe("The host shell command to execute."),
@@ -115,12 +117,13 @@ export const hostShellInputSchema = z.looseObject({
     )
     .optional()
     .catch(undefined),
-  working_dir: z
-    .string()
-    .describe(
-      "Optional absolute host working directory (defaults to user home)",
-    )
-    .optional(),
+  working_dir: nullAsOmitted(
+    z
+      .string()
+      .describe(
+        "Optional absolute host working directory (defaults to user home)",
+      ),
+  ),
   timeout_seconds: z
     .number()
     .describe(

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -11,6 +11,8 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute } from "node:path";
 
+import { z } from "zod";
+
 import { supportsHostProxy } from "../../channels/types.js";
 import { getConfig } from "../../config/loader.js";
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
@@ -36,6 +38,10 @@ import {
   formatShellOutput,
   MAX_OUTPUT_LENGTH,
 } from "../shared/shell-output.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import { buildSanitizedEnv } from "../terminal/safe-env.js";
 import type {
   ToolContext,
@@ -90,6 +96,54 @@ function buildHostBashProxyEnv(conversationId: string): Record<string, string> {
   return env;
 }
 
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below.
+ * `timeout_seconds` / `background` / `target_client_id` / `activity` catch
+ * to `undefined` because the tool has always degraded a malformed value to
+ * its default (configured timeout, foreground, untargeted, status-only);
+ * `working_dir` does NOT catch — the tool has always rejected a malformed
+ * working directory rather than silently running in the wrong place, and its
+ * null-byte / absolute-path checks stay bespoke below.
+ */
+export const hostShellInputSchema = z.looseObject({
+  command: z.string().min(1).describe("The host shell command to execute."),
+  activity: z
+    .string()
+    .describe(
+      'Brief non-technical explanation of what this command does and why, shown to a non-technical user in the permission prompt. Avoid jargon and technical terms. Good: "to check if a required program is installed on your computer". Bad: "to check if gcloud CLI is installed". Good: "to download a helper program". Bad: "to run npm install".',
+    )
+    .optional()
+    .catch(undefined),
+  working_dir: z
+    .string()
+    .describe(
+      "Optional absolute host working directory (defaults to user home)",
+    )
+    .optional(),
+  timeout_seconds: z
+    .number()
+    .describe(
+      "Optional timeout in seconds. Uses configured default and max limits.",
+    )
+    .optional()
+    .catch(undefined),
+  background: z
+    .boolean()
+    .describe(
+      "Run the command in the background on the host machine. The tool returns immediately with a background tool ID. When the process exits, its output is delivered to the conversation as a wake.",
+    )
+    .optional()
+    .catch(undefined),
+  target_client_id: z
+    .string()
+    .describe(
+      "ID of the specific client to execute this command on. Required when multiple clients support host_bash; omit when only one client is connected. Obtain IDs from `assistant clients list --capability host_bash`.",
+    )
+    .optional()
+    .catch(undefined),
+});
+
 export const hostShellTool = {
   name: "host_bash",
   description:
@@ -98,64 +152,24 @@ export const hostShellTool = {
   executionTarget: "host",
   defaultRiskLevel: RiskLevel.Medium,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      command: {
-        type: "string",
-        description: "The host shell command to execute.",
-      },
-      activity: {
-        type: "string",
-        description:
-          'Brief non-technical explanation of what this command does and why, shown to a non-technical user in the permission prompt. Avoid jargon and technical terms. Good: "to check if a required program is installed on your computer". Bad: "to check if gcloud CLI is installed". Good: "to download a helper program". Bad: "to run npm install".',
-      },
-      working_dir: {
-        type: "string",
-        description:
-          "Optional absolute host working directory (defaults to user home)",
-      },
-      timeout_seconds: {
-        type: "number",
-        description:
-          "Optional timeout in seconds. Uses configured default and max limits.",
-      },
-      background: {
-        type: "boolean",
-        description:
-          "Run the command in the background on the host machine. The tool returns immediately with a background tool ID. When the process exits, its output is delivered to the conversation as a wake.",
-      },
-      target_client_id: {
-        type: "string",
-        description:
-          "ID of the specific client to execute this command on. Required when multiple clients support host_bash; omit when only one client is connected. Obtain IDs from `assistant clients list --capability host_bash`.",
-      },
-    },
-    required: ["command", "activity"],
-  },
+  input_schema: toToolInputSchema(hostShellInputSchema, {
+    advertiseRequired: ["activity"],
+  }),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const command = input.command as string;
-    if (!command || typeof command !== "string") {
-      return {
-        content: "Error: command is required and must be a string",
-        isError: true,
-      };
+    const parsed = hostShellInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("host_bash", parsed.error);
     }
+    const command = parsed.data.command;
     if (command.includes("\0")) {
       return { content: "Error: command contains null bytes", isError: true };
     }
 
-    const rawWorkingDir = input.working_dir;
-    if (rawWorkingDir != null && typeof rawWorkingDir !== "string") {
-      return {
-        content: "Error: working_dir must be a string when provided",
-        isError: true,
-      };
-    }
+    const rawWorkingDir = parsed.data.working_dir;
     if (typeof rawWorkingDir === "string" && rawWorkingDir.includes("\0")) {
       return {
         content: "Error: working_dir contains null bytes",
@@ -168,7 +182,7 @@ export const hostShellTool = {
         isError: true,
       };
     }
-    const background = input.background === true;
+    const background = parsed.data.background === true;
     if (background && context.diskPressureCleanupModeActive === true) {
       return {
         content:
@@ -178,9 +192,8 @@ export const hostShellTool = {
     }
 
     const targetClientId =
-      typeof input.target_client_id === "string" &&
-      input.target_client_id !== ""
-        ? input.target_client_id
+      parsed.data.target_client_id !== ""
+        ? parsed.data.target_client_id
         : undefined;
 
     const config = getConfig();
@@ -230,10 +243,7 @@ export const hostShellTool = {
     // Proxy to connected client for execution on the user's machine
     // when a capable client is available (managed/cloud-hosted mode).
     if (HostBashProxy.instance.isAvailable()) {
-      const rawSec =
-        typeof input.timeout_seconds === "number"
-          ? input.timeout_seconds
-          : shellDefaultTimeoutSec;
+      const rawSec = parsed.data.timeout_seconds ?? shellDefaultTimeoutSec;
       const normalizedTimeout = Math.max(
         1,
         Math.min(rawSec, shellMaxTimeoutSec),
@@ -419,10 +429,7 @@ export const hostShellTool = {
     const workingDir =
       typeof rawWorkingDir === "string" ? rawWorkingDir : homedir();
 
-    const requestedSec =
-      typeof input.timeout_seconds === "number"
-        ? input.timeout_seconds
-        : shellDefaultTimeoutSec;
+    const requestedSec = parsed.data.timeout_seconds ?? shellDefaultTimeoutSec;
     const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
     const timeoutMs = timeoutSec * 1000;
 
@@ -500,7 +507,9 @@ export const hostShellTool = {
       let completed = false;
 
       child.on("close", (code) => {
-        if (completed) {return;}
+        if (completed) {
+          return;
+        }
         completed = true;
         clearTimeout(timer);
         const stdout = Buffer.concat(stdoutChunks).toString();
@@ -572,7 +581,9 @@ export const hostShellTool = {
       });
 
       child.on("error", (err) => {
-        if (completed) {return;}
+        if (completed) {
+          return;
+        }
         completed = true;
         clearTimeout(timer);
         const status = aborted ? "cancelled" : "failed";

--- a/assistant/src/tools/subagent/abort.ts
+++ b/assistant/src/tools/subagent/abort.ts
@@ -1,15 +1,23 @@
 import { getSubagentManager } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentAbortInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentAbort(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  if (!subagentId && input.label) {
+  const parsedInput = subagentAbortInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_abort", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/consult-deadline.ts
+++ b/assistant/src/tools/subagent/consult-deadline.ts
@@ -29,8 +29,12 @@ export function createConsultDeadline(opts: {
 
   const recordProgress = (): void => {
     // Once aborted, don't re-arm — the consult is already being torn down.
-    if (controller.signal.aborted) return;
-    if (idleTimer) clearTimeout(idleTimer);
+    if (controller.signal.aborted) {
+      return;
+    }
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
     idleTimer = setTimeout(() => controller.abort(), opts.idleMs);
   };
 
@@ -41,7 +45,9 @@ export function createConsultDeadline(opts: {
   recordProgress();
 
   const dispose = (): void => {
-    if (idleTimer) clearTimeout(idleTimer);
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
     clearTimeout(maxTimer);
   };
 

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -1,17 +1,33 @@
+import { z } from "zod";
+
 import { getSubagentManager } from "../../subagent/index.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentMessageInputSchema = z.looseObject({
+  ...subagentRefInputSchema.shape,
+  content: nullAsOmitted(z.string()),
+});
 
 export async function executeSubagentMessage(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  const content = input.content as string;
+  const parsedInput = subagentMessageInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_message", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  const content = parsed.content;
 
-  if (!subagentId && input.label) {
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/notify-parent.ts
+++ b/assistant/src/tools/subagent/notify-parent.ts
@@ -1,17 +1,56 @@
+import { z } from "zod";
+
 import { RiskLevel } from "../../permissions/types.js";
 import { notifyParentFromChild } from "../../subagent/notify.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
 } from "../types.js";
 
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. `message`
+ * stays runtime-optional (`advertiseRequired`) so the bespoke
+ * '"message" is required.' check keeps its test-asserted error; `urgency`
+ * catches to `undefined` so a malformed value degrades to "info" instead of
+ * forwarding garbage to the parent's notification.
+ */
+export const notifyParentInputSchema = z.looseObject({
+  message: nullAsOmitted(
+    z.string().describe("The notification content for the parent."),
+  ),
+  urgency: z
+    .enum(["info", "important", "blocked"])
+    .describe(
+      "'info' for progress updates, 'important' for key findings, 'blocked' when you need guidance.",
+    )
+    .optional()
+    .catch(undefined),
+  activity: z
+    .string()
+    .describe(
+      "Brief non-technical explanation of what you are doing and why, shown as a status update.",
+    )
+    .optional()
+    .catch(undefined),
+});
+
 export async function executeSubagentNotifyParent(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const message = input.message as string;
-  const urgency = (input.urgency as string) || "info";
+  const parsed = notifyParentInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return invalidToolInputResult("notify_parent", parsed.error);
+  }
+  const message = parsed.data.message;
+  const urgency = parsed.data.urgency ?? "info";
 
   if (!message) {
     return { content: '"message" is required.', isError: true };
@@ -41,27 +80,9 @@ export const notifyParentTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      message: {
-        type: "string",
-        description: "The notification content for the parent.",
-      },
-      urgency: {
-        type: "string",
-        enum: ["info", "important", "blocked"],
-        description:
-          "'info' for progress updates, 'important' for key findings, 'blocked' when you need guidance.",
-      },
-      activity: {
-        type: "string",
-        description:
-          "Brief non-technical explanation of what you are doing and why, shown as a status update.",
-      },
-    },
-    required: ["message", "activity"],
-  },
+  input_schema: toToolInputSchema(notifyParentInputSchema, {
+    advertiseRequired: ["message", "activity"],
+  }),
 
   async execute(
     input: Record<string, unknown>,

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -1,17 +1,28 @@
 import { getMessages } from "../../persistence/conversation-crud.js";
 import { extractTextFromStoredMessageContent } from "../../persistence/message-content.js";
 import { getSubagentManager, TERMINAL_STATUSES } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+// `last_n` is deliberately UNDECLARED (loose passthrough): the executor's
+// typeof-guarded read below ignores it when malformed — including non-integer
+// numbers the advertised `integer` type wouldn't admit — and always has.
+export const subagentReadInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentRead(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
-  if (!subagentId && input.label) {
+  const parsedInput = subagentReadInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_read", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -7,7 +7,7 @@ import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
 
 // `last_n` is deliberately UNDECLARED (loose passthrough): the executor's
 // typeof-guarded read below ignores it when malformed — including non-integer
-// numbers the advertised `integer` type wouldn't admit — and always has.
+// numbers the advertised `integer` type wouldn't admit.
 export const subagentReadInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentRead(

--- a/assistant/src/tools/subagent/resolve.ts
+++ b/assistant/src/tools/subagent/resolve.ts
@@ -1,18 +1,40 @@
+import { z } from "zod";
+
 import { getSubagentManager } from "../../subagent/index.js";
+import { nullAsOmitted } from "../shared/zod-tool-schema.js";
 import type { ToolContext } from "../types.js";
 
 /**
- * Resolve a subagent ID from tool input.
+ * Shared model-input schema for the subagent tools that address an existing
+ * subagent by `subagent_id` or `label` (`subagent_status` / `subagent_abort`,
+ * extended by `subagent_message` / `subagent_read`). Same in-tool pattern and
+ * TOOLS.json drift guard as the other bundled-skill tools — see
+ * `subagent-tool-input-schemas.test.ts` and the schema block in
+ * `tools/document/document-tool.ts` for the framework. The
+ * '"subagent_id" or "label" is required' / not-found error messages stay
+ * bespoke in each executor.
+ */
+export const subagentRefInputSchema = z.looseObject({
+  subagent_id: nullAsOmitted(z.string()),
+  label: nullAsOmitted(z.string()),
+});
+
+export type SubagentRefInput = z.infer<typeof subagentRefInputSchema>;
+
+/**
+ * Resolve a subagent ID from parsed tool input.
  * Accepts either `subagent_id` (direct UUID) or `label` (case-insensitive lookup).
  */
 export function resolveSubagentId(
-  input: Record<string, unknown>,
+  input: SubagentRefInput,
   context: ToolContext,
 ): string | undefined {
-  if (input.subagent_id) return input.subagent_id as string;
+  if (input.subagent_id) {
+    return input.subagent_id;
+  }
   if (input.label) {
     const state = getSubagentManager().getByLabel(
-      input.label as string,
+      input.label,
       context.conversationId,
     );
     return state?.config.id;

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { AssistantEvent } from "../../api/index.js";
 import { validateInferenceProfileKey } from "../../config/inference-profile-validation.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
@@ -19,6 +21,10 @@ import {
 } from "../../subagent/index.js";
 import type { SubagentRole } from "../../subagent/types.js";
 import { getLogger } from "../../util/logger.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { createConsultDeadline } from "./consult-deadline.js";
 
@@ -42,16 +48,40 @@ const ADVISOR_IDLE_TIMEOUT_MS = 60_000;
  */
 const ADVISOR_MAX_TIMEOUT_MS = 300_000;
 
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeSubagentSpawn}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework.
+ *
+ * `fork` / `send_result_to_user` (deliberate `=== true` / `!== false`
+ * coercions) and `role` (SubagentManager.spawn's "Invalid subagent role"
+ * error, asserted by tests, owns non-enum values) are deliberately
+ * UNDECLARED — loose passthrough.
+ */
+export const subagentSpawnInputSchema = z.looseObject({
+  label: nullAsOmitted(z.string()),
+  objective: nullAsOmitted(z.string()),
+  context: nullAsOmitted(z.string()),
+  inference_profile: z.string().optional(),
+});
+
 export async function executeSubagentSpawn(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const label = input.label as string;
-  const objective = input.objective as string;
-  const extraContext = input.context as string | undefined;
+  const parsedInput = subagentSpawnInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_spawn", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+
+  const label = parsed.label;
+  const objective = parsed.objective;
+  const extraContext = parsed.context;
   const fork = input.fork === true;
   const role = (input.role as string | undefined) ?? undefined;
-  const inferenceProfile = input.inference_profile;
+  const inferenceProfile = parsed.inference_profile;
 
   // For fork mode, sendResultToUser defaults to false unless explicitly set to true.
   // For regular mode, sendResultToUser defaults to true (existing behavior).
@@ -69,12 +99,6 @@ export async function executeSubagentSpawn(
   let requestedOverrideProfile: string | undefined;
   let forceOverrideProfile = false;
   if (inferenceProfile !== undefined) {
-    if (typeof inferenceProfile !== "string") {
-      return {
-        content: "Error: inference_profile must be a string",
-        isError: true,
-      };
-    }
     const profileError = validateInferenceProfileKey(inferenceProfile);
     if (profileError) {
       return {

--- a/assistant/src/tools/subagent/status.ts
+++ b/assistant/src/tools/subagent/status.ts
@@ -1,19 +1,27 @@
 import { getSubagentManager } from "../../subagent/index.js";
+import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
-import { resolveSubagentId } from "./resolve.js";
+import { resolveSubagentId, subagentRefInputSchema } from "./resolve.js";
+
+export const subagentStatusInputSchema = subagentRefInputSchema;
 
 export async function executeSubagentStatus(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const subagentId = resolveSubagentId(input, context);
+  const parsedInput = subagentStatusInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("subagent_status", parsedInput.error);
+  }
+  const parsed = parsedInput.data;
+  const subagentId = resolveSubagentId(parsed, context);
   const manager = getSubagentManager();
 
   // If a label was provided but didn't resolve, that's an error — don't fall
   // through to the "list all" path.
-  if (!subagentId && input.label) {
+  if (!subagentId && parsed.label) {
     return {
-      content: `No subagent found with label "${input.label as string}".`,
+      content: `No subagent found with label "${parsed.label}".`,
       isError: true,
     };
   }

--- a/assistant/src/tools/system/request-permission.ts
+++ b/assistant/src/tools/system/request-permission.ts
@@ -1,4 +1,10 @@
+import { z } from "zod";
+
 import { RiskLevel } from "../../permissions/types.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -52,6 +58,26 @@ const FRIENDLY_NAMES: Record<PermissionType, string> = {
   camera: "Camera",
 };
 
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. `activity`
+ * is advertised-required purely to guide the model (it is shown in the
+ * prompt UI, never read here), so it stays runtime-optional via
+ * `advertiseRequired`.
+ */
+export const requestSystemPermissionInputSchema = z.looseObject({
+  permission_type: z
+    .enum(PERMISSION_TYPES)
+    .describe("The macOS system permission to request"),
+  activity: z
+    .string()
+    .describe(
+      "Short explanation of why this permission is needed (shown in the prompt)",
+    )
+    .optional()
+    .catch(undefined),
+});
+
 export const requestSystemPermissionTool = {
   name: "request_system_permission",
   description:
@@ -62,39 +88,22 @@ export const requestSystemPermissionTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.High,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      permission_type: {
-        type: "string",
-        enum: [...PERMISSION_TYPES],
-        description: "The macOS system permission to request",
-      },
-      activity: {
-        type: "string",
-        description:
-          "Short explanation of why this permission is needed (shown in the prompt)",
-      },
-    },
-    required: ["permission_type", "activity"],
-  },
+  input_schema: toToolInputSchema(requestSystemPermissionInputSchema, {
+    advertiseRequired: ["activity"],
+  }),
 
   async execute(
     input: Record<string, unknown>,
     _context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const permType = input.permission_type as string;
-    if (!PERMISSION_TYPES.includes(permType as PermissionType)) {
-      return {
-        content: `Error: unknown permission type "${permType}". Valid types: ${PERMISSION_TYPES.join(
-          ", ",
-        )}`,
-        isError: true,
-      };
+    const parsed = requestSystemPermissionInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("request_system_permission", parsed.error);
     }
+    const permType = parsed.data.permission_type;
 
-    const friendly = FRIENDLY_NAMES[permType as PermissionType];
-    const settingsUrl = SETTINGS_URLS[permType as PermissionType];
+    const friendly = FRIENDLY_NAMES[permType];
+    const settingsUrl = SETTINGS_URLS[permType];
 
     return {
       content: [

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -1,6 +1,8 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 
+import { z } from "zod";
+
 import type { BackgroundToolCompletedEvent } from "../../api/events/background-tool-completed.js";
 import { getConfig } from "../../config/loader.js";
 import { RiskLevel } from "../../permissions/types.js";
@@ -30,6 +32,10 @@ import {
   formatShellOutput,
   MAX_OUTPUT_LENGTH,
 } from "../shared/shell-output.js";
+import {
+  invalidToolInputResult,
+  toToolInputSchema,
+} from "../shared/zod-tool-schema.js";
 import type { ProxyEnvVars } from "../tool-types.js";
 import type {
   ToolContext,
@@ -49,6 +55,55 @@ function buildCredentialRefTrace(
 
 const log = getLogger("shell-tool");
 
+/**
+ * Model-input schema, the single source for both runtime validation (via
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. Optional
+ * fields catch to `undefined` so a malformed value degrades exactly as the
+ * tool always degraded: `timeout_seconds` falls back to the configured
+ * default (it is also read defensively pre-execution by
+ * `computePerToolTimeoutMs`), `network_mode` falls back to "off" (the
+ * `=== "proxied"` coercion), `background` to foreground (the `=== true`
+ * coercion), `credential_ids` to none, and `activity` is status-only.
+ */
+export const shellInputSchema = z.looseObject({
+  command: z.string().min(1).describe("The shell command to execute"),
+  activity: z
+    .string()
+    .describe(
+      'Brief non-technical explanation of what this command does and why, shown to a non-technical user in the permission prompt. Avoid jargon and technical terms. Good: "to check if a required program is installed on your computer". Bad: "to check if gcloud CLI is installed". Good: "to download a helper program". Bad: "to run npm install".',
+    )
+    .optional()
+    .catch(undefined),
+  timeout_seconds: z
+    .number()
+    .describe(
+      "Optional timeout in seconds. Defaults to the configured default (120s). Cannot exceed the configured maximum.",
+    )
+    .optional()
+    .catch(undefined),
+  network_mode: z
+    .enum(["off", "proxied"])
+    .describe(
+      'Network access mode for the command. "off" (default) blocks network access; "proxied" routes traffic through the credential proxy.',
+    )
+    .optional()
+    .catch(undefined),
+  credential_ids: z
+    .array(z.string())
+    .describe(
+      'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
+    )
+    .optional()
+    .catch(undefined),
+  background: z
+    .boolean()
+    .describe(
+      "Run the command in the background. The tool returns immediately with a background tool ID. When the process exits, its output is delivered to the conversation as a wake.",
+    )
+    .optional()
+    .catch(undefined),
+});
+
 export const shellTool = {
   name: "bash",
   description: "Execute a shell command on the local machine",
@@ -56,55 +111,19 @@ export const shellTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Medium,
 
-  input_schema: {
-    type: "object",
-    properties: {
-      command: {
-        type: "string",
-        description: "The shell command to execute",
-      },
-      activity: {
-        type: "string",
-        description:
-          'Brief non-technical explanation of what this command does and why, shown to a non-technical user in the permission prompt. Avoid jargon and technical terms. Good: "to check if a required program is installed on your computer". Bad: "to check if gcloud CLI is installed". Good: "to download a helper program". Bad: "to run npm install".',
-      },
-      timeout_seconds: {
-        type: "number",
-        description:
-          "Optional timeout in seconds. Defaults to the configured default (120s). Cannot exceed the configured maximum.",
-      },
-      network_mode: {
-        type: "string",
-        enum: ["off", "proxied"],
-        description:
-          'Network access mode for the command. "off" (default) blocks network access; "proxied" routes traffic through the credential proxy.',
-      },
-      credential_ids: {
-        type: "array",
-        items: { type: "string" },
-        description:
-          'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
-      },
-      background: {
-        type: "boolean",
-        description:
-          "Run the command in the background. The tool returns immediately with a background tool ID. When the process exits, its output is delivered to the conversation as a wake.",
-      },
-    },
-    required: ["command", "activity"],
-  },
+  input_schema: toToolInputSchema(shellInputSchema, {
+    advertiseRequired: ["activity"],
+  }),
 
   async execute(
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const command = input.command as string;
-    if (!command || typeof command !== "string") {
-      return {
-        content: "Error: command is required and must be a string",
-        isError: true,
-      };
+    const parsed = shellInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return invalidToolInputResult("bash", parsed.error);
     }
+    const command = parsed.data.command;
 
     // Reject commands containing null bytes - they cause truncation at the
     // OS level while the parser sees the full string, enabling bypass.
@@ -112,7 +131,7 @@ export const shellTool = {
       return { content: "Error: command contains null bytes", isError: true };
     }
 
-    const background = input.background === true;
+    const background = parsed.data.background === true;
     if (background && context.diskPressureCleanupModeActive === true) {
       return {
         content:
@@ -123,15 +142,12 @@ export const shellTool = {
 
     const config = getConfig();
 
-    const networkMode: "off" | "proxied" =
-      input.network_mode === "proxied" ? "proxied" : "off";
+    const networkMode: "off" | "proxied" = parsed.data.network_mode ?? "off";
 
     const rawCredentialRefs: string[] = [];
-    if (Array.isArray(input.credential_ids)) {
-      for (const id of input.credential_ids) {
-        if (typeof id === "string" && id.length > 0) {
-          rawCredentialRefs.push(id);
-        }
+    for (const id of parsed.data.credential_ids ?? []) {
+      if (id.length > 0) {
+        rawCredentialRefs.push(id);
       }
     }
 
@@ -222,10 +238,7 @@ export const shellTool = {
     }
 
     const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = config.timeouts;
-    const requestedSec =
-      typeof input.timeout_seconds === "number"
-        ? input.timeout_seconds
-        : shellDefaultTimeoutSec;
+    const requestedSec = parsed.data.timeout_seconds ?? shellDefaultTimeoutSec;
     const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
     const timeoutMs = timeoutSec * 1000;
 

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -58,8 +58,8 @@ const log = getLogger("shell-tool");
 /**
  * Model-input schema, the single source for both runtime validation (via
  * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. Optional
- * fields catch to `undefined` so a malformed value degrades exactly as the
- * tool always degraded: `timeout_seconds` falls back to the configured
+ * fields catch to `undefined` so a malformed value degrades to its
+ * default: `timeout_seconds` falls back to the configured
  * default (it is also read defensively pre-execution by
  * `computePerToolTimeoutMs`), `network_mode` falls back to "off" (the
  * `=== "proxied"` coercion), `background` to foreground (the `=== true`

--- a/assistant/src/tools/tool-input-schemas.ts
+++ b/assistant/src/tools/tool-input-schemas.ts
@@ -5,7 +5,14 @@ import { fileEditInputSchema } from "./filesystem/edit.js";
 import { fileListInputSchema } from "./filesystem/list.js";
 import { fileReadInputSchema } from "./filesystem/read.js";
 import { fileWriteInputSchema } from "./filesystem/write.js";
+import { hostFileEditInputSchema } from "./host-filesystem/edit.js";
+import { hostFileReadInputSchema } from "./host-filesystem/read.js";
+import { hostFileWriteInputSchema } from "./host-filesystem/write.js";
+import { hostShellInputSchema } from "./host-terminal/host-shell.js";
 import { formatToolInputError } from "./shared/zod-tool-schema.js";
+import { notifyParentInputSchema } from "./subagent/notify-parent.js";
+import { requestSystemPermissionInputSchema } from "./system/request-permission.js";
+import { shellInputSchema } from "./terminal/shell.js";
 
 /**
  * Per-tool Zod input schemas, keyed by tool name. Tool calls are a
@@ -39,10 +46,17 @@ import { formatToolInputError } from "./shared/zod-tool-schema.js";
  */
 export const TOOL_INPUT_SCHEMAS: Readonly<Record<string, z.ZodType>> = {
   ask_question: askQuestionInputSchema,
+  bash: shellInputSchema,
   file_edit: fileEditInputSchema,
   file_list: fileListInputSchema,
   file_read: fileReadInputSchema,
   file_write: fileWriteInputSchema,
+  host_bash: hostShellInputSchema,
+  host_file_edit: hostFileEditInputSchema,
+  host_file_read: hostFileReadInputSchema,
+  host_file_write: hostFileWriteInputSchema,
+  notify_parent: notifyParentInputSchema,
+  request_system_permission: requestSystemPermissionInputSchema,
 };
 
 /**

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -13,19 +13,45 @@
  * by the type checker.
  */
 
+import { z } from "zod";
+
 import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of
+ * {@link executeManageWorkflows}. Same in-tool pattern and TOOLS.json drift
+ * guard as the other bundled-skill tools — see the schema block in
+ * `tools/document/document-tool.ts` for the framework.
+ *
+ * `action` is deliberately UNDECLARED (loose passthrough): the switch's
+ * default case owns the unknown-action error, and `executor.ts` reads
+ * `input.action` / `input.run_id` pre-execution for the requireFreshApproval
+ * promotion (those reads are already defensive and see the raw input either
+ * way).
+ */
+export const manageWorkflowsInputSchema = z.looseObject({
+  run_id: nullAsOmitted(z.string()),
+});
 
 export async function executeManageWorkflows(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const parsedInput = manageWorkflowsInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("manage_workflows", parsedInput.error);
+  }
   const action = input.action as string | undefined;
-  const runId = input.run_id as string | undefined;
+  const runId = parsedInput.data.run_id;
   const manager = getWorkflowRunManager();
 
   // Authorization scope ({@link callerOwnsWorkflowRun}, shared with the
@@ -104,7 +130,9 @@ export async function executeManageWorkflows(
       // Only signal a run the caller owns. A non-owned (or absent) run is a
       // no-op with the same response shape, so existence is never revealed.
       const run = manager.status(runId);
-      if (run && ownsRun(run)) manager.abort(runId);
+      if (run && ownsRun(run)) {
+        manager.abort(runId);
+      }
       return {
         content: JSON.stringify({
           runId,

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -27,7 +27,9 @@ mock.module("../../daemon/conversation-registry.js", () => ({
 let lastStartArgs: Record<string, unknown> | null = null;
 let startThrows: Error | null = null;
 const startMock = mock((opts: Record<string, unknown>) => {
-  if (startThrows) throw startThrows;
+  if (startThrows) {
+    throw startThrows;
+  }
   lastStartArgs = opts;
   return { runId: "run-123" };
 });
@@ -36,7 +38,9 @@ const abortMock = mock(() => {});
 const listMock = mock(() => [] as unknown[]);
 let resumeThrows: Error | null = null;
 const resumeMock = mock((runId: string) => {
-  if (resumeThrows) throw resumeThrows;
+  if (resumeThrows) {
+    throw resumeThrows;
+  }
   return { runId };
 });
 
@@ -419,5 +423,53 @@ describe("manage_workflows", () => {
       contactContext(),
     );
     expect(abortMock).toHaveBeenCalledWith("mine");
+  });
+});
+
+// ── model-input schema validation (LUM-2855) ────────────────────────
+
+describe("workflow tools — model-input schema validation", () => {
+  test("run_workflow rejects a non-string script", async () => {
+    const result = await executeRunWorkflow({ script: 42 }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "run_workflow"');
+    expect(result.content).toContain("script");
+    expect(startMock).not.toHaveBeenCalled();
+  });
+
+  test("run_workflow treats explicit null script/name as omitted (bespoke exactly-one error)", async () => {
+    const result = await executeRunWorkflow(
+      { script: null, name: null },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("exactly one");
+  });
+
+  test("run_workflow passes args through unvalidated (workflow runtime accepts any JSON)", async () => {
+    const result = await executeRunWorkflow(
+      { script: "export const meta = {}", args: ["positional"] },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(lastStartArgs?.args).toEqual(["positional"]);
+  });
+
+  test("manage_workflows rejects a non-string run_id", async () => {
+    const result = await executeManageWorkflows(
+      { action: "status", run_id: 42 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Invalid input for tool "manage_workflows"',
+    );
+    expect(result.content).toContain("run_id");
+  });
+
+  test("manage_workflows keeps the bespoke unknown-action error", async () => {
+    const result = await executeManageWorkflows({ action: 42 }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unknown action");
   });
 });

--- a/assistant/src/tools/workflows/run-workflow.ts
+++ b/assistant/src/tools/workflows/run-workflow.ts
@@ -15,12 +15,36 @@
  * of truth the model reads when generating the `script`.
  */
 
+import { z } from "zod";
+
 import { findConversation } from "../../daemon/conversation-registry.js";
 import { FALLBACK_TURN_TRUST } from "../../daemon/trust-context.js";
 import type { TrustContext } from "../../daemon/trust-context-types.js";
 import { CapabilityManifestSchema } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of {@link executeRunWorkflow}.
+ * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
+ * tools — see the schema block in `tools/document/document-tool.ts` for the
+ * framework.
+ *
+ * `args` (the workflow runtime accepts any JSON value) and `capabilities`
+ * (`CapabilityManifestSchema` is the single validation authority, and
+ * `executor.ts` reads it pre-execution for the requireFreshApproval
+ * promotion) are deliberately UNDECLARED — loose passthrough. The
+ * exactly-one-of script/name rule stays a bespoke check below.
+ */
+export const runWorkflowInputSchema = z.looseObject({
+  script: nullAsOmitted(z.string()),
+  name: nullAsOmitted(z.string()),
+  label: nullAsOmitted(z.string()),
+});
 
 /**
  * Resolve the {@link TrustContext} to forward to the run's leaves. Prefer the
@@ -33,7 +57,9 @@ function resolveTrustContext(context: ToolContext): TrustContext {
   const conversation = findConversation(context.conversationId);
   const fromConversation =
     conversation?.currentTurnTrustContext ?? conversation?.trustContext;
-  if (fromConversation) return fromConversation;
+  if (fromConversation) {
+    return fromConversation;
+  }
   return { ...FALLBACK_TURN_TRUST, trustClass: context.trustClass };
 }
 
@@ -41,8 +67,11 @@ export async function executeRunWorkflow(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const script = input.script as string | undefined;
-  const name = input.name as string | undefined;
+  const parsedInput = runWorkflowInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult("run_workflow", parsedInput.error);
+  }
+  const { script, name, label } = parsedInput.data;
 
   // Exactly one of script/name is required.
   if ((script == null) === (name == null)) {
@@ -54,7 +83,6 @@ export async function executeRunWorkflow(
   }
 
   const args = (input.args as Record<string, unknown> | undefined) ?? {};
-  const label = input.label as string | undefined;
   const trustContext = resolveTrustContext(context);
 
   try {


### PR DESCRIPTION
> **Stacked on #39292 (LUM-2856)** → #39290 → #39285 → #39283. Merge in order; GitHub retargets as each base merges. Only the last commit is new here.

## Summary

Final tranche of [LUM-2797](https://linear.app/vellum/issue/LUM-2797) ([LUM-2857](https://linear.app/vellum/issue/LUM-2857)): the remaining **default-owned built-ins** — `host_file_read` / `host_file_write` / `host_file_edit`, `bash`, `host_bash`, `request_system_permission`, and `notify_parent` — now use the full #39272 pattern: one Zod schema per tool module feeding (1) the central `TOOL_INPUT_SCHEMAS` gate, (2) the advertised `input_schema` derived via `toToolInputSchema` (the hand-written JSON literals are deleted), and (3) an in-tool `safeParse` for defense in depth on non-executor paths.

## Implementation

- Host filesystem schemas mirror the sandbox filesystem schemas from #39272, plus `target_client_id` with `.catch(undefined)` (a non-string or empty value has always meant "untargeted").
- `bash` / `host_bash`: `timeout_seconds` keeps `.catch(undefined)` — it is also read defensively pre-execution by `computePerToolTimeoutMs`, per the ticket's caution. `network_mode` / `background` catch too: the existing `=== "proxied"` / `=== true` coercions treat any non-matching value as the default, and catch-to-undefined degrades identically. `host_bash.working_dir` deliberately does **not** catch — the tool has always *rejected* a malformed working dir rather than silently running somewhere unintended; its null-byte/absolute-path checks stay bespoke.
- `request_system_permission.permission_type` is now the Zod enum (its bespoke includes-check became unreachable and was removed); `notify_parent.message` keeps its bespoke test-asserted `'"message" is required.'` via `nullAsOmitted` + `advertiseRequired`, and a malformed `urgency` now degrades to `"info"` instead of forwarding garbage to the parent notification.
- **Cleanup per ticket:** `computePreviewDiff` in `executor.ts` reuses `fileWriteInputSchema` / `fileEditInputSchema` instead of five type-guarded casts, so the approval preview reads exactly the shape the executor will.
- Out of scope, per ticket: `network/web-search-error.ts` (internal error-classification object, not model input); the non-manifest subagent tools (done in LUM-2855).

## Behavior notes

- One deliberate tolerant-direction change: `bash.credential_ids` with mixed-type entries (e.g. `[42, "id"]`) previously kept the string entries; a malformed array now catches to "no credentials". Valid arrays are unchanged.
- Host-tool error messages for missing/mistyped fields move to the gate's `Invalid input for tool "…"` format — test assertions updated per the ticket (the `file_list` precedent from #39272).

## Testing

- `host-file-read/write/edit-tool`, `host-shell-tool` suites updated to the new message format — all pass (16/11/14/…)
- `tool-input-schemas.test.ts` derived-schema block now covers all 12 registered tools — 13 pass
- `subagent-notify-parent.test.ts` — 18 pass (2 new validation tests)
- `background-shell-bash`, `background-shell-host-bash`, `shell-observability`, `shell-tool-proxy-mode`, `tool-executor`, `run-standalone`, `host-file-proxy(-targeted)`, `host-file-routes-targeted` — all pass unchanged
- Known: `shell-credential-ref.test.ts` has one **pre-existing** environment-dependent failure on this machine (its safe-env mock sets `PATH=/usr/bin`, which lacks `bash` here) — verified to fail identically without this change.
- `bunx tsc --noEmit` clean; eslint + prettier clean; `lint:circular` unchanged (201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Latent prod bugs fixed (tracking)

Live, reachable paths in production code — any malformed model call could trigger them; fixed by this PR's validation:

1. **`notify_parent` urgency corruption** — `(input.urgency as string) || "info"`: a number `42` is truthy, so it bypassed the fallback and was forwarded verbatim as the urgency into the parent conversation's notification path. Now degrades to `"info"`.
2. **`bash` / `host_bash` `command` truthy-only check** — `command: 42` passed `!command` and was cast to string for spawn; now rejected before the null-byte check.

(The host-file tools' own casts were already guarded by bespoke typeof checks, so this PR's registry entries there are defense-in-depth plus derived-schema single-sourcing rather than bug fixes.)
