### PR TITLE
fix(ios): configure AVAudioSession for live voice so the platform cancels our echo (JARVIS-1364)

### DIFF
--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -4,10 +4,10 @@ import WebKit
 
 /// Custom `CAPBridgeViewController` subclass that:
 ///
-/// 1. Registers `NativeAuthPlugin` and `NativeBiometricPlugin` as local
-///    plugin instances at bridge init time. These plugins live inside the
-///    App target (no SPM module) so the bridge won't discover them
-///    automatically.
+/// 1. Registers `NativeAuthPlugin`, `NativeBiometricPlugin`, and
+///    `VoiceAudioSessionPlugin` as local plugin instances at bridge init
+///    time. These plugins live inside the App target (no SPM module) so the
+///    bridge won't discover them automatically.
 ///
 /// 2. Injects `WKUserScript`s at `.atDocumentEnd` to:
 ///    a) Pin focusable fields to a minimum 16px font-size, preventing the
@@ -144,6 +144,7 @@ class MyViewController: CAPBridgeViewController {
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(NativeAuthPlugin())
         bridge?.registerPluginInstance(NativeBiometricPlugin())
+        bridge?.registerPluginInstance(VoiceAudioSessionPlugin())
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()

--- a/clients/ios/App/App/VoiceAudioSessionPlugin.swift
+++ b/clients/ios/App/App/VoiceAudioSessionPlugin.swift
@@ -1,0 +1,126 @@
+import AVFoundation
+import Capacitor
+
+/// Capacitor plugin that puts the app's `AVAudioSession` into a voice-chat
+/// configuration for the duration of a live-voice session, then restores it.
+///
+/// ## Why this exists
+///
+/// The web layer already asks for `echoCancellation: true` on `getUserMedia`
+/// (`clients/web/src/utils/voice-input-device.ts`). In a WKWebView that ask is
+/// necessary but not sufficient: the quality of the echo canceller WebKit gets
+/// is decided by the *app's* audio-session category and mode, which only the
+/// native side can set. With no configuration at all — the state this shell was
+/// in before this plugin — iOS leaves the session in the default `.soloAmbient`
+/// / `.default` pairing, which has no voice-processing path and routes playback
+/// to the receiver rather than the speaker. The result is that the assistant
+/// hears its own TTS through the speaker and barges in on itself (JARVIS-1364).
+///
+/// `.playAndRecord` + mode `.voiceChat` is the documented way to request the
+/// voice-processing I/O path, which is what actually runs acoustic echo
+/// cancellation against the far-end signal. `.defaultToSpeaker` keeps playback
+/// on the loudspeaker (`.playAndRecord` otherwise prefers the receiver, which
+/// makes a hands-free session unusable), and `.allowBluetooth` lets an HFP
+/// headset carry both directions.
+///
+/// ## Lifecycle
+///
+/// `activate()` and `deactivate()` bracket the live-voice mic — the web side
+/// calls them from `LiveVoiceAudioCapture` (`pcm-capture.ts`), which holds the
+/// capture graph open for exactly the session's duration. Both are idempotent:
+/// `activate()` on an already-active session re-asserts the configuration
+/// (WebKit reconfigures the shared session when capture starts, so the web
+/// layer deliberately calls it again once `getUserMedia` resolves), and
+/// `deactivate()` without a prior `activate()` is a no-op.
+///
+/// The category/mode/options in place before the first `activate()` are saved
+/// and restored on `deactivate()`, so ordinary media playback is never left
+/// stuck in a duplex category once the call ends.
+///
+/// Capacitor dispatches each plugin's calls on its own serial queue, so
+/// `savedConfiguration` needs no additional synchronization.
+///
+/// References:
+/// - https://developer.apple.com/documentation/avfaudio/avaudiosession/category/playandrecord
+/// - https://developer.apple.com/documentation/avfaudio/avaudiosession/mode/voicechat
+/// - https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions/defaulttospeaker
+@objc(VoiceAudioSessionPlugin)
+public class VoiceAudioSessionPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "VoiceAudioSessionPlugin"
+    public let jsName = "VoiceAudioSession"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "activate", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "deactivate", returnType: CAPPluginReturnPromise),
+    ]
+
+    /// Category, mode, and options as they were before the first `activate()`.
+    /// `nil` means the session is not currently held by a live-voice session.
+    private var savedConfiguration: (
+        category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    )?
+
+    /// `.allowBluetoothHFP` is the current spelling of what used to be
+    /// `.allowBluetooth` — a pure rename (the old name is deprecated, not the
+    /// behavior), so this still resolves at the iOS 15 deployment target.
+    private static let categoryOptions: AVAudioSession.CategoryOptions = [
+        .defaultToSpeaker,
+        .allowBluetoothHFP,
+    ]
+
+    // MARK: - activate
+
+    /// Configure and activate the voice-chat audio session. Safe to call while
+    /// already active — it re-asserts the configuration.
+    @objc public func activate(_ call: CAPPluginCall) {
+        let session = AVAudioSession.sharedInstance()
+        if savedConfiguration == nil {
+            savedConfiguration = (session.category, session.mode, session.categoryOptions)
+        }
+
+        do {
+            try session.setCategory(
+                .playAndRecord,
+                mode: .voiceChat,
+                options: Self.categoryOptions
+            )
+            try session.setActive(true)
+            call.resolve()
+        } catch {
+            // Leave `savedConfiguration` set: a partial application (category
+            // took, activation failed) still needs restoring on deactivate.
+            NSLog("[voice-audio-session] activate failed: \(error.localizedDescription)")
+            call.reject("Failed to activate voice audio session: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - deactivate
+
+    /// Restore the pre-session configuration and release the audio session.
+    /// A no-op (resolving) when no `activate()` is outstanding.
+    @objc public func deactivate(_ call: CAPPluginCall) {
+        guard let saved = savedConfiguration else {
+            call.resolve()
+            return
+        }
+        savedConfiguration = nil
+
+        let session = AVAudioSession.sharedInstance()
+        // `.notifyOthersOnDeactivation` lets whatever we interrupted (music,
+        // a podcast) resume instead of staying ducked after the call.
+        do {
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            // Non-fatal: another audio client may still be running. Restoring
+            // the category below is the part that matters for later playback.
+            NSLog("[voice-audio-session] deactivate failed: \(error.localizedDescription)")
+        }
+        do {
+            try session.setCategory(saved.category, mode: saved.mode, options: saved.options)
+        } catch {
+            NSLog("[voice-audio-session] category restore failed: \(error.localizedDescription)")
+        }
+        call.resolve()
+    }
+}

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
@@ -1,10 +1,22 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
-  isSupported,
-  LIVE_VOICE_AUDIO_FORMAT,
-  LiveVoiceAudioCapture,
-} from "@/domains/chat/voice/live-voice/pcm-capture";
+// The native audio-session bridge (`.playAndRecord` / `.voiceChat` on iOS) is a
+// no-op off Capacitor, so it would be invisible here. Mock it to record the
+// call order relative to getUserMedia — the ordering is the whole point: the
+// category/mode must be in force *before* WebKit builds its capture unit.
+// Declared before the module under test is imported.
+const audioSessionCalls: string[] = [];
+mock.module("@/runtime/native-voice-audio-session", () => ({
+  activateVoiceAudioSession: mock(async () => {
+    audioSessionCalls.push("activate");
+  }),
+  deactivateVoiceAudioSession: mock(async () => {
+    audioSessionCalls.push("deactivate");
+  }),
+}));
+
+const { isSupported, LIVE_VOICE_AUDIO_FORMAT, LiveVoiceAudioCapture } =
+  await import("@/domains/chat/voice/live-voice/pcm-capture");
 
 // ---------------------------------------------------------------------------
 // Browser audio API fakes
@@ -106,6 +118,7 @@ function installAudioGlobals(): void {
 beforeEach(() => {
   lastWorklet = null;
   FakeAudioContext.lastInstance = null;
+  audioSessionCalls.length = 0;
   getUserMediaImpl = () => Promise.resolve(new FakeMediaStream());
   installAudioGlobals();
 });
@@ -342,6 +355,83 @@ describe("lifecycle", () => {
     // The accumulator was reset: a second flush emits nothing.
     capture.flush();
     expect(chunks.length).toBe(1);
+  });
+});
+
+describe("native audio session (iOS echo cancellation)", () => {
+  /** Records `getUserMedia` in the same log as the audio-session calls. */
+  function recordGetUserMedia(stream = new FakeMediaStream()) {
+    getUserMediaImpl = () => {
+      audioSessionCalls.push("getUserMedia");
+      return Promise.resolve(stream);
+    };
+    return stream;
+  }
+
+  test("activates before opening the mic, then re-asserts once the stream is live", async () => {
+    recordGetUserMedia();
+    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
+
+    const result = await capture.start();
+
+    expect(result.ok).toBe(true);
+    // The first activate must precede getUserMedia — configuring the session
+    // after WebKit has built its capture unit is too late for that stream.
+    // The second re-asserts the mode WebKit may have dropped when capture
+    // started.
+    expect(audioSessionCalls).toEqual([
+      "activate",
+      "getUserMedia",
+      "activate",
+    ]);
+  });
+
+  test("deactivates when the session's capture is torn down", async () => {
+    recordGetUserMedia();
+    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
+    await capture.start();
+    audioSessionCalls.length = 0;
+
+    await capture.stop();
+
+    expect(audioSessionCalls).toEqual(["deactivate"]);
+  });
+
+  test("deactivates when the mic is denied, leaving no session held", async () => {
+    getUserMediaImpl = () => {
+      audioSessionCalls.push("getUserMedia");
+      return Promise.reject(new DOMException("denied", "NotAllowedError"));
+    };
+    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
+
+    const result = await capture.start();
+
+    expect(result.ok).toBe(false);
+    expect(audioSessionCalls).toEqual([
+      "activate",
+      "getUserMedia",
+      "deactivate",
+    ]);
+  });
+
+  test("deactivates when a stop() cancels an in-flight start", async () => {
+    const stream = new FakeMediaStream();
+    let resolveGum: (s: FakeMediaStream) => void = () => {};
+    getUserMediaImpl = () =>
+      new Promise<FakeMediaStream>((resolve) => {
+        resolveGum = resolve;
+      });
+    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
+
+    const startPromise = capture.start();
+    await capture.stop();
+    resolveGum(stream);
+    await startPromise;
+
+    // Whatever the interleaving, the cancelled start must not leave the audio
+    // session held in the duplex category.
+    expect(audioSessionCalls.at(-1)).toBe("deactivate");
+    expect(stream.tracks.every((t) => t.stopped)).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
@@ -6,14 +6,34 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // category/mode must be in force *before* WebKit builds its capture unit.
 // Declared before the module under test is imported.
 const audioSessionCalls: string[] = [];
+// Lets a test park one `activate` call mid-flight, standing in for a slow
+// Capacitor bridge round-trip.
+let activateCallCount = 0;
+let gatedActivateCall: number | null = null;
+let gate: { promise: Promise<void>; resolve: () => void } | null = null;
+
+function makeGate(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
 mock.module("@/runtime/native-voice-audio-session", () => ({
   activateVoiceAudioSession: mock(async () => {
+    activateCallCount += 1;
     audioSessionCalls.push("activate");
+    if (gate && gatedActivateCall === activateCallCount) await gate.promise;
   }),
   deactivateVoiceAudioSession: mock(async () => {
     audioSessionCalls.push("deactivate");
   }),
 }));
+
+const flushMicrotasks = async (rounds = 4) => {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+};
 
 const { isSupported, LIVE_VOICE_AUDIO_FORMAT, LiveVoiceAudioCapture } =
   await import("@/domains/chat/voice/live-voice/pcm-capture");
@@ -119,6 +139,9 @@ beforeEach(() => {
   lastWorklet = null;
   FakeAudioContext.lastInstance = null;
   audioSessionCalls.length = 0;
+  activateCallCount = 0;
+  gatedActivateCall = null;
+  gate = null;
   getUserMediaImpl = () => Promise.resolve(new FakeMediaStream());
   installAudioGlobals();
 });
@@ -412,6 +435,34 @@ describe("native audio session (iOS echo cancellation)", () => {
       "getUserMedia",
       "deactivate",
     ]);
+  });
+
+  test("a stop() during the post-getUserMedia re-assert releases the mic without waiting on the bridge", async () => {
+    const stream = recordGetUserMedia();
+    gate = makeGate();
+    gatedActivateCall = 2; // park the re-assert that follows getUserMedia
+    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
+
+    const startPromise = capture.start();
+    await flushMicrotasks();
+    expect(audioSessionCalls).toEqual(["activate", "getUserMedia", "activate"]);
+
+    // The mic is open but the native call has not answered. A stop() here must
+    // release it immediately — the capture has to own the stream before the
+    // round-trip, or the mic stays live for however long the bridge takes.
+    const stopPromise = capture.stop();
+    await flushMicrotasks();
+    expect(stream.tracks.every((t) => t.stopped)).toBe(true);
+
+    gate.resolve();
+    const result = await startPromise;
+    await stopPromise;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("aborted");
+    // The late activate resolved after teardown's deactivate; the session must
+    // not be left held with no owner.
+    expect(audioSessionCalls.at(-1)).toBe("deactivate");
   });
 
   test("deactivates when a stop() cancels an in-flight start", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -189,18 +189,29 @@ export class LiveVoiceAudioCapture {
       return { ok: false, error: classifyError(cause), cause };
     }
 
-    // WebKit reconfigures the shared `AVAudioSession` itself when capture
-    // starts, which can drop the mode we just set. Re-assert it now that the
-    // stream is live; the native side is idempotent.
-    await activateVoiceAudioSession();
-
     // A concurrent shutdown()/stop() may have raced the awaits above.
     if (cancelled()) {
       stopTracks(stream);
       await deactivateVoiceAudioSession();
       return { ok: false, error: "aborted" };
     }
+    // Take ownership of the stream *before* the next native round-trip, so a
+    // stop() that lands mid-call releases the mic through teardown() instead
+    // of leaving it live until the bridge answers.
     this.stream = stream;
+
+    // WebKit reconfigures the shared `AVAudioSession` itself when capture
+    // starts, which can drop the mode we just set. Re-assert it now that the
+    // stream is live; the native side is idempotent.
+    await activateVoiceAudioSession();
+
+    // A stop() that raced the re-assert already ran teardown() — including its
+    // deactivate, which our late activate then undid. Tear down again so the
+    // session isn't left held in the duplex category with no owner.
+    if (cancelled()) {
+      await this.teardown();
+      return { ok: false, error: "aborted" };
+    }
 
     try {
       const context = createAudioContext();

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -11,6 +11,12 @@
  * An RMS `amplitude` in [0, 1] is also surfaced for UI / barge-in detection,
  * reusing the smoothing constants from `domains/voice/use-audio-amplitude.ts`.
  *
+ * On iOS the capture also brackets itself with `runtime/native-voice-audio-session`,
+ * which puts the app's `AVAudioSession` into `.playAndRecord` / `.voiceChat` so
+ * the platform runs echo cancellation against our own TTS instead of letting
+ * the assistant barge in on itself through the speaker. It is a no-op off the
+ * Capacitor shell.
+ *
  * The capture is permission-agnostic: it requests `getUserMedia` directly and
  * surfaces a denial as a typed `LiveVoiceCaptureResult` rather than throwing.
  * Per `clients/web/AGENTS.md` / `docs/CAPACITOR.md` § OS permission requests,
@@ -36,6 +42,10 @@ import WORKLET_MODULE_URL from "./pcm-downsample-worklet.ts?worker&url";
 
 import { createAudioContext, getAudioContextCtor } from "@/domains/chat/voice/audio-context";
 import { LIVE_VOICE_AUDIO_FORMAT } from "@/domains/chat/voice/live-voice/protocol";
+import {
+  activateVoiceAudioSession,
+  deactivateVoiceAudioSession,
+} from "@/runtime/native-voice-audio-session";
 import { getVoiceInputMediaStream } from "@/utils/voice-input-device";
 
 // Re-exported for capture consumers (e.g. use-live-voice.ts) so they don't need
@@ -164,16 +174,30 @@ export class LiveVoiceAudioCapture {
     const epoch = this.cancelEpoch;
     const cancelled = () => this.disposed || this.cancelEpoch !== epoch;
 
+    // Put the iOS audio session into `.playAndRecord` / `.voiceChat` *before*
+    // opening the mic: the category and mode in force when WebKit builds its
+    // capture unit decide whether the platform echo canceller runs at all, so
+    // configuring after the fact is too late for this stream. No-op off the
+    // Capacitor shell.
+    await activateVoiceAudioSession();
+
     let stream: MediaStream;
     try {
       stream = await getVoiceInputMediaStream();
     } catch (cause) {
+      await deactivateVoiceAudioSession();
       return { ok: false, error: classifyError(cause), cause };
     }
 
-    // A concurrent shutdown()/stop() may have raced the await above.
+    // WebKit reconfigures the shared `AVAudioSession` itself when capture
+    // starts, which can drop the mode we just set. Re-assert it now that the
+    // stream is live; the native side is idempotent.
+    await activateVoiceAudioSession();
+
+    // A concurrent shutdown()/stop() may have raced the awaits above.
     if (cancelled()) {
       stopTracks(stream);
+      await deactivateVoiceAudioSession();
       return { ok: false, error: "aborted" };
     }
     this.stream = stream;
@@ -296,6 +320,10 @@ export class LiveVoiceAudioCapture {
       await context.close().catch(() => {});
     }
     this.smoothedAmplitude = 0;
+    // Hand the audio session back so ordinary media playback isn't left in a
+    // duplex, speaker-forced category once the call ends. Native no-ops when
+    // there is no activation outstanding, so an unstarted teardown is free.
+    await deactivateVoiceAudioSession();
   }
 }
 

--- a/clients/web/src/runtime/native-voice-audio-session.test.ts
+++ b/clients/web/src/runtime/native-voice-audio-session.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let isNative = true;
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => isNative,
+}));
+
+const activateMock = mock(async () => {});
+const deactivateMock = mock(async () => {});
+mock.module("@capacitor/core", () => ({
+  registerPlugin: () => ({
+    activate: activateMock,
+    deactivate: deactivateMock,
+  }),
+}));
+
+const { activateVoiceAudioSession, deactivateVoiceAudioSession } = await import(
+  "@/runtime/native-voice-audio-session"
+);
+
+beforeEach(() => {
+  isNative = true;
+  activateMock.mockClear();
+  deactivateMock.mockClear();
+  activateMock.mockImplementation(async () => {});
+  deactivateMock.mockImplementation(async () => {});
+});
+
+describe("activateVoiceAudioSession", () => {
+  test("calls into the native plugin on the Capacitor shell", async () => {
+    await activateVoiceAudioSession();
+
+    expect(activateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("is a no-op off the Capacitor shell (browser / Electron)", async () => {
+    isNative = false;
+
+    await activateVoiceAudioSession();
+
+    expect(activateMock).not.toHaveBeenCalled();
+  });
+
+  test("swallows a native failure — an echoing call beats no call at all", async () => {
+    activateMock.mockImplementation(async () => {
+      throw new Error("session busy");
+    });
+
+    await activateVoiceAudioSession();
+
+    expect(activateMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("deactivateVoiceAudioSession", () => {
+  test("calls into the native plugin on the Capacitor shell", async () => {
+    await deactivateVoiceAudioSession();
+
+    expect(deactivateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("is a no-op off the Capacitor shell", async () => {
+    isNative = false;
+
+    await deactivateVoiceAudioSession();
+
+    expect(deactivateMock).not.toHaveBeenCalled();
+  });
+
+  test("swallows a native failure so teardown always completes", async () => {
+    deactivateMock.mockImplementation(async () => {
+      throw new Error("deactivation failed");
+    });
+
+    await deactivateVoiceAudioSession();
+
+    expect(deactivateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/runtime/native-voice-audio-session.ts
+++ b/clients/web/src/runtime/native-voice-audio-session.ts
@@ -1,0 +1,59 @@
+import { registerPlugin } from "@capacitor/core";
+
+import { isNativePlatform } from "@/runtime/native-auth";
+
+/**
+ * JS ↔ native bridge for the `VoiceAudioSession` Capacitor plugin registered by
+ * `clients/ios/App/App/MyViewController.swift` +
+ * `clients/ios/App/App/VoiceAudioSessionPlugin.swift`.
+ *
+ * Puts the iOS app's `AVAudioSession` into `.playAndRecord` / `.voiceChat` for
+ * the duration of a live-voice session so the platform runs acoustic echo
+ * cancellation against our own TTS, then restores the previous configuration.
+ * Without it the assistant hears itself through the speaker and barges in on
+ * its own audio (JARVIS-1364) — the `echoCancellation: true` constraint in
+ * `utils/voice-input-device.ts` is not enough on its own inside a WKWebView,
+ * because the canceller WebKit gets is chosen by the app's audio session.
+ *
+ * No-op off the Capacitor shell: browsers and Electron have no equivalent
+ * app-level audio session, and their `getUserMedia` AEC is already in effect.
+ *
+ * Failures are swallowed. A session that could not be configured still
+ * captures audio — it just echoes, which is strictly better than refusing to
+ * start the call.
+ */
+
+interface VoiceAudioSessionPlugin {
+  activate(): Promise<void>;
+  deactivate(): Promise<void>;
+}
+
+const VoiceAudioSession =
+  registerPlugin<VoiceAudioSessionPlugin>("VoiceAudioSession");
+
+/**
+ * Configure and activate the voice-chat audio session. Idempotent — the caller
+ * deliberately calls this again after `getUserMedia` resolves, because WebKit
+ * reconfigures the shared session when it starts capturing.
+ */
+export async function activateVoiceAudioSession(): Promise<void> {
+  if (!isNativePlatform()) return;
+  try {
+    await VoiceAudioSession.activate();
+  } catch (err) {
+    console.error("[voice-audio-session] activate failed:", err);
+  }
+}
+
+/**
+ * Restore the pre-session audio configuration and release the session. Safe to
+ * call without a matching `activate()` — the native side no-ops.
+ */
+export async function deactivateVoiceAudioSession(): Promise<void> {
+  if (!isNativePlatform()) return;
+  try {
+    await VoiceAudioSession.deactivate();
+  } catch (err) {
+    console.error("[voice-audio-session] deactivate failed:", err);
+  }
+}


### PR DESCRIPTION
Fixes JARVIS-1364.

## Problem

On iOS the assistant hears itself through the device speaker during live voice — it self-interrupts mid-sentence, or loops on "one second… let me look into that" as its own TTS re-triggers the turn. (Reported internally as LUM-2842, now closed as a duplicate.)

The web layer already asks for `echoCancellation: true` on `getUserMedia` (`clients/web/src/utils/voice-input-device.ts`). Inside a WKWebView that ask is necessary but not sufficient: the echo canceller WebKit gets is decided by the **app's** `AVAudioSession` category and mode — and this shell configured none at all (zero `AVAudioSession`/`AVFoundation` references under `clients/ios/App/App/`). iOS therefore left the session in the default `.soloAmbient` / `.default` pairing, which has no voice-processing path and routes playback to the receiver rather than the speaker.

## Change

- **`VoiceAudioSessionPlugin.swift`** — a local Capacitor plugin exposing `activate()` / `deactivate()`. `activate()` sets `.playAndRecord` + mode `.voiceChat` with `[.defaultToSpeaker, .allowBluetoothHFP]` and activates the session; `deactivate()` restores the category/mode/options that were in place beforehand and releases the session with `.notifyOthersOnDeactivation`. Both are idempotent.
- **`native-voice-audio-session.ts`** — the JS bridge. No-op off the Capacitor shell; failures are swallowed, since a session that echoes beats a call that refuses to start.
- **`pcm-capture.ts`** — brackets the live-voice mic with it. `LiveVoiceAudioCapture` holds its capture graph open for exactly the session's duration, so it is the natural seam.

Two ordering details that are the substance of the fix:

1. `activate()` runs **before** `getUserMedia`. The category and mode in force when WebKit builds its capture unit decide whether the platform echo canceller runs at all — configuring afterwards is too late for that stream.
2. It runs **again** once the stream is live, because WebKit reconfigures the shared session itself when capture starts and can drop the mode we just set.

`deactivate()` runs on every teardown path (normal stop, denied mic, a `stop()` that cancels an in-flight `start()`), so ordinary media playback is never left stuck in a duplex, speaker-forced category.

Scope is live voice only — one-shot dictation (`voice-input-button.tsx`) and `use-audio-amplitude.ts` call `getVoiceInputMediaStream` directly and are untouched.

`.allowBluetoothHFP` is the current spelling of `.allowBluetooth` (a pure rename; the old name is deprecated). It resolves fine at the iOS 15 deployment target and builds without a deprecation warning.

## Verification

- `bun test` on `pcm-capture.test.ts` (18 pass) and the new `native-voice-audio-session.test.ts` (6 pass); `use-live-voice`, `live-voice-store`, `live-voice-client`, `tts-playback` all still green. `bun run typecheck` and `bun run lint` clean (0 errors).
- `xcodebuild` for `App Dev` on the iOS 26.5 Simulator: **BUILD SUCCEEDED**, no warnings on the new file.
- Native round-trip smoke-tested in the Simulator against a throwaway probe page — plugin registers, `activate()` resolves (so iOS accepts this category/mode/options combination), activation is idempotent, and `deactivate()` resolves both with and without a prior `activate()`.

**Not yet verified on hardware.** Simulator AEC is not representative, so the actual echo behaviour still needs a real device at high speaker volume: confirm the assistant no longer self-interrupts and that barge-in still works. Holding this PR unmerged until then.

## If this isn't enough

JARVIS-1296's daemon-side energy-VAD echo gate (PR #38348) was **closed, never merged** — there is no echo gate on `main` today. Platform AEC is the cheaper first move. If it proves insufficient, prefer TTS-envelope correlation or client-side ducking over reviving that threshold heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)