### PR TITLE
feat(release): one-shot NEXT_RELEASE_BUMP variable for scheduled minor/major cuts

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -12,6 +12,14 @@ Cut a new release. Releases are a **two-step** process:
 
 The scheduled Tue/Fri 8:52am ET cut performs step 1 automatically; a human performs step 2 after the staging bake is green. A `release/v<X.Y.Z>` branch with no corresponding GitHub Release means a cut was never promoted — re-running step 1 refreshes it from current `main`.
 
+Scheduled cuts default to a patch bump. To make the **next** scheduled tick a minor or major, set the one-shot `NEXT_RELEASE_BUMP` repository variable — no dispatch needed:
+
+```bash
+gh variable set NEXT_RELEASE_BUMP --repo vellum-ai/vellum-assistant --body minor
+```
+
+The scheduled cut consumes the value and resets the variable to `patch`, so exactly one tick is upgraded. Valid values are `patch`, `minor`, `major` (`hotfix` is dispatch-only; anything else fails the scheduled run loudly). Manual dispatches ignore the variable entirely.
+
 The user may pass `$ARGUMENTS` as the bump type for step 1: `patch`, `minor`, `major`, or `hotfix` (patch cut from the latest release tag's commit instead of `main`, pushed `[skip ci]` for manual cherry-picks). Default to `patch`.
 
 ## Steps

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -624,6 +624,10 @@ Run `/release [patch|minor|major|hotfix]` in Claude Code. The command:
 
 A lingering `release/vX.Y.Z` branch with no matching GitHub Release means a scheduled cut was never promoted to production; re-running step 2 refreshes it from current `main`.
 
+#### Scheduling a minor or major
+
+Scheduled cuts default to a patch bump. The one-shot `NEXT_RELEASE_BUMP` repository variable upgrades the next scheduled tick without any dispatch: set it to `minor` or `major` (`gh variable set NEXT_RELEASE_BUMP --body minor`), and the next scheduled cut consumes the value and resets the variable to `patch`. Invalid values (including `hotfix`, which is dispatch-only) fail the scheduled run with a Slack notification rather than silently falling back. Manual dispatches ignore the variable.
+
 #### What happens after a release is created
 
 Creating the GitHub Release triggers three workflows in parallel:


### PR DESCRIPTION
## Prompt / plan

The scheduled Tue/Fri release cut always produces a patch bump — `schedule` events carry no workflow inputs, so `create-release-branch.yml` fell through to `patch` every tick. Requested behavior: a way to declare "the next scheduled tick is a minor (or major)" ahead of time, with no code change per release after this initial enablement.

Design: a one-shot **`NEXT_RELEASE_BUMP` repository variable**.

- Scheduled cuts resolve their bump from `vars.NEXT_RELEASE_BUMP` (default `patch`), validated to `patch|minor|major` — an invalid value (including `hotfix`, which stays dispatch-only) fails the run loudly, which lands in the existing Slack failure notification.
- After a successful scheduled cut that consumed a non-patch value, the `create-release-branch` job PATCHes the variable back to `patch`, so exactly one tick is upgraded and the cadence reverts automatically.
- Manual `workflow_dispatch` runs keep using the `bump` input and never read or reset the variable.
- Slack start/failure notifications report the resolved bump instead of assuming `inputs.bump || 'patch'`.

Usage: `gh variable set NEXT_RELEASE_BUMP --repo vellum-ai/vellum-assistant --body minor` — then the next Tue/Fri tick cuts a minor and resets itself.

**⚠️ Draft — the workflow file change could not be pushed from this session** (the session's git credential lacks the `workflow` OAuth scope, so pushes touching `.github/workflows/` are rejected). This branch currently carries only the docs/skill commits. Apply the remaining patch from a normal checkout and push:

```bash
git fetch origin claude/release-version-scheduling-ipnaoq
git checkout claude/release-version-scheduling-ipnaoq
git apply <<'PATCH' && git add -A && git commit -m "feat(release): one-shot NEXT_RELEASE_BUMP variable for scheduled minor/major cuts" && git push
diff --git a/.github/workflows/create-release-branch.yml b/.github/workflows/create-release-branch.yml
index 8bde8c9..d534b78 100644
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -65,6 +65,7 @@ jobs:
       version: ${{ steps.compute.outputs.version }}
       base-ref: ${{ steps.compute.outputs.base-ref }}
       skip-ci: ${{ steps.compute.outputs.skip-ci }}
+      bump: ${{ steps.compute.outputs.bump }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,8 +73,30 @@ jobs:
 
       - name: Compute version from bump type
         id: compute
+        env:
+          NEXT_RELEASE_BUMP: ${{ vars.NEXT_RELEASE_BUMP }}
         run: |
-          BUMP="${{ inputs.bump || 'patch' }}"
+          # Scheduled cuts take their bump type from the NEXT_RELEASE_BUMP
+          # repository variable (Settings → Secrets and variables → Actions →
+          # Variables, or `gh variable set NEXT_RELEASE_BUMP --body minor`).
+          # The variable is one-shot: the create-release-branch job resets it
+          # to patch after a successful scheduled cut, so setting it to minor
+          # or major upgrades exactly one scheduled tick. Unset or "patch"
+          # means the usual patch release. Manual dispatches use the bump
+          # input and never read or reset the variable.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            BUMP="${{ inputs.bump }}"
+          else
+            BUMP="${NEXT_RELEASE_BUMP:-patch}"
+            case "$BUMP" in
+              patch|minor|major) ;;
+              *)
+                echo "::error::NEXT_RELEASE_BUMP repository variable is '$BUMP' — scheduled cuts accept patch, minor, or major (hotfix is dispatch-only)."
+                exit 1
+                ;;
+            esac
+          fi
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
 
           LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -z "$LATEST_TAG" ]; then
@@ -130,7 +153,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Workflow:* Create Release Branch\n*Version:* `${{ needs.compute-version.outputs.version }}`\n*Bump:* `${{ inputs.bump || 'patch' }}`\n*Triggered by:* ${{ github.event_name == 'schedule' && 'Scheduled' || github.actor }}"
+                  text: "*Workflow:* Create Release Branch\n*Version:* `${{ needs.compute-version.outputs.version }}`\n*Bump:* `${{ needs.compute-version.outputs.bump || inputs.bump || 'unknown' }}`\n*Triggered by:* ${{ github.event_name == 'schedule' && 'Scheduled' || github.actor }}"
               - type: actions
                 elements:
                   - type: button
@@ -216,7 +239,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Workflow:* Create Release Branch\n*Version:* `${{ needs.compute-version.outputs.version }}`\n*Bump:* `${{ inputs.bump || 'patch' }}`\n*Triggered by:* ${{ github.event_name == 'schedule' && 'Scheduled' || github.actor }}"
+                  text: "*Workflow:* Create Release Branch\n*Version:* `${{ needs.compute-version.outputs.version }}`\n*Bump:* `${{ needs.compute-version.outputs.bump }}`\n*Triggered by:* ${{ github.event_name == 'schedule' && 'Scheduled' || github.actor }}"
               - type: actions
                 elements:
                   - type: button
@@ -348,3 +371,20 @@ jobs:
             git commit -m "$COMMIT_MSG"
           fi
           git push --no-verify origin "$BRANCH"
+
+      # NEXT_RELEASE_BUMP is one-shot: a scheduled cut that consumed a
+      # minor/major value resets it to patch so the next tick reverts to the
+      # normal cadence. Requires the automation GitHub App to have the
+      # "Variables" repository permission (read & write). A failure here is
+      # loud on purpose — a stale minor/major value would silently upgrade
+      # every following scheduled release.
+      - name: Reset NEXT_RELEASE_BUMP to patch
+        if: ${{ github.event_name == 'schedule' && needs.compute-version.outputs.bump != 'patch' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api --method PATCH \
+            "repos/${{ github.repository }}/actions/variables/NEXT_RELEASE_BUMP" \
+            -f name=NEXT_RELEASE_BUMP \
+            -f value=patch
+          echo "Consumed NEXT_RELEASE_BUMP=${{ needs.compute-version.outputs.bump }}; reset to patch."
PATCH
```

**One-time prerequisite**: the Vellum automation GitHub App (the one behind `VELLUM_AUTOMATION_GITHUB_APP_ID`) needs the **Variables** repository permission (read & write) so the reset step can PATCH the variable. Without it, a consumed minor/major cut succeeds but the reset step fails loudly (Slack failure notification) rather than silently leaving the variable armed.

## Test plan

- `yaml.safe_load` parses the updated workflow.
- Path check by trigger: `workflow_dispatch` keeps `inputs.bump` exactly as before (variable untouched); `schedule` with the variable unset resolves `patch` and skips the reset step (its `if` requires a non-patch bump); `schedule` with `minor`/`major` computes the right version and resets afterward; an invalid value exits 1 before any branch mutation, surfacing via the existing Slack failure notification.
- Full behavioral verification happens on the next scheduled tick after setting the variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEoETPmbcQUpCNgNCBTEgz

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEoETPmbcQUpCNgNCBTEgz)_