### PR TITLE
feat(web): carry the requested package through the already-Pro checkout bail

### DIFF
--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -53,7 +53,11 @@ let upgradeRejects = false;
 let holdUpgrade = false;
 let releaseUpgrade: (() => void) | null = null;
 let heldUpgrade: Promise<unknown> | null = null;
-let upgradeData: { status: string; checkout_url: string | null; message: string } = {
+let upgradeData: {
+  status: string;
+  checkout_url: string | null;
+  message: string;
+} = {
   status: "redirect",
   checkout_url: CHECKOUT_URL,
   message: "",
@@ -272,7 +276,7 @@ describe("CheckoutPage", () => {
     await waitFor(() => expect(upgradeCalls.length).toBe(1));
   });
 
-  test("a no_op result navigates to plans and clears any marked stash", async () => {
+  test("a no_op result navigates to plans carrying the package and clears any marked stash", async () => {
     upgradeData = { status: "no_op", checkout_url: null, message: "" };
     // A marked stash from the onboarding signup carry survives into this bounce;
     // the already-Pro no_op must clear it rather than leave it lingering its TTL.
@@ -284,8 +288,11 @@ describe("CheckoutPage", () => {
     const { getByTestId } = renderCheckout("/assistant/checkout?package=super");
 
     await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    // Already Pro is an upgrade request plans can still honor, in place.
     await waitFor(() =>
-      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+      expect(getByTestId("loc").textContent).toBe(
+        "/assistant/plans?package=super",
+      ),
     );
     expect(openedUrl).toBeNull();
     expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
@@ -650,8 +657,9 @@ describe("CheckoutPage", () => {
     expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
   });
 
-  test("a no_op result returns to the continuation when one is carried", async () => {
-    // Already Pro mid-onboarding still needs an assistant — plans is not it.
+  test("a no_op result returns to the continuation verbatim, without the package", async () => {
+    // Already Pro mid-onboarding still needs an assistant — plans is not it,
+    // and the resume must not be diverted into the package switch modal.
     upgradeData = { status: "no_op", checkout_url: null, message: "" };
     const { getByTestId } = renderCheckout(ONBOARDING_ENTRY);
 
@@ -659,6 +667,7 @@ describe("CheckoutPage", () => {
     await waitFor(() =>
       expect(getByTestId("loc").textContent).toBe(ONBOARDING_NEXT),
     );
+    expect(getByTestId("loc").textContent).not.toContain("package=");
   });
 
   test("an off-site continuation is rejected in favor of plans", async () => {

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -59,8 +59,8 @@ type CheckoutPhase = "idle" | "running" | "handed_off" | "settled";
  *   - Org header still resolving → hold on the spinner; resolution over with no
  *     organization → the retryable error, whose retry re-runs that resolution.
  *   - Gate `"full"` → fire the upgrade once and either redirect to Stripe
- *     (`redirect`), fall back to plans (`no_op`, already Pro), or surface a
- *     retryable error. It never dead-ends.
+ *     (`redirect`), fall back to plans carrying the requested package (`no_op`,
+ *     already Pro), or surface a retryable error. It never dead-ends.
  *
  * Every "no purchase happens here" exit honors the `continue` param when one is
  * present (see `checkout-continuation`), so a caller mid-flow — onboarding —
@@ -158,10 +158,19 @@ export function CheckoutPage() {
       }
       // `no_op` — already Pro, nothing to provision. Clear the marked stash so
       // an already-Pro bounce doesn't leave it lingering for its TTL, then hand
-      // off rather than stranding the user on a blank splash.
+      // off rather than stranding the user on a blank splash. Pro→Pro is an
+      // in-place package switch, never Stripe Checkout, so the requested
+      // package rides along to plans, which opens that switch from it. A
+      // carried continuation owns the destination instead — an onboarding
+      // resume must not divert into the switch modal.
       phaseRef.current = "settled";
       clearCheckoutIntent();
-      navigate(bailTarget, { replace: true });
+      navigate(
+        bailTarget === routes.plans && packageKey
+          ? `${routes.plans}?package=${encodeURIComponent(packageKey)}`
+          : bailTarget,
+        { replace: true },
+      );
     } catch {
       if (phaseRef.current !== "running") {
         return;


### PR DESCRIPTION
## Summary
- `no_op` (already Pro) now navigates to `/assistant/plans?package=<slug>` instead of bare plans, so the requested upgrade survives the bail and the plans page can open the in-place package switch from it.
- Only the `no_op` branch changes: the missing-package / gate-disabled / takeover-disabled bail and the `?continue=` onboarding continuation are untouched — a resume must not divert into the switch modal.
- `clearCheckoutIntent()` still runs before the navigate; the emitted param is inert until the plans-page reader (PR 1) lands, so either merge order works.

Part of plan: pricing-upgrade-path.md (PR 2 of 3)