### PR TITLE
fix(onboarding): route iOS through research onboarding

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-destination.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.test.ts
@@ -7,7 +7,6 @@ describe("onboardingDestinationAfterConsent", () => {
   test("platform/Vellum-Cloud routes straight to the research flow", () => {
     expect(
       onboardingDestinationAfterConsent({
-        isNative: false,
         isLocalHatch: false,
       }),
     ).toBe(routes.onboarding.research);
@@ -15,13 +14,7 @@ describe("onboardingDestinationAfterConsent", () => {
 
   test("local hosting routes to hatching first (foreground local hatch → research)", () => {
     expect(
-      onboardingDestinationAfterConsent({ isNative: false, isLocalHatch: true }),
-    ).toBe(routes.onboarding.hatching);
-  });
-
-  test("native keeps the standard hatching path", () => {
-    expect(
-      onboardingDestinationAfterConsent({ isNative: true, isLocalHatch: false }),
+      onboardingDestinationAfterConsent({ isLocalHatch: true }),
     ).toBe(routes.onboarding.hatching);
   });
 });

--- a/clients/web/src/domains/onboarding/onboarding-destination.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.ts
@@ -14,18 +14,14 @@ import { routes } from "@/utils/routes";
  *   gateway readyz → provider key) runs; the hatching screen then redirects into
  *   the research flow, which adopts that just-hatched assistant. Skipping
  *   hatching here would leave the research flow with no assistant to adopt.
- * - **Native** (iOS/Capacitor) → hatching, then chat: the research flow isn't
- *   wired for the native shell yet.
  */
 export function onboardingDestinationAfterConsent({
-  isNative,
   isLocalHatch,
 }: {
-  isNative: boolean;
   /** A local-hosting onboarding that must run the foreground local hatch. */
   isLocalHatch: boolean;
 }): string {
-  return isNative || isLocalHatch
+  return isLocalHatch
     ? routes.onboarding.hatching
     : routes.onboarding.research;
 }

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -278,7 +278,6 @@ mock.module("@/assistant/lifecycle", () => ({
 mock.module("@/assistant/lifecycle-service", () => ({
   lifecycleService: {
     checkAssistant: async () => {},
-    markExpectingFirstMessage: () => {},
   },
 }));
 
@@ -347,10 +346,6 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => false,
 }));
 
-mock.module("@/runtime/native-auth", () => ({
-  isNativePlatform: () => false,
-}));
-
 mock.module("@/assistant/selection", () => ({
   setSelectedAssistant: () => {},
 }));
@@ -403,7 +398,6 @@ mock.module("@/utils/avatar-svg-compositor", () => ({
 
 mock.module("@/utils/routes", () => ({
   routes: {
-    assistant: "/assistant",
     onboarding: {
       research: "/onboarding/research",
       hosting: "/onboarding/hosting",
@@ -512,6 +506,9 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
 
     await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
       timeout: 5000,
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/onboarding/research", {
+      replace: true,
     });
     // Not a Pro subscription: the resize phase is never entered.
     expect(screen.queryByText(RESIZE_LABEL)).toBeNull();

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -35,7 +35,6 @@ import {
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { hatchLocalAssistant } from "@/runtime/local-mode-host";
 import { isElectron } from "@/runtime/is-electron";
-import { isNativePlatform } from "@/runtime/native-auth";
 import { setSelectedAssistant } from "@/assistant/selection";
 import { useAuthStore } from "@/stores/auth-store";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
@@ -251,7 +250,9 @@ export function HatchingScreen() {
       setPhase("ready");
       phaseRef.current = "ready";
       navigateTimer = setTimeout(() => {
-        if (cancelled) return;
+        if (cancelled) {
+          return;
+        }
         // The hatch succeeded and we're leaving this screen for good. Release
         // the module-level guards so a later onboarding session (e.g. after
         // retiring this assistant) hatches a brand-new one instead of reusing
@@ -259,16 +260,7 @@ export function HatchingScreen() {
         releaseHatchGuards();
         void (async () => {
           await lifecycleService.checkAssistant();
-          if (cancelled) return;
-          if (isNativePlatform()) {
-            // Native flow skips the pre-chat screen, so there's no
-            // typed message to drive the auto-greet gate. Mark the
-            // lifecycle one-shot so the destination chat mount shows
-            // the loading gate until the server greeting arrives.
-            lifecycleService.markExpectingFirstMessage();
-            void navigate(`${routes.assistant}?onboarding=1`, {
-              replace: true,
-            });
+          if (cancelled) {
             return;
           }
           // A local hatch feeds the research/personality flow. The assistant is

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -50,11 +50,13 @@ mock.module("@/hooks/use-marketing-pricing-takeover", () => ({
   useMarketingPricingTakeover: () => takeoverValue,
 }));
 
+const PRIVACY_TOS_STEP = "privacy_tos";
 const emitFunnelStepCompletedMock = mock((..._args: unknown[]) => {});
+const getFunnelSessionIdMock = mock(() => "session-1");
 mock.module("@/domains/onboarding/funnel-events", () => ({
   emitOnboardingFunnelStepCompleted: emitFunnelStepCompletedMock,
-  getOnboardingFunnelSessionId: () => "session-1",
-  ONBOARDING_FUNNEL_STEPS: { privacyTos: "privacy_tos" },
+  getOnboardingFunnelSessionId: getFunnelSessionIdMock,
+  ONBOARDING_FUNNEL_STEPS: { privacyTos: PRIVACY_TOS_STEP },
 }));
 
 mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
@@ -127,6 +129,7 @@ describe("PrivacyScreen — Start navigation", () => {
     navigateMock.mockClear();
     saveConsentMock.mockClear();
     emitFunnelStepCompletedMock.mockClear();
+    getFunnelSessionIdMock.mockClear();
     clearCheckoutIntentMock.mockClear();
     nativePlatform = false;
     localMode = false;
@@ -197,14 +200,18 @@ describe("PrivacyScreen — Start navigation", () => {
     expect(target).toContain("hosting=local");
   });
 
-  test("native keeps the standard hatching flow (research not wired for the native shell)", () => {
+  test("native follows the same research onboarding as web", () => {
     nativePlatform = true;
     searchParamsValue = new URLSearchParams();
     render(<PrivacyScreen />);
 
     clickStart();
 
-    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hatching);
+    expect(getFunnelSessionIdMock).toHaveBeenCalledTimes(1);
+    expect(emitFunnelStepCompletedMock).toHaveBeenCalledWith(PRIVACY_TOS_STEP, {
+      userId: "user-1",
+    });
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.research);
   });
 
   test("resumes checkout when a pending signup-marked package intent is present", () => {

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -51,10 +51,8 @@ export function PrivacyScreen() {
   const takeover = useMarketingPricingTakeover();
 
   useEffect(() => {
-    if (!isNative) {
-      getOnboardingFunnelSessionId();
-    }
-  }, [isNative]);
+    getOnboardingFunnelSessionId();
+  }, []);
 
   const isPreview = searchParams.get("preview") === "true";
   const noop = useCallback((_next: boolean) => {}, []);
@@ -74,11 +72,9 @@ export function PrivacyScreen() {
     // Analytics isn't asked here — the server keeps share_analytics null
     // until the user opts in via settings or review-terms.
     saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics: null, shareDiagnostics: shareDiagnosticsChecked, hasPlatformSession });
-    if (!isNative) {
-      emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
-        userId,
-      });
-    }
+    emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
+      userId,
+    });
 
     // A completed checkout with nothing provisioned is funneled to the hatching
     // screen; an unconsented user is bounced here, and the funnel URL rides
@@ -110,7 +106,6 @@ export function PrivacyScreen() {
     const isLocalHatch =
       isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
     const destination = onboardingDestinationAfterConsent({
-      isNative,
       isLocalHatch,
     });
     const onboardingNext = `${destination}${qs ? `?${qs}` : ""}`;
@@ -152,7 +147,6 @@ export function PrivacyScreen() {
   }, [
     privacyConsent,
     hasPlatformSession,
-    isNative,
     isPreview,
     navigate,
     searchParams,

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -111,8 +111,8 @@ const postCheckoutBilling = `${routes.settings.root}/billing?session_id=cs_test_
 
 // The funnel entry carries the managed-hatch marker so a local-mode client
 // provisions on the platform rather than letting its own gateway answer for
-// the assistant. Non-native shells land on the headless research onboarding,
-// which runs the purchased-provisioning wait behind the form.
+// the assistant. Every client lands on the headless research onboarding, which
+// runs the purchased-provisioning wait behind the form.
 const managedFunnel = `${routes.onboarding.research}?hosting=vellum-cloud&post_checkout=1`;
 
 /**

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -19,16 +19,6 @@ mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthMode: () => false,
 }));
 
-// The shell fork the paid provisioning funnel reads. Spread the real module so
-// the rest of the platform auth graph (`isOAuthFlowInFlight` and friends) stays
-// available to the stores build-state pulls in.
-let mockIsNativePlatform = false;
-const nativeAuthActual = await import("@/runtime/native-auth");
-mock.module("@/runtime/native-auth", () => ({
-  ...nativeAuthActual,
-  isNativePlatform: () => mockIsNativePlatform,
-}));
-
 // Consent prefs read storage; pin them so the access decision is isolated.
 mock.module("@/domains/onboarding/prefs", () => ({
   readTosAccepted: () => true,
@@ -50,7 +40,6 @@ const initialAuthState = useAuthStore.getState();
 beforeEach(() => {
   mockIsLocalMode = true;
   mockIsRemoteGatewayMode = false;
-  mockIsNativePlatform = false;
   useAuthStore.setState(initialAuthState, true);
   useOrganizationStore.setState({
     currentOrganizationId: null,
@@ -122,22 +111,6 @@ describe("buildNavigationState — isAuthenticated mirrors sessionStatus", () =>
     });
 
     expect(buildNavigationState().platformSession).toBe("unknown");
-  });
-});
-
-describe("buildNavigationState — isNative", () => {
-  // The post-checkout provisioning funnel forks on this: native keeps the
-  // foreground hatching screen, web and Electron take the headless research
-  // entry.
-
-  test("false in a browser or the Electron shell", () => {
-    expect(buildNavigationState().isNative).toBe(false);
-  });
-
-  test("true inside the native Capacitor shell", () => {
-    mockIsNativePlatform = true;
-
-    expect(buildNavigationState().isNative).toBe(true);
   });
 });
 

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -15,7 +15,6 @@ import {
   readConsentHydrated,
 } from "@/domains/onboarding/prefs";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
-import { isNativePlatform } from "@/runtime/native-auth";
 import {
   assistantsValidForOrg,
   useResolvedAssistantsStore,
@@ -57,7 +56,6 @@ export function buildNavigationState(
       ? remoteGatewayPublicPathPrefix()
       : "",
     isGatewayAuth: isGatewayAuthMode(),
-    isNative: isNativePlatform(),
     hasAssistants: assistants.length > 0,
     hasPlatformHostedAssistant: hasPlatformHostedAssistant(assistants),
     sessionSettled: isSessionSettled(sessionStatus),

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -20,8 +20,6 @@ const base: NavigationState = {
   isRemoteGateway: false,
   remoteGatewayPublicPathPrefix: "",
   isGatewayAuth: false,
-  // Web/Electron by default; the native fork is exercised explicitly.
-  isNative: false,
   hasAssistants: true,
   hasPlatformHostedAssistant: true,
   sessionSettled: true,
@@ -612,13 +610,6 @@ describe("resolveNavigation", () => {
       action: "redirect",
       to: RESEARCH_FUNNEL_URL,
     };
-    // The native shell has no research flow, so it keeps the foreground
-    // hatching screen.
-    const NATIVE_MANAGED_FUNNEL: NavigationDecision = {
-      action: "redirect",
-      to: HATCHING_FUNNEL_URL,
-    };
-
     // A brand-new org: nothing resolved at all.
     const EMPTY_ORG = {
       hasAssistants: false,
@@ -637,20 +628,6 @@ describe("resolveNavigation", () => {
       expect(guard(s(EMPTY_ORG), POST_CHECKOUT_BILLING)).toEqual(
         MANAGED_FUNNEL,
       );
-    });
-
-    // The research flow isn't wired for the Capacitor shell, so the native paid
-    // return still gets the foreground hatching screen.
-    test("keeps the foreground hatching entry on native", () => {
-      expect(
-        guard(s({ ...EMPTY_ORG, isNative: true }), POST_CHECKOUT_BILLING),
-      ).toEqual(NATIVE_MANAGED_FUNNEL);
-      expect(
-        guard(
-          s({ ...NO_MANAGED_ASSISTANT, isNative: true }),
-          POST_CHECKOUT_BILLING,
-        ),
-      ).toEqual(NATIVE_MANAGED_FUNNEL);
     });
 
     // The decision is "does a managed plan have a target", not "is the list
@@ -1091,20 +1068,16 @@ describe("resolveNavigation", () => {
       }
     });
 
-    // The stale-toggle gate is research-only. The hatching entry — where the
-    // native paid return lands, and where a `returnTo` stashed by an older
-    // client still points — resolves `allow` here and re-reviews stale terms at
-    // the screen's own `hatch-gate` instead.
+    // The stale-toggle gate is research-only. The hatching entry — where a
+    // `returnTo` stashed by an older client may still point — resolves `allow`
+    // here and re-reviews stale terms at the screen's own `hatch-gate` instead.
     test("leaves a stale-consent paid hatching return on its allow", () => {
       for (const stale of STALE_TOGGLES) {
         expect(
           guard(s({ ...ELECTRON_PAID, ...stale }), HATCHING_FUNNEL_URL),
         ).toEqual(ALLOW);
         expect(
-          guard(
-            s({ ...EMPTY_ORG, isNative: true, ...stale }),
-            HATCHING_FUNNEL_URL,
-          ),
+          guard(s({ ...EMPTY_ORG, ...stale }), HATCHING_FUNNEL_URL),
         ).toEqual(ALLOW);
       }
     });

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -14,13 +14,6 @@ export interface NavigationState {
   isRemoteGateway: boolean;
   remoteGatewayPublicPathPrefix: string;
   isGatewayAuth: boolean;
-  /**
-   * Whether this is the native Capacitor shell (iOS/Android).
-   *
-   * The research onboarding is not wired for the native shell (see
-   * `onboarding-destination.ts`), so the paid provisioning funnel forks on it.
-   */
-  isNative: boolean;
   hasAssistants: boolean;
   /**
    * Whether the active organization has a **platform-hosted** assistant — the
@@ -189,26 +182,21 @@ export const POST_CHECKOUT_HATCH_PARAM = "post_checkout";
  * already changed hands, which is what lets the hatch treat a still-base
  * subscription read as a pending webhook rather than a free org.
  */
-function managedProvisioningDestination(state: NavigationState): string {
-  // The same shell fork the consent step takes: native has no research flow and
-  // keeps the foreground hatching screen, while web and Electron take the
-  // headless research entry, which runs the purchased-provisioning wait behind
+function managedProvisioningDestination(): string {
+  // The headless research entry runs the purchased-provisioning wait behind
   // the onboarding form. `isLocalHatch` is false by construction —
-  // `hosting=vellum-cloud` forces the managed hatch.
+  // `hosting=vellum-cloud` forces the managed hatch on every client.
   const route = onboardingDestinationAfterConsent({
-    isNative: state.isNative,
     isLocalHatch: false,
   });
   return `${route}?hosting=vellum-cloud&${POST_CHECKOUT_HATCH_PARAM}=1`;
 }
 
 /**
- * The provisioning funnel entries a paid return can name: the foreground
- * hatching screen (native only) and the headless research onboarding (web and
- * Electron). The shell is the only fork — {@link managedProvisioningDestination}
- * always resolves a managed hatch, so hosting never picks the entry. Both
- * provision the purchased assistant, so both are consent-gated and both are
- * resumable from the privacy screen.
+ * The provisioning funnel entries a paid return can name: the headless research
+ * onboarding and the foreground hatching screen retained for return URLs
+ * stashed by older clients. Both provision the purchased assistant, so both are
+ * consent-gated and resumable from the privacy screen.
  */
 const PROVISIONING_FUNNEL_PATHS: Set<string> = new Set([
   routes.onboarding.hatching,
@@ -440,7 +428,7 @@ function requirePostCheckoutProvisioning(
       return null;
     }
   }
-  return { action: "redirect", to: managedProvisioningDestination(state) };
+  return { action: "redirect", to: managedProvisioningDestination() };
 }
 
 /**
@@ -629,12 +617,12 @@ function enforceFunnelConsent(
   }
 
   // A stale toggle must be re-reviewed before a hatch the user paid for.
-  // Research-only: the hatching entry — the native paid return, and a
-  // `returnTo` stashed by an older client — reaches a screen whose own
-  // `hatch-gate` already re-reviews stale terms, so gating it twice would only
-  // change where it lands. Gated on the paid marker so the ordinary funnel
-  // keeps its exemption, and on a live platform session for the same reason as
-  // `requireConsent`: there is nothing to re-review against without one.
+  // Research-only: the hatching entry — where a `returnTo` stashed by an older
+  // client may still point — reaches a screen whose own `hatch-gate` already
+  // re-reviews stale terms, so gating it twice would only change where it
+  // lands. Gated on the paid marker so the ordinary funnel keeps its exemption,
+  // and on a live platform session for the same reason as `requireConsent`:
+  // there is nothing to re-review against without one.
   if (
     path === routes.onboarding.research &&
     postCheckoutHatchReturnTo(pathnameWithSearch) &&


### PR DESCRIPTION
## Summary
- route managed onboarding and paid provisioning through research on every client, including Capacitor iOS
- remove the native post-hatch empty-chat shortcut and record the same onboarding funnel steps across devices
- add regression coverage for native consent and hatch handoffs

## Validation
- `bun test src/domains/onboarding/onboarding-destination.test.ts src/domains/onboarding/pages/privacy-screen.test.tsx src/lib/navigation/build-state.test.ts src/lib/navigation/navigation-resolver.test.ts src/lib/auth/auth-middleware.test.ts`
- `bun test src/domains/onboarding/pages/hatching-screen.test.tsx`
- `bun run typecheck`
- focused ESLint (no errors)

## Original prompt
Fix iOS onboarding so new users follow the same research onboarding path as web instead of landing in an empty conversation after consent.