### PR TITLE
fix(notifications): pin guardian-card vellum destinations to their source conversation (LUM-2870)

### DIFF
--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -143,6 +143,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals[0].sourceEventName).toBe("guardian.question");
     expect(emittedSignals[0].sourceChannel).toBe("telegram");
     expect(emittedSignals[0].sourceContextId).toBe("conv-1");
+    // The in-app card is pinned to the conversation the confirmation was
+    // emitted in — never left to LLM conversation routing.
+    expect(emittedSignals[0].conversationAffinityHint).toEqual({
+      vellum: "conv-1",
+    });
 
     const payload = emittedSignals[0].contextPayload as Record<string, unknown>;
     expect(payload.requestId).toBe(guardianRequest.id);

--- a/assistant/src/__tests__/guardian-vellum-destination-pinning.test.ts
+++ b/assistant/src/__tests__/guardian-vellum-destination-pinning.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression tests for guardian-card vellum destination routing (LUM-2870).
+ *
+ * Two unrelated guardian requests must never share a vellum conversation:
+ * un-pinned requests are forced to `start_new` by the decision engine's
+ * guardian-request affinity guard (overriding any LLM `reuse_existing`
+ * choice), so each request pairs with its own fresh conversation; pinned
+ * requests land in their originating conversation via the affinity hint.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mocks — declared before imports that depend on them ─────────────
+
+let nextConversationSeq = 0;
+
+/** Simulated existing conversations for getConversation mock. */
+let mockExistingConversations: Record<
+  string,
+  { id: string; source: string; title: string | null }
+> = {};
+
+const createdConversationIds: string[] = [];
+const appendedMessages: Array<{ conversationId: string }> = [];
+
+const createConversationMock = mock((_opts?: unknown) => {
+  nextConversationSeq += 1;
+  const id = `conv-new-${nextConversationSeq}`;
+  createdConversationIds.push(id);
+  return { id };
+});
+
+const addMessageMock = mock(
+  (
+    conversationId: string,
+    _role: string,
+    _content: string,
+    _options?: unknown,
+  ) => {
+    appendedMessages.push({ conversationId });
+    return { id: `msg-${conversationId}` };
+  },
+);
+
+const getConversationMock = mock((id: string) => {
+  return mockExistingConversations[id] ?? null;
+});
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  createConversation: createConversationMock,
+  addMessage: addMessageMock,
+  getConversation: getConversationMock,
+}));
+
+mock.module("../persistence/external-conversation-store.js", () => ({
+  getBindingByChannelChat: () => null,
+  upsertOutboundBinding: () => {},
+}));
+
+import { pairDeliveryWithConversation } from "../notifications/conversation-pairing.js";
+import { enforceGuardianRequestConversationAffinity } from "../notifications/decision-engine.js";
+import type { NotificationSignal } from "../notifications/signal.js";
+import type {
+  ConversationAction,
+  NotificationDecision,
+} from "../notifications/types.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function makeSignal(
+  overrides?: Partial<NotificationSignal>,
+): NotificationSignal {
+  return {
+    signalId: `sig-${Math.random().toString(36).slice(2, 8)}`,
+    createdAt: Date.now(),
+    sourceChannel: "slack",
+    sourceContextId: "ctx-1",
+    sourceEventName: "guardian.question",
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: true,
+      urgency: "high",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    requiresConversation: true,
+    ...overrides,
+  };
+}
+
+function makeLlmDecisionReusing(conversationId: string): NotificationDecision {
+  return {
+    shouldNotify: true,
+    selectedChannels: ["vellum"],
+    reasoningSummary: "llm chose reuse",
+    renderedCopy: {
+      vellum: { title: "Approval needed", body: "Please decide." },
+    },
+    conversationActions: {
+      vellum: { action: "reuse_existing", conversationId },
+    },
+    dedupeKey: "test-key",
+    confidence: 0.9,
+    fallbackUsed: false,
+  };
+}
+
+/** Run a signal's decision through the guard and pair the vellum delivery. */
+async function routeVellumDelivery(
+  signal: NotificationSignal,
+  decision: NotificationDecision,
+) {
+  const guarded = enforceGuardianRequestConversationAffinity(decision, signal);
+  const conversationAction = guarded.conversationActions?.vellum as
+    | ConversationAction
+    | undefined;
+  return pairDeliveryWithConversation(
+    signal,
+    "vellum",
+    guarded.renderedCopy.vellum!,
+    { conversationAction },
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("guardian vellum destination pinning", () => {
+  beforeEach(() => {
+    nextConversationSeq = 0;
+    createdConversationIds.length = 0;
+    appendedMessages.length = 0;
+    mockExistingConversations = {
+      // The "catch-all" — a recent guardian conversation the LLM keeps
+      // offering as a reuse candidate.
+      "conv-catchall": {
+        id: "conv-catchall",
+        source: "notification",
+        title: "Access Request",
+      },
+      // An originating inbound conversation a producer can pin to.
+      "conv-origin": { id: "conv-origin", source: "user", title: "Slack chat" },
+    };
+    createConversationMock.mockClear();
+    addMessageMock.mockClear();
+  });
+
+  test("two unrelated un-pinned guardian requests land in two different conversations", async () => {
+    // Both decisions simulate the LLM steering to the same catch-all.
+    const accessRequest = makeSignal({
+      sourceEventName: "ingress.access_request",
+      contextPayload: { requestId: "access-req-1" },
+    });
+    const toolGrant = makeSignal({
+      sourceEventName: "guardian.question",
+      contextPayload: {
+        requestId: "tool-grant-1",
+        requestKind: "tool_grant_request",
+        toolName: "host_bash",
+      },
+    });
+
+    const first = await routeVellumDelivery(
+      accessRequest,
+      makeLlmDecisionReusing("conv-catchall"),
+    );
+    const second = await routeVellumDelivery(
+      toolGrant,
+      makeLlmDecisionReusing("conv-catchall"),
+    );
+
+    expect(first.conversationId).toBeTruthy();
+    expect(second.conversationId).toBeTruthy();
+    expect(first.conversationId).not.toBe(second.conversationId);
+    expect(first.createdNewConversation).toBe(true);
+    expect(second.createdNewConversation).toBe(true);
+    // The catch-all never receives either card.
+    expect(
+      appendedMessages.filter((m) => m.conversationId === "conv-catchall"),
+    ).toHaveLength(0);
+  });
+
+  test("a pinned guardian request lands in its originating conversation", async () => {
+    const pinned = makeSignal({
+      sourceEventName: "guardian.question",
+      contextPayload: {
+        requestId: "tool-approval-1",
+        requestKind: "tool_approval",
+        toolName: "bash",
+      },
+      conversationAffinityHint: { vellum: "conv-origin" },
+      conversationMetadata: { source: "user" },
+    });
+
+    // With a hint the guard is a no-op; affinity enforcement (exercised in
+    // decision-engine tests) rewrites the action to reuse the pinned target.
+    const guarded = enforceGuardianRequestConversationAffinity(
+      makeLlmDecisionReusing("conv-catchall"),
+      pinned,
+    );
+    expect(guarded.conversationActions?.vellum).toEqual({
+      action: "reuse_existing",
+      conversationId: "conv-catchall",
+    });
+
+    const pairing = await pairDeliveryWithConversation(
+      pinned,
+      "vellum",
+      guarded.renderedCopy.vellum!,
+      {
+        conversationAction: {
+          action: "reuse_existing",
+          conversationId: "conv-origin",
+        },
+      },
+    );
+
+    expect(pairing.conversationId).toBe("conv-origin");
+    expect(pairing.createdNewConversation).toBe(false);
+    expect(appendedMessages).toEqual([{ conversationId: "conv-origin" }]);
+  });
+});

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -19,7 +19,7 @@ import {
 import type { ConversationCandidateSet } from "../notifications/conversation-candidates.js";
 import { composeFallbackCopy } from "../notifications/copy-composer.js";
 import {
-  enforceGuardianCallConversationAffinity,
+  enforceGuardianRequestConversationAffinity,
   validateConversationActions,
 } from "../notifications/decision-engine.js";
 import {
@@ -945,9 +945,9 @@ describe("notification decision strategy", () => {
     });
   });
 
-  // -- Guardian call conversation affinity enforcement --------------------------------
+  // -- Guardian request conversation affinity enforcement -----------------------------
 
-  describe("guardian call conversation affinity enforcement", () => {
+  describe("guardian request conversation affinity enforcement", () => {
     function makeDecision(
       overrides?: Partial<NotificationDecision>,
     ): NotificationDecision {
@@ -979,7 +979,10 @@ describe("notification decision strategy", () => {
         },
       });
 
-      const result = enforceGuardianCallConversationAffinity(decision, signal);
+      const result = enforceGuardianRequestConversationAffinity(
+        decision,
+        signal,
+      );
       expect(result.conversationActions?.vellum).toEqual({
         action: "start_new",
       });
@@ -1004,7 +1007,10 @@ describe("notification decision strategy", () => {
         conversationAffinityHint: { vellum: "conv-123" },
       });
 
-      const result = enforceGuardianCallConversationAffinity(decision, signal);
+      const result = enforceGuardianRequestConversationAffinity(
+        decision,
+        signal,
+      );
       // Should remain unchanged — the affinity hint takes precedence
       expect(result.conversationActions?.vellum).toEqual({
         action: "reuse_existing",
@@ -1023,15 +1029,22 @@ describe("notification decision strategy", () => {
         contextPayload: { message: "Take out the trash" },
       });
 
-      const result = enforceGuardianCallConversationAffinity(decision, signal);
+      const result = enforceGuardianRequestConversationAffinity(
+        decision,
+        signal,
+      );
       expect(result.conversationActions?.vellum).toEqual({
         action: "reuse_existing",
         conversationId: "conv-456",
       });
     });
 
-    test("guardian.question without callSessionId is not affected", () => {
-      const decision = makeDecision();
+    test("guardian.question without callSessionId and no hint still forces start_new", () => {
+      const decision = makeDecision({
+        conversationActions: {
+          vellum: { action: "reuse_existing", conversationId: "conv-catchall" },
+        },
+      });
       const signal = makeSignal({
         sourceEventName: "guardian.question",
         contextPayload: {
@@ -1043,9 +1056,100 @@ describe("notification decision strategy", () => {
         },
       });
 
-      const result = enforceGuardianCallConversationAffinity(decision, signal);
-      // No callSessionId → no enforcement
-      expect(result.conversationActions).toBeUndefined();
+      const result = enforceGuardianRequestConversationAffinity(
+        decision,
+        signal,
+      );
+      // Un-pinned guardian requests must never reuse an LLM-chosen conversation
+      expect(result.conversationActions?.vellum).toEqual({
+        action: "start_new",
+      });
+    });
+
+    test("ingress.access_request without hint forces start_new over LLM reuse", () => {
+      const decision = makeDecision({
+        conversationActions: {
+          vellum: { action: "reuse_existing", conversationId: "conv-catchall" },
+        },
+      });
+      const signal = makeSignal({
+        sourceEventName: "ingress.access_request",
+        contextPayload: {
+          requestId: "access-req-1",
+          senderIdentifier: "Alice",
+        },
+      });
+
+      const result = enforceGuardianRequestConversationAffinity(
+        decision,
+        signal,
+      );
+      expect(result.conversationActions?.vellum).toEqual({
+        action: "start_new",
+      });
+    });
+
+    test("ingress.access_request with affinity hint is left to affinity enforcement", () => {
+      const decision = makeDecision({
+        conversationActions: {
+          vellum: { action: "reuse_existing", conversationId: "conv-origin" },
+        },
+      });
+      const signal = makeSignal({
+        sourceEventName: "ingress.access_request",
+        contextPayload: {
+          requestId: "access-req-2",
+          senderIdentifier: "Bob",
+        },
+        conversationAffinityHint: { vellum: "conv-origin" },
+      });
+
+      const result = enforceGuardianRequestConversationAffinity(
+        decision,
+        signal,
+      );
+      expect(result.conversationActions?.vellum).toEqual({
+        action: "reuse_existing",
+        conversationId: "conv-origin",
+      });
+    });
+
+    test("two unrelated un-pinned guardian requests never share a reuse target", () => {
+      // Simulates the LUM-2870 catch-all: the LLM offers the same recent
+      // guardian conversation as a reuse candidate for two unrelated
+      // requests. The guard must force each to start its own conversation.
+      const llmDecisionForRequest = () =>
+        makeDecision({
+          conversationActions: {
+            vellum: {
+              action: "reuse_existing",
+              conversationId: "conv-catchall",
+            },
+          },
+        });
+
+      const accessRequest = makeSignal({
+        sourceEventName: "ingress.access_request",
+        contextPayload: { requestId: "access-req-3" },
+      });
+      const toolGrant = makeSignal({
+        sourceEventName: "guardian.question",
+        contextPayload: {
+          requestId: "tool-grant-9",
+          requestKind: "tool_grant_request",
+          toolName: "host_bash",
+        },
+      });
+
+      for (const signal of [accessRequest, toolGrant]) {
+        const result = enforceGuardianRequestConversationAffinity(
+          llmDecisionForRequest(),
+          signal,
+        );
+        expect(result.conversationActions?.vellum).toEqual({
+          action: "start_new",
+        });
+      }
     });
   });
 });

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -228,6 +228,11 @@ describe("ToolApprovalHandler / grant-miss escalation", () => {
 
     // The guardian-facing question asks about the tool, never about the person.
     expect(emittedSignals.length).toBe(1);
+    // The in-app card is pinned to the conversation the escalated tool runs
+    // in — never left to LLM conversation routing.
+    expect(emittedSignals[0].conversationAffinityHint).toEqual({
+      vellum: "conv-1",
+    });
     const payload = emittedSignals[0].contextPayload as Record<string, unknown>;
     const questionText = payload.questionText as string;
     expect(questionText.startsWith("Approve tool: bash")).toBe(true);

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -974,7 +974,7 @@ export async function evaluateSignal(
     decision = enforceGuardianRequestCode(decision, signal);
     decision = enforceToolApprovalSeedBlocks(decision, signal);
     decision = enforceAccessRequestInstructions(decision, signal);
-    decision = enforceGuardianCallConversationAffinity(decision, signal);
+    decision = enforceGuardianRequestConversationAffinity(decision, signal);
     decision = enforceConversationAffinity(
       decision,
       signal.conversationAffinityHint,
@@ -992,7 +992,7 @@ export async function evaluateSignal(
     decision = enforceGuardianRequestCode(decision, signal);
     decision = enforceToolApprovalSeedBlocks(decision, signal);
     decision = enforceAccessRequestInstructions(decision, signal);
-    decision = enforceGuardianCallConversationAffinity(decision, signal);
+    decision = enforceGuardianRequestConversationAffinity(decision, signal);
     decision = enforceConversationAffinity(
       decision,
       signal.conversationAffinityHint,
@@ -1022,7 +1022,7 @@ export async function evaluateSignal(
   decision = enforceGuardianRequestCode(decision, signal);
   decision = enforceToolApprovalSeedBlocks(decision, signal);
   decision = enforceAccessRequestInstructions(decision, signal);
-  decision = enforceGuardianCallConversationAffinity(decision, signal);
+  decision = enforceGuardianRequestConversationAffinity(decision, signal);
   decision = enforceConversationAffinity(
     decision,
     signal.conversationAffinityHint,
@@ -1258,33 +1258,32 @@ export function enforceRoutingIntent(
   return decision;
 }
 
-// ── Guardian call conversation affinity ──────────────────────────────────
+// ── Guardian request conversation affinity ───────────────────────────────
 
 /**
- * Force a new vellum conversation for the first guardian question in a phone call.
+ * Force a new vellum conversation for guardian-request signals that carry no
+ * vellum affinity hint.
  *
- * When a guardian.question signal carries a callSessionId but has no
- * conversationAffinityHint, this is the first dispatch in a new call and
- * should get its own conversation. Without this guard the LLM might reuse a
- * conversation from a previous call. For subsequent dispatches within the same
- * call, the affinity hint already exists and enforceConversationAffinity
- * handles routing — so this guard is a no-op.
+ * Guardian cards (tool approvals, tool grants, access requests, voice and
+ * ask_question prompts) are pinned to their originating conversation by the
+ * producer via `conversationAffinityHint`. When no pin exists — e.g. an
+ * access request from a sender with no prior conversation, or the first
+ * question in a phone call — the card must open its own conversation:
+ * leaving the choice to the LLM lets unrelated requests accumulate in
+ * whichever guardian conversation is most recent. For hinted signals,
+ * enforceConversationAffinity applies the pin — this guard is a no-op.
  */
-export function enforceGuardianCallConversationAffinity(
+export function enforceGuardianRequestConversationAffinity(
   decision: NotificationDecision,
   signal: NotificationSignal,
 ): NotificationDecision {
-  if (signal.sourceEventName !== "guardian.question") {
+  if (
+    signal.sourceEventName !== "guardian.question" &&
+    signal.sourceEventName !== "ingress.access_request"
+  ) {
     return decision;
   }
 
-  const callSessionId = signal.contextPayload?.callSessionId;
-  if (typeof callSessionId !== "string" || callSessionId.trim().length === 0) {
-    return decision;
-  }
-
-  // If an affinity hint already exists for vellum, the second+ dispatch
-  // will be handled by enforceConversationAffinity — nothing to do here.
   if (signal.conversationAffinityHint?.vellum) {
     return decision;
   }
@@ -1299,8 +1298,8 @@ export function enforceGuardianCallConversationAffinity(
   enforced.conversationActions = conversationActions;
 
   log.info(
-    { callSessionId },
-    "Guardian call conversation affinity: first question in call — forcing start_new for vellum",
+    { sourceEventName: signal.sourceEventName },
+    "Guardian request conversation affinity: no vellum pin — forcing start_new",
   );
 
   return enforced;

--- a/assistant/src/notifications/vellum-card-affinity.ts
+++ b/assistant/src/notifications/vellum-card-affinity.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared vellum-card conversation pin for guardian-request producers.
+ *
+ * Guardian cards (access requests, tool grants, tool approvals, questions)
+ * that know their originating conversation pass this affinity fragment to
+ * `emitNotificationSignal` so the in-app (vellum) card lands inside that
+ * conversation instead of one the decision engine picks. The metadata mirrors
+ * the target's `source` because `pairDeliveryWithConversation` reuses a
+ * conversation only when its source matches the signal's (inbound
+ * conversations default to "user"); a stale/missing target falls back to a
+ * fresh conversation via the same pairing path.
+ */
+
+import { getConversation } from "../persistence/conversation-crud.js";
+
+export interface VellumCardAffinity {
+  conversationAffinityHint: { vellum: string };
+  conversationMetadata: { source: string };
+}
+
+/**
+ * Build the emit-signal affinity fragment pinning the vellum card to
+ * `destinationConversationId`, or `undefined` when the producer has no
+ * originating conversation (callers spread the result:
+ * `...(buildVellumCardAffinity(id) ?? {})`).
+ */
+export function buildVellumCardAffinity(
+  destinationConversationId: string | undefined,
+): VellumCardAffinity | undefined {
+  if (!destinationConversationId) {
+    return undefined;
+  }
+  return {
+    conversationAffinityHint: { vellum: destinationConversationId },
+    conversationMetadata: {
+      source: getConversation(destinationConversationId)?.source ?? "user",
+    },
+  };
+}

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -189,6 +189,51 @@ function resolveInboundConversation(
 }
 
 /**
+ * Resolve the internal conversation already bound to an inbound
+ * (channel, chat, thread) address, or `null` when none exists. Mirrors
+ * {@link resolveInboundConversation}'s lookup order — threaded key first,
+ * then the Slack flat-key alias when thread evidence exists — but is
+ * strictly read-only: deny lanes use it to attach the in-app
+ * access-request card to the originating conversation, and a denied
+ * inbound must never mint a conversation as a side effect.
+ */
+export function findInboundConversationId(
+  sourceChannel: string,
+  externalChatId: string,
+  sourceThreadId?: string | null,
+): string | null {
+  const threadedKey = buildScopedConversationKey(
+    sourceChannel,
+    externalChatId,
+    sourceThreadId,
+  );
+  const threadedMapping = getConversationByKey(threadedKey);
+  if (threadedMapping) {
+    return threadedMapping.conversationId;
+  }
+
+  const threadId = sourceThreadId?.trim();
+  if (sourceChannel !== "slack" || !threadId) {
+    return null;
+  }
+
+  const legacyKey = buildScopedConversationKey(sourceChannel, externalChatId);
+  const legacyMapping = getConversationByKey(legacyKey);
+  if (
+    legacyMapping &&
+    legacySlackConversationHasThreadEvidence(
+      legacyMapping.conversationId,
+      externalChatId,
+      threadId,
+    )
+  ) {
+    return legacyMapping.conversationId;
+  }
+
+  return null;
+}
+
+/**
  * Record an inbound channel event. Returns `duplicate: true` if this
  * exact (channel, chat, message) combination was already seen.
  */

--- a/assistant/src/runtime/__tests__/question-request-guardian-bridge.test.ts
+++ b/assistant/src/runtime/__tests__/question-request-guardian-bridge.test.ts
@@ -35,6 +35,11 @@ mock.module("../../notifications/guardian-delivery-recorder.js", () => ({
 mock.module("../channel-verification-service.js", () => ({
   getGuardianBinding: () => Promise.resolve(binding),
 }));
+// The vellum-card pin mirrors the target conversation's source; no DB here,
+// so resolve "conversation not found" and let the helper fall back to "user".
+mock.module("../../persistence/conversation-crud.js", () => ({
+  getConversation: () => null,
+}));
 
 const { bridgeQuestionRequestToGuardian } =
   await import("../question-request-guardian-bridge.js");
@@ -115,7 +120,11 @@ describe("bridgeQuestionRequestToGuardian", () => {
     const signal = emitSignalMock.mock.calls[0]?.[0] as {
       attentionHints: Record<string, unknown>;
       contextPayload: Record<string, unknown>;
+      conversationAffinityHint?: Record<string, string>;
     };
+    // The in-app card is pinned to the conversation the question was asked
+    // in — never left to LLM conversation routing.
+    expect(signal.conversationAffinityHint).toEqual({ vellum: "conv-1" });
     // REGRESSION PIN: visibleInSourceNow is a hard suppression pre-gate in
     // emitNotificationSignal. The question card is the channel's ONLY way to
     // display the parked prompt — a true here silently suppresses every

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -25,7 +25,7 @@ import {
   recordGuardianRequestDeliveries,
 } from "../notifications/guardian-delivery-recorder.js";
 import type { GuardianResolutionSource } from "../notifications/signal.js";
-import { getConversation } from "../persistence/conversation-crud.js";
+import { buildVellumCardAffinity } from "../notifications/vellum-card-affinity.js";
 import { IntegrityError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { resolveAnchoredGuardian } from "./anchored-guardian.js";
@@ -332,20 +332,12 @@ export async function notifyGuardianOfAccessRequest(
     TEXT_CHANNELS_WITH_DELIVERY.has(sourceChannel) &&
     guardianResolutionSource === "source-channel-contact";
 
-  // Pin the in-app (vellum) card to the originating conversation when the caller
-  // supplied one, so the card lands inside it instead of a fresh standalone
-  // "Chat". `pairDeliveryWithConversation` reuses a conversation only when its
-  // source matches the signal's, so mirror the target's source (inbound
-  // conversations default to "user"); a stale/missing target falls back to a
-  // new conversation via the same pairing path.
-  const vellumConversationAffinity = destinationConversationId
-    ? {
-        conversationAffinityHint: { vellum: destinationConversationId },
-        conversationMetadata: {
-          source: getConversation(destinationConversationId)?.source ?? "user",
-        },
-      }
-    : undefined;
+  // Pin the in-app (vellum) card to the originating conversation when the
+  // caller supplied one, so the card lands inside it instead of a fresh
+  // standalone "Chat".
+  const vellumConversationAffinity = buildVellumCardAffinity(
+    destinationConversationId,
+  );
 
   void emitNotificationSignal({
     sourceEventName: "ingress.access_request",

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -19,6 +19,7 @@ import {
   recordApprovalCardDelivery,
   recordGuardianRequestDeliveries,
 } from "../notifications/guardian-delivery-recorder.js";
+import { buildVellumCardAffinity } from "../notifications/vellum-card-affinity.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { resolveApprovalSourceReference } from "./approval-source-link.js";
@@ -166,6 +167,9 @@ export async function bridgeConfirmationRequestToGuardian(
     sourceChannel,
     sourceContextId: conversationId,
     requiresConversation: true,
+    // Pin the in-app (vellum) card to the conversation the confirmation was
+    // emitted in, so the guardian decides it in context.
+    ...(buildVellumCardAffinity(conversationId) ?? {}),
     attentionHints: {
       requiresAction: true,
       urgency: "high",

--- a/assistant/src/runtime/question-request-guardian-bridge.ts
+++ b/assistant/src/runtime/question-request-guardian-bridge.ts
@@ -24,6 +24,7 @@ import {
   recordApprovalCardDelivery,
   recordGuardianRequestDeliveries,
 } from "../notifications/guardian-delivery-recorder.js";
+import { buildVellumCardAffinity } from "../notifications/vellum-card-affinity.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -113,6 +114,9 @@ export async function bridgeQuestionRequestToGuardian(
     sourceChannel,
     sourceContextId: conversationId,
     requiresConversation: true,
+    // Pin the in-app (vellum) card to the conversation the question was
+    // asked in, so the guardian answers it in context.
+    ...(buildVellumCardAffinity(conversationId) ?? {}),
     attentionHints: {
       requiresAction: true,
       urgency: "high",

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1302,6 +1302,9 @@ export async function handleChannelInbound({
             actorExternalId: admittedSenderId,
             actorDisplayName: body.actorDisplayName,
             actorUsername: body.actorUsername,
+            // The nudge fires after recordInbound, so the originating
+            // conversation exists — attach the in-app card to it.
+            destinationConversationId: result.conversationId,
             messagePreview: truncate(
               trimmedContent,
               MESSAGE_PREVIEW_MAX_LENGTH,

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -59,6 +59,13 @@ mock.module("../../access-request-helper.js", () => ({
   isApprovalHandshakeInProgress: () => approvalHandshakeForTest,
 }));
 
+// The deny lanes resolve the originating conversation read-only through this
+// entrypoint; default to "no bound conversation" and let tests opt into one.
+let inboundConversationIdForTest: string | null = null;
+mock.module("../../../persistence/delivery-crud.js", () => ({
+  findInboundConversationId: () => inboundConversationIdForTest,
+}));
+
 // Gateway-backed verification-session client: track challenge minting so the
 // callback exemption (LUM-2673) can assert no session is created for button
 // presses; the throw toggle simulates an unreachable gateway (transport
@@ -129,6 +136,7 @@ beforeEach(() => {
   accessRequestCalls.length = 0;
   approvalHandshakeForTest = false;
   guardianDeliveryCalls.length = 0;
+  inboundConversationIdForTest = null;
 });
 
 describe("enforceIngressAcl — verdict-sourced member resolution", () => {
@@ -344,6 +352,48 @@ describe("enforceIngressAcl — present stranger verdict enters the stranger lan
     // guardian is notified and a canned reply is delivered.
     expect(accessRequestCalls.length).toBe(1);
     expect(deliverReplyCalls.length).toBe(1);
+  });
+
+  test("access request pins to the bound inbound conversation when one exists", async () => {
+    inboundConversationIdForTest = "conv-origin-1";
+    const strangerVerdict: TrustVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "stranger-1",
+    };
+
+    await enforceIngressAcl(
+      makeParams({
+        canonicalSenderId: "stranger-1",
+        rawSenderId: "stranger-1",
+        sourceMetadata: withVerdict(strangerVerdict),
+      }),
+    );
+
+    expect(accessRequestCalls.length).toBe(1);
+    expect(accessRequestCalls[0]).toMatchObject({
+      destinationConversationId: "conv-origin-1",
+    });
+  });
+
+  test("access request carries no destination pin when no conversation is bound", async () => {
+    const strangerVerdict: TrustVerdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "stranger-1",
+    };
+
+    await enforceIngressAcl(
+      makeParams({
+        canonicalSenderId: "stranger-1",
+        rawSenderId: "stranger-1",
+        sourceMetadata: withVerdict(strangerVerdict),
+      }),
+    );
+
+    expect(accessRequestCalls.length).toBe(1);
+    expect(
+      (accessRequestCalls[0] as { destinationConversationId?: string })
+        .destinationConversationId,
+    ).toBeUndefined();
   });
 });
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -25,6 +25,7 @@ import {
   isKeptOutStatus,
 } from "../../../contacts/member-status.js";
 import { MESSAGE_PREVIEW_MAX_LENGTH } from "../../../notifications/notification-utils.js";
+import { findInboundConversationId } from "../../../persistence/delivery-crud.js";
 import { resolveGuardianName } from "../../../prompts/user-reference.js";
 import { getLogger } from "../../../util/logger.js";
 import { truncate } from "../../../util/truncate.js";
@@ -210,6 +211,19 @@ export async function enforceIngressAcl(
 
   // Slack message timestamp for permalink construction.
   const messageTs = sourceMetadata?.messageId ?? undefined;
+
+  // Internal conversation already bound to this inbound address, when one
+  // exists. Pins the in-app access-request card to the originating
+  // conversation so unrelated requests never share a destination. Strictly
+  // read-only — the deny lanes below run before recordInbound, and a denied
+  // inbound must never mint a conversation; a sender with no prior
+  // conversation falls through to the decision engine's start_new guard.
+  const destinationConversationId =
+    findInboundConversationId(
+      sourceChannel,
+      conversationExternalId,
+      sourceMetadata?.threadId,
+    ) ?? undefined;
 
   // The shared usability predicate is the fail-closed gate: an unusable
   // verdict soft-denies with NO stranger-lane side effects (no access-request
@@ -426,6 +440,7 @@ export async function enforceIngressAcl(
                 isStranger,
                 isRestricted,
                 messageTs,
+                destinationConversationId,
               });
             } catch (err) {
               log.error(
@@ -508,6 +523,7 @@ export async function enforceIngressAcl(
                 isStranger,
                 isRestricted,
                 messageTs,
+                destinationConversationId,
               });
             } catch (err) {
               log.error(
@@ -559,6 +575,7 @@ export async function enforceIngressAcl(
               isStranger,
               isRestricted,
               messageTs,
+              destinationConversationId,
             });
             guardianNotified = accessResult.notified;
             handshakeInProgress =
@@ -730,6 +747,7 @@ export async function enforceIngressAcl(
                   isStranger,
                   isRestricted,
                   messageTs,
+                  destinationConversationId,
                 });
               } catch (err) {
                 log.error(
@@ -809,6 +827,7 @@ export async function enforceIngressAcl(
                   isStranger,
                   isRestricted,
                   messageTs,
+                  destinationConversationId,
                 });
                 guardianNotified = accessResult.notified;
                 handshakeInProgress =

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -21,6 +21,7 @@ import {
   recordApprovalCardDelivery,
   recordGuardianRequestDeliveries,
 } from "../notifications/guardian-delivery-recorder.js";
+import { buildVellumCardAffinity } from "../notifications/vellum-card-affinity.js";
 import { getLogger } from "../util/logger.js";
 import { resolveApprovalSourceReference } from "./approval-source-link.js";
 import { getGuardianBinding } from "./channel-verification-service.js";
@@ -177,6 +178,9 @@ export async function createOrReuseToolGrantRequest(
     sourceChannel,
     sourceContextId: conversationId,
     requiresConversation: true,
+    // Pin the in-app (vellum) card to the conversation the escalated tool is
+    // running in, so the guardian decides it in context.
+    ...(buildVellumCardAffinity(conversationId) ?? {}),
     attentionHints: {
       requiresAction: true,
       urgency: "high",


### PR DESCRIPTION
## TL;DR

Guardian approval cards delivered in-app were all landing in one stale "Access Request" conversation, because the vellum destination was chosen by the notification decision engine's LLM with a "prefer reuse" bias and nothing pinned it. This PR makes vellum routing deterministic: every guardian-card producer pins the card to the conversation the request originated from, and a decision-engine guard forces `start_new` for any guardian-request signal that arrives without a pin.

Part of LUM-2870 (slice 1 of 4). Full evidence and diagnosis: https://linear.app/vellum/issue/LUM-2870

## What changes for the user

| Before | After |
| --- | --- |
| A bash tool approval from a Slack contact appears in an unrelated hours-old "Access Request" conversation | It appears in the conversation where the tool is running |
| Two unrelated access requests (different senders, hours apart) share one conversation | Each access request gets its own conversation — the originating one when it exists, otherwise a fresh one |
| An `ask_question` / tool-approval card opens wherever the LLM routes it | It opens in the conversation the question/confirmation was raised in |
| Whether cards co-mingle depends on LLM judgment over a 24h candidate list | Vellum destination is deterministic; the LLM keeps choosing only for non-guardian notifications |

## Implementation

- **`notifications/vellum-card-affinity.ts` (new)** — shared `buildVellumCardAffinity()` producing the `conversationAffinityHint` + source-mirroring `conversationMetadata` fragment (extracted from the LUM-2815 access-request pattern; second-occurrence extraction).
- **Producers pinned** — tool-grant helper, confirmation bridge, and question bridge pass their `conversationId`; the access-request helper now consumes the shared fragment.
- **ACL deny lanes** — the five `notifyGuardianOfAccessRequest` call sites in `acl-enforcement.ts` run *before* `recordInbound`, so no conversation is guaranteed to exist. They now resolve one **read-only** via the new `findInboundConversationId()` in `delivery-crud.ts` (threaded key, then the Slack flat-key alias when thread evidence exists) — a denied inbound still never mints a conversation. The admitted-contact nudge (which runs after `recordInbound`) passes its recorded conversation, same as the LUM-2815 floor-deny path.
- **Decision-engine guard** — `enforceGuardianCallConversationAffinity` (voice-only) is generalized to `enforceGuardianRequestConversationAffinity`: any `guardian.question` / `ingress.access_request` signal without a vellum affinity hint is forced to `start_new`, overriding LLM `reuse_existing`. Hinted signals are untouched (the existing affinity enforcement applies the pin).

## Key technical choices

- **Deterministic-over-LLM for guardian routing.** Guardian cards are access-control surfaces; reuse was self-reinforcing (each reuse bumped the catch-all's recency and pending-request count, keeping it the top candidate). Non-guardian notifications keep LLM conversation routing.
- **Read-only resolution in deny lanes.** Minting a conversation for every denied stranger message would recreate the "Generating title..." placeholder leak (slice 3 territory). Senders with no prior conversation fall through to the guard's `start_new`, satisfying "fresh appropriately-scoped conversation" as the floor.
- **Source mirroring** stays inside the shared fragment because `pairDeliveryWithConversation` only reuses a conversation whose `source` matches the signal's; a stale/missing pin target falls back to a fresh conversation through the same pairing path.

## Why this is safe

- No gateway or assistant DB schema changes, no migrations — routing is in-process; delivery rows keep using the existing `guardian_request_deliveries.destination_conversation_id` column through the existing recorder.
- The broadcaster's per-dispatch `onConversationCreated` callback fires for **reused** pairings too (broadcaster.ts:507–522), so the "delivery row durable before the client can act" ordering holds for pinned cards.
- Voice behavior is unchanged: first-in-call still gets `start_new` (now via the general guard), later dispatches still follow the call-session affinity hint.
- Fail-open at every seam: invalid pin target → fresh conversation via existing pairing fallback; gateway-degraded reads unchanged.

## Testing

- New `guardian-vellum-destination-pinning.test.ts`: two unrelated guardian requests (access request + tool grant), both steered by a simulated LLM decision to the same catch-all, land in **two different** new conversations, and the catch-all receives no card; a pinned request lands in its originating conversation.
- `notification-decision-strategy.test.ts`: guard generalization coverage (no-hint → `start_new` for both event names, hint → untouched, non-guardian events unaffected).
- Producer assertions: confirmation bridge and tool-grant escalation tests now assert the emitted signal carries `conversationAffinityHint: { vellum: <source conversation> }`.
- All adjacent suites green: pairing, broadcaster, decision-engine, guardian-dispatch, ACL enforcement, admitted-nudge, non-member access request, deep-link, candidate validation. `tsgo --noEmit` clean.

## Deferred (later slices of LUM-2870)

- Denied-inbound persistence + post-approval replay (slice 2 — design first, on the ticket).
- Key-store hygiene: choke-point logging then SSE subscribe side-effect removal (slice 3).
- Denial signal collapse for the duplicate "Access Request Denied" conversations (slice 4 — next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->