### PR TITLE
fix(ios): gate the live-voice audio session behind a kill switch, drop the blind re-assert (JARVIS-1364)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
@@ -6,34 +6,14 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // category/mode must be in force *before* WebKit builds its capture unit.
 // Declared before the module under test is imported.
 const audioSessionCalls: string[] = [];
-// Lets a test park one `activate` call mid-flight, standing in for a slow
-// Capacitor bridge round-trip.
-let activateCallCount = 0;
-let gatedActivateCall: number | null = null;
-let gate: { promise: Promise<void>; resolve: () => void } | null = null;
-
-function makeGate(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((r) => {
-    resolve = r;
-  });
-  return { promise, resolve };
-}
-
 mock.module("@/runtime/native-voice-audio-session", () => ({
   activateVoiceAudioSession: mock(async () => {
-    activateCallCount += 1;
     audioSessionCalls.push("activate");
-    if (gate && gatedActivateCall === activateCallCount) await gate.promise;
   }),
   deactivateVoiceAudioSession: mock(async () => {
     audioSessionCalls.push("deactivate");
   }),
 }));
-
-const flushMicrotasks = async (rounds = 4) => {
-  for (let i = 0; i < rounds; i++) await Promise.resolve();
-};
 
 const { isSupported, LIVE_VOICE_AUDIO_FORMAT, LiveVoiceAudioCapture } =
   await import("@/domains/chat/voice/live-voice/pcm-capture");
@@ -139,9 +119,6 @@ beforeEach(() => {
   lastWorklet = null;
   FakeAudioContext.lastInstance = null;
   audioSessionCalls.length = 0;
-  activateCallCount = 0;
-  gatedActivateCall = null;
-  gate = null;
   getUserMediaImpl = () => Promise.resolve(new FakeMediaStream());
   installAudioGlobals();
 });
@@ -391,22 +368,18 @@ describe("native audio session (iOS echo cancellation)", () => {
     return stream;
   }
 
-  test("activates before opening the mic, then re-asserts once the stream is live", async () => {
+  test("activates before opening the mic, and never touches the session again while capture is live", async () => {
     recordGetUserMedia();
     const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
 
     const result = await capture.start();
 
     expect(result.ok).toBe(true);
-    // The first activate must precede getUserMedia — configuring the session
-    // after WebKit has built its capture unit is too late for that stream.
-    // The second re-asserts the mode WebKit may have dropped when capture
-    // started.
-    expect(audioSessionCalls).toEqual([
-      "activate",
-      "getUserMedia",
-      "activate",
-    ]);
+    // Activate must precede getUserMedia — configuring the session after
+    // WebKit has built its capture unit is too late for that stream. And
+    // nothing may touch the session afterwards: a blind re-assert under a
+    // live capture is what broke the mic on device.
+    expect(audioSessionCalls).toEqual(["activate", "getUserMedia"]);
   });
 
   test("deactivates when the session's capture is torn down", async () => {
@@ -435,34 +408,6 @@ describe("native audio session (iOS echo cancellation)", () => {
       "getUserMedia",
       "deactivate",
     ]);
-  });
-
-  test("a stop() during the post-getUserMedia re-assert releases the mic without waiting on the bridge", async () => {
-    const stream = recordGetUserMedia();
-    gate = makeGate();
-    gatedActivateCall = 2; // park the re-assert that follows getUserMedia
-    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
-
-    const startPromise = capture.start();
-    await flushMicrotasks();
-    expect(audioSessionCalls).toEqual(["activate", "getUserMedia", "activate"]);
-
-    // The mic is open but the native call has not answered. A stop() here must
-    // release it immediately — the capture has to own the stream before the
-    // round-trip, or the mic stays live for however long the bridge takes.
-    const stopPromise = capture.stop();
-    await flushMicrotasks();
-    expect(stream.tracks.every((t) => t.stopped)).toBe(true);
-
-    gate.resolve();
-    const result = await startPromise;
-    await stopPromise;
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toBe("aborted");
-    // The late activate resolved after teardown's deactivate; the session must
-    // not be left held with no owner.
-    expect(audioSessionCalls.at(-1)).toBe("deactivate");
   });
 
   test("deactivates when a stop() cancels an in-flight start", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -14,8 +14,8 @@
  * On iOS the capture also brackets itself with `runtime/native-voice-audio-session`,
  * which puts the app's `AVAudioSession` into `.playAndRecord` / `.voiceChat` so
  * the platform runs echo cancellation against our own TTS instead of letting
- * the assistant barge in on itself through the speaker. It is a no-op off the
- * Capacitor shell.
+ * the assistant barge in on itself through the speaker. It is gated on the
+ * `ios-voice-audio-session` flag and a no-op off the Capacitor shell.
  *
  * The capture is permission-agnostic: it requests `getUserMedia` directly and
  * surfaces a denial as a typed `LiveVoiceCaptureResult` rather than throwing.
@@ -177,8 +177,8 @@ export class LiveVoiceAudioCapture {
     // Put the iOS audio session into `.playAndRecord` / `.voiceChat` *before*
     // opening the mic: the category and mode in force when WebKit builds its
     // capture unit decide whether the platform echo canceller runs at all, so
-    // configuring after the fact is too late for this stream. No-op off the
-    // Capacitor shell.
+    // configuring after the fact is too late for this stream. Gated on the
+    // `ios-voice-audio-session` flag; a no-op off the Capacitor shell.
     await activateVoiceAudioSession();
 
     let stream: MediaStream;
@@ -197,14 +197,11 @@ export class LiveVoiceAudioCapture {
     }
     this.stream = stream;
 
-    // Nothing may touch the audio session between getUserMedia resolving and
-    // the assignment above. An earlier revision re-asserted the category here,
-    // on the theory that WebKit reconfigures the shared session when capture
-    // starts. That theory was never verified, the call ran while WebKit's
-    // capture unit was live, and it is the prime suspect for the device
-    // regression that followed (build 202607281114: mic picked up nothing).
-    // If the theory needs testing, read the category back and log it — do not
-    // blind-set it underneath a live capture.
+    // The audio session is configured once, before the mic opens, and not
+    // touched again while capture is live: `setCategory`/`setActive` under a
+    // running WebKit capture unit can leave the graph attached to a dead
+    // input. To learn what WebKit does to the session, read the category back
+    // and log it rather than setting it.
 
     try {
       const context = createAudioContext();

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -195,23 +195,16 @@ export class LiveVoiceAudioCapture {
       await deactivateVoiceAudioSession();
       return { ok: false, error: "aborted" };
     }
-    // Take ownership of the stream *before* the next native round-trip, so a
-    // stop() that lands mid-call releases the mic through teardown() instead
-    // of leaving it live until the bridge answers.
     this.stream = stream;
 
-    // WebKit reconfigures the shared `AVAudioSession` itself when capture
-    // starts, which can drop the mode we just set. Re-assert it now that the
-    // stream is live; the native side is idempotent.
-    await activateVoiceAudioSession();
-
-    // A stop() that raced the re-assert already ran teardown() — including its
-    // deactivate, which our late activate then undid. Tear down again so the
-    // session isn't left held in the duplex category with no owner.
-    if (cancelled()) {
-      await this.teardown();
-      return { ok: false, error: "aborted" };
-    }
+    // Nothing may touch the audio session between getUserMedia resolving and
+    // the assignment above. An earlier revision re-asserted the category here,
+    // on the theory that WebKit reconfigures the shared session when capture
+    // starts. That theory was never verified, the call ran while WebKit's
+    // capture unit was live, and it is the prime suspect for the device
+    // regression that followed (build 202607281114: mic picked up nothing).
+    // If the theory needs testing, read the category back and log it — do not
+    // blind-set it underneath a live capture.
 
     try {
       const context = createAudioContext();

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -8,7 +8,10 @@
       "label": "In-Chat Onboarding Tour",
       "description": "Multivariate experiment for the eyes-led in-chat onboarding tour. control = straight to chat after research onboarding (current behavior); tour = the extended tour auto-plays on first workspace entry. Desktop-only: phone-width viewports and the native shell get neither the tour nor its telemetry (not even the exposure event), so the funnel measures desktop sessions exclusively. Targeted via LaunchDarkly (70% tour / 30% control).",
       "defaultEnabled": "control",
-      "values": ["control", "tour"]
+      "values": [
+        "control",
+        "tour"
+      ]
     },
     {
       "id": "user-hosted-enabled",
@@ -25,7 +28,10 @@
       "label": "Proactive Tips",
       "description": "Gates the dismissible proactive tip card in the web sidebar. String-valued so future A/B arms can be added as new values.",
       "defaultEnabled": "off",
-      "values": ["off", "on"]
+      "values": [
+        "off",
+        "on"
+      ]
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
@@ -34,7 +40,11 @@
       "label": "Activation Flow Experiment 2026-06-03",
       "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; personal-page = new sign-up-page variant (front-end only). Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a", "personal-page"]
+      "values": [
+        "control",
+        "variant-a",
+        "personal-page"
+      ]
     },
     {
       "id": "experiment-billing-cta-2026-07-23",
@@ -43,7 +53,10 @@
       "label": "Experiment: Billing CTA 2026-07-23",
       "description": "Credit paywall CTA experiment. control = single Add Credits CTA for everyone (opens Add Credits modal). upgrade-cta = FREE users (plan_id base) get a single Upgrade CTA (View Plans takeover) instead; PAID users still get Add Credits.",
       "defaultEnabled": "control",
-      "values": ["control", "upgrade-cta"]
+      "values": [
+        "control",
+        "upgrade-cta"
+      ]
     },
     {
       "id": "local-docker-enabled",
@@ -355,6 +368,14 @@
       "key": "marketing-pricing-takeover",
       "label": "Marketing Pricing Takeover",
       "description": "Gates the marketing pricing takeover page (www.vellum.ai/pricing) and the `/assistant/checkout?package=<slug>` deep link its package CTAs target. One flag covers both halves of the funnel so they can never be enabled independently and strand a CTA. When off, the checkout deep link redirects to the in-app plans takeover.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ios-voice-audio-session",
+      "scope": "client",
+      "key": "ios-voice-audio-session",
+      "label": "iOS Voice Audio Session",
+      "description": "Gates the iOS AVAudioSession (.playAndRecord / .voiceChat) bracketing around a live-voice session, which asks the platform to cancel our own TTS. Default OFF: the first attempt (JARVIS-1364) stopped the mic picking up audio on device, and the native half ships in the app binary, so a web-side gate is the only way to disable it without an iOS release.",
       "defaultEnabled": false
     }
   ]

--- a/clients/web/src/runtime/native-voice-audio-session.test.ts
+++ b/clients/web/src/runtime/native-voice-audio-session.test.ts
@@ -33,11 +33,13 @@ const { activateVoiceAudioSession, deactivateVoiceAudioSession } = await import(
   "@/runtime/native-voice-audio-session"
 );
 
-beforeEach(() => {
+beforeEach(async () => {
   isNative = true;
   nativeThrows = false;
   storeThrows = false;
   flagValue = true;
+  // `sessionHeld` is module-level: drop any hold the previous test left.
+  await deactivateVoiceAudioSession();
   activateMock.mockClear();
   deactivateMock.mockClear();
   activateMock.mockImplementation(async () => {});
@@ -106,15 +108,30 @@ describe("activateVoiceAudioSession", () => {
 });
 
 describe("deactivateVoiceAudioSession", () => {
-  test("calls into the native plugin on the Capacitor shell", async () => {
+  test("releases a session this module holds", async () => {
+    await activateVoiceAudioSession();
+
     await deactivateVoiceAudioSession();
 
     expect(deactivateMock).toHaveBeenCalledTimes(1);
   });
 
-  // A session taken while the flag was on still has to be handed back if the
-  // flag flips off mid-session, so deactivate is deliberately ungated.
-  test("still releases the session when the flag is off", async () => {
+  // A disabled flag must mean no native traffic at all, in either direction —
+  // otherwise "off" still reaches the plugin on every capture teardown.
+  test("makes no native call when nothing was ever activated", async () => {
+    flagValue = false;
+    await activateVoiceAudioSession();
+
+    await deactivateVoiceAudioSession();
+
+    expect(activateMock).not.toHaveBeenCalled();
+    expect(deactivateMock).not.toHaveBeenCalled();
+  });
+
+  // The session outlives the flag: one taken while it was on still has to be
+  // handed back if it flips off mid-session.
+  test("still releases when the flag flips off mid-session", async () => {
+    await activateVoiceAudioSession();
     flagValue = false;
 
     await deactivateVoiceAudioSession();
@@ -122,15 +139,30 @@ describe("deactivateVoiceAudioSession", () => {
     expect(deactivateMock).toHaveBeenCalledTimes(1);
   });
 
-  test("is a no-op off the Capacitor shell", async () => {
-    isNative = false;
+  // A partial activation (category applied, activation failed) still leaves
+  // state the native side has to restore.
+  test("releases even when the activation failed", async () => {
+    activateMock.mockImplementation(async () => {
+      throw new Error("session busy");
+    });
+    await activateVoiceAudioSession();
 
     await deactivateVoiceAudioSession();
 
-    expect(deactivateMock).not.toHaveBeenCalled();
+    expect(deactivateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("is idempotent — a second release makes no further call", async () => {
+    await activateVoiceAudioSession();
+
+    await deactivateVoiceAudioSession();
+    await deactivateVoiceAudioSession();
+
+    expect(deactivateMock).toHaveBeenCalledTimes(1);
   });
 
   test("swallows a native rejection so teardown always completes", async () => {
+    await activateVoiceAudioSession();
     deactivateMock.mockImplementation(async () => {
       throw new Error("deactivation failed");
     });
@@ -138,13 +170,5 @@ describe("deactivateVoiceAudioSession", () => {
     await deactivateVoiceAudioSession();
 
     expect(deactivateMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("never throws when the platform check itself throws", async () => {
-    nativeThrows = true;
-
-    await deactivateVoiceAudioSession();
-
-    expect(deactivateMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/runtime/native-voice-audio-session.test.ts
+++ b/clients/web/src/runtime/native-voice-audio-session.test.ts
@@ -2,8 +2,23 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let isNative = true;
 mock.module("@/runtime/native-auth", () => ({
-  isNativePlatform: () => isNative,
+  isNativePlatform: () => {
+    if (nativeThrows) throw new TypeError("isNativePlatform is not a function");
+    return isNative;
+  },
 }));
+let nativeThrows = false;
+
+let flagValue: boolean | undefined = true;
+mock.module("@/stores/client-feature-flag-store", () => ({
+  useClientFeatureFlagStore: {
+    getState: () => {
+      if (storeThrows) throw new Error("store not initialised");
+      return { iosVoiceAudioSession: flagValue };
+    },
+  },
+}));
+let storeThrows = false;
 
 const activateMock = mock(async () => {});
 const deactivateMock = mock(async () => {});
@@ -20,6 +35,9 @@ const { activateVoiceAudioSession, deactivateVoiceAudioSession } = await import(
 
 beforeEach(() => {
   isNative = true;
+  nativeThrows = false;
+  storeThrows = false;
+  flagValue = true;
   activateMock.mockClear();
   deactivateMock.mockClear();
   activateMock.mockImplementation(async () => {});
@@ -27,10 +45,26 @@ beforeEach(() => {
 });
 
 describe("activateVoiceAudioSession", () => {
-  test("calls into the native plugin on the Capacitor shell", async () => {
+  test("calls into the native plugin when the flag is on", async () => {
     await activateVoiceAudioSession();
 
     expect(activateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("is a no-op when the flag is off — the kill switch", async () => {
+    flagValue = false;
+
+    await activateVoiceAudioSession();
+
+    expect(activateMock).not.toHaveBeenCalled();
+  });
+
+  test("is a no-op when the flag is absent (fails closed)", async () => {
+    flagValue = undefined;
+
+    await activateVoiceAudioSession();
+
+    expect(activateMock).not.toHaveBeenCalled();
   });
 
   test("is a no-op off the Capacitor shell (browser / Electron)", async () => {
@@ -41,7 +75,7 @@ describe("activateVoiceAudioSession", () => {
     expect(activateMock).not.toHaveBeenCalled();
   });
 
-  test("swallows a native failure — an echoing call beats no call at all", async () => {
+  test("swallows a native rejection", async () => {
     activateMock.mockImplementation(async () => {
       throw new Error("session busy");
     });
@@ -50,10 +84,39 @@ describe("activateVoiceAudioSession", () => {
 
     expect(activateMock).toHaveBeenCalledTimes(1);
   });
+
+  // start() is documented never to throw, and use-live-voice.ts awaits its
+  // promise with no catch — so a synchronous throw from the gate would take
+  // the whole live-voice session down, not just echo cancellation.
+  test("never throws when the platform check itself throws", async () => {
+    nativeThrows = true;
+
+    await activateVoiceAudioSession();
+
+    expect(activateMock).not.toHaveBeenCalled();
+  });
+
+  test("never throws when the flag store is unavailable", async () => {
+    storeThrows = true;
+
+    await activateVoiceAudioSession();
+
+    expect(activateMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("deactivateVoiceAudioSession", () => {
   test("calls into the native plugin on the Capacitor shell", async () => {
+    await deactivateVoiceAudioSession();
+
+    expect(deactivateMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A session taken while the flag was on still has to be handed back if the
+  // flag flips off mid-session, so deactivate is deliberately ungated.
+  test("still releases the session when the flag is off", async () => {
+    flagValue = false;
+
     await deactivateVoiceAudioSession();
 
     expect(deactivateMock).toHaveBeenCalledTimes(1);
@@ -67,7 +130,7 @@ describe("deactivateVoiceAudioSession", () => {
     expect(deactivateMock).not.toHaveBeenCalled();
   });
 
-  test("swallows a native failure so teardown always completes", async () => {
+  test("swallows a native rejection so teardown always completes", async () => {
     deactivateMock.mockImplementation(async () => {
       throw new Error("deactivation failed");
     });
@@ -75,5 +138,13 @@ describe("deactivateVoiceAudioSession", () => {
     await deactivateVoiceAudioSession();
 
     expect(deactivateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("never throws when the platform check itself throws", async () => {
+    nativeThrows = true;
+
+    await deactivateVoiceAudioSession();
+
+    expect(deactivateMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/runtime/native-voice-audio-session.ts
+++ b/clients/web/src/runtime/native-voice-audio-session.ts
@@ -19,13 +19,15 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
  * binary — a native gate could only be flipped by a TestFlight release,
  * whereas the web bundle hot-loads, so this one is a true runtime kill switch
  * and allows the configuration to be exercised on a device without cutting a
- * build. To enable on one device, from the WKWebView console:
+ * build.
  *
- *     localStorage.setItem("vellum:ff:iosVoiceAudioSession", "true")
- *
- * That is the *store* key (camel-cased), which is what
- * `client-feature-flag-store`'s override reader looks for — the kebab-case
- * registry key is not read from localStorage. Takes effect on reload.
+ * To enable on one device: Settings, seven taps on the version string, then
+ * the Feature Flags panel. That writes the local override through the store,
+ * under the camel-cased *store* key — which is the only form
+ * `client-feature-flag-store`'s override reader looks for, so a hand-written
+ * `localStorage` entry under the kebab-case registry key is ignored. Release
+ * builds are not Web Inspector-inspectable, so the panel is the only route on
+ * a TestFlight install.
  *
  * Nothing here may throw or reject. `LiveVoiceAudioCapture.start()` is
  * documented never to throw and `use-live-voice.ts` awaits its promise with no

--- a/clients/web/src/runtime/native-voice-audio-session.ts
+++ b/clients/web/src/runtime/native-voice-audio-session.ts
@@ -14,12 +14,10 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
  * `utils/voice-input-device.ts` is not sufficient on its own inside a
  * WKWebView: the canceller WebKit gets is chosen by the app's audio session.
  *
- * Gated on the `ios-voice-audio-session` client flag, default off. The gate
- * lives here rather than in Swift because the native half ships inside the app
- * binary — a native gate could only be flipped by a TestFlight release,
- * whereas the web bundle hot-loads, so this one is a true runtime kill switch
- * and allows the configuration to be exercised on a device without cutting a
- * build.
+ * Gated on the `ios-voice-audio-session` client flag, default off. The gate is
+ * in JS rather than Swift so it can be flipped at runtime on an installed
+ * build — which is what makes the configuration testable per-device, and
+ * switchable off without waiting on a deploy.
  *
  * To enable on one device: Settings, seven taps on the version string, then
  * the Feature Flags panel. That writes the local override through the store,
@@ -27,7 +25,7 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
  * `client-feature-flag-store`'s override reader looks for, so a hand-written
  * `localStorage` entry under the kebab-case registry key is ignored. Release
  * builds are not Web Inspector-inspectable, so the panel is the only route on
- * a TestFlight install.
+ * an installed build.
  *
  * Nothing here may throw or reject. `LiveVoiceAudioCapture.start()` is
  * documented never to throw and `use-live-voice.ts` awaits its promise with no

--- a/clients/web/src/runtime/native-voice-audio-session.ts
+++ b/clients/web/src/runtime/native-voice-audio-session.ts
@@ -1,6 +1,7 @@
 import { registerPlugin } from "@capacitor/core";
 
 import { isNativePlatform } from "@/runtime/native-auth";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 /**
  * JS ↔ native bridge for the `VoiceAudioSession` Capacitor plugin registered by
@@ -9,18 +10,32 @@ import { isNativePlatform } from "@/runtime/native-auth";
  *
  * Puts the iOS app's `AVAudioSession` into `.playAndRecord` / `.voiceChat` for
  * the duration of a live-voice session so the platform runs acoustic echo
- * cancellation against our own TTS, then restores the previous configuration.
- * Without it the assistant hears itself through the speaker and barges in on
- * its own audio (JARVIS-1364) — the `echoCancellation: true` constraint in
- * `utils/voice-input-device.ts` is not enough on its own inside a WKWebView,
- * because the canceller WebKit gets is chosen by the app's audio session.
+ * cancellation against our own TTS (JARVIS-1364) — the `echoCancellation: true`
+ * constraint in `utils/voice-input-device.ts` is not enough on its own inside a
+ * WKWebView, because the canceller WebKit gets is chosen by the app's audio
+ * session.
  *
- * No-op off the Capacitor shell: browsers and Electron have no equivalent
- * app-level audio session, and their `getUserMedia` AEC is already in effect.
+ * ## Default OFF, and why the gate is here rather than in Swift
  *
- * Failures are swallowed. A session that could not be configured still
- * captures audio — it just echoes, which is strictly better than refusing to
- * start the call.
+ * The first attempt at this shipped unconditionally and stopped the microphone
+ * picking up any audio on device (build `202607281114`); the Simulator could
+ * not have caught it, because it feeds a synthetic `Mock audio device` with no
+ * real audio unit behind it. The native half ships inside the app binary, so a
+ * native-side gate would need an App Store / TestFlight release to flip. This
+ * web-side gate hot-loads with the bundle, which makes it a genuine kill
+ * switch and lets the configuration be iterated on a real device without
+ * cutting a build.
+ *
+ * To try it on a device, set the local override in the WKWebView console:
+ *
+ *     localStorage.setItem("vellum:ff:ios-voice-audio-session", "true")
+ *
+ * ## Failure policy
+ *
+ * Nothing in here may throw or reject. `LiveVoiceAudioCapture.start()` is
+ * documented never to throw — `use-live-voice.ts` awaits its promise with no
+ * catch — so an exception escaping this module takes the whole live-voice
+ * session down rather than degrading to "no echo cancellation".
  */
 
 interface VoiceAudioSessionPlugin {
@@ -31,13 +46,45 @@ interface VoiceAudioSessionPlugin {
 const VoiceAudioSession =
   registerPlugin<VoiceAudioSessionPlugin>("VoiceAudioSession");
 
+/** Store key for the `ios-voice-audio-session` client flag (kebab → camel). */
+const FLAG_KEY = "iosVoiceAudioSession";
+
 /**
- * Configure and activate the voice-chat audio session. Idempotent — the caller
- * deliberately calls this again after `getUserMedia` resolves, because WebKit
- * reconfigures the shared session when it starts capturing.
+ * Whether to touch the audio session at all. Read non-reactively — the callers
+ * are capture lifecycle methods, not React render bodies.
+ *
+ * Deliberately does *not* wait on `hydrated`: capture must not block on an LD
+ * fetch, and the registry default (off) plus any local override is the right
+ * answer for a cold start. A flag that flips to on mid-session takes effect on
+ * the next session.
+ */
+function isEnabled(): boolean {
+  try {
+    if (!isNativePlatform()) return false;
+    return useClientFeatureFlagStore.getState()[FLAG_KEY] === true;
+  } catch {
+    return false;
+  }
+}
+
+/** `isNativePlatform()` behind the same never-throws guarantee. */
+function onNativeShell(): boolean {
+  try {
+    return isNativePlatform();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Configure and activate the voice-chat audio session, before the mic is
+ * opened: the category and mode in force when WebKit builds its capture unit
+ * are what decide whether the platform echo canceller runs at all.
+ *
+ * Resolves regardless of outcome.
  */
 export async function activateVoiceAudioSession(): Promise<void> {
-  if (!isNativePlatform()) return;
+  if (!isEnabled()) return;
   try {
     await VoiceAudioSession.activate();
   } catch (err) {
@@ -48,9 +95,14 @@ export async function activateVoiceAudioSession(): Promise<void> {
 /**
  * Restore the pre-session audio configuration and release the session. Safe to
  * call without a matching `activate()` — the native side no-ops.
+ *
+ * Not gated on the flag: if the flag was turned off mid-session, the session
+ * that an earlier `activate()` took still has to be handed back.
+ *
+ * Resolves regardless of outcome.
  */
 export async function deactivateVoiceAudioSession(): Promise<void> {
-  if (!isNativePlatform()) return;
+  if (!onNativeShell()) return;
   try {
     await VoiceAudioSession.deactivate();
   } catch (err) {

--- a/clients/web/src/runtime/native-voice-audio-session.ts
+++ b/clients/web/src/runtime/native-voice-audio-session.ts
@@ -10,31 +10,26 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
  *
  * Puts the iOS app's `AVAudioSession` into `.playAndRecord` / `.voiceChat` for
  * the duration of a live-voice session so the platform runs acoustic echo
- * cancellation against our own TTS (JARVIS-1364) — the `echoCancellation: true`
- * constraint in `utils/voice-input-device.ts` is not enough on its own inside a
- * WKWebView, because the canceller WebKit gets is chosen by the app's audio
- * session.
+ * cancellation against our own TTS. The `echoCancellation: true` constraint in
+ * `utils/voice-input-device.ts` is not sufficient on its own inside a
+ * WKWebView: the canceller WebKit gets is chosen by the app's audio session.
  *
- * ## Default OFF, and why the gate is here rather than in Swift
+ * Gated on the `ios-voice-audio-session` client flag, default off. The gate
+ * lives here rather than in Swift because the native half ships inside the app
+ * binary — a native gate could only be flipped by a TestFlight release,
+ * whereas the web bundle hot-loads, so this one is a true runtime kill switch
+ * and allows the configuration to be exercised on a device without cutting a
+ * build. To enable on one device, from the WKWebView console:
  *
- * The first attempt at this shipped unconditionally and stopped the microphone
- * picking up any audio on device (build `202607281114`); the Simulator could
- * not have caught it, because it feeds a synthetic `Mock audio device` with no
- * real audio unit behind it. The native half ships inside the app binary, so a
- * native-side gate would need an App Store / TestFlight release to flip. This
- * web-side gate hot-loads with the bundle, which makes it a genuine kill
- * switch and lets the configuration be iterated on a real device without
- * cutting a build.
+ *     localStorage.setItem("vellum:ff:iosVoiceAudioSession", "true")
  *
- * To try it on a device, set the local override in the WKWebView console:
+ * That is the *store* key (camel-cased), which is what
+ * `client-feature-flag-store`'s override reader looks for — the kebab-case
+ * registry key is not read from localStorage. Takes effect on reload.
  *
- *     localStorage.setItem("vellum:ff:ios-voice-audio-session", "true")
- *
- * ## Failure policy
- *
- * Nothing in here may throw or reject. `LiveVoiceAudioCapture.start()` is
- * documented never to throw — `use-live-voice.ts` awaits its promise with no
- * catch — so an exception escaping this module takes the whole live-voice
+ * Nothing here may throw or reject. `LiveVoiceAudioCapture.start()` is
+ * documented never to throw and `use-live-voice.ts` awaits its promise with no
+ * catch, so an exception escaping this module takes the whole live-voice
  * session down rather than degrading to "no echo cancellation".
  */
 
@@ -50,27 +45,28 @@ const VoiceAudioSession =
 const FLAG_KEY = "iosVoiceAudioSession";
 
 /**
+ * Whether an `activate()` has been attempted and not yet handed back. Gates
+ * `deactivate()` so that a disabled flag means *no* native traffic at all,
+ * while a session taken before the flag flipped off is still released.
+ *
+ * Set on attempt rather than on success: a partially-applied activation (the
+ * category took, activation failed) still leaves state the native side must
+ * restore.
+ */
+let sessionHeld = false;
+
+/**
  * Whether to touch the audio session at all. Read non-reactively — the callers
  * are capture lifecycle methods, not React render bodies.
  *
- * Deliberately does *not* wait on `hydrated`: capture must not block on an LD
- * fetch, and the registry default (off) plus any local override is the right
- * answer for a cold start. A flag that flips to on mid-session takes effect on
- * the next session.
+ * Does not wait on `hydrated`: capture must not block on an LD fetch, and the
+ * registry default plus any local override is the right answer for a cold
+ * start. A flag that flips mid-session takes effect on the next session.
  */
 function isEnabled(): boolean {
   try {
     if (!isNativePlatform()) return false;
     return useClientFeatureFlagStore.getState()[FLAG_KEY] === true;
-  } catch {
-    return false;
-  }
-}
-
-/** `isNativePlatform()` behind the same never-throws guarantee. */
-function onNativeShell(): boolean {
-  try {
-    return isNativePlatform();
   } catch {
     return false;
   }
@@ -85,6 +81,7 @@ function onNativeShell(): boolean {
  */
 export async function activateVoiceAudioSession(): Promise<void> {
   if (!isEnabled()) return;
+  sessionHeld = true;
   try {
     await VoiceAudioSession.activate();
   } catch (err) {
@@ -93,16 +90,14 @@ export async function activateVoiceAudioSession(): Promise<void> {
 }
 
 /**
- * Restore the pre-session audio configuration and release the session. Safe to
- * call without a matching `activate()` — the native side no-ops.
- *
- * Not gated on the flag: if the flag was turned off mid-session, the session
- * that an earlier `activate()` took still has to be handed back.
+ * Restore the pre-session audio configuration and release the session. A no-op
+ * unless this module holds one.
  *
  * Resolves regardless of outcome.
  */
 export async function deactivateVoiceAudioSession(): Promise<void> {
-  if (!onNativeShell()) return;
+  if (!sessionHeld) return;
+  sessionHeld = false;
   try {
     await VoiceAudioSession.deactivate();
   } catch (err) {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -8,7 +8,10 @@
       "label": "In-Chat Onboarding Tour",
       "description": "Multivariate experiment for the eyes-led in-chat onboarding tour. control = straight to chat after research onboarding (current behavior); tour = the extended tour auto-plays on first workspace entry. Desktop-only: phone-width viewports and the native shell get neither the tour nor its telemetry (not even the exposure event), so the funnel measures desktop sessions exclusively. Targeted via LaunchDarkly (70% tour / 30% control).",
       "defaultEnabled": "control",
-      "values": ["control", "tour"]
+      "values": [
+        "control",
+        "tour"
+      ]
     },
     {
       "id": "user-hosted-enabled",
@@ -25,7 +28,10 @@
       "label": "Proactive Tips",
       "description": "Gates the dismissible proactive tip card in the web sidebar. String-valued so future A/B arms can be added as new values.",
       "defaultEnabled": "off",
-      "values": ["off", "on"]
+      "values": [
+        "off",
+        "on"
+      ]
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
@@ -34,7 +40,11 @@
       "label": "Activation Flow Experiment 2026-06-03",
       "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; personal-page = new sign-up-page variant (front-end only). Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a", "personal-page"]
+      "values": [
+        "control",
+        "variant-a",
+        "personal-page"
+      ]
     },
     {
       "id": "experiment-billing-cta-2026-07-23",
@@ -43,7 +53,10 @@
       "label": "Experiment: Billing CTA 2026-07-23",
       "description": "Credit paywall CTA experiment. control = single Add Credits CTA for everyone (opens Add Credits modal). upgrade-cta = FREE users (plan_id base) get a single Upgrade CTA (View Plans takeover) instead; PAID users still get Add Credits.",
       "defaultEnabled": "control",
-      "values": ["control", "upgrade-cta"]
+      "values": [
+        "control",
+        "upgrade-cta"
+      ]
     },
     {
       "id": "local-docker-enabled",
@@ -355,6 +368,14 @@
       "key": "marketing-pricing-takeover",
       "label": "Marketing Pricing Takeover",
       "description": "Gates the marketing pricing takeover page (www.vellum.ai/pricing) and the `/assistant/checkout?package=<slug>` deep link its package CTAs target. One flag covers both halves of the funnel so they can never be enabled independently and strand a CTA. When off, the checkout deep link redirects to the in-app plans takeover.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ios-voice-audio-session",
+      "scope": "client",
+      "key": "ios-voice-audio-session",
+      "label": "iOS Voice Audio Session",
+      "description": "Gates the iOS AVAudioSession (.playAndRecord / .voiceChat) bracketing around a live-voice session, which asks the platform to cancel our own TTS. Default OFF: the first attempt (JARVIS-1364) stopped the mic picking up audio on device, and the native half ships in the app binary, so a web-side gate is the only way to disable it without an iOS release.",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
Forward fix for the regression from #39331. Supersedes the revert in #39345 (which I'll close if this lands).

## What broke

Dev build `202607281114` was cut from `2707ba5` — the commit containing the change — so the Swift plugin was present. The audio-session configuration itself is what stopped the mic picking up audio.

The Simulator could not have caught it: it feeds a synthetic `Mock audio device` with no real audio unit behind it, so the whole capture path passed there while being broken on hardware.

## Changes

**1. Drop the re-assert.** #39331 called `activate()` a second time after `getUserMedia`, on the theory that WebKit reconfigures the shared session when capture starts. That theory was never verified, and the call ran `setCategory` + `setActive` underneath a live WebKit capture unit — the prime suspect for the regression, and the one part of the change that wasn't load-bearing. If the theory needs testing, the right move is to read the category back and log it, not blind-set it under a live capture.

This also moots the Codex P2 from #39331: with no native round-trip between `getUserMedia` resolving and `this.stream = stream`, that window is microtask-sized again.

**2. The bridge can no longer throw.** `LiveVoiceAudioCapture.start()` is documented never to throw, and `use-live-voice.ts` awaits its promise with no catch — so anything escaping this module takes the whole session down rather than degrading to "no echo cancellation". The platform check and flag read are inside the guard, not just the plugin call.

**3. Gate it on `ios-voice-audio-session`, default off.** New client-scope flag. With it off, `activate()` and `deactivate()` both return before touching the plugin, so the capture path is identical to pre-#39331 — that is what restores iOS voice.

The gate is in JS rather than Swift so it can be flipped at runtime on an installed build: Settings → seven taps on the version string → Feature Flags panel. That writes the override through the store (and so avoids the store-key-vs-registry-key trap). Release builds are not Web Inspector-inspectable, so the panel is the only route on an installed build.

## On the flag and today's release

The flag is the mechanism that makes this release safe, not extra risk on top of it. It is one registry row and one boolean read; the flag is declared locally with `defaultEnabled: false` and has no LaunchDarkly counterpart, so it resolves to `false` for everyone. The audio session is inert unless someone toggles it by hand on their own device. iOS voice behaves exactly as it did before #39331.

Its value is narrower than I first described — a dev deploy ships the web bundle and the TestFlight build together, so changing the Swift is not much harder than changing the web. What the flag actually buys is per-device toggling while iterating on the configuration, and an instant off switch that doesn't wait on a deploy. If we'd rather not carry it, the alternative is to land #39345 instead and re-land the audio session as a focused change once there's device time.

## Verification

`bun test`: `pcm-capture.test.ts` (18), `native-voice-audio-session.test.ts` (13 — flag off, flag absent, throwing platform check, throwing store, mid-session flip, idempotent release). `client-feature-flag-store.test.ts` green. `bun run typecheck` clean. Store key resolves as `iosVoiceAudioSession`, default `false`.

**No hardware verification of the echo behaviour** — that is what the flag is for. Land this, confirm voice works with it off, then toggle it on one device and find out whether `.playAndRecord` / `.voiceChat` fixes the echo or breaks capture.

## Follow-up

The LD flag needs creating via Terraform in `vellum-assistant-platform` before it can be targeted remotely. Not required for the local override or the default-off behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)