### PR TITLE
build(ios): enforce extension-safe API and build-verify iOS on main

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -1,8 +1,9 @@
-name: PR iOS Checks
+name: CI/CD Main iOS
 
 on:
-  pull_request:
-    types: [synchronize, opened, reopened]
+  workflow_dispatch:
+  push:
+    branches: [main]
     paths:
       - 'package.json'
       - 'bun.lock'
@@ -10,16 +11,18 @@ on:
       - 'clients/ios/**'
       - 'clients/web/capacitor.config.ts'
       - 'clients/web/package.json'
-      - '.github/workflows/pr-ios.yaml'
+      - '.github/workflows/ci-main-ios.yaml'
 
 concurrency:
-  group: pr-ios-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     name: Build
-    # Duplicated as the post-merge gate in `ci-main-ios.yaml`; change both.
+    # Same build as `pr-ios.yaml`, re-run after merge: both are path-filtered,
+    # so two PRs that pass independently can still land a broken `main`.
+    # Change the two together.
     #
     # Runner and Xcode match `release-ios.yaml` so this check exercises the
     # same toolchain that produces TestFlight builds.

--- a/clients/ios/App/App/Config/Extension-Base.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Base.xcconfig
@@ -57,6 +57,20 @@ IPHONEOS_DEPLOYMENT_TARGET = 17.0
 // the value is keyed off CODE_SIGN_STYLE.
 PROVISIONING_PROFILE_SPECIFIER = $(PROVISIONING_PROFILE_SPECIFIER_$(CODE_SIGN_STYLE))
 
+// Turns extension-unsafe API — `UIApplication.shared` above all — into a
+// compile error rather than an App Store validation rejection ("linked
+// against non-extension-safe API"). That error is the backstop the
+// `#if VOICE_ACTIVITY_EXTENSION` guard in `App/Shared/VoiceModeDeepLink.swift`
+// relies on, and `clients/ios/docs/NATIVE_VOICE.md` asserts as an invariant.
+//
+// Redundant on Xcode 26.6, which already derives YES from PRODUCT_TYPE =
+// app-extension — and stated anyway, because nothing else in the repo
+// does. XcodeGen's `app-extension` preset contributes only
+// LD_RUNPATH_SEARCH_PATHS and the generated pbxproj carries no value, so
+// without this line an invariant the docs promise would be owned
+// entirely by an Xcode default. Same reasoning as SKIP_INSTALL below.
+APPLICATION_EXTENSION_API_ONLY = YES
+
 // Required for an embedded extension: the appex is copied into the app
 // bundle by the embed phase, and must not also be installed at the
 // archive root.

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -265,12 +265,18 @@ assertionFailure("Voice intents are performed in the app process, not the appex"
 #endif
 ```
 
-Two things make the body impossible to compile into the appex:
+Two things make the body impossible to compile into the appex. Delete the guard
+and build `VoiceActivity Dev` to see both:
 
 - **`UIApplication.shared` is unavailable under
-  `APPLICATION_EXTENSION_API_ONLY`**, which Xcode sets for app extensions. It is
-  a hard compile error, not a warning.
-- **`AppDelegate` links Capacitor**, which the appex does not — and must not.
+  `APPLICATION_EXTENSION_API_ONLY`** — `error: 'shared' is unavailable in
+  application extensions for iOS`. A hard compile error, not a warning. The
+  setting is pinned in
+  [`App/Config/Extension-Base.xcconfig`](../App/App/Config/Extension-Base.xcconfig)
+  so the guarantee is the repo's rather than an Xcode default's.
+- **`AppDelegate` links Capacitor**, which the appex does not — and must not. It
+  is not even compiled into the extension, whose sources are `VoiceActivity/`
+  plus `App/Shared/`: `error: cannot find type 'AppDelegate' in scope`.
 
 The signature stays, so callers compile on both sides. That matters because
 `StartNewVoiceConversationIntent` lives in `Shared/`: `StartVoiceControl` builds
@@ -428,7 +434,9 @@ Capacitor SPM graph (`IONFilesystemLib`), which is environmental and pre-existin
 — unrelated to anything here. **CI is the app-build gate**: `pr-ios.yaml` builds
 the `App Dev` scheme unsigned on every PR touching `clients/ios/**`, and the
 extension is embedded, so it builds too. Do not treat a green extension-only
-build as a green app build.
+build as a green app build. `ci-main-ios.yaml` runs the same build on pushes to
+`main`, because both workflows are path-filtered: two PRs that pass
+independently can still merge into a broken `main`.
 
 ### Device-only
 


### PR DESCRIPTION
Two infrastructure gaps found by an integration review of the iOS voice-mode branch.

## 1. `APPLICATION_EXTENSION_API_ONLY` is now stated in the repo

`Extension-Base.xcconfig` sets `APPLICATION_EXTENSION_API_ONLY = YES`, verified via
`-showBuildSettings` on all three extension targets (`VoiceActivity`, `VoiceActivity Staging`,
`VoiceActivity Dev`). App targets are unaffected (`NO`, the Xcode default). `VoiceActivity Dev`
still builds: `** BUILD SUCCEEDED **`.

**What the guard-removal experiment proved — and where the review's premise was wrong.**
Deleting the `#if VOICE_ACTIVITY_EXTENSION` guard in `VoiceModeDeepLink.swift` does fail the
extension build, so the compiler backstop the docs describe is real:

```
error: cannot find type 'AppDelegate' in scope
```

That is the *second* documented reason firing first — the appex compiles only `VoiceActivity/`
plus `App/Shared/`, so `AppDelegate` does not exist there, and it masks the availability check.
Isolating the first reason (`_ = UIApplication.shared.delegate`, no `AppDelegate`) produces
exactly the claimed error:

```
error: 'shared' is unavailable in application extensions for iOS:
       Use view controller based solutions where appropriate instead.
```

But the review's premise — that the appex *currently* compiles extension-unsafe API — does not
hold on this toolchain. Reverting the xcconfig line and rebuilding produces the same failure, and
`-showBuildSettings` still reports `YES`: **Xcode 26.6 derives the setting from
`PRODUCT_TYPE = com.apple.product-type.app-extension`**, not from the template. Confirmed from
both ends — XcodeGen 2.44.1's `app-extension` preset contributes only `LD_RUNPATH_SEARCH_PATHS`,
and the generated `project.pbxproj` contains zero occurrences of the key. Xcode 26 also actively
enforces it: overriding `APPLICATION_EXTENSION_API_ONLY=NO` on the command line fails the build
with *"Application extensions and any libraries they link to must be built with the
`APPLICATION_EXTENSION_API_ONLY` build setting set to YES."*

So the docs were right and the appex was never unguarded. The line is kept anyway — it is a no-op
on this toolchain and pins an invariant the docs promise to the repo instead of to an Xcode
default. `NATIVE_VOICE.md` is corrected to describe that mechanism, to quote both real errors, and
to stop attributing the setting to a template the project does not use.

## 2. iOS Swift is now build-verified on `main`

New `.github/workflows/ci-main-ios.yaml` runs `pr-ios.yaml`'s unsigned `App Dev` build on pushes
to `main`. Shape follows `ci-main-macos.yaml`: `${{ github.workflow }}-${{ github.ref }}`
concurrency with `cancel-in-progress`, and no Slack notify job — `send-build-alert` is used by the
six service/web `ci-main-*` workflows and by none of the four client-side ones. `workflow_dispatch`
is included, as 8 of 10 existing `ci-main-*` workflows have it.

`bun.lock`, root `package.json`, and `patches/**` are added to the `paths:` filter of **both**
`pr-ios.yaml` and `ci-main-ios.yaml` — `pr-macos.yaml` filters on all three, and any of them can
change the Capacitor native dependency graph. All `uses:` stay pinned to 40-char SHAs with
`# vX.Y.Z` comments.

Both workflows parse, and their `build` jobs compare structurally equal, so the intentional
duplication starts in lockstep; each file carries a one-line pointer at its twin per root
`AGENTS.md` § Workflow duplication.