### PR TITLE
feat(persistence): attribute conversation-key materializations in the log (LUM-2870)

### DIFF
--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -12,10 +12,13 @@ import { v4 as uuid } from "uuid";
 
 import { cleanupBootstrapFiles } from "../prompts/bootstrap-cleanup.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
+import { getLogger } from "../util/logger.js";
 import { initConversationDir } from "./conversation-disk-view.js";
 import { GENERATING_TITLE } from "./conversation-title-service.js";
 import { getDb } from "./db-connection.js";
 import { conversationKeys, conversations } from "./schema/index.js";
+
+const log = getLogger("conversation-key-store");
 
 /** Set after the first conversation is created so BOOTSTRAP.md is deleted on the second. */
 let firstConversationSeen = false;
@@ -267,6 +270,22 @@ export function getOrCreateConversation(
 
   if (result.created) {
     initConversationDir({ ...result.conversation, originChannel: null });
+    // Attribution for every key-materialized conversation: this is the single
+    // choke point through which all unseen-key creations flow (SSE subscribe,
+    // channel inbound, launchers, voice, signals), and a runaway caller here
+    // manifests as bursts of empty placeholder-titled conversations
+    // (LUM-2870). The caller frames make those attributable from the log
+    // alone; creations are rare enough that the stack capture is free.
+    log.info(
+      {
+        conversationKey,
+        conversationId: result.conversationId,
+        conversationType,
+        hasCustomTitle: Boolean(opts?.title?.trim()),
+        caller: captureCallerFrames(),
+      },
+      "Materialized conversation for unseen conversation key",
+    );
   }
 
   return {
@@ -274,4 +293,21 @@ export function getOrCreateConversation(
     conversationType: result.conversationType,
     created: result.created,
   };
+}
+
+/**
+ * Compact caller summary for creation attribution: the first few stack
+ * frames above this module, joined into one log-friendly line.
+ */
+function captureCallerFrames(): string {
+  const stack = new Error().stack?.split("\n") ?? [];
+  return stack
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line.startsWith("at ") && !line.includes("conversation-key-store"),
+    )
+    .slice(0, 4)
+    .join(" | ");
 }

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -271,14 +271,15 @@ export function getOrCreateConversation(
   if (result.created) {
     initConversationDir({ ...result.conversation, originChannel: null });
     // Attribution for every key-materialized conversation: this is the single
-    // choke point through which all unseen-key creations flow (SSE subscribe,
-    // channel inbound, launchers, voice, signals), and a runaway caller here
-    // manifests as bursts of empty placeholder-titled conversations
-    // (LUM-2870). The caller frames make those attributable from the log
-    // alone; creations are rare enough that the stack capture is free.
+    // choke point through which all unseen-key creations flow, and the key
+    // shape + caller frames identify the entry point from the log alone. The
+    // raw key is never logged — channel-backed keys embed external chat ids
+    // (phone numbers, Slack/Telegram ids), and assistant logs travel in
+    // support bundles. Emitted only on the creation branch, never on hot
+    // read/write paths.
     log.info(
       {
-        conversationKey,
+        conversationKeyShape: classifyConversationKey(conversationKey),
         conversationId: result.conversationId,
         conversationType,
         hasCustomTitle: Boolean(opts?.title?.trim()),
@@ -293,6 +294,32 @@ export function getOrCreateConversation(
     conversationType: result.conversationType,
     created: result.created,
   };
+}
+
+const UUID_SHAPE_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * PII-free shape label for a conversation key. Channel-backed keys embed
+ * external chat/user ids, so only the structural prefix is kept (e.g.
+ * `asst:<id>:slack:<chat>:thread:<ts>` → "asst-scoped:slack:threaded");
+ * free-form keys collapse to a coarse class.
+ */
+function classifyConversationKey(conversationKey: string): string {
+  if (conversationKey.startsWith("asst:")) {
+    const parts = conversationKey.split(":");
+    const channel = parts[2] ?? "unknown";
+    const threaded = parts.includes("thread") ? ":threaded" : "";
+    return `asst-scoped:${channel}${threaded}`;
+  }
+  const prefixed = conversationKey.match(/^([a-z-]+)[:-]/i);
+  if (prefixed) {
+    return `prefixed:${prefixed[1].toLowerCase()}`;
+  }
+  if (UUID_SHAPE_RE.test(conversationKey)) {
+    return "uuid";
+  }
+  return "opaque";
 }
 
 /**


### PR DESCRIPTION
## TL;DR

One log line (plus a caller-frame helper) at the single choke point where every unseen conversation key mints a conversation — `conversation-key-store.getOrCreateConversation`. This is slice 3, step 1 of LUM-2870: the phantom-conversation burst (8 empty `"Generating title..."` conversations in ~100ms during an approval decision) and the standing leak of 42 such conversations are all born here, but creation was previously silent, so the burst could not be attributed to its entry point (SSE subscribe-time materialization vs. empty-send key mint vs. channel inbound vs. launcher).

Step 2 — removing the `GET /v1/events` subscribe-time row materialization — deliberately waits until this log line has named the culprit on the next occurrence.

Part of LUM-2870. Diagnosis: https://linear.app/vellum/issue/LUM-2870

## What changes for the user

| Before | After |
| --- | --- |
| Empty phantom conversations appear with no trace of what created them | Every key-materialized conversation logs its key, id, type, and the first caller frames |
| Nothing user-visible otherwise | Nothing user-visible otherwise — log-only change |

## Why this is safe

- Log-only: no behavior, routing, schema, or migration changes.
- The stack capture runs only on the `created` branch — conversation creations are rare (never on message-send or read hot paths).
- Caller frames are filtered to skip this module's own frames and capped at 4, joined into one line.

## Testing

- `conversation-key-store-disk-view.test.ts` green; `tsgo --noEmit` clean; prettier/eslint clean (the one `curly` warning in the file predates this diff, on an untouched line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->