### PR TITLE
fix: keep the research funnel interactive under the hatch-error surface

### DIFF
--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@vellumai/design-library/components/button";
-import { Modal } from "@vellumai/design-library/components/modal";
+import { Notice } from "@vellumai/design-library/components/notice";
+import { createPortal } from "react-dom";
 
 import { PLATFORM_HOSTED_DISABLED_MESSAGE } from "@/assistant/lifecycle";
 
@@ -13,53 +14,46 @@ interface HatchErrorOverlayProps {
 /**
  * Terminal background-hatch failure, surfaced over the onboarding funnel.
  *
- * Layers on top of whatever step is on screen rather than replacing it, so the
- * funnel keeps its collected state and a successful retry resumes in place.
- * Retrying can't help while managed hosting is at capacity, so that case offers
- * the local-assistant off-ramp instead.
+ * A non-modal banner: it layers on top of whatever step is on screen without
+ * trapping focus or swallowing pointer events, so the funnel keeps both its
+ * collected state and its own escapes (each step's back chevron, the calendar
+ * step's "Skip for now") while the failure is up, and a successful retry
+ * resumes in place. Retrying can't help while managed hosting is at capacity,
+ * so that case offers the local-assistant off-ramp instead.
+ *
+ * Portaled to `document.body` so no step's stacking or clipping context can
+ * bury it.
  */
 export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
   const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;
-  return (
-    <Modal.Root open>
-      <Modal.Content
-        size="sm"
-        role="alertdialog"
-        hideCloseButton
-        dismissOnOverlayClick={false}
-        onEscapeKeyDown={(event) => event.preventDefault()}
-        onInteractOutside={(event) => event.preventDefault()}
-      >
-        <Modal.Header>
-          <Modal.Title>Something went wrong</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Modal.Description>{error}</Modal.Description>
-          {platformHostedDisabled ? (
-            <p className="mt-5 text-body-medium-default text-[var(--content-default)]">
-              Get started today with a local assistant
-            </p>
-          ) : null}
-        </Modal.Body>
-        <Modal.Footer>
-          {platformHostedDisabled ? (
-            <Button asChild variant="primary" size="regular" fullWidth>
+  return createPortal(
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center p-4">
+      <Notice
+        tone="error"
+        title="Something went wrong"
+        className="pointer-events-auto w-auto max-w-[480px] shadow-xl"
+        actions={
+          platformHostedDisabled ? (
+            <Button asChild variant="primary" size="regular">
               <a href={`${window.location.origin}/download`}>
                 Download the macOS app
               </a>
             </Button>
           ) : (
-            <Button
-              variant="primary"
-              size="regular"
-              fullWidth
-              onClick={onRetry}
-            >
+            <Button variant="primary" size="regular" onClick={onRetry}>
               Try again
             </Button>
-          )}
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal.Root>
+          )
+        }
+      >
+        {error}
+        {platformHostedDisabled ? (
+          <p className="mt-1 text-[color:var(--content-default)]">
+            Get started today with a local assistant
+          </p>
+        ) : null}
+      </Notice>
+    </div>,
+    document.body,
   );
 }

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -19,9 +19,12 @@
  *
  * The paid-return block covers the `post_checkout=1` marker reaching the
  * background hatch and the failure overlay that surfaces a dead hatch on any
- * step, with the at-capacity download off-ramp in place of a retry. The retry
- * block covers what that overlay's "Try again" has to un-poison: route state
- * that resolved against the dead hatch and would otherwise survive the retry.
+ * step, with the at-capacity download off-ramp in place of a retry. That
+ * surface is a banner rather than a modal, so it also covers the funnel staying
+ * usable underneath and the auto-advancing loading step holding its own
+ * position while the hatch is dead. The retry block covers what the banner's
+ * "Try again" has to un-poison: route state that resolved against the dead
+ * hatch and would otherwise survive the retry.
  *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
@@ -113,7 +116,7 @@ const backgroundHatch = {
   start: () => {},
   retry: retryHatchMock,
   ready: true,
-  assistantId: "asst-1",
+  assistantId: "asst-1" as string | null,
   error: null as string | null,
   awaitReady: () => awaitHatchReady(),
 };
@@ -308,13 +311,40 @@ mock.module("@/domains/onboarding/screens/create-personality-step", () => ({
   ),
 }));
 
+// Renders the real step's contract: the connect action can't enable until the
+// hatch is ready, and "Skip for now" is revealed early on a failed hatch so the
+// user is never trapped behind a button that can never enable.
 mock.module("@/domains/onboarding/screens/lets-chat-tomorrow-step", () => ({
-  LetsChatTomorrowStep: () => <div data-testid="letschat-step" />,
+  LetsChatTomorrowStep: (props: {
+    assistantId: string | null;
+    assistantReady: boolean;
+    hatchError?: string | null;
+    onSkip: () => void;
+  }) => {
+    const waitingForAssistant = !props.assistantId || !props.assistantReady;
+    return (
+      <div data-testid="letschat-step">
+        {!waitingForAssistant || props.hatchError ? (
+          <button
+            type="button"
+            data-testid="letschat-skip"
+            onClick={props.onSkip}
+          >
+            Skip for now
+          </button>
+        ) : null}
+      </div>
+    );
+  },
 }));
 
 mock.module("@/domains/onboarding/screens/research-result-steps", () => ({
   MeetingCreatedStep: () => <div data-testid="meeting-step" />,
-  LookingYouUpStep: () => <div data-testid="looking-step" />,
+  // Surfaces the `ready` gate so a test can pin when the carousel is allowed to
+  // advance out of the loading state.
+  LookingYouUpStep: (props: { ready: boolean }) => (
+    <div data-testid="looking-step" data-ready={String(props.ready)} />
+  ),
   FinishingUpStep: () => <div data-testid="finishing-step" />,
   ResearchResultsStep: () => <div data-testid="results-step" />,
   SuggestionsStep: () => <div data-testid="suggestions-step" />,
@@ -397,6 +427,8 @@ beforeEach(() => {
   releaseEstablishedCheck = () => {};
   searchParams.delete("post_checkout");
   backgroundHatch.error = null;
+  backgroundHatch.ready = true;
+  backgroundHatch.assistantId = "asst-1";
   awaitHatchReady = async () => "asst-1";
   onRetryHatch = () => {};
   navigateMock.mockClear();
@@ -624,7 +656,7 @@ describe("ResearchOnboardingRoute paid return", () => {
 
     render(<ResearchOnboardingRoute />);
 
-    const overlay = await screen.findByRole("alertdialog");
+    const overlay = await screen.findByRole("alert");
     expect(overlay.textContent).toContain(
       "Failed to start your assistant. Please try again.",
     );
@@ -640,7 +672,7 @@ describe("ResearchOnboardingRoute paid return", () => {
 
     render(<ResearchOnboardingRoute />);
 
-    const overlay = await screen.findByRole("alertdialog");
+    const overlay = await screen.findByRole("alert");
     expect(overlay.textContent).toContain(
       "Get started today with a local assistant",
     );
@@ -654,7 +686,59 @@ describe("ResearchOnboardingRoute paid return", () => {
     render(<ResearchOnboardingRoute />);
     await screen.findByTestId("form-submit");
 
-    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // The failure surface is a banner, not a modal: it must not hide the funnel
+  // from assistive tech nor swallow the escapes the steps deliberately expose
+  // while the hatch is dead.
+  test("leaves the funnel's own escapes usable behind the failure banner", async () => {
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "letschat" }));
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+    backgroundHatch.ready = false;
+    backgroundHatch.assistantId = null;
+
+    const { container } = render(<ResearchOnboardingRoute />);
+    await screen.findByRole("alert");
+
+    // The funnel behind is still exposed, not inerted by a modal layer.
+    expect(container.getAttribute("aria-hidden")).toBeNull();
+
+    // The calendar step reveals "Skip for now" precisely because the hatch
+    // failed — and the banner leaves it clickable, so the skip lands.
+    fireEvent.click(await screen.findByTestId("letschat-skip"));
+    expect(screen.getByTestId("looking-step")).toBeTruthy();
+  });
+
+  // The banner blocks input, not the step machine — so the auto-advancing
+  // loading step has to hold on its own while the hatch is dead, or the user is
+  // walked past the result steps and a recovered turn has nowhere to show.
+  test("holds the looking carousel while the hatch is dead, and resumes after a retry", async () => {
+    researchStatus = "error";
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "looking" }));
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+
+    // The turn has settled, but a dead hatch means its emptiness isn't final.
+    const looking = await screen.findByTestId("looking-step");
+    expect(looking.dataset.ready).toBe("false");
+
+    onRetryHatch = () => {
+      backgroundHatch.error = null;
+    };
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    // The retry re-fires the turn, so the step is legitimately loading again.
+    rerender(<ResearchOnboardingRoute />);
+    expect(screen.getByTestId("looking-step").dataset.ready).toBe("false");
+
+    // Once the recovered turn settles, the held carousel resumes — the
+    // re-fetched results get their step instead of having been skipped past.
+    researchStatus = "done";
+    rerender(<ResearchOnboardingRoute />);
+    await waitFor(() =>
+      expect(screen.getByTestId("looking-step").dataset.ready).toBe("true"),
+    );
   });
 });
 
@@ -687,7 +771,7 @@ describe("ResearchOnboardingRoute hatch retry", () => {
     establishedResult = { established: true, assistantName: "Viper" };
 
     render(<ResearchOnboardingRoute />);
-    await screen.findByRole("alertdialog");
+    await screen.findByRole("alert");
     // The dead hatch never got far enough to ask.
     expect(checkEstablishedAssistantMock).not.toHaveBeenCalled();
 
@@ -821,7 +905,7 @@ describe("ResearchOnboardingRoute hatch retry", () => {
     failFirstHatch();
 
     render(<ResearchOnboardingRoute />);
-    await screen.findByRole("alertdialog");
+    await screen.findByRole("alert");
 
     recoverOnRetry();
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
@@ -870,7 +954,7 @@ describe("ResearchOnboardingRoute hatch retry", () => {
     writeResearchSnapshot(USER_ID, postFormSnapshot());
 
     render(<ResearchOnboardingRoute />);
-    await screen.findByRole("alertdialog");
+    await screen.findByRole("alert");
 
     recoverOnRetry();
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -620,12 +620,15 @@ export function ResearchOnboardingRoute() {
 
   // If we're sitting on the results step when the research turn resolves empty
   // (it was still streaming when we arrived), skip ahead to the suggestions.
+  // A dead hatch settles the turn "error" with no claims, which is emptiness we
+  // may still recover from — hold here so a successful retry can refill this
+  // step instead of the user having been walked past it.
   useEffect(() => {
-    if (step === "results" && noClaims) {
+    if (step === "results" && noClaims && hatchError === null) {
       setForwardStack([]);
       setStep("suggestions");
     }
-  }, [step, noClaims]);
+  }, [step, noClaims, hatchError]);
 
   // Scrub the hidden aggregator-only drops from the assistant's memory when the
   // results step won't do it itself. The results step folds drops into its own
@@ -901,7 +904,8 @@ export function ResearchOnboardingRoute() {
   // A terminal hatch failure is layered over whichever step is on screen — the
   // assistant is dead at all of them, so the failure shouldn't wait for the
   // last step to be discovered. Layering (rather than replacing the step) keeps
-  // the funnel's collected state, so a successful retry resumes in place.
+  // the funnel's collected state, so a successful retry resumes in place; the
+  // banner is non-modal, so each step's own escapes stay usable while it's up.
   const withHatchError = (content: ReactNode) => (
     <>
       {content}
@@ -1030,7 +1034,11 @@ export function ResearchOnboardingRoute() {
             // decoupled in the background and is finished off in its own step
             // right before the chat handoff (see the "finishing" step), so this
             // quick loading state isn't held hostage to the persona turn.
-            ready={!researchLoading}
+            // A hatch failure holds the carousel too: the turn settles "error"
+            // the moment the hatch dies, and advancing would walk the user past
+            // the result steps into a handoff behind the failure banner, out
+            // from under its retry.
+            ready={!researchLoading && hatchError === null}
           />
         )}
         {step === "results" && (


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for headless-paid-hatch.md.

**Gap:** the hatch-error modal trapped the funnel (blocked the letschat Skip escape and the local-adopt exit) and the step machine auto-advanced behind it, losing recovered results after retry.
**Fix:** non-modal error surface; auto-advance gated on a live hatch, mirroring the finishing step.