### PR TITLE
ci(ios): don't fail every iOS release on the unprovisioned extension profile

### DIFF
--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -164,6 +164,7 @@ jobs:
             || { echo "::error::Apple Distribution identity not found in keychain."; exit 1; }
 
       - name: Install provisioning profiles
+        id: profiles
         env:
           IOS_PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE }}
           IOS_PROVISIONING_PROFILE_STAGING: ${{ secrets.IOS_PROVISIONING_PROFILE_STAGING }}
@@ -175,24 +176,43 @@ jobs:
           PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$PROFILE_DIR"
 
-          # Both profiles are required. The archive embeds the VoiceActivity
-          # appex, and neither `xcodebuild archive` nor `-exportArchive` can
-          # sign a bundle whose profile is absent. The filenames must differ:
-          # a second write to the same name silently clobbers the first, and
-          # the failure surfaces much later as an opaque export error.
+          # The filenames must differ: a second write to the same name
+          # silently clobbers the first, and the failure surfaces much later
+          # as an opaque export error.
+          #
+          # Returns non-zero when the secret is empty, leaving how fatal that
+          # is to the caller.
           install_profile() {
             local key="$1" filename="$2"
             local b64="${!key}"
             if [ -z "$b64" ]; then
-              echo "::error::Provisioning profile secret $key is empty"
-              exit 1
+              return 1
             fi
             echo "$b64" | base64 -D > "$PROFILE_DIR/$filename"
             echo "Provisioning profile installed from $key"
           }
 
-          install_profile "${{ steps.config.outputs.profile_key }}" ios_distribution.mobileprovision
-          install_profile "${{ steps.config.outputs.ext_profile_key }}" ios_distribution_ext.mobileprovision
+          # The app profile is non-negotiable: without it there is no build to
+          # attempt, and no later step could produce a more useful error.
+          APP_PROFILE_KEY="${{ steps.config.outputs.profile_key }}"
+          if ! install_profile "$APP_PROFILE_KEY" ios_distribution.mobileprovision; then
+            echo "::error::Provisioning profile secret $APP_PROFILE_KEY is empty"
+            exit 1
+          fi
+
+          # A missing extension profile is tolerated: the App IDs and profiles
+          # behind IOS_PROVISIONING_PROFILE_EXT* do not exist in the Apple
+          # Developer portal yet. The archive fails either way, so exiting here
+          # would only replace Xcode's precise, target-named signing error with
+          # an opaque one — and it would do so on releases whose only fault is
+          # sharing a workflow with the extension.
+          EXT_PROFILE_KEY="${{ steps.config.outputs.ext_profile_key }}"
+          if install_profile "$EXT_PROFILE_KEY" ios_distribution_ext.mobileprovision; then
+            echo "ext_profile_installed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ext_profile_installed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Provisioning profile secret $EXT_PROFILE_KEY is empty, so the VoiceActivity extension profile was not installed and is omitted from ExportOptions.plist. THIS RELEASE WILL STILL FAIL: every app target embeds the extension, so 'xcodebuild archive' stops at signing with \"No profile for team ... matching '${{ steps.config.outputs.ext_profile_name }}' found ... (in target 'VoiceActivity ...')\". No iOS release of any environment can be produced until the portal setup lands. Fix: follow 'Manual Apple Developer portal setup' in clients/ios/README.md to create the App ID and profile, then add $EXT_PROFILE_KEY."
+          fi
 
       - name: Set version
         id: version
@@ -211,7 +231,10 @@ jobs:
 
       # `provisioningProfiles` needs one entry per signed bundle, not just the
       # app: `-exportArchive` fails when an embedded extension has no entry,
-      # and its error does not name the offending extension.
+      # and its error does not name the offending extension. It fails just as
+      # hard on an entry naming a profile that was never installed, so the
+      # extension entry follows the install step's outcome rather than
+      # re-testing the secret here — the two decisions have to agree.
       - name: Generate ExportOptions.plist
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -219,8 +242,15 @@ jobs:
           PROFILE_NAME: ${{ steps.config.outputs.profile_name }}
           EXT_BUNDLE_ID: ${{ steps.config.outputs.ext_bundle_id }}
           EXT_PROFILE_NAME: ${{ steps.config.outputs.ext_profile_name }}
+          EXT_PROFILE_INSTALLED: ${{ steps.profiles.outputs.ext_profile_installed }}
           TESTFLIGHT_INTERNAL: ${{ steps.config.outputs.testflight_internal }}
         run: |
+          EXT_ENTRY=""
+          if [ "$EXT_PROFILE_INSTALLED" = "true" ]; then
+            EXT_ENTRY="<key>$EXT_BUNDLE_ID</key>
+                  <string>$EXT_PROFILE_NAME</string>"
+          fi
+
           INTERNAL_ENTRY=""
           if [ "$TESTFLIGHT_INTERNAL" = "true" ]; then
             INTERNAL_ENTRY="    <key>testFlightInternalTestingOnly</key>
@@ -241,8 +271,7 @@ jobs:
               <dict>
                   <key>$BUNDLE_ID</key>
                   <string>$PROFILE_NAME</string>
-                  <key>$EXT_BUNDLE_ID</key>
-                  <string>$EXT_PROFILE_NAME</string>
+                  $EXT_ENTRY
               </dict>
               $INTERNAL_ENTRY
           </dict>

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -579,6 +579,25 @@ an Apple Developer team admin (Vocify, Inc., team `7FZDXZR8P5`) has to
 register them by hand. Until all three environments are done, a release
 build of the affected environment fails while signing or exporting.
 
+> **What happens today, with the secrets absent.** This is expected, not a
+> regression. `release-ios.yaml` does not hard-fail on a missing
+> `IOS_PROVISIONING_PROFILE_EXT*`: "Install provisioning profiles" logs a
+> `::warning::` naming the secret, skips the install, and — kept consistent
+> through the step's `ext_profile_installed` output — omits the extension
+> from `ExportOptions.plist`, since an entry naming an uninstalled profile
+> fails `-exportArchive` on its own.
+>
+> The run still fails, one step later, at **Archive**, with Xcode's own
+> error: `No profile for team '7FZDXZR8P5' matching '<profile name>' found
+> … (in target 'VoiceActivity …')`. That is unavoidable — every app target
+> embeds its extension, and the release archives with
+> `CODE_SIGN_STYLE=Manual`, which never auto-provisions. **No iOS release,
+> of any environment, can be produced until the rows below are done.**
+> Deleting the extension's `PROVISIONING_PROFILE_SPECIFIER_Manual` does not
+> help either; manual signing then fails with `"VoiceActivity …" requires a
+> provisioning profile` instead. The fix is the portal work below, not a
+> workflow change.
+
 | Environment | Extension bundle ID | Profile name (exact) | GitHub secret |
 |-------------|---------------------|----------------------|---------------|
 | production | `ai.vocify-inc.vellum-assistant-ios.VoiceActivity` | `Vellum Assistant iOS VoiceActivity Distribution` | `IOS_PROVISIONING_PROFILE_EXT` |


### PR DESCRIPTION
## Problem

`install_profile` hard-fails (`exit 1`) on an empty provisioning-profile secret, and this branch started calling it for the new `VoiceActivity` extension via `IOS_PROVISIONING_PROFILE_EXT` / `_EXT_STAGING` / `_EXT_DEV`. **Those three secrets do not exist** — the Apple Developer portal App IDs and profiles behind them are documented human work that has not happened yet (`clients/ios/README.md` § "Manual Apple Developer portal setup").

So every iOS release run — dev, staging, and production, including releases with nothing to do with voice mode — would die at "Install provisioning profiles" before anything was attempted.

## Change

The **app** profile keeps its hard failure verbatim; without it there is genuinely no build to attempt. `install_profile` now returns non-zero instead of exiting, and the app caller re-raises the same `::error::` and exits 1.

The **extension** profile degrades instead:

- Emits a loud `::warning::` naming the empty secret and pointing at the README section.
- Records `ext_profile_installed` as a step output, and the `ExportOptions.plist` step keys the extension's `provisioningProfiles` entry off **that output** rather than re-testing the secret. The two have to agree: an entry naming a profile that was never installed fails `-exportArchive` on its own, so skipping the install without skipping the entry would just move the breakage.
- The extension's `PROVISIONING_PROFILE_SPECIFIER_Manual` xcconfig values are untouched.

Matches the existing house pattern for an absent optional signing secret (`release.yml`'s `CRX_PRIVATE_KEY` skip).

## Does the archive survive without the extension profile? No — verified, and the warning says so

I did not want to assert the comfortable version of this, so I reproduced it. A minimal XcodeGen project (app + embedded `app-extension`, same `CODE_SIGN_STYLE = $(PROVISIONING_PROFILE_SPECIFIER_$(CODE_SIGN_STYLE))` indirection as `Base.xcconfig`) archived under the workflow's exact `xcodebuild archive ... CODE_SIGN_STYLE=Manual` invocation, with the app target signing cleanly and **only** the extension's profile absent:

```
error: No profile for team '…' matching '…' found … (in target 'SigExt' from project 'SigTest')
** ARCHIVE FAILED **
```

The extension alone is sufficient to fail the archive, so `-exportArchive` is never reached. Every app target embeds its extension and manual signing never auto-provisions, so **the iOS release pipeline remains blocked for all three environments until the portal work lands** — this PR does not unblock it and does not claim to. I also confirmed that deleting the extension specifier (which this PR deliberately does not do) would not help either: manual signing then fails with `"SigExt" requires a provisioning profile`.

What this PR buys is that the failure lands at Archive as Xcode's own error naming the offending target, next to a warning that says which secret is missing and where the instructions are — instead of an opaque `exit 1` in a workflow step. The plist/install consistency also means nothing else breaks the moment the secrets do land.

`clients/ios/README.md` gets a note recording exactly this, so the next person hitting the warning knows it is expected and that the fix is the portal work, not a workflow change.

## Verification

- Workflow YAML parses; `Generate ExportOptions.plist` resolves `EXT_PROFILE_INSTALLED` from the `profiles` step.
- Smoke-tested the **actual** `run:` scripts extracted from the YAML, with the extension secret empty vs. populated:
  - empty → warning, `ext_profile_installed=false`, only `ios_distribution.mobileprovision` installed, plist contains only the app entry;
  - populated → no warning, both profiles installed, plist contains both entries.
  - Both plists pass `plutil -lint`; `testFlightInternalTestingOnly` unaffected.
- Empty **app** secret still exits 1 with the original `::error::`.
- Cannot run a real release.