### PR TITLE
fix(web): slim the voice surfaces so the header title survives (JARVIS-1363)

### DIFF
--- a/clients/web/src/domains/chat/chat-conversation-header.tsx
+++ b/clients/web/src/domains/chat/chat-conversation-header.tsx
@@ -50,9 +50,9 @@ export function ChatConversationHeader({
     // centre slot is a `flex-1 min-w-0 justify-center` box, so when the right
     // cluster (voice pill, assets pill) claims the row this item shrinks
     // toward zero. Without them the span refuses to shrink and overflows its
-    // box in *both* directions — `justify-center` splits the overflow — which
-    // painted "New Chat" underneath the hamburger (JARVIS-1363). The titled
-    // branch below already truncates for the same reason.
+    // box in *both* directions — `justify-center` splits the overflow evenly —
+    // painting the title underneath the surrounding chrome. The titled branch
+    // below truncates for the same reason.
     return (
       <span className="min-w-0 truncate text-sm font-medium text-[var(--content-default)]">
         New Chat

--- a/clients/web/src/domains/chat/chat-conversation-header.tsx
+++ b/clients/web/src/domains/chat/chat-conversation-header.tsx
@@ -46,8 +46,15 @@ export function ChatConversationHeader({
 }: ChatConversationHeaderProps) {
   if (!activeConversation) {
     if (!assistantId) {return null;}
+    // `min-w-0` + `truncate` are load-bearing, not cosmetic: the header's
+    // centre slot is a `flex-1 min-w-0 justify-center` box, so when the right
+    // cluster (voice pill, assets pill) claims the row this item shrinks
+    // toward zero. Without them the span refuses to shrink and overflows its
+    // box in *both* directions — `justify-center` splits the overflow — which
+    // painted "New Chat" underneath the hamburger (JARVIS-1363). The titled
+    // branch below already truncates for the same reason.
     return (
-      <span className="text-sm font-medium text-[var(--content-default)]">
+      <span className="min-w-0 truncate text-sm font-medium text-[var(--content-default)]">
         New Chat
       </span>
     );

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for `ChatLayoutHeader`'s right-cluster composition.
+ *
+ * The header is presentational, so tests drive it through props. Focus is the
+ * `collapseRightCluster` arm: while the voice-session pill occupies the row
+ * the remaining controls fold behind a ⋯ popover, the leading slot stays
+ * outside it, and the popover opens to reach what it swallowed.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+let mockIsElectron = false;
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => mockIsElectron,
+}));
+
+const toggleCommandPaletteSpy = mock(() => {});
+mock.module("@/stores/command-palette-store", () => ({
+  useCommandPaletteStore: {
+    use: { toggle: () => toggleCommandPaletteSpy },
+  },
+}));
+
+const setInlineTitleBarActiveSpy = mock((_active: boolean) => {});
+mock.module("@/stores/title-bar-store", () => ({
+  useTitleBarStore: {
+    use: { setInlineTitleBarActive: () => setInlineTitleBarActiveSpy },
+  },
+}));
+
+// Imported after the mocks so the header picks up the mocked modules.
+const { ChatLayoutHeader } = await import("@/domains/chat/chat-layout-header");
+
+beforeEach(() => {
+  mockIsElectron = false;
+  toggleCommandPaletteSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderHeader(props: Partial<
+  React.ComponentProps<typeof ChatLayoutHeader>
+> = {}) {
+  return render(
+    <ChatLayoutHeader
+      isMobile
+      drawerOpen={false}
+      collapsed={false}
+      toggleSidebar={() => {}}
+      {...props}
+    />,
+  );
+}
+
+const overflowTrigger = () =>
+  screen.queryByRole("button", { name: "More controls" });
+
+describe("ChatLayoutHeader — right cluster", () => {
+  test("renders the controls inline when not collapsed", () => {
+    renderHeader({
+      topBarRightLeading: <div data-testid="voice-pill" />,
+      topBarRightSlot: <button type="button">Notifications</button>,
+    });
+    expect(screen.getByTestId("voice-pill")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Search (Ctrl+K)" })).toBeTruthy();
+    expect(screen.getByText("Notifications")).toBeTruthy();
+    expect(overflowTrigger()).toBeNull();
+  });
+
+  test("collapsed: folds search and the slot behind ⋯, keeping the leading slot out", () => {
+    renderHeader({
+      collapseRightCluster: true,
+      topBarRightLeading: <div data-testid="voice-pill" />,
+      topBarRightSlot: <button type="button">Notifications</button>,
+    });
+    // The live-session indicator stays in the chrome — it must not be
+    // something the user opens a menu to discover.
+    expect(screen.getByTestId("voice-pill")).toBeTruthy();
+    expect(overflowTrigger()).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Search (Ctrl+K)" }),
+    ).toBeNull();
+    expect(screen.queryByText("Notifications")).toBeNull();
+  });
+
+  test("the ⋯ trigger opens, revealing the collapsed controls", () => {
+    // The collapse hides real affordances, so the trigger reaching them is
+    // the load-bearing part.
+    renderHeader({
+      collapseRightCluster: true,
+      topBarRightLeading: <div data-testid="voice-pill" />,
+      topBarRightSlot: <button type="button">Notifications</button>,
+    });
+
+    fireEvent.click(overflowTrigger()!);
+
+    expect(screen.getByRole("button", { name: "Search (Ctrl+K)" })).toBeTruthy();
+    expect(screen.getByText("Notifications")).toBeTruthy();
+  });
+
+  test("search inside the popover still reaches the command palette", () => {
+    renderHeader({ collapseRightCluster: true });
+    fireEvent.click(overflowTrigger()!);
+    fireEvent.click(screen.getByRole("button", { name: "Search (Ctrl+K)" }));
+    expect(toggleCommandPaletteSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -1,8 +1,9 @@
-import { Button } from "@vellumai/design-library";
+import { Button, Popover } from "@vellumai/design-library";
 import {
     ChevronLeft,
     ChevronRight,
     Menu as MenuIcon,
+    MoreHorizontal,
     PanelLeft,
     Search,
 } from "lucide-react";
@@ -40,6 +41,25 @@ export interface ChatLayoutHeaderProps {
    *  them visible for context but pulls them out of the attention field. */
   controlsDimmed?: boolean;
   topBarCenter?: ReactNode;
+  /**
+   * Leads the right cluster, ahead of the mobile search button. The
+   * voice-session pill sits here so a live session reads as the leftmost
+   * thing in the cluster rather than buried between search and the
+   * notification bell.
+   */
+  topBarRightLeading?: ReactNode;
+  /**
+   * Collapse the rest of the right cluster (search, `topBarRightSlot`) behind
+   * a single ⋯ popover, leaving `topBarRightLeading` beside it. Set while the
+   * voice-session pill occupies the row: three icon buttons squeezed the
+   * centre title on phone widths, and two is the budget that keeps a
+   * conversation title readable (JARVIS-1363).
+   *
+   * The leading slot deliberately stays out of the popover — a live
+   * microphone must keep an indicator visible in the chrome, not one the user
+   * has to open a menu to discover.
+   */
+  collapseRightCluster?: boolean;
   topBarRightSlot?: ReactNode;
   canGoBack?: boolean;
   canGoForward?: boolean;
@@ -57,6 +77,8 @@ export function ChatLayoutHeader({
   centerHidden = false,
   controlsDimmed = false,
   topBarCenter,
+  topBarRightLeading,
+  collapseRightCluster = false,
   topBarRightSlot,
   canGoBack,
   canGoForward,
@@ -75,6 +97,18 @@ export function ChatLayoutHeader({
   // context, would out-stack and swallow clicks on the header's buttons.
   // Gated to Electron so the web/iOS layouts are byte-for-byte unchanged.
   const electron = isElectron();
+
+  // Mobile-only: on desktop the same affordance lives in the left cluster.
+  // Hoisted so the collapsed and expanded arms render the identical node.
+  const searchButton = isMobile ? (
+    <Button
+      variant="ghost"
+      iconOnly={<Search />}
+      aria-label="Search (Ctrl+K)"
+      tooltip="Search (Ctrl+K)"
+      onClick={handleSearchClick}
+    />
+  ) : null;
 
   const setInlineTitleBarActive =
     useTitleBarStore.use.setInlineTitleBarActive();
@@ -104,7 +138,7 @@ export function ChatLayoutHeader({
         // `inert` (not just opacity/pointer-events) so the faded-out
         // controls also leave the tab order and accessibility tree.
         inert={controlsHidden || undefined}
-        className={`flex items-center gap-2 transition-[min-width,opacity] duration-300 ease-in-out max-md:min-w-0 max-md:flex-1${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
+        className={`flex items-center gap-2 transition-[min-width,opacity] duration-300 ease-in-out max-md:shrink-0${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
         style={{
           // `minWidth` reserves the sidebar column on desktop only. The Electron
           // inset clears the inline traffic lights regardless of `isMobile` —
@@ -172,20 +206,44 @@ export function ChatLayoutHeader({
         {topBarCenter}
       </div>
 
+      {/* `shrink-0`, not `flex-1`: these are fixed-size controls. Letting the
+          cluster flex meant a wide occupant (the voice-session pill) either
+          squashed the buttons into each other or held the row at its
+          intrinsic width and pushed the trailing ones off-screen. The centre
+          slot is the only zone that gives (JARVIS-1363). */}
       <div
         inert={controlsHidden || undefined}
-        className={`flex items-center gap-2 max-md:flex-1 max-md:justify-end transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
+        className={`flex shrink-0 items-center gap-2 max-md:justify-end transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
       >
-        {isMobile ? (
-          <Button
-            variant="ghost"
-            iconOnly={<Search />}
-            aria-label="Search (Ctrl+K)"
-            tooltip="Search (Ctrl+K)"
-            onClick={handleSearchClick}
-          />
-        ) : null}
-        {topBarRightSlot}
+        {topBarRightLeading}
+        {collapseRightCluster ? (
+          // The collapsed controls are relocated, not rebuilt: they render as
+          // the same nodes inside the popover, so contributors to
+          // `topBarRightSlot` need no menu-item form of themselves.
+          <Popover.Root>
+            <Popover.Trigger asChild>
+              <Button
+                variant="ghost"
+                iconOnly={<MoreHorizontal />}
+                aria-label="More controls"
+                tooltip="More controls"
+              />
+            </Popover.Trigger>
+            <Popover.Content
+              side="bottom"
+              align="end"
+              className="flex w-auto items-center gap-1 p-1"
+            >
+              {searchButton}
+              {topBarRightSlot}
+            </Popover.Content>
+          </Popover.Root>
+        ) : (
+          <>
+            {searchButton}
+            {topBarRightSlot}
+          </>
+        )}
       </div>
     </header>
   );

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -51,9 +51,8 @@ export interface ChatLayoutHeaderProps {
   /**
    * Collapse the rest of the right cluster (search, `topBarRightSlot`) behind
    * a single ⋯ popover, leaving `topBarRightLeading` beside it. Set while the
-   * voice-session pill occupies the row: three icon buttons squeezed the
-   * centre title on phone widths, and two is the budget that keeps a
-   * conversation title readable (JARVIS-1363).
+   * voice-session pill occupies the row: two icon buttons is the budget that
+   * keeps a conversation title readable at phone widths.
    *
    * The leading slot deliberately stays out of the popover — a live
    * microphone must keep an indicator visible in the chrome, not one the user
@@ -206,11 +205,11 @@ export function ChatLayoutHeader({
         {topBarCenter}
       </div>
 
-      {/* `shrink-0`, not `flex-1`: these are fixed-size controls. Letting the
-          cluster flex meant a wide occupant (the voice-session pill) either
-          squashed the buttons into each other or held the row at its
-          intrinsic width and pushed the trailing ones off-screen. The centre
-          slot is the only zone that gives (JARVIS-1363). */}
+      {/* `shrink-0`, not `flex-1`: these are fixed-size controls, and a wide
+          occupant (the voice-session pill) would otherwise either squash them
+          into each other or hold the row at its intrinsic width and push the
+          trailing ones off-screen. The centre slot is the only zone that
+          gives. */}
       <div
         inert={controlsHidden || undefined}
         className={`flex shrink-0 items-center gap-2 max-md:justify-end transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
@@ -222,11 +221,13 @@ export function ChatLayoutHeader({
           // `topBarRightSlot` need no menu-item form of themselves.
           <Popover.Root>
             <Popover.Trigger asChild>
+              {/* No `tooltip`: the collapse is mobile-only, and touch has no
+                  hover to show one on. The `aria-label` is what names the
+                  control for assistive tech. */}
               <Button
                 variant="ghost"
                 iconOnly={<MoreHorizontal />}
                 aria-label="More controls"
-                tooltip="More controls"
               />
             </Popover.Trigger>
             <Popover.Content

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -87,7 +87,10 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { ResearchResultsOverlay } from "@/domains/chat/onboarding-research/research-results-overlay";
 import { OnboardingCheckinOverlay } from "@/components/onboarding-checkin-overlay";
 import { OnboardingAvatarApplier } from "@/components/onboarding-avatar-applier";
-import { VoiceSessionPillHost } from "@/domains/chat/components/voice-session-pill-host";
+import {
+  useVoiceSessionPillPresence,
+  VoiceSessionPillHost,
+} from "@/domains/chat/components/voice-session-pill-host";
 import { useLiveVoiceSessionController } from "@/domains/chat/voice/live-voice/use-live-voice-session-controller";
 import { useSeedLiveVoiceSnapshot } from "@/domains/chat/voice/live-voice/use-seed-live-voice-snapshot";
 import { VoiceRoom } from "@/domains/chat/voice/voice-room/voice-room";
@@ -530,6 +533,13 @@ export function ChatLayout({
       isAssistantActive,
     ) ?? null;
 
+  // Drives the header's right-cluster collapse: while the voice pill occupies
+  // the row, the remaining controls fold behind a ⋯ so the centre title keeps
+  // a readable width. Same hook the host itself uses, so the two agree.
+  const { visible: voicePillVisible, showFailure: voicePillFailure } =
+    useVoiceSessionPillPresence();
+  const voicePillPresent = voicePillVisible || voicePillFailure;
+
   const topBarCenter =
     topBarCenterSlot ??
     (headerSupplements ? (
@@ -837,11 +847,16 @@ export function ChatLayout({
           // per-route hooks that unmount on navigation, exactly when the pill
           // must persist. The host renders null when no session is active (or
           // while viewing the owning thread's composer), so the header is
-          // unaffected otherwise.
+          // unaffected otherwise. It leads the cluster (ahead of the mobile
+          // search button) rather than sitting between search and the
+          // notification bell.
+          topBarRightLeading={<VoiceSessionPillHost />}
+          // Only phones need the collapse — desktop headers have the width for
+          // the full cluster, and the pill renders its expanded form there.
+          collapseRightCluster={isMobile && voicePillPresent}
           topBarRightSlot={
             <>
               {topBarRightSlot}
-              <VoiceSessionPillHost />
               {topBarAccessory}
             </>
           }

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1217,18 +1217,33 @@ describe("ChatComposer — live-voice integration", () => {
     expect(liveControls.stop).toHaveBeenCalledTimes(1);
   });
 
-  test("voice bar ↑ manually releases the turn while listening", () => {
+  test("voice bar offers no manual send — turns release themselves", () => {
     // GIVEN a listening session owned by this composer
     useTurnStore.setState(INITIAL_TURN_STATE);
     seedLiveVoiceSession("listening");
 
-    // WHEN the user clicks send-now
-    const { getByLabelText } = renderVoiceComposer();
-    fireEvent.click(getByLabelText("Send now"));
+    // WHEN the bar renders
+    const { queryByLabelText } = renderVoiceComposer();
 
-    // THEN the turn is released through the store-registered controls
-    expect(liveControls.release).toHaveBeenCalledTimes(1);
-    expect(liveControls.stop).not.toHaveBeenCalled();
+    // THEN there is no send-now control: server VAD (hands-free) and
+    // auto-release (manual fallback) both end the turn without the user, so
+    // the ↑ advertised an action they never need (JARVIS-1363).
+    expect(queryByLabelText("Send now")).toBeNull();
+    expect(liveControls.release).not.toHaveBeenCalled();
+  });
+
+  test("voice session hides the textarea and its placeholder", () => {
+    // GIVEN a listening session owned by this composer
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    seedLiveVoiceSession("listening");
+
+    // WHEN the bar renders
+    const { container } = renderVoiceComposer();
+
+    // THEN the textarea row is collapsed: it is disabled for the session's
+    // duration, so its placeholder invited an interaction that cannot happen.
+    const textarea = container.querySelector("textarea");
+    expect(textarea?.closest("div.hidden")).not.toBeNull();
   });
 
   test("dictation active hides the live-voice button (reverse mutual exclusion)", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1226,8 +1226,7 @@ describe("ChatComposer — live-voice integration", () => {
     const { queryByLabelText } = renderVoiceComposer();
 
     // THEN there is no send-now control: server VAD (hands-free) and
-    // auto-release (manual fallback) both end the turn without the user, so
-    // the ↑ advertised an action they never need (JARVIS-1363).
+    // auto-release (manual fallback) both end the turn without the user.
     expect(queryByLabelText("Send now")).toBeNull();
     expect(liveControls.release).not.toHaveBeenCalled();
   });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1402,10 +1402,24 @@ describe("ChatComposer — live-voice integration", () => {
 // ---------------------------------------------------------------------------
 // Live-voice transcript in the composer text area (Light 55)
 //
-// While speech streams, the disabled textarea is visually hidden and the
-// display-only `VoiceLiveTranscript` renders in its grid cell; with no
-// transcript yet the textarea (and its placeholder) stays visible.
+// An owned live-voice session collapses the textarea row for its whole
+// duration — the textarea is disabled throughout, so its placeholder would
+// invite an interaction that cannot happen. When the show-your-words pref is
+// on and speech is streaming, the display-only `VoiceLiveTranscript` takes
+// that same grid cell and the row stays mounted to carry it.
+//
+// The textarea's own `className` is not the signal: the row wrapping it is
+// what carries `hidden`, so assertions go through `textareaRowHidden`.
 // ---------------------------------------------------------------------------
+
+/** Whether the grid row wrapping the textarea is collapsed. */
+function textareaRowHidden(container: HTMLElement): boolean {
+  const textarea = container.querySelector("textarea");
+  if (!textarea) {
+    throw new Error("no textarea rendered");
+  }
+  return textarea.closest("div.hidden") !== null;
+}
 
 describe("ChatComposer — live-voice transcript area", () => {
   test("streaming speech hides the textarea and renders the transcript in its place", () => {
@@ -1452,11 +1466,12 @@ describe("ChatComposer — live-voice transcript area", () => {
     // WHEN the composer renders
     const { container, queryByLabelText } = renderVoiceComposer();
 
-    // THEN no transcript region mounts and the (still-uneditable) textarea
-    // stays visible so its placeholder shows through instead
+    // THEN no transcript region mounts, and with nothing to put in that cell
+    // the whole row collapses — the disabled textarea's placeholder must not
+    // show through for the session's duration
     expect(queryByLabelText("Voice transcript")).toBeNull();
+    expect(textareaRowHidden(container)).toBe(true);
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
-    expect(textarea.className).not.toContain("hidden");
     expect(textarea.disabled).toBe(true);
   });
 
@@ -1470,26 +1485,27 @@ describe("ChatComposer — live-voice transcript area", () => {
     // WHEN the composer renders
     const { container, queryByLabelText } = renderVoiceComposer();
 
-    // THEN no transcript region mounts and the textarea stays editable —
-    // thread A's speech must not leak into thread B's input
+    // THEN no transcript region mounts and this composer keeps a normal,
+    // editable input — thread A's speech must not leak into thread B's input,
+    // and thread B's own row is not a session surface
     expect(queryByLabelText("Voice transcript")).toBeNull();
+    expect(textareaRowHidden(container)).toBe(false);
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
-    expect(textarea.className).not.toContain("hidden");
     expect(textarea.disabled).toBe(false);
   });
 
-  test("empty transcript keeps the textarea (and its placeholder) visible", () => {
-    // GIVEN an active owned session with no speech yet (Light 53 baseline)
+  test("empty transcript collapses the row rather than showing a dead placeholder", () => {
+    // GIVEN an active owned session with no speech yet
     useTurnStore.setState(INITIAL_TURN_STATE);
     seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { container, queryByLabelText } = renderVoiceComposer();
 
-    // THEN nothing replaces the textarea — its placeholder shows through
+    // THEN there is nothing to occupy the cell, so the row collapses and the
+    // voice bar stands alone
     expect(queryByLabelText("Voice transcript")).toBeNull();
-    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
-    expect(textarea.className).not.toContain("hidden");
+    expect(textareaRowHidden(container)).toBe(true);
   });
 
   test("textarea is restored after the session ends, even with a leftover final transcript", () => {
@@ -1500,10 +1516,11 @@ describe("ChatComposer — live-voice transcript area", () => {
     // WHEN the composer renders
     const { container, queryByLabelText } = renderVoiceComposer();
 
-    // THEN the composer behaves normally: no transcript region, editable textarea
+    // THEN the composer behaves normally: no transcript region, and the row
+    // is back with an editable textarea
     expect(queryByLabelText("Voice transcript")).toBeNull();
+    expect(textareaRowHidden(container)).toBe(false);
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
-    expect(textarea.className).not.toContain("hidden");
     expect(textarea.disabled).toBe(false);
   });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -40,7 +40,6 @@ import {
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
-  releaseLiveVoiceTurn,
   restoreVoiceRoom,
   setLiveVoiceEntryOrigin,
   setLiveVoiceMuted,
@@ -350,8 +349,8 @@ export function ChatComposer({
     isLiveVoiceActive && hasLiveVoiceTranscript && showUserTranscriptPref;
   // Session verbs go through the store seams registered by the layout-owned
   // controller: `starter` (registered for the controller's whole mount) to
-  // start, per-session `controls` to stop/release — the latter via the shared
-  // module-level `endLiveVoiceSession`/`releaseLiveVoiceTurn` helpers, which
+  // start, per-session `controls` to end/interrupt — the latter via the shared
+  // module-level `endLiveVoiceSession`/`stopLiveVoiceResponse` helpers, which
   // read the store with `getState()` per STATE_MANAGEMENT.md (no subscription
   // needed for callback-only reads).
   // First-run interception: the very first voice-mode entry opens a
@@ -565,6 +564,13 @@ export function ChatComposer({
   const showInlineVoicePreview =
     isVoiceActive && !isLocallyGenerating && !isElectronHost;
   const hideTextareaForVoice = isNative && showInlineVoicePreview;
+  // A live-voice session disables the textarea outright (see its `disabled`
+  // below), so its placeholder is dead chrome inviting an interaction that
+  // cannot happen — the voice bar is the only live control. Collapse the row
+  // away and let the bar stand alone. The user transcript, when the pref is
+  // on, occupies that same grid cell and is real content, so it keeps the row.
+  const hideTextareaForLiveVoice = isLiveVoiceActive && !showLiveVoiceTranscript;
+  const hideTextareaRow = hideTextareaForVoice || hideTextareaForLiveVoice;
   const hasStagedQuotes = useQuoteReplyStore.use.stagedQuotes().length > 0;
   const canSendMessageContent =
     Boolean(input.trim()) || canSendAttachments || hasStagedQuotes;
@@ -679,7 +685,7 @@ export function ChatComposer({
             This avoids the iOS WKWebView re-dispatch bug entirely: no DOM
             geometry mutation means no re-fired input events.
             Reference: https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/ */}
-            <div className={hideTextareaForVoice ? "hidden" : "grid"}>
+            <div className={hideTextareaRow ? "hidden" : "grid"}>
               <div
                 aria-hidden
                 className="pointer-events-none col-start-1 row-start-1 overflow-hidden whitespace-pre-wrap break-words px-4 pt-3 pb-2 text-chat"
@@ -921,15 +927,13 @@ export function ChatComposer({
               // Voice session bar (Light 53): the whole action row — slots,
               // attach, both mic buttons, and send — is replaced by the bar
               // for the duration of the session. ✕ ends the session (the
-              // normal row returns via `isLiveVoiceActive` flipping false);
-              // green ↑ manually releases the current turn while listening.
+              // normal row returns via `isLiveVoiceActive` flipping false).
               <VoiceComposerBar
                 state={liveVoiceState}
                 getAmplitude={getLiveVoiceInputAmplitude}
                 muted={liveVoiceMuted}
                 onToggleMute={() => setLiveVoiceMuted(!liveVoiceMuted)}
                 onEnd={endLiveVoiceSession}
-                onSend={releaseLiveVoiceTurn}
                 // Turn-scoped stop is hands-free-only; a manual session's
                 // interrupt ends the whole session (✕ owns that).
                 onStop={liveVoiceHandsFree ? stopLiveVoiceResponse : undefined}
@@ -938,6 +942,7 @@ export function ChatComposer({
                 // is their only session surface).
                 onExpand={isPopout ? undefined : restoreVoiceRoom}
                 waveAccentHex={voiceWaveAccentHex}
+                standalone={hideTextareaForLiveVoice}
               />
             ) : (
               <div className="flex items-center justify-between gap-1 px-2 pb-2">

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -64,9 +64,8 @@ describe("VoiceComposerBar — state label", () => {
   });
 
   test("the state label is visually hidden, not painted", () => {
-    // The mic glyph and the animating waves already say "listening"; the text
-    // was redundant weight on a phone-width composer (JARVIS-1363). It stays
-    // in the tree for assistive tech only.
+    // The mic glyph and the animating waves carry "listening" on their own,
+    // so the text stays in the tree for assistive tech only.
     renderBar("listening");
     expect(screen.getByText("Listening…").className).toContain("sr-only");
   });
@@ -75,7 +74,7 @@ describe("VoiceComposerBar — state label", () => {
 describe("VoiceComposerBar — no manual send", () => {
   test("offers no send control in any state", () => {
     // Turns release themselves (server VAD hands-free, auto-release in the
-    // manual fallback), so the ↑ advertised an action the user never needs.
+    // manual fallback), so a send control would name an action nobody takes.
     for (const state of [
       "connecting",
       "listening",

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -2,7 +2,7 @@
  * Tests for `VoiceComposerBar`.
  *
  * The bar is purely presentational, so tests drive it prop-by-prop: state
- * label mapping, send-button enablement, callback wiring, and accessibility
+ * label mapping, control presence, callback wiring, and accessibility
  * attributes. The embedded `VoiceListeningWaves` is SVG + a rAF loop writing
  * a CSS var — inert under happy-dom, so no harness is needed here.
  */
@@ -22,9 +22,9 @@ function renderBar(state: LiveVoiceSessionState, overrides?: {
   muted?: boolean;
   onToggleMute?: () => void;
   onEnd?: () => void;
-  onSend?: () => void;
   onStop?: () => void;
   onExpand?: () => void;
+  standalone?: boolean;
 }) {
   return render(
     <VoiceComposerBar
@@ -33,9 +33,9 @@ function renderBar(state: LiveVoiceSessionState, overrides?: {
       muted={overrides?.muted ?? false}
       onToggleMute={overrides?.onToggleMute ?? (() => {})}
       onEnd={overrides?.onEnd ?? (() => {})}
-      onSend={overrides?.onSend ?? (() => {})}
       onStop={overrides?.onStop}
       onExpand={overrides?.onExpand}
+      standalone={overrides?.standalone}
     />,
   );
 }
@@ -51,7 +51,7 @@ describe("VoiceComposerBar — state label", () => {
   ];
 
   for (const [state, label] of labels) {
-    test(`renders "${label}" for the ${state} state`, () => {
+    test(`announces "${label}" for the ${state} state`, () => {
       renderBar(state);
       expect(screen.getByText(label)).toBeTruthy();
     });
@@ -62,30 +62,33 @@ describe("VoiceComposerBar — state label", () => {
     const label = screen.getByText("Listening…");
     expect(label.getAttribute("aria-live")).toBe("polite");
   });
+
+  test("the state label is visually hidden, not painted", () => {
+    // The mic glyph and the animating waves already say "listening"; the text
+    // was redundant weight on a phone-width composer (JARVIS-1363). It stays
+    // in the tree for assistive tech only.
+    renderBar("listening");
+    expect(screen.getByText("Listening…").className).toContain("sr-only");
+  });
 });
 
-describe("VoiceComposerBar — send enablement", () => {
-  test("send is enabled while listening", () => {
-    renderBar("listening");
-    const send = screen.getByRole("button", { name: "Send now" });
-    expect((send as HTMLButtonElement).disabled).toBe(false);
+describe("VoiceComposerBar — no manual send", () => {
+  test("offers no send control in any state", () => {
+    // Turns release themselves (server VAD hands-free, auto-release in the
+    // manual fallback), so the ↑ advertised an action the user never needs.
+    for (const state of [
+      "connecting",
+      "listening",
+      "transcribing",
+      "thinking",
+      "speaking",
+      "ending",
+    ] as LiveVoiceSessionState[]) {
+      const { unmount } = renderBar(state);
+      expect(screen.queryByRole("button", { name: "Send now" })).toBeNull();
+      unmount();
+    }
   });
-
-  const nonListening: LiveVoiceSessionState[] = [
-    "connecting",
-    "transcribing",
-    "thinking",
-    "speaking",
-    "ending",
-  ];
-
-  for (const state of nonListening) {
-    test(`send is disabled while ${state}`, () => {
-      renderBar(state);
-      const send = screen.getByRole("button", { name: "Send now" });
-      expect((send as HTMLButtonElement).disabled).toBe(true);
-    });
-  }
 
   test("end stays enabled in every session state", () => {
     for (const state of ["connecting", "listening", "speaking", "ending"] as const) {
@@ -105,19 +108,6 @@ describe("VoiceComposerBar — callbacks", () => {
     expect(onEnd).toHaveBeenCalledTimes(1);
   });
 
-  test("clicking send while listening fires onSend", () => {
-    const onSend = mock(() => {});
-    renderBar("listening", { onSend });
-    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
-    expect(onSend).toHaveBeenCalledTimes(1);
-  });
-
-  test("clicking send while disabled does not fire onSend", () => {
-    const onSend = mock(() => {});
-    renderBar("thinking", { onSend });
-    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
-    expect(onSend).not.toHaveBeenCalled();
-  });
 });
 
 describe("VoiceComposerBar — mute toggle", () => {
@@ -146,14 +136,6 @@ describe("VoiceComposerBar — stop response", () => {
       screen.getByRole("button", { name: "Stop assistant response" }),
     );
     expect(onStop).toHaveBeenCalledTimes(1);
-  });
-
-  test("■ takes the send slot while speaking (send absent)", () => {
-    renderBar("speaking", { onStop: () => {} });
-    expect(
-      screen.getByRole("button", { name: "Stop assistant response" }),
-    ).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Send now" })).toBeNull();
   });
 
   test("no ■ outside speaking, or without onStop (manual session)", () => {
@@ -200,11 +182,41 @@ describe("VoiceComposerBar — structure and accessibility", () => {
     ).toBeTruthy();
   });
 
-  test("both control buttons carry aria labels", () => {
+  test("standalone supplies its own top padding", () => {
+    // When the textarea collapses away for the session the bar is the card's
+    // only row, so it can no longer lean on the textarea's top padding.
+    const { unmount } = renderBar("listening", { standalone: true });
+    expect(
+      screen.getByRole("group", { name: "Voice session" }).className,
+    ).toContain("pt-3");
+    unmount();
+
     renderBar("listening");
     expect(
-      screen.getByRole("button", { name: "End voice session" }),
-    ).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Send now" })).toBeTruthy();
+      screen.getByRole("group", { name: "Voice session" }).className,
+    ).not.toContain("pt-3");
+  });
+
+  test("wave strip fades at both edges instead of hard-clipping", () => {
+    // Includes the -webkit- prefix: the iOS client is a WKWebView and drops
+    // the unprefixed property, which would silently disable the fade there.
+    const { container } = renderBar("listening");
+    const strip = container.querySelector(
+      ".voice-listening-waves--inline",
+    )?.parentElement;
+    expect(strip?.className).toContain("mask-image:linear-gradient");
+    expect(strip?.className).toContain("-webkit-mask-image:linear-gradient");
+  });
+
+  test("resting bar is exactly mute + expand + end", () => {
+    renderBar("listening", { onExpand: () => {} });
+    const names = screen
+      .getAllByRole("button")
+      .map((b) => b.getAttribute("aria-label"));
+    expect(names).toEqual([
+      "Mute microphone",
+      "Open voice room",
+      "End voice session",
+    ]);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -1,16 +1,26 @@
 /**
  * Voice-session composer bar (Light 53): while a live-voice session is
  * active the composer's action row is replaced by this bar — a mic mute
- * toggle and muted state label on the left, the voice room's listening
- * waves filling the middle (the same layered accent-tinted band, scaled to
- * the strip), and the session controls on the right: optional expand back
- * to the voice room, end (✕), and the turn slot — send-now (↑), replaced in
- * place by ■ stop-response while the assistant speaks.
+ * toggle on the left, the voice room's listening waves filling the middle
+ * (the same layered accent-tinted band, scaled to the strip), and the
+ * session controls on the right: optional expand back to the voice room,
+ * end (✕), and the stop slot — ■ stop-response, present only while the
+ * assistant speaks.
  *
  * Purely presentational: the composer observes the live-voice store and
- * wires `state`, an amplitude poll function, and the callbacks. The green ↑
- * is a manual "send now" (turn release) and is only meaningful while the
- * session is listening; the red ✕ ends the session and is always available.
+ * wires `state`, an amplitude poll function, and the callbacks. The red ✕
+ * ends the session and is always available.
+ *
+ * Textless by design (JARVIS-1363), matching the title-bar pill. The bar
+ * previously painted the state label ("Listening…") beside the mic; the mic
+ * glyph and the animating waves already carry that, and dropping the text
+ * buys the waves room on phone-width composers. The label survives as an
+ * `sr-only` live region so assistive tech still tracks session state.
+ *
+ * There is no manual "send now" (↑) — turns release themselves (server VAD
+ * hands-free, auto-release in the manual fallback), so a primary-weight send
+ * button advertised an action the user never needs. ■ stays: interrupting a
+ * reply in progress has no other silent equivalent.
  *
  * Layout mirrors the composer's bottom action row (`px-2 pb-2`, regular
  * `h-8` icon buttons) so swapping the rows in during a session causes no
@@ -19,16 +29,19 @@
 
 import type { CSSProperties } from "react";
 
-import { ArrowUp, Maximize2, Mic, MicOff, Square, X } from "lucide-react";
+import { Maximize2, Mic, MicOff, Square, X } from "lucide-react";
 
-import { Button } from "@vellumai/design-library";
+import { Button, cn } from "@vellumai/design-library";
 
 import {
   LIVE_VOICE_STATE_LABELS,
   isLiveVoiceMicLive,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { VoiceListeningWaves } from "@/domains/chat/voice/voice-room/voice-listening-waves";
+import {
+  VOICE_WAVE_EDGE_FADE_CLASS,
+  VoiceListeningWaves,
+} from "@/domains/chat/voice/voice-room/voice-listening-waves";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
 
 // While the mic is not live (muted, assistant speaking) the waves read a
@@ -46,13 +59,10 @@ export interface VoiceComposerBarProps {
   onToggleMute: () => void;
   /** Red ✕ — end the voice session. */
   onEnd: () => void;
-  /** Green ↑ — manually release the current turn (send now). */
-  onSend: () => void;
   /**
    * ■ — stop the in-flight assistant response without ending the session.
-   * Takes the send button's slot while `speaking` (send is unusable then
-   * anyway); the composer passes it only for hands-free sessions, where the
-   * interrupt is turn-scoped.
+   * Occupies the stop slot only while `speaking`; the composer passes it only
+   * for hands-free sessions, where the interrupt is turn-scoped.
    */
   onStop?: () => void;
   /**
@@ -67,6 +77,13 @@ export interface VoiceComposerBarProps {
    * Null/omitted falls back to the app-wide accent, then aurora.
    */
   waveAccentHex?: string | null;
+  /**
+   * Whether the bar is the composer card's only row — set when the textarea
+   * collapses away for the session. The bar normally sits beneath the
+   * textarea's own top padding; standing alone it has to supply its own, or
+   * it renders flush against the card's top edge.
+   */
+  standalone?: boolean;
 }
 
 export function VoiceComposerBar({
@@ -75,16 +92,19 @@ export function VoiceComposerBar({
   muted,
   onToggleMute,
   onEnd,
-  onSend,
   onStop,
   onExpand,
   waveAccentHex,
+  standalone = false,
 }: VoiceComposerBarProps) {
   return (
     <div
       role="group"
       aria-label="Voice session"
-      className="flex items-center gap-3 px-2 pb-2"
+      className={cn(
+        "flex items-center gap-3 px-2 pb-2",
+        standalone && "pt-3",
+      )}
     >
       {/* pl-1 keeps the toggle roughly on the textarea's px-4 text inset. */}
       <div className="flex shrink-0 items-center gap-2 pl-1">
@@ -105,11 +125,9 @@ export function VoiceComposerBar({
             muted ? "[--vbtn-fg:var(--system-negative-strong)]" : undefined
           }
         />
-        {/* Muted placeholder styling — matches the textarea's placeholder. */}
-        <span
-          aria-live="polite"
-          className="text-chat text-[var(--content-disabled)]"
-        >
+        {/* The bar paints no text, so the session state reaches assistive
+            tech here instead. Announced on change, like the title-bar pill. */}
+        <span aria-live="polite" className="sr-only">
           {muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
         </span>
       </div>
@@ -117,7 +135,10 @@ export function VoiceComposerBar({
           fill (the component is absolutely positioned) and overflow-hidden so
           the drifting layers clip to the strip. */}
       <div
-        className="relative h-6 min-w-0 flex-1 overflow-hidden"
+        className={cn(
+          "relative h-6 min-w-0 flex-1 overflow-hidden",
+          VOICE_WAVE_EDGE_FADE_CLASS,
+        )}
         style={
           waveAccentHex
             ? ({ [AVATAR_ACCENT_CSS_VAR]: waveAccentHex } as CSSProperties)
@@ -148,9 +169,8 @@ export function VoiceComposerBar({
           onClick={onEnd}
           aria-label="End voice session"
         />
-        {/* Turn slot: ↑ releases the turn while listening; while the
-            assistant speaks (send unusable) the ■ stop takes its place
-            instead of stacking beside a disabled send. */}
+        {/* Stop slot: ■ interrupts a reply in progress, and is present only
+            while one is playing — nothing occupies the slot otherwise. */}
         {onStop && state === "speaking" ? (
           <Button
             variant="primary"
@@ -159,15 +179,7 @@ export function VoiceComposerBar({
             aria-label="Stop assistant response"
             tooltip="Stop assistant response"
           />
-        ) : (
-          <Button
-            variant="primary"
-            iconOnly={<ArrowUp className="h-4 w-4" strokeWidth={2.5} />}
-            onClick={onSend}
-            disabled={state !== "listening"}
-            aria-label="Send now"
-          />
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -11,16 +11,15 @@
  * wires `state`, an amplitude poll function, and the callbacks. The red ✕
  * ends the session and is always available.
  *
- * Textless by design (JARVIS-1363), matching the title-bar pill. The bar
- * previously painted the state label ("Listening…") beside the mic; the mic
- * glyph and the animating waves already carry that, and dropping the text
- * buys the waves room on phone-width composers. The label survives as an
- * `sr-only` live region so assistive tech still tracks session state.
+ * Textless, matching the title-bar pill: the mic glyph and the animating
+ * waves carry the session state on their own, and the waves want the width on
+ * a phone-width composer. The state string reaches assistive tech through an
+ * `sr-only` live region instead.
  *
- * There is no manual "send now" (↑) — turns release themselves (server VAD
+ * The bar offers no manual "send now" — turns release themselves (server VAD
  * hands-free, auto-release in the manual fallback), so a primary-weight send
- * button advertised an action the user never needs. ■ stays: interrupting a
- * reply in progress has no other silent equivalent.
+ * button would advertise an action the user never needs. ■ earns its place:
+ * interrupting a reply in progress has no silent equivalent.
  *
  * Layout mirrors the composer's bottom action row (`px-2 pb-2`, regular
  * `h-8` icon buttons) so swapping the rows in during a session causes no

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -49,9 +49,9 @@ mock.module("react-router", () => ({
   useNavigate: () => navigateFn,
 }));
 
-// No `use-active-conversation` mock: the pill is textless (JARVIS-1363), so
-// the host no longer resolves the owning row at all. Only `conversationId`
-// matters, and only to decide whether the waves navigate.
+// No `use-active-conversation` mock: the pill is textless, so the host
+// resolves no owning row. Only `conversationId` matters, and only to decide
+// whether the waves navigate.
 
 let mockMainView: MainView = "chat";
 mock.module("@/stores/viewer-store", () => ({
@@ -360,8 +360,7 @@ describe("VoiceSessionPillHost — state announcement", () => {
   });
 
   test("renders no thread title — the pill is textless", () => {
-    // The host used to resolve the owning row to label line 2. It no longer
-    // fetches it at all (JARVIS-1363), so no thread name can reach the header.
+    // The host fetches no owning row, so no thread name can reach the header.
     startSession("listening");
     render(<VoiceSessionPillHost />);
     expect(screen.queryByText("Owning thread")).toBeNull();

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -22,7 +22,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import type { MainView } from "@/stores/viewer-store";
-import type { Conversation } from "@/types/conversation-types";
 import { routes } from "@/utils/routes";
 
 import {
@@ -50,14 +49,9 @@ mock.module("react-router", () => ({
   useNavigate: () => navigateFn,
 }));
 
-let mockOwningConversation: Conversation | undefined;
-const useActiveConversationSpy = mock(
-  (_assistantId: string | null, _conversationId: string | null | undefined, _enabled: boolean) =>
-    mockOwningConversation,
-);
-mock.module("@/domains/chat/hooks/use-active-conversation", () => ({
-  useActiveConversation: useActiveConversationSpy,
-}));
+// No `use-active-conversation` mock: the pill is textless (JARVIS-1363), so
+// the host no longer resolves the owning row at all. Only `conversationId`
+// matters, and only to decide whether the waves navigate.
 
 let mockMainView: MainView = "chat";
 mock.module("@/stores/viewer-store", () => ({
@@ -117,13 +111,8 @@ beforeEach(() => {
   mockSearch = "";
   mockMainView = "chat";
   mockIsMobile = false;
-  mockOwningConversation = {
-    conversationId: OWNING_CONVERSATION_ID,
-    title: "Owning thread",
-  };
   navigateFn.mockClear();
   navigateToConversationSpy.mockClear();
-  useActiveConversationSpy.mockClear();
   controls.stop.mockClear();
   controls.release.mockClear();
   controls.interrupt.mockClear();
@@ -152,7 +141,6 @@ describe("VoiceSessionPillHost — visibility", () => {
     render(<VoiceSessionPillHost />);
     expect(pill()).not.toBeNull();
     expect(screen.getByText("Listening…")).toBeTruthy();
-    expect(screen.getByText("Owning thread")).toBeTruthy();
   });
 
   test("hides the pill while viewing the owning conversation's composer", () => {
@@ -364,30 +352,20 @@ describe("VoiceSessionPillHost — standalone variant (headerless pop-outs)", ()
   });
 });
 
-describe("VoiceSessionPillHost — labels", () => {
-  test("omits the thread name while the owning row is still loading", () => {
-    mockOwningConversation = undefined;
+describe("VoiceSessionPillHost — state announcement", () => {
+  test("passes the session state through as the pill's announced label", () => {
     startSession("thinking");
     render(<VoiceSessionPillHost />);
     expect(screen.getByText("Thinking…")).toBeTruthy();
+  });
+
+  test("renders no thread title — the pill is textless", () => {
+    // The host used to resolve the owning row to label line 2. It no longer
+    // fetches it at all (JARVIS-1363), so no thread name can reach the header.
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
     expect(screen.queryByText("Owning thread")).toBeNull();
-  });
-
-  test("falls back to Untitled for an owning row without a title", () => {
-    mockOwningConversation = { conversationId: OWNING_CONVERSATION_ID };
-    startSession("listening");
-    render(<VoiceSessionPillHost />);
-    expect(screen.getByText("Untitled")).toBeTruthy();
-  });
-
-  test("resolves the owning row only while visible", () => {
-    startSession("listening");
-    render(<VoiceSessionPillHost />);
-    expect(useActiveConversationSpy).toHaveBeenCalledWith(
-      ASSISTANT_ID,
-      OWNING_CONVERSATION_ID,
-      true,
-    );
+    expect(screen.queryByText("Untitled")).toBeNull();
   });
 });
 
@@ -401,12 +379,11 @@ describe("VoiceSessionPillHost — controls", () => {
     expect(controls.interrupt).not.toHaveBeenCalled();
   });
 
-  test("↑ releases the current turn via controls.release", () => {
+  test("offers no manual send — turns release themselves", () => {
     startSession("listening");
     render(<VoiceSessionPillHost />);
-    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
-    expect(controls.release).toHaveBeenCalledTimes(1);
-    expect(controls.stop).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Send now" })).toBeNull();
+    expect(controls.release).not.toHaveBeenCalled();
   });
 
   test("■ stop-response control is not offered — V1 interrupt would end the whole session", () => {

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -61,9 +61,9 @@
  * contradicting the control's "without ending the session" contract, so
  * there the pill offers only ✕ (end).
  *
- * The pill takes no thread title (JARVIS-1363) — it is textless, so nothing
- * here resolves the owning conversation row. Only `conversationId` matters,
- * and only to decide whether the waves navigate.
+ * The pill is textless and takes no thread title, so nothing here resolves
+ * the owning conversation row. Only `conversationId` matters, and only to
+ * decide whether the waves navigate.
  */
 
 import { useCallback } from "react";

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -44,7 +44,8 @@
  * A session not yet attached to a conversation (started from a draft, before
  * the server's `ready` frame) still shows the pill when the user is away from
  * the owning composer — a live mic must always have a visible control — just
- * without a thread name or navigation target.
+ * without a navigation target, leaving its waves inert rather than a dead
+ * button.
  *
  * A `failed` session unmounts the pill (no longer active), but the failure
  * must not vanish silently: when no composer is on screen to render its
@@ -59,6 +60,10 @@
  * re-arms). A manual session's `interrupt()` ends the whole session,
  * contradicting the control's "without ending the session" contract, so
  * there the pill offers only ✕ (end).
+ *
+ * The pill takes no thread title (JARVIS-1363) — it is textless, so nothing
+ * here resolves the owning conversation row. Only `conversationId` matters,
+ * and only to decide whether the waves navigate.
  */
 
 import { useCallback } from "react";
@@ -71,7 +76,6 @@ import {
   VoiceSessionErrorChip,
   VoiceSessionPill,
 } from "@/domains/chat/components/voice-session-pill";
-import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import { useComposerOnScreen } from "@/domains/chat/hooks/use-composer-on-screen";
 import {
   LIVE_VOICE_STATE_LABELS,
@@ -79,7 +83,6 @@ import {
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
-  releaseLiveVoiceTurn,
   setLiveVoiceMuted,
   stopLiveVoiceResponse,
   useLiveVoiceStore,
@@ -99,6 +102,30 @@ export interface VoiceSessionPillHostProps {
   variant?: "header" | "standalone";
 }
 
+/**
+ * Whether this host renders anything — an active-session pill, or the failure
+ * chip that replaces it.
+ *
+ * Exported so the header can size its right cluster against a *live* session
+ * without re-deriving the rules (`ChatLayoutHeader` collapses its other
+ * controls behind an overflow menu once the pill occupies the row). The host
+ * consumes the same hook, so the two can never disagree about whether the
+ * slot is occupied.
+ */
+export function useVoiceSessionPillPresence(): {
+  visible: boolean;
+  showFailure: boolean;
+} {
+  const state = useLiveVoiceStore.use.state();
+  const error = useLiveVoiceStore.use.error();
+  const composerOnScreen = useComposerOnScreen();
+  const owningSurfaceVisible = useOwningComposerSurfaceVisible();
+  return {
+    visible: isLiveVoiceSessionActive(state) && !owningSurfaceVisible,
+    showFailure: state === "failed" && error !== null && !composerOnScreen,
+  };
+}
+
 export function VoiceSessionPillHost({
   variant = "header",
 }: VoiceSessionPillHostProps) {
@@ -114,34 +141,19 @@ export function VoiceSessionPillHost({
 
   const navigate = useNavigate();
 
-  const sessionActive = isLiveVoiceSessionActive(state);
-  // Shared with the voice room (see `use-composer-on-screen.ts`): a conversation
-  // chat route is mounted and not covered by the desktop fullscreen app viewer.
-  // The strict chat predicate matters — conversation subroutes like the
-  // inspector (`/assistant/conversations/:id/inspect`) render no composer, so
-  // the pill must stay up there even for the owning conversation. Retained here
-  // only for the failure surface below — the pill's own visibility keys off the
-  // owning-composer surface primitive.
-  const composerOnScreen = useComposerOnScreen();
-  // Exact complement of the owning-composer voice surface: the pill shows for an
-  // active session precisely when that surface is NOT on screen. Both derive
-  // from the one shared predicate so they can never drift. This is the room's
-  // popout-free core — so in a pop-out the pill still hides while the composer's
-  // voice bar owns the session (the room itself never renders there).
-  const owningSurfaceVisible = useOwningComposerSurfaceVisible();
-  const visible = sessionActive && !owningSurfaceVisible;
-  // Failure surface: exact complement of the composer's failure Notice, which
-  // any on-screen voice-enabled composer renders regardless of ownership.
-  const showFailure = state === "failed" && error !== null && !composerOnScreen;
-
-  // Resolves the owning row from whichever list cache holds it, fetching the
-  // single row when absent. Enabled only while the pill is shown so hidden
-  // states cost nothing.
-  const owningConversation = useActiveConversation(
-    sessionAssistantId,
-    sessionConversationId,
-    visible && sessionConversationId !== null,
-  );
+  // Both flags come from the shared hook above:
+  //
+  // - `visible` is the exact complement of the owning-composer voice surface —
+  //   the pill shows for an active session precisely when that surface is NOT
+  //   on screen. This is the room's popout-free core, so in a pop-out the pill
+  //   still hides while the composer's voice bar owns the session.
+  // - `showFailure` is the exact complement of the composer's failure Notice,
+  //   which any on-screen voice-enabled composer renders regardless of
+  //   ownership. Its `useComposerOnScreen` predicate is the strict one:
+  //   conversation subroutes like the inspector
+  //   (`/assistant/conversations/:id/inspect`) render no composer, so the
+  //   chip must stay up there even for the owning conversation.
+  const { visible, showFailure } = useVoiceSessionPillPresence();
 
   // Wave accent for the pill's listening waves — the same avatar-matched tint
   // the room resolves (see wave-accent.ts). Fetch-gated to a visible pill;
@@ -164,7 +176,10 @@ export function VoiceSessionPillHost({
   }, [navigate, sessionConversationId]);
 
   let content: ReactNode = null;
-  if (showFailure) {
+  // `showFailure` already implies a non-null `error`; repeating the check here
+  // is what re-narrows the type for the chip, since the flag now arrives from
+  // the shared hook rather than an inline comparison.
+  if (showFailure && error !== null) {
     content = (
       <VoiceSessionErrorChip message={error} onDismiss={dismissLiveVoiceFailure} />
     );
@@ -172,16 +187,12 @@ export function VoiceSessionPillHost({
     content = (
       <VoiceSessionPill
         primaryLabel={muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
-        secondaryLabel={
-          owningConversation ? (owningConversation.title ?? "Untitled") : undefined
-        }
         state={state}
         getAmplitude={getLiveVoiceInputAmplitude}
         muted={muted}
         onToggleMute={() => setLiveVoiceMuted(!muted)}
         onStop={handsFree ? stopLiveVoiceResponse : undefined}
         onEnd={endLiveVoiceSession}
-        onSend={releaseLiveVoiceTurn}
         onNavigate={sessionConversationId ? handleNavigate : undefined}
         waveAccentHex={waveAccentHex}
       />

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -4,18 +4,34 @@
  * The pill is purely presentational, so tests drive it directly through
  * props. The embedded `VoiceListeningWaves` is SVG + a rAF loop writing a
  * CSS var — inert under happy-dom, so no harness is needed here.
+ *
+ * `useIsMobile` is mocked because the pill has two genuinely different forms
+ * either side of the `md` breakpoint (JARVIS-1363): an inline control row on
+ * desktop, a single sheet trigger on mobile. `mockIsMobile` selects which one
+ * is under test; it resets to desktop in `beforeEach`.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
-import {
-  VoiceSessionErrorChip,
-  VoiceSessionPill,
-  type VoiceSessionPillProps,
-} from "@/domains/chat/components/voice-session-pill";
+
+let mockIsMobile = false;
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => mockIsMobile,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+// Imported after the mock so the component picks up the mocked module.
+const { VoiceSessionErrorChip, VoiceSessionPill } = await import(
+  "@/domains/chat/components/voice-session-pill"
+);
+type VoiceSessionPillProps = React.ComponentProps<typeof VoiceSessionPill>;
+
+beforeEach(() => {
+  mockIsMobile = false;
+});
 
 afterEach(() => {
   cleanup();
@@ -26,13 +42,11 @@ function renderPill(overrides: Partial<VoiceSessionPillProps> = {}) {
     onToggleMute: mock(() => {}),
     onStop: mock(() => {}),
     onEnd: mock(() => {}),
-    onSend: mock(() => {}),
     onNavigate: mock(() => {}),
   };
   render(
     <VoiceSessionPill
       primaryLabel="Working on App…"
-      secondaryLabel="Thread name here"
       state="listening"
       getAmplitude={() => 0.5}
       muted={false}
@@ -45,28 +59,28 @@ function renderPill(overrides: Partial<VoiceSessionPillProps> = {}) {
 
 const stopButton = () => screen.queryByRole("button", { name: "Stop assistant response" });
 const endButton = () => screen.getByRole("button", { name: "End voice session" });
-const sendButton = () => screen.getByRole("button", { name: "Send now" });
-const labelButton = () => screen.queryByRole("button", { name: "Go to voice session thread" });
+const navButton = () => screen.queryByRole("button", { name: "Go to voice session thread" });
 
-describe("VoiceSessionPill — labels", () => {
-  test("renders both label lines with truncation", () => {
+describe("VoiceSessionPill — textless surface", () => {
+  test("paints no visible label — state reaches AT via a live region only", () => {
     renderPill();
-    const primary = screen.getByText("Working on App…");
-    const secondary = screen.getByText("Thread name here");
-    expect(primary.className).toContain("truncate");
-    expect(secondary.className).toContain("truncate");
+    // The state text must exist for screen readers…
+    const live = screen.getByText("Working on App…");
+    // …but be visually hidden, so the pill stays narrow enough to leave the
+    // header's centre title its room (JARVIS-1363).
+    expect(live.className).toContain("sr-only");
+    expect(live.getAttribute("aria-live")).toBe("polite");
   });
 
-  test("omits the secondary line when not provided", () => {
-    renderPill({ secondaryLabel: undefined });
-    expect(screen.getByText("Working on App…")).toBeTruthy();
+  test("live region announces muted in place of the state label", () => {
+    renderPill({ muted: true });
+    expect(screen.getByText("Muted")).toBeTruthy();
+    expect(screen.queryByText("Working on App…")).toBeNull();
+  });
+
+  test("renders no thread title — the pill takes no secondary label", () => {
+    renderPill();
     expect(screen.queryByText("Thread name here")).toBeNull();
-  });
-
-  test("label area is a plain (non-interactive) element without onNavigate", () => {
-    renderPill({ onNavigate: undefined });
-    expect(labelButton()).toBeNull();
-    expect(screen.getByText("Working on App…")).toBeTruthy();
   });
 });
 
@@ -101,21 +115,45 @@ describe("VoiceSessionPill — stop control", () => {
     expect(onNavigate).not.toHaveBeenCalled();
   });
 
-  test("takes the send slot while speaking (send absent)", () => {
-    renderPill({ state: "speaking" });
-    expect(stopButton()).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Send now" })).toBeNull();
-  });
-
   test("hidden even while speaking when onStop is not provided", () => {
     // The host omits onStop for manual (version-skew fallback) sessions,
     // where stopping a response would end the whole session; the ✕ stays
-    // the only destructive control there — and the disabled send keeps the
-    // turn slot.
+    // the only destructive control there.
     renderPill({ state: "speaking", onStop: undefined });
     expect(stopButton()).toBeNull();
     expect(endButton()).toBeTruthy();
-    expect(sendButton().hasAttribute("disabled")).toBe(true);
+  });
+});
+
+describe("VoiceSessionPill — no manual send", () => {
+  test("offers no send control in any state", () => {
+    // Turns release themselves (server VAD hands-free, auto-release in the
+    // manual fallback), so a send affordance advertised a no-op action and
+    // cost the header ~40px it could not spare (JARVIS-1363).
+    for (const state of [
+      "connecting",
+      "listening",
+      "transcribing",
+      "thinking",
+      "speaking",
+      "ending",
+    ] as LiveVoiceSessionState[]) {
+      renderPill({ state });
+      expect(screen.queryByRole("button", { name: "Send now" })).toBeNull();
+      cleanup();
+    }
+  });
+
+  test("resting pill is exactly mute + waves + end", () => {
+    renderPill({ state: "listening" });
+    const names = screen
+      .getAllByRole("button")
+      .map((b) => b.getAttribute("aria-label"));
+    expect(names).toEqual([
+      "Mute microphone",
+      "Go to voice session thread",
+      "End voice session",
+    ]);
   });
 });
 
@@ -135,35 +173,6 @@ describe("VoiceSessionPill — mute toggle", () => {
   });
 });
 
-describe("VoiceSessionPill — send control", () => {
-  test("enabled while listening and fires onSend", () => {
-    const { onSend, onNavigate } = renderPill({ state: "listening" });
-    const send = sendButton();
-    expect(send.hasAttribute("disabled")).toBe(false);
-    fireEvent.click(send);
-    expect(onSend).toHaveBeenCalledTimes(1);
-    expect(onNavigate).not.toHaveBeenCalled();
-  });
-
-  test("disabled in every non-listening state", () => {
-    // `speaking` is exercised separately: with onStop wired the ■ stop
-    // replaces send in the turn slot; without it the disabled send stays.
-    for (const state of [
-      "connecting",
-      "transcribing",
-      "thinking",
-      "ending",
-    ] as LiveVoiceSessionState[]) {
-      const { onSend } = renderPill({ state });
-      const send = sendButton();
-      expect(send.hasAttribute("disabled")).toBe(true);
-      fireEvent.click(send);
-      expect(onSend).not.toHaveBeenCalled();
-      cleanup();
-    }
-  });
-});
-
 describe("VoiceSessionPill — end control", () => {
   test("always enabled and fires onEnd", () => {
     const { onEnd, onNavigate } = renderPill({ state: "thinking" });
@@ -176,13 +185,86 @@ describe("VoiceSessionPill — end control", () => {
 });
 
 describe("VoiceSessionPill — navigation", () => {
-  test("clicking the label area fires onNavigate only", () => {
-    const { onNavigate, onStop, onEnd, onSend } = renderPill();
-    fireEvent.click(labelButton()!);
+  test("the wave strip carries the tap and fires onNavigate only", () => {
+    const { onNavigate, onStop, onEnd } = renderPill();
+    fireEvent.click(navButton()!);
     expect(onNavigate).toHaveBeenCalledTimes(1);
     expect(onStop).not.toHaveBeenCalled();
     expect(onEnd).not.toHaveBeenCalled();
-    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test("waves stay inert (not a button) without onNavigate", () => {
+    // A session with no conversation yet has nowhere to go — the strip must
+    // not ship as a dead target.
+    renderPill({ onNavigate: undefined });
+    expect(navButton()).toBeNull();
+  });
+});
+
+describe("VoiceSessionPill — condensed mobile form", () => {
+  const trigger = () =>
+    screen.getByRole("button", { name: "Voice session controls" });
+
+  test("collapses the whole cluster to one trigger", () => {
+    mockIsMobile = true;
+    renderPill();
+    // The inline controls are gone — that is the entire point, since three
+    // icon buttons squeezed the header's centre title on phone widths.
+    expect(trigger()).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Mute microphone" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "End voice session" }),
+    ).toBeNull();
+  });
+
+  test("a live mic still announces its state without opening the sheet", () => {
+    mockIsMobile = true;
+    renderPill();
+    const live = screen.getByText("Working on App…");
+    expect(live.className).toContain("sr-only");
+    expect(live.getAttribute("aria-live")).toBe("polite");
+  });
+
+  test("opening the sheet offers mute and end, and fires them", () => {
+    mockIsMobile = true;
+    const { onToggleMute, onEnd } = renderPill();
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByText("Mute microphone"));
+    expect(onToggleMute).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByText("End voice session"));
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test("stop row appears only while speaking", () => {
+    mockIsMobile = true;
+    const { onStop } = renderPill({ state: "speaking" });
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByText("Stop response"));
+    expect(onStop).toHaveBeenCalledTimes(1);
+    cleanup();
+
+    mockIsMobile = true;
+    renderPill({ state: "listening" });
+    fireEvent.click(trigger());
+    expect(screen.queryByText("Stop response")).toBeNull();
+  });
+
+  test("navigate row is omitted when there is no thread to return to", () => {
+    mockIsMobile = true;
+    renderPill({ onNavigate: undefined });
+    fireEvent.click(trigger());
+    expect(screen.queryByText("Go to voice session thread")).toBeNull();
+  });
+
+  test("muted swaps the trigger glyph's label target, not the control itself", () => {
+    // The trigger keeps one stable accessible name in both states — it opens
+    // a menu, it is not itself the mute toggle.
+    mockIsMobile = true;
+    renderPill({ muted: true });
+    expect(trigger()).toBeTruthy();
+    expect(screen.getByText("Muted")).toBeTruthy();
   });
 });
 

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -6,9 +6,9 @@
  * CSS var — inert under happy-dom, so no harness is needed here.
  *
  * `useIsMobile` is mocked because the pill has two genuinely different forms
- * either side of the `md` breakpoint (JARVIS-1363): an inline control row on
- * desktop, a single sheet trigger on mobile. `mockIsMobile` selects which one
- * is under test; it resets to desktop in `beforeEach`.
+ * either side of the `md` breakpoint: an inline control row on desktop, a
+ * single sheet trigger on mobile. `mockIsMobile` selects which one is under
+ * test; it resets to desktop in `beforeEach`.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -67,7 +67,7 @@ describe("VoiceSessionPill — textless surface", () => {
     // The state text must exist for screen readers…
     const live = screen.getByText("Working on App…");
     // …but be visually hidden, so the pill stays narrow enough to leave the
-    // header's centre title its room (JARVIS-1363).
+    // header's centre title its room.
     expect(live.className).toContain("sr-only");
     expect(live.getAttribute("aria-live")).toBe("polite");
   });
@@ -128,8 +128,8 @@ describe("VoiceSessionPill — stop control", () => {
 describe("VoiceSessionPill — no manual send", () => {
   test("offers no send control in any state", () => {
     // Turns release themselves (server VAD hands-free, auto-release in the
-    // manual fallback), so a send affordance advertised a no-op action and
-    // cost the header ~40px it could not spare (JARVIS-1363).
+    // manual fallback), so a send affordance would name a no-op action and
+    // cost the header ~40px it cannot spare.
     for (const state of [
       "connecting",
       "listening",
@@ -208,8 +208,8 @@ describe("VoiceSessionPill — condensed mobile form", () => {
   test("collapses the whole cluster to one trigger", () => {
     mockIsMobile = true;
     renderPill();
-    // The inline controls are gone — that is the entire point, since three
-    // icon buttons squeezed the header's centre title on phone widths.
+    // One trigger, no inline controls: three icon buttons leave the header's
+    // centre title unreadable at phone widths.
     expect(trigger()).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Mute microphone" })).toBeNull();
     expect(

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -2,45 +2,40 @@
  * Title-bar pill for an active live-voice session (Light 54's right cluster).
  * Presentational — the mounting host owns store wiring and visibility rules.
  *
- * Two forms, split at the `md` breakpoint (JARVIS-1363), because the header
- * has room for a control cluster on a desktop window and none on a phone:
+ * Two forms, split at the `md` breakpoint, because the header has room for a
+ * control cluster on a desktop window and none on a phone:
  *
  * - **Desktop** — mic glyph (mute toggle), the voice room's listening waves
  *   in a compact strip, red ✕ (end session), and the stop slot: a circular ■
  *   that appears only while the assistant is `speaking` and the host provides
  *   `onStop`.
  * - **Mobile** — one `AudioLines` glyph, accent-tinted to read as the live
- *   session, opening a `BottomSheet` with the same actions as rows (mute,
+ *   session, opening a `BottomSheet` carrying the same actions as rows (mute,
  *   stop while speaking, go to thread, end). This is the repo's standard
  *   dropdown-on-desktop / sheet-on-mobile pattern; see
  *   `conversation-actions-menu.tsx`.
  *
- * Deliberately textless in both forms. The pill previously led with a two-line
- * label — state text over the owning thread's name — which on a phone-width
- * header consumed ~160px and pushed ✕/■ off the right edge entirely, and
- * squeezed the centre title until it overflowed under the hamburger. The mic
- * glyph and the animating waves already say "a voice session is live and
- * listening", so the label was redundant weight. State text survives for
- * assistive tech as an `sr-only` live region in both forms — the visual
- * cleanup must not cost a screen-reader user the session state.
+ * Both forms are textless: the mic glyph and the animating waves carry "a
+ * voice session is live and listening" on their own, and a phone-width header
+ * has no room for a label beside the centre title. The state string reaches
+ * assistive tech through an `sr-only` live region instead, so the session
+ * state is never visual-only.
  *
- * On desktop the wave strip carries the return-to-thread tap: with the label
- * gone it is the pill's largest target. It is a `button` only when
- * `onNavigate` is supplied (a session not yet attached to a conversation has
- * nowhere to go), so it never ships a dead target; mobile applies the same
- * rule by omitting the sheet's navigate row.
+ * On desktop the wave strip is the pill's largest target and carries the
+ * return-to-thread tap. It is a `button` only when `onNavigate` is supplied —
+ * a session not yet attached to a conversation has nowhere to go — so it
+ * never ships a dead target; mobile applies the same rule by omitting the
+ * sheet's navigate row.
  *
- * The mobile form softens a rule the desktop form keeps: mute is one tap
- * deeper rather than always on screen. A hot mic still has a *visible*
- * control at all times — the trigger itself — which is the invariant that
- * actually matters; making it a one-tap toggle cost the centre title more
- * room than the header had.
+ * Mute is one tap deeper on mobile than on desktop. The invariant a hot mic
+ * must hold is a *visible* control, which the trigger itself satisfies; a
+ * one-tap toggle would cost the centre title more room than the header has.
  *
- * There is no manual "send now" (↑). Turns release themselves — server VAD in
- * hands-free, auto-release in the manual fallback — so a persistent, primary
- * send affordance advertised an action the user never needs to take. ■
- * (barge-in) remains because interrupting a reply in progress has no other
- * silent equivalent.
+ * Neither form offers a manual "send now". Turns release themselves — server
+ * VAD in hands-free, auto-release in the manual fallback — so a persistent
+ * primary send affordance would advertise an action the user never needs to
+ * take. ■ (barge-in) earns its place because interrupting a reply in progress
+ * has no silent equivalent.
  *
  * The pill lives inside `ChatLayoutHeader`, which doubles as the Electron
  * macOS title bar (`-webkit-app-region: drag`). The root opts the whole
@@ -155,13 +150,11 @@ export function VoiceSessionPill({
     ? ({ [AVATAR_ACCENT_CSS_VAR]: waveAccentHex } as CSSProperties)
     : undefined;
 
-  // Phones collapse the whole cluster into one glyph. The expanded row costs
+  // Phones collapse the whole cluster into one glyph. The expanded row needs
   // ~160pt (mic + 96pt waves + ✕); on a 402pt phone the header's three zones
-  // share 338pt, so that left the centre title ~58pt — less than "New Chat"
-  // needs, and a conversation with an assets chip was worse. One 32pt trigger
-  // returns ~130pt to the title. Mute and end move one tap deeper, which is
-  // the deliberate cost: a hot mic keeps a *visible* control, not a
-  // one-tap one (JARVIS-1363).
+  // share 338pt, which leaves the centre title less than the ~62pt "New Chat"
+  // occupies — narrower still once a conversation carries an assets chip. A
+  // single 32pt trigger keeps the title readable.
   if (isMobile) {
     const close = () => setSheetOpen(false);
     return (
@@ -184,13 +177,10 @@ export function VoiceSessionPill({
                   <AudioLines className="size-4" />
                 )
               }
-              // NB: `expandOnMobile` stays at its default `true` here, unlike
-              // the desktop form below — it is what gives ghost icon-only
-              // buttons their `touch-mobile` 40px circular chrome, so the
-              // trigger matches the search and notification buttons it sits
-              // beside. Opting out (correct on desktop, where the pill must
-              // fit a 32px title-bar row) left a chrome-less glyph floating
-              // between two circular buttons.
+              // `expandOnMobile` keeps its default `true` here (the desktop
+              // form opts out): it supplies the `touch-mobile` 40px circular
+              // chrome that matches the search and notification buttons this
+              // trigger sits beside.
               aria-label="Voice session controls"
               // Tinted to the room's avatar accent so the glyph reads as the
               // live session rather than a generic header button; muted

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -273,9 +273,9 @@ export function VoiceSessionPill({
             muted ? "[--vbtn-fg:var(--system-negative-strong)]" : undefined
           }
         />
-        {/* With the label gone the waves are the pill's largest target, so
-            they carry the return-to-thread tap (a `button` only when there is
-            a thread to return to). */}
+        {/* The waves are the pill's largest target, so they carry the
+            return-to-thread tap — a `button` only when there is a thread to
+            return to. */}
         {onNavigate ? (
           <button
             type="button"

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -2,35 +2,81 @@
  * Title-bar pill for an active live-voice session (Light 54's right cluster).
  * Presentational — the mounting host owns store wiring and visibility rules.
  *
- * Layout, left → right: two-line context label (primary action text over the
- * owning thread's name), mic glyph + the voice room's listening waves in a
- * compact strip, red ✕ (end session), and the turn slot — green ↑ (manual
- * turn release, enabled only while `listening`), replaced in place by a
- * circular ■ stop while the assistant is `speaking` and the host provides
- * `onStop`.
+ * Two forms, split at the `md` breakpoint (JARVIS-1363), because the header
+ * has room for a control cluster on a desktop window and none on a phone:
+ *
+ * - **Desktop** — mic glyph (mute toggle), the voice room's listening waves
+ *   in a compact strip, red ✕ (end session), and the stop slot: a circular ■
+ *   that appears only while the assistant is `speaking` and the host provides
+ *   `onStop`.
+ * - **Mobile** — one `AudioLines` glyph, accent-tinted to read as the live
+ *   session, opening a `BottomSheet` with the same actions as rows (mute,
+ *   stop while speaking, go to thread, end). This is the repo's standard
+ *   dropdown-on-desktop / sheet-on-mobile pattern; see
+ *   `conversation-actions-menu.tsx`.
+ *
+ * Deliberately textless in both forms. The pill previously led with a two-line
+ * label — state text over the owning thread's name — which on a phone-width
+ * header consumed ~160px and pushed ✕/■ off the right edge entirely, and
+ * squeezed the centre title until it overflowed under the hamburger. The mic
+ * glyph and the animating waves already say "a voice session is live and
+ * listening", so the label was redundant weight. State text survives for
+ * assistive tech as an `sr-only` live region in both forms — the visual
+ * cleanup must not cost a screen-reader user the session state.
+ *
+ * On desktop the wave strip carries the return-to-thread tap: with the label
+ * gone it is the pill's largest target. It is a `button` only when
+ * `onNavigate` is supplied (a session not yet attached to a conversation has
+ * nowhere to go), so it never ships a dead target; mobile applies the same
+ * rule by omitting the sheet's navigate row.
+ *
+ * The mobile form softens a rule the desktop form keeps: mute is one tap
+ * deeper rather than always on screen. A hot mic still has a *visible*
+ * control at all times — the trigger itself — which is the invariant that
+ * actually matters; making it a one-tap toggle cost the centre title more
+ * room than the header had.
+ *
+ * There is no manual "send now" (↑). Turns release themselves — server VAD in
+ * hands-free, auto-release in the manual fallback — so a persistent, primary
+ * send affordance advertised an action the user never needs to take. ■
+ * (barge-in) remains because interrupting a reply in progress has no other
+ * silent equivalent.
  *
  * The pill lives inside `ChatLayoutHeader`, which doubles as the Electron
  * macOS title bar (`-webkit-app-region: drag`). The root opts the whole
  * cluster out via `no-drag` so every child — including the non-`button`
- * canvas/label area — stays clickable, matching the header's own treatment of
- * its interactive children.
+ * canvas area — stays clickable, matching the header's own treatment of its
+ * interactive children.
  *
  * Height is capped at `h-8` (32px): the header's Electron title-bar row is
  * 44px min-height with 32px controls, so the pill must never stretch it.
  */
 
-import type { CSSProperties } from "react";
+import { useState, type CSSProperties } from "react";
 
-import { ArrowUp, Mic, MicOff, Square, TriangleAlert, X } from "lucide-react";
+import {
+  AudioLines,
+  CornerUpRight,
+  Mic,
+  MicOff,
+  Square,
+  TriangleAlert,
+  X,
+} from "lucide-react";
 
-import { Button, Tag, Typography, cn } from "@vellumai/design-library";
+import { BottomSheet, Button, Tag, cn } from "@vellumai/design-library";
 
+import { buildPanelMenuItem } from "@/domains/chat/components/panel-menu-item";
 import {
   isLiveVoiceMicLive,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { VoiceListeningWaves } from "@/domains/chat/voice/voice-room/voice-listening-waves";
+import {
+  VOICE_WAVE_EDGE_FADE_CLASS,
+  VoiceListeningWaves,
+} from "@/domains/chat/voice/voice-room/voice-listening-waves";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 
 // While the mic is not live (muted, assistant speaking) the waves read a
 // steady zero and settle into their quiet drift — the room's own resting
@@ -39,12 +85,11 @@ const SILENT_AMPLITUDE = () => 0;
 
 export interface VoiceSessionPillProps {
   /**
-   * Line 1: the session's activity label (e.g. "Listening…" — see
-   * `LIVE_VOICE_STATE_LABELS`).
+   * The session's activity label (e.g. "Listening…" — see
+   * `LIVE_VOICE_STATE_LABELS`). Not painted: announced to assistive tech
+   * through an `sr-only` live region, since the pill itself is textless.
    */
   primaryLabel: string;
-  /** Line 2: the owning thread's name. */
-  secondaryLabel?: string;
   state: LiveVoiceSessionState;
   /** Polled by the waveform at ~30 Hz; must not force parent re-renders. */
   getAmplitude: () => number;
@@ -54,18 +99,19 @@ export interface VoiceSessionPillProps {
   onToggleMute: () => void;
   /**
    * Stop the in-flight assistant response without ending the session. The
-   * ■ control takes the send button's slot while `speaking` (send is
-   * unusable then anyway) and is hidden when absent — the host wires it only
-   * for hands-free sessions, where the interrupt is turn-scoped; a manual
-   * session's interrupt ends the whole session, so there the ✕ (`onEnd`) is
-   * the only stop.
+   * ■ control occupies the stop slot only while `speaking`, and is hidden
+   * when absent — the host wires it only for hands-free sessions, where the
+   * interrupt is turn-scoped; a manual session's interrupt ends the whole
+   * session, so there the ✕ (`onEnd`) is the only stop.
    */
   onStop?: () => void;
   /** End the voice session. */
   onEnd: () => void;
-  /** Manual turn release ("send now") while listening. */
-  onSend: () => void;
-  /** Invoked when the label area is clicked (navigate to the owning thread). */
+  /**
+   * Navigate to the owning thread. Turns the wave strip into the tap target;
+   * omitted when the session has no conversation to return to, leaving the
+   * waves inert rather than a dead button.
+   */
   onNavigate?: () => void;
   /**
    * Accent hex matching the avatar the voice room renders (see
@@ -77,40 +123,133 @@ export interface VoiceSessionPillProps {
 
 export function VoiceSessionPill({
   primaryLabel,
-  secondaryLabel,
   state,
   getAmplitude,
   muted,
   onToggleMute,
   onStop,
   onEnd,
-  onSend,
   onNavigate,
   waveAccentHex,
 }: VoiceSessionPillProps) {
-  const labelContent = (
-    <>
-      <Typography
-        as="p"
-        variant="body-medium-default"
-        className="truncate text-[var(--content-default)]"
-      >
-        {primaryLabel}
-      </Typography>
-      {secondaryLabel ? (
-        <Typography
-          as="p"
-          variant="label-medium-default"
-          className="truncate text-[var(--content-tertiary)]"
-        >
-          {secondaryLabel}
-        </Typography>
-      ) : null}
-    </>
-  );
+  const isMobile = useIsMobile();
+  const [sheetOpen, setSheetOpen] = useState(false);
 
-  // Right-aligned per Light 54: both lines rag toward the stop control.
-  const labelClass = "flex h-8 min-w-0 max-w-40 flex-col justify-center gap-0.5 text-right";
+  // The room's listening-wave band in a compact strip: needs a positioned box
+  // to fill (the component is absolutely positioned) and overflow-hidden so
+  // the drifting layers clip to it.
+  const waves = (
+    <VoiceListeningWaves
+      getAmplitude={
+        isLiveVoiceMicLive(state) && !muted ? getAmplitude : SILENT_AMPLITUDE
+      }
+      palette="accent"
+      placement="inline"
+    />
+  );
+  const waveStripClass = cn(
+    "relative h-4 w-24 overflow-hidden",
+    VOICE_WAVE_EDGE_FADE_CLASS,
+  );
+  const waveStripStyle = waveAccentHex
+    ? ({ [AVATAR_ACCENT_CSS_VAR]: waveAccentHex } as CSSProperties)
+    : undefined;
+
+  // Phones collapse the whole cluster into one glyph. The expanded row costs
+  // ~160pt (mic + 96pt waves + ✕); on a 402pt phone the header's three zones
+  // share 338pt, so that left the centre title ~58pt — less than "New Chat"
+  // needs, and a conversation with an assets chip was worse. One 32pt trigger
+  // returns ~130pt to the title. Mute and end move one tap deeper, which is
+  // the deliberate cost: a hot mic keeps a *visible* control, not a
+  // one-tap one (JARVIS-1363).
+  if (isMobile) {
+    const close = () => setSheetOpen(false);
+    return (
+      <div
+        role="group"
+        aria-label="Voice session"
+        className="flex h-8 items-center [-webkit-app-region:no-drag]"
+      >
+        <span aria-live="polite" className="sr-only">
+          {muted ? "Muted" : primaryLabel}
+        </span>
+        <BottomSheet.Root open={sheetOpen} onOpenChange={setSheetOpen}>
+          <BottomSheet.Trigger asChild>
+            <Button
+              variant="ghost"
+              iconOnly={
+                muted ? (
+                  <MicOff className="size-4" />
+                ) : (
+                  <AudioLines className="size-4" />
+                )
+              }
+              // NB: `expandOnMobile` stays at its default `true` here, unlike
+              // the desktop form below — it is what gives ghost icon-only
+              // buttons their `touch-mobile` 40px circular chrome, so the
+              // trigger matches the search and notification buttons it sits
+              // beside. Opting out (correct on desktop, where the pill must
+              // fit a 32px title-bar row) left a chrome-less glyph floating
+              // between two circular buttons.
+              aria-label="Voice session controls"
+              // Tinted to the room's avatar accent so the glyph reads as the
+              // live session rather than a generic header button; muted
+              // overrides it with the negative tone, matching the mic toggle.
+              // Inline, so it wins over the variant's `touch-mobile` fg.
+              className={
+                muted ? "[--vbtn-fg:var(--system-negative-strong)]" : undefined
+              }
+              style={
+                !muted && waveAccentHex
+                  ? ({ "--vbtn-fg": waveAccentHex } as CSSProperties)
+                  : undefined
+              }
+            />
+          </BottomSheet.Trigger>
+          <BottomSheet.Content aria-describedby={undefined}>
+            <BottomSheet.Header className="sr-only">
+              <BottomSheet.Title>Voice session</BottomSheet.Title>
+            </BottomSheet.Header>
+            <BottomSheet.Body className="pt-0">
+              {buildPanelMenuItem({
+                key: "mute",
+                icon: muted ? Mic : MicOff,
+                label: muted ? "Unmute microphone" : "Mute microphone",
+                run: onToggleMute,
+                onClose: close,
+              })}
+              {onStop && state === "speaking"
+                ? buildPanelMenuItem({
+                    key: "stop",
+                    icon: Square,
+                    label: "Stop response",
+                    run: onStop,
+                    onClose: close,
+                  })
+                : null}
+              {onNavigate
+                ? buildPanelMenuItem({
+                    key: "navigate",
+                    icon: CornerUpRight,
+                    label: "Go to voice session thread",
+                    run: onNavigate,
+                    onClose: close,
+                  })
+                : null}
+              {buildPanelMenuItem({
+                key: "end",
+                icon: X,
+                label: "End voice session",
+                className: "text-[var(--system-negative-strong)]",
+                run: onEnd,
+                onClose: close,
+              })}
+            </BottomSheet.Body>
+          </BottomSheet.Content>
+        </BottomSheet.Root>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -118,18 +257,11 @@ export function VoiceSessionPill({
       aria-label="Voice session"
       className="flex h-8 items-center gap-2 [-webkit-app-region:no-drag]"
     >
-      {onNavigate ? (
-        <button
-          type="button"
-          onClick={onNavigate}
-          aria-label="Go to voice session thread"
-          className={cn(labelClass, "cursor-pointer")}
-        >
-          {labelContent}
-        </button>
-      ) : (
-        <div className={labelClass}>{labelContent}</div>
-      )}
+      {/* The pill paints no text, so the session state reaches assistive tech
+          here instead. Announced on change, like the composer bar's label. */}
+      <span aria-live="polite" className="sr-only">
+        {muted ? "Muted" : primaryLabel}
+      </span>
       <div className="flex items-center gap-1">
         {/* The mic glyph doubles as the mute toggle — the one control a hot
             open mic must always offer, wherever the session surface is. */}
@@ -151,25 +283,24 @@ export function VoiceSessionPill({
             muted ? "[--vbtn-fg:var(--system-negative-strong)]" : undefined
           }
         />
-        {/* The room's listening-wave band in a compact strip: needs a
-            positioned box to fill (the component is absolutely positioned)
-            and overflow-hidden so the drifting layers clip to it. */}
-        <div
-          className="relative h-4 w-24 overflow-hidden"
-          style={
-            waveAccentHex
-              ? ({ [AVATAR_ACCENT_CSS_VAR]: waveAccentHex } as CSSProperties)
-              : undefined
-          }
-        >
-          <VoiceListeningWaves
-            getAmplitude={
-              isLiveVoiceMicLive(state) && !muted ? getAmplitude : SILENT_AMPLITUDE
-            }
-            palette="accent"
-            placement="inline"
-          />
-        </div>
+        {/* With the label gone the waves are the pill's largest target, so
+            they carry the return-to-thread tap (a `button` only when there is
+            a thread to return to). */}
+        {onNavigate ? (
+          <button
+            type="button"
+            onClick={onNavigate}
+            aria-label="Go to voice session thread"
+            className={cn(waveStripClass, "cursor-pointer")}
+            style={waveStripStyle}
+          >
+            {waves}
+          </button>
+        ) : (
+          <div className={waveStripClass} style={waveStripStyle}>
+            {waves}
+          </div>
+        )}
       </div>
       <Button
         variant="danger"
@@ -180,11 +311,11 @@ export function VoiceSessionPill({
         tooltip="End voice session"
         onClick={onEnd}
       />
-      {/* Turn slot: ↑ releases the turn while listening; while the assistant
-          speaks (send unusable) the ■ stop takes its place instead of
-          stacking beside a disabled send. `expandOnMobile={false}` keeps
-          desktop sizing so the pill never exceeds the header row height on
-          touch-mobile web. */}
+      {/* Stop slot: ■ interrupts a reply in progress, and is present only
+          while one is playing — nothing occupies the slot otherwise, which is
+          what keeps the resting pill to four compact controls.
+          `expandOnMobile={false}` keeps desktop sizing so the pill never
+          exceeds the header row height on touch-mobile web. */}
       {onStop && state === "speaking" ? (
         <Button
           variant="primary"
@@ -195,18 +326,7 @@ export function VoiceSessionPill({
           tooltip="Stop assistant response"
           onClick={onStop}
         />
-      ) : (
-        <Button
-          variant="primary"
-          iconOnly={<ArrowUp strokeWidth={2.5} />}
-          className="rounded-full"
-          expandOnMobile={false}
-          disabled={state !== "listening"}
-          aria-label="Send now"
-          tooltip="Send now"
-          onClick={onSend}
-        />
-      )}
+      ) : null}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
@@ -92,6 +92,20 @@ export type VoiceWavePalette = "aurora" | "accent" | "tone";
  */
 export type VoiceWavePlacement = "bottom" | "top" | "center" | "inline";
 
+/**
+ * Edge fade for the inline wave strips (composer bar, title-bar pill).
+ *
+ * Those strips clip the drifting layers with `overflow-hidden`, which ends
+ * the band on a hard vertical edge mid-wave. Masking the container instead
+ * lets the band dissolve into the surface at both ends, so the strip reads as
+ * a window onto a continuous wave rather than a cropped rectangle.
+ *
+ * `-webkit-mask-image` is not optional: the iOS client is a WKWebView, which
+ * still needs the prefixed property.
+ */
+export const VOICE_WAVE_EDGE_FADE_CLASS =
+  "[mask-image:linear-gradient(to_right,transparent_0%,black_12%,black_88%,transparent_100%)] [-webkit-mask-image:linear-gradient(to_right,transparent_0%,black_12%,black_88%,transparent_100%)]";
+
 export function VoiceListeningWaves({
   getAmplitude,
   waveStyle = "fill",


### PR DESCRIPTION
Closes JARVIS-1363.

## The bug

With a live-voice session on a phone, the title-bar centre title collided with the chrome — "New Chat" rendered underneath the hamburger as a `w`/`at` fragment.

| before | after |
|---|---|
| `[≡] Qew Chat〰️ [✕][🔔]` — title painted under the search icon and mic | `[≡] Initial Greeting ⌄ [〰️][⋯]` |

Two causes, and the second is why `truncate` alone wasn't the fix:

1. **The title couldn't shrink.** `ChatConversationHeader`'s no-conversation branch returned a bare span with no `min-w-0`/`truncate`. Its parent is a `flex-1 min-w-0 justify-center` box, so when the pill claimed the row the item shrank toward zero and the un-shrinkable span overflowed in *both* directions — `justify-center` splits the overflow. The titled branch already truncated, which is why this reproduced only on a fresh chat.
2. **The cluster didn't fit.** On a 402pt phone the header's three zones share 338pt. The voice pill claimed ~250 of it, leaving the title ~58pt against the ~62pt "New Chat" needs. No amount of truncation makes 58pt readable.

## Changes

- **Textless pill and composer bar.** The two-line label (state over thread name) was ~160pt of redundancy — the mic glyph and animating waves already say "live and listening". State text survives as an `sr-only` `aria-live` region in both surfaces, so a screen-reader user loses nothing.
- **No manual send.** Turns release themselves (server VAD hands-free, auto-release in the manual fallback), so the primary-weight ↑ advertised an action the user never needs. The ■ barge-in stop keeps the slot and renders only while the assistant speaks — interrupting a reply has no other silent equivalent.
- **Phones collapse the pill to one sheet trigger** (mute / stop / go to thread / end), following the repo's existing dropdown-on-desktop, sheet-on-mobile pattern from `conversation-actions-menu.tsx`. Desktop keeps the inline controls.
- **The pill leads the right cluster**, and the remaining controls fold behind a `⋯` popover while it's present. The pill deliberately stays *out* of that popover — a live mic must keep a visible indicator, not one you open a menu to discover. `useVoiceSessionPillPresence` is extracted and shared with the host so the header and the pill can't disagree about whether the slot is occupied.
- **Header side clusters become `shrink-0`.** They're fixed-size controls; letting them flex either squashed the buttons into each other or held the row at intrinsic width and pushed trailing ones off-screen. The centre slot is the only zone that gives.
- **The composer textarea hides for the session's duration.** It's `disabled` anyway, so its placeholder invited an interaction that couldn't happen. Gated on `!showLiveVoiceTranscript` — the user transcript holds that same grid cell and is real content, so it keeps the row. The bar gains `pt-3` via a new `standalone` prop when it's the card's only row.
- **Wave strips fade at both edges** instead of hard-clipping mid-wave, via a shared `VOICE_WAVE_EDGE_FADE_CLASS` next to `VoiceListeningWaves` so the two surfaces can't drift.

## Notes for review

- **The `-webkit-mask-image` duplicate is deliberate**, not copy-paste. The iOS client is a WKWebView and drops the unprefixed property, which would have silently disabled the fade on exactly the device this was reported from. Covered by a test.
- **`releaseLiveVoiceTurn` now has no UI caller.** Left in place rather than ripping out `controls.release()` and its `use-live-voice` plumbing — that's a wider refactor than this polish pass warrants. Worth a follow-up.
- **Accepted trade:** on phones, mute moves one tap deeper. A hot mic still has a permanently *visible* control (the trigger); it's no longer a one-tap toggle. That bought the centre title ~130pt.
- The Dynamic Island is expected to own voice-outside-the-room on iOS eventually, which would remove the pill from this row there. Web and desktop have no island, so this work stands regardless.

## Testing

- `voice-session-pill.test.tsx` — 23 pass (incl. new condensed-mobile-form coverage: collapse, sheet actions, stop-only-while-speaking, omitted navigate row)
- `voice-session-pill-host.test.tsx` — 28 pass
- `voice-composer-bar.test.tsx` — 22 pass (incl. standalone padding, edge fade)
- `chat-composer.test.tsx` — 81 pass (incl. collapsed textarea row)
- `bunx tsc --noEmit` and `bun run lint` clean
- Verified in the iOS Simulator (iPhone 17 Pro, iOS 26.5) against local web across several rounds of design iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)