### PR TITLE
fix(web): resolve platform assistant UUID before managed-email API calls

### DIFF
--- a/clients/web/src/domains/settings/ai/ai-page.test.tsx
+++ b/clients/web/src/domains/settings/ai/ai-page.test.tsx
@@ -48,6 +48,17 @@ mock.module("@/assistant/use-active-assistant-id", () => ({
   useActiveAssistantId: () => ASSISTANT_ID,
 }));
 
+// Platform-id resolution is effect-driven and never settles under
+// renderToStaticMarkup; resolve it synchronously so the managed form
+// (and the entitlement gate under test) renders.
+mock.module("@/hooks/use-platform-assistant-id", () => ({
+  usePlatformAssistantId: () => ({
+    platformAssistantId: ASSISTANT_ID,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 const { EmailServiceCard } = await import("@/domains/settings/ai/email-service-card");
 
 const ASSISTANT_HANDLE = "my-assistant";

--- a/clients/web/src/domains/settings/ai/email-service-card.tsx
+++ b/clients/web/src/domains/settings/ai/email-service-card.tsx
@@ -2,6 +2,7 @@ import {
     CircleCheck,
     ExternalLink,
     Info,
+    Loader2,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -14,6 +15,7 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import { credentialsInspectPost } from "@/generated/daemon/sdk.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { usePlatformAssistantId } from "@/hooks/use-platform-assistant-id";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useEnvironmentStore } from "@/stores/environment-store";
@@ -58,6 +60,21 @@ export function EmailServiceCard() {
     const raw = getLocalSetting(LS_EMAIL_BYO_PROVIDER, "resend");
     return raw === "mailgun" || raw === "resend" ? raw : "resend";
   });
+
+  // Managed email lives on the platform API, whose assistant routes key on
+  // the platform UUID — the local-mode lockfile id is a slug that no
+  // platform route matches. Resolve the platform id before rendering the
+  // managed form; on resolution failure fall back to the raw id so the
+  // platform can still answer with a real per-request error.
+  const {
+    platformAssistantId,
+    error: platformAssistantIdError,
+  } = usePlatformAssistantId(
+    assistantId,
+    platformGate === "full" && mode === "managed",
+  );
+  const managedAssistantId =
+    platformAssistantId ?? (platformAssistantIdError ? assistantId : null);
 
   // -- BYO credential check (your-own mode) ----------------------------------
   const byoCredentialQuery = useQuery({
@@ -203,9 +220,14 @@ export function EmailServiceCard() {
             <PlatformLoginNotice>
               Log in to the Vellum platform to manage email settings.
             </PlatformLoginNotice>
+          ) : managedAssistantId === null ? (
+            <div className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)]">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Connecting to the Vellum platform…
+            </div>
           ) : (
             <EmailManagedContent
-              assistantId={assistantId}
+              assistantId={managedAssistantId}
               assistantHandle={assistantHandle}
               emailRootDomain={emailRootDomain}
             />

--- a/clients/web/src/domains/settings/pages/integrations-page.test.tsx
+++ b/clients/web/src/domains/settings/pages/integrations-page.test.tsx
@@ -26,8 +26,8 @@ mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   }),
 }));
 
-mock.module("@/hooks/use-managed-oauth-platform-assistant-id", () => ({
-  useManagedOAuthPlatformAssistantId: () => ({
+mock.module("@/hooks/use-platform-assistant-id", () => ({
+  usePlatformAssistantId: () => ({
     platformAssistantId: "platform-assistant-123",
     isLoading: false,
   }),

--- a/clients/web/src/domains/settings/pages/integrations-page.tsx
+++ b/clients/web/src/domains/settings/pages/integrations-page.tsx
@@ -15,7 +15,7 @@ import { McpPage } from "@/domains/settings/mcp/mcp-page";
 import { assistantsOauthConnectionsListOptions } from "@/generated/api/@tanstack/react-query.gen";
 import type { OAuthConnection } from "@/generated/api/types.gen";
 import { oauthProvidersGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
-import { useManagedOAuthPlatformAssistantId } from "@/hooks/use-managed-oauth-platform-assistant-id";
+import { usePlatformAssistantId } from "@/hooks/use-platform-assistant-id";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
@@ -96,7 +96,7 @@ function IntegrationsPanelInner() {
   const {
     platformAssistantId,
     isLoading: platformAssistantIdLoading,
-  } = useManagedOAuthPlatformAssistantId(assistant?.id, platformGate === "full");
+  } = usePlatformAssistantId(assistant?.id, platformGate === "full");
 
   const {
     data: providers,

--- a/clients/web/src/hooks/use-platform-assistant-id.ts
+++ b/clients/web/src/hooks/use-platform-assistant-id.ts
@@ -2,17 +2,25 @@ import { useEffect, useState } from "react";
 
 import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 
-type ManagedOAuthPlatformAssistantIdState = {
+type PlatformAssistantIdState = {
   platformAssistantId: string | null;
   isLoading: boolean;
   error: Error | null;
 };
 
-export function useManagedOAuthPlatformAssistantId(
+/**
+ * Resolve the active assistant's **platform** id for platform-API path
+ * params. Local-mode lockfile ids are slugs (e.g. `vellum-dark-cub`),
+ * but every platform assistant route uses a `<uuid:assistant_id>` path
+ * converter — a slug id falls off Django's URL table and surfaces as a
+ * bare "Not found". Platform-hosted ids (already UUIDs) resolve to
+ * themselves without any network round-trip.
+ */
+export function usePlatformAssistantId(
   assistantId: string | null | undefined,
   enabled: boolean,
-): ManagedOAuthPlatformAssistantIdState {
-  const [state, setState] = useState<ManagedOAuthPlatformAssistantIdState>({
+): PlatformAssistantIdState {
+  const [state, setState] = useState<PlatformAssistantIdState>({
     platformAssistantId: null,
     isLoading: false,
     error: null,


### PR DESCRIPTION
## Summary

Registering a managed-email subdomain from the Email settings card failed with a bare **"Not found"** for local-mode assistants. The card passed the active assistant id straight into platform-API path params — in local mode that id is the lockfile slug (e.g. `vellum-dark-cub`), not the platform UUID stored separately as `platformAssistantId`.

## Why this is needed

Local-mode assistants have **two identities**: the lockfile `assistantId` (a slug, used by the daemon/gateway) and the `platformAssistantId` (a UUID, minted when the assistant registers with the platform). Managed email is a platform-owned feature, and every platform assistant route — including the runtime-proxy wildcard — uses a `<uuid:assistant_id>` path converter. A slug id therefore matches *no* Django URL pattern at all: the platform's generic 404 handler answers with `{"error": {"code": "not_found", "message": "Not found"}}`, which `extractErrorMessage` renders verbatim under the subdomain field. The same wrong id also silently 404'd the card's domains/addresses list queries, so an already-registered domain would never display either. Without this change, managed email is unusable from a local-mode assistant.

## Before / after

**Before** (local-mode assistant):
1. Open Settings → AI → Email (Managed), type a subdomain, click **Register**, confirm.
2. `POST /v1/assistants/vellum-dark-cub/domains/` → platform URL resolution fails → generic 404.
3. The field shows an unactionable red **"Not found"**. Retrying, changing the subdomain, or re-authing changes nothing. If a domain *was* already registered (e.g. via CLI), the card still shows the empty registration form because the list queries 404 the same way.

**After**:
1. The managed tab briefly shows "Connecting to the Vellum platform…" while the platform UUID resolves (cached; platform-hosted assistants and repeat visits resolve instantly).
2. `POST /v1/assistants/019e2208-…/domains/` reaches the real endpoint.
3. The user gets the real outcome: successful registration, or an actionable error from the actual viewset ("This subdomain is already taken.", entitlement 403, etc.). Existing domains/addresses now list correctly.

## How it fixes the issue

`EmailServiceCard` now resolves the platform assistant id before rendering the managed form, via the same machinery the integrations/OAuth pages already use — `resolveLocalAssistantPlatformIdentity()`, which returns the id unchanged when it's already a UUID or the app isn't in local mode, and otherwise resolves and caches the platform UUID through the local gateway's `platform/status` endpoint. The wrapping hook is renamed `useManagedOAuthPlatformAssistantId` → `usePlatformAssistantId` (it was never OAuth-specific); the integrations page, its only prior consumer, is updated for the rename. The managed form never fires a query with an unresolved id: the spinner gates rendering, including the pre-effect first paint.

## Why it's safe

- **Platform-hosted assistants are unaffected.** Their id is already the platform UUID, so resolution short-circuits to the input value — no network round-trip, no behavior change beyond one imperceptible effect tick.
- **No new code paths.** The resolver + hook are the exact pattern the integrations page has shipped with; this PR only adds a consumer and renames. The rename touches one production call site and one test mock.
- **Degraded mode preserved.** If resolution fails (local gateway unreachable), the card falls back to the raw id rather than dead-ending — same precedent as `integrations-page.tsx` — so the platform still answers with a real per-request error.
- **Scoped to the managed tab.** The hook is enabled only when `platformGate === "full"` and the managed mode is selected; the BYO branch keeps the daemon-bound `credentialsInspectPost` call on the local id, which is correct for daemon routes.
- **Audit for siblings.** The email card was the only component mixing the local id into platform assistant-scoped paths; other `useActiveAssistantId` + platform-SDK consumers use platform-owned data for their path params.

## Testing

- `bunx tsc --noEmit` clean; eslint no errors on touched files.
- `bun test src/domains/settings/ai/ai-page.test.tsx src/domains/settings/pages/integrations-page.test.tsx` — 5/5 pass. The email gate test now mocks `usePlatformAssistantId` (it renders via `renderToStaticMarkup`, where effects never run).
- Manual: with a local-mode assistant, the register call should now target `/v1/assistants/<platform-uuid>/domains/` and succeed or return a real validation error instead of "Not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)