### PR TITLE
fix(daemon): durable lineage, fail-closed skill-load guard, and direct-app resolution

### DIFF
--- a/assistant/src/__tests__/app-conversation-ids.test.ts
+++ b/assistant/src/__tests__/app-conversation-ids.test.ts
@@ -7,6 +7,7 @@ import {
   addAppConversationId,
   createApp,
   getApp,
+  isDirectAppConversation,
   linkAppToConversationLineage,
   listAppsByConversation,
 } from "../apps/app-store.js";
@@ -281,5 +282,74 @@ describe("linkAppToConversationLineage", () => {
     expect(() =>
       linkAppToConversationLineage("nonexistent-id", "conv-fork"),
     ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct vs inherited associations
+// ---------------------------------------------------------------------------
+
+describe("isDirectAppConversation", () => {
+  test("the seed conversation is direct and its ancestors are inherited", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-fork", "conv-visible");
+
+    const app = createApp(makeAppParams("Continuation App"));
+    linkAppToConversationLineage(app.id, "conv-fork");
+
+    const loaded = getApp(app.id)!;
+    expect(loaded.inheritedConversationIds).toEqual(["conv-visible"]);
+    expect(isDirectAppConversation(loaded, "conv-fork")).toBe(true);
+    expect(isDirectAppConversation(loaded, "conv-visible")).toBe(false);
+  });
+
+  test("an inherited association still lists the app in the ancestor thread", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-fork", "conv-visible");
+
+    const app = createApp(makeAppParams("Continuation App"));
+    linkAppToConversationLineage(app.id, "conv-fork");
+
+    expect(listAppsByConversation("conv-visible").map((a) => a.id)).toEqual([
+      app.id,
+    ]);
+  });
+
+  test("a record carrying no inherited list treats every association as direct", () => {
+    const app = createApp(makeAppParams("Plain App"));
+    addAppConversationId(app.id, "conv-plain");
+
+    const loaded = getApp(app.id)!;
+    expect(loaded.inheritedConversationIds).toBeUndefined();
+    expect(isDirectAppConversation(loaded, "conv-plain")).toBe(true);
+  });
+
+  test("a direct association supersedes an earlier inherited one", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-fork", "conv-visible");
+
+    const app = createApp(makeAppParams("Adopted App"));
+    linkAppToConversationLineage(app.id, "conv-fork");
+    // The user later works on the same app in the thread they can see.
+    expect(addAppConversationId(app.id, "conv-visible")).toBe(false);
+
+    const loaded = getApp(app.id)!;
+    expect(loaded.conversationIds).toEqual(["conv-fork", "conv-visible"]);
+    expect(loaded.inheritedConversationIds).toEqual([]);
+    expect(isDirectAppConversation(loaded, "conv-visible")).toBe(true);
+  });
+
+  test("an inherited link never demotes an existing direct association", () => {
+    registerConversation("conv-visible");
+    registerSubagent("conv-fork", "conv-visible");
+
+    const app = createApp(makeAppParams("Foreground App"));
+    addAppConversationId(app.id, "conv-visible");
+    linkAppToConversationLineage(app.id, "conv-fork");
+
+    const loaded = getApp(app.id)!;
+    expect(loaded.conversationIds).toEqual(["conv-visible", "conv-fork"]);
+    expect(loaded.inheritedConversationIds).toBeUndefined();
+    expect(isDirectAppConversation(loaded, "conv-visible")).toBe(true);
   });
 });

--- a/assistant/src/__tests__/conversation-lineage.test.ts
+++ b/assistant/src/__tests__/conversation-lineage.test.ts
@@ -40,6 +40,24 @@ mock.module("../daemon/conversation-registry.js", () => ({
   },
 }));
 
+/**
+ * Durable `parent_conversation_id` rows, keyed by conversation id. Stands for
+ * parentage that outlives residency in either in-memory index.
+ */
+let persistedParents = new Map<string, string>();
+
+/** When set, every durable read fails — the degraded-database case. */
+let persistedReadFails = false;
+
+mock.module("../persistence/conversation-parent.js", () => ({
+  getPersistedParentConversationId: (id: string) => {
+    if (persistedReadFails) {
+      throw new Error("database unavailable");
+    }
+    return persistedParents.get(id);
+  },
+}));
+
 const { MAX_LINEAGE_DEPTH, resolveConversationLineage } =
   await import("../daemon/conversation-lineage.js");
 
@@ -47,6 +65,8 @@ describe("resolveConversationLineage", () => {
   beforeEach(() => {
     residents = new Map();
     subagentResidents = new Map();
+    persistedParents = new Map();
+    persistedReadFails = false;
   });
 
   test("a plain conversation is its own lineage", () => {
@@ -101,17 +121,89 @@ describe("resolveConversationLineage", () => {
     ]);
   });
 
-  test("a non-resident conversation is its own lineage", () => {
+  test("a conversation resident nowhere and unparented in the database is its own lineage", () => {
     expect(resolveConversationLineage("conv-gone")).toEqual(["conv-gone"]);
   });
 
-  test("a non-resident ancestor ends the walk", () => {
+  test("a non-resident ancestor with no durable parentage ends the walk", () => {
     residents.set("conv-child", "conv-evicted");
 
     expect(resolveConversationLineage("conv-child")).toEqual([
       "conv-child",
       "conv-evicted",
     ]);
+  });
+
+  // ── Durable parentage ─────────────────────────────────────────────────────
+  // The subagent index entry is dropped as soon as a run goes terminal and
+  // idle top-level conversations are evicted, so an artifact linked after
+  // either point must still reach the user-visible thread.
+
+  test("a seed dropped from the subagent index still reaches its parent", () => {
+    persistedParents.set("conv-terminal-subagent", "conv-visible");
+    residents.set("conv-visible", undefined);
+
+    expect(resolveConversationLineage("conv-terminal-subagent")).toEqual([
+      "conv-terminal-subagent",
+      "conv-visible",
+    ]);
+  });
+
+  test("an ancestor resident only in the database is reached", () => {
+    subagentResidents.set("conv-inner", "conv-outer");
+    persistedParents.set("conv-outer", "conv-visible");
+
+    expect(resolveConversationLineage("conv-inner")).toEqual([
+      "conv-inner",
+      "conv-outer",
+      "conv-visible",
+    ]);
+  });
+
+  test("the resident record wins over the durable column", () => {
+    subagentResidents.set("conv-fork", "conv-resident-parent");
+    persistedParents.set("conv-fork", "conv-stale-parent");
+    residents.set("conv-resident-parent", undefined);
+
+    expect(resolveConversationLineage("conv-fork")).toEqual([
+      "conv-fork",
+      "conv-resident-parent",
+    ]);
+  });
+
+  test("a failing durable read degrades to the chain resolved so far", () => {
+    subagentResidents.set("conv-inner", "conv-outer");
+    persistedReadFails = true;
+
+    expect(() => resolveConversationLineage("conv-inner")).not.toThrow();
+    expect(resolveConversationLineage("conv-inner")).toEqual([
+      "conv-inner",
+      "conv-outer",
+    ]);
+  });
+
+  test("a cycle spanning the durable column terminates", () => {
+    persistedParents.set("conv-a", "conv-b");
+    persistedParents.set("conv-b", "conv-a");
+
+    expect(resolveConversationLineage("conv-a")).toEqual(["conv-a", "conv-b"]);
+  });
+
+  test("a durable chain longer than the depth cap is truncated at the cap", () => {
+    const chain = Array.from(
+      { length: MAX_LINEAGE_DEPTH + 5 },
+      (_, i) => `conv-durable-${i}`,
+    );
+    for (const [i, id] of chain.entries()) {
+      const parent = chain[i + 1];
+      if (parent) {
+        persistedParents.set(id, parent);
+      }
+    }
+
+    expect(resolveConversationLineage(chain[0]!)).toEqual(
+      chain.slice(0, MAX_LINEAGE_DEPTH),
+    );
   });
 
   test("a self-referential parent does not loop forever", () => {

--- a/assistant/src/__tests__/resolve-app-id.test.ts
+++ b/assistant/src/__tests__/resolve-app-id.test.ts
@@ -24,6 +24,18 @@ function makeApp(id: string, updatedAt: number): AppDefinition {
   };
 }
 
+/** An app the conversation only reached through a descendant's lineage. */
+function makeInheritedApp(
+  id: string,
+  updatedAt: number,
+  conversationId: string,
+): AppDefinition {
+  return {
+    ...makeApp(id, updatedAt),
+    inheritedConversationIds: [conversationId],
+  };
+}
+
 describe("resolveAppId", () => {
   test("returns an explicit non-empty app_id unchanged", () => {
     appsByConversation = [makeApp("other", 1)];
@@ -44,6 +56,26 @@ describe("resolveAppId", () => {
   test("returns null when no app_id is given and the conversation has no app", () => {
     appsByConversation = [];
     expect(resolveAppId({}, "conv-1")).toBeNull();
+  });
+
+  test("prefers a direct app over a more recent lineage-linked one", () => {
+    // A background subagent's app is linked into the parent thread and, being
+    // newest, heads the list — it must not capture the parent's implicit call.
+    appsByConversation = [
+      makeInheritedApp("background", 30, "conv-1"),
+      makeApp("foreground", 10),
+    ];
+    expect(resolveAppId({}, "conv-1")).toBe("foreground");
+  });
+
+  test("falls back to a lineage-linked app when the conversation has no direct one", () => {
+    appsByConversation = [makeInheritedApp("background", 30, "conv-1")];
+    expect(resolveAppId({}, "conv-1")).toBe("background");
+  });
+
+  test("an app inherited by another conversation is direct here", () => {
+    appsByConversation = [makeInheritedApp("shared", 30, "conv-other")];
+    expect(resolveAppId({}, "conv-1")).toBe("shared");
   });
 });
 

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -63,6 +63,12 @@ export interface AppDefinition {
   dirName?: string;
   /** Conversation IDs that have interacted with this app (create/open/refresh). */
   conversationIds?: string[];
+  /**
+   * The subset of {@link conversationIds} the app reached only by lineage —
+   * ancestors of the conversation that actually interacted with it. Absent
+   * means every association is direct.
+   */
+  inheritedConversationIds?: string[];
 }
 
 /**
@@ -1221,12 +1227,17 @@ export function editAppFile(
  * Associate a conversation with an app. Writes directly to the JSON metadata
  * file without bumping `updatedAt` so the app list ordering is preserved.
  *
+ * `inherited` marks an association the app reached through a descendant's
+ * lineage rather than through work done in the conversation itself. A direct
+ * association supersedes an inherited one for the same conversation.
+ *
  * @returns `true` if the association was added, `false` if the app was not
  *   found or the conversationId was already present (dedup).
  */
 export function addAppConversationId(
   appId: string,
   conversationId: string,
+  options?: { inherited?: boolean },
 ): boolean {
   const app = getApp(appId);
   if (!app) return false;
@@ -1246,10 +1257,27 @@ export function addAppConversationId(
   const onDiskIds = Array.isArray(parsed.conversationIds)
     ? (parsed.conversationIds as string[])
     : [];
+  // An absent list means the record holds only direct associations.
+  const onDiskInherited = Array.isArray(parsed.inheritedConversationIds)
+    ? (parsed.inheritedConversationIds as string[])
+    : [];
+  const inherited = options?.inherited === true;
 
-  if (onDiskIds.includes(conversationId)) return false;
+  if (onDiskIds.includes(conversationId)) {
+    if (inherited || !onDiskInherited.includes(conversationId)) {
+      return false;
+    }
+    parsed.inheritedConversationIds = onDiskInherited.filter(
+      (id) => id !== conversationId,
+    );
+    writeFileSync(jsonPath, JSON.stringify(parsed, null, 2));
+    return false;
+  }
 
   parsed.conversationIds = [...onDiskIds, conversationId];
+  if (inherited) {
+    parsed.inheritedConversationIds = [...onDiskInherited, conversationId];
+  }
   writeFileSync(jsonPath, JSON.stringify(parsed, null, 2));
 
   return true;
@@ -1263,15 +1291,21 @@ export function addAppConversationId(
  * has in front of them. Associations are additive and de-duplicated, so
  * linking the whole chain is safe.
  *
+ * The seed conversation's association is direct; every ancestor's is
+ * inherited, so an implicit "the app I am working on" lookup in an ancestor
+ * thread is not captured by a background run's app.
+ *
  * Best-effort per id: a link failure must never break app creation or opening.
  */
 export function linkAppToConversationLineage(
   appId: string,
   conversationId: string,
 ): void {
-  for (const id of resolveConversationLineage(conversationId)) {
+  for (const [index, id] of resolveConversationLineage(
+    conversationId,
+  ).entries()) {
     try {
-      addAppConversationId(appId, id);
+      addAppConversationId(appId, id, { inherited: index > 0 });
     } catch (err) {
       log.warn(
         { err, appId, conversationId: id },
@@ -1282,7 +1316,9 @@ export function linkAppToConversationLineage(
 }
 
 /**
- * Return all apps associated with a given conversation ID.
+ * Return all apps associated with a given conversation ID, whether the
+ * association is direct or inherited from a descendant subagent run — a user
+ * finds and opens a background run's app from the thread they can see.
  */
 export function listAppsByConversation(
   conversationId: string,
@@ -1290,6 +1326,19 @@ export function listAppsByConversation(
   return listApps().filter((app) =>
     app.conversationIds?.includes(conversationId),
   );
+}
+
+/**
+ * Whether an app's association with a conversation is direct — the app was
+ * created or operated on in that conversation itself, rather than reaching it
+ * through a descendant's lineage. A record carrying no
+ * `inheritedConversationIds` holds only direct associations.
+ */
+export function isDirectAppConversation(
+  app: AppDefinition,
+  conversationId: string,
+): boolean {
+  return app.inheritedConversationIds?.includes(conversationId) !== true;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/conversation-lineage.ts
+++ b/assistant/src/daemon/conversation-lineage.ts
@@ -3,30 +3,59 @@
  * leads back to the user-visible thread a background run belongs to.
  */
 
+import { getPersistedParentConversationId } from "../persistence/conversation-parent.js";
 import { findConversationOrSubagent } from "./conversation-registry.js";
 
-/** Depth cap: a subagent chain deeper than this is a bug, not a hierarchy. */
-export const MAX_LINEAGE_DEPTH = 8;
+/**
+ * Depth cap: a subagent chain deeper than this is a bug, not a hierarchy.
+ * Matches the fork-chain cap in the memory plugin's ancestor walk so the two
+ * conversation-ancestry walks agree on what counts as pathological.
+ */
+export const MAX_LINEAGE_DEPTH = 16;
+
+/**
+ * The spawner of a conversation: the in-memory registry's record, falling back
+ * to the persisted `parent_conversation_id` column. Returns `undefined` at the
+ * top of the chain.
+ *
+ * Both sources are consulted because residency is short-lived —
+ * `SubagentManager` drops a subagent's index entry the moment its run goes
+ * terminal, and the evictor sweeps idle top-level conversations — and because
+ * a resident instance does not necessarily carry the parentage its row does.
+ * The column is stamped at subagent bootstrap and outlives both.
+ *
+ * A failed durable read is swallowed: linking artifacts to a partial chain is
+ * better than failing the caller, which is always a best-effort side effect.
+ */
+function parentOf(conversationId: string): string | undefined {
+  const resident = findConversationOrSubagent(conversationId);
+  if (resident?.parentConversationId) {
+    return resident.parentConversationId;
+  }
+  try {
+    return getPersistedParentConversationId(conversationId);
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * The conversation itself plus every subagent ancestor above it, nearest
  * first. A subagent Conversation records its spawner in the readonly
- * `parentConversationId` set at construction (see subagent/manager.ts), so
- * walking that chain reaches the user-visible thread a background run was
- * forked from.
+ * `parentConversationId` set at construction (see subagent/manager.ts) and in
+ * the `parent_conversation_id` column written at bootstrap, so walking that
+ * chain reaches the user-visible thread a background run was forked from.
  *
- * Every hop — including the seed conversation — resolves through
- * {@link findConversationOrSubagent}, because the seed is typically a
- * background subagent, and `SubagentManager` keeps live subagent
- * conversations in their own index rather than the eviction-managed
- * top-level store.
+ * Resident hops resolve through {@link findConversationOrSubagent}, because
+ * the seed is typically a background subagent and `SubagentManager` keeps live
+ * subagent conversations in their own index rather than the eviction-managed
+ * top-level store. Non-resident hops fall back to the durable column, so a
+ * link attempted after the run went terminal or the thread was evicted still
+ * reaches the user-visible ancestor.
  *
- * Only resident conversations are readable: a top-level conversation until
- * the evictor sweeps it, a subagent conversation while its run is live (the
- * manager drops the index entry once the subagent goes terminal). An id
- * resolvable in neither index ends the walk, so the returned chain can be
- * shorter than the true ancestry. The user-visible thread is resident
- * whenever a live background run is producing artifacts for it.
+ * Never throws: a failed database read degrades to the chain resolved so far,
+ * which can therefore be shorter than the true ancestry. Bounded by
+ * {@link MAX_LINEAGE_DEPTH} and a visited set, so a cycle terminates.
  */
 export function resolveConversationLineage(conversationId: string): string[] {
   const lineage = [conversationId];
@@ -34,7 +63,7 @@ export function resolveConversationLineage(conversationId: string): string[] {
 
   let current = conversationId;
   while (lineage.length < MAX_LINEAGE_DEPTH) {
-    const parent = findConversationOrSubagent(current)?.parentConversationId;
+    const parent = parentOf(current);
     if (!parent || visited.has(parent)) {
       break;
     }

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -43,9 +43,24 @@ type MockSkill = {
 };
 let mockSkillCatalog: MockSkill[] = [];
 let mockResolvedSkill: MockSkill | null = null;
+// Set to make the corresponding skills-module call throw, modelling an
+// unreadable catalog or a selector resolution that hits the filesystem and
+// fails.
+let mockCatalogError: Error | null = null;
+let mockSelectorError: Error | null = null;
 mock.module("../config/skills.js", () => ({
-  loadSkillCatalog: () => mockSkillCatalog,
-  resolveSkillSelector: () => ({ skill: mockResolvedSkill }),
+  loadSkillCatalog: () => {
+    if (mockCatalogError) {
+      throw mockCatalogError;
+    }
+    return mockSkillCatalog;
+  },
+  resolveSkillSelector: () => {
+    if (mockSelectorError) {
+      throw mockSelectorError;
+    }
+    return { skill: mockResolvedSkill };
+  },
 }));
 
 // Mock skills helpers used for file context building.
@@ -209,6 +224,8 @@ describe("Permission Checker (gateway IPC)", () => {
     thresholdCallLog.length = 0;
     mockSkillCatalog = [];
     mockResolvedSkill = null;
+    mockCatalogError = null;
+    mockSelectorError = null;
   });
 
   // ── classifyRisk ──────────────────────────────────────────────────────────
@@ -1500,6 +1517,32 @@ describe("Permission Checker (gateway IPC)", () => {
       expect(
         isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
       ).toBe(true);
+    });
+
+    // ── Fail-closed ─────────────────────────────────────────────────────────
+    // The live-voice contention gate calls this from a synchronous event
+    // callback, so a throw would abort the rest of the frame's dispatch.
+
+    test("returns false when the catalog cannot be read", () => {
+      installSkill();
+      mockCatalogError = new Error("catalog unreadable");
+      expect(() =>
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).not.toThrow();
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
+    });
+
+    test("returns false when selector resolution throws", () => {
+      installSkill();
+      mockSelectorError = new Error("skill directory unreadable");
+      expect(() =>
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).not.toThrow();
+      expect(
+        isInstalledStaticSkillLoad("skill_load", { skill: "note-taker" }),
+      ).toBe(false);
     });
   });
 });

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -296,19 +296,23 @@ export function isDynamicSkillLoadInvocation(
  * writes to the workspace, an inline expansion anywhere in it executes shell,
  * and either makes the load something other than a read.
  *
- * Fails closed — a target that is absent from the catalog, a missing include, a
- * cycle, or an unreadable catalog all return false. Exported for gates that
- * must not proceed on anything capable of writing local state.
+ * Fails closed and never throws — an unresolvable selector, a target absent
+ * from the catalog, a missing include, a cycle, or an unreadable catalog all
+ * return false. Selector resolution and catalog reads both touch the
+ * filesystem, so both sit inside the guard: callers include a synchronous
+ * live-voice event callback where a throw would abort the rest of the frame's
+ * dispatch. Exported for gates that must not proceed on anything capable of
+ * writing local state.
  */
 export function isInstalledStaticSkillLoad(
   toolName: string,
   input: Record<string, unknown>,
 ): boolean {
-  const skillId = resolveSkillLoadTargetId(toolName, input);
-  if (skillId === null) {
-    return false;
-  }
   try {
+    const skillId = resolveSkillLoadTargetId(toolName, input);
+    if (skillId === null) {
+      return false;
+    }
     const catalogIndex = indexCatalogById(loadSkillCatalog());
     if (!catalogIndex.has(skillId)) {
       return false;

--- a/assistant/src/persistence/conversation-parent.ts
+++ b/assistant/src/persistence/conversation-parent.ts
@@ -1,0 +1,27 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "./db-connection.js";
+import { conversations } from "./schema/index.js";
+
+/**
+ * The durable spawn parent of a conversation: the `parent_conversation_id`
+ * column stamped at subagent bootstrap. Returns `undefined` for a conversation
+ * with no recorded parent or no row at all.
+ *
+ * Unlike the in-memory conversation registry — which drops a subagent entry as
+ * soon as its run goes terminal and evicts idle top-level conversations — this
+ * survives for the life of the row, so an ancestry walk still resolves long
+ * after the run that created the chain has finished.
+ *
+ * A single-row primary-key lookup.
+ */
+export function getPersistedParentConversationId(
+  conversationId: string,
+): string | undefined {
+  const row = getDb()
+    .select({ parentConversationId: conversations.parentConversationId })
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .get();
+  return row?.parentConversationId ?? undefined;
+}

--- a/assistant/src/tools/apps/resolve-app-id.ts
+++ b/assistant/src/tools/apps/resolve-app-id.ts
@@ -1,4 +1,7 @@
-import { listAppsByConversation } from "../../apps/app-store.js";
+import {
+  isDirectAppConversation,
+  listAppsByConversation,
+} from "../../apps/app-store.js";
 
 /**
  * Resolve the `app_id` an app-builder tool should operate on.
@@ -14,6 +17,12 @@ import { listAppsByConversation } from "../../apps/app-store.js";
  * Returns `null` when no app_id is supplied and the conversation has no app, so
  * callers can surface an actionable error instead of a raw store throw.
  *
+ * Apps a conversation only inherited — created by a background subagent that
+ * forked from it — rank behind its own. Without that, a background
+ * continuation's freshly created app sits at the head of the parent thread's
+ * list and captures a foreground `app_update` that omitted `app_id`, writing to
+ * an app the user is not looking at.
+ *
  * Not used for destructive operations (`app_delete`): deleting an inferred app
  * is unsafe, so deletion requires an explicit id.
  */
@@ -25,9 +34,12 @@ export function resolveAppId(
     return input.app_id;
   }
   // `listAppsByConversation` preserves `listApps`' updatedAt-descending order,
-  // so the first entry is the app the model is actively working on.
+  // so the first direct entry is the app the model is actively working on.
   const apps = listAppsByConversation(conversationId);
-  return apps.length > 0 ? apps[0].id : null;
+  const direct = apps.find((app) =>
+    isDirectAppConversation(app, conversationId),
+  );
+  return (direct ?? apps[0])?.id ?? null;
 }
 
 /** Error payload returned when no app_id is supplied and none can be inferred. */


### PR DESCRIPTION
## Summary
- `resolveConversationLineage` falls back to the persisted `parent_conversation_id` column when a hop is no longer resident, so a link attempted after a subagent goes terminal still reaches the user-visible thread.
- `isInstalledStaticSkillLoad` resolves its target inside the guard, so an unreadable catalog degrades to `false` instead of throwing into the voice bridge's synchronous event dispatch.
- `resolveAppId`'s implicit fallback prefers apps directly associated with the calling conversation, so a background subagent's app cannot capture a foreground `app_update` that omits `app_id`.

Part of plan: voice-duplex-gaps.md (self-review remediation)