### PR TITLE
fix: keep the hatch-failure banner clear of funnel controls and gate terminal handoffs

### DIFF
--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -22,12 +22,16 @@ interface HatchErrorOverlayProps {
  * so that case offers the local-assistant off-ramp instead.
  *
  * Portaled to `document.body` so no step's stacking or clipping context can
- * bury it.
+ * bury it — which also puts it outside the app shell's safe-area padding, so it
+ * owns its own inset. Anchored to the top strip, which every step reserves for
+ * chrome: bottom-anchored it would sit exactly over the results step's
+ * viewport-pinned Continue, the only way forward from there. The offset clears
+ * both the notch and `OnboardingTopBar`'s chevrons (`top-6` + `h-10`).
  */
 export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
   const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;
   return createPortal(
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center p-4">
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-[calc(var(--safe-area-inset-top,env(safe-area-inset-top,0px))+5rem)]">
       <Notice
         tone="error"
         title="Something went wrong"

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -18,13 +18,11 @@
  * it.
  *
  * The paid-return block covers the `post_checkout=1` marker reaching the
- * background hatch and the failure overlay that surfaces a dead hatch on any
- * step, with the at-capacity download off-ramp in place of a retry. That
- * surface is a banner rather than a modal, so it also covers the funnel staying
- * usable underneath and the auto-advancing loading step holding its own
- * position while the hatch is dead. The retry block covers what the banner's
- * "Try again" has to un-poison: route state that resolved against the dead
- * hatch and would otherwise survive the retry.
+ * background hatch, and the failure banner: its at-capacity download off-ramp,
+ * the funnel staying usable underneath it, and everything that must stay held
+ * while the hatch is dead (the auto-advancing loading step, the terminal
+ * handoffs). The retry block covers what "Try again" has to un-poison: route
+ * state that resolved against the dead hatch and would otherwise survive it.
  *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
@@ -311,31 +309,16 @@ mock.module("@/domains/onboarding/screens/create-personality-step", () => ({
   ),
 }));
 
-// Renders the real step's contract: the connect action can't enable until the
-// hatch is ready, and "Skip for now" is revealed early on a failed hatch so the
-// user is never trapped behind a button that can never enable.
+// Only the skip escape matters here — when it is revealed is the step's own
+// concern (see lets-chat-tomorrow-step.test.tsx).
 mock.module("@/domains/onboarding/screens/lets-chat-tomorrow-step", () => ({
-  LetsChatTomorrowStep: (props: {
-    assistantId: string | null;
-    assistantReady: boolean;
-    hatchError?: string | null;
-    onSkip: () => void;
-  }) => {
-    const waitingForAssistant = !props.assistantId || !props.assistantReady;
-    return (
-      <div data-testid="letschat-step">
-        {!waitingForAssistant || props.hatchError ? (
-          <button
-            type="button"
-            data-testid="letschat-skip"
-            onClick={props.onSkip}
-          >
-            Skip for now
-          </button>
-        ) : null}
-      </div>
-    );
-  },
+  LetsChatTomorrowStep: (props: { onSkip: () => void }) => (
+    <div data-testid="letschat-step">
+      <button type="button" data-testid="letschat-skip" onClick={props.onSkip}>
+        Skip for now
+      </button>
+    </div>
+  ),
 }));
 
 mock.module("@/domains/onboarding/screens/research-result-steps", () => ({
@@ -418,6 +401,24 @@ function postFormSnapshot(
   };
 }
 
+/**
+ * A finished journey: the runner hydrates straight to "done" and
+ * resolveResumeStep lands it on the terminal handoff step.
+ */
+function doneSnapshot(): ResearchOnboardingSnapshot {
+  return postFormSnapshot({
+    step: "suggestions",
+    research: {
+      status: "done",
+      claims: [],
+      droppedClaims: [],
+      suggestions: [],
+      installedPlugins: [],
+      pluginCatalog: {},
+    },
+  });
+}
+
 beforeEach(() => {
   localStorage.clear();
   researchStatus = "idle";
@@ -487,23 +488,9 @@ describe("ResearchOnboardingRoute resume guard", () => {
     expect(startResearchMock).not.toHaveBeenCalled();
   });
 
-  // A completed snapshot hydrates the runner to "done" and resolveResumeStep
-  // lands it on the suggestions step. That is NOT idle, so the pre-fix resume
-  // effect returned early and never consulted the guard — the user could walk a
-  // done journey into the chat handoff against an established assistant.
-  const doneSnapshot = (): ResearchOnboardingSnapshot =>
-    postFormSnapshot({
-      step: "suggestions",
-      research: {
-        status: "done",
-        claims: [],
-        droppedClaims: [],
-        suggestions: [],
-        installedPlugins: [],
-        pluginCatalog: {},
-      },
-    });
-
+  // A completed snapshot is NOT idle, so the pre-fix resume effect returned
+  // early and never consulted the guard — the user could walk a done journey
+  // into the chat handoff against an established assistant.
   test("a restored completed snapshot diverts to the decision screen when the assistant is established", async () => {
     establishedResult = { established: true, assistantName: "Viper" };
     researchStatus = "done";
@@ -687,6 +674,63 @@ describe("ResearchOnboardingRoute paid return", () => {
     await screen.findByTestId("form-submit");
 
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // The banner has to stay clear of the results step's viewport-pinned
+  // Continue, the only way forward from there — and, portaled out of the app
+  // shell, it owns its own iOS inset.
+  test("anchors the failure banner to the top strip, below the notch", async () => {
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+
+    render(<ResearchOnboardingRoute />);
+
+    const banner = (await screen.findByRole("alert")).parentElement;
+    expect(banner?.className).toContain("top-0");
+    expect(banner?.className).not.toContain("bottom-0");
+    expect(banner?.className).toContain("safe-area-inset-top");
+  });
+
+  // A resumed COMPLETED snapshot lands straight on the terminal handoff, past
+  // the carousel that otherwise gates on the hatch. Handing off there clears
+  // the resume snapshot and navigates with a null assistant id — into nothing,
+  // with no way back.
+  test("holds the terminal handoff while the hatch is dead, and releases it after a retry", async () => {
+    researchStatus = "done";
+    writeResearchSnapshot(USER_ID, doneSnapshot());
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+    backgroundHatch.ready = false;
+    backgroundHatch.assistantId = null;
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+      ).toBe(true),
+    );
+
+    // Clicking the held CTA hands off to nothing: no navigation, and the
+    // journey's resume state survives for the retry.
+    fireEvent.click(screen.getByTestId("letschat-start"));
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(readResearchSnapshot(USER_ID)).not.toBeNull();
+
+    onRetryHatch = () => {
+      backgroundHatch.error = null;
+      backgroundHatch.ready = true;
+      backgroundHatch.assistantId = "asst-1";
+    };
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    rerender(<ResearchOnboardingRoute />);
+
+    // A recovered hatch has an assistant to hand off to again.
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+    fireEvent.click(screen.getByTestId("letschat-start"));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled());
   });
 
   // The failure surface is a banner, not a modal: it must not hide the funnel

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -901,11 +901,7 @@ export function ResearchOnboardingRoute() {
     }
   }
 
-  // A terminal hatch failure is layered over whichever step is on screen — the
-  // assistant is dead at all of them, so the failure shouldn't wait for the
-  // last step to be discovered. Layering (rather than replacing the step) keeps
-  // the funnel's collected state, so a successful retry resumes in place; the
-  // banner is non-modal, so each step's own escapes stay usable while it's up.
+  // Layered over whichever step is on screen (see HatchErrorOverlay).
   const withHatchError = (content: ReactNode) => (
     <>
       {content}
@@ -1104,8 +1100,11 @@ export function ResearchOnboardingRoute() {
             installedPlugins={research.installedPlugins}
             pluginCatalog={research.pluginCatalog}
             // Hold the handoff until a resumed done journey's guard settles, so
-            // it can't fire against an established assistant before the verdict.
-            disabled={resumeGuardPending}
+            // it can't fire against an established assistant before the verdict
+            // — and while the hatch is dead, since a resumed COMPLETED snapshot
+            // lands straight here (past the gated carousel) and the handoff
+            // would clear the snapshot and navigate to a null assistant.
+            disabled={resumeGuardPending || hatchError !== null}
             onStart={async () => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the completion here (mirrors SuggestionsStep).
@@ -1134,6 +1133,8 @@ export function ResearchOnboardingRoute() {
             suggestions={research.suggestions}
             loading={researchLoading}
             installedPlugins={research.installedPlugins}
+            // Same terminal-handoff hold as LetsChatReadyStep above.
+            disabled={hatchError !== null}
             onSuggestionClick={async (suggestion) => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the suggestions completion here (mirrors the

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -705,6 +705,7 @@ export function SuggestionsStep({
   onSkip,
   onBack,
   onForward,
+  disabled = false,
 }: {
   /** Parsed research suggestions (streams in; may be empty while running). */
   suggestions: ResearchSuggestion[];
@@ -723,6 +724,11 @@ export function SuggestionsStep({
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
+  /**
+   * Externally hold both terminal handoffs (e.g. a dead background hatch, which
+   * has no assistant to hand off to). Back-navigation stays interactive.
+   */
+  disabled?: boolean;
 }) {
   // Constant dark surface for the UI; the avatar tone is only for the pills.
   const tone = DARK_TONE;
@@ -821,7 +827,8 @@ export function SuggestionsStep({
               <button
                 type="button"
                 onClick={onSkip}
-                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80"
+                disabled={disabled}
+                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60"
                 style={{ color: tone.fg }}
               >
                 Skip to Chat
@@ -838,12 +845,13 @@ export function SuggestionsStep({
               key={`${i}-${s.suggestion}`}
               type="button"
               onClick={() => onSuggestionClick(s)}
+              disabled={disabled}
               initial={reduce ? false : { opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={
                 reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
               }
-              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
+              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 enabled:hover:scale-[1.01] enabled:active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
               style={{
                 backgroundColor: tone.isLight
                   ? "rgba(0,0,0,0.06)"
@@ -924,9 +932,10 @@ export function LetsChatReadyStep({
   /** Redo into this step — only set when the user has stepped back. */
   onForward?: () => void;
   /**
-   * Externally hold the "Let's chat" CTA (e.g. a resumed completed journey
-   * still waiting on the established-assistant guard). Disables the button and
-   * no-ops the handoff until cleared, so the CTA can't fire before the verdict.
+   * Externally hold the "Let's chat" CTA (a resumed completed journey still
+   * waiting on the established-assistant guard, or a dead hatch with no
+   * assistant to hand off to). Disables the button and no-ops the handoff until
+   * cleared. Back-navigation stays interactive.
    */
   disabled?: boolean;
 }) {


### PR DESCRIPTION
## Summary
Fixes review gaps for headless-paid-hatch.md.

**Gap:** a resumed snapshot could hand off to a null assistant under a dead hatch; the failure banner covered the results step's pinned Continue and ignored the iOS safe area.
**Fix:** terminal actions gated on a live hatch (mirroring the finishing step); banner repositioned clear of pinned controls with safe-area handling.