### PR TITLE
fix(live-voice): exempt only installed, non-dynamic skill_load from foreground-wins (Codex P2)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 
 import type { TurnDetectorConfig } from "../../calls/media-turn-detector.js";
@@ -20,6 +22,7 @@ import type {
   SttStreamServerEvent,
 } from "../../stt/types.js";
 import { __resetRegistryForTesting } from "../../tools/registry.js";
+import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type { VoiceFrontDecider } from "../front-decision.js";
 import type { LiveVoiceAudioArchiveResult } from "../live-voice-archive.js";
 import {
@@ -309,6 +312,75 @@ async function waitFor(
 
 async function flushAsyncCallbacks(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+/**
+ * Write a skill into the (per-process temp) workspace skills dir so the
+ * `skill_load` contention gate resolves it from the real on-disk catalog.
+ */
+function installSkillFixture(id: string, body: string): void {
+  const directory = join(getWorkspaceSkillsDir(), id);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    join(directory, "SKILL.md"),
+    `---\nname: ${id}\ndescription: Fixture skill for the contention gate\n---\n\n${body}\n`,
+  );
+}
+
+/**
+ * Barge in during thinking so the interrupted turn detaches a continuation,
+ * then hand back the follow-up turn's options plus the continuation's abort
+ * signal — the two handles every foreground-wins assertion needs. The
+ * continuation hangs until its signal aborts, so it is still in flight while
+ * the follow-up turn starts tools.
+ */
+async function startForegroundWinsScenario(): Promise<{
+  followUp: VoiceTurnOptions | undefined;
+  signal: AbortSignal | undefined;
+}> {
+  setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+  const spawnBackgroundContinuation = mock(
+    (args: {
+      parentConversationId: string;
+      objective: string;
+      label: string;
+      signal: AbortSignal;
+    }): Promise<string> =>
+      new Promise<string>((resolve) => {
+        args.signal.addEventListener("abort", () => resolve(""), {
+          once: true,
+        });
+      }),
+  );
+  const calls: VoiceTurnOptions[] = [];
+  const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+    calls.push(options);
+    return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+  });
+  const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+    options.onAudioChunk(makeTtsChunk("assistant audio"));
+    return makeTtsResult("assistant audio");
+  });
+  const { frames, session } = createHarness({
+    finals: ["first question", "second question"],
+    startVoiceTurn,
+    streamTtsAudio,
+    spawnBackgroundContinuation,
+  });
+
+  await session.start();
+  await session.handleBinaryAudio(LOUD_CHUNK);
+  await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+  await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+  await waitFor(() => spawnBackgroundContinuation.mock.calls.length === 1);
+  await waitFor(() => calls.some((c) => c.content === "second question"));
+
+  const signal = spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal;
+  expect(signal?.aborted).toBe(false);
+  return {
+    followUp: calls.find((c) => c.content === "second question"),
+    signal,
+  };
 }
 
 describe("LiveVoiceSession server VAD", () => {
@@ -1428,57 +1500,13 @@ describe("LiveVoiceSession server VAD", () => {
   });
 
   test("voice-duplex-handoff on: a foreground consequential tool start aborts an in-flight continuation", async () => {
-    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
-    // Hang the continuation so it is still running when the follow-up turn
-    // starts mutating; resolve it when its signal aborts.
-    const spawnBackgroundContinuation = mock(
-      (args: {
-        parentConversationId: string;
-        objective: string;
-        label: string;
-        signal: AbortSignal;
-      }): Promise<string> =>
-        new Promise<string>((resolve) => {
-          args.signal.addEventListener("abort", () => resolve(""), {
-            once: true,
-          });
-        }),
-    );
-    const calls: VoiceTurnOptions[] = [];
-    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
-      calls.push(options);
-      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
-    });
-    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
-      options.onAudioChunk(makeTtsChunk("assistant audio"));
-      return makeTtsResult("assistant audio");
-    });
-    const { frames, session } = createHarness({
-      finals: ["first question", "second question"],
-      startVoiceTurn,
-      streamTtsAudio,
-      spawnBackgroundContinuation,
-    });
-
-    await session.start();
-    await session.handleBinaryAudio(LOUD_CHUNK);
-    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
-
-    // Barge in during thinking: the continuation detaches, the follow-up turn
-    // launches while it is still in flight.
-    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    await waitFor(() => spawnBackgroundContinuation.mock.calls.length === 1);
-    await waitFor(() => calls.some((c) => c.content === "second question"));
-
-    const signal = spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal;
-    expect(signal?.aborted).toBe(false);
+    const { followUp, signal } = await startForegroundWinsScenario();
 
     // The follow-up turn starts a consequential tool: foreground wins the
     // workspace, so the still-running continuation is aborted before the two
     // can race on writes. `remember` is deliberately NOT on the core
     // side-effect name list — the classification must fail closed on any
     // tool that is not provably read-only, not just named writers.
-    const followUp = calls.find((c) => c.content === "second question");
     followUp?.callbacks?.tool_use_start?.("remember", {
       toolUseId: "tool-1",
     });
@@ -1486,59 +1514,12 @@ describe("LiveVoiceSession server VAD", () => {
   });
 
   test("voice-duplex-handoff on: a read-only built-in leaves the continuation running; an unclassified tool fails closed", async () => {
-    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
-    let abortListenerArmed = false;
-    const spawnBackgroundContinuation = mock(
-      (args: {
-        parentConversationId: string;
-        objective: string;
-        label: string;
-        signal: AbortSignal;
-      }): Promise<string> =>
-        new Promise<string>((resolve) => {
-          abortListenerArmed = true;
-          args.signal.addEventListener("abort", () => resolve(""), {
-            once: true,
-          });
-        }),
-    );
-    const calls: VoiceTurnOptions[] = [];
-    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
-      calls.push(options);
-      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
-    });
-    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
-      options.onAudioChunk(makeTtsChunk("assistant audio"));
-      return makeTtsResult("assistant audio");
-    });
-    const { frames, session } = createHarness({
-      finals: ["first question", "second question"],
-      startVoiceTurn,
-      streamTtsAudio,
-      spawnBackgroundContinuation,
-    });
-
-    await session.start();
-    await session.handleBinaryAudio(LOUD_CHUNK);
-    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
-    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    await waitFor(() => abortListenerArmed);
-    await waitFor(() => calls.some((c) => c.content === "second question"));
+    const { followUp, signal } = await startForegroundWinsScenario();
 
     // A provably read-only built-in cannot contend on the workspace: the
     // continuation survives (this is the topic-change case the handoff
     // exists for).
-    const followUp = calls.find((c) => c.content === "second question");
     followUp?.callbacks?.tool_use_start?.("file_read", { toolUseId: "tool-1" });
-    const signal = spawnBackgroundContinuation.mock.calls[0]?.[0]?.signal;
-    expect(signal?.aborted).toBe(false);
-
-    // skill_load is non-contending too: it only registers tool definitions,
-    // and it is the first call of a follow-up turn that re-enters the skill
-    // the interrupted turn was using — it must not kill the continuation.
-    followUp?.callbacks?.tool_use_start?.("skill_load", {
-      toolUseId: "tool-2",
-    });
     expect(signal?.aborted).toBe(false);
 
     // web_fetch is a network read: it cannot corrupt local state, so it does
@@ -1555,6 +1536,61 @@ describe("LiveVoiceSession server VAD", () => {
     // provably non-contending: fail closed and abort.
     followUp?.callbacks?.tool_use_start?.("calendar_lookup", {
       toolUseId: "tool-4",
+    });
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("voice-duplex-handoff on: an installed static skill_load leaves the continuation running", async () => {
+    installSkillFixture("static-fixture-skill", "Plain instructions.");
+    const { followUp, signal } = await startForegroundWinsScenario();
+
+    // Re-entering a skill that is installed locally and renders no inline
+    // commands is a pure read — and it is the first call of nearly every
+    // barge-in follow-up, so it must not kill the continuation.
+    followUp?.callbacks?.tool_use_start?.("skill_load", {
+      toolUseId: "tool-1",
+      input: { skill: "static-fixture-skill" },
+    });
+    expect(signal?.aborted).toBe(false);
+
+    // web_fetch is exempt by name regardless of input.
+    followUp?.callbacks?.tool_use_start?.("web_fetch", {
+      toolUseId: "tool-2",
+      input: { url: "https://example.com" },
+    });
+    expect(signal?.aborted).toBe(false);
+
+    // skill_execute is a dispatcher whose resolved inner tool can mutate.
+    followUp?.callbacks?.tool_use_start?.("skill_execute", {
+      toolUseId: "tool-3",
+      input: { skill: "static-fixture-skill" },
+    });
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("voice-duplex-handoff on: a skill_load with inline command expansions aborts the continuation", async () => {
+    installSkillFixture(
+      "dynamic-fixture-skill",
+      "Current status: !`git status --short`",
+    );
+    const { followUp, signal } = await startForegroundWinsScenario();
+
+    // Inline expansions run shell at load time, so this load writes to the
+    // host and contends like any other mutator.
+    followUp?.callbacks?.tool_use_start?.("skill_load", {
+      toolUseId: "tool-1",
+      input: { skill: "dynamic-fixture-skill" },
+    });
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("voice-duplex-handoff on: a skill_load with no input aborts the continuation", async () => {
+    const { followUp, signal } = await startForegroundWinsScenario();
+
+    // Without the input there is no way to tell a pure read from an
+    // auto-installing load: fail closed.
+    followUp?.callbacks?.tool_use_start?.("skill_load", {
+      toolUseId: "tool-1",
     });
     expect(signal?.aborted).toBe(true);
   });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -40,6 +40,7 @@ import {
 import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { isRefusedInReadOnlyPass } from "../daemon/conversation-tool-setup.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import { isInstalledStaticSkillLoad } from "../permissions/checker.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
   listProviderIds,
@@ -700,18 +701,20 @@ function buildDuplexContinuationObjective(interruptedRequest: string): string {
 }
 
 // Built-ins beyond the strict read-only allowlist that cannot contend with a
-// background continuation's writes: they touch no workspace, host, or
-// extension state. `skill_load` reads skill files and registers tool
-// definitions — and it is the FIRST call of a barge-in follow-up that
-// re-enters the skill the interrupted turn was using, so counting it as
-// consequential would kill nearly every continuation doing skill-based work
-// at the moment it matters most.
-// `web_fetch` sits on the core SIDE_EFFECT_TOOLS list because an UNATTENDED
-// run firing off external requests is a permission concern — a different
-// question from this gate's, which is only "can these two writers corrupt the
-// same local state?". A network read cannot, so it does not contend.
+// background continuation's writes, whatever their input: they touch no
+// workspace, host, or extension state. `web_fetch` sits on the core
+// SIDE_EFFECT_TOOLS list because an UNATTENDED run firing off external requests
+// is a permission concern — a different question from this gate's, which is
+// only "can these two writers corrupt the same local state?". A network read
+// cannot, so it does not contend.
+//
+// `skill_load` is exempt per-invocation rather than by name. Re-entering an
+// already-installed static skill is the first call of nearly every barge-in
+// follow-up, and killing the continuation there would defeat the feature at the
+// moment it matters most — but a load that auto-installs a missing skill or
+// renders an inline command expansion writes local state and executes shell, so
+// it contends like anything else.
 const FOREGROUND_NON_CONTENDING_TOOLS: ReadonlySet<string> = new Set([
-  "skill_load",
   "web_fetch",
 ]);
 
@@ -724,16 +727,26 @@ const FOREGROUND_NON_CONTENDING_TOOLS: ReadonlySet<string> = new Set([
 // carry no "writes local state" metadata and some of them (app_*, document_*)
 // very much do. `skill_execute` always contends: it is a dispatcher whose
 // resolved inner tool can mutate.
-function foregroundToolContendsWithContinuation(toolName: string): boolean {
+function foregroundToolContendsWithContinuation(
+  toolName: string,
+  input?: Record<string, unknown>,
+): boolean {
   if (toolName === "skill_execute") {
     return true;
   }
   const ownerKind = getToolOwner(toolName)?.kind;
-  if (
-    FOREGROUND_NON_CONTENDING_TOOLS.has(toolName) &&
-    ownerKind === "default"
-  ) {
-    return false;
+  if (ownerKind === "default") {
+    if (FOREGROUND_NON_CONTENDING_TOOLS.has(toolName)) {
+      return false;
+    }
+    // Last, and behind the name checks above: `isInstalledStaticSkillLoad`
+    // re-reads the skill catalog from disk, so only a `skill_load` pays for it.
+    // Absent input fails closed — an unknown target could be an auto-install.
+    if (toolName === "skill_load") {
+      return (
+        input === undefined || !isInstalledStaticSkillLoad(toolName, input)
+      );
+    }
   }
   return isRefusedInReadOnlyPass(toolName, ownerKind);
 }
@@ -3183,7 +3196,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // background teardown here would stall the live call's turn.
             // This gate already makes voice stricter than that baseline; the
             // residual is bounded to one in-flight call at barge-over time.
-            if (foregroundToolContendsWithContinuation(toolName)) {
+            if (
+              foregroundToolContendsWithContinuation(toolName, detail?.input)
+            ) {
               this.abortDetachedRuns({
                 keepPendingResult: true,
                 reason: "foreground_tool_contends",


### PR DESCRIPTION
## Summary
- Narrow the foreground-wins `skill_load` exemption to loads that are provably pure reads: the selector resolves locally and the target plus every transitive include is present and free of inline command expansions.
- An auto-installing or inline-command load writes local state and executes shell at load time, so it contends with a running background continuation like any other mutator.
- Fails closed when the tool input is absent.

Part of plan: voice-duplex-gaps.md (PR 7 of 9)