### PR TITLE
feat(web): resync subagent store from subagents/reconcile on load, SSE reopen, and unknown-id events

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29498,9 +29498,9 @@ paths:
       summary: Reconcile subagent live status
       description:
         Returns the live in-memory state of all subagents known to the assistant for a given parent conversation.
-        Each entry carries enough detail (child conversation id, label, objective) for a client to rebuild its subagent
-        list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. Only
-        `status` is guaranteed to be present; every other field is optional.
+        Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a
+        client to rebuild its subagent list from scratch, not just refresh statuses. Subagents absent from the response
+        are orphaned or terminal. Only `status` is guaranteed to be present; every other field is optional.
       tags:
         - subagents
       parameters:
@@ -29536,6 +29536,22 @@ paths:
                         isFork:
                           type: boolean
                         parentToolUseId:
+                          type: string
+                        usage:
+                          type: object
+                          properties:
+                            inputTokens:
+                              type: number
+                            outputTokens:
+                              type: number
+                            estimatedCost:
+                              type: number
+                          required:
+                            - inputTokens
+                            - outputTokens
+                            - estimatedCost
+                          additionalProperties: false
+                        error:
                           type: string
                       required:
                         - status

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29497,10 +29497,12 @@ paths:
       operationId: subagents_reconcile_get
       summary: Reconcile subagent live status
       description:
-        Returns the live in-memory state of all subagents known to the assistant for a given parent conversation.
-        Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a
-        client to rebuild its subagent list from scratch, not just refresh statuses. Subagents absent from the response
-        are orphaned or terminal. Only `status` is guaranteed to be present; every other field is optional.
+        Returns every subagent the assistant knows for a given parent conversation — live, rehydrated, and durably
+        recorded, including terminal runs whose in-memory metadata the retention sweep has already evicted. Each entry
+        carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to
+        rebuild its subagent list from scratch, not just refresh statuses. A subagent absent from the response is one
+        the assistant has no knowledge of at all, so a client may settle its own stuck-active entries against this
+        snapshot. Only `status` is guaranteed to be present; every other field is optional.
       tags:
         - subagents
       parameters:

--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -324,6 +324,37 @@ describe("getSubagentDetail route resolution", () => {
     expect(result.status).toBe("aborted");
   });
 
+  test("settles a durable row still marked active into interrupted", () => {
+    // `setDbReady(true)` precedes `rehydrateFromDb()` during daemon startup, so
+    // a record can still carry its pre-crash status while the manager knows
+    // nothing about it. Nothing runs without an in-memory entry, so `running`
+    // on an orphaned row is stale — report what the rehydration will write.
+    seedConversation("orphan-child-conv", "orphan transcript");
+    durableRecords.set("sub-orphaned", {
+      conversationId: "orphan-child-conv",
+      label: "Orphaned label",
+      status: "running",
+    });
+
+    const result = fetchDetail("sub-orphaned", "parent-conv");
+
+    expect(result.status).toBe("interrupted");
+    expect(result.label).toBe("Orphaned label");
+    expect(result.conversationId).toBe("orphan-child-conv");
+  });
+
+  test("leaves a live subagent's active status alone", () => {
+    // In-memory state is authoritative: something IS driving this run.
+    seedConversation("still-running-conv", "still running transcript");
+    liveSubagents.set("sub-still-running", {
+      conversationId: "still-running-conv",
+      status: "running",
+      config: { label: "Still running" },
+    });
+
+    expect(fetchDetail("sub-still-running").status).toBe("running");
+  });
+
   test("omits status when the durable record holds an out-of-enum value", () => {
     seedConversation("odd-child-conv", "odd transcript");
     durableRecords.set("sub-odd", {

--- a/assistant/src/__tests__/subagent-reconcile-route.test.ts
+++ b/assistant/src/__tests__/subagent-reconcile-route.test.ts
@@ -150,6 +150,53 @@ describe("reconcileSubagents route", () => {
     expect(entry.error).toBeUndefined();
   });
 
+  test("keeps a terminal subagent the retention sweep evicted from memory", () => {
+    upsertSubagentRecord(
+      record({
+        id: "sub-swept",
+        conversationId: "child-conv-swept",
+        label: "swept",
+        status: "completed",
+        completedAt: 2000,
+        inputTokens: 90,
+        outputTokens: 20,
+        estimatedCost: 0.003,
+      }),
+    );
+    // No `rehydrateFromDb()`: the row with no in-memory state IS the
+    // post-sweep shape (`dispose(..., { keepRecord: true })`). Absence here
+    // would read as "interrupted" to a client settling orphans by absence.
+
+    expect(reconcile(PARENT_ID).subagents["sub-swept"]).toEqual({
+      status: "completed",
+      conversationId: "child-conv-swept",
+      label: "swept",
+      objective: "Research competitor pricing",
+      isFork: false,
+      usage: { inputTokens: 90, outputTokens: 20, estimatedCost: 0.003 },
+    });
+  });
+
+  test("lets an in-memory child shadow its own durable row", () => {
+    upsertSubagentRecord(record());
+    // In-flight at rehydrate time → the manager settles it to `interrupted`.
+    getSubagentManager().rehydrateFromDb();
+    // A stale row claiming otherwise must not win: the live state is fresher.
+    upsertSubagentRecord(
+      record({ status: "completed", error: "stale", completedAt: 2000 }),
+    );
+
+    const entry = reconcile(PARENT_ID).subagents["sub-1"];
+    expect(entry.status).toBe("interrupted");
+    expect(entry.error).toBeUndefined();
+  });
+
+  test("omits a durable row whose status is out of enum", () => {
+    upsertSubagentRecord(record({ status: "zombie" }));
+
+    expect(reconcile(PARENT_ID).subagents).toEqual({});
+  });
+
   test("returns an empty map for a parent with no known children", () => {
     upsertSubagentRecord(record());
     getSubagentManager().rehydrateFromDb();

--- a/assistant/src/__tests__/subagent-reconcile-route.test.ts
+++ b/assistant/src/__tests__/subagent-reconcile-route.test.ts
@@ -115,6 +115,41 @@ describe("reconcileSubagents route", () => {
     expect(subagents["sub-anchored"].parentToolUseId).toBe("toolu-abc");
   });
 
+  test("carries terminal usage and failure reason", () => {
+    upsertSubagentRecord(
+      record({
+        id: "sub-failed",
+        conversationId: "child-conv-failed",
+        label: "failed-run",
+        status: "failed",
+        error: "provider timed out",
+        completedAt: 2000,
+        inputTokens: 1200,
+        outputTokens: 340,
+        estimatedCost: 0.021,
+      }),
+    );
+    getSubagentManager().rehydrateFromDb();
+
+    // The terminal `subagent_status_changed` is exactly the event a
+    // reconciling client may have missed, so the snapshot has to carry what it
+    // would have delivered.
+    expect(reconcile(PARENT_ID).subagents["sub-failed"]).toMatchObject({
+      status: "failed",
+      error: "provider timed out",
+      usage: { inputTokens: 1200, outputTokens: 340, estimatedCost: 0.021 },
+    });
+  });
+
+  test("omits usage and error for a child that has spent nothing", () => {
+    upsertSubagentRecord(record());
+    getSubagentManager().rehydrateFromDb();
+
+    const entry = reconcile(PARENT_ID).subagents["sub-1"];
+    expect(entry.usage).toBeUndefined();
+    expect(entry.error).toBeUndefined();
+  });
+
   test("returns an empty map for a parent with no known children", () => {
     upsertSubagentRecord(record());
     getSubagentManager().rehydrateFromDb();

--- a/assistant/src/__tests__/subagent-reconcile-route.test.ts
+++ b/assistant/src/__tests__/subagent-reconcile-route.test.ts
@@ -191,6 +191,67 @@ describe("reconcileSubagents route", () => {
     expect(entry.error).toBeUndefined();
   });
 
+  test("settles an orphaned durable row still marked active", () => {
+    // The startup window: `setDbReady(true)` precedes `rehydrateFromDb()`, so
+    // a reconcile can read a pre-crash `running` row while the manager is
+    // still empty. Nothing can be running without an in-memory entry.
+    upsertSubagentRecord(record({ status: "running" }));
+    upsertSubagentRecord(
+      record({
+        id: "sub-pending",
+        conversationId: "child-conv-pending",
+        label: "pending",
+        status: "pending",
+      }),
+    );
+    upsertSubagentRecord(
+      record({
+        id: "sub-awaiting",
+        conversationId: "child-conv-awaiting",
+        label: "awaiting",
+        status: "awaiting_input",
+      }),
+    );
+    // Deliberately no `rehydrateFromDb()`.
+
+    const { subagents } = reconcile(PARENT_ID);
+    expect(subagents["sub-1"].status).toBe("interrupted");
+    expect(subagents["sub-pending"].status).toBe("interrupted");
+    expect(subagents["sub-awaiting"].status).toBe("interrupted");
+  });
+
+  test("leaves an orphaned durable row's terminal status untouched", () => {
+    for (const status of ["completed", "failed", "aborted", "interrupted"]) {
+      upsertSubagentRecord(
+        record({
+          id: `sub-${status}`,
+          conversationId: `child-conv-${status}`,
+          label: status,
+          status,
+          completedAt: 2000,
+        }),
+      );
+    }
+
+    const { subagents } = reconcile(PARENT_ID);
+    expect(subagents["sub-completed"].status).toBe("completed");
+    expect(subagents["sub-failed"].status).toBe("failed");
+    expect(subagents["sub-aborted"].status).toBe("aborted");
+    expect(subagents["sub-interrupted"].status).toBe("interrupted");
+  });
+
+  test("does not settle an active child the manager still holds", () => {
+    upsertSubagentRecord(record({ status: "running" }));
+    const manager = getSubagentManager();
+    manager.rehydrateFromDb();
+    // A live entry means something IS driving the run, so its active status is
+    // current rather than stale. `getState` hands back the manager's own state
+    // object — the very one the route's live pass reads.
+    manager.getState("sub-1")!.status = "running";
+
+    expect(reconcile(PARENT_ID).subagents["sub-1"].status).toBe("running");
+  });
+
   test("omits a durable row whose status is out of enum", () => {
     upsertSubagentRecord(record({ status: "zombie" }));
 

--- a/assistant/src/persistence/subagent-store.ts
+++ b/assistant/src/persistence/subagent-store.ts
@@ -160,6 +160,22 @@ export function getSubagentRecordById(id: string): SubagentRecord | undefined {
   return row ? rowToRecord(row) : undefined;
 }
 
+/**
+ * Every subagent record spawned under `parentConversationId`. Durable rows
+ * outlive the manager's in-memory metadata — the TTL sweep evicts terminal
+ * entries with `keepRecord: true` — so this is the only way to enumerate a
+ * parent's subagents that completed long enough ago to have been swept.
+ */
+export function getSubagentRecordsByParent(
+  parentConversationId: string,
+): SubagentRecord[] {
+  return rawAll<SubagentRow>(
+    "subagent:getByParent",
+    `SELECT * FROM subagents WHERE parent_conversation_id = ?`,
+    parentConversationId,
+  ).map(rowToRecord);
+}
+
 /** Delete a subagent record once the manager is fully done with it. */
 export function deleteSubagentRecord(id: string): void {
   rawRun("subagent:deleteRecord", `DELETE FROM subagents WHERE id = ?`, id);

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 
 import {
+  type SubagentStatus,
   SubagentStatusSchema,
   SubagentUsageStatsSchema,
 } from "../../api/events/subagent-status-changed.js";
@@ -22,6 +23,7 @@ import {
   getSubagentRecordsByParent,
 } from "../../persistence/subagent-store.js";
 import { getSubagentManager } from "../../subagent/index.js";
+import { TERMINAL_STATUSES } from "../../subagent/types.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
@@ -212,6 +214,30 @@ const ReconciledSubagentSchema = z.object({
 });
 
 /**
+ * Settle the status of a durable row that no live manager entry answers for.
+ *
+ * Invariant: a subagent runs from an in-memory entry, so a durable row without
+ * one can only describe a run that is no longer executing — whatever the row
+ * says, nothing is driving it. Its pre-crash `pending`/`running`/
+ * `awaiting_input` is therefore stale and reported as `interrupted`, exactly
+ * what `SubagentManager.rehydrateFromDb()` writes for the same row. Terminal
+ * statuses are the truth already and pass through untouched.
+ *
+ * This closes a startup window rather than a steady state: `setDbReady(true)`
+ * precedes `rehydrateFromDb()` in `daemon/lifecycle.ts`, so a request can pass
+ * the DB gate while the manager is still empty and read rows the rehydration
+ * has not yet normalized. Without the coercion a client reconciling on its SSE
+ * reopen adopts `running`, and the later rehydration flips the row to
+ * `interrupted` with no status event to say so — leaving the UI stuck.
+ *
+ * Only ever applied to record-derived statuses; live state is authoritative
+ * and never coerced.
+ */
+function settledDurableStatus(status: SubagentStatus): SubagentStatus {
+  return TERMINAL_STATUSES.has(status) ? status : "interrupted";
+}
+
+/**
  * A child that has spent nothing reports no usage at all, matching the detail
  * route — an all-zero snapshot tells a client nothing its own tally doesn't
  * already say.
@@ -284,7 +310,9 @@ export const ROUTES: RouteDefinition[] = [
           continue;
         }
         subagents[record.id] = {
-          status: status.data,
+          // Coerced here, before the live pass below overwrites any id the
+          // manager also holds — so only genuinely orphaned rows keep it.
+          status: settledDurableStatus(status.data),
           conversationId: record.conversationId,
           label: record.label,
           objective: record.objective,
@@ -364,9 +392,13 @@ export const ROUTES: RouteDefinition[] = [
       return {
         ...getSubagentDetail(pathParams!.id, conversationId),
         conversationId,
+        // `record` is only read when the manager has no state, so a
+        // record-derived status is by definition orphaned and gets settled.
         status:
           state?.status ??
-          (recordStatus?.success ? recordStatus.data : undefined),
+          (recordStatus?.success
+            ? settledDurableStatus(recordStatus.data)
+            : undefined),
         label: state?.config.label ?? record?.label,
         parentToolUseId: state?.config.parentToolUseId,
       };

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -7,7 +7,10 @@
  */
 import { z } from "zod";
 
-import { SubagentStatusSchema } from "../../api/events/subagent-status-changed.js";
+import {
+  SubagentStatusSchema,
+  SubagentUsageStatsSchema,
+} from "../../api/events/subagent-status-changed.js";
 import { SubagentDetailResponseSchema } from "../../api/responses/subagent-detail.js";
 import {
   getMessages,
@@ -194,6 +197,15 @@ const ReconciledSubagentSchema = z.object({
   objective: z.string().optional(),
   isFork: z.boolean().optional(),
   parentToolUseId: z.string().optional(),
+  /**
+   * Terminal metadata a client can otherwise only learn from the
+   * `subagent_status_changed` event — which is exactly the event a
+   * reconciling client may have missed. Carried here so the snapshot can
+   * restore final token/cost totals and a failure reason instead of leaving
+   * them owned by a lost event.
+   */
+  usage: SubagentUsageStatsSchema.optional(),
+  error: z.string().optional(),
 });
 
 export const ROUTES: RouteDefinition[] = [
@@ -207,7 +219,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Reconcile subagent live status",
     description:
-      "Returns the live in-memory state of all subagents known to the assistant for a given parent conversation. Each entry carries enough detail (child conversation id, label, objective) for a client to rebuild its subagent list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. Only `status` is guaranteed to be present; every other field is optional.",
+      "Returns the live in-memory state of all subagents known to the assistant for a given parent conversation. Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. Only `status` is guaranteed to be present; every other field is optional.",
     tags: ["subagents"],
     queryParams: [
       {
@@ -232,6 +244,7 @@ export const ROUTES: RouteDefinition[] = [
         z.infer<typeof ReconciledSubagentSchema>
       > = {};
       for (const child of manager.getChildrenOf(parentConversationId)) {
+        const usage = child.usage;
         subagents[child.config.id] = {
           status: child.status,
           conversationId: child.conversationId,
@@ -239,6 +252,21 @@ export const ROUTES: RouteDefinition[] = [
           objective: child.config.objective,
           isFork: child.isFork,
           parentToolUseId: child.config.parentToolUseId,
+          // A child that has spent nothing reports no usage at all, matching
+          // the detail route — an all-zero snapshot tells a client nothing its
+          // own tally doesn't already say.
+          usage:
+            usage &&
+            (usage.inputTokens > 0 ||
+              usage.outputTokens > 0 ||
+              usage.estimatedCost > 0)
+              ? {
+                  inputTokens: usage.inputTokens,
+                  outputTokens: usage.outputTokens,
+                  estimatedCost: usage.estimatedCost,
+                }
+              : undefined,
+          error: child.error,
         };
       }
       return { subagents };

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -17,7 +17,10 @@ import {
   type MessageRow,
 } from "../../persistence/conversation-crud.js";
 import { getConversationUsageTotals } from "../../persistence/llm-usage-store.js";
-import { getSubagentRecordById } from "../../persistence/subagent-store.js";
+import {
+  getSubagentRecordById,
+  getSubagentRecordsByParent,
+} from "../../persistence/subagent-store.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -208,6 +211,30 @@ const ReconciledSubagentSchema = z.object({
   error: z.string().optional(),
 });
 
+/**
+ * A child that has spent nothing reports no usage at all, matching the detail
+ * route — an all-zero snapshot tells a client nothing its own tally doesn't
+ * already say.
+ */
+function reconciledUsage(usage: {
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+}): z.infer<typeof SubagentUsageStatsSchema> | undefined {
+  if (
+    usage.inputTokens <= 0 &&
+    usage.outputTokens <= 0 &&
+    usage.estimatedCost <= 0
+  ) {
+    return undefined;
+  }
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    estimatedCost: usage.estimatedCost,
+  };
+}
+
 export const ROUTES: RouteDefinition[] = [
   {
     operationId: "reconcileSubagents",
@@ -219,7 +246,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Reconcile subagent live status",
     description:
-      "Returns the live in-memory state of all subagents known to the assistant for a given parent conversation. Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list from scratch, not just refresh statuses. Subagents absent from the response are orphaned or terminal. Only `status` is guaranteed to be present; every other field is optional.",
+      "Returns every subagent the assistant knows for a given parent conversation — live, rehydrated, and durably recorded, including terminal runs whose in-memory metadata the retention sweep has already evicted. Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list from scratch, not just refresh statuses. A subagent absent from the response is one the assistant has no knowledge of at all, so a client may settle its own stuck-active entries against this snapshot. Only `status` is guaranteed to be present; every other field is optional.",
     tags: ["subagents"],
     queryParams: [
       {
@@ -243,8 +270,32 @@ export const ROUTES: RouteDefinition[] = [
         string,
         z.infer<typeof ReconciledSubagentSchema>
       > = {};
+      // Durable rows first, so the live pass below overwrites any id it also
+      // holds. The retention sweep evicts terminal in-memory metadata while
+      // deliberately keeping the row, so a run that completed more than a TTL
+      // ago is absent from memory — and a client settling orphans by absence
+      // would rewrite its `completed` entry to `interrupted`.
+      for (const record of getSubagentRecordsByParent(parentConversationId)) {
+        // `SubagentRecord.status` is an untyped column; the response contract
+        // is the closed enum, so drop what doesn't parse rather than widening
+        // the wire type.
+        const status = SubagentStatusSchema.safeParse(record.status);
+        if (!status.success) {
+          continue;
+        }
+        subagents[record.id] = {
+          status: status.data,
+          conversationId: record.conversationId,
+          label: record.label,
+          objective: record.objective,
+          isFork: record.isFork,
+          parentToolUseId: record.parentToolUseId ?? undefined,
+          usage: reconciledUsage(record),
+          error: record.error ?? undefined,
+        };
+      }
+
       for (const child of manager.getChildrenOf(parentConversationId)) {
-        const usage = child.usage;
         subagents[child.config.id] = {
           status: child.status,
           conversationId: child.conversationId,
@@ -252,20 +303,7 @@ export const ROUTES: RouteDefinition[] = [
           objective: child.config.objective,
           isFork: child.isFork,
           parentToolUseId: child.config.parentToolUseId,
-          // A child that has spent nothing reports no usage at all, matching
-          // the detail route — an all-zero snapshot tells a client nothing its
-          // own tally doesn't already say.
-          usage:
-            usage &&
-            (usage.inputTokens > 0 ||
-              usage.outputTokens > 0 ||
-              usage.estimatedCost > 0)
-              ? {
-                  inputTokens: usage.inputTokens,
-                  outputTokens: usage.outputTokens,
-                  estimatedCost: usage.estimatedCost,
-                }
-              : undefined,
+          usage: child.usage ? reconciledUsage(child.usage) : undefined,
           error: child.error,
         };
       }

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -83,6 +83,7 @@ const DeployDialogs = lazy(() =>
 import { MobileChatOverlays } from "@/domains/chat/components/mobile-chat-overlays";
 import { useChatHeaderRegistration } from "@/domains/chat/hooks/use-chat-header-registration";
 import { useConversationChangeEffects } from "@/domains/chat/hooks/use-conversation-change-effects";
+import { useSubagentReconcile } from "@/domains/chat/hooks/use-subagent-reconcile";
 import { useComposerKeyboard } from "@/domains/chat/hooks/use-composer-keyboard";
 import { useAutoSendEffects } from "@/domains/chat/hooks/use-auto-send-effects";
 import { useOnboardingAttribution } from "@/hooks/use-onboarding-attribution";
@@ -373,6 +374,15 @@ export function ActiveChatView() {
   // Conversation-change side effects (dismiss prompts, reset subagent state,
   // auto-fetch subagent details for entries reconstructed from history)
   useConversationChangeEffects(assistantId, activeConversationId);
+
+  // Resync subagent rows from the daemon on load and after an SSE reopen, so a
+  // run that streamed nothing this session still shows up (and a stuck-running
+  // entry the daemon has forgotten settles).
+  useSubagentReconcile(
+    assistantId,
+    activeConversationId,
+    conversationExistsOnServer,
+  );
 
   // Debug API — dev-facing surface for in-the-moment chat inspection.
   // Unconditionally attached; negligible production overhead.

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
@@ -63,6 +63,47 @@ describe("reconcileSubagentStoreFromNotifications", () => {
     expect(store().byId["old"]?.status).toBe("completed");
   });
 
+  test("a stale running notification cannot regress a settled entry", () => {
+    // Restart ordering: reconcile settles a silent run as `interrupted`
+    // (durable-row recovery), then history hydration replays the run's
+    // MID-RUN notification whose status is still `running`. The run will
+    // emit no further terminal event, so regressing here would stick the
+    // overlay and Stop control forever.
+    spawn("settled", "interrupted");
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [
+        {
+          subagentId: "settled",
+          label: "settled",
+          status: "running",
+          conversationId: "child-conv",
+        },
+      ],
+      PARENT,
+      NOW,
+    );
+    expect(store().byId["settled"]?.status).toBe("interrupted");
+    // The non-status fields still land — the notification remains a valid
+    // source for identity/conversation wiring.
+    expect(store().byId["settled"]?.conversationId).toBe("child-conv");
+    expect(store().byId["settled"]?.parentConversationId).toBe(PARENT);
+  });
+
+  test("a terminal-to-terminal notification still applies to a settled entry", () => {
+    // Only the terminal→active direction is blocked: a notification carrying
+    // a truer terminal state (e.g. `failed` over provisional `interrupted`)
+    // must still land.
+    spawn("settled2", "interrupted");
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [{ subagentId: "settled2", label: "settled2", status: "failed" }],
+      PARENT,
+      NOW,
+    );
+    expect(store().byId["settled2"]?.status).toBe("failed");
+  });
+
   test("applies a terminal notification to a settled entry without dropping it", () => {
     spawn("sub", "interrupted");
     reconcileSubagentStoreFromNotifications(

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
@@ -40,16 +40,46 @@ describe("reconcileSubagentStoreFromNotifications", () => {
     expect(store().byId["done"]?.status).toBe("completed"); // notified added
   });
 
-  test("rebuilds from notifications (clears stale terminal entries) when nothing is in flight", () => {
-    spawn("old", "completed"); // terminal entry from a prior conversation
+  test("keeps a terminal entry reconcile recovered but no notification mentions", () => {
+    // A silent run — one that streamed nothing — is recovered from the daemon's
+    // durable rows as `interrupted`, so it appears in no history notification.
+    // Hydration is additive; deleting it would make its visibility depend on
+    // which request finished first. Cross-conversation cleanup belongs to the
+    // conversation-change reset, not here.
+    spawn("silent", "interrupted");
     reconcileSubagentStoreFromNotifications(
       store(),
       [{ subagentId: "new", label: "new", status: "completed" }],
       PARENT,
       NOW,
     );
-    expect(store().byId["old"]).toBeUndefined(); // reset cleared it
+    expect(store().byId["silent"]?.status).toBe("interrupted");
     expect(store().byId["new"]?.status).toBe("completed");
+  });
+
+  test("never deletes entries, even with nothing in flight and no notifications", () => {
+    spawn("old", "completed");
+    reconcileSubagentStoreFromNotifications(store(), [], PARENT, NOW);
+    expect(store().byId["old"]?.status).toBe("completed");
+  });
+
+  test("applies a terminal notification to a settled entry without dropping it", () => {
+    spawn("sub", "interrupted");
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [
+        {
+          subagentId: "sub",
+          label: "sub",
+          status: "completed",
+          conversationId: "conv-x",
+        },
+      ],
+      PARENT,
+      NOW,
+    );
+    expect(store().byId["sub"]?.status).toBe("completed");
+    expect(store().byId["sub"]?.conversationId).toBe("conv-x");
   });
 
   test("applies a terminal notification to a live entry without dropping it", () => {

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
@@ -49,7 +49,15 @@ export function reconcileSubagentStoreFromNotifications(
     isActiveStatus(entry.status),
   );
 
-  if (!hasInFlight) store.reset();
+  // An empty store has nothing to clear, and `reset()` is not free: it
+  // invalidates any in-flight `reconcileFromDaemon` as belonging to a
+  // conversation the user left. History hydration races that request on load,
+  // and discarding it would lose exactly the rows it exists to recover — a
+  // mid-run subagent that has streamed nothing and so appears in no
+  // notification.
+  if (!hasInFlight && Object.keys(priorById).length > 0) {
+    store.reset();
+  }
 
   for (const n of notifications) {
     const parsed = SubagentStatusSchema.safeParse(n.status);

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
@@ -1,6 +1,7 @@
 import { SubagentStatusSchema } from "@vellumai/assistant-api";
 
 import type { SubagentStore } from "@/domains/chat/subagent-store";
+import { isActiveStatus } from "@/utils/subagent-status";
 
 type SubagentStoreSlice = Pick<
   SubagentStore,
@@ -51,11 +52,20 @@ export function reconcileSubagentStoreFromNotifications(
 
   for (const n of notifications) {
     const parsed = SubagentStatusSchema.safeParse(n.status);
-    if (priorById[n.subagentId]) {
+    const existing = priorById[n.subagentId];
+    if (existing) {
       // An unparseable status carries no information about an entry we
       // already hold — keep what SSE or reconcile told us rather than
-      // flipping it terminal.
-      if (parsed.success) {
+      // flipping it terminal. A settled entry likewise never regresses to an
+      // active status on the say-so of a historical notification: reconcile
+      // may have just settled a run whose mid-run "running" notification
+      // still sits in history, and an interrupted run emits no further
+      // terminal event to re-correct the regression.
+      const regressesTerminal =
+        parsed.success &&
+        !isActiveStatus(existing.status) &&
+        isActiveStatus(parsed.data);
+      if (parsed.success && !regressesTerminal) {
         store.changeStatus({ subagentId: n.subagentId, status: parsed.data });
       }
       if (n.conversationId) {

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
@@ -1,12 +1,10 @@
 import { SubagentStatusSchema } from "@vellumai/assistant-api";
 
 import type { SubagentStore } from "@/domains/chat/subagent-store";
-import { isActiveStatus } from "@/utils/subagent-status";
 
 type SubagentStoreSlice = Pick<
   SubagentStore,
   | "byId"
-  | "reset"
   | "spawnSubagent"
   | "changeStatus"
   | "setConversationId"
@@ -23,16 +21,21 @@ export interface SubagentNotificationLike {
 }
 
 /**
- * Apply history subagent notifications to the store while preserving live
- * (in-flight) subagents.
+ * Apply history subagent notifications to the store as a pure upsert.
  *
- * In-flight subagent state streams from SSE, not history notifications, so a
- * blanket reset drops a subagent that's still running when the conversation
- * re-hydrates (e.g. after a tab switch). When nothing is in flight we rebuild
- * from scratch — clearing the prior conversation's terminal entries. When a
- * subagent is in flight we merge instead: upsert notified subagents and apply a
- * terminal status to a live entry that just finished, without discarding its
- * streamed events.
+ * Hydration never deletes. It is one additive evidence source among several —
+ * live SSE and the `/subagents/reconcile` snapshot are the others — and it is
+ * the least complete of them: in-flight state streams over SSE rather than
+ * appearing in history, and a run that streamed nothing at all (recovered from
+ * the daemon's durable rows) has no notification to be represented by. A reset
+ * here would delete exactly what the other two recover — a silent run that
+ * reconcile resurrected as terminal survives no rebuild-from-notifications,
+ * and which one wins would come down to whichever request finished first.
+ *
+ * Entry lifecycle cleanup is owned elsewhere: cross-conversation clearing by
+ * the conversation-change reset (`use-conversation-change-effects`' layout
+ * effect and `switchConversation`), staleness by reconcile's generation guard,
+ * and stuck-active settling by reconcile's orphan pass.
  *
  * `parentConversationId` is the conversation being hydrated — it scopes the
  * Active-Subagents overlay. A notification's own `conversationId` is the
@@ -45,25 +48,13 @@ export function reconcileSubagentStoreFromNotifications(
   now: number,
 ): void {
   const priorById = store.byId;
-  const hasInFlight = Object.values(priorById).some((entry) =>
-    isActiveStatus(entry.status),
-  );
-
-  // An empty store has nothing to clear, and `reset()` is not free: it
-  // invalidates any in-flight `reconcileFromDaemon` as belonging to a
-  // conversation the user left. History hydration races that request on load,
-  // and discarding it would lose exactly the rows it exists to recover — a
-  // mid-run subagent that has streamed nothing and so appears in no
-  // notification.
-  if (!hasInFlight && Object.keys(priorById).length > 0) {
-    store.reset();
-  }
 
   for (const n of notifications) {
     const parsed = SubagentStatusSchema.safeParse(n.status);
-    if (hasInFlight && priorById[n.subagentId]) {
-      // An unparseable status carries no information about a live entry —
-      // keep whatever the stream told us rather than flipping it terminal.
+    if (priorById[n.subagentId]) {
+      // An unparseable status carries no information about an entry we
+      // already hold — keep what SSE or reconcile told us rather than
+      // flipping it terminal.
       if (parsed.success) {
         store.changeStatus({ subagentId: n.subagentId, status: parsed.data });
       }

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.test.tsx
@@ -11,9 +11,9 @@
  *    closes that race because every layout effect fires before any passive one.
  *
  * 2. The conversation-switch reset clears a still-running subagent. Reconcile-
- *    on-hydration (`reconcileSubagentStoreFromNotifications`) deliberately
- *    preserves in-flight subagents — they stream from SSE, not history
- *    notifications — so this reset is the *only* thing that stops a live
+ *    on-hydration (`reconcileSubagentStoreFromNotifications`) is a pure upsert
+ *    that never deletes — it is one additive evidence source among SSE and the
+ *    reconcile snapshot — so this reset is the *only* thing that stops a
  *    subagent in conversation A from leaking into conversation B.
  *
  * 3. The auto-fetch reaches a stub recovered from a missed `subagent_spawned`

--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for `useSubagentReconcile` — when the hook asks the daemon to resync
+ * this conversation's subagents. Mocks the generated `subagentsReconcileGet`
+ * so each trigger is a countable round-trip; the reconcile's effect on the
+ * store is covered by `subagent-store.test.ts`.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import { __resetForTesting, publish } from "@/lib/event-bus";
+
+let getCalls = 0;
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  subagentsReconcileGet: async () => {
+    getCalls += 1;
+    return { data: { subagents: {} }, response: { ok: true, status: 200 } };
+  },
+  subagentsByIdAbortPost: async () => ({
+    data: undefined,
+    response: { ok: true },
+  }),
+  subagentsByIdGet: async () => ({
+    data: undefined,
+    response: { ok: false },
+  }),
+}));
+mock.module("@/lib/sentry/capture-error", () => ({ captureError: () => {} }));
+
+const { useSubagentReconcile } = await import(
+  "@/domains/chat/hooks/use-subagent-reconcile"
+);
+const { useSubagentStore } = await import("@/domains/chat/subagent-store");
+
+const ASSISTANT = "asst-1";
+const CONVERSATION = "conv-A";
+
+function mount(
+  assistantId: string | null = ASSISTANT,
+  conversationId: string | null = CONVERSATION,
+  existsOnServer = true,
+) {
+  return renderHook(() =>
+    useSubagentReconcile(assistantId, conversationId, existsOnServer),
+  );
+}
+
+beforeEach(() => {
+  getCalls = 0;
+  __resetForTesting();
+  useSubagentStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useSubagentReconcile", () => {
+  test("reconciles once on mount with both ids", async () => {
+    mount();
+
+    await waitFor(() => expect(getCalls).toBe(1));
+  });
+
+  test("does not reconcile without an assistant id", async () => {
+    mount(null);
+
+    await waitFor(() => expect(getCalls).toBe(0));
+  });
+
+  test("does not reconcile for a conversation the server has never seen", async () => {
+    mount(ASSISTANT, CONVERSATION, false);
+
+    await waitFor(() => expect(getCalls).toBe(0));
+  });
+
+  test("reconciles again when the SSE stream reopens on resume", async () => {
+    mount();
+    await waitFor(() => expect(getCalls).toBe(1));
+
+    publish("sse.opened", { assistantId: ASSISTANT, cause: "resume" });
+
+    await waitFor(() => expect(getCalls).toBe(2));
+  });
+
+  test("ignores a fresh open — the mount effect already owns that load", async () => {
+    mount();
+    await waitFor(() => expect(getCalls).toBe(1));
+
+    publish("sse.opened", { assistantId: ASSISTANT, cause: "fresh" });
+    publish("sse.opened", { assistantId: ASSISTANT, cause: "anchor" });
+
+    await waitFor(() => expect(getCalls).toBe(1));
+  });
+
+  test("ignores a reopen for a different assistant", async () => {
+    mount();
+    await waitFor(() => expect(getCalls).toBe(1));
+
+    publish("sse.opened", { assistantId: "asst-other", cause: "watchdog" });
+
+    await waitFor(() => expect(getCalls).toBe(1));
+  });
+
+  test("stops reconciling after unmount", async () => {
+    const { unmount } = mount();
+    await waitFor(() => expect(getCalls).toBe(1));
+
+    unmount();
+    publish("sse.opened", { assistantId: ASSISTANT, cause: "error" });
+
+    await waitFor(() => expect(getCalls).toBe(1));
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.ts
@@ -1,0 +1,68 @@
+/**
+ * Resync the subagent store against the daemon whenever this client's picture
+ * of a run could have gone stale.
+ *
+ * Two triggers:
+ *
+ * - **Conversation load.** The transcript's history notifications only name
+ *   subagents that reached a message; one that is still mid-run and has
+ *   streamed nothing leaves no trace in history at all. A reload during that
+ *   window would show no row for it (and no Active-Subagents overlay entry)
+ *   until it finally emitted something. One reconcile round-trip rebuilds the
+ *   rows from the daemon's live state instead.
+ *
+ * - **SSE reopen.** A connection that dropped past the daemon's replay ring can
+ *   miss a terminal `subagent_status_changed`, leaving the entry stuck
+ *   `running` with a live overlay and a Stop control that does nothing.
+ *   `"fresh"` and `"anchor"` opens are skipped: the conversation-load effect
+ *   owns the initial load, and an anchored reopen is caught up by the daemon's
+ *   ring replay.
+ *
+ * Drafts are excluded — a conversation the server has never seen has no
+ * subagents to reconcile against.
+ */
+
+import { useEffect } from "react";
+
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import type { BusEventPayload } from "@/lib/event-bus";
+
+type SseOpenedCause = BusEventPayload<"sse.opened">["cause"];
+
+const RESYNC_CAUSES: ReadonlySet<SseOpenedCause> = new Set<SseOpenedCause>([
+  "resume",
+  "watchdog",
+  "error",
+  "debug",
+]);
+
+export function useSubagentReconcile(
+  assistantId: string | null,
+  conversationId: string | null,
+  conversationExistsOnServer: boolean,
+): void {
+  useEffect(() => {
+    if (!assistantId || !conversationId || !conversationExistsOnServer) {
+      return;
+    }
+    void useSubagentStore
+      .getState()
+      .reconcileFromDaemon(assistantId, conversationId);
+  }, [assistantId, conversationId, conversationExistsOnServer]);
+
+  useBusSubscription("sse.opened", ({ assistantId: openedFor, cause }) => {
+    if (!RESYNC_CAUSES.has(cause)) {
+      return;
+    }
+    if (!assistantId || !conversationId || !conversationExistsOnServer) {
+      return;
+    }
+    if (openedFor !== assistantId) {
+      return;
+    }
+    void useSubagentStore
+      .getState()
+      .reconcileFromDaemon(assistantId, conversationId);
+  });
+}

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -1892,6 +1892,10 @@ describe("reconcileFromDaemon", () => {
     expect(entry?.hydrationPending).toBe(true);
   });
 
+  // Absence is authoritative because the daemon's snapshot spans live,
+  // rehydrated AND durably-recorded children — a run whose terminal metadata
+  // the retention sweep evicted still reports its terminal status, so only a
+  // subagent the daemon has no record of at all goes missing.
   it("settles an active entry the daemon no longer knows about", async () => {
     getState().spawnSubagent({
       subagentId: "sa-gone",
@@ -1905,6 +1909,39 @@ describe("reconcileFromDaemon", () => {
 
     await getState().reconcileFromDaemon("assistant-1", "conv-parent");
 
+    expect(getState().byId["sa-gone"]?.status).toBe("interrupted");
+  });
+
+  it("settles an absent entry even when the snapshot carries swept siblings", async () => {
+    for (const subagentId of ["sa-gone", "sa-swept"]) {
+      getState().spawnSubagent({
+        subagentId,
+        label: "Agent",
+        objective: "",
+        status: "running",
+        parentConversationId: "conv-parent",
+        timestamp: NOW,
+      });
+    }
+    // `sa-swept` is terminal in the daemon's durable rows only — its
+    // in-memory metadata is long gone. It reports `completed`; `sa-gone` has
+    // no row at all, so its absence is still the real thing.
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-swept": {
+          status: "completed",
+          conversationId: "conv-child-swept",
+          label: "Swept",
+          usage: { inputTokens: 90, outputTokens: 20, estimatedCost: 0.003 },
+        },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-swept"]?.status).toBe("completed");
+    expect(getState().byId["sa-swept"]?.inputTokens).toBe(90);
     expect(getState().byId["sa-gone"]?.status).toBe("interrupted");
   });
 

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -15,6 +15,38 @@ const fetchSubagentDetail = mock(
 );
 mock.module("./fetch-subagent-detail", () => ({ fetchSubagentDetail }));
 
+interface ReconcileReply {
+  ok: boolean;
+  subagents?: Record<string, Record<string, unknown>>;
+}
+
+const reconcileRequests: Array<{
+  path?: Record<string, string>;
+  query?: Record<string, unknown>;
+}> = [];
+let reconcileReply: ReconcileReply = { ok: true, subagents: {} };
+const subagentsReconcileGet = mock(
+  async (options: {
+    path?: Record<string, string>;
+    query?: Record<string, unknown>;
+  }) => {
+    reconcileRequests.push(options);
+    // Force at least one microtask hop so a second caller can join the
+    // in-flight promise before the first resolves.
+    await Promise.resolve();
+    return {
+      data: reconcileReply.ok
+        ? { subagents: reconcileReply.subagents ?? {} }
+        : undefined,
+      response: { ok: reconcileReply.ok, status: reconcileReply.ok ? 200 : 500 },
+    };
+  },
+);
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  subagentsReconcileGet,
+  subagentsByIdAbortPost: mock(async () => ({ data: undefined, response: { ok: true } })),
+}));
+
 const { useSubagentStore } = await import("@/domains/chat/subagent-store");
 
 // ---------------------------------------------------------------------------
@@ -31,6 +63,9 @@ beforeEach(() => {
   getState().reset();
   selfLookupSupported = true;
   fetchSubagentDetail.mockClear();
+  subagentsReconcileGet.mockClear();
+  reconcileRequests.length = 0;
+  reconcileReply = { ok: true, subagents: {} };
 });
 
 // ---------------------------------------------------------------------------
@@ -1718,5 +1753,310 @@ describe("fetchDetailIfNeeded conversation id", () => {
     await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
 
     expect(fetchSubagentDetail).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadDetail — child conversation id resolved by the daemon
+// ---------------------------------------------------------------------------
+
+describe("loadDetail conversation id", () => {
+  it("stamps the resolved child conversation onto a parent-only stub", () => {
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      parentConversationId: "conv-parent",
+    });
+
+    getState().loadDetail({
+      subagentId: "sa-1",
+      events: [],
+      conversationId: "conv-child",
+    });
+
+    expect(getState().byId["sa-1"]?.conversationId).toBe("conv-child");
+  });
+
+  it("ignores a conversation id that is just the queried parent echoed back", () => {
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      parentConversationId: "conv-parent",
+    });
+
+    getState().loadDetail({
+      subagentId: "sa-1",
+      events: [],
+      conversationId: "conv-parent",
+    });
+
+    expect(getState().byId["sa-1"]?.conversationId).toBeUndefined();
+  });
+
+  it("keeps the existing child id when the detail omits one", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      conversationId: "conv-child",
+      timestamp: NOW,
+    });
+
+    getState().loadDetail({ subagentId: "sa-1", events: [] });
+
+    expect(getState().byId["sa-1"]?.conversationId).toBe("conv-child");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcileFromDaemon
+// ---------------------------------------------------------------------------
+
+describe("reconcileFromDaemon", () => {
+  it("queries the reconcile route scoped to the parent conversation", async () => {
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(reconcileRequests).toHaveLength(1);
+    expect(reconcileRequests[0]).toMatchObject({
+      path: { assistant_id: "assistant-1" },
+      query: { parentConversationId: "conv-parent" },
+    });
+  });
+
+  it("materializes a full entry from an enriched response", async () => {
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": {
+          status: "running",
+          conversationId: "conv-child",
+          label: "Audit defenses",
+          objective: "Find the hole",
+          isFork: true,
+          parentToolUseId: "toolu_1",
+        },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.label).toBe("Audit defenses");
+    expect(entry?.objective).toBe("Find the hole");
+    expect(entry?.status).toBe("running");
+    expect(entry?.isFork).toBe(true);
+    expect(entry?.conversationId).toBe("conv-child");
+    expect(entry?.parentConversationId).toBe("conv-parent");
+    expect(entry?.parentToolUseId).toBe("toolu_1");
+    expect(getState().byToolUseId.get("toolu_1")).toBe("sa-1");
+    expect(getState().orderedIds).toEqual(["sa-1"]);
+  });
+
+  it("refreshes a known entry's status and conversation ids", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      timestamp: NOW,
+    });
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": { status: "completed", conversationId: "conv-child" },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.status).toBe("completed");
+    expect(entry?.label).toBe("Agent");
+    expect(entry?.conversationId).toBe("conv-child");
+    expect(entry?.parentConversationId).toBe("conv-parent");
+  });
+
+  it("creates only a stub for an unknown id on a bare-status daemon", async () => {
+    reconcileReply = { ok: true, subagents: { "sa-1": { status: "running" } } };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.label).toBe("");
+    expect(entry?.objective).toBe("");
+    expect(entry?.status).toBe("running");
+    expect(entry?.parentConversationId).toBe("conv-parent");
+    expect(entry?.hydrationPending).toBe(true);
+  });
+
+  it("settles an active entry the daemon no longer knows about", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-gone",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    reconcileReply = { ok: true, subagents: {} };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-gone"]?.status).toBe("interrupted");
+  });
+
+  it("never walks a settled entry back to an active status", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      status: "completed",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    // A snapshot taken before the terminal event landed over SSE.
+    reconcileReply = { ok: true, subagents: { "sa-1": { status: "running" } } };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-1"]?.status).toBe("completed");
+  });
+
+  it("leaves an entry spawned after the request went out alone", async () => {
+    reconcileReply = { ok: true, subagents: {} };
+
+    const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    getState().spawnSubagent({
+      subagentId: "sa-late",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: Date.now(),
+    });
+    await pending;
+
+    expect(getState().byId["sa-late"]?.status).toBe("running");
+  });
+
+  it("leaves an absent entry from another conversation untouched", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-other",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-other",
+      timestamp: NOW,
+    });
+    reconcileReply = { ok: true, subagents: {} };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-other"]?.status).toBe("running");
+  });
+
+  it("leaves a terminal entry alone rather than re-settling it", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-done",
+      label: "Agent",
+      objective: "",
+      status: "completed",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    reconcileReply = { ok: true, subagents: {} };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-done"]?.status).toBe("completed");
+  });
+
+  it("changes nothing on a non-ok response", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    const byIdBefore = getState().byId;
+    reconcileReply = { ok: false };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId).toBe(byIdBefore);
+    expect(getState().byId["sa-1"]?.status).toBe("running");
+  });
+
+  it("shares one request between concurrent calls for the same conversation", async () => {
+    await Promise.all([
+      getState().reconcileFromDaemon("assistant-1", "conv-parent"),
+      getState().reconcileFromDaemon("assistant-1", "conv-parent"),
+    ]);
+
+    expect(subagentsReconcileGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-requests once the previous call has settled", async () => {
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(subagentsReconcileGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips an item whose status is not a known subagent status", async () => {
+    reconcileReply = {
+      ok: true,
+      subagents: { "sa-1": { status: "zombie", label: "Agent" } },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-1"]).toBeUndefined();
+  });
+
+  it("does not settle a known entry whose reported status is unparseable", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    reconcileReply = { ok: true, subagents: { "sa-1": { status: "zombie" } } };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-1"]?.status).toBe("running");
+  });
+
+  it("updates a known entry from a bare-status daemon without touching its timeline", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: {
+        type: "assistant_text_delta",
+        content: "hello",
+      } as SubagentInnerEvent,
+      timestamp: NOW,
+    });
+    reconcileReply = { ok: true, subagents: { "sa-1": { status: "completed" } } };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.status).toBe("completed");
+    expect(entry?.label).toBe("Agent");
+    expect(entry?.objective).toBe("Task");
+    expect(entry?.events).toHaveLength(1);
+    expect(entry?.hydrationPending).toBeUndefined();
   });
 });

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -6,6 +6,11 @@ mock.module("@/lib/backwards-compat/subagent-detail-self-lookup", () => ({
   supportsSubagentDetailSelfLookup: () => selfLookupSupported,
 }));
 
+let reconcileSupported = true;
+mock.module("@/lib/backwards-compat/subagents-reconcile", () => ({
+  supportsSubagentsReconcile: () => reconcileSupported,
+}));
+
 const fetchSubagentDetail = mock(
   async (
     _assistantId: string,
@@ -66,6 +71,7 @@ const NOW = 1700000000000;
 beforeEach(() => {
   getState().reset();
   selfLookupSupported = true;
+  reconcileSupported = true;
   fetchSubagentDetail.mockClear();
   subagentsReconcileGet.mockClear();
   reconcileRequests.length = 0;
@@ -1817,6 +1823,12 @@ describe("loadDetail conversation id", () => {
 // ---------------------------------------------------------------------------
 
 describe("reconcileFromDaemon", () => {
+  it("does not call the route when the assistant predates it", async () => {
+    reconcileSupported = false;
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    expect(subagentsReconcileGet).not.toHaveBeenCalled();
+  });
+
   it("queries the reconcile route scoped to the parent conversation", async () => {
     await getState().reconcileFromDaemon("assistant-1", "conv-parent");
 

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -2261,10 +2261,21 @@ describe("reconcileFromDaemon", () => {
       },
     };
 
+    // A settled entry already in the store — enough to make a reset-based
+    // hydration bump the generation and throw the snapshot away.
+    getState().spawnSubagent({
+      subagentId: "sa-prior",
+      label: "Prior",
+      objective: "",
+      status: "completed",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+
     const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
-    // History for the SAME conversation arrives while the request is out. It
-    // rebuilds from notifications, but with nothing to clear it must not
-    // invalidate the snapshot that recovers a run history never heard about.
+    // History for the SAME conversation arrives while the request is out.
+    // Hydration is a pure upsert — it never resets — so it cannot invalidate
+    // the snapshot that recovers a run history never heard about.
     reconcileSubagentStoreFromNotifications(
       getState(),
       [{ subagentId: "sa-history", label: "Historical", status: "completed" }],
@@ -2275,6 +2286,7 @@ describe("reconcileFromDaemon", () => {
 
     expect(getState().byId["sa-silent"]?.status).toBe("running");
     expect(getState().byId["sa-history"]?.status).toBe("completed");
+    expect(getState().byId["sa-prior"]?.status).toBe("completed");
   });
 
   it("re-requests after a reset instead of joining the invalidated call", async () => {

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -48,6 +48,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
 }));
 
 const { useSubagentStore } = await import("@/domains/chat/subagent-store");
+// Imported after the SDK mock so it binds to the same mocked store module.
+const { reconcileSubagentStoreFromNotifications } = await import(
+  "@/domains/chat/hooks/reconcile-subagent-hydration"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2058,5 +2062,195 @@ describe("reconcileFromDaemon", () => {
     expect(entry?.objective).toBe("Task");
     expect(entry?.events).toHaveLength(1);
     expect(entry?.hydrationPending).toBeUndefined();
+  });
+
+  it("restores terminal usage and error when the terminal event was lost", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    // A streamed timeline makes the detail auto-fetch refuse this entry, so
+    // the snapshot is the only thing that can restore its final numbers.
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: {
+        type: "assistant_text_delta",
+        content: "hello",
+      } as SubagentInnerEvent,
+      timestamp: NOW,
+    });
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 100,
+      outputTokens: 20,
+      estimatedCost: 0.001,
+    });
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": {
+          status: "failed",
+          error: "provider timed out",
+          usage: {
+            inputTokens: 1200,
+            outputTokens: 340,
+            estimatedCost: 0.021,
+          },
+        },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.status).toBe("failed");
+    expect(entry?.error).toBe("provider timed out");
+    expect(entry?.inputTokens).toBe(1200);
+    expect(entry?.outputTokens).toBe(340);
+    expect(entry?.totalCost).toBe(0.021);
+    expect(entry?.events).toHaveLength(1);
+  });
+
+  it("leaves existing tallies intact when the snapshot carries no usage", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "Task",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    getState().updateUsage({
+      subagentId: "sa-1",
+      inputTokens: 100,
+      outputTokens: 20,
+      estimatedCost: 0.001,
+    });
+    reconcileReply = {
+      ok: true,
+      subagents: { "sa-1": { status: "completed" } },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.status).toBe("completed");
+    expect(entry?.inputTokens).toBe(100);
+    expect(entry?.outputTokens).toBe(20);
+    expect(entry?.totalCost).toBe(0.001);
+    expect(entry?.error).toBeUndefined();
+  });
+
+  it("stamps usage and error onto an entry materialized from the snapshot", async () => {
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": {
+          status: "failed",
+          label: "Audit defenses",
+          error: "provider timed out",
+          usage: {
+            inputTokens: 900,
+            outputTokens: 120,
+            estimatedCost: 0.014,
+          },
+        },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.status).toBe("failed");
+    expect(entry?.error).toBe("provider timed out");
+    expect(entry?.inputTokens).toBe(900);
+    expect(entry?.outputTokens).toBe(120);
+    expect(entry?.totalCost).toBe(0.014);
+  });
+
+  it("discards a snapshot that lands after the store was reset", async () => {
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": { status: "running", label: "Agent", objective: "Task" },
+      },
+    };
+
+    const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    // The user switched conversation (or assistant) mid-round-trip.
+    getState().reset();
+    await pending;
+
+    expect(getState().byId["sa-1"]).toBeUndefined();
+    expect(getState().orderedIds).toEqual([]);
+  });
+
+  it("does not settle orphans against a store reset mid-flight", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-old",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    reconcileReply = { ok: true, subagents: {} };
+
+    const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    getState().reset();
+    // A row the newly-active context spawned, absent from the stale snapshot.
+    getState().spawnSubagent({
+      subagentId: "sa-new",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    await pending;
+
+    expect(getState().byId["sa-new"]?.status).toBe("running");
+  });
+
+  it("survives a history hydration that lands mid-flight", async () => {
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-silent": { status: "running", label: "Agent", objective: "Task" },
+      },
+    };
+
+    const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    // History for the SAME conversation arrives while the request is out. It
+    // rebuilds from notifications, but with nothing to clear it must not
+    // invalidate the snapshot that recovers a run history never heard about.
+    reconcileSubagentStoreFromNotifications(
+      getState(),
+      [{ subagentId: "sa-history", label: "Historical", status: "completed" }],
+      "conv-parent",
+      NOW,
+    );
+    await pending;
+
+    expect(getState().byId["sa-silent"]?.status).toBe("running");
+    expect(getState().byId["sa-history"]?.status).toBe("completed");
+  });
+
+  it("re-requests after a reset instead of joining the invalidated call", async () => {
+    const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    getState().reset();
+    reconcileReply = {
+      ok: true,
+      subagents: { "sa-1": { status: "running", label: "Agent" } },
+    };
+    const next = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    await Promise.all([pending, next]);
+
+    expect(subagentsReconcileGet).toHaveBeenCalledTimes(2);
+    expect(getState().byId["sa-1"]?.label).toBe("Agent");
   });
 });

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -13,10 +13,20 @@
 import { create } from "zustand";
 
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { subagentsByIdAbortPost } from "@/generated/daemon/sdk.gen";
+import {
+  subagentsByIdAbortPost,
+  subagentsReconcileGet,
+} from "@/generated/daemon/sdk.gen";
+import type { SubagentsReconcileGetResponse } from "@/generated/daemon/types.gen";
 import { useConversationStore } from "@/stores/conversation-store";
 import { createSelectors } from "@/utils/create-selectors";
-import type { SubagentStatus, SubagentInnerEvent } from "@vellumai/assistant-api";
+import { recordDiagnostic } from "@/lib/diagnostics";
+import { captureError } from "@/lib/sentry/capture-error";
+import {
+  SubagentStatusSchema,
+  type SubagentStatus,
+  type SubagentInnerEvent,
+} from "@vellumai/assistant-api";
 import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
 import { isActiveStatus } from "@/utils/subagent-status";
 import { supportsSubagentDetailSelfLookup } from "@/lib/backwards-compat/subagent-detail-self-lookup";
@@ -226,6 +236,12 @@ export interface SubagentActions {
      * for entries recovered without their `subagent_spawned` event.
      */
     parentToolUseId?: string;
+    /**
+     * The child conversation the daemon resolved for this subagent
+     * (0.10.13+). A stub that could only address the fetch through the
+     * parent-id fallback learns its true child conversation here.
+     */
+    conversationId?: string;
   }) => void;
 
   /**
@@ -265,6 +281,32 @@ export interface SubagentActions {
    * Clears the marker on failure or empty events so callers can retry.
    */
   fetchDetailIfNeeded: (assistantId: string, subagentId: string) => Promise<void>;
+
+  /**
+   * Rebuild this conversation's subagent rows from the daemon's live
+   * `subagents/reconcile` snapshot. Recovers subagents whose
+   * `subagent_spawned` never reached this client — a mid-run reload, or an
+   * SSE gap wider than the daemon's replay ring — including ones that stream
+   * nothing at all and so leave no other evidence behind.
+   *
+   * Degraded, never destructive: a non-ok response (transport error, a daemon
+   * without the route) leaves the store exactly as it was. Only a successful
+   * snapshot settles this conversation's still-active entries that the daemon
+   * no longer knows about to `interrupted` — they died with a daemon restart
+   * and no terminal event is ever coming.
+   *
+   * 0.10.13+ daemons return full identity per child (label, objective, child
+   * conversation id, spawn anchor) so unknown ids materialize as complete
+   * rows; older ones return only `status`, which recovers stub-level rows the
+   * detail auto-fetch can still flesh out. Timeline backfill stays with that
+   * auto-fetch — this never touches `events` or `hydrationPending`.
+   *
+   * Concurrent calls for the same parent conversation share one request.
+   */
+  reconcileFromDaemon: (
+    assistantId: string,
+    parentConversationId: string,
+  ) => Promise<void>;
 
   /**
    * Best-effort abort of a running subagent. Reads `assistantId` and
@@ -436,6 +478,131 @@ let timelineEventCounter = 0;
 /** Generate a unique ID for timeline events. */
 function generateTimelineEventId(): string {
   return `te-${++timelineEventCounter}`;
+}
+
+/**
+ * In-flight `reconcileFromDaemon` calls keyed by parent conversation id, so
+ * the mount pass, an `sse.opened` reopen and an unknown-id kick that land
+ * together share a single round-trip instead of racing three writes.
+ */
+const reconcileInFlight = new Map<string, Promise<void>>();
+
+/** Minimum spacing between `requestSubagentReconcile` kicks. */
+const RECONCILE_KICK_INTERVAL_MS = 5_000;
+
+let lastReconcileKickAt = 0;
+
+/** One child row from the reconcile snapshot; only `status` is guaranteed. */
+type ReconciledSubagent = SubagentsReconcileGetResponse["subagents"][string];
+
+/**
+ * Apply one child row from the reconcile snapshot. A known entry is refreshed
+ * in place; an unknown one is materialized as a full row when the daemon
+ * supplied its identity, and as a stub otherwise.
+ */
+function applyReconciledSubagent(
+  store: SubagentStore,
+  subagentId: string,
+  info: ReconciledSubagent,
+  status: SubagentStatus,
+  parentConversationId: string,
+): void {
+  const existing = store.byId[subagentId];
+  if (existing) {
+    // The snapshot is a round-trip old, so it can still say `running` for a
+    // subagent whose terminal event has since landed over SSE. Settled entries
+    // only ever move between terminal states.
+    if (isActiveStatus(existing.status) || !isActiveStatus(status)) {
+      store.changeStatus({ subagentId, status });
+    }
+    if (info.conversationId) {
+      store.setConversationId(subagentId, info.conversationId);
+    }
+    store.setParentConversationId(subagentId, parentConversationId);
+    return;
+  }
+
+  if (info.label) {
+    store.spawnSubagent({
+      subagentId,
+      label: info.label,
+      objective: info.objective ?? "",
+      status,
+      isFork: info.isFork,
+      conversationId: info.conversationId,
+      parentConversationId,
+      timestamp: Date.now(),
+      parentToolUseId: info.parentToolUseId,
+    });
+    return;
+  }
+
+  // Pre-enrichment daemon: `status` is all we get, so fall back to the same
+  // stub the missed-spawn recovery path builds.
+  store.ensureEntry({
+    subagentId,
+    timestamp: Date.now(),
+    parentConversationId,
+    status,
+  });
+}
+
+async function runReconcile(
+  get: () => SubagentStore,
+  assistantId: string,
+  parentConversationId: string,
+): Promise<void> {
+  const requestedAt = Date.now();
+  let snapshot: Record<string, ReconciledSubagent>;
+  try {
+    const { data, response } = await subagentsReconcileGet({
+      path: { assistant_id: assistantId },
+      query: { parentConversationId },
+      throwOnError: false,
+    });
+    if (!response?.ok || !data?.subagents) {
+      return;
+    }
+    snapshot = data.subagents;
+  } catch (err) {
+    captureError(err, { context: "reconcileFromDaemon", bestEffort: true });
+    return;
+  }
+
+  for (const [subagentId, info] of Object.entries(snapshot)) {
+    const parsed = SubagentStatusSchema.safeParse(info.status);
+    // A row whose status doesn't parse tells us nothing trustworthy; skip it
+    // entirely rather than guess. Its presence still counts against orphan
+    // settling below — the daemon does know this subagent.
+    if (!parsed.success) {
+      continue;
+    }
+    applyReconciledSubagent(
+      get(),
+      subagentId,
+      info,
+      parsed.data,
+      parentConversationId,
+    );
+  }
+
+  // Only a successful snapshot is authoritative enough to settle orphans: an
+  // entry this conversation still shows as active that the daemon no longer
+  // knows about died with a restart, and no terminal event is coming. An entry
+  // younger than the request postdates the snapshot, so its absence proves
+  // nothing about it.
+  const { byId, changeStatus } = get();
+  for (const entry of Object.values(byId)) {
+    if (
+      entry.parentConversationId !== parentConversationId ||
+      !isActiveStatus(entry.status) ||
+      entry.spawnedAt >= requestedAt ||
+      Object.hasOwn(snapshot, entry.subagentId)
+    ) {
+      continue;
+    }
+    changeStatus({ subagentId: entry.subagentId, status: "interrupted" });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -656,11 +823,21 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
         ? setToolUseAnchor(get().byToolUseId, parentToolUseId, params.subagentId)
         : get().byToolUseId;
 
+    // The daemon echoes back the id we queried with when it can't resolve the
+    // subagent itself, so a stub that fetched through the parent-id fallback
+    // would otherwise stamp the PARENT id into the child-semantic field.
+    const resolvedConversationId =
+      params.conversationId &&
+      params.conversationId !== existing.parentConversationId
+        ? params.conversationId
+        : existing.conversationId;
+
     set({
       byId: {
         ...byId,
         [params.subagentId]: {
           ...existing,
+          conversationId: resolvedConversationId,
           // A stub's placeholder label yields to the fetched one; a label
           // learned from `subagent_spawned` wins (same source of truth).
           label: existing.label || (params.label ?? ""),
@@ -830,7 +1007,23 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       events,
       label: detail.label,
       parentToolUseId: detail.parentToolUseId,
+      conversationId: detail.conversationId,
     });
+  },
+
+  reconcileFromDaemon: (assistantId, parentConversationId) => {
+    const inFlight = reconcileInFlight.get(parentConversationId);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const run = runReconcile(get, assistantId, parentConversationId).finally(
+      () => {
+        reconcileInFlight.delete(parentConversationId);
+      },
+    );
+    reconcileInFlight.set(parentConversationId, run);
+    return run;
   },
 
   abortSubagent: async (subagentId) => {
@@ -848,7 +1041,10 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     }
   },
 
-  reset: () =>
+  reset: () => {
+    // A reset means a conversation switch, so the next unknown-id kick should
+    // fire immediately instead of inheriting the previous chat's window.
+    lastReconcileKickAt = 0;
     set({
       byId: {},
       orderedIds: [],
@@ -856,7 +1052,38 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       byParent: new Map<string, SubagentEntry[]>(),
       byToolUseId: new Map<string, string>(),
       fetchedAt: new Map<string, number>(),
-    }),
+    });
+  },
 }));
 
 export const useSubagentStore = createSelectors(useSubagentStoreBase);
+
+/**
+ * Ask the daemon to resync this conversation's subagents, best-effort.
+ *
+ * For imperative call sites that only hold a reason — the stream handlers hit
+ * this when an event names a subagent the store has never seen, which means
+ * the client's picture of the run is incomplete. Reads the active assistant
+ * and conversation from their stores (same pattern as `abortSubagent`) and
+ * rate-limits to one round-trip per `RECONCILE_KICK_INTERVAL_MS`, so a burst
+ * of events for the same missing subagent costs a single fetch.
+ */
+export function requestSubagentReconcile(reason: string): void {
+  const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+  const parentConversationId =
+    useConversationStore.getState().activeConversationId;
+  if (!assistantId || !parentConversationId) {
+    return;
+  }
+
+  const now = Date.now();
+  if (now - lastReconcileKickAt < RECONCILE_KICK_INTERVAL_MS) {
+    return;
+  }
+  lastReconcileKickAt = now;
+
+  recordDiagnostic("subagent_reconcile_kick", { reason });
+  void useSubagentStoreBase
+    .getState()
+    .reconcileFromDaemon(assistantId, parentConversationId);
+}

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -301,7 +301,10 @@ export interface SubagentActions {
    * detail auto-fetch can still flesh out. Timeline backfill stays with that
    * auto-fetch — this never touches `events` or `hydrationPending`.
    *
-   * Concurrent calls for the same parent conversation share one request.
+   * Concurrent calls for the same parent conversation share one request. A
+   * `reset()` while one is in flight invalidates it — the snapshot describes
+   * the conversation the user just left, so it is dropped rather than merged
+   * into the store that now belongs to a different chat.
    */
   reconcileFromDaemon: (
     assistantId: string,
@@ -487,6 +490,14 @@ function generateTimelineEventId(): string {
  */
 const reconcileInFlight = new Map<string, Promise<void>>();
 
+/**
+ * Bumped by every `reset()` — i.e. every conversation or assistant switch.
+ * A reconcile round-trip captures the generation before its await; a snapshot
+ * that lands after a bump describes the context the user has already left, so
+ * it is dropped wholesale rather than merged into the freshly-reset store.
+ */
+let resetGeneration = 0;
+
 /** Minimum spacing between `requestSubagentReconcile` kicks. */
 const RECONCILE_KICK_INTERVAL_MS = 5_000;
 
@@ -513,7 +524,19 @@ function applyReconciledSubagent(
     // subagent whose terminal event has since landed over SSE. Settled entries
     // only ever move between terminal states.
     if (isActiveStatus(existing.status) || !isActiveStatus(status)) {
-      store.changeStatus({ subagentId, status });
+      // Usage and error ride along so an entry whose terminal
+      // `subagent_status_changed` was lost still recovers its final totals and
+      // failure reason — the detail auto-fetch won't, since it refuses any
+      // entry that already has events. `changeStatus` preserves what it
+      // already holds when the snapshot omits these.
+      store.changeStatus({
+        subagentId,
+        status,
+        error: info.error,
+        inputTokens: info.usage?.inputTokens,
+        outputTokens: info.usage?.outputTokens,
+        totalCost: info.usage?.estimatedCost,
+      });
     }
     if (info.conversationId) {
       store.setConversationId(subagentId, info.conversationId);
@@ -529,11 +552,25 @@ function applyReconciledSubagent(
       objective: info.objective ?? "",
       status,
       isFork: info.isFork,
+      error: info.error,
       conversationId: info.conversationId,
       parentConversationId,
       timestamp: Date.now(),
       parentToolUseId: info.parentToolUseId,
     });
+    // A spawn starts every tally at zero, so stamp the snapshot's totals
+    // through `changeStatus` — which also marks a terminal entry so a late
+    // usage event can't double-count on top of them.
+    if (info.usage) {
+      store.changeStatus({
+        subagentId,
+        status,
+        error: info.error,
+        inputTokens: info.usage.inputTokens,
+        outputTokens: info.usage.outputTokens,
+        totalCost: info.usage.estimatedCost,
+      });
+    }
     return;
   }
 
@@ -553,6 +590,7 @@ async function runReconcile(
   parentConversationId: string,
 ): Promise<void> {
   const requestedAt = Date.now();
+  const generation = resetGeneration;
   let snapshot: Record<string, ReconciledSubagent>;
   try {
     const { data, response } = await subagentsReconcileGet({
@@ -566,6 +604,15 @@ async function runReconcile(
     snapshot = data.subagents;
   } catch (err) {
     captureError(err, { context: "reconcileFromDaemon", bestEffort: true });
+    return;
+  }
+
+  // The store is global but a snapshot is not: a `reset()` during the
+  // round-trip means the user switched conversation or assistant, so these
+  // rows belong to a context that is no longer on screen. Applying them would
+  // repopulate the fresh store with the previous chat's subagents — and settle
+  // its orphans against the wrong state — so drop the whole step.
+  if (generation !== resetGeneration) {
     return;
   }
 
@@ -1017,11 +1064,18 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       return inFlight;
     }
 
-    const run = runReconcile(get, assistantId, parentConversationId).finally(
-      () => {
+    const run: Promise<void> = runReconcile(
+      get,
+      assistantId,
+      parentConversationId,
+    ).finally(() => {
+      // Only clear our own entry: a `reset()` may have already evicted this
+      // one and a later call may have registered its own request under the
+      // same key, which this settlement says nothing about.
+      if (reconcileInFlight.get(parentConversationId) === run) {
         reconcileInFlight.delete(parentConversationId);
-      },
-    );
+      }
+    });
     reconcileInFlight.set(parentConversationId, run);
     return run;
   },
@@ -1045,6 +1099,11 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     // A reset means a conversation switch, so the next unknown-id kick should
     // fire immediately instead of inheriting the previous chat's window.
     lastReconcileKickAt = 0;
+    // Invalidate every in-flight snapshot (they describe the context being
+    // left) and drop them from the single-flight map so a reconcile for the
+    // new context issues a fresh request instead of joining a doomed one.
+    resetGeneration++;
+    reconcileInFlight.clear();
     set({
       byId: {},
       orderedIds: [],

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -30,6 +30,7 @@ import {
 import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
 import { isActiveStatus } from "@/utils/subagent-status";
 import { supportsSubagentDetailSelfLookup } from "@/lib/backwards-compat/subagent-detail-self-lookup";
+import { supportsSubagentsReconcile } from "@/lib/backwards-compat/subagents-reconcile";
 import { fetchSubagentDetail } from "./fetch-subagent-detail";
 import { mapDetailEvents } from "./map-detail-events";
 import { setToolUseAnchor } from "./store-helpers/by-tool-use-id-index";
@@ -1065,6 +1066,12 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
   },
 
   reconcileFromDaemon: (assistantId, parentConversationId) => {
+    // Single choke point for every trigger (mount, SSE reopen, unknown-id
+    // kick): assistants older than 0.10.0 don't serve the route, and the
+    // triggers re-fire on every reopen — gate rather than 404 repeatedly.
+    if (!supportsSubagentsReconcile()) {
+      return Promise.resolve();
+    }
     const inFlight = reconcileInFlight.get(parentConversationId);
     if (inFlight) {
       return inFlight;

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -498,10 +498,16 @@ const reconcileInFlight = new Map<string, Promise<void>>();
  */
 let resetGeneration = 0;
 
-/** Minimum spacing between `requestSubagentReconcile` kicks. */
+/** Minimum spacing between `requestSubagentReconcile` kicks for one parent. */
 const RECONCILE_KICK_INTERVAL_MS = 5_000;
 
-let lastReconcileKickAt = 0;
+/**
+ * Last kick time keyed by parent conversation id, mirroring
+ * `reconcileInFlight`. Subagent events are routed globally, so a background
+ * conversation's kick must not consume the window the conversation on screen
+ * needs — a single shared throttle lets either starve the other.
+ */
+const lastReconcileKickAt = new Map<string, number>();
 
 /** One child row from the reconcile snapshot; only `status` is guaranteed. */
 type ReconciledSubagent = SubagentsReconcileGetResponse["subagents"][string];
@@ -1098,7 +1104,7 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
   reset: () => {
     // A reset means a conversation switch, so the next unknown-id kick should
     // fire immediately instead of inheriting the previous chat's window.
-    lastReconcileKickAt = 0;
+    lastReconcileKickAt.clear();
     // Invalidate every in-flight snapshot (they describe the context being
     // left) and drop them from the single-flight map so a reconcile for the
     // new context issues a fresh request instead of joining a doomed one.
@@ -1123,26 +1129,37 @@ export const useSubagentStore = createSelectors(useSubagentStoreBase);
  * For imperative call sites that only hold a reason — the stream handlers hit
  * this when an event names a subagent the store has never seen, which means
  * the client's picture of the run is incomplete. Reads the active assistant
- * and conversation from their stores (same pattern as `abortSubagent`) and
- * rate-limits to one round-trip per `RECONCILE_KICK_INTERVAL_MS`, so a burst
- * of events for the same missing subagent costs a single fetch.
+ * from its store (same pattern as `abortSubagent`) and rate-limits to one
+ * round-trip per parent per `RECONCILE_KICK_INTERVAL_MS`, so a burst of events
+ * for the same missing subagent costs a single fetch.
+ *
+ * `parentConversationId` names the conversation to resync. Subagent events are
+ * routed globally, so an event for a background conversation must reconcile
+ * ITS parent rather than whichever chat is on screen. Callers with no id at
+ * hand — `subagent_status_changed` carries none — fall back to the active
+ * conversation.
  */
-export function requestSubagentReconcile(reason: string): void {
+export function requestSubagentReconcile(
+  reason: string,
+  parentConversationId?: string,
+): void {
   const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
-  const parentConversationId =
+  const targetConversationId =
+    parentConversationId ??
     useConversationStore.getState().activeConversationId;
-  if (!assistantId || !parentConversationId) {
+  if (!assistantId || !targetConversationId) {
     return;
   }
 
   const now = Date.now();
-  if (now - lastReconcileKickAt < RECONCILE_KICK_INTERVAL_MS) {
+  const lastKickAt = lastReconcileKickAt.get(targetConversationId) ?? 0;
+  if (now - lastKickAt < RECONCILE_KICK_INTERVAL_MS) {
     return;
   }
-  lastReconcileKickAt = now;
+  lastReconcileKickAt.set(targetConversationId, now);
 
   recordDiagnostic("subagent_reconcile_kick", { reason });
   void useSubagentStoreBase
     .getState()
-    .reconcileFromDaemon(assistantId, parentConversationId);
+    .reconcileFromDaemon(assistantId, targetConversationId);
 }

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
@@ -28,9 +28,13 @@ mock.module("@/lib/backwards-compat/subagent-detail-self-lookup", () => ({
 }));
 
 let reconcileCalls = 0;
+const reconciledParents: string[] = [];
 mock.module("@/generated/daemon/sdk.gen", () => ({
-  subagentsReconcileGet: async () => {
+  subagentsReconcileGet: async (options: {
+    query?: { parentConversationId?: string };
+  }) => {
     reconcileCalls += 1;
+    reconciledParents.push(options.query?.parentConversationId ?? "");
     return { data: { subagents: {} }, response: { ok: true, status: 200 } };
   },
   subagentsByIdGet: async () => ({ data: undefined, response: { ok: false } }),
@@ -56,6 +60,7 @@ const { makeCtx } = await import(
 
 const PARENT = "conv-parent";
 const CHILD = "conv-child";
+const BACKGROUND = "conv-background";
 
 const ctx = {} as StreamHandlerContext;
 
@@ -64,6 +69,7 @@ beforeEach(() => {
   useSubagentStore.getState().reset();
   selfLookupSupported = true;
   reconcileCalls = 0;
+  reconciledParents.length = 0;
   useResolvedAssistantsStore.getState().setActiveAssistantId(null);
   useConversationStore.getState().setActiveConversationId(null);
 });
@@ -316,5 +322,63 @@ describe("unknown-id reconcile kick", () => {
     await Promise.resolve();
 
     expect(reconcileCalls).toBe(0);
+  });
+
+  it("reconciles the event's own parent, not the conversation on screen", async () => {
+    activate();
+
+    // Subagent events are routed globally, so this one belongs to a
+    // conversation running in the background.
+    handleSubagentEvent(
+      {
+        type: "subagent_event",
+        subagentId: "sa-bg",
+        conversationId: BACKGROUND,
+        event: { type: "assistant_text_delta", text: "working…" },
+      },
+      ctx,
+    );
+    await Promise.resolve();
+
+    expect(reconciledParents).toEqual([BACKGROUND]);
+  });
+
+  it("throttles per parent so a background kick can't starve the active one", async () => {
+    activate();
+
+    handleSubagentEvent(
+      {
+        type: "subagent_event",
+        subagentId: "sa-bg",
+        conversationId: BACKGROUND,
+        event: { type: "assistant_text_delta", text: "working…" },
+      },
+      ctx,
+    );
+    // Inside the background parent's 5s window, but the active parent has a
+    // window of its own.
+    handleSubagentStatusChanged(statusEvent("sa-active"), ctx);
+    // A second background kick is still throttled.
+    handleSubagentEvent(
+      {
+        type: "subagent_event",
+        subagentId: "sa-bg-2",
+        conversationId: BACKGROUND,
+        event: { type: "assistant_text_delta", text: "working…" },
+      },
+      ctx,
+    );
+    await Promise.resolve();
+
+    expect(reconciledParents).toEqual([BACKGROUND, PARENT]);
+  });
+
+  it("targets the active conversation for a status change, which carries no ids", async () => {
+    activate();
+
+    handleSubagentStatusChanged(statusEvent("sa-1"), ctx);
+    await Promise.resolve();
+
+    expect(reconciledParents).toEqual([PARENT]);
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
@@ -27,12 +27,29 @@ mock.module("@/lib/backwards-compat/subagent-detail-self-lookup", () => ({
   supportsSubagentDetailSelfLookup: () => selfLookupSupported,
 }));
 
+let reconcileCalls = 0;
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  subagentsReconcileGet: async () => {
+    reconcileCalls += 1;
+    return { data: { subagents: {} }, response: { ok: true, status: 200 } };
+  },
+  subagentsByIdGet: async () => ({ data: undefined, response: { ok: false } }),
+  subagentsByIdAbortPost: async () => ({
+    data: undefined,
+    response: { ok: true },
+  }),
+}));
+
 const {
   handleSubagentEvent,
   handleSubagentSpawned,
   handleSubagentStatusChanged,
 } = await import("@/domains/chat/utils/stream-handlers/subagent-handlers");
 const { useSubagentStore } = await import("@/domains/chat/subagent-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
 const { makeCtx } = await import(
   "@/domains/chat/utils/stream-handlers/test-helpers"
 );
@@ -43,8 +60,12 @@ const CHILD = "conv-child";
 const ctx = {} as StreamHandlerContext;
 
 beforeEach(() => {
+  // Also clears the reconcile-kick debounce window.
   useSubagentStore.getState().reset();
   selfLookupSupported = true;
+  reconcileCalls = 0;
+  useResolvedAssistantsStore.getState().setActiveAssistantId(null);
+  useConversationStore.getState().setActiveConversationId(null);
 });
 
 describe("handleSubagentSpawned", () => {
@@ -224,5 +245,76 @@ describe("handleSubagentStatusChanged — unknown subagent id", () => {
     expect(entry?.conversationId).toBeUndefined();
     expect(entry?.parentConversationId).toBeUndefined();
     expect(entry?.hydrationPending).toBeUndefined();
+  });
+});
+
+describe("unknown-id reconcile kick", () => {
+  function activate() {
+    useResolvedAssistantsStore.getState().setActiveAssistantId("asst-1");
+    useConversationStore.getState().setActiveConversationId(PARENT);
+  }
+
+  function statusEvent(subagentId: string) {
+    return {
+      type: "subagent_status_changed" as const,
+      subagentId,
+      status: "running" as const,
+    };
+  }
+
+  it("kicks a reconcile for an unknown status-change id", async () => {
+    activate();
+
+    handleSubagentStatusChanged(statusEvent("sa-1"), ctx);
+    await Promise.resolve();
+
+    expect(reconcileCalls).toBe(1);
+  });
+
+  it("collapses a burst of unknown ids into one round-trip", async () => {
+    activate();
+
+    handleSubagentStatusChanged(statusEvent("sa-1"), ctx);
+    handleSubagentStatusChanged(statusEvent("sa-2"), ctx);
+    handleSubagentEvent(
+      {
+        type: "subagent_event",
+        subagentId: "sa-3",
+        conversationId: PARENT,
+        event: { type: "assistant_text_delta", text: "working…" },
+      },
+      ctx,
+    );
+    await Promise.resolve();
+
+    expect(reconcileCalls).toBe(1);
+    // Every id still got its own stub — the kick is additive, not a substitute.
+    expect(useSubagentStore.getState().orderedIds).toEqual([
+      "sa-1",
+      "sa-2",
+      "sa-3",
+    ]);
+  });
+
+  it("does not kick for an id the store already knows", async () => {
+    activate();
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "auditor",
+      objective: "audit",
+      timestamp: Date.now(),
+    });
+
+    handleSubagentStatusChanged(statusEvent("sa-1"), ctx);
+    await Promise.resolve();
+
+    expect(reconcileCalls).toBe(0);
+  });
+
+  it("does not kick without an active assistant and conversation", async () => {
+    handleSubagentStatusChanged(statusEvent("sa-1"), ctx);
+    await Promise.resolve();
+
+    expect(reconcileCalls).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -96,7 +96,10 @@ export function handleSubagentEvent(
       conversationId: childConversationId,
       parentConversationId,
     });
-    requestSubagentReconcile("unknown_subagent_id");
+    // Reconcile the envelope's OWN parent: this event may belong to a
+    // background conversation, whose subagents the active chat's snapshot
+    // would say nothing about.
+    requestSubagentReconcile("unknown_subagent_id", parentConversationId);
   }
 
   if (inner.type === "usage_progress") {

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -5,7 +5,10 @@ import {
   UsageProgressEventSchema,
 } from "@vellumai/assistant-api";
 
-import { useSubagentStore } from "@/domains/chat/subagent-store";
+import {
+  requestSubagentReconcile,
+  useSubagentStore,
+} from "@/domains/chat/subagent-store";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 
 export function handleSubagentSpawned(
@@ -33,13 +36,16 @@ export function handleSubagentStatusChanged(
   // was missed (SSE gap, page reload) or the store was reset after it
   // arrived. Materialize a stub so the status lands instead of silently
   // vanishing — a dropped terminal status is how the inline card dies (the
-  // avatar row expands to nothing and the detail panel can't open).
+  // avatar row expands to nothing and the detail panel can't open). The
+  // reconcile kick then recovers the real identity, and any sibling subagent
+  // that streamed nothing at all, a round-trip later.
   if (!store.byId[event.subagentId]) {
     store.ensureEntry({
       subagentId: event.subagentId,
       timestamp: Date.now(),
       status: event.status,
     });
+    requestSubagentReconcile("unknown_subagent_id");
   }
   store.changeStatus({
     subagentId: event.subagentId,
@@ -90,6 +96,7 @@ export function handleSubagentEvent(
       conversationId: childConversationId,
       parentConversationId,
     });
+    requestSubagentReconcile("unknown_subagent_id");
   }
 
   if (inner.type === "usage_progress") {

--- a/clients/web/src/lib/backwards-compat/subagents-reconcile.ts
+++ b/clients/web/src/lib/backwards-compat/subagents-reconcile.ts
@@ -1,0 +1,25 @@
+/**
+ * Backwards-compat gate: subagent reconcile endpoint.
+ *
+ * From assistant 0.10.0, `GET /subagents/reconcile` reports the live status
+ * of a parent conversation's subagents. Assistants older than that 404 the
+ * route, and the reconcile triggers fire on every conversation mount and
+ * SSE reopen — an unconditional call would produce a steady stream of
+ * failed requests against older installations.
+ *
+ * Response *enrichment* (label/objective/child conversation id, added in
+ * 0.10.13) is not gated here: `reconcileFromDaemon` degrades per-field, so
+ * a bare `{status}` response from 0.10.0–0.10.12 still updates known
+ * entries and stubs unknowns.
+ */
+import { assistantSupports } from "@/lib/backwards-compat/utils";
+
+const MIN_VERSION = "0.10.0";
+
+/**
+ * Snapshot check (safe outside React — stream handlers, store actions):
+ * `true` when the connected assistant serves `GET /subagents/reconcile`.
+ */
+export function supportsSubagentsReconcile(): boolean {
+  return assistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
## Summary
- Adds reconcileFromDaemon: rebuilds/updates subagent store entries from GET /v1/subagents/reconcile (full identity on 0.10.13+ assistants, stub-level on older ones) and settles orphaned running entries to interrupted
- Triggers: conversation load, SSE reopen (resume/watchdog/error/debug), and a debounced kick when events arrive for unknown subagent ids
- Armed stubs learn their true child conversation id from the enriched detail response

## Staleness guards
The snapshot is a round-trip old, so two staleness cases are handled explicitly (each has a regression test):
- A known entry that has since settled over SSE is never walked back to an active status — settled entries only move between terminal states.
- Orphan settling skips entries whose `spawnedAt` postdates the request; a subagent spawned after the daemon built the snapshot is legitimately absent from it.

## Known limits (deliberate)
- A reconcile in flight when the user switches conversations still applies its writes. The entries carry the old `parentConversationId`, so `useActiveSubagentIds` filters them out of the overlay and the next conversation-change `reset()` clears them; the cost is a few wasted detail fetches. Guarding on the active conversation id would couple the store action to navigation state.
- The full-identity branch assumes an enriched response carrying `label` also carries `conversationId` (the daemon route sets both from live child state). If only `label` arrived, the row would render and fill from the live stream but skip the history backfill.
- The unknown-id kick is leading-edge and globally keyed, so a genuinely new unknown id arriving inside the 5s window is not reconciled immediately; `ensureEntry` plus the detail auto-fetch still cover that id.

## Notes
- `clients/web/src/generated/` is gitignored, so the regenerated daemon SDK is not in the diff — run `bun run openapi-ts` locally to pick up `subagentsReconcileGet`.
- `useSubagentReconcile` takes `conversationExistsOnServer` (already computed by `useConversationLoader`) rather than sniffing a draft id: draft conversation ids are plain UUIDs with no distinguishing shape, so there is no id-only predicate to grep for.

Part of plan: subagent-running-state-fixes.md (PR 5 — final)
