### PR TITLE
fix: scope the paid consent hardening to the research entry

### DIFF
--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -36,15 +36,22 @@ mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthMode: () => mockGatewayAuthMode,
 }));
 
-// Consent prefs are read by buildNavigationState; pin them current so the
-// consent gate doesn't interfere with the session-admission assertions below.
+// Consent prefs are read by buildNavigationState; pinned current by default so
+// the consent gate doesn't interfere with the session-admission assertions
+// below. `consentPrefs` lets a case drive the boot defaults instead.
+const consentPrefs = {
+  tos: true,
+  privacy: true,
+  analytics: true,
+  diagnostics: true,
+};
 const prefsActual = await import("@/domains/onboarding/prefs");
 mock.module("@/domains/onboarding/prefs", () => ({
   ...prefsActual,
-  readTosAccepted: () => true,
-  readPrivacyConsent: () => true,
-  readAnalyticsConsentCurrent: () => true,
-  readDiagnosticsConsentCurrent: () => true,
+  readTosAccepted: () => consentPrefs.tos,
+  readPrivacyConsent: () => consentPrefs.privacy,
+  readAnalyticsConsentCurrent: () => consentPrefs.analytics,
+  readDiagnosticsConsentCurrent: () => consentPrefs.diagnostics,
 }));
 
 // Clamp whenStoreState timeouts so hydration-timeout paths are testable
@@ -202,6 +209,10 @@ const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 beforeEach(() => {
   isLocalModeMock.mockImplementation(() => true);
   hasAssistantsMock.mockImplementation(() => false);
+  consentPrefs.tos = true;
+  consentPrefs.privacy = true;
+  consentPrefs.analytics = true;
+  consentPrefs.diagnostics = true;
   mockSelectedAssistant = undefined;
   mockGatewayTokenPresent = false;
   mockGatewayAuthMode = false;
@@ -664,6 +675,67 @@ describe("authMiddleware — hydration timeout", () => {
       useResolvedAssistantsStore.setState({
         assistantsHydrated: priorAssistantsHydrated,
       });
+    }
+  });
+
+  // The research entry waits for consent to hydrate. Forcing the hydration flag
+  // after the timeout leaves the consent flags at their boot `false`, so the
+  // funnel's own gate would read a consented user as un-onboarded and evict
+  // them into privacy — losing a paid return's markers, restarting a free
+  // user's onboarding. It admits instead.
+  test("admits a research funnel entry whose consent hydration hung", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    // The boot state a cold deep link sees: nothing read back from the server
+    // yet, and the fetch that would never reports.
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: true,
+    });
+
+    try {
+      const outcome = await runMiddlewareOutcome(managedFunnel);
+      expect(outcome.admitted).toBe(true);
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+    }
+  });
+
+  // Fail-open is scoped to the unhydrated read: consent that actually hydrated
+  // on an unconsented user still bounces, carrying the funnel URL so the paid
+  // markers survive the privacy screen.
+  test("bounces the same entry once consent hydrates unconsented", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    useOnboardingStore.setState({ consentHydrated: true });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: true,
+    });
+
+    try {
+      const res = await runMiddleware(managedFunnel);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(
+        `${routes.onboarding.privacy}?returnTo=${encodeURIComponent(managedFunnel)}`,
+      );
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
     }
   });
 });

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -81,9 +81,18 @@ const resolveWithGuard = async (
   // a non-decision into that documented fallback. A result that lands after the
   // timeout re-runs the guard (see `revalidateWhenPlatformProbeSettles`), so a
   // slow-but-successful probe still reaches its platform-session destination.
+  //
+  // Forcing `consentHydrated` hides that the consent flags underneath it are
+  // still their boot `false`, so the forcing itself is reported too: a step
+  // that would otherwise read them as a settled "not consented" — and evict a
+  // consented user mid-funnel — can fail open on it instead.
   const state = buildNavigationState({
     ...(hydrationTimedOut
-      ? { consentHydrated: true, assistantsHydrated: true }
+      ? {
+          consentHydrated: true,
+          consentHydrationTimedOut: true,
+          assistantsHydrated: true,
+        }
       : {}),
     ...(platformProbeTimedOut ? { platformSession: "absent" as const } : {}),
   });

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -892,8 +892,8 @@ describe("resolveNavigation", () => {
       });
     });
 
-    // Closes a consent gap: an unconsented user could previously walk the
-    // research funnel directly, which provisions an assistant.
+    // The research funnel provisions an assistant, so an unconsented user does
+    // not reach it by navigating there directly either.
     test("bounces an unconsented bare research visit to the entrypoint", () => {
       expect(guard(s(UNCONSENTED), "/assistant/onboarding/research")).toEqual({
         action: "redirect",
@@ -910,6 +910,25 @@ describe("resolveNavigation", () => {
         guard(s({ hasAssistants: false }), "/assistant/onboarding/research"),
       ).toEqual(ALLOW);
       expect(guard(s({}), RESEARCH_FUNNEL_URL)).toEqual(ALLOW);
+    });
+
+    // Onboarding is complete but a toggle went stale: the terms are re-reviewed
+    // before the purchased hatch, with the funnel URL (markers intact) as
+    // `returnTo` so the plan is not lost on the round trip. The marker is what
+    // scopes this — an ordinary research visit keeps its onboarding exemption.
+    test("sends a stale-consent paid research return to review-terms", () => {
+      for (const stale of [
+        { analyticsConsentCurrent: false },
+        { diagnosticsConsentCurrent: false },
+      ]) {
+        expect(guard(s({ ...EMPTY_ORG, ...stale }), RESEARCH_FUNNEL_URL)).toEqual({
+          action: "redirect",
+          to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+        });
+        expect(
+          guard(s({ ...EMPTY_ORG, ...stale }), "/assistant/onboarding/research"),
+        ).toEqual(ALLOW);
+      }
     });
 
     // A cold paid deep link reaches the research route before the consent flags
@@ -933,6 +952,70 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({ ...UNCONSENTED, consentHydrated: false }),
+          HATCHING_FUNNEL_URL,
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(HATCHING_FUNNEL_URL)}`,
+      });
+    });
+
+    // The auth middleware forces `consentHydrated` once its wait runs out, so
+    // the flags underneath are still their boot `false`. Bouncing on them
+    // evicts an already-consented user mid-funnel — a paid return loses its
+    // markers, a free one restarts onboarding — so the research entry falls
+    // back to the unconditional admission it had before it joined the funnel.
+    test("admits the research route when consent hydration timed out", () => {
+      for (const url of ["/assistant/onboarding/research", RESEARCH_FUNNEL_URL]) {
+        expect(
+          guard(
+            s({
+              ...EMPTY_ORG,
+              ...UNCONSENTED,
+              consentHydrated: true,
+              consentHydrationTimedOut: true,
+            }),
+            url,
+          ),
+        ).toEqual(ALLOW);
+      }
+      // The stale-toggle gate reads the same unhydrated flags, so it fails open
+      // too rather than sending a paid return to review-terms it can't answer.
+      expect(
+        guard(
+          s({
+            ...EMPTY_ORG,
+            analyticsConsentCurrent: false,
+            diagnosticsConsentCurrent: false,
+            consentHydrated: true,
+            consentHydrationTimedOut: true,
+          }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual(ALLOW);
+    });
+
+    // Fail-open is scoped to the unhydrated read: a hydration that actually
+    // landed on an unconsented user still bounces.
+    test("still bounces a genuinely hydrated unconsented research visit", () => {
+      expect(
+        guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), RESEARCH_FUNNEL_URL),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+      });
+    });
+
+    // The hatching entry never waits on hydration, so it never sees the forced
+    // flag either — its bounce is unchanged by the fail-open.
+    test("the hatching bounce is unaffected by a consent hydration timeout", () => {
+      expect(
+        guard(
+          s({
+            ...UNCONSENTED,
+            consentHydrated: true,
+            consentHydrationTimedOut: true,
+          }),
           HATCHING_FUNNEL_URL,
         ),
       ).toEqual({
@@ -993,24 +1076,39 @@ describe("resolveNavigation", () => {
     // Onboarding is complete but a toggle went stale, so the terms are
     // re-reviewed before the purchased hatch — with the funnel URL as
     // `returnTo`, so the markers survive and the plan is not lost.
-    test("sends a stale-consent gateway-auth paid return to review-terms", () => {
-      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+    test("sends a stale-consent gateway-auth paid research return to review-terms", () => {
+      for (const stale of [
+        { analyticsConsentCurrent: false },
+        { diagnosticsConsentCurrent: false },
+      ]) {
         expect(
-          guard(s({ ...ELECTRON_PAID, analyticsConsentCurrent: false }), url),
+          guard(s({ ...ELECTRON_PAID, ...stale }), RESEARCH_FUNNEL_URL),
         ).toEqual({
           action: "redirect",
-          to: `/assistant/review-terms?returnTo=${encodeURIComponent(url)}`,
+          to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
         });
       }
-      expect(
-        guard(
-          s({ ...ELECTRON_PAID, diagnosticsConsentCurrent: false }),
-          RESEARCH_FUNNEL_URL,
-        ),
-      ).toEqual({
-        action: "redirect",
-        to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
-      });
+    });
+
+    // The stale-toggle gate is research-only. The hatching entry — where the
+    // native paid return lands, and where a `returnTo` stashed by an older
+    // client still points — resolves `allow` here and re-reviews stale terms at
+    // the screen's own `hatch-gate` instead.
+    test("leaves a stale-consent paid hatching return on its allow", () => {
+      for (const stale of [
+        { analyticsConsentCurrent: false },
+        { diagnosticsConsentCurrent: false },
+      ]) {
+        expect(
+          guard(s({ ...ELECTRON_PAID, ...stale }), HATCHING_FUNNEL_URL),
+        ).toEqual(ALLOW);
+        expect(
+          guard(
+            s({ ...EMPTY_ORG, isNative: true, ...stale }),
+            HATCHING_FUNNEL_URL,
+          ),
+        ).toEqual(ALLOW);
+      }
     });
 
     // Only the paid marker suspends the bypass. The local adopt flow reaches

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -45,6 +45,14 @@ export interface NavigationState {
    * hydration would misread an established user as un-onboarded.
    */
   consentHydrated: boolean;
+  /**
+   * Whether `consentHydrated` above was forced by the auth middleware after its
+   * hydration wait timed out. The consent flags then still read their boot
+   * `false`, so a gate that treats them as a settled "not consented" would
+   * evict a consented user. Absent on every other caller — only the middleware
+   * can know its own wait ran out.
+   */
+  consentHydrationTimedOut?: boolean;
   /** Whether the resolved assistants list reflects at least one authoritative load. */
   assistantsHydrated: boolean;
 }
@@ -196,9 +204,11 @@ function managedProvisioningDestination(state: NavigationState): string {
 
 /**
  * The provisioning funnel entries a paid return can name: the foreground
- * hatching screen (native, and local/Docker hosting) and the headless research
- * onboarding (web). Both provision the purchased assistant, so both are
- * consent-gated and both are resumable from the privacy screen.
+ * hatching screen (native only) and the headless research onboarding (web and
+ * Electron). The shell is the only fork — {@link managedProvisioningDestination}
+ * always resolves a managed hatch, so hosting never picks the entry. Both
+ * provision the purchased assistant, so both are consent-gated and both are
+ * resumable from the privacy screen.
  */
 const PROVISIONING_FUNNEL_PATHS: Set<string> = new Set([
   routes.onboarding.hatching,
@@ -533,9 +543,13 @@ function enforceModeBoundary(
  * A paid return carries its funnel URL as `returnTo`, the same contract
  * `review-terms` uses, and the privacy screen resumes it on Start. Without the
  * carry the funnel's markers are lost on the bounce and the paying user
- * finishes the hatch at the baseline plan. Every other funnel bounce — and
- * local mode, whose entrypoint is `welcome` and reads no `returnTo` — gets the
+ * finishes the hatch at the baseline plan. Every other funnel bounce gets the
  * bare entrypoint.
+ *
+ * Local mode is a deliberate exception to that carry: its entrypoint is
+ * `welcome`, which reads no `returnTo`, so an unconsented local paid return
+ * finishes the hatch at baseline and the server-side post-hatch reconcile
+ * applies the purchased specs. That is the parity local mode has always had.
  */
 function consentBounceDestination(
   state: NavigationState,
@@ -561,48 +575,77 @@ function allowSetupRoutes(
     return { action: "allow" };
   }
 
-  if (isOnboardingPath(path)) {
-    // The research route is the headless funnel entry, so it is the one reached
-    // by a cold paid deep link — the consent flags are still at their boot
-    // defaults there, and bouncing on them would send an already-consented user
-    // to privacy. Local mode is excluded for the same reason as in
-    // `requireConsent`: its consent either hydrates synchronously during session
-    // init or never does, so waiting would hang navigation.
-    if (
-      path === routes.onboarding.research &&
-      !state.isLocalMode &&
-      !state.consentHydrated
-    ) {
+  if (!isOnboardingPath(path)) {
+    return null;
+  }
+
+  return enforceFunnelConsent(state, path, pathnameWithSearch) ?? { action: "allow" };
+}
+
+/**
+ * Consent for the two provisioning funnel entries, which `requireConsent` never
+ * reaches — every onboarding path is allowed before it runs.
+ *
+ * The hatching entry keeps exactly the gate it has always had — reached from
+ * in-app navigation and from the native paid return, it decides on the flags in
+ * hand and leaves stale-toggle review to the screen's own `hatch-gate`. The
+ * research entry is the one a cold paid deep link lands on, so it also waits
+ * for the flags to hydrate and re-reviews a stale toggle before starting a
+ * hatch the user paid for.
+ */
+function enforceFunnelConsent(
+  state: NavigationState,
+  path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
+  if (!PROVISIONING_FUNNEL_PATHS.has(path)) {
+    return null;
+  }
+
+  if (path === routes.onboarding.research) {
+    // The consent flags are still at their boot defaults on a cold deep link,
+    // and bouncing on them would send an already-consented user to privacy.
+    // Local mode is excluded for the same reason as in `requireConsent`: its
+    // consent either hydrates synchronously during session init or never does,
+    // so waiting would hang navigation.
+    if (!state.isLocalMode && !state.consentHydrated) {
       return { action: "wait" };
     }
-
-    if (PROVISIONING_FUNNEL_PATHS.has(path)) {
-      if (!hasCompletedOnboarding(state)) {
-        return {
-          action: "redirect",
-          to: consentBounceDestination(state, pathnameWithSearch),
-        };
-      }
-      // A stale toggle must be re-reviewed before a hatch the user paid for.
-      // `requireConsent` can't reach this — every onboarding path is allowed
-      // above — so the paid funnel enforces it here, scoped to the paid marker
-      // so the ordinary funnel keeps its exemption. Gated on a live platform
-      // session for the same reason as `requireConsent`: there is nothing to
-      // re-review against without one.
-      if (
-        postCheckoutHatchReturnTo(pathnameWithSearch) &&
-        !state.isPlatformDisabled &&
-        state.platformSession === "present" &&
-        !consentIsCurrent(state)
-      ) {
-        const returnTo = encodeURIComponent(pathnameWithSearch);
-        return {
-          action: "redirect",
-          to: `${routes.reviewTerms}?returnTo=${returnTo}`,
-        };
-      }
+    // A hydration that never landed leaves those boot defaults behind a forced
+    // `consentHydrated`, so the gates below would read a consented user as
+    // un-onboarded and restart their funnel. Fail open to the entry's
+    // unconditional contract instead; a hydrated read still gates.
+    if (state.consentHydrationTimedOut) {
+      return null;
     }
-    return { action: "allow" };
+  }
+
+  if (!hasCompletedOnboarding(state)) {
+    return {
+      action: "redirect",
+      to: consentBounceDestination(state, pathnameWithSearch),
+    };
+  }
+
+  // A stale toggle must be re-reviewed before a hatch the user paid for.
+  // Research-only: the hatching entry — the native paid return, and a
+  // `returnTo` stashed by an older client — reaches a screen whose own
+  // `hatch-gate` already re-reviews stale terms, so gating it twice would only
+  // change where it lands. Gated on the paid marker so the ordinary funnel
+  // keeps its exemption, and on a live platform session for the same reason as
+  // `requireConsent`: there is nothing to re-review against without one.
+  if (
+    path === routes.onboarding.research &&
+    postCheckoutHatchReturnTo(pathnameWithSearch) &&
+    !state.isPlatformDisabled &&
+    state.platformSession === "present" &&
+    !consentIsCurrent(state)
+  ) {
+    const returnTo = encodeURIComponent(pathnameWithSearch);
+    return {
+      action: "redirect",
+      to: `${routes.reviewTerms}?returnTo=${returnTo}`,
+    };
   }
 
   return null;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for headless-paid-hatch.md.

**Gap:** the stale-consent gate applied to native hatching returns (breaking native byte-parity), and a >5s consent-hydration stall bounced consented users into the privacy screen on the research route.
**Fix:** stale-consent gate scoped to the research entry; research fails open on hydration timeout, matching its pre-flip contract; docstrings corrected.