### PR TITLE
refactor(calls): let startVoiceTurn callers declare a hidden synthetic prompt

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -33,7 +33,7 @@ mock.module("../../daemon/conversation-store.js", () => ({
 
 // Conversation-CRUD doubles for the teardown transcript-hygiene pass. The
 // real module is spread so every other export keeps its production behavior;
-// only the three functions the hygiene pass (and discard) touch are recorded.
+// only the functions the hygiene pass (and discard) touch are recorded.
 import * as realConversationCrud from "../../persistence/conversation-crud.js";
 
 let getMessageByIdImpl: (
@@ -65,10 +65,14 @@ mock.module("../../persistence/conversation-crud.js", () => ({
     crudLog.deletes.push(messageId);
     return { segmentIds: [], deletedSummaryIds: [] };
   },
+  // The echo path advances the snapshot anchor for a real-user turn; the
+  // fake conversation has no row in SQLite, so stub the write out.
+  recordConversationPersistedSeq: () => {},
 }));
 
 import { setConfig } from "../../__tests__/helpers/set-config.js";
 import { ABORT_WATCHDOG_MS } from "../../daemon/abort-watchdog.js";
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import { CALL_OPENING_MARKER } from "../voice-control-protocol.js";
 import {
   cutFrontDoorContentAtVerdict,
@@ -344,6 +348,67 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
     await startVoiceTurn(makeTurnOptions()); // content: CALL_OPENING_MARKER
 
     expect(fake.lastPersistOpts()?.metadata).toBeUndefined();
+  });
+});
+
+describe("startVoiceTurn hiddenSyntheticPrompt", () => {
+  // A caller whose internal instruction is composed per call carries no
+  // sentinel for the content comparisons to recognize, so it declares itself.
+  const SYNTHETIC_CONTENT =
+    "(the background task finished — announce the result)";
+
+  /** The `user_message_echo` events `turn` publishes to hub subscribers. */
+  async function collectUserMessageEchoes(
+    turn: () => Promise<unknown>,
+  ): Promise<Array<{ type: string }>> {
+    const published: Array<{ type: string }> = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      filter: { conversationId: "conv-voice-bridge-test" },
+      callback: (event) => {
+        published.push(event.message);
+      },
+    });
+    try {
+      await turn();
+    } finally {
+      subscription.dispose();
+    }
+    return published.filter((msg) => msg.type === "user_message_echo");
+  }
+
+  test("a declared prompt persists hidden and suppresses its echo", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    const echoes = await collectUserMessageEchoes(() =>
+      startVoiceTurn({
+        ...makeTurnOptions(),
+        content: SYNTHETIC_CONTENT,
+        hiddenSyntheticPrompt: true,
+      }),
+    );
+
+    expect(fake.lastPersistOpts()?.content).toBe(SYNTHETIC_CONTENT);
+    expect(fake.lastPersistOpts()?.metadata).toEqual({ hidden: true });
+    expect(echoes).toHaveLength(0);
+  });
+
+  test("the same content without the flag stays a plain user turn", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    const echoes = await collectUserMessageEchoes(() =>
+      startVoiceTurn({
+        ...makeTurnOptions(),
+        content: SYNTHETIC_CONTENT,
+      }),
+    );
+
+    expect(fake.lastPersistOpts()?.metadata).toBeUndefined();
+    expect(echoes).toEqual([
+      expect.objectContaining({ text: SYNTHETIC_CONTENT }),
+    ]);
   });
 });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -309,6 +309,14 @@ export interface VoiceTurnOptions {
    */
   spokenEscalationBridge?: string;
   /**
+   * Marks this turn's `content` as an internal instruction rather than user
+   * speech: it persists `hidden` so `/messages` filters it after a reload,
+   * its echo is suppressed, and prompt-as-user-speech consumers (title
+   * generation) skip it. Set by callers whose synthetic prompt text is not a
+   * fixed sentinel.
+   */
+  hiddenSyntheticPrompt?: boolean;
+  /**
    * Unified front-door: this leg was dispatched speculatively at a silence
    * boundary, so its decision rule includes the hold branch (leading token
    * `[0]` = the caller is mid-thought). Only ever set on front-door legs —
@@ -680,11 +688,13 @@ export async function startVoiceTurn(
         ? "(verification completed — transitioning into conversation)"
         : opts.content;
 
-  // Opener / verification / escalation-continuation prompts are internal
-  // scaffolding: they persist a row so the model wakes, but they are not user
-  // speech and must not render as a live user bubble. Their echo is suppressed
-  // below (parity with `isEchoSuppressedUserMessage` on the text path).
+  // Opener / verification / escalation-continuation prompts, plus any turn a
+  // caller declares hidden, are internal scaffolding: they persist a row so the
+  // model wakes, but they are not user speech and must not render as a live
+  // user bubble. Their echo is suppressed below (parity with
+  // `isEchoSuppressedUserMessage` on the text path).
   const isSyntheticVoicePrompt =
+    opts.hiddenSyntheticPrompt === true ||
     opts.content === CALL_OPENING_MARKER ||
     opts.content === CALL_VERIFICATION_COMPLETE_MARKER ||
     opts.content === ESCALATION_CONTINUATION_CONTENT;
@@ -696,8 +706,10 @@ export async function startVoiceTurn(
   // `/messages` filters it out after a refetch/reload, and flag the turn as a
   // hidden prompt so prompt-as-user-speech consumers (e.g. title generation)
   // skip it. The escalated model still sees the row in context — `hidden` only
-  // affects client display.
+  // affects client display. A caller whose prompt text is not a fixed sentinel
+  // opts into the same treatment with `hiddenSyntheticPrompt`.
   const isHiddenSyntheticPrompt =
+    opts.hiddenSyntheticPrompt === true ||
     opts.content === ESCALATION_CONTINUATION_CONTENT;
 
   // Build the call-control protocol prompt so the model knows how to emit


### PR DESCRIPTION
## Summary
- Add an optional `hiddenSyntheticPrompt` to the bridge's `startVoiceTurn` options, so a caller can declare its content is an internal instruction rather than user speech.
- The bridge otherwise infers this only by comparing content against fixed sentinel strings, which cannot express a prompt whose text varies per call.
- Optional and defaults to the marker-based behavior; the escalation-continuation path is unchanged.

Part of plan: voice-duplex-gaps.md (PR 8 of 9)