### PR TITLE
feat(live-voice): speak a finished continuation's result during an idle call

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1664,10 +1664,25 @@ describe("LiveVoiceSession server VAD", () => {
     });
   }
 
+  // ~600 ms of 24 kHz mono PCM in a single chunk, so the client-side playback
+  // tail estimate outlives the turn that produced it by a wide margin.
+  function makeLongTailTts(): LiveVoiceTtsStreamer {
+    const audio = "x".repeat(28_800);
+    return mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk(audio));
+      return makeTtsResult(audio);
+    });
+  }
+
   function announcementOf(
     calls: VoiceTurnOptions[],
   ): VoiceTurnOptions | undefined {
     return calls.find((c) => c.content === CONTINUATION_DELIVERY_CONTENT);
+  }
+
+  function announcementCount(calls: VoiceTurnOptions[]): number {
+    return calls.filter((c) => c.content === CONTINUATION_DELIVERY_CONTENT)
+      .length;
   }
 
   test("voice-duplex-handoff on: a continuation finishing on an idle live call is announced", async () => {
@@ -1913,6 +1928,100 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => countType(frames, "turn_cancelled") === 2);
     await flushAsyncCallbacks();
     expect(continuation.spawnBackgroundContinuation.mock.calls.length).toBe(1);
+  });
+
+  test("voice-duplex-handoff on: an announcement turn that cannot start hands the answer back to the stash", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      // The announcement turn cannot start — the conversation is busy from
+      // another surface. Real user turns still start normally.
+      if (options.content === CONTINUATION_DELIVERY_CONTENT) {
+        throw new Error("conversation is busy");
+      }
+      if (options.content !== "first question") {
+        options.callbacks?.assistant_text_delta?.(makeTextDelta("ok"));
+        options.callbacks?.message_complete?.(makeMessageComplete());
+      }
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 20,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await waitFor(() => announcementOf(calls) !== undefined);
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+    await flushAsyncCallbacks();
+    // The failed attempt is not retried; the stash is the fallback route.
+    expect(announcementCount(calls)).toBe(1);
+
+    // Nothing was spoken, so the answer is still there for the user's next turn
+    // rather than being dropped with the announcement.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const later = calls.find((c) => c.content === "third question");
+    expect(later?.voiceControlPrompt).toContain("THE_RESULT");
+  });
+
+  test("voice-duplex-handoff on: an announcement waits out the client's queued playback", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeNeverCompletingTurnStarter();
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeLongTailTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 200,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+
+    // The continuation finishes while the follow-up turn still holds the floor.
+    continuation.finish("THE_RESULT");
+    await flushAsyncCallbacks();
+
+    // That reply completes: the turn is cleared server-side, but the client
+    // still has ~600 ms of its audio queued.
+    const followUp = calls.find((c) => c.content === "second question");
+    followUp?.callbacks?.assistant_text_delta?.(makeTextDelta("ok"));
+    followUp?.callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The silence timer elapses mid-tail: the call looks idle but the previous
+    // reply is still audible, so the announcement holds.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(announcementOf(calls)).toBeUndefined();
+
+    // Once the queued audio has drained it lands, instead of being dropped for
+    // having been blocked.
+    await waitFor(() => announcementOf(calls) !== undefined);
+    expect(announcementOf(calls)?.voiceControlPrompt).toContain("THE_RESULT");
   });
 
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -2024,6 +2024,55 @@ describe("LiveVoiceSession server VAD", () => {
     expect(announcementOf(calls)?.voiceControlPrompt).toContain("THE_RESULT");
   });
 
+  test("voice-duplex-handoff on: captured push-to-talk audio with no transcript yet defers the announcement", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const { session } = createHarness({
+      startFrame: MANUAL_START_FRAME,
+      finals: ["ptt question"],
+      startVoiceTurn,
+      continuationAnnounceSilenceMs: 20,
+    });
+
+    await session.start();
+    // Settle the arm so the cycle is streaming: from here audio goes straight
+    // to the transcriber and never lands in the pending buffer.
+    await flushAsyncCallbacks();
+
+    // The user is holding the button and talking. The transcriber emits
+    // nothing until the release, so the cycle has no partial and no final —
+    // every transcript-derived idle signal still reads "nobody is speaking".
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    // A manual session reaches the announcement path only through machinery a
+    // server_vad barge-in owns, so the state a finished continuation leaves
+    // behind is staged directly: the stashed answer plus its queued
+    // announcement.
+    const internals = session as unknown as {
+      pendingContinuationResult: string | null;
+      pendingAnnouncement: { request: string; answer: string } | null;
+      scheduleContinuationAnnouncement: () => void;
+    };
+    internals.pendingContinuationResult = "THE_RESULT";
+    internals.pendingAnnouncement = {
+      request: "the first question",
+      answer: "THE_RESULT",
+    };
+    internals.scheduleContinuationAnnouncement();
+
+    // The silence timer and the single retry both find the utterance in
+    // flight, so the session never speaks over the in-progress utterance.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(announcementOf(calls)).toBeUndefined();
+
+    // ...and the answer is still stashed for the turn the user does start.
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => calls.some((c) => c.content === "ptt question"));
+    expect(
+      calls.find((c) => c.content === "ptt question")?.voiceControlPrompt,
+    ).toContain("THE_RESULT");
+  });
+
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1930,6 +1930,47 @@ describe("LiveVoiceSession server VAD", () => {
     expect(continuation.spawnBackgroundContinuation.mock.calls.length).toBe(1);
   });
 
+  test("voice-duplex-handoff on: a barge-in over an announcement returns the answer to the stash", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeNeverCompletingTurnStarter();
+    const { frames, session } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 20,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await waitFor(() => announcementOf(calls) !== undefined);
+
+    // The user cuts in while the announcement turn is still in flight, so it
+    // never delivers. Nothing is forked to replace it (the work is finished),
+    // so the stash is the only route left for the answer.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => countType(frames, "turn_cancelled") === 2);
+
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const later = calls.find((c) => c.content === "third question");
+    expect(later?.voiceControlPrompt).toContain("THE_RESULT");
+    // One announcement, and no second one racing the real turn: the answer is
+    // recoverable, not duplicated.
+    await flushAsyncCallbacks();
+    expect(announcementCount(calls)).toBe(1);
+  });
+
   test("voice-duplex-handoff on: an announcement turn that cannot start hands the answer back to the stash", async () => {
     setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
     const continuation = makeControlledContinuation();

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -23,6 +23,7 @@ import { __resetRegistryForTesting } from "../../tools/registry.js";
 import type { VoiceFrontDecider } from "../front-decision.js";
 import type { LiveVoiceAudioArchiveResult } from "../live-voice-archive.js";
 import {
+  CONTINUATION_DELIVERY_CONTENT,
   createLiveVoiceSession,
   type LiveVoiceBackgroundContinuationSpawner,
   LiveVoiceSession,
@@ -152,6 +153,7 @@ function createHarness(options: {
   spawnBackgroundContinuation?: LiveVoiceBackgroundContinuationSpawner;
   getTurnTeardown?: (conversationId: string) => Promise<void> | undefined;
   detachTeardownSettleTimeoutMs?: number;
+  continuationAnnounceSilenceMs?: number;
 }) {
   const sequencer = createLiveVoiceServerFrameSequencer();
   const frames: LiveVoiceServerFrame[] = [];
@@ -214,6 +216,11 @@ function createHarness(options: {
       : {}),
     ...(options.detachTeardownSettleTimeoutMs !== undefined
       ? { detachTeardownSettleTimeoutMs: options.detachTeardownSettleTimeoutMs }
+      : {}),
+    ...(options.continuationAnnounceSilenceMs !== undefined
+      ? {
+          continuationAnnounceSilenceMs: options.continuationAnnounceSilenceMs,
+        }
       : {}),
   };
   const session = options.viaFactory
@@ -1051,6 +1058,20 @@ describe("LiveVoiceSession server VAD", () => {
     return { startVoiceTurn, calls };
   }
 
+  // Records every turn's options and completes none of them, so every turn
+  // stays "thinking" and a barge-in always lands on a live one.
+  function makeNeverCompletingTurnStarter(): {
+    startVoiceTurn: LiveVoiceTurnStarter;
+    calls: VoiceTurnOptions[];
+  } {
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    return { startVoiceTurn, calls };
+  }
+
   test("voice-duplex-handoff on: a completed continuation's result folds into the next turn's control prompt", async () => {
     setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
     // Control the continuation's resolution so we know exactly when its result
@@ -1573,11 +1594,7 @@ describe("LiveVoiceSession server VAD", () => {
           resolveContinuation = resolve;
         }),
     );
-    const calls: VoiceTurnOptions[] = [];
-    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
-      calls.push(options);
-      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
-    });
+    const { startVoiceTurn, calls } = makeNeverCompletingTurnStarter();
     const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
       options.onAudioChunk(makeTtsChunk("assistant audio"));
       return makeTtsResult("assistant audio");
@@ -1617,6 +1634,285 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => calls.some((c) => c.content === "third question"));
     const resurfaced = calls.find((c) => c.content === "third question");
     expect(resurfaced?.voiceControlPrompt).toContain("THE_RESULT");
+  });
+
+  // A continuation spawner whose run resolves only when the test says so, so
+  // the finished-continuation moment is exact.
+  function makeControlledContinuation() {
+    let resolveContinuation: ((result: string) => void) | undefined;
+    const spawnBackgroundContinuation = mock(
+      (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          resolveContinuation = resolve;
+        }),
+    );
+    return {
+      spawnBackgroundContinuation,
+      finish: (result: string) => resolveContinuation?.(result),
+    };
+  }
+
+  function makeImmediateTts(): LiveVoiceTtsStreamer {
+    return mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+  }
+
+  function announcementOf(
+    calls: VoiceTurnOptions[],
+  ): VoiceTurnOptions | undefined {
+    return calls.find((c) => c.content === CONTINUATION_DELIVERY_CONTENT);
+  }
+
+  test("voice-duplex-handoff on: a continuation finishing on an idle live call is announced", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const { frames, session } = createHarness({
+      // The barge-in utterance transcribes to nothing, so no follow-up turn
+      // runs and the call goes quiet.
+      finals: ["first question", ""],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 20,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    // Nobody is speaking, so the session starts the delivery turn itself.
+    continuation.finish("THE_RESULT");
+    await waitFor(() => announcementOf(calls) !== undefined);
+    const announcement = announcementOf(calls);
+    expect(announcement?.voiceControlPrompt).toContain("THE_RESULT");
+    expect(announcement?.voiceControlPrompt).toContain("first question");
+  });
+
+  test("voice-duplex-handoff on: an announcement persists hidden and is never delivered twice", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const { frames, session } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 20,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await waitFor(() => announcementOf(calls) !== undefined);
+    const announcement = announcementOf(calls);
+    // The turn the user never started persists as an internal instruction, so
+    // nothing renders as a user bubble; the answer rides the control prompt.
+    expect(announcement?.content).toBe(CONTINUATION_DELIVERY_CONTENT);
+    expect(announcement?.hiddenSyntheticPrompt).toBe(true);
+
+    // Announced, so the stash must not repeat it on the user's next turn.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const later = calls.find((c) => c.content === "third question");
+    expect(later?.voiceControlPrompt).not.toContain("THE_RESULT");
+  });
+
+  test("voice-duplex-handoff on: a user utterance before the silence elapses cancels the announcement", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const { frames, session } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      // Long enough that the user always speaks first.
+      continuationAnnounceSilenceMs: 5_000,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await flushAsyncCallbacks();
+
+    // The user speaks first: their turn delivers the answer through the stash,
+    // and the announcement is dropped rather than repeating it after.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const spoken = calls.find((c) => c.content === "third question");
+    expect(spoken?.voiceControlPrompt).toContain("THE_RESULT");
+    await flushAsyncCallbacks();
+    expect(announcementOf(calls)).toBeUndefined();
+  });
+
+  test("voice-duplex-handoff on: an active turn at fire time defers the announcement, then gives up", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeNeverCompletingTurnStarter();
+    const { frames, session } = createHarness({
+      // The barge-in utterance transcribes, so a follow-up turn holds the floor
+      // for the whole announcement window.
+      finals: ["first question", "second question", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 20,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+
+    // The continuation finishes while the follow-up turn is still running: the
+    // first attempt defers, the single retry defers again, and the announcement
+    // is dropped rather than spoken over the assistant.
+    continuation.finish("THE_RESULT");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(announcementOf(calls)).toBeUndefined();
+
+    // The stash still carries it, so the answer is not lost.
+    const followUp = calls.find((c) => c.content === "second question");
+    followUp?.callbacks?.assistant_text_delta?.(makeTextDelta("ok"));
+    followUp?.callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const later = calls.find((c) => c.content === "third question");
+    expect(later?.voiceControlPrompt).toContain("THE_RESULT");
+    expect(announcementOf(calls)).toBeUndefined();
+  });
+
+  test("voice-duplex-handoff on: a client interrupt between finish and fire cancels the announcement", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const { frames, session } = createHarness({
+      finals: ["first question", ""],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 300,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await flushAsyncCallbacks();
+    await session.handleClientFrame({ type: "interrupt" });
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(announcementOf(calls)).toBeUndefined();
+  });
+
+  test("voice-duplex-handoff on: closing the session between finish and fire cancels the announcement", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const { frames, session } = createHarness({
+      finals: ["first question", ""],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 300,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await flushAsyncCallbacks();
+    await session.close("client_end");
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(announcementOf(calls)).toBeUndefined();
+  });
+
+  test("voice-duplex-handoff on: a barge-in over an announcement spawns no continuation", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeNeverCompletingTurnStarter();
+    const { frames, session } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      continuationAnnounceSilenceMs: 20,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await waitFor(() => announcementOf(calls) !== undefined);
+
+    // Cutting in over an announcement means the user is answering it, not
+    // asking for it to be finished in the background — the skip reason is
+    // `announcement_turn` and nothing new is forked.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => countType(frames, "turn_cancelled") === 2);
+    await flushAsyncCallbacks();
+    expect(continuation.spawnBackgroundContinuation.mock.calls.length).toBe(1);
   });
 
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -153,6 +153,16 @@ const BARGE_IN_MAX_TOLERATED_SILENCE_RATIO = 4;
 // a segment is at most ~180 chars of speech (~10 s of 24 kHz mono PCM
 // ≈ 480 KB), so one buffered segment is an acceptable bound.
 const TTS_MAX_OPEN_SYNTHESIS_JOBS = 2;
+// Audible silence required before a finished background continuation's result
+// is spoken into a live call. Long enough that the announcement lands in a real
+// lull rather than on the heels of the turn that just ended; short enough that
+// the user is not left wondering whether the work survived.
+const CONTINUATION_ANNOUNCE_SILENCE_MS = 1_500;
+// `content` of an announcement turn. The answer never rides here — it goes in
+// the model-facing control prompt (buildLiveDeliveryNote), so the only thing
+// persisted on the user side is this marker, and it persists hidden.
+export const CONTINUATION_DELIVERY_CONTENT =
+  "(background work finished — deliver it now)";
 
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
@@ -170,11 +180,12 @@ export type LiveVoiceTtsStreamer = (
 ) => Promise<LiveVoiceTtsResult>;
 
 // Runs an interrupted live-voice turn to completion on a background subagent
-// (true-duplex handoff, gated behind voice-duplex-handoff). The run stays silent
-// (no parent notification, never spoken unprompted); it RESOLVES with the
-// continuation's final answer text, which the session folds into the next turn
-// the user starts as context. Aborts when `signal` fires (rejecting). Injected
-// for testability; the factory wires the real SubagentManager-backed impl.
+// (true-duplex handoff, gated behind voice-duplex-handoff). The run itself is
+// silent (no parent notification); it RESOLVES with the continuation's final
+// answer text, and the session decides where that goes — the next turn the user
+// starts, an announcement into audible silence, or the conversation once the
+// call has ended. Aborts when `signal` fires (rejecting). Injected for
+// testability; the factory wires the real SubagentManager-backed impl.
 export type LiveVoiceBackgroundContinuationSpawner = (args: {
   parentConversationId: string;
   objective: string;
@@ -273,6 +284,12 @@ export interface LiveVoiceSessionOptions {
    * teardown budget (`resolveProcessingWaitMs`).
    */
   detachTeardownSettleTimeoutMs?: number;
+  /**
+   * Overrides the audible silence a finished continuation waits out before its
+   * result is announced into a live, idle call (test hook). Defaults to
+   * `CONTINUATION_ANNOUNCE_SILENCE_MS`.
+   */
+  continuationAnnounceSilenceMs?: number;
 }
 
 type LiveVoiceUtterancePhase =
@@ -481,9 +498,14 @@ interface ActiveAssistantTurn {
   interruptedRequest: string | null;
   // The completed background continuation's answer (voice-duplex-handoff),
   // folded into this turn's control prompt as context so the model can deliver
-  // or reference it in reply to the user, without ever speaking it unprompted.
-  // Null when no continuation result is pending for this turn.
+  // or reference it in reply to the user's own utterance. Null when no
+  // continuation result is pending for this turn.
   continuationResult: string | null;
+  // Set only on an announcement turn: the interrupted request and the
+  // continuation's answer, which the turn exists solely to deliver. The turn has
+  // no user utterance behind it — `content` is CONTINUATION_DELIVERY_CONTENT and
+  // the answer rides the control prompt (buildLiveDeliveryNote).
+  continuationDelivery: ContinuationDelivery | null;
   // Set when a barge-in handed the interrupted work to a background subagent:
   // that request's transcript, so the model can tell the user the work is
   // still running instead of appearing to have dropped it.
@@ -624,9 +646,10 @@ function buildInterruptionMergeNote(interruptedRequest: string): string {
 // System-level guidance appended to the NEXT turn's control prompt after a
 // background continuation (voice-duplex-handoff) finished the reply the user
 // interrupted. Folds the completed answer in as context so the model can
-// deliver or reference it in reply to the user; it must never be spoken
-// unprompted (live-voice is non-interactive, JARVIS-1291). Reaches the model
-// only; it is not a user message and never renders as a transcript bubble.
+// deliver or reference it in its reply to whatever the user just said — this
+// turn answers the user, so the result is offered only if it fits. Reaches the
+// model only; it is not a user message and never renders as a transcript
+// bubble.
 function buildResurfaceContextNote(continuationResult: string): string {
   return `Earlier the user interrupted you, and in the background you finished the reply they cut off. What you worked out was: "${continuationResult}". If their current message relates to it, use it to answer; otherwise you may briefly offer it or leave it aside, and do not repeat it verbatim if it no longer fits.`;
 }
@@ -643,12 +666,39 @@ function buildHandoffAnnouncementNote(handedOffRequest: string): string {
   return `You handed your unfinished work on "${handedOffRequest}" to a background task, which is still running. If the user has moved to a different topic, briefly let them know you are still working on it in the background before answering them. If they are asking you to continue that same work, just continue and do not mention the background task.`;
 }
 
+// Names the interrupted request inside a delivery prompt. A barge-in can fire
+// before any transcript landed, so the request may be empty.
+function describeInterruptedRequest(request: string): string {
+  return request.length > 0
+    ? `their earlier request ("${request}")`
+    : "their earlier request";
+}
+
+// A finished background continuation waiting to be delivered: the request it
+// took over and the answer it produced.
+interface ContinuationDelivery {
+  request: string;
+  answer: string;
+}
+
+// Appended to an announcement turn's control prompt: the turn the session
+// starts on its own when a background continuation finishes while the call is
+// live and nobody is speaking. There is no user utterance behind it, so this
+// note is the whole instruction and the answer rides here rather than in the
+// turn's `content`. Reaches the model only; it is not a user message and never
+// renders as a transcript bubble.
+function buildLiveDeliveryNote(request: string, answer: string): string {
+  const what = describeInterruptedRequest(request);
+  return `The user interrupted you earlier, and in the background you finished ${what}. The call is still live and nobody is speaking, so tell them briefly that it is done and give them the result. Do not re-run any tool calls; the work is already complete, and do not repeat it verbatim if it no longer fits. What you produced was:\n\n${answer}`;
+}
+
 // Assemble a leg's model-facing control prompt: the base live-voice rules,
 // the [-1] minimize teaching (withheld from the front-door leg — see
 // LIVE_VOICE_MINIMIZE_MARKER_TEACHING), the shared no-setup-flows rule, plus
-// any pending barge-in merge context and/or completed-continuation context. A
-// turn can carry both (a barge-in follow-up that also has a continuation
-// result waiting); the notes are model-only and never render as user bubbles.
+// any pending barge-in merge context, completed-continuation context, and/or
+// the announcement instruction. A turn can carry several (a barge-in follow-up
+// that also has a continuation result waiting); the notes are model-only and
+// never render as user bubbles.
 function buildVoiceControlPrompt(
   turn: ActiveAssistantTurn,
   leg: { frontDoor?: boolean },
@@ -666,6 +716,12 @@ function buildVoiceControlPrompt(
   if (turn.handedOffRequest) {
     prompt = `${prompt}\n\n${buildHandoffAnnouncementNote(turn.handedOffRequest)}`;
   }
+  if (turn.continuationDelivery) {
+    prompt = `${prompt}\n\n${buildLiveDeliveryNote(
+      turn.continuationDelivery.request,
+      turn.continuationDelivery.answer,
+    )}`;
+  }
   return prompt;
 }
 
@@ -678,11 +734,51 @@ function buildClosedSessionDeliveryPrompt(
   interruptedRequest: string,
   answer: string,
 ): string {
-  const what =
-    interruptedRequest.length > 0
-      ? `their earlier request ("${interruptedRequest}")`
-      : "their earlier request";
+  const what = describeInterruptedRequest(interruptedRequest);
   return `[Background work finished] The voice call ended while you were still finishing ${what} in the background. You have now finished it. Tell the user briefly that it is done and give them the result. Do not re-run any tool calls; the work is already complete. What you produced was:\n\n${answer}`;
+}
+
+// A fresh cycle: nothing captured, nothing released, no metrics turn open.
+function createUtteranceCycle(): UtteranceCycle {
+  return {
+    phase: "pending",
+    released: false,
+    assistantTurnStarted: false,
+    completed: false,
+    finalizeRequested: false,
+    transcriber: null,
+    pendingAudioChunks: [],
+    pendingAudioBytes: 0,
+    finalTranscriptSegments: [],
+    latestPartialText: null,
+    endpointExtensionCount: 0,
+    heldSpeculativeContent: null,
+    turnId: null,
+    userMessageId: null,
+    userAudioChunks: [],
+    metricsTurnStarted: false,
+    metricsTurnFinished: false,
+    stashedMetricsMarks: {
+      firstAudioAtMs: null,
+      firstPartialAtMs: null,
+      speechStartAtMs: null,
+      utteranceEndAtMs: null,
+      finalTranscriptAtMs: null,
+    },
+  };
+}
+
+// Carrier cycle for an assistant-initiated turn: the turn machinery is
+// utterance-shaped (metrics marks, audio archival, turn ids all hang off a
+// cycle), but an announcement has no capture behind it. The record starts fully
+// released with an empty transcript so nothing routes audio into it, and it is
+// never installed as `currentUtterance` — that field belongs to the VAD cycle.
+function createSyntheticUtterance(): UtteranceCycle {
+  return {
+    ...createUtteranceCycle(),
+    phase: "transcriber_closed",
+    released: true,
+  };
 }
 
 // Objective handed to the background subagent that continues a barged-in turn.
@@ -767,6 +863,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     | ((conversationId: string) => Promise<void> | undefined)
     | null;
   private readonly detachTeardownSettleTimeoutMs: number;
+  private readonly continuationAnnounceSilenceMs: number;
   // Abort handles for background continuations started when a barge-in detached
   // an interrupted turn (voice-duplex-handoff). Each controller is registered
   // synchronously before its spawn, so interrupt()/close() abort a continuation
@@ -837,8 +934,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Set when a background continuation (voice-duplex-handoff) finishes the reply
   // a barge-in cut off: its final answer, folded into the next turn the user
   // starts as context. Consumed (and cleared) when that turn launches; cleared
-  // on a hard stop (abortDetachedRuns) so a stale result never surfaces later.
+  // on a hard stop (abortDetachedRuns) so a stale result never surfaces later,
+  // and cleared by an announcement that delivers the same answer itself.
   private pendingContinuationResult: string | null = null;
+  // The same finished continuation, queued for an announcement turn: the
+  // session speaks the result on its own once the call has been quiet for
+  // `continuationAnnounceSilenceMs`. This and `pendingContinuationResult` are
+  // armed together and are two routes for ONE answer — whichever fires first
+  // clears the other, so the user hears it exactly once.
+  private pendingAnnouncement: ContinuationDelivery | null = null;
+  private announcementTimer: ReturnType<typeof setTimeout> | null = null;
   // Set when a continuation actually spawns: the request it took over, so the
   // NEXT turn can tell the user the work is still running. Consumed by that
   // turn; cleared when the continuation finishes (by then the result note
@@ -928,6 +1033,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.detachTeardownSettleTimeoutMs =
       options.detachTeardownSettleTimeoutMs ??
       defaultDetachTeardownSettleTimeoutMs();
+    this.continuationAnnounceSilenceMs =
+      options.continuationAnnounceSilenceMs ?? CONTINUATION_ANNOUNCE_SILENCE_MS;
     this.emitMetrics = options.emitMetrics ?? false;
     this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =
@@ -1067,6 +1174,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.state = "closed";
     this.turnDetector?.dispose();
     this.clearEndpointExtensionTimer();
+    // There is no longer anyone on the call to speak to, so a queued
+    // announcement is dropped; a continuation that finishes after this point
+    // delivers into the conversation instead.
+    this.clearContinuationAnnouncement();
     this.stopSessionTranscriber();
     // Deliberately NOT aborting detached continuations: outliving the call is
     // the entire premise of the handoff. Hanging up used to destroy the work
@@ -1090,32 +1201,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // mode, again after every finalized turn (per-utterance phase tracks the
   // cycle).
   private async beginUtterance(): Promise<UtteranceStartResult> {
-    const utterance: UtteranceCycle = {
-      phase: "pending",
-      released: false,
-      assistantTurnStarted: false,
-      completed: false,
-      finalizeRequested: false,
-      transcriber: null,
-      pendingAudioChunks: [],
-      pendingAudioBytes: 0,
-      finalTranscriptSegments: [],
-      latestPartialText: null,
-      endpointExtensionCount: 0,
-      heldSpeculativeContent: null,
-      turnId: null,
-      userMessageId: null,
-      userAudioChunks: [],
-      metricsTurnStarted: false,
-      metricsTurnFinished: false,
-      stashedMetricsMarks: {
-        firstAudioAtMs: null,
-        firstPartialAtMs: null,
-        speechStartAtMs: null,
-        utteranceEndAtMs: null,
-        finalTranscriptAtMs: null,
-      },
-    };
+    const utterance = createUtteranceCycle();
     this.currentUtterance = utterance;
     // Speech parked while the previous cycle wound down belongs to this
     // cycle: buffer it before the transcriber arms, and capture the detector
@@ -1668,8 +1754,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // non-interactive permission policy; if a foreground turn starts its own
   // side-effecting tool, the foreground-wins abort in the tool_use_start
   // handler kills the continuation before the two can race on the workspace.
-  // The run stays silent (never spoken unprompted) and a later stop/interrupt
-  // aborts it.
+  // The run itself makes no sound; its result reaches the user through the next
+  // turn they start, an announcement into audible silence, or the conversation
+  // once the call ends. A later stop/interrupt aborts it.
   private detachInterruptedTurn(
     turn: ActiveAssistantTurn,
     stopGeneration: number,
@@ -1684,21 +1771,26 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ? "no_spawner"
       : this.isClosed
         ? "session_closed"
-        : // The model already finished generating (barge-in during TTS playback
-          // of a complete reply): there is nothing to continue, so a
-          // continuation would just re-do a finished answer.
-          turn.assistantCompleted
-          ? "assistant_already_completed"
-          : // A stop (interrupt/close) or a superseding invalidation landed
-            // during the barge-in teardown: honor it.
-            this.detachStopGeneration !== stopGeneration
-            ? "invalidated_during_barge_teardown"
-            : !isAssistantFeatureFlagEnabled(
-                  "voice-duplex-handoff",
-                  getConfig(),
-                )
-              ? "flag_disabled"
-              : null;
+        : // Barging in over an announcement means the user is answering it, not
+          // asking for it to be finished in the background — there is no
+          // pending request behind an announcement turn to continue.
+          turn.continuationDelivery !== null
+          ? "announcement_turn"
+          : // The model already finished generating (barge-in during TTS playback
+            // of a complete reply): there is nothing to continue, so a
+            // continuation would just re-do a finished answer.
+            turn.assistantCompleted
+            ? "assistant_already_completed"
+            : // A stop (interrupt/close) or a superseding invalidation landed
+              // during the barge-in teardown: honor it.
+              this.detachStopGeneration !== stopGeneration
+              ? "invalidated_during_barge_teardown"
+              : !isAssistantFeatureFlagEnabled(
+                    "voice-duplex-handoff",
+                    getConfig(),
+                  )
+                ? "flag_disabled"
+                : null;
     if (skipReason !== null || !spawn) {
       // debug for the always-off configurations, info for the dynamic skips.
       if (skipReason === "flag_disabled" || skipReason === "no_spawner") {
@@ -1799,13 +1891,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           label: `voice-continue-${turn.turnId}`,
           signal: controller.signal,
         });
-        // Fold the completed continuation's answer into the next turn the user
-        // starts (never spoken unprompted). Re-check the stop guards after the
-        // await: an interrupt/close during the run must suppress it. Only the
-        // latest-started detach may populate the result, so once a newer
-        // barge-in has started, an older continuation completing (before or
-        // after it, empty or not) can't surface a stale answer. Only non-empty
-        // text is actually surfaced.
+        // Route the completed continuation's answer. Re-check the stop guards
+        // after the await: an interrupt/close during the run must suppress it.
+        // Only the latest-started detach may populate the result, so once a
+        // newer barge-in has started, an older continuation completing (before
+        // or after it, empty or not) can't surface a stale answer. Only
+        // non-empty text is actually surfaced.
         this.pendingHandoffRequest = null;
         const answer = resultText.trim();
         const notInvalidated =
@@ -1813,14 +1904,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           this.detachStopGeneration === stopGeneration &&
           detachSeq === this.detachSequence;
         // Two destinations, decided by whether a next voice turn still exists.
-        // Live session: stash for that turn's control prompt (never spoken
-        // unprompted). Session closed: there is no next turn, so deliver into
-        // the conversation — the call is over, nobody is being talked over,
-        // and the thread is exactly where the user goes looking for the work.
+        // Live session: stash for the next turn the user starts, AND queue an
+        // announcement that speaks it into audible silence if the user says
+        // nothing — the two are routes for one answer and cancel each other,
+        // so it is delivered exactly once. Session closed: there is no next
+        // turn and nobody to speak to, so deliver into the conversation — the
+        // thread is exactly where the user goes looking for the work.
         const deliverToConversation =
           notInvalidated && this.isClosed && answer.length > 0;
         if (notInvalidated && !this.isClosed) {
           this.pendingContinuationResult = answer.length > 0 ? answer : null;
+          if (answer.length > 0) {
+            this.pendingAnnouncement = { request: interruptedRequest, answer };
+            this.scheduleContinuationAnnouncement();
+          }
         }
         if (deliverToConversation) {
           const { injectMessageIntoParent } =
@@ -1835,10 +1932,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             turnId: turn.turnId,
             ranMs: Date.now() - detachStartedAtMs,
             resultChars: answer.length,
-            // Where the answer went. "stashed" = folded into the next voice
-            // turn; "conversation" = the call had ended, so it was delivered
-            // into the thread; "dropped" = a stop/interrupt or a newer
-            // barge-in landed while it ran.
+            // Where the answer went. "stashed" = queued for the next voice
+            // turn and for an announcement into silence, whichever comes first
+            // (the announcement logs "announced" when it wins);
+            // "conversation" = the call had ended, so it was delivered into the
+            // thread; "dropped" = a stop/interrupt or a newer barge-in landed
+            // while it ran.
             resultDestination: !notInvalidated
               ? "dropped"
               : answer.length === 0
@@ -1912,6 +2011,119 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (!opts?.keepPendingResult) {
       this.pendingContinuationResult = null;
     }
+    // The announcement dies either way: even the foreground-wins variant (which
+    // keeps the stash) has a foreground turn claiming the floor, so speaking up
+    // on our own is exactly what must not happen.
+    this.clearContinuationAnnouncement();
+  }
+
+  private clearContinuationAnnouncement(): void {
+    this.pendingAnnouncement = null;
+    if (this.announcementTimer) {
+      clearTimeout(this.announcementTimer);
+      this.announcementTimer = null;
+    }
+  }
+
+  /**
+   * Live-voice is non-interactive (JARVIS-1291) and the session never starts a
+   * turn on its own — with one narrow exception, this: a background
+   * continuation the user asked for has finished, the call is still live, and
+   * nobody is speaking. Arms the silence timer that decides whether that
+   * exception applies. Re-arming resets the wait, so a run of arms collapses
+   * into one announcement.
+   *
+   * `retry` marks the single re-arm a blocked attempt gets. Beyond that the
+   * announcement is dropped rather than retried forever: the stash path still
+   * delivers the same answer on the user's next turn, so a busy call loses
+   * nothing.
+   */
+  private scheduleContinuationAnnouncement(retry = false): void {
+    if (this.announcementTimer) {
+      clearTimeout(this.announcementTimer);
+    }
+    this.announcementTimer = setTimeout(() => {
+      this.announcementTimer = null;
+      const blockedBy = this.continuationAnnouncementBlocker();
+      if (blockedBy === null) {
+        void this.announceContinuation().catch((err: unknown) => {
+          log.warn({ err }, "Voice duplex continuation announcement failed");
+        });
+        return;
+      }
+      log.debug(
+        { conversationId: this.conversationId, blockedBy, retry },
+        "Voice duplex continuation announcement deferred",
+      );
+      if (retry || this.pendingAnnouncement === null) {
+        this.pendingAnnouncement = null;
+        return;
+      }
+      this.scheduleContinuationAnnouncement(true);
+    }, this.continuationAnnounceSilenceMs);
+  }
+
+  // Why the session must not speak up right now, or null when the call is
+  // genuinely idle: live, no turn running, and no user speech anywhere in
+  // flight (onset latch, barge-in guard, detector, or a cycle that has already
+  // captured something). The server-VAD re-arm keeps an empty cycle armed
+  // between turns, so an untouched `currentUtterance` IS the idle state.
+  private continuationAnnouncementBlocker(): string | null {
+    if (this.pendingAnnouncement === null) {
+      return "nothing_pending";
+    }
+    if (this.isClosed || this.state === "failed" || !this.startVoiceTurn) {
+      return "session_unavailable";
+    }
+    if (this.activeAssistantTurn !== null) {
+      return "turn_active";
+    }
+    if (this.vadSpeechStartPending || this.pendingBargeIn !== null) {
+      return "speech_onset";
+    }
+    if (this.turnDetector?.isActive === true) {
+      return "user_speaking";
+    }
+    const utterance = this.currentUtterance;
+    if (
+      utterance !== null &&
+      !utterance.completed &&
+      (utterance.released ||
+        utterance.assistantTurnStarted ||
+        utterance.finalTranscriptSegments.length > 0 ||
+        utterance.latestPartialText !== null)
+    ) {
+      return "utterance_in_flight";
+    }
+    return null;
+  }
+
+  // Speak the finished continuation's result on a turn the session starts
+  // itself. The turn rides a synthetic cycle rather than the armed VAD one —
+  // `currentUtterance` belongs to the capture loop, and overwriting it would
+  // collide with the user's next real utterance.
+  private async announceContinuation(): Promise<void> {
+    const pending = this.pendingAnnouncement;
+    if (!pending) {
+      return;
+    }
+    this.pendingAnnouncement = null;
+    // Delivered here, so the stash must not deliver the same answer again on
+    // the user's next turn.
+    this.pendingContinuationResult = null;
+    log.info(
+      {
+        conversationId: this.conversationId,
+        resultChars: pending.answer.length,
+        resultDestination: "announced",
+      },
+      "Voice duplex continuation announced",
+    );
+    await this.launchAssistantTurn(
+      createSyntheticUtterance(),
+      CONTINUATION_DELIVERY_CONTENT,
+      { continuationDelivery: pending },
+    );
   }
 
   // VAD closed the utterance — the analog of ptt_release: emit
@@ -2737,6 +2949,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.pendingInterruptedRequest = null;
     const continuationResult = this.pendingContinuationResult;
     this.pendingContinuationResult = null;
+    // The user spoke first, so this turn delivers the continuation's answer;
+    // a queued announcement would only say the same thing twice.
+    this.clearContinuationAnnouncement();
     const handedOffRequest = this.pendingHandoffRequest;
     this.pendingHandoffRequest = null;
     await this.launchAssistantTurn(utterance, content, {
@@ -2761,6 +2976,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Set when a barge-in handed this request's work to a background
       // subagent, so the model can say it is still running.
       handedOffRequest?: string | null;
+      // Set on an announcement turn: the finished continuation this turn exists
+      // to deliver. Its answer goes in the control prompt, not in `content`.
+      continuationDelivery?: ContinuationDelivery | null;
       // Unified front-door: dispatch without releasing the utterance. The
       // thinking frame and floor-holding timers are deferred until the leg's
       // leading verdict commits the turn (see commitSpeculativeTurn); a hold
@@ -2812,6 +3030,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       interruptedRequest: opts?.interruptedRequest ?? null,
       continuationResult: opts?.continuationResult ?? null,
       handedOffRequest: opts?.handedOffRequest ?? null,
+      continuationDelivery: opts?.continuationDelivery ?? null,
       toolUseStarted: false,
       firstDeltaSeen: false,
       deltaEpoch: 0,
@@ -2990,6 +3209,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         isInbound: true,
         launchedAtMs: activeTurn.launchedAtMs,
         signal: activeTurn.abortController.signal,
+        // An announcement turn's content is a fixed marker, not user speech:
+        // persist it hidden and suppress its echo so nothing renders as a user
+        // bubble for a turn the user never started.
+        ...(activeTurn.continuationDelivery !== null
+          ? { hiddenSyntheticPrompt: true }
+          : {}),
         ...(leg.overrideProfile != null
           ? { overrideProfile: leg.overrideProfile }
           : {}),
@@ -4721,10 +4946,10 @@ export function createLiveVoiceSession(
 // the interrupted turn. The fork inherits the conversation's current messages
 // (which include the interrupted turn's completed tool calls after teardown),
 // so it resumes without repeating them. Uses spawnAndAwait (synchronous mode)
-// so the terminal parent-notification is skipped — the continuation stays
-// silent (never spoken unprompted); its final answer is RETURNED so the session
-// can fold it into the next turn the user starts. The `signal` aborts the child
-// on a stop/interrupt (spawnAndAwait then rejects).
+// so the terminal parent-notification is skipped — the run itself says nothing;
+// its final answer is RETURNED so the session decides how it reaches the user.
+// The `signal` aborts the child on a stop/interrupt (spawnAndAwait then
+// rejects).
 //
 // Exported for tests only: every production caller reaches it through the
 // `spawnBackgroundContinuation` option default in `createLiveVoiceSession`.
@@ -4810,8 +5035,9 @@ export async function defaultSpawnBackgroundContinuation(args: {
     // Broadcast subagent events to clients attached to this conversation so
     // the continuation appears in the UI like any other handoff — a background
     // run the user cannot see reads as the assistant silently dropping their
-    // work. "Silent" means never SPOKEN unprompted (live-voice has no unbidden
-    // TTS); it was never meant to mean invisible.
+    // work. "Silent" means the RUN makes no sound of its own — its result is
+    // spoken by a session turn, on the session's terms; it was never meant to
+    // mean invisible.
     //
     // NOT the conversation's own sender: the voice bridge resets that to a
     // no-op at turn teardown (see voice-session-bridge's clientCallbackInstalled

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -949,15 +949,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // a barge-in cut off: its final answer, folded into the next turn the user
   // starts as context. Consumed (and cleared) when that turn launches; cleared
   // on a hard stop (abortDetachedRuns) so a stale result never surfaces later,
-  // and cleared by an announcement that delivers the same answer itself.
+  // and cleared by an announcement that delivers the same answer itself — an
+  // announcement the user cuts short hands it straight back.
   private pendingContinuationResult: string | null = null;
   // The same finished continuation, queued for an announcement turn: the
   // session speaks the result on its own once the call has been quiet for
   // `continuationAnnounceSilenceMs`. This and `pendingContinuationResult` are
   // armed together and are two routes for ONE answer — whichever fires first
   // clears the other, so the user hears it exactly once. An announcement whose
-  // turn fails to start hands the answer back to the stash, so a lost dispatch
-  // costs the announcement, not the answer.
+  // turn fails to start, or whose turn a barge-in cuts short, hands the answer
+  // back to the stash, so a lost delivery costs the announcement, not the
+  // answer.
   private pendingAnnouncement: ContinuationDelivery | null = null;
   private announcementTimer: ReturnType<typeof setTimeout> | null = null;
   // Set when a continuation actually spawns: the request it took over, so the
@@ -1712,6 +1714,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // out the interrupted TURN's teardown before forking, which bounds the
     // overlap to that one abandoned call.
     this.abortDetachedRuns({ reason: "superseded_by_new_barge_in" });
+    // An announcement turn is the one interruption with nothing to continue:
+    // the work is already finished, which is why detachInterruptedTurn skips it
+    // as `announcement_turn`. The analog of "the interrupted work survives" is
+    // therefore the stash — the answer goes back into it so the user's next real
+    // turn still carries it, and the announcement (cut short, at best partly
+    // spoken) is not the delivery it was supposed to be. The restore sits after
+    // the abort above, which clears the stash, so nothing in this sequence
+    // re-drops it. Only a barge-in restores: interrupt/close/a superseding new
+    // continuation are resets the user asked for, and their answer stays gone.
+    if (turn.continuationDelivery !== null) {
+      this.pendingContinuationResult = turn.continuationDelivery.answer;
+    }
     // Order this barge-in among concurrent detaches SYNCHRONOUSLY, in barge
     // order — the actual detach runs after an async teardown chain, and those
     // chains can interleave, so bumping there could assign sequences out of
@@ -1792,7 +1806,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         ? "session_closed"
         : // Barging in over an announcement means the user is answering it, not
           // asking for it to be finished in the background — there is no
-          // pending request behind an announcement turn to continue.
+          // pending request behind an announcement turn to continue. Its answer
+          // is already finished, so bargeIn returns it to the stash instead.
           turn.continuationDelivery !== null
           ? "announcement_turn"
           : // The model already finished generating (barge-in during TTS playback
@@ -2165,8 +2180,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     this.pendingAnnouncement = null;
     // The two routes for one answer are mutually exclusive: while this turn is
-    // in flight the stash must not deliver the same answer again, and the stash
-    // only comes back if the turn provably never started.
+    // in flight the stash must not deliver the same answer again. It comes back
+    // only if this turn provably never started (below) or a barge-in cuts it
+    // short before it delivers (see bargeIn).
     this.pendingContinuationResult = null;
     // Pins the invalidation state this hand-off was decided in: a hard stop
     // landing while the turn starts owns the drop, and must not be undone by

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -324,6 +324,13 @@ interface UtteranceCycle {
   // this set at a time — see pumpFinalizeQueue.
   finalizeRequested: boolean;
   transcriber: StreamingTranscriber | null;
+  // Manual (push-to-talk) capture routed at least one chunk into this cycle.
+  // It is the only evidence the user is mid-utterance before STT emits
+  // anything: the pending buffers empty out as soon as the transcriber is
+  // streaming, and the archival buffer only fills when audio archiving is on.
+  // server_vad has the turn detector for the same question, and never sets
+  // this — its ingress is handleServerVadAudio.
+  manualAudioCaptured: boolean;
   pendingAudioChunks: Buffer[];
   pendingAudioBytes: number;
   finalTranscriptSegments: string[];
@@ -753,6 +760,7 @@ function createUtteranceCycle(): UtteranceCycle {
     completed: false,
     finalizeRequested: false,
     transcriber: null,
+    manualAudioCaptured: false,
     pendingAudioChunks: [],
     pendingAudioBytes: 0,
     finalTranscriptSegments: [],
@@ -1390,6 +1398,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
+    // The chunk belongs to an utterance the user is still holding the button
+    // for, whether or not the transcriber has produced any text for it yet.
+    utterance.manualAudioCaptured = true;
     this.collectUserAudio(utterance, chunk);
     if (utterance.phase === "pending") {
       // The transcriber is still arming (session start overlaps the STT
@@ -2125,11 +2136,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return "user_speaking";
     }
     const utterance = this.currentUtterance;
+    // Every transcript-derived signal here trails the STT provider, so on its
+    // own it leaves manual mode blind to a user who is talking right now and
+    // has no text yet — hence the captured-audio flag, which manual ingress
+    // sets from the first chunk.
     if (
       utterance !== null &&
       !utterance.completed &&
       (utterance.released ||
         utterance.assistantTurnStarted ||
+        utterance.manualAudioCaptured ||
         utterance.finalTranscriptSegments.length > 0 ||
         utterance.latestPartialText !== null)
     ) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -158,6 +158,12 @@ const TTS_MAX_OPEN_SYNTHESIS_JOBS = 2;
 // lull rather than on the heels of the turn that just ended; short enough that
 // the user is not left wondering whether the work survived.
 const CONTINUATION_ANNOUNCE_SILENCE_MS = 1_500;
+// How many times a pending announcement re-arms itself against a client
+// playback tail that outlasted its timer. Each re-arm waits out the whole
+// remaining tail, so one covers a reply of any length; the rest cover a fresh
+// reply's audio landing between two checks. Beyond the cap the announcement
+// falls back to the stash rather than chasing a call that keeps talking.
+const CONTINUATION_ANNOUNCE_MAX_DRAIN_REARMS = 3;
 // `content` of an announcement turn. The answer never rides here — it goes in
 // the model-facing control prompt (buildLiveDeliveryNote), so the only thing
 // persisted on the user side is this marker, and it persists hidden.
@@ -941,7 +947,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // session speaks the result on its own once the call has been quiet for
   // `continuationAnnounceSilenceMs`. This and `pendingContinuationResult` are
   // armed together and are two routes for ONE answer — whichever fires first
-  // clears the other, so the user hears it exactly once.
+  // clears the other, so the user hears it exactly once. An announcement whose
+  // turn fails to start hands the answer back to the stash, so a lost dispatch
+  // costs the announcement, not the answer.
   private pendingAnnouncement: ContinuationDelivery | null = null;
   private announcementTimer: ReturnType<typeof setTimeout> | null = null;
   // Set when a continuation actually spawns: the request it took over, so the
@@ -2033,15 +2041,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * exception applies. Re-arming resets the wait, so a run of arms collapses
    * into one announcement.
    *
+   * The silence the timer waits out starts when the audio the client already
+   * has queued runs out, so a continuation finishing at the tail end of a long
+   * spoken reply waits for that reply to actually finish playing.
+   *
    * `retry` marks the single re-arm a blocked attempt gets. Beyond that the
    * announcement is dropped rather than retried forever: the stash path still
    * delivers the same answer on the user's next turn, so a busy call loses
    * nothing.
    */
-  private scheduleContinuationAnnouncement(retry = false): void {
+  private scheduleContinuationAnnouncement(
+    retry = false,
+    drainRearms = 0,
+  ): void {
     if (this.announcementTimer) {
       clearTimeout(this.announcementTimer);
     }
+    // Queued client-side audio is the previous reply still being audible, so
+    // the silence window only begins once it has drained.
+    const drainMs = Math.max(0, this.assistantPlaybackTailUntilMs - Date.now());
     this.announcementTimer = setTimeout(() => {
       this.announcementTimer = null;
       const blockedBy = this.continuationAnnouncementBlocker();
@@ -2052,15 +2070,31 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       log.debug(
-        { conversationId: this.conversationId, blockedBy, retry },
+        { conversationId: this.conversationId, blockedBy, retry, drainRearms },
         "Voice duplex continuation announcement deferred",
       );
+      // A tail that grew while the timer ran (the reply was still streaming
+      // TTS when it was armed) is a wait of known length rather than a busy
+      // call, so it re-arms against the new deadline without spending the
+      // single retry the busy-call blockers get — otherwise a long reply's
+      // playback alone outlasts the budget and the announcement is dropped
+      // even though the call goes idle right after. The tail only extends
+      // while a turn is active, which blocks earlier, so the re-arms converge;
+      // the cap bounds the interleaving where a fresh turn's audio lands
+      // between two checks.
+      if (
+        blockedBy === "playback_draining" &&
+        drainRearms < CONTINUATION_ANNOUNCE_MAX_DRAIN_REARMS
+      ) {
+        this.scheduleContinuationAnnouncement(retry, drainRearms + 1);
+        return;
+      }
       if (retry || this.pendingAnnouncement === null) {
         this.pendingAnnouncement = null;
         return;
       }
-      this.scheduleContinuationAnnouncement(true);
-    }, this.continuationAnnounceSilenceMs);
+      this.scheduleContinuationAnnouncement(true, drainRearms);
+    }, drainMs + this.continuationAnnounceSilenceMs);
   }
 
   // Why the session must not speak up right now, or null when the call is
@@ -2077,6 +2111,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     if (this.activeAssistantTurn !== null) {
       return "turn_active";
+    }
+    // The turn can be cleared server-side (tts_done sent) while the client is
+    // still playing the audio it queued: that tail is the previous reply still
+    // being audible, so announcing over it is announcing over the assistant.
+    if (Date.now() < this.assistantPlaybackTailUntilMs) {
+      return "playback_draining";
     }
     if (this.vadSpeechStartPending || this.pendingBargeIn !== null) {
       return "speech_onset";
@@ -2108,21 +2148,49 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     this.pendingAnnouncement = null;
-    // Delivered here, so the stash must not deliver the same answer again on
-    // the user's next turn.
+    // The two routes for one answer are mutually exclusive: while this turn is
+    // in flight the stash must not deliver the same answer again, and the stash
+    // only comes back if the turn provably never started.
     this.pendingContinuationResult = null;
-    log.info(
-      {
-        conversationId: this.conversationId,
-        resultChars: pending.answer.length,
-        resultDestination: "announced",
-      },
-      "Voice duplex continuation announced",
-    );
-    await this.launchAssistantTurn(
+    // Pins the invalidation state this hand-off was decided in: a hard stop
+    // landing while the turn starts owns the drop, and must not be undone by
+    // the restore below.
+    const stopGeneration = this.detachStopGeneration;
+    const started = await this.launchAssistantTurn(
       createSyntheticUtterance(),
       CONTINUATION_DELIVERY_CONTENT,
       { continuationDelivery: pending },
+    );
+    if (started) {
+      log.info(
+        {
+          conversationId: this.conversationId,
+          resultChars: pending.answer.length,
+          resultDestination: "announced",
+        },
+        "Voice duplex continuation announced",
+      );
+      return;
+    }
+    // The turn never reached the bridge (the conversation is busy from another
+    // surface, or the bridge threw), so nothing was persisted or spoken. Hand
+    // the answer back to the stash — the user's next turn is the fallback route
+    // that exists for exactly this. A newer continuation's answer already in
+    // the stash wins over this older one rather than being overwritten.
+    const restashed =
+      !this.isClosed &&
+      this.detachStopGeneration === stopGeneration &&
+      this.pendingContinuationResult === null;
+    if (restashed) {
+      this.pendingContinuationResult = pending.answer;
+    }
+    log.warn(
+      {
+        conversationId: this.conversationId,
+        resultChars: pending.answer.length,
+        resultDestination: restashed ? "stashed" : "dropped",
+      },
+      "Voice duplex continuation announcement could not start",
     );
   }
 
@@ -2962,7 +3030,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   // Build the ActiveAssistantTurn for a released utterance and drive its model
-  // leg.
+  // leg. Resolves true once the leg has a live turn handle, false when the
+  // dispatch never reached the bridge — the signal a caller with a fallback
+  // route (announceContinuation) needs, since a failed start is otherwise
+  // handled entirely inside startAssistantLeg.
   private async launchAssistantTurn(
     utterance: UtteranceCycle,
     content: string,
@@ -2985,7 +3056,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // verdict rolls everything back instead.
       speculative?: boolean;
     },
-  ): Promise<void> {
+  ): Promise<boolean> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
     const turnId = this.ensureTurnId(utterance);
@@ -3054,7 +3125,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (!opts?.speculative) {
       await this.sendFrame({ type: "thinking", turnId });
       if (!this.isActiveAssistantTurn(token)) {
-        return;
+        return false;
       }
     } else {
       // Verdict-deadline fail-open: the deferred-everything window is only
@@ -3108,7 +3179,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Front-door leg: a fast model fronts every turn (the `voiceFrontDoor`
     // call site pins it) and may hand off to a quality leg on the escalate
     // verdict.
-    await this.startAssistantLeg(activeTurn, {
+    return await this.startAssistantLeg(activeTurn, {
       content,
       routingLeg: "front-door",
       frontDoor: true,
@@ -3119,7 +3190,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * Drive one model leg of an assistant turn through the session bridge,
    * streaming its deltas to the live-voice client and TTS. Returns once the
    * leg's turn handle is acquired (or the start fails) — turn completion stays
-   * callback-driven via message_complete, exactly as the single-leg path did.
+   * callback-driven via message_complete. The resolved boolean is whether the
+   * bridge actually handed back a turn handle: false means the leg never
+   * started (no bridge wired, or the start threw and was reported as an error
+   * frame), so nothing of this turn was persisted or spoken.
    *
    * A turn runs one leg normally. Under triage-and-escalate the front-door leg
    * (`frontDoor: true`) runs the verdict-first protocol: its leading tokens
@@ -3140,9 +3214,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       frontDoor?: boolean;
       spokenEscalationBridge?: string;
     },
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!this.startVoiceTurn) {
-      return;
+      return false;
     }
     const { token, utterance, turnId } = activeTurn;
 
@@ -3521,23 +3595,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         } else {
           handle.abort();
         }
-        return;
+        // The bridge ran: the leg's user row was persisted (or explicitly
+        // rolled back by the discard above), so this counts as started even
+        // though a newer turn owns the session.
+        return true;
       }
       if (current.finalized) {
         this.activeAssistantTurn = null;
-        return;
+        return true;
       }
       // The front-door leg may have handed off before its handle resolved;
       // abort it rather than exposing it as the turn's live handle.
       if (leg.frontDoor && current.escalationHandedOff) {
         handle.abort();
-        return;
+        return true;
       }
 
       current.handle = handle;
+      return true;
     } catch (err) {
       if (!this.isActiveAssistantTurn(token)) {
-        return;
+        return false;
       }
 
       this.clearFillerTimers(activeTurn);
@@ -3551,6 +3629,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       });
       await this.finalizePendingUtterance(utterance, "assistant_start_error");
       this.scheduleRearmAfterTurn();
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- A background continuation that finishes mid-call now delivers its result into genuine audible silence, instead of waiting for the user to speak again.
- Gated on a live, idle session: no active turn, no in-flight utterance, no pending barge-in. Otherwise it falls back to today's stash-into-the-next-turn path.
- The announcement runs as an assistant-initiated turn whose content is a fixed marker persisted hidden; the answer rides the model-facing control prompt, so nothing renders as a user bubble.
- Delivered once: announcing clears the stashed result, and a user utterance before the timer fires cancels the announcement.

Part of plan: voice-duplex-gaps.md (PR 9 of 9)