### PR TITLE
fix(web): split subagent entry conversation ids — child for detail, parent for overlay scoping

### DIFF
--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
@@ -5,6 +5,7 @@ import { reconcileSubagentStoreFromNotifications } from "@/domains/chat/hooks/re
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 
 const NOW = 1700000000000;
+const PARENT = "conv-parent";
 
 function store() {
   return useSubagentStore.getState();
@@ -32,6 +33,7 @@ describe("reconcileSubagentStoreFromNotifications", () => {
     reconcileSubagentStoreFromNotifications(
       store(),
       [{ subagentId: "done", label: "done", status: "completed" }],
+      PARENT,
       NOW,
     );
     expect(store().byId["live"]?.status).toBe("running"); // live preserved
@@ -43,6 +45,7 @@ describe("reconcileSubagentStoreFromNotifications", () => {
     reconcileSubagentStoreFromNotifications(
       store(),
       [{ subagentId: "new", label: "new", status: "completed" }],
+      PARENT,
       NOW,
     );
     expect(store().byId["old"]).toBeUndefined(); // reset cleared it
@@ -61,10 +64,75 @@ describe("reconcileSubagentStoreFromNotifications", () => {
           conversationId: "conv-x",
         },
       ],
+      PARENT,
       NOW,
     );
     expect(store().byId["sub"]).toBeDefined();
     expect(store().byId["sub"]?.status).toBe("completed");
     expect(store().byId["sub"]?.conversationId).toBe("conv-x");
+  });
+
+  test("stamps the child id from the notification and the parent id from the arg on a fresh spawn", () => {
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [
+        {
+          subagentId: "fresh",
+          label: "fresh",
+          status: "running",
+          conversationId: "conv-child",
+        },
+      ],
+      PARENT,
+      NOW,
+    );
+
+    const entry = store().byId["fresh"]!;
+    expect(entry.conversationId).toBe("conv-child");
+    expect(entry.parentConversationId).toBe(PARENT);
+  });
+
+  test("stamps the parent id on a live entry via the merge path", () => {
+    spawn("sub", "running");
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [{ subagentId: "sub", label: "sub", status: "running" }],
+      PARENT,
+      NOW,
+    );
+
+    expect(store().byId["sub"]?.parentConversationId).toBe(PARENT);
+  });
+
+  test("an out-of-enum status leaves a live entry's status alone", () => {
+    spawn("sub", "running");
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [
+        {
+          subagentId: "sub",
+          label: "sub",
+          status: "bogus",
+          conversationId: "conv-child",
+        },
+      ],
+      PARENT,
+      NOW,
+    );
+
+    expect(store().byId["sub"]?.status).toBe("running");
+    expect(store().byId["sub"]?.conversationId).toBe("conv-child");
+    expect(store().byId["sub"]?.parentConversationId).toBe(PARENT);
+  });
+
+  test("an out-of-enum status falls back to completed on a fresh spawn", () => {
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [{ subagentId: "hist", label: "hist", status: "bogus" }],
+      PARENT,
+      NOW,
+    );
+
+    expect(store().byId["hist"]?.status).toBe("completed");
   });
 });

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
@@ -1,11 +1,16 @@
-import type { SubagentStatus } from "@vellumai/assistant-api";
+import { SubagentStatusSchema } from "@vellumai/assistant-api";
 
 import type { SubagentStore } from "@/domains/chat/subagent-store";
 import { isActiveStatus } from "@/utils/subagent-status";
 
 type SubagentStoreSlice = Pick<
   SubagentStore,
-  "byId" | "reset" | "spawnSubagent" | "changeStatus" | "setConversationId"
+  | "byId"
+  | "reset"
+  | "spawnSubagent"
+  | "changeStatus"
+  | "setConversationId"
+  | "setParentConversationId"
 >;
 
 export interface SubagentNotificationLike {
@@ -28,10 +33,15 @@ export interface SubagentNotificationLike {
  * subagent is in flight we merge instead: upsert notified subagents and apply a
  * terminal status to a live entry that just finished, without discarding its
  * streamed events.
+ *
+ * `parentConversationId` is the conversation being hydrated — it scopes the
+ * Active-Subagents overlay. A notification's own `conversationId` is the
+ * subagent's (child) conversation, used only for detail fetch.
  */
 export function reconcileSubagentStoreFromNotifications(
   store: SubagentStoreSlice,
   notifications: Iterable<SubagentNotificationLike>,
+  parentConversationId: string,
   now: number,
 ): void {
   const priorById = store.byId;
@@ -42,20 +52,28 @@ export function reconcileSubagentStoreFromNotifications(
   if (!hasInFlight) store.reset();
 
   for (const n of notifications) {
-    const status = (n.status as SubagentStatus) || "completed";
+    const parsed = SubagentStatusSchema.safeParse(n.status);
     if (hasInFlight && priorById[n.subagentId]) {
-      store.changeStatus({ subagentId: n.subagentId, status });
+      // An unparseable status carries no information about a live entry —
+      // keep whatever the stream told us rather than flipping it terminal.
+      if (parsed.success) {
+        store.changeStatus({ subagentId: n.subagentId, status: parsed.data });
+      }
       if (n.conversationId) {
         store.setConversationId(n.subagentId, n.conversationId);
       }
+      store.setParentConversationId(n.subagentId, parentConversationId);
     } else {
       store.spawnSubagent({
         subagentId: n.subagentId,
         label: n.label,
         objective: "",
-        status,
+        // A notification for an unknown subagent with no parseable status is
+        // historical, so a terminal default is the safe read.
+        status: parsed.success ? parsed.data : "completed",
         error: n.error,
         conversationId: n.conversationId,
+        parentConversationId,
         timestamp: now,
         parentMessageId: n.parentMessageId,
       });

--- a/clients/web/src/domains/chat/hooks/use-active-subagent-ids.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-subagent-ids.test.ts
@@ -88,10 +88,11 @@ describe("useActiveSubagentIds", () => {
 });
 
 describe("useActiveSubagentIds — conversation scoping", () => {
+  /** Seed an entry scoped to `parentConversationId` (the viewed conversation). */
   function seedIn(
     subagentId: string,
     status: SubagentStatus,
-    conversationId?: string,
+    parentConversationId?: string,
   ) {
     const store = useSubagentStore.getState();
     store.spawnSubagent({
@@ -101,7 +102,9 @@ describe("useActiveSubagentIds — conversation scoping", () => {
       timestamp: Date.now(),
     });
     store.changeStatus({ subagentId, status });
-    if (conversationId) store.setConversationId(subagentId, conversationId);
+    if (parentConversationId) {
+      store.setParentConversationId(subagentId, parentConversationId);
+    }
   }
 
   test("excludes an active subagent from a different conversation", () => {
@@ -117,7 +120,7 @@ describe("useActiveSubagentIds — conversation scoping", () => {
 
   test("keeps a subagent whose conversation isn't known yet (set post-spawn)", () => {
     act(() => {
-      seedIn("unknown", "running"); // conversationId not assigned yet
+      seedIn("unknown", "running"); // parentConversationId not assigned yet
       seedIn("elsewhere", "running", "conv-2");
     });
 
@@ -126,5 +129,25 @@ describe("useActiveSubagentIds — conversation scoping", () => {
     // The unknown-conversation entry stays visible; the one known to belong to
     // another conversation is filtered out.
     expect(result.current).toEqual(["unknown"]);
+  });
+
+  test("keeps an entry whose child conversationId differs from the active one", () => {
+    // A subagent's own conversation id never equals the viewed conversation, so
+    // scoping on it would hide every entry rebuilt from history.
+    act(() => {
+      useSubagentStore.getState().spawnSubagent({
+        subagentId: "rebuilt",
+        label: "rebuilt",
+        objective: "",
+        status: "running",
+        conversationId: "conv-child",
+        parentConversationId: "conv-1",
+        timestamp: Date.now(),
+      });
+    });
+
+    const { result } = renderHook(() => useActiveSubagentIds("conv-1"));
+
+    expect(result.current).toEqual(["rebuilt"]);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-active-subagent-ids.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-subagent-ids.ts
@@ -6,10 +6,12 @@ import { isActiveStatus } from "@/utils/subagent-status";
 /**
  * Active (running | pending | awaiting_input) subagent ids for `conversationId`,
  * in stable `orderedIds` order. The store is global (all conversations'
- * subagents), so the results are scoped by the subagent's `conversationId` to
- * keep one spawned in another conversation from surfacing here. `conversationId`
- * is assigned after spawn (via `subagent_event`), so an entry that hasn't
- * received it yet is unknown and stays visible rather than disappearing.
+ * subagents), so the results are scoped by the entry's `parentConversationId` —
+ * the conversation whose turn spawned it, assigned at spawn or hydration — to
+ * keep one spawned in another conversation from surfacing here. (The entry's
+ * own `conversationId` is the subagent's child conversation, used only for
+ * detail fetch; it never equals the viewed conversation.) An entry without a
+ * parent id yet is unknown and stays visible rather than disappearing.
  *
  * `useShallow` keeps the returned array reference stable across unrelated store
  * ticks (e.g. token-usage updates) so consumers only re-render when the active
@@ -24,8 +26,8 @@ export function useActiveSubagentIds(conversationId: string | null): string[] {
           return false;
         }
         return (
-          entry.conversationId === undefined ||
-          entry.conversationId === conversationId
+          entry.parentConversationId === undefined ||
+          entry.parentConversationId === conversationId
         );
       }),
     ),

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.test.tsx
@@ -15,15 +15,34 @@
  *    preserves in-flight subagents — they stream from SSE, not history
  *    notifications — so this reset is the *only* thing that stops a live
  *    subagent in conversation A from leaking into conversation B.
+ *
+ * 3. The auto-fetch reaches a stub recovered from a missed `subagent_spawned`
+ *    that only knows its parent conversation. Such a stub defers live events
+ *    until its backfill lands, so nothing else would ever un-stick it.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 
-import { useConversationChangeEffects } from "@/domains/chat/hooks/use-conversation-change-effects";
-import { useSubagentStore } from "@/domains/chat/subagent-store";
-import { useWorkflowStore } from "@/domains/chat/workflow-store";
+mock.module("@/lib/backwards-compat/subagent-detail-self-lookup", () => ({
+  supportsSubagentDetailSelfLookup: () => true,
+}));
+
+const fetchSubagentDetail = mock(
+  async (
+    _assistantId: string,
+    _subagentId: string,
+    _conversationId: string,
+  ): Promise<null> => null,
+);
+mock.module("../fetch-subagent-detail", () => ({ fetchSubagentDetail }));
+
+const { useConversationChangeEffects } = await import(
+  "@/domains/chat/hooks/use-conversation-change-effects"
+);
+const { useSubagentStore } = await import("@/domains/chat/subagent-store");
+const { useWorkflowStore } = await import("@/domains/chat/workflow-store");
 
 const NOW = 1700000000000;
 
@@ -31,6 +50,7 @@ afterEach(() => {
   cleanup();
   useWorkflowStore.getState().reset();
   useSubagentStore.getState().reset();
+  fetchSubagentDetail.mockClear();
 });
 
 describe("useConversationChangeEffects — reset ordering", () => {
@@ -94,5 +114,32 @@ describe("useConversationChangeEffects — subagent reset on conversation switch
 
     expect(useSubagentStore.getState().byId["sa-running"]).toBeUndefined();
     expect(useSubagentStore.getState().orderedIds).toEqual([]);
+  });
+});
+
+describe("useConversationChangeEffects — stub detail auto-fetch", () => {
+  function Harness() {
+    useConversationChangeEffects("asst-1", "conv-A");
+    return null;
+  }
+
+  test("hydrates a stub that only knows its parent conversation", async () => {
+    render(<Harness />);
+
+    // A `subagent_event` for an unknown id on a self-lookup daemon: the stub is
+    // armed for backfill but carries no child conversation id.
+    useSubagentStore.getState().ensureEntry({
+      subagentId: "sa-stub",
+      timestamp: NOW,
+      parentConversationId: "conv-A",
+    });
+
+    await waitFor(() =>
+      expect(fetchSubagentDetail).toHaveBeenCalledWith(
+        "asst-1",
+        "sa-stub",
+        "conv-A",
+      ),
+    );
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
@@ -4,7 +4,9 @@
  * - Reset subagent tracking state (needed for URL-navigation paths that
  *   bypass the `switchConversation` / `startNewConversation` wrappers)
  * - Auto-fetch detail for subagents reconstructed from conversation history
- *   (entries with a `conversationId` but no events yet)
+ *   (entries with a `conversationId` but no events yet) and for stubs
+ *   recovered from a missed `subagent_spawned` that are awaiting their
+ *   backfill (`hydrationPending`)
  *
  * Note: interaction store cleanup (`dismissQuestion`, `resetAll`) is NOT
  * handled here — `switchToConversation()` in `chat-session-store` already
@@ -14,8 +16,26 @@
 
 import { useEffect, useLayoutEffect } from "react";
 
-import { useSubagentStore } from "@/domains/chat/subagent-store";
+import {
+  useSubagentStore,
+  type SubagentEntry,
+} from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
+
+/**
+ * An entry whose timeline is still empty and that carries an id the daemon can
+ * resolve. `hydrationPending` covers the stub armed with only a parent
+ * conversation id: `fetchDetailIfNeeded` can address it (0.10.13+ daemons
+ * self-resolve the subagent's conversation) even though the child-semantic
+ * `conversationId` is deliberately unset. Without it such a stub would defer
+ * live events forever waiting on a fetch nothing triggers.
+ */
+function needsDetailFetch(entry: SubagentEntry): boolean {
+  return (
+    entry.events.length === 0 &&
+    Boolean(entry.conversationId || entry.hydrationPending)
+  );
+}
 
 export function useConversationChangeEffects(
   assistantId: string | null,
@@ -38,15 +58,13 @@ export function useConversationChangeEffects(
   }, [activeConversationId]);
 
   // Stable signal: changes only when the set of subagent IDs that need a
-  // detail fetch changes (entry appears with conversationId + no events,
-  // or an entry receives events). Immune to loadDetail calls that update
-  // status/objective without changing events, preventing retrigger loops.
+  // detail fetch changes (an entry becomes eligible, or an entry receives
+  // events). Immune to loadDetail calls that update status/objective without
+  // changing events, preventing retrigger loops.
   const unfetchedSubagentKey = useSubagentStore((s) => {
     const ids: string[] = [];
     for (const entry of Object.values(s.byId)) {
-      if (entry.conversationId && entry.events.length === 0) {
-        ids.push(entry.subagentId);
-      }
+      if (needsDetailFetch(entry)) ids.push(entry.subagentId);
     }
     return ids.sort().join(',');
   });
@@ -55,7 +73,7 @@ export function useConversationChangeEffects(
   useEffect(() => {
     if (!assistantId || !unfetchedSubagentKey) return;
     for (const entry of Object.values(useSubagentStore.getState().byId)) {
-      if (entry.conversationId && entry.events.length === 0) {
+      if (needsDetailFetch(entry)) {
         void useSubagentStore.getState().fetchDetailIfNeeded(assistantId, entry.subagentId);
       }
     }

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
@@ -64,14 +64,18 @@ export function useConversationChangeEffects(
   const unfetchedSubagentKey = useSubagentStore((s) => {
     const ids: string[] = [];
     for (const entry of Object.values(s.byId)) {
-      if (needsDetailFetch(entry)) ids.push(entry.subagentId);
+      if (needsDetailFetch(entry)) {
+        ids.push(entry.subagentId);
+      }
     }
     return ids.sort().join(',');
   });
 
   // Auto-fetch details for subagents reconstructed from history
   useEffect(() => {
-    if (!assistantId || !unfetchedSubagentKey) return;
+    if (!assistantId || !unfetchedSubagentKey) {
+      return;
+    }
     for (const entry of Object.values(useSubagentStore.getState().byId)) {
       if (needsDetailFetch(entry)) {
         void useSubagentStore.getState().fetchDetailIfNeeded(assistantId, entry.subagentId);

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -341,6 +341,7 @@ export function useConversationHistory({
       reconcileSubagentStoreFromNotifications(
         useSubagentStore.getState(),
         deduped.values(),
+        activeConversationId,
         Date.now(),
       );
     }

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -1,6 +1,21 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { SubagentInnerEvent } from "@vellumai/assistant-api";
-import { useSubagentStore } from "@/domains/chat/subagent-store";
+
+let selfLookupSupported = true;
+mock.module("@/lib/backwards-compat/subagent-detail-self-lookup", () => ({
+  supportsSubagentDetailSelfLookup: () => selfLookupSupported,
+}));
+
+const fetchSubagentDetail = mock(
+  async (
+    _assistantId: string,
+    _subagentId: string,
+    _conversationId: string,
+  ): Promise<null> => null,
+);
+mock.module("./fetch-subagent-detail", () => ({ fetchSubagentDetail }));
+
+const { useSubagentStore } = await import("@/domains/chat/subagent-store");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -14,6 +29,8 @@ const NOW = 1700000000000;
 
 beforeEach(() => {
   getState().reset();
+  selfLookupSupported = true;
+  fetchSubagentDetail.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -147,6 +164,64 @@ describe("spawnSubagent", () => {
     const state = getState();
     expect(state.orderedIds).toEqual(["sa-a", "sa-b", "sa-c"]);
     expect(Object.keys(state.byId)).toHaveLength(3);
+  });
+
+  it("stores the parent conversation id separately from the child one", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-parented",
+      label: "Agent",
+      objective: "",
+      conversationId: "conv-child",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+
+    const entry = getState().byId["sa-parented"]!;
+    expect(entry.conversationId).toBe("conv-child");
+    expect(entry.parentConversationId).toBe("conv-parent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setParentConversationId
+// ---------------------------------------------------------------------------
+
+describe("setParentConversationId", () => {
+  it("stamps the parent conversation id without touching the child one", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-p",
+      label: "Agent",
+      objective: "",
+      conversationId: "conv-child",
+      timestamp: NOW,
+    });
+
+    getState().setParentConversationId("sa-p", "conv-parent");
+
+    const entry = getState().byId["sa-p"]!;
+    expect(entry.parentConversationId).toBe("conv-parent");
+    expect(entry.conversationId).toBe("conv-child");
+  });
+
+  it("no-ops for an unknown subagent id", () => {
+    getState().setParentConversationId("sa-missing", "conv-parent");
+
+    expect(getState().byId["sa-missing"]).toBeUndefined();
+  });
+
+  it("preserves entry identity when the value is unchanged", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-same",
+      label: "Agent",
+      objective: "",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    const before = getState().byId["sa-same"]!;
+
+    getState().setParentConversationId("sa-same", "conv-parent");
+
+    expect(getState().byId["sa-same"]).toBe(before);
   });
 });
 
@@ -1394,12 +1469,58 @@ describe("ensureEntry", () => {
     getState().ensureEntry({
       subagentId: "sa-1",
       timestamp: NOW,
-      conversationId: "conv-parent",
+      conversationId: "conv-child",
     });
 
     const entry = getState().byId["sa-1"];
-    expect(entry?.conversationId).toBe("conv-parent");
+    expect(entry?.conversationId).toBe("conv-child");
     expect(entry?.hydrationPending).toBe(true);
+  });
+
+  it("arms on the child id even on a pre-0.10.13 daemon", () => {
+    // The child id addresses the subagent's own conversation, so an old
+    // daemon trusting it verbatim still parses the right messages.
+    selfLookupSupported = false;
+
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      conversationId: "conv-child",
+      parentConversationId: "conv-parent",
+    });
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.conversationId).toBe("conv-child");
+    expect(entry?.parentConversationId).toBe("conv-parent");
+    expect(entry?.hydrationPending).toBe(true);
+  });
+
+  it("arms on a parent-only stub without polluting the child field", () => {
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      parentConversationId: "conv-parent",
+    });
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.parentConversationId).toBe("conv-parent");
+    expect(entry?.conversationId).toBeUndefined();
+    expect(entry?.hydrationPending).toBe(true);
+  });
+
+  it("leaves a parent-only stub un-armed on a pre-0.10.13 daemon", () => {
+    selfLookupSupported = false;
+
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      parentConversationId: "conv-parent",
+    });
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.parentConversationId).toBe("conv-parent");
+    expect(entry?.conversationId).toBeUndefined();
+    expect(entry?.hydrationPending).toBeUndefined();
   });
 
   it("is a no-op when the entry already exists", () => {
@@ -1446,7 +1567,7 @@ describe("hydrationPending", () => {
     getState().ensureEntry({
       subagentId: "sa-1",
       timestamp: NOW,
-      conversationId: "conv-parent",
+      conversationId: "conv-child",
     });
 
     getState().receiveEvent({
@@ -1462,7 +1583,7 @@ describe("hydrationPending", () => {
     getState().ensureEntry({
       subagentId: "sa-1",
       timestamp: NOW,
-      conversationId: "conv-parent",
+      conversationId: "conv-child",
     });
 
     getState().loadDetail({ subagentId: "sa-1", events: [] });
@@ -1487,7 +1608,7 @@ describe("loadDetail identity backfill", () => {
     getState().ensureEntry({
       subagentId: "sa-1",
       timestamp: NOW,
-      conversationId: "conv-parent",
+      conversationId: "conv-child",
     });
 
     getState().loadDetail({
@@ -1539,5 +1660,63 @@ describe("loadDetail identity backfill", () => {
 
     expect(getState().byId["sa-1"]?.parentToolUseId).toBe("toolu_original");
     expect(getState().byToolUseId).toBe(byToolUseIdBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchDetailIfNeeded — which conversation id addresses the subagent
+// ---------------------------------------------------------------------------
+
+describe("fetchDetailIfNeeded conversation id", () => {
+  it("queries with the child id when the entry knows it", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      conversationId: "conv-child",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+
+    await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
+
+    expect(fetchSubagentDetail).toHaveBeenCalledWith(
+      "assistant-1",
+      "sa-1",
+      "conv-child",
+    );
+  });
+
+  it("falls back to the parent id only on a self-lookup daemon", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+
+    await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
+
+    expect(fetchSubagentDetail).toHaveBeenCalledWith(
+      "assistant-1",
+      "sa-1",
+      "conv-parent",
+    );
+  });
+
+  it("does not fetch with a parent-only entry on a pre-0.10.13 daemon", async () => {
+    selfLookupSupported = false;
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+
+    await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
+
+    expect(fetchSubagentDetail).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -19,6 +19,7 @@ import { createSelectors } from "@/utils/create-selectors";
 import type { SubagentStatus, SubagentInnerEvent } from "@vellumai/assistant-api";
 import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
 import { isActiveStatus } from "@/utils/subagent-status";
+import { supportsSubagentDetailSelfLookup } from "@/lib/backwards-compat/subagent-detail-self-lookup";
 import { fetchSubagentDetail } from "./fetch-subagent-detail";
 import { mapDetailEvents } from "./map-detail-events";
 import { setToolUseAnchor } from "./store-helpers/by-tool-use-id-index";
@@ -73,6 +74,12 @@ export interface SubagentEntry {
   events: SubagentTimelineEvent[];
   /** The subagent's own conversation ID, used to fetch detail data. */
   conversationId?: string;
+  /**
+   * Conversation ID of the PARENT conversation whose turn spawned this
+   * subagent. Scopes the Active-Subagents overlay to the viewed conversation
+   * (`useActiveSubagentIds`); never used to fetch detail.
+   */
+  parentConversationId?: string;
   /** StableId of the parent assistant message that spawned this subagent. */
   parentMessageStableId?: string;
   /** Daemon UUID of the parent assistant message. Stable across reloads. */
@@ -157,6 +164,7 @@ export interface SubagentActions {
     isFork?: boolean;
     timestamp: number;
     conversationId?: string;
+    parentConversationId?: string;
     status?: SubagentStatus;
     error?: string;
     parentMessageStableId?: string;
@@ -179,16 +187,20 @@ export interface SubagentActions {
    * because the `subagent_spawned` event was missed (SSE gap, page reload)
    * or the store was reset after it arrived. No-op when the entry exists.
    *
-   * When `conversationId` is provided the stub is marked
-   * `hydrationPending` and left with zero events, which makes the
-   * detail auto-fetch (`fetchDetailIfNeeded`) backfill the authoritative
-   * label/objective/status/timeline. Without one the stub renders from
-   * whatever streams in — a generic but functional card.
+   * The stub is marked `hydrationPending` and left with zero events —
+   * making the detail auto-fetch (`fetchDetailIfNeeded`) backfill the
+   * authoritative label/objective/status/timeline — whenever the ids at hand
+   * can address the subagent's own conversation: either `conversationId`
+   * (the child id, good on every daemon) or, on a daemon that resolves the
+   * subagent's conversation itself, `parentConversationId` as a wire
+   * placeholder. Otherwise the stub renders from whatever streams in — a
+   * generic but functional card.
    */
   ensureEntry: (params: {
     subagentId: string;
     timestamp: number;
     conversationId?: string;
+    parentConversationId?: string;
     status?: SubagentStatus;
   }) => void;
 
@@ -216,7 +228,18 @@ export interface SubagentActions {
     parentToolUseId?: string;
   }) => void;
 
+  /**
+   * Stamp the subagent's own conversation id, used to fetch detail. No-ops
+   * when the entry is unknown or already carries that id, so the per-event
+   * call path doesn't churn store identity.
+   */
   setConversationId: (subagentId: string, conversationId: string) => void;
+
+  /** Same, for the parent conversation id that scopes the overlay. */
+  setParentConversationId: (
+    subagentId: string,
+    parentConversationId: string,
+  ) => void;
 
   /**
    * Attach the durable server `messageId` to every entry currently anchored
@@ -439,6 +462,7 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       spawnedAt: params.timestamp,
       events: [],
       conversationId: params.conversationId,
+      parentConversationId: params.parentConversationId,
       parentMessageStableId: params.parentMessageStableId,
       parentMessageId: params.parentMessageId,
       parentToolUseId: params.parentToolUseId,
@@ -463,6 +487,15 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
 
   ensureEntry: (params) => {
     if (get().byId[params.subagentId]) return;
+    // The child id addresses the subagent's conversation on every daemon. The
+    // parent id only works as a placeholder on a daemon that self-resolves the
+    // subagent's conversation — and even then it stays out of the
+    // child-semantic `conversationId` field.
+    const armsBackfill =
+      Boolean(params.conversationId) ||
+      (Boolean(params.parentConversationId) &&
+        supportsSubagentDetailSelfLookup());
+
     get().spawnSubagent({
       subagentId: params.subagentId,
       // Placeholder identity — the detail fetch backfills the real label
@@ -471,20 +504,20 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       objective: "",
       status: params.status ?? "running",
       conversationId: params.conversationId,
+      parentConversationId: params.parentConversationId,
       timestamp: params.timestamp,
     });
-    if (params.conversationId) {
-      const { byId } = get();
-      const entry = byId[params.subagentId];
-      if (entry) {
-        set({
-          byId: {
-            ...byId,
-            [params.subagentId]: { ...entry, hydrationPending: true },
-          },
-        });
-      }
-    }
+
+    if (!armsBackfill) return;
+    const { byId } = get();
+    const entry = byId[params.subagentId];
+    if (!entry) return;
+    set({
+      byId: {
+        ...byId,
+        [params.subagentId]: { ...entry, hydrationPending: true },
+      },
+    });
   },
 
   changeStatus: (params) => {
@@ -654,11 +687,26 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     const { byId } = get();
     const existing = byId[subagentId];
     if (!existing) return;
+    if (existing.conversationId === conversationId) return;
 
     set({
       byId: {
         ...byId,
         [subagentId]: { ...existing, conversationId },
+      },
+    });
+  },
+
+  setParentConversationId: (subagentId, parentConversationId) => {
+    const { byId } = get();
+    const existing = byId[subagentId];
+    if (!existing) return;
+    if (existing.parentConversationId === parentConversationId) return;
+
+    set({
+      byId: {
+        ...byId,
+        [subagentId]: { ...existing, parentConversationId },
       },
     });
   },
@@ -716,7 +764,18 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
   fetchDetailIfNeeded: async (assistantId, subagentId) => {
     const { byId, fetchedAt } = get();
     const entry = byId[subagentId];
-    if (!entry?.conversationId) return;
+    if (!entry) return;
+    // A stub recovered without its `subagent_spawned` may only know the parent
+    // conversation. 0.10.13+ daemons resolve the subagent's own conversation
+    // and treat this parameter as a fallback, so the parent id is a harmless
+    // wire placeholder there; an older daemon would trust it verbatim and
+    // parse the parent's messages as the subagent's.
+    const queryConversationId =
+      entry.conversationId ??
+      (supportsSubagentDetailSelfLookup()
+        ? entry.parentConversationId
+        : undefined);
+    if (!queryConversationId) return;
     if (entry.events.length > 0) return;
 
     const prev = fetchedAt.get(subagentId);
@@ -727,7 +786,11 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     nextFetchedAt.set(subagentId, entry.spawnedAt);
     set({ fetchedAt: nextFetchedAt });
 
-    const detail = await fetchSubagentDetail(assistantId, subagentId, entry.conversationId);
+    const detail = await fetchSubagentDetail(
+      assistantId,
+      subagentId,
+      queryConversationId,
+    );
 
     const clearMarker = () => {
       const next = new Map(get().fetchedAt);

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
@@ -1,15 +1,21 @@
 /**
- * Unit tests for the subagent stream handlers' missed-spawn recovery
- * (LUM-2875): a `subagent_event` or `subagent_status_changed` for an id the
- * store has never seen must materialize a stub entry instead of being
- * silently dropped — a dropped event chain is how the inline subagent card
- * dies (the avatar row expands to nothing and the detail panel can't open).
+ * Unit tests for the subagent stream handlers' conversation-id routing and
+ * missed-spawn recovery (LUM-2875).
  *
- * The backwards-compat gate decides whether the stub is armed for detail
- * backfill with the parent conversation id: only 0.10.13+ daemons resolve
- * the subagent's own conversation themselves, so on older daemons the stub
- * must stay un-armed (a fetch with the parent id would parse the parent's
- * messages as the subagent's).
+ * Routing: the `subagent_event` envelope carries the PARENT conversation id
+ * and the inner event carries the subagent's own (CHILD) id. They land in
+ * separate entry fields — `parentConversationId` scopes the Active-Subagents
+ * overlay, `conversationId` addresses the detail fetch — so neither can be
+ * mistaken for the other.
+ *
+ * Recovery: a `subagent_event` or `subagent_status_changed` for an id the
+ * store has never seen must materialize a stub instead of being silently
+ * dropped — a dropped event chain is how the inline subagent card dies (the
+ * avatar row expands to nothing and the detail panel can't open). The
+ * backwards-compat gate decides whether a stub that only knows the parent id
+ * is armed for detail backfill: only 0.10.13+ daemons resolve the subagent's
+ * own conversation themselves, so on older daemons the parent id is useless
+ * (a fetch with it would parse the parent's messages as the subagent's).
  */
 
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -21,10 +27,18 @@ mock.module("@/lib/backwards-compat/subagent-detail-self-lookup", () => ({
   supportsSubagentDetailSelfLookup: () => selfLookupSupported,
 }));
 
-const { handleSubagentEvent, handleSubagentStatusChanged } = await import(
-  "@/domains/chat/utils/stream-handlers/subagent-handlers"
-);
+const {
+  handleSubagentEvent,
+  handleSubagentSpawned,
+  handleSubagentStatusChanged,
+} = await import("@/domains/chat/utils/stream-handlers/subagent-handlers");
 const { useSubagentStore } = await import("@/domains/chat/subagent-store");
+const { makeCtx } = await import(
+  "@/domains/chat/utils/stream-handlers/test-helpers"
+);
+
+const PARENT = "conv-parent";
+const CHILD = "conv-child";
 
 const ctx = {} as StreamHandlerContext;
 
@@ -33,54 +47,159 @@ beforeEach(() => {
   selfLookupSupported = true;
 });
 
-describe("handleSubagentEvent — unknown subagent id", () => {
-  const event = {
-    type: "subagent_event" as const,
-    subagentId: "sa-1",
-    conversationId: "conv-parent",
-    event: { type: "assistant_text_delta", text: "working…" },
-  };
-
-  it("materializes a hydration-pending stub on a self-lookup daemon", () => {
-    handleSubagentEvent(event, ctx);
-
-    const entry = useSubagentStore.getState().byId["sa-1"];
-    expect(entry).toBeDefined();
-    expect(entry?.status).toBe("running");
-    expect(entry?.conversationId).toBe("conv-parent");
-    expect(entry?.hydrationPending).toBe(true);
-    // The triggering event is deferred to the authoritative backfill.
-    expect(entry?.events).toEqual([]);
-  });
-
-  it("materializes an un-armed stub on a pre-0.10.13 daemon", () => {
-    selfLookupSupported = false;
-
-    handleSubagentEvent(event, ctx);
+describe("handleSubagentSpawned", () => {
+  it("stamps the parent conversation id from the spawn event", () => {
+    handleSubagentSpawned(
+      {
+        type: "subagent_spawned",
+        subagentId: "sa-1",
+        parentConversationId: PARENT,
+        label: "Agent",
+        objective: "Task",
+      },
+      makeCtx(),
+    );
 
     const entry = useSubagentStore.getState().byId["sa-1"];
-    expect(entry).toBeDefined();
-    // No conversationId: the old daemon would trust it verbatim and parse
-    // the PARENT conversation's messages as the subagent's.
+    expect(entry?.parentConversationId).toBe(PARENT);
     expect(entry?.conversationId).toBeUndefined();
-    expect(entry?.hydrationPending).toBeUndefined();
-    // Un-armed stubs accrue the live stream instead.
-    expect(entry?.events).toHaveLength(1);
   });
+});
 
-  it("leaves known entries on the historical path", () => {
+describe("handleSubagentEvent — known subagent id", () => {
+  function spawn() {
     useSubagentStore.getState().spawnSubagent({
       subagentId: "sa-1",
       label: "auditor",
       objective: "audit",
       timestamp: Date.now(),
     });
+  }
 
-    handleSubagentEvent(event, ctx);
+  it("routes the envelope id to parent and the inner id to child", () => {
+    spawn();
+
+    handleSubagentEvent(
+      {
+        type: "subagent_event",
+        conversationId: PARENT,
+        subagentId: "sa-1",
+        event: {
+          type: "assistant_text_delta",
+          text: "hello",
+          conversationId: CHILD,
+        },
+      },
+      ctx,
+    );
 
     const entry = useSubagentStore.getState().byId["sa-1"];
+    expect(entry?.conversationId).toBe(CHILD);
+    expect(entry?.parentConversationId).toBe(PARENT);
     expect(entry?.label).toBe("auditor");
-    expect(entry?.conversationId).toBe("conv-parent");
+    expect(entry?.events).toHaveLength(1);
+  });
+
+  it("never writes the parent id into the child field", () => {
+    spawn();
+
+    // Malformed envelope: the inner event echoes the parent id.
+    handleSubagentEvent(
+      {
+        type: "subagent_event",
+        conversationId: PARENT,
+        subagentId: "sa-1",
+        event: {
+          type: "assistant_text_delta",
+          text: "hello",
+          conversationId: PARENT,
+        },
+      },
+      ctx,
+    );
+
+    const entry = useSubagentStore.getState().byId["sa-1"];
+    expect(entry?.conversationId).toBeUndefined();
+    expect(entry?.parentConversationId).toBe(PARENT);
+  });
+});
+
+describe("handleSubagentEvent — unknown subagent id", () => {
+  const eventWithoutChildId = {
+    type: "subagent_event" as const,
+    subagentId: "sa-1",
+    conversationId: PARENT,
+    event: { type: "assistant_text_delta", text: "working…" },
+  };
+
+  it("materializes a stub carrying both ids when the inner event knows the child", () => {
+    handleSubagentEvent(
+      {
+        ...eventWithoutChildId,
+        event: {
+          type: "assistant_text_delta",
+          text: "working…",
+          conversationId: CHILD,
+        },
+      },
+      ctx,
+    );
+
+    const entry = useSubagentStore.getState().byId["sa-1"];
+    expect(entry).toBeDefined();
+    expect(entry?.status).toBe("running");
+    expect(entry?.conversationId).toBe(CHILD);
+    expect(entry?.parentConversationId).toBe(PARENT);
+    expect(entry?.hydrationPending).toBe(true);
+    // The triggering event is deferred to the authoritative backfill.
+    expect(entry?.events).toEqual([]);
+  });
+
+  it("arms a child-id stub on a pre-0.10.13 daemon too", () => {
+    selfLookupSupported = false;
+
+    handleSubagentEvent(
+      {
+        ...eventWithoutChildId,
+        event: {
+          type: "assistant_text_delta",
+          text: "working…",
+          conversationId: CHILD,
+        },
+      },
+      ctx,
+    );
+
+    const entry = useSubagentStore.getState().byId["sa-1"];
+    expect(entry?.conversationId).toBe(CHILD);
+    expect(entry?.hydrationPending).toBe(true);
+  });
+
+  it("arms a parent-only stub on a self-lookup daemon", () => {
+    handleSubagentEvent(eventWithoutChildId, ctx);
+
+    const entry = useSubagentStore.getState().byId["sa-1"];
+    expect(entry).toBeDefined();
+    // The parent id never enters the child-semantic field, even armed.
+    expect(entry?.conversationId).toBeUndefined();
+    expect(entry?.parentConversationId).toBe(PARENT);
+    expect(entry?.hydrationPending).toBe(true);
+    expect(entry?.events).toEqual([]);
+  });
+
+  it("materializes an un-armed stub on a pre-0.10.13 daemon", () => {
+    selfLookupSupported = false;
+
+    handleSubagentEvent(eventWithoutChildId, ctx);
+
+    const entry = useSubagentStore.getState().byId["sa-1"];
+    expect(entry).toBeDefined();
+    // No id an old daemon can resolve: it would trust the parent id verbatim
+    // and parse the PARENT conversation's messages as the subagent's.
+    expect(entry?.conversationId).toBeUndefined();
+    expect(entry?.parentConversationId).toBe(PARENT);
+    expect(entry?.hydrationPending).toBeUndefined();
+    // Un-armed stubs accrue the live stream instead.
     expect(entry?.events).toHaveLength(1);
   });
 });
@@ -101,5 +220,9 @@ describe("handleSubagentStatusChanged — unknown subagent id", () => {
     expect(entry).toBeDefined();
     expect(entry?.status).toBe("completed");
     expect(entry?.inputTokens).toBe(10);
+    // A status event carries no conversation ids at all.
+    expect(entry?.conversationId).toBeUndefined();
+    expect(entry?.parentConversationId).toBeUndefined();
+    expect(entry?.hydrationPending).toBeUndefined();
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -6,7 +6,6 @@ import {
 } from "@vellumai/assistant-api";
 
 import { useSubagentStore } from "@/domains/chat/subagent-store";
-import { supportsSubagentDetailSelfLookup } from "@/lib/backwards-compat/subagent-detail-self-lookup";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 
 export function handleSubagentSpawned(
@@ -19,6 +18,7 @@ export function handleSubagentSpawned(
     objective: event.objective,
     isFork: event.isFork,
     timestamp: Date.now(),
+    parentConversationId: event.parentConversationId,
     parentMessageStableId: ctx.currentAssistantMessageIdRef.current,
     parentToolUseId: event.parentToolUseId,
   });
@@ -56,30 +56,42 @@ export function handleSubagentEvent(
   _ctx: StreamHandlerContext,
 ): void {
   const store = useSubagentStore.getState();
+  const inner = event.event;
+
+  // The envelope's `conversationId` is the PARENT conversation (stamped by
+  // `wrappedSendToClient` in `assistant/src/subagent/manager.ts`); the
+  // subagent's own id rides on the inner event, where
+  // `SubagentInnerEventSchema`'s passthrough preserves it without declaring it
+  // on the inferred type — hence the narrow cast.
+  const parentConversationId = event.conversationId || undefined;
+  const innerConversationId = (inner as { conversationId?: string })
+    .conversationId;
+  const childConversationId =
+    typeof innerConversationId === "string" &&
+    innerConversationId.length > 0 &&
+    innerConversationId !== parentConversationId
+      ? innerConversationId
+      : undefined;
+
   // Same recovery as `handleSubagentStatusChanged`: an unknown id means the
-  // spawn event was missed, so materialize a stub. `event.conversationId` is
-  // the PARENT conversation id — only pass it (arming the detail backfill)
-  // when the daemon resolves the subagent's own conversation itself; an
-  // older daemon would parse the parent's messages as the subagent's.
-  const wasKnown = Boolean(store.byId[event.subagentId]);
-  if (!wasKnown) {
+  // spawn event was missed, so materialize a stub. `ensureEntry` decides from
+  // the ids at hand whether the detail backfill can be armed.
+  if (store.byId[event.subagentId]) {
+    if (parentConversationId) {
+      store.setParentConversationId(event.subagentId, parentConversationId);
+    }
+    if (childConversationId) {
+      store.setConversationId(event.subagentId, childConversationId);
+    }
+  } else {
     store.ensureEntry({
       subagentId: event.subagentId,
       timestamp: Date.now(),
-      conversationId: supportsSubagentDetailSelfLookup()
-        ? event.conversationId
-        : undefined,
+      conversationId: childConversationId,
+      parentConversationId,
     });
   }
-  // Don't stamp the parent conversation id onto a stub on a pre-0.10.13
-  // daemon: it would arm the detail auto-fetch with an id the old daemon
-  // trusts verbatim, backfilling the PARENT conversation's messages as the
-  // subagent's. Known entries keep the historical behavior.
-  if (event.conversationId && (wasKnown || supportsSubagentDetailSelfLookup())) {
-    store.setConversationId(event.subagentId, event.conversationId);
-  }
 
-  const inner = event.event;
   if (inner.type === "usage_progress") {
     const parsed = UsageProgressEventSchema.safeParse(inner);
     store.updateUsage({


### PR DESCRIPTION
`SubagentEntry.conversationId` was carrying two different conversations depending on which code path wrote it, and both readers were wrong as a result.

The daemon stamps the **parent** conversation id on the `subagent_event` envelope (`wrappedSendToClient` in `assistant/src/subagent/manager.ts`), while the subagent's **own** (child) id rides on the inner event. `handleSubagentEvent` wrote the envelope's parent id into `conversationId` — the field the detail fetch uses — and `useActiveSubagentIds` scoped the Active-Subagents overlay on that same field, so an entry rebuilt from history (which carries the real child id) never matched the viewed conversation and vanished from the overlay.

## What changed

- **New `parentConversationId` field.** `conversationId` now only ever holds the subagent's own (child) conversation — the one the detail fetch addresses. `parentConversationId` holds the conversation whose turn spawned it, and is used only for overlay scoping. Mirrors the shape `acp-run-store` already uses for ACP runs.
- **`handleSubagentEvent` routes both ids.** Envelope id → `setParentConversationId`; the inner event's `conversationId` (a passthrough field, read via a narrow cast) → `setConversationId` when it's a non-empty string that differs from the envelope's. `handleSubagentSpawned` stamps `parentConversationId` from `event.parentConversationId`.
- **Overlay filter moved to `parentConversationId`** (`useActiveSubagentIds`) — the follow-up #39355 explicitly left open. History-hydrated running subagents now surface again; an entry with no parent id yet still stays visible rather than disappearing.
- **Hydration status is validated.** `reconcileSubagentStoreFromNotifications` replaces a blind `as SubagentStatus` cast with `SubagentStatusSchema.safeParse`: an unparseable status is skipped entirely on the merge path (a live `running` entry is never clobbered) and falls back to `"completed"` only for a fresh historical spawn. It also takes the conversation being hydrated as a new argument, so hydrated entries get scoped correctly.

## Building on #39355

This rebases onto the stub self-heal work and adjusts it rather than duplicating it:

- The arming decision moved **into** `ensureEntry`. A stub arms its detail backfill when it has the child id (good on **every** daemon version) **or** when it has only the parent id and `supportsSubagentDetailSelfLookup()` is true. In the parent-only case `conversationId` is deliberately left unset — the parent id never enters the child-semantic field — and `fetchDetailIfNeeded` falls back to `parentConversationId` behind the same gate, where 0.10.13+ daemons ignore the query param anyway.
- **Net effect:** stubs armed via the inner event's child id now backfill correctly on *all* daemon versions, not just 0.10.13+. The version gate now only matters when the child id isn't known yet — e.g. a stub materialized from `subagent_status_changed`, which carries no conversation ids at all. The `wasKnown || supportsSubagentDetailSelfLookup()` parent-stamping branch is gone.
- **`useConversationChangeEffects` auto-fetch predicate.** It gated on `entry.conversationId`, which #39355's parent-armed stubs satisfied only because the parent id was being written there. With that write removed, a parent-only stub would have stayed `hydrationPending` forever, dropping every live event with nothing to un-stick it. The predicate now also accepts `hydrationPending`.
- `setConversationId` gained the same unchanged-value no-op guard as the new `setParentConversationId`, so the per-event handler path stops churning store identity after the first event.

## Tests

`subagent-store.test.ts` (arming matrix across daemon versions, `setParentConversationId` semantics, `fetchDetailIfNeeded` id resolution), `subagent-handlers.test.ts` (envelope/inner routing, parent-echo case, unknown-id stub on both daemon versions), `reconcile-subagent-hydration.test.ts`, `use-active-subagent-ids.test.ts`, `use-conversation-change-effects.test.tsx`.

`bunx tsc --noEmit` clean; all 20 suites that touch the subagent store pass.

Part of plan: subagent-running-state-fixes.md (PR 1 of 4 remaining)
