### PR TITLE
feat(web): wire the paid return into the research onboarding with a failure surface

### DIFF
--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -1,0 +1,65 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { Modal } from "@vellumai/design-library/components/modal";
+
+import { PLATFORM_HOSTED_DISABLED_MESSAGE } from "@/assistant/lifecycle";
+
+interface HatchErrorOverlayProps {
+  /** Terminal failure message from the background hatch. */
+  error: string;
+  /** Re-run the failed hatch from the top. */
+  onRetry: () => void;
+}
+
+/**
+ * Terminal background-hatch failure, surfaced over the onboarding funnel.
+ *
+ * Layers on top of whatever step is on screen rather than replacing it, so the
+ * funnel keeps its collected state and a successful retry resumes in place.
+ * Retrying can't help while managed hosting is at capacity, so that case offers
+ * the local-assistant off-ramp instead.
+ */
+export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
+  const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;
+  return (
+    <Modal.Root open>
+      <Modal.Content
+        size="sm"
+        role="alertdialog"
+        hideCloseButton
+        dismissOnOverlayClick={false}
+        onEscapeKeyDown={(event) => event.preventDefault()}
+        onInteractOutside={(event) => event.preventDefault()}
+      >
+        <Modal.Header>
+          <Modal.Title>Something went wrong</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Modal.Description>{error}</Modal.Description>
+          {platformHostedDisabled ? (
+            <p className="mt-5 text-body-medium-default text-[var(--content-default)]">
+              Get started today with a local assistant
+            </p>
+          ) : null}
+        </Modal.Body>
+        <Modal.Footer>
+          {platformHostedDisabled ? (
+            <Button asChild variant="primary" size="regular" fullWidth>
+              <a href={`${window.location.origin}/download`}>
+                Download the macOS app
+              </a>
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              size="regular"
+              fullWidth
+              onClick={onRetry}
+            >
+              Try again
+            </Button>
+          )}
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -58,6 +58,8 @@ const startResearchMock = mock((_opts: unknown) => {
 });
 const hydrateResearchMock = mock((_results: unknown, _await?: unknown) => {});
 const resetResearchMock = mock(() => {});
+const reinstallPluginsMock = mock((_names: string[], _await: unknown) => {});
+let installedPlugins: string[] = [];
 const researchRunner = {
   get status() {
     return researchStatus;
@@ -65,11 +67,14 @@ const researchRunner = {
   claims: [] as unknown[],
   droppedClaims: [] as string[],
   suggestions: [] as unknown[],
-  installedPlugins: [] as string[],
+  get installedPlugins() {
+    return installedPlugins;
+  },
   pluginCatalog: {} as Record<string, string>,
   start: startResearchMock,
   hydrate: hydrateResearchMock,
   reset: resetResearchMock,
+  reinstallPlugins: reinstallPluginsMock,
   awaitPluginInstalls: async () => {},
 };
 
@@ -147,7 +152,7 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
     use: {
-      user: () => ({ id: USER_ID, firstName: "Ada", lastName: "Lovelace" }),
+      user: () => ({ id: USER_ID, firstName: "Alice", lastName: "Example" }),
     },
   },
 }));
@@ -189,8 +194,10 @@ mock.module("@/domains/onboarding/send-research-correction", () => ({
   sendResearchCorrection: async () => {},
 }));
 
+const applyPersonalityMock = mock(async (_options: unknown) => {});
+
 mock.module("@/domains/onboarding/apply-personality", () => ({
-  applyPersonality: async () => {},
+  applyPersonality: applyPersonalityMock,
 }));
 
 mock.module("@/domains/onboarding/lets-chat-kickoff", () => ({
@@ -247,8 +254,8 @@ mock.module("@/domains/onboarding/screens/research-onboarding-screen", () => ({
       data-testid="form-submit"
       onClick={() =>
         props.onSubmit({
-          firstName: "Ada",
-          lastName: "Lovelace",
+          firstName: "Alice",
+          lastName: "Example",
           role: "Engineer",
           hobbies: [],
         })
@@ -275,8 +282,30 @@ mock.module("@/domains/onboarding/screens/integration-step", () => ({
   IntegrationStep: () => <div data-testid="integration-step" />,
 }));
 
+// Renders the real step's contract: sliders that write back through
+// `onValueChange`, and a continue that fires the one-shot persona apply.
 mock.module("@/domains/onboarding/screens/create-personality-step", () => ({
-  CreatePersonalityStep: () => <div data-testid="personality-step" />,
+  CreatePersonalityStep: (props: {
+    onValueChange: (axisId: string, value: number) => void;
+    onContinue: () => void;
+  }) => (
+    <div data-testid="personality-step">
+      <button
+        type="button"
+        data-testid="personality-slide"
+        onClick={() => props.onValueChange("warmth", 80)}
+      >
+        slide
+      </button>
+      <button
+        type="button"
+        data-testid="personality-continue"
+        onClick={props.onContinue}
+      >
+        continue
+      </button>
+    </div>
+  ),
 }));
 
 mock.module("@/domains/onboarding/screens/lets-chat-tomorrow-step", () => ({
@@ -346,8 +375,8 @@ function postFormSnapshot(
   return {
     step: "looking",
     formValues: {
-      firstName: "Ada",
-      lastName: "Lovelace",
+      firstName: "Alice",
+      lastName: "Example",
       role: "Engineer",
       hobbies: ["chess"],
     },
@@ -362,6 +391,7 @@ function postFormSnapshot(
 beforeEach(() => {
   localStorage.clear();
   researchStatus = "idle";
+  installedPlugins = [];
   establishedResult = { established: false, assistantName: null };
   establishedCheckGate = null;
   releaseEstablishedCheck = () => {};
@@ -376,6 +406,8 @@ beforeEach(() => {
   checkEstablishedAssistantMock.mockClear();
   useBackgroundHatchMock.mockClear();
   retryHatchMock.mockClear();
+  reinstallPluginsMock.mockClear();
+  applyPersonalityMock.mockClear();
 });
 
 afterEach(() => {
@@ -628,9 +660,12 @@ describe("ResearchOnboardingRoute paid return", () => {
 
 // Retrying the hatch must restart everything that already resolved against the
 // dead one: the established-assistant verdict (otherwise it stays fail-open
-// from the rejected `awaitReady`) and a research turn that settled "error"
-// while holding its subject key (otherwise an identical resubmit dedupes to a
-// no-op).
+// from the rejected `awaitReady`), a research turn that settled "error" while
+// holding its subject key (otherwise an identical resubmit dedupes to a no-op),
+// the persona apply that swallowed the same rejection behind locked sliders,
+// and the restored plugin installs that resolved having installed nothing. The
+// retried research turn also keeps the conversation the journey already minted,
+// so recovery never posts a second search alongside the first.
 describe("ResearchOnboardingRoute hatch retry", () => {
   const HATCH_ERROR = "Failed to start your assistant. Please try again.";
 
@@ -709,5 +744,142 @@ describe("ResearchOnboardingRoute hatch retry", () => {
 
     expect(resetResearchMock).not.toHaveBeenCalled();
     expect(startResearchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The runner only mints a conversation AFTER the hatch resolves, so a turn
+  // that died with the hatch never made one — the id it re-attaches to is the
+  // one a prior session persisted. Re-firing without it posts a second research
+  // conversation while the first is still there.
+  test("re-attaches the retried turn to the conversation the journey already minted", async () => {
+    writeResearchSnapshot(
+      USER_ID,
+      postFormSnapshot({ researchConversationId: "conv-1" }),
+    );
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+    const resumed = startResearchMock.mock.calls[0]?.[0] as {
+      resumeConversationId?: string;
+    };
+    expect(resumed.resumeConversationId).toBe("conv-1");
+
+    researchStatus = "error";
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    expect(startResearchMock).toHaveBeenCalledTimes(2);
+    const refired = startResearchMock.mock.calls[1]?.[0] as {
+      resumeConversationId?: string;
+    };
+    expect(refired.resumeConversationId).toBe("conv-1");
+    // A re-run owns its own installs — the restored-install path is not it.
+    expect(reinstallPluginsMock).not.toHaveBeenCalled();
+  });
+
+  test("a journey with no research conversation re-fires without one", async () => {
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("form-submit"));
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+
+    researchStatus = "error";
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    const refired = startResearchMock.mock.calls[1]?.[0] as {
+      resumeConversationId?: string;
+    };
+    expect(refired.resumeConversationId).toBeUndefined();
+  });
+
+  // A completed snapshot hydrates to "done" and re-enqueues its persisted
+  // installs against the hatch. Those catch a dead hatch and resolve having
+  // installed nothing while the runner stays "done" — so nothing re-runs them
+  // and the handoff promises capabilities that were never materialized.
+  test("re-enqueues restored plugin installs that settled against the dead hatch", async () => {
+    researchStatus = "done";
+    installedPlugins = ["admin-copilot"];
+    writeResearchSnapshot(
+      USER_ID,
+      postFormSnapshot({
+        step: "suggestions",
+        research: {
+          status: "done",
+          claims: [],
+          droppedClaims: [],
+          suggestions: [],
+          installedPlugins: ["admin-copilot"],
+          pluginCatalog: {},
+        },
+      }),
+    );
+    failFirstHatch();
+
+    render(<ResearchOnboardingRoute />);
+    await screen.findByRole("alertdialog");
+
+    recoverOnRetry();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(checkEstablishedAssistantMock).toHaveBeenCalled());
+    expect(reinstallPluginsMock).toHaveBeenCalledTimes(1);
+    const [names, awaitAssistantId] = reinstallPluginsMock.mock.calls[0] ?? [];
+    expect(names).toEqual(["admin-copilot"]);
+    // Ordering stays the runner's job: the installs await the retried hatch
+    // themselves rather than the handler awaiting readiness first.
+    expect(awaitAssistantId).toBe(backgroundHatch.awaitReady);
+    // The restored results stand — only the installs are redone.
+    expect(startResearchMock).not.toHaveBeenCalled();
+    expect(resetResearchMock).not.toHaveBeenCalled();
+  });
+
+  // `applyPersonality` awaits the hatch and swallows its rejection, so a hatch
+  // that dies while the user walks the later steps leaves the sliders locked as
+  // if the persona had been rewritten — it never was.
+  test("re-applies the personality that died with the hatch", async () => {
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "personality" }));
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("personality-slide"));
+    fireEvent.click(screen.getByTestId("personality-continue"));
+    await waitFor(() => expect(applyPersonalityMock).toHaveBeenCalledTimes(1));
+
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(applyPersonalityMock).toHaveBeenCalledTimes(2));
+    const reapplied = applyPersonalityMock.mock.calls[1]?.[0] as {
+      values: Record<string, number>;
+      awaitAssistantId: () => Promise<string>;
+    };
+    // The user's own choices, against the retried hatch.
+    expect(reapplied.values).toEqual({ warmth: 80 });
+    expect(reapplied.awaitAssistantId).toBe(backgroundHatch.awaitReady);
+  });
+
+  test("does not apply a personality the user never chose", async () => {
+    failFirstHatch();
+    writeResearchSnapshot(USER_ID, postFormSnapshot());
+
+    render(<ResearchOnboardingRoute />);
+    await screen.findByRole("alertdialog");
+
+    recoverOnRetry();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    // The retry did re-arm what the dead hatch poisoned…
+    await waitFor(() => expect(checkEstablishedAssistantMock).toHaveBeenCalled());
+    // …but the sliders were never locked in, so there is no persona write to
+    // redo — and an idle turn has no restored installs to re-enqueue either.
+    expect(applyPersonalityMock).not.toHaveBeenCalled();
+    expect(reinstallPluginsMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -19,7 +19,9 @@
  *
  * The paid-return block covers the `post_checkout=1` marker reaching the
  * background hatch and the failure overlay that surfaces a dead hatch on any
- * step, with the at-capacity download off-ramp in place of a retry.
+ * step, with the at-capacity download off-ramp in place of a retry. The retry
+ * block covers what that overlay's "Try again" has to un-poison: route state
+ * that resolved against the dead hatch and would otherwise survive the retry.
  *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
@@ -47,9 +49,15 @@ const USER_ID = "user-1";
 const navigateMock = mock((_to: string, _opts?: unknown) => {});
 const searchParams = new URLSearchParams();
 
-const startResearchMock = mock((_opts: unknown) => {});
-const hydrateResearchMock = mock((_results: unknown, _await?: unknown) => {});
 let researchStatus = "idle";
+// Mirrors the real runner, which flips to "running" synchronously inside
+// `start` — that is what keeps the mid-flow resume effect from firing a second
+// turn behind a form submit.
+const startResearchMock = mock((_opts: unknown) => {
+  researchStatus = "running";
+});
+const hydrateResearchMock = mock((_results: unknown, _await?: unknown) => {});
+const resetResearchMock = mock(() => {});
 const researchRunner = {
   get status() {
     return researchStatus;
@@ -61,6 +69,7 @@ const researchRunner = {
   pluginCatalog: {} as Record<string, string>,
   start: startResearchMock,
   hydrate: hydrateResearchMock,
+  reset: resetResearchMock,
   awaitPluginInstalls: async () => {},
 };
 
@@ -86,14 +95,22 @@ const checkEstablishedAssistantMock = mock(async (_id: string) => {
   return establishedResult;
 });
 
-const retryHatchMock = mock(() => {});
+// The hatch's readiness promise is swapped per test (a dead first attempt
+// rejects; the retry hands back a healthy one), and `onRetryHatch` is where a
+// test stages that recovery — it runs inside the overlay's click, exactly where
+// the real `retry()` would clear the hook's terminal state.
+let awaitHatchReady: () => Promise<string> = async () => "asst-1";
+let onRetryHatch: () => void = () => {};
+const retryHatchMock = mock(() => {
+  onRetryHatch();
+});
 const backgroundHatch = {
   start: () => {},
   retry: retryHatchMock,
   ready: true,
   assistantId: "asst-1",
   error: null as string | null,
-  awaitReady: async () => "asst-1",
+  awaitReady: () => awaitHatchReady(),
 };
 const useBackgroundHatchMock = mock(
   (_options: { postCheckoutReturn?: boolean }) => backgroundHatch,
@@ -350,9 +367,12 @@ beforeEach(() => {
   releaseEstablishedCheck = () => {};
   searchParams.delete("post_checkout");
   backgroundHatch.error = null;
+  awaitHatchReady = async () => "asst-1";
+  onRetryHatch = () => {};
   navigateMock.mockClear();
   startResearchMock.mockClear();
   hydrateResearchMock.mockClear();
+  resetResearchMock.mockClear();
   checkEstablishedAssistantMock.mockClear();
   useBackgroundHatchMock.mockClear();
   retryHatchMock.mockClear();
@@ -603,5 +623,91 @@ describe("ResearchOnboardingRoute paid return", () => {
     await screen.findByTestId("form-submit");
 
     expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+});
+
+// Retrying the hatch has to restart everything that already resolved against
+// the dead one. Both of these used to survive the retry poisoned: the
+// established-assistant verdict (cached fail-open from the rejected
+// `awaitReady`) and a research turn that settled "error" while keeping its
+// subject key, which made even an identical resubmit a no-op.
+describe("ResearchOnboardingRoute hatch retry", () => {
+  const HATCH_ERROR = "Failed to start your assistant. Please try again.";
+
+  function failFirstHatch() {
+    backgroundHatch.error = HATCH_ERROR;
+    awaitHatchReady = () => Promise.reject(new Error("hatch failed"));
+  }
+
+  function recoverOnRetry() {
+    onRetryHatch = () => {
+      backgroundHatch.error = null;
+      awaitHatchReady = async () => "asst-1";
+    };
+  }
+
+  test("re-runs the established-assistant check against the retried hatch", async () => {
+    failFirstHatch();
+    // The retry recovers an assistant that already has a life.
+    establishedResult = { established: true, assistantName: "Viper" };
+
+    render(<ResearchOnboardingRoute />);
+    await screen.findByRole("alertdialog");
+    // The dead hatch never got far enough to ask.
+    expect(checkEstablishedAssistantMock).not.toHaveBeenCalled();
+
+    recoverOnRetry();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    fireEvent.click(screen.getByTestId("form-submit"));
+
+    // The gate recomputed against the new attempt, so the submit lands on the
+    // keep/redo choice instead of running research + persona writes against an
+    // established assistant.
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-step").textContent).toBe("Viper"),
+    );
+    expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  test("re-fires a research turn that died with the hatch", async () => {
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("form-submit"));
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+
+    // The hatch dies after the submit: the runner's `awaitAssistantId` rejects
+    // and the turn settles "error", still holding the submitted subject key.
+    researchStatus = "error";
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    expect(resetResearchMock).toHaveBeenCalledTimes(1);
+    expect(startResearchMock).toHaveBeenCalledTimes(2);
+    // Ordering stays the runner's job: the re-fired turn awaits the retried
+    // hatch itself rather than the handler awaiting readiness first.
+    const refired = startResearchMock.mock.calls[1]?.[0] as {
+      awaitAssistantId: () => Promise<string>;
+    };
+    expect(refired.awaitAssistantId).toBe(backgroundHatch.awaitReady);
+  });
+
+  test("does not re-fire a research turn that never errored", async () => {
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("form-submit"));
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+
+    // Still running when the hatch failed — the turn is already parked on the
+    // runner's own `awaitAssistantId`, so a retry must not double-fire it.
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    expect(resetResearchMock).not.toHaveBeenCalled();
+    expect(startResearchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -1,5 +1,6 @@
 /**
- * Route-level regression tests for the research-onboarding resume guard.
+ * Route-level regression tests for the research-onboarding resume guard and the
+ * paid-checkout return.
  *
  * The established-assistant guard used to run only on form submit; a restored
  * post-form snapshot (persisted before the verdict settled, or after a transient
@@ -16,6 +17,10 @@
  * — so a refresh re-lands on the keep/redo choice instead of auto-resuming past
  * it.
  *
+ * The paid-return block covers the `post_checkout=1` marker reaching the
+ * background hatch and the failure overlay that surfaces a dead hatch on any
+ * step, with the at-capacity download off-ramp in place of a retry.
+ *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
  */
@@ -30,6 +35,7 @@ import {
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { type ReactNode } from "react";
 
+import { PLATFORM_HOSTED_DISABLED_MESSAGE } from "@/assistant/lifecycle";
 import {
   readResearchSnapshot,
   writeResearchSnapshot,
@@ -80,13 +86,18 @@ const checkEstablishedAssistantMock = mock(async (_id: string) => {
   return establishedResult;
 });
 
+const retryHatchMock = mock(() => {});
 const backgroundHatch = {
   start: () => {},
+  retry: retryHatchMock,
   ready: true,
   assistantId: "asst-1",
-  error: null as Error | null,
+  error: null as string | null,
   awaitReady: async () => "asst-1",
 };
+const useBackgroundHatchMock = mock(
+  (_options: { postCheckoutReturn?: boolean }) => backgroundHatch,
+);
 
 const noop = () => {};
 
@@ -108,6 +119,12 @@ mock.module("@/lib/auth/gateway-session", () => ({
 
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => false,
+}));
+
+// The real module builds its destinations from `routes` at import time, and the
+// `@/utils/routes` stub below carries only the assistant path.
+mock.module("@/lib/navigation/navigation-resolver", () => ({
+  POST_CHECKOUT_HATCH_PARAM: "post_checkout",
 }));
 
 mock.module("@/stores/auth-store", () => ({
@@ -144,7 +161,7 @@ mock.module("@/domains/onboarding/adopt-existing-assistant", () => ({
 }));
 
 mock.module("@/domains/onboarding/use-background-hatch", () => ({
-  useBackgroundHatch: () => backgroundHatch,
+  useBackgroundHatch: useBackgroundHatchMock,
 }));
 
 mock.module("@/domains/onboarding/research-runner", () => ({
@@ -331,10 +348,14 @@ beforeEach(() => {
   establishedResult = { established: false, assistantName: null };
   establishedCheckGate = null;
   releaseEstablishedCheck = () => {};
+  searchParams.delete("post_checkout");
+  backgroundHatch.error = null;
   navigateMock.mockClear();
   startResearchMock.mockClear();
   hydrateResearchMock.mockClear();
   checkEstablishedAssistantMock.mockClear();
+  useBackgroundHatchMock.mockClear();
+  retryHatchMock.mockClear();
 });
 
 afterEach(() => {
@@ -518,5 +539,69 @@ describe("ResearchOnboardingRoute resume guard", () => {
       expect(screen.getByTestId("existing-step")).toBeTruthy(),
     );
     expect(startResearchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("ResearchOnboardingRoute paid return", () => {
+  function lastHatchOptions() {
+    const call = useBackgroundHatchMock.mock.calls.at(-1);
+    if (!call) {
+      throw new Error("expected useBackgroundHatch to have been called");
+    }
+    return call[0];
+  }
+
+  test("carries the paid marker into the background hatch", async () => {
+    searchParams.set("post_checkout", "1");
+
+    render(<ResearchOnboardingRoute />);
+    await screen.findByTestId("form-submit");
+
+    expect(lastHatchOptions().postCheckoutReturn).toBe(true);
+  });
+
+  test("a free onboarding leaves the purchased-provisioning wait off", async () => {
+    render(<ResearchOnboardingRoute />);
+    await screen.findByTestId("form-submit");
+
+    expect(lastHatchOptions().postCheckoutReturn).toBe(false);
+  });
+
+  test("a terminal hatch failure surfaces a retry over the funnel", async () => {
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+
+    render(<ResearchOnboardingRoute />);
+
+    const overlay = await screen.findByRole("alertdialog");
+    expect(overlay.textContent).toContain(
+      "Failed to start your assistant. Please try again.",
+    );
+    // Layered, not swapped in: the funnel keeps its state behind the overlay.
+    expect(screen.getByTestId("form-submit")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(retryHatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("an at-capacity failure offers the macOS download instead of a retry", async () => {
+    backgroundHatch.error = PLATFORM_HOSTED_DISABLED_MESSAGE;
+
+    render(<ResearchOnboardingRoute />);
+
+    const overlay = await screen.findByRole("alertdialog");
+    expect(overlay.textContent).toContain(
+      "Get started today with a local assistant",
+    );
+    expect(
+      screen.getByRole("link", { name: "Download the macOS app" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+
+  test("a healthy hatch renders no overlay", async () => {
+    render(<ResearchOnboardingRoute />);
+    await screen.findByTestId("form-submit");
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -626,11 +626,11 @@ describe("ResearchOnboardingRoute paid return", () => {
   });
 });
 
-// Retrying the hatch has to restart everything that already resolved against
-// the dead one. Both of these used to survive the retry poisoned: the
-// established-assistant verdict (cached fail-open from the rejected
-// `awaitReady`) and a research turn that settled "error" while keeping its
-// subject key, which made even an identical resubmit a no-op.
+// Retrying the hatch must restart everything that already resolved against the
+// dead one: the established-assistant verdict (otherwise it stays fail-open
+// from the rejected `awaitReady`) and a research turn that settled "error"
+// while holding its subject key (otherwise an identical resubmit dedupes to a
+// no-op).
 describe("ResearchOnboardingRoute hatch retry", () => {
   const HATCH_ERROR = "Failed to start your assistant. Please try again.";
 

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -371,7 +371,12 @@ export function ResearchOnboardingRoute() {
   // personality step rewrites the persona, so an already-customized assistant
   // must never be run through them silently. The submit handler awaits this
   // verdict (briefly) and branches to the "existing" guard step.
-  useEffect(() => {
+  //
+  // The ref both memoizes the verdict and marks the CURRENT hatch attempt as
+  // covered, so a retry must clear it (see `handleHatchRetry`) — otherwise the
+  // fail-open verdict a dead hatch produced would outlive it and let a
+  // recovered, already-established assistant through the gate.
+  const armEstablishedCheck = useCallback(() => {
     if (establishedCheckRef.current) return;
     const check = awaitHatchReady()
       .then((id) => checkEstablishedAssistant(id))
@@ -380,6 +385,10 @@ export function ResearchOnboardingRoute() {
     establishedCheckRef.current = check;
     void check.then(setEstablishedCheck);
   }, [awaitHatchReady]);
+
+  useEffect(() => {
+    armEstablishedCheck();
+  }, [armEstablishedCheck]);
 
   // Resolve the established-assistant verdict for a gate decision: race the
   // in-flight check (kicked off at mount, above) against a short timeout so a
@@ -833,6 +842,22 @@ export function ResearchOnboardingRoute() {
     goForwardTo("meeting");
   }
 
+  // "Try again" restarts the hatch AND everything that resolved against the
+  // dead one. The established verdict failed open on the rejected `awaitReady`,
+  // and a research turn fired before the failure settled to "error" while
+  // keeping its subject key (so an identical resubmit would dedupe to nothing).
+  // Both re-arm against the new attempt; research goes through the runner's own
+  // hatch await, so it still can't run ahead of readiness.
+  function handleHatchRetry() {
+    establishedCheckRef.current = null;
+    retryHatch();
+    armEstablishedCheck();
+    if (research.status === "error" && formValues) {
+      research.reset();
+      fireResearch(formValues);
+    }
+  }
+
   // A terminal hatch failure is layered over whichever step is on screen — the
   // assistant is dead at all of them, so the failure shouldn't wait for the
   // last step to be discovered. Layering (rather than replacing the step) keeps
@@ -841,7 +866,7 @@ export function ResearchOnboardingRoute() {
     <>
       {content}
       {hatchError !== null && (
-        <HatchErrorOverlay error={hatchError} onRetry={retryHatch} />
+        <HatchErrorOverlay error={hatchError} onRetry={handleHatchRetry} />
       )}
     </>
   );

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -23,12 +23,14 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalMode } from "@/lib/local-mode";
+import { POST_CHECKOUT_HATCH_PARAM } from "@/lib/navigation/navigation-resolver";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
@@ -86,6 +88,7 @@ import {
   LetsChatReadyStep,
 } from "@/domains/onboarding/screens/research-result-steps";
 import { OnboardingTonedBackdrop } from "@/domains/onboarding/components/onboarding-toned-backdrop";
+import { HatchErrorOverlay } from "@/domains/onboarding/components/hatch-error-overlay";
 import {
   OnboardingStageSizeProvider,
   useElementSize,
@@ -280,6 +283,10 @@ export function ResearchOnboardingRoute() {
   // param, pinning adoption to that exact one — a stale selection or leftover
   // lockfile entries from previous sessions can't answer for it.
   const adoptAssistantId = searchParams.get("assistant") ?? undefined;
+  // On the return leg of a completed checkout the hatch also waits out the
+  // purchased resize, so the paid user never starts on a baseline assistant.
+  const postCheckoutReturn =
+    searchParams.get(POST_CHECKOUT_HATCH_PARAM) === "1";
   // The day-2 check-in offer ("letschat" → "meeting") books through the
   // platform's managed Google Calendar OAuth. A local-hosting onboarding can
   // run with no platform session at all (the assistant itself is fully
@@ -289,6 +296,7 @@ export function ResearchOnboardingRoute() {
   const skipCheckinSteps = adoptExistingAssistant;
   const {
     start: startHatch,
+    retry: retryHatch,
     ready: hatchReady,
     assistantId: hatchedAssistantId,
     error: hatchError,
@@ -296,6 +304,7 @@ export function ResearchOnboardingRoute() {
   } = useBackgroundHatch({
     adoptExisting: adoptExistingAssistant,
     adoptAssistantId,
+    postCheckoutReturn,
   });
   const research = useResearchRunner();
   // Stable across renders (useCallback in the runner); safe as effect deps.
@@ -824,6 +833,19 @@ export function ResearchOnboardingRoute() {
     goForwardTo("meeting");
   }
 
+  // A terminal hatch failure is layered over whichever step is on screen — the
+  // assistant is dead at all of them, so the failure shouldn't wait for the
+  // last step to be discovered. Layering (rather than replacing the step) keeps
+  // the funnel's collected state, so a successful retry resumes in place.
+  const withHatchError = (content: ReactNode) => (
+    <>
+      {content}
+      {hatchError !== null && (
+        <HatchErrorOverlay error={hatchError} onRetry={retryHatch} />
+      )}
+    </>
+  );
+
   // The later steps share one persistent toned backdrop (assistant color +
   // eyes + tone characters) so the avatars stay put while the foreground
   // content swaps. Extra edge characters pop in per step to build excitement.
@@ -850,7 +872,7 @@ export function ResearchOnboardingRoute() {
     const peekLevel = ["looking", "results", "suggestions", "finishing"].includes(step)
       ? edgeAvatars
       : 0;
-    return (
+    return withHatchError(
       <div ref={tonedStageRef} data-theme="dark" className="relative h-full overflow-hidden">
         <OnboardingStageSizeProvider size={tonedStageSize}>
         <OnboardingTonedBackdrop
@@ -1096,7 +1118,7 @@ export function ResearchOnboardingRoute() {
           />
         )}
         </OnboardingStageSizeProvider>
-      </div>
+      </div>,
     );
   }
 
@@ -1104,7 +1126,7 @@ export function ResearchOnboardingRoute() {
   // instead of advancing to "face" when the submitted-to assistant already has
   // a life (see handleFormSubmit); a genuinely new user never lands here.
   if (step === "existing") {
-    return (
+    return withHatchError(
       <ExistingAssistantStep
         assistantName={establishedCheck?.assistantName ?? null}
         onKeep={() => {
@@ -1144,24 +1166,24 @@ export function ResearchOnboardingRoute() {
           setGatedFormValues(null);
           goBackTo("form");
         }}
-      />
+      />,
     );
   }
 
   if (step === "intro" && formValues) {
-    return (
+    return withHatchError(
       <IntroductionScreen
         firstName={formValues.firstName}
         assistantName={faceValues?.name}
         onContinue={() => goForwardTo("different")}
         onBack={() => goBackTo("face")}
         onForward={onForward}
-      />
+      />,
     );
   }
 
   if (step === "face" && formValues) {
-    return (
+    return withHatchError(
       <GiveMeAFaceScreen
         onContinue={(face) => {
           setFaceValues(face);
@@ -1169,15 +1191,15 @@ export function ResearchOnboardingRoute() {
         }}
         onBack={() => goBackTo("form")}
         onForward={onForward}
-      />
+      />,
     );
   }
 
-  return (
+  return withHatchError(
     <ResearchOnboardingScreen
       initialFirstName={user?.firstName ?? ""}
       initialLastName={user?.lastName ?? ""}
       onSubmit={handleFormSubmit}
-    />
+    />,
   );
 }

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -407,6 +407,37 @@ export function ResearchOnboardingRoute() {
     [],
   );
 
+  // Fire the research turn; the runner awaits hatch readiness internally, so it
+  // starts at the later of the caller's submit and the background hatch. Every
+  // start goes through here — a submit, a resume, a redo, or a restart after the
+  // hatch died — so a run always re-attaches to the conversation this journey
+  // already minted instead of posting a second search alongside the first.
+  const fireResearch = useCallback(
+    (values: ResearchOnboardingValues) => {
+      // A fresh run produces fresh drops — re-arm the one-shot scrub below.
+      syncDroppedClaimsScrubbed(false);
+      startResearch({
+        awaitAssistantId: awaitHatchReady,
+        subject: researchSubjectFrom(values),
+        conversationTitle: researchTitleFor(values),
+        ...(researchConversationId
+          ? { resumeConversationId: researchConversationId }
+          : {}),
+        onConversationCreated: setResearchConversationId,
+        // The "Let's chat" final step replaces suggestions when personality
+        // onboarding is on, so don't ask the model to generate any.
+        includeSuggestions: !personalityEnabled,
+      });
+    },
+    [
+      syncDroppedClaimsScrubbed,
+      startResearch,
+      awaitHatchReady,
+      researchConversationId,
+      personalityEnabled,
+    ],
+  );
+
   // Resume a journey saved by a previous session (a page refresh). Runs once,
   // as soon as the user id is known, BEFORE the persistence write / research
   // re-fire effects below (which gate on `restored`). useLayoutEffect so we
@@ -570,16 +601,7 @@ export function ResearchOnboardingRoute() {
       // search; a hydrated "done" journey keeps its restored results.
       setResumeGuardPending(false);
       if (wasIdle) {
-        startResearch({
-          awaitAssistantId: awaitHatchReady,
-          subject: researchSubjectFrom(values),
-          conversationTitle: researchTitleFor(values),
-          ...(researchConversationId
-            ? { resumeConversationId: researchConversationId }
-            : {}),
-          onConversationCreated: setResearchConversationId,
-          includeSuggestions: !personalityEnabled,
-        });
+        fireResearch(values);
       }
     })();
     return () => {
@@ -591,11 +613,8 @@ export function ResearchOnboardingRoute() {
   }, [
     restored,
     formValues,
-    researchConversationId,
     research.status,
-    startResearch,
-    awaitHatchReady,
-    personalityEnabled,
+    fireResearch,
     resolveEstablishedGate,
   ]);
 
@@ -620,7 +639,11 @@ export function ResearchOnboardingRoute() {
     if (droppedClaimsScrubbedRef.current) return;
     if (researchLoading) return;
     if (research.droppedClaims.length === 0) return;
-    if (!researchConversationId || !hatchedAssistantId) return;
+    // Only against a live hatch: the guard flips before the request, so a scrub
+    // posted at an unreachable assistant would be marked sent and never retried.
+    // A resumed journey hydrates results while the hatch is still coming up (or
+    // has died), so this waits — and re-fires once a retry lands.
+    if (!researchConversationId || !hatchedAssistantId || !hatchReady) return;
     // With card claims present the results step owns the scrub — unless we've
     // resumed straight onto the suggestions step, past that correction.
     if (research.claims.length > 0 && step !== "suggestions") return;
@@ -637,6 +660,7 @@ export function ResearchOnboardingRoute() {
     research.droppedClaims,
     researchConversationId,
     hatchedAssistantId,
+    hatchReady,
     step,
     syncDroppedClaimsScrubbed,
   ]);
@@ -760,20 +784,19 @@ export function ResearchOnboardingRoute() {
     );
   }
 
-  // Fire the research turn; the runner awaits hatch readiness internally, so
-  // it starts at the later of the caller's submit and the background hatch.
-  function fireResearch(values: ResearchOnboardingValues) {
-    // A fresh run produces fresh drops — re-arm the one-shot scrub above.
-    syncDroppedClaimsScrubbed(false);
-    research.start({
+  // Hand the collected sliders to the assistant's persona on a throwaway side
+  // thread (it awaits hatch readiness internally, then archives). The rewrite
+  // turn runs during the later steps; the promise (and pending flag) let the
+  // loading steps hold for it and the chat handoff await it, so the persona is
+  // reshaped before the first real chat. Best-effort; it never rejects.
+  function startPersonalityApply() {
+    setPersonalityPending(true);
+    personalityAppliedRef.current = applyPersonality({
       awaitAssistantId: awaitHatchReady,
-      subject: researchSubjectFrom(values),
-      conversationTitle: researchTitleFor(values),
-      onConversationCreated: setResearchConversationId,
-      // The "Let's chat" final step replaces suggestions when personality
-      // onboarding is on, so don't ask the model to generate any.
-      includeSuggestions: !personalityEnabled,
-    });
+      values: personalityValues,
+      userName: formValues?.firstName?.trim() || undefined,
+      assistantName: faceValues?.name?.trim() || undefined,
+    }).finally(() => setPersonalityPending(false));
   }
 
   async function handleFormSubmit(values: ResearchOnboardingValues) {
@@ -843,18 +866,35 @@ export function ResearchOnboardingRoute() {
   }
 
   // "Try again" restarts the hatch AND everything that resolved against the
-  // dead one. The established verdict failed open on the rejected `awaitReady`,
-  // and a research turn fired before the failure settled to "error" while
-  // keeping its subject key (so an identical resubmit would dedupe to nothing).
-  // Both re-arm against the new attempt; research goes through the runner's own
-  // hatch await, so it still can't run ahead of readiness.
+  // dead one. Reaching this handler proves no attempt has ever readied (the
+  // hatch settles once, and a ready one can't later error), so every
+  // hatch-dependent effect started so far was rejected — each is re-armed below,
+  // and none of them can be healthy work this would redo. Every restart runs
+  // after `retryHatch()` has cleared the terminal state, so its waiters park on
+  // the fresh attempt; each awaits readiness inside its own work rather than
+  // here, so nothing runs ahead of the new hatch.
   function handleHatchRetry() {
+    // The verdict failed open on the rejected `awaitReady`; keeping it would let
+    // a recovered, already-established assistant through the gate.
     establishedCheckRef.current = null;
     retryHatch();
     armEstablishedCheck();
     if (research.status === "error" && formValues) {
+      // The turn settled "error" still holding its subject key, so an identical
+      // resubmit would dedupe to nothing — release it, then re-fire (onto the
+      // same research conversation when this journey already minted one).
       research.reset();
       fireResearch(formValues);
+    } else if (research.status === "done") {
+      // Results restored from a snapshot: the search doesn't re-run, but the
+      // installs re-enqueued alongside them caught the dead hatch and resolved
+      // having installed nothing, while the runner stayed `done`.
+      research.reinstallPlugins(research.installedPlugins, awaitHatchReady);
+    }
+    if (personalityLocked) {
+      // The apply swallowed the same rejection and left the sliders locked as if
+      // it had landed — re-apply the user's choices to the recovered assistant.
+      startPersonalityApply();
     }
   }
 
@@ -932,23 +972,11 @@ export function ResearchOnboardingRoute() {
             }
             locked={personalityLocked}
             onContinue={() => {
-              // First continue applies the sliders to the assistant's persona on
-              // a throwaway side thread (awaits hatch readiness internally, then
-              // archives) and locks them — the prompt has been sent, so a later
-              // step-back can't silently diverge. The rewrite turn runs during
-              // the later steps; we track its promise (and pending flag) so the
-              // looking-you-up loader holds until it settles and the chat handoff
-              // awaits it, guaranteeing the persona is reshaped before the first
-              // real chat. Best-effort; it never rejects. A continue while
-              // already locked just advances.
+              // First continue applies the sliders and locks them — the prompt
+              // has been sent, so a later step-back can't silently diverge. A
+              // continue while already locked just advances.
               if (!personalityLocked) {
-                setPersonalityPending(true);
-                personalityAppliedRef.current = applyPersonality({
-                  awaitAssistantId: awaitHatchReady,
-                  values: personalityValues,
-                  userName: formValues?.firstName?.trim() || undefined,
-                  assistantName: faceValues?.name?.trim() || undefined,
-                }).finally(() => setPersonalityPending(false));
+                startPersonalityApply();
                 setPersonalityLocked(true);
               }
               goForwardTo("integration");
@@ -1137,8 +1165,11 @@ export function ResearchOnboardingRoute() {
           <FinishingUpStep
             // Hold the carousel until the personality rewrite settles, then hand
             // off. `finishAndEnterChat` also awaits the (usually already-resolved)
-            // plugin installs + correction before dropping into chat.
-            ready={!personalityPending}
+            // plugin installs + correction before dropping into chat. A hatch
+            // failure holds it too: the rewrite settles the moment the hatch
+            // rejects, and handing off would clear the snapshot and navigate away
+            // behind the failure overlay, out from under its retry.
+            ready={!personalityPending && hatchError === null}
             onDone={() => void finishAndEnterChat()}
           />
         )}

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -231,6 +231,76 @@ describe("useResearchRunner reset", () => {
   });
 });
 
+describe("useResearchRunner reinstallPlugins", () => {
+  const restored = {
+    status: "done" as const,
+    claims: [],
+    droppedClaims: [],
+    suggestions: [],
+    installedPlugins: ["admin-copilot"],
+    pluginCatalog: {},
+  };
+
+  function renderRunner() {
+    const queryClient = new QueryClient();
+    return renderHook(() => useResearchRunner(), {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+  }
+
+  /** Did the install gate settle, or is it still holding the handoff? */
+  async function raceInstallGate(gate: Promise<void>): Promise<string> {
+    return Promise.race([
+      gate.then(() => "settled"),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("holding"), 20);
+      }),
+    ]);
+  }
+
+  test("re-arms installs that resolved against a dead hatch", async () => {
+    const { result } = renderRunner();
+
+    // A resume enqueues the restored installs; the hatch they await then dies,
+    // so each swallows the rejection and the gate lets the handoff through with
+    // nothing installed.
+    act(() => {
+      result.current.hydrate(restored, () =>
+        Promise.reject(new Error("hatch failed")),
+      );
+    });
+    expect(await raceInstallGate(result.current.awaitPluginInstalls())).toBe(
+      "settled",
+    );
+
+    // Re-enqueued against the retried hatch, the gate holds again — the handoff
+    // waits for the capabilities to genuinely land this time.
+    act(() => {
+      result.current.reinstallPlugins(
+        restored.installedPlugins,
+        () => new Promise<string>(() => {}),
+      );
+    });
+    expect(await raceInstallGate(result.current.awaitPluginInstalls())).toBe(
+      "holding",
+    );
+  });
+
+  test("tracks nothing when the run installed nothing", async () => {
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.reinstallPlugins([], () => new Promise<string>(() => {}));
+    });
+
+    // No installs to redo — the click gate must not start blocking.
+    expect(await raceInstallGate(result.current.awaitPluginInstalls())).toBe(
+      "settled",
+    );
+  });
+});
+
 describe("shouldArchiveCompletedResearchConversation", () => {
   test("archives when a complete payload was observed", () => {
     expect(

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -157,8 +157,8 @@ describe("resolveResearchCompletionStatus", () => {
 
 describe("useResearchRunner reset", () => {
   const subject: ResearchSubject = {
-    firstName: "Ada",
-    lastName: "Lovelace",
+    firstName: "Alice",
+    lastName: "Example",
     occupation: "Engineer",
     hobbies: [],
     timezone: "UTC",

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -1,19 +1,26 @@
 /**
- * Tests for the catalog filter that decides which plugins onboarding surfaces.
+ * Tests for the catalog filter that decides which plugins onboarding surfaces,
+ * plus the runner's subject-key dedupe and the `reset` that releases it.
  *
  * The hard rule: only Vellum-hosted (first-party, reviewed) plugins are ever
  * offered or installed during onboarding — never third-party/external
  * marketplace repos — minus a couple of Vellum-owned infra/meta plugins.
  */
 
+import { createElement, type ReactNode } from "react";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, test } from "bun:test";
 
+import type { ResearchSubject } from "@/domains/onboarding/research-prompt";
 import {
   resolveResearchCompletionStatus,
   resolveOnboardingPluginInstalls,
   selectRecommendableCapabilities,
   shouldArchiveCompletedResearchConversation,
   shouldSettleResearchPoll,
+  useResearchRunner,
 } from "@/domains/onboarding/research-runner";
 
 type Match = Parameters<typeof selectRecommendableCapabilities>[0][number];
@@ -145,6 +152,82 @@ describe("resolveResearchCompletionStatus", () => {
     expect(
       resolveResearchCompletionStatus({ sawCompletePayload: false }),
     ).toBe("error");
+  });
+});
+
+describe("useResearchRunner reset", () => {
+  const subject: ResearchSubject = {
+    firstName: "Ada",
+    lastName: "Lovelace",
+    occupation: "Engineer",
+    hobbies: [],
+    timezone: "UTC",
+  };
+
+  function renderRunner() {
+    const queryClient = new QueryClient();
+    return renderHook(() => useResearchRunner(), {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+  }
+
+  // Park every run on its hatch await so the turn never reaches the network.
+  function pendingHatch() {
+    let calls = 0;
+    return {
+      awaitAssistantId: () => {
+        calls += 1;
+        return new Promise<string>(() => {});
+      },
+      get calls() {
+        return calls;
+      },
+    };
+  }
+
+  test("dedupes an identical subject until reset releases the key", () => {
+    const hatch = pendingHatch();
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({ awaitAssistantId: hatch.awaitAssistantId, subject });
+    });
+    expect(result.current.status).toBe("running");
+    expect(hatch.calls).toBe(1);
+
+    // The dedupe that makes an unchanged resubmit a no-op.
+    act(() => {
+      result.current.start({ awaitAssistantId: hatch.awaitAssistantId, subject });
+    });
+    expect(hatch.calls).toBe(1);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe("idle");
+
+    // Same subject, but the run it belonged to is gone — so it fires again.
+    act(() => {
+      result.current.start({ awaitAssistantId: hatch.awaitAssistantId, subject });
+    });
+    expect(hatch.calls).toBe(2);
+    expect(result.current.status).toBe("running");
+  });
+
+  test("reset leaves the plugin-install gate resolved", async () => {
+    const hatch = pendingHatch();
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({ awaitAssistantId: hatch.awaitAssistantId, subject });
+    });
+    act(() => {
+      result.current.reset();
+    });
+
+    // The abandoned run's click gate would otherwise never resolve.
+    await result.current.awaitPluginInstalls();
   });
 });
 

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -326,6 +326,17 @@ export interface ResearchRunnerState {
   pluginCatalog: Record<string, string>;
 }
 
+function emptyResearchState(status: ResearchStatus): ResearchRunnerState {
+  return {
+    status,
+    claims: [],
+    droppedClaims: [],
+    suggestions: [],
+    installedPlugins: [],
+    pluginCatalog: {},
+  };
+}
+
 export interface StartResearchOptions {
   /** Resolves with the hatched assistant id once it's healthy. */
   awaitAssistantId: () => Promise<string>;
@@ -388,6 +399,14 @@ export interface UseResearchRunner extends ResearchRunnerState {
     results: ResearchRunnerState,
     awaitAssistantId?: () => Promise<string>,
   ) => void;
+  /**
+   * Drop the run's subject key and results so a following `start` with the SAME
+   * subject re-fires instead of deduping to a no-op. For restarting a turn that
+   * died with the dependency it was waiting on — a failed hatch rejects
+   * `awaitAssistantId` and settles the run "error" while it keeps holding the
+   * key — not for ordinary resubmits, which the key is there to collapse.
+   */
+  reset: () => void;
 }
 
 const sleep = (ms: number): Promise<void> =>
@@ -411,14 +430,9 @@ export function resolveOnboardingPluginInstalls({
 }
 
 export function useResearchRunner(): UseResearchRunner {
-  const [state, setState] = useState<ResearchRunnerState>({
-    status: "idle",
-    claims: [],
-    droppedClaims: [],
-    suggestions: [],
-    installedPlugins: [],
-    pluginCatalog: {},
-  });
+  const [state, setState] = useState<ResearchRunnerState>(() =>
+    emptyResearchState("idle"),
+  );
   // Monotonic run id: every fresh run claims the next id; in-flight loops bail
   // the moment a newer run supersedes them. Paired with the last subject key so
   // an identical resubmit is a no-op but an edited one restarts.
@@ -461,14 +475,7 @@ export function useResearchRunner(): UseResearchRunner {
         resolvePluginsReady = res;
       });
       installPromisesRef.current.clear();
-      setState({
-        status: "running",
-        claims: [],
-        droppedClaims: [],
-        suggestions: [],
-        installedPlugins: [],
-        pluginCatalog: {},
-      });
+      setState(emptyResearchState("running"));
 
       void (async () => {
         let resolvedAssistantId: string | undefined;
@@ -784,6 +791,18 @@ export function useResearchRunner(): UseResearchRunner {
     [queryClient],
   );
 
+  const reset = useCallback(() => {
+    // Supersede any in-flight loop, release the subject key so an identical
+    // resubmit is treated as a genuinely fresh run, and re-arm an already-
+    // resolved click gate so `awaitPluginInstalls` can't hang on a run that no
+    // longer exists.
+    runIdRef.current += 1;
+    subjectKeyRef.current = null;
+    installPromisesRef.current.clear();
+    pluginsReadyRef.current = Promise.resolve();
+    setState(emptyResearchState("idle"));
+  }, []);
+
   const awaitPluginInstalls = useCallback(async (): Promise<void> => {
     // Wait only for the plugin decision to be final (so a click that beats the
     // parse doesn't await an empty map), then for those installs — never for the
@@ -828,5 +847,5 @@ export function useResearchRunner(): UseResearchRunner {
     [],
   );
 
-  return { ...state, start, awaitPluginInstalls, hydrate };
+  return { ...state, start, awaitPluginInstalls, hydrate, reset };
 }

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -400,6 +400,18 @@ export interface UseResearchRunner extends ResearchRunnerState {
     awaitAssistantId?: () => Promise<string>,
   ) => void;
   /**
+   * Re-enqueue installs for `names` against a fresh assistant promise, replacing
+   * whatever the run is tracking. For a settled run whose installs raced a hatch
+   * that then died: each one swallowed the rejection and resolved without
+   * installing anything while the run stayed `done`, so `awaitPluginInstalls`
+   * lets the handoff through on capabilities that aren't there. Idempotent and
+   * best-effort, like every other install path.
+   */
+  reinstallPlugins: (
+    names: string[],
+    awaitAssistantId: () => Promise<string>,
+  ) => void;
+  /**
    * Drop the run's subject key and results so a following `start` with the SAME
    * subject re-fires instead of deduping to a no-op. For restarting a turn that
    * died with the dependency it was waiting on — a failed hatch rejects
@@ -451,6 +463,30 @@ export function useResearchRunner(): UseResearchRunner {
   // aren't frozen until the whole reply settles.
   const pluginsReadyRef = useRef<Promise<void>>(Promise.resolve());
   const queryClient = useQueryClient();
+
+  // Track an install per name against a hatch promise, replacing the map. Used
+  // by both the resume hydrate and a post-retry re-enqueue, so the click gate
+  // always awaits installs bound to the CURRENT hatch attempt.
+  const enqueuePluginInstalls = useCallback(
+    (names: string[], awaitAssistantId: () => Promise<string>) => {
+      const installs = installPromisesRef.current;
+      installs.clear();
+      for (const name of names) {
+        installs.set(
+          name,
+          (async () => {
+            try {
+              const assistantId = await awaitAssistantId();
+              await installCapabilityBestEffort(assistantId, name);
+            } catch {
+              // Hatch never readied / install failed — don't block the click.
+            }
+          })(),
+        );
+      }
+    },
+    [],
+  );
 
   const start = useCallback(
     ({
@@ -827,25 +863,18 @@ export function useResearchRunner(): UseResearchRunner {
       // suggestion click awaits real promises rather than an empty map. Idempotent
       // and best-effort: a failed hatch / install never blocks the click.
       if (awaitAssistantId && results.installedPlugins.length > 0) {
-        const installs = installPromisesRef.current;
-        installs.clear();
-        for (const name of results.installedPlugins) {
-          installs.set(
-            name,
-            (async () => {
-              try {
-                const assistantId = await awaitAssistantId();
-                await installCapabilityBestEffort(assistantId, name);
-              } catch {
-                // Hatch never readied / install failed — don't block the click.
-              }
-            })(),
-          );
-        }
+        enqueuePluginInstalls(results.installedPlugins, awaitAssistantId);
       }
     },
-    [],
+    [enqueuePluginInstalls],
   );
 
-  return { ...state, start, awaitPluginInstalls, hydrate, reset };
+  return {
+    ...state,
+    start,
+    awaitPluginInstalls,
+    hydrate,
+    reinstallPlugins: enqueuePluginInstalls,
+    reset,
+  };
 }


### PR DESCRIPTION
## Summary
- Research route parses post_checkout=1 and passes postCheckoutReturn into the background hatch, activating the purchased-provisioning wait for paid returns
- New HatchErrorOverlay surfaces terminal hatch failures on any step with retry (or the macOS download off-ramp for platform-hosted-disabled), instead of only at the late calendar step

Part of plan: headless-paid-hatch.md (PR 3 of 5)