### PR TITLE
Headless hatch for the paid checkout funnel

### DIFF
--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -22,11 +22,13 @@ interface HatchErrorOverlayProps {
  * so that case offers the local-assistant off-ramp instead.
  *
  * Portaled to `document.body` so no step's stacking or clipping context can
- * bury it — which also puts it outside the app shell's safe-area padding, so it
- * owns its own inset. Anchored to the top strip, which every step reserves for
- * chrome: bottom-anchored it would sit exactly over the results step's
- * viewport-pinned Continue, the only way forward from there. The offset clears
- * both the notch and `OnboardingTopBar`'s chevrons (`top-6` + `h-10`).
+ * bury it. Onboarding routes suppress the shell's top inset entirely (see
+ * `utils/status-banner-visibility.ts`), so nothing upstream reserves the notch
+ * and this banner adds it itself. Anchored to the top strip, which every step
+ * reserves for chrome: bottom-anchored it would sit exactly over the results
+ * step's viewport-pinned Continue, the only way forward from there. The offset
+ * stacks the inset on top of `OnboardingTopBar`'s un-inset chevrons (`top-6` +
+ * `h-10`), so it clears both them and the notch.
  */
 export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
   const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;

--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@vellumai/design-library/components/button";
-import { Modal } from "@vellumai/design-library/components/modal";
+import { Notice } from "@vellumai/design-library/components/notice";
+import { createPortal } from "react-dom";
 
 import { PLATFORM_HOSTED_DISABLED_MESSAGE } from "@/assistant/lifecycle";
 
@@ -13,53 +14,46 @@ interface HatchErrorOverlayProps {
 /**
  * Terminal background-hatch failure, surfaced over the onboarding funnel.
  *
- * Layers on top of whatever step is on screen rather than replacing it, so the
- * funnel keeps its collected state and a successful retry resumes in place.
- * Retrying can't help while managed hosting is at capacity, so that case offers
- * the local-assistant off-ramp instead.
+ * A non-modal banner: it layers on top of whatever step is on screen without
+ * trapping focus or swallowing pointer events, so the funnel keeps both its
+ * collected state and its own escapes (each step's back chevron, the calendar
+ * step's "Skip for now") while the failure is up, and a successful retry
+ * resumes in place. Retrying can't help while managed hosting is at capacity,
+ * so that case offers the local-assistant off-ramp instead.
+ *
+ * Portaled to `document.body` so no step's stacking or clipping context can
+ * bury it.
  */
 export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
   const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;
-  return (
-    <Modal.Root open>
-      <Modal.Content
-        size="sm"
-        role="alertdialog"
-        hideCloseButton
-        dismissOnOverlayClick={false}
-        onEscapeKeyDown={(event) => event.preventDefault()}
-        onInteractOutside={(event) => event.preventDefault()}
-      >
-        <Modal.Header>
-          <Modal.Title>Something went wrong</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Modal.Description>{error}</Modal.Description>
-          {platformHostedDisabled ? (
-            <p className="mt-5 text-body-medium-default text-[var(--content-default)]">
-              Get started today with a local assistant
-            </p>
-          ) : null}
-        </Modal.Body>
-        <Modal.Footer>
-          {platformHostedDisabled ? (
-            <Button asChild variant="primary" size="regular" fullWidth>
+  return createPortal(
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center p-4">
+      <Notice
+        tone="error"
+        title="Something went wrong"
+        className="pointer-events-auto w-auto max-w-[480px] shadow-xl"
+        actions={
+          platformHostedDisabled ? (
+            <Button asChild variant="primary" size="regular">
               <a href={`${window.location.origin}/download`}>
                 Download the macOS app
               </a>
             </Button>
           ) : (
-            <Button
-              variant="primary"
-              size="regular"
-              fullWidth
-              onClick={onRetry}
-            >
+            <Button variant="primary" size="regular" onClick={onRetry}>
               Try again
             </Button>
-          )}
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal.Root>
+          )
+        }
+      >
+        {error}
+        {platformHostedDisabled ? (
+          <p className="mt-1 text-[color:var(--content-default)]">
+            Get started today with a local assistant
+          </p>
+        ) : null}
+      </Notice>
+    </div>,
+    document.body,
   );
 }

--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -1,0 +1,65 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { Modal } from "@vellumai/design-library/components/modal";
+
+import { PLATFORM_HOSTED_DISABLED_MESSAGE } from "@/assistant/lifecycle";
+
+interface HatchErrorOverlayProps {
+  /** Terminal failure message from the background hatch. */
+  error: string;
+  /** Re-run the failed hatch from the top. */
+  onRetry: () => void;
+}
+
+/**
+ * Terminal background-hatch failure, surfaced over the onboarding funnel.
+ *
+ * Layers on top of whatever step is on screen rather than replacing it, so the
+ * funnel keeps its collected state and a successful retry resumes in place.
+ * Retrying can't help while managed hosting is at capacity, so that case offers
+ * the local-assistant off-ramp instead.
+ */
+export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
+  const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;
+  return (
+    <Modal.Root open>
+      <Modal.Content
+        size="sm"
+        role="alertdialog"
+        hideCloseButton
+        dismissOnOverlayClick={false}
+        onEscapeKeyDown={(event) => event.preventDefault()}
+        onInteractOutside={(event) => event.preventDefault()}
+      >
+        <Modal.Header>
+          <Modal.Title>Something went wrong</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Modal.Description>{error}</Modal.Description>
+          {platformHostedDisabled ? (
+            <p className="mt-5 text-body-medium-default text-[var(--content-default)]">
+              Get started today with a local assistant
+            </p>
+          ) : null}
+        </Modal.Body>
+        <Modal.Footer>
+          {platformHostedDisabled ? (
+            <Button asChild variant="primary" size="regular" fullWidth>
+              <a href={`${window.location.origin}/download`}>
+                Download the macOS app
+              </a>
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              size="regular"
+              fullWidth
+              onClick={onRetry}
+            >
+              Try again
+            </Button>
+          )}
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -22,12 +22,16 @@ interface HatchErrorOverlayProps {
  * so that case offers the local-assistant off-ramp instead.
  *
  * Portaled to `document.body` so no step's stacking or clipping context can
- * bury it.
+ * bury it — which also puts it outside the app shell's safe-area padding, so it
+ * owns its own inset. Anchored to the top strip, which every step reserves for
+ * chrome: bottom-anchored it would sit exactly over the results step's
+ * viewport-pinned Continue, the only way forward from there. The offset clears
+ * both the notch and `OnboardingTopBar`'s chevrons (`top-6` + `h-10`).
  */
 export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
   const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;
   return createPortal(
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center p-4">
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-[calc(var(--safe-area-inset-top,env(safe-area-inset-top,0px))+5rem)]">
       <Notice
         tone="error"
         title="Something went wrong"

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -182,6 +182,7 @@ mock.module("@/lib/local-mode", () => ({
   loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
   setActiveLockfileAssistant: async () => {},
   saveLockfileAssistant: async () => {},
+  saveManagedLockfileAssistant: async () => {},
   updateLockfileAssistant: async () => {},
   primeLocalGatewayConnection: async () => {},
   primeLocalGatewayConnectionWithRepair: async () => {},

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -301,7 +301,6 @@ mock.module("@/domains/onboarding/plugin-attribution", () => ({
 
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => isLocalModeValue,
-  getPlatformRuntimeUrl: () => "https://runtime.example",
   loadLockfile: async () => {},
   primeLocalGatewayConnection: async () => {},
   probeLocalGatewayReady: async () => true,

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -367,9 +367,7 @@ mock.module("@/stores/auth-store", () => ({
 }));
 
 mock.module("@/stores/organization-store", () => ({
-  useOrganizationStore: {
-    getState: () => ({ currentOrganizationId: null }),
-  },
+  getActiveOrganizationIdForRequests: () => null,
 }));
 
 mock.module("@/stores/resolved-assistants-store", () => ({

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -206,7 +206,14 @@ const hatchLocalAssistantMock = mock(async () => ({
 }));
 
 const saveLockfileAssistantMock = mock(
-  async (_entry: { assistantId: string; cloud: string }) => {},
+  async (_entry: {
+    assistantId: string;
+    cloud: string;
+    name?: string;
+    runtimeUrl?: string;
+    hatchedAt?: string;
+    organizationId?: string;
+  }) => {},
 );
 const clearGatewayTokenMock = mock(() => {});
 const setSelfHostedConnectionMock = mock((_connection: unknown) => {});
@@ -298,7 +305,22 @@ mock.module("@/lib/local-mode", () => ({
   loadLockfile: async () => {},
   primeLocalGatewayConnection: async () => {},
   probeLocalGatewayReady: async () => true,
-  saveLockfileAssistant: saveLockfileAssistantMock,
+  // Stands in for the real helper (whose payload `local-mode.test.ts` pins) so
+  // the lockfile entry the hatch writes stays visible to the assertions below.
+  saveManagedLockfileAssistant: async (
+    assistantId: string,
+    name: string | undefined,
+    organizationId: string | undefined,
+  ): Promise<void> => {
+    await saveLockfileAssistantMock({
+      assistantId,
+      name,
+      cloud: "vellum",
+      runtimeUrl: "https://runtime.example",
+      hatchedAt: new Date().toISOString(),
+      organizationId,
+    });
+  },
 }));
 
 mock.module("@/lib/auth/gateway-session", () => ({

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -25,7 +25,7 @@ import {
     MAX_HATCH_WAIT_MS,
     POLL_INTERVAL_MS,
 } from "@/domains/onboarding/purchased-provisioning";
-import { getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveLockfileAssistant } from "@/lib/local-mode";
+import { isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveManagedLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import {
@@ -325,15 +325,12 @@ export function HatchingScreen() {
           const preflightState = resolveAssistantLifecycleState(existing);
           if (!cancelled && existing.ok && preflightState.kind === "active") {
             if (isLocalMode()) {
-              void saveLockfileAssistant({
-                assistantId: existing.data.id,
-                name: existing.data.name,
-                cloud: "vellum",
-                runtimeUrl: getPlatformRuntimeUrl(),
-                hatchedAt: new Date().toISOString(),
-                organizationId:
-                  useOrganizationStore.getState().currentOrganizationId ?? undefined,
-              });
+              void saveManagedLockfileAssistant(
+                existing.data.id,
+                existing.data.name,
+                useOrganizationStore.getState().currentOrganizationId ??
+                  undefined,
+              );
             }
             // Route the reload path through the same provisioning wait as the
             // polled-active path so a purchased resize is never skipped.
@@ -607,15 +604,12 @@ export function HatchingScreen() {
               void persistHatchAvatar(assistantId);
             }
             if (isLocalMode()) {
-              void saveLockfileAssistant({
+              void saveManagedLockfileAssistant(
                 assistantId,
-                name: result.data.name,
-                cloud: "vellum",
-                runtimeUrl: getPlatformRuntimeUrl(),
-                hatchedAt: new Date().toISOString(),
-                organizationId:
-                  useOrganizationStore.getState().currentOrganizationId ?? undefined,
-              });
+                result.data.name,
+                useOrganizationStore.getState().currentOrganizationId ??
+                  undefined,
+              );
             }
 
             // Wait for healthz, then hold for the purchased resize before

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -20,7 +20,11 @@ import {
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
-import { awaitPurchasedProvisioning } from "@/domains/onboarding/purchased-provisioning";
+import {
+    awaitPurchasedProvisioning,
+    MAX_HATCH_WAIT_MS,
+    POLL_INTERVAL_MS,
+} from "@/domains/onboarding/purchased-provisioning";
 import { getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
@@ -46,9 +50,7 @@ import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { ProgressBar } from "@vellumai/design-library/components/progress-bar";
 
-const POLL_INTERVAL_MS = 3000;
 const COMPLETION_NAVIGATE_DELAY_MS = 800;
-const MAX_HATCH_WAIT_MS = 300_000;
 
 // Module-level state so HMR remounts, StrictMode double-mounts, and — critically
 // — the auth-driven provider remount survive without spawning duplicate hatches.

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -38,7 +38,7 @@ import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { setSelectedAssistant } from "@/assistant/selection";
 import { useAuthStore } from "@/stores/auth-store";
-import { useOrganizationStore } from "@/stores/organization-store";
+import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { isSessionSettled } from "@/stores/session-status";
 import type { CharacterTraits } from "@/types/avatar";
@@ -328,7 +328,7 @@ export function HatchingScreen() {
               void saveManagedLockfileAssistant(
                 existing.data.id,
                 existing.data.name,
-                useOrganizationStore.getState().currentOrganizationId ??
+                getActiveOrganizationIdForRequests() ??
                   undefined,
               );
             }
@@ -607,7 +607,7 @@ export function HatchingScreen() {
               void saveManagedLockfileAssistant(
                 assistantId,
                 result.data.name,
-                useOrganizationStore.getState().currentOrganizationId ??
+                getActiveOrganizationIdForRequests() ??
                   undefined,
               );
             }

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -5,19 +5,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { getAssistant, getAssistantHealthz, hatchAssistant, type Assistant } from "@/assistant/api";
-import {
-    assistantsOperationalStatusDetailRead,
-    organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate,
-    organizationsBillingSubscriptionOnboardingRetrieve,
-    organizationsBillingSubscriptionRetrieve,
-} from "@/generated/api/sdk.gen";
-import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
-import {
-    isEntitlementRaceVerdict,
-    isResizeOperationInFlight,
-    targetsMet,
-    type ProvisioningDimensions,
-} from "@/lib/billing/provisioning-targets";
 import { seedHatchAvatar } from "@/assistant/seed-hatch-avatar";
 import {
     isPlatformHostedDisabled,
@@ -33,6 +20,7 @@ import {
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
+import { awaitPurchasedProvisioning } from "@/domains/onboarding/purchased-provisioning";
 import { getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
@@ -61,10 +49,6 @@ import { ProgressBar } from "@vellumai/design-library/components/progress-bar";
 const POLL_INTERVAL_MS = 3000;
 const COMPLETION_NAVIGATE_DELAY_MS = 800;
 const MAX_HATCH_WAIT_MS = 300_000;
-// Hard cap on the post-payment resize wait, mirroring PROVISION_STALL_MS in the
-// pro-onboarding takeover. On expiry the assistant completes at baseline and the
-// server reconciles the purchased specs later — the user is never trapped.
-const RESIZE_WAIT_MAX_MS = 90_000;
 
 // Module-level state so HMR remounts, StrictMode double-mounts, and — critically
 // — the auth-driven provider remount survive without spawning duplicate hatches.
@@ -92,11 +76,6 @@ type HatchPhase =
   | "connecting"
   | "resizing"
   | "ready";
-
-// How the purchased-provisioning wait ended. `health_timeout` means the
-// assistant never answered healthz within MAX_HATCH_WAIT_MS after the resize,
-// so the hatch must be failed rather than completed onto an unreachable pod.
-type HatchProvisioningOutcome = "ready" | "health_timeout";
 
 const PHASE_TARGET: Record<HatchPhase, number> = {
   initializing: 0,
@@ -196,9 +175,6 @@ export function HatchingScreen() {
   const segmentStartRef = useRef(0);
   const segmentStartTimeRef = useRef(0);
   const displayProgressRef = useRef(0);
-  // Fire-once guard for the idempotent post-payment provisioning reconcile, so a
-  // remount or an extra poll can't re-trigger it within a single hatch.
-  const provisioningReconcileFiredRef = useRef(false);
 
   const transitionPhase = useCallback((next: HatchPhase) => {
     segmentStartRef.current = displayProgressRef.current;
@@ -534,253 +510,6 @@ export function HatchingScreen() {
       pollTimer = setTimeout(runPoll, delay);
     };
 
-    // Platform-only: once the assistant is active and healthz-ready, hold the
-    // hatching screen until the server-side resize to the purchased machine and
-    // storage specs converges, then re-probe healthz (the resize restarts the
-    // pod). The reconcile is idempotent and fire-and-forget; a genuinely free
-    // org, and the RESIZE_WAIT_MAX_MS cap, fall through to completion at
-    // baseline, so a Pro hatch emerges at the right size without ever trapping
-    // the user. Every wait that entered the provisioning phase leaves through
-    // the healthz probe, and the caller must honour a `health_timeout` outcome.
-    const awaitPurchasedProvisioning = async (
-      assistantId: string,
-    ): Promise<HatchProvisioningOutcome> => {
-      // Purchased specs live on the platform, so only a managed hatch reads
-      // them. A local-mode run without the managed marker can reach here off a
-      // preflight that resolved the lockfile assistant, which has no billing
-      // surface — short-circuit there.
-      if (isLocalMode() && !managedHatch) {
-        return "ready";
-      }
-      // Fire the idempotent grow-only reconcile — the same resize the subscribe
-      // webhook triggers — covering a webhook that never fired or whose resize
-      // was lost. It is marked done only when it RECONCILES: a 503 ("nothing
-      // queued"), a network error, a pre-org-hydration mount, or a race reply
-      // leaves the guard unset so a later poll iteration re-fires the nudge. It
-      // never blocks completion (which keys off targets + op-status); the
-      // re-fires stay bounded by the RESIZE_WAIT_MAX_MS cap below.
-      const fireProvisioningReconcile = (): void => {
-        if (provisioningReconcileFiredRef.current) {
-          return;
-        }
-        void organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate({
-          throwOnError: false,
-        })
-          .then((result) => {
-            // Success carries a body; a 503/5xx resolves with no data under
-            // throwOnError:false. A race body — the entitlement not yet
-            // visible, or no settled assistant to provision, which is the
-            // common case this early in a hatch — is not an answer: nothing was
-            // queued, so it must not consume the guard or the nudge is lost for
-            // the whole hatch.
-            if (
-              result.data != null &&
-              !isEntitlementRaceVerdict(result.data)
-            ) {
-              provisioningReconcileFiredRef.current = true;
-            }
-          })
-          .catch(() => {
-            // Network/thrown error: leave the guard unset to re-fire on a later poll.
-          });
-      };
-
-      // A reconciled resize restarts the pod, so every exit from the waits below
-      // ends here before the hatch completes — otherwise the screen navigates
-      // onto a mid-restart daemon. Bounded by MAX_HATCH_WAIT_MS measured from
-      // the poll start, past which the assistant is not coming back and the
-      // hatch is a failure.
-      const waitForPostResizeHealth =
-        async (): Promise<HatchProvisioningOutcome> => {
-          while (!cancelled) {
-            try {
-              const health = await getAssistantHealthz(assistantId);
-              if (health.ok) {
-                return "ready";
-              }
-            } catch {
-              // Daemon not reachable yet during the post-resize restart.
-            }
-            if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
-              return "health_timeout";
-            }
-            await new Promise<void>((resolve) => {
-              pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
-            });
-            pollTimer = null;
-          }
-          return "ready";
-        };
-
-      // The cap covers both waits below — the entitlement/targets confirmation
-      // and the resize itself — so a lagging subscription can never hold the
-      // user past RESIZE_WAIT_MAX_MS.
-      const resizeDeadline = Date.now() + RESIZE_WAIT_MAX_MS;
-
-      // Confirm the entitlement before concluding "free". A paid checkout can
-      // return before the onboarding targets are visible, so gate the no-wait
-      // completion on the actual subscription plan rather than on the first null
-      // targets. While the plan reads Pro but the targets aren't provisioned yet
-      // (the entitlement race), keep polling the subscription and targets within
-      // the cap instead of completing at baseline.
-      let targets: ProvisioningDimensions | null = null;
-      while (!cancelled) {
-        // Re-fire the reconcile until it succeeds (or the cap): a failed first
-        // attempt must not permanently consume the guard.
-        fireProvisioningReconcile();
-        // Tri-state entitlement read. Only a CONFIRMED non-Pro plan — a
-        // successful response whose plan_id is definitively not "pro" —
-        // completes early. An unknown result (a thrown error, or a 5xx that
-        // resolves with no data under throwOnError:false) must not be mistaken
-        // for "free"; it behaves like "Pro but targets not yet provisioned" and
-        // keeps polling within the cap so a purchased resize is never skipped.
-        let subscriptionState: "pro" | "non_pro" | "unknown" = "unknown";
-        try {
-          const subscription = await organizationsBillingSubscriptionRetrieve({
-            throwOnError: false,
-          });
-          if (cancelled) {
-            return "ready";
-          }
-          if (subscription.data) {
-            subscriptionState =
-              subscription.data.plan_id === "pro" ? "pro" : "non_pro";
-          }
-        } catch {
-          // Subscription endpoint blip: stay "unknown" and keep polling to the cap.
-        }
-
-        try {
-          const onboarding =
-            await organizationsBillingSubscriptionOnboardingRetrieve({
-              throwOnError: false,
-            });
-          if (cancelled) {
-            return "ready";
-          }
-          const data = onboarding.data;
-          if (data) {
-            targets = {
-              machineSize:
-                allowedMachineSizesForTier(data.max_machine_tier).at(-1) ?? null,
-              storageGib: data.selected_storage_gib ?? null,
-            };
-          }
-        } catch {
-          // Targets fetch blip; keep polling to the cap.
-        }
-
-        const hasTargets =
-          targets != null &&
-          (targets.machineSize != null || targets.storageGib != null);
-
-        // Confirmed non-Pro on an ordinary hatch — genuinely free. Complete
-        // exactly as a non-provisioned hatch does today, with no added poll.
-        // On a post-checkout return the same read is not an answer: Stripe
-        // redirects before the subscribe webhook updates the org, so the plan
-        // still reads at its pre-checkout base. That case falls through to the
-        // capped wait below.
-        if (subscriptionState === "non_pro" && !postCheckoutReturn) {
-          return "ready";
-        }
-        // Confirmed Pro with a purchased ceiling to wait on: hold for the resize
-        // below.
-        if (subscriptionState === "pro" && hasTargets) {
-          break;
-        }
-        // Pro with targets not yet visible, a still-base read on a paid return,
-        // or an unknown/errored subscription read: keep polling within the cap
-        // rather than completing at baseline onto an unprovisioned assistant.
-        // The cap is the ultimate escape, so a subscription that never flips —
-        // a persistently-erroring endpoint, a lost webhook — still completes.
-        if (Date.now() >= resizeDeadline) {
-          // Nothing was confirmed, but the reconcile has been nudged on every
-          // iteration, so a resize may already have restarted the pod. Health
-          // check before completing rather than returning straight to the
-          // caller.
-          return waitForPostResizeHealth();
-        }
-        await new Promise<void>((resolve) => {
-          pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
-        });
-        pollTimer = null;
-      }
-      if (cancelled) {
-        return "ready";
-      }
-
-      // Hold in an in-progress phase while the resize lands.
-      transitionPhase("resizing");
-
-      while (!cancelled) {
-        // Keep nudging the resize in case the reconcile hasn't landed yet; the
-        // guard stops the re-fire once it succeeds.
-        fireProvisioningReconcile();
-        let actuals: ProvisioningDimensions | null = null;
-        try {
-          const actualsResult = await getAssistant(assistantId);
-          if (cancelled) {
-            return "ready";
-          }
-          if (actualsResult.ok) {
-            actuals = {
-              machineSize: actualsResult.data.machine_size ?? null,
-              storageGib: actualsResult.data.provisioned_storage_gib ?? null,
-            };
-          }
-        } catch {
-          // Assistant endpoint unreachable mid-resize; keep polling to the cap.
-        }
-
-        // Default to in-flight so an uncertain status read withholds completion.
-        // Under throwOnError:false a 5xx resolves with no data rather than
-        // throwing, and isResizeOperationInFlight(undefined) is false — so only
-        // a successful read (data present) may downgrade to "not in flight".
-        // Otherwise the screen could navigate onto a pod that is still restarting.
-        let operationInFlight = true;
-        try {
-          const opStatus = await assistantsOperationalStatusDetailRead({
-            path: { id: assistantId },
-            throwOnError: false,
-          });
-          if (cancelled) {
-            return "ready";
-          }
-          if (opStatus.data) {
-            operationInFlight = isResizeOperationInFlight(opStatus.data);
-          }
-        } catch {
-          // Operational-status endpoint unreachable mid-resize: retain the
-          // conservative in-flight value and keep polling to the cap.
-          operationInFlight = true;
-        }
-
-        // The platform persists the effective sizes before the pod finishes
-        // restarting, so completion requires the resize operation to have
-        // cleared — not just targets-met — to avoid landing on a soon-dead pod.
-        if (targetsMet(targets, actuals) && !operationInFlight) {
-          break;
-        }
-        if (Date.now() >= resizeDeadline) {
-          // Cap reached: stop waiting for the resize but still fall through to
-          // the healthz probe below, so completion never routes onto a pod
-          // mid-restart. The server reconciles the remaining resize later.
-          break;
-        }
-        await new Promise<void>((resolve) => {
-          pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
-        });
-        pollTimer = null;
-      }
-      if (cancelled) {
-        return "ready";
-      }
-
-      // Both the converged and the cap-expiry exit above land on a pod the
-      // resize may still be restarting.
-      return waitForPostResizeHealth();
-    };
-
     // Both the preflight-active path (a reload onto an already-active assistant)
     // and the polled-active path converge here: wait for healthz, hold for the
     // purchased resize, then complete. Sharing this tail keeps a reload from
@@ -813,7 +542,17 @@ export function HatchingScreen() {
         return;
       }
 
-      const outcome = await awaitPurchasedProvisioning(assistantId);
+      const outcome = await awaitPurchasedProvisioning({
+        assistantId,
+        postCheckoutReturn,
+        managedHatch,
+        hatchStartMs: pollStartMs,
+        isCancelled: () => cancelled,
+        onResizeWait: () => transitionPhase("resizing"),
+        registerTimer: (timer) => {
+          pollTimer = timer;
+        },
+      });
       if (cancelled) {
         return;
       }

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -18,13 +18,11 @@
  * it.
  *
  * The paid-return block covers the `post_checkout=1` marker reaching the
- * background hatch and the failure overlay that surfaces a dead hatch on any
- * step, with the at-capacity download off-ramp in place of a retry. That
- * surface is a banner rather than a modal, so it also covers the funnel staying
- * usable underneath and the auto-advancing loading step holding its own
- * position while the hatch is dead. The retry block covers what the banner's
- * "Try again" has to un-poison: route state that resolved against the dead
- * hatch and would otherwise survive the retry.
+ * background hatch, and the failure banner: its at-capacity download off-ramp,
+ * the funnel staying usable underneath it, and everything that must stay held
+ * while the hatch is dead (the auto-advancing loading step, the terminal
+ * handoffs). The retry block covers what "Try again" has to un-poison: route
+ * state that resolved against the dead hatch and would otherwise survive it.
  *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
@@ -311,31 +309,16 @@ mock.module("@/domains/onboarding/screens/create-personality-step", () => ({
   ),
 }));
 
-// Renders the real step's contract: the connect action can't enable until the
-// hatch is ready, and "Skip for now" is revealed early on a failed hatch so the
-// user is never trapped behind a button that can never enable.
+// Only the skip escape matters here — when it is revealed is the step's own
+// concern (see lets-chat-tomorrow-step.test.tsx).
 mock.module("@/domains/onboarding/screens/lets-chat-tomorrow-step", () => ({
-  LetsChatTomorrowStep: (props: {
-    assistantId: string | null;
-    assistantReady: boolean;
-    hatchError?: string | null;
-    onSkip: () => void;
-  }) => {
-    const waitingForAssistant = !props.assistantId || !props.assistantReady;
-    return (
-      <div data-testid="letschat-step">
-        {!waitingForAssistant || props.hatchError ? (
-          <button
-            type="button"
-            data-testid="letschat-skip"
-            onClick={props.onSkip}
-          >
-            Skip for now
-          </button>
-        ) : null}
-      </div>
-    );
-  },
+  LetsChatTomorrowStep: (props: { onSkip: () => void }) => (
+    <div data-testid="letschat-step">
+      <button type="button" data-testid="letschat-skip" onClick={props.onSkip}>
+        Skip for now
+      </button>
+    </div>
+  ),
 }));
 
 mock.module("@/domains/onboarding/screens/research-result-steps", () => ({
@@ -418,6 +401,24 @@ function postFormSnapshot(
   };
 }
 
+/**
+ * A finished journey: the runner hydrates straight to "done" and
+ * resolveResumeStep lands it on the terminal handoff step.
+ */
+function doneSnapshot(): ResearchOnboardingSnapshot {
+  return postFormSnapshot({
+    step: "suggestions",
+    research: {
+      status: "done",
+      claims: [],
+      droppedClaims: [],
+      suggestions: [],
+      installedPlugins: [],
+      pluginCatalog: {},
+    },
+  });
+}
+
 beforeEach(() => {
   localStorage.clear();
   researchStatus = "idle";
@@ -487,23 +488,9 @@ describe("ResearchOnboardingRoute resume guard", () => {
     expect(startResearchMock).not.toHaveBeenCalled();
   });
 
-  // A completed snapshot hydrates the runner to "done" and resolveResumeStep
-  // lands it on the suggestions step. That is NOT idle, so the pre-fix resume
-  // effect returned early and never consulted the guard — the user could walk a
-  // done journey into the chat handoff against an established assistant.
-  const doneSnapshot = (): ResearchOnboardingSnapshot =>
-    postFormSnapshot({
-      step: "suggestions",
-      research: {
-        status: "done",
-        claims: [],
-        droppedClaims: [],
-        suggestions: [],
-        installedPlugins: [],
-        pluginCatalog: {},
-      },
-    });
-
+  // A completed snapshot is NOT idle, so the pre-fix resume effect returned
+  // early and never consulted the guard — the user could walk a done journey
+  // into the chat handoff against an established assistant.
   test("a restored completed snapshot diverts to the decision screen when the assistant is established", async () => {
     establishedResult = { established: true, assistantName: "Viper" };
     researchStatus = "done";
@@ -687,6 +674,63 @@ describe("ResearchOnboardingRoute paid return", () => {
     await screen.findByTestId("form-submit");
 
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // The banner has to stay clear of the results step's viewport-pinned
+  // Continue, the only way forward from there — and, portaled out of the app
+  // shell, it owns its own iOS inset.
+  test("anchors the failure banner to the top strip, below the notch", async () => {
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+
+    render(<ResearchOnboardingRoute />);
+
+    const banner = (await screen.findByRole("alert")).parentElement;
+    expect(banner?.className).toContain("top-0");
+    expect(banner?.className).not.toContain("bottom-0");
+    expect(banner?.className).toContain("safe-area-inset-top");
+  });
+
+  // A resumed COMPLETED snapshot lands straight on the terminal handoff, past
+  // the carousel that otherwise gates on the hatch. Handing off there clears
+  // the resume snapshot and navigates with a null assistant id — into nothing,
+  // with no way back.
+  test("holds the terminal handoff while the hatch is dead, and releases it after a retry", async () => {
+    researchStatus = "done";
+    writeResearchSnapshot(USER_ID, doneSnapshot());
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+    backgroundHatch.ready = false;
+    backgroundHatch.assistantId = null;
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+      ).toBe(true),
+    );
+
+    // Clicking the held CTA hands off to nothing: no navigation, and the
+    // journey's resume state survives for the retry.
+    fireEvent.click(screen.getByTestId("letschat-start"));
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(readResearchSnapshot(USER_ID)).not.toBeNull();
+
+    onRetryHatch = () => {
+      backgroundHatch.error = null;
+      backgroundHatch.ready = true;
+      backgroundHatch.assistantId = "asst-1";
+    };
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    rerender(<ResearchOnboardingRoute />);
+
+    // A recovered hatch has an assistant to hand off to again.
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+    fireEvent.click(screen.getByTestId("letschat-start"));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled());
   });
 
   // The failure surface is a banner, not a modal: it must not hide the funnel

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -1,5 +1,6 @@
 /**
- * Route-level regression tests for the research-onboarding resume guard.
+ * Route-level regression tests for the research-onboarding resume guard and the
+ * paid-checkout return.
  *
  * The established-assistant guard used to run only on form submit; a restored
  * post-form snapshot (persisted before the verdict settled, or after a transient
@@ -16,6 +17,12 @@
  * — so a refresh re-lands on the keep/redo choice instead of auto-resuming past
  * it.
  *
+ * The paid-return block covers the `post_checkout=1` marker reaching the
+ * background hatch and the failure overlay that surfaces a dead hatch on any
+ * step, with the at-capacity download off-ramp in place of a retry. The retry
+ * block covers what that overlay's "Try again" has to un-poison: route state
+ * that resolved against the dead hatch and would otherwise survive the retry.
+ *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
  */
@@ -30,6 +37,7 @@ import {
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { type ReactNode } from "react";
 
+import { PLATFORM_HOSTED_DISABLED_MESSAGE } from "@/assistant/lifecycle";
 import {
   readResearchSnapshot,
   writeResearchSnapshot,
@@ -41,9 +49,17 @@ const USER_ID = "user-1";
 const navigateMock = mock((_to: string, _opts?: unknown) => {});
 const searchParams = new URLSearchParams();
 
-const startResearchMock = mock((_opts: unknown) => {});
-const hydrateResearchMock = mock((_results: unknown, _await?: unknown) => {});
 let researchStatus = "idle";
+// Mirrors the real runner, which flips to "running" synchronously inside
+// `start` — that is what keeps the mid-flow resume effect from firing a second
+// turn behind a form submit.
+const startResearchMock = mock((_opts: unknown) => {
+  researchStatus = "running";
+});
+const hydrateResearchMock = mock((_results: unknown, _await?: unknown) => {});
+const resetResearchMock = mock(() => {});
+const reinstallPluginsMock = mock((_names: string[], _await: unknown) => {});
+let installedPlugins: string[] = [];
 const researchRunner = {
   get status() {
     return researchStatus;
@@ -51,10 +67,14 @@ const researchRunner = {
   claims: [] as unknown[],
   droppedClaims: [] as string[],
   suggestions: [] as unknown[],
-  installedPlugins: [] as string[],
+  get installedPlugins() {
+    return installedPlugins;
+  },
   pluginCatalog: {} as Record<string, string>,
   start: startResearchMock,
   hydrate: hydrateResearchMock,
+  reset: resetResearchMock,
+  reinstallPlugins: reinstallPluginsMock,
   awaitPluginInstalls: async () => {},
 };
 
@@ -80,13 +100,26 @@ const checkEstablishedAssistantMock = mock(async (_id: string) => {
   return establishedResult;
 });
 
+// The hatch's readiness promise is swapped per test (a dead first attempt
+// rejects; the retry hands back a healthy one), and `onRetryHatch` is where a
+// test stages that recovery — it runs inside the overlay's click, exactly where
+// the real `retry()` would clear the hook's terminal state.
+let awaitHatchReady: () => Promise<string> = async () => "asst-1";
+let onRetryHatch: () => void = () => {};
+const retryHatchMock = mock(() => {
+  onRetryHatch();
+});
 const backgroundHatch = {
   start: () => {},
+  retry: retryHatchMock,
   ready: true,
   assistantId: "asst-1",
-  error: null as Error | null,
-  awaitReady: async () => "asst-1",
+  error: null as string | null,
+  awaitReady: () => awaitHatchReady(),
 };
+const useBackgroundHatchMock = mock(
+  (_options: { postCheckoutReturn?: boolean }) => backgroundHatch,
+);
 
 const noop = () => {};
 
@@ -110,10 +143,16 @@ mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => false,
 }));
 
+// The real module builds its destinations from `routes` at import time, and the
+// `@/utils/routes` stub below carries only the assistant path.
+mock.module("@/lib/navigation/navigation-resolver", () => ({
+  POST_CHECKOUT_HATCH_PARAM: "post_checkout",
+}));
+
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
     use: {
-      user: () => ({ id: USER_ID, firstName: "Ada", lastName: "Lovelace" }),
+      user: () => ({ id: USER_ID, firstName: "Alice", lastName: "Example" }),
     },
   },
 }));
@@ -144,7 +183,7 @@ mock.module("@/domains/onboarding/adopt-existing-assistant", () => ({
 }));
 
 mock.module("@/domains/onboarding/use-background-hatch", () => ({
-  useBackgroundHatch: () => backgroundHatch,
+  useBackgroundHatch: useBackgroundHatchMock,
 }));
 
 mock.module("@/domains/onboarding/research-runner", () => ({
@@ -155,8 +194,10 @@ mock.module("@/domains/onboarding/send-research-correction", () => ({
   sendResearchCorrection: async () => {},
 }));
 
+const applyPersonalityMock = mock(async (_options: unknown) => {});
+
 mock.module("@/domains/onboarding/apply-personality", () => ({
-  applyPersonality: async () => {},
+  applyPersonality: applyPersonalityMock,
 }));
 
 mock.module("@/domains/onboarding/lets-chat-kickoff", () => ({
@@ -213,8 +254,8 @@ mock.module("@/domains/onboarding/screens/research-onboarding-screen", () => ({
       data-testid="form-submit"
       onClick={() =>
         props.onSubmit({
-          firstName: "Ada",
-          lastName: "Lovelace",
+          firstName: "Alice",
+          lastName: "Example",
           role: "Engineer",
           hobbies: [],
         })
@@ -241,8 +282,30 @@ mock.module("@/domains/onboarding/screens/integration-step", () => ({
   IntegrationStep: () => <div data-testid="integration-step" />,
 }));
 
+// Renders the real step's contract: sliders that write back through
+// `onValueChange`, and a continue that fires the one-shot persona apply.
 mock.module("@/domains/onboarding/screens/create-personality-step", () => ({
-  CreatePersonalityStep: () => <div data-testid="personality-step" />,
+  CreatePersonalityStep: (props: {
+    onValueChange: (axisId: string, value: number) => void;
+    onContinue: () => void;
+  }) => (
+    <div data-testid="personality-step">
+      <button
+        type="button"
+        data-testid="personality-slide"
+        onClick={() => props.onValueChange("warmth", 80)}
+      >
+        slide
+      </button>
+      <button
+        type="button"
+        data-testid="personality-continue"
+        onClick={props.onContinue}
+      >
+        continue
+      </button>
+    </div>
+  ),
 }));
 
 mock.module("@/domains/onboarding/screens/lets-chat-tomorrow-step", () => ({
@@ -312,8 +375,8 @@ function postFormSnapshot(
   return {
     step: "looking",
     formValues: {
-      firstName: "Ada",
-      lastName: "Lovelace",
+      firstName: "Alice",
+      lastName: "Example",
       role: "Engineer",
       hobbies: ["chess"],
     },
@@ -328,13 +391,23 @@ function postFormSnapshot(
 beforeEach(() => {
   localStorage.clear();
   researchStatus = "idle";
+  installedPlugins = [];
   establishedResult = { established: false, assistantName: null };
   establishedCheckGate = null;
   releaseEstablishedCheck = () => {};
+  searchParams.delete("post_checkout");
+  backgroundHatch.error = null;
+  awaitHatchReady = async () => "asst-1";
+  onRetryHatch = () => {};
   navigateMock.mockClear();
   startResearchMock.mockClear();
   hydrateResearchMock.mockClear();
+  resetResearchMock.mockClear();
   checkEstablishedAssistantMock.mockClear();
+  useBackgroundHatchMock.mockClear();
+  retryHatchMock.mockClear();
+  reinstallPluginsMock.mockClear();
+  applyPersonalityMock.mockClear();
 });
 
 afterEach(() => {
@@ -518,5 +591,295 @@ describe("ResearchOnboardingRoute resume guard", () => {
       expect(screen.getByTestId("existing-step")).toBeTruthy(),
     );
     expect(startResearchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("ResearchOnboardingRoute paid return", () => {
+  function lastHatchOptions() {
+    const call = useBackgroundHatchMock.mock.calls.at(-1);
+    if (!call) {
+      throw new Error("expected useBackgroundHatch to have been called");
+    }
+    return call[0];
+  }
+
+  test("carries the paid marker into the background hatch", async () => {
+    searchParams.set("post_checkout", "1");
+
+    render(<ResearchOnboardingRoute />);
+    await screen.findByTestId("form-submit");
+
+    expect(lastHatchOptions().postCheckoutReturn).toBe(true);
+  });
+
+  test("a free onboarding leaves the purchased-provisioning wait off", async () => {
+    render(<ResearchOnboardingRoute />);
+    await screen.findByTestId("form-submit");
+
+    expect(lastHatchOptions().postCheckoutReturn).toBe(false);
+  });
+
+  test("a terminal hatch failure surfaces a retry over the funnel", async () => {
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+
+    render(<ResearchOnboardingRoute />);
+
+    const overlay = await screen.findByRole("alertdialog");
+    expect(overlay.textContent).toContain(
+      "Failed to start your assistant. Please try again.",
+    );
+    // Layered, not swapped in: the funnel keeps its state behind the overlay.
+    expect(screen.getByTestId("form-submit")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(retryHatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("an at-capacity failure offers the macOS download instead of a retry", async () => {
+    backgroundHatch.error = PLATFORM_HOSTED_DISABLED_MESSAGE;
+
+    render(<ResearchOnboardingRoute />);
+
+    const overlay = await screen.findByRole("alertdialog");
+    expect(overlay.textContent).toContain(
+      "Get started today with a local assistant",
+    );
+    expect(
+      screen.getByRole("link", { name: "Download the macOS app" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+
+  test("a healthy hatch renders no overlay", async () => {
+    render(<ResearchOnboardingRoute />);
+    await screen.findByTestId("form-submit");
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+});
+
+// Retrying the hatch must restart everything that already resolved against the
+// dead one: the established-assistant verdict (otherwise it stays fail-open
+// from the rejected `awaitReady`), a research turn that settled "error" while
+// holding its subject key (otherwise an identical resubmit dedupes to a no-op),
+// the persona apply that swallowed the same rejection behind locked sliders,
+// and the restored plugin installs that resolved having installed nothing. The
+// retried research turn also keeps the conversation the journey already minted,
+// so recovery never posts a second search alongside the first.
+describe("ResearchOnboardingRoute hatch retry", () => {
+  const HATCH_ERROR = "Failed to start your assistant. Please try again.";
+
+  function failFirstHatch() {
+    backgroundHatch.error = HATCH_ERROR;
+    awaitHatchReady = () => Promise.reject(new Error("hatch failed"));
+  }
+
+  function recoverOnRetry() {
+    onRetryHatch = () => {
+      backgroundHatch.error = null;
+      awaitHatchReady = async () => "asst-1";
+    };
+  }
+
+  test("re-runs the established-assistant check against the retried hatch", async () => {
+    failFirstHatch();
+    // The retry recovers an assistant that already has a life.
+    establishedResult = { established: true, assistantName: "Viper" };
+
+    render(<ResearchOnboardingRoute />);
+    await screen.findByRole("alertdialog");
+    // The dead hatch never got far enough to ask.
+    expect(checkEstablishedAssistantMock).not.toHaveBeenCalled();
+
+    recoverOnRetry();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    fireEvent.click(screen.getByTestId("form-submit"));
+
+    // The gate recomputed against the new attempt, so the submit lands on the
+    // keep/redo choice instead of running research + persona writes against an
+    // established assistant.
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-step").textContent).toBe("Viper"),
+    );
+    expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  test("re-fires a research turn that died with the hatch", async () => {
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("form-submit"));
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+
+    // The hatch dies after the submit: the runner's `awaitAssistantId` rejects
+    // and the turn settles "error", still holding the submitted subject key.
+    researchStatus = "error";
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    expect(resetResearchMock).toHaveBeenCalledTimes(1);
+    expect(startResearchMock).toHaveBeenCalledTimes(2);
+    // Ordering stays the runner's job: the re-fired turn awaits the retried
+    // hatch itself rather than the handler awaiting readiness first.
+    const refired = startResearchMock.mock.calls[1]?.[0] as {
+      awaitAssistantId: () => Promise<string>;
+    };
+    expect(refired.awaitAssistantId).toBe(backgroundHatch.awaitReady);
+  });
+
+  test("does not re-fire a research turn that never errored", async () => {
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("form-submit"));
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+
+    // Still running when the hatch failed — the turn is already parked on the
+    // runner's own `awaitAssistantId`, so a retry must not double-fire it.
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    expect(resetResearchMock).not.toHaveBeenCalled();
+    expect(startResearchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The runner only mints a conversation AFTER the hatch resolves, so a turn
+  // that died with the hatch never made one — the id it re-attaches to is the
+  // one a prior session persisted. Re-firing without it posts a second research
+  // conversation while the first is still there.
+  test("re-attaches the retried turn to the conversation the journey already minted", async () => {
+    writeResearchSnapshot(
+      USER_ID,
+      postFormSnapshot({ researchConversationId: "conv-1" }),
+    );
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+    const resumed = startResearchMock.mock.calls[0]?.[0] as {
+      resumeConversationId?: string;
+    };
+    expect(resumed.resumeConversationId).toBe("conv-1");
+
+    researchStatus = "error";
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    expect(startResearchMock).toHaveBeenCalledTimes(2);
+    const refired = startResearchMock.mock.calls[1]?.[0] as {
+      resumeConversationId?: string;
+    };
+    expect(refired.resumeConversationId).toBe("conv-1");
+    // A re-run owns its own installs — the restored-install path is not it.
+    expect(reinstallPluginsMock).not.toHaveBeenCalled();
+  });
+
+  test("a journey with no research conversation re-fires without one", async () => {
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("form-submit"));
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+
+    researchStatus = "error";
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    const refired = startResearchMock.mock.calls[1]?.[0] as {
+      resumeConversationId?: string;
+    };
+    expect(refired.resumeConversationId).toBeUndefined();
+  });
+
+  // A completed snapshot hydrates to "done" and re-enqueues its persisted
+  // installs against the hatch. Those catch a dead hatch and resolve having
+  // installed nothing while the runner stays "done" — so nothing re-runs them
+  // and the handoff promises capabilities that were never materialized.
+  test("re-enqueues restored plugin installs that settled against the dead hatch", async () => {
+    researchStatus = "done";
+    installedPlugins = ["admin-copilot"];
+    writeResearchSnapshot(
+      USER_ID,
+      postFormSnapshot({
+        step: "suggestions",
+        research: {
+          status: "done",
+          claims: [],
+          droppedClaims: [],
+          suggestions: [],
+          installedPlugins: ["admin-copilot"],
+          pluginCatalog: {},
+        },
+      }),
+    );
+    failFirstHatch();
+
+    render(<ResearchOnboardingRoute />);
+    await screen.findByRole("alertdialog");
+
+    recoverOnRetry();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(checkEstablishedAssistantMock).toHaveBeenCalled());
+    expect(reinstallPluginsMock).toHaveBeenCalledTimes(1);
+    const [names, awaitAssistantId] = reinstallPluginsMock.mock.calls[0] ?? [];
+    expect(names).toEqual(["admin-copilot"]);
+    // Ordering stays the runner's job: the installs await the retried hatch
+    // themselves rather than the handler awaiting readiness first.
+    expect(awaitAssistantId).toBe(backgroundHatch.awaitReady);
+    // The restored results stand — only the installs are redone.
+    expect(startResearchMock).not.toHaveBeenCalled();
+    expect(resetResearchMock).not.toHaveBeenCalled();
+  });
+
+  // `applyPersonality` awaits the hatch and swallows its rejection, so a hatch
+  // that dies while the user walks the later steps leaves the sliders locked as
+  // if the persona had been rewritten — it never was.
+  test("re-applies the personality that died with the hatch", async () => {
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "personality" }));
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("personality-slide"));
+    fireEvent.click(screen.getByTestId("personality-continue"));
+    await waitFor(() => expect(applyPersonalityMock).toHaveBeenCalledTimes(1));
+
+    backgroundHatch.error = HATCH_ERROR;
+    rerender(<ResearchOnboardingRoute />);
+
+    recoverOnRetry();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(applyPersonalityMock).toHaveBeenCalledTimes(2));
+    const reapplied = applyPersonalityMock.mock.calls[1]?.[0] as {
+      values: Record<string, number>;
+      awaitAssistantId: () => Promise<string>;
+    };
+    // The user's own choices, against the retried hatch.
+    expect(reapplied.values).toEqual({ warmth: 80 });
+    expect(reapplied.awaitAssistantId).toBe(backgroundHatch.awaitReady);
+  });
+
+  test("does not apply a personality the user never chose", async () => {
+    failFirstHatch();
+    writeResearchSnapshot(USER_ID, postFormSnapshot());
+
+    render(<ResearchOnboardingRoute />);
+    await screen.findByRole("alertdialog");
+
+    recoverOnRetry();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    // The retry did re-arm what the dead hatch poisoned…
+    await waitFor(() => expect(checkEstablishedAssistantMock).toHaveBeenCalled());
+    // …but the sliders were never locked in, so there is no persona write to
+    // redo — and an idle turn has no restored installs to re-enqueue either.
+    expect(applyPersonalityMock).not.toHaveBeenCalled();
+    expect(reinstallPluginsMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -19,9 +19,12 @@
  *
  * The paid-return block covers the `post_checkout=1` marker reaching the
  * background hatch and the failure overlay that surfaces a dead hatch on any
- * step, with the at-capacity download off-ramp in place of a retry. The retry
- * block covers what that overlay's "Try again" has to un-poison: route state
- * that resolved against the dead hatch and would otherwise survive the retry.
+ * step, with the at-capacity download off-ramp in place of a retry. That
+ * surface is a banner rather than a modal, so it also covers the funnel staying
+ * usable underneath and the auto-advancing loading step holding its own
+ * position while the hatch is dead. The retry block covers what the banner's
+ * "Try again" has to un-poison: route state that resolved against the dead
+ * hatch and would otherwise survive the retry.
  *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
@@ -113,7 +116,7 @@ const backgroundHatch = {
   start: () => {},
   retry: retryHatchMock,
   ready: true,
-  assistantId: "asst-1",
+  assistantId: "asst-1" as string | null,
   error: null as string | null,
   awaitReady: () => awaitHatchReady(),
 };
@@ -308,13 +311,40 @@ mock.module("@/domains/onboarding/screens/create-personality-step", () => ({
   ),
 }));
 
+// Renders the real step's contract: the connect action can't enable until the
+// hatch is ready, and "Skip for now" is revealed early on a failed hatch so the
+// user is never trapped behind a button that can never enable.
 mock.module("@/domains/onboarding/screens/lets-chat-tomorrow-step", () => ({
-  LetsChatTomorrowStep: () => <div data-testid="letschat-step" />,
+  LetsChatTomorrowStep: (props: {
+    assistantId: string | null;
+    assistantReady: boolean;
+    hatchError?: string | null;
+    onSkip: () => void;
+  }) => {
+    const waitingForAssistant = !props.assistantId || !props.assistantReady;
+    return (
+      <div data-testid="letschat-step">
+        {!waitingForAssistant || props.hatchError ? (
+          <button
+            type="button"
+            data-testid="letschat-skip"
+            onClick={props.onSkip}
+          >
+            Skip for now
+          </button>
+        ) : null}
+      </div>
+    );
+  },
 }));
 
 mock.module("@/domains/onboarding/screens/research-result-steps", () => ({
   MeetingCreatedStep: () => <div data-testid="meeting-step" />,
-  LookingYouUpStep: () => <div data-testid="looking-step" />,
+  // Surfaces the `ready` gate so a test can pin when the carousel is allowed to
+  // advance out of the loading state.
+  LookingYouUpStep: (props: { ready: boolean }) => (
+    <div data-testid="looking-step" data-ready={String(props.ready)} />
+  ),
   FinishingUpStep: () => <div data-testid="finishing-step" />,
   ResearchResultsStep: () => <div data-testid="results-step" />,
   SuggestionsStep: () => <div data-testid="suggestions-step" />,
@@ -397,6 +427,8 @@ beforeEach(() => {
   releaseEstablishedCheck = () => {};
   searchParams.delete("post_checkout");
   backgroundHatch.error = null;
+  backgroundHatch.ready = true;
+  backgroundHatch.assistantId = "asst-1";
   awaitHatchReady = async () => "asst-1";
   onRetryHatch = () => {};
   navigateMock.mockClear();
@@ -624,7 +656,7 @@ describe("ResearchOnboardingRoute paid return", () => {
 
     render(<ResearchOnboardingRoute />);
 
-    const overlay = await screen.findByRole("alertdialog");
+    const overlay = await screen.findByRole("alert");
     expect(overlay.textContent).toContain(
       "Failed to start your assistant. Please try again.",
     );
@@ -640,7 +672,7 @@ describe("ResearchOnboardingRoute paid return", () => {
 
     render(<ResearchOnboardingRoute />);
 
-    const overlay = await screen.findByRole("alertdialog");
+    const overlay = await screen.findByRole("alert");
     expect(overlay.textContent).toContain(
       "Get started today with a local assistant",
     );
@@ -654,7 +686,59 @@ describe("ResearchOnboardingRoute paid return", () => {
     render(<ResearchOnboardingRoute />);
     await screen.findByTestId("form-submit");
 
-    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // The failure surface is a banner, not a modal: it must not hide the funnel
+  // from assistive tech nor swallow the escapes the steps deliberately expose
+  // while the hatch is dead.
+  test("leaves the funnel's own escapes usable behind the failure banner", async () => {
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "letschat" }));
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+    backgroundHatch.ready = false;
+    backgroundHatch.assistantId = null;
+
+    const { container } = render(<ResearchOnboardingRoute />);
+    await screen.findByRole("alert");
+
+    // The funnel behind is still exposed, not inerted by a modal layer.
+    expect(container.getAttribute("aria-hidden")).toBeNull();
+
+    // The calendar step reveals "Skip for now" precisely because the hatch
+    // failed — and the banner leaves it clickable, so the skip lands.
+    fireEvent.click(await screen.findByTestId("letschat-skip"));
+    expect(screen.getByTestId("looking-step")).toBeTruthy();
+  });
+
+  // The banner blocks input, not the step machine — so the auto-advancing
+  // loading step has to hold on its own while the hatch is dead, or the user is
+  // walked past the result steps and a recovered turn has nowhere to show.
+  test("holds the looking carousel while the hatch is dead, and resumes after a retry", async () => {
+    researchStatus = "error";
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "looking" }));
+    backgroundHatch.error = "Failed to start your assistant. Please try again.";
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+
+    // The turn has settled, but a dead hatch means its emptiness isn't final.
+    const looking = await screen.findByTestId("looking-step");
+    expect(looking.dataset.ready).toBe("false");
+
+    onRetryHatch = () => {
+      backgroundHatch.error = null;
+    };
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    // The retry re-fires the turn, so the step is legitimately loading again.
+    rerender(<ResearchOnboardingRoute />);
+    expect(screen.getByTestId("looking-step").dataset.ready).toBe("false");
+
+    // Once the recovered turn settles, the held carousel resumes — the
+    // re-fetched results get their step instead of having been skipped past.
+    researchStatus = "done";
+    rerender(<ResearchOnboardingRoute />);
+    await waitFor(() =>
+      expect(screen.getByTestId("looking-step").dataset.ready).toBe("true"),
+    );
   });
 });
 
@@ -687,7 +771,7 @@ describe("ResearchOnboardingRoute hatch retry", () => {
     establishedResult = { established: true, assistantName: "Viper" };
 
     render(<ResearchOnboardingRoute />);
-    await screen.findByRole("alertdialog");
+    await screen.findByRole("alert");
     // The dead hatch never got far enough to ask.
     expect(checkEstablishedAssistantMock).not.toHaveBeenCalled();
 
@@ -821,7 +905,7 @@ describe("ResearchOnboardingRoute hatch retry", () => {
     failFirstHatch();
 
     render(<ResearchOnboardingRoute />);
-    await screen.findByRole("alertdialog");
+    await screen.findByRole("alert");
 
     recoverOnRetry();
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
@@ -870,7 +954,7 @@ describe("ResearchOnboardingRoute hatch retry", () => {
     writeResearchSnapshot(USER_ID, postFormSnapshot());
 
     render(<ResearchOnboardingRoute />);
-    await screen.findByRole("alertdialog");
+    await screen.findByRole("alert");
 
     recoverOnRetry();
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -488,9 +488,9 @@ describe("ResearchOnboardingRoute resume guard", () => {
     expect(startResearchMock).not.toHaveBeenCalled();
   });
 
-  // A completed snapshot is NOT idle, so the pre-fix resume effect returned
-  // early and never consulted the guard — the user could walk a done journey
-  // into the chat handoff against an established assistant.
+  // A completed snapshot is NOT idle, so the resume effect must still consult
+  // the established-assistant guard: otherwise a done journey walks straight
+  // into the chat handoff against an assistant that already has a life.
   test("a restored completed snapshot diverts to the decision screen when the assistant is established", async () => {
     establishedResult = { established: true, assistantName: "Viper" };
     researchStatus = "done";
@@ -715,12 +715,25 @@ describe("ResearchOnboardingRoute paid return", () => {
     expect(navigateMock).not.toHaveBeenCalled();
     expect(readResearchSnapshot(USER_ID)).not.toBeNull();
 
+    // "Try again" clears the terminal error synchronously, but the fresh
+    // attempt has to provision before it has an assistant.
     onRetryHatch = () => {
       backgroundHatch.error = null;
-      backgroundHatch.ready = true;
-      backgroundHatch.assistantId = "asst-1";
     };
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    rerender(<ResearchOnboardingRoute />);
+
+    // The retry window: no error left, still nothing to hand off to. Releasing
+    // the CTA here would enter a null assistant, exactly as the dead hatch did.
+    expect(
+      (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByTestId("letschat-start"));
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(readResearchSnapshot(USER_ID)).not.toBeNull();
+
+    backgroundHatch.ready = true;
+    backgroundHatch.assistantId = "asst-1";
     rerender(<ResearchOnboardingRoute />);
 
     // A recovered hatch has an assistant to hand off to again.

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -1101,10 +1101,17 @@ export function ResearchOnboardingRoute() {
             pluginCatalog={research.pluginCatalog}
             // Hold the handoff until a resumed done journey's guard settles, so
             // it can't fire against an established assistant before the verdict
-            // — and while the hatch is dead, since a resumed COMPLETED snapshot
-            // lands straight here (past the gated carousel) and the handoff
-            // would clear the snapshot and navigate to a null assistant.
-            disabled={resumeGuardPending || hatchError !== null}
+            // — and until the hatch has a live assistant to hand off to, since a
+            // resumed COMPLETED snapshot lands straight here (past the gated
+            // carousel) and the handoff would clear the snapshot and navigate to
+            // a null assistant. Readiness is its own condition: a retry clears
+            // the error while the fresh attempt is still provisioning.
+            disabled={
+              resumeGuardPending ||
+              hatchError !== null ||
+              !hatchReady ||
+              hatchedAssistantId === null
+            }
             onStart={async () => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the completion here (mirrors SuggestionsStep).
@@ -1133,8 +1140,6 @@ export function ResearchOnboardingRoute() {
             suggestions={research.suggestions}
             loading={researchLoading}
             installedPlugins={research.installedPlugins}
-            // Same terminal-handoff hold as LetsChatReadyStep above.
-            disabled={hatchError !== null}
             onSuggestionClick={async (suggestion) => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the suggestions completion here (mirrors the

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -901,11 +901,7 @@ export function ResearchOnboardingRoute() {
     }
   }
 
-  // A terminal hatch failure is layered over whichever step is on screen — the
-  // assistant is dead at all of them, so the failure shouldn't wait for the
-  // last step to be discovered. Layering (rather than replacing the step) keeps
-  // the funnel's collected state, so a successful retry resumes in place; the
-  // banner is non-modal, so each step's own escapes stay usable while it's up.
+  // Layered over whichever step is on screen (see HatchErrorOverlay).
   const withHatchError = (content: ReactNode) => (
     <>
       {content}
@@ -1104,8 +1100,11 @@ export function ResearchOnboardingRoute() {
             installedPlugins={research.installedPlugins}
             pluginCatalog={research.pluginCatalog}
             // Hold the handoff until a resumed done journey's guard settles, so
-            // it can't fire against an established assistant before the verdict.
-            disabled={resumeGuardPending}
+            // it can't fire against an established assistant before the verdict
+            // — and while the hatch is dead, since a resumed COMPLETED snapshot
+            // lands straight here (past the gated carousel) and the handoff
+            // would clear the snapshot and navigate to a null assistant.
+            disabled={resumeGuardPending || hatchError !== null}
             onStart={async () => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the completion here (mirrors SuggestionsStep).
@@ -1134,6 +1133,8 @@ export function ResearchOnboardingRoute() {
             suggestions={research.suggestions}
             loading={researchLoading}
             installedPlugins={research.installedPlugins}
+            // Same terminal-handoff hold as LetsChatReadyStep above.
+            disabled={hatchError !== null}
             onSuggestionClick={async (suggestion) => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the suggestions completion here (mirrors the

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -620,12 +620,15 @@ export function ResearchOnboardingRoute() {
 
   // If we're sitting on the results step when the research turn resolves empty
   // (it was still streaming when we arrived), skip ahead to the suggestions.
+  // A dead hatch settles the turn "error" with no claims, which is emptiness we
+  // may still recover from — hold here so a successful retry can refill this
+  // step instead of the user having been walked past it.
   useEffect(() => {
-    if (step === "results" && noClaims) {
+    if (step === "results" && noClaims && hatchError === null) {
       setForwardStack([]);
       setStep("suggestions");
     }
-  }, [step, noClaims]);
+  }, [step, noClaims, hatchError]);
 
   // Scrub the hidden aggregator-only drops from the assistant's memory when the
   // results step won't do it itself. The results step folds drops into its own
@@ -901,7 +904,8 @@ export function ResearchOnboardingRoute() {
   // A terminal hatch failure is layered over whichever step is on screen — the
   // assistant is dead at all of them, so the failure shouldn't wait for the
   // last step to be discovered. Layering (rather than replacing the step) keeps
-  // the funnel's collected state, so a successful retry resumes in place.
+  // the funnel's collected state, so a successful retry resumes in place; the
+  // banner is non-modal, so each step's own escapes stay usable while it's up.
   const withHatchError = (content: ReactNode) => (
     <>
       {content}
@@ -1030,7 +1034,11 @@ export function ResearchOnboardingRoute() {
             // decoupled in the background and is finished off in its own step
             // right before the chat handoff (see the "finishing" step), so this
             // quick loading state isn't held hostage to the persona turn.
-            ready={!researchLoading}
+            // A hatch failure holds the carousel too: the turn settles "error"
+            // the moment the hatch dies, and advancing would walk the user past
+            // the result steps into a handoff behind the failure banner, out
+            // from under its retry.
+            ready={!researchLoading && hatchError === null}
           />
         )}
         {step === "results" && (

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -23,12 +23,14 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalMode } from "@/lib/local-mode";
+import { POST_CHECKOUT_HATCH_PARAM } from "@/lib/navigation/navigation-resolver";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
@@ -86,6 +88,7 @@ import {
   LetsChatReadyStep,
 } from "@/domains/onboarding/screens/research-result-steps";
 import { OnboardingTonedBackdrop } from "@/domains/onboarding/components/onboarding-toned-backdrop";
+import { HatchErrorOverlay } from "@/domains/onboarding/components/hatch-error-overlay";
 import {
   OnboardingStageSizeProvider,
   useElementSize,
@@ -280,6 +283,10 @@ export function ResearchOnboardingRoute() {
   // param, pinning adoption to that exact one — a stale selection or leftover
   // lockfile entries from previous sessions can't answer for it.
   const adoptAssistantId = searchParams.get("assistant") ?? undefined;
+  // On the return leg of a completed checkout the hatch also waits out the
+  // purchased resize, so the paid user never starts on a baseline assistant.
+  const postCheckoutReturn =
+    searchParams.get(POST_CHECKOUT_HATCH_PARAM) === "1";
   // The day-2 check-in offer ("letschat" → "meeting") books through the
   // platform's managed Google Calendar OAuth. A local-hosting onboarding can
   // run with no platform session at all (the assistant itself is fully
@@ -289,6 +296,7 @@ export function ResearchOnboardingRoute() {
   const skipCheckinSteps = adoptExistingAssistant;
   const {
     start: startHatch,
+    retry: retryHatch,
     ready: hatchReady,
     assistantId: hatchedAssistantId,
     error: hatchError,
@@ -296,6 +304,7 @@ export function ResearchOnboardingRoute() {
   } = useBackgroundHatch({
     adoptExisting: adoptExistingAssistant,
     adoptAssistantId,
+    postCheckoutReturn,
   });
   const research = useResearchRunner();
   // Stable across renders (useCallback in the runner); safe as effect deps.
@@ -362,7 +371,12 @@ export function ResearchOnboardingRoute() {
   // personality step rewrites the persona, so an already-customized assistant
   // must never be run through them silently. The submit handler awaits this
   // verdict (briefly) and branches to the "existing" guard step.
-  useEffect(() => {
+  //
+  // The ref both memoizes the verdict and marks the CURRENT hatch attempt as
+  // covered, so a retry must clear it (see `handleHatchRetry`) — otherwise the
+  // fail-open verdict a dead hatch produced would outlive it and let a
+  // recovered, already-established assistant through the gate.
+  const armEstablishedCheck = useCallback(() => {
     if (establishedCheckRef.current) return;
     const check = awaitHatchReady()
       .then((id) => checkEstablishedAssistant(id))
@@ -371,6 +385,10 @@ export function ResearchOnboardingRoute() {
     establishedCheckRef.current = check;
     void check.then(setEstablishedCheck);
   }, [awaitHatchReady]);
+
+  useEffect(() => {
+    armEstablishedCheck();
+  }, [armEstablishedCheck]);
 
   // Resolve the established-assistant verdict for a gate decision: race the
   // in-flight check (kicked off at mount, above) against a short timeout so a
@@ -387,6 +405,37 @@ export function ResearchOnboardingRoute() {
         }),
       ]),
     [],
+  );
+
+  // Fire the research turn; the runner awaits hatch readiness internally, so it
+  // starts at the later of the caller's submit and the background hatch. Every
+  // start goes through here — a submit, a resume, a redo, or a restart after the
+  // hatch died — so a run always re-attaches to the conversation this journey
+  // already minted instead of posting a second search alongside the first.
+  const fireResearch = useCallback(
+    (values: ResearchOnboardingValues) => {
+      // A fresh run produces fresh drops — re-arm the one-shot scrub below.
+      syncDroppedClaimsScrubbed(false);
+      startResearch({
+        awaitAssistantId: awaitHatchReady,
+        subject: researchSubjectFrom(values),
+        conversationTitle: researchTitleFor(values),
+        ...(researchConversationId
+          ? { resumeConversationId: researchConversationId }
+          : {}),
+        onConversationCreated: setResearchConversationId,
+        // The "Let's chat" final step replaces suggestions when personality
+        // onboarding is on, so don't ask the model to generate any.
+        includeSuggestions: !personalityEnabled,
+      });
+    },
+    [
+      syncDroppedClaimsScrubbed,
+      startResearch,
+      awaitHatchReady,
+      researchConversationId,
+      personalityEnabled,
+    ],
   );
 
   // Resume a journey saved by a previous session (a page refresh). Runs once,
@@ -552,16 +601,7 @@ export function ResearchOnboardingRoute() {
       // search; a hydrated "done" journey keeps its restored results.
       setResumeGuardPending(false);
       if (wasIdle) {
-        startResearch({
-          awaitAssistantId: awaitHatchReady,
-          subject: researchSubjectFrom(values),
-          conversationTitle: researchTitleFor(values),
-          ...(researchConversationId
-            ? { resumeConversationId: researchConversationId }
-            : {}),
-          onConversationCreated: setResearchConversationId,
-          includeSuggestions: !personalityEnabled,
-        });
+        fireResearch(values);
       }
     })();
     return () => {
@@ -573,11 +613,8 @@ export function ResearchOnboardingRoute() {
   }, [
     restored,
     formValues,
-    researchConversationId,
     research.status,
-    startResearch,
-    awaitHatchReady,
-    personalityEnabled,
+    fireResearch,
     resolveEstablishedGate,
   ]);
 
@@ -602,7 +639,11 @@ export function ResearchOnboardingRoute() {
     if (droppedClaimsScrubbedRef.current) return;
     if (researchLoading) return;
     if (research.droppedClaims.length === 0) return;
-    if (!researchConversationId || !hatchedAssistantId) return;
+    // Only against a live hatch: the guard flips before the request, so a scrub
+    // posted at an unreachable assistant would be marked sent and never retried.
+    // A resumed journey hydrates results while the hatch is still coming up (or
+    // has died), so this waits — and re-fires once a retry lands.
+    if (!researchConversationId || !hatchedAssistantId || !hatchReady) return;
     // With card claims present the results step owns the scrub — unless we've
     // resumed straight onto the suggestions step, past that correction.
     if (research.claims.length > 0 && step !== "suggestions") return;
@@ -619,6 +660,7 @@ export function ResearchOnboardingRoute() {
     research.droppedClaims,
     researchConversationId,
     hatchedAssistantId,
+    hatchReady,
     step,
     syncDroppedClaimsScrubbed,
   ]);
@@ -742,20 +784,19 @@ export function ResearchOnboardingRoute() {
     );
   }
 
-  // Fire the research turn; the runner awaits hatch readiness internally, so
-  // it starts at the later of the caller's submit and the background hatch.
-  function fireResearch(values: ResearchOnboardingValues) {
-    // A fresh run produces fresh drops — re-arm the one-shot scrub above.
-    syncDroppedClaimsScrubbed(false);
-    research.start({
+  // Hand the collected sliders to the assistant's persona on a throwaway side
+  // thread (it awaits hatch readiness internally, then archives). The rewrite
+  // turn runs during the later steps; the promise (and pending flag) let the
+  // loading steps hold for it and the chat handoff await it, so the persona is
+  // reshaped before the first real chat. Best-effort; it never rejects.
+  function startPersonalityApply() {
+    setPersonalityPending(true);
+    personalityAppliedRef.current = applyPersonality({
       awaitAssistantId: awaitHatchReady,
-      subject: researchSubjectFrom(values),
-      conversationTitle: researchTitleFor(values),
-      onConversationCreated: setResearchConversationId,
-      // The "Let's chat" final step replaces suggestions when personality
-      // onboarding is on, so don't ask the model to generate any.
-      includeSuggestions: !personalityEnabled,
-    });
+      values: personalityValues,
+      userName: formValues?.firstName?.trim() || undefined,
+      assistantName: faceValues?.name?.trim() || undefined,
+    }).finally(() => setPersonalityPending(false));
   }
 
   async function handleFormSubmit(values: ResearchOnboardingValues) {
@@ -824,6 +865,52 @@ export function ResearchOnboardingRoute() {
     goForwardTo("meeting");
   }
 
+  // "Try again" restarts the hatch AND everything that resolved against the
+  // dead one. Reaching this handler proves no attempt has ever readied (the
+  // hatch settles once, and a ready one can't later error), so every
+  // hatch-dependent effect started so far was rejected — each is re-armed below,
+  // and none of them can be healthy work this would redo. Every restart runs
+  // after `retryHatch()` has cleared the terminal state, so its waiters park on
+  // the fresh attempt; each awaits readiness inside its own work rather than
+  // here, so nothing runs ahead of the new hatch.
+  function handleHatchRetry() {
+    // The verdict failed open on the rejected `awaitReady`; keeping it would let
+    // a recovered, already-established assistant through the gate.
+    establishedCheckRef.current = null;
+    retryHatch();
+    armEstablishedCheck();
+    if (research.status === "error" && formValues) {
+      // The turn settled "error" still holding its subject key, so an identical
+      // resubmit would dedupe to nothing — release it, then re-fire (onto the
+      // same research conversation when this journey already minted one).
+      research.reset();
+      fireResearch(formValues);
+    } else if (research.status === "done") {
+      // Results restored from a snapshot: the search doesn't re-run, but the
+      // installs re-enqueued alongside them caught the dead hatch and resolved
+      // having installed nothing, while the runner stayed `done`.
+      research.reinstallPlugins(research.installedPlugins, awaitHatchReady);
+    }
+    if (personalityLocked) {
+      // The apply swallowed the same rejection and left the sliders locked as if
+      // it had landed — re-apply the user's choices to the recovered assistant.
+      startPersonalityApply();
+    }
+  }
+
+  // A terminal hatch failure is layered over whichever step is on screen — the
+  // assistant is dead at all of them, so the failure shouldn't wait for the
+  // last step to be discovered. Layering (rather than replacing the step) keeps
+  // the funnel's collected state, so a successful retry resumes in place.
+  const withHatchError = (content: ReactNode) => (
+    <>
+      {content}
+      {hatchError !== null && (
+        <HatchErrorOverlay error={hatchError} onRetry={handleHatchRetry} />
+      )}
+    </>
+  );
+
   // The later steps share one persistent toned backdrop (assistant color +
   // eyes + tone characters) so the avatars stay put while the foreground
   // content swaps. Extra edge characters pop in per step to build excitement.
@@ -850,7 +937,7 @@ export function ResearchOnboardingRoute() {
     const peekLevel = ["looking", "results", "suggestions", "finishing"].includes(step)
       ? edgeAvatars
       : 0;
-    return (
+    return withHatchError(
       <div ref={tonedStageRef} data-theme="dark" className="relative h-full overflow-hidden">
         <OnboardingStageSizeProvider size={tonedStageSize}>
         <OnboardingTonedBackdrop
@@ -885,23 +972,11 @@ export function ResearchOnboardingRoute() {
             }
             locked={personalityLocked}
             onContinue={() => {
-              // First continue applies the sliders to the assistant's persona on
-              // a throwaway side thread (awaits hatch readiness internally, then
-              // archives) and locks them — the prompt has been sent, so a later
-              // step-back can't silently diverge. The rewrite turn runs during
-              // the later steps; we track its promise (and pending flag) so the
-              // looking-you-up loader holds until it settles and the chat handoff
-              // awaits it, guaranteeing the persona is reshaped before the first
-              // real chat. Best-effort; it never rejects. A continue while
-              // already locked just advances.
+              // First continue applies the sliders and locks them — the prompt
+              // has been sent, so a later step-back can't silently diverge. A
+              // continue while already locked just advances.
               if (!personalityLocked) {
-                setPersonalityPending(true);
-                personalityAppliedRef.current = applyPersonality({
-                  awaitAssistantId: awaitHatchReady,
-                  values: personalityValues,
-                  userName: formValues?.firstName?.trim() || undefined,
-                  assistantName: faceValues?.name?.trim() || undefined,
-                }).finally(() => setPersonalityPending(false));
+                startPersonalityApply();
                 setPersonalityLocked(true);
               }
               goForwardTo("integration");
@@ -1090,13 +1165,16 @@ export function ResearchOnboardingRoute() {
           <FinishingUpStep
             // Hold the carousel until the personality rewrite settles, then hand
             // off. `finishAndEnterChat` also awaits the (usually already-resolved)
-            // plugin installs + correction before dropping into chat.
-            ready={!personalityPending}
+            // plugin installs + correction before dropping into chat. A hatch
+            // failure holds it too: the rewrite settles the moment the hatch
+            // rejects, and handing off would clear the snapshot and navigate away
+            // behind the failure overlay, out from under its retry.
+            ready={!personalityPending && hatchError === null}
             onDone={() => void finishAndEnterChat()}
           />
         )}
         </OnboardingStageSizeProvider>
-      </div>
+      </div>,
     );
   }
 
@@ -1104,7 +1182,7 @@ export function ResearchOnboardingRoute() {
   // instead of advancing to "face" when the submitted-to assistant already has
   // a life (see handleFormSubmit); a genuinely new user never lands here.
   if (step === "existing") {
-    return (
+    return withHatchError(
       <ExistingAssistantStep
         assistantName={establishedCheck?.assistantName ?? null}
         onKeep={() => {
@@ -1144,24 +1222,24 @@ export function ResearchOnboardingRoute() {
           setGatedFormValues(null);
           goBackTo("form");
         }}
-      />
+      />,
     );
   }
 
   if (step === "intro" && formValues) {
-    return (
+    return withHatchError(
       <IntroductionScreen
         firstName={formValues.firstName}
         assistantName={faceValues?.name}
         onContinue={() => goForwardTo("different")}
         onBack={() => goBackTo("face")}
         onForward={onForward}
-      />
+      />,
     );
   }
 
   if (step === "face" && formValues) {
-    return (
+    return withHatchError(
       <GiveMeAFaceScreen
         onContinue={(face) => {
           setFaceValues(face);
@@ -1169,15 +1247,15 @@ export function ResearchOnboardingRoute() {
         }}
         onBack={() => goBackTo("form")}
         onForward={onForward}
-      />
+      />,
     );
   }
 
-  return (
+  return withHatchError(
     <ResearchOnboardingScreen
       initialFirstName={user?.firstName ?? ""}
       initialLastName={user?.lastName ?? ""}
       onSubmit={handleFormSubmit}
-    />
+    />,
   );
 }

--- a/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for `awaitPurchasedProvisioning` — the post-payment provisioning
+ * wait shared by the foreground hatching screen and the background hatch. The
+ * invariants under test: a confirmed non-Pro read only completes early on a
+ * NON-paid hatch, the reconcile nudge re-fires until it actually reconciles,
+ * every exit routes through the post-resize healthz probe, and a healthz that
+ * never recovers is a `health_timeout` failure rather than a completion.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GetAssistantResult, GetHealthzResult } from "@/assistant/api";
+
+let localMode = false;
+let getAssistantResult: GetAssistantResult = {
+  ok: true,
+  status: 200,
+  data: {
+    id: "ast-1",
+    machine_size: "medium",
+    provisioned_storage_gib: 50,
+  } as never,
+};
+let healthzResult: GetHealthzResult = { ok: true, status: 200, data: {} as never };
+let subscriptionReply: { data?: { plan_id?: string } } = {
+  data: { plan_id: "pro" },
+};
+let onboardingReply: {
+  data?: { max_machine_tier?: string; selected_storage_gib?: number };
+} = { data: { max_machine_tier: "medium", selected_storage_gib: 50 } };
+let opStatusReply: { data?: { state?: string } } = { data: { state: "running" } };
+let ensureProvisionedReply: { data?: { state?: string; reason?: string } } = {
+  data: { state: "queued" },
+};
+
+const getAssistantMock = mock(
+  async (_id?: string): Promise<GetAssistantResult> => getAssistantResult,
+);
+const getAssistantHealthzMock = mock(
+  async (_id: string): Promise<GetHealthzResult> => healthzResult,
+);
+mock.module("@/assistant/api", () => ({
+  getAssistant: getAssistantMock,
+  getAssistantHealthz: getAssistantHealthzMock,
+}));
+
+const subscriptionRetrieveMock = mock(async () => subscriptionReply);
+const onboardingRetrieveMock = mock(async () => onboardingReply);
+const ensureProvisionedMock = mock(async () => ensureProvisionedReply);
+const opStatusMock = mock(async () => opStatusReply);
+mock.module("@/generated/api/sdk.gen", () => ({
+  organizationsBillingSubscriptionRetrieve: subscriptionRetrieveMock,
+  organizationsBillingSubscriptionOnboardingRetrieve: onboardingRetrieveMock,
+  organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate:
+    ensureProvisionedMock,
+  assistantsOperationalStatusDetailRead: opStatusMock,
+}));
+
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => localMode,
+}));
+
+const { awaitPurchasedProvisioning } = await import("./purchased-provisioning");
+
+const MAX_HATCH_WAIT_MS = 300_000;
+
+/** Poll a predicate without depending on the wait's own 3s poll interval. */
+async function until(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("condition never became true");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function baseOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    assistantId: "ast-1",
+    postCheckoutReturn: false,
+    managedHatch: true,
+    hatchStartMs: Date.now(),
+    isCancelled: () => false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localMode = false;
+  getAssistantResult = {
+    ok: true,
+    status: 200,
+    data: {
+      id: "ast-1",
+      machine_size: "medium",
+      provisioned_storage_gib: 50,
+    } as never,
+  };
+  healthzResult = { ok: true, status: 200, data: {} as never };
+  subscriptionReply = { data: { plan_id: "pro" } };
+  onboardingReply = { data: { max_machine_tier: "medium", selected_storage_gib: 50 } };
+  opStatusReply = { data: { state: "running" } };
+  ensureProvisionedReply = { data: { state: "queued" } };
+  getAssistantMock.mockClear();
+  getAssistantHealthzMock.mockClear();
+  subscriptionRetrieveMock.mockClear();
+  onboardingRetrieveMock.mockClear();
+  ensureProvisionedMock.mockClear();
+  opStatusMock.mockClear();
+});
+
+describe("awaitPurchasedProvisioning", () => {
+  test("a non-managed local hatch short-circuits with no network calls", async () => {
+    localMode = true;
+
+    const outcome = await awaitPurchasedProvisioning(
+      baseOptions({ managedHatch: false }),
+    );
+
+    expect(outcome).toBe("ready");
+    expect(ensureProvisionedMock).not.toHaveBeenCalled();
+    expect(subscriptionRetrieveMock).not.toHaveBeenCalled();
+    expect(getAssistantMock).not.toHaveBeenCalled();
+    expect(getAssistantHealthzMock).not.toHaveBeenCalled();
+  });
+
+  test("confirmed non-Pro on a non-paid hatch completes with no resize hold", async () => {
+    subscriptionReply = { data: { plan_id: "free" } };
+    const onResizeWait = mock(() => {});
+
+    const outcome = await awaitPurchasedProvisioning(
+      baseOptions({ onResizeWait }),
+    );
+
+    expect(outcome).toBe("ready");
+    expect(subscriptionRetrieveMock).toHaveBeenCalledTimes(1);
+    expect(onResizeWait).not.toHaveBeenCalled();
+    // No resize wait and no post-resize probe on a genuinely free hatch.
+    expect(getAssistantMock).not.toHaveBeenCalled();
+    expect(getAssistantHealthzMock).not.toHaveBeenCalled();
+  });
+
+  test("confirmed non-Pro on a post-checkout return keeps polling instead of completing", async () => {
+    // Stripe redirects before the subscribe webhook lands, so the still-base
+    // plan read is not an answer on a paid return.
+    subscriptionReply = { data: { plan_id: "free" } };
+    onboardingReply = {};
+    let armed: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
+
+    void awaitPurchasedProvisioning(
+      baseOptions({
+        postCheckoutReturn: true,
+        registerTimer: (timer: ReturnType<typeof setTimeout> | null) => {
+          if (timer) armed = timer;
+        },
+      }),
+    ).then(() => {
+      settled = true;
+    });
+
+    await until(() => armed !== null);
+    expect(settled).toBe(false);
+    // Abandon the pending poll rather than burning the real 3s interval.
+    clearTimeout(armed!);
+  });
+
+  test("Pro with targets holds for the resize, signals it once, then probes healthz", async () => {
+    const onResizeWait = mock(() => {});
+
+    const outcome = await awaitPurchasedProvisioning(
+      baseOptions({ onResizeWait }),
+    );
+
+    expect(outcome).toBe("ready");
+    expect(onResizeWait).toHaveBeenCalledTimes(1);
+    expect(getAssistantMock).toHaveBeenCalledWith("ast-1");
+    expect(opStatusMock).toHaveBeenCalledTimes(1);
+    expect(getAssistantHealthzMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unrecovered healthz after the resize is a health_timeout, not a completion", async () => {
+    healthzResult = { ok: false, status: 503, error: {} as never };
+
+    const outcome = await awaitPurchasedProvisioning(
+      baseOptions({ hatchStartMs: Date.now() - MAX_HATCH_WAIT_MS - 1 }),
+    );
+
+    expect(outcome).toBe("health_timeout");
+  });
+
+  test("an entitlement-race reconcile reply re-fires the nudge; a reconciled one does not", async () => {
+    ensureProvisionedReply = {
+      data: { state: "not_applicable", reason: "no_active_pro" },
+    };
+
+    await awaitPurchasedProvisioning(baseOptions());
+
+    // Entitlement loop + resize loop each nudge, because the race reply never
+    // consumed the guard.
+    expect(ensureProvisionedMock).toHaveBeenCalledTimes(2);
+
+    ensureProvisionedMock.mockClear();
+    ensureProvisionedReply = { data: { state: "queued" } };
+
+    await awaitPurchasedProvisioning(baseOptions());
+
+    expect(ensureProvisionedMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("cancellation mid-wait resolves without further network calls", async () => {
+    let cancelled = false;
+    subscriptionRetrieveMock.mockImplementationOnce(async () => {
+      cancelled = true;
+      return subscriptionReply;
+    });
+
+    const outcome = await awaitPurchasedProvisioning(
+      baseOptions({ isCancelled: () => cancelled }),
+    );
+
+    expect(outcome).toBe("ready");
+    expect(onboardingRetrieveMock).not.toHaveBeenCalled();
+    expect(getAssistantMock).not.toHaveBeenCalled();
+    expect(getAssistantHealthzMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
@@ -60,9 +60,8 @@ mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => localMode,
 }));
 
-const { awaitPurchasedProvisioning, MAX_HATCH_WAIT_MS } = await import(
-  "./purchased-provisioning"
-);
+const { awaitPurchasedProvisioning, MAX_HATCH_WAIT_MS, POLL_INTERVAL_MS } =
+  await import("./purchased-provisioning");
 
 /** Poll a predicate without depending on the wait's own 3s poll interval. */
 async function until(
@@ -227,5 +226,27 @@ describe("awaitPurchasedProvisioning", () => {
     expect(onboardingRetrieveMock).not.toHaveBeenCalled();
     expect(getAssistantMock).not.toHaveBeenCalled();
     expect(getAssistantHealthzMock).not.toHaveBeenCalled();
+  });
+
+  test("a cancelled wait never sleeps out another poll interval", async () => {
+    // Both reads reject, so the iteration reaches its sleep without passing a
+    // cancellation check — the one path that could park a timer on a caller
+    // that has already gone away.
+    let cancelled = false;
+    subscriptionRetrieveMock.mockImplementationOnce(async () => {
+      cancelled = true;
+      throw new Error("network");
+    });
+    onboardingRetrieveMock.mockImplementationOnce(async () => {
+      throw new Error("network");
+    });
+
+    const startedAt = Date.now();
+    const outcome = await awaitPurchasedProvisioning(
+      baseOptions({ isCancelled: () => cancelled }),
+    );
+
+    expect(outcome).toBe("ready");
+    expect(Date.now() - startedAt).toBeLessThan(POLL_INTERVAL_MS);
   });
 });

--- a/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
@@ -60,9 +60,9 @@ mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => localMode,
 }));
 
-const { awaitPurchasedProvisioning } = await import("./purchased-provisioning");
-
-const MAX_HATCH_WAIT_MS = 300_000;
+const { awaitPurchasedProvisioning, MAX_HATCH_WAIT_MS } = await import(
+  "./purchased-provisioning"
+);
 
 /** Poll a predicate without depending on the wait's own 3s poll interval. */
 async function until(

--- a/clients/web/src/domains/onboarding/purchased-provisioning.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.ts
@@ -1,0 +1,308 @@
+/**
+ * The post-payment provisioning wait, shared by every hatch entry point.
+ *
+ * Once a platform assistant is active and healthz-ready, hold until the
+ * server-side resize to the purchased machine and storage specs converges, then
+ * re-probe healthz (the resize restarts the pod). The reconcile is idempotent
+ * and fire-and-forget; a genuinely free org, and the `RESIZE_WAIT_MAX_MS` cap,
+ * fall through to completion at baseline, so a Pro hatch emerges at the right
+ * size without ever trapping the user. Every wait that entered the provisioning
+ * phase leaves through the healthz probe, and the caller must honour a
+ * `health_timeout` outcome.
+ *
+ * Deliberately free of React: callers inject cancellation, the resize-phase
+ * signal, and timer bookkeeping so the same wait runs behind a foreground
+ * screen or inside a headless background hatch.
+ */
+
+import { getAssistant, getAssistantHealthz } from "@/assistant/api";
+import {
+  assistantsOperationalStatusDetailRead,
+  organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate,
+  organizationsBillingSubscriptionOnboardingRetrieve,
+  organizationsBillingSubscriptionRetrieve,
+} from "@/generated/api/sdk.gen";
+import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
+import {
+  isEntitlementRaceVerdict,
+  isResizeOperationInFlight,
+  targetsMet,
+  type ProvisioningDimensions,
+} from "@/lib/billing/provisioning-targets";
+import { isLocalMode } from "@/lib/local-mode";
+
+const POLL_INTERVAL_MS = 3000;
+const MAX_HATCH_WAIT_MS = 300_000;
+// Hard cap on the post-payment resize wait, mirroring PROVISION_STALL_MS in the
+// pro-onboarding takeover. On expiry the assistant completes at baseline and the
+// server reconciles the purchased specs later — the user is never trapped.
+export const RESIZE_WAIT_MAX_MS = 90_000;
+
+// How the purchased-provisioning wait ended. `health_timeout` means the
+// assistant never answered healthz within MAX_HATCH_WAIT_MS after the resize,
+// so the hatch must be failed rather than completed onto an unreachable pod.
+export type PurchasedProvisioningOutcome = "ready" | "health_timeout";
+
+export interface AwaitPurchasedProvisioningOptions {
+  assistantId: string;
+  /** This hatch is the return leg of a completed checkout (`post_checkout=1`). */
+  postCheckoutReturn: boolean;
+  /** `hosting=vellum-cloud` — a managed hatch even in a local-mode build. */
+  managedHatch: boolean;
+  /** Epoch ms the overall hatch poll started; bounds the post-resize health wait. */
+  hatchStartMs: number;
+  /** Cooperative cancellation — checked before every await resumes. */
+  isCancelled: () => boolean;
+  /** Fired once when the wait enters the resize-hold (the screen shows "resizing"). */
+  onResizeWait?: () => void;
+  /** Receives each pending poll timer (and null when it fires) so callers can clear it on unmount. */
+  registerTimer?: (timer: ReturnType<typeof setTimeout> | null) => void;
+}
+
+export async function awaitPurchasedProvisioning(
+  options: AwaitPurchasedProvisioningOptions,
+): Promise<PurchasedProvisioningOutcome> {
+  const {
+    assistantId,
+    postCheckoutReturn,
+    managedHatch,
+    hatchStartMs,
+    isCancelled,
+    onResizeWait,
+    registerTimer,
+  } = options;
+
+  const sleep = (ms: number): Promise<void> =>
+    new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        registerTimer?.(null);
+        resolve();
+      }, ms);
+      registerTimer?.(timer);
+    });
+
+  // Purchased specs live on the platform, so only a managed hatch reads them. A
+  // local-mode run without the managed marker can reach here off a preflight
+  // that resolved the lockfile assistant, which has no billing surface —
+  // short-circuit there.
+  if (isLocalMode() && !managedHatch) {
+    return "ready";
+  }
+
+  // Per-invocation guard: a retry re-nudges the idempotent reconcile once more,
+  // which is harmless and self-limiting under the caps below.
+  let reconcileFired = false;
+
+  // Fire the idempotent grow-only reconcile — the same resize the subscribe
+  // webhook triggers — covering a webhook that never fired or whose resize was
+  // lost. It is marked done only when it RECONCILES: a 503 ("nothing queued"), a
+  // network error, a pre-org-hydration mount, or a race reply leaves the guard
+  // unset so a later poll iteration re-fires the nudge. It never blocks
+  // completion (which keys off targets + op-status); the re-fires stay bounded
+  // by the RESIZE_WAIT_MAX_MS cap below.
+  const fireProvisioningReconcile = (): void => {
+    if (reconcileFired) {
+      return;
+    }
+    void organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate({
+      throwOnError: false,
+    })
+      .then((result) => {
+        // Success carries a body; a 503/5xx resolves with no data under
+        // throwOnError:false. A race body — the entitlement not yet visible, or
+        // no settled assistant to provision, which is the common case this early
+        // in a hatch — is not an answer: nothing was queued, so it must not
+        // consume the guard or the nudge is lost for the whole hatch.
+        if (result.data != null && !isEntitlementRaceVerdict(result.data)) {
+          reconcileFired = true;
+        }
+      })
+      .catch(() => {
+        // Network/thrown error: leave the guard unset to re-fire on a later poll.
+      });
+  };
+
+  // A reconciled resize restarts the pod, so every exit from the waits below
+  // ends here before the hatch completes — otherwise the caller completes onto a
+  // mid-restart daemon. Bounded by MAX_HATCH_WAIT_MS measured from the hatch
+  // start, past which the assistant is not coming back and the hatch is a
+  // failure.
+  const waitForPostResizeHealth =
+    async (): Promise<PurchasedProvisioningOutcome> => {
+      while (!isCancelled()) {
+        try {
+          const health = await getAssistantHealthz(assistantId);
+          if (health.ok) {
+            return "ready";
+          }
+        } catch {
+          // Daemon not reachable yet during the post-resize restart.
+        }
+        if (Date.now() - hatchStartMs >= MAX_HATCH_WAIT_MS) {
+          return "health_timeout";
+        }
+        await sleep(POLL_INTERVAL_MS);
+      }
+      return "ready";
+    };
+
+  // The cap covers both waits below — the entitlement/targets confirmation and
+  // the resize itself — so a lagging subscription can never hold the user past
+  // RESIZE_WAIT_MAX_MS.
+  const resizeDeadline = Date.now() + RESIZE_WAIT_MAX_MS;
+
+  // Confirm the entitlement before concluding "free". A paid checkout can return
+  // before the onboarding targets are visible, so gate the no-wait completion on
+  // the actual subscription plan rather than on the first null targets. While the
+  // plan reads Pro but the targets aren't provisioned yet (the entitlement race),
+  // keep polling the subscription and targets within the cap instead of
+  // completing at baseline.
+  let targets: ProvisioningDimensions | null = null;
+  while (!isCancelled()) {
+    // Re-fire the reconcile until it succeeds (or the cap): a failed first
+    // attempt must not permanently consume the guard.
+    fireProvisioningReconcile();
+    // Tri-state entitlement read. Only a CONFIRMED non-Pro plan — a successful
+    // response whose plan_id is definitively not "pro" — completes early. An
+    // unknown result (a thrown error, or a 5xx that resolves with no data under
+    // throwOnError:false) must not be mistaken for "free"; it behaves like "Pro
+    // but targets not yet provisioned" and keeps polling within the cap so a
+    // purchased resize is never skipped.
+    let subscriptionState: "pro" | "non_pro" | "unknown" = "unknown";
+    try {
+      const subscription = await organizationsBillingSubscriptionRetrieve({
+        throwOnError: false,
+      });
+      if (isCancelled()) {
+        return "ready";
+      }
+      if (subscription.data) {
+        subscriptionState =
+          subscription.data.plan_id === "pro" ? "pro" : "non_pro";
+      }
+    } catch {
+      // Subscription endpoint blip: stay "unknown" and keep polling to the cap.
+    }
+
+    try {
+      const onboarding =
+        await organizationsBillingSubscriptionOnboardingRetrieve({
+          throwOnError: false,
+        });
+      if (isCancelled()) {
+        return "ready";
+      }
+      const data = onboarding.data;
+      if (data) {
+        targets = {
+          machineSize:
+            allowedMachineSizesForTier(data.max_machine_tier).at(-1) ?? null,
+          storageGib: data.selected_storage_gib ?? null,
+        };
+      }
+    } catch {
+      // Targets fetch blip; keep polling to the cap.
+    }
+
+    const hasTargets =
+      targets != null &&
+      (targets.machineSize != null || targets.storageGib != null);
+
+    // Confirmed non-Pro on an ordinary hatch — genuinely free. Complete exactly
+    // as a non-provisioned hatch does today, with no added poll. On a
+    // post-checkout return the same read is not an answer: Stripe redirects
+    // before the subscribe webhook updates the org, so the plan still reads at
+    // its pre-checkout base. That case falls through to the capped wait below.
+    if (subscriptionState === "non_pro" && !postCheckoutReturn) {
+      return "ready";
+    }
+    // Confirmed Pro with a purchased ceiling to wait on: hold for the resize
+    // below.
+    if (subscriptionState === "pro" && hasTargets) {
+      break;
+    }
+    // Pro with targets not yet visible, a still-base read on a paid return, or
+    // an unknown/errored subscription read: keep polling within the cap rather
+    // than completing at baseline onto an unprovisioned assistant. The cap is
+    // the ultimate escape, so a subscription that never flips — a
+    // persistently-erroring endpoint, a lost webhook — still completes.
+    if (Date.now() >= resizeDeadline) {
+      // Nothing was confirmed, but the reconcile has been nudged on every
+      // iteration, so a resize may already have restarted the pod. Health check
+      // before completing rather than returning straight to the caller.
+      return waitForPostResizeHealth();
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  if (isCancelled()) {
+    return "ready";
+  }
+
+  // Hold in an in-progress phase while the resize lands.
+  onResizeWait?.();
+
+  while (!isCancelled()) {
+    // Keep nudging the resize in case the reconcile hasn't landed yet; the guard
+    // stops the re-fire once it succeeds.
+    fireProvisioningReconcile();
+    let actuals: ProvisioningDimensions | null = null;
+    try {
+      const actualsResult = await getAssistant(assistantId);
+      if (isCancelled()) {
+        return "ready";
+      }
+      if (actualsResult.ok) {
+        actuals = {
+          machineSize: actualsResult.data.machine_size ?? null,
+          storageGib: actualsResult.data.provisioned_storage_gib ?? null,
+        };
+      }
+    } catch {
+      // Assistant endpoint unreachable mid-resize; keep polling to the cap.
+    }
+
+    // Default to in-flight so an uncertain status read withholds completion.
+    // Under throwOnError:false a 5xx resolves with no data rather than throwing,
+    // and isResizeOperationInFlight(undefined) is false — so only a successful
+    // read (data present) may downgrade to "not in flight". Otherwise the caller
+    // could complete onto a pod that is still restarting.
+    let operationInFlight = true;
+    try {
+      const opStatus = await assistantsOperationalStatusDetailRead({
+        path: { id: assistantId },
+        throwOnError: false,
+      });
+      if (isCancelled()) {
+        return "ready";
+      }
+      if (opStatus.data) {
+        operationInFlight = isResizeOperationInFlight(opStatus.data);
+      }
+    } catch {
+      // Operational-status endpoint unreachable mid-resize: retain the
+      // conservative in-flight value and keep polling to the cap.
+      operationInFlight = true;
+    }
+
+    // The platform persists the effective sizes before the pod finishes
+    // restarting, so completion requires the resize operation to have cleared —
+    // not just targets-met — to avoid landing on a soon-dead pod.
+    if (targetsMet(targets, actuals) && !operationInFlight) {
+      break;
+    }
+    if (Date.now() >= resizeDeadline) {
+      // Cap reached: stop waiting for the resize but still fall through to the
+      // healthz probe below, so completion never routes onto a pod mid-restart.
+      // The server reconciles the remaining resize later.
+      break;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  if (isCancelled()) {
+    return "ready";
+  }
+
+  // Both the converged and the cap-expiry exit above land on a pod the resize
+  // may still be restarting.
+  return waitForPostResizeHealth();
+}

--- a/clients/web/src/domains/onboarding/purchased-provisioning.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.ts
@@ -31,10 +31,7 @@ import {
 } from "@/lib/billing/provisioning-targets";
 import { isLocalMode } from "@/lib/local-mode";
 
-// The single source for the hatch poll cadence and the overall wait ceiling,
-// shared by every hatch entry point. `MAX_HATCH_WAIT_MS` decides the
-// `health_timeout` outcome below, so a caller reporting its own copy in
-// telemetry would be reporting a number that didn't make the decision.
+// Owned here: `MAX_HATCH_WAIT_MS` decides the `health_timeout` outcome below.
 export const POLL_INTERVAL_MS = 3000;
 export const MAX_HATCH_WAIT_MS = 300_000;
 // Hard cap on the post-payment resize wait, mirroring PROVISION_STALL_MS in the
@@ -76,8 +73,14 @@ export async function awaitPurchasedProvisioning(
     registerTimer,
   } = options;
 
+  // A cancelled wait resolves without scheduling anything, so the loop reaches
+  // its next check with no timer left behind.
   const sleep = (ms: number): Promise<void> =>
     new Promise<void>((resolve) => {
+      if (isCancelled()) {
+        resolve();
+        return;
+      }
       const timer = setTimeout(() => {
         registerTimer?.(null);
         resolve();

--- a/clients/web/src/domains/onboarding/purchased-provisioning.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.ts
@@ -31,8 +31,12 @@ import {
 } from "@/lib/billing/provisioning-targets";
 import { isLocalMode } from "@/lib/local-mode";
 
-const POLL_INTERVAL_MS = 3000;
-const MAX_HATCH_WAIT_MS = 300_000;
+// The single source for the hatch poll cadence and the overall wait ceiling,
+// shared by every hatch entry point. `MAX_HATCH_WAIT_MS` decides the
+// `health_timeout` outcome below, so a caller reporting its own copy in
+// telemetry would be reporting a number that didn't make the decision.
+export const POLL_INTERVAL_MS = 3000;
+export const MAX_HATCH_WAIT_MS = 300_000;
 // Hard cap on the post-payment resize wait, mirroring PROVISION_STALL_MS in the
 // pro-onboarding takeover. On expiry the assistant completes at baseline and the
 // server reconciles the purchased specs later — the user is never trapped.

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -1,19 +1,26 @@
 /**
- * Tests for the catalog filter that decides which plugins onboarding surfaces.
+ * Tests for the catalog filter that decides which plugins onboarding surfaces,
+ * plus the runner's subject-key dedupe and the `reset` that releases it.
  *
  * The hard rule: only Vellum-hosted (first-party, reviewed) plugins are ever
  * offered or installed during onboarding — never third-party/external
  * marketplace repos — minus a couple of Vellum-owned infra/meta plugins.
  */
 
+import { createElement, type ReactNode } from "react";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, test } from "bun:test";
 
+import type { ResearchSubject } from "@/domains/onboarding/research-prompt";
 import {
   resolveResearchCompletionStatus,
   resolveOnboardingPluginInstalls,
   selectRecommendableCapabilities,
   shouldArchiveCompletedResearchConversation,
   shouldSettleResearchPoll,
+  useResearchRunner,
 } from "@/domains/onboarding/research-runner";
 
 type Match = Parameters<typeof selectRecommendableCapabilities>[0][number];
@@ -145,6 +152,152 @@ describe("resolveResearchCompletionStatus", () => {
     expect(
       resolveResearchCompletionStatus({ sawCompletePayload: false }),
     ).toBe("error");
+  });
+});
+
+describe("useResearchRunner reset", () => {
+  const subject: ResearchSubject = {
+    firstName: "Alice",
+    lastName: "Example",
+    occupation: "Engineer",
+    hobbies: [],
+    timezone: "UTC",
+  };
+
+  function renderRunner() {
+    const queryClient = new QueryClient();
+    return renderHook(() => useResearchRunner(), {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+  }
+
+  // Park every run on its hatch await so the turn never reaches the network.
+  function pendingHatch() {
+    let calls = 0;
+    return {
+      awaitAssistantId: () => {
+        calls += 1;
+        return new Promise<string>(() => {});
+      },
+      get calls() {
+        return calls;
+      },
+    };
+  }
+
+  test("dedupes an identical subject until reset releases the key", () => {
+    const hatch = pendingHatch();
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({ awaitAssistantId: hatch.awaitAssistantId, subject });
+    });
+    expect(result.current.status).toBe("running");
+    expect(hatch.calls).toBe(1);
+
+    // The dedupe that makes an unchanged resubmit a no-op.
+    act(() => {
+      result.current.start({ awaitAssistantId: hatch.awaitAssistantId, subject });
+    });
+    expect(hatch.calls).toBe(1);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe("idle");
+
+    // Same subject, but the run it belonged to is gone — so it fires again.
+    act(() => {
+      result.current.start({ awaitAssistantId: hatch.awaitAssistantId, subject });
+    });
+    expect(hatch.calls).toBe(2);
+    expect(result.current.status).toBe("running");
+  });
+
+  test("reset leaves the plugin-install gate resolved", async () => {
+    const hatch = pendingHatch();
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({ awaitAssistantId: hatch.awaitAssistantId, subject });
+    });
+    act(() => {
+      result.current.reset();
+    });
+
+    // The abandoned run's click gate would otherwise never resolve.
+    await result.current.awaitPluginInstalls();
+  });
+});
+
+describe("useResearchRunner reinstallPlugins", () => {
+  const restored = {
+    status: "done" as const,
+    claims: [],
+    droppedClaims: [],
+    suggestions: [],
+    installedPlugins: ["admin-copilot"],
+    pluginCatalog: {},
+  };
+
+  function renderRunner() {
+    const queryClient = new QueryClient();
+    return renderHook(() => useResearchRunner(), {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+  }
+
+  /** Did the install gate settle, or is it still holding the handoff? */
+  async function raceInstallGate(gate: Promise<void>): Promise<string> {
+    return Promise.race([
+      gate.then(() => "settled"),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("holding"), 20);
+      }),
+    ]);
+  }
+
+  test("re-arms installs that resolved against a dead hatch", async () => {
+    const { result } = renderRunner();
+
+    // A resume enqueues the restored installs; the hatch they await then dies,
+    // so each swallows the rejection and the gate lets the handoff through with
+    // nothing installed.
+    act(() => {
+      result.current.hydrate(restored, () =>
+        Promise.reject(new Error("hatch failed")),
+      );
+    });
+    expect(await raceInstallGate(result.current.awaitPluginInstalls())).toBe(
+      "settled",
+    );
+
+    // Re-enqueued against the retried hatch, the gate holds again — the handoff
+    // waits for the capabilities to genuinely land this time.
+    act(() => {
+      result.current.reinstallPlugins(
+        restored.installedPlugins,
+        () => new Promise<string>(() => {}),
+      );
+    });
+    expect(await raceInstallGate(result.current.awaitPluginInstalls())).toBe(
+      "holding",
+    );
+  });
+
+  test("tracks nothing when the run installed nothing", async () => {
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.reinstallPlugins([], () => new Promise<string>(() => {}));
+    });
+
+    // No installs to redo — the click gate must not start blocking.
+    expect(await raceInstallGate(result.current.awaitPluginInstalls())).toBe(
+      "settled",
+    );
   });
 });
 

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -326,6 +326,17 @@ export interface ResearchRunnerState {
   pluginCatalog: Record<string, string>;
 }
 
+function emptyResearchState(status: ResearchStatus): ResearchRunnerState {
+  return {
+    status,
+    claims: [],
+    droppedClaims: [],
+    suggestions: [],
+    installedPlugins: [],
+    pluginCatalog: {},
+  };
+}
+
 export interface StartResearchOptions {
   /** Resolves with the hatched assistant id once it's healthy. */
   awaitAssistantId: () => Promise<string>;
@@ -388,6 +399,26 @@ export interface UseResearchRunner extends ResearchRunnerState {
     results: ResearchRunnerState,
     awaitAssistantId?: () => Promise<string>,
   ) => void;
+  /**
+   * Re-enqueue installs for `names` against a fresh assistant promise, replacing
+   * whatever the run is tracking. For a settled run whose installs raced a hatch
+   * that then died: each one swallowed the rejection and resolved without
+   * installing anything while the run stayed `done`, so `awaitPluginInstalls`
+   * lets the handoff through on capabilities that aren't there. Idempotent and
+   * best-effort, like every other install path.
+   */
+  reinstallPlugins: (
+    names: string[],
+    awaitAssistantId: () => Promise<string>,
+  ) => void;
+  /**
+   * Drop the run's subject key and results so a following `start` with the SAME
+   * subject re-fires instead of deduping to a no-op. For restarting a turn that
+   * died with the dependency it was waiting on — a failed hatch rejects
+   * `awaitAssistantId` and settles the run "error" while it keeps holding the
+   * key — not for ordinary resubmits, which the key is there to collapse.
+   */
+  reset: () => void;
 }
 
 const sleep = (ms: number): Promise<void> =>
@@ -411,14 +442,9 @@ export function resolveOnboardingPluginInstalls({
 }
 
 export function useResearchRunner(): UseResearchRunner {
-  const [state, setState] = useState<ResearchRunnerState>({
-    status: "idle",
-    claims: [],
-    droppedClaims: [],
-    suggestions: [],
-    installedPlugins: [],
-    pluginCatalog: {},
-  });
+  const [state, setState] = useState<ResearchRunnerState>(() =>
+    emptyResearchState("idle"),
+  );
   // Monotonic run id: every fresh run claims the next id; in-flight loops bail
   // the moment a newer run supersedes them. Paired with the last subject key so
   // an identical resubmit is a no-op but an edited one restarts.
@@ -437,6 +463,30 @@ export function useResearchRunner(): UseResearchRunner {
   // aren't frozen until the whole reply settles.
   const pluginsReadyRef = useRef<Promise<void>>(Promise.resolve());
   const queryClient = useQueryClient();
+
+  // Track an install per name against a hatch promise, replacing the map. Used
+  // by both the resume hydrate and a post-retry re-enqueue, so the click gate
+  // always awaits installs bound to the CURRENT hatch attempt.
+  const enqueuePluginInstalls = useCallback(
+    (names: string[], awaitAssistantId: () => Promise<string>) => {
+      const installs = installPromisesRef.current;
+      installs.clear();
+      for (const name of names) {
+        installs.set(
+          name,
+          (async () => {
+            try {
+              const assistantId = await awaitAssistantId();
+              await installCapabilityBestEffort(assistantId, name);
+            } catch {
+              // Hatch never readied / install failed — don't block the click.
+            }
+          })(),
+        );
+      }
+    },
+    [],
+  );
 
   const start = useCallback(
     ({
@@ -461,14 +511,7 @@ export function useResearchRunner(): UseResearchRunner {
         resolvePluginsReady = res;
       });
       installPromisesRef.current.clear();
-      setState({
-        status: "running",
-        claims: [],
-        droppedClaims: [],
-        suggestions: [],
-        installedPlugins: [],
-        pluginCatalog: {},
-      });
+      setState(emptyResearchState("running"));
 
       void (async () => {
         let resolvedAssistantId: string | undefined;
@@ -784,6 +827,18 @@ export function useResearchRunner(): UseResearchRunner {
     [queryClient],
   );
 
+  const reset = useCallback(() => {
+    // Supersede any in-flight loop, release the subject key so an identical
+    // resubmit is treated as a genuinely fresh run, and re-arm an already-
+    // resolved click gate so `awaitPluginInstalls` can't hang on a run that no
+    // longer exists.
+    runIdRef.current += 1;
+    subjectKeyRef.current = null;
+    installPromisesRef.current.clear();
+    pluginsReadyRef.current = Promise.resolve();
+    setState(emptyResearchState("idle"));
+  }, []);
+
   const awaitPluginInstalls = useCallback(async (): Promise<void> => {
     // Wait only for the plugin decision to be final (so a click that beats the
     // parse doesn't await an empty map), then for those installs — never for the
@@ -808,25 +863,18 @@ export function useResearchRunner(): UseResearchRunner {
       // suggestion click awaits real promises rather than an empty map. Idempotent
       // and best-effort: a failed hatch / install never blocks the click.
       if (awaitAssistantId && results.installedPlugins.length > 0) {
-        const installs = installPromisesRef.current;
-        installs.clear();
-        for (const name of results.installedPlugins) {
-          installs.set(
-            name,
-            (async () => {
-              try {
-                const assistantId = await awaitAssistantId();
-                await installCapabilityBestEffort(assistantId, name);
-              } catch {
-                // Hatch never readied / install failed — don't block the click.
-              }
-            })(),
-          );
-        }
+        enqueuePluginInstalls(results.installedPlugins, awaitAssistantId);
       }
     },
-    [],
+    [enqueuePluginInstalls],
   );
 
-  return { ...state, start, awaitPluginInstalls, hydrate };
+  return {
+    ...state,
+    start,
+    awaitPluginInstalls,
+    hydrate,
+    reinstallPlugins: enqueuePluginInstalls,
+    reset,
+  };
 }

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -705,7 +705,6 @@ export function SuggestionsStep({
   onSkip,
   onBack,
   onForward,
-  disabled = false,
 }: {
   /** Parsed research suggestions (streams in; may be empty while running). */
   suggestions: ResearchSuggestion[];
@@ -724,11 +723,6 @@ export function SuggestionsStep({
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
-  /**
-   * Externally hold both terminal handoffs (e.g. a dead background hatch, which
-   * has no assistant to hand off to). Back-navigation stays interactive.
-   */
-  disabled?: boolean;
 }) {
   // Constant dark surface for the UI; the avatar tone is only for the pills.
   const tone = DARK_TONE;
@@ -827,8 +821,7 @@ export function SuggestionsStep({
               <button
                 type="button"
                 onClick={onSkip}
-                disabled={disabled}
-                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60"
+                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80"
                 style={{ color: tone.fg }}
               >
                 Skip to Chat
@@ -845,13 +838,12 @@ export function SuggestionsStep({
               key={`${i}-${s.suggestion}`}
               type="button"
               onClick={() => onSuggestionClick(s)}
-              disabled={disabled}
               initial={reduce ? false : { opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={
                 reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
               }
-              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 enabled:hover:scale-[1.01] enabled:active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
+              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
               style={{
                 backgroundColor: tone.isLight
                   ? "rgba(0,0,0,0.06)"

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -705,6 +705,7 @@ export function SuggestionsStep({
   onSkip,
   onBack,
   onForward,
+  disabled = false,
 }: {
   /** Parsed research suggestions (streams in; may be empty while running). */
   suggestions: ResearchSuggestion[];
@@ -723,6 +724,11 @@ export function SuggestionsStep({
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
+  /**
+   * Externally hold both terminal handoffs (e.g. a dead background hatch, which
+   * has no assistant to hand off to). Back-navigation stays interactive.
+   */
+  disabled?: boolean;
 }) {
   // Constant dark surface for the UI; the avatar tone is only for the pills.
   const tone = DARK_TONE;
@@ -821,7 +827,8 @@ export function SuggestionsStep({
               <button
                 type="button"
                 onClick={onSkip}
-                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80"
+                disabled={disabled}
+                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60"
                 style={{ color: tone.fg }}
               >
                 Skip to Chat
@@ -838,12 +845,13 @@ export function SuggestionsStep({
               key={`${i}-${s.suggestion}`}
               type="button"
               onClick={() => onSuggestionClick(s)}
+              disabled={disabled}
               initial={reduce ? false : { opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={
                 reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
               }
-              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
+              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 enabled:hover:scale-[1.01] enabled:active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
               style={{
                 backgroundColor: tone.isLight
                   ? "rgba(0,0,0,0.06)"
@@ -924,9 +932,10 @@ export function LetsChatReadyStep({
   /** Redo into this step — only set when the user has stepped back. */
   onForward?: () => void;
   /**
-   * Externally hold the "Let's chat" CTA (e.g. a resumed completed journey
-   * still waiting on the established-assistant guard). Disables the button and
-   * no-ops the handoff until cleared, so the CTA can't fire before the verdict.
+   * Externally hold the "Let's chat" CTA (a resumed completed journey still
+   * waiting on the established-assistant guard, or a dead hatch with no
+   * assistant to hand off to). Disables the button and no-ops the handoff until
+   * cleared. Back-navigation stays interactive.
    */
   disabled?: boolean;
 }) {

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -55,9 +55,22 @@ let lockfileEntries: Record<string, { assistantId: string }> = {};
 const getLockfileAssistantMock = mock(
   (id: string): { assistantId: string } | undefined => lockfileEntries[id],
 );
+// The desktop (Electron) build reports local mode even for a managed hatch.
+let localMode = false;
+const saveLockfileAssistantMock = mock(async (_entry: unknown): Promise<void> =>
+  undefined,
+);
 mock.module("@/lib/local-mode", () => ({
   probeLocalGatewayReady: probeLocalGatewayReadyMock,
   getLockfileAssistant: getLockfileAssistantMock,
+  isLocalMode: () => localMode,
+  getPlatformRuntimeUrl: () => "https://runtime.example",
+  saveLockfileAssistant: saveLockfileAssistantMock,
+}));
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({ currentOrganizationId: "org-1" }),
+  },
 }));
 mock.module("@/utils/api-errors", () => ({
   extractErrorMessage: (e: unknown, _r: unknown, fallback?: string) =>
@@ -89,8 +102,12 @@ const awaitPurchasedProvisioningMock = mock(
     return provisioningOutcome;
   },
 );
+// The hook reads the poll cadence and the wait ceiling from this module too
+// (single-sourced); a short interval keeps the poll-loop tests fast.
 mock.module("@/domains/onboarding/purchased-provisioning", () => ({
   awaitPurchasedProvisioning: awaitPurchasedProvisioningMock,
+  POLL_INTERVAL_MS: 10,
+  MAX_HATCH_WAIT_MS: 300_000,
 }));
 
 const seedHatchAvatarMock = mock(
@@ -116,12 +133,19 @@ beforeEach(() => {
   getAssistantResult = {
     ok: true,
     status: 200,
-    data: { id: "ast-research", status: "active", is_local: false } as never,
+    data: {
+      id: "ast-research",
+      name: "Research",
+      status: "active",
+      is_local: false,
+    } as never,
   };
   healthzResult = { ok: true, status: 200, data: {} as never };
   lockfileEntries = {};
+  localMode = false;
   provisioningOutcome = "ready";
   provisioningGate = null;
+  saveLockfileAssistantMock.mockClear();
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
   getAssistantHealthzMock.mockClear();
@@ -420,5 +444,117 @@ describe("useBackgroundHatch", () => {
     await waitFor(() => expect(existing.result.current.ready).toBe(true));
     // A returning user may have a real avatar; only a fresh hatch is seeded.
     expect(seedHatchAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("unmounting stops the assistant poll loop", async () => {
+    getAssistantResult = {
+      ok: true,
+      status: 200,
+      data: {
+        id: "ast-research",
+        status: "initializing",
+        is_local: false,
+      } as never,
+    };
+
+    const { result, unmount } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() =>
+      expect(getAssistantMock.mock.calls.length).toBeGreaterThanOrEqual(2),
+    );
+    unmount();
+    const callsAtUnmount = getAssistantMock.mock.calls.length;
+
+    // Leaving the funnel mid-hatch must not keep polling from a dead
+    // component: many poll intervals elapse here with no further calls.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(getAssistantMock.mock.calls.length).toBeLessThanOrEqual(
+      callsAtUnmount + 1,
+    );
+  });
+
+  test("unmounting cancels the purchased-provisioning wait without settling", async () => {
+    const release = holdProvisioning();
+
+    const { result, unmount } = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    let resolved: string | undefined;
+    act(() => {
+      void result.current.awaitReady().then((id) => {
+        resolved = id;
+      });
+      result.current.start();
+    });
+
+    await waitFor(() =>
+      expect(awaitPurchasedProvisioningMock).toHaveBeenCalledTimes(1),
+    );
+    const options = awaitPurchasedProvisioningMock.mock.calls[0][0] as {
+      isCancelled: () => boolean;
+      registerTimer?: (timer: ReturnType<typeof setTimeout> | null) => void;
+    };
+    expect(options.isCancelled()).toBe(false);
+    // The wait's own poll timer has to be clearable from the caller.
+    expect(typeof options.registerTimer).toBe("function");
+
+    unmount();
+    expect(options.isCancelled()).toBe(true);
+
+    // A cancelled wait still resolves "ready"; the hatch must not complete on
+    // it once the component is gone.
+    release();
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(resolved).toBeUndefined();
+  });
+
+  test("a managed hatch in local mode records the assistant in the lockfile", async () => {
+    // The desktop build's assistant list and switcher are lockfile-driven, so
+    // a headless managed hatch has to register there like the foreground one.
+    localMode = true;
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(saveLockfileAssistantMock).toHaveBeenCalledTimes(1);
+    expect(saveLockfileAssistantMock.mock.calls[0][0]).toMatchObject({
+      assistantId: "ast-research",
+      name: "Research",
+      cloud: "vellum",
+      runtimeUrl: "https://runtime.example",
+      organizationId: "org-1",
+    });
+
+    // Adopting a foreground-hatched assistant is the hatching screen's own
+    // write; the background hatch must not duplicate it.
+    saveLockfileAssistantMock.mockClear();
+    const adopt = renderHook(() => useBackgroundHatch({ adoptExisting: true }));
+
+    act(() => {
+      adopt.result.current.start();
+    });
+
+    await waitFor(() => expect(adopt.result.current.ready).toBe(true));
+    expect(saveLockfileAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a non-local build writes no lockfile entry", async () => {
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(saveLockfileAssistantMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -64,8 +64,8 @@ mock.module("@/lib/local-mode", () => ({
   probeLocalGatewayReady: probeLocalGatewayReadyMock,
   getLockfileAssistant: getLockfileAssistantMock,
   isLocalMode: () => localMode,
-  // Stands in for the real helper (whose payload `local-mode.test.ts` pins) so
-  // the lockfile entry the hatch writes stays visible to the assertions below.
+  // Surfaces the written entry to the assertions below; payload pinned by
+  // `local-mode.test.ts`.
   saveManagedLockfileAssistant: async (
     assistantId: string,
     name: string | undefined,
@@ -476,6 +476,9 @@ describe("useBackgroundHatch", () => {
   });
 
   test("unmounting stops the assistant poll loop", async () => {
+    // Local mode so the discovery branch would write the lockfile — which sets
+    // the ACTIVE assistant, and is not covered by `settleReady`'s own guard.
+    localMode = true;
     getAssistantResult = {
       ok: true,
       status: 200,
@@ -495,15 +498,43 @@ describe("useBackgroundHatch", () => {
     await waitFor(() =>
       expect(getAssistantMock.mock.calls.length).toBeGreaterThanOrEqual(2),
     );
+
+    // Hold one poll open across the unmount, then answer it `active` — the
+    // response a departed hatch would otherwise claim the assistant on.
+    let releasePoll!: () => void;
+    let pollStarted = false;
+    const heldPoll = new Promise<void>((resolve) => {
+      releasePoll = resolve;
+    });
+    getAssistantMock.mockImplementationOnce(async () => {
+      pollStarted = true;
+      await heldPoll;
+      return {
+        ok: true,
+        status: 200,
+        data: {
+          id: "ast-research",
+          name: "Research",
+          status: "active",
+          is_local: false,
+        } as never,
+      };
+    });
+    await until(() => pollStarted);
+
     unmount();
     const callsAtUnmount = getAssistantMock.mock.calls.length;
+    await act(async () => {
+      releasePoll();
+    });
 
     // Leaving the funnel mid-hatch must not keep polling from a dead
-    // component: the in-flight request may land, but nothing follows it —
-    // the aborted sleep schedules no timer to poll from.
+    // component — the aborted sleep schedules no timer to poll from — and the
+    // late answer must not switch the user's active assistant.
     await expect(
-      until(() => getAssistantMock.mock.calls.length > callsAtUnmount + 1),
+      until(() => getAssistantMock.mock.calls.length > callsAtUnmount),
     ).rejects.toThrow();
+    expect(saveLockfileAssistantMock).not.toHaveBeenCalled();
   });
 
   test("unmounting during the initial hatch never settles", async () => {

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -102,9 +102,7 @@ mock.module("@/lib/local-mode", () => ({
   },
 }));
 mock.module("@/stores/organization-store", () => ({
-  useOrganizationStore: {
-    getState: () => ({ currentOrganizationId: "org-1" }),
-  },
+  getActiveOrganizationIdForRequests: () => "org-1",
 }));
 mock.module("@/utils/api-errors", () => ({
   extractErrorMessage: (e: unknown, _r: unknown, fallback?: string) =>

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -13,6 +13,7 @@ import type {
   GetHealthzResult,
   HatchResult,
 } from "@/assistant/api";
+import type { PurchasedProvisioningOutcome } from "@/domains/onboarding/purchased-provisioning";
 
 let hatchResult: HatchResult = {
   ok: true,
@@ -66,8 +67,49 @@ mock.module("@/utils/api-errors", () => ({
       ? (e as { detail: string }).detail
       : (fallback ?? "error"),
 }));
+mock.module("@sentry/react", () => ({
+  captureMessage: () => {},
+}));
+
+// The paid stage only: the free path must never reach this module at all.
+let provisioningOutcome: PurchasedProvisioningOutcome = "ready";
+// Optional gate holding the provisioning wait open, so a test can assert
+// `ready` stays false for as long as the resize hasn't converged.
+let provisioningGate: Promise<void> | null = null;
+const holdProvisioning = (): (() => void) => {
+  let release!: () => void;
+  provisioningGate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return release;
+};
+const awaitPurchasedProvisioningMock = mock(
+  async (_options: unknown): Promise<PurchasedProvisioningOutcome> => {
+    if (provisioningGate) await provisioningGate;
+    return provisioningOutcome;
+  },
+);
+mock.module("@/domains/onboarding/purchased-provisioning", () => ({
+  awaitPurchasedProvisioning: awaitPurchasedProvisioningMock,
+}));
+
+const seedHatchAvatarMock = mock(
+  async (_id: string, _traits: unknown, _queryClient: unknown): Promise<void> =>
+    undefined,
+);
+mock.module("@/assistant/seed-hatch-avatar", () => ({
+  seedHatchAvatar: seedHatchAvatarMock,
+}));
+
+const stableQueryClient = {};
+mock.module("@tanstack/react-query", () => ({
+  useQueryClient: () => stableQueryClient,
+}));
 
 const { useBackgroundHatch } = await import("./use-background-hatch");
+
+const TIMEOUT_MESSAGE =
+  "Your assistant is taking longer than expected. Please try again.";
 
 beforeEach(() => {
   hatchResult = { ok: true, status: 201, data: { id: "ast-research" } as never };
@@ -78,11 +120,15 @@ beforeEach(() => {
   };
   healthzResult = { ok: true, status: 200, data: {} as never };
   lockfileEntries = {};
+  provisioningOutcome = "ready";
+  provisioningGate = null;
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
   getAssistantHealthzMock.mockClear();
   probeLocalGatewayReadyMock.mockClear();
   getLockfileAssistantMock.mockClear();
+  awaitPurchasedProvisioningMock.mockClear();
+  seedHatchAvatarMock.mockClear();
 });
 
 describe("useBackgroundHatch", () => {
@@ -226,5 +272,153 @@ describe("useBackgroundHatch", () => {
     await waitFor(() => expect(result.current.ready).toBe(true));
     // Vellum-Cloud / managed path still provisions via hatchAssistant.
     expect(hatchAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("post-checkout return withholds ready until the provisioning wait resolves", async () => {
+    const release = holdProvisioning();
+
+    const { result } = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    let resolved: string | undefined;
+    act(() => {
+      void result.current.awaitReady().then((id) => {
+        resolved = id;
+      });
+      result.current.start();
+    });
+
+    await waitFor(() =>
+      expect(awaitPurchasedProvisioningMock).toHaveBeenCalledTimes(1),
+    );
+    // The wait runs AFTER healthz passes, and holds `ready` while pending.
+    expect(getAssistantHealthzMock).toHaveBeenCalledTimes(1);
+    expect(awaitPurchasedProvisioningMock.mock.calls[0][0]).toMatchObject({
+      assistantId: "ast-research",
+      postCheckoutReturn: true,
+      managedHatch: true,
+    });
+    expect(result.current.ready).toBe(false);
+    expect(resolved).toBeUndefined();
+
+    await act(async () => {
+      release();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    await waitFor(() => expect(resolved).toBe("ast-research"));
+  });
+
+  test("a health_timeout from the provisioning wait fails the hatch", async () => {
+    provisioningOutcome = "health_timeout";
+
+    const { result } = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    let rejection: Error | undefined;
+    act(() => {
+      void result.current.awaitReady().catch((err: Error) => {
+        rejection = err;
+      });
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(TIMEOUT_MESSAGE));
+    // A resize the assistant never came back from is a failure, never a
+    // completion onto an unreachable pod.
+    expect(result.current.ready).toBe(false);
+    await waitFor(() => expect(rejection?.message).toBe(TIMEOUT_MESSAGE));
+  });
+
+  test("the free path never runs the purchased-provisioning wait", async () => {
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    // No subscription polling and no avatar seed without the paid marker.
+    expect(awaitPurchasedProvisioningMock).not.toHaveBeenCalled();
+    expect(seedHatchAvatarMock).not.toHaveBeenCalled();
+  });
+
+  test("retry() re-runs the hatch after a terminal failure", async () => {
+    hatchResult = {
+      ok: false,
+      status: 400,
+      error: { detail: "Bad hatch request" },
+    };
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe("Bad hatch request"));
+
+    hatchResult = {
+      ok: true,
+      status: 201,
+      data: { id: "ast-research" } as never,
+    };
+
+    let resolved: string | undefined;
+    act(() => {
+      result.current.retry();
+      // Waiters from the failed attempt were already rejected, so callers
+      // re-await after retrying.
+      void result.current.awaitReady().then((id) => {
+        resolved = id;
+      });
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(result.current.assistantId).toBe("ast-research");
+    expect(hatchAssistantMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(resolved).toBe("ast-research"));
+
+    // The restarted hatch is ref-guarded again.
+    act(() => {
+      result.current.start();
+    });
+    expect(hatchAssistantMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a 201 paid hatch seeds the avatar; an existing (200) one does not", async () => {
+    const fresh = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    act(() => {
+      fresh.result.current.start();
+    });
+
+    await waitFor(() => expect(fresh.result.current.ready).toBe(true));
+    expect(seedHatchAvatarMock).toHaveBeenCalledTimes(1);
+    expect(seedHatchAvatarMock.mock.calls[0][0]).toBe("ast-research");
+
+    seedHatchAvatarMock.mockClear();
+    hatchResult = {
+      ok: true,
+      status: 200,
+      data: { id: "ast-research" } as never,
+    };
+
+    const existing = renderHook(() =>
+      useBackgroundHatch({ postCheckoutReturn: true }),
+    );
+
+    act(() => {
+      existing.result.current.start();
+    });
+
+    await waitFor(() => expect(existing.result.current.ready).toBe(true));
+    // A returning user may have a real avatar; only a fresh hatch is seeded.
+    expect(seedHatchAvatarMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -64,8 +64,22 @@ mock.module("@/lib/local-mode", () => ({
   probeLocalGatewayReady: probeLocalGatewayReadyMock,
   getLockfileAssistant: getLockfileAssistantMock,
   isLocalMode: () => localMode,
-  getPlatformRuntimeUrl: () => "https://runtime.example",
-  saveLockfileAssistant: saveLockfileAssistantMock,
+  // Stands in for the real helper (whose payload `local-mode.test.ts` pins) so
+  // the lockfile entry the hatch writes stays visible to the assertions below.
+  saveManagedLockfileAssistant: async (
+    assistantId: string,
+    name: string | undefined,
+    organizationId: string | undefined,
+  ): Promise<void> => {
+    await saveLockfileAssistantMock({
+      assistantId,
+      name,
+      cloud: "vellum",
+      runtimeUrl: "https://runtime.example",
+      hatchedAt: new Date().toISOString(),
+      organizationId,
+    });
+  },
 }));
 mock.module("@/stores/organization-store", () => ({
   useOrganizationStore: {
@@ -127,6 +141,21 @@ const { useBackgroundHatch } = await import("./use-background-hatch");
 
 const TIMEOUT_MESSAGE =
   "Your assistant is taking longer than expected. Please try again.";
+
+/**
+ * Poll a predicate without depending on the hook's own poll cadence, rejecting
+ * if it never holds. An absence is asserted with `.rejects`, so a slow machine
+ * only lengthens the wait instead of changing the verdict.
+ */
+async function until(predicate: () => boolean, timeoutMs = 300): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("condition never became true");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
 
 beforeEach(() => {
   hatchResult = { ok: true, status: 201, data: { id: "ast-research" } as never };
@@ -470,11 +499,56 @@ describe("useBackgroundHatch", () => {
     const callsAtUnmount = getAssistantMock.mock.calls.length;
 
     // Leaving the funnel mid-hatch must not keep polling from a dead
-    // component: many poll intervals elapse here with no further calls.
-    await new Promise((resolve) => setTimeout(resolve, 80));
-    expect(getAssistantMock.mock.calls.length).toBeLessThanOrEqual(
-      callsAtUnmount + 1,
-    );
+    // component: the in-flight request may land, but nothing follows it —
+    // the aborted sleep schedules no timer to poll from.
+    await expect(
+      until(() => getAssistantMock.mock.calls.length > callsAtUnmount + 1),
+    ).rejects.toThrow();
+  });
+
+  test("unmounting during the initial hatch never settles", async () => {
+    // A terminal failure is the sharpest case: it settles straight from the
+    // hatch response, without a poll-loop check in between.
+    hatchResult = {
+      ok: false,
+      status: 400,
+      error: { detail: "Bad hatch request" },
+    };
+    let releaseHatch!: () => void;
+    hatchAssistantMock.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseHatch = resolve;
+      });
+      return hatchResult;
+    });
+
+    const { result, unmount } = renderHook(() => useBackgroundHatch());
+
+    let resolved: string | undefined;
+    let rejection: Error | undefined;
+    act(() => {
+      void result.current.awaitReady().then(
+        (id) => {
+          resolved = id;
+        },
+        (err: Error) => {
+          rejection = err;
+        },
+      );
+      result.current.start();
+    });
+
+    await waitFor(() => expect(hatchAssistantMock).toHaveBeenCalledTimes(1));
+    unmount();
+
+    // The hatch response lands after the component is gone, so it settles
+    // nothing — the waiters of a hook nobody is watching stay pending.
+    await act(async () => {
+      releaseHatch();
+    });
+    await expect(
+      until(() => resolved != null || rejection != null),
+    ).rejects.toThrow();
   });
 
   test("unmounting cancels the purchased-provisioning wait without settling", async () => {
@@ -508,8 +582,9 @@ describe("useBackgroundHatch", () => {
 
     // A cancelled wait still resolves "ready"; the hatch must not complete on
     // it once the component is gone.
-    release();
-    await new Promise((resolve) => setTimeout(resolve, 40));
+    await act(async () => {
+      release();
+    });
     expect(resolved).toBeUndefined();
   });
 

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -14,6 +14,7 @@ import type {
   HatchResult,
 } from "@/assistant/api";
 import type { PurchasedProvisioningOutcome } from "@/domains/onboarding/purchased-provisioning";
+import type { OrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 
 let hatchResult: HatchResult = {
   ok: true,
@@ -101,8 +102,22 @@ mock.module("@/lib/local-mode", () => ({
     });
   },
 }));
+const fetchOrganizationsMock = mock(async (): Promise<void> => undefined);
 mock.module("@/stores/organization-store", () => ({
   getActiveOrganizationIdForRequests: () => "org-1",
+  useOrganizationStore: {
+    getState: () => ({ fetchOrganizations: fetchOrganizationsMock }),
+  },
+}));
+// Whether the `Vellum-Organization-Id` source can answer yet. The managed hatch
+// holds its platform sequence on this; a warm store (the default) is ready on
+// the first synchronous check and adds no delay.
+let orgReadiness: OrgHeaderReadiness = "ready";
+mock.module("@/hooks/use-is-org-ready", () => ({
+  getOrgHeaderReadiness: () => orgReadiness,
+  // Short ceiling so the never-settles case doesn't hold the suite open, while
+  // still leaving room for a few of the hook's 100ms poll ticks.
+  ORG_HEADER_SETTLE_TIMEOUT_MS: 500,
 }));
 mock.module("@/utils/api-errors", () => ({
   extractErrorMessage: (e: unknown, _r: unknown, fallback?: string) =>
@@ -159,6 +174,8 @@ const { useBackgroundHatch } = await import("./use-background-hatch");
 
 const TIMEOUT_MESSAGE =
   "Your assistant is taking longer than expected. Please try again.";
+const ORG_HEADER_MESSAGE =
+  "We couldn't confirm your organization. Please try again.";
 
 /**
  * Poll a predicate without depending on the hook's own poll cadence, rejecting
@@ -192,6 +209,8 @@ beforeEach(() => {
   localMode = false;
   provisioningOutcome = "ready";
   provisioningGate = null;
+  orgReadiness = "ready";
+  fetchOrganizationsMock.mockClear();
   saveLockfileAssistantMock.mockClear();
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
@@ -770,5 +789,143 @@ describe("useBackgroundHatch", () => {
     await waitFor(() => expect(result.current.ready).toBe(true));
     expect(clearsAtHatch).toEqual({ gateway: 2, selfHosted: 2 });
     expect(setSelfHostedConnectionMock.mock.calls).toEqual([[null], [null]]);
+  });
+
+  // -- org header readiness -------------------------------------------------
+  //
+  // Every platform call here is scoped by `Vellum-Organization-Id`, sourced
+  // from a store that hydrates after auth. A checkout deep link can relaunch
+  // the app straight into this hook before that lands, so the managed sequence
+  // holds until the header source can answer.
+
+  test("a warm org store costs the managed hatch no delay", async () => {
+    // Microtasks only — no timer elapses — so a POST here proves the wait
+    // short-circuits on its first synchronous check.
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    expect(hatchAssistantMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.ready).toBe(true));
+  });
+
+  test("the managed hatch holds its POST until the org header resolves", async () => {
+    orgReadiness = "resolving";
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    // Nothing may address the platform while the header source is unresolved.
+    // Sampled well inside the wait's ceiling, so the absence is the hold rather
+    // than a hatch that already gave up.
+    await expect(
+      until(() => hatchAssistantMock.mock.calls.length > 0, 60),
+    ).rejects.toThrow();
+    expect(result.current.error).toBeNull();
+
+    orgReadiness = "ready";
+
+    await waitFor(() => expect(hatchAssistantMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+  });
+
+  test("an org header that never settles fails the hatch, retryably", async () => {
+    orgReadiness = "resolving";
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    let rejection: Error | undefined;
+    act(() => {
+      void result.current.awaitReady().catch((err: Error) => {
+        rejection = err;
+      });
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(ORG_HEADER_MESSAGE));
+    // A header-less hatch would be rejected by the platform, so none is sent.
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+    expect(result.current.ready).toBe(false);
+    await waitFor(() => expect(rejection?.message).toBe(ORG_HEADER_MESSAGE));
+
+    // The banner's retry re-runs the wait, which passes once hydration lands.
+    orgReadiness = "ready";
+    act(() => {
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(hatchAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("concluded org resolution is re-run once before the hatch fails", async () => {
+    orgReadiness = "unavailable";
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(ORG_HEADER_MESSAGE));
+    // Resolution that already ended without an id is never arriving on its own,
+    // so the wait kicks it once — and stops rather than waiting forever.
+    expect(fetchOrganizationsMock).toHaveBeenCalledTimes(1);
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("unmounting during the org wait settles nothing", async () => {
+    orgReadiness = "resolving";
+
+    const { result, unmount } = renderHook(() => useBackgroundHatch());
+
+    let resolved: string | undefined;
+    let rejection: Error | undefined;
+    act(() => {
+      void result.current.awaitReady().then(
+        (id) => {
+          resolved = id;
+        },
+        (err: Error) => {
+          rejection = err;
+        },
+      );
+      result.current.start();
+    });
+
+    unmount();
+    orgReadiness = "ready";
+
+    // The aborted sleep schedules no timer, so the wait never reaches the
+    // header it was holding for, and the departed hatch neither POSTs nor
+    // settles its waiters.
+    await expect(
+      until(() => resolved != null || rejection != null),
+    ).rejects.toThrow();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("the adopt path skips the org wait", async () => {
+    // The assistant is already live and adoption resolves it through the local
+    // gateway, so an unresolved platform org can't hold that hand-off.
+    orgReadiness = "unavailable";
+
+    const { result } = renderHook(() =>
+      useBackgroundHatch({ adoptExisting: true }),
+    );
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(fetchOrganizationsMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -31,7 +31,27 @@ let healthzResult: GetHealthzResult = {
   data: {} as never,
 };
 
-const hatchAssistantMock = mock(async (): Promise<HatchResult> => hatchResult);
+// Local-gateway routing state. A managed hatch drops both before it POSTs so
+// discovery, healthz and the onboarding writes address the platform.
+const clearGatewayTokenMock = mock(() => {});
+const setSelfHostedConnectionMock = mock((_connection: unknown) => {});
+mock.module("@/lib/auth/gateway-session", () => ({
+  clearGatewayToken: clearGatewayTokenMock,
+}));
+mock.module("@/lib/self-hosted/connection", () => ({
+  setSelfHostedConnection: setSelfHostedConnectionMock,
+}));
+// Clear counts sampled when the hatch POST fires, so ordering is asserted
+// rather than mere occurrence.
+let clearsAtHatch = { gateway: 0, selfHosted: 0 };
+
+const hatchAssistantMock = mock(async (): Promise<HatchResult> => {
+  clearsAtHatch = {
+    gateway: clearGatewayTokenMock.mock.calls.length,
+    selfHosted: setSelfHostedConnectionMock.mock.calls.length,
+  };
+  return hatchResult;
+});
 const getAssistantMock = mock(
   async (_id?: string): Promise<GetAssistantResult> => getAssistantResult,
 );
@@ -182,6 +202,9 @@ beforeEach(() => {
   getLockfileAssistantMock.mockClear();
   awaitPurchasedProvisioningMock.mockClear();
   seedHatchAvatarMock.mockClear();
+  clearGatewayTokenMock.mockClear();
+  setSelfHostedConnectionMock.mockClear();
+  clearsAtHatch = { gateway: 0, selfHosted: 0 };
 });
 
 describe("useBackgroundHatch", () => {
@@ -662,5 +685,92 @@ describe("useBackgroundHatch", () => {
 
     await waitFor(() => expect(result.current.ready).toBe(true));
     expect(saveLockfileAssistantMock).not.toHaveBeenCalled();
+  });
+
+  // -- local gateway routing ------------------------------------------------
+  //
+  // The paid funnel routes an org whose only assistants are local/self-hosted
+  // to the managed hatch (`hosting=vellum-cloud`), so `adoptExisting` is false
+  // while the desktop build still holds a live gateway token and a primed
+  // self-hosted connection. Both would rewrite discovery, healthz and the
+  // onboarding writes to the old local gateway.
+
+  test("a managed hatch in local mode drops the local gateway before the hatch POST", async () => {
+    localMode = true;
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(clearGatewayTokenMock).toHaveBeenCalledTimes(1);
+    expect(setSelfHostedConnectionMock).toHaveBeenCalledWith(null);
+    expect(clearsAtHatch).toEqual({ gateway: 1, selfHosted: 1 });
+  });
+
+  test("an adopting hatch keeps its gateway session", async () => {
+    // Adoption resolves the live local assistant through that very session —
+    // dropping it would strand the flow on an unreachable gateway.
+    localMode = true;
+
+    const { result } = renderHook(() =>
+      useBackgroundHatch({ adoptExisting: true }),
+    );
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(clearGatewayTokenMock).not.toHaveBeenCalled();
+    expect(setSelfHostedConnectionMock).not.toHaveBeenCalled();
+  });
+
+  test("a non-local build leaves the routing state untouched", async () => {
+    // In a browser there is no local gateway to address, so the free web hatch
+    // makes no routing write at all.
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(clearGatewayTokenMock).not.toHaveBeenCalled();
+    expect(setSelfHostedConnectionMock).not.toHaveBeenCalled();
+  });
+
+  test("retry() re-clears the routing state harmlessly", async () => {
+    localMode = true;
+    hatchResult = {
+      ok: false,
+      status: 400,
+      error: { detail: "Bad hatch request" },
+    };
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe("Bad hatch request"));
+    expect(clearsAtHatch).toEqual({ gateway: 1, selfHosted: 1 });
+
+    hatchResult = {
+      ok: true,
+      status: 201,
+      data: { id: "ast-research" } as never,
+    };
+
+    act(() => {
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(clearsAtHatch).toEqual({ gateway: 2, selfHosted: 2 });
+    expect(setSelfHostedConnectionMock.mock.calls).toEqual([[null], [null]]);
   });
 });

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -880,6 +880,69 @@ describe("useBackgroundHatch", () => {
     expect(hatchAssistantMock).not.toHaveBeenCalled();
   });
 
+  test("the first attempt waits out in-flight resolution without kicking it", async () => {
+    orgReadiness = "resolving";
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(ORG_HEADER_MESSAGE));
+    // A cold boot resolves the org on its own; a duplicate request here would
+    // only race the store's own hydration.
+    expect(fetchOrganizationsMock).not.toHaveBeenCalled();
+  });
+
+  test("a retry supersedes resolution still in flight past the ceiling", async () => {
+    orgReadiness = "resolving";
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(ORG_HEADER_MESSAGE));
+
+    act(() => {
+      result.current.retry();
+    });
+
+    // A fetch still pending past the ceiling is a stalled request the store
+    // will never time out, so the retry replaces it rather than waiting again.
+    await waitFor(() => expect(fetchOrganizationsMock).toHaveBeenCalledTimes(1));
+    // The replacement answering mid-wait lets the held hatch proceed.
+    orgReadiness = "ready";
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(hatchAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a retry whose replacement fetch also hangs fails once more", async () => {
+    orgReadiness = "resolving";
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(ORG_HEADER_MESSAGE));
+
+    act(() => {
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(ORG_HEADER_MESSAGE));
+    // One kick per attempt — a wedged network can't turn the wait into a
+    // request loop.
+    expect(fetchOrganizationsMock).toHaveBeenCalledTimes(1);
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+  });
+
   test("unmounting during the org wait settles nothing", async () => {
     orgReadiness = "resolving";
 

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -19,6 +19,10 @@ import {
   MAX_HATCH_WAIT_MS,
   POLL_INTERVAL_MS,
 } from "@/domains/onboarding/purchased-provisioning";
+import {
+  getOrgHeaderReadiness,
+  ORG_HEADER_SETTLE_TIMEOUT_MS,
+} from "@/hooks/use-is-org-ready";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import {
   getLockfileAssistant,
@@ -28,7 +32,10 @@ import {
 } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { captureError } from "@/lib/sentry/capture-error";
-import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
+import {
+  getActiveOrganizationIdForRequests,
+  useOrganizationStore,
+} from "@/stores/organization-store";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { randomCharacterTraits } from "@/utils/avatar-random";
@@ -37,6 +44,11 @@ const GENERIC_HATCH_ERROR =
   "Failed to start your assistant. Please try again.";
 const TIMEOUT_ERROR =
   "Your assistant is taking longer than expected. Please try again.";
+const ORG_HEADER_ERROR =
+  "We couldn't confirm your organization. Please try again.";
+// Cadence for the org-header wait. Tighter than the assistant poll: the store
+// hydrates in one round trip, so every tick is dead time before the hatch POST.
+const ORG_HEADER_POLL_INTERVAL_MS = 100;
 
 export interface UseBackgroundHatch {
   /** Fire the hatch. Idempotent — only the first call provisions. */
@@ -199,6 +211,42 @@ export function useBackgroundHatch(
         }, ms);
       });
 
+    // Every platform request below is scoped by `Vellum-Organization-Id`, which
+    // the interceptor reads from the org store — and that store hydrates after
+    // auth. A checkout deep link can relaunch the app straight into this hook
+    // before hydration lands (no list yet, no persisted id either), where a
+    // header-less hatch is rejected and a paying user meets the failure banner.
+    //
+    // Resolves true once the header source can answer, which on a warm store is
+    // the first synchronous check. False means the sequence must stop: aborted,
+    // or settled without an id — terminal but retryable, since `retry()` re-runs
+    // this wait. Resolution that already concluded without an id is re-run once
+    // per attempt, so "Try again" has something new to wait on.
+    const awaitOrgHeader = async (): Promise<boolean> => {
+      const waitStartMs = Date.now();
+      let refetched = false;
+      while (true) {
+        if (abortedRef.current) {
+          return false;
+        }
+        const readiness = getOrgHeaderReadiness();
+        if (readiness === "ready") {
+          return true;
+        }
+        if (readiness === "unavailable" && !refetched) {
+          refetched = true;
+          void useOrganizationStore.getState().fetchOrganizations();
+        } else if (
+          readiness === "unavailable" ||
+          Date.now() - waitStartMs >= ORG_HEADER_SETTLE_TIMEOUT_MS
+        ) {
+          settleError(ORG_HEADER_ERROR);
+          return false;
+        }
+        await sleep(ORG_HEADER_POLL_INTERVAL_MS);
+      }
+    };
+
     void (async () => {
       // 0. Adopt straight from the lockfile when the handed-off id resolves.
       //
@@ -240,6 +288,11 @@ export function useBackgroundHatch(
         ? adoptAssistantId
         : undefined;
       if (!adoptExisting) {
+        // Hold the whole platform sequence — hatch, discovery, the purchased
+        // resize — until the org header can be attached.
+        if (!(await awaitOrgHeader())) {
+          return;
+        }
         // A managed hatch in a local-mode build must address the platform, not
         // the machine's own gateway: `getAssistant()` answers from the selected
         // lockfile entry while a gateway token is held, and daemon SDK calls

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   getAssistant,
@@ -14,29 +14,28 @@ import {
   shouldRecoverFromHatchFailure,
 } from "@/assistant/lifecycle";
 import { seedHatchAvatar } from "@/assistant/seed-hatch-avatar";
-import { awaitPurchasedProvisioning } from "@/domains/onboarding/purchased-provisioning";
-import { getLockfileAssistant, probeLocalGatewayReady } from "@/lib/local-mode";
+import {
+  awaitPurchasedProvisioning,
+  MAX_HATCH_WAIT_MS,
+  POLL_INTERVAL_MS,
+} from "@/domains/onboarding/purchased-provisioning";
+import {
+  getLockfileAssistant,
+  getPlatformRuntimeUrl,
+  isLocalMode,
+  probeLocalGatewayReady,
+  saveLockfileAssistant,
+} from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
+import { useOrganizationStore } from "@/stores/organization-store";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { randomCharacterTraits } from "@/utils/avatar-random";
-
-// Mirrors the poll/backoff constants in
-// `@/domains/onboarding/pages/hatching-screen.tsx`. The research-onboarding
-// flow kicks this hatch off in the background the moment the user lands on the
-// onboarding page, so by the time they finish the intro/pitch steps and submit
-// their details the assistant is (usually) already healthy and the flow can
-// immediately fire its research turn.
-const POLL_INTERVAL_MS = 3000;
-const MAX_HATCH_WAIT_MS = 300_000;
 
 const GENERIC_HATCH_ERROR =
   "Failed to start your assistant. Please try again.";
 const TIMEOUT_ERROR =
   "Your assistant is taking longer than expected. Please try again.";
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 export interface UseBackgroundHatch {
   /** Fire the hatch. Idempotent — only the first call provisions. */
@@ -105,6 +104,10 @@ export interface UseBackgroundHatchOptions {
  * Terminal failures (platform-hosted disabled, non-recoverable hatch errors,
  * lifecycle errors, timeout) set `error` and reject `awaitReady()`.
  * Recoverable failures (5xx / network) keep polling.
+ *
+ * Unmounting aborts the sequence: every loop and the purchased-provisioning
+ * wait stop at their next check and the pending poll timer is cleared, so
+ * leaving the funnel mid-hatch doesn't keep polling from a dead component.
  */
 export function useBackgroundHatch(
   {
@@ -129,6 +132,24 @@ export function useBackgroundHatch(
   const settledRef = useRef<
     { kind: "ready"; id: string } | { kind: "error"; message: string } | null
   >(null);
+  // The hatch sequence outlives a render by minutes (a 90s purchased-resize
+  // hold, a 300s health poll), so unmount has to stop it: every loop and the
+  // provisioning wait check this, and the pending poll timer is cleared.
+  const abortedRef = useRef(false);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // Reset on (re)mount so StrictMode's simulated unmount doesn't abort the
+    // hatch its own second mount is about to keep running.
+    abortedRef.current = false;
+    return () => {
+      abortedRef.current = true;
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const settleReady = useCallback((id: string) => {
     if (settledRef.current) return;
@@ -153,6 +174,15 @@ export function useBackgroundHatch(
 
     const startMs = Date.now();
     const timedOut = () => Date.now() - startMs >= MAX_HATCH_WAIT_MS;
+    // Parks the pending handle so unmount can clear it; an aborted sleep never
+    // resumes, which is how the loops stop mid-wait.
+    const sleep = (ms: number): Promise<void> =>
+      new Promise((resolve) => {
+        pollTimerRef.current = setTimeout(() => {
+          pollTimerRef.current = null;
+          resolve();
+        }, ms);
+      });
 
     void (async () => {
       // 0. Adopt straight from the lockfile when the handed-off id resolves.
@@ -200,9 +230,10 @@ export function useBackgroundHatch(
           if (result.ok) {
             hatchedAssistantId = result.data.id;
             setAssistantId(result.data.id);
-            // The Dock/tray icons are avatar-driven, so a freshly hatched (201)
-            // assistant needs seeded traits — parity with the foreground hatch.
-            // Fire-and-forget; the research face step overwrites them later.
+            // Seed a freshly hatched (201) assistant's traits — parity with the
+            // foreground hatch. Paid-only because the free research hatch must
+            // stay byte-identical to today, adding no writes it doesn't already
+            // make. Fire-and-forget; the research face step overwrites later.
             if (postCheckoutReturn && result.status === 201) {
               void seedHatchAvatar(
                 result.data.id,
@@ -232,21 +263,39 @@ export function useBackgroundHatch(
       // 2. Poll until the assistant reports `active`.
       let activeAssistantId: string | undefined;
       while (!activeAssistantId) {
+        if (abortedRef.current) return;
         if (timedOut()) {
           settleError(TIMEOUT_ERROR);
           return;
         }
         try {
           let result = await getAssistant(hatchedAssistantId);
+          if (abortedRef.current) return;
           // A stale hatched id (404) falls back to list-based discovery.
           if (hatchedAssistantId && !result.ok && result.status === 404) {
             hatchedAssistantId = undefined;
             result = await getAssistant();
+            if (abortedRef.current) return;
           }
           const state = resolveAssistantLifecycleState(result);
           if (state.kind === "active" && result.ok) {
             activeAssistantId = result.data.id;
             setAssistantId(activeAssistantId);
+            // Mirrors the hatching screen: on the desktop build the assistant
+            // list and switcher are lockfile-driven, so a managed assistant
+            // hatched headlessly here would otherwise be missing from them.
+            if (!adoptExisting && isLocalMode()) {
+              void saveLockfileAssistant({
+                assistantId: activeAssistantId,
+                name: result.data.name,
+                cloud: "vellum",
+                runtimeUrl: getPlatformRuntimeUrl(),
+                hatchedAt: new Date().toISOString(),
+                organizationId:
+                  useOrganizationStore.getState().currentOrganizationId ??
+                  undefined,
+              });
+            }
             break;
           }
           if (state.kind === "error") {
@@ -273,6 +322,7 @@ export function useBackgroundHatch(
       // still being alive.
       if (adoptExisting) {
         while (!(await probeLocalGatewayReady())) {
+          if (abortedRef.current) return;
           if (timedOut()) {
             settleError(TIMEOUT_ERROR);
             return;
@@ -281,8 +331,10 @@ export function useBackgroundHatch(
         }
       } else {
         while (true) {
+          if (abortedRef.current) return;
           try {
             const health = await getAssistantHealthz(activeAssistantId);
+            if (abortedRef.current) return;
             if (health.ok) break;
           } catch {
             // Daemon not reachable yet.
@@ -294,6 +346,7 @@ export function useBackgroundHatch(
           await sleep(POLL_INTERVAL_MS);
         }
       }
+      if (abortedRef.current) return;
 
       // 4. On a paid return, hold `ready` until the purchased resize converges.
       //
@@ -303,11 +356,17 @@ export function useBackgroundHatch(
       if (!adoptExisting && postCheckoutReturn) {
         const outcome = await awaitPurchasedProvisioning({
           assistantId: activeAssistantId,
-          postCheckoutReturn: true,
+          postCheckoutReturn,
           managedHatch: true,
           hatchStartMs: startMs,
-          isCancelled: () => settledRef.current?.kind === "error",
+          isCancelled: () => abortedRef.current,
+          registerTimer: (timer) => {
+            pollTimerRef.current = timer;
+          },
         });
+        // A cancelled wait also returns "ready" — the component is gone, so
+        // leave the hatch unsettled rather than completing into nothing.
+        if (abortedRef.current) return;
         if (outcome === "health_timeout") {
           // The assistant never answered healthz after the resize; completing
           // would hand the user an unreachable assistant.

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -19,12 +19,14 @@ import {
   MAX_HATCH_WAIT_MS,
   POLL_INTERVAL_MS,
 } from "@/domains/onboarding/purchased-provisioning";
+import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import {
   getLockfileAssistant,
   isLocalMode,
   probeLocalGatewayReady,
   saveManagedLockfileAssistant,
 } from "@/lib/local-mode";
+import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { extractErrorMessage } from "@/utils/api-errors";
@@ -238,6 +240,18 @@ export function useBackgroundHatch(
         ? adoptAssistantId
         : undefined;
       if (!adoptExisting) {
+        // A managed hatch in a local-mode build must address the platform, not
+        // the machine's own gateway: `getAssistant()` answers from the selected
+        // lockfile entry while a gateway token is held, and daemon SDK calls
+        // (the healthz probe below, and the research/personality writes that
+        // follow) rewrite to the local gateway while a self-hosted connection
+        // is primed. Same handoff the hatching screen performs for its managed
+        // path. Both are module-level writes — idempotent under `retry()`, and
+        // no auth/org store slice moves, so nothing remounts this hook.
+        if (isLocalMode()) {
+          clearGatewayToken();
+          setSelfHostedConnection(null);
+        }
         try {
           const result = await hatchAssistant();
           if (result.ok) {

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -21,10 +21,9 @@ import {
 } from "@/domains/onboarding/purchased-provisioning";
 import {
   getLockfileAssistant,
-  getPlatformRuntimeUrl,
   isLocalMode,
   probeLocalGatewayReady,
-  saveLockfileAssistant,
+  saveManagedLockfileAssistant,
 } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useOrganizationStore } from "@/stores/organization-store";
@@ -105,9 +104,7 @@ export interface UseBackgroundHatchOptions {
  * lifecycle errors, timeout) set `error` and reject `awaitReady()`.
  * Recoverable failures (5xx / network) keep polling.
  *
- * Unmounting aborts the sequence: every loop and the purchased-provisioning
- * wait stop at their next check and the pending poll timer is cleared, so
- * leaving the funnel mid-hatch doesn't keep polling from a dead component.
+ * Unmounting aborts the sequence — see `abortedRef`.
  */
 export function useBackgroundHatch(
   {
@@ -133,8 +130,9 @@ export function useBackgroundHatch(
     { kind: "ready"; id: string } | { kind: "error"; message: string } | null
   >(null);
   // The hatch sequence outlives a render by minutes (a 90s purchased-resize
-  // hold, a 300s health poll), so unmount has to stop it: every loop and the
-  // provisioning wait check this, and the pending poll timer is cleared.
+  // hold, a 300s health poll), so unmount has to stop it: an aborted hatch
+  // refuses to settle, every loop and the provisioning wait check this, sleeps
+  // resolve immediately, and the pending poll timer is cleared.
   const abortedRef = useRef(false);
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -152,32 +150,47 @@ export function useBackgroundHatch(
   }, []);
 
   const settleReady = useCallback((id: string) => {
-    if (settledRef.current) return;
+    if (abortedRef.current || settledRef.current) {
+      return;
+    }
     settledRef.current = { kind: "ready", id };
     setReady(true);
-    for (const w of waitersRef.current) w.resolve(id);
+    for (const w of waitersRef.current) {
+      w.resolve(id);
+    }
     waitersRef.current = [];
   }, []);
 
   const settleError = useCallback((message: string) => {
-    if (settledRef.current) return;
+    if (abortedRef.current || settledRef.current) {
+      return;
+    }
     settledRef.current = { kind: "error", message };
     setError(message);
     const err = new Error(message);
-    for (const w of waitersRef.current) w.reject(err);
+    for (const w of waitersRef.current) {
+      w.reject(err);
+    }
     waitersRef.current = [];
   }, []);
 
   const start = useCallback(() => {
-    if (startedRef.current) return;
+    if (startedRef.current) {
+      return;
+    }
     startedRef.current = true;
 
     const startMs = Date.now();
     const timedOut = () => Date.now() - startMs >= MAX_HATCH_WAIT_MS;
-    // Parks the pending handle so unmount can clear it; an aborted sleep never
-    // resumes, which is how the loops stop mid-wait.
+    // Parks the pending handle so unmount can clear it. Once aborted the wait
+    // resolves without scheduling anything, so the loop reaches its next check
+    // with no timer left behind.
     const sleep = (ms: number): Promise<void> =>
       new Promise((resolve) => {
+        if (abortedRef.current) {
+          resolve();
+          return;
+        }
         pollTimerRef.current = setTimeout(() => {
           pollTimerRef.current = null;
           resolve();
@@ -230,10 +243,9 @@ export function useBackgroundHatch(
           if (result.ok) {
             hatchedAssistantId = result.data.id;
             setAssistantId(result.data.id);
-            // Seed a freshly hatched (201) assistant's traits — parity with the
-            // foreground hatch. Paid-only because the free research hatch must
-            // stay byte-identical to today, adding no writes it doesn't already
-            // make. Fire-and-forget; the research face step overwrites later.
+            // Dock and tray icons are avatar-driven, so a freshly created (201)
+            // assistant gets seeded traits. Paid-only: the free hatch makes no
+            // avatar write. Fire-and-forget; the research face step overwrites.
             if (postCheckoutReturn && result.status === 201) {
               void seedHatchAvatar(
                 result.data.id,
@@ -263,38 +275,33 @@ export function useBackgroundHatch(
       // 2. Poll until the assistant reports `active`.
       let activeAssistantId: string | undefined;
       while (!activeAssistantId) {
-        if (abortedRef.current) return;
+        if (abortedRef.current) {
+          return;
+        }
         if (timedOut()) {
           settleError(TIMEOUT_ERROR);
           return;
         }
         try {
           let result = await getAssistant(hatchedAssistantId);
-          if (abortedRef.current) return;
           // A stale hatched id (404) falls back to list-based discovery.
           if (hatchedAssistantId && !result.ok && result.status === 404) {
             hatchedAssistantId = undefined;
             result = await getAssistant();
-            if (abortedRef.current) return;
           }
           const state = resolveAssistantLifecycleState(result);
           if (state.kind === "active" && result.ok) {
             activeAssistantId = result.data.id;
             setAssistantId(activeAssistantId);
-            // Mirrors the hatching screen: on the desktop build the assistant
-            // list and switcher are lockfile-driven, so a managed assistant
-            // hatched headlessly here would otherwise be missing from them.
+            // Desktop-only: the list and switcher read the lockfile. An adopted
+            // assistant is already the hatching screen's own write.
             if (!adoptExisting && isLocalMode()) {
-              void saveLockfileAssistant({
-                assistantId: activeAssistantId,
-                name: result.data.name,
-                cloud: "vellum",
-                runtimeUrl: getPlatformRuntimeUrl(),
-                hatchedAt: new Date().toISOString(),
-                organizationId:
-                  useOrganizationStore.getState().currentOrganizationId ??
+              void saveManagedLockfileAssistant(
+                activeAssistantId,
+                result.data.name,
+                useOrganizationStore.getState().currentOrganizationId ??
                   undefined,
-              });
+              );
             }
             break;
           }
@@ -322,7 +329,9 @@ export function useBackgroundHatch(
       // still being alive.
       if (adoptExisting) {
         while (!(await probeLocalGatewayReady())) {
-          if (abortedRef.current) return;
+          if (abortedRef.current) {
+            return;
+          }
           if (timedOut()) {
             settleError(TIMEOUT_ERROR);
             return;
@@ -331,11 +340,14 @@ export function useBackgroundHatch(
         }
       } else {
         while (true) {
-          if (abortedRef.current) return;
+          if (abortedRef.current) {
+            return;
+          }
           try {
             const health = await getAssistantHealthz(activeAssistantId);
-            if (abortedRef.current) return;
-            if (health.ok) break;
+            if (health.ok) {
+              break;
+            }
           } catch {
             // Daemon not reachable yet.
           }
@@ -346,7 +358,6 @@ export function useBackgroundHatch(
           await sleep(POLL_INTERVAL_MS);
         }
       }
-      if (abortedRef.current) return;
 
       // 4. On a paid return, hold `ready` until the purchased resize converges.
       //
@@ -364,9 +375,6 @@ export function useBackgroundHatch(
             pollTimerRef.current = timer;
           },
         });
-        // A cancelled wait also returns "ready" — the component is gone, so
-        // leave the hatch unsettled rather than completing into nothing.
-        if (abortedRef.current) return;
         if (outcome === "health_timeout") {
           // The assistant never answered healthz after the resize; completing
           // would hand the user an unreachable assistant.
@@ -401,8 +409,12 @@ export function useBackgroundHatch(
 
   const awaitReady = useCallback((): Promise<string> => {
     const settled = settledRef.current;
-    if (settled?.kind === "ready") return Promise.resolve(settled.id);
-    if (settled?.kind === "error") return Promise.reject(new Error(settled.message));
+    if (settled?.kind === "ready") {
+      return Promise.resolve(settled.id);
+    }
+    if (settled?.kind === "error") {
+      return Promise.reject(new Error(settled.message));
+    }
     return new Promise<string>((resolve, reject) => {
       waitersRef.current.push({ resolve, reject });
     });

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -149,6 +149,9 @@ export function useBackgroundHatch(
   // resolve immediately, and the pending poll timer is cleared.
   const abortedRef = useRef(false);
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Set by `retry()`, so the org-header wait can tell a user-driven second
+  // attempt from the first one. See `awaitOrgHeader`.
+  const retriedRef = useRef(false);
 
   useEffect(() => {
     // Reset on (re)mount so StrictMode's simulated unmount doesn't abort the
@@ -194,6 +197,7 @@ export function useBackgroundHatch(
     }
     startedRef.current = true;
 
+    const isRetryAttempt = retriedRef.current;
     const startMs = Date.now();
     const timedOut = () => Date.now() - startMs >= MAX_HATCH_WAIT_MS;
     // Parks the pending handle so unmount can clear it. Once aborted the wait
@@ -220,8 +224,17 @@ export function useBackgroundHatch(
     // Resolves true once the header source can answer, which on a warm store is
     // the first synchronous check. False means the sequence must stop: aborted,
     // or settled without an id — terminal but retryable, since `retry()` re-runs
-    // this wait. Resolution that already concluded without an id is re-run once
-    // per attempt, so "Try again" has something new to wait on.
+    // this wait.
+    //
+    // Each attempt re-triggers resolution once so "Try again" has something new
+    // to wait on. Resolution that already concluded without an id gets that kick
+    // on any attempt: nothing else is coming. Resolution still in flight only
+    // gets it on a RETRY — a first attempt must not race the store's own
+    // cold-boot hydration, but by the time the user presses "Try again" a fetch
+    // still pending past the ceiling is a stalled request, and the store neither
+    // times out nor dedupes, so a fresh one supersedes it. Without that, every
+    // retry re-runs the same timeout and the hatch can't recover from a hung
+    // request even after connectivity returns.
     const awaitOrgHeader = async (): Promise<boolean> => {
       const waitStartMs = Date.now();
       let refetched = false;
@@ -233,7 +246,7 @@ export function useBackgroundHatch(
         if (readiness === "ready") {
           return true;
         }
-        if (readiness === "unavailable" && !refetched) {
+        if (!refetched && (readiness === "unavailable" || isRetryAttempt)) {
           refetched = true;
           void useOrganizationStore.getState().fetchOrganizations();
         } else if (
@@ -481,6 +494,7 @@ export function useBackgroundHatch(
   ]);
 
   const retry = useCallback(() => {
+    retriedRef.current = true;
     startedRef.current = false;
     settledRef.current = null;
     setError(null);

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -284,10 +284,19 @@ export function useBackgroundHatch(
         }
         try {
           let result = await getAssistant(hatchedAssistantId);
+          // Re-checked after every await here, not just at the loop head: the
+          // branch below writes the lockfile — which sets the ACTIVE assistant
+          // — and that write is not guarded by `settleReady`.
+          if (abortedRef.current) {
+            return;
+          }
           // A stale hatched id (404) falls back to list-based discovery.
           if (hatchedAssistantId && !result.ok && result.status === 404) {
             hatchedAssistantId = undefined;
             result = await getAssistant();
+            if (abortedRef.current) {
+              return;
+            }
           }
           const state = resolveAssistantLifecycleState(result);
           if (state.kind === "active" && result.ok) {
@@ -375,6 +384,12 @@ export function useBackgroundHatch(
             pollTimerRef.current = timer;
           },
         });
+        // A cancellation landing mid-healthz past the deadline also reports
+        // `"health_timeout"`, and nobody is waiting on this hatch any more —
+        // reporting it would be a false alarm.
+        if (abortedRef.current) {
+          return;
+        }
         if (outcome === "health_timeout") {
           // The assistant never answered healthz after the resize; completing
           // would hand the user an unreachable assistant.

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -28,7 +28,7 @@ import {
 } from "@/lib/local-mode";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { captureError } from "@/lib/sentry/capture-error";
-import { useOrganizationStore } from "@/stores/organization-store";
+import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { randomCharacterTraits } from "@/utils/avatar-random";
@@ -322,7 +322,7 @@ export function useBackgroundHatch(
               void saveManagedLockfileAssistant(
                 activeAssistantId,
                 result.data.name,
-                useOrganizationStore.getState().currentOrganizationId ??
+                getActiveOrganizationIdForRequests() ??
                   undefined,
               );
             }

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 
 import {
@@ -11,9 +13,13 @@ import {
   resolveAssistantLifecycleState,
   shouldRecoverFromHatchFailure,
 } from "@/assistant/lifecycle";
+import { seedHatchAvatar } from "@/assistant/seed-hatch-avatar";
+import { awaitPurchasedProvisioning } from "@/domains/onboarding/purchased-provisioning";
 import { getLockfileAssistant, probeLocalGatewayReady } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { extractErrorMessage } from "@/utils/api-errors";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { randomCharacterTraits } from "@/utils/avatar-random";
 
 // Mirrors the poll/backoff constants in
 // `@/domains/onboarding/pages/hatching-screen.tsx`. The research-onboarding
@@ -35,6 +41,12 @@ const sleep = (ms: number): Promise<void> =>
 export interface UseBackgroundHatch {
   /** Fire the hatch. Idempotent — only the first call provisions. */
   start: () => void;
+  /**
+   * Re-run a failed hatch from the top, clearing the terminal state first.
+   * `awaitReady()` waiters from the failed attempt were already rejected at
+   * `settleError` time, so callers must re-await after retrying.
+   */
+  retry: () => void;
   /** True only once the assistant has passed a health check. */
   ready: boolean;
   /** The provisioned assistant id, set once the hatch resolves. */
@@ -66,6 +78,13 @@ export interface UseBackgroundHatchOptions {
    * out stale), discovery falls back to the selected/active assistant.
    */
   adoptAssistantId?: string;
+  /**
+   * The hatch is the return leg of a completed checkout (`post_checkout=1`):
+   * after healthz, hold `ready` until the purchased machine/storage resize
+   * converges (`awaitPurchasedProvisioning`), then re-probe healthz. Never set
+   * on the free path — the free hatch must not add subscription polling.
+   */
+  postCheckoutReturn?: boolean;
 }
 
 /**
@@ -79,15 +98,22 @@ export interface UseBackgroundHatchOptions {
  * the hatch return.
  *
  * When `adoptExisting` is set (a local-hosting onboarding), the managed hatch is
- * skipped and we adopt the already-live assistant instead.
+ * skipped and we adopt the already-live assistant instead. When
+ * `postCheckoutReturn` is set, `ready` additionally waits on the purchased
+ * machine/storage resize so the paid user never starts on a baseline assistant.
  *
  * Terminal failures (platform-hosted disabled, non-recoverable hatch errors,
  * lifecycle errors, timeout) set `error` and reject `awaitReady()`.
  * Recoverable failures (5xx / network) keep polling.
  */
 export function useBackgroundHatch(
-  { adoptExisting = false, adoptAssistantId }: UseBackgroundHatchOptions = {},
+  {
+    adoptExisting = false,
+    adoptAssistantId,
+    postCheckoutReturn = false,
+  }: UseBackgroundHatchOptions = {},
 ): UseBackgroundHatch {
+  const queryClient = useQueryClient();
   const [ready, setReady] = useState(false);
   const [assistantId, setAssistantId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -174,6 +200,16 @@ export function useBackgroundHatch(
           if (result.ok) {
             hatchedAssistantId = result.data.id;
             setAssistantId(result.data.id);
+            // The Dock/tray icons are avatar-driven, so a freshly hatched (201)
+            // assistant needs seeded traits — parity with the foreground hatch.
+            // Fire-and-forget; the research face step overwrites them later.
+            if (postCheckoutReturn && result.status === 201) {
+              void seedHatchAvatar(
+                result.data.id,
+                randomCharacterTraits(BUNDLED_COMPONENTS),
+                queryClient,
+              );
+            }
           } else {
             if (isPlatformHostedDisabled(result.status, result.error)) {
               settleError(PLATFORM_HOSTED_DISABLED_MESSAGE);
@@ -259,9 +295,50 @@ export function useBackgroundHatch(
         }
       }
 
+      // 4. On a paid return, hold `ready` until the purchased resize converges.
+      //
+      // `managedHatch` is true by construction: the checkout destination always
+      // carries `hosting=vellum-cloud`, and `adoptExisting` already excludes the
+      // local foreground hatch.
+      if (!adoptExisting && postCheckoutReturn) {
+        const outcome = await awaitPurchasedProvisioning({
+          assistantId: activeAssistantId,
+          postCheckoutReturn: true,
+          managedHatch: true,
+          hatchStartMs: startMs,
+          isCancelled: () => settledRef.current?.kind === "error",
+        });
+        if (outcome === "health_timeout") {
+          // The assistant never answered healthz after the resize; completing
+          // would hand the user an unreachable assistant.
+          Sentry.captureMessage("Onboarding hatch wait exceeded timeout", {
+            level: "warning",
+            extra: { maxWaitMs: MAX_HATCH_WAIT_MS, stage: "post_resize_health" },
+          });
+          settleError(TIMEOUT_ERROR);
+          return;
+        }
+      }
+
       settleReady(activeAssistantId);
     })();
-  }, [settleError, settleReady, adoptExisting, adoptAssistantId]);
+  }, [
+    settleError,
+    settleReady,
+    adoptExisting,
+    adoptAssistantId,
+    postCheckoutReturn,
+    queryClient,
+  ]);
+
+  const retry = useCallback(() => {
+    startedRef.current = false;
+    settledRef.current = null;
+    setError(null);
+    setReady(false);
+    setAssistantId(null);
+    start();
+  }, [start]);
 
   const awaitReady = useCallback((): Promise<string> => {
     const settled = settledRef.current;
@@ -272,5 +349,5 @@ export function useBackgroundHatch(
     });
   }, []);
 
-  return { start, ready, assistantId, error, awaitReady };
+  return { start, retry, ready, assistantId, error, awaitReady };
 }

--- a/clients/web/src/hooks/use-is-org-ready.ts
+++ b/clients/web/src/hooks/use-is-org-ready.ts
@@ -1,8 +1,11 @@
-import { useHasPlatformSession } from "@/stores/auth-store";
+import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import {
+  getActiveOrganizationIdForRequests,
   useOrganizationStore,
   useRequestOrganizationId,
+  type OrganizationStatus,
 } from "@/stores/organization-store";
+import { hasLivePlatformSession } from "@/stores/session-status";
 
 /**
  * How close the `Vellum-Organization-Id` header source is to producing an id.
@@ -24,10 +27,19 @@ import {
  */
 export type OrgHeaderReadiness = "ready" | "resolving" | "unavailable";
 
-export function useOrgHeaderReadiness(): OrgHeaderReadiness {
-  const requestOrganizationId = useRequestOrganizationId();
-  const status = useOrganizationStore.use.status();
-  const hasPlatformSession = useHasPlatformSession();
+/**
+ * How long an imperative caller gives `"resolving"` to settle before treating
+ * the header source as unavailable. Matches the auth middleware's hydration
+ * ceiling: org resolution is a single round trip, so waiting longer only
+ * postpones the retry the user has to take anyway.
+ */
+export const ORG_HEADER_SETTLE_TIMEOUT_MS = 5_000;
+
+function resolveOrgHeaderReadiness(
+  requestOrganizationId: string | null,
+  status: OrganizationStatus,
+  hasPlatformSession: boolean,
+): OrgHeaderReadiness {
   if (!hasPlatformSession) {
     return "ready";
   }
@@ -35,6 +47,28 @@ export function useOrgHeaderReadiness(): OrgHeaderReadiness {
     return "ready";
   }
   return status === "error" ? "unavailable" : "resolving";
+}
+
+export function useOrgHeaderReadiness(): OrgHeaderReadiness {
+  return resolveOrgHeaderReadiness(
+    useRequestOrganizationId(),
+    useOrganizationStore.use.status(),
+    useHasPlatformSession(),
+  );
+}
+
+/**
+ * Imperative read of {@link useOrgHeaderReadiness}, for async sequences outside
+ * the render cycle that must not fire a header-less platform request while the
+ * org store is still hydrating. Same derivation the hook and the interceptor
+ * share, so a gate built on it moves with the header rather than trailing it.
+ */
+export function getOrgHeaderReadiness(): OrgHeaderReadiness {
+  return resolveOrgHeaderReadiness(
+    getActiveOrganizationIdForRequests(),
+    useOrganizationStore.getState().status,
+    hasLivePlatformSession(useAuthStore.getState().platformSession),
+  );
 }
 
 /**

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -36,15 +36,22 @@ mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthMode: () => mockGatewayAuthMode,
 }));
 
-// Consent prefs are read by buildNavigationState; pin them current so the
-// consent gate doesn't interfere with the session-admission assertions below.
+// Consent prefs are read by buildNavigationState; pinned current by default so
+// the consent gate doesn't interfere with the session-admission assertions
+// below. `consentPrefs` lets a case drive the boot defaults instead.
+const consentPrefs = {
+  tos: true,
+  privacy: true,
+  analytics: true,
+  diagnostics: true,
+};
 const prefsActual = await import("@/domains/onboarding/prefs");
 mock.module("@/domains/onboarding/prefs", () => ({
   ...prefsActual,
-  readTosAccepted: () => true,
-  readPrivacyConsent: () => true,
-  readAnalyticsConsentCurrent: () => true,
-  readDiagnosticsConsentCurrent: () => true,
+  readTosAccepted: () => consentPrefs.tos,
+  readPrivacyConsent: () => consentPrefs.privacy,
+  readAnalyticsConsentCurrent: () => consentPrefs.analytics,
+  readDiagnosticsConsentCurrent: () => consentPrefs.diagnostics,
 }));
 
 // Clamp whenStoreState timeouts so hydration-timeout paths are testable
@@ -202,6 +209,10 @@ const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 beforeEach(() => {
   isLocalModeMock.mockImplementation(() => true);
   hasAssistantsMock.mockImplementation(() => false);
+  consentPrefs.tos = true;
+  consentPrefs.privacy = true;
+  consentPrefs.analytics = true;
+  consentPrefs.diagnostics = true;
   mockSelectedAssistant = undefined;
   mockGatewayTokenPresent = false;
   mockGatewayAuthMode = false;
@@ -664,6 +675,67 @@ describe("authMiddleware — hydration timeout", () => {
       useResolvedAssistantsStore.setState({
         assistantsHydrated: priorAssistantsHydrated,
       });
+    }
+  });
+
+  // The research entry waits for consent to hydrate. Forcing the hydration flag
+  // after the timeout leaves the consent flags at their boot `false`, so the
+  // funnel's own gate would read a consented user as un-onboarded and evict
+  // them into privacy — losing a paid return's markers, restarting a free
+  // user's onboarding. It admits instead.
+  test("admits a research funnel entry whose consent hydration hung", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    // The boot state a cold deep link sees: nothing read back from the server
+    // yet, and the fetch that would never reports.
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: true,
+    });
+
+    try {
+      const outcome = await runMiddlewareOutcome(managedFunnel);
+      expect(outcome.admitted).toBe(true);
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+    }
+  });
+
+  // Fail-open is scoped to the unhydrated read: consent that actually hydrated
+  // on an unconsented user still bounces, carrying the funnel URL so the paid
+  // markers survive the privacy screen.
+  test("bounces the same entry once consent hydrates unconsented", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    useOnboardingStore.setState({ consentHydrated: true });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: true,
+    });
+
+    try {
+      const res = await runMiddleware(managedFunnel);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(
+        `${routes.onboarding.privacy}?returnTo=${encodeURIComponent(managedFunnel)}`,
+      );
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
     }
   });
 });

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -783,6 +783,52 @@ describe("authMiddleware — hydration timeout", () => {
     }
   });
 
+  // The consent wait runs first, so a fetch that reports just after it — while
+  // the assistants wait is still running — leaves a settled "not consented" by
+  // the time the guard recurses. Carrying the expired stall forward would fail
+  // the gate open on a hydration that has since landed.
+  test("bounces an unconsented research entry when consent lands during the assistants wait", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    const priorAssistantsHydrated =
+      useResolvedAssistantsStore.getState().assistantsHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: false,
+    });
+
+    try {
+      const pending = runMiddleware(managedFunnel);
+      // Past the (clamped) consent wait but inside the assistants one, which
+      // never reports.
+      setTimeout(
+        () => {
+          useOnboardingStore.setState({ consentHydrated: true });
+        },
+        WAIT_TIMEOUT_CLAMP_MS + 30,
+      );
+
+      const res = await pending;
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(
+        `${routes.onboarding.privacy}?returnTo=${encodeURIComponent(managedFunnel)}`,
+      );
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+      useResolvedAssistantsStore.setState({
+        assistantsHydrated: priorAssistantsHydrated,
+      });
+    }
+  });
+
   // Both fetches hang, so the consent wait times out on its own account and the
   // entry falls back to its unconditional admission.
   test("admits the research entry when both hydration waits stall", async () => {

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -104,8 +104,9 @@ const postCheckoutBilling = `${routes.settings.root}/billing?session_id=cs_test_
 
 // The funnel entry carries the managed-hatch marker so a local-mode client
 // provisions on the platform rather than letting its own gateway answer for
-// the assistant.
-const managedFunnel = `${routes.onboarding.hatching}?hosting=vellum-cloud&post_checkout=1`;
+// the assistant. Non-native shells land on the headless research onboarding,
+// which runs the purchased-provisioning wait behind the form.
+const managedFunnel = `${routes.onboarding.research}?hosting=vellum-cloud&post_checkout=1`;
 
 /**
  * A checkout return on a local-mode client whose lockfile already holds a
@@ -374,7 +375,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
     });
   }
 
-  test("funnels the paid return into hatching", async () => {
+  test("funnels the paid return into provisioning", async () => {
     makePaidPlatformReturn();
 
     const res = await runMiddleware(postCheckoutBilling);
@@ -561,7 +562,7 @@ describe("authMiddleware — late-probe re-run through a real router", () => {
   function createGuardedRouter(): ReturnType<typeof createMemoryRouter> {
     return createMemoryRouter(
       [
-        { path: routes.onboarding.hatching, Component: () => null },
+        { path: routes.onboarding.research, Component: () => null },
         {
           path: "/assistant",
           middleware: [authMiddleware],

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -682,7 +682,8 @@ describe("authMiddleware — hydration timeout", () => {
   // after the timeout leaves the consent flags at their boot `false`, so the
   // funnel's own gate would read a consented user as un-onboarded and evict
   // them into privacy — losing a paid return's markers, restarting a free
-  // user's onboarding. It admits instead.
+  // user's onboarding. It admits instead. The assistants list is hydrated here,
+  // so the fail-open rests on the consent wait alone.
   test("admits a research funnel entry whose consent hydration hung", async () => {
     isLocalModeMock.mockImplementation(() => false);
     useAuthStore.setState({
@@ -736,6 +737,80 @@ describe("authMiddleware — hydration timeout", () => {
       );
     } finally {
       useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+    }
+  });
+
+  // The fail-open belongs to the consent wait alone. Consent that hydrates on
+  // time reports a settled "not consented" whatever the assistants list is
+  // doing, so a stalled list must not launder an unconsented user past the gate
+  // and into a hatch they would be charged for.
+  test("bounces an unconsented research entry when only the assistants list stalls", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    const priorAssistantsHydrated =
+      useResolvedAssistantsStore.getState().assistantsHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: false,
+    });
+
+    try {
+      const pending = runMiddleware(managedFunnel);
+      // Consent lands well inside its (clamped) wait; the assistants fetch
+      // never reports, so only that second wait runs out.
+      setTimeout(() => {
+        useOnboardingStore.setState({ consentHydrated: true });
+      }, 10);
+
+      const res = await pending;
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(
+        `${routes.onboarding.privacy}?returnTo=${encodeURIComponent(managedFunnel)}`,
+      );
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+      useResolvedAssistantsStore.setState({
+        assistantsHydrated: priorAssistantsHydrated,
+      });
+    }
+  });
+
+  // Both fetches hang, so the consent wait times out on its own account and the
+  // entry falls back to its unconditional admission.
+  test("admits the research entry when both hydration waits stall", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    consentPrefs.tos = false;
+    consentPrefs.privacy = false;
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    const priorAssistantsHydrated =
+      useResolvedAssistantsStore.getState().assistantsHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: false,
+    });
+
+    try {
+      const outcome = await runMiddlewareOutcome(managedFunnel);
+      expect(outcome.admitted).toBe(true);
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+      useResolvedAssistantsStore.setState({
+        assistantsHydrated: priorAssistantsHydrated,
+      });
     }
   });
 });

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -81,9 +81,18 @@ const resolveWithGuard = async (
   // a non-decision into that documented fallback. A result that lands after the
   // timeout re-runs the guard (see `revalidateWhenPlatformProbeSettles`), so a
   // slow-but-successful probe still reaches its platform-session destination.
+  //
+  // Forcing `consentHydrated` hides that the consent flags underneath it are
+  // still their boot `false`, so the forcing itself is reported too: a step
+  // that would otherwise read them as a settled "not consented" — and evict a
+  // consented user mid-funnel — can fail open on it instead.
   const state = buildNavigationState({
     ...(hydrationTimedOut
-      ? { consentHydrated: true, assistantsHydrated: true }
+      ? {
+          consentHydrated: true,
+          consentHydrationTimedOut: true,
+          assistantsHydrated: true,
+        }
       : {}),
     ...(platformProbeTimedOut ? { platformSession: "absent" as const } : {}),
   });

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -60,41 +60,53 @@ function revalidateWhenPlatformProbeSettles(): void {
   });
 }
 
+/** Waits that ran out on an earlier pass; each stays forced from then on. */
+interface TimedOutWaits {
+  consentHydration: boolean;
+  assistantsHydration: boolean;
+  platformProbe: boolean;
+}
+
+const NO_TIMED_OUT_WAITS: TimedOutWaits = {
+  consentHydration: false,
+  assistantsHydration: false,
+  platformProbe: false,
+};
+
 export const authMiddleware: MiddlewareFunction = (args, next) =>
-  resolveWithGuard(args, next, false, false);
+  resolveWithGuard(args, next, NO_TIMED_OUT_WAITS);
 
 const resolveWithGuard = async (
   { request, context }: Parameters<MiddlewareFunction>[0],
   next: Parameters<MiddlewareFunction>[1],
-  hydrationTimedOut: boolean,
-  platformProbeTimedOut: boolean,
+  timedOut: TimedOutWaits,
 ): Promise<Awaited<ReturnType<MiddlewareFunction>>> => {
   const url = new URL(request.url);
 
-  // After a timed-out hydration wait, force the hydration flags so the
-  // resolver decides on whatever state exists instead of returning another
-  // "wait" — a fetch that hangs (never reaching any settle path) must degrade
-  // to a decision, not loop navigation in timeout-sized chunks. A platform
-  // probe that outran its wait degrades the same way, to `"absent"`: every step
-  // that reads the probe treats an unsettled session as "no decision yet" and
-  // a settled-absent one as "no platform account", so forcing it can only turn
-  // a non-decision into that documented fallback. A result that lands after the
-  // timeout re-runs the guard (see `revalidateWhenPlatformProbeSettles`), so a
-  // slow-but-successful probe still reaches its platform-session destination.
+  // After a timed-out wait, force that wait's own flag so the resolver decides
+  // on whatever state exists instead of returning another "wait" — a fetch that
+  // hangs (never reaching any settle path) must degrade to a decision, not loop
+  // navigation in timeout-sized chunks. A platform probe that outran its wait
+  // degrades the same way, to `"absent"`: every step that reads the probe
+  // treats an unsettled session as "no decision yet" and a settled-absent one
+  // as "no platform account", so forcing it can only turn a non-decision into
+  // that documented fallback. A result that lands after the timeout re-runs the
+  // guard (see `revalidateWhenPlatformProbeSettles`), so a slow-but-successful
+  // probe still reaches its platform-session destination.
   //
   // Forcing `consentHydrated` hides that the consent flags underneath it are
   // still their boot `false`, so the forcing itself is reported too: a step
   // that would otherwise read them as a settled "not consented" — and evict a
-  // consented user mid-funnel — can fail open on it instead.
+  // consented user mid-funnel — can fail open on it instead. That report is why
+  // the two waits are tracked apart: raising it for a stalled assistants list
+  // would fail the funnel's consent gate open for a genuinely unconsented user,
+  // admitting them to a paid hatch.
   const state = buildNavigationState({
-    ...(hydrationTimedOut
-      ? {
-          consentHydrated: true,
-          consentHydrationTimedOut: true,
-          assistantsHydrated: true,
-        }
+    ...(timedOut.consentHydration
+      ? { consentHydrated: true, consentHydrationTimedOut: true }
       : {}),
-    ...(platformProbeTimedOut ? { platformSession: "absent" as const } : {}),
+    ...(timedOut.assistantsHydration ? { assistantsHydrated: true } : {}),
+    ...(timedOut.platformProbe ? { platformSession: "absent" as const } : {}),
   });
 
   const decision = resolveNavigation(state, {
@@ -110,7 +122,7 @@ const resolveWithGuard = async (
     // the latter with `hasAssistants()` already true.
     let platformProbeStillUnknown = false;
     if (
-      !platformProbeTimedOut &&
+      !timedOut.platformProbe &&
       isLocalMode() &&
       (!hasAssistants() || decision.waitFor === "platform-session")
     ) {
@@ -128,33 +140,42 @@ const resolveWithGuard = async (
     // Platform mode also waits for consent and the assistants list to hydrate
     // — the resolver defers to them, and deciding on their boot defaults would
     // misroute an established user into onboarding. Both resolve immediately
-    // when already hydrated. Scoped to sessions that can actually hydrate:
-    // local mode's resolver steps never wait on hydration (lockfile-driven),
-    // and an unauthenticated session never populates either store, so waiting
-    // in those cases would only stall boot.
-    let hydrationStillPending = false;
+    // when already hydrated, and each is skipped once its own wait has run out
+    // so neither can burn a second timeout. Scoped to sessions that can
+    // actually hydrate: local mode's resolver steps never wait on hydration
+    // (lockfile-driven), and an unauthenticated session never populates either
+    // store, so waiting in those cases would only stall boot.
+    let consentStillPending = false;
+    let assistantsStillPending = false;
     if (
-      !hydrationTimedOut &&
       !isLocalMode() &&
       isAuthenticated(useAuthStore.getState().sessionStatus)
     ) {
-      await whenStoreState(useOnboardingStore, (s) => s.consentHydrated, {
-        timeoutMs: STATE_HYDRATION_TIMEOUT_MS,
-      });
-      await whenStoreState(
-        useResolvedAssistantsStore,
-        (s) => s.assistantsHydrated,
-        { timeoutMs: STATE_HYDRATION_TIMEOUT_MS },
-      );
-      hydrationStillPending =
-        !useOnboardingStore.getState().consentHydrated ||
-        !useResolvedAssistantsStore.getState().assistantsHydrated;
+      if (!timedOut.consentHydration) {
+        await whenStoreState(useOnboardingStore, (s) => s.consentHydrated, {
+          timeoutMs: STATE_HYDRATION_TIMEOUT_MS,
+        });
+        consentStillPending = !useOnboardingStore.getState().consentHydrated;
+      }
+      if (!timedOut.assistantsHydration) {
+        await whenStoreState(
+          useResolvedAssistantsStore,
+          (s) => s.assistantsHydrated,
+          { timeoutMs: STATE_HYDRATION_TIMEOUT_MS },
+        );
+        assistantsStillPending =
+          !useResolvedAssistantsStore.getState().assistantsHydrated;
+      }
     }
     return resolveWithGuard(
       { request, context } as Parameters<MiddlewareFunction>[0],
       next,
-      hydrationTimedOut || hydrationStillPending,
-      platformProbeTimedOut || platformProbeStillUnknown,
+      {
+        consentHydration: timedOut.consentHydration || consentStillPending,
+        assistantsHydration:
+          timedOut.assistantsHydration || assistantsStillPending,
+        platformProbe: timedOut.platformProbe || platformProbeStillUnknown,
+      },
     );
   }
 

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -167,11 +167,19 @@ const resolveWithGuard = async (
           !useResolvedAssistantsStore.getState().assistantsHydrated;
       }
     }
+    // Consent is re-read here rather than trusted from its own wait: the
+    // assistants wait runs after it, and consent that lands during that window
+    // is a settled read by the time the recursion decides. Reporting the stale
+    // "still pending" would force the consent gate open for a genuinely
+    // unconsented user on the strength of a stall that has since cleared.
     return resolveWithGuard(
       { request, context } as Parameters<MiddlewareFunction>[0],
       next,
       {
-        consentHydration: timedOut.consentHydration || consentStillPending,
+        consentHydration:
+          timedOut.consentHydration ||
+          (consentStillPending &&
+            !useOnboardingStore.getState().consentHydrated),
         assistantsHydration:
           timedOut.assistantsHydration || assistantsStillPending,
         platformProbe: timedOut.platformProbe || platformProbeStillUnknown,

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -18,10 +18,18 @@ const loadLockfileHost = mock(async () => {
   throw new Error("host down");
 });
 
+const saveLockfileAssistantHost = mock(
+  async (_assistant: Record<string, unknown>, _activeId?: string) => ({
+    ok: true as const,
+    lockfile: { assistants: [], activeAssistant: null },
+  }),
+);
+
 mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,
   replacePlatformAssistantsHost,
   loadLockfileHost,
+  saveLockfileAssistantHost,
 }));
 
 import {
@@ -30,6 +38,7 @@ import {
   getLocalAssistants,
   getLockfile,
   getPlatformAssistants,
+  getPlatformRuntimeUrl,
   getSelectedAssistant,
   isCliWakeableAssistant,
   isLocalAssistant,
@@ -39,6 +48,7 @@ import {
   loadLockfile,
   primeLocalGatewayConnection,
   reconcileSelectedAssistant,
+  saveManagedLockfileAssistant,
   syncPlatformAssistantsToLockfile,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
@@ -86,6 +96,7 @@ afterEach(() => {
   localStorage.removeItem(LOCKFILE_STORAGE_KEY);
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   replacePlatformAssistantsHost.mockClear();
+  saveLockfileAssistantHost.mockClear();
 });
 
 describe("remote gateway mode", () => {
@@ -161,6 +172,33 @@ describe("syncPlatformAssistantsToLockfile", () => {
     expect(replacePlatformAssistantsHost).toHaveBeenCalledTimes(1);
     expect(useLockfileStore.getState().lockfile).toBeNull();
     expect(localStorage.getItem(LOCKFILE_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("saveManagedLockfileAssistant", () => {
+  test("writes the platform entry every managed hatch shares", async () => {
+    await saveManagedLockfileAssistant("ast-1", "Research", "org-1");
+
+    expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
+    const [entry, activeId] = saveLockfileAssistantHost.mock.calls[0]!;
+    // The written entry also becomes the lockfile's active assistant.
+    expect(activeId).toBe("ast-1");
+    expect(entry).toMatchObject({
+      assistantId: "ast-1",
+      name: "Research",
+      cloud: "vellum",
+      runtimeUrl: getPlatformRuntimeUrl(),
+      organizationId: "org-1",
+    });
+    expect(Number.isNaN(Date.parse(entry.hatchedAt as string))).toBe(false);
+  });
+
+  test("omits an unresolved organization", async () => {
+    await saveManagedLockfileAssistant("ast-1", undefined, undefined);
+
+    const [entry] = saveLockfileAssistantHost.mock.calls[0]!;
+    expect(entry.organizationId).toBeUndefined();
+    expect(entry.name).toBeUndefined();
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -213,6 +213,30 @@ export async function saveLockfileAssistant(assistant: {
 }
 
 /**
+ * Record a managed (platform) assistant in the lockfile. The desktop build's
+ * assistant list and switcher are lockfile-driven, so every managed hatch —
+ * foreground hatching screen or headless background hatch — registers its
+ * assistant here, stamped with the org whose session hatched it.
+ *
+ * The org id is a parameter because the organization store imports back through
+ * the auth store into this module; reading it here would cycle.
+ */
+export async function saveManagedLockfileAssistant(
+  assistantId: string,
+  name: string | undefined,
+  organizationId: string | undefined,
+): Promise<void> {
+  await saveLockfileAssistant({
+    assistantId,
+    name,
+    cloud: "vellum",
+    runtimeUrl: getPlatformRuntimeUrl(),
+    hatchedAt: new Date().toISOString(),
+    organizationId,
+  });
+}
+
+/**
  * Update an existing assistant entry without changing the lockfile's active
  * assistant pointer.
  */

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -19,6 +19,16 @@ mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthMode: () => false,
 }));
 
+// The shell fork the paid provisioning funnel reads. Spread the real module so
+// the rest of the platform auth graph (`isOAuthFlowInFlight` and friends) stays
+// available to the stores build-state pulls in.
+let mockIsNativePlatform = false;
+const nativeAuthActual = await import("@/runtime/native-auth");
+mock.module("@/runtime/native-auth", () => ({
+  ...nativeAuthActual,
+  isNativePlatform: () => mockIsNativePlatform,
+}));
+
 // Consent prefs read storage; pin them so the access decision is isolated.
 mock.module("@/domains/onboarding/prefs", () => ({
   readTosAccepted: () => true,
@@ -40,6 +50,7 @@ const initialAuthState = useAuthStore.getState();
 beforeEach(() => {
   mockIsLocalMode = true;
   mockIsRemoteGatewayMode = false;
+  mockIsNativePlatform = false;
   useAuthStore.setState(initialAuthState, true);
   useOrganizationStore.setState({
     currentOrganizationId: null,
@@ -111,6 +122,22 @@ describe("buildNavigationState — isAuthenticated mirrors sessionStatus", () =>
     });
 
     expect(buildNavigationState().platformSession).toBe("unknown");
+  });
+});
+
+describe("buildNavigationState — isNative", () => {
+  // The post-checkout provisioning funnel forks on this: native keeps the
+  // foreground hatching screen, web and Electron take the headless research
+  // entry.
+
+  test("false in a browser or the Electron shell", () => {
+    expect(buildNavigationState().isNative).toBe(false);
+  });
+
+  test("true inside the native Capacitor shell", () => {
+    mockIsNativePlatform = true;
+
+    expect(buildNavigationState().isNative).toBe(true);
   });
 });
 

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -15,6 +15,7 @@ import {
   readConsentHydrated,
 } from "@/domains/onboarding/prefs";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
+import { isNativePlatform } from "@/runtime/native-auth";
 import {
   assistantsValidForOrg,
   useResolvedAssistantsStore,
@@ -56,6 +57,7 @@ export function buildNavigationState(
       ? remoteGatewayPublicPathPrefix()
       : "",
     isGatewayAuth: isGatewayAuthMode(),
+    isNative: isNativePlatform(),
     hasAssistants: assistants.length > 0,
     hasPlatformHostedAssistant: hasPlatformHostedAssistant(assistants),
     sessionSettled: isSessionSettled(sessionStatus),

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -831,6 +831,13 @@ describe("resolveNavigation", () => {
 
     const UNCONSENTED = { tosAccepted: false, privacyConsent: false } as const;
 
+    // Either toggle going stale forces the same re-review, so the cases below
+    // assert against both.
+    const STALE_TOGGLES = [
+      { analyticsConsentCurrent: false },
+      { diagnosticsConsentCurrent: false },
+    ] as const;
+
     // Consent is enforced at the destination, not skipped: both funnel entries
     // are onboarding paths, and re-resolving one bounces an unconsented user on.
     test("consent is still enforced once the funnel destination is resolved", () => {
@@ -917,10 +924,7 @@ describe("resolveNavigation", () => {
     // `returnTo` so the plan is not lost on the round trip. The marker is what
     // scopes this — an ordinary research visit keeps its onboarding exemption.
     test("sends a stale-consent paid research return to review-terms", () => {
-      for (const stale of [
-        { analyticsConsentCurrent: false },
-        { diagnosticsConsentCurrent: false },
-      ]) {
+      for (const stale of STALE_TOGGLES) {
         expect(guard(s({ ...EMPTY_ORG, ...stale }), RESEARCH_FUNNEL_URL)).toEqual({
           action: "redirect",
           to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
@@ -1077,10 +1081,7 @@ describe("resolveNavigation", () => {
     // re-reviewed before the purchased hatch — with the funnel URL as
     // `returnTo`, so the markers survive and the plan is not lost.
     test("sends a stale-consent gateway-auth paid research return to review-terms", () => {
-      for (const stale of [
-        { analyticsConsentCurrent: false },
-        { diagnosticsConsentCurrent: false },
-      ]) {
+      for (const stale of STALE_TOGGLES) {
         expect(
           guard(s({ ...ELECTRON_PAID, ...stale }), RESEARCH_FUNNEL_URL),
         ).toEqual({
@@ -1095,10 +1096,7 @@ describe("resolveNavigation", () => {
     // client still points — resolves `allow` here and re-reviews stale terms at
     // the screen's own `hatch-gate` instead.
     test("leaves a stale-consent paid hatching return on its allow", () => {
-      for (const stale of [
-        { analyticsConsentCurrent: false },
-        { diagnosticsConsentCurrent: false },
-      ]) {
+      for (const stale of STALE_TOGGLES) {
         expect(
           guard(s({ ...ELECTRON_PAID, ...stale }), HATCHING_FUNNEL_URL),
         ).toEqual(ALLOW);

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -20,6 +20,8 @@ const base: NavigationState = {
   isRemoteGateway: false,
   remoteGatewayPublicPathPrefix: "",
   isGatewayAuth: false,
+  // Web/Electron by default; the native fork is exercised explicitly.
+  isNative: false,
   hasAssistants: true,
   hasPlatformHostedAssistant: true,
   sessionSettled: true,
@@ -47,6 +49,16 @@ function redirectPath(decision: NavigationDecision): string | null {
   const qIdx = decision.to.indexOf("?");
   return qIdx < 0 ? decision.to : decision.to.slice(0, qIdx);
 }
+
+// The two provisioning funnel entries a paid return can name. Both carry the
+// managed-hatch marker, so a local-mode client provisions on the platform
+// instead of letting its own gateway answer for the assistant and skipping the
+// purchased-provisioning wait, plus the post-checkout marker that tells that
+// wait a still-base subscription read is a lagging webhook, not a free org.
+const RESEARCH_FUNNEL_URL =
+  "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
+const HATCHING_FUNNEL_URL =
+  "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
 
 const ALLOW: NavigationDecision = { action: "allow" };
 const WAIT: NavigationDecision = { action: "wait" };
@@ -594,14 +606,17 @@ describe("resolveNavigation", () => {
     const POST_CHECKOUT_BILLING =
       "/assistant/settings/billing?session_id=cs_test_123";
 
-    // The funnel entry carries the managed-hatch marker, so a local-mode
-    // client provisions on the platform instead of letting its own gateway
-    // answer for the assistant and skipping the purchased-provisioning wait,
-    // plus the post-checkout marker that tells the hatching screen a
-    // still-base subscription read is a lagging webhook, not a free org.
+    // Web and Electron land the paid return on the headless research
+    // onboarding, which runs the purchased-provisioning wait behind the form.
     const MANAGED_FUNNEL: NavigationDecision = {
       action: "redirect",
-      to: "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1",
+      to: RESEARCH_FUNNEL_URL,
+    };
+    // The native shell has no research flow, so it keeps the foreground
+    // hatching screen.
+    const NATIVE_MANAGED_FUNNEL: NavigationDecision = {
+      action: "redirect",
+      to: HATCHING_FUNNEL_URL,
     };
 
     // A brand-new org: nothing resolved at all.
@@ -618,10 +633,24 @@ describe("resolveNavigation", () => {
       hasPlatformHostedAssistant: false,
     } as const;
 
-    test("funnels a no-assistant post-checkout return into hatching", () => {
+    test("funnels a no-assistant post-checkout return into the research onboarding", () => {
       expect(guard(s(EMPTY_ORG), POST_CHECKOUT_BILLING)).toEqual(
         MANAGED_FUNNEL,
       );
+    });
+
+    // The research flow isn't wired for the Capacitor shell, so the native paid
+    // return still gets the foreground hatching screen.
+    test("keeps the foreground hatching entry on native", () => {
+      expect(
+        guard(s({ ...EMPTY_ORG, isNative: true }), POST_CHECKOUT_BILLING),
+      ).toEqual(NATIVE_MANAGED_FUNNEL);
+      expect(
+        guard(
+          s({ ...NO_MANAGED_ASSISTANT, isNative: true }),
+          POST_CHECKOUT_BILLING,
+        ),
+      ).toEqual(NATIVE_MANAGED_FUNNEL);
     });
 
     // The decision is "does a managed plan have a target", not "is the list
@@ -801,30 +830,31 @@ describe("resolveNavigation", () => {
     });
 
     const UNCONSENTED = { tosAccepted: false, privacyConsent: false } as const;
-    const MANAGED_FUNNEL_URL =
-      "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
 
-    // Consent is enforced at the destination, not skipped: the funnel entry is
-    // an onboarding path, and re-resolving it bounces an unconsented user on.
+    // Consent is enforced at the destination, not skipped: both funnel entries
+    // are onboarding paths, and re-resolving one bounces an unconsented user on.
     test("consent is still enforced once the funnel destination is resolved", () => {
       expect(
         guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), POST_CHECKOUT_BILLING),
       ).toEqual(MANAGED_FUNNEL);
-      expect(
-        redirectPath(guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), MANAGED_FUNNEL_URL)),
-      ).toBe("/assistant/onboarding/privacy");
+      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+        expect(
+          redirectPath(guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), url)),
+        ).toBe("/assistant/onboarding/privacy");
+      }
     });
 
     // The bounce carries the funnel URL as `returnTo` — the same contract
     // review-terms uses — so the privacy screen resumes it on Start. Dropping
     // it loses the paid-return marker, and the paying user finishes the hatch
-    // at the baseline plan.
+    // at the baseline plan. The hatching form round-trips too, because a
+    // `returnTo` stashed by an older client names it.
     test("carries the paid funnel destination through the consent bounce", () => {
       expect(
-        guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), MANAGED_FUNNEL_URL),
+        guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), HATCHING_FUNNEL_URL),
       ).toEqual({
         action: "redirect",
-        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(MANAGED_FUNNEL_URL)}`,
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(HATCHING_FUNNEL_URL)}`,
       });
     });
 
@@ -847,15 +877,12 @@ describe("resolveNavigation", () => {
     // `returnTo`, so its bounce stays bare.
     test("a local-mode hatching bounce keeps the bare welcome entrypoint", () => {
       expect(
-        guard(s({ isLocalMode: true, ...UNCONSENTED }), MANAGED_FUNNEL_URL),
+        guard(s({ isLocalMode: true, ...UNCONSENTED }), HATCHING_FUNNEL_URL),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     // The research route is the headless paid provisioning entry, so it bounces
     // and carries exactly like the hatching entry does.
-    const RESEARCH_FUNNEL_URL =
-      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
-
     test("carries a paid research destination through the consent bounce", () => {
       expect(
         guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), RESEARCH_FUNNEL_URL),
@@ -904,10 +931,13 @@ describe("resolveNavigation", () => {
     // in-app navigation, never a cold deep link, and it bounces immediately.
     test("the hatching bounce does not wait on consent hydration", () => {
       expect(
-        guard(s({ ...UNCONSENTED, consentHydrated: false }), MANAGED_FUNNEL_URL),
+        guard(
+          s({ ...UNCONSENTED, consentHydrated: false }),
+          HATCHING_FUNNEL_URL,
+        ),
       ).toEqual({
         action: "redirect",
-        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(MANAGED_FUNNEL_URL)}`,
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(HATCHING_FUNNEL_URL)}`,
       });
     });
 
@@ -929,15 +959,105 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
+    // A gateway session short-circuits the pipeline to "allow" before any
+    // consent step runs, so the paid funnel entries suspend that bypass —
+    // otherwise an Electron paid return starts the purchased hatch with no
+    // consent recorded. The Electron desktop shape: gateway auth against a
+    // local assistant, with a platform session to provision into.
+    const ELECTRON_PAID = {
+      isGatewayAuth: true,
+      isLocalMode: true,
+      platformSession: "present",
+      ...NO_MANAGED_ASSISTANT,
+    } as const;
+
+    // Local mode's entrypoint is `welcome`, which reads no `returnTo` — the
+    // same bare bounce the hatching screen's own gate already gave this user.
+    test("bounces an unconsented gateway-auth paid return to the local entrypoint", () => {
+      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+        expect(guard(s({ ...ELECTRON_PAID, ...UNCONSENTED }), url)).toEqual({
+          action: "redirect",
+          to: "/assistant/welcome",
+        });
+      }
+    });
+
+    // Suspending the bypass must not bounce a consented paid return: it is the
+    // whole point of the funnel that it reaches the hatch.
+    test("allows a consented gateway-auth paid return", () => {
+      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+        expect(guard(s(ELECTRON_PAID), url)).toEqual(ALLOW);
+      }
+    });
+
+    // Onboarding is complete but a toggle went stale, so the terms are
+    // re-reviewed before the purchased hatch — with the funnel URL as
+    // `returnTo`, so the markers survive and the plan is not lost.
+    test("sends a stale-consent gateway-auth paid return to review-terms", () => {
+      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+        expect(
+          guard(s({ ...ELECTRON_PAID, analyticsConsentCurrent: false }), url),
+        ).toEqual({
+          action: "redirect",
+          to: `/assistant/review-terms?returnTo=${encodeURIComponent(url)}`,
+        });
+      }
+      expect(
+        guard(
+          s({ ...ELECTRON_PAID, diagnosticsConsentCurrent: false }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+      });
+    });
+
+    // Only the paid marker suspends the bypass. The local adopt flow reaches
+    // the research entry unmarked and keeps the bypass it has always had.
+    test("keeps the gateway-auth bypass on an unmarked funnel entry", () => {
+      for (const url of [
+        "/assistant/onboarding/research",
+        "/assistant/onboarding/research?hosting=vellum-cloud",
+        "/assistant/onboarding/hatching",
+        "/assistant/onboarding/hatching?post_checkout=0",
+      ]) {
+        expect(
+          guard(s({ ...ELECTRON_PAID, ...UNCONSENTED }), url),
+        ).toEqual(ALLOW);
+      }
+    });
+
+    // A remote-gateway session is gateway auth too. Paired (authenticated), it
+    // passes the pairing step untouched; unpaired it pairs first, and the
+    // pairing `returnTo` keeps the markers so the funnel resumes after.
+    test("leaves remote-gateway pairing intact on a paid funnel entry", () => {
+      expect(
+        guard(
+          s({ ...ELECTRON_PAID, isRemoteGateway: true }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual(ALLOW);
+      expect(
+        guard(
+          s({ ...ELECTRON_PAID, isRemoteGateway: true, isAuthenticated: false }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/pair?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+      });
+    });
+
     // The funnel destination must not itself read as a checkout return, or the
     // redirect would loop.
     test("the funnel destination is not treated as a post-checkout return", () => {
-      expect(
-        guard(
-          s(EMPTY_ORG),
-          "/assistant/onboarding/hatching?session_id=cs_test_123",
-        ),
-      ).toEqual(ALLOW);
+      for (const url of [
+        "/assistant/onboarding/hatching?session_id=cs_test_123",
+        "/assistant/onboarding/research?session_id=cs_test_123",
+      ]) {
+        expect(guard(s(EMPTY_ORG), url)).toEqual(ALLOW);
+      }
     });
 
     test("redirects brand-new platform user with no assistant to privacy, unaffected by stale-toggle gate", () => {
@@ -1290,11 +1410,6 @@ describe("resolveNavigation", () => {
   // postCheckoutHatchReturnTo
   // -----------------------------------------------------------------------
   describe("postCheckoutHatchReturnTo", () => {
-    const RESEARCH_FUNNEL_URL =
-      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
-    const HATCHING_FUNNEL_URL =
-      "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
-
     test("accepts the headless research funnel entry", () => {
       expect(postCheckoutHatchReturnTo(RESEARCH_FUNNEL_URL)).toBe(
         RESEARCH_FUNNEL_URL,

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/billing/checkout-intent";
 
 import {
+  postCheckoutHatchReturnTo,
   resolveNavigation,
   resolveLoginReturnTo,
   type NavigationState,
@@ -850,6 +851,84 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
+    // The research route is the headless paid provisioning entry, so it bounces
+    // and carries exactly like the hatching entry does.
+    const RESEARCH_FUNNEL_URL =
+      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
+
+    test("carries a paid research destination through the consent bounce", () => {
+      expect(
+        guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), RESEARCH_FUNNEL_URL),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+      });
+    });
+
+    // Closes a consent gap: an unconsented user could previously walk the
+    // research funnel directly, which provisions an assistant.
+    test("bounces an unconsented bare research visit to the entrypoint", () => {
+      expect(guard(s(UNCONSENTED), "/assistant/onboarding/research")).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/privacy",
+      });
+      expect(
+        guard(s({ isLocalMode: true, ...UNCONSENTED }), "/assistant/onboarding/research"),
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
+    });
+
+    test("allows a consented user on the research route", () => {
+      expect(guard(s({}), "/assistant/onboarding/research")).toEqual(ALLOW);
+      expect(
+        guard(s({ hasAssistants: false }), "/assistant/onboarding/research"),
+      ).toEqual(ALLOW);
+      expect(guard(s({}), RESEARCH_FUNNEL_URL)).toEqual(ALLOW);
+    });
+
+    // A cold paid deep link reaches the research route before the consent flags
+    // hydrate, and they boot false — deciding there would bounce an established
+    // user to privacy, and a `redirect` gives the auth middleware nothing to
+    // wait on.
+    test("waits on the research route until consent hydrates", () => {
+      for (const url of ["/assistant/onboarding/research", RESEARCH_FUNNEL_URL]) {
+        expect(
+          guard(s({ ...EMPTY_ORG, ...UNCONSENTED, consentHydrated: false }), url),
+        ).toEqual(WAIT);
+        // Same wait for an already-consented user whose flags have not been
+        // confirmed yet: hydration is read before the flags either way.
+        expect(guard(s({ consentHydrated: false }), url)).toEqual(WAIT);
+      }
+    });
+
+    // The wait is research-only: the foreground hatching entry is reached from
+    // in-app navigation, never a cold deep link, and it bounces immediately.
+    test("the hatching bounce does not wait on consent hydration", () => {
+      expect(
+        guard(s({ ...UNCONSENTED, consentHydrated: false }), MANAGED_FUNNEL_URL),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(MANAGED_FUNNEL_URL)}`,
+      });
+    });
+
+    // Local mode is excluded from hydration waits everywhere in the pipeline —
+    // its consent hydrates during session init or not at all — so its research
+    // bounce decides immediately.
+    test("a local-mode research bounce decides without waiting on hydration", () => {
+      expect(
+        guard(
+          s({ isLocalMode: true, ...UNCONSENTED, consentHydrated: false }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
+      expect(
+        guard(
+          s({ isLocalMode: true, ...UNCONSENTED, consentHydrated: false }),
+          "/assistant/onboarding/research",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
+    });
+
     // The funnel destination must not itself read as a checkout return, or the
     // redirect would loop.
     test("the funnel destination is not treated as a post-checkout return", () => {
@@ -1204,6 +1283,69 @@ describe("resolveNavigation", () => {
       expect(
         resolveLoginReturnTo(s({}), "/assistant/onboarding/hosting"),
       ).toBe("/assistant/onboarding/hosting");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // postCheckoutHatchReturnTo
+  // -----------------------------------------------------------------------
+  describe("postCheckoutHatchReturnTo", () => {
+    const RESEARCH_FUNNEL_URL =
+      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1";
+    const HATCHING_FUNNEL_URL =
+      "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
+
+    test("accepts the headless research funnel entry", () => {
+      expect(postCheckoutHatchReturnTo(RESEARCH_FUNNEL_URL)).toBe(
+        RESEARCH_FUNNEL_URL,
+      );
+    });
+
+    // A `returnTo` stashed on the privacy screen by an older client names the
+    // hatching entry; it must still resume rather than drop the paid markers.
+    test("accepts the foreground hatching funnel entry", () => {
+      expect(postCheckoutHatchReturnTo(HATCHING_FUNNEL_URL)).toBe(
+        HATCHING_FUNNEL_URL,
+      );
+    });
+
+    test("rejects any other path, even carrying the marker", () => {
+      for (const url of [
+        "/assistant/onboarding/privacy?post_checkout=1",
+        "/assistant/settings/billing?post_checkout=1",
+        "/assistant?post_checkout=1",
+        "/assistant/onboarding/research-mock?post_checkout=1",
+      ]) {
+        expect(postCheckoutHatchReturnTo(url)).toBeNull();
+      }
+    });
+
+    test("rejects a funnel path without the paid marker", () => {
+      for (const url of [
+        "/assistant/onboarding/research",
+        "/assistant/onboarding/research?hosting=vellum-cloud",
+        "/assistant/onboarding/research?post_checkout=0",
+        "/assistant/onboarding/hatching",
+        "/assistant/onboarding/hatching?hosting=vellum-cloud",
+      ]) {
+        expect(postCheckoutHatchReturnTo(url)).toBeNull();
+      }
+    });
+
+    test("rejects absolute and protocol-relative URLs", () => {
+      for (const url of [
+        "https://evil.example.com/assistant/onboarding/research?post_checkout=1",
+        "//evil.example.com/assistant/onboarding/research?post_checkout=1",
+        "http://localhost/assistant/onboarding/hatching?post_checkout=1",
+      ]) {
+        expect(postCheckoutHatchReturnTo(url)).toBeNull();
+      }
+    });
+
+    test("rejects absent values", () => {
+      expect(postCheckoutHatchReturnTo(null)).toBeNull();
+      expect(postCheckoutHatchReturnTo(undefined)).toBeNull();
+      expect(postCheckoutHatchReturnTo("")).toBeNull();
     });
   });
 });

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -892,8 +892,8 @@ describe("resolveNavigation", () => {
       });
     });
 
-    // Closes a consent gap: an unconsented user could previously walk the
-    // research funnel directly, which provisions an assistant.
+    // The research funnel provisions an assistant, so an unconsented user does
+    // not reach it by navigating there directly either.
     test("bounces an unconsented bare research visit to the entrypoint", () => {
       expect(guard(s(UNCONSENTED), "/assistant/onboarding/research")).toEqual({
         action: "redirect",
@@ -910,6 +910,25 @@ describe("resolveNavigation", () => {
         guard(s({ hasAssistants: false }), "/assistant/onboarding/research"),
       ).toEqual(ALLOW);
       expect(guard(s({}), RESEARCH_FUNNEL_URL)).toEqual(ALLOW);
+    });
+
+    // Onboarding is complete but a toggle went stale: the terms are re-reviewed
+    // before the purchased hatch, with the funnel URL (markers intact) as
+    // `returnTo` so the plan is not lost on the round trip. The marker is what
+    // scopes this — an ordinary research visit keeps its onboarding exemption.
+    test("sends a stale-consent paid research return to review-terms", () => {
+      for (const stale of [
+        { analyticsConsentCurrent: false },
+        { diagnosticsConsentCurrent: false },
+      ]) {
+        expect(guard(s({ ...EMPTY_ORG, ...stale }), RESEARCH_FUNNEL_URL)).toEqual({
+          action: "redirect",
+          to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+        });
+        expect(
+          guard(s({ ...EMPTY_ORG, ...stale }), "/assistant/onboarding/research"),
+        ).toEqual(ALLOW);
+      }
     });
 
     // A cold paid deep link reaches the research route before the consent flags
@@ -933,6 +952,70 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({ ...UNCONSENTED, consentHydrated: false }),
+          HATCHING_FUNNEL_URL,
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(HATCHING_FUNNEL_URL)}`,
+      });
+    });
+
+    // The auth middleware forces `consentHydrated` once its wait runs out, so
+    // the flags underneath are still their boot `false`. Bouncing on them
+    // evicts an already-consented user mid-funnel — a paid return loses its
+    // markers, a free one restarts onboarding — so the research entry falls
+    // back to the unconditional admission it had before it joined the funnel.
+    test("admits the research route when consent hydration timed out", () => {
+      for (const url of ["/assistant/onboarding/research", RESEARCH_FUNNEL_URL]) {
+        expect(
+          guard(
+            s({
+              ...EMPTY_ORG,
+              ...UNCONSENTED,
+              consentHydrated: true,
+              consentHydrationTimedOut: true,
+            }),
+            url,
+          ),
+        ).toEqual(ALLOW);
+      }
+      // The stale-toggle gate reads the same unhydrated flags, so it fails open
+      // too rather than sending a paid return to review-terms it can't answer.
+      expect(
+        guard(
+          s({
+            ...EMPTY_ORG,
+            analyticsConsentCurrent: false,
+            diagnosticsConsentCurrent: false,
+            consentHydrated: true,
+            consentHydrationTimedOut: true,
+          }),
+          RESEARCH_FUNNEL_URL,
+        ),
+      ).toEqual(ALLOW);
+    });
+
+    // Fail-open is scoped to the unhydrated read: a hydration that actually
+    // landed on an unconsented user still bounces.
+    test("still bounces a genuinely hydrated unconsented research visit", () => {
+      expect(
+        guard(s({ ...EMPTY_ORG, ...UNCONSENTED }), RESEARCH_FUNNEL_URL),
+      ).toEqual({
+        action: "redirect",
+        to: `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
+      });
+    });
+
+    // The hatching entry never waits on hydration, so it never sees the forced
+    // flag either — its bounce is unchanged by the fail-open.
+    test("the hatching bounce is unaffected by a consent hydration timeout", () => {
+      expect(
+        guard(
+          s({
+            ...UNCONSENTED,
+            consentHydrated: true,
+            consentHydrationTimedOut: true,
+          }),
           HATCHING_FUNNEL_URL,
         ),
       ).toEqual({
@@ -993,24 +1076,39 @@ describe("resolveNavigation", () => {
     // Onboarding is complete but a toggle went stale, so the terms are
     // re-reviewed before the purchased hatch — with the funnel URL as
     // `returnTo`, so the markers survive and the plan is not lost.
-    test("sends a stale-consent gateway-auth paid return to review-terms", () => {
-      for (const url of [RESEARCH_FUNNEL_URL, HATCHING_FUNNEL_URL]) {
+    test("sends a stale-consent gateway-auth paid research return to review-terms", () => {
+      for (const stale of [
+        { analyticsConsentCurrent: false },
+        { diagnosticsConsentCurrent: false },
+      ]) {
         expect(
-          guard(s({ ...ELECTRON_PAID, analyticsConsentCurrent: false }), url),
+          guard(s({ ...ELECTRON_PAID, ...stale }), RESEARCH_FUNNEL_URL),
         ).toEqual({
           action: "redirect",
-          to: `/assistant/review-terms?returnTo=${encodeURIComponent(url)}`,
+          to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
         });
       }
-      expect(
-        guard(
-          s({ ...ELECTRON_PAID, diagnosticsConsentCurrent: false }),
-          RESEARCH_FUNNEL_URL,
-        ),
-      ).toEqual({
-        action: "redirect",
-        to: `/assistant/review-terms?returnTo=${encodeURIComponent(RESEARCH_FUNNEL_URL)}`,
-      });
+    });
+
+    // The stale-toggle gate is research-only. The hatching entry — where the
+    // native paid return lands, and where a `returnTo` stashed by an older
+    // client still points — resolves `allow` here and re-reviews stale terms at
+    // the screen's own `hatch-gate` instead.
+    test("leaves a stale-consent paid hatching return on its allow", () => {
+      for (const stale of [
+        { analyticsConsentCurrent: false },
+        { diagnosticsConsentCurrent: false },
+      ]) {
+        expect(
+          guard(s({ ...ELECTRON_PAID, ...stale }), HATCHING_FUNNEL_URL),
+        ).toEqual(ALLOW);
+        expect(
+          guard(
+            s({ ...EMPTY_ORG, isNative: true, ...stale }),
+            HATCHING_FUNNEL_URL,
+          ),
+        ).toEqual(ALLOW);
+      }
     });
 
     // Only the paid marker suspends the bypass. The local adopt flow reaches

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -1,5 +1,6 @@
 import type { PlatformSessionStatus } from "@/stores/session-status";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
+import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { resolveSignupCheckoutDestination } from "@/lib/billing/post-auth-checkout";
 import { routes } from "@/utils/routes";
 
@@ -13,6 +14,13 @@ export interface NavigationState {
   isRemoteGateway: boolean;
   remoteGatewayPublicPathPrefix: string;
   isGatewayAuth: boolean;
+  /**
+   * Whether this is the native Capacitor shell (iOS/Android).
+   *
+   * The research onboarding is not wired for the native shell (see
+   * `onboarding-destination.ts`), so the paid provisioning funnel forks on it.
+   */
+  isNative: boolean;
   hasAssistants: boolean;
   /**
    * Whether the active organization has a **platform-hosted** assistant — the
@@ -145,14 +153,15 @@ function isPostCheckoutReturn(
 }
 
 /**
- * The hatching-screen query param naming a hatch that is the return leg of a
- * completed Stripe Checkout. Only {@link MANAGED_PROVISIONING_DESTINATION} sets
+ * The onboarding query param naming a hatch that is the return leg of a
+ * completed Stripe Checkout. Only {@link managedProvisioningDestination} sets
  * it, and only for a billing landing carrying Stripe's `session_id`.
  *
  * Deliberately separate from `hosting=vellum-cloud`, which says only that the
- * hatch is managed — a hosting choice a free user can make too. The hatching
- * screen holds for a lagging subscription webhook on this param alone, so
- * conflating the two would park every free managed hatch on a spinner.
+ * hatch is managed — a hosting choice a free user can make too. The purchased-
+ * provisioning wait holds for a lagging subscription webhook on this param
+ * alone, so conflating the two would park every free managed hatch on a
+ * spinner.
  */
 export const POST_CHECKOUT_HATCH_PARAM = "post_checkout";
 
@@ -162,14 +171,28 @@ export const POST_CHECKOUT_HATCH_PARAM = "post_checkout";
  *
  * `hosting=vellum-cloud` is the onboarding flow's managed-hatch marker (see
  * `adopt-existing-assistant`): it names a managed hatch even in a local-mode
- * build, where the hatching screen would otherwise let the local gateway answer
- * for the assistant and skip the purchased-provisioning wait.
+ * build, where the client would otherwise let the local gateway answer for the
+ * assistant and skip the purchased-provisioning wait. Carrying it onto the
+ * research entry is load-bearing on Electron for exactly that reason —
+ * `shouldAdoptExistingAssistant` reads it to force the managed hatch instead of
+ * adopting a local gateway assistant.
  *
  * {@link POST_CHECKOUT_HATCH_PARAM} adds the narrower fact that money has
- * already changed hands, which is what lets the hatching screen treat a
- * still-base subscription read as a pending webhook rather than a free org.
+ * already changed hands, which is what lets the hatch treat a still-base
+ * subscription read as a pending webhook rather than a free org.
  */
-const MANAGED_PROVISIONING_DESTINATION = `${routes.onboarding.hatching}?hosting=vellum-cloud&${POST_CHECKOUT_HATCH_PARAM}=1`;
+function managedProvisioningDestination(state: NavigationState): string {
+  // The same shell fork the consent step takes: native has no research flow and
+  // keeps the foreground hatching screen, while web and Electron take the
+  // headless research entry, which runs the purchased-provisioning wait behind
+  // the onboarding form. `isLocalHatch` is false by construction —
+  // `hosting=vellum-cloud` forces the managed hatch.
+  const route = onboardingDestinationAfterConsent({
+    isNative: state.isNative,
+    isLocalHatch: false,
+  });
+  return `${route}?hosting=vellum-cloud&${POST_CHECKOUT_HATCH_PARAM}=1`;
+}
 
 /**
  * The provisioning funnel entries a paid return can name: the foreground
@@ -277,7 +300,7 @@ export function resolveNavigation(
 // Conceptual layers:
 //   1. Readiness          — is the session ready?
 //   2. Paid return        — a checkout return with nothing provisioned yet
-//   3. Bypass             — gateway auth skips everything
+//   3. Bypass             — gateway auth skips everything but a paid return
 //   4. Identity           — is the user authenticated?
 //   5. Mode boundary      — is this path valid for the user's mode?
 //   6. Setup exemptions   — onboarding/consent paths are always reachable
@@ -329,11 +352,11 @@ function waitForSession(state: NavigationState): NavigationDecision | null {
  * billing landing. Every billing surface mounts under `ActiveAssistantGate`,
  * which renders a "Connecting to your assistant…" placeholder for as long as
  * no assistant resolves — so the paid return dead-ends on a spinner. Send it
- * into the hatching funnel instead, which provisions the assistant and applies
- * the purchased specs.
+ * into the provisioning funnel instead, which provisions the assistant and
+ * applies the purchased specs.
  *
- * The destination is {@link MANAGED_PROVISIONING_DESTINATION}: the marker is
- * what makes a local-mode client provision on the platform and hold for the
+ * The destination is {@link managedProvisioningDestination}: its marker is what
+ * makes a local-mode client provision on the platform and hold for the
  * purchased machine and storage instead of letting its own gateway answer for
  * the assistant.
  *
@@ -361,9 +384,10 @@ function waitForSession(state: NavigationState): NavigationDecision | null {
  * Electron takes the `"native"` checkout return, but its deep-link handler
  * lands on the same in-app billing path carrying `session_id`, so it resolves
  * through this pipeline too.
- * Consent is still enforced: the destination is an onboarding path, and
- * `onboardingCompletedMiddleware` re-runs this pipeline there, where
- * `allowSetupRoutes` bounces an unconsented user to the privacy screen.
+ * Consent is still enforced: re-resolving the destination runs
+ * `allowSetupRoutes`, which bounces an unconsented user to the consent
+ * entrypoint. `allowGatewayAuth` suspends its bypass for exactly these URLs so
+ * a gateway session reaches that step.
  */
 function requirePostCheckoutProvisioning(
   state: NavigationState,
@@ -406,11 +430,28 @@ function requirePostCheckoutProvisioning(
       return null;
     }
   }
-  return { action: "redirect", to: MANAGED_PROVISIONING_DESTINATION };
+  return { action: "redirect", to: managedProvisioningDestination(state) };
 }
 
-function allowGatewayAuth(state: NavigationState): NavigationDecision | null {
-  return state.isGatewayAuth ? { action: "allow" } : null;
+/**
+ * A gateway session answers for itself, so it skips the rest of the pipeline —
+ * except on a paid return to a provisioning funnel entry.
+ *
+ * The bypass runs before `allowSetupRoutes`, so leaving it unconditional would
+ * let an Electron paid return reach the headless research entry and start the
+ * purchased hatch with no consent recorded. Suspending it only for a
+ * {@link postCheckoutHatchReturnTo} URL keeps every other gateway-auth surface
+ * — including the local adopt flow's unmarked research entry — on today's
+ * bypass, and hands exactly the paid case to the consent steps below.
+ */
+function allowGatewayAuth(
+  state: NavigationState,
+  _path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
+  if (!state.isGatewayAuth) return null;
+  if (postCheckoutHatchReturnTo(pathnameWithSearch)) return null;
+  return { action: "allow" };
 }
 
 function stripRemoteGatewayPublicPathPrefix(
@@ -535,11 +576,31 @@ function allowSetupRoutes(
       return { action: "wait" };
     }
 
-    if (PROVISIONING_FUNNEL_PATHS.has(path) && !hasCompletedOnboarding(state)) {
-      return {
-        action: "redirect",
-        to: consentBounceDestination(state, pathnameWithSearch),
-      };
+    if (PROVISIONING_FUNNEL_PATHS.has(path)) {
+      if (!hasCompletedOnboarding(state)) {
+        return {
+          action: "redirect",
+          to: consentBounceDestination(state, pathnameWithSearch),
+        };
+      }
+      // A stale toggle must be re-reviewed before a hatch the user paid for.
+      // `requireConsent` can't reach this — every onboarding path is allowed
+      // above — so the paid funnel enforces it here, scoped to the paid marker
+      // so the ordinary funnel keeps its exemption. Gated on a live platform
+      // session for the same reason as `requireConsent`: there is nothing to
+      // re-review against without one.
+      if (
+        postCheckoutHatchReturnTo(pathnameWithSearch) &&
+        !state.isPlatformDisabled &&
+        state.platformSession === "present" &&
+        !consentIsCurrent(state)
+      ) {
+        const returnTo = encodeURIComponent(pathnameWithSearch);
+        return {
+          action: "redirect",
+          to: `${routes.reviewTerms}?returnTo=${returnTo}`,
+        };
+      }
     }
     return { action: "allow" };
   }

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -172,14 +172,26 @@ export const POST_CHECKOUT_HATCH_PARAM = "post_checkout";
 const MANAGED_PROVISIONING_DESTINATION = `${routes.onboarding.hatching}?hosting=vellum-cloud&${POST_CHECKOUT_HATCH_PARAM}=1`;
 
 /**
+ * The provisioning funnel entries a paid return can name: the foreground
+ * hatching screen (native, and local/Docker hosting) and the headless research
+ * onboarding (web). Both provision the purchased assistant, so both are
+ * consent-gated and both are resumable from the privacy screen.
+ */
+const PROVISIONING_FUNNEL_PATHS: Set<string> = new Set([
+  routes.onboarding.hatching,
+  routes.onboarding.research,
+]);
+
+/**
  * `value` when it names a paid managed hatch, else `null`.
  *
  * Narrower than {@link sanitizeReturnTo}'s open-redirect check: the onboarding
  * privacy screen navigates here in place of the standard onboarding step once
  * consent is recorded, so admitting any same-origin path would let a crafted
- * link skip the rest of the funnel. Only the hatching route carrying
- * {@link POST_CHECKOUT_HATCH_PARAM} qualifies, which only
- * {@link MANAGED_PROVISIONING_DESTINATION} produces.
+ * link skip the rest of the funnel. Only a {@link PROVISIONING_FUNNEL_PATHS}
+ * entry carrying {@link POST_CHECKOUT_HATCH_PARAM} qualifies — the screen
+ * resumes either the foreground or the headless paid provisioning entry, and
+ * that closed set of two keeps the anti-open-redirect property.
  */
 export function postCheckoutHatchReturnTo(
   value: string | null | undefined,
@@ -189,7 +201,7 @@ export function postCheckoutHatchReturnTo(
     return null;
   }
   const qIdx = destination.indexOf("?");
-  if (qIdx < 0 || destination.slice(0, qIdx) !== routes.onboarding.hatching) {
+  if (qIdx < 0 || !PROVISIONING_FUNNEL_PATHS.has(destination.slice(0, qIdx))) {
     return null;
   }
   const params = new URLSearchParams(destination.slice(qIdx + 1));
@@ -475,12 +487,12 @@ function enforceModeBoundary(
 }
 
 /**
- * Where an unconsented user who reached the hatching screen is sent.
+ * Where an unconsented user who reached a provisioning funnel entry is sent.
  *
- * A paid return carries its hatching URL as `returnTo`, the same contract
+ * A paid return carries its funnel URL as `returnTo`, the same contract
  * `review-terms` uses, and the privacy screen resumes it on Start. Without the
  * carry the funnel's markers are lost on the bounce and the paying user
- * finishes the hatch at the baseline plan. Every other hatching bounce — and
+ * finishes the hatch at the baseline plan. Every other funnel bounce — and
  * local mode, whose entrypoint is `welcome` and reads no `returnTo` — gets the
  * bare entrypoint.
  */
@@ -509,7 +521,21 @@ function allowSetupRoutes(
   }
 
   if (isOnboardingPath(path)) {
-    if (path === routes.onboarding.hatching && !hasCompletedOnboarding(state)) {
+    // The research route is the headless funnel entry, so it is the one reached
+    // by a cold paid deep link — the consent flags are still at their boot
+    // defaults there, and bouncing on them would send an already-consented user
+    // to privacy. Local mode is excluded for the same reason as in
+    // `requireConsent`: its consent either hydrates synchronously during session
+    // init or never does, so waiting would hang navigation.
+    if (
+      path === routes.onboarding.research &&
+      !state.isLocalMode &&
+      !state.consentHydrated
+    ) {
+      return { action: "wait" };
+    }
+
+    if (PROVISIONING_FUNNEL_PATHS.has(path) && !hasCompletedOnboarding(state)) {
       return {
         action: "redirect",
         to: consentBounceDestination(state, pathnameWithSearch),

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -45,6 +45,14 @@ export interface NavigationState {
    * hydration would misread an established user as un-onboarded.
    */
   consentHydrated: boolean;
+  /**
+   * Whether `consentHydrated` above was forced by the auth middleware after its
+   * hydration wait timed out. The consent flags then still read their boot
+   * `false`, so a gate that treats them as a settled "not consented" would
+   * evict a consented user. Absent on every other caller — only the middleware
+   * can know its own wait ran out.
+   */
+  consentHydrationTimedOut?: boolean;
   /** Whether the resolved assistants list reflects at least one authoritative load. */
   assistantsHydrated: boolean;
 }
@@ -196,9 +204,11 @@ function managedProvisioningDestination(state: NavigationState): string {
 
 /**
  * The provisioning funnel entries a paid return can name: the foreground
- * hatching screen (native, and local/Docker hosting) and the headless research
- * onboarding (web). Both provision the purchased assistant, so both are
- * consent-gated and both are resumable from the privacy screen.
+ * hatching screen (native only) and the headless research onboarding (web and
+ * Electron). The shell is the only fork — {@link managedProvisioningDestination}
+ * always resolves a managed hatch, so hosting never picks the entry. Both
+ * provision the purchased assistant, so both are consent-gated and both are
+ * resumable from the privacy screen.
  */
 const PROVISIONING_FUNNEL_PATHS: Set<string> = new Set([
   routes.onboarding.hatching,
@@ -533,9 +543,13 @@ function enforceModeBoundary(
  * A paid return carries its funnel URL as `returnTo`, the same contract
  * `review-terms` uses, and the privacy screen resumes it on Start. Without the
  * carry the funnel's markers are lost on the bounce and the paying user
- * finishes the hatch at the baseline plan. Every other funnel bounce — and
- * local mode, whose entrypoint is `welcome` and reads no `returnTo` — gets the
+ * finishes the hatch at the baseline plan. Every other funnel bounce gets the
  * bare entrypoint.
+ *
+ * Local mode is a deliberate exception to that carry: its entrypoint is
+ * `welcome`, which reads no `returnTo`, so an unconsented local paid return
+ * finishes the hatch at baseline and the server-side post-hatch reconcile
+ * applies the purchased specs. That is the parity local mode has always had.
  */
 function consentBounceDestination(
   state: NavigationState,
@@ -561,48 +575,77 @@ function allowSetupRoutes(
     return { action: "allow" };
   }
 
-  if (isOnboardingPath(path)) {
-    // The research route is the headless funnel entry, so it is the one reached
-    // by a cold paid deep link — the consent flags are still at their boot
-    // defaults there, and bouncing on them would send an already-consented user
-    // to privacy. Local mode is excluded for the same reason as in
-    // `requireConsent`: its consent either hydrates synchronously during session
-    // init or never does, so waiting would hang navigation.
-    if (
-      path === routes.onboarding.research &&
-      !state.isLocalMode &&
-      !state.consentHydrated
-    ) {
+  if (!isOnboardingPath(path)) {
+    return null;
+  }
+
+  return enforceFunnelConsent(state, path, pathnameWithSearch) ?? { action: "allow" };
+}
+
+/**
+ * Consent for the two provisioning funnel entries, which `requireConsent` never
+ * reaches — every onboarding path is allowed before it runs.
+ *
+ * The hatching entry keeps exactly the gate it has always had — reached from
+ * in-app navigation and from the native paid return, it decides on the flags in
+ * hand and leaves stale-toggle review to the screen's own `hatch-gate`. The
+ * research entry is the one a cold paid deep link lands on, so it also waits
+ * for the flags to hydrate and re-reviews a stale toggle before starting a
+ * hatch the user paid for.
+ */
+function enforceFunnelConsent(
+  state: NavigationState,
+  path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
+  if (!PROVISIONING_FUNNEL_PATHS.has(path)) {
+    return null;
+  }
+
+  if (path === routes.onboarding.research) {
+    // The consent flags are still at their boot defaults on a cold deep link,
+    // and bouncing on them would send an already-consented user to privacy.
+    // Local mode is excluded for the same reason as in `requireConsent`: its
+    // consent either hydrates synchronously during session init or never does,
+    // so waiting would hang navigation.
+    if (!state.isLocalMode && !state.consentHydrated) {
       return { action: "wait" };
     }
-
-    if (PROVISIONING_FUNNEL_PATHS.has(path)) {
-      if (!hasCompletedOnboarding(state)) {
-        return {
-          action: "redirect",
-          to: consentBounceDestination(state, pathnameWithSearch),
-        };
-      }
-      // A stale toggle must be re-reviewed before a hatch the user paid for.
-      // `requireConsent` can't reach this — every onboarding path is allowed
-      // above — so the paid funnel enforces it here, scoped to the paid marker
-      // so the ordinary funnel keeps its exemption. Gated on a live platform
-      // session for the same reason as `requireConsent`: there is nothing to
-      // re-review against without one.
-      if (
-        postCheckoutHatchReturnTo(pathnameWithSearch) &&
-        !state.isPlatformDisabled &&
-        state.platformSession === "present" &&
-        !consentIsCurrent(state)
-      ) {
-        const returnTo = encodeURIComponent(pathnameWithSearch);
-        return {
-          action: "redirect",
-          to: `${routes.reviewTerms}?returnTo=${returnTo}`,
-        };
-      }
+    // A hydration that never landed leaves those boot defaults behind a forced
+    // `consentHydrated`, so the gates below would read a consented user as
+    // un-onboarded and restart their funnel. Fail open to the entry's
+    // unconditional contract instead; a hydrated read still gates.
+    if (state.consentHydrationTimedOut) {
+      return null;
     }
-    return { action: "allow" };
+  }
+
+  if (!hasCompletedOnboarding(state)) {
+    return {
+      action: "redirect",
+      to: consentBounceDestination(state, pathnameWithSearch),
+    };
+  }
+
+  // A stale toggle must be re-reviewed before a hatch the user paid for.
+  // Research-only: the hatching entry — the native paid return, and a
+  // `returnTo` stashed by an older client — reaches a screen whose own
+  // `hatch-gate` already re-reviews stale terms, so gating it twice would only
+  // change where it lands. Gated on the paid marker so the ordinary funnel
+  // keeps its exemption, and on a live platform session for the same reason as
+  // `requireConsent`: there is nothing to re-review against without one.
+  if (
+    path === routes.onboarding.research &&
+    postCheckoutHatchReturnTo(pathnameWithSearch) &&
+    !state.isPlatformDisabled &&
+    state.platformSession === "present" &&
+    !consentIsCurrent(state)
+  ) {
+    const returnTo = encodeURIComponent(pathnameWithSearch);
+    return {
+      action: "redirect",
+      to: `${routes.reviewTerms}?returnTo=${returnTo}`,
+    };
   }
 
   return null;

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -546,10 +546,9 @@ function enforceModeBoundary(
  * finishes the hatch at the baseline plan. Every other funnel bounce gets the
  * bare entrypoint.
  *
- * Local mode is a deliberate exception to that carry: its entrypoint is
- * `welcome`, which reads no `returnTo`, so an unconsented local paid return
- * finishes the hatch at baseline and the server-side post-hatch reconcile
- * applies the purchased specs. That is the parity local mode has always had.
+ * Local mode is a deliberate exception to that carry: its `welcome` entrypoint
+ * reads no `returnTo`, so the hatch finishes at baseline and the server-side
+ * post-hatch reconcile applies the purchased specs.
  */
 function consentBounceDestination(
   state: NavigationState,
@@ -579,12 +578,14 @@ function allowSetupRoutes(
     return null;
   }
 
-  return enforceFunnelConsent(state, path, pathnameWithSearch) ?? { action: "allow" };
+  return enforceFunnelConsent(state, path, pathnameWithSearch);
 }
 
 /**
  * Consent for the two provisioning funnel entries, which `requireConsent` never
- * reaches — every onboarding path is allowed before it runs.
+ * reaches — every onboarding path is allowed before it runs. It decides every
+ * onboarding path outright: anything that is not a funnel entry is plainly
+ * allowed.
  *
  * The hatching entry keeps exactly the gate it has always had — reached from
  * in-app navigation and from the native paid return, it decides on the flags in
@@ -597,9 +598,9 @@ function enforceFunnelConsent(
   state: NavigationState,
   path: string,
   pathnameWithSearch: string,
-): NavigationDecision | null {
+): NavigationDecision {
   if (!PROVISIONING_FUNNEL_PATHS.has(path)) {
-    return null;
+    return { action: "allow" };
   }
 
   if (path === routes.onboarding.research) {
@@ -616,7 +617,7 @@ function enforceFunnelConsent(
     // un-onboarded and restart their funnel. Fail open to the entry's
     // unconditional contract instead; a hydrated read still gates.
     if (state.consentHydrationTimedOut) {
-      return null;
+      return { action: "allow" };
     }
   }
 
@@ -648,7 +649,7 @@ function enforceFunnelConsent(
     };
   }
 
-  return null;
+  return { action: "allow" };
 }
 
 function requireAssistant(

--- a/clients/web/src/routes.test.ts
+++ b/clients/web/src/routes.test.ts
@@ -230,6 +230,20 @@ describe("onboarding funnel middleware order", () => {
     expect(onboardingIndex).toBeGreaterThanOrEqual(0);
     expect(authIndex).toBeLessThan(onboardingIndex);
   });
+
+  // The paid return lands here on web and Electron. Its markers survive the
+  // consent bounce because `authMiddleware` — which resolves with pathname +
+  // search — is the only guard on the route. Moving it under the onboarding
+  // guard, which resolves with the pathname alone, would drop them and finish
+  // the hatch at the baseline plan.
+  test("guards the research funnel route with the auth middleware alone", () => {
+    const order = middlewareExecutionOrder(
+      "/assistant/onboarding/research?hosting=vellum-cloud&post_checkout=1",
+    );
+
+    expect(order).toContain(authMiddleware);
+    expect(order).not.toContain(onboardingCompletedMiddleware);
+  });
 });
 
 describe("settings route compatibility", () => {

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -27,7 +27,7 @@ import { hasLivePlatformSession } from "@/stores/session-status";
 
 const ACTIVE_ORGANIZATION_STORAGE_KEY = "vellum_active_organization_id";
 
-type OrganizationStatus = "idle" | "loading" | "ready" | "error";
+export type OrganizationStatus = "idle" | "loading" | "ready" | "error";
 
 interface OrganizationState {
   organizations: OrganizationRead[];


### PR DESCRIPTION
## Summary
The paid checkout return now lands directly on the research onboarding on web/Electron — the purchased machine/storage resize runs invisibly inside the background hatch while the user fills in the form — instead of parking the user on the visible hatching screen. Native iOS keeps the foreground hatching screen (the research flow isn't wired for the native shell). The free path is byte-identical.

## Self-review result
GAPS FOUND → fixed across 4 review rounds (7 fix PRs). Multi-pass self-review (external-feedback / plan-faithfulness / integration / slop audits) ran twice in full plus two focused delta rounds; final round verified all plan invariants on the merged head.

## PRs merged into the feature branch
- #39330: refactor(web): extract the purchased-provisioning wait from the hatching screen
- #39329: feat(web): let the paid-return marker name the research route through consent
- #39332: feat(web): run the purchased-provisioning wait inside the background hatch
- #39333: feat(web): wire the paid return into the research onboarding with a failure surface
- #39335: feat(web): land the paid checkout return on the research onboarding headlessly

### Fix PRs (self-review remediation)
- #39337: non-modal hatch-failure banner; auto-advance gated on a live hatch
- #39338: abort-on-unmount for the background paid wait; constants single-sourced; Electron lockfile write
- #39339: consent hardening scoped to the research entry; hydration-timeout fail-open
- #39340: per-wait hydration-timeout tracking (closes a consent bypass)
- #39341: banner moved to the top strip w/ safe-area; terminal handoffs gated on a dead hatch
- #39342: settle-guarded abort; shared managed lockfile write; comment cleanup
- #39343: consent-latch recompute; retry-window handoff gating; discovery-loop abort guards

## Outstanding manual QA (not performed — needs a dev build + Stripe test mode)
- [ ] New user, web: marketing /pricing → signup → checkout → Stripe test purchase → lands on the research form with NO hatching screen; machine size is Pro-sized by the time chat starts
- [ ] Unconsented variant: privacy screen appears first; Start resumes the research URL with post_checkout=1 intact
- [ ] Kill the network mid-hatch on the research form → top failure banner with Try again; retry recovers (established-assistant guard, research turn, personality, plugin installs all re-arm)
- [ ] Free signup (no purchase) → unchanged; no subscription polling in the network tab during the research hatch
- [ ] Native (iOS simulator) paid return → still gets the hatching screen
- [ ] Banner geometry eyeball on a phone-width viewport (top strip straddles step headings on short viewports; the at-capacity variant is tall — analyzed statically, never browser-verified)

## Known deferred (reported by self-review, deliberately not done here)
- Consolidation polish: shared sleep/copy/targets-derivation helpers, pruning ~15 double-covered hatching-screen wait tests, POST_CHECKOUT_HATCH_PARAM module placement (route test mocks it), error-kind discrimination instead of message comparison, consentHydration tri-state
- Local-mode (Electron) unconsented paid return still drops the paid markers at the welcome bounce (pre-existing parity, documented in consentBounceDestination; server-side reconcile is the backstop)
- #39343 received no external review (tracked in UNREVIEWED_PRS.md); this PR's review covers its delta

Part of plan: headless-paid-hatch.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)