### PR TITLE
fix(live-voice): deliver the continuation answer on speculative turns and hang-up

### DIFF
--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -1269,7 +1269,19 @@ export function linkAppToConversationLineage(
   appId: string,
   conversationId: string,
 ): void {
-  for (const id of resolveConversationLineage(conversationId)) {
+  // Lineage resolution reaches the conversation store; an unexpected throw
+  // there degrades to the conversation itself rather than breaking the link.
+  let lineage: string[];
+  try {
+    lineage = resolveConversationLineage(conversationId);
+  } catch (err) {
+    log.warn(
+      { err, appId, conversationId },
+      "Failed to resolve conversation lineage for app association",
+    );
+    lineage = [conversationId];
+  }
+  for (const id of lineage) {
     try {
       addAppConversationId(appId, id);
     } catch (err) {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -46,6 +46,20 @@ import {
   type LiveVoiceServerFrame,
 } from "../protocol.js";
 
+// The closed-session delivery route writes into the parent conversation, which
+// needs a live conversation store. Stub the seam so the assertion is about
+// where the answer went, not about conversation plumbing.
+//
+// `mock.module` is process-global in Bun and leaks into sibling files that run
+// in the same process — run this file on its own (`bun test <path>`).
+const injectMessageIntoParentMock = mock(
+  (_parentConversationId: string, _message: string) => {},
+);
+mock.module("../../subagent/notify.js", () => ({
+  injectMessageIntoParent: injectMessageIntoParentMock,
+  notifyParentFromChild: mock(async () => {}),
+}));
+
 const SAMPLE_RATE = 24_000;
 
 const VAD_START_FRAME = {
@@ -2056,6 +2070,217 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => calls.some((c) => c.content === "third question"));
     const later = calls.find((c) => c.content === "third question");
     expect(later?.voiceControlPrompt).toContain("THE_RESULT");
+  });
+
+  test("voice-duplex-handoff on: an announcement whose launch throws hands the answer back to the stash", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const { session } = createHarness({
+      finals: ["stashed question"],
+      startVoiceTurn,
+      continuationAnnounceSilenceMs: 20,
+    });
+
+    await session.start();
+    await flushAsyncCallbacks();
+
+    const internals = session as unknown as {
+      pendingContinuationResult: string | null;
+      pendingAnnouncement: { request: string; answer: string } | null;
+      scheduleContinuationAnnouncement: () => void;
+      launchAssistantTurn: (
+        utterance: unknown,
+        content: string,
+        opts?: unknown,
+      ) => Promise<boolean>;
+    };
+    // The announcement's launch REJECTS rather than returning false — a frame
+    // write failing ahead of the leg's own error handling. The `started ===
+    // false` re-stash never runs on that path, so only the catch can save the
+    // answer.
+    const launch = internals.launchAssistantTurn.bind(session);
+    internals.launchAssistantTurn = async (utterance, content, opts) => {
+      if (content === CONTINUATION_DELIVERY_CONTENT) {
+        throw new Error("thinking frame write failed");
+      }
+      return launch(utterance, content, opts);
+    };
+    internals.pendingContinuationResult = "THE_RESULT";
+    internals.pendingAnnouncement = {
+      request: "the first question",
+      answer: "THE_RESULT",
+    };
+    internals.scheduleContinuationAnnouncement();
+
+    // The attempt runs (the queue empties) and throws.
+    await waitFor(() => internals.pendingAnnouncement === null);
+    await flushAsyncCallbacks();
+    expect(announcementOf(calls)).toBeUndefined();
+    expect(internals.pendingContinuationResult).toBe("THE_RESULT");
+
+    // ...so the user's next turn still carries it.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "stashed question"));
+    expect(
+      calls.find((c) => c.content === "stashed question")?.voiceControlPrompt,
+    ).toContain("THE_RESULT");
+  });
+
+  test("voice-duplex-handoff on: closing the room delivers a queued announcement into the conversation", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    injectMessageIntoParentMock.mockClear();
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn } = makeResurfaceTurnStarter();
+    const { frames, session } = createHarness({
+      finals: ["first question", ""],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      // Long enough that the announcement is still queued when the room closes.
+      continuationAnnounceSilenceMs: 5_000,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await flushAsyncCallbacks();
+    expect(injectMessageIntoParentMock).not.toHaveBeenCalled();
+
+    // The user hangs up before the silence elapses. Neither armed route can
+    // still run, so the finished answer takes the closed-session route into the
+    // thread instead of being dropped.
+    await session.close("client_end");
+    expect(injectMessageIntoParentMock).toHaveBeenCalledTimes(1);
+    const [conversationId, message] =
+      injectMessageIntoParentMock.mock.calls[0] ?? [];
+    expect(conversationId).toBe("conversation-123");
+    expect(message).toContain("THE_RESULT");
+    expect(message).toContain("[Background work finished]");
+    expect(message).toContain("first question");
+  });
+
+  test("voice-duplex-handoff on: a speculatively dispatched turn carries the stashed answer and cancels the announcement", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const { frames, session, transcribers } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      // Long enough for the speculative turn below to launch first, short
+      // enough that an announcement that survived it would fire inside the
+      // test's own wait.
+      continuationAnnounceSilenceMs: 250,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    // The continuation finishes on an idle call: stash and announcement are
+    // both armed for the one answer.
+    continuation.finish("THE_RESULT");
+    await flushAsyncCallbacks();
+
+    // The user speaks again with a partial already in hand, so the silence
+    // boundary dispatches the turn SPECULATIVELY — the default hands-free path
+    // (endpointMaxExtensions defaults to 2) rather than the release path.
+    await waitFor(() => transcribers.length === 3);
+    transcribers[2]?.emit({ type: "partial", text: "third question" });
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const speculative = calls.find((c) => c.content === "third question");
+    // The verdict rule is the proof this leg was dispatched speculatively.
+    expect(speculative?.unifiedVerdict).toBe(true);
+    expect(speculative?.voiceControlPrompt).toContain("THE_RESULT");
+
+    // The user's own turn is the delivery, so the queued announcement is
+    // cancelled rather than speaking the same answer again afterwards.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(announcementCount(calls)).toBe(0);
+  });
+
+  test("voice-duplex-handoff on: a held speculative turn hands the stashed answer back for the replay", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const continuation = makeControlledContinuation();
+    const calls: VoiceTurnOptions[] = [];
+    const discard = mock(async () => {});
+    // The first turn stays thinking so the barge-in lands on it. Every
+    // speculative leg afterwards answers with the hold token while it is
+    // offered one (`unifiedVerdict`), and answers for real on the replay.
+    const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
+      calls.push(options);
+      const index = calls.length;
+      if (options.content !== "first question") {
+        const reply = options.unifiedVerdict === true ? "[0]" : "Sure thing.";
+        setTimeout(() => {
+          options.callbacks?.assistant_text_delta?.(makeTextDelta(reply));
+          if (reply !== "[0]") {
+            options.callbacks?.message_complete?.(makeMessageComplete());
+          }
+        }, 0);
+      }
+      return { turnId: `bridge-turn-${index}`, abort: mock(), discard };
+    };
+    const { frames, session, transcribers } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio: makeImmediateTts(),
+      spawnBackgroundContinuation: continuation.spawnBackgroundContinuation,
+      frontModelConfig: { endpointExtensionMs: 30 },
+      // The announcement must not fire during the hold window — the replay
+      // turn is the delivery this test is about.
+      continuationAnnounceSilenceMs: 5_000,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(
+      () => continuation.spawnBackgroundContinuation.mock.calls.length === 1,
+    );
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    continuation.finish("THE_RESULT");
+    await flushAsyncCallbacks();
+
+    await waitFor(() => transcribers.length === 3);
+    transcribers[2]?.emit({ type: "partial", text: "third question" });
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    // The speculative leg holds: it is rolled back, taking nothing with it.
+    await waitFor(() => discard.mock.calls.length === 1);
+
+    // The extension replays the boundary and the replay leg answers. It is a
+    // different dispatch, so it only carries the answer if the rollback gave
+    // it back.
+    await waitFor(
+      () => calls.filter((c) => c.content === "third question").length === 2,
+    );
+    const replay = calls.filter((c) => c.content === "third question")[1];
+    expect(replay?.unifiedVerdict).toBeUndefined();
+    expect(replay?.voiceControlPrompt).toContain("THE_RESULT");
   });
 
   test("voice-duplex-handoff on: an announcement waits out the client's queued playback", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -524,6 +524,16 @@ interface ActiveAssistantTurn {
   // that request's transcript, so the model can tell the user the work is
   // still running instead of appearing to have dropped it.
   handedOffRequest: string | null;
+  // The queued announcement this turn consumed alongside `continuationResult`
+  // — the two are routes for one answer, so launching consumes both. Held here
+  // so a rolled-back speculative dispatch can re-arm it (see
+  // restorePendingTurnContext). Null on the announcement turn itself, which
+  // owns its delivery outright.
+  consumedAnnouncement: ContinuationDelivery | null;
+  // `detachStopGeneration` at the moment this turn consumed the pending
+  // context. A bump since then means a stop/interrupt/supersede deliberately
+  // dropped the continuation, so a rollback must not resurrect it.
+  pendingContextStopGeneration: number;
   // The agent run started a definitive tool use this turn — tool use implies
   // a guaranteed-slow turn, so acknowledgment logic can key off this.
   toolUseStarted: boolean;
@@ -1206,8 +1216,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.turnDetector?.dispose();
     this.clearEndpointExtensionTimer();
     // There is no longer anyone on the call to speak to, so a queued
-    // announcement is dropped; a continuation that finishes after this point
-    // delivers into the conversation instead.
+    // announcement cannot be spoken — but the answer behind it is finished
+    // work the user asked for, so it takes the same conversation route a
+    // continuation finishing after this point takes. Then the queue is
+    // cleared: the announcement is dead either way.
+    await this.deliverPendingContinuationToConversation();
     this.clearContinuationAnnouncement();
     this.stopSessionTranscriber();
     // Deliberately NOT aborting detached continuations: outliving the call is
@@ -2073,6 +2086,49 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
+   * Hang-up delivery for a continuation that already finished: the call is
+   * ending, so neither route that was armed for its answer can still run — the
+   * announcement has nobody to speak to and the stash has no next voice turn to
+   * fold into. Deliver it into the conversation instead, exactly as a
+   * continuation finishing after the close does, because that thread is where
+   * the user goes looking for the work ("barge in, hear the answer, close the
+   * room, go look for the result").
+   *
+   * Best-effort and consume-once: the fields are emptied whether or not the
+   * injection lands, so a close cannot deliver twice.
+   */
+  private async deliverPendingContinuationToConversation(): Promise<void> {
+    const announcement = this.pendingAnnouncement;
+    const answer = announcement?.answer ?? this.pendingContinuationResult;
+    const request = announcement?.request ?? "";
+    this.pendingAnnouncement = null;
+    this.pendingContinuationResult = null;
+    if (answer === null || answer.length === 0) {
+      return;
+    }
+    try {
+      const { injectMessageIntoParent } = await import("../subagent/notify.js");
+      injectMessageIntoParent(
+        this.conversationId,
+        buildClosedSessionDeliveryPrompt(request, answer),
+      );
+      log.info(
+        {
+          conversationId: this.conversationId,
+          resultChars: answer.length,
+          resultDestination: "conversation",
+        },
+        "Voice duplex continuation delivered on session close",
+      );
+    } catch (err) {
+      log.warn(
+        { err, conversationId: this.conversationId },
+        "Voice duplex continuation delivery on session close failed",
+      );
+    }
+  }
+
+  /**
    * Live-voice is non-interactive (JARVIS-1291) and the session never starts a
    * turn on its own — with one narrow exception, this: a background
    * continuation the user asked for has finished, the call is still live, and
@@ -2201,11 +2257,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // landing while the turn starts owns the drop, and must not be undone by
     // the restore below.
     const stopGeneration = this.detachStopGeneration;
-    const started = await this.launchAssistantTurn(
-      createSyntheticUtterance(),
-      CONTINUATION_DELIVERY_CONTENT,
-      { continuationDelivery: pending },
-    );
+    let started: boolean;
+    try {
+      started = await this.launchAssistantTurn(
+        createSyntheticUtterance(),
+        CONTINUATION_DELIVERY_CONTENT,
+        { continuationDelivery: pending },
+      );
+    } catch (err) {
+      // A throw before the leg's own error handling (an outbound frame write
+      // rejecting, say) leaves the same state a false return does: nothing
+      // persisted, nothing spoken, and the stash already emptied above. Take
+      // the identical fallback rather than letting the answer die with the
+      // rejection.
+      started = false;
+      log.warn(
+        { err, conversationId: this.conversationId },
+        "Voice duplex continuation announcement threw while starting",
+      );
+    }
     if (started) {
       log.info(
         {
@@ -2445,15 +2515,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   /**
    * Abort a speculative leg and roll back everything it touched: the
    * persisted user message (via the handle's discard), the active-turn
-   * slot, and the utterance's turn-started latch, so the utterance can be
-   * re-dispatched (hold replay) or keep accumulating (speech resumed).
-   * Nothing was ever user-visible — no frames were sent for this turn.
+   * slot, the pending context it consumed, and the utterance's turn-started
+   * latch, so the utterance can be re-dispatched (hold replay) or keep
+   * accumulating (speech resumed). Nothing was ever user-visible — no frames
+   * were sent for this turn.
    */
   private discardSpeculativeTurn(
     turn: ActiveAssistantTurn,
     reason: string,
   ): void {
     turn.speculativePending = false;
+    // The dispatch is being unwound, so the barge-in merge note, the finished
+    // continuation's answer, and its queued announcement all go back to the
+    // session — the turn that would have delivered them is gone.
+    this.restorePendingTurnContext(turn);
     // Latched before the handle check: when the discard beats the bridge
     // handle's resolution (startVoiceTurn still persisting), the handle's
     // arrival in startAssistantLeg completes the rollback via discard().
@@ -3056,22 +3131,87 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    // Consume any pending barge-in merge context and completed-continuation
-    // context for this turn (each feeds exactly the next launched turn).
-    const interruptedRequest = this.pendingInterruptedRequest;
+    await this.launchAssistantTurn(utterance, content);
+  }
+
+  /**
+   * Take the barge-in merge context, the completed-continuation context, and
+   * the handoff note for the turn being launched — each feeds exactly the next
+   * launched turn — and cancel the queued announcement, because the turn this
+   * context rides delivers the same answer and would otherwise say it twice.
+   *
+   * Every real user turn consumes here, speculative or not: a speculative
+   * dispatch latches `assistantTurnStarted`, so a turn that skipped this would
+   * never pick the context up on any later pass. A rolled-back dispatch hands
+   * it all back (restorePendingTurnContext).
+   */
+  private consumePendingTurnContext(): {
+    interruptedRequest: string | null;
+    continuationResult: string | null;
+    handedOffRequest: string | null;
+    announcement: ContinuationDelivery | null;
+  } {
+    const consumed = {
+      interruptedRequest: this.pendingInterruptedRequest,
+      continuationResult: this.pendingContinuationResult,
+      handedOffRequest: this.pendingHandoffRequest,
+      announcement: this.pendingAnnouncement,
+    };
     this.pendingInterruptedRequest = null;
-    const continuationResult = this.pendingContinuationResult;
     this.pendingContinuationResult = null;
-    // The user spoke first, so this turn delivers the continuation's answer;
-    // a queued announcement would only say the same thing twice.
-    this.clearContinuationAnnouncement();
-    const handedOffRequest = this.pendingHandoffRequest;
     this.pendingHandoffRequest = null;
-    await this.launchAssistantTurn(utterance, content, {
-      interruptedRequest,
-      continuationResult,
-      handedOffRequest,
-    });
+    this.clearContinuationAnnouncement();
+    return consumed;
+  }
+
+  /**
+   * Hand a turn's consumed pending context back to the session because the
+   * turn never happened: a speculative dispatch was discarded or held, or the
+   * launch never reached the bridge. Without this a hold verdict would destroy
+   * a finished continuation's answer outright — the stash was already emptied
+   * and no later turn would ever see it.
+   *
+   * Restores are conservative. A hard stop (interrupt/close/supersede) bumps
+   * `detachStopGeneration`, and that drop is deliberate — never undone here.
+   * Anything newer already sitting in a slot wins over the older value being
+   * returned to it.
+   */
+  private restorePendingTurnContext(turn: ActiveAssistantTurn): void {
+    const interruptedRequest = turn.interruptedRequest;
+    const continuationResult = turn.continuationResult;
+    const handedOffRequest = turn.handedOffRequest;
+    const announcement = turn.consumedAnnouncement;
+    // One restore per turn: the rollback paths overlap (a discarded turn whose
+    // leg start also fails), and the second pass must be a no-op.
+    turn.interruptedRequest = null;
+    turn.continuationResult = null;
+    turn.handedOffRequest = null;
+    turn.consumedAnnouncement = null;
+    if (
+      this.isClosed ||
+      this.detachStopGeneration !== turn.pendingContextStopGeneration
+    ) {
+      return;
+    }
+    if (this.pendingInterruptedRequest === null) {
+      this.pendingInterruptedRequest = interruptedRequest;
+    }
+    if (this.pendingContinuationResult === null) {
+      this.pendingContinuationResult = continuationResult;
+    }
+    // "Still running" is stale the moment a result exists, which is why the
+    // detach clears the handoff note when it finishes — don't reinstate it
+    // against a continuation that has since completed.
+    if (
+      this.pendingHandoffRequest === null &&
+      this.pendingContinuationResult === null
+    ) {
+      this.pendingHandoffRequest = handedOffRequest;
+    }
+    if (announcement !== null && this.pendingAnnouncement === null) {
+      this.pendingAnnouncement = announcement;
+      this.scheduleContinuationAnnouncement();
+    }
   }
 
   // Build the ActiveAssistantTurn for a released utterance and drive its model
@@ -3083,15 +3223,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance: UtteranceCycle,
     content: string,
     opts?: {
-      // Set on a barge-in follow-up turn: the interrupted request's transcript,
-      // appended to the turn's control prompt so the model merges the two.
-      interruptedRequest?: string | null;
-      // Set when a background continuation finished the interrupted reply: its
-      // answer, appended to the turn's control prompt as context.
-      continuationResult?: string | null;
-      // Set when a barge-in handed this request's work to a background
-      // subagent, so the model can say it is still running.
-      handedOffRequest?: string | null;
       // Set on an announcement turn: the finished continuation this turn exists
       // to deliver. Its answer goes in the control prompt, not in `content`.
       continuationDelivery?: ContinuationDelivery | null;
@@ -3103,6 +3234,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     },
   ): Promise<boolean> {
     utterance.assistantTurnStarted = true;
+    // The announcement turn IS the delivery of the pending continuation, so it
+    // must not also consume the stash — feeding it both would deliver the same
+    // answer twice. Every other turn is a real user turn and takes the context.
+    const pending =
+      opts?.continuationDelivery == null
+        ? this.consumePendingTurnContext()
+        : null;
     const token = Symbol("live-voice-assistant-turn");
     const turnId = this.ensureTurnId(utterance);
     this.startMetricsTurnIfNeeded(utterance, turnId);
@@ -3143,9 +3281,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       verdictDeadlineTimer: null,
       discardRequested: false,
       speculativeBuffer: "",
-      interruptedRequest: opts?.interruptedRequest ?? null,
-      continuationResult: opts?.continuationResult ?? null,
-      handedOffRequest: opts?.handedOffRequest ?? null,
+      interruptedRequest: pending?.interruptedRequest ?? null,
+      continuationResult: pending?.continuationResult ?? null,
+      handedOffRequest: pending?.handedOffRequest ?? null,
+      consumedAnnouncement: pending?.announcement ?? null,
+      pendingContextStopGeneration: this.detachStopGeneration,
       continuationDelivery: opts?.continuationDelivery ?? null,
       toolUseStarted: false,
       firstDeltaSeen: false,
@@ -3170,6 +3310,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (!opts?.speculative) {
       await this.sendFrame({ type: "thinking", turnId });
       if (!this.isActiveAssistantTurn(token)) {
+        this.restorePendingTurnContext(activeTurn);
         return false;
       }
     } else {
@@ -3224,11 +3365,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Front-door leg: a fast model fronts every turn (the `voiceFrontDoor`
     // call site pins it) and may hand off to a quality leg on the escalate
     // verdict.
-    return await this.startAssistantLeg(activeTurn, {
+    const started = await this.startAssistantLeg(activeTurn, {
       content,
       routingLeg: "front-door",
       frontDoor: true,
     });
+    if (!started) {
+      // Nothing was persisted or spoken, so the context this turn consumed goes
+      // back to the session rather than dying with the failed dispatch.
+      this.restorePendingTurnContext(activeTurn);
+    }
+    return started;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Every real user turn now consumes the pending continuation context, not just non-speculative ones. The speculative front-door path (the default hands-free path, `endpointMaxExtensions` defaults to 2) launched without it and set `assistantTurnStarted`, so the stash was never read and a queued announcement was blocked as `turn_active` — the finished answer reached the user by neither route.
- Rolled-back speculation restores the consumed context so a hold verdict cannot destroy the answer.
- Hanging up with a pending announcement now delivers into the conversation via the existing closed-session route instead of discarding it.
- `announceContinuation` restores the stash when the launch throws, not only when it returns false.
- `linkAppToConversationLineage` honors its best-effort contract if lineage resolution throws.

Part of plan: voice-duplex-gaps.md (self-review remediation)