### PR TITLE
feat(web): land the paid checkout return on the research onboarding headlessly

### DIFF
--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -104,8 +104,9 @@ const postCheckoutBilling = `${routes.settings.root}/billing?session_id=cs_test_
 
 // The funnel entry carries the managed-hatch marker so a local-mode client
 // provisions on the platform rather than letting its own gateway answer for
-// the assistant.
-const managedFunnel = `${routes.onboarding.hatching}?hosting=vellum-cloud&post_checkout=1`;
+// the assistant. Non-native shells land on the headless research onboarding,
+// which runs the purchased-provisioning wait behind the form.
+const managedFunnel = `${routes.onboarding.research}?hosting=vellum-cloud&post_checkout=1`;
 
 /**
  * A checkout return on a local-mode client whose lockfile already holds a
@@ -374,7 +375,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
     });
   }
 
-  test("funnels the paid return into hatching", async () => {
+  test("funnels the paid return into provisioning", async () => {
     makePaidPlatformReturn();
 
     const res = await runMiddleware(postCheckoutBilling);
@@ -561,7 +562,7 @@ describe("authMiddleware — late-probe re-run through a real router", () => {
   function createGuardedRouter(): ReturnType<typeof createMemoryRouter> {
     return createMemoryRouter(
       [
-        { path: routes.onboarding.hatching, Component: () => null },
+        { path: routes.onboarding.research, Component: () => null },
         {
           path: "/assistant",
           middleware: [authMiddleware],

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -19,6 +19,16 @@ mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthMode: () => false,
 }));
 
+// The shell fork the paid provisioning funnel reads. Spread the real module so
+// the rest of the platform auth graph (`isOAuthFlowInFlight` and friends) stays
+// available to the stores build-state pulls in.
+let mockIsNativePlatform = false;
+const nativeAuthActual = await import("@/runtime/native-auth");
+mock.module("@/runtime/native-auth", () => ({
+  ...nativeAuthActual,
+  isNativePlatform: () => mockIsNativePlatform,
+}));
+
 // Consent prefs read storage; pin them so the access decision is isolated.
 mock.module("@/domains/onboarding/prefs", () => ({
   readTosAccepted: () => true,
@@ -40,6 +50,7 @@ const initialAuthState = useAuthStore.getState();
 beforeEach(() => {
   mockIsLocalMode = true;
   mockIsRemoteGatewayMode = false;
+  mockIsNativePlatform = false;
   useAuthStore.setState(initialAuthState, true);
   useOrganizationStore.setState({
     currentOrganizationId: null,
@@ -111,6 +122,22 @@ describe("buildNavigationState — isAuthenticated mirrors sessionStatus", () =>
     });
 
     expect(buildNavigationState().platformSession).toBe("unknown");
+  });
+});
+
+describe("buildNavigationState — isNative", () => {
+  // The post-checkout provisioning funnel forks on this: native keeps the
+  // foreground hatching screen, web and Electron take the headless research
+  // entry.
+
+  test("false in a browser or the Electron shell", () => {
+    expect(buildNavigationState().isNative).toBe(false);
+  });
+
+  test("true inside the native Capacitor shell", () => {
+    mockIsNativePlatform = true;
+
+    expect(buildNavigationState().isNative).toBe(true);
   });
 });
 

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -15,6 +15,7 @@ import {
   readConsentHydrated,
 } from "@/domains/onboarding/prefs";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
+import { isNativePlatform } from "@/runtime/native-auth";
 import {
   assistantsValidForOrg,
   useResolvedAssistantsStore,
@@ -56,6 +57,7 @@ export function buildNavigationState(
       ? remoteGatewayPublicPathPrefix()
       : "",
     isGatewayAuth: isGatewayAuthMode(),
+    isNative: isNativePlatform(),
     hasAssistants: assistants.length > 0,
     hasPlatformHostedAssistant: hasPlatformHostedAssistant(assistants),
     sessionSettled: isSessionSettled(sessionStatus),

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -20,6 +20,8 @@ const base: NavigationState = {
   isRemoteGateway: false,
   remoteGatewayPublicPathPrefix: "",
   isGatewayAuth: false,
+  // Web/Electron by default; the native fork is exercised explicitly.
+  isNative: false,
   hasAssistants: true,
   hasPlatformHostedAssistant: true,
   sessionSettled: true,
@@ -47,6 +49,16 @@ function redirectPath(decision: NavigationDecision): string | null {
   const qIdx = decision.to.indexOf("?");
   return qIdx < 0 ? decision.to : decision.to.slice(0, qIdx);
 }
+
+// The two provisioning funnel entries a paid return can name. Both carry the
+// managed-hatch marker, so a local-mode client provisions on the platform
+// instead of letting its own gateway answer for the assistant and skipping the
+// purchased-provisioning wait, plus the post-checkout marker that tells that
+// wait a still-base subscription read is a lagging webhook, not a free org.
+const RESEARCH_FUNNEL_URL =
+  "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
+const HATCHING_FUNNEL_URL =
+  "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
 
 const ALLOW: NavigationDecision = { action: "allow" };
 const WAIT: NavigationDecision = { action: "wait" };
@@ -594,14 +606,17 @@ describe("resolveNavigation", () => {
     const POST_CHECKOUT_BILLING =
       "/assistant/settings/billing?session_id=cs_test_123";
 
-    // The funnel entry carries the managed-hatch marker, so a local-mode
-    // client provisions on the platform instead of letting its own gateway
-    // answer for the assistant and skipping the purchased-provisioning wait,
-    // plus the post-checkout marker that tells the hatching screen a
-    // still-base subscription read is a lagging webhook, not a free org.
+    // Web and Electron land the paid return on the headless research
+    // onboarding, which runs the purchased-provisioning wait behind the form.
     const MANAGED_FUNNEL: NavigationDecision = {
       action: "redirect",
-      to: "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1",
+      to: RESEARCH_FUNNEL_URL,
+    };
+    // The native shell has no research flow, so it keeps the foreground
+    // hatching screen.
+    const NATIVE_MANAGED_FUNNEL: NavigationDecision = {
+      action: "redirect",
+      to: HATCHING_FUNNEL_URL,
     };
 
     // A brand-new org: nothing resolved at all.
@@ -618,10 +633,24 @@ describe("resolveNavigation", () => {
       hasPlatformHostedAssistant: false,
     } as const;
 
-    test("funnels a no-assistant post-checkout return into hatching", () => {
+    test("funnels a no-assistant post-checkout return into the research onboarding", () => {
       expect(guard(s(EMPTY_ORG), POST_CHECKOUT_BILLING)).toEqual(
         MANAGED_FUNNEL,
       );
+    });
+
+    // The research flow isn't wired for the Capacitor shell, so the native paid
+    // return still gets the foreground hatching screen.
+    test("keeps the foreground hatching entry on native", () => {
+      expect(
+        guard(s({ ...EMPTY_ORG, isNative: true }), POST_CHECKOUT_BILLING),
+      ).toEqual(NATIVE_MANAGED_FUNNEL);
+      expect(
+        guard(
+          s({ ...NO_MANAGED_ASSISTANT, isNative: true }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual(NATIVE_MANAGED_FUNNEL);
     });
 
     // The decision is "does a managed plan have a target", not "is the list
@@ -801,30 +830,31 @@ describe("resolveNavigation", () => {
     });
 
     const UNCONSENTED = { tosAccepted: false, privacyConsent: false } as const;
-    const MANAGED_FUNNEL_URL =
-      "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
 
-    // Consent is enforced at the destination, not skipped: the funnel entry is
-    // an onboarding path, and re-resolving it bounces an unconsented user on.
+    // Consent is enforced at the destination, not skipped: both funnel entries
+    // are onboarding paths, and re-resolving one bounces an unconsented user on.
     test("consent is still enforced once the funnel destination is resolved", () => {
       expect(
         guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), POST_CHECKOUT_BILLING),
       ).toEqual(MANAGED_FUNNEL);
-      expect(
-        redirectPath(guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), MANAGED_FUNNEL_URL)),
-      ).toBe("/assistant/onboarding/privacy");
+      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+        expect(
+          redirectPath(guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), url)),
+        ).toBe("/assistant/onboarding/privacy");
+      }
     });
 
     // The bounce carries the funnel URL as `returnTo` — the same contract
     // review-terms uses — so the privacy screen resumes it on Start. Dropping
     // it loses the paid-return marker, and the paying user finishes the hatch
-    // at the baseline plan.
+    // at the baseline plan. The hatching form round-trips too, because a
+    // `returnTo` stashed by an older client names it.
     test("carries the paid funnel destination through the consent bounce", () => {
       expect(
-        guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), MANAGED_FUNNEL_URL),
+        guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), HATCHING_FUNNEL_URL),
       ).toEqual({
         action: "redirect",
-        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(MANAGED_FUNNEL_URL)}`,
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(HATCHING_FUNNEL_URL)}`,
       });
     });
 
@@ -847,15 +877,12 @@ describe("resolveNavigation", () => {
     // `returnTo`, so its bounce stays bare.
     test("a local-mode hatching bounce keeps the bare welcome entrypoint", () => {
       expect(
-        guard(s({ isLocalMode: true, ...UNCONSENTED }), MANAGED_FUNNEL_URL),
+        guard(s({ isLocalMode: true, ...UNCONSENTED }), HATCHING_FUNNEL_URL),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     // The research route is the headless paid provisioning entry, so it bounces
     // and carries exactly like the hatching entry does.
-    const RESEARCH_FUNNEL_URL =
-      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
-
     test("carries a paid research destination through the consent bounce", () => {
       expect(
         guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), RESEARCH_FUNNEL_URL),
@@ -904,10 +931,13 @@ describe("resolveNavigation", () => {
     // in-app navigation, never a cold deep link, and it bounces immediately.
     test("the hatching bounce does not wait on consent hydration", () => {
       expect(
-        guard(s({ ...UNCONSENTED, consentHydrated: false }), MANAGED_FUNNEL_URL),
+        guard(
+          s({ ...UNCONSENTED, consentHydrated: false }),
+          HATCHING_FUNNEL_URL,
+        ),
       ).toEqual({
         action: "redirect",
-        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(MANAGED_FUNNEL_URL)}`,
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(HATCHING_FUNNEL_URL)}`,
       });
     });
 
@@ -932,12 +962,12 @@ describe("resolveNavigation", () => {
     // The funnel destination must not itself read as a checkout return, or the
     // redirect would loop.
     test("the funnel destination is not treated as a post-checkout return", () => {
-      expect(
-        guard(
-          s(EMPTY_ORG),
-          "/assistant/onboarding/hatching?session_id=cs_test_123",
-        ),
-      ).toEqual(ALLOW);
+      for (const url of [
+        "/assistant/onboarding/hatching?session_id=cs_test_123",
+        "/assistant/onboarding/research?session_id=cs_test_123",
+      ]) {
+        expect(guard(s(EMPTY_ORG), url)).toEqual(ALLOW);
+      }
     });
 
     test("redirects brand-new platform user with no assistant to privacy, unaffected by stale-toggle gate", () => {
@@ -1290,11 +1320,6 @@ describe("resolveNavigation", () => {
   // postCheckoutHatchReturnTo
   // -----------------------------------------------------------------------
   describe("postCheckoutHatchReturnTo", () => {
-    const RESEARCH_FUNNEL_URL =
-      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
-    const HATCHING_FUNNEL_URL =
-      "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
-
     test("accepts the headless research funnel entry", () => {
       expect(postCheckoutHatchReturnTo(RESEARCH_FUNNEL_URL)).toBe(
         RESEARCH_FUNNEL_URL,

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -959,6 +959,96 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
+    // A gateway session short-circuits the pipeline to "allow" before any
+    // consent step runs, so the paid funnel entries suspend that bypass —
+    // otherwise an Electron paid return starts the purchased hatch with no
+    // consent recorded. The Electron desktop shape: gateway auth against a
+    // local assistant, with a platform session to provision into.
+    const ELECTRON_PAID = {
+      isGatewayAuth: true,
+      isLocalMode: true,
+      platformSession: "present",
+      ...NO_MANAGED_ASSISTANT,
+    } as const;
+
+    // Local mode's entrypoint is `welcome`, which reads no `returnTo` — the
+    // same bare bounce the hatching screen's own gate already gave this user.
+    test("bounces an unconsented gateway-auth paid return to the local entrypoint", () => {
+      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+        expect(guard(s({ ...ELECTRON_PAID, ...UNCONSENTED }), url)).toEqual({
+          action: "redirect",
+          to: "/assistant/welcome",
+        });
+      }
+    });
+
+    // Suspending the bypass must not bounce a consented paid return: it is the
+    // whole point of the funnel that it reaches the hatch.
+    test("allows a consented gateway-auth paid return", () => {
+      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+        expect(guard(s(ELECTRON_PAID), url)).toEqual(ALLOW);
+      }
+    });
+
+    // Onboarding is complete but a toggle went stale, so the terms are
+    // re-reviewed before the purchased hatch — with the funnel URL as
+    // `returnTo`, so the markers survive and the plan is not lost.
+    test("sends a stale-consent gateway-auth paid return to review-terms", () => {
+      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+        expect(
+          guard(s({ ...ELECTRON_PAID, analyticsConsentCurrent: false }), url),
+        ).toEqual({
+          action: "redirect",
+          to: `/assistant/review-terms?returnTo=${encodeURIComponent(url)}`,
+        });
+      }
+      expect(
+        guard(
+          s({ ...ELECTRON_PAID, diagnosticsConsentCurrent: false }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+      });
+    });
+
+    // Only the paid marker suspends the bypass. The local adopt flow reaches
+    // the research entry unmarked and keeps the bypass it has always had.
+    test("keeps the gateway-auth bypass on an unmarked funnel entry", () => {
+      for (const url of [
+        "/assistant/onboarding/research",
+        "/assistant/onboarding/research?hosting=vellum-cloud",
+        "/assistant/onboarding/hatching",
+        "/assistant/onboarding/hatching?post_checkout=0",
+      ]) {
+        expect(
+          guard(s({ ...ELECTRON_PAID, ...UNCONSENTED }), url),
+        ).toEqual(ALLOW);
+      }
+    });
+
+    // A remote-gateway session is gateway auth too. Paired (authenticated), it
+    // passes the pairing step untouched; unpaired it pairs first, and the
+    // pairing `returnTo` keeps the markers so the funnel resumes after.
+    test("leaves remote-gateway pairing intact on a paid funnel entry", () => {
+      expect(
+        guard(
+          s({ ...ELECTRON_PAID, isRemoteGateway: true }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual(ALLOW);
+      expect(
+        guard(
+          s({ ...ELECTRON_PAID, isRemoteGateway: true, isAuthenticated: false }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/pair?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+      });
+    });
+
     // The funnel destination must not itself read as a checkout return, or the
     // redirect would loop.
     test("the funnel destination is not treated as a post-checkout return", () => {

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -1,5 +1,6 @@
 import type { PlatformSessionStatus } from "@/stores/session-status";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
+import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { resolveSignupCheckoutDestination } from "@/lib/billing/post-auth-checkout";
 import { routes } from "@/utils/routes";
 
@@ -13,6 +14,13 @@ export interface NavigationState {
   isRemoteGateway: boolean;
   remoteGatewayPublicPathPrefix: string;
   isGatewayAuth: boolean;
+  /**
+   * Whether this is the native Capacitor shell (iOS/Android).
+   *
+   * The research onboarding is not wired for the native shell (see
+   * `onboarding-destination.ts`), so the paid provisioning funnel forks on it.
+   */
+  isNative: boolean;
   hasAssistants: boolean;
   /**
    * Whether the active organization has a **platform-hosted** assistant — the
@@ -145,14 +153,15 @@ function isPostCheckoutReturn(
 }
 
 /**
- * The hatching-screen query param naming a hatch that is the return leg of a
- * completed Stripe Checkout. Only {@link MANAGED_PROVISIONING_DESTINATION} sets
+ * The onboarding query param naming a hatch that is the return leg of a
+ * completed Stripe Checkout. Only {@link managedProvisioningDestination} sets
  * it, and only for a billing landing carrying Stripe's `session_id`.
  *
  * Deliberately separate from `hosting=vellum-cloud`, which says only that the
- * hatch is managed — a hosting choice a free user can make too. The hatching
- * screen holds for a lagging subscription webhook on this param alone, so
- * conflating the two would park every free managed hatch on a spinner.
+ * hatch is managed — a hosting choice a free user can make too. The purchased-
+ * provisioning wait holds for a lagging subscription webhook on this param
+ * alone, so conflating the two would park every free managed hatch on a
+ * spinner.
  */
 export const POST_CHECKOUT_HATCH_PARAM = "post_checkout";
 
@@ -162,14 +171,28 @@ export const POST_CHECKOUT_HATCH_PARAM = "post_checkout";
  *
  * `hosting=vellum-cloud` is the onboarding flow's managed-hatch marker (see
  * `adopt-existing-assistant`): it names a managed hatch even in a local-mode
- * build, where the hatching screen would otherwise let the local gateway answer
- * for the assistant and skip the purchased-provisioning wait.
+ * build, where the client would otherwise let the local gateway answer for the
+ * assistant and skip the purchased-provisioning wait. Carrying it onto the
+ * research entry is load-bearing on Electron for exactly that reason —
+ * `shouldAdoptExistingAssistant` reads it to force the managed hatch instead of
+ * adopting a local gateway assistant.
  *
  * {@link POST_CHECKOUT_HATCH_PARAM} adds the narrower fact that money has
- * already changed hands, which is what lets the hatching screen treat a
- * still-base subscription read as a pending webhook rather than a free org.
+ * already changed hands, which is what lets the hatch treat a still-base
+ * subscription read as a pending webhook rather than a free org.
  */
-const MANAGED_PROVISIONING_DESTINATION = `${routes.onboarding.hatching}?hosting=vellum-cloud&${POST_CHECKOUT_HATCH_PARAM}=1`;
+function managedProvisioningDestination(state: NavigationState): string {
+  // The same shell fork the consent step takes: native has no research flow and
+  // keeps the foreground hatching screen, while web and Electron take the
+  // headless research entry, which runs the purchased-provisioning wait behind
+  // the onboarding form. `isLocalHatch` is false by construction —
+  // `hosting=vellum-cloud` forces the managed hatch.
+  const route = onboardingDestinationAfterConsent({
+    isNative: state.isNative,
+    isLocalHatch: false,
+  });
+  return `${route}?hosting=vellum-cloud&${POST_CHECKOUT_HATCH_PARAM}=1`;
+}
 
 /**
  * The provisioning funnel entries a paid return can name: the foreground
@@ -329,11 +352,11 @@ function waitForSession(state: NavigationState): NavigationDecision | null {
  * billing landing. Every billing surface mounts under `ActiveAssistantGate`,
  * which renders a "Connecting to your assistant…" placeholder for as long as
  * no assistant resolves — so the paid return dead-ends on a spinner. Send it
- * into the hatching funnel instead, which provisions the assistant and applies
- * the purchased specs.
+ * into the provisioning funnel instead, which provisions the assistant and
+ * applies the purchased specs.
  *
- * The destination is {@link MANAGED_PROVISIONING_DESTINATION}: the marker is
- * what makes a local-mode client provision on the platform and hold for the
+ * The destination is {@link managedProvisioningDestination}: its marker is what
+ * makes a local-mode client provision on the platform and hold for the
  * purchased machine and storage instead of letting its own gateway answer for
  * the assistant.
  *
@@ -406,7 +429,7 @@ function requirePostCheckoutProvisioning(
       return null;
     }
   }
-  return { action: "redirect", to: MANAGED_PROVISIONING_DESTINATION };
+  return { action: "redirect", to: managedProvisioningDestination(state) };
 }
 
 function allowGatewayAuth(state: NavigationState): NavigationDecision | null {

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -300,7 +300,7 @@ export function resolveNavigation(
 // Conceptual layers:
 //   1. Readiness          — is the session ready?
 //   2. Paid return        — a checkout return with nothing provisioned yet
-//   3. Bypass             — gateway auth skips everything
+//   3. Bypass             — gateway auth skips everything but a paid return
 //   4. Identity           — is the user authenticated?
 //   5. Mode boundary      — is this path valid for the user's mode?
 //   6. Setup exemptions   — onboarding/consent paths are always reachable
@@ -384,9 +384,10 @@ function waitForSession(state: NavigationState): NavigationDecision | null {
  * Electron takes the `"native"` checkout return, but its deep-link handler
  * lands on the same in-app billing path carrying `session_id`, so it resolves
  * through this pipeline too.
- * Consent is still enforced: the destination is an onboarding path, and
- * `onboardingCompletedMiddleware` re-runs this pipeline there, where
- * `allowSetupRoutes` bounces an unconsented user to the privacy screen.
+ * Consent is still enforced: re-resolving the destination runs
+ * `allowSetupRoutes`, which bounces an unconsented user to the consent
+ * entrypoint. `allowGatewayAuth` suspends its bypass for exactly these URLs so
+ * a gateway session reaches that step.
  */
 function requirePostCheckoutProvisioning(
   state: NavigationState,
@@ -432,8 +433,25 @@ function requirePostCheckoutProvisioning(
   return { action: "redirect", to: managedProvisioningDestination(state) };
 }
 
-function allowGatewayAuth(state: NavigationState): NavigationDecision | null {
-  return state.isGatewayAuth ? { action: "allow" } : null;
+/**
+ * A gateway session answers for itself, so it skips the rest of the pipeline —
+ * except on a paid return to a provisioning funnel entry.
+ *
+ * The bypass runs before `allowSetupRoutes`, so leaving it unconditional would
+ * let an Electron paid return reach the headless research entry and start the
+ * purchased hatch with no consent recorded. Suspending it only for a
+ * {@link postCheckoutHatchReturnTo} URL keeps every other gateway-auth surface
+ * — including the local adopt flow's unmarked research entry — on today's
+ * bypass, and hands exactly the paid case to the consent steps below.
+ */
+function allowGatewayAuth(
+  state: NavigationState,
+  _path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
+  if (!state.isGatewayAuth) return null;
+  if (postCheckoutHatchReturnTo(pathnameWithSearch)) return null;
+  return { action: "allow" };
 }
 
 function stripRemoteGatewayPublicPathPrefix(
@@ -558,11 +576,31 @@ function allowSetupRoutes(
       return { action: "wait" };
     }
 
-    if (PROVISIONING_FUNNEL_PATHS.has(path) && !hasCompletedOnboarding(state)) {
-      return {
-        action: "redirect",
-        to: consentBounceDestination(state, pathnameWithSearch),
-      };
+    if (PROVISIONING_FUNNEL_PATHS.has(path)) {
+      if (!hasCompletedOnboarding(state)) {
+        return {
+          action: "redirect",
+          to: consentBounceDestination(state, pathnameWithSearch),
+        };
+      }
+      // A stale toggle must be re-reviewed before a hatch the user paid for.
+      // `requireConsent` can't reach this — every onboarding path is allowed
+      // above — so the paid funnel enforces it here, scoped to the paid marker
+      // so the ordinary funnel keeps its exemption. Gated on a live platform
+      // session for the same reason as `requireConsent`: there is nothing to
+      // re-review against without one.
+      if (
+        postCheckoutHatchReturnTo(pathnameWithSearch) &&
+        !state.isPlatformDisabled &&
+        state.platformSession === "present" &&
+        !consentIsCurrent(state)
+      ) {
+        const returnTo = encodeURIComponent(pathnameWithSearch);
+        return {
+          action: "redirect",
+          to: `${routes.reviewTerms}?returnTo=${returnTo}`,
+        };
+      }
     }
     return { action: "allow" };
   }

--- a/clients/web/src/routes.test.ts
+++ b/clients/web/src/routes.test.ts
@@ -230,6 +230,20 @@ describe("onboarding funnel middleware order", () => {
     expect(onboardingIndex).toBeGreaterThanOrEqual(0);
     expect(authIndex).toBeLessThan(onboardingIndex);
   });
+
+  // The paid return lands here on web and Electron. Its markers survive the
+  // consent bounce because `authMiddleware` — which resolves with pathname +
+  // search — is the only guard on the route. Moving it under the onboarding
+  // guard, which resolves with the pathname alone, would drop them and finish
+  // the hatch at the baseline plan.
+  test("guards the research funnel route with the auth middleware alone", () => {
+    const order = middlewareExecutionOrder(
+      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1",
+    );
+
+    expect(order).toContain(authMiddleware);
+    expect(order).not.toContain(onboardingCompletedMiddleware);
+  });
 });
 
 describe("settings route compatibility", () => {


### PR DESCRIPTION
## Summary
- The post-checkout provisioning redirect now targets the research onboarding on web/Electron (headless purchased-provisioning wait behind the form) while native keeps the foreground hatching screen
- NavigationState gains isNative so the resolver can fork per shell
- Stashed pre-flip hatching returnTo values still resume via the resolver's dual-path acceptance

Part of plan: headless-paid-hatch.md (PR 5 of 5)