### PR TITLE
feat(web): run the purchased-provisioning wait inside the background hatch

### DIFF
--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -13,6 +13,7 @@ import type {
   GetHealthzResult,
   HatchResult,
 } from "@/assistant/api";
+import type { PurchasedProvisioningOutcome } from "@/domains/onboarding/purchased-provisioning";
 
 let hatchResult: HatchResult = {
   ok: true,
@@ -66,8 +67,49 @@ mock.module("@/utils/api-errors", () => ({
       ? (e as { detail: string }).detail
       : (fallback ?? "error"),
 }));
+mock.module("@sentry/react", () => ({
+  captureMessage: () => {},
+}));
+
+// The paid stage only: the free path must never reach this module at all.
+let provisioningOutcome: PurchasedProvisioningOutcome = "ready";
+// Optional gate holding the provisioning wait open, so a test can assert
+// `ready` stays false for as long as the resize hasn't converged.
+let provisioningGate: Promise<void> | null = null;
+const holdProvisioning = (): (() => void) => {
+  let release!: () => void;
+  provisioningGate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return release;
+};
+const awaitPurchasedProvisioningMock = mock(
+  async (_options: unknown): Promise<PurchasedProvisioningOutcome> => {
+    if (provisioningGate) await provisioningGate;
+    return provisioningOutcome;
+  },
+);
+mock.module("@/domains/onboarding/purchased-provisioning", () => ({
+  awaitPurchasedProvisioning: awaitPurchasedProvisioningMock,
+}));
+
+const seedHatchAvatarMock = mock(
+  async (_id: string, _traits: unknown, _queryClient: unknown): Promise<void> =>
+    undefined,
+);
+mock.module("@/assistant/seed-hatch-avatar", () => ({
+  seedHatchAvatar: seedHatchAvatarMock,
+}));
+
+const stableQueryClient = {};
+mock.module("@tanstack/react-query", () => ({
+  useQueryClient: () => stableQueryClient,
+}));
 
 const { useBackgroundHatch } = await import("./use-background-hatch");
+
+const TIMEOUT_MESSAGE =
+  "Your assistant is taking longer than expected. Please try again.";
 
 beforeEach(() => {
   hatchResult = { ok: true, status: 201, data: { id: "ast-research" } as never };
@@ -78,11 +120,15 @@ beforeEach(() => {
   };
   healthzResult = { ok: true, status: 200, data: {} as never };
   lockfileEntries = {};
+  provisioningOutcome = "ready";
+  provisioningGate = null;
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
   getAssistantHealthzMock.mockClear();
   probeLocalGatewayReadyMock.mockClear();
   getLockfileAssistantMock.mockClear();
+  awaitPurchasedProvisioningMock.mockClear();
+  seedHatchAvatarMock.mockClear();
 });
 
 describe("useBackgroundHatch", () => {
@@ -226,5 +272,153 @@ describe("useBackgroundHatch", () => {
     await waitFor(() => expect(result.current.ready).toBe(true));
     // Vellum-Cloud / managed path still provisions via hatchAssistant.
     expect(hatchAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("post-checkout return withholds ready until the provisioning wait resolves", async () => {
+    const release = holdProvisioning();
+
+    const { result } = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    let resolved: string | undefined;
+    act(() => {
+      void result.current.awaitReady().then((id) => {
+        resolved = id;
+      });
+      result.current.start();
+    });
+
+    await waitFor(() =>
+      expect(awaitPurchasedProvisioningMock).toHaveBeenCalledTimes(1),
+    );
+    // The wait runs AFTER healthz passes, and holds `ready` while pending.
+    expect(getAssistantHealthzMock).toHaveBeenCalledTimes(1);
+    expect(awaitPurchasedProvisioningMock.mock.calls[0][0]).toMatchObject({
+      assistantId: "ast-research",
+      postCheckoutReturn: true,
+      managedHatch: true,
+    });
+    expect(result.current.ready).toBe(false);
+    expect(resolved).toBeUndefined();
+
+    await act(async () => {
+      release();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    await waitFor(() => expect(resolved).toBe("ast-research"));
+  });
+
+  test("a health_timeout from the provisioning wait fails the hatch", async () => {
+    provisioningOutcome = "health_timeout";
+
+    const { result } = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    let rejection: Error | undefined;
+    act(() => {
+      void result.current.awaitReady().catch((err: Error) => {
+        rejection = err;
+      });
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(TIMEOUT_MESSAGE));
+    // A resize the assistant never came back from is a failure, never a
+    // completion onto an unreachable pod.
+    expect(result.current.ready).toBe(false);
+    await waitFor(() => expect(rejection?.message).toBe(TIMEOUT_MESSAGE));
+  });
+
+  test("the free path never runs the purchased-provisioning wait", async () => {
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    // No subscription polling and no avatar seed without the paid marker.
+    expect(awaitPurchasedProvisioningMock).not.toHaveBeenCalled();
+    expect(seedHatchAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("retry() re-runs the hatch after a terminal failure", async () => {
+    hatchResult = {
+      ok: false,
+      status: 400,
+      error: { detail: "Bad hatch request" },
+    };
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe("Bad hatch request"));
+
+    hatchResult = {
+      ok: true,
+      status: 201,
+      data: { id: "ast-research" } as never,
+    };
+
+    let resolved: string | undefined;
+    act(() => {
+      result.current.retry();
+      // Waiters from the failed attempt were already rejected, so callers
+      // re-await after retrying.
+      void result.current.awaitReady().then((id) => {
+        resolved = id;
+      });
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(result.current.assistantId).toBe("ast-research");
+    expect(hatchAssistantMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(resolved).toBe("ast-research"));
+
+    // The restarted hatch is ref-guarded again.
+    act(() => {
+      result.current.start();
+    });
+    expect(hatchAssistantMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a 201 paid hatch seeds the avatar; an existing (200) one does not", async () => {
+    const fresh = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    act(() => {
+      fresh.result.current.start();
+    });
+
+    await waitFor(() => expect(fresh.result.current.ready).toBe(true));
+    expect(seedHatchAvatarMock).toHaveBeenCalledTimes(1);
+    expect(seedHatchAvatarMock.mock.calls[0][0]).toBe("ast-research");
+
+    seedHatchAvatarMock.mockClear();
+    hatchResult = {
+      ok: true,
+      status: 200,
+      data: { id: "ast-research" } as never,
+    };
+
+    const existing = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    act(() => {
+      existing.result.current.start();
+    });
+
+    await waitFor(() => expect(existing.result.current.ready).toBe(true));
+    // A returning user may have a real avatar; only a fresh hatch is seeded.
+    expect(seedHatchAvatarMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 
 import {
@@ -11,9 +13,13 @@ import {
   resolveAssistantLifecycleState,
   shouldRecoverFromHatchFailure,
 } from "@/assistant/lifecycle";
+import { seedHatchAvatar } from "@/assistant/seed-hatch-avatar";
+import { awaitPurchasedProvisioning } from "@/domains/onboarding/purchased-provisioning";
 import { getLockfileAssistant, probeLocalGatewayReady } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { extractErrorMessage } from "@/utils/api-errors";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { randomCharacterTraits } from "@/utils/avatar-random";
 
 // Mirrors the poll/backoff constants in
 // `@/domains/onboarding/pages/hatching-screen.tsx`. The research-onboarding
@@ -35,6 +41,12 @@ const sleep = (ms: number): Promise<void> =>
 export interface UseBackgroundHatch {
   /** Fire the hatch. Idempotent — only the first call provisions. */
   start: () => void;
+  /**
+   * Re-run a failed hatch from the top, clearing the terminal state first.
+   * `awaitReady()` waiters from the failed attempt were already rejected at
+   * `settleError` time, so callers must re-await after retrying.
+   */
+  retry: () => void;
   /** True only once the assistant has passed a health check. */
   ready: boolean;
   /** The provisioned assistant id, set once the hatch resolves. */
@@ -66,6 +78,13 @@ export interface UseBackgroundHatchOptions {
    * out stale), discovery falls back to the selected/active assistant.
    */
   adoptAssistantId?: string;
+  /**
+   * The hatch is the return leg of a completed checkout (`post_checkout=1`):
+   * after healthz, hold `ready` until the purchased machine/storage resize
+   * converges (`awaitPurchasedProvisioning`), then re-probe healthz. Never set
+   * on the free path — the free hatch must not add subscription polling.
+   */
+  postCheckoutReturn?: boolean;
 }
 
 /**
@@ -79,15 +98,22 @@ export interface UseBackgroundHatchOptions {
  * the hatch return.
  *
  * When `adoptExisting` is set (a local-hosting onboarding), the managed hatch is
- * skipped and we adopt the already-live assistant instead.
+ * skipped and we adopt the already-live assistant instead. When
+ * `postCheckoutReturn` is set, `ready` additionally waits on the purchased
+ * machine/storage resize so the paid user never starts on a baseline assistant.
  *
  * Terminal failures (platform-hosted disabled, non-recoverable hatch errors,
  * lifecycle errors, timeout) set `error` and reject `awaitReady()`.
  * Recoverable failures (5xx / network) keep polling.
  */
 export function useBackgroundHatch(
-  { adoptExisting = false, adoptAssistantId }: UseBackgroundHatchOptions = {},
+  {
+    adoptExisting = false,
+    adoptAssistantId,
+    postCheckoutReturn = false,
+  }: UseBackgroundHatchOptions = {},
 ): UseBackgroundHatch {
+  const queryClient = useQueryClient();
   const [ready, setReady] = useState(false);
   const [assistantId, setAssistantId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -174,6 +200,16 @@ export function useBackgroundHatch(
           if (result.ok) {
             hatchedAssistantId = result.data.id;
             setAssistantId(result.data.id);
+            // The Dock/tray icons are avatar-driven, so a freshly hatched (201)
+            // assistant needs seeded traits — parity with the foreground hatch.
+            // Fire-and-forget; the research face step overwrites them later.
+            if (postCheckoutReturn && result.status === 201) {
+              void seedHatchAvatar(
+                result.data.id,
+                randomCharacterTraits(BUNDLED_COMPONENTS),
+                queryClient,
+              );
+            }
           } else {
             if (isPlatformHostedDisabled(result.status, result.error)) {
               settleError(PLATFORM_HOSTED_DISABLED_MESSAGE);
@@ -259,9 +295,50 @@ export function useBackgroundHatch(
         }
       }
 
+      // 4. On a paid return, hold `ready` until the purchased resize converges.
+      //
+      // `managedHatch` is true by construction: the checkout destination always
+      // carries `hosting=vellum-cloud`, and `adoptExisting` already excludes the
+      // local foreground hatch.
+      if (!adoptExisting && postCheckoutReturn) {
+        const outcome = await awaitPurchasedProvisioning({
+          assistantId: activeAssistantId,
+          postCheckoutReturn: true,
+          managedHatch: true,
+          hatchStartMs: startMs,
+          isCancelled: () => settledRef.current?.kind === "error",
+        });
+        if (outcome === "health_timeout") {
+          // The assistant never answered healthz after the resize; completing
+          // would hand the user an unreachable assistant.
+          Sentry.captureMessage("Onboarding hatch wait exceeded timeout", {
+            level: "warning",
+            extra: { maxWaitMs: MAX_HATCH_WAIT_MS, stage: "post_resize_health" },
+          });
+          settleError(TIMEOUT_ERROR);
+          return;
+        }
+      }
+
       settleReady(activeAssistantId);
     })();
-  }, [settleError, settleReady, adoptExisting, adoptAssistantId]);
+  }, [
+    settleError,
+    settleReady,
+    adoptExisting,
+    adoptAssistantId,
+    postCheckoutReturn,
+    queryClient,
+  ]);
+
+  const retry = useCallback(() => {
+    startedRef.current = false;
+    settledRef.current = null;
+    setError(null);
+    setReady(false);
+    setAssistantId(null);
+    start();
+  }, [start]);
 
   const awaitReady = useCallback((): Promise<string> => {
     const settled = settledRef.current;
@@ -272,5 +349,5 @@ export function useBackgroundHatch(
     });
   }, []);
 
-  return { start, ready, assistantId, error, awaitReady };
+  return { start, retry, ready, assistantId, error, awaitReady };
 }


### PR DESCRIPTION
## Summary
- useBackgroundHatch gains an opt-in postCheckoutReturn stage: after healthz, hold ready until the purchased resize converges via awaitPurchasedProvisioning, honoring health_timeout as terminal failure
- Adds retry() for terminal errors and paid-path avatar seeding parity with the foreground hatch
- Free path unchanged: no subscription polling without the marker

Part of plan: headless-paid-hatch.md (PR 2 of 5)