### PR TITLE
fix(plugin-api): keep the ambient namespace types in the d.ts build

### DIFF
--- a/assistant/tsconfig.plugin-api.json
+++ b/assistant/tsconfig.plugin-api.json
@@ -9,5 +9,5 @@
     "outDir": "./.plugin-api-build/dts",
     "rootDir": "./src"
   },
-  "include": ["src/plugin-api/index.ts"]
+  "include": ["src/plugin-api/index.ts", "src/vellum-assistant-namespace.d.ts"]
 }


### PR DESCRIPTION
Fixes the Release v0.11.0 failure in [run 30363805227](https://github.com/vellum-ai/vellum-assistant/actions/runs/30363805227/job/90291855309), where `bun run scripts/build-plugin-api.ts` died with 11 `TS2304: Cannot find name 'Vellum*'` errors.

## Prompt / plan

Asked to diagnose why that Release run failed.

Root cause: `assistant/tsconfig.plugin-api.json` narrows `include` to just `src/plugin-api/index.ts`. `include` **replaces** the base config's value rather than merging with it, so `src/vellum-assistant-namespace.d.ts` stopped being part of that program. Nothing imports that file — by design, it is ambient precisely so referencing its types adds no runtime import edge — and a `.d.ts` that is neither imported nor matched by `include` is simply not in the program.

Its globals therefore vanished from the plugin-api declaration build, and every module reachable from the entrypoint that reads a `globalThis.vellumAssistant` slot failed to compile: `config/feature-flag-cache.ts`, `persistence/db-singleton.ts`, `runtime/process-role.ts`, `security/store-path-override.ts`.

The ambient file landed in #39308; `tsconfig.plugin-api.json` was untouched by it. The main `tsc -p tsconfig.json` build never saw the breakage because its `src/**/*` include picks the file up, which is why this only surfaced on the release path.

Fix: add the ambient declaration to the plugin-api include list. `.d.ts` inputs emit no declarations of their own, so the built package is byte-identical apart from now compiling.

## Test plan

- Reproduced the exact 11 CI errors locally with `tsc -p tsconfig.plugin-api.json`.
- After the change, `tsc -p tsconfig.plugin-api.json` exits 0.
- Ran the full failing CI step end-to-end: `bun run scripts/build-plugin-api.ts --version "0.11.0-staging.1"` → "API Extractor completed successfully", package built. Remaining API Extractor output is pre-existing `@legacy`/`ae-forgotten-export` warnings, unchanged by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVgkng43AKXN3Aa6LRFCEg)_