### PR TITLE
feat(telegram): detect a dark Telegram webhook and alert the guardian (LUM-2862)

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -170,6 +170,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "messaging/providers/slack/api.ts", // Slack Web API client (bot token for direct sends)
       "messaging/providers/telegram-bot/api.ts", // Telegram Bot API client (bot token for direct sends)
       "runtime/channel-readiness-service.ts", // channel readiness probes for Telegram connectivity
+      "telegram/webhook-health.ts", // Telegram webhook health sweep — reads bot_token to call getWebhookInfo (Bot API authenticates via the token in the URL path) and checks webhook_secret for existence only; neither value is logged, persisted, or returned
       "messaging/providers/whatsapp/adapter.ts", // WhatsApp credential lookup for connectivity check
       "messaging/providers/whatsapp/api.ts", // WhatsApp Cloud API client (bot token for direct sends)
       "messaging/providers/slack/adapter.ts", // Slack bot token lookup for Socket Mode connectivity check

--- a/assistant/src/config/webhook-routing.ts
+++ b/assistant/src/config/webhook-routing.ts
@@ -1,0 +1,67 @@
+/**
+ * Derivations answering "is this deployment set up to receive provider
+ * webhooks?" from workspace config.
+ *
+ * Two consumers ask the same question for different reasons: the channel
+ * readiness probes report it to the user, and the Telegram webhook health
+ * sweep uses it to decide whether a missing/broken registration is even
+ * meaningful. Both must agree — a probe that says "ingress is configured"
+ * while the sweep says "no webhook expected" would be a silent divergence.
+ */
+
+import {
+  normalizePublicBaseUrl,
+  resolveTwilioPublicBaseUrl,
+} from "@vellumai/service-contracts/twilio-ingress";
+
+import { getIsPlatform } from "./env-registry.js";
+import { loadRawConfig } from "./loader.js";
+
+/**
+ * True when a public ingress base URL is set and ingress is enabled.
+ *
+ * `ingress.enabled` is treated as opt-out: an unset flag with a base URL
+ * present counts as enabled, matching how the URL alone has always been
+ * enough to drive registration.
+ */
+export function hasIngressConfigured(
+  options: { twilio?: boolean } = {},
+): boolean {
+  try {
+    const raw = loadRawConfig();
+    const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
+    const effectiveBaseUrl = options.twilio
+      ? (resolveTwilioPublicBaseUrl(ingress) ?? "")
+      : (normalizePublicBaseUrl(ingress.publicBaseUrl) ?? "");
+    const enabled =
+      (ingress.enabled as boolean | undefined) ??
+      (effectiveBaseUrl ? true : false);
+    return enabled && effectiveBaseUrl.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when inbound webhooks have somewhere to land: either a self-hosted
+ * public ingress URL, or — when `allowManagedCallbacks` is set and this is a
+ * platform deployment — the platform's managed callback routes.
+ */
+export function hasWebhookRoutingConfigured(
+  allowManagedCallbacks = false,
+  options: { twilio?: boolean } = {},
+): {
+  configured: boolean;
+  usesManagedCallbacks: boolean;
+} {
+  const ingressConfigured = hasIngressConfigured(options);
+  if (ingressConfigured) {
+    return { configured: true, usesManagedCallbacks: false };
+  }
+
+  const usesManagedCallbacks = allowManagedCallbacks && getIsPlatform();
+  return {
+    configured: usesManagedCallbacks,
+    usesManagedCallbacks,
+  };
+}

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -159,6 +159,7 @@ const EVENT_CATEGORY_MAP: Record<string, FeedItemCategory> = {
   "guardian.question": "security",
   "guardian.channel_activation": "security",
   "ingress.access_request": "security",
+  "telegram.webhook_health_alert": "system",
 };
 
 function deriveCategory(signal: NotificationSignal): FeedItemCategory {
@@ -269,6 +270,9 @@ const NOTEWORTHY_EVENT_NAMES: ReadonlySet<string> = new Set([
   "guardian.channel_activation",
   "ingress.access_request",
   "credential.health_alert",
+  // A dark messaging channel is inbox-worthy: the guardian may be waiting on
+  // replies that are silently queueing at Telegram.
+  "telegram.webhook_health_alert",
 ]);
 
 function deriveNoteworthy(signal: NotificationSignal): boolean {

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -126,6 +126,11 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     description:
       "OAuth credential health issue detected (expired, revoked, missing scopes)",
   },
+  {
+    id: "telegram.webhook_health_alert",
+    description:
+      "Telegram webhook is not delivering (unregistered, or failing per getWebhookInfo)",
+  },
 ] as const;
 
 export type NotificationSourceEventName =

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -1,14 +1,10 @@
 import { isInviteCodeRedemptionEnabled } from "@vellumai/gateway-client";
-import {
-  normalizePublicBaseUrl,
-  resolveTwilioPublicBaseUrl,
-} from "@vellumai/service-contracts/twilio-ingress";
 import { z } from "zod";
 
 import { resolveTwilioPhoneNumber } from "../calls/twilio-config.js";
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
-import { getIsPlatform } from "../config/env-registry.js";
 import { getNestedValue, loadRawConfig } from "../config/loader.js";
+import { hasWebhookRoutingConfigured } from "../config/webhook-routing.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { resolveWhatsAppDisplayNumber } from "./channel-invite-transports/whatsapp.js";
@@ -113,41 +109,6 @@ function scopeGrantCheck(rawHeader: string | null): ReadinessCheckResult {
     `Bot token carries all ${SLACK_REQUIRED_BOT_SCOPES.length} required scopes`,
     `Bot token is missing ${missing.length} of ${SLACK_REQUIRED_BOT_SCOPES.length} required scopes (${missing.join(", ")}) — open the app at https://api.slack.com/apps, accept the update prompt, then OAuth & Permissions → Reinstall to Workspace`,
   );
-}
-
-function hasIngressConfigured(options: { twilio?: boolean } = {}): boolean {
-  try {
-    const raw = loadRawConfig();
-    const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
-    const effectiveBaseUrl = options.twilio
-      ? (resolveTwilioPublicBaseUrl(ingress) ?? "")
-      : (normalizePublicBaseUrl(ingress.publicBaseUrl) ?? "");
-    const enabled =
-      (ingress.enabled as boolean | undefined) ??
-      (effectiveBaseUrl ? true : false);
-    return enabled && effectiveBaseUrl.trim().length > 0;
-  } catch {
-    return false;
-  }
-}
-
-function hasWebhookRoutingConfigured(
-  allowManagedCallbacks = false,
-  options: { twilio?: boolean } = {},
-): {
-  configured: boolean;
-  usesManagedCallbacks: boolean;
-} {
-  const ingressConfigured = hasIngressConfigured(options);
-  if (ingressConfigured) {
-    return { configured: true, usesManagedCallbacks: false };
-  }
-
-  const usesManagedCallbacks = allowManagedCallbacks && getIsPlatform();
-  return {
-    configured: usesManagedCallbacks,
-    usesManagedCallbacks,
-  };
 }
 
 // ── Shared check helpers ────────────────────────────────────────────────────

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -37,6 +37,10 @@ import {
   activeSttStreamSessions,
   SttStreamSession,
 } from "../stt/stt-stream-session.js";
+import {
+  startTelegramWebhookHealthSweep,
+  stopTelegramWebhookHealthSweep,
+} from "../telegram/webhook-health.js";
 import { getLogger } from "../util/logger.js";
 import { authenticateRequest } from "./auth/middleware.js";
 import { parseSub } from "./auth/subject.js";
@@ -504,11 +508,15 @@ export class RuntimeHttpServer {
 
     startInferenceProfileSessionReaper();
     log.info("Inference profile session reaper started");
+
+    startTelegramWebhookHealthSweep();
+    log.info("Telegram webhook health sweep started");
   }
 
   async stop(): Promise<void> {
     stopGuardianExpirySweep();
     stopInferenceProfileSessionReaper();
+    stopTelegramWebhookHealthSweep();
     if (this.retrySweepTimer) {
       clearInterval(this.retrySweepTimer);
       this.retrySweepTimer = null;

--- a/assistant/src/telegram/__tests__/webhook-health.test.ts
+++ b/assistant/src/telegram/__tests__/webhook-health.test.ts
@@ -21,7 +21,7 @@ let fetchCallCount = 0;
 const fetchedUrls: string[] = [];
 
 const emittedSignals: Array<Record<string, unknown>> = [];
-let emitThrows = false;
+let emitFails = false;
 
 // ── Module mocks ──────────────────────────────────────────────────────
 
@@ -50,10 +50,24 @@ mock.module("../../config/loader.js", () => ({
   getConfig: () => ({ telegram: { apiBaseUrl } }),
 }));
 
+// Mirrors the real `emitNotificationSignal` contract: it swallows pipeline
+// errors and resolves with `dispatched: false` UNLESS `throwOnError` is set.
+// The mock reproduces that conditional rather than throwing unconditionally —
+// otherwise it would validate a contract the real function does not have, and
+// the caller's retry path could be dead in production while tests pass.
 mock.module("../../notifications/emit-signal.js", () => ({
   emitNotificationSignal: async (params: Record<string, unknown>) => {
-    if (emitThrows) {
-      throw new Error("emit failed");
+    if (emitFails) {
+      if (params.throwOnError) {
+        throw new Error("emit failed");
+      }
+      return {
+        signalId: "sig",
+        deduplicated: false,
+        dispatched: false,
+        reason: "Signal pipeline failed: emit failed",
+        deliveryResults: [],
+      };
     }
     emittedSignals.push(params);
     return {
@@ -91,6 +105,7 @@ const {
 // ── Helpers ───────────────────────────────────────────────────────────
 
 const BOT_TOKEN_KEY = "credential/telegram/bot_token";
+const WEBHOOK_SECRET_KEY = "credential/telegram/webhook_secret";
 const WEBHOOK_URL = "https://example.test/webhooks/telegram";
 
 /** Unix seconds, `secondsAgo` in the past — Telegram reports seconds, not ms. */
@@ -105,13 +120,14 @@ function setWebhookInfo(result: Record<string, unknown>): void {
 beforeEach(() => {
   secureKeyValues.clear();
   secureKeyValues.set(BOT_TOKEN_KEY, "12345:test-token");
+  secureKeyValues.set(WEBHOOK_SECRET_KEY, "s3cret");
   webhookRouting = { configured: true, usesManagedCallbacks: false };
   setWebhookInfo({ url: WEBHOOK_URL, pending_update_count: 0 });
   fetchCallCount = 0;
   fetchedUrls.length = 0;
   apiBaseUrl = "https://api.telegram.org";
   emittedSignals.length = 0;
-  emitThrows = false;
+  emitFails = false;
   _resetTelegramWebhookHealthState();
 });
 
@@ -120,6 +136,19 @@ beforeEach(() => {
 describe("gating", () => {
   test("does not run when no Telegram bot token is configured", async () => {
     secureKeyValues.delete(BOT_TOKEN_KEY);
+
+    const result = await runTelegramWebhookHealthCheck();
+
+    expect(result.status).toBe("skipped");
+    expect(fetchCallCount).toBe(0);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("does not run when the webhook secret is missing", async () => {
+    // The gateway reconciler bails before setWebhook without the secret, so a
+    // bot_token-only workspace has no webhook by design. Alerting here would
+    // name the wrong cause and point at an ingress URL the user hasn't set yet.
+    secureKeyValues.delete(WEBHOOK_SECRET_KEY);
 
     const result = await runTelegramWebhookHealthCheck();
 
@@ -283,7 +312,14 @@ describe("alerting", () => {
     const signal = emittedSignals[0]!;
     expect(signal.sourceEventName).toBe("telegram.webhook_health_alert");
     // Never routed as if it came from Telegram — that channel is the broken one.
-    expect(signal.sourceChannel).toBe("watcher");
+    // "assistant_tool" specifically, because that plus requestedMessage is what
+    // takes the decision engine's verbatim pass-through and skips the LLM
+    // classifier. AGENTS.md forbids LLM work on unconditional timers, and a
+    // classifier could also suppress the alert outright.
+    expect(signal.sourceChannel).toBe("assistant_tool");
+    // Pins the emitNotificationSignal contract: without this the pipeline
+    // swallows failures and the latch-release retry path below is dead code.
+    expect(signal.throwOnError).toBe(true);
     expect(signal.attentionHints).toMatchObject({
       requiresAction: true,
       urgency: "high",
@@ -296,6 +332,12 @@ describe("alerting", () => {
     expect(payload.pendingUpdateCount).toBe(3);
     expect(String(payload.body)).toContain("Telegram (@test_bot)");
     expect(String(payload.body)).toContain("404 Not Found");
+    // The pass-through reads requestedMessage/requestedTitle; the home-feed
+    // writer reads body/title. Both must carry the composed copy or the alert
+    // silently falls back to the LLM path (or renders empty).
+    expect(payload.requestedMessage).toBe(payload.body);
+    expect(payload.requestedTitle).toBe(payload.title);
+    expect(String(payload.requestedMessage)).not.toHaveLength(0);
   });
 
   test("an unregistered webhook alerts with a title matching that status", async () => {
@@ -378,12 +420,15 @@ describe("alerting", () => {
   });
 
   test("a failed emit is retried on the next round", async () => {
+    // Exercises the real contract: the mock only throws because the caller
+    // passes throwOnError. Drop that param and this test fails, which is the
+    // point — the retry path must not be able to go dead silently.
     setFailing();
-    emitThrows = true;
+    emitFails = true;
     await runTelegramWebhookHealthCheck();
     expect(emittedSignals).toHaveLength(0);
 
-    emitThrows = false;
+    emitFails = false;
     await runTelegramWebhookHealthCheck();
 
     expect(emittedSignals).toHaveLength(1);

--- a/assistant/src/telegram/__tests__/webhook-health.test.ts
+++ b/assistant/src/telegram/__tests__/webhook-health.test.ts
@@ -1,0 +1,397 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mutable mock state ────────────────────────────────────────────────
+
+const secureKeyValues = new Map<string, string>();
+
+let webhookRouting: { configured: boolean; usesManagedCallbacks: boolean } = {
+  configured: true,
+  usesManagedCallbacks: false,
+};
+
+type FetchOutcome =
+  | { kind: "json"; status?: number; body: unknown }
+  | { kind: "throw"; message: string };
+
+let fetchOutcome: FetchOutcome = {
+  kind: "json",
+  body: { ok: true, result: { url: "https://example.test/webhooks/telegram" } },
+};
+let fetchCallCount = 0;
+const fetchedUrls: string[] = [];
+
+const emittedSignals: Array<Record<string, unknown>> = [];
+let emitThrows = false;
+
+// ── Module mocks ──────────────────────────────────────────────────────
+
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
+}));
+
+mock.module("../../security/credential-key.js", () => ({
+  credentialKey: (service: string, field: string) =>
+    `credential/${service}/${field}`,
+}));
+
+mock.module("../../config/webhook-routing.js", () => ({
+  hasWebhookRoutingConfigured: () => webhookRouting,
+  hasIngressConfigured: () => webhookRouting.configured,
+}));
+
+mock.module("../bot-username.js", () => ({
+  getTelegramBotUsername: () => "test_bot",
+  getTelegramBotId: () => "123",
+}));
+
+let apiBaseUrl = "https://api.telegram.org";
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ telegram: { apiBaseUrl } }),
+}));
+
+mock.module("../../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    if (emitThrows) {
+      throw new Error("emit failed");
+    }
+    emittedSignals.push(params);
+    return {
+      signalId: "sig",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    };
+  },
+}));
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (async (input: string) => {
+  fetchCallCount++;
+  fetchedUrls.push(String(input));
+  const outcome = fetchOutcome;
+  if (outcome.kind === "throw") {
+    throw new Error(outcome.message);
+  }
+  const status = outcome.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => outcome.body,
+  } as Response;
+}) as unknown as typeof fetch;
+
+const {
+  _resetTelegramWebhookHealthState,
+  checkTelegramWebhookHealth,
+  runTelegramWebhookHealthCheck,
+} = await import("../webhook-health.js");
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const BOT_TOKEN_KEY = "credential/telegram/bot_token";
+const WEBHOOK_URL = "https://example.test/webhooks/telegram";
+
+/** Unix seconds, `secondsAgo` in the past — Telegram reports seconds, not ms. */
+function unixSecondsAgo(secondsAgo: number): number {
+  return Math.floor((Date.now() - secondsAgo * 1000) / 1000);
+}
+
+function setWebhookInfo(result: Record<string, unknown>): void {
+  fetchOutcome = { kind: "json", body: { ok: true, result } };
+}
+
+beforeEach(() => {
+  secureKeyValues.clear();
+  secureKeyValues.set(BOT_TOKEN_KEY, "12345:test-token");
+  webhookRouting = { configured: true, usesManagedCallbacks: false };
+  setWebhookInfo({ url: WEBHOOK_URL, pending_update_count: 0 });
+  fetchCallCount = 0;
+  fetchedUrls.length = 0;
+  apiBaseUrl = "https://api.telegram.org";
+  emittedSignals.length = 0;
+  emitThrows = false;
+  _resetTelegramWebhookHealthState();
+});
+
+// ── Gating ────────────────────────────────────────────────────────────
+
+describe("gating", () => {
+  test("does not run when no Telegram bot token is configured", async () => {
+    secureKeyValues.delete(BOT_TOKEN_KEY);
+
+    const result = await runTelegramWebhookHealthCheck();
+
+    expect(result.status).toBe("skipped");
+    expect(fetchCallCount).toBe(0);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("does not run when no webhook routing is configured", async () => {
+    webhookRouting = { configured: false, usesManagedCallbacks: false };
+
+    const result = await runTelegramWebhookHealthCheck();
+
+    expect(result.status).toBe("skipped");
+    expect(fetchCallCount).toBe(0);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("runs when platform-managed callbacks stand in for public ingress", async () => {
+    webhookRouting = { configured: true, usesManagedCallbacks: true };
+    setWebhookInfo({
+      url: WEBHOOK_URL,
+      last_error_date: unixSecondsAgo(30),
+      last_error_message: "Wrong response from the webhook: 404 Not Found",
+    });
+
+    const result = await runTelegramWebhookHealthCheck();
+
+    expect(result.status).toBe("delivery_failing");
+    expect(emittedSignals).toHaveLength(1);
+    // Managed deployments can't set the ingress URL themselves, so the
+    // self-hosted remediation must not be offered to them.
+    expect(result.detail).not.toContain("assistant config set");
+    expect(result.detail).toContain("contact support");
+  });
+});
+
+// ── Detection ─────────────────────────────────────────────────────────
+
+describe("detection", () => {
+  test("a recent delivery error is a failure", async () => {
+    setWebhookInfo({
+      url: WEBHOOK_URL,
+      pending_update_count: 3,
+      last_error_date: unixSecondsAgo(60),
+      last_error_message: "Wrong response from the webhook: 404 Not Found",
+    });
+
+    const result = await checkTelegramWebhookHealth();
+
+    expect(result.status).toBe("delivery_failing");
+    expect(result.pendingUpdateCount).toBe(3);
+    expect(result.lastErrorMessage).toBe(
+      "Wrong response from the webhook: 404 Not Found",
+    );
+  });
+
+  test("a stale delivery error is not a failure", async () => {
+    // Telegram never clears last_error_date, so an old error must not be read
+    // as an ongoing outage — otherwise one historical blip alerts forever.
+    setWebhookInfo({
+      url: WEBHOOK_URL,
+      pending_update_count: 0,
+      last_error_date: unixSecondsAgo(7 * 24 * 60 * 60),
+      last_error_message: "Wrong response from the webhook: 404 Not Found",
+    });
+
+    const result = await checkTelegramWebhookHealth();
+
+    expect(result.status).toBe("healthy");
+  });
+
+  test("an empty webhook URL means the channel is dark", async () => {
+    setWebhookInfo({ url: "", pending_update_count: 0 });
+
+    const result = await checkTelegramWebhookHealth();
+
+    expect(result.status).toBe("not_registered");
+    expect(result.detail).toContain("no webhook registered");
+  });
+
+  test("an unreachable Telegram API yields unknown, not a failure", async () => {
+    fetchOutcome = { kind: "throw", message: "network unreachable" };
+
+    const result = await checkTelegramWebhookHealth();
+
+    expect(result.status).toBe("unknown");
+  });
+
+  test("a non-2xx response yields unknown, not a failure", async () => {
+    fetchOutcome = { kind: "json", status: 500, body: {} };
+
+    const result = await checkTelegramWebhookHealth();
+
+    expect(result.status).toBe("unknown");
+  });
+
+  test("an unexpected response shape yields unknown, not a failure", async () => {
+    fetchOutcome = { kind: "json", body: { ok: false, description: "nope" } };
+
+    const result = await checkTelegramWebhookHealth();
+
+    expect(result.status).toBe("unknown");
+  });
+
+  test("honors a configured telegram.apiBaseUrl", async () => {
+    apiBaseUrl = "https://telegram-proxy.internal/";
+
+    await checkTelegramWebhookHealth();
+
+    expect(fetchedUrls[0]).toBe(
+      "https://telegram-proxy.internal/bot12345:test-token/getWebhookInfo",
+    );
+  });
+
+  test("the detail names the channel and the reported error", async () => {
+    setWebhookInfo({
+      url: WEBHOOK_URL,
+      pending_update_count: 3,
+      last_error_date: unixSecondsAgo(60),
+      last_error_message: "Wrong response from the webhook: 404 Not Found",
+    });
+
+    const result = await checkTelegramWebhookHealth();
+
+    expect(result.detail).toContain("Telegram (@test_bot)");
+    expect(result.detail).toContain(
+      "Wrong response from the webhook: 404 Not Found",
+    );
+    expect(result.detail).toContain("3 update(s) are queued");
+    expect(result.detail).toContain(
+      "assistant config set ingress.publicBaseUrl",
+    );
+  });
+});
+
+// ── Alerting ──────────────────────────────────────────────────────────
+
+describe("alerting", () => {
+  function setFailing(
+    message = "Wrong response from the webhook: 404 Not Found",
+  ) {
+    setWebhookInfo({
+      url: WEBHOOK_URL,
+      pending_update_count: 3,
+      last_error_date: unixSecondsAgo(30),
+      last_error_message: message,
+    });
+  }
+
+  function setHealthy() {
+    setWebhookInfo({ url: WEBHOOK_URL, pending_update_count: 0 });
+  }
+
+  test("a failing webhook notifies the guardian once", async () => {
+    setFailing();
+
+    await runTelegramWebhookHealthCheck();
+
+    expect(emittedSignals).toHaveLength(1);
+    const signal = emittedSignals[0]!;
+    expect(signal.sourceEventName).toBe("telegram.webhook_health_alert");
+    // Never routed as if it came from Telegram — that channel is the broken one.
+    expect(signal.sourceChannel).toBe("watcher");
+    expect(signal.attentionHints).toMatchObject({
+      requiresAction: true,
+      urgency: "high",
+      isAsyncBackground: true,
+    });
+
+    const payload = signal.contextPayload as Record<string, unknown>;
+    expect(payload.channel).toBe("telegram");
+    expect(payload.status).toBe("delivery_failing");
+    expect(payload.pendingUpdateCount).toBe(3);
+    expect(String(payload.body)).toContain("Telegram (@test_bot)");
+    expect(String(payload.body)).toContain("404 Not Found");
+  });
+
+  test("an unregistered webhook alerts with a title matching that status", async () => {
+    setWebhookInfo({ url: "", pending_update_count: 0 });
+
+    await runTelegramWebhookHealthCheck();
+
+    expect(emittedSignals).toHaveLength(1);
+    const payload = emittedSignals[0]!.contextPayload as Record<
+      string,
+      unknown
+    >;
+    expect(payload.status).toBe("not_registered");
+    expect(payload.title).toBe("Telegram webhook is not registered");
+  });
+
+  test("an ongoing failure does not re-alert on every poll", async () => {
+    setFailing();
+
+    await runTelegramWebhookHealthCheck();
+    await runTelegramWebhookHealthCheck();
+    await runTelegramWebhookHealthCheck();
+
+    expect(emittedSignals).toHaveLength(1);
+  });
+
+  test("a changing error message mid-outage does not re-alert", async () => {
+    setFailing("Wrong response from the webhook: 404 Not Found");
+    await runTelegramWebhookHealthCheck();
+
+    setFailing("Connection timed out");
+    await runTelegramWebhookHealthCheck();
+
+    expect(emittedSignals).toHaveLength(1);
+  });
+
+  test("a recovered webhook does not alert again", async () => {
+    setFailing();
+    await runTelegramWebhookHealthCheck();
+    expect(emittedSignals).toHaveLength(1);
+
+    setHealthy();
+    await runTelegramWebhookHealthCheck();
+    await runTelegramWebhookHealthCheck();
+
+    // Recovery is silent — one alert total, and no "recovered" notification.
+    expect(emittedSignals).toHaveLength(1);
+  });
+
+  test("a new outage after a recovery alerts again", async () => {
+    setFailing();
+    await runTelegramWebhookHealthCheck();
+
+    setHealthy();
+    await runTelegramWebhookHealthCheck();
+
+    setFailing();
+    await runTelegramWebhookHealthCheck();
+
+    expect(emittedSignals).toHaveLength(2);
+    // Distinct dedupe keys, or the pipeline would swallow the second alert.
+    expect(emittedSignals[0]!.dedupeKey).not.toBe(emittedSignals[1]!.dedupeKey);
+  });
+
+  test("an unknown result neither alerts nor clears an existing alert", async () => {
+    setFailing();
+    await runTelegramWebhookHealthCheck();
+    expect(emittedSignals).toHaveLength(1);
+
+    // Our own network dropping is not evidence the webhook recovered.
+    fetchOutcome = { kind: "throw", message: "network unreachable" };
+    await runTelegramWebhookHealthCheck();
+    expect(emittedSignals).toHaveLength(1);
+
+    setFailing();
+    await runTelegramWebhookHealthCheck();
+
+    // Still the same outage — the latch survived the unknown round.
+    expect(emittedSignals).toHaveLength(1);
+  });
+
+  test("a failed emit is retried on the next round", async () => {
+    setFailing();
+    emitThrows = true;
+    await runTelegramWebhookHealthCheck();
+    expect(emittedSignals).toHaveLength(0);
+
+    emitThrows = false;
+    await runTelegramWebhookHealthCheck();
+
+    expect(emittedSignals).toHaveLength(1);
+  });
+});
+
+// Restore after the suite, not at module scope — a top-level restore would run
+// while the describes are still registering, i.e. before any test executes.
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});

--- a/assistant/src/telegram/webhook-health.ts
+++ b/assistant/src/telegram/webhook-health.ts
@@ -167,6 +167,23 @@ export async function checkTelegramWebhookHealth(): Promise<TelegramWebhookHealt
     };
   }
 
+  // Both credentials, matching the gateway reconciler and the readiness probe.
+  // `reconcileTelegramWebhook` returns before calling setWebhook when the
+  // secret is absent, so a bot_token-only workspace (manual credential import,
+  // a half-finished CLI setup) has no webhook by design. Alerting there would
+  // report a real absence with the wrong cause and the wrong fix — an ingress
+  // URL the user has not got to yet.
+  const webhookSecret = await getSecureKeyAsync(
+    credentialKey("telegram", "webhook_secret"),
+  );
+  if (!webhookSecret) {
+    return {
+      status: "skipped",
+      detail:
+        "Telegram webhook secret is not configured — registration has not been completed, so there is no webhook to check",
+    };
+  }
+
   const { configured, usesManagedCallbacks } =
     hasWebhookRoutingConfigured(true);
   if (!configured) {
@@ -290,18 +307,35 @@ async function notifyWebhookFailure(
   result: TelegramWebhookHealthResult,
   dedupeKey: string,
 ): Promise<void> {
+  const title =
+    result.status === "not_registered"
+      ? "Telegram webhook is not registered"
+      : "Telegram webhook is failing";
+
   await emitNotificationSignal({
     sourceEventName: "telegram.webhook_health_alert",
-    // Deliberately NOT "telegram": the signal is produced by a daemon
-    // background sweep, not by traffic arriving over Telegram — and the
-    // Telegram channel is precisely the one that can't be relied on to carry
-    // this news. "watcher" is the background-subsystem producer channel, as
-    // used by the credential-health alerts.
-    sourceChannel: "watcher",
+    // Deliberately NOT "telegram": the Telegram channel is precisely the one
+    // that can't be relied on to carry this news.
+    //
+    // "assistant_tool" specifically (rather than "watcher") is what takes the
+    // decision engine's verbatim pass-through: paired with requestedMessage
+    // below, evaluateSignal skips the LLM classifier entirely. That matters
+    // twice over. AGENTS.md ("No LLM Work at Daemon Startup") forbids invoking
+    // LLM providers from unconditional timers, and this sweep is one — the
+    // heartbeat's exemption does not extend to it. And the copy here is fully
+    // computed already, so a classifier could only re-render it, or decide
+    // shouldNotify: false and suppress a high-urgency outage alert outright.
+    // background-job-runner.ts uses the same channel for the same reason.
+    sourceChannel: "assistant_tool",
     sourceContextId: "telegram-webhook-health",
     // Keyed to the episode, not the error text: a redundant emit inside one
     // outage collapses, while the next outage gets a fresh key and alerts.
     dedupeKey,
+    // emitNotificationSignal swallows pipeline errors and resolves with
+    // `dispatched: false` unless this is set. Without it the catch in
+    // runTelegramWebhookHealthCheck can never fire, and a failed emit would
+    // latch the episode forever with the guardian never told.
+    throwOnError: true,
     attentionHints: {
       requiresAction: true,
       urgency: "high",
@@ -311,10 +345,12 @@ async function notifyWebhookFailure(
     contextPayload: {
       channel: "telegram",
       status: result.status,
-      title:
-        result.status === "not_registered"
-          ? "Telegram webhook is not registered"
-          : "Telegram webhook is failing",
+      // requestedTitle/requestedMessage are the pass-through's contract; title
+      // and body are what the home-feed writer reads. Both carry the same
+      // already-composed copy.
+      requestedTitle: title,
+      requestedMessage: result.detail,
+      title,
       body: result.detail,
       ...(result.lastErrorMessage
         ? { lastErrorMessage: result.lastErrorMessage }
@@ -378,6 +414,13 @@ export async function runTelegramWebhookHealthCheck(): Promise<TelegramWebhookHe
   } catch (err) {
     // The guardian was never told, so this outage is still un-alerted. Release
     // the latch and let the next round try again.
+    //
+    // Only thrown failures release it. A signal the pipeline deliberately
+    // suppresses (deterministic checks returning `dispatched: false` without
+    // throwing) keeps the latch, on purpose: releasing it would mint a fresh
+    // episode key next round and re-emit every 5 minutes for as long as the
+    // suppression held. Staying quiet is the better failure mode, and matches
+    // how credential-health alerts behave.
     alertedEpisodeKey = null;
     log.error({ err }, "Failed to emit Telegram webhook health notification");
   }

--- a/assistant/src/telegram/webhook-health.ts
+++ b/assistant/src/telegram/webhook-health.ts
@@ -40,6 +40,12 @@
  * riding the heartbeat would mute this check exactly when it matters most.
  * One unauthenticated-cost HTTP GET has none of that token pressure, so it runs
  * on its own interval alongside the other daemon sweeps.
+ *
+ * That choice carries an obligation: AGENTS.md ("No LLM Work at Daemon
+ * Startup") bars LLM providers from unconditional timers and exempts the
+ * heartbeat, and this sweep gave up that exemption. So the alert deliberately
+ * takes the decision engine's verbatim pass-through — see notifyWebhookFailure.
+ * Anything added here that reaches an LLM has to re-answer that rule.
  */
 
 import { z } from "zod";

--- a/assistant/src/telegram/webhook-health.ts
+++ b/assistant/src/telegram/webhook-health.ts
@@ -1,0 +1,429 @@
+/**
+ * Telegram webhook health sweep.
+ *
+ * When the public ingress URL behind the Telegram webhook stops working (dead
+ * tunnel, rotated ngrok URL, changed gateway route), Telegram keeps accepting
+ * updates and queueing them, and nothing on our side notices: the gateway
+ * registers the webhook (`telegram/webhook-manager.ts`) but never re-reads it,
+ * so the channel goes dark indefinitely. Telegram itself reports the failure
+ * via `getWebhookInfo`; this sweep polls that and tells the guardian.
+ *
+ * Detection only — the sweep never calls `setWebhook`. Re-registration stays
+ * with the gateway reconciler, which already fires on credential change,
+ * ingress-config change, and system wake. Auto-repairing from here would fight
+ * a user mid-setup, and in the common case (a rotated tunnel URL that config
+ * still points at) re-registering would just re-register the same dead URL.
+ *
+ * ## Why recency, not presence
+ *
+ * `last_error_date` is documented as "Unix time for the most recent error that
+ * happened when trying to deliver an update via webhook"
+ * (https://core.telegram.org/bots/api#webhookinfo). Telegram does not document
+ * clearing it on recovery, and in practice it persists — so its mere presence
+ * is NOT evidence of a current outage. A bot that had one blip last month would
+ * alert forever. We therefore treat the webhook as failing only when the most
+ * recent error is inside `ERROR_RECENCY_WINDOW_MS`.
+ *
+ * Known limitation: Telegram only produces delivery errors when it has
+ * something to deliver. A dead webhook on a channel with no inbound traffic
+ * stops refreshing `last_error_date` and reads as healthy here. That is the
+ * benign case — nobody is being dropped — and the first message that does
+ * arrive re-arms the error, so the next sweep catches it.
+ *
+ * ## Why its own timer rather than the heartbeat
+ *
+ * The credential-health check rides `HeartbeatService.executeRun`, which is
+ * gated by active hours, `maxConsecutiveRuns`, and `maxDailyRuns`. Those gates
+ * exist to stop burning LLM tokens while the guardian is away, and
+ * `maxConsecutiveRuns` resets only when the guardian sends a message. A
+ * guardian whose only channel is the broken one can't send that message, so
+ * riding the heartbeat would mute this check exactly when it matters most.
+ * One unauthenticated-cost HTTP GET has none of that token pressure, so it runs
+ * on its own interval alongside the other daemon sweeps.
+ */
+
+import { z } from "zod";
+
+import { getConfig } from "../config/loader.js";
+import { hasWebhookRoutingConfigured } from "../config/webhook-routing.js";
+import { getDbMigrationReadiness } from "../daemon/daemon-readiness.js";
+import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import { credentialKey } from "../security/credential-key.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+import { getTelegramBotUsername } from "./bot-username.js";
+
+const log = getLogger("telegram-webhook-health");
+
+/** Timeout for the `getWebhookInfo` call. */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** How often the sweep polls Telegram. */
+export const HEALTH_CHECK_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * How recent a delivery error must be to count as an ongoing outage.
+ *
+ * Deliberately several sweep intervals wide: an error that lands just after a
+ * poll must still be recent enough to catch on the following poll, and a
+ * webhook Telegram is actively retrying refreshes the timestamp continuously.
+ */
+const ERROR_RECENCY_WINDOW_MS = 15 * 60_000;
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export type TelegramWebhookHealthStatus =
+  /** Webhook registered, no recent delivery errors. */
+  | "healthy"
+  /** Telegram holds no webhook URL at all — the channel is definitively dark. */
+  | "not_registered"
+  /** Telegram reported a delivery error inside the recency window. */
+  | "delivery_failing"
+  /** Preconditions unmet (no bot token / no webhook routing) — nothing to check. */
+  | "skipped"
+  /** Telegram was unreachable or answered unusably — health is unknown. */
+  | "unknown";
+
+export interface TelegramWebhookHealthResult {
+  status: TelegramWebhookHealthStatus;
+  /** Human-readable explanation, safe to log and to show the guardian. */
+  detail: string;
+  lastErrorMessage?: string;
+  lastErrorDate?: number;
+  pendingUpdateCount?: number;
+}
+
+/**
+ * Tolerant schema for the `getWebhookInfo` envelope. Every field is optional
+ * so an added or retyped field can't turn a health check into a crash — a
+ * field that fails to parse collapses to `undefined` and is treated as absent.
+ */
+const WebhookInfoResponseSchema = z.object({
+  ok: z.boolean().optional().catch(undefined),
+  description: z.string().optional().catch(undefined),
+  result: z
+    .object({
+      url: z.string().optional().catch(undefined),
+      pending_update_count: z.number().optional().catch(undefined),
+      last_error_date: z.number().optional().catch(undefined),
+      last_error_message: z.string().optional().catch(undefined),
+    })
+    .optional()
+    .catch(undefined),
+});
+
+// ── Detection ─────────────────────────────────────────────────────────
+
+/**
+ * Honor `telegram.apiBaseUrl` like the gateway's Telegram client does — a
+ * deployment pointed at a proxy or a local mock must not have its health
+ * checked against the real api.telegram.org.
+ */
+function telegramApiBaseUrl(): string {
+  try {
+    return getConfig().telegram.apiBaseUrl.replace(/\/+$/, "");
+  } catch {
+    return "https://api.telegram.org";
+  }
+}
+
+/** Name the channel concretely when the bot username is known. */
+function channelLabel(): string {
+  const username = getTelegramBotUsername();
+  return username ? `Telegram (@${username.replace(/^@/, "")})` : "Telegram";
+}
+
+/**
+ * The remediation path, which differs by deployment. Self-hosted users own the
+ * ingress URL; platform-managed callback routes are registered for them.
+ */
+function fixPath(usesManagedCallbacks: boolean): string {
+  if (usesManagedCallbacks) {
+    return (
+      "This deployment uses platform-managed callback routes, so the webhook URL is not yours to set — " +
+      "if it stays broken, contact support."
+    );
+  }
+  return (
+    "Check that your public ingress URL is reachable (an ngrok free-tier tunnel gets a new URL every restart), " +
+    "then point config at the current one with `assistant config set ingress.publicBaseUrl <url>`. " +
+    "The gateway re-registers the Telegram webhook whenever that value changes."
+  );
+}
+
+/**
+ * Read Telegram's own view of the webhook and classify it. Performs no
+ * notification and mutates no state — `runTelegramWebhookHealthCheck` layers
+ * alerting on top.
+ */
+export async function checkTelegramWebhookHealth(): Promise<TelegramWebhookHealthResult> {
+  const botToken = await getSecureKeyAsync(
+    credentialKey("telegram", "bot_token"),
+  );
+  if (!botToken) {
+    return {
+      status: "skipped",
+      detail: "No Telegram bot token configured — webhook check not applicable",
+    };
+  }
+
+  const { configured, usesManagedCallbacks } =
+    hasWebhookRoutingConfigured(true);
+  if (!configured) {
+    return {
+      status: "skipped",
+      detail:
+        "No public ingress URL or managed callback route configured — no Telegram webhook is expected",
+    };
+  }
+
+  let payload: unknown;
+  try {
+    const response = await fetch(
+      `${telegramApiBaseUrl()}/bot${botToken}/getWebhookInfo`,
+      { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+    );
+    if (!response.ok) {
+      return {
+        status: "unknown",
+        detail: `Telegram getWebhookInfo returned HTTP ${response.status}`,
+      };
+    }
+    payload = await response.json();
+  } catch (err) {
+    // Network error or timeout. Our own connectivity being down is not
+    // evidence that the webhook is broken, so this must not alert.
+    return {
+      status: "unknown",
+      detail: `Could not reach Telegram getWebhookInfo: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  const parsed = WebhookInfoResponseSchema.safeParse(payload);
+  const info = parsed.success ? parsed.data.result : undefined;
+  if (!info) {
+    return {
+      status: "unknown",
+      detail: "Telegram getWebhookInfo returned an unexpected response shape",
+    };
+  }
+
+  const pendingUpdateCount = info.pending_update_count;
+  const label = channelLabel();
+
+  if (!info.url || info.url.trim().length === 0) {
+    return {
+      status: "not_registered",
+      detail:
+        `${label} has no webhook registered with Telegram, so inbound messages are not reaching ` +
+        `the assistant. ${fixPath(usesManagedCallbacks)}`,
+      ...(pendingUpdateCount !== undefined ? { pendingUpdateCount } : {}),
+    };
+  }
+
+  const lastErrorDate = info.last_error_date;
+  const errorIsRecent =
+    lastErrorDate !== undefined &&
+    Date.now() - lastErrorDate * 1000 <= ERROR_RECENCY_WINDOW_MS;
+
+  if (errorIsRecent) {
+    const reported = info.last_error_message ?? "no error message reported";
+    const queued =
+      pendingUpdateCount && pendingUpdateCount > 0
+        ? ` ${pendingUpdateCount} update(s) are queued and undelivered.`
+        : "";
+    return {
+      status: "delivery_failing",
+      detail:
+        `${label} cannot receive messages: Telegram reported "${reported}" while delivering to the ` +
+        `webhook.${queued} ${fixPath(usesManagedCallbacks)}`,
+      ...(info.last_error_message
+        ? { lastErrorMessage: info.last_error_message }
+        : {}),
+      lastErrorDate,
+      ...(pendingUpdateCount !== undefined ? { pendingUpdateCount } : {}),
+    };
+  }
+
+  return {
+    status: "healthy",
+    detail: `${label} webhook is registered and reporting no recent delivery errors`,
+    ...(lastErrorDate !== undefined ? { lastErrorDate } : {}),
+    ...(pendingUpdateCount !== undefined ? { pendingUpdateCount } : {}),
+  };
+}
+
+// ── Alerting ──────────────────────────────────────────────────────────
+
+/**
+ * Episode latch: the dedupe key of the outage currently in progress, or `null`
+ * when the webhook is believed healthy.
+ *
+ * One alert per outage. It clears only on an observed-healthy poll, so an
+ * ongoing failure stays quiet no matter how many times we poll it or how the
+ * error message changes mid-outage, and a genuinely new outage after a
+ * recovery alerts again.
+ *
+ * In-memory by design: a daemon restart re-alerts once for an outage that is
+ * still ongoing, which is the behaviour we want — a fresh boot should tell the
+ * guardian the channel is still dark.
+ */
+let alertedEpisodeKey: string | null = null;
+
+/**
+ * Monotonic episode counter. The dedupe key can't be the episode's timestamp
+ * alone: a fail → recover → fail sequence inside one millisecond would reuse
+ * the key and the notification pipeline would silently swallow the second
+ * outage's alert.
+ */
+let episodeSeq = 0;
+
+/** Test-only: clear the episode latch between cases. */
+export function _resetTelegramWebhookHealthState(): void {
+  alertedEpisodeKey = null;
+  episodeSeq = 0;
+}
+
+async function notifyWebhookFailure(
+  result: TelegramWebhookHealthResult,
+  dedupeKey: string,
+): Promise<void> {
+  await emitNotificationSignal({
+    sourceEventName: "telegram.webhook_health_alert",
+    // Deliberately NOT "telegram": the signal is produced by a daemon
+    // background sweep, not by traffic arriving over Telegram — and the
+    // Telegram channel is precisely the one that can't be relied on to carry
+    // this news. "watcher" is the background-subsystem producer channel, as
+    // used by the credential-health alerts.
+    sourceChannel: "watcher",
+    sourceContextId: "telegram-webhook-health",
+    // Keyed to the episode, not the error text: a redundant emit inside one
+    // outage collapses, while the next outage gets a fresh key and alerts.
+    dedupeKey,
+    attentionHints: {
+      requiresAction: true,
+      urgency: "high",
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      channel: "telegram",
+      status: result.status,
+      title:
+        result.status === "not_registered"
+          ? "Telegram webhook is not registered"
+          : "Telegram webhook is failing",
+      body: result.detail,
+      ...(result.lastErrorMessage
+        ? { lastErrorMessage: result.lastErrorMessage }
+        : {}),
+      ...(result.lastErrorDate ? { lastErrorDate: result.lastErrorDate } : {}),
+      ...(result.pendingUpdateCount !== undefined
+        ? { pendingUpdateCount: result.pendingUpdateCount }
+        : {}),
+    },
+    routingIntent: "single_channel",
+    conversationMetadata: {
+      source: "telegram-webhook-health",
+      groupId: "system:background",
+      conversationType: "background",
+    },
+  });
+}
+
+/**
+ * Run one health round: check, then alert on the transition into failure.
+ * Returns the result so callers and tests can assert on it.
+ */
+export async function runTelegramWebhookHealthCheck(): Promise<TelegramWebhookHealthResult> {
+  const result = await checkTelegramWebhookHealth();
+
+  // Neither evidence of health nor of failure — leave the latch as-is so an
+  // unreachable Telegram (or a channel that isn't set up) can't either raise a
+  // false alarm or silently clear a real one.
+  if (result.status === "skipped" || result.status === "unknown") {
+    log.debug({ status: result.status }, result.detail);
+    return result;
+  }
+
+  if (result.status === "healthy") {
+    if (alertedEpisodeKey !== null) {
+      log.info(
+        { episode: alertedEpisodeKey },
+        "Telegram webhook recovered — clearing alert latch",
+      );
+      alertedEpisodeKey = null;
+    }
+    return result;
+  }
+
+  if (alertedEpisodeKey !== null) {
+    log.debug(
+      { status: result.status, episode: alertedEpisodeKey },
+      "Telegram webhook still failing — guardian already alerted for this outage",
+    );
+    return result;
+  }
+
+  // Latch before awaiting the emit so an overlapping round can't double-fire.
+  episodeSeq++;
+  const dedupeKey = `telegram-webhook-health:${Date.now()}:${episodeSeq}`;
+  alertedEpisodeKey = dedupeKey;
+  log.warn({ status: result.status }, result.detail);
+
+  try {
+    await notifyWebhookFailure(result, dedupeKey);
+  } catch (err) {
+    // The guardian was never told, so this outage is still un-alerted. Release
+    // the latch and let the next round try again.
+    alertedEpisodeKey = null;
+    log.error({ err }, "Failed to emit Telegram webhook health notification");
+  }
+
+  return result;
+}
+
+// ── Sweep lifecycle ───────────────────────────────────────────────────
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+let sweepInProgress = false;
+
+/**
+ * Start the periodic Telegram webhook health sweep. Idempotent — calling it
+ * multiple times reuses the same timer.
+ */
+export function startTelegramWebhookHealthSweep(): void {
+  if (sweepTimer) {
+    return;
+  }
+  sweepTimer = setInterval(() => {
+    if (sweepInProgress) {
+      return;
+    }
+    // Alerting writes a notification event, so the round is pointless (and
+    // noisy) while the schema is unusable. Sweeps also start in the failed
+    // degraded mode, where the DB is open but may be mid-migration-repair.
+    if (!getDbMigrationReadiness().ready) {
+      return;
+    }
+    sweepInProgress = true;
+    void runTelegramWebhookHealthCheck()
+      .catch((err) => {
+        log.error({ err }, "Telegram webhook health sweep failed");
+      })
+      .finally(() => {
+        sweepInProgress = false;
+      });
+  }, HEALTH_CHECK_INTERVAL_MS);
+}
+
+/** Stop the periodic sweep. Used in tests and shutdown. */
+export function stopTelegramWebhookHealthSweep(): void {
+  if (sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+  sweepInProgress = false;
+}


### PR DESCRIPTION
## TL;DR

The Telegram channel can go dark indefinitely with zero signal — a dead tunnel or rotated ingress URL breaks inbound delivery, Telegram queues the updates and reports the exact error via `getWebhookInfo`, and nothing on our side ever reads it. This adds a daemon-side sweep that polls `getWebhookInfo` every 5 minutes and puts a home-feed notification in front of the guardian naming the channel, the error, the queue depth, and the fix.

Detection and notification only — no auto-repair (see [Deferred](#deferred-work)).

Closes LUM-2862.

## What changes for the user

| Situation | Before | After |
| --- | --- | --- |
| Ingress URL dies (laptop restart rotates the ngrok tunnel) | Telegram silently queues messages. No notification, no health surface. You find out by noticing the assistant stopped answering. | Within ~5 minutes, a home-feed alert: which bot, what Telegram reported ("Wrong response from the webhook: 404 Not Found"), how many updates are stuck, and how to fix it. |
| Webhook never got registered | Channel appears configured but silently receives nothing. | Alert saying no webhook is registered, with the same fix path. |
| Webhook is failing and stays failing | — | One alert, not one every 5 minutes. |
| Webhook recovers | — | Silence. No "recovered" notification, and no repeat of the original alert. |
| A later, separate outage | — | Alerts again. |
| Your network blips while the webhook is fine | — | Nothing. An unreachable Telegram API is not treated as a webhook failure. |
| No Telegram bot token, or no ingress/managed callback configured | — | The check never runs and makes no API calls. |

## Why this is safe

- **Read-only against Telegram.** One `getWebhookInfo` GET with a 10s timeout. The sweep never calls `setWebhook` or `deleteWebhook`, so it cannot fight the gateway reconciler or a user mid-setup.
- **Fails toward silence, not toward false alarms.** Unreachable API, non-2xx, and unparseable responses all resolve to `unknown`, which neither alerts nor clears an existing alert. The only paths that alert are an empty webhook URL or a delivery error inside the recency window.
- **Bounded notification volume.** One alert per outage episode, enforced by a latch that clears only on an observed-healthy poll — so a flapping or long-running outage cannot spam the feed.
- **Gated on the check being meaningful.** Requires both `telegram:bot_token` and `telegram:webhook_secret` *and* webhook routing configured (`ingress.publicBaseUrl`, or platform-managed callbacks). Both credentials, because the gateway reconciler bails before `setWebhook` without the secret — so a bot-token-only workspace has no webhook by design and must not be alerted about. Absent any of these, no network call is made at all.
- **No LLM in the path.** The alert takes the decision engine's verbatim pass-through, so this timer never invokes a model (`AGENTS.md` → "No LLM Work at Daemon Startup"). It also means a classifier can't suppress a high-urgency outage alert.
- **Respects daemon startup rules.** Registered in `startBackgroundSweeps()` (post-migration), and each round additionally checks `getDbMigrationReadiness().ready` before running, since alerting writes a notification event.
- **No new surface area.** No routes, no config keys, no schema changes, no new dependencies.

## Implementation

**`assistant/src/telegram/webhook-health.ts`** — the whole feature. `checkTelegramWebhookHealth()` is pure detection (no state, no notification); `runTelegramWebhookHealthCheck()` layers the alert latch on top; `start/stopTelegramWebhookHealthSweep()` follow the `guardian-expiry-sweep.ts` shape and are wired into `RuntimeHttpServer`'s existing sweep lifecycle.

**`assistant/src/config/webhook-routing.ts`** — `hasIngressConfigured` / `hasWebhookRoutingConfigured` lifted out of `channel-readiness-service.ts`. Both the readiness probes and this sweep need to answer "is a webhook expected in this deployment?", and a probe reporting *ingress is configured* while the sweep concluded *no webhook expected* would be a silent divergence. Behavior is unchanged — the 48 existing readiness tests cover the managed-callback and whitespace-URL edges and pass untouched.

Registers `telegram.webhook_health_alert` in the notification signal registry, mapped to the `system` feed category and the noteworthy (inbox) set.

## Key technical choices

**Its own 5-minute timer rather than the heartbeat.** The obvious precedent is `runCredentialHealthCheck`, which rides `HeartbeatService.executeRun`. That path is gated by active hours, `maxConsecutiveRuns` (default 3), and `maxDailyRuns` — gates that exist to stop burning LLM tokens while the guardian is away. `maxConsecutiveRuns` resets only when the guardian *sends a message*, which a guardian whose only channel is the broken one cannot do. Riding the heartbeat would mute this check precisely in the scenario it exists for. A single HTTP GET carries none of that token pressure, so it runs as an independent sweep alongside the guardian-expiry sweep and the profile reaper.

**Error recency, not error presence.** Telegram documents `last_error_date` as "Unix time for the most recent error that happened when trying to deliver an update via webhook" ([docs](https://core.telegram.org/bots/api#webhookinfo)) and does not document clearing it on recovery — in practice it persists. Treating its presence as a fault would mean a bot that had one blip last month alerts forever. A webhook is therefore classified as failing only when its most recent error falls inside a 15-minute window, deliberately several sweep intervals wide so an error landing just after one poll is still caught by the next.

**One alert per outage episode.** The latch holds the current episode's dedupe key and clears only on an observed-healthy poll. That gives "alert once, stay quiet while it's broken, alert again on a genuinely new outage" without any time-based re-alert heuristic. The dedupe key carries a monotonic episode counter alongside the timestamp rather than the timestamp alone: a fail → recover → fail sequence inside a single millisecond would otherwise reuse the key and the notification pipeline would silently swallow the second outage's alert. It is in-memory by design — a daemon restart re-alerts once for a still-ongoing outage, which is the desired behavior for a fresh boot.

**`sourceChannel: "assistant_tool"`, never `"telegram"`.** Telegram is precisely the channel that cannot be relied on to carry this particular news. `assistant_tool` specifically — rather than `watcher` — because that plus `requestedMessage` takes the decision engine's verbatim pass-through (`decision-engine.ts:895-903`) and skips the LLM classifier entirely. That matters twice: `AGENTS.md:273-275` forbids invoking LLM providers from unconditional timers (the heartbeat is exempt; this sweep is not, which is the cost of running it on its own timer), and the copy here is already fully composed, so a classifier could only re-render it or decide `shouldNotify: false` and suppress the alert. `background-job-runner.ts:436` uses the same channel for the same reason.

**`throwOnError: true` on the emit.** `emitNotificationSignal` swallows pipeline errors and resolves `{ dispatched: false }` unless this is set, which would leave the episode latched with the guardian never told. A signal the pipeline *deliberately* suppresses still keeps the latch, on purpose: releasing it would mint a fresh episode key and re-emit every 5 minutes for as long as the suppression held.

**Honors `telegram.apiBaseUrl`.** The gateway's Telegram client already reads this config key; a deployment pointed at a proxy or local mock must not have its health checked against the real `api.telegram.org`.

## Testing

`cd assistant && bun test src/telegram/__tests__/webhook-health.test.ts` — 19 tests covering the three behaviors the ticket asks for plus the failure modes that make the feature trustworthy:

- failing webhook → notification fired **once**; recovered webhook → **no** repeat alert; no Telegram credentials → check doesn't run (and makes no API call)
- no webhook routing configured → check doesn't run
- platform-managed callbacks → check runs, and the self-hosted remediation copy is *not* offered
- stale `last_error_date` → healthy (the recency invariant)
- unreachable / non-2xx / unparseable response → `unknown`, which neither alerts nor clears an existing alert
- error message changing mid-outage → still no re-alert
- new outage after recovery → alerts again, with a distinct dedupe key
- failed emit → retried next round rather than silently latched (the mock mirrors `emitNotificationSignal`'s real conditional-throw contract, and the emit params are asserted, so this path cannot go dead silently)
- missing `webhook_secret` → check doesn't run, no API call, no alert

Also verified: `bun run typecheck:fast` clean, `bun run lint` adds no warnings, prettier clean, and the readiness suites (`channel-readiness-{service,routes,slack-remote}`, 48 tests) pass unchanged, which is what backs the "extraction is behavior-preserving" claim.

Each suite was run in its own process, matching how CI executes them: `bun run test` goes through `assistant/scripts/test.ts`, which spawns one Bun process per test file specifically because `mock.module` is process-global.

## Deferred work

**Auto re-registration / self-heal** — deliberately out of scope, per the ticket's own slicing. Worth flagging for whoever picks it up: in the Jul 27 occurrence, auto-re-registration would **not** have helped. The tunnel rotated its URL but `ingress.publicBaseUrl` still held the dead one, so re-registering would have re-registered the same 404. The real fix is tunnel-URL discovery, which is what **ATL-424** (move tunnel management into the gateway) is about. Notification-over-repair is also the safer default: auto re-registering could fight a user mid-setup.

**Idle-channel blind spot** — Telegram only generates delivery errors when it has something to deliver, so a dead webhook on a channel with no inbound traffic stops refreshing `last_error_date` and reads as healthy here. This is the benign case: nothing is being dropped, because nothing is arriving. The first message that does arrive re-arms the error and the next sweep catches it. Documented in the module header rather than worked around — closing it would require tracking expected-vs-actual inbound volume, which is a much larger change for a case with no user impact.

**Generalizing to other channels** — the failure class is shared by every ingress-dependent channel (WhatsApp, phone/Twilio, email); Slack and Discord are socket-based and have a different failure mode with existing reconnect logic. The blocker is detection, not plumbing: Telegram is unusually generous in exposing the error message and queue depth in one GET, and whether Meta and Twilio offer an equivalent delivery-error read is an open question tracked in **LUM-2864**. Keeping this single-provider is also the repo's own rule — extract on the second occurrence, not the first. The reusable spine (latch, emit, sweep, "is a webhook expected" gating) is already isolated; only the probe is provider-specific, so lifting it into a shared module later is a small change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

