### PR TITLE
fix(security): gate system-section prompt overrides as control-plane writes (ATL-1146)

### DIFF
--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -968,6 +968,10 @@ describe("ToolApprovalHandler / approval cell lifts the sensitive-tool floor", (
       ["its identity", "IDENTITY.md"],
       ["a per-user context file", "users/someone.md"],
       ["a per-channel context file", "channels/general.md"],
+      [
+        "a system-section override",
+        "prompts/system/10a-non-guardian-boundary.md",
+      ],
     ])("a write to %s — %s", async (_label, path) => {
       await expectFloored("file_write", { path, content: "x" });
     });

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -1,6 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 
 import * as envRegistry from "../config/env-registry.js";
@@ -560,6 +566,40 @@ describe("isControlPlaneWorkspaceWrite / prompt surfaces", () => {
       true,
     );
   });
+
+  // The reverse symlink dodge: the control-plane *name* is itself a link to
+  // a benign path. The write's bytes land at the destination, but the
+  // renderer and the loaders open the control-plane name and follow the
+  // link — so the addressed name must match the baselines even though the
+  // canonical destination does not.
+  test.each([
+    ["a section override", "prompts/system/06-credential-security.md"],
+    ["an executable sink entry", "hooks/on-boot.ts"],
+    ["a per-user context file", "users/someone.md"],
+  ])(
+    "blocks a write addressed at %s that is a symlink to a benign path",
+    (_label, addressedPath) => {
+      const parentDir = join(wsRoot, dirname(addressedPath));
+      const parentExisted = existsSync(parentDir);
+      mkdirSync(parentDir, { recursive: true });
+      const destination = join(wsRoot, "notes-real", "decoy.txt");
+      symlinkSync(destination, join(wsRoot, addressedPath));
+      try {
+        expect(
+          isControlPlaneWorkspaceWrite(
+            "file_write",
+            { path: addressedPath },
+            wsRoot,
+          ),
+        ).toBe(true);
+      } finally {
+        rmSync(join(wsRoot, addressedPath), { force: true });
+        if (!parentExisted) {
+          rmSync(parentDir, { recursive: true, force: true });
+        }
+      }
+    },
+  );
 
   // Drift guard: the override path for every bundled section id must be
   // covered, so adding a section cannot silently open a writable override

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -536,6 +536,47 @@ describe("isControlPlaneWorkspaceWrite / prompt surfaces", () => {
     );
   });
 
+  // The section override layer: any `<section-id>.md` under prompts/system/
+  // replaces the bundled section of the same id — or, stripped to nothing,
+  // silences it — including the security-policy sections. A brand-new id
+  // adds a workspace-only section, so the whole directory is a prompt
+  // surface, not just the bundled ids.
+  test.each([
+    ["a security-section override", "prompts/system/06-credential-security.md"],
+    [
+      "the non-guardian boundary override",
+      "prompts/system/10a-non-guardian-boundary.md",
+    ],
+    ["a workspace-only addition", "prompts/system/99-injected-section.md"],
+    [
+      "the container /workspace form",
+      "/workspace/prompts/system/07-external-content.md",
+    ],
+  ])("blocks %s — %s", (_label, path) => {
+    expect(isControlPlaneWorkspaceWrite("file_write", { path }, wsRoot)).toBe(
+      true,
+    );
+    expect(isControlPlaneWorkspaceWrite("file_edit", { path }, wsRoot)).toBe(
+      true,
+    );
+  });
+
+  // Drift guard: the override path for every bundled section id must be
+  // covered, so adding a section cannot silently open a writable override
+  // for it.
+  test("covers the override path of every bundled system section", () => {
+    expect(BUNDLED_SYSTEM_SECTIONS.length).toBeGreaterThan(0);
+    for (const section of BUNDLED_SYSTEM_SECTIONS) {
+      expect(
+        isControlPlaneWorkspaceWrite(
+          "file_write",
+          { path: `prompts/system/${section.id}.md` },
+          wsRoot,
+        ),
+      ).toBe(true);
+    }
+  });
+
   // A surface that is itself a symlink is read through the link by the
   // renderer, so a write to either name rewrites the prompt — the baselines
   // canonicalize like the targets do.

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -9,6 +9,7 @@ import {
   getWorkspacePluginsDir,
   getWorkspaceRoutesDir,
   getWorkspaceSkillsDir,
+  getWorkspaceSystemPromptDir,
   getWorkspaceToolsDir,
   getWorkspaceWorkflowsDir,
 } from "../util/platform.js";
@@ -276,7 +277,15 @@ export function isControlPlaneWorkspaceWrite(
     ) ||
     PROMPT_SURFACE_DIRS.some((dir) =>
       isAtOrUnderCanonicalDir(target, canonicalize(`${root}/${dir}`)),
-    )
+    ) ||
+    // The system-section override layer: a `<section-id>.md` under
+    // `prompts/system/` replaces the bundled section of the same id — or,
+    // stripped to nothing, silences it — including the security-policy
+    // sections (credential handling, external content, the non-guardian
+    // boundary). A brand-new id adds a workspace-only section, so the whole
+    // directory is a prompt surface. The baseline is the getter the renderer
+    // itself resolves, like {@link executableSinkDirs}.
+    isAtOrUnderCanonicalDir(target, canonicalize(getWorkspaceSystemPromptDir()))
   );
 }
 

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -44,6 +44,20 @@ function canonicalizeExisting(abs: string): string {
 }
 
 /**
+ * Canonicalize a path's directory chain while keeping the final segment as
+ * addressed: symlinks among the ancestors (macOS `/var` → `/private/var`, a
+ * linked parent directory) resolve, a trailing symlink does not. This is
+ * the *name* the daemon acts on — the prompt renderer and the code loaders
+ * open control-plane paths by name and follow links while reading, so when
+ * the final segment is itself a symlink, a write addressed at it changes
+ * what they read even though the bytes land at the link's destination.
+ */
+function canonicalizeAddressedName(p: string): string {
+  const abs = resolve(p);
+  return `${canonicalizeExisting(dirname(abs))}/${basename(abs)}`;
+}
+
+/**
  * Whether a canonical path is a canonical directory or falls under it. The
  * trailing separator keeps `/workspace-extra` from matching `/workspace`.
  * Both arguments must already be canonicalized — comparing a canonical path
@@ -244,10 +258,20 @@ const PROMPT_SURFACE_DIRS = ["users", "channels"];
  * mode too: the workspace boundary is what contains an escaping *path*, and
  * these paths do not escape — the daemon acts on them from inside.
  *
- * Both sides are canonicalized before comparing, for the same reason
- * {@link isPathWithinWorkspaceRoot} canonicalizes: a symlink whose name
- * looks benign but whose target is a control-plane path is a write to that
- * path, and a lexical prefix check does not see it.
+ * Two views of the write are checked against every baseline, because a
+ * symlink at either end dodges a single view:
+ *
+ * - The canonical destination ({@link canonicalize}): a benign-looking name
+ *   whose trailing link points at a control-plane path is a write to that
+ *   path, and a lexical check does not see it.
+ * - The addressed name ({@link canonicalizeAddressedName}): a control-plane
+ *   name that is itself a symlink to a benign path still changes what the
+ *   daemon reads under that name — the renderer and the loaders follow the
+ *   link — while the destination alone canonicalizes past the surface.
+ *
+ * The baselines are canonicalized too: a prompt surface may itself be a
+ * symlink (SOUL.md → personas/current.md), and the renderer reads through
+ * it — so a write to the link's destination must match as well.
  */
 export function isControlPlaneWorkspaceWrite(
   toolName: string,
@@ -262,22 +286,22 @@ export function isControlPlaneWorkspaceWrite(
     return false;
   }
   const target = canonicalize(filePath);
+  const addressed = canonicalizeAddressedName(filePath);
   const root = canonicalize(workspaceRoot);
-  // The baselines are canonicalized too, not just the target: a prompt
-  // surface may itself be a symlink (SOUL.md → personas/current.md), and the
-  // renderer reads through it — so a write to either name must match. A
-  // lexical baseline would miss both the through-link write (target
-  // canonicalizes past it) and the direct write to the link's destination.
+  const writesUnder = (dir: string): boolean => {
+    const canonicalDir = canonicalize(dir);
+    return (
+      isAtOrUnderCanonicalDir(target, canonicalDir) ||
+      isAtOrUnderCanonicalDir(addressed, canonicalDir)
+    );
+  };
   return (
-    executableSinkDirs().some((dir) =>
-      isAtOrUnderCanonicalDir(target, canonicalize(dir)),
-    ) ||
-    PROMPT_SURFACE_FILES.some(
-      (file) => target === canonicalize(`${root}/${file}`),
-    ) ||
-    PROMPT_SURFACE_DIRS.some((dir) =>
-      isAtOrUnderCanonicalDir(target, canonicalize(`${root}/${dir}`)),
-    ) ||
+    executableSinkDirs().some(writesUnder) ||
+    PROMPT_SURFACE_FILES.some((file) => {
+      const canonicalFile = canonicalize(`${root}/${file}`);
+      return target === canonicalFile || addressed === canonicalFile;
+    }) ||
+    PROMPT_SURFACE_DIRS.some((dir) => writesUnder(`${root}/${dir}`)) ||
     // The system-section override layer: a `<section-id>.md` under
     // `prompts/system/` replaces the bundled section of the same id — or,
     // stripped to nothing, silences it — including the security-policy
@@ -285,7 +309,7 @@ export function isControlPlaneWorkspaceWrite(
     // boundary). A brand-new id adds a workspace-only section, so the whole
     // directory is a prompt surface. The baseline is the getter the renderer
     // itself resolves, like {@link executableSinkDirs}.
-    isAtOrUnderCanonicalDir(target, canonicalize(getWorkspaceSystemPromptDir()))
+    writesUnder(getWorkspaceSystemPromptDir())
   );
 }
 

--- a/assistant/src/prompts/sections.ts
+++ b/assistant/src/prompts/sections.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 
 import { parseFrontmatterFields } from "../skills/frontmatter.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
+import {
+  getWorkspacePromptPath,
+  getWorkspaceSystemPromptDir,
+} from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 import {
   BUNDLED_SYSTEM_SECTIONS,
@@ -24,21 +27,6 @@ const log = getLogger("system-prompt-sections");
  * interpolation.
  */
 export type SectionRenderContext = Record<string, unknown>;
-
-/**
- * Workspace override location for user-authored system prompt sections.
- * Layout: `<workspace>/prompts/system/<NN-name>.md`.
- *
- * The bundled section registry (`templates/system-sections.ts`) is the
- * source of default truth; this directory is an optional override layer.
- * Drop a file with the same id as a bundled section to replace its body,
- * or drop a file with a brand-new `<NN-name>` to add a workspace-only
- * section.  Either path is opt-in — the directory may not exist on a
- * fresh install, and the renderer will simply use bundled defaults.
- */
-export function getWorkspaceSystemPromptDir(): string {
-  return join(getWorkspaceDir(), "prompts", "system");
-}
 
 /**
  * Render static sections in id-sort order, then dynamic sections in id-sort

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -434,6 +434,21 @@ export function getWorkspacePromptPath(file: string): string {
   return join(getWorkspaceDir(), file);
 }
 
+/**
+ * Returns `<workspaceDir>/prompts/system` — the workspace override layer for
+ * system prompt sections. Layout: `prompts/system/<NN-name>.md`.
+ *
+ * The bundled section registry (`prompts/templates/system-sections.ts`) is
+ * the source of default truth; a file here with the same id replaces the
+ * bundled body (or, stripped to nothing, silences it), and a brand-new
+ * `<NN-name>` adds a workspace-only section. Because that includes the
+ * security-policy sections, writes under this directory are gated as a
+ * control-plane prompt surface (`permissions/workspace-policy.ts`).
+ */
+export function getWorkspaceSystemPromptDir(): string {
+  return join(getWorkspaceDir(), "prompts", "system");
+}
+
 // ── Profiler filesystem layout ──────────────────────────────────────────
 // Managed profiler runs live under <workspace>/data/profiler/. These
 // helpers enforce a single canonical layout so every runtime caller


### PR DESCRIPTION
## Summary

The prompt renderer resolves every bundled system section against `<workspace>/prompts/system/<section-id>.md` before falling back to the bundled body, so a file there replaces — or, stripped to nothing, silences — sections like `06-credential-security`, `07-external-content`, and `10a-non-guardian-boundary`. `isControlPlaneWorkspaceWrite()` covered the root prompt files (`IDENTITY.md`, `SOUL.md`, `VOICE.md`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `NOW.md`) plus `users/` and `channels/`, but not this override layer. A channel contact in a room with a non-`none` approval cell (including the Conservative default) could therefore get such a write classified as liftable, skip the guardian grant path, and persistently rewrite the assistant's security-policy instructions.

## Changes

- **`permissions/workspace-policy.ts`** — `isControlPlaneWorkspaceWrite()` now also matches targets under the section override directory, with the same canonicalization as the other baselines (symlinks, `..` traversal, and the container `/workspace` form are all seen). The channel-lift path (`isChannelLiftable`) already consults this predicate, so these writes stay on the guardian floor at every cell level.
- **`util/platform.ts` / `prompts/sections.ts`** — moved `getWorkspaceSystemPromptDir()` to `util/platform.ts` beside the other workspace-dir getters so the renderer and the policy share one definition instead of duplicating the path.
- **Tests** — predicate coverage for override writes (bundled ids, a workspace-only id, the container path form, `file_edit` as well as `file_write`); a floored case in the approval-handler "what no cell lifts" suite; and a drift guard asserting the override path of every bundled section id is covered, so adding a section cannot silently open a writable override.

## Testing

- `bun test src/__tests__/workspace-policy.test.ts src/__tests__/tool-approval-handler.test.ts src/__tests__/system-prompt.test.ts src/__tests__/platform.test.ts` — 255 pass
- `bunx tsgo --noEmit` — clean
- `bunx eslint` on the touched files — no errors

Fixes ATL-1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyP9fNwVKEUJ5EVJNRPUc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyP9fNwVKEUJ5EVJNRPUc8)_