### PR TITLE
fix(web): don't reset subagent/workflow stores when switching to the already-active conversation

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { applyConversationSwitch } from "@/domains/chat/hooks/use-conversation-loader";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+import { routes } from "@/utils/routes";
+
+const NOW = 1700000000000;
+const ACTIVE_CONVERSATION_ID = "conv-active";
+
+function seedRunningState() {
+  useSubagentStore.getState().spawnSubagent({
+    subagentId: "sub-1",
+    label: "sub-1",
+    objective: "",
+    timestamp: NOW,
+    status: "running",
+  });
+  useWorkflowStore.getState().startRun({ runId: "run-1", timestamp: NOW });
+}
+
+function navigateSpy() {
+  const calls: string[] = [];
+  return { calls, navigate: (path: string) => void calls.push(path) };
+}
+
+beforeEach(() => {
+  useSubagentStore.getState().reset();
+  useWorkflowStore.getState().reset();
+  useConversationStore
+    .getState()
+    .setActiveConversationId(ACTIVE_CONVERSATION_ID);
+  useViewerStore.getState().setMainView("app");
+  seedRunningState();
+});
+
+describe("applyConversationSwitch", () => {
+  test("keeps live subagent/workflow state when re-selecting the active conversation", () => {
+    const { calls, navigate } = navigateSpy();
+
+    applyConversationSwitch(ACTIVE_CONVERSATION_ID, navigate);
+
+    expect(useSubagentStore.getState().byId["sub-1"]?.status).toBe("running");
+    expect(useWorkflowStore.getState().byId["run-1"]).toBeDefined();
+    expect(calls).toEqual([]);
+    // Side panels still close on a re-click.
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+
+  test("resets both stores and navigates on a genuine conversation change", () => {
+    const { calls, navigate } = navigateSpy();
+
+    applyConversationSwitch("conv-other", navigate);
+
+    expect(useSubagentStore.getState().byId["sub-1"]).toBeUndefined();
+    expect(useWorkflowStore.getState().byId["run-1"]).toBeUndefined();
+    expect(calls).toEqual([routes.conversation("conv-other")]);
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -71,6 +71,32 @@ interface UseConversationLoaderParams {
 }
 
 // ---------------------------------------------------------------------------
+// switchConversation side effects
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies the store + navigation side effects of selecting a conversation.
+ *
+ * Resetting the subagent/workflow stores discards live run state, so it only
+ * runs on a genuine conversation change — re-selecting the conversation
+ * already on screen just closes any open side panel.
+ */
+export function applyConversationSwitch(
+  key: string,
+  navigate: (path: string) => void | Promise<unknown>,
+): void {
+  const isSameConversation =
+    key === useConversationStore.getState().activeConversationId;
+  if (!isSameConversation) {
+    useSubagentStore.getState().reset();
+    useWorkflowStore.getState().reset();
+  }
+  useViewerStore.getState().setMainView("chat");
+  if (isSameConversation) return;
+  void navigate(routes.conversation(key));
+}
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
@@ -380,13 +406,7 @@ export function useConversationLoader({
   // switchConversation
   // -------------------------------------------------------------------------
   const switchConversation = useCallback(
-    (key: string) => {
-      useSubagentStore.getState().reset();
-      useWorkflowStore.getState().reset();
-      useViewerStore.getState().setMainView("chat");
-      if (key === useConversationStore.getState().activeConversationId) return;
-      void navigate(routes.conversation(key));
-    },
+    (key: string) => applyConversationSwitch(key, navigate),
     [navigate],
   );
 


### PR DESCRIPTION
## Summary
- switchConversation resets the subagent/workflow stores only on a genuine conversation change
- Re-clicking the active conversation keeps live subagent/workflow cards intact (was one of the store-wipe triggers behind the subagents-look-dead bug)

Part of plan: subagent-running-state-fixes.md (PR 4 of 5)