### PR TITLE
feat(web): let the paid-return marker name the research route through consent

### DIFF
--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/billing/checkout-intent";
 
 import {
+  postCheckoutHatchReturnTo,
   resolveNavigation,
   resolveLoginReturnTo,
   type NavigationState,
@@ -850,6 +851,40 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
+    // The research route is the headless paid provisioning entry, so it bounces
+    // and carries exactly like the hatching entry does.
+    const RESEARCH_FUNNEL_URL =
+      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
+
+    test("carries a paid research destination through the consent bounce", () => {
+      expect(
+        guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), RESEARCH_FUNNEL_URL),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+      });
+    });
+
+    // Closes a consent gap: an unconsented user could previously walk the
+    // research funnel directly, which provisions an assistant.
+    test("bounces an unconsented bare research visit to the entrypoint", () => {
+      expect(guard(s(UNCONSENTED), "/assistant/onboarding/research")).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/privacy",
+      });
+      expect(
+        guard(s({ isLocalMode: true, ...UNCONSENTED }), "/assistant/onboarding/research"),
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
+    });
+
+    test("allows a consented user on the research route", () => {
+      expect(guard(s({}), "/assistant/onboarding/research")).toEqual(ALLOW);
+      expect(
+        guard(s({ hasAssistants: false }), "/assistant/onboarding/research"),
+      ).toEqual(ALLOW);
+      expect(guard(s({}), RESEARCH_FUNNEL_URL)).toEqual(ALLOW);
+    });
+
     // The funnel destination must not itself read as a checkout return, or the
     // redirect would loop.
     test("the funnel destination is not treated as a post-checkout return", () => {
@@ -1204,6 +1239,69 @@ describe("resolveNavigation", () => {
       expect(
         resolveLoginReturnTo(s({}), "/assistant/onboarding/hosting"),
       ).toBe("/assistant/onboarding/hosting");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // postCheckoutHatchReturnTo
+  // -----------------------------------------------------------------------
+  describe("postCheckoutHatchReturnTo", () => {
+    const RESEARCH_FUNNEL_URL =
+      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
+    const HATCHING_FUNNEL_URL =
+      "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
+
+    test("accepts the headless research funnel entry", () => {
+      expect(postCheckoutHatchReturnTo(RESEARCH_FUNNEL_URL)).toBe(
+        RESEARCH_FUNNEL_URL,
+      );
+    });
+
+    // A `returnTo` stashed on the privacy screen by an older client names the
+    // hatching entry; it must still resume rather than drop the paid markers.
+    test("accepts the foreground hatching funnel entry", () => {
+      expect(postCheckoutHatchReturnTo(HATCHING_FUNNEL_URL)).toBe(
+        HATCHING_FUNNEL_URL,
+      );
+    });
+
+    test("rejects any other path, even carrying the marker", () => {
+      for (const url of [
+        "/assistant/onboarding/privacy?post_checkout=1",
+        "/assistant/settings/billing?post_checkout=1",
+        "/assistant?post_checkout=1",
+        "/assistant/onboarding/research-mock?post_checkout=1",
+      ]) {
+        expect(postCheckoutHatchReturnTo(url)).toBeNull();
+      }
+    });
+
+    test("rejects a funnel path without the paid marker", () => {
+      for (const url of [
+        "/assistant/onboarding/research",
+        "/assistant/onboarding/research?hosting=vellum-cloud",
+        "/assistant/onboarding/research?post_checkout=0",
+        "/assistant/onboarding/hatching",
+        "/assistant/onboarding/hatching?hosting=vellum-cloud",
+      ]) {
+        expect(postCheckoutHatchReturnTo(url)).toBeNull();
+      }
+    });
+
+    test("rejects absolute and protocol-relative URLs", () => {
+      for (const url of [
+        "https://evil.example.com/assistant/onboarding/research?post_checkout=1",
+        "//evil.example.com/assistant/onboarding/research?post_checkout=1",
+        "http://localhost/assistant/onboarding/hatching?post_checkout=1",
+      ]) {
+        expect(postCheckoutHatchReturnTo(url)).toBeNull();
+      }
+    });
+
+    test("rejects absent values", () => {
+      expect(postCheckoutHatchReturnTo(null)).toBeNull();
+      expect(postCheckoutHatchReturnTo(undefined)).toBeNull();
+      expect(postCheckoutHatchReturnTo("")).toBeNull();
     });
   });
 });

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -885,6 +885,50 @@ describe("resolveNavigation", () => {
       expect(guard(s({}), RESEARCH_FUNNEL_URL)).toEqual(ALLOW);
     });
 
+    // A cold paid deep link reaches the research route before the consent flags
+    // hydrate, and they boot false — deciding there would bounce an established
+    // user to privacy, and a `redirect` gives the auth middleware nothing to
+    // wait on.
+    test("waits on the research route until consent hydrates", () => {
+      for (const url of ["/assistant/onboarding/research", RESEARCH_FUNNEL_URL]) {
+        expect(
+          guard(s({ ...EMPTY_ORG, ...UNCONSENTED, consentHydrated: false }), url),
+        ).toEqual(WAIT);
+        // Same wait for an already-consented user whose flags have not been
+        // confirmed yet: hydration is read before the flags either way.
+        expect(guard(s({ consentHydrated: false }), url)).toEqual(WAIT);
+      }
+    });
+
+    // The wait is research-only: the foreground hatching entry is reached from
+    // in-app navigation, never a cold deep link, and it bounces immediately.
+    test("the hatching bounce does not wait on consent hydration", () => {
+      expect(
+        guard(s({ ...UNCONSENTED, consentHydrated: false }), MANAGED_FUNNEL_URL),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(MANAGED_FUNNEL_URL)}`,
+      });
+    });
+
+    // Local mode is excluded from hydration waits everywhere in the pipeline —
+    // its consent hydrates during session init or not at all — so its research
+    // bounce decides immediately.
+    test("a local-mode research bounce decides without waiting on hydration", () => {
+      expect(
+        guard(
+          s({ isLocalMode: true, ...UNCONSENTED, consentHydrated: false }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
+      expect(
+        guard(
+          s({ isLocalMode: true, ...UNCONSENTED, consentHydrated: false }),
+          "/assistant/onboarding/research",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
+    });
+
     // The funnel destination must not itself read as a checkout return, or the
     // redirect would loop.
     test("the funnel destination is not treated as a post-checkout return", () => {

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -521,6 +521,20 @@ function allowSetupRoutes(
   }
 
   if (isOnboardingPath(path)) {
+    // The research route is the headless funnel entry, so it is the one reached
+    // by a cold paid deep link — the consent flags are still at their boot
+    // defaults there, and bouncing on them would send an already-consented user
+    // to privacy. Local mode is excluded for the same reason as in
+    // `requireConsent`: its consent either hydrates synchronously during session
+    // init or never does, so waiting would hang navigation.
+    if (
+      path === routes.onboarding.research &&
+      !state.isLocalMode &&
+      !state.consentHydrated
+    ) {
+      return { action: "wait" };
+    }
+
     if (PROVISIONING_FUNNEL_PATHS.has(path) && !hasCompletedOnboarding(state)) {
       return {
         action: "redirect",

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -172,14 +172,26 @@ export const POST_CHECKOUT_HATCH_PARAM = "post_checkout";
 const MANAGED_PROVISIONING_DESTINATION = `${routes.onboarding.hatching}?hosting=vellum-cloud&${POST_CHECKOUT_HATCH_PARAM}=1`;
 
 /**
+ * The provisioning funnel entries a paid return can name: the foreground
+ * hatching screen (native, and local/Docker hosting) and the headless research
+ * onboarding (web). Both provision the purchased assistant, so both are
+ * consent-gated and both are resumable from the privacy screen.
+ */
+const PROVISIONING_FUNNEL_PATHS: Set<string> = new Set([
+  routes.onboarding.hatching,
+  routes.onboarding.research,
+]);
+
+/**
  * `value` when it names a paid managed hatch, else `null`.
  *
  * Narrower than {@link sanitizeReturnTo}'s open-redirect check: the onboarding
  * privacy screen navigates here in place of the standard onboarding step once
  * consent is recorded, so admitting any same-origin path would let a crafted
- * link skip the rest of the funnel. Only the hatching route carrying
- * {@link POST_CHECKOUT_HATCH_PARAM} qualifies, which only
- * {@link MANAGED_PROVISIONING_DESTINATION} produces.
+ * link skip the rest of the funnel. Only a {@link PROVISIONING_FUNNEL_PATHS}
+ * entry carrying {@link POST_CHECKOUT_HATCH_PARAM} qualifies — the screen
+ * resumes either the foreground or the headless paid provisioning entry, and
+ * that closed set of two keeps the anti-open-redirect property.
  */
 export function postCheckoutHatchReturnTo(
   value: string | null | undefined,
@@ -189,7 +201,7 @@ export function postCheckoutHatchReturnTo(
     return null;
   }
   const qIdx = destination.indexOf("?");
-  if (qIdx < 0 || destination.slice(0, qIdx) !== routes.onboarding.hatching) {
+  if (qIdx < 0 || !PROVISIONING_FUNNEL_PATHS.has(destination.slice(0, qIdx))) {
     return null;
   }
   const params = new URLSearchParams(destination.slice(qIdx + 1));
@@ -475,12 +487,12 @@ function enforceModeBoundary(
 }
 
 /**
- * Where an unconsented user who reached the hatching screen is sent.
+ * Where an unconsented user who reached a provisioning funnel entry is sent.
  *
- * A paid return carries its hatching URL as `returnTo`, the same contract
+ * A paid return carries its funnel URL as `returnTo`, the same contract
  * `review-terms` uses, and the privacy screen resumes it on Start. Without the
  * carry the funnel's markers are lost on the bounce and the paying user
- * finishes the hatch at the baseline plan. Every other hatching bounce — and
+ * finishes the hatch at the baseline plan. Every other funnel bounce — and
  * local mode, whose entrypoint is `welcome` and reads no `returnTo` — gets the
  * bare entrypoint.
  */
@@ -509,7 +521,7 @@ function allowSetupRoutes(
   }
 
   if (isOnboardingPath(path)) {
-    if (path === routes.onboarding.hatching && !hasCompletedOnboarding(state)) {
+    if (PROVISIONING_FUNNEL_PATHS.has(path) && !hasCompletedOnboarding(state)) {
       return {
         action: "redirect",
         to: consentBounceDestination(state, pathnameWithSearch),


### PR DESCRIPTION
## Summary
- `postCheckoutHatchReturnTo` now accepts the research route carrying `post_checkout=1` (the hatching form is still accepted, so a `returnTo` stashed by an older client keeps resuming with its paid markers intact)
- The consent bounce in `allowSetupRoutes` now covers the research route as well as hatching, so an unconsented paid return round-trips through the privacy screen with the marker intact
- Closes a pre-existing consent gap: a bare (free) research visit by an unconsented user was silently allowed even though that route provisions an assistant; it now bounces to the onboarding entrypoint
- Inert until the paid destination flips to research in a later PR — no production path emits a research paid return yet, and every existing hatching-path behavior is preserved

## Verification
- `bun run typecheck` clean; `bun run lint` 0 errors
- `bun test src/lib/navigation/navigation-resolver.test.ts` — 119 pass
- Also re-ran isolated and green: `hatching-screen.test.tsx`, `onboarding-lifecycle-sync.test.tsx`, `retire-service.test.ts`, `research-onboarding-route.test.tsx`

Part of plan: headless-paid-hatch.md (PR 4 of 5)