### PR TITLE
fix(apps): associate apps with the visible ancestor conversation, not just the fork

### DIFF
--- a/assistant/src/__tests__/app-conversation-ids.test.ts
+++ b/assistant/src/__tests__/app-conversation-ids.test.ts
@@ -7,14 +7,56 @@ import {
   addAppConversationId,
   createApp,
   getApp,
+  linkAppToConversationLineage,
   listAppsByConversation,
 } from "../apps/app-store.js";
+import {
+  deleteConversation,
+  removeSubagentConversation,
+  setConversation,
+  setSubagentConversation,
+} from "../daemon/conversation-registry.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 let testDataDir: string;
+
+/**
+ * The registry stores live `Conversation` instances; lineage resolution only
+ * reads `parentConversationId`, so a minimal stand-in is enough.
+ */
+type RegistryConversation = Parameters<typeof setConversation>[1];
+
+const registeredTopLevel: string[] = [];
+const registeredSubagents: [string, RegistryConversation][] = [];
+
+function stubConversation(parentConversationId?: string): RegistryConversation {
+  return { parentConversationId } as unknown as RegistryConversation;
+}
+
+/** Register a resident top-level conversation, optionally forked from a parent. */
+function registerConversation(id: string, parentId?: string): void {
+  setConversation(id, stubConversation(parentId));
+  registeredTopLevel.push(id);
+}
+
+/** Register a live subagent conversation forked from `parentId`. */
+function registerSubagent(id: string, parentId: string): void {
+  const conversation = stubConversation(parentId);
+  setSubagentConversation(id, conversation);
+  registeredSubagents.push([id, conversation]);
+}
+
+function clearRegisteredConversations(): void {
+  for (const id of registeredTopLevel.splice(0)) {
+    deleteConversation(id);
+  }
+  for (const [id, conversation] of registeredSubagents.splice(0)) {
+    removeSubagentConversation(id, conversation);
+  }
+}
 
 function freshTempDir(): string {
   return join(
@@ -41,6 +83,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearRegisteredConversations();
   if (existsSync(testDataDir)) {
     rmSync(testDataDir, { recursive: true, force: true });
   }
@@ -147,5 +190,96 @@ describe("listAppsByConversation", () => {
   test("returns empty array when no apps exist", () => {
     const result = listAppsByConversation("conv-any");
     expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// linkAppToConversationLineage
+// ---------------------------------------------------------------------------
+
+describe("linkAppToConversationLineage", () => {
+  test("an app created in a forked conversation carries the fork and its parent", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-fork", "conv-visible");
+
+    const app = createApp(makeAppParams("Continuation App"));
+    linkAppToConversationLineage(app.id, "conv-fork");
+
+    expect(getApp(app.id)?.conversationIds).toEqual([
+      "conv-fork",
+      "conv-visible",
+    ]);
+  });
+
+  test("the user-visible ancestor lists an app created by a background subagent", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-fork", "conv-visible");
+
+    const app = createApp(makeAppParams("Continuation App"));
+    linkAppToConversationLineage(app.id, "conv-fork");
+
+    const visible = listAppsByConversation("conv-visible");
+    expect(visible).toHaveLength(1);
+    expect(visible[0].id).toBe(app.id);
+  });
+
+  test("walks nested subagents up to the user-visible thread", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-outer", "conv-visible");
+    registerSubagent("conv-inner", "conv-outer");
+
+    const app = createApp(makeAppParams("Nested App"));
+    linkAppToConversationLineage(app.id, "conv-inner");
+
+    expect(getApp(app.id)?.conversationIds).toEqual([
+      "conv-inner",
+      "conv-outer",
+      "conv-visible",
+    ]);
+  });
+
+  test("re-linking the same lineage is idempotent", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-fork", "conv-visible");
+
+    const app = createApp(makeAppParams("Repeat App"));
+    linkAppToConversationLineage(app.id, "conv-fork");
+    linkAppToConversationLineage(app.id, "conv-fork");
+
+    expect(getApp(app.id)?.conversationIds).toEqual([
+      "conv-fork",
+      "conv-visible",
+    ]);
+  });
+
+  test("a lineage of one behaves exactly like addAppConversationId", () => {
+    registerConversation("conv-plain");
+
+    const linked = createApp(makeAppParams("Linked App"));
+    const direct = createApp(makeAppParams("Direct App"));
+    linkAppToConversationLineage(linked.id, "conv-plain");
+    addAppConversationId(direct.id, "conv-plain");
+
+    expect(getApp(linked.id)?.conversationIds).toEqual(["conv-plain"]);
+    expect(getApp(direct.id)?.conversationIds).toEqual(
+      getApp(linked.id)?.conversationIds,
+    );
+    expect(listAppsByConversation("conv-plain")).toHaveLength(2);
+  });
+
+  test("an unregistered conversation links only itself", () => {
+    const app = createApp(makeAppParams("Orphan App"));
+    linkAppToConversationLineage(app.id, "conv-gone");
+
+    expect(getApp(app.id)?.conversationIds).toEqual(["conv-gone"]);
+  });
+
+  test("a non-existent app is a no-op", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-fork", "conv-visible");
+
+    expect(() =>
+      linkAppToConversationLineage("nonexistent-id", "conv-fork"),
+    ).not.toThrow();
   });
 });

--- a/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
@@ -54,6 +54,7 @@ mock.module("../apps/app-store.js", () => ({
   editAppFile: mock(() => ({})),
   inlineDistAssets: mock((_, html: string) => html),
   addAppConversationId: mock(() => false),
+  linkAppToConversationLineage: mock(() => {}),
 }));
 mock.module("../services/published-app-updater.js", () => ({
   updatePublishedAppDeployment: mock(() => Promise.resolve()),

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -34,12 +34,15 @@ import {
   resolve,
 } from "node:path";
 
+import { resolveConversationLineage } from "../daemon/conversation-lineage.js";
 import { rawAll } from "../persistence/raw-query.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import type { EditEngineResult } from "../tools/shared/filesystem/edit-engine.js";
 import { applyEdit } from "../tools/shared/filesystem/edit-engine.js";
 import { getLogger } from "../util/logger.js";
 import { getDataDir, getWorkspacePluginsDir } from "../util/platform.js";
+
+const log = getLogger("app-store");
 
 export interface AppDefinition {
   id: string;
@@ -1253,6 +1256,32 @@ export function addAppConversationId(
 }
 
 /**
+ * Associate an app with the conversation that produced it and every subagent
+ * ancestor above it. A background subagent (e.g. the live-voice duplex
+ * continuation) runs in a forked conversation the user never sees, so linking
+ * only the fork leaves the app unopenable from the thread the user actually
+ * has in front of them. Associations are additive and de-duplicated, so
+ * linking the whole chain is safe.
+ *
+ * Best-effort per id: a link failure must never break app creation or opening.
+ */
+export function linkAppToConversationLineage(
+  appId: string,
+  conversationId: string,
+): void {
+  for (const id of resolveConversationLineage(conversationId)) {
+    try {
+      addAppConversationId(appId, id);
+    } catch (err) {
+      log.warn(
+        { err, appId, conversationId: id },
+        "Failed to associate app with conversation",
+      );
+    }
+  }
+}
+
+/**
  * Return all apps associated with a given conversation ID.
  */
 export function listAppsByConversation(
@@ -1280,8 +1309,6 @@ export function listAppsByConversation(
  * Wrapped in try/catch so failures never block daemon start.
  */
 export function backfillAppConversationIds(): void {
-  const log = getLogger("app-store");
-
   // Check sentinel — skip the potentially expensive scan when already done.
   const sentinelPath = join(getAppsDir(), ".conversation-ids-backfilled");
   if (existsSync(sentinelPath)) {

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -18,10 +18,10 @@ import {
   SurfaceTypeSchema,
 } from "../api/surfaces.js";
 import {
-  addAppConversationId,
   getApp,
   getAppDirPath,
   getAppPreview,
+  linkAppToConversationLineage,
   listAppsByConversation,
   resolveAppDir,
   resolveEffectiveAppHtml,
@@ -3411,7 +3411,7 @@ export async function surfaceProxyResolver(
 
     // Track conversation association (best-effort — failures must not break open flow).
     try {
-      addAppConversationId(appId, ctx.conversationId);
+      linkAppToConversationLineage(appId, ctx.conversationId);
     } catch (err) {
       log.warn({ err, appId }, "Failed to track conversation ID on app_open");
     }

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -10,7 +10,7 @@
 import { isAbsolute, resolve, sep } from "node:path";
 
 import type { AssistantEvent } from "../api/index.js";
-import { addAppConversationId, getApp } from "../apps/app-store.js";
+import { getApp, linkAppToConversationLineage } from "../apps/app-store.js";
 import { findActiveSession } from "../channels/gateway-verification-sessions.js";
 import { getConfig } from "../config/loader.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
@@ -121,7 +121,7 @@ registerHook("app_create", (_name, _input, result, { ctx }) => {
     return;
   }
   try {
-    addAppConversationId(appId, ctx.conversationId);
+    linkAppToConversationLineage(appId, ctx.conversationId);
   } catch (err) {
     log.warn({ err, appId }, "Failed to track conversation ID on app_create");
   }
@@ -169,7 +169,7 @@ function registerAppSurfaceRefreshHook(toolName: string): void {
       return;
     }
     try {
-      addAppConversationId(appId, ctx.conversationId);
+      linkAppToConversationLineage(appId, ctx.conversationId);
     } catch (err) {
       log.warn({ err, appId }, `Failed to track conversation ID on ${name}`);
     }
@@ -181,7 +181,9 @@ registerAppSurfaceRefreshHook("app_update");
 
 registerHook("voice_config_update", (_name, input) => {
   const setting = input.setting as string | undefined;
-  if (!setting) {return;}
+  if (!setting) {
+    return;
+  }
 
   const SETTING_TO_KEY: Record<string, string> = {
     activation_key: "pttActivationKey",
@@ -191,7 +193,9 @@ registerHook("voice_config_update", (_name, input) => {
     fish_audio_reference_id: "fishAudioReferenceId",
   };
   const key = SETTING_TO_KEY[setting];
-  if (!key) {return;}
+  if (!key) {
+    return;
+  }
 
   // `ttsVoiceId` is an ElevenLabs concept on the desktop client. When the
   // active provider is managed (vellum) or anything else, the voice lives only
@@ -231,8 +235,12 @@ registerHook("voice_config_update", (_name, input) => {
 // This hook runs in the unsandboxed daemon process and delivers the DM.
 registerHook("bash", async (_name, input, result) => {
   const command = (input.command ?? "") as string;
-  if (!command.includes("channel-verification-sessions")) {return;}
-  if (!result.content.includes("_pendingSlackDm")) {return;}
+  if (!command.includes("channel-verification-sessions")) {
+    return;
+  }
+  if (!result.content.includes("_pendingSlackDm")) {
+    return;
+  }
 
   type PendingDm = { userId: string; text: string; assistantId: string };
   type Parsed = { _pendingSlackDm?: PendingDm };
@@ -288,18 +296,24 @@ registerHook("bash", async (_name, input, result) => {
     // multi-object output (e.g. cancel + create chained with &&).
   }
   if (singleObject !== undefined) {
-    if ((await dispatch(singleObject)) !== null) {return;}
+    if ((await dispatch(singleObject)) !== null) {
+      return;
+    }
   }
   for (const line of result.content.split("\n")) {
     const trimmed = line.trim();
-    if (!trimmed.startsWith("{")) {continue;}
+    if (!trimmed.startsWith("{")) {
+      continue;
+    }
     let parsed: Parsed;
     try {
       parsed = JSON.parse(trimmed) as Parsed;
     } catch {
       continue;
     }
-    if ((await dispatch(parsed)) === "delivered") {return;}
+    if ((await dispatch(parsed)) === "delivered") {
+      return;
+    }
   }
 });
 
@@ -311,7 +325,9 @@ function invalidateEdgeIndexIfConceptPage(
   input: Record<string, unknown>,
 ): void {
   const rawPath = input.path;
-  if (typeof rawPath !== "string" || rawPath.length === 0) {return;}
+  if (typeof rawPath !== "string" || rawPath.length === 0) {
+    return;
+  }
   const workspaceDir = getWorkspaceDir();
   const conceptsRoot = getConceptsDir(workspaceDir);
   const absPath = isAbsolute(rawPath)


### PR DESCRIPTION
## Summary
- Add `linkAppToConversationLineage`, associating an app with the conversation that produced it and every subagent ancestor above it.
- A background subagent runs in a forked conversation the user never sees, so linking only the fork leaves the app unopenable from the thread the user has in front of them.
- Adopted at the three production link sites (`app_create`, `app_refresh`/`app_update`, `app_open`). Associations are additive and de-duplicated, so a non-forked conversation is unaffected.

Part of plan: voice-duplex-gaps.md (PR 6 of 9)