### PR TITLE
fix(ios): route live voice TTS through WebKit AEC

### DIFF
--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -171,7 +171,9 @@ reference. `LiveVoiceAudioPlayer` is the canonical implementation.
 
 Start the media element from the same user gesture that prewarms the
 `AudioContext`, and on teardown pause it, clear `srcObject`, and stop every
-track owned by the destination stream.
+track owned by the destination stream. Automatic reconnects must reuse the
+already-started player and MediaStream element: creating a replacement from a
+backoff timer loses the original user activation and can make `play()` fail.
 
 References:
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -170,10 +170,11 @@ playback through the same voice-processing unit and can use it as the echo
 reference. `LiveVoiceAudioPlayer` is the canonical implementation.
 
 Start the media element from the same user gesture that prewarms the
-`AudioContext`, and on teardown pause it, clear `srcObject`, and stop every
-track owned by the destination stream. Automatic reconnects must reuse the
-already-started player and MediaStream element: creating a replacement from a
-backoff timer loses the original user activation and can make `play()` fail.
+`AudioContext`, before awaiting readiness preflight or any other asynchronous
+work. On teardown, pause it, clear `srcObject`, and stop every track owned by
+the destination stream. Automatic reconnects must reuse the already-started
+player and MediaStream element: creating a replacement from a backoff timer
+loses the original user activation and can make `play()` fail.
 
 References:
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -153,6 +153,34 @@ References:
 
 ---
 
+## Full-duplex TTS must render through a MediaStream track
+
+WebKit owns the shared `AVAudioSession` used by `getUserMedia()` in a
+`WKWebView`: it selects a play-and-record category and voice-processing mode,
+and it creates a `VoiceProcessingIO` capture unit when echo cancellation is
+requested. Do not add a Capacitor plugin that reconfigures or reactivates that
+session around microphone capture. Changing the active session underneath
+WebKit can leave its live capture unit detached from the microphone.
+
+Direct `AudioContext.destination` playback is not supplied to WebKit's capture
+unit as far-end audio for acoustic echo cancellation. On Capacitor iOS, route
+full-duplex TTS into a `MediaStreamAudioDestinationNode` and play that stream
+through an `HTMLAudioElement`. WebKit routes default-device MediaStream-track
+playback through the same voice-processing unit and can use it as the echo
+reference. `LiveVoiceAudioPlayer` is the canonical implementation.
+
+Start the media element from the same user gesture that prewarms the
+`AudioContext`, and on teardown pause it, clear `srcObject`, and stop every
+track owned by the destination stream.
+
+References:
+
+- WebKit — [`MediaSessionManagerCocoa` selects the capture audio-session category and mode](https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm#L174-L218)
+- WebKit — [`CoreAudioCaptureUnit` selects `VoiceProcessingIO` for echo cancellation](https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureUnit.cpp#L75-L87)
+- WebKit — [MediaStream-track playback is rendered through the active capture unit](https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp#L228-L292)
+
+---
+
 ## Full-screen overlays must respect safe-area insets
 
 Any element that takes over the full viewport (modals, detail panels, drawers) via `position: fixed; inset: 0` **must** apply safe-area padding so content does not render behind the iPhone status bar, Dynamic Island, or home indicator. The `ChatLayoutHeader` handles this for the persistent top bar, but overlays that cover the header lose its protection.

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -72,6 +72,8 @@ import {
 const liveStarterSpy = mock(
   (_assistantId: string, _conversationId: string | null) => {},
 );
+const livePrewarmSpy = mock(() => {});
+const liveCancelPrewarmSpy = mock(() => {});
 const liveControls = makeControlsSpies();
 
 /**
@@ -215,11 +217,17 @@ function resetLiveVoiceMocks() {
   navigateSpy.mockClear();
   setAudioLevelSpy.mockClear();
   liveStarterSpy.mockClear();
+  livePrewarmSpy.mockClear();
+  liveCancelPrewarmSpy.mockClear();
   liveControls.stop.mockClear();
   liveControls.release.mockClear();
   liveControls.interrupt.mockClear();
   useLiveVoiceStore.getState().reset();
-  useLiveVoiceStore.getState().setStarter(liveStarterSpy);
+  useLiveVoiceStore.getState().setStarter({
+    prewarm: livePrewarmSpy,
+    cancelPrewarm: liveCancelPrewarmSpy,
+    start: liveStarterSpy,
+  });
   // Default to the returning-user path so the entry-point mic starts a session
   // directly. First-run interception (the prefs card) is covered by
   // `voice-first-run-card.test.tsx`; a test that wants it opts in by setting
@@ -953,14 +961,20 @@ describe("ChatComposer — live-voice integration", () => {
     // WHEN the user clicks the entry-point mic
     const { getByLabelText } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
+
+    // Playback unlock happens synchronously in the click task, while the
+    // readiness request is still pending.
+    expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
+    expect(preflightSpy).toHaveBeenCalledWith("asst_test");
+    expect(liveStarterSpy).not.toHaveBeenCalled();
+
     await flushPreflight();
 
-    // THEN the readiness preflight ran first, and only then the layout-owned
-    // controller is asked to start with the bound context (the composer holds
-    // no controller of its own)
-    expect(preflightSpy).toHaveBeenCalledWith("asst_test");
+    // THEN the layout-owned controller starts with the bound context after the
+    // ready verdict (the composer holds no controller of its own).
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    expect(liveCancelPrewarmSpy).not.toHaveBeenCalled();
   });
 
   test("a not-ready verdict keeps the room closed and surfaces the configure-voice prompt", async () => {
@@ -981,6 +995,8 @@ describe("ChatComposer — live-voice integration", () => {
     // daemon's configure-voice message is shown instead
     expect(preflightSpy).toHaveBeenCalledWith("asst_test");
     expect(liveStarterSpy).not.toHaveBeenCalled();
+    expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
+    expect(liveCancelPrewarmSpy).toHaveBeenCalledTimes(1);
     expect(useLiveVoiceStore.getState().state).toBe("idle");
     expect(getByText("Add a voice provider to start talking.")).toBeTruthy();
 
@@ -1005,6 +1021,8 @@ describe("ChatComposer — live-voice integration", () => {
     // the WS-level handshake surfaces any real credential problem
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
+    expect(liveCancelPrewarmSpy).not.toHaveBeenCalled();
   });
 
   test("switching chats mid-preflight drops the verdict instead of binding the room to the chat the user left", async () => {
@@ -1030,6 +1048,7 @@ describe("ChatComposer — live-voice integration", () => {
     // is not opened against `conv_test`, the chat the user already left
     expect(preflightSpy).toHaveBeenCalledWith("asst_test");
     expect(liveStarterSpy).not.toHaveBeenCalled();
+    expect(liveCancelPrewarmSpy).toHaveBeenCalledTimes(1);
     expect(useLiveVoiceStore.getState().state).toBe("idle");
   });
 
@@ -1049,6 +1068,7 @@ describe("ChatComposer — live-voice integration", () => {
       getByTestId("first-run-card").getAttribute("data-non-dismissible"),
     ).toBe("false");
     expect(liveStarterSpy).not.toHaveBeenCalled();
+    expect(livePrewarmSpy).not.toHaveBeenCalled();
   });
 
   test("first-run card Start persists the flag then starts the session", async () => {
@@ -1068,6 +1088,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
   });
 
   test("dismissing the first-run card cancels without consuming the first run", () => {
@@ -1084,6 +1105,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).not.toHaveBeenCalled();
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
+    expect(livePrewarmSpy).not.toHaveBeenCalled();
   });
 
   test("Capacitor iOS: first-ever entry shows the prefs card too (web↔iOS parity)", () => {
@@ -1108,9 +1130,10 @@ describe("ChatComposer — live-voice integration", () => {
       getByTestId("first-run-card").getAttribute("data-non-dismissible"),
     ).toBe("true");
     expect(liveStarterSpy).not.toHaveBeenCalled();
+    expect(livePrewarmSpy).not.toHaveBeenCalled();
   });
 
-  test("Capacitor iOS: returning-user entry still starts directly (unchanged)", async () => {
+  test("Capacitor iOS: returning-user entry prewarms and starts after preflight", async () => {
     // GIVEN the native iOS shell with the first run already consumed
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockIsNativeIOS = true;
@@ -1125,6 +1148,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
   });
 
   test("owned active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -395,6 +395,11 @@ export function ChatComposer({
     if (!assistantId || liveVoicePreflightPendingRef.current) {
       return;
     }
+    // WebKit's media-element playback permission is transient. Reserve and
+    // prewarm the controller-owned player synchronously from this gesture,
+    // before the readiness request yields to the event loop.
+    const starter = useLiveVoiceStore.getState().starter;
+    starter?.prewarm();
     // Gate the open on the daemon's readiness verdict BEFORE starting, so the
     // room never flashes open then immediately closes for a user with no
     // usable STT/TTS provider. The daemon runs managed-speech defaulting as
@@ -416,6 +421,13 @@ export function ChatComposer({
       latest.assistantId !== assistantId ||
       latest.conversationId !== conversationId
     ) {
+      starter?.cancelPrewarm();
+      return;
+    }
+    // The layout-owned controller may have unmounted while preflight was in
+    // flight. Do not invoke a stale starter captured from the old mount.
+    if (useLiveVoiceStore.getState().starter !== starter) {
+      starter?.cancelPrewarm();
       return;
     }
     // Fail OPEN on a null verdict (preflight network/daemon error): a preflight
@@ -423,6 +435,7 @@ export function ChatComposer({
     // WS-level start handshake surface any real credential problem via the
     // existing failure `Notice`. Only an explicit `not-ready` keeps us closed.
     if (verdict?.status === "not-ready") {
+      starter?.cancelPrewarm();
       setVoiceConfigNotice(
         verdict.userMessage ??
           "Voice isn't set up yet. Configure a voice provider to start talking.",
@@ -439,7 +452,7 @@ export function ChatComposer({
     // Publish the origin BEFORE starting; the controller carries it across its
     // start-time `reset()` (see the live-voice store's `entryOrigin`).
     setLiveVoiceEntryOrigin(origin);
-    useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
+    starter?.start(assistantId, conversationId ?? null);
   }, [assistantId, conversationId]);
   const handleLiveVoiceStart = useCallback(
     (origin?: { x: number; y: number }) => {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -34,6 +34,14 @@ beforeEach(() => {
   useLiveVoiceStore.getState().setStarter(null);
 });
 
+function makeStarter() {
+  return {
+    prewarm: mock(() => {}),
+    cancelPrewarm: mock(() => {}),
+    start: mock((_assistantId: string, _conversationId: string | null) => {}),
+  };
+}
+
 describe("useLiveVoiceStore — session context", () => {
   test("defaults to null assistant/conversation when idle", () => {
     expect(useLiveVoiceStore.getState().assistantId).toBeNull();
@@ -79,7 +87,7 @@ describe("useLiveVoiceStore — session starter", () => {
   });
 
   test("setStarter registers and deregisters the controller's starter", () => {
-    const starter = mock(() => {});
+    const starter = makeStarter();
     useLiveVoiceStore.getState().setStarter(starter);
     expect(useLiveVoiceStore.getState().starter).toBe(starter);
     useLiveVoiceStore.getState().setStarter(null);
@@ -87,7 +95,7 @@ describe("useLiveVoiceStore — session starter", () => {
   });
 
   test("reset preserves the starter — session teardown must not deregister the mounted controller", () => {
-    const starter = mock(() => {});
+    const starter = makeStarter();
     useLiveVoiceStore.getState().setStarter(starter);
     // Simulate a full session lifecycle ending in teardown's reset().
     useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
@@ -347,7 +355,7 @@ describe("dismissLiveVoiceFailure", () => {
   });
 
   test("preserves the mount-scoped starter, like any reset", () => {
-    const starter = mock(() => {});
+    const starter = makeStarter();
     useLiveVoiceStore.getState().setStarter(starter);
     useLiveVoiceStore.getState().fail("boom");
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -163,16 +163,18 @@ export interface LiveVoiceEntryOrigin {
 }
 
 /**
- * Starts a live-voice session for `assistantId`, attaching `conversationId`
- * when non-null. Registered into the store by the persistently mounted
- * session-controller hook (see `use-live-voice-session-controller.ts`) so any
- * surface — e.g. the composer's entry-point mic — can start a session without
- * owning the controller hook instance.
+ * Mount-scoped entry points for starting live voice. The composer prewarms
+ * playback synchronously from the user's gesture, before its async readiness
+ * preflight, then either starts with that player or cancels the reservation.
  */
-export type LiveVoiceSessionStarter = (
-  assistantId: string,
-  conversationId: string | null,
-) => void;
+export interface LiveVoiceSessionStarter {
+  /** Unlock playback while the initiating user gesture is still active. */
+  prewarm(): void;
+  /** Release playback reserved by a preflight that will not start a session. */
+  cancelPrewarm(): void;
+  /** Start a session, consuming the prewarmed player when one exists. */
+  start(assistantId: string, conversationId: string | null): void;
+}
 
 export interface LiveVoiceState {
   /** Current phase of the session lifecycle. */

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import {
   LiveVoiceAudioPlayer,
@@ -16,6 +16,7 @@ import {
 
 interface MockSource {
   buffer: AudioBuffer | null;
+  connectedTo: AudioNode | null;
   startedAt: number | null;
   stopped: boolean;
   disconnected: boolean;
@@ -30,6 +31,19 @@ class MockAudioContext {
   state: AudioContextState = "suspended";
   resumeCount = 0;
   readonly sources: MockSource[] = [];
+  mediaStreamDestinationCreateCount = 0;
+  readonly mediaStreamTrack = {
+    stopped: false,
+    stop() {
+      this.stopped = true;
+    },
+  };
+  readonly mediaStream = {
+    getTracks: () => [this.mediaStreamTrack],
+  } as unknown as MediaStream;
+  readonly mediaStreamDestination = {
+    stream: this.mediaStream,
+  } as unknown as MediaStreamAudioDestinationNode;
 
   async resume(): Promise<void> {
     this.resumeCount++;
@@ -73,6 +87,7 @@ class MockAudioContext {
     const getCurrentTime = () => this.currentTime;
     const source: MockSource = {
       buffer: null,
+      connectedTo: null,
       startedAt: null,
       stopped: false,
       disconnected: false,
@@ -95,7 +110,9 @@ class MockAudioContext {
       set onended(cb: (() => void) | null) {
         source.onended = cb;
       },
-      connect() {},
+      connect(destination: AudioNode) {
+        source.connectedTo = destination;
+      },
       disconnect() {
         source.disconnected = true;
       },
@@ -110,8 +127,32 @@ class MockAudioContext {
     return node;
   }
 
+  createMediaStreamDestination(): MediaStreamAudioDestinationNode {
+    this.mediaStreamDestinationCreateCount += 1;
+    return this.mediaStreamDestination;
+  }
+
   async close(): Promise<void> {
     this.closed = true;
+  }
+}
+
+class MockMediaStreamPlaybackElement {
+  srcObject: HTMLMediaElement["srcObject"] = null;
+  playCount = 0;
+  pauseCount = 0;
+
+  constructor(private readonly playError?: Error) {}
+
+  async play(): Promise<void> {
+    this.playCount += 1;
+    if (this.playError) {
+      throw this.playError;
+    }
+  }
+
+  pause(): void {
+    this.pauseCount += 1;
   }
 }
 
@@ -124,7 +165,9 @@ function encodePcm16Base64(samples: number[]): string {
     bytes[i * 2 + 1] = (v >> 8) & 0xff;
   });
   let binary = "";
-  for (const b of bytes) binary += String.fromCharCode(b);
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
   return btoa(binary);
 }
 
@@ -139,7 +182,25 @@ function makePlayer(): {
   return { player, ctx };
 }
 
-function chunk(samples: number[], sampleRate = 24000): {
+function makeMediaStreamPlayer(playError?: Error): {
+  player: LiveVoiceAudioPlayer;
+  ctx: MockAudioContext;
+  mediaElement: MockMediaStreamPlaybackElement;
+} {
+  const ctx = new MockAudioContext();
+  const mediaElement = new MockMediaStreamPlaybackElement(playError);
+  const player = new LiveVoiceAudioPlayer({
+    audioContextFactory: () => ctx as unknown as AudioContextLike,
+    useMediaStreamOutput: true,
+    mediaStreamPlaybackElementFactory: () => mediaElement,
+  });
+  return { player, ctx, mediaElement };
+}
+
+function chunk(
+  samples: number[],
+  sampleRate = 24000,
+): {
   dataBase64: string;
   sampleRate: number;
   mimeType: string;
@@ -153,7 +214,9 @@ function chunk(samples: number[], sampleRate = 24000): {
 
 /** Drain the microtask queue so serialized async decodes settle. */
 async function flushMicrotasks(): Promise<void> {
-  for (let i = 0; i < 8; i++) await Promise.resolve();
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
 }
 
 /** Build a frame with an arbitrary mimeType and opaque (non-PCM) payload. */
@@ -215,6 +278,48 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(ctx.resumeCount).toBe(1);
   });
 
+  test("Capacitor iOS routes TTS through a playing MediaStream track", () => {
+    const {
+      player: mediaStreamPlayer,
+      ctx: mediaStreamContext,
+      mediaElement,
+    } = makeMediaStreamPlayer();
+
+    mediaStreamPlayer.prewarm();
+    mediaStreamPlayer.enqueue(chunk(new Array(24000).fill(100)));
+
+    expect(mediaStreamContext.mediaStreamDestinationCreateCount).toBe(1);
+    expect(mediaElement.srcObject).toBe(mediaStreamContext.mediaStream);
+    expect(mediaElement.playCount).toBe(1);
+    expect(mediaStreamContext.sources[0]!.connectedTo).toBe(
+      mediaStreamContext.mediaStreamDestination,
+    );
+  });
+
+  test("falls back to direct output when MediaStream playback is rejected", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const {
+        player: mediaStreamPlayer,
+        ctx: mediaStreamContext,
+        mediaElement,
+      } = makeMediaStreamPlayer(new Error("playback rejected"));
+
+      mediaStreamPlayer.prewarm();
+      await flushMicrotasks();
+      mediaStreamPlayer.enqueue(chunk(new Array(24000).fill(100)));
+
+      expect(mediaElement.srcObject).toBeNull();
+      expect(mediaStreamContext.mediaStreamTrack.stopped).toBe(true);
+      expect(mediaStreamContext.sources[0]!.connectedTo).toBe(
+        mediaStreamContext.destination,
+      );
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   test("schedules chunks in order, gaplessly, at the frame sample rate", () => {
     // Two 24 kHz frames of 24000 samples each => 1.0s buffers.
     player.enqueue(chunk(new Array(24000).fill(100)));
@@ -227,6 +332,7 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(ctx.sources[1]!.startedAt).toBeCloseTo(1.0, 6);
     // Buffers were built at the frame's own 24 kHz rate, not the 48 kHz ctx.
     expect(ctx.sources[0]!.buffer!.sampleRate).toBe(24000);
+    expect(ctx.sources[0]!.connectedTo).toBe(ctx.destination);
 
     expect(player.isPlaying).toBe(true);
   });
@@ -551,6 +657,21 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(ctx.sources.every((s) => s.stopped)).toBe(true);
     expect(ctx.closed).toBe(true);
     expect(player.isPlaying).toBe(false);
+  });
+
+  test("dispose() releases the iOS MediaStream output route", async () => {
+    const {
+      player: mediaStreamPlayer,
+      ctx: mediaStreamContext,
+      mediaElement,
+    } = makeMediaStreamPlayer();
+    mediaStreamPlayer.prewarm();
+
+    await mediaStreamPlayer.dispose();
+
+    expect(mediaElement.pauseCount).toBe(1);
+    expect(mediaElement.srcObject).toBeNull();
+    expect(mediaStreamContext.mediaStreamTrack.stopped).toBe(true);
   });
 
   test("dispose() is a no-op when no context was ever created", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -19,7 +19,11 @@
  * misdecoded as raw PCM (which would play header/interleaved bytes as garbage).
  *
  * {@link LiveVoiceAudioPlayer} schedules gapless sequential playback through a
- * Web Audio `AudioContext` by chaining `AudioBufferSourceNode` start times.
+ * Web Audio `AudioContext` by chaining `AudioBufferSourceNode` start times. In
+ * the Capacitor iOS shell, the context feeds a `MediaStreamAudioDestinationNode`
+ * played by an `HTMLAudioElement` so WebKit renders TTS through the same
+ * VoiceProcessingIO unit that captures the microphone. That gives WebKit's
+ * acoustic echo canceller the assistant audio as its far-end reference.
  *
  * Playback is gapless because each source is started at the running
  * `playheadTime` cursor — the precise `AudioContext.currentTime` at which the
@@ -35,6 +39,8 @@
  */
 
 import { createAudioContext } from "@/domains/chat/voice/audio-context";
+import { captureError } from "@/lib/sentry/capture-error";
+import { isNativeIOS } from "@/runtime/platform-detection";
 
 /** A single TTS audio frame as delivered by the live-voice channel. */
 export interface TtsAudioChunk {
@@ -132,6 +138,11 @@ export interface AudioContextLike {
   ): AudioBuffer;
   createBufferSource(): AudioBufferSourceNode;
   /**
+   * Create a MediaStream-backed output bus. Capacitor iOS uses this so WebKit
+   * can render TTS through its voice-processing audio unit.
+   */
+  createMediaStreamDestination?(): MediaStreamAudioDestinationNode;
+  /**
    * Create an analyser tapping the output bus for amplitude metering (drives
    * the voice-room avatar's TTS-reactive pulse). Optional so lightweight test
    * contexts can omit it — the player then degrades to no metering
@@ -152,6 +163,21 @@ export type AudioContextFactory = () => AudioContextLike;
 const defaultAudioContextFactory: AudioContextFactory = () =>
   createAudioContext() as unknown as AudioContextLike;
 
+type MediaStreamPlaybackElement = Pick<
+  HTMLAudioElement,
+  "pause" | "play" | "srcObject"
+>;
+
+type MediaStreamPlaybackElementFactory = () => MediaStreamPlaybackElement;
+
+const defaultMediaStreamPlaybackElementFactory: MediaStreamPlaybackElementFactory =
+  () => new Audio();
+
+interface MediaStreamOutputRoute {
+  destination: MediaStreamAudioDestinationNode;
+  element: MediaStreamPlaybackElement;
+}
+
 /**
  * Decode base64-encoded little-endian 16-bit PCM into normalized Float32
  * samples in the range [-1, 1).
@@ -170,7 +196,9 @@ export function decodePcm16Base64(dataBase64: string): Float32Array {
     const hi = binary.charCodeAt(i * 2 + 1);
     // Reassemble little-endian, then sign-extend the 16-bit value.
     let int16 = (hi << 8) | lo;
-    if (int16 >= 0x8000) int16 -= 0x10000;
+    if (int16 >= 0x8000) {
+      int16 -= 0x10000;
+    }
     // Divide by 32768 so full-scale negative maps to exactly -1.
     samples[i] = int16 / 0x8000;
   }
@@ -179,7 +207,10 @@ export function decodePcm16Base64(dataBase64: string): Float32Array {
 
 export class LiveVoiceAudioPlayer {
   private readonly createContext: AudioContextFactory;
+  private readonly useMediaStreamOutput: boolean;
+  private readonly createMediaStreamPlaybackElement: MediaStreamPlaybackElementFactory;
   private context: AudioContextLike | null = null;
+  private mediaStreamOutput: MediaStreamOutputRoute | null = null;
 
   /** Sources currently scheduled (playing or pending). */
   private activeSources = new Set<AudioBufferSourceNode>();
@@ -246,8 +277,17 @@ export class LiveVoiceAudioPlayer {
    */
   private containerDecodeChain: Promise<void> = Promise.resolve();
 
-  constructor(options?: { audioContextFactory?: AudioContextFactory }) {
-    this.createContext = options?.audioContextFactory ?? defaultAudioContextFactory;
+  constructor(options?: {
+    audioContextFactory?: AudioContextFactory;
+    useMediaStreamOutput?: boolean;
+    mediaStreamPlaybackElementFactory?: MediaStreamPlaybackElementFactory;
+  }) {
+    this.createContext =
+      options?.audioContextFactory ?? defaultAudioContextFactory;
+    this.useMediaStreamOutput = options?.useMediaStreamOutput ?? isNativeIOS();
+    this.createMediaStreamPlaybackElement =
+      options?.mediaStreamPlaybackElementFactory ??
+      defaultMediaStreamPlaybackElementFactory;
   }
 
   /** Whether any audio is scheduled, playing, or still decoding. */
@@ -288,7 +328,9 @@ export class LiveVoiceAudioPlayer {
   /** Synchronous raw-PCM fast path. */
   private enqueueRawPcm(chunk: TtsAudioChunk): void {
     const samples = decodePcm16Base64(chunk.dataBase64);
-    if (samples.length === 0) return;
+    if (samples.length === 0) {
+      return;
+    }
 
     const context = this.ensureContext();
 
@@ -368,7 +410,11 @@ export class LiveVoiceAudioPlayer {
 
     // Route through the metering analyser when present (so output amplitude can
     // drive the room avatar), otherwise straight to the destination.
-    source.connect(this.analyser ?? context.destination);
+    source.connect(
+      this.analyser ??
+        this.mediaStreamOutput?.destination ??
+        context.destination,
+    );
 
     // Chain start time from the running playhead. Never schedule in the past:
     // if the queue drained the playhead may lag behind currentTime.
@@ -427,7 +473,9 @@ export class LiveVoiceAudioPlayer {
    * or after a {@link stop}. Resolves immediately when nothing is playing.
    */
   waitUntilDrained(): Promise<void> {
-    if (!this.isPlaying) return Promise.resolve();
+    if (!this.isPlaying) {
+      return Promise.resolve();
+    }
     return new Promise<void>((resolve) => {
       this.drainResolvers.push(resolve);
     });
@@ -445,12 +493,15 @@ export class LiveVoiceAudioPlayer {
     this.stop();
     const context = this.context;
     this.context = null;
+    this.disposeMediaStreamOutput();
     // The analyser belongs to the closed context; drop it (and its buffer) so a
     // reused player rebuilds metering against a fresh context.
     this.analyser = null;
     this.analyserSamples = null;
     this.smoothedOutputAmplitude = 0;
-    if (context) await context.close();
+    if (context) {
+      await context.close();
+    }
   }
 
   /**
@@ -464,7 +515,9 @@ export class LiveVoiceAudioPlayer {
    */
   prewarm(): void {
     const context = this.ensureContext();
-    if (context.state !== "running") void context.resume();
+    if (context.state !== "running") {
+      void context.resume();
+    }
   }
 
   private ensureContext(): AudioContextLike {
@@ -473,6 +526,7 @@ export class LiveVoiceAudioPlayer {
       this.context = context;
       this.playheadTime = 0;
       this.totalScheduledSeconds = 0;
+      const outputNode = this.createOutputNode(context);
       // Tap the output bus for amplitude metering when the context supports it.
       // Scheduled sources connect through this analyser to the destination; a
       // context without createAnalyser (test mock) skips metering entirely and
@@ -480,12 +534,64 @@ export class LiveVoiceAudioPlayer {
       if (context.createAnalyser) {
         const analyser = context.createAnalyser();
         analyser.fftSize = 256;
-        analyser.connect(context.destination);
+        analyser.connect(outputNode);
         this.analyser = analyser;
         this.analyserSamples = new Float32Array(analyser.fftSize);
       }
+      this.startMediaStreamOutput(context);
     }
     return this.context;
+  }
+
+  private createOutputNode(context: AudioContextLike): AudioNode {
+    // WebKit only supplies default-device MediaStream-track playback to its
+    // VoiceProcessingIO capture unit as far-end echo-cancellation audio:
+    // https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp#L228-L292
+    if (!this.useMediaStreamOutput || !context.createMediaStreamDestination) {
+      return context.destination;
+    }
+
+    const destination = context.createMediaStreamDestination();
+    const element = this.createMediaStreamPlaybackElement();
+    element.srcObject = destination.stream;
+    this.mediaStreamOutput = { destination, element };
+    return destination;
+  }
+
+  private startMediaStreamOutput(context: AudioContextLike): void {
+    const route = this.mediaStreamOutput;
+    if (!route) {
+      return;
+    }
+
+    void route.element.play().catch((error: unknown) => {
+      if (this.context !== context || this.mediaStreamOutput !== route) {
+        return;
+      }
+
+      this.disposeMediaStreamOutput();
+      if (this.analyser) {
+        this.analyser.disconnect();
+        this.analyser.connect(context.destination);
+      }
+      captureError(error, {
+        context: "live_voice_ios_media_stream_output",
+      });
+    });
+  }
+
+  private disposeMediaStreamOutput(): void {
+    const route = this.mediaStreamOutput;
+    this.mediaStreamOutput = null;
+    if (!route) {
+      return;
+    }
+
+    route.element.pause();
+    route.element.srcObject = null;
+    for (const track of route.destination.stream.getTracks()) {
+      track.stop();
+    }
   }
 
   /**
@@ -502,7 +608,9 @@ export class LiveVoiceAudioPlayer {
   getOutputAmplitude(): number {
     const analyser = this.analyser;
     const samples = this.analyserSamples;
-    if (!analyser || !samples) return 0;
+    if (!analyser || !samples) {
+      return 0;
+    }
 
     if (!this.playingState) {
       // Nothing scheduled — ease back to rest so the avatar settles between
@@ -537,7 +645,9 @@ export class LiveVoiceAudioPlayer {
    * `played == total`. Side-effect-free: reading never advances state.
    */
   getPlaybackProgress(): LiveVoicePlaybackProgress | null {
-    if (this.context === null || this.totalScheduledSeconds === 0) return null;
+    if (this.context === null || this.totalScheduledSeconds === 0) {
+      return null;
+    }
     const remaining = Math.max(0, this.playheadTime - this.context.currentTime);
     const played = Math.min(
       this.totalScheduledSeconds,
@@ -556,7 +666,9 @@ export class LiveVoiceAudioPlayer {
   }
 
   private handleSourceEnded(source: AudioBufferSourceNode): void {
-    if (!this.activeSources.delete(source)) return;
+    if (!this.activeSources.delete(source)) {
+      return;
+    }
     source.disconnect();
     this.settleIfIdle();
   }
@@ -567,7 +679,9 @@ export class LiveVoiceAudioPlayer {
    * could still schedule one. Called whenever either count reaches zero.
    */
   private settleIfIdle(): void {
-    if (this.activeSources.size > 0 || this.pendingContainerDecodes > 0) return;
+    if (this.activeSources.size > 0 || this.pendingContainerDecodes > 0) {
+      return;
+    }
     this.playheadTime = 0;
     this.playingState = false;
     this.resolveDrain();
@@ -576,6 +690,8 @@ export class LiveVoiceAudioPlayer {
   private resolveDrain(): void {
     const resolvers = this.drainResolvers;
     this.drainResolvers = [];
-    for (const resolve of resolvers) resolve();
+    for (const resolve of resolvers) {
+      resolve();
+    }
   }
 }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -86,7 +86,7 @@ async function startListeningViaStarter(
   conversationId: string | null = "conv-1",
 ) {
   await act(async () => {
-    useLiveVoiceStore.getState().starter?.("assistant-1", conversationId);
+    useLiveVoiceStore.getState().starter?.start("assistant-1", conversationId);
     await Promise.resolve();
   });
   await act(async () => {
@@ -151,10 +151,21 @@ describe("starter registration", () => {
     expect(useLiveVoiceStore.getState().controls).not.toBeNull();
   });
 
+  test("starter prewarms playback without opening a session", () => {
+    const h = renderPersistentController();
+
+    useLiveVoiceStore.getState().starter?.prewarm();
+
+    expect(h.player.prewarmCount).toBe(1);
+    expect(h.clients).toHaveLength(0);
+    expect(h.captures).toHaveLength(0);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+  });
+
   test("starter maps a null conversation to a conversation-less start (draft case)", async () => {
     const h = renderPersistentController();
     await act(async () => {
-      useLiveVoiceStore.getState().starter?.("assistant-1", null);
+      useLiveVoiceStore.getState().starter?.start("assistant-1", null);
       await Promise.resolve();
     });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -44,12 +44,16 @@ export function useLiveVoiceSessionController(
   // `observeAudioState: false` — the controller consumes nothing reactive
   // beyond the low-frequency `state`/`error` fields, so high-frequency
   // amplitude/transcript updates must not re-render the mounting layout.
-  const { start } = useLiveVoice({ ...options, observeAudioState: false });
+  const { start, prewarmPlayback, cancelPrewarmedPlayback } = useLiveVoice({
+    ...options,
+    observeAudioState: false,
+  });
 
   useEffect(() => {
-    useLiveVoiceStore
-      .getState()
-      .setStarter((assistantId, conversationId) =>
+    useLiveVoiceStore.getState().setStarter({
+      prewarm: prewarmPlayback,
+      cancelPrewarm: cancelPrewarmedPlayback,
+      start: (assistantId, conversationId) =>
         // Hands-free (server-side turn detection) is the only mode the voice
         // button starts — it keeps one socket open across turns so the
         // assistant's TTS drains instead of the session tearing down each
@@ -58,9 +62,9 @@ export function useLiveVoiceSessionController(
         void start(assistantId, conversationId ?? undefined, {
           handsFree: true,
         }),
-      );
+    });
     return () => {
       useLiveVoiceStore.getState().setStarter(null);
     };
-  }, [start]);
+  }, [start, prewarmPlayback, cancelPrewarmedPlayback]);
 }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -82,12 +82,16 @@ function renderController(
   const player = new FakePlayer();
   let capture!: FakeCapture;
   let renderCount = 0;
+  let playerCreateCount = 0;
 
   const view = renderHook(() => {
     renderCount++;
     return useLiveVoice({
       createClient: () => client as unknown as LiveVoiceChannelClient,
-      createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
+      createPlayer: () => {
+        playerCreateCount += 1;
+        return player as unknown as LiveVoiceAudioPlayer;
+      },
       createCapture: (options) => {
         capture = new FakeCapture(options);
         onCaptureCreated?.(capture);
@@ -102,6 +106,7 @@ function renderController(
     client,
     player,
     getCapture: () => capture,
+    getPlayerCreateCount: () => playerCreateCount,
     getRenderCount: () => renderCount,
   };
 }
@@ -2600,12 +2605,16 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
     // the user can still bail during the gap.
     expect(h.view.result.current.state).toBe("connecting");
     expect(useLiveVoiceStore.getState().controls).not.toBeNull();
+    expect(h.player.disposeCount).toBe(0);
 
     // Backoff elapses → a fresh connect to the SAME conversation (no turn-taking
-    // overrides, since none were set).
+    // overrides, since none were set). The player remains the one prewarmed by
+    // the original user gesture, so its iOS MediaStream route stays active.
     await act(async () => {
       await sleep(80);
     });
+    expect(h.getPlayerCreateCount()).toBe(1);
+    expect(h.player.disposeCount).toBe(0);
     expect(h.client.connectArgs).toEqual({
       assistantId: "assistant-1",
       conversationId: "conv-1",
@@ -2670,6 +2679,7 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
       await h.view.result.current.stop();
     });
     expect(h.view.result.current.state).toBe("idle");
+    expect(h.player.disposeCount).toBe(1);
 
     // The backoff would have elapsed by now — but the timer was cancelled, so
     // no reconnect connect fires.
@@ -2697,6 +2707,7 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
     });
     expect(useLiveVoiceStore.getState().state).toBe("idle");
     expect(useLiveVoiceStore.getState().controls).toBeNull();
+    expect(h.player.disposeCount).toBe(1);
 
     // The pending reconnect was cancelled — nothing reconnects after the gap.
     await act(async () => {
@@ -2889,6 +2900,8 @@ describe("initial-connect resilience (JARVIS-1282)", () => {
     await act(async () => {
       await sleep(30);
     });
+    expect(h.getPlayerCreateCount()).toBe(1);
+    expect(h.player.disposeCount).toBe(0);
     expect(h.client.connectArgs).toEqual({
       assistantId: "assistant-1",
       conversationId: "conv-1",

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -153,6 +153,38 @@ afterEach(() => {
   useLiveVoiceStore.getState().reset();
 });
 
+describe("playback prewarm", () => {
+  test("reserves playback before start and reuses it for the session", async () => {
+    const h = renderController();
+
+    act(() => {
+      h.view.result.current.prewarmPlayback();
+    });
+
+    expect(h.getPlayerCreateCount()).toBe(1);
+    expect(h.player.prewarmCount).toBe(1);
+    expect(h.view.result.current.state).toBe("idle");
+
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+
+    expect(h.getPlayerCreateCount()).toBe(1);
+    expect(h.player.prewarmCount).toBe(2);
+  });
+
+  test("canceling a prewarm releases the reserved player", () => {
+    const h = renderController();
+    act(() => {
+      h.view.result.current.prewarmPlayback();
+      h.view.result.current.cancelPrewarmedPlayback();
+    });
+
+    expect(h.player.disposeCount).toBe(1);
+    expect(h.view.result.current.state).toBe("idle");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Full turn
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -154,6 +154,10 @@ export interface UseLiveVoiceResult {
   inputAmplitude: number;
   /** Failure message when `state === "failed"`, else `null`. */
   error: string | null;
+  /** Unlock assistant playback synchronously from the initiating user gesture. */
+  prewarmPlayback: () => void;
+  /** Release playback reserved by a readiness check that will not start. */
+  cancelPrewarmedPlayback: () => void;
   /** Start a session for `assistantId`, optionally attaching a conversation. */
   start: (
     assistantId: string,
@@ -372,10 +376,10 @@ export function useLiveVoice(
   // useCallback self-reference cycle.
   const reconnectAttemptRef = useRef(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Owns the prewarmed player while a reconnect is waiting on its backoff
-  // timer. Keeping its MediaStream element alive preserves the user activation
-  // that started iOS voice-processing playback.
-  const reconnectPlayerRef = useRef<LiveVoiceAudioPlayer | null>(null);
+  // Owns a prewarmed player before the first connection and during reconnect
+  // backoff. Keeping its MediaStream element alive preserves the user
+  // activation that started iOS voice-processing playback.
+  const standbyPlayerRef = useRef<LiveVoiceAudioPlayer | null>(null);
   // Initial-connect resilience (JARVIS-1282). `hasReadyRef` records whether the
   // current session lifecycle ever reached `ready` — false during the very
   // first connect, so a transient pre-`ready` connection failure (cold velay
@@ -396,17 +400,25 @@ export function useLiveVoice(
     | null
   >(null);
 
-  const cancelReconnect = useCallback(() => {
+  const clearReconnectTimer = useCallback(() => {
     if (reconnectTimerRef.current !== null) {
       clearTimeout(reconnectTimerRef.current);
       reconnectTimerRef.current = null;
     }
-    const player = reconnectPlayerRef.current;
-    reconnectPlayerRef.current = null;
+  }, []);
+
+  const disposeStandbyPlayer = useCallback(() => {
+    const player = standbyPlayerRef.current;
+    standbyPlayerRef.current = null;
     if (player) {
       void player.dispose();
     }
   }, []);
+
+  const cancelPendingConnection = useCallback(() => {
+    clearReconnectTimer();
+    disposeStandbyPlayer();
+  }, [clearReconnectTimer, disposeStandbyPlayer]);
 
   /**
    * Tear down the active session's primitives, clear the ref, and reset the
@@ -421,7 +433,7 @@ export function useLiveVoice(
   const teardown = useCallback(() => {
     // Cancel any pending hands-free reconnect first — teardown is terminal, so
     // a queued reconnect must not resurrect the session behind idle UI.
-    cancelReconnect();
+    cancelPendingConnection();
     reconnectAttemptRef.current = 0;
     initialConnectAttemptRef.current = 0;
     hasReadyRef.current = false;
@@ -441,12 +453,12 @@ export function useLiveVoice(
     sessionRef.current = null;
     disposeSessionPrimitives(session);
     useLiveVoiceStore.getState().reset();
-  }, [cancelReconnect]);
+  }, [cancelPendingConnection]);
 
   const stop = useCallback(async () => {
     // A user-initiated stop ends the session outright — drop any pending
     // reconnect and its attempt budget.
-    cancelReconnect();
+    cancelPendingConnection();
     reconnectAttemptRef.current = 0;
     initialConnectAttemptRef.current = 0;
     hasReadyRef.current = false;
@@ -471,7 +483,7 @@ export function useLiveVoice(
     // here would leave that session's mic hot behind idle UI.
     if (startGenerationRef.current !== startGeneration) return;
     useLiveVoiceStore.getState().reset();
-  }, [cancelReconnect]);
+  }, [cancelPendingConnection]);
 
   /**
    * Manual turn release ("send now"). Guarded to `listening` so a stray click
@@ -545,6 +557,34 @@ export function useLiveVoice(
     [],
   );
 
+  const createPlayer = useCallback(
+    () =>
+      (
+        optionsRef.current.createPlayer ?? (() => new LiveVoiceAudioPlayer())
+      )(),
+    [],
+  );
+
+  const prewarmPlayback = useCallback(() => {
+    if (
+      sessionRef.current ||
+      standbyPlayerRef.current ||
+      isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)
+    ) {
+      return;
+    }
+    const player = createPlayer();
+    standbyPlayerRef.current = player;
+    player.prewarm();
+  }, [createPlayer]);
+
+  const cancelPrewarmedPlayback = useCallback(() => {
+    if (reconnectTimerRef.current !== null) {
+      return;
+    }
+    disposeStandbyPlayer();
+  }, [disposeStandbyPlayer]);
+
   // The connect flow, shared by the user-facing `start()` and the hands-free
   // reconnect path. `start()` owns the "already active" guard and resets the
   // reconnect budget; `connectSession` assumes it may run. On reconnect it is
@@ -602,15 +642,12 @@ export function useLiveVoice(
       const client = (
         opts.createClient ?? (() => new LiveVoiceChannelClient())
       )();
-      const player =
-        reconnectPlayerRef.current ??
-        (opts.createPlayer ?? (() => new LiveVoiceAudioPlayer()))();
-      reconnectPlayerRef.current = null;
-      // A fresh session prewarms playback inside the mic-button gesture.
-      // Reconnects reuse that already-started player, and this repeated call is
-      // a no-op while its AudioContext is running. Deferring fresh setup to the
-      // first `tts_audio` frame would land outside any gesture and start
-      // suspended.
+      const player = standbyPlayerRef.current ?? createPlayer();
+      standbyPlayerRef.current = null;
+      // The composer reserves and prewarms this player before its async
+      // readiness check. Reconnects reuse it too; this repeated call is a no-op
+      // while its AudioContext is running. Direct callers without a reservation
+      // still create and prewarm here.
       player.prewarm();
       // Route the room avatar's `responding` pulse to real TTS output. The mic
       // amplitude (the only prior source) is near-silent while the assistant
@@ -951,7 +988,7 @@ export function useLiveVoice(
               // entry origin, which the re-entered `connectSession` preserves),
               // so the avatar keeps animating and the user can still bail.
               sessionRef.current = null;
-              reconnectPlayerRef.current = session.player;
+              standbyPlayerRef.current = session.player;
               disposeSessionPrimitives(session, { keepPlayerAlive: true });
               const s = useLiveVoiceStore.getState();
               s.setState("connecting");
@@ -1011,7 +1048,7 @@ export function useLiveVoice(
             // reconnect rather than a vanished session and the user can still
             // bail during the gap.
             sessionRef.current = null;
-            reconnectPlayerRef.current = session.player;
+            standbyPlayerRef.current = session.player;
             disposeSessionPrimitives(session, { keepPlayerAlive: true });
             const s = useLiveVoiceStore.getState();
             s.setState("connecting");
@@ -1068,7 +1105,7 @@ export function useLiveVoice(
           : {}),
       });
     },
-    [teardown, stop, release, interrupt, setMuted, updateConfig],
+    [teardown, stop, release, interrupt, setMuted, updateConfig, createPlayer],
   );
 
   // Let the transport `closed` handler re-enter the connect flow for a
@@ -1095,13 +1132,13 @@ export function useLiveVoice(
       if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) return;
       // Fresh user-initiated session: drop any stale reconnect budget/timer and
       // the initial-connect resilience budget (a new session starts unreadied).
-      cancelReconnect();
+      clearReconnectTimer();
       reconnectAttemptRef.current = 0;
       initialConnectAttemptRef.current = 0;
       hasReadyRef.current = false;
       await connectSession(assistantId, conversationId, startOptions ?? {});
     },
-    [connectSession, cancelReconnect],
+    [connectSession, clearReconnectTimer],
   );
 
   // Release everything if the consumer unmounts mid-session. teardown() also
@@ -1117,6 +1154,8 @@ export function useLiveVoice(
     assistantTranscript,
     inputAmplitude,
     error,
+    prewarmPlayback,
+    cancelPrewarmedPlayback,
     start,
     stop,
   };

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -372,6 +372,10 @@ export function useLiveVoice(
   // useCallback self-reference cycle.
   const reconnectAttemptRef = useRef(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Owns the prewarmed player while a reconnect is waiting on its backoff
+  // timer. Keeping its MediaStream element alive preserves the user activation
+  // that started iOS voice-processing playback.
+  const reconnectPlayerRef = useRef<LiveVoiceAudioPlayer | null>(null);
   // Initial-connect resilience (JARVIS-1282). `hasReadyRef` records whether the
   // current session lifecycle ever reached `ready` — false during the very
   // first connect, so a transient pre-`ready` connection failure (cold velay
@@ -392,10 +396,15 @@ export function useLiveVoice(
     | null
   >(null);
 
-  const clearReconnectTimer = useCallback(() => {
+  const cancelReconnect = useCallback(() => {
     if (reconnectTimerRef.current !== null) {
       clearTimeout(reconnectTimerRef.current);
       reconnectTimerRef.current = null;
+    }
+    const player = reconnectPlayerRef.current;
+    reconnectPlayerRef.current = null;
+    if (player) {
+      void player.dispose();
     }
   }, []);
 
@@ -412,7 +421,7 @@ export function useLiveVoice(
   const teardown = useCallback(() => {
     // Cancel any pending hands-free reconnect first — teardown is terminal, so
     // a queued reconnect must not resurrect the session behind idle UI.
-    clearReconnectTimer();
+    cancelReconnect();
     reconnectAttemptRef.current = 0;
     initialConnectAttemptRef.current = 0;
     hasReadyRef.current = false;
@@ -432,12 +441,12 @@ export function useLiveVoice(
     sessionRef.current = null;
     disposeSessionPrimitives(session);
     useLiveVoiceStore.getState().reset();
-  }, [clearReconnectTimer]);
+  }, [cancelReconnect]);
 
   const stop = useCallback(async () => {
     // A user-initiated stop ends the session outright — drop any pending
     // reconnect and its attempt budget.
-    clearReconnectTimer();
+    cancelReconnect();
     reconnectAttemptRef.current = 0;
     initialConnectAttemptRef.current = 0;
     hasReadyRef.current = false;
@@ -462,7 +471,7 @@ export function useLiveVoice(
     // here would leave that session's mic hot behind idle UI.
     if (startGenerationRef.current !== startGeneration) return;
     useLiveVoiceStore.getState().reset();
-  }, [clearReconnectTimer]);
+  }, [cancelReconnect]);
 
   /**
    * Manual turn release ("send now"). Guarded to `listening` so a stray click
@@ -593,13 +602,15 @@ export function useLiveVoice(
       const client = (
         opts.createClient ?? (() => new LiveVoiceChannelClient())
       )();
-      const player = (
-        opts.createPlayer ?? (() => new LiveVoiceAudioPlayer())
-      )();
-      // Resume the playback AudioContext now, while we're still in the
-      // mic-button click's gesture. Deferring to the first `tts_audio` frame
-      // (its lazy creation point) lands outside any gesture, so the browser
-      // starts it suspended and the first turn's audio is silently dropped.
+      const player =
+        reconnectPlayerRef.current ??
+        (opts.createPlayer ?? (() => new LiveVoiceAudioPlayer()))();
+      reconnectPlayerRef.current = null;
+      // A fresh session prewarms playback inside the mic-button gesture.
+      // Reconnects reuse that already-started player, and this repeated call is
+      // a no-op while its AudioContext is running. Deferring fresh setup to the
+      // first `tts_audio` frame would land outside any gesture and start
+      // suspended.
       player.prewarm();
       // Route the room avatar's `responding` pulse to real TTS output. The mic
       // amplitude (the only prior source) is near-silent while the assistant
@@ -940,7 +951,8 @@ export function useLiveVoice(
               // entry origin, which the re-entered `connectSession` preserves),
               // so the avatar keeps animating and the user can still bail.
               sessionRef.current = null;
-              disposeSessionPrimitives(session);
+              reconnectPlayerRef.current = session.player;
+              disposeSessionPrimitives(session, { keepPlayerAlive: true });
               const s = useLiveVoiceStore.getState();
               s.setState("connecting");
               s.setControls({
@@ -999,7 +1011,8 @@ export function useLiveVoice(
             // reconnect rather than a vanished session and the user can still
             // bail during the gap.
             sessionRef.current = null;
-            disposeSessionPrimitives(session);
+            reconnectPlayerRef.current = session.player;
+            disposeSessionPrimitives(session, { keepPlayerAlive: true });
             const s = useLiveVoiceStore.getState();
             s.setState("connecting");
             // Hold the reconnect label through the backoff gap (before the
@@ -1082,13 +1095,13 @@ export function useLiveVoice(
       if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) return;
       // Fresh user-initiated session: drop any stale reconnect budget/timer and
       // the initial-connect resilience budget (a new session starts unreadied).
-      clearReconnectTimer();
+      cancelReconnect();
       reconnectAttemptRef.current = 0;
       initialConnectAttemptRef.current = 0;
       hasReadyRef.current = false;
       await connectSession(assistantId, conversationId, startOptions ?? {});
     },
-    [connectSession, clearReconnectTimer],
+    [connectSession, cancelReconnect],
   );
 
   // Release everything if the consumer unmounts mid-session. teardown() also
@@ -1114,20 +1127,28 @@ export function useLiveVoice(
 // ---------------------------------------------------------------------------
 
 /**
- * Release a session's primitives (event subscriptions, socket, playback
- * AudioContext, mic capture) and bump its generation so any in-flight async
- * callbacks become stale no-ops. Does NOT touch the store — callers set the
- * next store phase themselves (`teardown()` → idle; the reconnect path →
- * `connecting`). `dispose()` (not a bare `stop()`) releases the AudioContext,
- * which a bare stop would leak across sessions until page unload.
+ * Release a session's primitives and bump its generation so any in-flight
+ * async callbacks become stale no-ops. A reconnect keeps the prewarmed player
+ * alive but stops queued audio; terminal disposal releases its AudioContext.
+ * Does NOT touch the store — callers set the next store phase themselves
+ * (`teardown()` → idle; the reconnect path → `connecting`).
  */
-function disposeSessionPrimitives(session: SessionContext): void {
+function disposeSessionPrimitives(
+  session: SessionContext,
+  options?: { keepPlayerAlive?: boolean },
+): void {
   session.generation += 1;
   clearAssistantAudioActive(session);
-  for (const unsubscribe of session.unsubscribes) unsubscribe();
+  for (const unsubscribe of session.unsubscribes) {
+    unsubscribe();
+  }
   session.unsubscribes = [];
   session.client.close();
-  void session.player.dispose();
+  if (options?.keepPlayerAlive) {
+    session.player.stop();
+  } else {
+    void session.player.dispose();
+  }
   void session.capture.shutdown();
 }
 


### PR DESCRIPTION
## Summary

- Route Capacitor iOS live-voice TTS through a MediaStream track so WebKit can render it through the voice-processing capture unit as the far-end echo reference.
- Prewarm the controller-owned player synchronously before readiness preflight, preserve it across automatic reconnects, and dispose it on rejected preflight, stop, or unmount.
- Leave AVAudioSession ownership with WebKit, retain direct Web Audio output on other platforms, and document the WebKit behavior without a feature flag.

## Root cause

WebKit already selects a play-and-record audio session with a video-chat mode for microphone capture, then creates a VoiceProcessingIO unit when `echoCancellation` is requested. The reverted #39331 plugin set a competing voice-chat session before capture and reasserted it after `getUserMedia()`, changing the shared active session underneath the capture graph WebKit had just created. That explains the device-only state where permission and the live mic indicator remained present but microphone samples stopped flowing.

Removing that override restores microphone capture, but the original echo remains because TTS currently terminates at `AudioContext.destination`. That path does not use the MediaStream speaker-samples producer that WebKit registers with its capture unit. Routing the same Web Audio graph into a `MediaStreamAudioDestinationNode` and playing its track through an audio element gives WebKit the far-end render stream without modifying native session state.

The composer synchronously reserves and prewarms that player in the initiating click task before awaiting the readiness request. A ready or fail-open result consumes it; a not-ready or stale result disposes it. Automatic reconnects reuse the same prewarmed player so the iOS audio element retains the user activation from the original tap while the socket and microphone are rebuilt.

This is a deterministic Capacitor iOS runtime requirement, so the fix intentionally has no feature flag.

WebKit references:

- https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm#L174-L218
- https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureUnit.cpp#L75-L87
- https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp#L228-L292

## Validation

- Five focused voice/composer suites: 266 passed.
- `bunx eslint` on the changed TypeScript files: 0 errors.
- Commit hook regenerated the web clients and completed `bunx tsc --noEmit` successfully.
- Both prior CI rounds: all 7 checks passed.

## Original prompt

okay thanks, i reverted it. please help me rca and a fix on a new dev branch