### PR TITLE
feat(web): empty-chat avatar peeks, Figma empty state, and composer action row

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
@@ -242,7 +242,11 @@ export const AttachFileButton: FC<AttachFileButtonProps> = ({
         disabled={disabled}
         aria-label="Attach file"
         title={title}
-        className="[--vbtn-fg:var(--content-secondary)]"
+        // Tertiary resting tone, matching the composer action row's icons
+        // (Figma: New-App 7471-25234). The touch-mobile override beats the
+        // ghost icon-only variant's default-tone mobile chrome so mobile
+        // matches desktop.
+        className="[--vbtn-fg:var(--content-tertiary)] touch-mobile:[--vbtn-fg:var(--content-tertiary)]"
       />
     </div>
   );

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -140,6 +140,10 @@ export interface ChatComposerProps {
   // chrome surfacing existing buttons (rendered in the form's bottom-left row)
   thresholdPickerSlot?: ReactNode;
   contextWindowIndicatorSlot?: ReactNode;
+  // Model-profile picker rendered on the row's right end, beside the mic
+  // (Figma: New-App 7471-25234). The orchestrator passes a second
+  // `ComposerSettingsMenu` instance scoped to the profile segment.
+  modelPickerSlot?: ReactNode;
 
   // Slot rendered above the form (between the max-width wrapper and the form).
   // The main variant uses this for attachment-error / voice-error / disk-pressure
@@ -212,6 +216,7 @@ export function ChatComposer({
   assistantId,
   conversationId,
   thresholdPickerSlot,
+  modelPickerSlot,
   contextWindowIndicatorSlot,
   noticesAboveFormSlot,
   hasBillingBanner = false,
@@ -880,12 +885,27 @@ export function ChatComposer({
                 onStop={liveVoiceHandsFree ? stopLiveVoiceResponse : undefined}
               />
             ) : (
+              // Action row per Figma 7471-25234: attach | divider | access
+              // on the left; model profile | divider | mic, send on the
+              // right.
               <div className="flex items-center justify-between gap-1 px-2 pb-2">
-                <div className="flex min-w-0 items-center gap-1">
+                <div className="flex min-w-0 items-center gap-2">
                   {contextWindowIndicatorSlot}
+                  {!isAssistantBusy && (
+                    <AttachFileButton
+                      disabled={typingDisabled || !assistantId}
+                      onFilesSelected={onAddAttachmentFiles}
+                    />
+                  )}
+                  {!isAssistantBusy && thresholdPickerSlot ? (
+                    <div
+                      aria-hidden="true"
+                      className="h-4 w-px shrink-0 bg-[var(--border-base)] touch-mobile:-mx-1"
+                    />
+                  ) : null}
                   {thresholdPickerSlot}
                 </div>
-                <div className="flex shrink-0 items-center gap-1">
+                <div className="flex shrink-0 items-center gap-2">
                   {isAssistantBusy ? (
                     <>
                       {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
@@ -921,10 +941,13 @@ export function ChatComposer({
                     </>
                   ) : (
                     <>
-                      <AttachFileButton
-                        disabled={typingDisabled || !assistantId}
-                        onFilesSelected={onAddAttachmentFiles}
-                      />
+                      {modelPickerSlot}
+                      {modelPickerSlot && showVoiceInput ? (
+                        <div
+                          aria-hidden="true"
+                          className="h-4 w-px shrink-0 bg-[var(--border-base)] touch-mobile:-mx-1"
+                        />
+                      ) : null}
                       {showVoiceInput && (
                         <VoiceInputButton
                           ref={voiceInputRef}

--- a/clients/web/src/domains/chat/components/chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/components/chat-empty-state.tsx
@@ -1,12 +1,11 @@
 
-import { type ReactNode } from "react";
-
 import { BusyIndicator } from "@/domains/chat/components/busy-indicator";
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
-import { Typography } from "@vellumai/design-library";
 
 /**
- * Empty-state hero for a fresh chat: optional avatar and greeting headline.
+ * Empty-state hero for a fresh chat: the serif greeting headline. The
+ * avatar itself lives in `ComposerPeek` (hanging from the top of the
+ * screen, or peeking behind the input), not beside the headline.
  * Presentational only — the composer and conversation-starter chips are
  * rendered by the parent `ChatBody` in the same flex column so that
  * greeting → composer → starters appear as one vertically-centered group.
@@ -28,36 +27,30 @@ export interface ChatEmptyStateProps {
    * greeting doesn't flash before the personalized one arrives.
    */
   isGenerating?: boolean;
-  /**
-   * Optional avatar rendered above the greeting on mobile, or to its left on
-   * desktop. Caller passes a
-   * `<ChatAvatar … size={40} interactive />` when avatar data is available;
-   * omit the slot to render greeting-only.
-   */
-  avatarSlot?: ReactNode;
 }
 
 export function ChatEmptyState({
   greeting = DEFAULT_EMPTY_STATE_GREETING,
   isGenerating = false,
-  avatarSlot,
 }: ChatEmptyStateProps) {
   return (
-    <div className="py-8">
+    // Extra bottom padding over the top: the greeting reads as its own
+    // group with clear air above the composer (Figma: New-App 7471-25035).
+    <div className="pt-8 pb-16">
       <div className="mx-auto w-full max-w-[var(--chat-max-width)] px-3 sm:px-6">
-        <div className="flex flex-col items-center justify-center gap-3 md:flex-row">
-          {avatarSlot}
+        <div className="flex flex-col items-center justify-center">
           {isGenerating ? (
             <BusyIndicator size={10} />
           ) : (
-            <>
-              <Typography variant="title-medium" className="text-[var(--content-emphasized)] md:hidden">
-                {greeting}
-              </Typography>
-              <Typography variant="title-large" className="hidden text-[var(--content-emphasized)] md:block">
-                {greeting}
-              </Typography>
-            </>
+            /* The serif brand headline (Figma "Brand/Medium": Instrument
+               Serif 32px) — larger than the old title tokens, scaled down
+               a step on mobile. */
+            <h1
+              className="text-center text-[24px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasized)] md:text-[32px]"
+              style={{ fontFamily: "var(--font-serif)" }}
+            >
+              {greeting}
+            </h1>
           )}
         </div>
       </div>

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -976,6 +976,7 @@ export function ChatMainPanel({
     dockStartersToBottom,
     renderAvatar,
     emptyStatePlaceholder,
+    composerPeekSlot,
   } = useChatEmptyState({
     assistantId,
     conversationId: activeConversationId,
@@ -1104,6 +1105,16 @@ export function ChatMainPanel({
           <ComposerSettingsMenu
             assistantId={assistantId}
             conversationId={activeConversation?.conversationId}
+            segments="access"
+          />
+        ) : undefined
+      }
+      modelPickerSlot={
+        assistantId ? (
+          <ComposerSettingsMenu
+            assistantId={assistantId}
+            conversationId={activeConversation?.conversationId}
+            segments="profile"
           />
         ) : undefined
       }
@@ -1316,6 +1327,7 @@ export function ChatMainPanel({
   return (
     <>
       {mainContent}
+      {composerPeekSlot}
       <MicPermissionPrimer
         open={showPrimer}
         onContinue={handlePrimerContinue}

--- a/clients/web/src/domains/chat/components/composer-peek.tsx
+++ b/clients/web/src/domains/chat/components/composer-peek.tsx
@@ -1,0 +1,342 @@
+/**
+ * The empty chat screen's avatar peeks (Figma: New-App 7471-25035 /
+ * 7471-25213). The avatar renders with its real body shape and eyes
+ * (`AnimatedAvatar`) in two perches:
+ *
+ * - **Resting** (input not focused): a big avatar hangs down from the
+ *   top edge of the screen, eyes half cut off by the edge with the rest
+ *   of the body exposed, breathing and blinking over the chrome.
+ * - **Focused** (the input is active): the top dude retreats up off
+ *   screen and the avatar surfaces over the input's top edge instead,
+ *   its lower half hidden behind the rim, while the input casts a soft
+ *   unoffset shadow over it so the body reads as sitting behind the
+ *   card. This peek is anchored toward the input's left side.
+ *
+ * The composer is located by its `data-slot="chat-composer"` anchor and
+ * its rect tracked per-frame, so the overlays stay glued through
+ * reflows and composer remounts. Rendered into a `document.body`
+ * portal, decorative and pointer-transparent. Fully suppressed under
+ * `prefers-reduced-motion` and while the in-chat onboarding tour owns
+ * the chrome.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { motion, useReducedMotion } from "motion/react";
+
+import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { avatarPeekMetrics } from "@/utils/avatar-peek-metrics";
+
+interface TargetRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Both perches derive their crop from `avatarPeekMetrics` — where the
+ * active body shape + eye style actually place the eye ink — so every
+ * avatar shows its eyes at the edge. Bodies whose face sits low (a lot
+ * of body above the eyes) get scaled DOWN instead of exposing an ever
+ * taller slab, capping each perch's on-screen height.
+ */
+
+/** Largest square the input-peek avatar renders at. */
+const PEEK_SIZE_MAX = 100;
+/** Cap on how much of it sticks out above the input's top edge. */
+const PEEK_EXPOSED_MAX_PX = 52;
+/** Air between the eye ink's bottom and the input's rim. */
+const PEEK_EYE_PAD_FRAC = 0.03;
+/** Fallback exposure when metrics can't resolve (custom avatars). */
+const PEEK_EXPOSED_FRAC_FALLBACK = 0.46;
+/** Clip-container headroom above the exposed avatar — room for the idle
+ *  breathing pulse. */
+const CLIP_HEADROOM = 14;
+/** Avatar anchor along the input's width — off toward the left side. */
+const PEEK_X_FRACTION = 0.15;
+/** Exit choreography length before the input-peek overlay unmounts. */
+const EXIT_MS = 300;
+/** The composer card's own radius — the shadow caster matches it. */
+const PANEL_RADIUS = 10;
+/** Soft, unoffset shadow the input casts over the peeking avatar, so the
+ *  body reads as sitting behind the card. */
+const PEEK_SHADOW = "0 0 20px rgba(0, 0, 0, 0.15)";
+
+/** The top-of-screen dude, sized off the input width (Figma ~half). */
+const TOP_SIZE_FRACTION = 0.45;
+const TOP_SIZE_MIN = 220;
+const TOP_SIZE_MAX = 360;
+/** Cap on the visible dangle's height, whatever the body shape. */
+const TOP_DANGLE_MAX_PX = 190;
+/** Air between the screen edge and the (mirrored) eye ink's top. */
+const TOP_EYE_PAD_FRAC = 0.02;
+/** Fallback cut when metrics can't resolve. */
+const TOP_CUT_FRACTION_FALLBACK = 0.5;
+
+type Mode = "rest" | "focus" | "focus-exit";
+
+interface ComposerPeekProps {
+  components: CharacterComponents | null;
+  traits: CharacterTraits | null;
+  /** True while the empty state is the visible view; false tears down. */
+  active: boolean;
+}
+
+export function ComposerPeek({ components, traits, active }: ComposerPeekProps) {
+  const reduce = useReducedMotion();
+  // The onboarding tour floods the composer itself — never compete with it.
+  const navTourActive = useInChatOnboardingStore.use.navTourActive();
+  const [rect, setRect] = useState<TargetRect | null>(null);
+  const [mode, setMode] = useState<Mode>("rest");
+
+  const runnable =
+    active && !reduce && !navTourActive && !!components && !!traits;
+
+  // Where this avatar's eye ink sits in its rendered square — drives the
+  // per-shape crop/size below so the eyes always ride the edge.
+  const metrics = useMemo(
+    () => (components && traits ? avatarPeekMetrics(components, traits) : null),
+    [components, traits],
+  );
+
+  useEffect(() => {
+    if (!runnable) {
+      return;
+    }
+    let exitTimer: ReturnType<typeof setTimeout> | undefined;
+
+    // Re-queried on every measure, never captured: the composer form
+    // remounts (e.g. as a draft conversation settles), and a held
+    // reference would go stale — a detached node measures 0×0 and the
+    // overlay would freeze on the pre-remount rect.
+    const measure = (): TargetRect | null => {
+      const r = document
+        .querySelector<HTMLElement>('[data-slot="chat-composer"]')
+        ?.getBoundingClientRect();
+      if (!r || r.width === 0 || r.height === 0) {
+        return null;
+      }
+      return { left: r.left, top: r.top, width: r.width, height: r.height };
+    };
+    const enter = () => {
+      clearTimeout(exitTimer);
+      setMode("focus");
+    };
+    const leave = () => {
+      setMode((m) => (m === "focus" ? "focus-exit" : m));
+      clearTimeout(exitTimer);
+      exitTimer = setTimeout(() => setMode("rest"), EXIT_MS);
+    };
+    // Document-level so listeners survive composer remounts. Focus moving
+    // within the composer (textarea → mic button) isn't a leave — only
+    // retract when it lands outside the card.
+    const onFocusIn = (event: FocusEvent) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest('[data-slot="chat-composer"]')
+      ) {
+        enter();
+      }
+    };
+    const onFocusOut = (event: FocusEvent) => {
+      const from =
+        event.target instanceof Element &&
+        event.target.closest('[data-slot="chat-composer"]');
+      const to =
+        event.relatedTarget instanceof Element &&
+        event.relatedTarget.closest('[data-slot="chat-composer"]');
+      if (from && !to) {
+        leave();
+      }
+    };
+    // The composer moves and resizes under the peeks without firing any
+    // event we could subscribe to — the centered empty-state group reflows
+    // as the greeting streams in, the textarea autogrows, slots settle.
+    // Track its rect every frame; the updater bails (same state object)
+    // when nothing changed, so idle frames don't re-render.
+    let raf = 0;
+    const track = () => {
+      setRect((prev) => {
+        const next = measure();
+        if (!next) {
+          return prev;
+        }
+        if (
+          prev &&
+          next.left === prev.left &&
+          next.top === prev.top &&
+          next.width === prev.width &&
+          next.height === prev.height
+        ) {
+          return prev;
+        }
+        return next;
+      });
+      raf = requestAnimationFrame(track);
+    };
+    raf = requestAnimationFrame(track);
+
+    document.addEventListener("focusin", onFocusIn);
+    document.addEventListener("focusout", onFocusOut);
+
+    // The composer may already hold focus when the act arms (it autofocuses
+    // on a fresh chat) — surface immediately instead of waiting for a blur
+    // round-trip.
+    if (
+      document.activeElement instanceof Element &&
+      document.activeElement.closest('[data-slot="chat-composer"]')
+    ) {
+      enter();
+    }
+
+    return () => {
+      document.removeEventListener("focusin", onFocusIn);
+      document.removeEventListener("focusout", onFocusOut);
+      cancelAnimationFrame(raf);
+      clearTimeout(exitTimer);
+      setRect(null);
+      setMode("rest");
+    };
+  }, [runnable]);
+
+  // `components`/`traits` re-checked for narrowing — `runnable` implies both.
+  if (!runnable || !rect || !components || !traits) {
+    return null;
+  }
+
+  const focused = mode === "focus";
+
+  // Input peek geometry: expose down to just below the eye ink, capped —
+  // low-faced bodies scale down rather than exposing a taller slab.
+  const peekExposedFrac = metrics
+    ? Math.min(
+        0.95,
+        Math.max(
+          0.25,
+          metrics.eyeCenterFrac + metrics.eyeHalfFrac + PEEK_EYE_PAD_FRAC,
+        ),
+      )
+    : PEEK_EXPOSED_FRAC_FALLBACK;
+  const peekSize = Math.min(PEEK_SIZE_MAX, PEEK_EXPOSED_MAX_PX / peekExposedFrac);
+  const peekExposedPx = peekSize * peekExposedFrac;
+  const clipHeight = peekExposedPx + CLIP_HEADROOM;
+  const risePx = peekExposedPx + 8;
+  const peekX = Math.max(peekSize / 2 + 16, rect.width * PEEK_X_FRACTION);
+
+  // Top dude geometry: centered over the input, hanging mirrored from
+  // the screen's top edge with its eyes peering down just below the cut
+  // and the visible dangle capped in height.
+  const topCut = metrics
+    ? Math.min(
+        0.85,
+        Math.max(
+          0,
+          1 - metrics.eyeCenterFrac - metrics.eyeHalfFrac - TOP_EYE_PAD_FRAC,
+        ),
+      )
+    : TOP_CUT_FRACTION_FALLBACK;
+  const topVisibleFrac = 1 - topCut;
+  const topSize = Math.min(
+    Math.min(TOP_SIZE_MAX, Math.max(TOP_SIZE_MIN, rect.width * TOP_SIZE_FRACTION)),
+    TOP_DANGLE_MAX_PX / topVisibleFrac,
+  );
+  const topExposed = topSize * topVisibleFrac;
+
+  return createPortal(
+    <div aria-hidden="true" className="pointer-events-none fixed inset-0 z-30">
+      {/* Top-of-screen dude, shown while the input is idle. */}
+      <motion.div
+        className="absolute"
+        style={{
+          width: topSize,
+          height: topSize,
+          left: rect.left + rect.width / 2 - topSize / 2,
+          top: -topSize * topCut,
+        }}
+        initial={{ y: -topExposed - 8 }}
+        animate={{ y: focused ? -topExposed - 8 : 0 }}
+        transition={
+          focused
+            ? { duration: 0.25, ease: "easeIn" }
+            : { type: "spring", stiffness: 220, damping: 20, delay: 0.15 }
+        }
+      >
+        {/* Inner wrapper carries the vertical mirror so it can't interact
+            with the motion `y` transform above (a flipped element's
+            translateY would slide the wrong way). */}
+        <div className="h-full w-full" style={{ transform: "scaleY(-1)" }}>
+          <AnimatedAvatar
+            components={components}
+            traits={traits}
+            size={topSize}
+          />
+        </div>
+      </motion.div>
+      {mode !== "rest" && (
+        <>
+          {/* Input-peek avatar, clipped at the input's top edge so the
+              body reads as peeking out from behind the rim. */}
+          <div
+            className="absolute overflow-hidden"
+            style={{
+              left: rect.left,
+              top: rect.top - clipHeight,
+              width: rect.width,
+              height: clipHeight,
+            }}
+          >
+            <motion.div
+              className="absolute"
+              style={{
+                width: peekSize,
+                height: peekSize,
+                left: peekX - peekSize / 2,
+                top: clipHeight - peekExposedPx,
+              }}
+              initial={{ y: risePx }}
+              animate={focused ? { y: 0 } : { y: risePx }}
+              transition={
+                focused
+                  ? {
+                      type: "spring",
+                      stiffness: 280,
+                      damping: 14,
+                      delay: 0.15,
+                    }
+                  : { duration: 0.25, ease: "easeIn" }
+              }
+            >
+              <AnimatedAvatar
+                components={components}
+                traits={traits}
+                size={peekSize}
+              />
+            </motion.div>
+          </div>
+          {/* Shadow caster painted over the avatar: a transparent rect
+              matching the card whose box-shadow falls on everything around
+              it — the avatar sits under the input's shadow, so it reads as
+              behind. */}
+          <motion.div
+            className="absolute"
+            style={{
+              left: rect.left,
+              top: rect.top,
+              width: rect.width,
+              height: rect.height,
+              borderRadius: PANEL_RADIUS,
+              boxShadow: PEEK_SHADOW,
+            }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: focused ? 1 : 0 }}
+            transition={{ duration: 0.2 }}
+          />
+        </>
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -52,9 +52,21 @@ import { toast } from "@vellumai/design-library/components/toast";
 interface Props {
   assistantId: string;
   conversationId: string | undefined;
+  /**
+   * Which trigger segment(s) this instance renders. The composer's action
+   * row splits them across its two ends (Figma: New-App 7471-25234 —
+   * access on the left beside the attach button, model profile on the
+   * right beside the mic), mounting one instance per side. Server state
+   * is TanStack-Query-cached, so the two instances share fetches.
+   */
+  segments?: "both" | "access" | "profile";
 }
 
-export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
+export function ComposerSettingsMenu({
+  assistantId,
+  conversationId,
+  segments = "both",
+}: Props) {
   const isMobile = useIsMobile();
   const queryClient = useQueryClient();
   // Two independent menus/triggers — the access-level segment and the model-
@@ -486,52 +498,78 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
   // value loads. Only the icon is shown inline — the label lives in a tooltip
   // and the menu — to keep the composer's bottom bar compact.
   const AccessIcon = activePreset.icon;
-  const showAccess = globalThresholdsQuery.isSuccess || serverIsOverride;
+  const showAccess =
+    (globalThresholdsQuery.isSuccess || serverIsOverride) &&
+    segments !== "profile";
+  const showProfile = segments !== "access";
 
-  // Each trigger is a self-contained button: highlights on hover and while its
-  // own menu is open, independent of the sibling trigger.
+  // Each trigger is the design library's ghost Button — same chrome and
+  // sizing as the row's other icon buttons (attach, mic) — in the action
+  // row's tertiary resting tone, held open-highlighted while its own menu
+  // is up.
   const triggerClass =
-    "flex h-7 items-center gap-1.5 rounded-md px-1.5 py-1 text-body-small-default text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)] data-[state=open]:bg-[var(--surface-active)] data-[state=open]:text-[var(--content-default)]";
+    "[--vbtn-fg:var(--content-tertiary)] touch-mobile:[--vbtn-fg:var(--content-tertiary)] data-[state=open]:bg-[color-mix(in_srgb,var(--primary-second-hover)_15%,transparent)]";
+  const triggerLabelClass = "gap-1.5 px-1.5 text-body-small-default";
 
-  // Access trigger — icon only. Sits between the context-window ring and the
-  // model-profile trigger. `title` surfaces the active preset name since the
-  // label is no longer shown inline.
-  const accessTrigger = (
-    <button
-      type="button"
-      aria-label={`Assistant access: ${activePreset.label}`}
-      title={`Assistant access: ${activePreset.label}`}
-      className={`${triggerClass} shrink-0`}
+  // Access trigger — icon plus, on desktop, the active preset's name
+  // (Figma 7471-25243). Mobile stays icon-only to keep the bottom bar
+  // compact; there the label lives in the tooltip and the sheet.
+  const accessLabel = `Assistant access: ${activePreset.label}`;
+  const accessTrigger = isMobile ? (
+    <Button
+      variant="ghost"
+      iconOnly={<AccessIcon />}
+      aria-label={accessLabel}
+      title={accessLabel}
+      className={triggerClass}
+    />
+  ) : (
+    <Button
+      variant="ghost"
+      leftIcon={<AccessIcon className="h-3.5 w-3.5 shrink-0" />}
+      aria-label={accessLabel}
+      title={accessLabel}
+      className={`${triggerClass} ${triggerLabelClass} shrink-0`}
     >
-      <AccessIcon className="h-3.5 w-3.5 shrink-0" />
-    </button>
+      {activePreset.label}
+    </Button>
   );
 
-  // Profile trigger — Sparkles + label. Falls back to the sliders icon until
-  // the active profile resolves so there's always an affordance to open it.
-  const profileTrigger = (
-    <button
-      type="button"
-      aria-label="Model profile"
-      className={`${triggerClass} min-w-0`}
-    >
-      {activeProfileLabel ? (
-        <>
-          <Sparkles className="h-3.5 w-3.5 shrink-0" />
-          {/* min-w-0 + truncate keeps a long label from pushing the composer's
-              action buttons off-screen on narrow viewports; the cap is tighter
-              on mobile where the bottom bar has the least room. */}
-          {/* leading-snug: text-body-small-default is line-height:1, so truncate
-              clips descenders (e.g. the "g" in profile names). */}
-          <span className="max-w-[7rem] truncate leading-snug sm:max-w-[10rem]">
-            {activeProfileLabel}
-          </span>
-        </>
-      ) : (
-        <SlidersHorizontal className="h-[18px] w-[18px]" />
-      )}
-    </button>
-  );
+  // Profile trigger — Sparkles + label on desktop; icon-only on mobile
+  // (the label lives in the sheet there), matching the access trigger.
+  // Falls back to the sliders icon until the active profile resolves so
+  // there's always an affordance to open it.
+  const profileLabel = activeProfileLabel
+    ? `Model profile: ${activeProfileLabel}`
+    : "Model profile";
+  const profileTrigger =
+    isMobile || !activeProfileLabel ? (
+      <Button
+        variant="ghost"
+        iconOnly={
+          activeProfileLabel ? <Sparkles /> : <SlidersHorizontal />
+        }
+        aria-label="Model profile"
+        title={profileLabel}
+        className={triggerClass}
+      />
+    ) : (
+      <Button
+        variant="ghost"
+        leftIcon={<Sparkles className="h-3.5 w-3.5 shrink-0" />}
+        aria-label="Model profile"
+        title={profileLabel}
+        className={`${triggerClass} ${triggerLabelClass} min-w-0`}
+      >
+        {/* min-w-0 + truncate keeps a long label from pushing the composer's
+            action buttons off-screen on narrow viewports. leading-snug:
+            text-body-small-default is line-height:1, so truncate clips
+            descenders (e.g. the "g" in profile names). */}
+        <span className="max-w-[10rem] truncate leading-snug">
+          {activeProfileLabel}
+        </span>
+      </Button>
+    );
 
   const accessItems = THRESHOLD_PRESETS.map((preset) => ({
     preset,
@@ -579,6 +617,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
             </BottomSheet.Content>
           </BottomSheet.Root>
         )}
+        {showProfile && (
         <BottomSheet.Root open={profileOpen} onOpenChange={setProfileOpen}>
           <BottomSheet.Trigger asChild>{profileTrigger}</BottomSheet.Trigger>
           <BottomSheet.Content aria-describedby={undefined}>
@@ -615,6 +654,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
             </BottomSheet.Body>
           </BottomSheet.Content>
         </BottomSheet.Root>
+        )}
       </>
     );
   }
@@ -659,6 +699,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
           </Menu.Content>
         </Menu.Root>
       )}
+      {showProfile && (
       <Menu.Root open={profileOpen} onOpenChange={setProfileOpen}>
         <Menu.Trigger asChild>{profileTrigger}</Menu.Trigger>
         <Menu.Content side="top" align="start">
@@ -690,6 +731,7 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
           })}
         </Menu.Content>
       </Menu.Root>
+      )}
     </>
   );
 }

--- a/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
@@ -6,12 +6,12 @@ import { cn } from "@/utils/misc";
 import { Button } from "@vellumai/design-library";
 
 /**
- * Suggestion-pill primitive used in the chat empty state. Wraps the `Button`
- * primitive (`variant="outlined"`, `fullWidth`) so interactive surface
- * tokens stay owned by `Button`. Overrides cover layout only — Button's
- * default `h-8` / `whitespace-nowrap` / `body-medium-default` are swapped
- * for a 56px-min, two-line-clamped, `body-medium-lighter` card via
- * tailwind-merge.
+ * Suggestion-pill primitive used in the chat empty state's bottom dock
+ * (Figma: New-App 7471-25035). Wraps the `Button` primitive
+ * (`variant="ghost"`, `fullWidth`) so interactive surface tokens stay
+ * owned by `Button`. Overrides cover layout only — Button's default
+ * `h-8` / `whitespace-nowrap` is swapped for a soft white rounded card
+ * via tailwind-merge.
  */
 export interface ConversationStarterChipProps {
   /** Suggestion text. Truncated to two lines via `line-clamp-2`. */
@@ -44,14 +44,17 @@ export const ConversationStarterChip = forwardRef<
       className={cn(
         // Override Button's fixed h-8 / single-line / default body size.
         "h-auto whitespace-normal",
-        // Slimmer + smaller text on mobile, full size on sm+.
-        "px-3 py-2 sm:px-4 sm:py-3 rounded-[10px]",
-        "text-body-small-default sm:text-body-medium-lighter text-center",
-        // Light fill, no border, secondary content text.
-        "bg-[var(--surface-lift)] [--vbtn-fg:var(--content-secondary)]",
+        "min-h-[44px] sm:min-h-[52px]",
+        "px-3 py-2.5 sm:px-4 sm:py-3 rounded-[16px]",
+        "text-body-small-default sm:text-title-small text-center",
+        // Soft white card, no border (Figma 7471-25047).
+        "bg-[var(--surface-lift)] [--vbtn-fg:var(--content-default)]",
       )}
     >
-      <span className="line-clamp-2">{label}</span>
+      {/* leading-normal: the title-small token is line-height:1, and
+          line-clamp's overflow clipping would cut descenders (the "g" in
+          "morning") without real line height. */}
+      <span className="line-clamp-2 leading-normal">{label}</span>
     </Button>
   );
 });

--- a/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
@@ -44,11 +44,13 @@ export const ConversationStarterChip = forwardRef<
       className={cn(
         // Override Button's fixed h-8 / single-line / default body size.
         "h-auto whitespace-normal",
-        "min-h-[44px] sm:min-h-[52px]",
-        "px-3 py-2.5 sm:px-4 sm:py-3 rounded-[16px]",
-        "text-body-small-default sm:text-title-small text-center",
+        "min-h-[40px] sm:min-h-[44px]",
+        "px-3 py-2 sm:px-4 sm:py-2.5 rounded-[12px]",
+        // Theme body type in the secondary tone — reads like the app's
+        // buttons rather than heavy title text.
+        "text-body-small-lighter sm:text-body-medium-lighter text-center",
         // Soft white card, no border (Figma 7471-25047).
-        "bg-[var(--surface-lift)] [--vbtn-fg:var(--content-default)]",
+        "bg-[var(--surface-lift)] [--vbtn-fg:var(--content-secondary)]",
       )}
     >
       {/* leading-normal: the title-small token is line-height:1, and

--- a/clients/web/src/domains/chat/components/conversation-starter-grid.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-grid.tsx
@@ -33,7 +33,7 @@ export function ConversationStarterGrid({
     return null;
   }
   return (
-    <div className="grid grid-cols-2 gap-3">
+    <div className="grid grid-cols-2 gap-4">
       {visible.map((starter) => (
         <ConversationStarterChip
           key={starter.id}

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -1048,7 +1048,11 @@ export const VoiceInputButton = forwardRef<
       aria-busy={processing}
       title={label}
       className={cn(
-        "[--vbtn-fg:var(--content-secondary)]",
+        // Tertiary resting tone, matching the composer action row's icons
+        // (Figma: New-App 7471-25234). The touch-mobile override beats the
+        // ghost icon-only variant's default-tone mobile chrome so mobile
+        // matches desktop.
+        "[--vbtn-fg:var(--content-tertiary)] touch-mobile:[--vbtn-fg:var(--content-tertiary)]",
         isNative && recording && "h-12 w-12 max-md:h-12 max-md:w-12",
       )}
     />

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -12,6 +12,7 @@ import { type ReactNode, useMemo } from "react";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import type { ChatEmptyStateProps } from "@/domains/chat/components/chat-empty-state";
+import { ComposerPeek } from "@/domains/chat/components/composer-peek";
 import { ConversationStarterGrid } from "@/domains/chat/components/conversation-starter-grid";
 import {
   SuggestionFeaturedRow,
@@ -69,6 +70,12 @@ export interface ChatEmptyStateResult {
   dockStartersToBottom: boolean;
   renderAvatar: (() => ReactNode) | undefined;
   emptyStatePlaceholder: string;
+  /**
+   * The composer's hover peek for the empty state (see `ComposerPeek`):
+   * mount it once alongside the chat body. `undefined` outside the plain
+   * empty state (active conversation, app editing).
+   */
+  composerPeekSlot: ReactNode | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -107,6 +114,12 @@ export function useChatEmptyState({
       ? { name: openedAppState.name, dirName: openedAppState.dirName }
       : null;
 
+  // The avatar's presence on the empty state lives entirely in
+  // `ComposerPeek` (hanging from the top of the screen while idle,
+  // peeking behind the input while it's focused) — the greeting headline
+  // renders alone.
+  const actsEnabled = isEmptyConversation && !editingApp;
+
   // Behind the flag, the new suggestions library replaces the starter chips
   // on a fresh thread. The app-editing override keeps its bespoke chips
   // regardless of the flag, so it stays on the grid path. The library also
@@ -127,20 +140,6 @@ export function useChatEmptyState({
   );
 
   const emptyStateProps: ChatEmptyStateProps = {
-    avatarSlot:
-      avatarComponents || avatarImageUrl ? (
-        <ChatAvatar
-          components={avatarComponents}
-          traits={avatarTraits}
-          customImageUrl={avatarImageUrl}
-          size={40}
-          interactive
-          isAssistantBusy={isAssistantBusy}
-          // The empty-state greeting avatar — the room's entrance grows from
-          // here on a fresh chat.
-          originAnchor
-        />
-      ) : null,
     greeting: editingApp ? buildEditAppGreeting(editingApp) : emptyStateGreeting,
     isGenerating: editingApp ? false : greetingIsGenerating,
   };
@@ -161,14 +160,36 @@ export function useChatEmptyState({
       <SuggestionGroups groups={groups} onSelect={onSelectSuggestion} />
     );
   } else if (isEmptyConversation && emptyStateStarters.length > 0) {
-    startersSlot = (
-      <div className="mt-4">
-        <ConversationStarterGrid
-          starters={emptyStateStarters}
-          onSelect={onSelectStarter}
-        />
-      </div>
-    );
+    if (editingApp) {
+      // The app-editing side panel keeps its bespoke chips inline under
+      // the composer.
+      startersSlot = (
+        <div className="mt-4">
+          <ConversationStarterGrid
+            starters={emptyStateStarters}
+            onSelect={onSelectStarter}
+          />
+        </div>
+      );
+    } else {
+      // Plain empty state: the chips dock to the bottom of the first
+      // viewport in a subtle panel with a muted caption (Figma: New-App
+      // 7471-25035; the Figma's 1×3 row stays a 2×2 grid here). Top
+      // corners only, and `-mb-3` swallows the dock wrapper's bottom
+      // padding so the panel sits flush against the viewport's bottom
+      // edge.
+      startersSlot = (
+        <div className="-mb-3 rounded-t-2xl bg-[var(--surface-active)] px-6 pt-5 pb-6">
+          <p className="mb-4 text-center text-body-medium-default text-[var(--content-tertiary)]">
+            Suggestions
+          </p>
+          <ConversationStarterGrid
+            starters={emptyStateStarters}
+            onSelect={onSelectStarter}
+          />
+        </div>
+      );
+    }
   }
 
   // Stable callback so the latest-turn avatar slot isn't rebuilt on every
@@ -200,12 +221,29 @@ export function useChatEmptyState({
     ],
   );
 
+  // Portal component — mounting location doesn't matter, but it only runs
+  // on the plain empty state (never over the app-editing side panel, whose
+  // composer shares the same DOM anchor).
+  const composerPeekSlot = actsEnabled ? (
+    <ComposerPeek
+      components={avatarComponents}
+      traits={avatarTraits}
+      active={actsEnabled}
+    />
+  ) : undefined;
+
   return {
     emptyStateProps,
     startersSlot,
     belowFoldSlot,
-    dockStartersToBottom: showSuggestionLibrary,
+    // Both the suggestions library and the plain chip dock pin the
+    // starters to the bottom of the first viewport; only the app-editing
+    // side panel keeps them inline under the composer.
+    dockStartersToBottom:
+      showSuggestionLibrary ||
+      (isEmptyConversation && !editingApp && emptyStateStarters.length > 0),
     renderAvatar,
     emptyStatePlaceholder,
+    composerPeekSlot,
   };
 }

--- a/clients/web/src/utils/avatar-peek-metrics.ts
+++ b/clients/web/src/utils/avatar-peek-metrics.ts
@@ -1,0 +1,80 @@
+/**
+ * Face-placement metrics for the empty-chat peeks (`ComposerPeek`).
+ *
+ * Body shapes carry their face at wildly different heights (ghost wears
+ * it near the top of a tall body, sprout near the bottom under a tall
+ * stem), and eye styles vary in ink height (gentle is nearly square,
+ * grumpy is a flat strip). A fixed "show the top N pixels" crop
+ * therefore hides some avatars' eyes entirely. These metrics express,
+ * per body-shape + eye-style combination — including the catalog's
+ * `faceCenterOverrides` — where the eye ink actually sits inside the
+ * rendered square, so the peeks can size and crop every avatar such
+ * that the eyes always ride the edge.
+ *
+ * The math mirrors `computeTransforms` / `AnimatedAvatar`'s layout
+ * (body fit-centered into a square, eye art remapped onto the face
+ * center) evaluated on a unit square, so the fractions hold at any
+ * render size.
+ */
+
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { pathBBox, unionBBox } from "@/utils/eye-bbox";
+import { resolveDefinitions } from "@/utils/avatar-svg-compositor";
+
+export interface AvatarPeekMetrics {
+  /** Vertical center of the eye ink, as a fraction of the square. */
+  eyeCenterFrac: number;
+  /** Half the eye ink's height, as a fraction of the square. */
+  eyeHalfFrac: number;
+}
+
+/**
+ * Metrics for the avatar described by `traits`, or null when the traits
+ * don't resolve against the component catalog (unknown ids, custom
+ * image). Callers fall back to neutral defaults on null.
+ */
+export function avatarPeekMetrics(
+  components: CharacterComponents,
+  traits: CharacterTraits,
+): AvatarPeekMetrics | null {
+  let resolved;
+  try {
+    resolved = resolveDefinitions(
+      components,
+      traits.bodyShape,
+      traits.eyeStyle,
+      traits.color,
+    );
+  } catch {
+    return null;
+  }
+  const { bodyShape, eyeStyle } = resolved;
+  if (!eyeStyle) {
+    return null;
+  }
+
+  const vb = bodyShape.viewBox;
+  // Body fit-centered into a unit square.
+  const k = Math.min(1 / vb.width, 1 / vb.height);
+  const bodyTy = (1 - vb.height * k) / 2;
+
+  const override = components.faceCenterOverrides.find(
+    (o) => o.bodyShape === bodyShape.id && o.eyeStyle === eyeStyle.id,
+  );
+  const faceCenter = override ? override.faceCenter : bodyShape.faceCenter;
+
+  // Eye art remapped so its declared eyeCenter lands on the face center;
+  // the ink's own bbox gives the true drawn extent (it can sit off the
+  // declared center for asymmetric styles).
+  const eyeVB = eyeStyle.sourceViewBox;
+  const remapScale = Math.min(vb.width / eyeVB.width, vb.height / eyeVB.height);
+  const ink = unionBBox(eyeStyle.paths.map((p) => pathBBox(p.svgPath)));
+  const inkCenterY = ink.y + ink.h / 2;
+
+  const eyeCenterFrac =
+    k * (faceCenter.y + (inkCenterY - eyeStyle.eyeCenter.y) * remapScale) +
+    bodyTy;
+  const eyeHalfFrac = (ink.h * remapScale * k) / 2;
+
+  return { eyeCenterFrac, eyeHalfFrac };
+}


### PR DESCRIPTION
## Summary

Redesigns the new-chat empty state per Figma (New-App [7471-25035](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=7471-25035), [7471-25213](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=7471-25213), [7471-25234](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=7471-25234)) and gives the assistant's avatar a living presence on the screen.

### Avatar peeks (`composer-peek.tsx`, new)
- **Idle**: a large, vertically-mirrored avatar hangs from the top of the screen peering down the page, sized off the input width and capped at a 190px dangle.
- **Input focused**: the top dude retreats and the avatar (real body shape + eyes via `AnimatedAvatar`, breathing/blinking) surfaces behind the input's top rim, left-anchored, while the input casts a soft unoffset 20px shadow over it so it reads as behind the card.
- Anchored by `data-slot="chat-composer"` with the rect tracked per animation frame, so the overlay survives layout reflows and composer remounts. Fully suppressed under `prefers-reduced-motion` and while the in-chat onboarding tour owns the chrome.

### Per-avatar geometry (`avatar-peek-metrics.ts`, new)
Derives — per body shape × eye style, including `faceCenterOverrides` and the eye ink's bbox — where the eyes sit in the rendered square, mirroring the compositor's math. Both perches use it to crop and size every avatar so the eyes always ride the edge; tall-faced bodies (sprout, cloud) scale down against exposure caps instead of towering.

### Empty state
- Serif brand headline (Instrument Serif 32px desktop / 24px mobile) with more air below; no avatar beside the greeting.
- Starter chips docked flush to the viewport's bottom edge in a subtle rounded-top panel captioned "Suggestions", kept as a 2×2 grid.
- Fixed descender clipping in chip labels (`line-clamp` + line-height:1 token).

### Composer action row (Figma 7471-25234)
- Left: attach | divider | assistant access, now showing the active preset's name on desktop. Right: model profile | divider | mic, send.
- Access/profile triggers are now the design library's ghost `Button` — same chrome and sizing as the row's icon buttons; profile trigger is icon-only on mobile.
- Tertiary icon tones on desktop **and** touch-mobile (overrides the ghost icon-only variant's darker mobile chrome); dividers pull in on touch-mobile.

## Testing

- `bunx tsc --noEmit` clean (only pre-existing `settings/ai` poolside errors on main).
- `bun test` green for the touched areas (empty-state hook, chat body, composer, settings menu, route content).
- `bun run build` passes; visually QA'd across the iterations on desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)