### PR TITLE
fix(web): skip OAuth on signup/login when a session already exists

### DIFF
--- a/clients/web/src/domains/account/components/return-to-redirect.tsx
+++ b/clients/web/src/domains/account/components/return-to-redirect.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { Navigate } from "react-router";
+
+import { requiresFullPageNavigation } from "@/domains/account/login-flow";
+import { hardNavigate } from "@/lib/auth/hard-navigate";
+
+/**
+ * Send an already-signed-in visitor to a sanitized `returnTo` destination.
+ *
+ * Destinations outside this SPA (absolute URLs, Django routes, the marketing
+ * import funnel) need a real page load — routing them through `<Navigate>`
+ * would dead-end on the SPA's not-found route.
+ */
+export function ReturnToRedirect({ to }: { to: string }) {
+  const fullPage = requiresFullPageNavigation(to);
+
+  useEffect(() => {
+    if (fullPage) hardNavigate(to);
+  }, [fullPage, to]);
+
+  if (fullPage) return null;
+  return <Navigate to={to} replace />;
+}

--- a/clients/web/src/domains/account/components/return-to-redirect.tsx
+++ b/clients/web/src/domains/account/components/return-to-redirect.tsx
@@ -15,9 +15,13 @@ export function ReturnToRedirect({ to }: { to: string }) {
   const fullPage = requiresFullPageNavigation(to);
 
   useEffect(() => {
-    if (fullPage) hardNavigate(to);
+    if (fullPage) {
+      hardNavigate(to);
+    }
   }, [fullPage, to]);
 
-  if (fullPage) return null;
+  if (fullPage) {
+    return null;
+  }
   return <Navigate to={to} replace />;
 }

--- a/clients/web/src/domains/account/components/use-return-to-short-circuit.tsx
+++ b/clients/web/src/domains/account/components/use-return-to-short-circuit.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from "react";
+import { useSearchParams } from "react-router";
+
+import { ReturnToRedirect } from "@/domains/account/components/return-to-redirect";
+import { requiresPlatformSession } from "@/domains/account/login-flow";
+import { sanitizeReturnTo } from "@/domains/account/return-to";
+import { usePlatformGateWithPending } from "@/hooks/use-platform-gate";
+import {
+  useIsAuthenticated,
+  useIsSessionInitializing,
+} from "@/stores/auth-store";
+import { routes } from "@/utils/routes";
+
+/**
+ * What an auth entry point should render, given its `returnTo` and the session
+ * behind it.
+ *
+ * - `"wait"` — a session the decision depends on is still settling. Hold the
+ *   page's own loading shell; both branches below are still reachable.
+ * - `"redirect"` — an existing session already reaches `returnTo`. Render
+ *   `node` instead of the auth screen.
+ * - `"proceed"` — render the auth screen, handing it `returnTo`.
+ */
+export type ReturnToShortCircuit =
+  | { kind: "wait"; returnTo: string | null }
+  | { kind: "redirect"; returnTo: string; node: ReactElement }
+  | { kind: "proceed"; returnTo: string | null };
+
+/**
+ * Decide whether `/account/login` and `/account/signup` can skip OAuth.
+ *
+ * A `returnTo` means something sent the visitor here on the way somewhere
+ * specific (e.g. a marketing pricing CTA), so an existing session lands there
+ * directly. A bare visit always gets the auth screen — a signed-in visitor may
+ * be there to switch accounts or create another one.
+ *
+ * "An existing session" is not the same question for every destination.
+ * `useIsAuthenticated()` also covers a local gateway identity, which the
+ * self-hosted and remote-gateway clients have without any platform account; a
+ * platform-dependent destination reached on one of those bails on arrival and
+ * discards whatever the link carried. So those destinations additionally
+ * require the platform gate to clear, and fall through to the auth screen when
+ * it does not — the visitor genuinely does need to sign in. A local-only
+ * destination keeps the plain authenticated check, so a local-mode user is
+ * never pushed into an OAuth prompt they have no use for.
+ *
+ * The platform-session probe's pre-settle window is a wait, not a decision, and
+ * `usePlatformGateWithPending` bounds it the same way the route guard does: it
+ * resolves to `"disabled"` if the probe never lands, so an auth screen can
+ * never hang on it. `"gated"` — local mode with the platform API switched off —
+ * short-circuits: no auth screen here can mint a session that does not exist.
+ */
+export function useReturnToShortCircuit(): ReturnToShortCircuit {
+  const [searchParams] = useSearchParams();
+  const isAuthenticated = useIsAuthenticated();
+  const isSessionInitializing = useIsSessionInitializing();
+  const platformGate = usePlatformGateWithPending();
+
+  const rawReturnTo = searchParams.get("returnTo");
+  const destination = sanitizeReturnTo(rawReturnTo, routes.assistant);
+
+  if (!rawReturnTo) {
+    return { kind: "proceed", returnTo: null };
+  }
+  if (isSessionInitializing) {
+    return { kind: "wait", returnTo: destination };
+  }
+  if (!isAuthenticated) {
+    return { kind: "proceed", returnTo: destination };
+  }
+  if (requiresPlatformSession(destination)) {
+    if (platformGate === "pending") {
+      return { kind: "wait", returnTo: destination };
+    }
+    if (platformGate === "disabled") {
+      return { kind: "proceed", returnTo: destination };
+    }
+  }
+  return {
+    kind: "redirect",
+    returnTo: destination,
+    node: <ReturnToRedirect to={destination} />,
+  };
+}

--- a/clients/web/src/domains/account/login-flow.ts
+++ b/clients/web/src/domains/account/login-flow.ts
@@ -46,6 +46,41 @@ export function requiresFullPageNavigation(destination: string): boolean {
   );
 }
 
+/**
+ * In-SPA destinations that mean nothing without a live platform account: the
+ * checkout / plans / billing funnel and the platform account pages. Each runs
+ * its own platform gate on arrival and bails when the session is missing —
+ * `CheckoutPage` drops the selected package and bounces to plans — so landing
+ * there on a local gateway identity throws the deep link away.
+ */
+const PLATFORM_DEPENDENT_PATHS: readonly string[] = [
+  routes.checkout,
+  routes.plans,
+  routes.settings.usage,
+  routes.settings.upgradeSuccess,
+  routes.settings.upgradeCancel,
+  routes.account.root,
+];
+
+/**
+ * Does landing on `destination` need a live platform session, or is a local
+ * gateway identity enough?
+ *
+ * Anything served by the platform rather than by this SPA needs one — the
+ * Django account routes, the API, the marketing import funnel and any
+ * vellum.ai URL all sit behind the same session. So do the in-app surfaces
+ * above. Everything else is daemon-served and works on a local session.
+ */
+export function requiresPlatformSession(destination: string): boolean {
+  if (requiresFullPageNavigation(destination)) {
+    return true;
+  }
+  const path = destination.split(/[?#]/)[0] ?? destination;
+  return PLATFORM_DEPENDENT_PATHS.some(
+    (candidate) => path === candidate || path.startsWith(`${candidate}/`),
+  );
+}
+
 export function resolvePostLoginDestination(
   returnTo: string | null,
   fallback: string,

--- a/clients/web/src/domains/account/login-flow.ts
+++ b/clients/web/src/domains/account/login-flow.ts
@@ -1,4 +1,7 @@
-import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
+import {
+  POST_CHECKOUT_LANDING_PATHS,
+  resolveNavigation,
+} from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { routes } from "@/utils/routes";
 
@@ -56,7 +59,10 @@ export function requiresFullPageNavigation(destination: string): boolean {
 const PLATFORM_DEPENDENT_PATHS: readonly string[] = [
   routes.checkout,
   routes.plans,
-  routes.settings.usage,
+  // Shared with the route guard rather than restated, so the legacy
+  // `/assistant/settings/billing` landing — the platform's hardcoded Stripe
+  // `success_url` — can never fall out of one list and stay in the other.
+  ...POST_CHECKOUT_LANDING_PATHS,
   routes.settings.upgradeSuccess,
   routes.settings.upgradeCancel,
   routes.account.root,

--- a/clients/web/src/domains/account/pages/auth-entry-contract-test-helpers.tsx
+++ b/clients/web/src/domains/account/pages/auth-entry-contract-test-helpers.tsx
@@ -1,0 +1,224 @@
+/**
+ * The auth-entry contract shared by `/account/signup` and `/account/login`:
+ * both delegate to `useReturnToShortCircuit`, so an existing session plus a
+ * `returnTo` skips OAuth and lands on the sanitized destination. The scenarios
+ * live here once and run against each page.
+ *
+ * Bun's `mock.module()` only takes effect from the file that installs it, so
+ * each test file registers the factories below itself and then dynamically
+ * imports its page — this module supplies the mock bodies and the state they
+ * read, never the registration.
+ */
+
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+
+import * as authStore from "@/stores/auth-store";
+import * as nativeAuth from "@/runtime/native-auth";
+import type { PlatformSessionStatus } from "@/stores/session-status";
+
+export const CHECKOUT = "/assistant/checkout?package=super";
+export const LOCAL_DESTINATION = "/assistant/settings/general";
+// The platform's hardcoded Stripe `success_url` — the real post-checkout return.
+export const LEGACY_BILLING_LANDING =
+  "/assistant/settings/billing?session_id=cs_test_123";
+const HOSTILE_DESTINATION = "https://evil.example";
+
+interface AuthFlowCall {
+  callbackUrl: string;
+  returnTo: string | null;
+}
+
+/** Session and platform inputs the mocked modules read on every render. */
+export const authEntry = {
+  authenticated: false,
+  initializing: false,
+  native: false,
+  authFlowCalls: [] as AuthFlowCall[],
+};
+
+export const mockAuthStore = () => ({
+  ...authStore,
+  useIsAuthenticated: () => authEntry.authenticated,
+  useIsSessionInitializing: () => authEntry.initializing,
+});
+
+export const mockNativeAuth = () => ({
+  ...nativeAuth,
+  startAuthFlow: (
+    _provider: string,
+    callbackUrl: string,
+    options?: { returnTo?: string | null },
+  ) => {
+    authEntry.authFlowCalls.push({
+      callbackUrl,
+      returnTo: options?.returnTo ?? null,
+    });
+    return Promise.resolve();
+  },
+  startNativeLogin: () => Promise.resolve(),
+  useIsNativePlatform: () => authEntry.native,
+});
+
+export function setPlatformSession(platformSession: PlatformSessionStatus) {
+  authStore.useAuthStore.setState({ platformSession });
+}
+
+/** Registers the per-scenario reset and teardown the helpers below assume. */
+export function setupAuthEntry() {
+  beforeEach(() => {
+    authEntry.authenticated = false;
+    authEntry.initializing = false;
+    authEntry.native = false;
+    authEntry.authFlowCalls = [];
+    setPlatformSession("present");
+  });
+
+  afterEach(cleanup);
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+}
+
+export function renderAuthEntry(
+  Page: ComponentType,
+  route: string,
+  url: string,
+) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <LocationProbe />
+      <Routes>
+        <Route path={route} element={<Page />} />
+        <Route path="*" element={null} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+export function entryUrl(route: string, returnTo: string) {
+  return `${route}?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
+export const currentLocation = () => screen.getByTestId("location").textContent;
+
+export interface AuthEntryPage {
+  /** The page component, dynamically imported after the module mocks land. */
+  Page: ComponentType;
+  /** Route the page is mounted at. */
+  route: string;
+  /** Text that renders only once the auth screen itself is on screen. */
+  authScreenText: string;
+  /** The control that hands off to OAuth. */
+  oauthTriggerText: string;
+}
+
+export function describeAuthEntryContract(
+  name: string,
+  { Page, route, authScreenText, oauthTriggerText }: AuthEntryPage,
+) {
+  const renderEntry = (url: string) => renderAuthEntry(Page, route, url);
+  const authScreen = () => screen.queryByText(authScreenText);
+
+  describe(name, () => {
+    setupAuthEntry();
+
+    test("an authenticated visitor with returnTo lands there without OAuth", () => {
+      authEntry.authenticated = true;
+      renderEntry(entryUrl(route, CHECKOUT));
+
+      expect(currentLocation()).toBe(CHECKOUT);
+      expect(authScreen()).toBeNull();
+      expect(authEntry.authFlowCalls).toHaveLength(0);
+    });
+
+    test("a platform-dependent returnTo without a platform session still signs in", () => {
+      authEntry.authenticated = true;
+      setPlatformSession("absent");
+      const entry = entryUrl(route, CHECKOUT);
+      renderEntry(entry);
+
+      expect(currentLocation()).toBe(entry);
+      expect(authScreen()).toBeTruthy();
+    });
+
+    test("the legacy billing landing without a platform session still signs in", () => {
+      authEntry.authenticated = true;
+      setPlatformSession("absent");
+      const entry = entryUrl(route, LEGACY_BILLING_LANDING);
+      renderEntry(entry);
+
+      expect(currentLocation()).toBe(entry);
+      expect(authScreen()).toBeTruthy();
+    });
+
+    test("a platform-dependent returnTo waits out the platform-session probe", () => {
+      authEntry.authenticated = true;
+      setPlatformSession("unknown");
+      const entry = entryUrl(route, CHECKOUT);
+      renderEntry(entry);
+
+      expect(currentLocation()).toBe(entry);
+      expect(authScreen()).toBeNull();
+    });
+
+    test("a local-only returnTo skips OAuth without a platform session", () => {
+      authEntry.authenticated = true;
+      setPlatformSession("absent");
+      renderEntry(entryUrl(route, LOCAL_DESTINATION));
+
+      expect(currentLocation()).toBe(LOCAL_DESTINATION);
+      expect(authEntry.authFlowCalls).toHaveLength(0);
+    });
+
+    test("an unauthenticated visitor with returnTo still gets the auth screen", () => {
+      const entry = entryUrl(route, CHECKOUT);
+      renderEntry(entry);
+
+      expect(authScreen()).toBeTruthy();
+      expect(currentLocation()).toBe(entry);
+    });
+
+    test("an authenticated visitor with no returnTo still gets the auth screen", () => {
+      authEntry.authenticated = true;
+      renderEntry(route);
+
+      expect(authScreen()).toBeTruthy();
+      expect(currentLocation()).toBe(route);
+    });
+
+    test("a hostile returnTo falls back to the assistant", () => {
+      authEntry.authenticated = true;
+      renderEntry(entryUrl(route, HOSTILE_DESTINATION));
+
+      expect(currentLocation()).toBe("/assistant");
+    });
+
+    test("a hostile returnTo is sanitized before it reaches the auth flow", () => {
+      renderEntry(entryUrl(route, HOSTILE_DESTINATION));
+      fireEvent.click(screen.getByText(oauthTriggerText));
+
+      expect(authEntry.authFlowCalls).toHaveLength(1);
+      expect(authEntry.authFlowCalls[0]?.returnTo).toBe("/assistant");
+      expect(authEntry.authFlowCalls[0]?.callbackUrl).not.toContain(
+        "evil.example",
+      );
+    });
+
+    test("an unsettled session with returnTo neither redirects nor offers OAuth", () => {
+      authEntry.authenticated = true;
+      authEntry.initializing = true;
+      const entry = entryUrl(route, CHECKOUT);
+      renderEntry(entry);
+
+      expect(currentLocation()).toBe(entry);
+      expect(authScreen()).toBeNull();
+    });
+  });
+}

--- a/clients/web/src/domains/account/pages/login-page.test.tsx
+++ b/clients/web/src/domains/account/pages/login-page.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Tests for the login entry gate: an existing session plus a `returnTo`
+ * skips OAuth and lands on the sanitized destination.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+
+import * as authStore from "@/stores/auth-store";
+import * as nativeAuth from "@/runtime/native-auth";
+
+const CHECKOUT = "/assistant/checkout?package=super";
+
+let authenticated = false;
+let initializing = false;
+let authFlowCalls: { callbackUrl: string; returnTo: string | null }[] = [];
+
+mock.module("@/stores/auth-store", () => ({
+  ...authStore,
+  useIsAuthenticated: () => authenticated,
+  useIsSessionInitializing: () => initializing,
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  ...nativeAuth,
+  startAuthFlow: (
+    _provider: string,
+    callbackUrl: string,
+    options?: { returnTo?: string | null },
+  ) => {
+    authFlowCalls.push({ callbackUrl, returnTo: options?.returnTo ?? null });
+    return Promise.resolve();
+  },
+  startNativeLogin: () => Promise.resolve(),
+  useIsNativePlatform: () => false,
+}));
+
+const { LoginPage } = await import("@/domains/account/pages/login-page");
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+}
+
+function renderAt(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/account/login" element={<LoginPage />} />
+        <Route path="*" element={null} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const location = () => screen.getByTestId("location").textContent;
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    authenticated = false;
+    initializing = false;
+    authFlowCalls = [];
+  });
+
+  afterEach(cleanup);
+
+  test("an authenticated visitor with returnTo lands there without OAuth", () => {
+    authenticated = true;
+    renderAt(`/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`);
+
+    expect(location()).toBe(CHECKOUT);
+    expect(screen.queryByText("Sign in to Vellum")).toBeNull();
+    expect(authFlowCalls).toHaveLength(0);
+  });
+
+  test("an unauthenticated visitor with returnTo still gets the sign-in screen", () => {
+    const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(screen.getByText("Sign in to Vellum")).toBeTruthy();
+    expect(location()).toBe(entry);
+  });
+
+  test("an authenticated visitor with no returnTo still gets the sign-in screen", () => {
+    authenticated = true;
+    renderAt("/account/login");
+
+    expect(screen.getByText("Sign in to Vellum")).toBeTruthy();
+    expect(location()).toBe("/account/login");
+  });
+
+  test("a hostile returnTo falls back to the assistant", () => {
+    authenticated = true;
+    renderAt("/account/login?returnTo=https%3A%2F%2Fevil.example");
+
+    expect(location()).toBe("/assistant");
+  });
+
+  test("a hostile returnTo is sanitized before it reaches the auth flow", () => {
+    renderAt("/account/login?returnTo=https%3A%2F%2Fevil.example");
+    fireEvent.click(screen.getByText("Continue"));
+
+    expect(authFlowCalls).toHaveLength(1);
+    expect(authFlowCalls[0]?.returnTo).toBe("/assistant");
+    expect(authFlowCalls[0]?.callbackUrl).not.toContain("evil.example");
+  });
+
+  test("an unsettled session with returnTo neither redirects nor offers OAuth", () => {
+    authenticated = true;
+    initializing = true;
+    const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(location()).toBe(entry);
+    expect(screen.queryByText("Sign in to Vellum")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/account/pages/login-page.test.tsx
+++ b/clients/web/src/domains/account/pages/login-page.test.tsx
@@ -13,6 +13,9 @@ import type { PlatformSessionStatus } from "@/stores/session-status";
 
 const CHECKOUT = "/assistant/checkout?package=super";
 const LOCAL_DESTINATION = "/assistant/settings/general";
+// The platform's hardcoded Stripe `success_url` — the real post-checkout return.
+const LEGACY_BILLING_LANDING =
+  "/assistant/settings/billing?session_id=cs_test_123";
 
 let authenticated = false;
 let initializing = false;
@@ -88,6 +91,16 @@ describe("LoginPage", () => {
     authenticated = true;
     setPlatformSession("absent");
     const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(location()).toBe(entry);
+    expect(screen.getByText("Sign in to Vellum")).toBeTruthy();
+  });
+
+  test("the legacy billing landing without a platform session still signs in", () => {
+    authenticated = true;
+    setPlatformSession("absent");
+    const entry = `/account/login?returnTo=${encodeURIComponent(LEGACY_BILLING_LANDING)}`;
     renderAt(entry);
 
     expect(location()).toBe(entry);

--- a/clients/web/src/domains/account/pages/login-page.test.tsx
+++ b/clients/web/src/domains/account/pages/login-page.test.tsx
@@ -9,12 +9,18 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 
 import * as authStore from "@/stores/auth-store";
 import * as nativeAuth from "@/runtime/native-auth";
+import type { PlatformSessionStatus } from "@/stores/session-status";
 
 const CHECKOUT = "/assistant/checkout?package=super";
+const LOCAL_DESTINATION = "/assistant/settings/general";
 
 let authenticated = false;
 let initializing = false;
 let authFlowCalls: { callbackUrl: string; returnTo: string | null }[] = [];
+
+const setPlatformSession = (platformSession: PlatformSessionStatus) => {
+  authStore.useAuthStore.setState({ platformSession });
+};
 
 mock.module("@/stores/auth-store", () => ({
   ...authStore,
@@ -64,6 +70,7 @@ describe("LoginPage", () => {
     authenticated = false;
     initializing = false;
     authFlowCalls = [];
+    setPlatformSession("present");
   });
 
   afterEach(cleanup);
@@ -74,6 +81,37 @@ describe("LoginPage", () => {
 
     expect(location()).toBe(CHECKOUT);
     expect(screen.queryByText("Sign in to Vellum")).toBeNull();
+    expect(authFlowCalls).toHaveLength(0);
+  });
+
+  test("a platform-dependent returnTo without a platform session still signs in", () => {
+    authenticated = true;
+    setPlatformSession("absent");
+    const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(location()).toBe(entry);
+    expect(screen.getByText("Sign in to Vellum")).toBeTruthy();
+  });
+
+  test("a platform-dependent returnTo waits out the platform-session probe", () => {
+    authenticated = true;
+    setPlatformSession("unknown");
+    const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(location()).toBe(entry);
+    expect(screen.queryByText("Sign in to Vellum")).toBeNull();
+  });
+
+  test("a local-only returnTo skips OAuth without a platform session", () => {
+    authenticated = true;
+    setPlatformSession("absent");
+    renderAt(
+      `/account/login?returnTo=${encodeURIComponent(LOCAL_DESTINATION)}`,
+    );
+
+    expect(location()).toBe(LOCAL_DESTINATION);
     expect(authFlowCalls).toHaveLength(0);
   });
 

--- a/clients/web/src/domains/account/pages/login-page.test.tsx
+++ b/clients/web/src/domains/account/pages/login-page.test.tsx
@@ -1,172 +1,65 @@
 /**
- * Tests for the login entry gate: an existing session plus a `returnTo`
- * skips OAuth and lands on the sanitized destination.
+ * The shared auth-entry contract run against the login page, plus the things
+ * only this page decides: the native/web split of the waiting shell and of the
+ * sign-in screen itself.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { describe, expect, mock, test } from "bun:test";
+import { screen } from "@testing-library/react";
 
-import * as authStore from "@/stores/auth-store";
-import * as nativeAuth from "@/runtime/native-auth";
-import type { PlatformSessionStatus } from "@/stores/session-status";
+import {
+  CHECKOUT,
+  authEntry,
+  describeAuthEntryContract,
+  entryUrl,
+  mockAuthStore,
+  mockNativeAuth,
+  renderAuthEntry,
+  setupAuthEntry,
+} from "./auth-entry-contract-test-helpers";
 
-const CHECKOUT = "/assistant/checkout?package=super";
-const LOCAL_DESTINATION = "/assistant/settings/general";
-// The platform's hardcoded Stripe `success_url` — the real post-checkout return.
-const LEGACY_BILLING_LANDING =
-  "/assistant/settings/billing?session_id=cs_test_123";
-
-let authenticated = false;
-let initializing = false;
-let authFlowCalls: { callbackUrl: string; returnTo: string | null }[] = [];
-
-const setPlatformSession = (platformSession: PlatformSessionStatus) => {
-  authStore.useAuthStore.setState({ platformSession });
-};
-
-mock.module("@/stores/auth-store", () => ({
-  ...authStore,
-  useIsAuthenticated: () => authenticated,
-  useIsSessionInitializing: () => initializing,
-}));
-
-mock.module("@/runtime/native-auth", () => ({
-  ...nativeAuth,
-  startAuthFlow: (
-    _provider: string,
-    callbackUrl: string,
-    options?: { returnTo?: string | null },
-  ) => {
-    authFlowCalls.push({ callbackUrl, returnTo: options?.returnTo ?? null });
-    return Promise.resolve();
-  },
-  startNativeLogin: () => Promise.resolve(),
-  useIsNativePlatform: () => false,
-}));
+mock.module("@/stores/auth-store", mockAuthStore);
+mock.module("@/runtime/native-auth", mockNativeAuth);
 
 const { LoginPage } = await import("@/domains/account/pages/login-page");
 
-function LocationProbe() {
-  const location = useLocation();
-  return (
-    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
-  );
-}
+const ROUTE = "/account/login";
 
-function renderAt(url: string) {
-  return render(
-    <MemoryRouter initialEntries={[url]}>
-      <LocationProbe />
-      <Routes>
-        <Route path="/account/login" element={<LoginPage />} />
-        <Route path="*" element={null} />
-      </Routes>
-    </MemoryRouter>,
-  );
-}
+describeAuthEntryContract("LoginPage", {
+  Page: LoginPage,
+  route: ROUTE,
+  authScreenText: "Sign in to Vellum",
+  oauthTriggerText: "Continue",
+});
 
-const location = () => screen.getByTestId("location").textContent;
+describe("LoginPage native split", () => {
+  setupAuthEntry();
 
-describe("LoginPage", () => {
-  beforeEach(() => {
-    authenticated = false;
-    initializing = false;
-    authFlowCalls = [];
-    setPlatformSession("present");
-  });
+  const renderEntry = () =>
+    renderAuthEntry(LoginPage, ROUTE, entryUrl(ROUTE, CHECKOUT));
 
-  afterEach(cleanup);
+  test("the wait holds the dark login shell in the browser", () => {
+    authEntry.initializing = true;
+    const { container } = renderEntry();
 
-  test("an authenticated visitor with returnTo lands there without OAuth", () => {
-    authenticated = true;
-    renderAt(`/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`);
-
-    expect(location()).toBe(CHECKOUT);
-    expect(screen.queryByText("Sign in to Vellum")).toBeNull();
-    expect(authFlowCalls).toHaveLength(0);
-  });
-
-  test("a platform-dependent returnTo without a platform session still signs in", () => {
-    authenticated = true;
-    setPlatformSession("absent");
-    const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
-    renderAt(entry);
-
-    expect(location()).toBe(entry);
-    expect(screen.getByText("Sign in to Vellum")).toBeTruthy();
-  });
-
-  test("the legacy billing landing without a platform session still signs in", () => {
-    authenticated = true;
-    setPlatformSession("absent");
-    const entry = `/account/login?returnTo=${encodeURIComponent(LEGACY_BILLING_LANDING)}`;
-    renderAt(entry);
-
-    expect(location()).toBe(entry);
-    expect(screen.getByText("Sign in to Vellum")).toBeTruthy();
-  });
-
-  test("a platform-dependent returnTo waits out the platform-session probe", () => {
-    authenticated = true;
-    setPlatformSession("unknown");
-    const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
-    renderAt(entry);
-
-    expect(location()).toBe(entry);
+    expect(container.querySelector(".dark")).toBeTruthy();
     expect(screen.queryByText("Sign in to Vellum")).toBeNull();
   });
 
-  test("a local-only returnTo skips OAuth without a platform session", () => {
-    authenticated = true;
-    setPlatformSession("absent");
-    renderAt(
-      `/account/login?returnTo=${encodeURIComponent(LOCAL_DESTINATION)}`,
-    );
+  test("the wait holds the native splash on native", () => {
+    authEntry.initializing = true;
+    authEntry.native = true;
+    const { container } = renderEntry();
 
-    expect(location()).toBe(LOCAL_DESTINATION);
-    expect(authFlowCalls).toHaveLength(0);
+    expect(container.querySelector(".dark")).toBeNull();
+    expect(screen.getAllByAltText("Vellum").length).toBeGreaterThan(0);
   });
 
-  test("an unauthenticated visitor with returnTo still gets the sign-in screen", () => {
-    const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
-    renderAt(entry);
+  test("the native sign-in screen offers the splash CTA, not the web card", () => {
+    authEntry.native = true;
+    renderEntry();
 
-    expect(screen.getByText("Sign in to Vellum")).toBeTruthy();
-    expect(location()).toBe(entry);
-  });
-
-  test("an authenticated visitor with no returnTo still gets the sign-in screen", () => {
-    authenticated = true;
-    renderAt("/account/login");
-
-    expect(screen.getByText("Sign in to Vellum")).toBeTruthy();
-    expect(location()).toBe("/account/login");
-  });
-
-  test("a hostile returnTo falls back to the assistant", () => {
-    authenticated = true;
-    renderAt("/account/login?returnTo=https%3A%2F%2Fevil.example");
-
-    expect(location()).toBe("/assistant");
-  });
-
-  test("a hostile returnTo is sanitized before it reaches the auth flow", () => {
-    renderAt("/account/login?returnTo=https%3A%2F%2Fevil.example");
-    fireEvent.click(screen.getByText("Continue"));
-
-    expect(authFlowCalls).toHaveLength(1);
-    expect(authFlowCalls[0]?.returnTo).toBe("/assistant");
-    expect(authFlowCalls[0]?.callbackUrl).not.toContain("evil.example");
-  });
-
-  test("an unsettled session with returnTo neither redirects nor offers OAuth", () => {
-    authenticated = true;
-    initializing = true;
-    const entry = `/account/login?returnTo=${encodeURIComponent(CHECKOUT)}`;
-    renderAt(entry);
-
-    expect(location()).toBe(entry);
+    expect(screen.getByText("Sign in")).toBeTruthy();
     expect(screen.queryByText("Sign in to Vellum")).toBeNull();
   });
 });

--- a/clients/web/src/domains/account/pages/login-page.tsx
+++ b/clients/web/src/domains/account/pages/login-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { Link } from "react-router";
 
 import { NativeSplash } from "@/components/native-splash";
 import {
@@ -8,21 +8,16 @@ import {
   LoginErrorText,
   LoginHeading,
 } from "@/domains/account/components/login-shell";
-import { ReturnToRedirect } from "@/domains/account/components/return-to-redirect";
+import { useReturnToShortCircuit } from "@/domains/account/components/use-return-to-short-circuit";
 import {
   PROVIDER_ID,
   buildProviderCallbackUrl,
 } from "@/domains/account/login-flow";
-import { sanitizeReturnTo } from "@/domains/account/return-to";
 import {
   startAuthFlow,
   startNativeLogin,
   useIsNativePlatform,
 } from "@/runtime/native-auth";
-import {
-  useIsAuthenticated,
-  useIsSessionInitializing,
-} from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library";
 
@@ -166,31 +161,23 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
  * Delegates to `NativeLoginForm` (Capacitor iOS) or `WebLoginForm`
  * (standard browser / Electron) based on platform detection.
  *
- * A `returnTo` means something sent the visitor here on the way somewhere
- * specific (e.g. a marketing pricing CTA), so an existing session skips OAuth
- * and lands there directly. A bare visit always gets the sign-in screen — a
- * signed-in visitor may be there to re-authenticate or switch accounts.
+ * `useReturnToShortCircuit` owns whether an existing session skips OAuth and
+ * lands on the `returnTo` destination directly — the same decision
+ * `SignupPage` makes. Only the loading shell differs.
  */
 export function LoginPage() {
-  const [searchParams] = useSearchParams();
   const isNative = useIsNativePlatform();
-  const isAuthenticated = useIsAuthenticated();
-  const isSessionInitializing = useIsSessionInitializing();
-  const rawReturnTo = searchParams.get("returnTo");
-  const destination = sanitizeReturnTo(rawReturnTo, routes.assistant);
+  const shortCircuit = useReturnToShortCircuit();
 
-  if (rawReturnTo) {
-    if (isSessionInitializing) {
-      return isNative ? (
-        <NativeSplash />
-      ) : (
-        <DarkLoginShell>{null}</DarkLoginShell>
-      );
-    }
-    if (isAuthenticated) return <ReturnToRedirect to={destination} />;
+  if (shortCircuit.kind === "wait") {
+    return isNative ? (
+      <NativeSplash />
+    ) : (
+      <DarkLoginShell>{null}</DarkLoginShell>
+    );
   }
+  if (shortCircuit.kind === "redirect") return shortCircuit.node;
 
-  const returnTo = rawReturnTo ? destination : null;
-  if (isNative) return <NativeLoginForm returnTo={returnTo} />;
-  return <WebLoginForm returnTo={returnTo} />;
+  if (isNative) return <NativeLoginForm returnTo={shortCircuit.returnTo} />;
+  return <WebLoginForm returnTo={shortCircuit.returnTo} />;
 }

--- a/clients/web/src/domains/account/pages/login-page.tsx
+++ b/clients/web/src/domains/account/pages/login-page.tsx
@@ -2,9 +2,27 @@ import { useState } from "react";
 import { Link, useSearchParams } from "react-router";
 
 import { NativeSplash } from "@/components/native-splash";
-import { DarkLoginShell, LoginCard, LoginErrorText, LoginHeading } from "@/domains/account/components/login-shell";
-import { PROVIDER_ID, buildProviderCallbackUrl } from "@/domains/account/login-flow";
-import { startAuthFlow, startNativeLogin, useIsNativePlatform } from "@/runtime/native-auth";
+import {
+  DarkLoginShell,
+  LoginCard,
+  LoginErrorText,
+  LoginHeading,
+} from "@/domains/account/components/login-shell";
+import { ReturnToRedirect } from "@/domains/account/components/return-to-redirect";
+import {
+  PROVIDER_ID,
+  buildProviderCallbackUrl,
+} from "@/domains/account/login-flow";
+import { sanitizeReturnTo } from "@/domains/account/return-to";
+import {
+  startAuthFlow,
+  startNativeLogin,
+  useIsNativePlatform,
+} from "@/runtime/native-auth";
+import {
+  useIsAuthenticated,
+  useIsSessionInitializing,
+} from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library";
 
@@ -46,7 +64,8 @@ function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
             ? err.data.authError
             : undefined;
         setErrorMessage(
-          (errorKey && AUTH_ERROR_MESSAGES[errorKey]) ?? "Something went wrong. Please try again.",
+          (errorKey && AUTH_ERROR_MESSAGES[errorKey]) ??
+            "Something went wrong. Please try again.",
         );
       } else {
         console.error("[native-auth] auth flow failed:", err);
@@ -64,7 +83,9 @@ function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
     <NativeSplash>
       <div className="z-10 mt-8 flex w-full max-w-[320px] flex-col items-center gap-3">
         {errorMessage && (
-          <LoginErrorText className="max-w-[280px]">{errorMessage}</LoginErrorText>
+          <LoginErrorText className="max-w-[280px]">
+            {errorMessage}
+          </LoginErrorText>
         )}
         <Button
           type="button"
@@ -144,12 +165,32 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
  *
  * Delegates to `NativeLoginForm` (Capacitor iOS) or `WebLoginForm`
  * (standard browser / Electron) based on platform detection.
+ *
+ * A `returnTo` means something sent the visitor here on the way somewhere
+ * specific (e.g. a marketing pricing CTA), so an existing session skips OAuth
+ * and lands there directly. A bare visit always gets the sign-in screen — a
+ * signed-in visitor may be there to re-authenticate or switch accounts.
  */
 export function LoginPage() {
   const [searchParams] = useSearchParams();
   const isNative = useIsNativePlatform();
-  const returnTo = searchParams.get("returnTo");
+  const isAuthenticated = useIsAuthenticated();
+  const isSessionInitializing = useIsSessionInitializing();
+  const rawReturnTo = searchParams.get("returnTo");
+  const destination = sanitizeReturnTo(rawReturnTo, routes.assistant);
 
+  if (rawReturnTo) {
+    if (isSessionInitializing) {
+      return isNative ? (
+        <NativeSplash />
+      ) : (
+        <DarkLoginShell>{null}</DarkLoginShell>
+      );
+    }
+    if (isAuthenticated) return <ReturnToRedirect to={destination} />;
+  }
+
+  const returnTo = rawReturnTo ? destination : null;
   if (isNative) return <NativeLoginForm returnTo={returnTo} />;
   return <WebLoginForm returnTo={returnTo} />;
 }

--- a/clients/web/src/domains/account/pages/login-page.tsx
+++ b/clients/web/src/domains/account/pages/login-page.tsx
@@ -176,8 +176,12 @@ export function LoginPage() {
       <DarkLoginShell>{null}</DarkLoginShell>
     );
   }
-  if (shortCircuit.kind === "redirect") return shortCircuit.node;
+  if (shortCircuit.kind === "redirect") {
+    return shortCircuit.node;
+  }
 
-  if (isNative) return <NativeLoginForm returnTo={shortCircuit.returnTo} />;
+  if (isNative) {
+    return <NativeLoginForm returnTo={shortCircuit.returnTo} />;
+  }
   return <WebLoginForm returnTo={shortCircuit.returnTo} />;
 }

--- a/clients/web/src/domains/account/pages/signup-page.test.tsx
+++ b/clients/web/src/domains/account/pages/signup-page.test.tsx
@@ -1,173 +1,48 @@
 /**
- * Tests for the signup entry gate: an existing session plus a `returnTo`
- * skips OAuth and lands on the sanitized destination.
+ * The shared auth-entry contract run against the signup page, plus the one
+ * thing only this page decides: which shell covers the waiting state.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { describe, expect, mock, test } from "bun:test";
+import { screen } from "@testing-library/react";
 
-import * as authStore from "@/stores/auth-store";
-import * as nativeAuth from "@/runtime/native-auth";
-import type { PlatformSessionStatus } from "@/stores/session-status";
+import {
+  CHECKOUT,
+  authEntry,
+  describeAuthEntryContract,
+  entryUrl,
+  mockAuthStore,
+  mockNativeAuth,
+  renderAuthEntry,
+  setupAuthEntry,
+} from "./auth-entry-contract-test-helpers";
 
-const CHECKOUT = "/assistant/checkout?package=super";
-const LOCAL_DESTINATION = "/assistant/settings/general";
-// The platform's hardcoded Stripe `success_url` — the real post-checkout return.
-const LEGACY_BILLING_LANDING =
-  "/assistant/settings/billing?session_id=cs_test_123";
-
-let authenticated = false;
-let initializing = false;
-let authFlowCalls: { callbackUrl: string; returnTo: string | null }[] = [];
-
-const setPlatformSession = (platformSession: PlatformSessionStatus) => {
-  authStore.useAuthStore.setState({ platformSession });
-};
-
-mock.module("@/stores/auth-store", () => ({
-  ...authStore,
-  useIsAuthenticated: () => authenticated,
-  useIsSessionInitializing: () => initializing,
-}));
-
-mock.module("@/runtime/native-auth", () => ({
-  ...nativeAuth,
-  startAuthFlow: (
-    _provider: string,
-    callbackUrl: string,
-    options?: { returnTo?: string | null },
-  ) => {
-    authFlowCalls.push({ callbackUrl, returnTo: options?.returnTo ?? null });
-    return Promise.resolve();
-  },
-  startNativeLogin: () => Promise.resolve(),
-  useIsNativePlatform: () => false,
-}));
+mock.module("@/stores/auth-store", mockAuthStore);
+mock.module("@/runtime/native-auth", mockNativeAuth);
 
 const { SignupPage } = await import("@/domains/account/pages/signup-page");
 
-function LocationProbe() {
-  const location = useLocation();
-  return (
-    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
-  );
-}
+const ROUTE = "/account/signup";
 
-function renderAt(url: string) {
-  return render(
-    <MemoryRouter initialEntries={[url]}>
-      <LocationProbe />
-      <Routes>
-        <Route path="/account/signup" element={<SignupPage />} />
-        <Route path="*" element={null} />
-      </Routes>
-    </MemoryRouter>,
-  );
-}
+describeAuthEntryContract("SignupPage", {
+  Page: SignupPage,
+  route: ROUTE,
+  authScreenText: "Continue",
+  oauthTriggerText: "Continue",
+});
 
-const location = () => screen.getByTestId("location").textContent;
+describe("SignupPage waiting shell", () => {
+  setupAuthEntry();
 
-describe("SignupPage", () => {
-  beforeEach(() => {
-    authenticated = false;
-    initializing = false;
-    authFlowCalls = [];
-    setPlatformSession("present");
-  });
-
-  afterEach(cleanup);
-
-  test("an authenticated visitor with returnTo lands there without OAuth", () => {
-    authenticated = true;
-    renderAt(`/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`);
-
-    expect(location()).toBe(CHECKOUT);
-    expect(screen.queryByText("Continue")).toBeNull();
-    expect(authFlowCalls).toHaveLength(0);
-  });
-
-  test("a platform-dependent returnTo without a platform session still signs in", () => {
-    authenticated = true;
-    setPlatformSession("absent");
-    const entry = `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`;
-    renderAt(entry);
-
-    expect(location()).toBe(entry);
-    expect(screen.getByText("Continue")).toBeTruthy();
-  });
-
-  test("the legacy billing landing without a platform session still signs in", () => {
-    authenticated = true;
-    setPlatformSession("absent");
-    const entry = `/account/signup?returnTo=${encodeURIComponent(LEGACY_BILLING_LANDING)}`;
-    renderAt(entry);
-
-    expect(location()).toBe(entry);
-    expect(screen.getByText("Continue")).toBeTruthy();
-  });
-
-  test("a platform-dependent returnTo waits out the platform-session probe", () => {
-    authenticated = true;
-    setPlatformSession("unknown");
-    const entry = `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`;
-    renderAt(entry);
-
-    expect(location()).toBe(entry);
-    expect(screen.queryByText("Continue")).toBeNull();
-  });
-
-  test("a local-only returnTo skips OAuth without a platform session", () => {
-    authenticated = true;
-    setPlatformSession("absent");
-    renderAt(
-      `/account/signup?returnTo=${encodeURIComponent(LOCAL_DESTINATION)}`,
+  test("the wait holds the branded sign-up shell", () => {
+    authEntry.initializing = true;
+    const { container } = renderAuthEntry(
+      SignupPage,
+      ROUTE,
+      entryUrl(ROUTE, CHECKOUT),
     );
 
-    expect(location()).toBe(LOCAL_DESTINATION);
-    expect(authFlowCalls).toHaveLength(0);
-  });
-
-  test("an unauthenticated visitor with returnTo still gets the sign-up screen", () => {
-    renderAt(`/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`);
-
-    expect(screen.getByText("Continue")).toBeTruthy();
-    expect(location()).toBe(
-      `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`,
-    );
-  });
-
-  test("an authenticated visitor with no returnTo still gets the sign-up screen", () => {
-    authenticated = true;
-    renderAt("/account/signup");
-
-    expect(screen.getByText("Continue")).toBeTruthy();
-    expect(location()).toBe("/account/signup");
-  });
-
-  test("a hostile returnTo falls back to the assistant", () => {
-    authenticated = true;
-    renderAt("/account/signup?returnTo=https%3A%2F%2Fevil.example");
-
-    expect(location()).toBe("/assistant");
-  });
-
-  test("a hostile returnTo is sanitized before it reaches the auth flow", () => {
-    renderAt("/account/signup?returnTo=https%3A%2F%2Fevil.example");
-    fireEvent.click(screen.getByText("Continue"));
-
-    expect(authFlowCalls).toHaveLength(1);
-    expect(authFlowCalls[0]?.returnTo).toBe("/assistant");
-    expect(authFlowCalls[0]?.callbackUrl).not.toContain("evil.example");
-  });
-
-  test("an unsettled session with returnTo neither redirects nor offers OAuth", () => {
-    authenticated = true;
-    initializing = true;
-    const entry = `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`;
-    renderAt(entry);
-
-    expect(location()).toBe(entry);
+    expect(container.querySelector(".signup")).toBeTruthy();
     expect(screen.queryByText("Continue")).toBeNull();
   });
 });

--- a/clients/web/src/domains/account/pages/signup-page.test.tsx
+++ b/clients/web/src/domains/account/pages/signup-page.test.tsx
@@ -13,6 +13,9 @@ import type { PlatformSessionStatus } from "@/stores/session-status";
 
 const CHECKOUT = "/assistant/checkout?package=super";
 const LOCAL_DESTINATION = "/assistant/settings/general";
+// The platform's hardcoded Stripe `success_url` — the real post-checkout return.
+const LEGACY_BILLING_LANDING =
+  "/assistant/settings/billing?session_id=cs_test_123";
 
 let authenticated = false;
 let initializing = false;
@@ -88,6 +91,16 @@ describe("SignupPage", () => {
     authenticated = true;
     setPlatformSession("absent");
     const entry = `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(location()).toBe(entry);
+    expect(screen.getByText("Continue")).toBeTruthy();
+  });
+
+  test("the legacy billing landing without a platform session still signs in", () => {
+    authenticated = true;
+    setPlatformSession("absent");
+    const entry = `/account/signup?returnTo=${encodeURIComponent(LEGACY_BILLING_LANDING)}`;
     renderAt(entry);
 
     expect(location()).toBe(entry);

--- a/clients/web/src/domains/account/pages/signup-page.test.tsx
+++ b/clients/web/src/domains/account/pages/signup-page.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Tests for the signup entry gate: an existing session plus a `returnTo`
+ * skips OAuth and lands on the sanitized destination.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+
+import * as authStore from "@/stores/auth-store";
+import * as nativeAuth from "@/runtime/native-auth";
+
+const CHECKOUT = "/assistant/checkout?package=super";
+
+let authenticated = false;
+let initializing = false;
+let authFlowCalls: { callbackUrl: string; returnTo: string | null }[] = [];
+
+mock.module("@/stores/auth-store", () => ({
+  ...authStore,
+  useIsAuthenticated: () => authenticated,
+  useIsSessionInitializing: () => initializing,
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  ...nativeAuth,
+  startAuthFlow: (
+    _provider: string,
+    callbackUrl: string,
+    options?: { returnTo?: string | null },
+  ) => {
+    authFlowCalls.push({ callbackUrl, returnTo: options?.returnTo ?? null });
+    return Promise.resolve();
+  },
+  startNativeLogin: () => Promise.resolve(),
+  useIsNativePlatform: () => false,
+}));
+
+const { SignupPage } = await import("@/domains/account/pages/signup-page");
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+}
+
+function renderAt(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/account/signup" element={<SignupPage />} />
+        <Route path="*" element={null} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const location = () => screen.getByTestId("location").textContent;
+
+describe("SignupPage", () => {
+  beforeEach(() => {
+    authenticated = false;
+    initializing = false;
+    authFlowCalls = [];
+  });
+
+  afterEach(cleanup);
+
+  test("an authenticated visitor with returnTo lands there without OAuth", () => {
+    authenticated = true;
+    renderAt(`/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`);
+
+    expect(location()).toBe(CHECKOUT);
+    expect(screen.queryByText("Continue")).toBeNull();
+    expect(authFlowCalls).toHaveLength(0);
+  });
+
+  test("an unauthenticated visitor with returnTo still gets the sign-up screen", () => {
+    renderAt(`/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`);
+
+    expect(screen.getByText("Continue")).toBeTruthy();
+    expect(location()).toBe(
+      `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`,
+    );
+  });
+
+  test("an authenticated visitor with no returnTo still gets the sign-up screen", () => {
+    authenticated = true;
+    renderAt("/account/signup");
+
+    expect(screen.getByText("Continue")).toBeTruthy();
+    expect(location()).toBe("/account/signup");
+  });
+
+  test("a hostile returnTo falls back to the assistant", () => {
+    authenticated = true;
+    renderAt("/account/signup?returnTo=https%3A%2F%2Fevil.example");
+
+    expect(location()).toBe("/assistant");
+  });
+
+  test("a hostile returnTo is sanitized before it reaches the auth flow", () => {
+    renderAt("/account/signup?returnTo=https%3A%2F%2Fevil.example");
+    fireEvent.click(screen.getByText("Continue"));
+
+    expect(authFlowCalls).toHaveLength(1);
+    expect(authFlowCalls[0]?.returnTo).toBe("/assistant");
+    expect(authFlowCalls[0]?.callbackUrl).not.toContain("evil.example");
+  });
+
+  test("an unsettled session with returnTo neither redirects nor offers OAuth", () => {
+    authenticated = true;
+    initializing = true;
+    const entry = `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(location()).toBe(entry);
+    expect(screen.queryByText("Continue")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/account/pages/signup-page.test.tsx
+++ b/clients/web/src/domains/account/pages/signup-page.test.tsx
@@ -9,12 +9,18 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 
 import * as authStore from "@/stores/auth-store";
 import * as nativeAuth from "@/runtime/native-auth";
+import type { PlatformSessionStatus } from "@/stores/session-status";
 
 const CHECKOUT = "/assistant/checkout?package=super";
+const LOCAL_DESTINATION = "/assistant/settings/general";
 
 let authenticated = false;
 let initializing = false;
 let authFlowCalls: { callbackUrl: string; returnTo: string | null }[] = [];
+
+const setPlatformSession = (platformSession: PlatformSessionStatus) => {
+  authStore.useAuthStore.setState({ platformSession });
+};
 
 mock.module("@/stores/auth-store", () => ({
   ...authStore,
@@ -64,6 +70,7 @@ describe("SignupPage", () => {
     authenticated = false;
     initializing = false;
     authFlowCalls = [];
+    setPlatformSession("present");
   });
 
   afterEach(cleanup);
@@ -74,6 +81,37 @@ describe("SignupPage", () => {
 
     expect(location()).toBe(CHECKOUT);
     expect(screen.queryByText("Continue")).toBeNull();
+    expect(authFlowCalls).toHaveLength(0);
+  });
+
+  test("a platform-dependent returnTo without a platform session still signs in", () => {
+    authenticated = true;
+    setPlatformSession("absent");
+    const entry = `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(location()).toBe(entry);
+    expect(screen.getByText("Continue")).toBeTruthy();
+  });
+
+  test("a platform-dependent returnTo waits out the platform-session probe", () => {
+    authenticated = true;
+    setPlatformSession("unknown");
+    const entry = `/account/signup?returnTo=${encodeURIComponent(CHECKOUT)}`;
+    renderAt(entry);
+
+    expect(location()).toBe(entry);
+    expect(screen.queryByText("Continue")).toBeNull();
+  });
+
+  test("a local-only returnTo skips OAuth without a platform session", () => {
+    authenticated = true;
+    setPlatformSession("absent");
+    renderAt(
+      `/account/signup?returnTo=${encodeURIComponent(LOCAL_DESTINATION)}`,
+    );
+
+    expect(location()).toBe(LOCAL_DESTINATION);
     expect(authFlowCalls).toHaveLength(0);
   });
 

--- a/clients/web/src/domains/account/pages/signup-page.tsx
+++ b/clients/web/src/domains/account/pages/signup-page.tsx
@@ -15,8 +15,12 @@ import { useReturnToShortCircuit } from "@/domains/account/components/use-return
 export function SignupPage() {
   const shortCircuit = useReturnToShortCircuit();
 
-  if (shortCircuit.kind === "wait") return <SignupShell>{null}</SignupShell>;
-  if (shortCircuit.kind === "redirect") return shortCircuit.node;
+  if (shortCircuit.kind === "wait") {
+    return <SignupShell>{null}</SignupShell>;
+  }
+  if (shortCircuit.kind === "redirect") {
+    return shortCircuit.node;
+  }
 
   return <SignupScreen returnTo={shortCircuit.returnTo} />;
 }

--- a/clients/web/src/domains/account/pages/signup-page.tsx
+++ b/clients/web/src/domains/account/pages/signup-page.tsx
@@ -1,14 +1,6 @@
-import { useSearchParams } from "react-router";
-
-import { ReturnToRedirect } from "@/domains/account/components/return-to-redirect";
 import { SignupScreen } from "@/domains/account/components/signup-screen";
 import { SignupShell } from "@/domains/account/components/signup-shell";
-import { sanitizeReturnTo } from "@/domains/account/return-to";
-import {
-  useIsAuthenticated,
-  useIsSessionInitializing,
-} from "@/stores/auth-store";
-import { routes } from "@/utils/routes";
+import { useReturnToShortCircuit } from "@/domains/account/components/use-return-to-short-circuit";
 
 /**
  * Signup entry. Renders the branded sign-up screen for everyone: a rotating
@@ -16,22 +8,15 @@ import { routes } from "@/utils/routes";
  * WorkOS auth flow (`intent: "signup"`); the post-OAuth name/occupation step
  * lives in `ProviderSignupPage`.
  *
- * A `returnTo` means something sent the visitor here on the way somewhere
- * specific (e.g. a marketing pricing CTA), so an existing session skips OAuth
- * and lands there directly. A bare visit always gets the sign-up screen — a
- * signed-in visitor may be there to create another account.
+ * `useReturnToShortCircuit` owns whether an existing session skips OAuth and
+ * lands on the `returnTo` destination directly — the same decision
+ * `LoginPage` makes. Only the loading shell differs.
  */
 export function SignupPage() {
-  const [searchParams] = useSearchParams();
-  const isAuthenticated = useIsAuthenticated();
-  const isSessionInitializing = useIsSessionInitializing();
-  const rawReturnTo = searchParams.get("returnTo");
-  const destination = sanitizeReturnTo(rawReturnTo, routes.assistant);
+  const shortCircuit = useReturnToShortCircuit();
 
-  if (rawReturnTo) {
-    if (isSessionInitializing) return <SignupShell>{null}</SignupShell>;
-    if (isAuthenticated) return <ReturnToRedirect to={destination} />;
-  }
+  if (shortCircuit.kind === "wait") return <SignupShell>{null}</SignupShell>;
+  if (shortCircuit.kind === "redirect") return shortCircuit.node;
 
-  return <SignupScreen returnTo={rawReturnTo ? destination : null} />;
+  return <SignupScreen returnTo={shortCircuit.returnTo} />;
 }

--- a/clients/web/src/domains/account/pages/signup-page.tsx
+++ b/clients/web/src/domains/account/pages/signup-page.tsx
@@ -1,16 +1,37 @@
 import { useSearchParams } from "react-router";
 
+import { ReturnToRedirect } from "@/domains/account/components/return-to-redirect";
 import { SignupScreen } from "@/domains/account/components/signup-screen";
+import { SignupShell } from "@/domains/account/components/signup-shell";
+import { sanitizeReturnTo } from "@/domains/account/return-to";
+import {
+  useIsAuthenticated,
+  useIsSessionInitializing,
+} from "@/stores/auth-store";
+import { routes } from "@/utils/routes";
 
 /**
  * Signup entry. Renders the branded sign-up screen for everyone: a rotating
  * headline with Google / Apple / Email buttons. Each button hands off to the
  * WorkOS auth flow (`intent: "signup"`); the post-OAuth name/occupation step
  * lives in `ProviderSignupPage`.
+ *
+ * A `returnTo` means something sent the visitor here on the way somewhere
+ * specific (e.g. a marketing pricing CTA), so an existing session skips OAuth
+ * and lands there directly. A bare visit always gets the sign-up screen — a
+ * signed-in visitor may be there to create another account.
  */
 export function SignupPage() {
   const [searchParams] = useSearchParams();
-  const returnTo = searchParams.get("returnTo");
+  const isAuthenticated = useIsAuthenticated();
+  const isSessionInitializing = useIsSessionInitializing();
+  const rawReturnTo = searchParams.get("returnTo");
+  const destination = sanitizeReturnTo(rawReturnTo, routes.assistant);
 
-  return <SignupScreen returnTo={returnTo} />;
+  if (rawReturnTo) {
+    if (isSessionInitializing) return <SignupShell>{null}</SignupShell>;
+    if (isAuthenticated) return <ReturnToRedirect to={destination} />;
+  }
+
+  return <SignupScreen returnTo={rawReturnTo ? destination : null} />;
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -121,8 +121,11 @@ function onboardingEntrypoint(isLocalMode: boolean): string {
  * hardcoded non-native `success_url` (`/assistant/settings/billing`, which
  * `BillingRedirectPage` forwards) and the Billing tab's own path, which the
  * native deep-link return and `usageBillingCheckout()` build directly.
+ *
+ * Exported so the auth entry points gate on the same pair — a second hand-kept
+ * copy would drift and let a paid return skip the platform login.
  */
-const POST_CHECKOUT_LANDING_PATHS: Set<string> = new Set([
+export const POST_CHECKOUT_LANDING_PATHS: ReadonlySet<string> = new Set([
   `${routes.settings.root}/billing`,
   routes.settings.usage,
 ]);


### PR DESCRIPTION
## Summary
- `SignupPage` / `LoginPage` now read `useIsAuthenticated()` + `useIsSessionInitializing()` and, **only when a `returnTo` param is present**, replace-navigate an already-signed-in visitor to that destination instead of rendering the OAuth screen. While the session is unsettled they render the page's existing chrome; a bare visit (no `returnTo`) is unchanged, so a signed-in user can still re-auth or switch accounts.
- Both pages now run `returnTo` through `sanitizeReturnTo` before handing it to `SignupScreen` / `WebLoginForm` / `NativeLoginForm` (previously passed raw, which leaked into the OAuth callback URL). Off-SPA destinations (absolute URLs, `/import`, Django routes) go through a hard navigation via the shared `ReturnToRedirect` so they don't dead-end on the SPA not-found route.
- New tests for both pages: authenticated + `returnTo=/assistant/checkout?package=super` redirects with no `startAuthFlow` call, unauthenticated / bare-visit render as today, hostile `returnTo` falls back to `/assistant` (both for the redirect and for the value handed to the auth flow), and an unsettled session neither redirects nor offers OAuth.

Part of plan: pricing-upgrade-path.md (PR 3 of 3)