### PR TITLE
feat(permissions): export a predicate for installed, non-dynamic skill_load

### DIFF
--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -32,10 +32,19 @@ mock.module("../config/memory-v3-gate.js", () => ({
     (memory?.v3?.live === true || memory?.v2?.enabled === true),
 }));
 
-// Mock skill resolution — return null by default (no skill found).
+// Mock skill resolution — return null by default (no skill found). The
+// `skill_load` predicate tests drive both slots to model a locally installed
+// skill with or without inline command expansions.
+type MockSkill = {
+  id: string;
+  directoryPath: string;
+  inlineCommandExpansions?: string[];
+};
+let mockSkillCatalog: MockSkill[] = [];
+let mockResolvedSkill: MockSkill | null = null;
 mock.module("../config/skills.js", () => ({
-  loadSkillCatalog: () => [],
-  resolveSkillSelector: () => ({ skill: null }),
+  loadSkillCatalog: () => mockSkillCatalog,
+  resolveSkillSelector: () => ({ skill: mockResolvedSkill }),
 }));
 
 // Mock skills helpers used for file context building.
@@ -182,6 +191,7 @@ import {
   generateAllowlistOptions,
   generateScopeOptions,
   getCachedAssessment,
+  isInstalledStaticSkillLoad,
 } from "./checker.js";
 import { RiskLevel } from "./types.js";
 
@@ -196,6 +206,8 @@ describe("Permission Checker (gateway IPC)", () => {
     mockRefreshedThreshold = null;
     mockV3TierActive = true;
     thresholdCallLog.length = 0;
+    mockSkillCatalog = [];
+    mockResolvedSkill = null;
   });
 
   // ── classifyRisk ──────────────────────────────────────────────────────────
@@ -1336,6 +1348,61 @@ describe("Permission Checker (gateway IPC)", () => {
     test("returns empty for non-scope-aware tools", () => {
       const options = generateScopeOptions("/home/user/project", "web_fetch");
       expect(options).toEqual([]);
+    });
+  });
+
+  // ── isInstalledStaticSkillLoad ────────────────────────────────────────────
+
+  describe("isInstalledStaticSkillLoad", () => {
+    function installSkill(inlineCommandExpansions?: string[]): void {
+      const skill: MockSkill = {
+        id: "note-taker",
+        directoryPath: "/mock/skills/bundled/note-taker",
+        inlineCommandExpansions,
+      };
+      mockResolvedSkill = skill;
+      mockSkillCatalog = [skill];
+    }
+
+    test("returns false for a tool other than skill_load", () => {
+      installSkill();
+      expect(isInstalledStaticSkillLoad("bash", { skill: "note-taker" })).toBe(
+        false,
+      );
+    });
+
+    test("returns false when the selector is missing", () => {
+      installSkill();
+      expect(isInstalledStaticSkillLoad("skill_load", {})).toBe(false);
+    });
+
+    test("returns false when the selector is blank", () => {
+      installSkill();
+      expect(isInstalledStaticSkillLoad("skill_load", { skill: "   " })).toBe(
+        false,
+      );
+    });
+
+    test("returns false when the skill is not installed locally", () => {
+      mockResolvedSkill = null;
+      mockSkillCatalog = [];
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
+    });
+
+    test("returns false when the resolved skill has inline expansions", () => {
+      installSkill(["git status"]);
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
+    });
+
+    test("returns true for an installed skill with no inline expansions", () => {
+      installSkill();
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(true);
     });
   });
 });

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -39,6 +39,7 @@ type MockSkill = {
   id: string;
   directoryPath: string;
   inlineCommandExpansions?: string[];
+  includes?: string[];
 };
 let mockSkillCatalog: MockSkill[] = [];
 let mockResolvedSkill: MockSkill | null = null;
@@ -53,9 +54,9 @@ mock.module("../skills/path-classifier.js", () => ({
   getSkillRoots: () => ["/mock/skills/managed/", "/mock/skills/bundled/"],
 }));
 
-mock.module("../skills/include-graph.js", () => ({
-  indexCatalogById: () => new Map(),
-}));
+// `../skills/include-graph.js` is intentionally left unmocked: it is a pure,
+// side-effect-free traversal, and the `skill_load` predicate tests below need
+// the production include walk to run over `mockSkillCatalog`.
 
 mock.module("../skills/transitive-version-hash.js", () => ({
   computeTransitiveSkillVersionHash: () => "mock-transitive-hash",
@@ -1364,6 +1365,34 @@ describe("Permission Checker (gateway IPC)", () => {
       mockSkillCatalog = [skill];
     }
 
+    /**
+     * Install a `note-taker` parent whose selector resolves, plus whichever
+     * children are given. Children the parent includes but that are absent
+     * from `children` model an include that is not installed locally.
+     */
+    function installGraph(
+      parentIncludes: string[],
+      children: MockSkill[],
+      parentInlineCommandExpansions?: string[],
+    ): void {
+      const parent: MockSkill = {
+        id: "note-taker",
+        directoryPath: "/mock/skills/bundled/note-taker",
+        inlineCommandExpansions: parentInlineCommandExpansions,
+        includes: parentIncludes,
+      };
+      mockResolvedSkill = parent;
+      mockSkillCatalog = [parent, ...children];
+    }
+
+    function child(id: string, overrides: Partial<MockSkill> = {}): MockSkill {
+      return {
+        id,
+        directoryPath: `/mock/skills/bundled/${id}`,
+        ...overrides,
+      };
+    }
+
     test("returns false for a tool other than skill_load", () => {
       installSkill();
       expect(isInstalledStaticSkillLoad("bash", { skill: "note-taker" })).toBe(
@@ -1400,6 +1429,74 @@ describe("Permission Checker (gateway IPC)", () => {
 
     test("returns true for an installed skill with no inline expansions", () => {
       installSkill();
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(true);
+    });
+
+    // ── Transitive include graph ────────────────────────────────────────────
+    // Loading a parent auto-installs its missing includes and renders inline
+    // commands in included children, so the predicate must clear the whole
+    // graph, not just the target.
+
+    test("returns false when an included skill is missing locally", () => {
+      installGraph(["formatting"], []);
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
+    });
+
+    test("returns false when an included skill has inline expansions", () => {
+      installGraph(
+        ["formatting"],
+        [child("formatting", { inlineCommandExpansions: ["git status"] })],
+      );
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
+    });
+
+    test("returns false when a grandchild include is missing locally", () => {
+      installGraph(
+        ["formatting"],
+        [child("formatting", { includes: ["typography"] })],
+      );
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
+    });
+
+    test("returns false when a grandchild include has inline expansions", () => {
+      installGraph(
+        ["formatting"],
+        [
+          child("formatting", { includes: ["typography"] }),
+          child("typography", { inlineCommandExpansions: ["date"] }),
+        ],
+      );
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
+    });
+
+    test("returns false for a cyclic include graph", () => {
+      installGraph(
+        ["formatting"],
+        [child("formatting", { includes: ["note-taker"] })],
+      );
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
+    });
+
+    test("returns true when every transitive include is installed and static", () => {
+      installGraph(
+        ["formatting"],
+        [
+          child("formatting", { includes: ["typography"] }),
+          child("typography"),
+        ],
+      );
       expect(
         isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
       ).toBe(true);

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -237,6 +237,25 @@ function hasInlineExpansions(skillId: string): boolean {
 }
 
 /**
+ * The id of the skill a `skill_load` invocation targets, or `null` for any
+ * other tool, a blank selector, or a selector that names no skill in the
+ * local catalog.
+ */
+function resolveSkillLoadTargetId(
+  toolName: string,
+  input: Record<string, unknown>,
+): string | null {
+  if (toolName !== "skill_load") {
+    return null;
+  }
+  const selector = getStringField(input, "skill").trim();
+  if (!selector) {
+    return null;
+  }
+  return resolveSkillIdAndHash(selector)?.id ?? null;
+}
+
+/**
  * Whether this invocation is an inline-command ("dynamic") skill load: a
  * `skill_load` whose resolved skill carries inline command expansions,
  * which execute shell commands at load time via child_process.spawn.
@@ -250,15 +269,24 @@ export function isDynamicSkillLoadInvocation(
   toolName: string,
   input: Record<string, unknown>,
 ): boolean {
-  if (toolName !== "skill_load") {
-    return false;
-  }
-  const selector = getStringField(input, "skill").trim();
-  if (!selector) {
-    return false;
-  }
-  const resolved = resolveSkillIdAndHash(selector);
-  return resolved !== null && hasInlineExpansions(resolved.id);
+  const skillId = resolveSkillLoadTargetId(toolName, input);
+  return skillId !== null && hasInlineExpansions(skillId);
+}
+
+/**
+ * Whether a `skill_load` invocation resolves to a skill that is already
+ * installed locally and carries no inline command expansions. Only such a
+ * load is a pure read: it neither auto-installs from the remote catalog
+ * (see tools/skills/load.ts `autoInstallFromCatalog`) nor executes embedded
+ * shell at load time. Exported for gates that must fail closed on anything
+ * that can write local state.
+ */
+export function isInstalledStaticSkillLoad(
+  toolName: string,
+  input: Record<string, unknown>,
+): boolean {
+  const skillId = resolveSkillLoadTargetId(toolName, input);
+  return skillId !== null && !hasInlineExpansions(skillId);
 }
 
 /**

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -4,13 +4,17 @@ import { dirname, join, resolve } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
-import { loadSkillCatalog, resolveSkillSelector } from "../config/skills.js";
+import {
+  loadSkillCatalog,
+  resolveSkillSelector,
+  type SkillSummary,
+} from "../config/skills.js";
 import { ipcClassifyRisk } from "../ipc/gateway-client.js";
 import {
   MEMORY_RETROSPECTIVE_ORIGIN,
   SKILL_MANAGEMENT_SKILL_ID,
 } from "../plugins/defaults/memory/memory-retrospective-constants.js";
-import { indexCatalogById } from "../skills/include-graph.js";
+import { indexCatalogById, validateIncludes } from "../skills/include-graph.js";
 import { getSkillRoots } from "../skills/path-classifier.js";
 import { computeTransitiveSkillVersionHash } from "../skills/transitive-version-hash.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
@@ -224,16 +228,23 @@ export function isToolOwnerSkillBundled(tool: Tool | undefined): boolean {
 }
 
 /**
+ * Whether a catalog entry carries parsed inline command expansions, which
+ * execute shell commands at load time. Returns false for an absent entry.
+ */
+function summaryHasInlineExpansions(skill: SkillSummary | undefined): boolean {
+  return (
+    skill?.inlineCommandExpansions != null &&
+    skill.inlineCommandExpansions.length > 0
+  );
+}
+
+/**
  * Check whether a skill (by id) has parsed inline command expansions.
  * Returns false when the skill is not found in the catalog.
  */
 function hasInlineExpansions(skillId: string): boolean {
   const catalog = loadSkillCatalog();
-  const skill = catalog.find((s) => s.id === skillId);
-  return (
-    skill?.inlineCommandExpansions != null &&
-    skill.inlineCommandExpansions.length > 0
-  );
+  return summaryHasInlineExpansions(catalog.find((s) => s.id === skillId));
 }
 
 /**
@@ -274,19 +285,47 @@ export function isDynamicSkillLoadInvocation(
 }
 
 /**
- * Whether a `skill_load` invocation resolves to a skill that is already
- * installed locally and carries no inline command expansions. Only such a
- * load is a pure read: it neither auto-installs from the remote catalog
- * (see tools/skills/load.ts `autoInstallFromCatalog`) nor executes embedded
- * shell at load time. Exported for gates that must fail closed on anything
- * that can write local state.
+ * Whether a `skill_load` invocation is a pure read: the target skill and every
+ * skill reachable through its `includes` graph are installed locally and carry
+ * no inline command expansions.
+ *
+ * The whole graph matters because the load executor (tools/skills/load.ts)
+ * auto-installs missing includes from the remote catalog
+ * (`autoInstallFromCatalog`) and renders inline command expansions for both the
+ * target and its included children. So a missing include anywhere in the graph
+ * writes to the workspace, an inline expansion anywhere in it executes shell,
+ * and either makes the load something other than a read.
+ *
+ * Fails closed — a target that is absent from the catalog, a missing include, a
+ * cycle, or an unreadable catalog all return false. Exported for gates that
+ * must not proceed on anything capable of writing local state.
  */
 export function isInstalledStaticSkillLoad(
   toolName: string,
   input: Record<string, unknown>,
 ): boolean {
   const skillId = resolveSkillLoadTargetId(toolName, input);
-  return skillId !== null && !hasInlineExpansions(skillId);
+  if (skillId === null) {
+    return false;
+  }
+  try {
+    const catalogIndex = indexCatalogById(loadSkillCatalog());
+    if (!catalogIndex.has(skillId)) {
+      return false;
+    }
+    // `validateIncludes` is the shared include-graph walk: it reports the first
+    // missing child or cycle, and on success yields every transitively included
+    // id in DFS order.
+    const validation = validateIncludes(skillId, catalogIndex);
+    if (!validation.ok) {
+      return false;
+    }
+    return validation.visited.every(
+      (id) => !summaryHasInlineExpansions(catalogIndex.get(id)),
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `isInstalledStaticSkillLoad`, which is true only when a `skill_load` selector resolves in the local catalog and the resolved skill carries no inline command expansions.
- Only such a load is a pure read: it neither auto-installs from the remote catalog nor executes embedded shell at load time.
- Reuses the existing `resolveSkillIdAndHash` / `hasInlineExpansions` helpers that back `isDynamicSkillLoadInvocation`.

Part of plan: voice-duplex-gaps.md (PR 4 of 9)