### PR TITLE
feat(daemon): resolve a conversation's subagent lineage

### DIFF
--- a/assistant/src/__tests__/conversation-lineage.test.ts
+++ b/assistant/src/__tests__/conversation-lineage.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for `resolveConversationLineage`: a conversation plus every subagent
+ * ancestor above it, nearest first, bounded by a depth cap and a visited set.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * Resident conversations, mapped to the id they were forked from. A key
+ * absent from the map stands for a conversation that is not resident.
+ */
+let residents = new Map<string, string | undefined>();
+
+mock.module("../daemon/conversation-registry.js", () => ({
+  findConversation: (id: string | undefined) =>
+    id !== undefined && residents.has(id)
+      ? { parentConversationId: residents.get(id) }
+      : undefined,
+}));
+
+const { MAX_LINEAGE_DEPTH, resolveConversationLineage } =
+  await import("../daemon/conversation-lineage.js");
+
+describe("resolveConversationLineage", () => {
+  beforeEach(() => {
+    residents = new Map();
+  });
+
+  test("a plain conversation is its own lineage", () => {
+    residents.set("conv-a", undefined);
+
+    expect(resolveConversationLineage("conv-a")).toEqual(["conv-a"]);
+  });
+
+  test("one fork level reaches the spawner", () => {
+    residents.set("conv-child", "conv-parent");
+    residents.set("conv-parent", undefined);
+
+    expect(resolveConversationLineage("conv-child")).toEqual([
+      "conv-child",
+      "conv-parent",
+    ]);
+  });
+
+  test("two fork levels are ordered nearest first", () => {
+    residents.set("conv-child", "conv-mid");
+    residents.set("conv-mid", "conv-root");
+    residents.set("conv-root", undefined);
+
+    expect(resolveConversationLineage("conv-child")).toEqual([
+      "conv-child",
+      "conv-mid",
+      "conv-root",
+    ]);
+  });
+
+  test("a non-resident conversation is its own lineage", () => {
+    expect(resolveConversationLineage("conv-gone")).toEqual(["conv-gone"]);
+  });
+
+  test("a non-resident ancestor ends the walk", () => {
+    residents.set("conv-child", "conv-evicted");
+
+    expect(resolveConversationLineage("conv-child")).toEqual([
+      "conv-child",
+      "conv-evicted",
+    ]);
+  });
+
+  test("a self-referential parent does not loop forever", () => {
+    residents.set("conv-self", "conv-self");
+
+    expect(resolveConversationLineage("conv-self")).toEqual(["conv-self"]);
+  });
+
+  test("a cycle between two conversations terminates", () => {
+    residents.set("conv-a", "conv-b");
+    residents.set("conv-b", "conv-a");
+
+    expect(resolveConversationLineage("conv-a")).toEqual(["conv-a", "conv-b"]);
+  });
+
+  test("a chain longer than the depth cap is truncated at the cap", () => {
+    const chain = Array.from(
+      { length: MAX_LINEAGE_DEPTH + 5 },
+      (_, i) => `conv-${i}`,
+    );
+    for (const [i, id] of chain.entries()) {
+      residents.set(id, chain[i + 1]);
+    }
+
+    expect(resolveConversationLineage(chain[0]!)).toEqual(
+      chain.slice(0, MAX_LINEAGE_DEPTH),
+    );
+  });
+});

--- a/assistant/src/__tests__/conversation-lineage.test.ts
+++ b/assistant/src/__tests__/conversation-lineage.test.ts
@@ -6,16 +6,38 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 /**
- * Resident conversations, mapped to the id they were forked from. A key
- * absent from the map stands for a conversation that is not resident.
+ * Resident top-level conversations, mapped to the id they were forked from —
+ * the eviction-managed store. A key absent from the map stands for a
+ * conversation that is not resident there.
  */
 let residents = new Map<string, string | undefined>();
 
+/**
+ * Resident subagent conversations, in the separate index `SubagentManager`
+ * owns. A background subagent's id lives only here, never in `residents`.
+ */
+let subagentResidents = new Map<string, string | undefined>();
+
 mock.module("../daemon/conversation-registry.js", () => ({
-  findConversation: (id: string | undefined) =>
-    id !== undefined && residents.has(id)
-      ? { parentConversationId: residents.get(id) }
-      : undefined,
+  findConversationOrSubagent: (id: string | undefined) => {
+    if (id === undefined) {
+      return undefined;
+    }
+    // Mirrors the registry: top-level store first, then the subagent index.
+    if (residents.has(id)) {
+      return { parentConversationId: residents.get(id) };
+    }
+    if (subagentResidents.has(id)) {
+      return { parentConversationId: subagentResidents.get(id) };
+    }
+    return undefined;
+  },
+  /** Present so a lookup through the top-level-only accessor fails loudly. */
+  findConversation: () => {
+    throw new Error(
+      "lineage must resolve through findConversationOrSubagent, not findConversation",
+    );
+  },
 }));
 
 const { MAX_LINEAGE_DEPTH, resolveConversationLineage } =
@@ -24,6 +46,7 @@ const { MAX_LINEAGE_DEPTH, resolveConversationLineage } =
 describe("resolveConversationLineage", () => {
   beforeEach(() => {
     residents = new Map();
+    subagentResidents = new Map();
   });
 
   test("a plain conversation is its own lineage", () => {
@@ -51,6 +74,30 @@ describe("resolveConversationLineage", () => {
       "conv-child",
       "conv-mid",
       "conv-root",
+    ]);
+  });
+
+  test("a background subagent id reaches its user-visible parent", () => {
+    // The live-voice duplex continuation: the seed id is registered only in
+    // the subagent index, never in the eviction-managed top-level store.
+    subagentResidents.set("conv-subagent", "conv-visible");
+    residents.set("conv-visible", undefined);
+
+    expect(resolveConversationLineage("conv-subagent")).toEqual([
+      "conv-subagent",
+      "conv-visible",
+    ]);
+  });
+
+  test("nested subagents walk out of the subagent index into the store", () => {
+    subagentResidents.set("conv-inner", "conv-outer");
+    subagentResidents.set("conv-outer", "conv-visible");
+    residents.set("conv-visible", undefined);
+
+    expect(resolveConversationLineage("conv-inner")).toEqual([
+      "conv-inner",
+      "conv-outer",
+      "conv-visible",
     ]);
   });
 

--- a/assistant/src/daemon/conversation-lineage.ts
+++ b/assistant/src/daemon/conversation-lineage.ts
@@ -3,7 +3,7 @@
  * leads back to the user-visible thread a background run belongs to.
  */
 
-import { findConversation } from "./conversation-registry.js";
+import { findConversationOrSubagent } from "./conversation-registry.js";
 
 /** Depth cap: a subagent chain deeper than this is a bug, not a hierarchy. */
 export const MAX_LINEAGE_DEPTH = 8;
@@ -13,8 +13,20 @@ export const MAX_LINEAGE_DEPTH = 8;
  * first. A subagent Conversation records its spawner in the readonly
  * `parentConversationId` set at construction (see subagent/manager.ts), so
  * walking that chain reaches the user-visible thread a background run was
- * forked from. A non-resident ancestor ends the walk — the visible thread
- * is resident whenever a live background run is producing artifacts for it.
+ * forked from.
+ *
+ * Every hop — including the seed conversation — resolves through
+ * {@link findConversationOrSubagent}, because the seed is typically a
+ * background subagent, and `SubagentManager` keeps live subagent
+ * conversations in their own index rather than the eviction-managed
+ * top-level store.
+ *
+ * Only resident conversations are readable: a top-level conversation until
+ * the evictor sweeps it, a subagent conversation while its run is live (the
+ * manager drops the index entry once the subagent goes terminal). An id
+ * resolvable in neither index ends the walk, so the returned chain can be
+ * shorter than the true ancestry. The user-visible thread is resident
+ * whenever a live background run is producing artifacts for it.
  */
 export function resolveConversationLineage(conversationId: string): string[] {
   const lineage = [conversationId];
@@ -22,7 +34,7 @@ export function resolveConversationLineage(conversationId: string): string[] {
 
   let current = conversationId;
   while (lineage.length < MAX_LINEAGE_DEPTH) {
-    const parent = findConversation(current)?.parentConversationId;
+    const parent = findConversationOrSubagent(current)?.parentConversationId;
     if (!parent || visited.has(parent)) {
       break;
     }

--- a/assistant/src/daemon/conversation-lineage.ts
+++ b/assistant/src/daemon/conversation-lineage.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolution of a conversation's subagent lineage — the chain of forks that
+ * leads back to the user-visible thread a background run belongs to.
+ */
+
+import { findConversation } from "./conversation-registry.js";
+
+/** Depth cap: a subagent chain deeper than this is a bug, not a hierarchy. */
+export const MAX_LINEAGE_DEPTH = 8;
+
+/**
+ * The conversation itself plus every subagent ancestor above it, nearest
+ * first. A subagent Conversation records its spawner in the readonly
+ * `parentConversationId` set at construction (see subagent/manager.ts), so
+ * walking that chain reaches the user-visible thread a background run was
+ * forked from. A non-resident ancestor ends the walk — the visible thread
+ * is resident whenever a live background run is producing artifacts for it.
+ */
+export function resolveConversationLineage(conversationId: string): string[] {
+  const lineage = [conversationId];
+  const visited = new Set([conversationId]);
+
+  let current = conversationId;
+  while (lineage.length < MAX_LINEAGE_DEPTH) {
+    const parent = findConversation(current)?.parentConversationId;
+    if (!parent || visited.has(parent)) {
+      break;
+    }
+    lineage.push(parent);
+    visited.add(parent);
+    current = parent;
+  }
+
+  return lineage;
+}


### PR DESCRIPTION
## Summary
- Add `resolveConversationLineage`, returning a conversation plus every subagent ancestor above it, nearest first.
- Walks the readonly `parentConversationId` a forked Conversation records at construction, so a background run can reach the user-visible thread it was forked from.
- Bounded by a depth cap and a visited set; a missing ancestor ends the walk and it never throws.

Part of plan: voice-duplex-gaps.md (PR 5 of 9)