### PR TITLE
chore(repo): add .prettierignore covering nested git worktrees

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Nested git worktrees hold a full second copy of this repo. They are gitignored
+# (see .gitignore), but Prettier does not consult .gitignore — so an ad-hoc
+# `prettier --write .` from the repo root would rewrite files inside another
+# session's worktree. Keep these patterns in sync with .gitignore:38-41.
+.claude/worktrees/
+worktrees/
+.worktrees/
+.codex-worktrees/
+*-worktrees/


### PR DESCRIPTION
## Summary

Adds a repo-root `.prettierignore` so Prettier never descends into a nested git worktree.

## Why

The Claude Code desktop app's worktree location is controlled by the `chillingSlothLocation` preference in `~/Library/Application Support/Claude/claude_desktop_config.json`:

```json
"preferences": {
  "chillingSlothLocation": { "customPath": "/Users/you/Development/claude-worktrees" }
}
```

`getWorktreeParentDir()` joins `customPath` with the repo's basename, giving `<customPath>/<repo>/<name>` — outside the repo. **But the default value is the string `"default"`, and that places worktrees *inside* the repo at `<repo>/.claude/worktrees/<name>`** — a full second copy of the tree under the repo root.

So any contributor who hasn't set a custom path gets in-repo worktrees. `.claude/worktrees/` is gitignored (`.gitignore:48`, plus `worktrees/` at `:38`), but **Prettier does not consult `.gitignore`**, and this repo had no `.prettierignore`. An ad-hoc `prettier --write .` from the repo root would walk into a worktree and reformat files underneath an active session.

This is not hypothetical even with a custom path configured: an in-repo worktree at `.claude/worktrees/` exists on at least one machine here alongside the custom-path setting, created through a different code path than the app's pooled-worktree flow.

## Scope of the hazard

Nothing in the repo's *configured* tooling recurses today — verified:

| Check | Result |
|---|---|
| Root `package.json` | zero scripts; `workspaces` is 21 explicit paths, no globs |
| tsconfig | no root tsconfig; per-workspace only |
| CI | every test/lint/typecheck step sets `working-directory:` to a workspace |
| Workspace scripts | all workspace-scoped (`bun test src/`, `prettier --write .` run from their own dir) |

So this is a latent hazard that becomes real the moment anything is invoked from the repo root. This PR closes the Prettier half cheaply and protects contributors running default settings.

## What this does not fix

The `bun test` half **cannot be closed by configuration**. `bun test` discovery walks the tree from cwd and does not consult `.gitignore`, and bunfig has no path-ignore option. The mitigation there is pointing `chillingSlothLocation.customPath` outside the repo — see [claude-skills#243](https://github.com/vellum-ai/claude-skills/issues/243) for aligning our `.claude/worktree` helper with the same convention.

## Verification

```
$ npx prettier --file-info .claude/worktrees/some-wt/assistant/src/foo.ts
{"ignored":true,"inferredParser":null}
$ npx prettier --file-info assistant/src/real.ts
{"ignored":false,"inferredParser":"typescript"}
```

Worktree paths ignored; real source unaffected.

## Files Changed

- `.prettierignore` (new) — patterns mirror `.gitignore:38-41`, with a comment explaining why the duplication exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)