### PR TITLE
feat: add Kimi K3 to the Fireworks provider catalog

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -833,6 +833,22 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       {
+        id: "accounts/fireworks/models/kimi-k3",
+        displayName: "Kimi K3",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        adaptiveThinkingOnly: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 3,
+          outputPer1mTokens: 15,
+          cacheReadPer1mTokens: 0.3,
+        },
+      },
+      {
         id: "accounts/fireworks/models/kimi-k2p6",
         displayName: "Kimi K2.6",
         contextWindowTokens: 262144,

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -301,6 +301,15 @@ export const MODELS_BY_PROVIDER = {
   ],
   fireworks: [
     {
+      id: "accounts/fireworks/models/kimi-k3",
+      displayName: "Kimi K3",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+      adaptiveThinkingOnly: true,
+    },
+    {
       id: "accounts/fireworks/models/kimi-k2p6",
       displayName: "Kimi K2.6",
       contextWindowTokens: 262_144,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -725,6 +725,24 @@
       "defaultModel": "accounts/fireworks/models/kimi-k2p5",
       "models": [
         {
+          "id": "accounts/fireworks/models/kimi-k3",
+          "displayName": "Kimi K3",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "adaptiveThinkingOnly": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 3,
+            "outputPer1mTokens": 15,
+            "cacheReadPer1mTokens": 0.3
+          }
+        },
+        {
           "id": "accounts/fireworks/models/kimi-k2p6",
           "displayName": "Kimi K2.6",
           "contextWindowTokens": 262144,


### PR DESCRIPTION
Fireworks now serves Kimi K3, so expose it as a selectable model on the Fireworks provider (daemon + web UI).

- `assistant/src/providers/model-catalog.ts`: new `accounts/fireworks/models/kimi-k3` entry — 1M context, 131,072 max output, adaptive-only thinking, vision, tool use, caching; $3 in / $15 out / $0.30 cache reads per 1M tokens, matching the [Fireworks model page](https://app.fireworks.ai/models/fireworks/kimi-k3).
- `meta/llm-provider-catalog.json`: regenerated via `bun run sync:llm-catalog`.
- `clients/web/src/assistant/llm-model-catalog.ts`: mirrored the UI subset.

Managed ("Vellum") routing and the model pickers derive from the catalog, so no other code changes are needed. `maxEffort` is omitted to inherit the provider default, same as the OpenRouter Kimi K3 entry; `weak-open-model` deliberately excludes K3 per its docblock.

Tests: `llm-catalog-parity.test.ts` (daemon) and `llm-model-catalog.test.ts` (web) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BE1YhEVUqsMQoMYDFPRQe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->