### PR TITLE
fix(approvals): emit one lifecycle signal per access-request denial (LUM-2870)

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -374,10 +374,9 @@ External users who are not the guardian can gain access to the assistant through
 **Notification signals:** The flow emits signals at each lifecycle transition via `emitNotificationSignal()`:
 
 - `ingress.access_request` — unknown contact denied, guardian notified
-- `ingress.trusted_contact.guardian_decision` — guardian approved or denied
-- `ingress.trusted_contact.verification_sent` — code created and delivered
+- `ingress.trusted_contact.guardian_decision` — the guardian's verdict (the payload's `decision` field carries approved/denied; exactly one lifecycle signal fires per denial)
+- `ingress.trusted_contact.verification_sent` — code created and delivered (stands in for `guardian_decision` on approve so the pipeline doesn't announce approval before verification)
 - `ingress.trusted_contact.activated` — requester verified, contact active
-- `ingress.trusted_contact.denied` — guardian explicitly denied
 
 **HTTP API (for management):**
 

--- a/assistant/src/__tests__/copy-composer-tc-templates.test.ts
+++ b/assistant/src/__tests__/copy-composer-tc-templates.test.ts
@@ -1,10 +1,9 @@
 /**
  * Tests for the trusted contact lifecycle fallback copy templates.
  *
- * Verifies that `ingress.trusted_contact.guardian_decision` and
- * `ingress.trusted_contact.denied` templates in copy-composer.ts render
- * display names when available and fall back to Slack <@ID> mention format
- * for raw user IDs on the Slack source channel.
+ * Verifies that the `ingress.trusted_contact.guardian_decision` template in
+ * copy-composer.ts renders display names when available and falls back to
+ * Slack <@ID> mention format for raw user IDs on the Slack source channel.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -36,35 +35,6 @@ function buildGuardianDecisionSignal(
     attentionHints: {
       requiresAction: false,
       urgency: "medium",
-      isAsyncBackground: false,
-      visibleInSourceNow: false,
-    },
-  };
-}
-
-function buildDeniedSignal(
-  payloadOverrides: Record<string, unknown> = {},
-  sourceChannel: "slack" | "telegram" | "vellum" = "slack",
-): NotificationSignal {
-  return {
-    signalId: "test-signal-denied",
-    createdAt: Date.now(),
-    sourceChannel,
-    sourceContextId: "test-ctx-2",
-    sourceEventName: "ingress.trusted_contact.denied",
-    contextPayload: {
-      sourceChannel,
-      requesterExternalUserId: "U07CLDQ4TB3",
-      requesterChatId: "D0AQ9C5PPPF",
-      decidedByExternalUserId: "U099H19C0KA",
-      requesterDisplayName: null,
-      decidedByDisplayName: null,
-      decision: "denied",
-      ...payloadOverrides,
-    },
-    attentionHints: {
-      requiresAction: false,
-      urgency: "low",
       isAsyncBackground: false,
       visibleInSourceNow: false,
     },
@@ -250,103 +220,5 @@ describe("guardian_decision fallback copy", () => {
     expect(copy.body).toBe(
       "Someone's access request has been denied by a guardian.",
     );
-  });
-});
-
-// ── denied template ──────────────────────────────────────────────────────────
-
-describe("trusted_contact.denied fallback copy", () => {
-  test("uses display name when present", () => {
-    const signal = buildDeniedSignal({
-      requesterDisplayName: "Alice",
-    });
-    const result = composeFallbackCopy(signal, ["vellum"]);
-    const copy = result.vellum!;
-
-    expect(copy.title).toBe("Trusted Contact Denied");
-    expect(copy.body).toBe(
-      "A trusted contact request from Alice has been denied.",
-    );
-  });
-
-  test("falls back to Slack <@ID> mention format on Slack when display name absent", () => {
-    const signal = buildDeniedSignal({
-      requesterDisplayName: null,
-      requesterExternalUserId: "U07CLDQ4TB3",
-      sourceChannel: "slack",
-    });
-    const result = composeFallbackCopy(signal, ["vellum"]);
-    const copy = result.vellum!;
-
-    expect(copy.body).toBe(
-      "A trusted contact request from <@U07CLDQ4TB3> has been denied.",
-    );
-  });
-
-  test("uses raw user ID without Slack formatting on non-Slack channels", () => {
-    const signal = buildDeniedSignal(
-      {
-        requesterDisplayName: null,
-        requesterExternalUserId: "U07CLDQ4TB3",
-        sourceChannel: "telegram",
-      },
-      "telegram",
-    );
-    const result = composeFallbackCopy(signal, ["vellum"]);
-    const copy = result.vellum!;
-
-    expect(copy.body).toBe(
-      "A trusted contact request from U07CLDQ4TB3 has been denied.",
-    );
-    expect(copy.body).not.toContain("<@");
-  });
-
-  test("falls back to 'Someone' when requester identity is absent", () => {
-    const signal = buildDeniedSignal({
-      requesterDisplayName: null,
-      requesterExternalUserId: null,
-    });
-    const result = composeFallbackCopy(signal, ["vellum"]);
-    const copy = result.vellum!;
-
-    expect(copy.body).toBe(
-      "A trusted contact request from Someone has been denied.",
-    );
-  });
-
-  test("does not expose raw conversation IDs (requesterChatId) in output", () => {
-    const signal = buildDeniedSignal({
-      requesterDisplayName: null,
-      requesterExternalUserId: "U07CLDQ4TB3",
-      requesterChatId: "D0AQ9C5PPPF",
-    });
-    const result = composeFallbackCopy(signal, ["vellum"]);
-    const copy = result.vellum!;
-
-    expect(copy.body).not.toContain("D0AQ9C5PPPF");
-  });
-
-  test("sanitizes control characters from display names", () => {
-    const signal = buildDeniedSignal({
-      requesterDisplayName: "Alice\x00\x07\nEvil",
-    });
-    const result = composeFallbackCopy(signal, ["vellum"]);
-    const copy = result.vellum!;
-
-    expect(copy.body).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
-    expect(copy.body).toContain("Alice");
-  });
-
-  test("clamps excessively long display names", () => {
-    const longName = "A".repeat(200);
-    const signal = buildDeniedSignal({
-      requesterDisplayName: longName,
-    });
-    const result = composeFallbackCopy(signal, ["vellum"]);
-    const copy = result.vellum!;
-
-    // sanitizeIdentityField clamps to 120 chars + ellipsis
-    expect(copy.body.length).toBeLessThan(longName.length);
-    expect(copy.body).toContain("…");
   });
 });

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -206,8 +206,9 @@ describe("trusted contact lifecycle notification signals", () => {
 
     await handleChannelInbound(guardianReq, undefined, TEST_BEARER_TOKEN);
 
-    // Should emit guardian_decision and denied signals
-
+    // A denial emits exactly one lifecycle signal — guardian_decision with
+    // decision: "denied". A second event for the same verdict would escape
+    // dedupe (distinct keys) and duplicate the guardian-facing notification.
     const guardianDecisionSignals = emitSignalCalls.filter(
       (c) => c.sourceEventName === "ingress.trusted_contact.guardian_decision",
     );
@@ -216,7 +217,7 @@ describe("trusted contact lifecycle notification signals", () => {
     );
 
     expect(guardianDecisionSignals.length).toBe(1);
-    expect(deniedSignals.length).toBe(1);
+    expect(deniedSignals.length).toBe(0);
 
     // Verify guardian_decision payload
     const gdPayload = guardianDecisionSignals[0].contextPayload as Record<
@@ -229,18 +230,9 @@ describe("trusted contact lifecycle notification signals", () => {
     expect(gdPayload.requesterDisplayName).toBe("Alice Requester");
     expect(gdPayload.decidedByDisplayName).toBe("Guardian Bob");
 
-    // Verify denied payload
-    const dPayload = deniedSignals[0].contextPayload as Record<string, unknown>;
-    expect(dPayload.decision).toBe("denied");
-    expect(dPayload.requesterExternalUserId).toBe("requester-user-456");
-    expect(dPayload.requesterDisplayName).toBe("Alice Requester");
-    expect(dPayload.decidedByDisplayName).toBe("Guardian Bob");
-
-    // Verify deduplication keys are distinct
     expect(guardianDecisionSignals[0].dedupeKey).toContain(
       "trusted-contact:guardian-decision:",
     );
-    expect(deniedSignals[0].dedupeKey).toContain("trusted-contact:denied:");
   });
 
   test("guardian approve emits guardian_decision and verification_sent signals with display names", async () => {
@@ -381,8 +373,11 @@ describe("trusted contact lifecycle notification signals", () => {
         typeof c.dedupeKey === "string" &&
         (c.dedupeKey as string).includes(approval.id),
     );
-    // guardian_decision and denied — both keyed on approval.id
-    expect(signals.length).toBe(2);
+    // Exactly one lifecycle signal per denial, keyed on the request id.
+    expect(signals.length).toBe(1);
+    expect(signals[0].sourceEventName).toBe(
+      "ingress.trusted_contact.guardian_decision",
+    );
   });
 
   test("display name fields fall back to null when contacts have no display name", async () => {
@@ -451,12 +446,8 @@ describe("trusted contact lifecycle notification signals", () => {
     const guardianDecisionSignals = emitSignalCalls.filter(
       (c) => c.sourceEventName === "ingress.trusted_contact.guardian_decision",
     );
-    const deniedSignals = emitSignalCalls.filter(
-      (c) => c.sourceEventName === "ingress.trusted_contact.denied",
-    );
 
     expect(guardianDecisionSignals.length).toBe(1);
-    expect(deniedSignals.length).toBe(1);
 
     // Verify display names fall back to null/empty when contacts have no
     // display name set.
@@ -469,10 +460,6 @@ describe("trusted contact lifecycle notification signals", () => {
     // The signal enrichment resolves displayName from the contact record,
     // so decidedByDisplayName will be "" (empty string) rather than null.
     expect(gdPayload.decidedByDisplayName).toBe("");
-
-    const dPayload = deniedSignals[0].contextPayload as Record<string, unknown>;
-    expect(dPayload.requesterDisplayName).toBeNull();
-    expect(dPayload.decidedByDisplayName).toBe("");
   });
 });
 

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -760,9 +760,9 @@ async function deliverRequesterNotice(params: {
 }
 
 /**
- * Emit the guardian-facing denial lifecycle signals and, unless suppressed,
+ * Emit the guardian-facing denial lifecycle signal and, unless suppressed,
  * deliver the "declined" notice to the requester. Both the `leave_unverified`
- * and `block` outcomes call this for the lifecycle signals, but the requester
+ * and `block` outcomes call this for the lifecycle signal, but the requester
  * notice is delivered only for `block` (in denied mode) — `leave_unverified`
  * always passes `suppressRequesterNotice: true`, staying a silent park at
  * `unverified`. The notice text is a plain decline that does not reveal whether
@@ -814,6 +814,12 @@ async function notifyRequesterOfDenial(params: {
     });
   }
 
+  // Exactly one signal per denial: the payload's `decision: "denied"`
+  // carries the verdict, and the pipeline can only dedupe within a single
+  // event stream — a second event name would materialize a second
+  // conversation for the same decision. The approve path holds the same
+  // one-signal invariant via `verification_sent` standing in for
+  // `guardian_decision`.
   if (channelDeliveryContext) {
     void emitNotificationSignal({
       sourceEventName: "ingress.trusted_contact.guardian_decision",
@@ -827,20 +833,6 @@ async function notifyRequesterOfDenial(params: {
       },
       contextPayload: deniedPayload,
       dedupeKey: `trusted-contact:guardian-decision:${requestId}`,
-    });
-
-    void emitNotificationSignal({
-      sourceEventName: "ingress.trusted_contact.denied",
-      sourceChannel: channel,
-      sourceContextId: conversationId ?? "",
-      attentionHints: {
-        requiresAction: false,
-        urgency: "low",
-        isAsyncBackground: false,
-        visibleInSourceNow: false,
-      },
-      contextPayload: deniedPayload,
-      dedupeKey: `trusted-contact:denied:${requestId}`,
     });
   }
 }

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -222,21 +222,6 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     };
   },
 
-  "ingress.trusted_contact.denied": (payload) => {
-    const parsed = parseTrustedContactDecisionPayload(payload);
-    const requesterLabel = formatTrustedContactActor(
-      parsed?.requesterDisplayName,
-      parsed?.requesterExternalUserId,
-      parsed?.sourceChannel,
-      "Someone",
-    );
-
-    return {
-      title: "Trusted Contact Denied",
-      body: `A trusted contact request from ${requesterLabel} has been denied.`,
-    };
-  },
-
   "watcher.notification": (payload) => ({
     title: str(payload.title, "Watcher Notification"),
     body: str(payload.body, "A watcher event occurred"),

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -84,10 +84,6 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     description: "Guardian decided on trusted contact request",
   },
   {
-    id: "ingress.trusted_contact.denied",
-    description: "Trusted contact request denied",
-  },
-  {
     id: "ingress.trusted_contact.verification_sent",
     description: "Verification sent to trusted contact",
   },

--- a/assistant/src/notifications/trusted-contact-payloads.ts
+++ b/assistant/src/notifications/trusted-contact-payloads.ts
@@ -31,10 +31,9 @@ const TrustedContactIdentitySchema = z.object({
 });
 
 /**
- * Payload for `ingress.trusted_contact.guardian_decision` and
- * `ingress.trusted_contact.denied` — the guardian's verdict on an access
- * request. The deny path emits both events from one object; the approve path
- * emits `guardian_decision` with `decision: "approved"` (identical shape).
+ * Payload for `ingress.trusted_contact.guardian_decision` — the guardian's
+ * verdict on an access request. `decision` distinguishes the deny path from
+ * an approve (identical shape).
  */
 export const TrustedContactDecisionPayloadSchema =
   TrustedContactIdentitySchema.extend({


### PR DESCRIPTION
## TL;DR

One guardian denial fired **two** notification signals from the same payload — `ingress.trusted_contact.guardian_decision` and `ingress.trusted_contact.denied` — with distinct dedupe keys, so the pipeline couldn't collapse them: each denial produced two near-identical background conversations ~1s apart (two independent LLM copy round-trips over the same payload). Observed live on Jul 27: two "Access Request Denied" conversations created at 14:11:49Z and 14:11:50Z for a single decision.

This PR keeps `guardian_decision` (whose payload carries `decision: "denied"` and whose copy names both parties) and removes the redundant `denied` event entirely.

Part of LUM-2870 (slice 4 of 4). Diagnosis: https://linear.app/vellum/issue/LUM-2870

## What changes for the user

| Before | After |
| --- | --- |
| Denying an access request spawns two near-duplicate "…denied" background conversations | One denial → one lifecycle notification → at most one conversation |
| Guardian sees "Trusted Contact Decision" *and* "Trusted Contact Denied" for the same click | One "Trusted Contact Decision" notice |

## Implementation

- `guardian-request-resolvers.ts` — `notifyRequesterOfDenial` emits only the `guardian_decision` signal; a comment records the one-signal-per-decision invariant (mirroring the approve path, where `verification_sent` stands in for `guardian_decision`).
- Dead code removed with the emission: the `ingress.trusted_contact.denied` copy-composer template and its signal-registry entry (nothing else in assistant/gateway/clients references the event).
- The requester-facing "declined" notice is untouched — it's a direct channel reply, not a signal.

## Why this is safe

- Both signals were guardian-facing and carried the identical `TrustedContactDecisionPayload`; the surviving one has the richer copy ("X's access request has been denied by Y").
- No DB schema or migration changes. Persisted historical events with the removed name are unaffected — the composer map is consulted at decision time only, never for re-rendering stored events.
- `leave_unverified` vs `block` behavior (requester-notice suppression) is unchanged; only the duplicate emission is gone.

## Testing

- `trusted-contact-lifecycle-notifications.test.ts` — deny paths now assert exactly one `guardian_decision` signal and zero `denied` signals; the dedupe-key test asserts one request-keyed signal per denial.
- `copy-composer-tc-templates.test.ts` — `denied`-template tests removed; every generic property they covered (sanitization, clamping, chat-id non-exposure, Someone/guardian fallbacks) is already asserted against the surviving `guardian_decision` template.
- Adjacent suites green (introduction-card resolver, non-member access request, copy-composer, signal registry); `tsgo --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->