### PR TITLE
fix(gateway): reject non-canonical ingress paths; see symlinked plugin roots

### DIFF
--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -88,6 +94,57 @@ describe("parsePluginIngressManifest", () => {
     }
   });
 
+  it("rejects percent-encoded traversal", () => {
+    // Velay decodes before matching, so `%2e%2e/` would escape the
+    // declaring plugin's namespace despite passing a literal-segment check.
+    for (const path of [
+      "%2e%2e/other/hook",
+      "%2E%2E/other/hook",
+      "a/%2e%2e/b",
+    ]) {
+      expect(() =>
+        parsePluginIngressManifest({
+          routes: [{ path, kind: "http", description: "d" }],
+        }),
+      ).toThrow();
+    }
+  });
+
+  it("rejects an encoded path separator", () => {
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [{ path: "a%2fb", kind: "http", description: "d" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects malformed percent-encoding", () => {
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [{ path: "100%", kind: "http", description: "d" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-canonical segments that would clean to a different path", () => {
+    // `a//b` cleans to `a/b`, so it would collide with a separate `a/b`
+    // declaration that the exact-string duplicate check treats as distinct.
+    for (const path of ["a//b", "a/./b"]) {
+      expect(() =>
+        parsePluginIngressManifest({
+          routes: [{ path, kind: "http", description: "d" }],
+        }),
+      ).toThrow();
+    }
+  });
+
+  it("accepts a canonical multi-segment path", () => {
+    const manifest = parsePluginIngressManifest({
+      routes: [{ path: "a/b/c", kind: "http", description: "d" }],
+    });
+    expect(manifest.routes[0]!.path).toBe("a/b/c");
+  });
+
   it("rejects a trailing slash", () => {
     expect(() =>
       parsePluginIngressManifest({
@@ -175,6 +232,34 @@ describe("discoverPluginIngress", () => {
     writeFileSync(join(pluginDir, ".disabled"), "");
 
     expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
+  });
+
+  it("discovers a plugin installed as a symlinked root", () => {
+    // Plugins may be installed by symlinking a checkout into place, where
+    // Dirent.isDirectory() is false but the target is a directory.
+    const workspaceDir = makeWorkspace();
+    const external = makeWorkspace();
+    const target = join(external, "meeting-bot");
+    mkdirSync(join(target, "channels"), { recursive: true });
+    writeFileSync(join(target, PLUGIN_INGRESS_MANIFEST_RELPATH), VALID);
+
+    mkdirSync(join(workspaceDir, "plugins"), { recursive: true });
+    symlinkSync(target, join(workspaceDir, "plugins", "meeting-bot"));
+
+    const { plugins, problems } = discoverPluginIngress({ workspaceDir });
+    expect(problems).toEqual([]);
+    expect(plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+  });
+
+  it("ignores a plain file sitting in the plugins directory", () => {
+    const workspaceDir = makeWorkspace();
+    mkdirSync(join(workspaceDir, "plugins"), { recursive: true });
+    writeFileSync(join(workspaceDir, "plugins", ".DS_Store"), "");
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+
+    const { plugins, problems } = discoverPluginIngress({ workspaceDir });
+    expect(problems).toEqual([]);
+    expect(plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
   });
 
   it("reports a malformed declaration without dropping the others", () => {

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -1,48 +1,7 @@
-/**
- * Discovery of plugin-declared public ingress routes.
- *
- * A plugin that needs inbound traffic — a webhook, a provider dialling a
- * realtime socket — cannot reach the public surface today. Every public
- * route in the gateway is hand-written and the Velay path allowlist is a
- * frozen literal, which works for first-party integrations (someone edits
- * the gateway when they add one) but not for a plugin, which ships
- * separately and cannot patch a frozen array. The workaround has been for
- * the plugin to stand up its own tunnel and public address.
- *
- * Instead a plugin declares what it needs in a static file on the
- * workspace volume the gateway already reads:
- *
- *     <workspaceDir>/plugins/<plugin>/channels/ingress.json
- *
- *     {
- *       "routes": [
- *         { "path": "realtime", "kind": "websocket", "description": "…" }
- *       ]
- *     }
- *
- * and the gateway composes the public path from the plugin's own name:
- *
- *     /webhooks/plugins/<plugin>/<path>
- *
- * The file is inert data, never code: the gateway must not execute
- * assistant-supplied logic to find out what to expose.
- *
- * ## What this module does and does not do
- *
- * It discovers and validates declarations. It does **not** serve them. A
- * declaration is a request, not a grant — routing them requires a guardian
- * approval gate that does not exist yet, so nothing here is wired into the
- * request path.
- *
- * ## Trust
- *
- * Everything below treats the manifest as untrusted input from the
- * assistant, because that is what it is. The plugin repo validating its
- * own file is a convenience for its authors, not a guarantee to us.
- */
+/** Discovery of plugin-declared public ingress routes from the workspace volume. */
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, posix } from "node:path";
 
 import { z } from "zod";
 
@@ -58,37 +17,44 @@ export const PLUGIN_WEBHOOK_PREFIX = "/webhooks/plugins";
 export const PLUGIN_INGRESS_MANIFEST_RELPATH = join("channels", "ingress.json");
 
 /**
- * Transport a declared route expects. The gateway bridges HTTP and
- * WebSocket differently (`velay/http-bridge.ts` vs `websocket-bridge.ts`),
- * so it has to know which before a connection arrives.
+ * Transport a declared route expects. HTTP and WebSocket are bridged
+ * differently (`velay/http-bridge.ts` vs `velay/websocket-bridge.ts`), so
+ * the kind has to be known before a connection arrives.
  */
 export const IngressRouteKindSchema = z.enum(["http", "websocket"]);
 export type IngressRouteKind = z.infer<typeof IngressRouteKindSchema>;
 
-/**
- * A plugin directory name that is safe to place in a public URL.
- *
- * The directory name becomes a path segment, so it is validated rather
- * than trusted: anything that could alter the shape of the composed path
- * is rejected outright.
- */
+/** Plugin directory name usable as a public URL path segment. */
 const SAFE_PLUGIN_NAME = /^[a-z0-9][a-z0-9._-]*$/i;
+
+/**
+ * A path is canonical when percent-decoding and POSIX normalization both
+ * leave it unchanged.
+ *
+ * Velay percent-decodes and `path.Clean`s an inbound path before matching
+ * it against the allowlist, so a non-canonical declaration is served under
+ * a different path than the one declared: `%2e%2e/other/hook` decodes out
+ * of the declaring plugin's namespace, and `a//b` cleans to `a/b`,
+ * colliding with a separate `a/b` declaration that the exact-string
+ * duplicate check treats as distinct.
+ */
+function isCanonicalPath(value: string): boolean {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    // Malformed percent-encoding — Velay's decode would fail or differ.
+    return false;
+  }
+  return decoded === value && posix.normalize(value) === value;
+}
 
 export const IngressRouteSchema = z.object({
   /**
    * Path relative to the plugin's own namespace — `"realtime"`, not
-   * `/webhooks/plugins/meeting-bot/realtime`. The plugin never writes the
-   * prefix, so it cannot name another plugin's route: cross-plugin
-   * interception is unrepresentable rather than something we have to
-   * detect.
-   *
-   * `.` and `..` segments are rejected because Velay percent-decodes and
-   * runs `path.Clean` on the inbound path before matching its allowlist
-   * (see `IsPathAllowed` in the platform repo). A declared
-   * `../other/steal` would otherwise compose to a path that cleans out of
-   * the declaring plugin's namespace. A trailing slash is rejected for
-   * the same reason — `path.Clean` strips it, so a composed path ending
-   * in one could never match.
+   * `/webhooks/plugins/meeting-bot/realtime`. The prefix and the plugin
+   * name are supplied by the gateway, so a declaration cannot name another
+   * plugin's route.
    */
   path: z
     .string()
@@ -100,6 +66,10 @@ export const IngressRouteSchema = z.object({
     .refine((p) => !p.endsWith("/"), {
       message: "path must not end in a trailing slash",
     })
+    .refine(isCanonicalPath, {
+      message:
+        "path must be canonical: unencoded, with no empty, '.' or redundant segments",
+    })
     .refine((p) => !p.split("/").some((seg) => seg === "." || seg === ".."), {
       message: "path must not contain . or .. segments",
     }),
@@ -110,12 +80,9 @@ export const IngressRouteSchema = z.object({
 export type IngressRoute = z.infer<typeof IngressRouteSchema>;
 
 /**
- * The declaration itself.
- *
- * No version and no plugin name. The format is ours, not something a
- * plugin versions independently, and the plugin's identity is already
- * known from the directory the file was read from — taking it from the
- * file content would let a manifest claim to be a different plugin.
+ * A plugin's declaration. The plugin's identity comes from the directory
+ * the file is read from, not from its contents, so a manifest cannot claim
+ * to belong to a different plugin.
  */
 export const PluginIngressManifestSchema = z.object({
   routes: z.array(IngressRouteSchema).min(1),
@@ -128,7 +95,7 @@ export interface DiscoveredPluginIngress {
   routes: readonly IngressRoute[];
 }
 
-/** A declaration that was found but could not be used, and why. */
+/** A declaration that was found but rejected, and why. */
 export interface PluginIngressProblem {
   plugin: string;
   reason: string;
@@ -137,8 +104,8 @@ export interface PluginIngressProblem {
 export interface PluginIngressDiscovery {
   plugins: DiscoveredPluginIngress[];
   /**
-   * Rejected declarations. Surfaced rather than thrown: one plugin's
-   * malformed file must never take down discovery for every other plugin.
+   * Rejected declarations, reported rather than thrown so that one
+   * malformed manifest cannot suppress discovery for every other plugin.
    */
   problems: PluginIngressProblem[];
 }
@@ -148,7 +115,7 @@ export function pluginWebhookPath(plugin: string, path: string): string {
   return `${PLUGIN_WEBHOOK_PREFIX}/${plugin}/${path.replace(/^\/+/, "")}`;
 }
 
-/** Absolute paths a discovered plugin is asking us to expose. */
+/** Absolute paths a discovered plugin is asking the gateway to expose. */
 export function ingressRoutePaths(
   discovered: DiscoveredPluginIngress,
 ): string[] {
@@ -180,13 +147,15 @@ export interface DiscoverPluginIngressOptions {
 /**
  * Scan the workspace for plugin ingress declarations.
  *
- * Skips plugins carrying a `.disabled` sentinel — the same source of truth
- * the assistant uses for hooks, tools, and routes. Without this, disabling
- * a plugin would leave its public routes live.
+ * A manifest is untrusted input from the assistant and is validated here
+ * independently of any checks the plugin performs on itself.
  *
- * Note that only workspace-installed plugins are visible here. Default
- * plugins ship inside the assistant binary, which the gateway cannot read,
- * so they cannot declare ingress by this route.
+ * Plugins carrying a `.disabled` sentinel are skipped, matching the source
+ * of truth the assistant uses for hooks, tools, and routes, so a disabled
+ * plugin holds no public routes.
+ *
+ * Only workspace-installed plugins are visible. Default plugins ship
+ * inside the assistant binary, which the gateway cannot read.
  */
 export function discoverPluginIngress(
   opts: DiscoverPluginIngressOptions = {},
@@ -198,25 +167,31 @@ export function discoverPluginIngress(
 
   let entries: string[];
   try {
-    entries = readdirSync(pluginsDir, { withFileTypes: true })
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name);
+    entries = readdirSync(pluginsDir);
   } catch {
-    // No plugins directory at all is the normal empty case, not an error.
+    // An absent plugins directory is the empty case, not a failure.
     return { plugins, problems };
   }
 
   for (const plugin of entries) {
+    const pluginDir = join(pluginsDir, plugin);
+    try {
+      // statSync rather than Dirent.isDirectory so plugins installed as
+      // symlinked roots are seen, matching the assistant's own plugin scan.
+      if (!statSync(pluginDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
     if (!SAFE_PLUGIN_NAME.test(plugin)) {
-      // Never report a name we would not serve — it lands in logs.
       problems.push({
+        // Quoted so an unservable name is unambiguous in logs.
         plugin: JSON.stringify(plugin),
         reason: "plugin directory name is not a safe URL path segment",
       });
       continue;
     }
 
-    const pluginDir = join(pluginsDir, plugin);
     if (existsSync(join(pluginDir, ".disabled"))) continue;
 
     const manifestPath = join(pluginDir, PLUGIN_INGRESS_MANIFEST_RELPATH);
@@ -258,12 +233,9 @@ export function discoverPluginIngress(
 const DEFAULT_TTL_MS = 5000;
 
 /**
- * TTL-cached view of {@link discoverPluginIngress}.
- *
- * Discovery walks the filesystem, so the request path should not repeat it
- * per connection. The TTL means installing, enabling, or disabling a
- * plugin takes effect without a gateway restart — the same
- * read-through-with-staleness contract as {@link ConfigFileCache}.
+ * TTL-cached view of {@link discoverPluginIngress}, so the request path
+ * does not re-walk the filesystem per connection and plugin installs or
+ * toggles take effect without a gateway restart.
  */
 export class PluginIngressCache {
   private readonly ttlMs: number;


### PR DESCRIPTION
## Prompt / plan

Addresses the three review findings on #39349, before this discovery output is wired into routing.

### 1. Non-canonical paths could escape the namespace or collide

Path validation checked for literal `.` and `..` segments, but not their encoded forms or redundant separators. That matters because Velay percent-decodes and `path.Clean`s an inbound path *before* matching its allowlist — so a declaration is served under the decoded and cleaned path, not the literal one. Two classes slipped through:

- `%2e%2e/other/hook` — decodes to `../other/hook`, cleaning out of the declaring plugin's namespace. Cross-plugin interception, which is exactly what the namespace design is meant to make impossible.
- `a//b` — cleans to `a/b`, so it collides with a separate `a/b` declaration that the exact-string duplicate check treats as distinct.

Paths must now be **canonical**: percent-decoding and POSIX normalization both leave them unchanged. One predicate covers both classes, plus malformed encoding like `100%` that would fail Velay's decode outright. `a/b/c` still passes — this rejects non-canonical forms, not nesting.

### 2. Symlinked plugin roots were invisible

Discovery filtered entries with `Dirent.isDirectory()`, which is **false for a symlink**. Installing a plugin by symlinking a checkout into the plugins directory is supported (`assistant/examples/plugins/echo`), and the assistant's own scan handles it with `statSync` in `plugins/mtime-cache.ts`. So such a plugin would load and run normally while its declared ingress was silently never discovered — the worst kind of failure, since nothing reports it.

Discovery now stats the entry, matching that scan. A plain file in the plugins directory is still skipped (covered by a test, since `statSync` alone would have accepted one).

### 3. Module comment carried change history

Reduced to one line per `AGENTS.md`. What it was carrying — why the hand-written approach existed, what the workaround "has been" — is change history, which belongs here rather than in the source.

## Test plan

26 unit tests (up from 19), against real temp workspaces. New coverage:

- percent-encoded traversal in three forms (`%2e%2e/`, uppercase `%2E%2E/`, mid-path `a/%2e%2e/b`)
- encoded path separator (`a%2fb`)
- malformed percent-encoding (`100%`)
- non-canonical separators (`a//b`, `a/./b`)
- a canonical multi-segment path still accepted (`a/b/c`)
- a plugin installed as a symlinked root is discovered
- a plain file in the plugins directory is ignored

`bunx tsc --noEmit`, prettier, and eslint clean; the pre-push hook ran them too.

## CLI verb checklist

No new IPC routes under `assistant/src/runtime/routes/` — gateway-internal module only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ)_