### PR TITLE
fix(assistant): durable-record fallback + resolved conversationId in subagent detail, with route tests

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29335,8 +29335,8 @@ paths:
           schema:
             type: string
           description:
-            The subagent's own conversation ID. Fallback only — when the daemon knows the subagent (live or
-            rehydrated), it resolves the conversation itself and this parameter is ignored.
+            The subagent's own conversation ID. Fallback only — when the daemon knows the subagent (live, rehydrated,
+            or in its durable records), it resolves the conversation itself and this parameter is ignored.
       responses:
         "200":
           description: Successful response
@@ -29402,6 +29402,8 @@ paths:
                   label:
                     type: string
                   parentToolUseId:
+                    type: string
+                  conversationId:
                     type: string
                 required:
                   - subagentId

--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -48,7 +48,7 @@ mock.module("../subagent/index.js", () => ({
 /** Subagents that survive only in durable records, keyed by subagent id. */
 const durableRecords = new Map<
   string,
-  { conversationId: string; label: string }
+  { conversationId: string; label: string; status: string }
 >();
 
 mock.module("../persistence/subagent-store.js", () => ({
@@ -292,14 +292,54 @@ describe("getSubagentDetail route resolution", () => {
     durableRecords.set("sub-evicted", {
       conversationId: "evicted-child-conv",
       label: "Recorded label",
+      status: "completed",
     });
 
     const result = fetchDetail("sub-evicted", "parent-conv");
 
     expect(result.events.map((e) => e.content)).toContain("evicted transcript");
-    expect(result.status).toBeUndefined();
+    expect(result.status).toBe("completed");
     expect(result.label).toBe("Recorded label");
     expect(result.conversationId).toBe("evicted-child-conv");
+  });
+
+  test("serves the row the TTL sweep left behind, terminal status included", () => {
+    // The sweep frees in-memory metadata (`dispose(id, { keepRecord: true })`)
+    // but keeps the durable row, so the manager no longer knows this subagent
+    // while the record still answers for it.
+    seedConversation("swept-child-conv", "swept transcript");
+    durableRecords.set("sub-swept", {
+      conversationId: "swept-child-conv",
+      label: "Swept label",
+      status: "aborted",
+    });
+
+    // Client recovering from a missed spawn only knows the PARENT id.
+    const result = fetchDetail("sub-swept", "parent-conv");
+
+    expect(result.events.map((e) => e.content)).toContain("swept transcript");
+    expect(result.conversationId).toBe("swept-child-conv");
+    expect(result.label).toBe("Swept label");
+    // Without this the client keeps its stub marked running forever.
+    expect(result.status).toBe("aborted");
+  });
+
+  test("omits status when the durable record holds an out-of-enum value", () => {
+    seedConversation("odd-child-conv", "odd transcript");
+    durableRecords.set("sub-odd", {
+      conversationId: "odd-child-conv",
+      label: "Odd label",
+      status: "zombie",
+    });
+
+    const result = fetchDetail("sub-odd", "parent-conv");
+
+    // The row still resolves conversation and label; only the unparseable
+    // status is dropped, so the closed response enum stays honest.
+    expect(result.events.map((e) => e.content)).toContain("odd transcript");
+    expect(result.conversationId).toBe("odd-child-conv");
+    expect(result.label).toBe("Odd label");
+    expect(result.status).toBeUndefined();
   });
 
   test("uses the query param when the daemon knows nothing about the subagent", () => {

--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -1,12 +1,66 @@
 /**
  * Tests for parseSubagentMessages — verifies that tool result content is
- * correctly extracted from both string and array formats.
+ * correctly extracted from both string and array formats — and for the
+ * getSubagentDetail route handler's server-side resolution of the subagent's
+ * own conversation id.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be registered before importing the module under test
+// ---------------------------------------------------------------------------
+
+/** conversationId → messages, so a wrong id yields a visibly wrong transcript. */
+const conversations = new Map<string, MessageRow[]>();
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  getMessages: (conversationId: string) =>
+    conversations.get(conversationId) ?? [],
+}));
+
+const usageByConversation = new Map<
+  string,
+  { inputTokens: number; outputTokens: number; estimatedCost: number }
+>();
+
+mock.module("../persistence/llm-usage-store.js", () => ({
+  getConversationUsageTotals: (conversationId: string) =>
+    usageByConversation.get(conversationId) ?? {
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+    },
+}));
+
+/** Subagents the live manager still holds, keyed by subagent id. */
+const liveSubagents = new Map<
+  string,
+  { conversationId: string; status: string; config: { label: string } }
+>();
+
+mock.module("../subagent/index.js", () => ({
+  getSubagentManager: () => ({
+    getState: (id: string) => liveSubagents.get(id),
+  }),
+}));
+
+/** Subagents that survive only in durable records, keyed by subagent id. */
+const durableRecords = new Map<
+  string,
+  { conversationId: string; label: string }
+>();
+
+mock.module("../persistence/subagent-store.js", () => ({
+  getSubagentRecordById: (id: string) => durableRecords.get(id),
+}));
 
 import type { MessageRow } from "../persistence/conversation-crud.js";
-import { parseSubagentMessages } from "../runtime/routes/subagents-routes.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
+import {
+  parseSubagentMessages,
+  ROUTES,
+} from "../runtime/routes/subagents-routes.js";
 
 let msgCounter = 0;
 function msg(role: string, content: unknown[]): MessageRow {
@@ -168,5 +222,97 @@ describe("parseSubagentMessages", () => {
     const textEvent = result.events.find((e) => e.type === "text");
     expect(textEvent).toBeDefined();
     expect(textEvent!.messageId).toBe(messages[1].id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSubagentDetail route — server-side conversation resolution
+// ---------------------------------------------------------------------------
+
+const detailRoute = ROUTES.find((r) => r.operationId === "getSubagentDetail")!;
+
+interface DetailResponse {
+  events: Array<{ type: string; content: string }>;
+  usage?: { inputTokens: number; outputTokens: number; estimatedCost: number };
+  status?: string;
+  label?: string;
+  conversationId?: string;
+}
+
+function fetchDetail(id: string, conversationId?: string): DetailResponse {
+  return detailRoute.handler({
+    pathParams: { id },
+    queryParams: conversationId ? { conversationId } : {},
+  }) as DetailResponse;
+}
+
+function seedConversation(conversationId: string, text: string): void {
+  conversations.set(conversationId, [
+    msg("user", [{ type: "text", text: `objective for ${conversationId}` }]),
+    msg("assistant", [{ type: "text", text }]),
+  ]);
+}
+
+describe("getSubagentDetail route resolution", () => {
+  test("ignores a wrong conversationId param when the manager knows the subagent", () => {
+    seedConversation("parent-conv", "parent transcript");
+    seedConversation("child-conv", "child transcript");
+    usageByConversation.set("parent-conv", {
+      inputTokens: 999,
+      outputTokens: 999,
+      estimatedCost: 9.99,
+    });
+    usageByConversation.set("child-conv", {
+      inputTokens: 12,
+      outputTokens: 34,
+      estimatedCost: 0.5,
+    });
+    liveSubagents.set("sub-live", {
+      conversationId: "child-conv",
+      status: "running",
+      config: { label: "Live label" },
+    });
+
+    // The client sends the PARENT id — server-side resolution must win.
+    const result = fetchDetail("sub-live", "parent-conv");
+
+    expect(result.events.map((e) => e.content)).toContain("child transcript");
+    expect(result.usage).toEqual({
+      inputTokens: 12,
+      outputTokens: 34,
+      estimatedCost: 0.5,
+    });
+    expect(result.status).toBe("running");
+    expect(result.label).toBe("Live label");
+    expect(result.conversationId).toBe("child-conv");
+  });
+
+  test("falls back to the durable record when the manager has evicted the subagent", () => {
+    seedConversation("evicted-child-conv", "evicted transcript");
+    durableRecords.set("sub-evicted", {
+      conversationId: "evicted-child-conv",
+      label: "Recorded label",
+    });
+
+    const result = fetchDetail("sub-evicted", "parent-conv");
+
+    expect(result.events.map((e) => e.content)).toContain("evicted transcript");
+    expect(result.status).toBeUndefined();
+    expect(result.label).toBe("Recorded label");
+    expect(result.conversationId).toBe("evicted-child-conv");
+  });
+
+  test("uses the query param when the daemon knows nothing about the subagent", () => {
+    seedConversation("orphan-conv", "orphan transcript");
+
+    const result = fetchDetail("sub-orphan", "orphan-conv");
+
+    expect(result.events.map((e) => e.content)).toContain("orphan transcript");
+    expect(result.label).toBeUndefined();
+    expect(result.conversationId).toBe("orphan-conv");
+  });
+
+  test("throws BadRequestError when no conversation can be resolved", () => {
+    expect(() => fetchDetail("sub-unknown")).toThrow(BadRequestError);
   });
 });

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantEvent } from "../api/index.js";
+import { migrateCreateSubagentsTable } from "../persistence/migrations/311-create-subagents-table.js";
+import { resetTestTables } from "../persistence/raw-query.js";
+import {
+  getSubagentRecordById,
+  type SubagentRecord,
+  upsertSubagentRecord,
+} from "../persistence/subagent-store.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
 
@@ -355,6 +362,99 @@ describe("SubagentManager terminal disposal", () => {
     expect(state.status).toBe("completed");
 
     asInternals(manager).stopSweep();
+  });
+});
+
+describe("durable record lifetime across disposal paths", () => {
+  beforeEach(() => {
+    // Idempotent; the table may already exist from a prior run.
+    migrateCreateSubagentsTable();
+    resetTestTables("subagents");
+  });
+
+  function seedRecord(id: string): void {
+    const rec: SubagentRecord = {
+      id,
+      parentConversationId: "parent-sess-1",
+      conversationId: "conv-sub-1",
+      label: "Test subagent",
+      objective: "Do something",
+      role: "generalist",
+      isFork: false,
+      sendResultToUser: null,
+      status: "completed",
+      error: null,
+      createdAt: 1000,
+      startedAt: 1001,
+      completedAt: 2000,
+      inputTokens: 5,
+      outputTokens: 7,
+      estimatedCost: 0.01,
+    };
+    upsertSubagentRecord(rec);
+  }
+
+  test("TTL sweep frees in-memory metadata but keeps the durable row", () => {
+    const manager = new SubagentManager();
+    seedRecord("sub-swept");
+    injectFakeSubagent(
+      manager,
+      "sub-swept",
+      makeState("sub-swept", { status: "completed" }),
+      undefined,
+      null, // conversation already released
+    );
+    asInternals(manager).subagents.get("sub-swept")!.retainedUntil =
+      Date.now() - 1000; // expired
+
+    asInternals(manager).sweepTerminal();
+
+    // Metadata is gone…
+    expect(manager.getState("sub-swept")).toBeUndefined();
+    // …but the row survives, so getSubagentDetail can still resolve the child
+    // conversation for a client that missed `subagent_spawned`.
+    expect(getSubagentRecordById("sub-swept")?.conversationId).toBe(
+      "conv-sub-1",
+    );
+
+    asInternals(manager).stopSweep();
+  });
+
+  test("disposeAllForParent deletes the durable row", () => {
+    const manager = new SubagentManager();
+    seedRecord("sub-parent-gone");
+    injectFakeSubagent(
+      manager,
+      "sub-parent-gone",
+      makeState("sub-parent-gone", { status: "completed" }),
+      undefined,
+      null,
+    );
+
+    // The parent conversation's data is going away — the child goes with it.
+    manager.disposeAllForParent("parent-sess-1");
+
+    expect(manager.getState("sub-parent-gone")).toBeUndefined();
+    expect(getSubagentRecordById("sub-parent-gone")).toBeUndefined();
+
+    asInternals(manager).stopSweep();
+  });
+
+  test("shutdown disposal keeps the row for rehydration", () => {
+    const manager = new SubagentManager();
+    seedRecord("sub-shutdown");
+    injectFakeSubagent(
+      manager,
+      "sub-shutdown",
+      makeState("sub-shutdown", { status: "running" }),
+      undefined,
+      null,
+    );
+
+    manager.disposeAll();
+
+    expect(manager.getState("sub-shutdown")).toBeUndefined();
+    expect(getSubagentRecordById("sub-shutdown")).toBeDefined();
   });
 });
 

--- a/assistant/src/api/responses/subagent-detail.ts
+++ b/assistant/src/api/responses/subagent-detail.ts
@@ -59,10 +59,10 @@ export const SubagentDetailResponseSchema = z.object({
   usage: SubagentUsageStatsSchema.optional(),
   events: z.array(SubagentDetailEventSchema),
   /**
-   * The subagent's task label, from the live manager state. Lets a client
-   * that missed the `subagent_spawned` event (SSE gap, store reset, page
-   * reload mid-run) recover the display name it would otherwise only learn
-   * at spawn time.
+   * The subagent's task label, from the live manager state or, once that is
+   * gone, the durable record. Lets a client that missed the
+   * `subagent_spawned` event (SSE gap, store reset, page reload mid-run)
+   * recover the display name it would otherwise only learn at spawn time.
    */
   label: z.string().optional(),
   /**
@@ -71,6 +71,12 @@ export const SubagentDetailResponseSchema = z.object({
    * spawn tool call (same role as the field on `subagent_spawned`).
    */
   parentToolUseId: z.string().optional(),
+  /**
+   * The resolved child conversation id, so a client recovering from a missed
+   * spawn can learn it — the id the daemon actually read the transcript from,
+   * which may differ from the `conversationId` the caller passed.
+   */
+  conversationId: z.string().optional(),
 });
 
 export type SubagentDetailResponse = z.infer<

--- a/assistant/src/persistence/subagent-store.ts
+++ b/assistant/src/persistence/subagent-store.ts
@@ -137,6 +137,20 @@ export function getSubagentRecordByConversationId(
   return row ? rowToRecord(row) : undefined;
 }
 
+/**
+ * Look up a subagent record by its own id. This is the durable fallback for
+ * subagents the live SubagentManager no longer holds — evicted by the TTL sweep
+ * or not yet rehydrated after a restart.
+ */
+export function getSubagentRecordById(id: string): SubagentRecord | undefined {
+  const row = rawGet<SubagentRow>(
+    "subagent:getById",
+    `SELECT * FROM subagents WHERE id = ?`,
+    id,
+  );
+  return row ? rowToRecord(row) : undefined;
+}
+
 /** Delete a subagent record once the manager is fully done with it. */
 export function deleteSubagentRecord(id: string): void {
   rawRun("subagent:deleteRecord", `DELETE FROM subagents WHERE id = ?`, id);

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -13,6 +13,7 @@ import {
   type MessageRow,
 } from "../../persistence/conversation-crud.js";
 import { getConversationUsageTotals } from "../../persistence/llm-usage-store.js";
+import { getSubagentRecordById } from "../../persistence/subagent-store.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -164,22 +165,13 @@ function getSubagentDetail(
   conversationId: string,
 ): SubagentDetailResult {
   const messages = getMessages(conversationId);
-  log.info(
-    {
-      subagentId,
-      conversationId,
-      messageCount: messages.length,
-      roles: messages.map((m) => m.role),
-    },
+  log.debug(
+    { subagentId, conversationId, messageCount: messages.length },
     "getSubagentDetail: raw messages from DB",
   );
   const result = parseSubagentMessages(subagentId, messages);
-  log.info(
-    {
-      subagentId,
-      eventCount: result.events.length,
-      eventTypes: result.events.map((e) => `${e.type}:${e.toolName ?? ""}`),
-    },
+  log.debug(
+    { subagentId, eventCount: result.events.length },
     "getSubagentDetail: parsed events",
   );
   const usage = getConversationUsageTotals(conversationId);
@@ -255,29 +247,36 @@ export const ROUTES: RouteDefinition[] = [
         schema: { type: "string" },
         description:
           "The subagent's own conversation ID. Fallback only — when the " +
-          "daemon knows the subagent (live or rehydrated), it resolves the " +
-          "conversation itself and this parameter is ignored.",
+          "daemon knows the subagent (live, rehydrated, or in its durable " +
+          "records), it resolves the conversation itself and this parameter " +
+          "is ignored.",
       },
     ],
     responseBody: SubagentDetailResponseSchema,
     handler: ({ pathParams, queryParams }) => {
       const manager = getSubagentManager();
       const state = manager.getState(pathParams!.id);
+      // Durable records outlive manager state (TTL eviction, daemon restart),
+      // so they answer for both the conversation and the label once it's gone.
+      const record = state ? undefined : getSubagentRecordById(pathParams!.id);
 
-      // Prefer the authoritative child-conversation id from manager state.
+      // Prefer the authoritative child-conversation id the daemon holds.
       // Clients recovering from a missed `subagent_spawned` only know the
       // PARENT conversation id (that's what `subagent_event` carries), so a
       // caller-supplied id may point at the wrong conversation entirely.
       const conversationId =
-        state?.conversationId ?? queryParams?.conversationId;
+        state?.conversationId ??
+        record?.conversationId ??
+        queryParams?.conversationId;
       if (!conversationId) {
         throw new BadRequestError("conversationId query parameter is required");
       }
 
       return {
         ...getSubagentDetail(pathParams!.id, conversationId),
+        conversationId,
         status: state?.status,
-        label: state?.config.label,
+        label: state?.config.label ?? record?.label,
         parentToolUseId: state?.config.parentToolUseId,
       };
     },

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -7,6 +7,7 @@
  */
 import { z } from "zod";
 
+import { SubagentStatusSchema } from "../../api/events/subagent-status-changed.js";
 import { SubagentDetailResponseSchema } from "../../api/responses/subagent-detail.js";
 import {
   getMessages,
@@ -256,9 +257,17 @@ export const ROUTES: RouteDefinition[] = [
     handler: ({ pathParams, queryParams }) => {
       const manager = getSubagentManager();
       const state = manager.getState(pathParams!.id);
-      // Durable records outlive manager state (TTL eviction, daemon restart),
-      // so they answer for both the conversation and the label once it's gone.
+      // Durable rows outlive manager state — the TTL sweep evicts in-memory
+      // metadata but keeps the row, and after a restart the row answers until
+      // `rehydrateFromDb()` runs — so they supply the conversation, label and
+      // status once the live state is gone.
       const record = state ? undefined : getSubagentRecordById(pathParams!.id);
+      // `SubagentRecord.status` is an untyped column; the response contract is
+      // the closed `SubagentStatusSchema` enum. Drop anything that doesn't
+      // parse rather than widening the wire type.
+      const recordStatus = record
+        ? SubagentStatusSchema.safeParse(record.status)
+        : undefined;
 
       // Prefer the authoritative child-conversation id the daemon holds.
       // Clients recovering from a missed `subagent_spawned` only know the
@@ -275,7 +284,9 @@ export const ROUTES: RouteDefinition[] = [
       return {
         ...getSubagentDetail(pathParams!.id, conversationId),
         conversationId,
-        status: state?.status,
+        status:
+          state?.status ??
+          (recordStatus?.success ? recordStatus.data : undefined),
         label: state?.config.label ?? record?.label,
         parentToolUseId: state?.config.parentToolUseId,
       };

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -1187,8 +1187,16 @@ export class SubagentManager {
    * Dispose a subagent and remove it from tracking.
    * Should be called after the subagent reaches a terminal state
    * and its data is no longer needed.
+   *
+   * Durable-row invariant: a subagent's row in the `subagents` table lives as
+   * long as its parent conversation. Only disposals that mean "the parent's
+   * data is going away" (`disposeAllForParent` / `disposeAllForAllParents`)
+   * delete it. The TTL sweep passes `keepRecord` so it frees in-memory
+   * metadata only, leaving the row to answer `getSubagentDetail` for a client
+   * that missed the spawn event; shutdown likewise keeps rows (`shuttingDown`)
+   * so an in-flight subagent can rehydrate as `interrupted` on the next boot.
    */
-  dispose(subagentId: string): void {
+  dispose(subagentId: string, opts?: { keepRecord?: boolean }): void {
     const managed = this.subagents.get(subagentId);
     if (!managed) {
       return;
@@ -1211,10 +1219,10 @@ export class SubagentManager {
     }
     this.subagents.delete(subagentId);
 
-    // Drop the durable record too — but only during normal operation. On
-    // shutdown we keep rows so a subagent that was in flight can rehydrate as
-    // `interrupted` on the next boot.
-    if (!this.shuttingDown) {
+    // Drop the durable record only when the caller owns its lifetime — the
+    // parent conversation is going away. The TTL sweep (`keepRecord`) and
+    // shutdown both evict in-memory metadata while leaving the row.
+    if (!this.shuttingDown && !opts?.keepRecord) {
       try {
         deleteSubagentRecord(subagentId);
       } catch (err) {
@@ -1418,7 +1426,9 @@ export class SubagentManager {
         { subagentId: id },
         "Sweeping expired terminal subagent metadata",
       );
-      this.dispose(id);
+      // Metadata only — the durable row outlives the sweep so a client that
+      // missed `subagent_spawned` can still resolve the child conversation.
+      this.dispose(id, { keepRecord: true });
     }
     // Stop the timer if there are no more entries to sweep.
     const hasTerminal = [...this.subagents.values()].some(


### PR DESCRIPTION
## Summary

Builds on #39355, which taught `getSubagentDetail` to resolve the subagent's own conversation id from live manager state instead of trusting the caller's query param. This PR implements the hardening and coverage that PR explicitly deferred ("no daemon unit test for the route tweak").

- **Durable-record fallback.** New `getSubagentRecordById()` in `persistence/subagent-store.ts` slots into the middle of the resolution chain: `manager state → durable record → query param`. Detail now survives manager TTL eviction and daemon restarts, not just the live window. The record is looked up only when manager state is gone (at most one query).
- **`label` falls back to the record.** When manager state is gone but the durable row survives, the response still carries the subagent's display name instead of dropping to `undefined`.
- **Response carries the resolved `conversationId`.** Additive optional field on the non-strict `SubagentDetailResponseSchema` — a client recovering from a missed `subagent_spawned` only knows the PARENT id, and this tells it the child id the daemon actually read from.
- **Log noise.** The two per-fetch logs in the `getSubagentDetail()` helper drop from `log.info` to `log.debug` and shed their per-message `roles` / per-event `eventTypes` arrays (`messageCount` / `eventCount` kept).
- **Route tests.** New `getSubagentDetail route resolution` block in `src/__tests__/subagent-detail.test.ts` covers all four resolution outcomes: wrong (parent) `conversationId` param on a live subagent yields the child transcript + child usage + live status + label; manager-evicted subagent resolves via the durable record and returns the record's label; unknown-to-daemon subagent falls back to the param; nothing resolvable throws `BadRequestError`. The resolved `conversationId` is asserted in every resolvable case.

`openapi.yaml` regenerated on top of the base's copy.

## Test plan
- `cd assistant && bun test src/__tests__/subagent-detail.test.ts` — 11 pass
- `bun test src/__tests__/subagent-persistence.test.ts`, `bun test src/__tests__/conversation-history-web-search.test.ts` — green
- `bun run typecheck`, `bun run lint`, prettier — clean

Part of plan: subagent-running-state-fixes.md (PR 3 of 5)