### PR TITLE
feat(web): open the package-switch flow from a plans-page deep link

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -1,11 +1,19 @@
 /**
- * Interaction tests for the PlansPage CTA checkout wiring.
+ * Interaction tests for the PlansPage CTA checkout wiring and the `?package=`
+ * deep link.
  *
  * A base subscriber clicking a package button (Power Up / Go Super / Unleash
  * Ultra) fires the Stripe upgrade for THAT package and redirects to the
- * returned checkout URL. A Pro subscriber instead routes to the billing
- * manage modal (`?adjust_plan`), because the platform upgrade endpoint no-ops
- * for an active Pro org.
+ * returned checkout URL. An active Pro subscriber switches packages in place
+ * (the confirm modal → change-package), and only an *ineligible* Pro sub —
+ * cancelling or off an entitlement status — routes to the billing manage modal
+ * (`?adjust_plan`), because change-package can only fail for it.
+ *
+ * The `?package=<key>` deep link reuses that same click handler, so it inherits
+ * every guard: it opens the confirm modal for an eligible Pro sub, bails to
+ * `?adjust_plan` for an ineligible one, no-ops on the current or an unknown
+ * key, and never starts a checkout for a non-Pro user. The param is stripped
+ * either way and consumed exactly once.
  *
  * Strategy mirrors adjust-plan-modal.test.tsx: mock the generated SDK to
  * capture the upgrade body and return a redirect, mock `openUrl` to capture the
@@ -14,7 +22,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 
@@ -153,9 +167,16 @@ function LocationProbe() {
   return <div data-testid="loc">{location.pathname + location.search}</div>;
 }
 
-function renderPage(subscription: SubscriptionResponse) {
+function renderPage(
+  subscription: SubscriptionResponse,
+  entry = "/assistant/plans",
+) {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      // The seeded cache is the only data source — the read endpoints aren't
+      // mocked, so a background refetch would hit the network.
+      queries: { retry: false, staleTime: Infinity, refetchOnMount: false },
+    },
   });
   client.setQueryData(
     organizationsBillingSubscriptionRetrieveQueryKey(),
@@ -165,14 +186,17 @@ function renderPage(subscription: SubscriptionResponse) {
     organizationsBillingPlansRetrieveQueryKey(),
     fullCatalog(),
   );
-  return render(
-    <MemoryRouter initialEntries={["/assistant/plans"]}>
-      <QueryClientProvider client={client}>
-        <PlansPage />
-      </QueryClientProvider>
-      <LocationProbe />
-    </MemoryRouter>,
-  );
+  return {
+    client,
+    ...render(
+      <MemoryRouter initialEntries={[entry]}>
+        <QueryClientProvider client={client}>
+          <PlansPage />
+        </QueryClientProvider>
+        <LocationProbe />
+      </MemoryRouter>,
+    ),
+  };
 }
 
 beforeEach(() => {
@@ -233,5 +257,111 @@ describe("PlansPage checkout — Pro subscriber", () => {
 
     expect(upgradeCall).toBeNull();
     expect(readCheckoutIntent()).toBeNull();
+  });
+});
+
+// `?package=<key>` is the URL entry into the in-place package switch — the
+// funnel marketing's upgrade CTAs and the checkout no-op bail land on. It calls
+// the same handler a card click does, so every assertion below is really about
+// a guard being inherited rather than re-implemented.
+describe("PlansPage — ?package= deep link", () => {
+  // Emptying the query leaves React Router with a bare "?" on the path, so the
+  // assertion is on the param being gone rather than an exact string.
+  const ON_PLANS_WITHOUT_PARAM = /^\/assistant\/plans\??$/;
+
+  test("an eligible Pro sub opens the switch confirm for the requested package", async () => {
+    const { findByText, getByTestId } = renderPage(
+      proMightySubscription(),
+      "/assistant/plans?package=super",
+    );
+
+    // The confirm modal — not a checkout, not a direct change-package.
+    await findByText("Upgrade to Super");
+    expect(upgradeCall).toBeNull();
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toMatch(ON_PLANS_WITHOUT_PARAM),
+    );
+  });
+
+  test("an ineligible Pro sub bails to the billing manage surface", async () => {
+    const { getByTestId, queryByTestId } = renderPage(
+      { ...proMightySubscription(), cancel_at_period_end: true },
+      "/assistant/plans?package=super",
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(
+        "/assistant/settings/usage?tab=billing&adjust_plan",
+      ),
+    );
+    expect(queryByTestId("confirm-package-switch-button")).toBeNull();
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("the current package is a no-op", async () => {
+    const { getByTestId, queryByTestId } = renderPage(
+      proMightySubscription(),
+      "/assistant/plans?package=mighty",
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toMatch(ON_PLANS_WITHOUT_PARAM),
+    );
+    expect(queryByTestId("confirm-package-switch-button")).toBeNull();
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("an unknown package key is a no-op", async () => {
+    const { getByTestId, queryByTestId } = renderPage(
+      proMightySubscription(),
+      "/assistant/plans?package=bogus",
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toMatch(ON_PLANS_WITHOUT_PARAM),
+    );
+    expect(queryByTestId("confirm-package-switch-button")).toBeNull();
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("a non-Pro sub starts no checkout, and the param is still dropped", async () => {
+    const { getByTestId, queryByTestId } = renderPage(
+      freeSubscription(),
+      "/assistant/plans?package=super",
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toMatch(ON_PLANS_WITHOUT_PARAM),
+    );
+    // A URL alone must never charge anyone: the base user still has to press
+    // the card's CTA.
+    expect(upgradeCall).toBeNull();
+    expect(readCheckoutIntent()).toBeNull();
+    expect(queryByTestId("confirm-package-switch-button")).toBeNull();
+  });
+
+  test("the param is consumed once — a later query settle doesn't reopen the modal", async () => {
+    const { client, findByText, findByRole, getByTestId, queryByTestId } =
+      renderPage(proMightySubscription(), "/assistant/plans?package=super");
+
+    await findByText("Upgrade to Super");
+    fireEvent.click(await findByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(queryByTestId("confirm-package-switch-button")).toBeNull(),
+    );
+
+    // A subscription refetch settling re-runs the effect; the one-shot ref (and
+    // the already-stripped URL) keep it from reopening.
+    act(() => {
+      client.setQueryData(
+        organizationsBillingSubscriptionRetrieveQueryKey(),
+        proMightySubscription(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toMatch(ON_PLANS_WITHOUT_PARAM),
+    );
+    expect(queryByTestId("confirm-package-switch-button")).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, Loader2 } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -150,6 +150,7 @@ function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
  */
 export function PlansPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const electron = isElectron();
 
@@ -198,6 +199,9 @@ export function PlansPage() {
   const [resizeCreditTier, setResizeCreditTier] = useState<
     CreditTierEnum | null | undefined
   >(undefined);
+  // `?package=<key>` is a one-shot deep link (from marketing / the checkout
+  // no-op bail); once acted on it must never re-fire.
+  const packageParamConsumedRef = useRef(false);
 
   const subscription = subscriptionQuery.data;
   const proPlan = plansQuery.data?.plans.find(
@@ -206,6 +210,18 @@ export function PlansPage() {
   const packages = proPlan?.packages ?? [];
   const hasPackages = packages.length > 0;
   const isProUser = subscription?.plan_id === "pro";
+
+  // A Custom sub (unpinned or customized) has no meaningful catalog rank, so
+  // it has no current tier: every named card is offered as a switch target —
+  // including a customized sub's own pinned key, which is a real
+  // revert-to-stock operation.
+  const currentTierKey = !subscription
+    ? null
+    : subscription.plan_id === "base"
+      ? "free"
+      : isCleanPin(subscription.package)
+        ? subscription.package.key
+        : null;
 
   // Pro → Free is a cancellation: after a confirm step it opens the Stripe
   // billing portal (the same destination as the adjust-plan modal's "Downgrade
@@ -316,19 +332,106 @@ export function PlansPage() {
     }
   };
 
+  const selectTier = (tierKey: string) => {
+    if (!subscription) {
+      return;
+    }
+    // A billing action is already in flight (checkout / package switch /
+    // portal opening) — ignore the click. The CTAs are also disabled; this
+    // guards against a race between the click and the disabled re-render.
+    if (billingActionPending) {
+      return;
+    }
+    if (isProUser) {
+      if (tierKey === "free") {
+        // Pro → Free is a subscription cancellation, not a package switch.
+        // Confirm first (which Pro features are lost), then open the Stripe
+        // billing portal — the same destination as the adjust-plan modal's
+        // "Downgrade to Base" — where the user actually cancels. The
+        // package-only change-package endpoint 400s on non-package keys.
+        setFreeDowngradeOpen(true);
+        return;
+      }
+      // Active Pro orgs switch packages in place via the change-package
+      // endpoint (up or down). Only the named Pro packages route here.
+      const pkg = packages.find((p) => p.key === tierKey);
+      if (!pkg) {
+        return;
+      }
+      if (tierRelation(currentTierKey, pkg.key) === "current") {
+        return;
+      }
+      // Any active Pro sub — pinned, unpinned, or customized — switches in
+      // place via change-package. Only a cancelling or non-entitlement-status
+      // sub can't; route it to the billing manage/cancel surface instead of
+      // posting a change-package that can only fail (the same fallback the
+      // Pro → Free case uses).
+      if (!isPackageSwitchEligible(subscription)) {
+        navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
+        return;
+      }
+      setSwitchTarget(pkg);
+      return;
+    }
+    if (tierKey === "free") {
+      return;
+    }
+    // A package checkout resolves its own line items server-side; only the
+    // package key is sent (mirrors the plan-card upgrade path).
+    void startCheckout({
+      target_plan_id: "pro",
+      package: tierKey,
+      confirm: true,
+    });
+  };
+
+  // The deep-link effect below fires at most once, so it reads the handler
+  // through a ref rather than depending on an identity that changes every
+  // render.
+  const selectTierRef = useRef(selectTier);
+  useEffect(() => {
+    selectTierRef.current = selectTier;
+  });
+
+  // `?package=<key>` opens the switch flow for the requested package exactly
+  // once, reusing `selectTier` so the deep link inherits every guard a click
+  // gets. Non-Pro users get no checkout from a URL — but the param is still
+  // dropped so it can't fire later once they are Pro.
+  const packageParam = searchParams.get("package");
+  useEffect(() => {
+    if (packageParam == null || packageParamConsumedRef.current) {
+      return;
+    }
+    if (
+      !platformReady ||
+      !subscriptionQuery.isSuccess ||
+      !plansQuery.isSuccess
+    ) {
+      return;
+    }
+    packageParamConsumedRef.current = true;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("package");
+        return next;
+      },
+      { replace: true },
+    );
+    if (isProUser) {
+      selectTierRef.current(packageParam);
+    }
+  }, [
+    packageParam,
+    platformReady,
+    subscriptionQuery.isSuccess,
+    plansQuery.isSuccess,
+    isProUser,
+    setSearchParams,
+  ]);
+
   let body: ReactNode;
   if (subscription && proPlan && hasPackages) {
-    // A Custom sub (unpinned or customized) has no meaningful catalog rank, so
-    // it has no current tier: every named card is offered as a switch target —
-    // including a customized sub's own pinned key, which is a real
-    // revert-to-stock operation.
-    const currentTierKey =
-      subscription.plan_id === "base"
-        ? "free"
-        : isCleanPin(subscription.package)
-          ? subscription.package.key
-          : null;
-
     // A Pro sub with no clean pin (unpinned, customized, or legacy) — exactly
     // the subs `currentTierKey` leaves null — is represented by the Custom row,
     // not any named card. Mark that row as their current plan and summarize its
@@ -343,56 +446,6 @@ export function PlansPage() {
     const currentSummary = showCurrentPlan
       ? customCurrentSummary(current, proPlan)
       : undefined;
-
-    const selectTier = (tierKey: string) => {
-      // A billing action is already in flight (checkout / package switch /
-      // portal opening) — ignore the click. The CTAs are also disabled; this
-      // guards against a race between the click and the disabled re-render.
-      if (billingActionPending) {
-        return;
-      }
-      if (isProUser) {
-        if (tierKey === "free") {
-          // Pro → Free is a subscription cancellation, not a package switch.
-          // Confirm first (which Pro features are lost), then open the Stripe
-          // billing portal — the same destination as the adjust-plan modal's
-          // "Downgrade to Base" — where the user actually cancels. The
-          // package-only change-package endpoint 400s on non-package keys.
-          setFreeDowngradeOpen(true);
-          return;
-        }
-        // Active Pro orgs switch packages in place via the change-package
-        // endpoint (up or down). Only the named Pro packages route here.
-        const pkg = packages.find((p) => p.key === tierKey);
-        if (!pkg) {
-          return;
-        }
-        if (tierRelation(currentTierKey, pkg.key) === "current") {
-          return;
-        }
-        // Any active Pro sub — pinned, unpinned, or customized — switches in
-        // place via change-package. Only a cancelling or non-entitlement-status
-        // sub can't; route it to the billing manage/cancel surface instead of
-        // posting a change-package that can only fail (the same fallback the
-        // Pro → Free case uses).
-        if (!isPackageSwitchEligible(subscription)) {
-          navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
-          return;
-        }
-        setSwitchTarget(pkg);
-        return;
-      }
-      if (tierKey === "free") {
-        return;
-      }
-      // A package checkout resolves its own line items server-side; only the
-      // package key is sent (mirrors the plan-card upgrade path).
-      void startCheckout({
-        target_plan_id: "pro",
-        package: tierKey,
-        confirm: true,
-      });
-    };
 
     // Confirmed Pro → Free cancellation: close the confirm and hand off to the
     // Stripe billing portal, where the actual cancellation happens.


### PR DESCRIPTION
## Summary

- `/assistant/plans?package=<key>` now opens the in-place package-switch confirm for an active Pro sub, reusing the existing `selectTier` click handler so every guard (free-downgrade confirm, unknown key, already-current, `isPackageSwitchEligible` bail to `?tab=billing&adjust_plan`) is inherited rather than re-implemented. The modal is the only entry — nothing auto-confirms and no `change-package` fires from the effect.
- The param is consumed exactly once and stripped from the URL (`replace: true`, mirroring `billing-page.tsx`), including for non-Pro users, who get no checkout from a URL.
- `selectTier` / `currentTierKey` hoisted to the component body (bodies untouched) so the effect can call them; six new tests in `plans-page-checkout.test.tsx` cover the eligible, ineligible, current-key, unknown-key, non-Pro, and consumed-once cases, and its stale header comment is corrected.

Part of plan: pricing-upgrade-path.md (PR 1 of 3)