### PR TITLE
fix(ios): dedupe cold-launch URL delivery, unblock termination, mark stale activities

### DIFF
--- a/clients/ios/App/App/AppDelegate.swift
+++ b/clients/ios/App/App/AppDelegate.swift
@@ -8,22 +8,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // A QR scan that launches the terminated app delivers the connect URL
-        // here, not through `application(_:open:)` (which only covers warm
-        // opens). Persist the origin now so the bridge boots to it.
+        // here as well as through `application(_:open:)`. Persist the origin
+        // now, synchronously, so the bridge boots straight to it — by the time
+        // the `open:` call lands, `instanceDescriptor()` may already have run.
         if let url = launchOptions?[.url] as? URL, !handleConnectDeepLink(url) {
             // Every *other* custom-scheme launch URL — a `voice` link from an
-            // App Intent, the Live Activity, or Safari — would otherwise be
-            // dropped on the floor. Unlike the warm-open `application(_:open:)`
-            // path, this one never reaches `ApplicationDelegateProxy`, and the
-            // bridge web view does not exist yet, so there is nothing to
-            // forward to. Stash it and replay it once the web view is live.
+            // App Intent, the Live Activity, or Safari — is stashed as a
+            // *backstop*, not as the delivery. See `launchURL` for why it is
+            // both kept and deduped.
+            launchURL = url
             pendingVoiceCommandURL = url
         }
         return true
     }
 
     func applicationWillResignActive(_ application: UIApplication) {}
-    func applicationDidEnterBackground(_ application: UIApplication) {}
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Launch-URL dedupe is scoped to the launch. Re-opening the identical
+        // URL later requires leaving this app first, so anything arriving after
+        // a background transition is a genuinely new open, never the launch
+        // URL arriving twice.
+        launchURL = nil
+        launchURLWasReplayed = false
+    }
     func applicationWillEnterForeground(_ application: UIApplication) {}
     func applicationDidBecomeActive(_ application: UIApplication) {}
     /// A backgrounded voice session keeps the app alive (the `audio` background
@@ -36,6 +43,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         if handleConnectDeepLink(url) {
+            return true
+        }
+        if swallowIfLaunchURLAlreadyDelivered(url) {
             return true
         }
         return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
@@ -172,6 +182,71 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// superseded command is stale by definition.
     private var pendingVoiceCommandURL: URL?
 
+    /// The URL this process was launched with (`launchOptions[.url]`), while it
+    /// is still eligible to arrive a second time through
+    /// `application(_:open:)`.
+    ///
+    /// UIKit delivers a cold-launch URL through **both** routes on a non-scene
+    /// app: `launchOptions[.url]` here, *and* `application(_:open:options:)`,
+    /// which "is not called if your implementations return false from both the
+    /// `application(_:willFinishLaunchingWithOptions:)` and
+    /// `application(_:didFinishLaunchingWithOptions:)` methods"
+    /// (https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:open:options:)).
+    /// This delegate implements only the latter and returns `true`
+    /// unconditionally, so the `open:` call always comes — which is why a stock
+    /// Capacitor app, whose delegate handles URLs only in `application(_:open:)`,
+    /// receives `appUrlOpen` from a terminated state at all.
+    ///
+    /// The launch stash is kept anyway, because the `open:` route has a race of
+    /// its own: `ApplicationDelegateProxy` delivers by posting
+    /// `.capacitorOpenURL`, and `AppPlugin` only subscribes in its `load()`, so
+    /// a URL that arrives before the bridge finishes registering plugins has no
+    /// observer and is dropped. Nothing in the web layer calls
+    /// `App.getLaunchUrl()`, Capacitor's usual escape hatch for exactly that.
+    ///
+    /// So: `open:` is the delivery, the stash is the backstop, and this holds
+    /// the identity that lets whichever one loses the race stay silent.
+    private var launchURL: URL?
+
+    /// Whether the backstop replayed ``launchURL`` before `application(_:open:)`
+    /// got to it, so the `open:` call that follows is recognized as the same
+    /// delivery rather than a second one.
+    private var launchURLWasReplayed = false
+
+    /// Reconcile an `application(_:open:)` call against the launch URL,
+    /// answering whether it is a second delivery of something the web layer
+    /// already has and should be dropped here.
+    ///
+    /// Three cases, and only the launch URL reaches any of them:
+    ///
+    /// 1. The backstop already replayed it — swallow, the web layer has it.
+    /// 2. The bridge is up, so this forward will be observed. Drop the backstop
+    ///    and deliver here.
+    /// 3. The bridge is not up yet: `ApplicationDelegateProxy` posts
+    ///    `.capacitorOpenURL` to an `AppPlugin` that has not subscribed, so this
+    ///    forward goes nowhere. Keep the backstop — it is the only delivery
+    ///    left. The forward still happens, harmlessly, and sets the proxy's
+    ///    `lastURL` for `App.getLaunchUrl()`.
+    ///
+    /// The bridge check is `webView != nil`, which is exactly what the replay
+    /// waits for: `CAPBridgeViewController` builds the web view and registers
+    /// plugins in one synchronous `viewDidLoad`, so from the outside the two are
+    /// the same fact.
+    private func swallowIfLaunchURLAlreadyDelivered(_ url: URL) -> Bool {
+        guard url == launchURL else { return false }
+        if launchURLWasReplayed {
+            launchURL = nil
+            launchURLWasReplayed = false
+            return true
+        }
+        guard currentBridgeViewController()?.webView != nil else {
+            return false
+        }
+        launchURL = nil
+        pendingVoiceCommandURL = nil
+        return false
+    }
+
     /// Hand a voice command to the web layer, deferring until the bridge web
     /// view exists.
     ///
@@ -194,6 +269,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// code. `AppPlugin` posts that event with `retainUntilConsumed: true`, so a
     /// command delivered before the SPA has registered its listener is replayed
     /// rather than lost.
+    ///
+    /// Exactly one delivery of a launch URL, whichever route wins the race —
+    /// see ``launchURL``.
     func deliverPendingVoiceCommand() {
         guard let url = pendingVoiceCommandURL,
               currentBridgeViewController()?.webView != nil
@@ -201,6 +279,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return
         }
         pendingVoiceCommandURL = nil
+        if url == launchURL {
+            launchURLWasReplayed = true
+        }
         _ = ApplicationDelegateProxy.shared.application(
             UIApplication.shared,
             open: url,

--- a/clients/ios/App/App/VoiceLiveActivityPlugin.swift
+++ b/clients/ios/App/App/VoiceLiveActivityPlugin.swift
@@ -42,10 +42,11 @@ import Foundation
 /// ## No stranded islands
 ///
 /// An island outlives its process unless something ends it, so teardown is
-/// belt-and-braces: ``load()`` ends anything left over by a previous launch
-/// (the crash case, where neither hook below runs), `applicationWillTerminate`
-/// ends the running activity when the user force-quits a backgrounded voice
-/// session, and `deinit` covers bridge teardown.
+/// belt-and-braces: ``load()`` ends anything left over by a previous launch —
+/// the only *guarantee*, since it is the one hook that cannot be cut short by
+/// the process going away — while `applicationWillTerminate` makes a
+/// best-effort end when the user force-quits a backgrounded voice session and
+/// `deinit` covers bridge teardown.
 ///
 /// References:
 /// - https://developer.apple.com/documentation/activitykit/activity
@@ -65,11 +66,34 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     /// branch on it without matching against a localized message.
     private static let failureCode = "LIVE_ACTIVITY_FAILED"
 
-    /// How long `applicationWillTerminate` may block the main thread waiting for
-    /// the activity to actually end. iOS allows roughly five seconds before it
-    /// kills the process; ending is asynchronous, so without a bounded wait the
-    /// app can die first and strand the island.
-    private static let terminationEndTimeout: DispatchTimeInterval = .milliseconds(1500)
+    /// How long a pushed content state stays trustworthy before ActivityKit
+    /// marks it stale.
+    ///
+    /// Every update comes from the web layer's JS main thread, which WebKit
+    /// throttles and eventually suspends in a backgrounded app — so a session
+    /// whose socket and mic are gone can leave a confident "Listening…" on the
+    /// Lock Screen indefinitely. Past this horizon the system flips the
+    /// activity to `ActivityState.stale` and sets `context.isStale`, which
+    /// `VoiceSessionLiveActivity` renders as "no longer current" instead of a
+    /// live phase.
+    ///
+    /// Two minutes is the shortest horizon that does not accuse a *healthy*
+    /// session of being wedged: a real conversation changes phase every few
+    /// seconds, and the only silence longer than this is a session nobody is
+    /// talking to — which the island may as well show as idle. Shorter would
+    /// flag long pauses; much longer and the wedged case, the one this exists
+    /// for, keeps lying past the point the user would act on it.
+    private static let contentStaleAfter: TimeInterval = 120
+
+    /// Wrap a content state with the staleness horizon every push shares.
+    private static func content(
+        _ state: VoiceSessionAttributes.ContentState
+    ) -> ActivityContent<VoiceSessionAttributes.ContentState> {
+        ActivityContent(
+            state: state,
+            staleDate: Date().addingTimeInterval(contentStaleAfter)
+        )
+    }
 
     /// The live plugin instance, so `AppDelegate.applicationWillTerminate` can
     /// reach it. Weak: the bridge owns the plugin's lifetime, not this.
@@ -129,7 +153,7 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
                 return
             }
             if let running = self.activity {
-                await running.update(ActivityContent(state: state, staleDate: nil))
+                await running.update(Self.content(state))
                 call.resolve(["started": true])
                 return
             }
@@ -140,7 +164,7 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             do {
                 self.activity = try Activity.request(
                     attributes: VoiceSessionAttributes(assistantName: assistantName),
-                    content: ActivityContent(state: state, staleDate: nil)
+                    content: Self.content(state)
                 )
                 call.resolve(["started": true])
             } catch {
@@ -170,7 +194,7 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.resolve()
                 return
             }
-            await running.update(ActivityContent(state: state, staleDate: nil))
+            await running.update(Self.content(state))
             call.resolve()
         }
     }
@@ -200,21 +224,28 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     /// `AppDelegate.applicationWillTerminate`, which is what a user swiping away
     /// a backgrounded voice session triggers.
     ///
-    /// Blocks the main thread for at most ``terminationEndTimeout``: the process
-    /// is about to go away, so fire-and-forget would lose the race and leave the
-    /// island on screen with no owner. A launch-time sweep (``load()``) is the
-    /// backstop for the paths this cannot cover, such as a crash.
+    /// Best-effort and non-blocking. Waiting for the end to complete is the
+    /// obvious thing to want here and is the wrong thing to do:
+    /// `applicationWillTerminate` runs on the main thread inside iOS's ~5s
+    /// termination budget, `Activity.end` is free to hop to the main actor
+    /// internally, and a main-thread semaphore wait cannot let that
+    /// continuation run — so the wait deadlocks until its own timeout, burns
+    /// the budget, and strands the island anyway. Returning immediately at
+    /// least lets the end task run before the process is torn down.
+    ///
+    /// The real guarantee is the launch-time sweep in ``load()``: anything that
+    /// outlives this process is ended the next time the plugin loads. An island
+    /// cleaned up on next launch beats a hung termination.
     static func endRunningActivityBeforeTermination() {
         guard let activity = registered?.activity else { return }
         // Cleared so the `deinit` that follows during teardown does not fire a
         // second end at an activity already on its way out.
         registered?.activity = nil
-        let ended = DispatchSemaphore(value: 0)
-        Task {
+        // Detached so the end runs on the global executor rather than behind
+        // whatever the terminating main thread is still doing.
+        Task.detached(priority: .userInitiated) {
             await activity.end(nil, dismissalPolicy: .immediate)
-            ended.signal()
         }
-        _ = ended.wait(timeout: .now() + terminationEndTimeout)
     }
 
     /// Dismiss any voice activity still on screen from a previous process. A

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -36,6 +36,20 @@ extension VoiceSessionAttributes.ContentState {
             ?? Color(cssHex: Self.neutralAccentHex)
             ?? .secondary
     }
+
+    /// The phase label to render, or nothing once ActivityKit has marked the
+    /// content stale.
+    ///
+    /// Staleness means the app stopped pushing updates before this state's
+    /// `staleDate` (`VoiceLiveActivityPlugin.contentStaleAfter`). For a session
+    /// driven entirely by a web view that iOS may have suspended, that is far
+    /// more likely to mean "wedged" than "still genuinely listening" — and the
+    /// phase wording is the one thing on the island that can be *wrong*, so it
+    /// is what drops. The assistant name and accent stay: a session with this
+    /// assistant does exist, and tapping through still returns to it.
+    func displayLabel(isStale: Bool) -> String {
+        isStale ? "" : label
+    }
 }
 
 /// The accent-tinted state indicator: a waveform, tinted with the avatar
@@ -117,13 +131,16 @@ struct VoiceSessionText: View {
 struct VoiceSessionLockScreenView: View {
     let assistantName: String
     let state: VoiceSessionAttributes.ContentState
+    /// Whether ActivityKit considers this content out of date; drops the phase
+    /// label. See `ContentState.displayLabel(isStale:)`.
+    let isStale: Bool
 
     var body: some View {
         HStack(spacing: 12) {
             VoiceAccentBadge(accent: state.accentColor)
             VStack(alignment: .leading, spacing: 2) {
                 VoiceSessionText(text: assistantName, font: .headline)
-                VoiceSessionText(text: state.label, color: .secondary)
+                VoiceSessionText(text: state.displayLabel(isStale: isStale), color: .secondary)
             }
             Spacer(minLength: 0)
             if state.muted {

--- a/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
@@ -29,11 +29,13 @@ struct VoiceSessionLiveActivity: Widget {
         ActivityConfiguration(for: VoiceSessionAttributes.self) { context in
             VoiceSessionLockScreenView(
                 assistantName: context.attributes.assistantName,
-                state: context.state
+                state: context.state,
+                isStale: context.isStale
             )
             .widgetURL(VoiceModeDeepLink.resume.url())
         } dynamicIsland: { context in
             let state = context.state
+            let label = state.displayLabel(isStale: context.isStale)
             return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     VoiceAccentBadge(accent: state.accentColor)
@@ -46,7 +48,7 @@ struct VoiceSessionLiveActivity: Widget {
                     }
                 }
                 DynamicIslandExpandedRegion(.center) {
-                    VoiceSessionText(text: state.label, font: .headline)
+                    VoiceSessionText(text: label, font: .headline)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     VoiceSessionText(
@@ -60,7 +62,7 @@ struct VoiceSessionLiveActivity: Widget {
                 // The tightest slot there is. It still shows the passed label,
                 // truncated — substituting a shorter native string here is
                 // precisely the fossilization this design avoids.
-                VoiceSessionText(text: state.label, font: .caption2, color: .secondary)
+                VoiceSessionText(text: label, font: .caption2, color: .secondary)
             } minimal: {
                 VoiceAccentGlyph(accent: state.accentColor, scale: .small)
             }

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -161,7 +161,7 @@ otherwise arrive as a `prompt` of `Ben ` plus a stray parameter.
 | Live Activity `widgetURL` (island / Lock Screen tap) | `resume` | `App/VoiceActivity/VoiceSessionLiveActivity.swift` |
 | Safari, a note, another app, a test link | either | — |
 
-### Delivery paths, and the one that used to drop
+### Delivery paths, and why a cold launch delivers exactly once
 
 Intents run **in the app process** and never pass through
 `application(_:open:)`, so `VoiceModeDeepLink.route()` hands the URL directly to
@@ -172,18 +172,61 @@ and needs no new web code. `AppPlugin` posts that event with
 `retainUntilConsumed: true`, so a command delivered before the SPA registers its
 listener is replayed rather than lost.
 
-A **terminated** launch is the case that needs care.
-`didFinishLaunchingWithOptions` receives the URL in `launchOptions[.url]` and
-does *not* forward to `ApplicationDelegateProxy`; before this feature it only
-tried `handleConnectDeepLink`, which returns `false` for any host that is not
-`connect` and takes no other action — so a `voice` URL from Siri, the Action
-Button, or Safari was silently discarded before the web view existed. It now
-stashes any non-`connect` launch URL as `pendingVoiceCommandURL` and delivers it
-from `MyViewController.viewDidAppear`.
+A **terminated** launch is the case that needs care, and the reason is the
+opposite of the obvious one: the launch URL arrives **twice**, not zero times.
+
+This app declares no `UIApplicationSceneManifest`, so it is a non-scene app and
+`launchOptions[.url]` is populated ("If the app supports scenes, this is `nil`" —
+[`application(_:didFinishLaunchingWithOptions:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:didfinishlaunchingwithoptions:))).
+`application(_:open:options:)` is then called for that same URL as well:
+
+> This method is not called if your implementations return `false` from both the
+> `application(_:willFinishLaunchingWithOptions:)` and
+> `application(_:didFinishLaunchingWithOptions:)` methods.
+>
+> — [`application(_:open:options:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:open:options:))
+
+`AppDelegate` implements only `didFinishLaunchingWithOptions` and returns `true`
+unconditionally, so the `open:` call always comes. That is also why a stock
+Capacitor app — whose delegate handles URLs *only* in `application(_:open:)` —
+receives `appUrlOpen` from a terminated state at all.
+
+So `application(_:open:)` is the delivery. The launch stash is kept as a
+**backstop**, because the `open:` route has a race of its own:
+`ApplicationDelegateProxy` delivers by posting `.capacitorOpenURL`, and
+`AppPlugin` only subscribes in its `load()` — a URL that arrives before the
+bridge finishes registering plugins has no observer and is dropped, and nothing
+in the web layer calls `App.getLaunchUrl()`, Capacitor's usual escape hatch for
+exactly that. See [capacitor#5584](https://github.com/ionic-team/capacitor/issues/5584).
+
+The two are deduped on the launch URL's identity, so the command reaches the web
+layer exactly once whichever route wins:
+
+- `AppDelegate.launchURL` holds the URL while it is still eligible to arrive a
+  second time, and is cleared on the first background transition (re-opening the
+  same URL requires leaving the app, so anything after that is genuinely new).
+- If the `viewDidAppear` replay gets there first, it records
+  `launchURLWasReplayed` and the `open:` call that follows is swallowed.
+- If `application(_:open:)` gets there first **and the bridge web view exists**,
+  the forward will be observed, so the backstop is dropped.
+- If it gets there first with **no** web view yet, the forward goes nowhere and
+  the backstop is deliberately kept — that is the case it was added for.
+  `webView != nil` is the test because `CAPBridgeViewController` builds the web
+  view and registers plugins in one synchronous `viewDidLoad`.
+
+**No `connect` URL ever reaches any of this.** `handleConnectDeepLink` returns
+`true` for *every* URL whose host is `connect`, malformed ones included (it logs
+and returns `true`), and it is the guard on both the stash in
+`didFinishLaunchingWithOptions` and the early return in `application(_:open:)`.
+A cold-launch connect URL is therefore handled twice by `handleConnectDeepLink`
+itself, which is harmless: it re-persists the same base and re-stashes the same
+pair URL, and `deliverPendingConnectNavigation` clears
+`pendingConnectPairURL` before loading, so the pair page loads once.
 
 There are **two** independent cold-launch races and both fixes are required:
 
-- **Native**: the URL never reaches the web layer (fixed above).
+- **Native**: the URL reaches the web layer once — never twice, never zero times
+  (above).
 - **Web**: the URL arrives before `ChatLayout` registers the live-voice
   `starter`. `start-voice-deep-link.ts` parks the request and
   `use-live-voice-session-controller.ts` drains it when the starter registers.
@@ -336,6 +379,13 @@ the platform half is not. Worth doing only if the session needs to update while
 the app is suspended — which is not the case today, because the web layer that
 drives the phase is suspended at the same time.
 
+That symmetry is also the hazard: a suspended web layer stops pushing, and an
+island frozen on "Listening…" is a claim about a live socket and a live mic that
+nothing is checking. Every push therefore carries a `staleDate`
+(`VoiceLiveActivityPlugin.contentStaleAfter`, two minutes), and the views drop
+the phase label once `context.isStale` goes true. It does not make the island
+correct — only honest about not knowing.
+
 ### 2. No App Group
 
 `ContentState` carries only primitives: `phase`, `label`, `accentHex`, `muted`,
@@ -445,7 +495,8 @@ The Simulator does not faithfully reproduce any of these.
 | `.notifyOthersOnDeactivation` | Start music, run a voice session, end it, confirm the music resumes |
 | Interruption handling | Take a real phone call mid-session; the session should end, not keep "listening" into a dead mic |
 | Bluetooth / AirPods routing | `.voiceChat` HFP routing needs real hardware |
-| No stranded island | Force-quit mid-session and confirm the island disappears; then crash-and-relaunch and confirm `load()`'s sweep clears anything left over |
+| No stranded island | Force-quit mid-session; the `applicationWillTerminate` end is fire-and-forget, so it may or may not win the race — relaunch and confirm `load()`'s sweep clears whatever survived. Same check after a crash |
+| Stale island | Background a session and leave it long enough for iOS to suspend the web view; past the two-minute `staleDate` the island must stop showing a phase label rather than keep claiming "Listening…" |
 
 ## Shipping prerequisites
 


### PR DESCRIPTION
Three native-side defects from review on the voice-mode branch.

## 1. Cold-launch URLs were being delivered twice, not zero times

The terminated-launch fix stashed every non-`connect` `launchOptions[.url]` and replayed it from `viewDidAppear`, on the premise that such URLs were silently dropped. **That premise was wrong**, and the stash added a second delivery — `deeplink.startVoice` published twice, and `oauth-complete` / `billing/checkout-complete` cold launches silently changed behavior.

This app declares no `UIApplicationSceneManifest`, so it is a non-scene app (`launchOptions` is populated — *"If the app supports scenes, this is `nil`"*, [`application(_:didFinishLaunchingWithOptions:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:didfinishlaunchingwithoptions:))). For such an app Apple documents that `application(_:open:options:)` **is** called for the launch URL:

> This method is not called if your implementations return `false` from both the `application(_:willFinishLaunchingWithOptions:)` and `application(_:didFinishLaunchingWithOptions:)` methods.
>
> — [`application(_:open:options:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:open:options:))

`AppDelegate` implements only `didFinishLaunchingWithOptions` and returns `true` unconditionally, so the `open:` call always comes. That is also why stock Capacitor apps — whose delegate handles URLs only in `application(_:open:)` — receive `appUrlOpen` from a terminated state at all.

Rather than delete the stash, delivery is now idempotent under either ordering, because the `open:` route has a race of its own: `ApplicationDelegateProxy` delivers by posting `.capacitorOpenURL`, and `AppPlugin` only subscribes in its `load()`, so a URL arriving before the bridge registers plugins has no observer (see [capacitor#5584](https://github.com/ionic-team/capacitor/issues/5584); nothing in the web layer calls `App.getLaunchUrl()`).

- `launchURL` holds the launch URL's identity; cleared on the first background transition.
- Replay-first → records `launchURLWasReplayed`, and the later `open:` is swallowed.
- `open:`-first **with a bridge web view** → the forward will be observed, so the backstop is dropped.
- `open:`-first with **no** web view → the forward goes nowhere, so the backstop is deliberately kept. That is the only case it was ever needed for.

**`connect` is unaffected, verified:** `handleConnectDeepLink` returns `true` for every URL whose host is `connect`, malformed ones included, and it guards both the stash and the `open:` early return — so no `connect` URL reaches the stash or the dedupe. The double `handleConnectDeepLink` call on a cold launch is harmless (same base re-persisted, same pair URL re-stashed, and `deliverPendingConnectNavigation` clears `pendingConnectPairURL` before loading).

## 2. `applicationWillTerminate` no longer blocks the main thread

`endRunningActivityBeforeTermination()` spawned a `Task` then waited 1500ms on a `DispatchSemaphore` on the main thread. If `Activity.end` hops to the main actor internally, that continuation cannot run while the semaphore holds main — deadlocking until timeout, burning 1.5s of iOS's ~5s budget, and stranding the island anyway. Now a detached fire-and-forget end that returns immediately. The `load()`-time sweep (`endActivitiesStrandedByAPreviousLaunch`, verified present and unchanged) is the real guarantee.

## 3. The Live Activity can no longer lie about a wedged session

Every `start`/`update` passed `staleDate: nil`. With background survival unmeasured and no background hardening, a suspended web layer left a confident "Listening…" on the Lock Screen. All pushes now go through one helper carrying a 120s `staleDate`, and the views drop the phase label once `context.isStale` goes true — `staleDate` alone only flips `ActivityState` to `.stale`, so the view has to react for anything to change visibly. Assistant name and accent stay: those are still true.

## Verification

- `xcodebuild -target "VoiceActivity Dev" -sdk iphonesimulator -configuration Release` → **BUILD SUCCEEDED**.
- `AppDelegate.swift` and `VoiceLiveActivityPlugin.swift` typecheck clean via `swiftc -typecheck -sdk iphoneos -target arm64-apple-ios17.0` against Capacitor stubs (the local full-app build fails on the pre-existing `IONFilesystemLib` SPM issue before reaching them). CI's `PR iOS Checks` is the app-build gate.

## Unverified

- **Which route actually wins on device.** The dedupe is correct under either ordering, but I did not measure whether `application(_:open:)` lands before or after the bridge's `viewDidLoad` on a real cold launch. UIKit's ordering here is not documented.
- **`webView != nil` as the "AppPlugin has loaded" test.** Reasoned from `CAPBridgeViewController` building the web view and registering plugins inside one synchronous `viewDidLoad`; not instrumented.
- **Whether the cold-launch drop ever really happened.** The backstop is retained defensively; the Capacitor issue reports are circumstantial, not a repro on this app.
- **120s stale horizon.** Picked from reasoning about phase cadence (a real conversation changes phase every few seconds), not from measuring a wedged session — which is the spike that was never run.
- **Live-activity staleness rendering.** Not observed on device; the Dynamic Island does not render in the Simulator.