### PR TITLE
feat(gateway): discover plugin-declared ingress routes from the workspace

### DIFF
--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -1,0 +1,242 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+  PLUGIN_INGRESS_MANIFEST_RELPATH,
+  PLUGIN_WEBHOOK_PREFIX,
+  PluginIngressCache,
+  discoverPluginIngress,
+  ingressRoutePaths,
+  parsePluginIngressManifest,
+  pluginWebhookPath,
+} from "./plugin-ingress.js";
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "plugin-ingress-"));
+  created.push(dir);
+  return dir;
+}
+
+/** Write a plugin's ingress manifest (raw string, so invalid JSON is testable). */
+function writeManifest(
+  workspaceDir: string,
+  plugin: string,
+  contents: string,
+): string {
+  const pluginDir = join(workspaceDir, "plugins", plugin);
+  mkdirSync(join(pluginDir, "channels"), { recursive: true });
+  writeFileSync(join(pluginDir, PLUGIN_INGRESS_MANIFEST_RELPATH), contents);
+  return pluginDir;
+}
+
+const VALID = JSON.stringify({
+  routes: [
+    { path: "realtime", kind: "websocket", description: "realtime events" },
+  ],
+});
+
+describe("pluginWebhookPath", () => {
+  it("composes under the reserved namespace", () => {
+    expect(pluginWebhookPath("meeting-bot", "realtime")).toBe(
+      `${PLUGIN_WEBHOOK_PREFIX}/meeting-bot/realtime`,
+    );
+  });
+
+  it("normalizes a leading slash rather than emitting a double slash", () => {
+    expect(pluginWebhookPath("acme", "/hook")).toBe(
+      `${PLUGIN_WEBHOOK_PREFIX}/acme/hook`,
+    );
+  });
+});
+
+describe("parsePluginIngressManifest", () => {
+  it("accepts a well-formed declaration", () => {
+    const manifest = parsePluginIngressManifest(JSON.parse(VALID));
+    expect(manifest.routes).toHaveLength(1);
+    expect(manifest.routes[0]!.path).toBe("realtime");
+  });
+
+  it("rejects an absolute path", () => {
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [{ path: "/hook", kind: "http", description: "d" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects traversal that would clean out of the plugin's namespace", () => {
+    // Velay percent-decodes and path.Cleans before matching its allowlist,
+    // so `../other/steal` would otherwise escape the namespace.
+    for (const path of ["../other/steal", "a/../../b", "./hook"]) {
+      expect(() =>
+        parsePluginIngressManifest({
+          routes: [{ path, kind: "http", description: "d" }],
+        }),
+      ).toThrow();
+    }
+  });
+
+  it("rejects a trailing slash", () => {
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [{ path: "hook/", kind: "http", description: "d" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects query strings and fragments", () => {
+    for (const path of ["hook?x=1", "hook#frag"]) {
+      expect(() =>
+        parsePluginIngressManifest({
+          routes: [{ path, kind: "http", description: "d" }],
+        }),
+      ).toThrow();
+    }
+  });
+
+  it("rejects an unknown transport kind", () => {
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [{ path: "hook", kind: "grpc", description: "d" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects duplicate paths", () => {
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [
+          { path: "hook", kind: "http", description: "one" },
+          { path: "hook", kind: "http", description: "two" },
+        ],
+      }),
+    ).toThrow(/duplicate route/);
+  });
+
+  it("rejects an empty route list", () => {
+    expect(() => parsePluginIngressManifest({ routes: [] })).toThrow();
+  });
+
+  it("strips unknown fields rather than carrying them through", () => {
+    const manifest = parsePluginIngressManifest({
+      routes: [
+        { path: "hook", kind: "http", description: "d", auth: "query-token" },
+      ],
+    });
+    expect(manifest.routes[0]).not.toHaveProperty("auth");
+  });
+});
+
+describe("discoverPluginIngress", () => {
+  it("returns empty when there is no plugins directory", () => {
+    const workspaceDir = makeWorkspace();
+    expect(discoverPluginIngress({ workspaceDir })).toEqual({
+      plugins: [],
+      problems: [],
+    });
+  });
+
+  it("discovers a declaring plugin and composes its paths", () => {
+    const workspaceDir = makeWorkspace();
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+
+    const { plugins, problems } = discoverPluginIngress({ workspaceDir });
+    expect(problems).toEqual([]);
+    expect(plugins).toHaveLength(1);
+    expect(ingressRoutePaths(plugins[0]!)).toEqual([
+      "/webhooks/plugins/meeting-bot/realtime",
+    ]);
+  });
+
+  it("ignores plugins that declare nothing", () => {
+    const workspaceDir = makeWorkspace();
+    mkdirSync(join(workspaceDir, "plugins", "quiet"), { recursive: true });
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+
+    const { plugins } = discoverPluginIngress({ workspaceDir });
+    expect(plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+  });
+
+  it("skips a disabled plugin so its routes do not stay live", () => {
+    const workspaceDir = makeWorkspace();
+    const pluginDir = writeManifest(workspaceDir, "meeting-bot", VALID);
+    writeFileSync(join(pluginDir, ".disabled"), "");
+
+    expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
+  });
+
+  it("reports a malformed declaration without dropping the others", () => {
+    const workspaceDir = makeWorkspace();
+    writeManifest(workspaceDir, "broken", "{ not json");
+    writeManifest(
+      workspaceDir,
+      "invalid",
+      JSON.stringify({ routes: [{ path: "/absolute", kind: "http" }] }),
+    );
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+
+    const { plugins, problems } = discoverPluginIngress({ workspaceDir });
+    // One bad manifest must not take down discovery for every plugin.
+    expect(plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+    expect(problems.map((p) => p.plugin).sort()).toEqual(["broken", "invalid"]);
+  });
+
+  it("does not trust the manifest's own view of validity", () => {
+    // A plugin repo validating its own file is a convenience for its
+    // authors, not a guarantee to us — traversal is rejected here too.
+    const workspaceDir = makeWorkspace();
+    writeManifest(
+      workspaceDir,
+      "sneaky",
+      JSON.stringify({
+        routes: [
+          { path: "../meeting-bot/realtime", kind: "http", description: "d" },
+        ],
+      }),
+    );
+
+    const { plugins, problems } = discoverPluginIngress({ workspaceDir });
+    expect(plugins).toEqual([]);
+    expect(problems).toHaveLength(1);
+  });
+});
+
+describe("PluginIngressCache", () => {
+  it("serves a cached snapshot within the TTL and re-scans after it", () => {
+    const workspaceDir = makeWorkspace();
+    const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
+    expect(cache.get().plugins).toEqual([]);
+
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+    // Still inside the TTL — the new plugin is not visible yet.
+    expect(cache.get().plugins).toEqual([]);
+
+    // Invalidating stands in for the TTL elapsing, so the test does not
+    // have to sleep.
+    cache.invalidate();
+    expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+  });
+
+  it("force re-scans regardless of the TTL", () => {
+    const workspaceDir = makeWorkspace();
+    const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
+    expect(cache.get().plugins).toEqual([]);
+
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+    expect(cache.get({ force: true }).plugins.map((p) => p.plugin)).toEqual([
+      "meeting-bot",
+    ]);
+  });
+});

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -1,0 +1,295 @@
+/**
+ * Discovery of plugin-declared public ingress routes.
+ *
+ * A plugin that needs inbound traffic — a webhook, a provider dialling a
+ * realtime socket — cannot reach the public surface today. Every public
+ * route in the gateway is hand-written and the Velay path allowlist is a
+ * frozen literal, which works for first-party integrations (someone edits
+ * the gateway when they add one) but not for a plugin, which ships
+ * separately and cannot patch a frozen array. The workaround has been for
+ * the plugin to stand up its own tunnel and public address.
+ *
+ * Instead a plugin declares what it needs in a static file on the
+ * workspace volume the gateway already reads:
+ *
+ *     <workspaceDir>/plugins/<plugin>/channels/ingress.json
+ *
+ *     {
+ *       "routes": [
+ *         { "path": "realtime", "kind": "websocket", "description": "…" }
+ *       ]
+ *     }
+ *
+ * and the gateway composes the public path from the plugin's own name:
+ *
+ *     /webhooks/plugins/<plugin>/<path>
+ *
+ * The file is inert data, never code: the gateway must not execute
+ * assistant-supplied logic to find out what to expose.
+ *
+ * ## What this module does and does not do
+ *
+ * It discovers and validates declarations. It does **not** serve them. A
+ * declaration is a request, not a grant — routing them requires a guardian
+ * approval gate that does not exist yet, so nothing here is wired into the
+ * request path.
+ *
+ * ## Trust
+ *
+ * Everything below treats the manifest as untrusted input from the
+ * assistant, because that is what it is. The plugin repo validating its
+ * own file is a convenience for its authors, not a guarantee to us.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import { getLogger } from "../logger.js";
+import { getWorkspaceDir } from "../paths.js";
+
+const log = getLogger("plugin-ingress");
+
+/** Reserved namespace every plugin webhook is composed under. */
+export const PLUGIN_WEBHOOK_PREFIX = "/webhooks/plugins";
+
+/** Manifest location relative to a plugin's workspace directory. */
+export const PLUGIN_INGRESS_MANIFEST_RELPATH = join("channels", "ingress.json");
+
+/**
+ * Transport a declared route expects. The gateway bridges HTTP and
+ * WebSocket differently (`velay/http-bridge.ts` vs `websocket-bridge.ts`),
+ * so it has to know which before a connection arrives.
+ */
+export const IngressRouteKindSchema = z.enum(["http", "websocket"]);
+export type IngressRouteKind = z.infer<typeof IngressRouteKindSchema>;
+
+/**
+ * A plugin directory name that is safe to place in a public URL.
+ *
+ * The directory name becomes a path segment, so it is validated rather
+ * than trusted: anything that could alter the shape of the composed path
+ * is rejected outright.
+ */
+const SAFE_PLUGIN_NAME = /^[a-z0-9][a-z0-9._-]*$/i;
+
+export const IngressRouteSchema = z.object({
+  /**
+   * Path relative to the plugin's own namespace — `"realtime"`, not
+   * `/webhooks/plugins/meeting-bot/realtime`. The plugin never writes the
+   * prefix, so it cannot name another plugin's route: cross-plugin
+   * interception is unrepresentable rather than something we have to
+   * detect.
+   *
+   * `.` and `..` segments are rejected because Velay percent-decodes and
+   * runs `path.Clean` on the inbound path before matching its allowlist
+   * (see `IsPathAllowed` in the platform repo). A declared
+   * `../other/steal` would otherwise compose to a path that cleans out of
+   * the declaring plugin's namespace. A trailing slash is rejected for
+   * the same reason — `path.Clean` strips it, so a composed path ending
+   * in one could never match.
+   */
+  path: z
+    .string()
+    .min(1)
+    .regex(
+      /^[^/?#\s][^?#\s]*$/,
+      "path must be relative (no leading slash) and free of query/fragment",
+    )
+    .refine((p) => !p.endsWith("/"), {
+      message: "path must not end in a trailing slash",
+    })
+    .refine((p) => !p.split("/").some((seg) => seg === "." || seg === ".."), {
+      message: "path must not contain . or .. segments",
+    }),
+  kind: IngressRouteKindSchema,
+  /** Human-readable purpose, surfaced in gateway logs and admin UI. */
+  description: z.string().min(1),
+});
+export type IngressRoute = z.infer<typeof IngressRouteSchema>;
+
+/**
+ * The declaration itself.
+ *
+ * No version and no plugin name. The format is ours, not something a
+ * plugin versions independently, and the plugin's identity is already
+ * known from the directory the file was read from — taking it from the
+ * file content would let a manifest claim to be a different plugin.
+ */
+export const PluginIngressManifestSchema = z.object({
+  routes: z.array(IngressRouteSchema).min(1),
+});
+export type PluginIngressManifest = z.infer<typeof PluginIngressManifestSchema>;
+
+/** One plugin's validated declaration. */
+export interface DiscoveredPluginIngress {
+  plugin: string;
+  routes: readonly IngressRoute[];
+}
+
+/** A declaration that was found but could not be used, and why. */
+export interface PluginIngressProblem {
+  plugin: string;
+  reason: string;
+}
+
+export interface PluginIngressDiscovery {
+  plugins: DiscoveredPluginIngress[];
+  /**
+   * Rejected declarations. Surfaced rather than thrown: one plugin's
+   * malformed file must never take down discovery for every other plugin.
+   */
+  problems: PluginIngressProblem[];
+}
+
+/** Compose the absolute public path the gateway serves for a route. */
+export function pluginWebhookPath(plugin: string, path: string): string {
+  return `${PLUGIN_WEBHOOK_PREFIX}/${plugin}/${path.replace(/^\/+/, "")}`;
+}
+
+/** Absolute paths a discovered plugin is asking us to expose. */
+export function ingressRoutePaths(
+  discovered: DiscoveredPluginIngress,
+): string[] {
+  return discovered.routes.map((route) =>
+    pluginWebhookPath(discovered.plugin, route.path),
+  );
+}
+
+/** Parse and validate one manifest's contents. Throws on invalid input. */
+export function parsePluginIngressManifest(
+  raw: unknown,
+): PluginIngressManifest {
+  const manifest = PluginIngressManifestSchema.parse(raw);
+  const seen = new Set<string>();
+  for (const route of manifest.routes) {
+    if (seen.has(route.path)) {
+      throw new Error(`duplicate route ${route.path}`);
+    }
+    seen.add(route.path);
+  }
+  return manifest;
+}
+
+export interface DiscoverPluginIngressOptions {
+  /** Workspace root. Defaults to {@link getWorkspaceDir}. */
+  workspaceDir?: string;
+}
+
+/**
+ * Scan the workspace for plugin ingress declarations.
+ *
+ * Skips plugins carrying a `.disabled` sentinel — the same source of truth
+ * the assistant uses for hooks, tools, and routes. Without this, disabling
+ * a plugin would leave its public routes live.
+ *
+ * Note that only workspace-installed plugins are visible here. Default
+ * plugins ship inside the assistant binary, which the gateway cannot read,
+ * so they cannot declare ingress by this route.
+ */
+export function discoverPluginIngress(
+  opts: DiscoverPluginIngressOptions = {},
+): PluginIngressDiscovery {
+  const workspaceDir = opts.workspaceDir ?? getWorkspaceDir();
+  const pluginsDir = join(workspaceDir, "plugins");
+  const plugins: DiscoveredPluginIngress[] = [];
+  const problems: PluginIngressProblem[] = [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(pluginsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    // No plugins directory at all is the normal empty case, not an error.
+    return { plugins, problems };
+  }
+
+  for (const plugin of entries) {
+    if (!SAFE_PLUGIN_NAME.test(plugin)) {
+      // Never report a name we would not serve — it lands in logs.
+      problems.push({
+        plugin: JSON.stringify(plugin),
+        reason: "plugin directory name is not a safe URL path segment",
+      });
+      continue;
+    }
+
+    const pluginDir = join(pluginsDir, plugin);
+    if (existsSync(join(pluginDir, ".disabled"))) continue;
+
+    const manifestPath = join(pluginDir, PLUGIN_INGRESS_MANIFEST_RELPATH);
+    if (!existsSync(manifestPath)) continue;
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(manifestPath, "utf8"));
+    } catch (err) {
+      problems.push({
+        plugin,
+        reason: `unreadable or malformed JSON: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+
+    try {
+      const manifest = parsePluginIngressManifest(raw);
+      plugins.push({ plugin, routes: manifest.routes });
+    } catch (err) {
+      problems.push({
+        plugin,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (problems.length > 0) {
+    log.warn(
+      { problems },
+      "Ignored plugin ingress declarations that failed validation",
+    );
+  }
+
+  return { plugins, problems };
+}
+
+/** Default staleness window for {@link PluginIngressCache}. */
+const DEFAULT_TTL_MS = 5000;
+
+/**
+ * TTL-cached view of {@link discoverPluginIngress}.
+ *
+ * Discovery walks the filesystem, so the request path should not repeat it
+ * per connection. The TTL means installing, enabling, or disabling a
+ * plugin takes effect without a gateway restart — the same
+ * read-through-with-staleness contract as {@link ConfigFileCache}.
+ */
+export class PluginIngressCache {
+  private readonly ttlMs: number;
+  private readonly workspaceDir: string | undefined;
+  private snapshot: PluginIngressDiscovery = { plugins: [], problems: [] };
+  private lastReadAt = 0;
+
+  constructor(opts?: { ttlMs?: number; workspaceDir?: string }) {
+    this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+    this.workspaceDir = opts?.workspaceDir;
+  }
+
+  /** Current discovery, refreshed if the snapshot is stale. */
+  get(opts?: { force?: boolean }): PluginIngressDiscovery {
+    const now = Date.now();
+    if (opts?.force || now - this.lastReadAt >= this.ttlMs) {
+      this.snapshot = discoverPluginIngress({
+        workspaceDir: this.workspaceDir,
+      });
+      this.lastReadAt = Date.now();
+    }
+    return this.snapshot;
+  }
+
+  /** Force a re-scan on the next {@link get}. */
+  invalidate(): void {
+    this.lastReadAt = 0;
+  }
+}


### PR DESCRIPTION
## Prompt / plan

Step 2 of the plugin-ingress plan discussed in `vellum-ai/meeting-bot` (#54, #55): let plugins declare public routes so the gateway can expose them through Velay, instead of each plugin standing up its own tunnel. The matching plugin-side declaration format landed in meeting-bot as `channels/ingress.json`.

**The problem.** A plugin that needs inbound traffic has no route to the public surface. Every public route is hand-written and `VELAY_ALLOWED_PATHS` is a frozen literal with a guard test enforcing symmetry — fine for first-party integrations, where someone edits the gateway when they add one, but a plugin ships separately and cannot patch a frozen array. The workaround has been for the plugin to run its own tunnel and public address, which is exactly what meeting-bot does today with `publicWsUrl` + `verificationToken`.

**The shape.** A plugin declares what it needs in a static file on the workspace volume the gateway already reads:

```
<workspaceDir>/plugins/<plugin>/channels/ingress.json

{ "routes": [ { "path": "realtime", "kind": "websocket", "description": "…" } ] }
```

and the gateway composes `/webhooks/plugins/<plugin>/<path>` from the directory the file was read from. Inert data, never code — the gateway must not execute assistant-supplied logic to discover what to expose.

**Scope: discovery only.** Nothing here is wired into the request path. A declaration is a *request*, not a grant; serving one needs the guardian approval gate that doesn't exist yet. This ships dark and is safe to land on its own.

## Trust model

The manifest is untrusted input from the assistant, and is treated that way throughout. A plugin repo validating its own file is a convenience for its authors, not a guarantee to us.

- **`.` / `..` segments and trailing slashes are rejected.** Velay percent-decodes and runs `path.Clean` on the inbound path before matching its allowlist (`IsPathAllowed`, platform repo), so a declared `../other/steal` would otherwise compose to a path that cleans *out* of the declaring plugin's namespace — cross-plugin interception. A trailing slash is rejected for the mirror reason: `path.Clean` strips it, so such a path could never match.
- **The plugin name comes from the directory, never the file**, so a manifest cannot claim to be a different plugin. Directory names are validated as safe URL segments before becoming part of a public path.
- **One bad manifest cannot take down discovery.** Malformed files are collected as `problems` and skipped, not thrown.
- **The `.disabled` sentinel is honoured** — the same source of truth the assistant uses for hooks, tools, and routes — so disabling a plugin doesn't leave its public routes live.

`PluginIngressCache` adds a TTL read-through so the request path won't re-walk the filesystem per connection, and so installing or toggling a plugin takes effect without a gateway restart. Same contract as `ConfigFileCache`.

## Known gap

Only workspace-installed plugins are visible. Default plugins ship inside the assistant binary, which the gateway can't read, so they can't declare ingress this way. Fine for meeting-bot (installed), but worth a decision before a default plugin needs inbound traffic.

## Test plan

19 unit tests in `gateway/src/channels/plugin-ingress.test.ts`, driven against real temp workspaces so the path and filesystem logic is genuinely exercised rather than mocked: composition and leading-slash normalization; schema rejection of absolute paths, traversal, trailing slashes, query/fragment, unknown transport kinds, duplicates, and empty route lists; unknown-field stripping; discovery with no plugins directory, a declaring plugin, a non-declaring plugin, a disabled plugin, and a mix of valid and malformed manifests; an explicit "we don't trust the plugin's own validation" case; and TTL/force behaviour on the cache.

`bunx tsc --noEmit`, prettier, and eslint all clean (the pre-push hook ran them too).

## CLI verb checklist

No new IPC routes under `assistant/src/runtime/routes/` — this adds a gateway-internal module only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ)_