### PR TITLE
refactor(live-voice): carry tool input on the bridge's tool_use_start callback

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1101,7 +1101,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     fakeConversation = fake.conversation;
   }
 
-  test("tool_use_start delivers the tool name and toolUseId", async () => {
+  test("tool_use_start delivers the tool name, toolUseId, and input", async () => {
     makeEventEmittingConversation([
       {
         type: "tool_use_start",
@@ -1121,7 +1121,10 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await flushMicrotasks();
 
     expect(starts).toEqual([
-      { toolName: "web_search", detail: { toolUseId: "toolu-1" } },
+      {
+        toolName: "web_search",
+        detail: { toolUseId: "toolu-1", input: { query: "weather" } },
+      },
     ]);
   });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -241,7 +241,10 @@ export interface VoiceTurnCallbacks {
   persisted_user_message_id?: (messageId: string) => void;
   persisted_assistant_message_id?: (messageId: string) => void;
   /** Fired when the agent run starts a definitive tool use this turn. */
-  tool_use_start?: (toolName: string, detail?: { toolUseId?: string }) => void;
+  tool_use_start?: (
+    toolName: string,
+    detail?: { toolUseId?: string; input?: Record<string, unknown> },
+  ) => void;
   /** Fired when a tool invocation finishes. */
   tool_result?: (event: VoiceToolResultEvent) => void;
 }
@@ -644,7 +647,7 @@ export async function startVoiceTurn(
     },
     onToolUse: (toolName, input, toolUseId) => {
       log.debug({ toolName, input }, "Voice turn tool_use event");
-      opts.callbacks?.tool_use_start?.(toolName, { toolUseId });
+      opts.callbacks?.tool_use_start?.(toolName, { toolUseId, input });
     },
     onToolResult: (event) => {
       opts.callbacks?.tool_result?.(event);


### PR DESCRIPTION
## Summary
- Widen the voice bridge's `tool_use_start` callback detail to carry the tool's structured input alongside `toolUseId`.
- The agent-loop event already carries the input; the bridge was dropping it at the sink.
- Optional field, so existing callback implementations are unaffected.

Part of plan: voice-duplex-gaps.md (PR 3 of 9)