### PR TITLE
fix: settle-guarded abort, shared managed lockfile write, and comment cleanup

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -182,6 +182,7 @@ mock.module("@/lib/local-mode", () => ({
   loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
   setActiveLockfileAssistant: async () => {},
   saveLockfileAssistant: async () => {},
+  saveManagedLockfileAssistant: async () => {},
   updateLockfileAssistant: async () => {},
   primeLocalGatewayConnection: async () => {},
   primeLocalGatewayConnectionWithRepair: async () => {},

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -206,7 +206,14 @@ const hatchLocalAssistantMock = mock(async () => ({
 }));
 
 const saveLockfileAssistantMock = mock(
-  async (_entry: { assistantId: string; cloud: string }) => {},
+  async (_entry: {
+    assistantId: string;
+    cloud: string;
+    name?: string;
+    runtimeUrl?: string;
+    hatchedAt?: string;
+    organizationId?: string;
+  }) => {},
 );
 const clearGatewayTokenMock = mock(() => {});
 const setSelfHostedConnectionMock = mock((_connection: unknown) => {});
@@ -298,7 +305,22 @@ mock.module("@/lib/local-mode", () => ({
   loadLockfile: async () => {},
   primeLocalGatewayConnection: async () => {},
   probeLocalGatewayReady: async () => true,
-  saveLockfileAssistant: saveLockfileAssistantMock,
+  // Stands in for the real helper (whose payload `local-mode.test.ts` pins) so
+  // the lockfile entry the hatch writes stays visible to the assertions below.
+  saveManagedLockfileAssistant: async (
+    assistantId: string,
+    name: string | undefined,
+    organizationId: string | undefined,
+  ): Promise<void> => {
+    await saveLockfileAssistantMock({
+      assistantId,
+      name,
+      cloud: "vellum",
+      runtimeUrl: "https://runtime.example",
+      hatchedAt: new Date().toISOString(),
+      organizationId,
+    });
+  },
 }));
 
 mock.module("@/lib/auth/gateway-session", () => ({

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -25,7 +25,7 @@ import {
     MAX_HATCH_WAIT_MS,
     POLL_INTERVAL_MS,
 } from "@/domains/onboarding/purchased-provisioning";
-import { getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveLockfileAssistant } from "@/lib/local-mode";
+import { isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveManagedLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import {
@@ -325,15 +325,12 @@ export function HatchingScreen() {
           const preflightState = resolveAssistantLifecycleState(existing);
           if (!cancelled && existing.ok && preflightState.kind === "active") {
             if (isLocalMode()) {
-              void saveLockfileAssistant({
-                assistantId: existing.data.id,
-                name: existing.data.name,
-                cloud: "vellum",
-                runtimeUrl: getPlatformRuntimeUrl(),
-                hatchedAt: new Date().toISOString(),
-                organizationId:
-                  useOrganizationStore.getState().currentOrganizationId ?? undefined,
-              });
+              void saveManagedLockfileAssistant(
+                existing.data.id,
+                existing.data.name,
+                useOrganizationStore.getState().currentOrganizationId ??
+                  undefined,
+              );
             }
             // Route the reload path through the same provisioning wait as the
             // polled-active path so a purchased resize is never skipped.
@@ -607,15 +604,12 @@ export function HatchingScreen() {
               void persistHatchAvatar(assistantId);
             }
             if (isLocalMode()) {
-              void saveLockfileAssistant({
+              void saveManagedLockfileAssistant(
                 assistantId,
-                name: result.data.name,
-                cloud: "vellum",
-                runtimeUrl: getPlatformRuntimeUrl(),
-                hatchedAt: new Date().toISOString(),
-                organizationId:
-                  useOrganizationStore.getState().currentOrganizationId ?? undefined,
-              });
+                result.data.name,
+                useOrganizationStore.getState().currentOrganizationId ??
+                  undefined,
+              );
             }
 
             // Wait for healthz, then hold for the purchased resize before

--- a/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
@@ -60,9 +60,8 @@ mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => localMode,
 }));
 
-const { awaitPurchasedProvisioning, MAX_HATCH_WAIT_MS } = await import(
-  "./purchased-provisioning"
-);
+const { awaitPurchasedProvisioning, MAX_HATCH_WAIT_MS, POLL_INTERVAL_MS } =
+  await import("./purchased-provisioning");
 
 /** Poll a predicate without depending on the wait's own 3s poll interval. */
 async function until(
@@ -227,5 +226,27 @@ describe("awaitPurchasedProvisioning", () => {
     expect(onboardingRetrieveMock).not.toHaveBeenCalled();
     expect(getAssistantMock).not.toHaveBeenCalled();
     expect(getAssistantHealthzMock).not.toHaveBeenCalled();
+  });
+
+  test("a cancelled wait never sleeps out another poll interval", async () => {
+    // Both reads reject, so the iteration reaches its sleep without passing a
+    // cancellation check — the one path that could park a timer on a caller
+    // that has already gone away.
+    let cancelled = false;
+    subscriptionRetrieveMock.mockImplementationOnce(async () => {
+      cancelled = true;
+      throw new Error("network");
+    });
+    onboardingRetrieveMock.mockImplementationOnce(async () => {
+      throw new Error("network");
+    });
+
+    const startedAt = Date.now();
+    const outcome = await awaitPurchasedProvisioning(
+      baseOptions({ isCancelled: () => cancelled }),
+    );
+
+    expect(outcome).toBe("ready");
+    expect(Date.now() - startedAt).toBeLessThan(POLL_INTERVAL_MS);
   });
 });

--- a/clients/web/src/domains/onboarding/purchased-provisioning.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.ts
@@ -31,10 +31,7 @@ import {
 } from "@/lib/billing/provisioning-targets";
 import { isLocalMode } from "@/lib/local-mode";
 
-// The single source for the hatch poll cadence and the overall wait ceiling,
-// shared by every hatch entry point. `MAX_HATCH_WAIT_MS` decides the
-// `health_timeout` outcome below, so a caller reporting its own copy in
-// telemetry would be reporting a number that didn't make the decision.
+// Owned here: `MAX_HATCH_WAIT_MS` decides the `health_timeout` outcome below.
 export const POLL_INTERVAL_MS = 3000;
 export const MAX_HATCH_WAIT_MS = 300_000;
 // Hard cap on the post-payment resize wait, mirroring PROVISION_STALL_MS in the
@@ -76,8 +73,14 @@ export async function awaitPurchasedProvisioning(
     registerTimer,
   } = options;
 
+  // A cancelled wait resolves without scheduling anything, so the loop reaches
+  // its next check with no timer left behind.
   const sleep = (ms: number): Promise<void> =>
     new Promise<void>((resolve) => {
+      if (isCancelled()) {
+        resolve();
+        return;
+      }
       const timer = setTimeout(() => {
         registerTimer?.(null);
         resolve();

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -64,8 +64,22 @@ mock.module("@/lib/local-mode", () => ({
   probeLocalGatewayReady: probeLocalGatewayReadyMock,
   getLockfileAssistant: getLockfileAssistantMock,
   isLocalMode: () => localMode,
-  getPlatformRuntimeUrl: () => "https://runtime.example",
-  saveLockfileAssistant: saveLockfileAssistantMock,
+  // Stands in for the real helper (whose payload `local-mode.test.ts` pins) so
+  // the lockfile entry the hatch writes stays visible to the assertions below.
+  saveManagedLockfileAssistant: async (
+    assistantId: string,
+    name: string | undefined,
+    organizationId: string | undefined,
+  ): Promise<void> => {
+    await saveLockfileAssistantMock({
+      assistantId,
+      name,
+      cloud: "vellum",
+      runtimeUrl: "https://runtime.example",
+      hatchedAt: new Date().toISOString(),
+      organizationId,
+    });
+  },
 }));
 mock.module("@/stores/organization-store", () => ({
   useOrganizationStore: {
@@ -127,6 +141,21 @@ const { useBackgroundHatch } = await import("./use-background-hatch");
 
 const TIMEOUT_MESSAGE =
   "Your assistant is taking longer than expected. Please try again.";
+
+/**
+ * Poll a predicate without depending on the hook's own poll cadence, rejecting
+ * if it never holds. An absence is asserted with `.rejects`, so a slow machine
+ * only lengthens the wait instead of changing the verdict.
+ */
+async function until(predicate: () => boolean, timeoutMs = 300): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("condition never became true");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
 
 beforeEach(() => {
   hatchResult = { ok: true, status: 201, data: { id: "ast-research" } as never };
@@ -470,11 +499,56 @@ describe("useBackgroundHatch", () => {
     const callsAtUnmount = getAssistantMock.mock.calls.length;
 
     // Leaving the funnel mid-hatch must not keep polling from a dead
-    // component: many poll intervals elapse here with no further calls.
-    await new Promise((resolve) => setTimeout(resolve, 80));
-    expect(getAssistantMock.mock.calls.length).toBeLessThanOrEqual(
-      callsAtUnmount + 1,
-    );
+    // component: the in-flight request may land, but nothing follows it —
+    // the aborted sleep schedules no timer to poll from.
+    await expect(
+      until(() => getAssistantMock.mock.calls.length > callsAtUnmount + 1),
+    ).rejects.toThrow();
+  });
+
+  test("unmounting during the initial hatch never settles", async () => {
+    // A terminal failure is the sharpest case: it settles straight from the
+    // hatch response, without a poll-loop check in between.
+    hatchResult = {
+      ok: false,
+      status: 400,
+      error: { detail: "Bad hatch request" },
+    };
+    let releaseHatch!: () => void;
+    hatchAssistantMock.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseHatch = resolve;
+      });
+      return hatchResult;
+    });
+
+    const { result, unmount } = renderHook(() => useBackgroundHatch());
+
+    let resolved: string | undefined;
+    let rejection: Error | undefined;
+    act(() => {
+      void result.current.awaitReady().then(
+        (id) => {
+          resolved = id;
+        },
+        (err: Error) => {
+          rejection = err;
+        },
+      );
+      result.current.start();
+    });
+
+    await waitFor(() => expect(hatchAssistantMock).toHaveBeenCalledTimes(1));
+    unmount();
+
+    // The hatch response lands after the component is gone, so it settles
+    // nothing — the waiters of a hook nobody is watching stay pending.
+    await act(async () => {
+      releaseHatch();
+    });
+    await expect(
+      until(() => resolved != null || rejection != null),
+    ).rejects.toThrow();
   });
 
   test("unmounting cancels the purchased-provisioning wait without settling", async () => {
@@ -508,8 +582,9 @@ describe("useBackgroundHatch", () => {
 
     // A cancelled wait still resolves "ready"; the hatch must not complete on
     // it once the component is gone.
-    release();
-    await new Promise((resolve) => setTimeout(resolve, 40));
+    await act(async () => {
+      release();
+    });
     expect(resolved).toBeUndefined();
   });
 

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -21,10 +21,9 @@ import {
 } from "@/domains/onboarding/purchased-provisioning";
 import {
   getLockfileAssistant,
-  getPlatformRuntimeUrl,
   isLocalMode,
   probeLocalGatewayReady,
-  saveLockfileAssistant,
+  saveManagedLockfileAssistant,
 } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useOrganizationStore } from "@/stores/organization-store";
@@ -105,9 +104,7 @@ export interface UseBackgroundHatchOptions {
  * lifecycle errors, timeout) set `error` and reject `awaitReady()`.
  * Recoverable failures (5xx / network) keep polling.
  *
- * Unmounting aborts the sequence: every loop and the purchased-provisioning
- * wait stop at their next check and the pending poll timer is cleared, so
- * leaving the funnel mid-hatch doesn't keep polling from a dead component.
+ * Unmounting aborts the sequence — see `abortedRef`.
  */
 export function useBackgroundHatch(
   {
@@ -133,8 +130,9 @@ export function useBackgroundHatch(
     { kind: "ready"; id: string } | { kind: "error"; message: string } | null
   >(null);
   // The hatch sequence outlives a render by minutes (a 90s purchased-resize
-  // hold, a 300s health poll), so unmount has to stop it: every loop and the
-  // provisioning wait check this, and the pending poll timer is cleared.
+  // hold, a 300s health poll), so unmount has to stop it: an aborted hatch
+  // refuses to settle, every loop and the provisioning wait check this, sleeps
+  // resolve immediately, and the pending poll timer is cleared.
   const abortedRef = useRef(false);
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -152,32 +150,47 @@ export function useBackgroundHatch(
   }, []);
 
   const settleReady = useCallback((id: string) => {
-    if (settledRef.current) return;
+    if (abortedRef.current || settledRef.current) {
+      return;
+    }
     settledRef.current = { kind: "ready", id };
     setReady(true);
-    for (const w of waitersRef.current) w.resolve(id);
+    for (const w of waitersRef.current) {
+      w.resolve(id);
+    }
     waitersRef.current = [];
   }, []);
 
   const settleError = useCallback((message: string) => {
-    if (settledRef.current) return;
+    if (abortedRef.current || settledRef.current) {
+      return;
+    }
     settledRef.current = { kind: "error", message };
     setError(message);
     const err = new Error(message);
-    for (const w of waitersRef.current) w.reject(err);
+    for (const w of waitersRef.current) {
+      w.reject(err);
+    }
     waitersRef.current = [];
   }, []);
 
   const start = useCallback(() => {
-    if (startedRef.current) return;
+    if (startedRef.current) {
+      return;
+    }
     startedRef.current = true;
 
     const startMs = Date.now();
     const timedOut = () => Date.now() - startMs >= MAX_HATCH_WAIT_MS;
-    // Parks the pending handle so unmount can clear it; an aborted sleep never
-    // resumes, which is how the loops stop mid-wait.
+    // Parks the pending handle so unmount can clear it. Once aborted the wait
+    // resolves without scheduling anything, so the loop reaches its next check
+    // with no timer left behind.
     const sleep = (ms: number): Promise<void> =>
       new Promise((resolve) => {
+        if (abortedRef.current) {
+          resolve();
+          return;
+        }
         pollTimerRef.current = setTimeout(() => {
           pollTimerRef.current = null;
           resolve();
@@ -230,10 +243,9 @@ export function useBackgroundHatch(
           if (result.ok) {
             hatchedAssistantId = result.data.id;
             setAssistantId(result.data.id);
-            // Seed a freshly hatched (201) assistant's traits — parity with the
-            // foreground hatch. Paid-only because the free research hatch must
-            // stay byte-identical to today, adding no writes it doesn't already
-            // make. Fire-and-forget; the research face step overwrites later.
+            // Dock and tray icons are avatar-driven, so a freshly created (201)
+            // assistant gets seeded traits. Paid-only: the free hatch makes no
+            // avatar write. Fire-and-forget; the research face step overwrites.
             if (postCheckoutReturn && result.status === 201) {
               void seedHatchAvatar(
                 result.data.id,
@@ -263,38 +275,33 @@ export function useBackgroundHatch(
       // 2. Poll until the assistant reports `active`.
       let activeAssistantId: string | undefined;
       while (!activeAssistantId) {
-        if (abortedRef.current) return;
+        if (abortedRef.current) {
+          return;
+        }
         if (timedOut()) {
           settleError(TIMEOUT_ERROR);
           return;
         }
         try {
           let result = await getAssistant(hatchedAssistantId);
-          if (abortedRef.current) return;
           // A stale hatched id (404) falls back to list-based discovery.
           if (hatchedAssistantId && !result.ok && result.status === 404) {
             hatchedAssistantId = undefined;
             result = await getAssistant();
-            if (abortedRef.current) return;
           }
           const state = resolveAssistantLifecycleState(result);
           if (state.kind === "active" && result.ok) {
             activeAssistantId = result.data.id;
             setAssistantId(activeAssistantId);
-            // Mirrors the hatching screen: on the desktop build the assistant
-            // list and switcher are lockfile-driven, so a managed assistant
-            // hatched headlessly here would otherwise be missing from them.
+            // Desktop-only: the list and switcher read the lockfile. An adopted
+            // assistant is already the hatching screen's own write.
             if (!adoptExisting && isLocalMode()) {
-              void saveLockfileAssistant({
-                assistantId: activeAssistantId,
-                name: result.data.name,
-                cloud: "vellum",
-                runtimeUrl: getPlatformRuntimeUrl(),
-                hatchedAt: new Date().toISOString(),
-                organizationId:
-                  useOrganizationStore.getState().currentOrganizationId ??
+              void saveManagedLockfileAssistant(
+                activeAssistantId,
+                result.data.name,
+                useOrganizationStore.getState().currentOrganizationId ??
                   undefined,
-              });
+              );
             }
             break;
           }
@@ -322,7 +329,9 @@ export function useBackgroundHatch(
       // still being alive.
       if (adoptExisting) {
         while (!(await probeLocalGatewayReady())) {
-          if (abortedRef.current) return;
+          if (abortedRef.current) {
+            return;
+          }
           if (timedOut()) {
             settleError(TIMEOUT_ERROR);
             return;
@@ -331,11 +340,14 @@ export function useBackgroundHatch(
         }
       } else {
         while (true) {
-          if (abortedRef.current) return;
+          if (abortedRef.current) {
+            return;
+          }
           try {
             const health = await getAssistantHealthz(activeAssistantId);
-            if (abortedRef.current) return;
-            if (health.ok) break;
+            if (health.ok) {
+              break;
+            }
           } catch {
             // Daemon not reachable yet.
           }
@@ -346,7 +358,6 @@ export function useBackgroundHatch(
           await sleep(POLL_INTERVAL_MS);
         }
       }
-      if (abortedRef.current) return;
 
       // 4. On a paid return, hold `ready` until the purchased resize converges.
       //
@@ -364,9 +375,6 @@ export function useBackgroundHatch(
             pollTimerRef.current = timer;
           },
         });
-        // A cancelled wait also returns "ready" — the component is gone, so
-        // leave the hatch unsettled rather than completing into nothing.
-        if (abortedRef.current) return;
         if (outcome === "health_timeout") {
           // The assistant never answered healthz after the resize; completing
           // would hand the user an unreachable assistant.
@@ -401,8 +409,12 @@ export function useBackgroundHatch(
 
   const awaitReady = useCallback((): Promise<string> => {
     const settled = settledRef.current;
-    if (settled?.kind === "ready") return Promise.resolve(settled.id);
-    if (settled?.kind === "error") return Promise.reject(new Error(settled.message));
+    if (settled?.kind === "ready") {
+      return Promise.resolve(settled.id);
+    }
+    if (settled?.kind === "error") {
+      return Promise.reject(new Error(settled.message));
+    }
     return new Promise<string>((resolve, reject) => {
       waitersRef.current.push({ resolve, reject });
     });

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -18,10 +18,18 @@ const loadLockfileHost = mock(async () => {
   throw new Error("host down");
 });
 
+const saveLockfileAssistantHost = mock(
+  async (_assistant: Record<string, unknown>, _activeId?: string) => ({
+    ok: true as const,
+    lockfile: { assistants: [], activeAssistant: null },
+  }),
+);
+
 mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,
   replacePlatformAssistantsHost,
   loadLockfileHost,
+  saveLockfileAssistantHost,
 }));
 
 import {
@@ -30,6 +38,7 @@ import {
   getLocalAssistants,
   getLockfile,
   getPlatformAssistants,
+  getPlatformRuntimeUrl,
   getSelectedAssistant,
   isCliWakeableAssistant,
   isLocalAssistant,
@@ -39,6 +48,7 @@ import {
   loadLockfile,
   primeLocalGatewayConnection,
   reconcileSelectedAssistant,
+  saveManagedLockfileAssistant,
   syncPlatformAssistantsToLockfile,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
@@ -86,6 +96,7 @@ afterEach(() => {
   localStorage.removeItem(LOCKFILE_STORAGE_KEY);
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   replacePlatformAssistantsHost.mockClear();
+  saveLockfileAssistantHost.mockClear();
 });
 
 describe("remote gateway mode", () => {
@@ -161,6 +172,33 @@ describe("syncPlatformAssistantsToLockfile", () => {
     expect(replacePlatformAssistantsHost).toHaveBeenCalledTimes(1);
     expect(useLockfileStore.getState().lockfile).toBeNull();
     expect(localStorage.getItem(LOCKFILE_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("saveManagedLockfileAssistant", () => {
+  test("writes the platform entry every managed hatch shares", async () => {
+    await saveManagedLockfileAssistant("ast-1", "Research", "org-1");
+
+    expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
+    const [entry, activeId] = saveLockfileAssistantHost.mock.calls[0]!;
+    // The written entry also becomes the lockfile's active assistant.
+    expect(activeId).toBe("ast-1");
+    expect(entry).toMatchObject({
+      assistantId: "ast-1",
+      name: "Research",
+      cloud: "vellum",
+      runtimeUrl: getPlatformRuntimeUrl(),
+      organizationId: "org-1",
+    });
+    expect(Number.isNaN(Date.parse(entry.hatchedAt as string))).toBe(false);
+  });
+
+  test("omits an unresolved organization", async () => {
+    await saveManagedLockfileAssistant("ast-1", undefined, undefined);
+
+    const [entry] = saveLockfileAssistantHost.mock.calls[0]!;
+    expect(entry.organizationId).toBeUndefined();
+    expect(entry.name).toBeUndefined();
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -213,6 +213,30 @@ export async function saveLockfileAssistant(assistant: {
 }
 
 /**
+ * Record a managed (platform) assistant in the lockfile. The desktop build's
+ * assistant list and switcher are lockfile-driven, so every managed hatch —
+ * foreground hatching screen or headless background hatch — registers its
+ * assistant here, stamped with the org whose session hatched it.
+ *
+ * The org id is a parameter because the organization store imports back through
+ * the auth store into this module; reading it here would cycle.
+ */
+export async function saveManagedLockfileAssistant(
+  assistantId: string,
+  name: string | undefined,
+  organizationId: string | undefined,
+): Promise<void> {
+  await saveLockfileAssistant({
+    assistantId,
+    name,
+    cloud: "vellum",
+    runtimeUrl: getPlatformRuntimeUrl(),
+    hatchedAt: new Date().toISOString(),
+    organizationId,
+  });
+}
+
+/**
  * Update an existing assistant entry without changing the lockfile's active
  * assistant pointer.
  */


### PR DESCRIPTION
## Summary
Fixes review gaps for headless-paid-hatch.md.

**Gap:** braceless abort guards with uneven coverage (unmount during the initial hatch could still settle), sleeps schedulable after unmount, a triplicated managed lockfile payload, and diff-relative comments.
**Fix:** abort enforced at settleReady/settleError, abort-aware sleeps, saveManagedLockfileAssistant extracted to lib/local-mode, comments rewritten present-tense; flake-prone real-timer test waits made deterministic.