### PR TITLE
fix: cancel the background paid wait on unmount and single-source its constants

### DIFF
--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -20,7 +20,11 @@ import {
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
-import { awaitPurchasedProvisioning } from "@/domains/onboarding/purchased-provisioning";
+import {
+    awaitPurchasedProvisioning,
+    MAX_HATCH_WAIT_MS,
+    POLL_INTERVAL_MS,
+} from "@/domains/onboarding/purchased-provisioning";
 import { getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
@@ -46,9 +50,7 @@ import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { ProgressBar } from "@vellumai/design-library/components/progress-bar";
 
-const POLL_INTERVAL_MS = 3000;
 const COMPLETION_NAVIGATE_DELAY_MS = 800;
-const MAX_HATCH_WAIT_MS = 300_000;
 
 // Module-level state so HMR remounts, StrictMode double-mounts, and — critically
 // — the auth-driven provider remount survive without spawning duplicate hatches.

--- a/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
@@ -60,9 +60,9 @@ mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => localMode,
 }));
 
-const { awaitPurchasedProvisioning } = await import("./purchased-provisioning");
-
-const MAX_HATCH_WAIT_MS = 300_000;
+const { awaitPurchasedProvisioning, MAX_HATCH_WAIT_MS } = await import(
+  "./purchased-provisioning"
+);
 
 /** Poll a predicate without depending on the wait's own 3s poll interval. */
 async function until(

--- a/clients/web/src/domains/onboarding/purchased-provisioning.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.ts
@@ -31,8 +31,12 @@ import {
 } from "@/lib/billing/provisioning-targets";
 import { isLocalMode } from "@/lib/local-mode";
 
-const POLL_INTERVAL_MS = 3000;
-const MAX_HATCH_WAIT_MS = 300_000;
+// The single source for the hatch poll cadence and the overall wait ceiling,
+// shared by every hatch entry point. `MAX_HATCH_WAIT_MS` decides the
+// `health_timeout` outcome below, so a caller reporting its own copy in
+// telemetry would be reporting a number that didn't make the decision.
+export const POLL_INTERVAL_MS = 3000;
+export const MAX_HATCH_WAIT_MS = 300_000;
 // Hard cap on the post-payment resize wait, mirroring PROVISION_STALL_MS in the
 // pro-onboarding takeover. On expiry the assistant completes at baseline and the
 // server reconciles the purchased specs later — the user is never trapped.

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -55,9 +55,22 @@ let lockfileEntries: Record<string, { assistantId: string }> = {};
 const getLockfileAssistantMock = mock(
   (id: string): { assistantId: string } | undefined => lockfileEntries[id],
 );
+// The desktop (Electron) build reports local mode even for a managed hatch.
+let localMode = false;
+const saveLockfileAssistantMock = mock(async (_entry: unknown): Promise<void> =>
+  undefined,
+);
 mock.module("@/lib/local-mode", () => ({
   probeLocalGatewayReady: probeLocalGatewayReadyMock,
   getLockfileAssistant: getLockfileAssistantMock,
+  isLocalMode: () => localMode,
+  getPlatformRuntimeUrl: () => "https://runtime.example",
+  saveLockfileAssistant: saveLockfileAssistantMock,
+}));
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({ currentOrganizationId: "org-1" }),
+  },
 }));
 mock.module("@/utils/api-errors", () => ({
   extractErrorMessage: (e: unknown, _r: unknown, fallback?: string) =>
@@ -89,8 +102,12 @@ const awaitPurchasedProvisioningMock = mock(
     return provisioningOutcome;
   },
 );
+// The hook reads the poll cadence and the wait ceiling from this module too
+// (single-sourced); a short interval keeps the poll-loop tests fast.
 mock.module("@/domains/onboarding/purchased-provisioning", () => ({
   awaitPurchasedProvisioning: awaitPurchasedProvisioningMock,
+  POLL_INTERVAL_MS: 10,
+  MAX_HATCH_WAIT_MS: 300_000,
 }));
 
 const seedHatchAvatarMock = mock(
@@ -116,12 +133,19 @@ beforeEach(() => {
   getAssistantResult = {
     ok: true,
     status: 200,
-    data: { id: "ast-research", status: "active", is_local: false } as never,
+    data: {
+      id: "ast-research",
+      name: "Research",
+      status: "active",
+      is_local: false,
+    } as never,
   };
   healthzResult = { ok: true, status: 200, data: {} as never };
   lockfileEntries = {};
+  localMode = false;
   provisioningOutcome = "ready";
   provisioningGate = null;
+  saveLockfileAssistantMock.mockClear();
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
   getAssistantHealthzMock.mockClear();
@@ -420,5 +444,117 @@ describe("useBackgroundHatch", () => {
     await waitFor(() => expect(existing.result.current.ready).toBe(true));
     // A returning user may have a real avatar; only a fresh hatch is seeded.
     expect(seedHatchAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("unmounting stops the assistant poll loop", async () => {
+    getAssistantResult = {
+      ok: true,
+      status: 200,
+      data: {
+        id: "ast-research",
+        status: "initializing",
+        is_local: false,
+      } as never,
+    };
+
+    const { result, unmount } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() =>
+      expect(getAssistantMock.mock.calls.length).toBeGreaterThanOrEqual(2),
+    );
+    unmount();
+    const callsAtUnmount = getAssistantMock.mock.calls.length;
+
+    // Leaving the funnel mid-hatch must not keep polling from a dead
+    // component: many poll intervals elapse here with no further calls.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(getAssistantMock.mock.calls.length).toBeLessThanOrEqual(
+      callsAtUnmount + 1,
+    );
+  });
+
+  test("unmounting cancels the purchased-provisioning wait without settling", async () => {
+    const release = holdProvisioning();
+
+    const { result, unmount } = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    let resolved: string | undefined;
+    act(() => {
+      void result.current.awaitReady().then((id) => {
+        resolved = id;
+      });
+      result.current.start();
+    });
+
+    await waitFor(() =>
+      expect(awaitPurchasedProvisioningMock).toHaveBeenCalledTimes(1),
+    );
+    const options = awaitPurchasedProvisioningMock.mock.calls[0][0] as {
+      isCancelled: () => boolean;
+      registerTimer?: (timer: ReturnType<typeof setTimeout> | null) => void;
+    };
+    expect(options.isCancelled()).toBe(false);
+    // The wait's own poll timer has to be clearable from the caller.
+    expect(typeof options.registerTimer).toBe("function");
+
+    unmount();
+    expect(options.isCancelled()).toBe(true);
+
+    // A cancelled wait still resolves "ready"; the hatch must not complete on
+    // it once the component is gone.
+    release();
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(resolved).toBeUndefined();
+  });
+
+  test("a managed hatch in local mode records the assistant in the lockfile", async () => {
+    // The desktop build's assistant list and switcher are lockfile-driven, so
+    // a headless managed hatch has to register there like the foreground one.
+    localMode = true;
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(saveLockfileAssistantMock).toHaveBeenCalledTimes(1);
+    expect(saveLockfileAssistantMock.mock.calls[0][0]).toMatchObject({
+      assistantId: "ast-research",
+      name: "Research",
+      cloud: "vellum",
+      runtimeUrl: "https://runtime.example",
+      organizationId: "org-1",
+    });
+
+    // Adopting a foreground-hatched assistant is the hatching screen's own
+    // write; the background hatch must not duplicate it.
+    saveLockfileAssistantMock.mockClear();
+    const adopt = renderHook(() => useBackgroundHatch({ adoptExisting: true }));
+
+    act(() => {
+      adopt.result.current.start();
+    });
+
+    await waitFor(() => expect(adopt.result.current.ready).toBe(true));
+    expect(saveLockfileAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a non-local build writes no lockfile entry", async () => {
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(saveLockfileAssistantMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   getAssistant,
@@ -14,29 +14,28 @@ import {
   shouldRecoverFromHatchFailure,
 } from "@/assistant/lifecycle";
 import { seedHatchAvatar } from "@/assistant/seed-hatch-avatar";
-import { awaitPurchasedProvisioning } from "@/domains/onboarding/purchased-provisioning";
-import { getLockfileAssistant, probeLocalGatewayReady } from "@/lib/local-mode";
+import {
+  awaitPurchasedProvisioning,
+  MAX_HATCH_WAIT_MS,
+  POLL_INTERVAL_MS,
+} from "@/domains/onboarding/purchased-provisioning";
+import {
+  getLockfileAssistant,
+  getPlatformRuntimeUrl,
+  isLocalMode,
+  probeLocalGatewayReady,
+  saveLockfileAssistant,
+} from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { randomCharacterTraits } from "@/utils/avatar-random";
-
-// Mirrors the poll/backoff constants in
-// `@/domains/onboarding/pages/hatching-screen.tsx`. The research-onboarding
-// flow kicks this hatch off in the background the moment the user lands on the
-// onboarding page, so by the time they finish the intro/pitch steps and submit
-// their details the assistant is (usually) already healthy and the flow can
-// immediately fire its research turn.
-const POLL_INTERVAL_MS = 3000;
-const MAX_HATCH_WAIT_MS = 300_000;
 
 const GENERIC_HATCH_ERROR =
   "Failed to start your assistant. Please try again.";
 const TIMEOUT_ERROR =
   "Your assistant is taking longer than expected. Please try again.";
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 export interface UseBackgroundHatch {
   /** Fire the hatch. Idempotent — only the first call provisions. */
@@ -105,6 +104,10 @@ export interface UseBackgroundHatchOptions {
  * Terminal failures (platform-hosted disabled, non-recoverable hatch errors,
  * lifecycle errors, timeout) set `error` and reject `awaitReady()`.
  * Recoverable failures (5xx / network) keep polling.
+ *
+ * Unmounting aborts the sequence: every loop and the purchased-provisioning
+ * wait stop at their next check and the pending poll timer is cleared, so
+ * leaving the funnel mid-hatch doesn't keep polling from a dead component.
  */
 export function useBackgroundHatch(
   {
@@ -129,6 +132,24 @@ export function useBackgroundHatch(
   const settledRef = useRef<
     { kind: "ready"; id: string } | { kind: "error"; message: string } | null
   >(null);
+  // The hatch sequence outlives a render by minutes (a 90s purchased-resize
+  // hold, a 300s health poll), so unmount has to stop it: every loop and the
+  // provisioning wait check this, and the pending poll timer is cleared.
+  const abortedRef = useRef(false);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // Reset on (re)mount so StrictMode's simulated unmount doesn't abort the
+    // hatch its own second mount is about to keep running.
+    abortedRef.current = false;
+    return () => {
+      abortedRef.current = true;
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const settleReady = useCallback((id: string) => {
     if (settledRef.current) return;
@@ -153,6 +174,15 @@ export function useBackgroundHatch(
 
     const startMs = Date.now();
     const timedOut = () => Date.now() - startMs >= MAX_HATCH_WAIT_MS;
+    // Parks the pending handle so unmount can clear it; an aborted sleep never
+    // resumes, which is how the loops stop mid-wait.
+    const sleep = (ms: number): Promise<void> =>
+      new Promise((resolve) => {
+        pollTimerRef.current = setTimeout(() => {
+          pollTimerRef.current = null;
+          resolve();
+        }, ms);
+      });
 
     void (async () => {
       // 0. Adopt straight from the lockfile when the handed-off id resolves.
@@ -200,9 +230,10 @@ export function useBackgroundHatch(
           if (result.ok) {
             hatchedAssistantId = result.data.id;
             setAssistantId(result.data.id);
-            // The Dock/tray icons are avatar-driven, so a freshly hatched (201)
-            // assistant needs seeded traits — parity with the foreground hatch.
-            // Fire-and-forget; the research face step overwrites them later.
+            // Seed a freshly hatched (201) assistant's traits — parity with the
+            // foreground hatch. Paid-only because the free research hatch must
+            // stay byte-identical to today, adding no writes it doesn't already
+            // make. Fire-and-forget; the research face step overwrites later.
             if (postCheckoutReturn && result.status === 201) {
               void seedHatchAvatar(
                 result.data.id,
@@ -232,21 +263,39 @@ export function useBackgroundHatch(
       // 2. Poll until the assistant reports `active`.
       let activeAssistantId: string | undefined;
       while (!activeAssistantId) {
+        if (abortedRef.current) return;
         if (timedOut()) {
           settleError(TIMEOUT_ERROR);
           return;
         }
         try {
           let result = await getAssistant(hatchedAssistantId);
+          if (abortedRef.current) return;
           // A stale hatched id (404) falls back to list-based discovery.
           if (hatchedAssistantId && !result.ok && result.status === 404) {
             hatchedAssistantId = undefined;
             result = await getAssistant();
+            if (abortedRef.current) return;
           }
           const state = resolveAssistantLifecycleState(result);
           if (state.kind === "active" && result.ok) {
             activeAssistantId = result.data.id;
             setAssistantId(activeAssistantId);
+            // Mirrors the hatching screen: on the desktop build the assistant
+            // list and switcher are lockfile-driven, so a managed assistant
+            // hatched headlessly here would otherwise be missing from them.
+            if (!adoptExisting && isLocalMode()) {
+              void saveLockfileAssistant({
+                assistantId: activeAssistantId,
+                name: result.data.name,
+                cloud: "vellum",
+                runtimeUrl: getPlatformRuntimeUrl(),
+                hatchedAt: new Date().toISOString(),
+                organizationId:
+                  useOrganizationStore.getState().currentOrganizationId ??
+                  undefined,
+              });
+            }
             break;
           }
           if (state.kind === "error") {
@@ -273,6 +322,7 @@ export function useBackgroundHatch(
       // still being alive.
       if (adoptExisting) {
         while (!(await probeLocalGatewayReady())) {
+          if (abortedRef.current) return;
           if (timedOut()) {
             settleError(TIMEOUT_ERROR);
             return;
@@ -281,8 +331,10 @@ export function useBackgroundHatch(
         }
       } else {
         while (true) {
+          if (abortedRef.current) return;
           try {
             const health = await getAssistantHealthz(activeAssistantId);
+            if (abortedRef.current) return;
             if (health.ok) break;
           } catch {
             // Daemon not reachable yet.
@@ -294,6 +346,7 @@ export function useBackgroundHatch(
           await sleep(POLL_INTERVAL_MS);
         }
       }
+      if (abortedRef.current) return;
 
       // 4. On a paid return, hold `ready` until the purchased resize converges.
       //
@@ -303,11 +356,17 @@ export function useBackgroundHatch(
       if (!adoptExisting && postCheckoutReturn) {
         const outcome = await awaitPurchasedProvisioning({
           assistantId: activeAssistantId,
-          postCheckoutReturn: true,
+          postCheckoutReturn,
           managedHatch: true,
           hatchStartMs: startMs,
-          isCancelled: () => settledRef.current?.kind === "error",
+          isCancelled: () => abortedRef.current,
+          registerTimer: (timer) => {
+            pollTimerRef.current = timer;
+          },
         });
+        // A cancelled wait also returns "ready" — the component is gone, so
+        // leave the hatch unsettled rather than completing into nothing.
+        if (abortedRef.current) return;
         if (outcome === "health_timeout") {
           // The assistant never answered healthz after the resize; completing
           // would hand the user an unreachable assistant.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for headless-paid-hatch.md.

**Gap:** the background paid wait had a provably-dead cancellation predicate and no unmount teardown; poll constants were mirrored in four places with telemetry drift risk; the Electron managed hatch lost the hatching screen's lockfile write; the avatar-seed comment misstated its own rationale.
**Fix:** real abort-on-unmount wired through the wait and the hook's own polls; constants exported from purchased-provisioning; local-mode lockfile write ported; comment corrected.