### PR TITLE
feat(assistant): return label/objective/child conversation id from subagents/reconcile

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29495,8 +29495,10 @@ paths:
       operationId: subagents_reconcile_get
       summary: Reconcile subagent live status
       description:
-        Returns the live in-memory status of all subagents known to the daemon for a given parent conversation.
-        Subagents not in the response are orphaned.
+        "Returns the live in-memory state of all subagents known to the daemon for a given parent conversation.
+        Each entry carries enough detail (child conversation id, label, objective) for a client to rebuild its subagent
+        list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. The
+        descriptive fields are optional: older daemons return only `status`."
       tags:
         - subagents
       parameters:
@@ -29522,6 +29524,16 @@ paths:
                       type: object
                       properties:
                         status:
+                          type: string
+                        conversationId:
+                          type: string
+                        label:
+                          type: string
+                        objective:
+                          type: string
+                        isFork:
+                          type: boolean
+                        parentToolUseId:
                           type: string
                       required:
                         - status

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29335,7 +29335,7 @@ paths:
           schema:
             type: string
           description:
-            The subagent's own conversation ID. Fallback only — when the daemon knows the subagent (live or
+            The subagent's own conversation ID. Fallback only — when the assistant knows the subagent (live or
             rehydrated), it resolves the conversation itself and this parameter is ignored.
       responses:
         "200":
@@ -29495,10 +29495,10 @@ paths:
       operationId: subagents_reconcile_get
       summary: Reconcile subagent live status
       description:
-        "Returns the live in-memory state of all subagents known to the daemon for a given parent conversation.
+        Returns the live in-memory state of all subagents known to the assistant for a given parent conversation.
         Each entry carries enough detail (child conversation id, label, objective) for a client to rebuild its subagent
-        list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. The
-        descriptive fields are optional: older daemons return only `status`."
+        list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. Only
+        `status` is guaranteed to be present; every other field is optional.
       tags:
         - subagents
       parameters:

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -116,6 +116,7 @@ function seedSubagent(
     role: "general",
     isFork: false,
     sendResultToUser: null,
+    parentToolUseId: null,
     status: "running",
     error: null,
     createdAt: 0,

--- a/assistant/src/__tests__/subagent-persistence.test.ts
+++ b/assistant/src/__tests__/subagent-persistence.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { getDb } from "../persistence/db-connection.js";
 import { migrateCreateSubagentsTable } from "../persistence/migrations/311-create-subagents-table.js";
+import { migrateAddSubagentParentToolUseId } from "../persistence/migrations/354-add-subagent-parent-tool-use-id.js";
 import { resetTestTables } from "../persistence/raw-query.js";
 import {
   deleteSubagentRecord,
@@ -20,6 +22,7 @@ function record(over: Partial<SubagentRecord> = {}): SubagentRecord {
     role: "researcher",
     isFork: false,
     sendResultToUser: true,
+    parentToolUseId: null,
     status: "running",
     error: null,
     createdAt: 1000,
@@ -35,13 +38,19 @@ function record(over: Partial<SubagentRecord> = {}): SubagentRecord {
 beforeEach(() => {
   // Idempotent; the table may already exist from a prior run.
   migrateCreateSubagentsTable();
+  migrateAddSubagentParentToolUseId(getDb());
   resetTestTables("subagents");
 });
 
 describe("subagent-store", () => {
   test("round-trips a record, mapping booleans and nullable fields", () => {
     upsertSubagentRecord(
-      record({ isFork: true, sendResultToUser: null, error: null }),
+      record({
+        isFork: true,
+        sendResultToUser: null,
+        error: null,
+        parentToolUseId: "toolu-abc",
+      }),
     );
 
     const rows = loadAllSubagentRecords();
@@ -50,10 +59,17 @@ describe("subagent-store", () => {
       id: "s1",
       isFork: true,
       sendResultToUser: null,
+      parentToolUseId: "toolu-abc",
       role: "researcher",
       status: "running",
       inputTokens: 5,
     });
+  });
+
+  test("a spawn with no anchoring tool call stores a null parentToolUseId", () => {
+    upsertSubagentRecord(record({ parentToolUseId: null }));
+
+    expect(loadAllSubagentRecords()[0].parentToolUseId).toBeNull();
   });
 
   test("upsert refreshes mutable lifecycle fields on conflict", () => {
@@ -110,6 +126,29 @@ describe("SubagentManager.rehydrateFromDb", () => {
     expect(
       loadAllSubagentRecords().find((r) => r.id === "running-1")?.status,
     ).toBe("interrupted");
+
+    mgr.disposeAll();
+  });
+
+  test("restores the spawn tool-call anchor onto rehydrated config", () => {
+    upsertSubagentRecord(
+      record({ id: "anchored", label: "anchored", parentToolUseId: "toolu-1" }),
+    );
+    upsertSubagentRecord(
+      record({ id: "loose", label: "loose", parentToolUseId: null }),
+    );
+
+    const mgr = new SubagentManager();
+    mgr.rehydrateFromDb();
+
+    expect(mgr.getState("anchored")?.config.parentToolUseId).toBe("toolu-1");
+    expect(mgr.getState("loose")?.config.parentToolUseId).toBeUndefined();
+
+    // The anchor survives the interrupted re-persist a rehydrate performs.
+    expect(
+      loadAllSubagentRecords().find((r) => r.id === "anchored")
+        ?.parentToolUseId,
+    ).toBe("toolu-1");
 
     mgr.disposeAll();
   });

--- a/assistant/src/__tests__/subagent-reconcile-route.test.ts
+++ b/assistant/src/__tests__/subagent-reconcile-route.test.ts
@@ -6,7 +6,9 @@
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { getDb } from "../persistence/db-connection.js";
 import { migrateCreateSubagentsTable } from "../persistence/migrations/311-create-subagents-table.js";
+import { migrateAddSubagentParentToolUseId } from "../persistence/migrations/354-add-subagent-parent-tool-use-id.js";
 import { resetTestTables } from "../persistence/raw-query.js";
 import {
   type SubagentRecord,
@@ -27,6 +29,7 @@ function record(over: Partial<SubagentRecord> = {}): SubagentRecord {
     role: "researcher",
     isFork: false,
     sendResultToUser: true,
+    parentToolUseId: null,
     status: "running",
     error: null,
     createdAt: 1000,
@@ -53,6 +56,7 @@ function reconcile(parentConversationId: string) {
 
 beforeEach(() => {
   migrateCreateSubagentsTable();
+  migrateAddSubagentParentToolUseId(getDb());
   resetTestTables("subagents");
   getSubagentManager().disposeAll();
 });
@@ -93,18 +97,22 @@ describe("reconcileSubagents route", () => {
   });
 
   test("includes parentToolUseId only when the spawn recorded one", () => {
-    upsertSubagentRecord(record());
-    const manager = getSubagentManager();
-    manager.rehydrateFromDb();
-    expect(
-      reconcile(PARENT_ID).subagents["sub-1"].parentToolUseId,
-    ).toBeUndefined();
-
-    manager.getState("sub-1")!.config.parentToolUseId = "toolu-abc";
-
-    expect(reconcile(PARENT_ID).subagents["sub-1"].parentToolUseId).toBe(
-      "toolu-abc",
+    upsertSubagentRecord(record({ parentToolUseId: null }));
+    upsertSubagentRecord(
+      record({
+        id: "sub-anchored",
+        conversationId: "child-conv-anchored",
+        label: "anchored",
+        parentToolUseId: "toolu-abc",
+      }),
     );
+    getSubagentManager().rehydrateFromDb();
+
+    const { subagents } = reconcile(PARENT_ID);
+    expect(subagents["sub-1"].parentToolUseId).toBeUndefined();
+    // The anchor is persisted, so it survives the restart `rehydrateFromDb`
+    // models rather than silently dropping out of the response.
+    expect(subagents["sub-anchored"].parentToolUseId).toBe("toolu-abc");
   });
 
   test("returns an empty map for a parent with no known children", () => {

--- a/assistant/src/__tests__/subagent-reconcile-route.test.ts
+++ b/assistant/src/__tests__/subagent-reconcile-route.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the `subagents/reconcile` route handler — verifies that the
+ * per-child payload carries enough detail (child conversationId, label,
+ * objective, fork flag) for a client to rebuild its subagent list from
+ * scratch after a reload, not just refresh statuses of entries it already has.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { migrateCreateSubagentsTable } from "../persistence/migrations/311-create-subagents-table.js";
+import { resetTestTables } from "../persistence/raw-query.js";
+import {
+  type SubagentRecord,
+  upsertSubagentRecord,
+} from "../persistence/subagent-store.js";
+import { ROUTES } from "../runtime/routes/subagents-routes.js";
+import { getSubagentManager } from "../subagent/index.js";
+
+const PARENT_ID = "parent-reconcile-1";
+
+function record(over: Partial<SubagentRecord> = {}): SubagentRecord {
+  return {
+    id: "sub-1",
+    parentConversationId: PARENT_ID,
+    conversationId: "child-conv-1",
+    label: "research-pricing",
+    objective: "Research competitor pricing",
+    role: "researcher",
+    isFork: false,
+    sendResultToUser: true,
+    status: "running",
+    error: null,
+    createdAt: 1000,
+    startedAt: 1001,
+    completedAt: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    estimatedCost: 0,
+    ...over,
+  };
+}
+
+const reconcileRoute = ROUTES.find(
+  (r) => r.operationId === "reconcileSubagents",
+)!;
+
+function reconcile(parentConversationId: string) {
+  return reconcileRoute.handler({
+    queryParams: { parentConversationId },
+  } as Parameters<typeof reconcileRoute.handler>[0]) as {
+    subagents: Record<string, Record<string, unknown>>;
+  };
+}
+
+beforeEach(() => {
+  migrateCreateSubagentsTable();
+  resetTestTables("subagents");
+  getSubagentManager().disposeAll();
+});
+
+describe("reconcileSubagents route", () => {
+  test("returns status plus child conversation id, label and objective", () => {
+    upsertSubagentRecord(record());
+    upsertSubagentRecord(
+      record({
+        id: "sub-2",
+        conversationId: "child-conv-2",
+        label: "fork-review",
+        objective: "Review the diff",
+        isFork: true,
+        status: "completed",
+        completedAt: 2000,
+      }),
+    );
+    getSubagentManager().rehydrateFromDb();
+
+    const { subagents } = reconcile(PARENT_ID);
+
+    expect(Object.keys(subagents).sort()).toEqual(["sub-1", "sub-2"]);
+    expect(subagents["sub-1"]).toEqual({
+      // In-flight at rehydrate time → interrupted.
+      status: "interrupted",
+      conversationId: "child-conv-1",
+      label: "research-pricing",
+      objective: "Research competitor pricing",
+      isFork: false,
+    });
+    expect(subagents["sub-2"]).toMatchObject({
+      status: "completed",
+      conversationId: "child-conv-2",
+      label: "fork-review",
+      isFork: true,
+    });
+  });
+
+  test("includes parentToolUseId only when the spawn recorded one", () => {
+    upsertSubagentRecord(record());
+    const manager = getSubagentManager();
+    manager.rehydrateFromDb();
+    expect(
+      reconcile(PARENT_ID).subagents["sub-1"].parentToolUseId,
+    ).toBeUndefined();
+
+    manager.getState("sub-1")!.config.parentToolUseId = "toolu-abc";
+
+    expect(reconcile(PARENT_ID).subagents["sub-1"].parentToolUseId).toBe(
+      "toolu-abc",
+    );
+  });
+
+  test("returns an empty map for a parent with no known children", () => {
+    upsertSubagentRecord(record());
+    getSubagentManager().rehydrateFromDb();
+
+    expect(reconcile("some-other-parent").subagents).toEqual({});
+  });
+
+  test("rejects a request without parentConversationId", () => {
+    expect(() => reconcile("")).toThrow(
+      "parentConversationId query parameter is required",
+    );
+  });
+});

--- a/assistant/src/persistence/migrations/354-add-subagent-parent-tool-use-id.test.ts
+++ b/assistant/src/persistence/migrations/354-add-subagent-parent-tool-use-id.test.ts
@@ -1,0 +1,87 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateAddSubagentParentToolUseId } from "./354-add-subagent-parent-tool-use-id.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-354 shape: only the columns the migration and tests touch.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE subagents (
+      id TEXT PRIMARY KEY,
+      parent_conversation_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at INTEGER NOT NULL
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnInfo(sqlite: Database) {
+  return sqlite.query("PRAGMA table_info(subagents)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+function toolUseIdOf(sqlite: Database, id: string): unknown {
+  const row = sqlite
+    .query("SELECT parent_tool_use_id FROM subagents WHERE id = ?")
+    .get(id) as { parent_tool_use_id: unknown };
+  return row.parent_tool_use_id;
+}
+
+describe("migration 354: subagents.parent_tool_use_id", () => {
+  test("adds the nullable column", () => {
+    const { sqlite, db } = createTestDb();
+    expect(columnInfo(sqlite).map((c) => c.name)).not.toContain(
+      "parent_tool_use_id",
+    );
+
+    migrateAddSubagentParentToolUseId(db);
+
+    const column = columnInfo(sqlite).find(
+      (c) => c.name === "parent_tool_use_id",
+    );
+    expect(column).toBeDefined();
+    expect(column?.notnull).toBe(0);
+  });
+
+  test("rows written before the column existed read back null", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO subagents (id, parent_conversation_id, conversation_id, created_at)
+      VALUES ('sub-old', 'parent-1', 'conv-1', 1000)
+    `);
+
+    migrateAddSubagentParentToolUseId(db);
+
+    expect(toolUseIdOf(sqlite, "sub-old")).toBeNull();
+  });
+
+  test("round-trips an insert that sets the new column", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAddSubagentParentToolUseId(db);
+
+    sqlite.exec(/*sql*/ `
+      INSERT INTO subagents (id, parent_conversation_id, conversation_id, created_at, parent_tool_use_id)
+      VALUES ('sub-new', 'parent-1', 'conv-2', 2000, 'toolu-abc')
+    `);
+
+    expect(toolUseIdOf(sqlite, "sub-new")).toBe("toolu-abc");
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateAddSubagentParentToolUseId(db);
+    expect(() => migrateAddSubagentParentToolUseId(db)).not.toThrow();
+
+    const names = columnInfo(sqlite).map((c) => c.name);
+    expect(names.filter((n) => n === "parent_tool_use_id")).toHaveLength(1);
+  });
+});

--- a/assistant/src/persistence/migrations/354-add-subagent-parent-tool-use-id.ts
+++ b/assistant/src/persistence/migrations/354-add-subagent-parent-tool-use-id.ts
@@ -1,0 +1,30 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const COLUMN_NAME = "parent_tool_use_id";
+const COLUMN_DEFINITION = "parent_tool_use_id TEXT";
+
+/**
+ * Add `parent_tool_use_id` column to the `subagents` table (migration 311).
+ *
+ * The column is the nullable tool-use id of the `skill_execute` call that
+ * spawned the subagent. `SubagentManager` carries it on `SubagentConfig` so
+ * the `subagent_spawned` event and the reconcile/detail routes can anchor an
+ * inline subagent card to the exact spawn tool call. Persisting it keeps that
+ * anchor resolvable after `rehydrateFromDb()` rebuilds children from this
+ * table, so a client reloading after an assistant restart still lands the card
+ * on the right tool call.
+ *
+ * Nullable with no backfill: the id is only known at spawn time and rows
+ * written before this column existed have no surviving record of it, so they
+ * correctly stay NULL and the field is simply omitted from route responses.
+ *
+ * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
+ * TABLE` and the checkpoint write doesn't cause a duplicate-column error on
+ * the next boot.
+ */
+export function migrateAddSubagentParentToolUseId(database: DrizzleDb): void {
+  if (!tableHasColumn(database, "subagents", COLUMN_NAME)) {
+    database.run(`ALTER TABLE subagents ADD COLUMN ${COLUMN_DEFINITION}`);
+  }
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -461,6 +461,7 @@ import { migrateConversationsTotalInputTokensNullable } from "./migrations/350-c
 import { migrateScheduleSkillScriptHandoff } from "./migrations/351-schedule-skill-script-handoff.js";
 import { migrateDropScheduleSkillScriptHandoff } from "./migrations/352-drop-schedule-skill-script-handoff.js";
 import { migrateAddLlmUsageConversationType } from "./migrations/353-add-llm-usage-conversation-type.js";
+import { migrateAddSubagentParentToolUseId } from "./migrations/354-add-subagent-parent-tool-use-id.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1479,4 +1480,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateScheduleSkillScriptHandoff,
   migrateDropScheduleSkillScriptHandoff,
   migrateAddLlmUsageConversationType,
+  migrateAddSubagentParentToolUseId,
 ];

--- a/assistant/src/persistence/subagent-store.ts
+++ b/assistant/src/persistence/subagent-store.ts
@@ -20,6 +20,11 @@ export interface SubagentRecord {
   isFork: boolean;
   /** Tri-state: null when the spawner left it unset. */
   sendResultToUser: boolean | null;
+  /**
+   * Tool-use id of the call that spawned this subagent; null when the spawn
+   * had no anchoring tool call.
+   */
+  parentToolUseId: string | null;
   status: string;
   error: string | null;
   createdAt: number;
@@ -40,6 +45,7 @@ interface SubagentRow {
   role: string;
   is_fork: number;
   send_result_to_user: number | null;
+  parent_tool_use_id: string | null;
   status: string;
   error: string | null;
   created_at: number;
@@ -61,6 +67,7 @@ function rowToRecord(r: SubagentRow): SubagentRecord {
     isFork: r.is_fork === 1,
     sendResultToUser:
       r.send_result_to_user == null ? null : r.send_result_to_user === 1,
+    parentToolUseId: r.parent_tool_use_id,
     status: r.status,
     error: r.error,
     createdAt: r.created_at,
@@ -82,9 +89,10 @@ export function upsertSubagentRecord(rec: SubagentRecord): void {
     "subagent:upsertRecord",
     `INSERT INTO subagents (
        id, parent_conversation_id, conversation_id, label, objective, role,
-       is_fork, send_result_to_user, status, error, created_at, started_at,
-       completed_at, input_tokens, output_tokens, estimated_cost
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       is_fork, send_result_to_user, parent_tool_use_id, status, error,
+       created_at, started_at, completed_at, input_tokens, output_tokens,
+       estimated_cost
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(id) DO UPDATE SET
        status = excluded.status,
        error = excluded.error,
@@ -101,6 +109,7 @@ export function upsertSubagentRecord(rec: SubagentRecord): void {
     rec.role,
     rec.isFork ? 1 : 0,
     rec.sendResultToUser == null ? null : rec.sendResultToUser ? 1 : 0,
+    rec.parentToolUseId,
     rec.status,
     rec.error,
     rec.createdAt,

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -193,6 +193,16 @@ function getSubagentDetail(
 // Route definitions
 // ---------------------------------------------------------------------------
 
+/** Everything besides `status` is optional: older daemons omit it. */
+const ReconciledSubagentSchema = z.object({
+  status: z.string(),
+  conversationId: z.string().optional(),
+  label: z.string().optional(),
+  objective: z.string().optional(),
+  isFork: z.boolean().optional(),
+  parentToolUseId: z.string().optional(),
+});
+
 export const ROUTES: RouteDefinition[] = [
   {
     operationId: "reconcileSubagents",
@@ -204,7 +214,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Reconcile subagent live status",
     description:
-      "Returns the live in-memory status of all subagents known to the daemon for a given parent conversation. Subagents not in the response are orphaned.",
+      "Returns the live in-memory state of all subagents known to the daemon for a given parent conversation. Each entry carries enough detail (child conversation id, label, objective) for a client to rebuild its subagent list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. The descriptive fields are optional: older daemons return only `status`.",
     tags: ["subagents"],
     queryParams: [
       {
@@ -214,12 +224,7 @@ export const ROUTES: RouteDefinition[] = [
       },
     ],
     responseBody: z.object({
-      subagents: z.record(
-        z.string(),
-        z.object({
-          status: z.string(),
-        }),
-      ),
+      subagents: z.record(z.string(), ReconciledSubagentSchema),
     }),
     handler: ({ queryParams }) => {
       const parentConversationId = queryParams?.parentConversationId;
@@ -229,10 +234,19 @@ export const ROUTES: RouteDefinition[] = [
         );
       }
       const manager = getSubagentManager();
-      const children = manager.getChildrenOf(parentConversationId);
-      const subagents: Record<string, { status: string }> = {};
-      for (const child of children) {
-        subagents[child.config.id] = { status: child.status };
+      const subagents: Record<
+        string,
+        z.infer<typeof ReconciledSubagentSchema>
+      > = {};
+      for (const child of manager.getChildrenOf(parentConversationId)) {
+        subagents[child.config.id] = {
+          status: child.status,
+          conversationId: child.conversationId,
+          label: child.config.label,
+          objective: child.config.objective,
+          isFork: child.isFork,
+          parentToolUseId: child.config.parentToolUseId,
+        };
       }
       return { subagents };
     },

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -193,7 +193,7 @@ function getSubagentDetail(
 // Route definitions
 // ---------------------------------------------------------------------------
 
-/** Everything besides `status` is optional: older daemons omit it. */
+/** `status` is the only guaranteed key; every other field is optional. */
 const ReconciledSubagentSchema = z.object({
   status: z.string(),
   conversationId: z.string().optional(),
@@ -214,7 +214,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Reconcile subagent live status",
     description:
-      "Returns the live in-memory state of all subagents known to the daemon for a given parent conversation. Each entry carries enough detail (child conversation id, label, objective) for a client to rebuild its subagent list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. The descriptive fields are optional: older daemons return only `status`.",
+      "Returns the live in-memory state of all subagents known to the assistant for a given parent conversation. Each entry carries enough detail (child conversation id, label, objective) for a client to rebuild its subagent list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. Only `status` is guaranteed to be present; every other field is optional.",
     tags: ["subagents"],
     queryParams: [
       {
@@ -269,7 +269,7 @@ export const ROUTES: RouteDefinition[] = [
         schema: { type: "string" },
         description:
           "The subagent's own conversation ID. Fallback only — when the " +
-          "daemon knows the subagent (live or rehydrated), it resolves the " +
+          "assistant knows the subagent (live or rehydrated), it resolves the " +
           "conversation itself and this parameter is ignored.",
       },
     ],

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -1271,6 +1271,7 @@ export class SubagentManager {
         role: state.config.role ?? "general",
         isFork: state.isFork,
         sendResultToUser: state.config.sendResultToUser ?? null,
+        parentToolUseId: state.config.parentToolUseId ?? null,
         status: state.status,
         error: state.error ?? null,
         createdAt: state.createdAt,
@@ -1323,6 +1324,9 @@ export class SubagentManager {
           fork: rec.isFork,
           ...(rec.sendResultToUser != null
             ? { sendResultToUser: rec.sendResultToUser }
+            : {}),
+          ...(rec.parentToolUseId != null
+            ? { parentToolUseId: rec.parentToolUseId }
             : {}),
         },
         status,


### PR DESCRIPTION
## Summary
- Enrich the per-child reconcile payload with child conversationId, label, objective, isFork, parentToolUseId (all optional/additive)
- Lets the web client rebuild subagent store entries after a reload instead of only updating known ones

Part of plan: subagent-running-state-fixes.md (PR 2 of 5)