### PR TITLE
fix: fail the paid consent gate open only on a consent-hydration stall

### DIFF
--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -682,7 +682,8 @@ describe("authMiddleware — hydration timeout", () => {
   // after the timeout leaves the consent flags at their boot `false`, so the
   // funnel's own gate would read a consented user as un-onboarded and evict
   // them into privacy — losing a paid return's markers, restarting a free
-  // user's onboarding. It admits instead.
+  // user's onboarding. It admits instead. The assistants list is hydrated here,
+  // so the fail-open rests on the consent wait alone.
   test("admits a research funnel entry whose consent hydration hung", async () => {
     isLocalModeMock.mockImplementation(() => false);
     useAuthStore.setState({
@@ -736,6 +737,80 @@ describe("authMiddleware — hydration timeout", () => {
       );
     } finally {
       useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+    }
+  });
+
+  // The fail-open belongs to the consent wait alone. Consent that hydrates on
+  // time reports a settled "not consented" whatever the assistants list is
+  // doing, so a stalled list must not launder an unconsented user past the gate
+  // and into a hatch they would be charged for.
+  test("bounces an unconsented research entry when only the assistants list stalls", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    const priorAssistantsHydrated =
+      useResolvedAssistantsStore.getState().assistantsHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: false,
+    });
+
+    try {
+      const pending = runMiddleware(managedFunnel);
+      // Consent lands well inside its (clamped) wait; the assistants fetch
+      // never reports, so only that second wait runs out.
+      setTimeout(() => {
+        useOnboardingStore.setState({ consentHydrated: true });
+      }, 10);
+
+      const res = await pending;
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(
+        `${routes.onboarding.privacy}?returnTo=${encodeURIComponent(managedFunnel)}`,
+      );
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+      useResolvedAssistantsStore.setState({
+        assistantsHydrated: priorAssistantsHydrated,
+      });
+    }
+  });
+
+  // Both fetches hang, so the consent wait times out on its own account and the
+  // entry falls back to its unconditional admission.
+  test("admits the research entry when both hydration waits stall", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    const priorAssistantsHydrated =
+      useResolvedAssistantsStore.getState().assistantsHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: false,
+    });
+
+    try {
+      const outcome = await runMiddlewareOutcome(managedFunnel);
+      expect(outcome.admitted).toBe(true);
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+      useResolvedAssistantsStore.setState({
+        assistantsHydrated: priorAssistantsHydrated,
+      });
     }
   });
 });

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -60,41 +60,53 @@ function revalidateWhenPlatformProbeSettles(): void {
   });
 }
 
+/** Waits that ran out on an earlier pass; each stays forced from then on. */
+interface TimedOutWaits {
+  consentHydration: boolean;
+  assistantsHydration: boolean;
+  platformProbe: boolean;
+}
+
+const NO_TIMED_OUT_WAITS: TimedOutWaits = {
+  consentHydration: false,
+  assistantsHydration: false,
+  platformProbe: false,
+};
+
 export const authMiddleware: MiddlewareFunction = (args, next) =>
-  resolveWithGuard(args, next, false, false);
+  resolveWithGuard(args, next, NO_TIMED_OUT_WAITS);
 
 const resolveWithGuard = async (
   { request, context }: Parameters<MiddlewareFunction>[0],
   next: Parameters<MiddlewareFunction>[1],
-  hydrationTimedOut: boolean,
-  platformProbeTimedOut: boolean,
+  timedOut: TimedOutWaits,
 ): Promise<Awaited<ReturnType<MiddlewareFunction>>> => {
   const url = new URL(request.url);
 
-  // After a timed-out hydration wait, force the hydration flags so the
-  // resolver decides on whatever state exists instead of returning another
-  // "wait" — a fetch that hangs (never reaching any settle path) must degrade
-  // to a decision, not loop navigation in timeout-sized chunks. A platform
-  // probe that outran its wait degrades the same way, to `"absent"`: every step
-  // that reads the probe treats an unsettled session as "no decision yet" and
-  // a settled-absent one as "no platform account", so forcing it can only turn
-  // a non-decision into that documented fallback. A result that lands after the
-  // timeout re-runs the guard (see `revalidateWhenPlatformProbeSettles`), so a
-  // slow-but-successful probe still reaches its platform-session destination.
+  // After a timed-out wait, force that wait's own flag so the resolver decides
+  // on whatever state exists instead of returning another "wait" — a fetch that
+  // hangs (never reaching any settle path) must degrade to a decision, not loop
+  // navigation in timeout-sized chunks. A platform probe that outran its wait
+  // degrades the same way, to `"absent"`: every step that reads the probe
+  // treats an unsettled session as "no decision yet" and a settled-absent one
+  // as "no platform account", so forcing it can only turn a non-decision into
+  // that documented fallback. A result that lands after the timeout re-runs the
+  // guard (see `revalidateWhenPlatformProbeSettles`), so a slow-but-successful
+  // probe still reaches its platform-session destination.
   //
   // Forcing `consentHydrated` hides that the consent flags underneath it are
   // still their boot `false`, so the forcing itself is reported too: a step
   // that would otherwise read them as a settled "not consented" — and evict a
-  // consented user mid-funnel — can fail open on it instead.
+  // consented user mid-funnel — can fail open on it instead. That report is why
+  // the two waits are tracked apart: raising it for a stalled assistants list
+  // would fail the funnel's consent gate open for a genuinely unconsented user,
+  // admitting them to a paid hatch.
   const state = buildNavigationState({
-    ...(hydrationTimedOut
-      ? {
-          consentHydrated: true,
-          consentHydrationTimedOut: true,
-          assistantsHydrated: true,
-        }
+    ...(timedOut.consentHydration
+      ? { consentHydrated: true, consentHydrationTimedOut: true }
       : {}),
-    ...(platformProbeTimedOut ? { platformSession: "absent" as const } : {}),
+    ...(timedOut.assistantsHydration ? { assistantsHydrated: true } : {}),
+    ...(timedOut.platformProbe ? { platformSession: "absent" as const } : {}),
   });
 
   const decision = resolveNavigation(state, {
@@ -110,7 +122,7 @@ const resolveWithGuard = async (
     // the latter with `hasAssistants()` already true.
     let platformProbeStillUnknown = false;
     if (
-      !platformProbeTimedOut &&
+      !timedOut.platformProbe &&
       isLocalMode() &&
       (!hasAssistants() || decision.waitFor === "platform-session")
     ) {
@@ -128,33 +140,42 @@ const resolveWithGuard = async (
     // Platform mode also waits for consent and the assistants list to hydrate
     // — the resolver defers to them, and deciding on their boot defaults would
     // misroute an established user into onboarding. Both resolve immediately
-    // when already hydrated. Scoped to sessions that can actually hydrate:
-    // local mode's resolver steps never wait on hydration (lockfile-driven),
-    // and an unauthenticated session never populates either store, so waiting
-    // in those cases would only stall boot.
-    let hydrationStillPending = false;
+    // when already hydrated, and each is skipped once its own wait has run out
+    // so neither can burn a second timeout. Scoped to sessions that can
+    // actually hydrate: local mode's resolver steps never wait on hydration
+    // (lockfile-driven), and an unauthenticated session never populates either
+    // store, so waiting in those cases would only stall boot.
+    let consentStillPending = false;
+    let assistantsStillPending = false;
     if (
-      !hydrationTimedOut &&
       !isLocalMode() &&
       isAuthenticated(useAuthStore.getState().sessionStatus)
     ) {
-      await whenStoreState(useOnboardingStore, (s) => s.consentHydrated, {
-        timeoutMs: STATE_HYDRATION_TIMEOUT_MS,
-      });
-      await whenStoreState(
-        useResolvedAssistantsStore,
-        (s) => s.assistantsHydrated,
-        { timeoutMs: STATE_HYDRATION_TIMEOUT_MS },
-      );
-      hydrationStillPending =
-        !useOnboardingStore.getState().consentHydrated ||
-        !useResolvedAssistantsStore.getState().assistantsHydrated;
+      if (!timedOut.consentHydration) {
+        await whenStoreState(useOnboardingStore, (s) => s.consentHydrated, {
+          timeoutMs: STATE_HYDRATION_TIMEOUT_MS,
+        });
+        consentStillPending = !useOnboardingStore.getState().consentHydrated;
+      }
+      if (!timedOut.assistantsHydration) {
+        await whenStoreState(
+          useResolvedAssistantsStore,
+          (s) => s.assistantsHydrated,
+          { timeoutMs: STATE_HYDRATION_TIMEOUT_MS },
+        );
+        assistantsStillPending =
+          !useResolvedAssistantsStore.getState().assistantsHydrated;
+      }
     }
     return resolveWithGuard(
       { request, context } as Parameters<MiddlewareFunction>[0],
       next,
-      hydrationTimedOut || hydrationStillPending,
-      platformProbeTimedOut || platformProbeStillUnknown,
+      {
+        consentHydration: timedOut.consentHydration || consentStillPending,
+        assistantsHydration:
+          timedOut.assistantsHydration || assistantsStillPending,
+        platformProbe: timedOut.platformProbe || platformProbeStillUnknown,
+      },
     );
   }
 

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -831,6 +831,13 @@ describe("resolveNavigation", () => {
 
     const UNCONSENTED = { tosAccepted: false, privacyConsent: false } as const;
 
+    // Either toggle going stale forces the same re-review, so the cases below
+    // assert against both.
+    const STALE_TOGGLES = [
+      { analyticsConsentCurrent: false },
+      { diagnosticsConsentCurrent: false },
+    ] as const;
+
     // Consent is enforced at the destination, not skipped: both funnel entries
     // are onboarding paths, and re-resolving one bounces an unconsented user on.
     test("consent is still enforced once the funnel destination is resolved", () => {
@@ -917,10 +924,7 @@ describe("resolveNavigation", () => {
     // `returnTo` so the plan is not lost on the round trip. The marker is what
     // scopes this — an ordinary research visit keeps its onboarding exemption.
     test("sends a stale-consent paid research return to review-terms", () => {
-      for (const stale of [
-        { analyticsConsentCurrent: false },
-        { diagnosticsConsentCurrent: false },
-      ]) {
+      for (const stale of STALE_TOGGLES) {
         expect(guard(s({ ...EMPTY_ORG, ...stale }), RESEARCH_FUNNEL_URL)).toEqual({
           action: "redirect",
           to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
@@ -1077,10 +1081,7 @@ describe("resolveNavigation", () => {
     // re-reviewed before the purchased hatch — with the funnel URL as
     // `returnTo`, so the markers survive and the plan is not lost.
     test("sends a stale-consent gateway-auth paid research return to review-terms", () => {
-      for (const stale of [
-        { analyticsConsentCurrent: false },
-        { diagnosticsConsentCurrent: false },
-      ]) {
+      for (const stale of STALE_TOGGLES) {
         expect(
           guard(s({ ...ELECTRON_PAID, ...stale }), RESEARCH_FUNNEL_URL),
         ).toEqual({
@@ -1095,10 +1096,7 @@ describe("resolveNavigation", () => {
     // client still points — resolves `allow` here and re-reviews stale terms at
     // the screen's own `hatch-gate` instead.
     test("leaves a stale-consent paid hatching return on its allow", () => {
-      for (const stale of [
-        { analyticsConsentCurrent: false },
-        { diagnosticsConsentCurrent: false },
-      ]) {
+      for (const stale of STALE_TOGGLES) {
         expect(
           guard(s({ ...ELECTRON_PAID, ...stale }), HATCHING_FUNNEL_URL),
         ).toEqual(ALLOW);

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -546,10 +546,9 @@ function enforceModeBoundary(
  * finishes the hatch at the baseline plan. Every other funnel bounce gets the
  * bare entrypoint.
  *
- * Local mode is a deliberate exception to that carry: its entrypoint is
- * `welcome`, which reads no `returnTo`, so an unconsented local paid return
- * finishes the hatch at baseline and the server-side post-hatch reconcile
- * applies the purchased specs. That is the parity local mode has always had.
+ * Local mode is a deliberate exception to that carry: its `welcome` entrypoint
+ * reads no `returnTo`, so the hatch finishes at baseline and the server-side
+ * post-hatch reconcile applies the purchased specs.
  */
 function consentBounceDestination(
   state: NavigationState,
@@ -579,12 +578,14 @@ function allowSetupRoutes(
     return null;
   }
 
-  return enforceFunnelConsent(state, path, pathnameWithSearch) ?? { action: "allow" };
+  return enforceFunnelConsent(state, path, pathnameWithSearch);
 }
 
 /**
  * Consent for the two provisioning funnel entries, which `requireConsent` never
- * reaches — every onboarding path is allowed before it runs.
+ * reaches — every onboarding path is allowed before it runs. It decides every
+ * onboarding path outright: anything that is not a funnel entry is plainly
+ * allowed.
  *
  * The hatching entry keeps exactly the gate it has always had — reached from
  * in-app navigation and from the native paid return, it decides on the flags in
@@ -597,9 +598,9 @@ function enforceFunnelConsent(
   state: NavigationState,
   path: string,
   pathnameWithSearch: string,
-): NavigationDecision | null {
+): NavigationDecision {
   if (!PROVISIONING_FUNNEL_PATHS.has(path)) {
-    return null;
+    return { action: "allow" };
   }
 
   if (path === routes.onboarding.research) {
@@ -616,7 +617,7 @@ function enforceFunnelConsent(
     // un-onboarded and restart their funnel. Fail open to the entry's
     // unconditional contract instead; a hydrated read still gates.
     if (state.consentHydrationTimedOut) {
-      return null;
+      return { action: "allow" };
     }
   }
 
@@ -648,7 +649,7 @@ function enforceFunnelConsent(
     };
   }
 
-  return null;
+  return { action: "allow" };
 }
 
 function requireAssistant(


### PR DESCRIPTION
## Summary
Fixes a review gap for headless-paid-hatch.md.

**Gap:** the middleware's combined hydration-timeout flag let an assistants-list stall set consentHydrationTimedOut, failing the research consent gate open for a genuinely unconsented user.
**Fix:** consent and assistants stalls tracked separately; only a consent stall forces consent state or sets the fail-open flag. Plus small resolver readability fixes.