### PR TITLE
fix(web): drop React state from decorative animation + probe commit pressure (LUM-2859)

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -668,6 +668,49 @@ References:
 - [React — useRef caveats: "Do not write or read ref.current during rendering"](https://react.dev/reference/react/useRef#caveats)
 - [React — useCallback: preventing an Effect from firing too often](https://react.dev/reference/react/useCallback#preventing-an-effect-from-firing-too-often)
 
+### Keep decorative animation out of the commit stream
+
+A timer or `requestAnimationFrame` loop that only changes how something
+*looks* — a wobble, a pulse, a shimmer, a cursor blink — must not drive
+React state. Prefer CSS, and when the value has to be computed in JS,
+write it to the node through a ref instead:
+
+```ts
+// Good — the DOM changes, React does not re-render
+const pathRef = useRef<SVGPathElement | null>(null);
+useEffect(() => {
+  const timer = setInterval(() => {
+    pathRef.current?.setAttribute("d", nextFrame());
+  }, 150);
+  return () => clearInterval(timer);
+}, []);
+
+// Avoid — a decorative frame counter in state
+const [frame, setFrame] = useState(0);
+useEffect(() => {
+  const timer = setInterval(() => setFrame((f) => f + 1), 150);
+  return () => clearInterval(timer);
+}, []);
+```
+
+This is not micro-optimization. React increments an internal counter on
+every commit that finishes with an ordinary update already queued, and
+throws `Maximum update depth exceeded` once fifty-one land back to back —
+no render loop required, just enough independent updaters overlapping. A
+streaming conversation already runs several (the transcript snapshot, the
+smooth-text reveal, scroll classification, query notifications); a
+decorative animation that adds one more per visible instance, for the
+whole length of a turn, is what tipped that over in production
+(LUM-2859).
+
+When a component drives `d`/`transform`/`style` imperatively, the value
+it renders must stay constant across re-renders — React only patches
+attributes whose props changed, and a changing prop would clobber the
+imperative write.
+
+Reference: `lib/commit-pressure.ts` — the probe that measures this
+traffic and attaches it to error-185 Sentry events.
+
 ---
 
 ## Framework strategy

--- a/clients/web/src/components/avatar/animated-avatar.test.tsx
+++ b/clients/web/src/components/avatar/animated-avatar.test.tsx
@@ -30,21 +30,35 @@ function eyeTransform(container: HTMLElement): string {
   return (groups[1] as SVGGElement).style.transform;
 }
 
+/** The body outline is the single <path> in the first <g> of the avatar SVG. */
+function bodyPath(container: HTMLElement): SVGPathElement {
+  return container.querySelector("svg > g path") as SVGPathElement;
+}
+
 let timeoutCallbacks: Array<() => void>;
+let intervalCallbacks: Array<() => void>;
 let realSetTimeout: typeof globalThis.setTimeout;
+let realSetInterval: typeof globalThis.setInterval;
 
 beforeEach(() => {
   timeoutCallbacks = [];
+  intervalCallbacks = [];
   realSetTimeout = globalThis.setTimeout;
+  realSetInterval = globalThis.setInterval;
   // Capture scheduled callbacks instead of running them on a real clock.
   globalThis.setTimeout = ((fn: () => void) => {
     timeoutCallbacks.push(fn);
     return 0 as unknown as ReturnType<typeof setTimeout>;
   }) as typeof globalThis.setTimeout;
+  globalThis.setInterval = ((fn: () => void) => {
+    intervalCallbacks.push(fn);
+    return 0 as unknown as ReturnType<typeof setInterval>;
+  }) as typeof globalThis.setInterval;
 });
 
 afterEach(() => {
   globalThis.setTimeout = realSetTimeout;
+  globalThis.setInterval = realSetInterval;
   cleanup();
 });
 
@@ -79,5 +93,70 @@ describe("AnimatedAvatar blink", () => {
       />,
     );
     expect(eyeTransform(container)).toBe("scaleY(1)");
+  });
+});
+
+describe("AnimatedAvatar streaming morph", () => {
+  test("cycles the body path without a React state update", () => {
+    const { container } = render(
+      <AnimatedAvatar
+        components={BUNDLED_COMPONENTS}
+        traits={TRAITS}
+        size={56}
+        isAssistantBusy
+      />,
+    );
+
+    const restingPath = bodyPath(container).getAttribute("d");
+    expect(restingPath).toBeTruthy();
+
+    // Deliberately NOT wrapped in `act()`. The morph is a direct attribute
+    // write, so the DOM must change with no commit to flush — a `setState`
+    // here would not be applied outside `act()`, which is the regression this
+    // guards (a 6.7Hz React update per busy avatar for the whole turn).
+    intervalCallbacks[0]?.();
+
+    expect(bodyPath(container).getAttribute("d")).not.toBe(restingPath);
+  });
+
+  test("settles back to the resting shape when the turn ends", () => {
+    const { container, rerender } = render(
+      <AnimatedAvatar
+        components={BUNDLED_COMPONENTS}
+        traits={TRAITS}
+        size={56}
+        isAssistantBusy
+      />,
+    );
+
+    const restingPath = bodyPath(container).getAttribute("d");
+    intervalCallbacks[0]?.();
+    expect(bodyPath(container).getAttribute("d")).not.toBe(restingPath);
+
+    rerender(
+      <AnimatedAvatar
+        components={BUNDLED_COMPONENTS}
+        traits={TRAITS}
+        size={56}
+        isAssistantBusy={false}
+      />,
+    );
+
+    // Without the cleanup write the body would stay frozen on whichever
+    // wobbled variant the cycle happened to land on.
+    expect(bodyPath(container).getAttribute("d")).toBe(restingPath);
+  });
+
+  test("stays still while streaming is not active", () => {
+    render(
+      <AnimatedAvatar
+        components={BUNDLED_COMPONENTS}
+        traits={TRAITS}
+        size={56}
+        isAssistantBusy={false}
+      />,
+    );
+
+    expect(intervalCallbacks).toHaveLength(0);
   });
 });

--- a/clients/web/src/components/avatar/animated-avatar.tsx
+++ b/clients/web/src/components/avatar/animated-avatar.tsx
@@ -171,9 +171,8 @@ export function AnimatedAvatar({
 
   const [isBlinking, setIsBlinking] = useState(false);
   const [twitchAngle, setTwitchAngle] = useState(0);
-  const [morphIndex, setMorphIndex] = useState(0);
 
-  const morphTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const bodyPathRef = useRef<SVGPathElement | null>(null);
 
   useEffect(() => {
     // Force eyes open whenever blinking is disabled (reduced-motion or
@@ -258,24 +257,40 @@ export function AnimatedAvatar({
     };
   }, [reduce, isAssistantBusy]);
 
-  // Morph path cycling (only during streaming)
+  // Morph path cycling (only during streaming).
+  //
+  // Written straight to the DOM rather than held in React state. The morph is
+  // decoration — a 6.7Hz wobble on a body outline — but as state it put a
+  // React update on the queue every 150ms, per visible busy avatar, for the
+  // whole length of every streaming turn. React counts commits that finish
+  // with an update already pending and throws `Maximum update depth exceeded`
+  // once fifty-one land back to back, so purely visual work has no business in
+  // the commit stream at all; this was the most frequently blamed frame in
+  // that error family (LUM-2859). `d` stays out of the rendered props below,
+  // so an unrelated re-render never clobbers the imperative value.
   useEffect(() => {
-    if (!isAssistantBusy || reduce) {
-      setMorphIndex(0);
+    const el = bodyPathRef.current;
+    if (!el) return;
+    const basePath = morphPaths[0] ?? bodyShape.svgPath;
+    if (!isAssistantBusy || reduce || morphPaths.length <= 1) {
+      el.setAttribute("d", basePath);
       return;
     }
 
     let idx = 0;
-    morphTimerRef.current = setInterval(() => {
+    const timer = setInterval(() => {
       idx = (idx + 1) % morphPaths.length;
-      setMorphIndex(idx);
+      const next = morphPaths[idx];
+      if (next) el.setAttribute("d", next);
     }, 150);
 
     return () => {
-      if (morphTimerRef.current) clearInterval(morphTimerRef.current);
-      morphTimerRef.current = null;
+      clearInterval(timer);
+      // A turn that ends mid-cycle would otherwise leave the body frozen on a
+      // wobbled variant instead of settling back to its resting shape.
+      el.setAttribute("d", basePath);
     };
-  }, [isAssistantBusy, reduce, morphPaths.length]);
+  }, [isAssistantBusy, reduce, morphPaths, bodyShape.svgPath]);
 
   const bodyCenterX = size / 2;
   const bodyCenterY = size / 2;
@@ -292,7 +307,10 @@ export function AnimatedAvatar({
   // Never squish the eyes while streaming — guards the one frame between
   // `isAssistantBusy` flipping true and the blink effect resetting `isBlinking`.
   const effectiveBlinking = isBlinking && !isAssistantBusy;
-  const currentBodyPath = morphPaths[morphIndex] ?? bodyShape.svgPath;
+  // Resting shape. The morph effect above drives `d` from here on, so this
+  // value must stay stable across re-renders — React only patches attributes
+  // whose props changed, which is what keeps the imperative writes intact.
+  const baseBodyPath = morphPaths[0] ?? bodyShape.svgPath;
 
   return (
     <svg
@@ -316,7 +334,8 @@ export function AnimatedAvatar({
         }}
       >
         <path
-          d={currentBodyPath}
+          ref={bodyPathRef}
+          d={baseBodyPath}
           fill={color.hex}
           transform={bodyTransform}
           style={{

--- a/clients/web/src/components/providers.tsx
+++ b/clients/web/src/components/providers.tsx
@@ -23,9 +23,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@vellumai/design-library";
 import { Toaster } from "@vellumai/design-library/components/toast";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import { ProfileQuickAddProvider } from "@/components/profile-quick-add-provider";
+import { installQueryPressureProbe } from "@/lib/commit-pressure";
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { queryRetryDelay, shouldRetryQuery } from "@/utils/query-retry";
@@ -62,6 +63,12 @@ function RequestScopedQueryClientProvider({
   children: ReactNode;
 }) {
   const [queryClient] = useState(() => createQueryClient());
+  // Query notifications re-render through `useSyncExternalStore`, so they are
+  // part of the same commit traffic as the chat route's timer-driven updates.
+  // Only this client is probed: it is the one the conversation route's queries
+  // live under, and the auth-scoped client above serves a handful of
+  // low-frequency reads.
+  useEffect(() => installQueryPressureProbe(queryClient), [queryClient]);
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -54,6 +54,7 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone";
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
 import { useSupportsNewChatPlugins } from "@/lib/backwards-compat/use-supports-new-chat-plugins";
+import { recordCommit } from "@/lib/commit-pressure";
 import { NewChatPluginsSection } from "@/domains/chat/components/new-chat-plugins/new-chat-plugins-section";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
@@ -481,6 +482,14 @@ export function ChatMainPanel({
     transcriptContainerRef.current = el;
   });
   useNativeQuoteReply(transcriptContainerRef);
+
+  // Commit counter for the chat-route subtree. Deliberately dependency-less:
+  // it has to run on every commit to measure how tightly they are packed,
+  // which is what `Maximum update depth exceeded` actually reacts to. Records
+  // nothing but two integers — see `lib/commit-pressure.ts`.
+  useEffect(() => {
+    recordCommit();
+  });
 
   // Clear staged quotes and dismiss the reply bubble when the active
   // conversation changes to prevent quotes from one conversation leaking

--- a/clients/web/src/domains/chat/hooks/use-smooth-stream-text.ts
+++ b/clients/web/src/domains/chat/hooks/use-smooth-stream-text.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react";
 
 import { useReducedMotion } from "motion/react";
 
+import { recordUpdate } from "@/lib/commit-pressure";
+
 /**
  * Fraction-per-frame drain: each frame reveals the share of the outstanding
  * backlog that a `1 - e^(-dt/τ)` exponential approach with τ = 220ms yields.
@@ -77,6 +79,9 @@ export function useSmoothStreamText(target: string | null): string | null {
         revealedRef.current = revealed;
         if (now - lastCommit >= COMMIT_INTERVAL_MS || revealed >= targetLength) {
           lastCommit = now;
+          // One of the constant update sources during a streaming turn — see
+          // `lib/commit-pressure.ts` for why they are counted.
+          recordUpdate("smooth-stream");
           setRevealedLength(Math.floor(revealed));
         }
       }

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -31,6 +31,7 @@ import {
   useState,
 } from "react";
 
+import { recordUpdate } from "@/lib/commit-pressure";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
   type AnchorSnapshot,
@@ -350,9 +351,11 @@ export function useTranscriptScroll(
         },
       );
       if (classification.isPinned !== latest.isPinnedToLatest) {
+        recordUpdate("transcript-scroll");
         setIsPinnedToLatest(classification.isPinned);
       }
       if (classification.showScrollToLatest !== latest.showScrollToLatest) {
+        recordUpdate("transcript-scroll");
         setShowScrollToLatest(classification.showScrollToLatest);
       }
 
@@ -514,9 +517,11 @@ export function useTranscriptScroll(
     });
 
     if (classification.isPinned !== latest.isPinnedToLatest) {
+      recordUpdate("transcript-scroll");
       setIsPinnedToLatest(classification.isPinned);
     }
     if (classification.showScrollToLatest !== latest.showScrollToLatest) {
+      recordUpdate("transcript-scroll");
       setShowScrollToLatest(classification.showScrollToLatest);
     }
 

--- a/clients/web/src/domains/chat/transcript/use-viewport-min-height.ts
+++ b/clients/web/src/domains/chat/transcript/use-viewport-min-height.ts
@@ -1,6 +1,8 @@
 
 import { type RefObject, useEffect, useState } from "react";
 
+import { recordUpdate } from "@/lib/commit-pressure";
+
 /**
  * Track the current `clientHeight` of a scroll container via `ResizeObserver`
  * and re-render subscribers on every resize.
@@ -29,7 +31,8 @@ export function useViewportMinHeight(
 
     // Seed with the current height so the first paint has a reasonable value
     // even if `ResizeObserver` fires asynchronously.
-    setHeight(node.clientHeight);
+    let lastHeight = node.clientHeight;
+    setHeight(lastHeight);
 
     if (typeof ResizeObserver === "undefined") {
       return;
@@ -38,7 +41,16 @@ export function useViewportMinHeight(
     const observer = new ResizeObserver(() => {
       const current = scrollContainerRef.current;
       if (!current) return;
-      setHeight(current.clientHeight);
+      const next = current.clientHeight;
+      // The observer fires on width changes too, and the scroll container is
+      // resized by anything that reflows the chat pane. Only the height feeds
+      // `minHeight`, so bail before scheduling an update React would discard
+      // anyway — every queued update is one more commit that can finish with
+      // work still pending (see `lib/commit-pressure.ts`).
+      if (next === lastHeight) return;
+      lastHeight = next;
+      recordUpdate("viewport-min-height");
+      setHeight(next);
     });
 
     observer.observe(node);

--- a/clients/web/src/lib/commit-pressure.test.ts
+++ b/clients/web/src/lib/commit-pressure.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  recordCommit,
+  recordUpdate,
+  resetCommitPressure,
+  snapshotCommitPressure,
+} from "@/lib/commit-pressure";
+
+// The probe reads `performance.now()`; drive it from the test so bucket
+// rollover and back-to-back detection are exercised without real waiting.
+let clock = 0;
+let realNow: () => number;
+
+beforeEach(() => {
+  clock = 1000;
+  realNow = performance.now.bind(performance);
+  performance.now = () => clock;
+  resetCommitPressure();
+});
+
+afterEach(() => {
+  performance.now = realNow;
+  resetCommitPressure();
+});
+
+describe("commit-pressure probe", () => {
+  test("reports null until something is recorded", () => {
+    expect(snapshotCommitPressure()).toBeNull();
+  });
+
+  test("tallies updates per source, highest first", () => {
+    recordUpdate("smooth-stream");
+    recordUpdate("smooth-stream");
+    recordUpdate("smooth-stream");
+    recordUpdate("transcript-scroll");
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.updates).toBe(4);
+    expect(snapshot?.sources).toEqual({
+      "smooth-stream": 3,
+      "transcript-scroll": 1,
+    });
+    // Highest-count source must come first so a truncated payload keeps the
+    // signal.
+    expect(Object.keys(snapshot?.sources ?? {})[0]).toBe("smooth-stream");
+  });
+
+  test("keeps the previous bucket so a snapshot always has ~1s of history", () => {
+    recordUpdate("avatar-morph");
+    clock += 1200; // roll into a new bucket
+    recordUpdate("smooth-stream");
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.updates).toBe(2);
+    expect(snapshot?.sources["avatar-morph"]).toBe(1);
+  });
+
+  test("drops history after an idle gap rather than reporting stale pressure", () => {
+    recordUpdate("avatar-morph");
+    clock += 5000;
+
+    expect(snapshotCommitPressure()).toBeNull();
+  });
+
+  test("counts a run of sub-frame commits as back-to-back", () => {
+    for (let i = 0; i < 12; i += 1) {
+      recordCommit();
+      clock += 2; // well inside one frame
+    }
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.commits).toBe(12);
+    expect(snapshot?.maxBackToBackCommits).toBe(12);
+  });
+
+  test("a paced commit stream does not register as back-to-back", () => {
+    for (let i = 0; i < 12; i += 1) {
+      recordCommit();
+      clock += 33; // ~30fps — React yielded between commits
+    }
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.maxBackToBackCommits).toBe(1);
+  });
+
+  test("remembers the longest run, not the most recent one", () => {
+    for (let i = 0; i < 6; i += 1) {
+      recordCommit();
+      clock += 1;
+    }
+    clock += 50; // breather
+    recordCommit();
+
+    expect(snapshotCommitPressure()?.maxBackToBackCommits).toBe(6);
+  });
+
+  test("caps distinct sources so the payload stays bounded", () => {
+    for (let i = 0; i < 40; i += 1) {
+      recordUpdate(`source-${i}`);
+    }
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.updates).toBe(40);
+    expect(Object.keys(snapshot?.sources ?? {}).length).toBeLessThanOrEqual(25);
+    expect(snapshot?.sources.other).toBe(16);
+  });
+});

--- a/clients/web/src/lib/commit-pressure.ts
+++ b/clients/web/src/lib/commit-pressure.ts
@@ -1,0 +1,213 @@
+/**
+ * Commit-pressure probe — what was updating React when something went wrong.
+ *
+ * Motivation: `Maximum update depth exceeded` (React error 185) is thrown from
+ * whatever `setState` happens to run *after* the limit is already breached, so
+ * the reported stack frame names a victim rather than a cause. React increments
+ * its counter on every commit that finishes with an ordinary update already
+ * queued (`react-dom-client` — `committedLanes & 261930 && pendingLanes & 42`,
+ * where `42` is `Sync | InputContinuous | Default`) and resets it on the first
+ * commit that does not. Fifty-one consecutive such commits throw — which a
+ * genuine render loop produces, but so does enough independent update traffic
+ * landing mid-commit, which is what a streaming conversation looks like.
+ *
+ * Distinguishing those two from a production stack alone is not possible, so
+ * this module keeps a rolling tally of who is scheduling updates and how
+ * tightly commits are packed. `sentry-init` attaches the snapshot to error-185
+ * events; the next occurrence names the traffic instead of a bystander.
+ *
+ * Hot-path constraints: recording is a couple of integer writes against two
+ * fixed buckets — no allocation, no timers, no array growth. The source set is
+ * capped so an unexpected caller cannot grow the payload without bound.
+ */
+
+import type { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Length of one tally bucket. Two are kept (current + previous), so a snapshot
+ * covers between one and two seconds of history depending on where in the
+ * current bucket it lands.
+ */
+const BUCKET_MS = 1000;
+
+/**
+ * Gap below which two commits count as back-to-back. A frame is ~16.7ms, so
+ * anything under half a frame means React re-entered the commit phase without
+ * yielding to paint — the observable analogue of the counter React itself
+ * keeps.
+ */
+const BACK_TO_BACK_MS = 8;
+
+/** Cap on distinct source keys, so a caller passing dynamic strings can't
+ *  grow the Sentry payload without bound. Overflow is tallied as `other`. */
+const MAX_SOURCES = 24;
+
+/**
+ * Known high-frequency update sources on the conversation route. Callers are
+ * not restricted to these — the type documents the ones we deliberately
+ * instrumented, and `query:*` keys are minted from live query ids.
+ */
+export type UpdateSource =
+  | "avatar-morph"
+  | "smooth-stream"
+  | "transcript-scroll"
+  | "viewport-min-height"
+  | (string & {});
+
+export interface CommitPressureSnapshot {
+  /** Span the tallies cover. Between `BUCKET_MS` and `2 × BUCKET_MS`. */
+  windowMs: number;
+  /** Updates recorded in the window, all sources. */
+  updates: number;
+  /** Per-source update counts, highest first. */
+  sources: Record<string, number>;
+  /** Commits observed in the window (chat-route subtree only). */
+  commits: number;
+  /** Longest run of commits separated by less than {@link BACK_TO_BACK_MS}. */
+  maxBackToBackCommits: number;
+}
+
+interface Bucket {
+  startedAt: number;
+  updates: number;
+  commits: number;
+  sources: Map<string, number>;
+}
+
+function emptyBucket(startedAt: number): Bucket {
+  return { startedAt, updates: 0, commits: 0, sources: new Map() };
+}
+
+let current: Bucket = emptyBucket(0);
+let previous: Bucket = emptyBucket(0);
+
+// Back-to-back run tracking spans buckets: a run that starts in one second and
+// ends in the next is exactly the case worth catching.
+let lastCommitAt = 0;
+let backToBackRun = 0;
+let maxBackToBackRun = 0;
+
+function now(): number {
+  return typeof performance !== "undefined" && performance.now
+    ? performance.now()
+    : Date.now();
+}
+
+/** Roll buckets forward so `current` always covers the live second. */
+function roll(ts: number): void {
+  const age = ts - current.startedAt;
+  if (age < BUCKET_MS) return;
+  if (age >= BUCKET_MS * 2) {
+    // Idle gap — everything on record is stale.
+    previous = emptyBucket(ts);
+    maxBackToBackRun = 0;
+    backToBackRun = 0;
+  } else {
+    previous = current;
+  }
+  current = emptyBucket(ts);
+}
+
+/**
+ * Record that `source` scheduled a React update. Call this at the `setState`
+ * call site of any updater that fires more than a few times a second while a
+ * conversation streams.
+ */
+export function recordUpdate(source: UpdateSource): void {
+  const ts = now();
+  roll(ts);
+  current.updates += 1;
+  const key =
+    current.sources.has(source) || current.sources.size < MAX_SOURCES
+      ? source
+      : "other";
+  current.sources.set(key, (current.sources.get(key) ?? 0) + 1);
+}
+
+/**
+ * Record a React commit. Called from a dependency-less effect in the chat
+ * route, so it counts commits of that subtree — not every root commit.
+ */
+export function recordCommit(): void {
+  const ts = now();
+  roll(ts);
+  current.commits += 1;
+  if (lastCommitAt !== 0 && ts - lastCommitAt < BACK_TO_BACK_MS) {
+    backToBackRun += 1;
+    if (backToBackRun > maxBackToBackRun) maxBackToBackRun = backToBackRun;
+  } else {
+    backToBackRun = 1;
+    if (maxBackToBackRun === 0) maxBackToBackRun = 1;
+  }
+  lastCommitAt = ts;
+}
+
+/**
+ * Current tallies, or `null` when nothing has been recorded — a null snapshot
+ * means the probe never ran (route never mounted, error raised elsewhere) and
+ * should be read as "no data", not as "no pressure".
+ */
+export function snapshotCommitPressure(): CommitPressureSnapshot | null {
+  const ts = now();
+  roll(ts);
+  const updates = current.updates + previous.updates;
+  const commits = current.commits + previous.commits;
+  if (updates === 0 && commits === 0) return null;
+
+  const merged = new Map<string, number>(previous.sources);
+  for (const [key, count] of current.sources) {
+    merged.set(key, (merged.get(key) ?? 0) + count);
+  }
+  const sources: Record<string, number> = {};
+  for (const [key, count] of [...merged].sort((a, b) => b[1] - a[1])) {
+    sources[key] = count;
+  }
+
+  return {
+    windowMs: Math.round(ts - previous.startedAt),
+    updates,
+    sources,
+    commits,
+    maxBackToBackCommits: maxBackToBackRun,
+  };
+}
+
+/**
+ * Label a query for the tally. HeyAPI mints keys as `[{ _id, path }]`, so the
+ * endpoint id is the stable, bounded name; hand-written keys lead with a
+ * string. Anything else collapses to one bucket rather than minting a key per
+ * query.
+ */
+function queryLabel(queryKey: readonly unknown[]): string {
+  const head = queryKey[0];
+  if (typeof head === "string") return head;
+  if (head && typeof head === "object" && "_id" in head) {
+    const id = (head as { _id: unknown })._id;
+    if (typeof id === "string") return id;
+  }
+  return "unknown";
+}
+
+/**
+ * Tally every query-cache update as an update source. Query notifications
+ * re-render through `useSyncExternalStore`, so they are part of the same
+ * commit traffic as the timer-driven sources — and the notify path is what the
+ * LUM-2859 stack was standing in when the limit tripped.
+ *
+ * Returns the unsubscribe handle.
+ */
+export function installQueryPressureProbe(queryClient: QueryClient): () => void {
+  return queryClient.getQueryCache().subscribe((event) => {
+    if (event.type !== "updated") return;
+    recordUpdate(`query:${queryLabel(event.query.queryKey)}`);
+  });
+}
+
+/** Test seam — drops all recorded history. */
+export function resetCommitPressure(): void {
+  current = emptyBucket(0);
+  previous = emptyBucket(0);
+  lastCommitAt = 0;
+  backToBackRun = 0;
+  maxBackToBackRun = 0;
+}

--- a/clients/web/src/lib/sentry/flavor-capacitor.test.ts
+++ b/clients/web/src/lib/sentry/flavor-capacitor.test.ts
@@ -70,6 +70,31 @@ describe("capacitorFlavor.init", () => {
     consent = false; // user opts out after the client was initialized
     expect(beforeSend?.(anEvent(), {})).toBeNull();
   });
+
+  test("composes the caller's beforeSend instead of replacing it", () => {
+    // The caller's hook carries diagnostic enrichment that every surface
+    // should get; overwriting it here silently exempted iOS.
+    consent = true;
+    const enriched = { event_id: "enriched" } as ErrorEvent;
+    capacitorFlavor.init({ ...OPTIONS, beforeSend: () => enriched });
+
+    expect(lastInitOptions?.beforeSend?.(anEvent(), {})).toBe(enriched);
+  });
+
+  test("consent is checked before the caller's beforeSend runs", () => {
+    consent = false;
+    let callerRan = false;
+    capacitorFlavor.init({
+      ...OPTIONS,
+      beforeSend: (event) => {
+        callerRan = true;
+        return event;
+      },
+    });
+
+    expect(lastInitOptions?.beforeSend?.(anEvent(), {})).toBeNull();
+    expect(callerRan).toBe(false);
+  });
 });
 
 describe("capacitorFlavor.close", () => {

--- a/clients/web/src/lib/sentry/flavor-capacitor.ts
+++ b/clients/web/src/lib/sentry/flavor-capacitor.ts
@@ -37,13 +37,23 @@ import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
  */
 export const capacitorFlavor: SentryFlavor = {
   init(options) {
+    const enrich = options.beforeSend;
     Capacitor.init(
       {
         ...options,
         enabled: true,
         // Defensive gate for JS-bridged webview events; native envelopes
         // bypass beforeSend, so consent-gated init + close is the native gate.
-        beforeSend: (event) => (diagnosticsConsentGranted() ? event : null),
+        //
+        // Composed, not replaced: the caller's `beforeSend` carries the
+        // diagnostic enrichment every surface should get (see `sentry-init`),
+        // and overwriting it here would silently exempt iOS. The consent check
+        // stays first so a denied event is dropped before any work is done on
+        // it — the gate is not weakened by what runs after it.
+        beforeSend: (event, hint) => {
+          if (!diagnosticsConsentGranted()) return null;
+          return enrich ? enrich(event, hint) : event;
+        },
       },
       reactInit,
     );

--- a/clients/web/src/lib/sentry/sentry-init.test.ts
+++ b/clients/web/src/lib/sentry/sentry-init.test.ts
@@ -117,6 +117,41 @@ describe("initSentry commit-pressure enrichment", () => {
     expect(pressure?.sources["smooth-stream"]).toBe(2);
   });
 
+  test("attaches to the MINIFIED form the production bundle actually throws", () => {
+    // `react-dom-client.production.js` contains no occurrence of the expanded
+    // sentence — it throws `formatProdErrorMessage(185)`. Sentry expands it
+    // server-side, so an events-page reading of the message is misleading:
+    // `beforeSend` sees this string. Matching only the dev text meant the
+    // enrichment never ran in the builds it was written for.
+    recordUpdate("smooth-stream");
+
+    const sent = sendEvent(
+      "Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.",
+    );
+
+    expect(sent?.contexts?.commit_pressure).toBeDefined();
+  });
+
+  test("does not match a different minified React error", () => {
+    recordUpdate("smooth-stream");
+
+    const sent = sendEvent(
+      "Minified React error #186; visit https://react.dev/errors/186 for the full message.",
+    );
+
+    expect(sent?.contexts?.commit_pressure).toBeUndefined();
+  });
+
+  test("does not match a longer code that merely starts with 185", () => {
+    recordUpdate("smooth-stream");
+
+    const sent = sendEvent(
+      "Minified React error #1850; visit https://react.dev/errors/1850 for the full message.",
+    );
+
+    expect(sent?.contexts?.commit_pressure).toBeUndefined();
+  });
+
   test("leaves unrelated errors untouched", () => {
     recordUpdate("smooth-stream");
 

--- a/clients/web/src/lib/sentry/sentry-init.test.ts
+++ b/clients/web/src/lib/sentry/sentry-init.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { BrowserOptions } from "@sentry/react";
+import type { BrowserOptions, ErrorEvent } from "@sentry/react";
+
+import { recordUpdate, resetCommitPressure } from "@/lib/commit-pressure";
 
 // Capture the options the init path dispatches so we can assert the resolved DSN.
 let syncedOptions: BrowserOptions | undefined;
@@ -81,5 +83,52 @@ describe("initSentry client_os tag", () => {
     electron = true;
     initSentry();
     expect(clientOsTag()).toBe("macos");
+  });
+});
+
+describe("initSentry commit-pressure enrichment", () => {
+  function sendEvent(message: string): ErrorEvent | null {
+    initSentry();
+    const beforeSend = syncedOptions?.beforeSend;
+    if (!beforeSend) throw new Error("beforeSend not configured");
+    const event = {
+      exception: { values: [{ type: "Error", value: message }] },
+    } as ErrorEvent;
+    return beforeSend(event, {}) as ErrorEvent | null;
+  }
+
+  beforeEach(() => {
+    resetCommitPressure();
+  });
+
+  test("attaches the pressure snapshot to a max-update-depth event", () => {
+    recordUpdate("smooth-stream");
+    recordUpdate("avatar-morph");
+    recordUpdate("smooth-stream");
+
+    const sent = sendEvent(
+      "Maximum update depth exceeded. This can happen when a component repeatedly calls setState...",
+    );
+
+    const pressure = sent?.contexts?.commit_pressure as
+      | { updates: number; sources: Record<string, number> }
+      | undefined;
+    expect(pressure?.updates).toBe(3);
+    expect(pressure?.sources["smooth-stream"]).toBe(2);
+  });
+
+  test("leaves unrelated errors untouched", () => {
+    recordUpdate("smooth-stream");
+
+    const sent = sendEvent("Something else broke");
+
+    expect(sent?.contexts?.commit_pressure).toBeUndefined();
+  });
+
+  test("passes the event through when the probe has no data", () => {
+    const sent = sendEvent("Maximum update depth exceeded.");
+
+    expect(sent).not.toBeNull();
+    expect(sent?.contexts?.commit_pressure).toBeUndefined();
   });
 });

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -20,6 +20,26 @@ import { detectClientOs } from "@/runtime/platform-detection";
  *
  * The Electron check comes first since the renderer also runs the web bundle.
  */
+/**
+ * Recognize React's nested-update-limit error in every form it ships as.
+ *
+ * The expanded sentence only exists in the development bundle:
+ * `react-dom-client.production.js` throws `formatProdErrorMessage(185)`, which
+ * reads "Minified React error #185; visit https://react.dev/errors/185 …".
+ * Sentry expands it server-side for display, so the stored events read like
+ * the development text while the value reaching `beforeSend` — client-side,
+ * pre-transmit — is the minified one. Matching only the sentence would mean
+ * the enrichment never ran anywhere it matters.
+ *
+ * The digit guards keep `#185` from also matching a future `#1850`.
+ */
+const REACT_ERROR_185 =
+  /Maximum update depth exceeded|Minified React error #185(?!\d)|react\.dev\/errors\/185(?!\d)/;
+
+function isReactError185(message: string): boolean {
+  return REACT_ERROR_185.test(message);
+}
+
 function resolveDsn(): string | undefined {
   if (isElectron()) return import.meta.env.VITE_SENTRY_DSN_MACOS;
   if (isNativePlatform()) return import.meta.env.VITE_SENTRY_DSN_IOS;
@@ -79,8 +99,8 @@ const options: BrowserOptions = {
     // occurrence so far has blamed a different frame. Attach the update
     // traffic that was actually in flight so the next one names the cause.
     // See `lib/commit-pressure.ts`.
-    const raisedMaxUpdateDepth = event.exception?.values?.some((value) =>
-      value.value?.includes("Maximum update depth exceeded"),
+    const raisedMaxUpdateDepth = event.exception?.values?.some(
+      (value) => value.value != null && isReactError185(value.value),
     );
     if (!raisedMaxUpdateDepth) return event;
     const pressure = snapshotCommitPressure();

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -1,5 +1,6 @@
 import type { BrowserOptions } from "@sentry/react";
 
+import { snapshotCommitPressure } from "@/lib/commit-pressure";
 import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
 import {
   installSentryControlListeners,
@@ -35,6 +36,10 @@ function resolveDsn(): string | undefined {
  * here must never match errors raised from `src/` — fix those at the call
  * site so real regressions are not hidden.
  *
+ * `beforeSend` enriches React's `Maximum update depth exceeded` with the
+ * commit-pressure snapshot — that error's stack frame is a bystander, so
+ * without the extra context the events are not actionable.
+ *
  * `beforeBreadcrumb` strips auth codes, invite tokens, and OAuth fragment
  * tokens from URLs the browser SDK records on navigation / fetch / XHR.
  * Regex-based scrubbing of CC/SSN/password patterns is handled by
@@ -68,6 +73,23 @@ const options: BrowserOptions = {
   // after sourcemap upload.
   // Reference: https://docs.sentry.io/platforms/javascript/configuration/options/#attach-stacktrace
   attachStacktrace: true,
+  beforeSend(event) {
+    // React error 185 is thrown from whatever `setState` runs after the nested
+    // update limit is already breached, so its stack names a bystander — every
+    // occurrence so far has blamed a different frame. Attach the update
+    // traffic that was actually in flight so the next one names the cause.
+    // See `lib/commit-pressure.ts`.
+    const raisedMaxUpdateDepth = event.exception?.values?.some((value) =>
+      value.value?.includes("Maximum update depth exceeded"),
+    );
+    if (!raisedMaxUpdateDepth) return event;
+    const pressure = snapshotCommitPressure();
+    if (!pressure) return event;
+    return {
+      ...event,
+      contexts: { ...event.contexts, commit_pressure: { ...pressure } },
+    };
+  },
   beforeBreadcrumb(breadcrumb) {
     const data = breadcrumb.data;
     if (!data || typeof data !== "object") return breadcrumb;


### PR DESCRIPTION
## What
Removes React state from the avatar morph (the top identified contributor to error 185 pressure) and adds a bounded probe on `beforeSend` to measure whether other decorative paths are still queuing sub-frame commits.

- `animated-avatar.tsx` — morph runs via `ref` + `setAttribute("d", …)` instead of `setMorphIndex`. Cleanup restores the resting shape so a turn ending mid-cycle doesn't freeze the body wobbled.
- `useViewportMinHeight` — one-line guard so `ResizeObserver` width changes don't schedule no-op React updates.
- `commit-pressure.ts` — fixed buckets, no hot-path allocation, source keys capped at 24, `maxBackToBackCommits` counter. Attached to error-185 events only via `beforeSend`.
- Smooth-stream left as-is (holding until probe data justifies touching it).
- `CONVENTIONS.md` — new rule: decorative animation doesn't go through React state, with the counter mechanics as the reason.

## Verification
- 19 new tests pass; the morph test fires the interval callback outside `act()`, so it only passes if the DOM changed without a commit.
- `bun run typecheck` clean; lint clean (0 errors; pre-existing `curly` warnings are house style).
- `bun scripts/run-tests.ts` over the touched areas (`src/lib`, `src/components/avatar`, `src/domains/chat/transcript`): **104 test files, 0 failures**.

> **Correction to an earlier revision of this description**, which reported "85 failures before and after" from a pre-existing design-library resolution error. That was an artifact of invoking `bun test <dir>`, which shares one process across files and lets `mock.module` leak — the very thing `scripts/run-tests.ts` exists to prevent by running each file in its own subprocess. Under the repo's actual runner there are no failures. The design-library breakage I reported does not exist; apologies for the noise.

## Review fixes (c417551872)
- **Minified React error 185** (@chatgpt-codex-connector, @devin-ai-integration): confirmed — `react-dom-client.production.js` contains zero occurrences of "Maximum update depth exceeded" and throws `formatProdErrorMessage(185)` instead. Sentry expands that server-side, which is why the stored events read like the dev text and why the original matcher looked right. The matcher now covers the expanded sentence, `Minified React error #185`, and the decoder URL, with digit guards so `#185` can't match a future `#1850`.
- **iOS `beforeSend` composition** (@chatgpt-codex-connector): confirmed — `capacitorFlavor.init` overwrote the caller's `beforeSend`, exempting iOS. Now composed, with the consent gate still evaluated first so a denied event is dropped before the caller's hook runs.

## Notes
- LUM-2858 / LUM-2860 / LUM-2861 are duplicates of LUM-2859 — will merge on the Linear side.
- LUM-2715 (previously closed as fixed by the Radix bump) had its Sentry group fire again this session — reopening regardless.

Fixes LUM-2859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)