### PR TITLE
fix: close the consent-latch and retry-window edges in the paid hatch flow

### DIFF
--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -22,11 +22,13 @@ interface HatchErrorOverlayProps {
  * so that case offers the local-assistant off-ramp instead.
  *
  * Portaled to `document.body` so no step's stacking or clipping context can
- * bury it — which also puts it outside the app shell's safe-area padding, so it
- * owns its own inset. Anchored to the top strip, which every step reserves for
- * chrome: bottom-anchored it would sit exactly over the results step's
- * viewport-pinned Continue, the only way forward from there. The offset clears
- * both the notch and `OnboardingTopBar`'s chevrons (`top-6` + `h-10`).
+ * bury it. Onboarding routes suppress the shell's top inset entirely (see
+ * `utils/status-banner-visibility.ts`), so nothing upstream reserves the notch
+ * and this banner adds it itself. Anchored to the top strip, which every step
+ * reserves for chrome: bottom-anchored it would sit exactly over the results
+ * step's viewport-pinned Continue, the only way forward from there. The offset
+ * stacks the inset on top of `OnboardingTopBar`'s un-inset chevrons (`top-6` +
+ * `h-10`), so it clears both them and the notch.
  */
 export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
   const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -301,7 +301,6 @@ mock.module("@/domains/onboarding/plugin-attribution", () => ({
 
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => isLocalModeValue,
-  getPlatformRuntimeUrl: () => "https://runtime.example",
   loadLockfile: async () => {},
   primeLocalGatewayConnection: async () => {},
   probeLocalGatewayReady: async () => true,

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -488,9 +488,9 @@ describe("ResearchOnboardingRoute resume guard", () => {
     expect(startResearchMock).not.toHaveBeenCalled();
   });
 
-  // A completed snapshot is NOT idle, so the pre-fix resume effect returned
-  // early and never consulted the guard — the user could walk a done journey
-  // into the chat handoff against an established assistant.
+  // A completed snapshot is NOT idle, so the resume effect must still consult
+  // the established-assistant guard: otherwise a done journey walks straight
+  // into the chat handoff against an assistant that already has a life.
   test("a restored completed snapshot diverts to the decision screen when the assistant is established", async () => {
     establishedResult = { established: true, assistantName: "Viper" };
     researchStatus = "done";
@@ -715,12 +715,25 @@ describe("ResearchOnboardingRoute paid return", () => {
     expect(navigateMock).not.toHaveBeenCalled();
     expect(readResearchSnapshot(USER_ID)).not.toBeNull();
 
+    // "Try again" clears the terminal error synchronously, but the fresh
+    // attempt has to provision before it has an assistant.
     onRetryHatch = () => {
       backgroundHatch.error = null;
-      backgroundHatch.ready = true;
-      backgroundHatch.assistantId = "asst-1";
     };
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    rerender(<ResearchOnboardingRoute />);
+
+    // The retry window: no error left, still nothing to hand off to. Releasing
+    // the CTA here would enter a null assistant, exactly as the dead hatch did.
+    expect(
+      (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByTestId("letschat-start"));
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(readResearchSnapshot(USER_ID)).not.toBeNull();
+
+    backgroundHatch.ready = true;
+    backgroundHatch.assistantId = "asst-1";
     rerender(<ResearchOnboardingRoute />);
 
     // A recovered hatch has an assistant to hand off to again.

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -1101,10 +1101,17 @@ export function ResearchOnboardingRoute() {
             pluginCatalog={research.pluginCatalog}
             // Hold the handoff until a resumed done journey's guard settles, so
             // it can't fire against an established assistant before the verdict
-            // — and while the hatch is dead, since a resumed COMPLETED snapshot
-            // lands straight here (past the gated carousel) and the handoff
-            // would clear the snapshot and navigate to a null assistant.
-            disabled={resumeGuardPending || hatchError !== null}
+            // — and until the hatch has a live assistant to hand off to, since a
+            // resumed COMPLETED snapshot lands straight here (past the gated
+            // carousel) and the handoff would clear the snapshot and navigate to
+            // a null assistant. Readiness is its own condition: a retry clears
+            // the error while the fresh attempt is still provisioning.
+            disabled={
+              resumeGuardPending ||
+              hatchError !== null ||
+              !hatchReady ||
+              hatchedAssistantId === null
+            }
             onStart={async () => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the completion here (mirrors SuggestionsStep).
@@ -1133,8 +1140,6 @@ export function ResearchOnboardingRoute() {
             suggestions={research.suggestions}
             loading={researchLoading}
             installedPlugins={research.installedPlugins}
-            // Same terminal-handoff hold as LetsChatReadyStep above.
-            disabled={hatchError !== null}
             onSuggestionClick={async (suggestion) => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the suggestions completion here (mirrors the

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -705,7 +705,6 @@ export function SuggestionsStep({
   onSkip,
   onBack,
   onForward,
-  disabled = false,
 }: {
   /** Parsed research suggestions (streams in; may be empty while running). */
   suggestions: ResearchSuggestion[];
@@ -724,11 +723,6 @@ export function SuggestionsStep({
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
-  /**
-   * Externally hold both terminal handoffs (e.g. a dead background hatch, which
-   * has no assistant to hand off to). Back-navigation stays interactive.
-   */
-  disabled?: boolean;
 }) {
   // Constant dark surface for the UI; the avatar tone is only for the pills.
   const tone = DARK_TONE;
@@ -827,8 +821,7 @@ export function SuggestionsStep({
               <button
                 type="button"
                 onClick={onSkip}
-                disabled={disabled}
-                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60"
+                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80"
                 style={{ color: tone.fg }}
               >
                 Skip to Chat
@@ -845,13 +838,12 @@ export function SuggestionsStep({
               key={`${i}-${s.suggestion}`}
               type="button"
               onClick={() => onSuggestionClick(s)}
-              disabled={disabled}
               initial={reduce ? false : { opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={
                 reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
               }
-              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 enabled:hover:scale-[1.01] enabled:active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
+              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
               style={{
                 backgroundColor: tone.isLight
                   ? "rgba(0,0,0,0.06)"

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -64,8 +64,8 @@ mock.module("@/lib/local-mode", () => ({
   probeLocalGatewayReady: probeLocalGatewayReadyMock,
   getLockfileAssistant: getLockfileAssistantMock,
   isLocalMode: () => localMode,
-  // Stands in for the real helper (whose payload `local-mode.test.ts` pins) so
-  // the lockfile entry the hatch writes stays visible to the assertions below.
+  // Surfaces the written entry to the assertions below; payload pinned by
+  // `local-mode.test.ts`.
   saveManagedLockfileAssistant: async (
     assistantId: string,
     name: string | undefined,
@@ -476,6 +476,9 @@ describe("useBackgroundHatch", () => {
   });
 
   test("unmounting stops the assistant poll loop", async () => {
+    // Local mode so the discovery branch would write the lockfile — which sets
+    // the ACTIVE assistant, and is not covered by `settleReady`'s own guard.
+    localMode = true;
     getAssistantResult = {
       ok: true,
       status: 200,
@@ -495,15 +498,43 @@ describe("useBackgroundHatch", () => {
     await waitFor(() =>
       expect(getAssistantMock.mock.calls.length).toBeGreaterThanOrEqual(2),
     );
+
+    // Hold one poll open across the unmount, then answer it `active` — the
+    // response a departed hatch would otherwise claim the assistant on.
+    let releasePoll!: () => void;
+    let pollStarted = false;
+    const heldPoll = new Promise<void>((resolve) => {
+      releasePoll = resolve;
+    });
+    getAssistantMock.mockImplementationOnce(async () => {
+      pollStarted = true;
+      await heldPoll;
+      return {
+        ok: true,
+        status: 200,
+        data: {
+          id: "ast-research",
+          name: "Research",
+          status: "active",
+          is_local: false,
+        } as never,
+      };
+    });
+    await until(() => pollStarted);
+
     unmount();
     const callsAtUnmount = getAssistantMock.mock.calls.length;
+    await act(async () => {
+      releasePoll();
+    });
 
     // Leaving the funnel mid-hatch must not keep polling from a dead
-    // component: the in-flight request may land, but nothing follows it —
-    // the aborted sleep schedules no timer to poll from.
+    // component — the aborted sleep schedules no timer to poll from — and the
+    // late answer must not switch the user's active assistant.
     await expect(
-      until(() => getAssistantMock.mock.calls.length > callsAtUnmount + 1),
+      until(() => getAssistantMock.mock.calls.length > callsAtUnmount),
     ).rejects.toThrow();
+    expect(saveLockfileAssistantMock).not.toHaveBeenCalled();
   });
 
   test("unmounting during the initial hatch never settles", async () => {

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -284,10 +284,19 @@ export function useBackgroundHatch(
         }
         try {
           let result = await getAssistant(hatchedAssistantId);
+          // Re-checked after every await here, not just at the loop head: the
+          // branch below writes the lockfile — which sets the ACTIVE assistant
+          // — and that write is not guarded by `settleReady`.
+          if (abortedRef.current) {
+            return;
+          }
           // A stale hatched id (404) falls back to list-based discovery.
           if (hatchedAssistantId && !result.ok && result.status === 404) {
             hatchedAssistantId = undefined;
             result = await getAssistant();
+            if (abortedRef.current) {
+              return;
+            }
           }
           const state = resolveAssistantLifecycleState(result);
           if (state.kind === "active" && result.ok) {
@@ -375,6 +384,12 @@ export function useBackgroundHatch(
             pollTimerRef.current = timer;
           },
         });
+        // A cancellation landing mid-healthz past the deadline also reports
+        // `"health_timeout"`, and nobody is waiting on this hatch any more —
+        // reporting it would be a false alarm.
+        if (abortedRef.current) {
+          return;
+        }
         if (outcome === "health_timeout") {
           // The assistant never answered healthz after the resize; completing
           // would hand the user an unreachable assistant.

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -783,6 +783,52 @@ describe("authMiddleware — hydration timeout", () => {
     }
   });
 
+  // The consent wait runs first, so a fetch that reports just after it — while
+  // the assistants wait is still running — leaves a settled "not consented" by
+  // the time the guard recurses. Carrying the expired stall forward would fail
+  // the gate open on a hydration that has since landed.
+  test("bounces an unconsented research entry when consent lands during the assistants wait", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    const priorAssistantsHydrated =
+      useResolvedAssistantsStore.getState().assistantsHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: false,
+    });
+
+    try {
+      const pending = runMiddleware(managedFunnel);
+      // Past the (clamped) consent wait but inside the assistants one, which
+      // never reports.
+      setTimeout(
+        () => {
+          useOnboardingStore.setState({ consentHydrated: true });
+        },
+        WAIT_TIMEOUT_CLAMP_MS + 30,
+      );
+
+      const res = await pending;
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(
+        `${routes.onboarding.privacy}?returnTo=${encodeURIComponent(managedFunnel)}`,
+      );
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+      useResolvedAssistantsStore.setState({
+        assistantsHydrated: priorAssistantsHydrated,
+      });
+    }
+  });
+
   // Both fetches hang, so the consent wait times out on its own account and the
   // entry falls back to its unconditional admission.
   test("admits the research entry when both hydration waits stall", async () => {

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -167,11 +167,19 @@ const resolveWithGuard = async (
           !useResolvedAssistantsStore.getState().assistantsHydrated;
       }
     }
+    // Consent is re-read here rather than trusted from its own wait: the
+    // assistants wait runs after it, and consent that lands during that window
+    // is a settled read by the time the recursion decides. Reporting the stale
+    // "still pending" would force the consent gate open for a genuinely
+    // unconsented user on the strength of a stall that has since cleared.
     return resolveWithGuard(
       { request, context } as Parameters<MiddlewareFunction>[0],
       next,
       {
-        consentHydration: timedOut.consentHydration || consentStillPending,
+        consentHydration:
+          timedOut.consentHydration ||
+          (consentStillPending &&
+            !useOnboardingStore.getState().consentHydrated),
         assistantsHydration:
           timedOut.assistantsHydration || assistantsStillPending,
         platformProbe: timedOut.platformProbe || platformProbeStillUnknown,


### PR DESCRIPTION
## Summary
Final consolidated review fixes for headless-paid-hatch.md.

- Consent hydration re-read at the middleware recursion so an assistants-wait landing can't force the paid gate open
- Terminal handoffs additionally gated on hatch readiness (retry window + slow first hatch)
- Discovery-loop abort guards restored so an aborted hatch can't write the lockfile or emit a spurious timeout metric
- Dead SuggestionsStep gating removed; docstring/mock nits