### PR TITLE
fix(live-voice): hydrate the duplex fork parent under resolved trust (Codex P2)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-continuation-fork-hydration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-continuation-fork-hydration.test.ts
@@ -1,0 +1,286 @@
+/**
+ * The duplex continuation's fork parent is hydrated under resolved guardian
+ * trust.
+ *
+ * `Conversation.loadFromDb` filters history by the instance's own trust class:
+ * a load with no trust context resolves the fail-closed `unknown` capability
+ * set, which drops memory blocks and forces the in-context compaction summary
+ * to null. `defaultSpawnBackgroundContinuation` snapshots the parent's messages
+ * straight into the fork, so an unstamped load would hand the continuation a
+ * lobotomized view of the very turn it is meant to finish. These tests pin the
+ * ordering (resolve trust → stamp → load) and the restore that keeps the
+ * bridge's per-turn ownership of the parent's trust intact.
+ *
+ * `mock.module` is process-global in Bun and leaks into sibling files that run
+ * later in the same `bun test` invocation, so every stub delegates to the real
+ * implementation unless this file's tests are active (`forkMocksActive`,
+ * toggled in beforeAll/afterAll). Run this file on its own.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type { Conversation } from "../../daemon/conversation.js";
+import type { TrustContext } from "../../daemon/trust-context-types.js";
+import type { Message } from "../../providers/types.js";
+import type { TrustClass } from "../../runtime/trust-class.js";
+
+let forkMocksActive = false;
+
+// Snapshotted into plain objects NOW, before the stubs register — a module
+// namespace is a live view, so reading the real export after the stub installs
+// would resolve back to the stub (infinite recursion).
+const realConversationStoreModule = {
+  ...(await import("../../daemon/conversation-store.js")),
+};
+const realLocalActorIdentityModule = {
+  ...(await import("../../runtime/local-actor-identity.js")),
+};
+const realLocalPrincipalTrustModule = {
+  ...(await import("../../runtime/local-principal-trust.js")),
+};
+const realSubagentModule = { ...(await import("../../subagent/index.js")) };
+
+const PARENT_CONVERSATION_ID = "conversation-fork-parent";
+const GUARDIAN_PRINCIPAL_ID = "principal-guardian-1";
+
+function textMessage(text: string): Message {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+/** What a trusted `loadFromDb` puts into the parent's in-memory history. */
+const HYDRATED_MESSAGES: Message[] = [
+  textMessage("persisted-turn"),
+  textMessage("memory-block"),
+];
+
+/**
+ * Stands in for the resident `Conversation` the spawn helper snapshots. Only
+ * the surface `defaultSpawnBackgroundContinuation` touches is modelled, mirroring
+ * the real trust-class bookkeeping: `loadFromDb` records the trust context in
+ * force at the instant it runs and remembers the class it loaded under, and
+ * `ensureActorScopedHistory` reloads only when the current class differs.
+ */
+class FakeParentConversation {
+  trustContext: TrustContext | undefined;
+  /** The instance's trust context as observed inside each `loadFromDb` call. */
+  readonly loadTrustContexts: (TrustContext | undefined)[] = [];
+  private messages: Message[];
+  private loadedHistoryTrustClass: TrustClass | undefined;
+
+  constructor(messages: Message[] = [], loadedAs?: TrustClass) {
+    this.messages = messages;
+    this.loadedHistoryTrustClass = loadedAs;
+  }
+
+  setTrustContext(ctx: TrustContext | null): void {
+    this.trustContext = ctx ?? undefined;
+  }
+
+  getMessages(): Message[] {
+    return this.messages;
+  }
+
+  getCurrentSystemPrompt(): string {
+    return "parent-system-prompt";
+  }
+
+  async ensureActorScopedHistory(): Promise<void> {
+    if (this.loadedHistoryTrustClass === this.trustContext?.trustClass) {
+      return;
+    }
+    await this.loadFromDb();
+  }
+
+  async loadFromDb(): Promise<{
+    rows: never[];
+    rowToHistoryIndex: null;
+  }> {
+    this.loadTrustContexts.push(this.trustContext);
+    this.loadedHistoryTrustClass = this.trustContext?.trustClass;
+    this.messages = [...HYDRATED_MESSAGES];
+    return { rows: [], rowToHistoryIndex: null };
+  }
+}
+
+// -- Mutable stub state -------------------------------------------------------
+
+/** The conversation `getOrCreateConversation` hands back. */
+let parentConversation: FakeParentConversation;
+/** `undefined` models an assistant with no local guardian binding. */
+let guardianPrincipalId: string | undefined;
+/** Trust class the local principal resolver returns for that guardian. */
+let resolvedTrustClass: TrustClass;
+/** Configs passed to `spawnAndAwait`, in call order. */
+let spawnConfigs: { trustContext?: TrustContext; parentMessages?: Message[] }[];
+
+mock.module("../../daemon/conversation-store.js", () => ({
+  ...realConversationStoreModule,
+  getOrCreateConversation: async (conversationId: string) =>
+    forkMocksActive
+      ? (parentConversation as unknown as Conversation)
+      : realConversationStoreModule.getOrCreateConversation(conversationId),
+}));
+
+mock.module("../../runtime/local-actor-identity.js", () => ({
+  ...realLocalActorIdentityModule,
+  findLocalGuardianPrincipalId: async () =>
+    forkMocksActive
+      ? guardianPrincipalId
+      : realLocalActorIdentityModule.findLocalGuardianPrincipalId(),
+}));
+
+mock.module("../../runtime/local-principal-trust.js", () => ({
+  ...realLocalPrincipalTrustModule,
+  resolveLocalPrincipalTrustContext: async (
+    input: Parameters<
+      typeof realLocalPrincipalTrustModule.resolveLocalPrincipalTrustContext
+    >[0],
+  ) => {
+    if (!forkMocksActive) {
+      return realLocalPrincipalTrustModule.resolveLocalPrincipalTrustContext(
+        input,
+      );
+    }
+    return {
+      sourceChannel: "vellum",
+      trustClass: resolvedTrustClass,
+      guardianPrincipalId: input.actorPrincipalId,
+    } satisfies TrustContext;
+  },
+}));
+
+mock.module("../../subagent/index.js", () => ({
+  ...realSubagentModule,
+  getSubagentManager: () =>
+    forkMocksActive
+      ? {
+          spawnAndAwait: async (config: {
+            trustContext?: TrustContext;
+            parentMessages?: Message[];
+          }) => {
+            spawnConfigs.push(config);
+            return "continuation answer";
+          },
+        }
+      : realSubagentModule.getSubagentManager(),
+}));
+
+import { defaultSpawnBackgroundContinuation } from "../live-voice-session.js";
+
+async function spawnContinuation(): Promise<string> {
+  return await defaultSpawnBackgroundContinuation({
+    parentConversationId: PARENT_CONVERSATION_ID,
+    objective: "finish the interrupted build",
+    label: "continuation",
+    signal: new AbortController().signal,
+  });
+}
+
+describe("duplex continuation fork-parent hydration", () => {
+  beforeAll(() => {
+    forkMocksActive = true;
+  });
+
+  afterAll(() => {
+    forkMocksActive = false;
+  });
+
+  beforeEach(() => {
+    parentConversation = new FakeParentConversation();
+    guardianPrincipalId = GUARDIAN_PRINCIPAL_ID;
+    resolvedTrustClass = "guardian";
+    spawnConfigs = [];
+  });
+
+  test("loads a cold parent under the resolved guardian trust", async () => {
+    await spawnContinuation();
+
+    // The trust context in force AT LOAD TIME is what `loadFromDb` filters
+    // against, so resolving trust after the hydration would not help.
+    expect(parentConversation.loadTrustContexts).toHaveLength(1);
+    expect(parentConversation.loadTrustContexts[0]).toBeDefined();
+    expect(parentConversation.loadTrustContexts[0]?.trustClass).toBe(
+      "guardian",
+    );
+    expect(spawnConfigs[0]?.parentMessages).toEqual(HYDRATED_MESSAGES);
+  });
+
+  test("restores the parent's prior trust context after the load", async () => {
+    const priorTrustContext: TrustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+      guardianPrincipalId: "principal-prior",
+    };
+    parentConversation.setTrustContext(priorTrustContext);
+
+    await spawnContinuation();
+
+    expect(parentConversation.loadTrustContexts).toHaveLength(1);
+    // The bridge owns this conversation's trust per-turn; the stamp must not
+    // outlive the load.
+    expect(parentConversation.trustContext).toBe(priorTrustContext);
+  });
+
+  test("clears the stamp when the parent had no trust context", async () => {
+    await spawnContinuation();
+
+    expect(parentConversation.trustContext).toBeUndefined();
+  });
+
+  test("reloads a parent that was hydrated with no trust context", async () => {
+    // Warm instance: `getOrCreateConversation` already loaded it, but without a
+    // trust context — so its history may be trust-filtered and cannot be forked
+    // as-is.
+    parentConversation = new FakeParentConversation([
+      textMessage("filtered-history"),
+    ]);
+
+    await spawnContinuation();
+
+    expect(parentConversation.loadTrustContexts).toHaveLength(1);
+    expect(parentConversation.loadTrustContexts[0]?.trustClass).toBe(
+      "guardian",
+    );
+    expect(spawnConfigs[0]?.parentMessages).toEqual(HYDRATED_MESSAGES);
+  });
+
+  test("leaves an already-guardian-scoped warm parent alone", async () => {
+    parentConversation = new FakeParentConversation(
+      [textMessage("warm")],
+      "guardian",
+    );
+
+    await spawnContinuation();
+
+    expect(parentConversation.loadTrustContexts).toHaveLength(0);
+    expect(spawnConfigs[0]?.parentMessages).toEqual([textMessage("warm")]);
+  });
+
+  test("hydrates unstamped when no guardian trust resolves", async () => {
+    guardianPrincipalId = undefined;
+
+    await spawnContinuation();
+
+    // Fail-closed by design: with no guardian binding there is nothing to stamp,
+    // so the continuation runs as `unknown` exactly as an unstamped turn does.
+    expect(parentConversation.loadTrustContexts).toEqual([undefined]);
+    expect(parentConversation.trustContext).toBeUndefined();
+    expect(spawnConfigs[0]?.trustContext).toBeUndefined();
+  });
+
+  test("does not stamp a non-guardian resolution", async () => {
+    resolvedTrustClass = "unknown";
+
+    await spawnContinuation();
+
+    expect(parentConversation.loadTrustContexts).toEqual([undefined]);
+    expect(spawnConfigs[0]?.trustContext).toBeUndefined();
+  });
+});

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -4725,12 +4725,25 @@ export function createLiveVoiceSession(
 // silent (never spoken unprompted); its final answer is RETURNED so the session
 // can fold it into the next turn the user starts. The `signal` aborts the child
 // on a stop/interrupt (spawnAndAwait then rejects).
-async function defaultSpawnBackgroundContinuation(args: {
+//
+// Exported for tests only: every production caller reaches it through the
+// `spawnBackgroundContinuation` option default in `createLiveVoiceSession`.
+export async function defaultSpawnBackgroundContinuation(args: {
   parentConversationId: string;
   objective: string;
   label: string;
   signal: AbortSignal;
 }): Promise<string> {
+  // Trust first, before anything can hydrate: the bridge stamps trust per-turn
+  // and clears it at teardown, which has settled by now — inheriting from the
+  // parent would read the cleared window and run the continuation fail-closed
+  // as `unknown`, denying every consequential tool. Resolve the same guardian
+  // trust the foreground turn ran under and pass it explicitly (resolution
+  // itself stays fail-closed: on a miss the continuation runs as `unknown`,
+  // exactly as an unstamped turn does).
+  const trustContext = await resolveLocalLiveVoiceTrustContext(
+    args.parentConversationId,
+  );
   // getOrCreateConversation (not a raw registry read): it rebuilds a stale
   // instance and awaits loadFromDb, so the snapshot below sees the persisted
   // history. A raw findConversation can return a cold instance whose in-memory
@@ -4740,23 +4753,39 @@ async function defaultSpawnBackgroundContinuation(args: {
   const parentConversation = await getOrCreateConversation(
     args.parentConversationId,
   );
-  // Belt-and-suspenders for a resident-but-unhydrated instance: the teardown
-  // settle that gated this spawn guarantees the interrupted turn's partial is
-  // persisted, so an empty in-memory history on a conversation that has rows
-  // means the instance is cold — hydrate before snapshotting. A genuinely new
-  // conversation loads zero rows; harmless.
-  if (parentConversation.getMessages().length === 0) {
+  // Hydration runs under the resolved trust: `loadFromDb` filters history by
+  // the instance's own trust class, so a load with no trust context drops
+  // memory blocks and forces the compaction summary to null — the fork would
+  // inherit a lobotomized snapshot. Stamp for the duration of the load and
+  // restore the prior value, the same set-load-restore idiom
+  // `elevatePointerConversationToGuardian` uses to un-filter a cold pointer
+  // turn. The restore matters: the bridge owns this conversation's trust
+  // per-turn and expects the window between turns to be empty.
+  //
+  // `ensureActorScopedHistory` reloads exactly when the resident history was
+  // loaded under a different trust class — covering both the never-loaded cold
+  // instance and the untrusted load `getOrCreateConversation` may have just
+  // run — and no-ops when the history is already guardian-scoped. Without a
+  // guardian to stamp there is nothing to re-scope, so an unhydrated instance
+  // falls back to a plain load; a genuinely new conversation reads zero rows,
+  // harmless.
+  const priorTrustContext = parentConversation.trustContext;
+  if (trustContext) {
+    const stampedTrustContext = { ...trustContext };
+    parentConversation.setTrustContext(stampedTrustContext);
+    try {
+      await parentConversation.ensureActorScopedHistory();
+    } finally {
+      // Only undo the stamp this block installed: the user's next foreground
+      // turn can start during the load and stamp its own trust, and clearing
+      // that would run the live turn fail-closed.
+      if (parentConversation.trustContext === stampedTrustContext) {
+        parentConversation.setTrustContext(priorTrustContext ?? null);
+      }
+    }
+  } else if (parentConversation.getMessages().length === 0) {
     await parentConversation.loadFromDb();
   }
-  // The bridge stamps trust per-turn and clears it at teardown, which has
-  // settled by now — inheriting from the parent would read the cleared window
-  // and run the continuation fail-closed as `unknown`, denying every
-  // consequential tool. Resolve the same guardian trust the foreground turn
-  // ran under and pass it explicitly (resolution itself stays fail-closed:
-  // on a miss the continuation runs as `unknown`, exactly as before).
-  const trustContext = await resolveLocalLiveVoiceTrustContext(
-    args.parentConversationId,
-  );
   return await getSubagentManager().spawnAndAwait(
     {
       parentConversationId: args.parentConversationId,


### PR DESCRIPTION
## Summary
- Resolve the guardian trust context before hydrating the continuation's fork parent, so `loadFromDb` does not filter history by the fail-closed `unknown` trust class.
- Stamp the resolved trust for the duration of the load and restore the prior value afterward, mirroring the set-load-restore precedent in `conversation.ts`.
- A cold parent otherwise forks a snapshot missing memory blocks and compaction summaries.

Part of plan: voice-duplex-gaps.md (PR 2 of 9)