### PR TITLE
feat(web): hide context window indicator behind an opt-in preference

### DIFF
--- a/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for `ContextWindowIndicator`'s opt-in gate.
+ *
+ * The ring is hidden unless the user turns it on in Settings → General →
+ * Preferences: a gauge filling toward "full" reads as an impending failure
+ * even though the assistant compacts its own context. These tests pin both
+ * halves of that contract — silent by default, visible once opted in.
+ * Uses happy-dom via the bun:test preload configured in `web/bunfig.toml`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, render, screen } from "@testing-library/react";
+
+let indicatorEnabled = false;
+
+mock.module("@/utils/composer-settings", () => ({
+  showContextWindowIndicator: {
+    useValue: () => indicatorEnabled,
+    save: () => {},
+  },
+}));
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+import { ContextWindowIndicator } from "@/domains/chat/components/context-window-indicator";
+
+const USAGE = { tokens: 90_000, maxTokens: 200_000, fillRatio: 0.45 };
+
+beforeEach(() => {
+  indicatorEnabled = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ContextWindowIndicator", () => {
+  test("renders nothing while the preference is off", () => {
+    // GIVEN usage that would otherwise paint a 45%-full ring
+    // WHEN the opt-in preference is off (the shipped default)
+    const { container } = render(
+      <ContextWindowIndicator usage={USAGE} assistantName="Vellum" />,
+    );
+
+    // THEN the composer gets no ring at all
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByLabelText(/Context window/)).toBeNull();
+  });
+
+  test("renders the ring once the preference is on", () => {
+    // GIVEN the user has opted in
+    indicatorEnabled = true;
+
+    // WHEN the same usage renders
+    render(<ContextWindowIndicator usage={USAGE} assistantName="Vellum" />);
+
+    // THEN the ring appears, labelled with the rounded fill percentage
+    expect(screen.getByLabelText("Context window 45% full")).toBeDefined();
+  });
+
+  test("stays hidden when opted in but usage is unknown", () => {
+    // GIVEN the preference is on but no usage has streamed in yet
+    indicatorEnabled = true;
+
+    // WHEN the indicator renders without usage
+    const { container } = render(
+      <ContextWindowIndicator usage={null} assistantName="Vellum" />,
+    );
+
+    // THEN there is nothing to show
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { showContextWindowIndicator } from "@/utils/composer-settings";
 import { BottomSheet, Button } from "@vellumai/design-library";
 
 export interface ContextWindowUsage {
@@ -205,12 +206,20 @@ function MobileSheetContent({
   );
 }
 
+/**
+ * Composer ring showing how full the context window is.
+ *
+ * Opt-in via Settings → General → Preferences ("Show context window usage");
+ * hidden by default. Gating lives here rather than at the mount site so every
+ * caller inherits the preference.
+ */
 export function ContextWindowIndicator({
   usage,
   assistantName,
   onClearContext,
 }: ContextWindowIndicatorProps) {
   const assistantDisplayName = assistantName?.trim() || "Your assistant";
+  const enabled = showContextWindowIndicator.useValue();
   const isMobile = useIsMobile();
   const [sheetOpen, setSheetOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
@@ -245,7 +254,7 @@ export function ContextWindowIndicator({
     setTooltipPosition({ top, left: clampedLeft });
   }, [isHovered, usage]);
 
-  if (!usage || usage.fillRatio == null) {
+  if (!enabled || !usage || usage.fillRatio == null) {
     return null;
   }
 

--- a/clients/web/src/domains/settings/components/preferences-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/preferences-modal.test.tsx
@@ -7,7 +7,7 @@
  * toggle but no Appearance/theme control.
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 const applyThemePreferenceMock = mock((_theme: string) => {});
 const writeStoredThemePreferenceMock = mock((_theme: string) => {});
@@ -38,10 +38,16 @@ mock.module("@/runtime/platform-detection", () => ({
   isMacOSBrowser: () => true,
 }));
 
+const saveShowContextWindowIndicator = mock((_next: boolean) => {});
+
 mock.module("@/utils/composer-settings", () => ({
   cmdEnterToSend: {
     useValue: () => false,
     save: () => {},
+  },
+  showContextWindowIndicator: {
+    useValue: () => false,
+    save: saveShowContextWindowIndicator,
   },
 }));
 
@@ -73,5 +79,25 @@ describe("PreferencesModal", () => {
 
     expect(screen.queryByText("Appearance")).toBeNull();
     expect(screen.queryByLabelText("Theme")).toBeNull();
+  });
+
+  test("hosts the context window usage toggle, unchecked by default", () => {
+    render(<PreferencesModal open onClose={() => {}} />);
+
+    const toggle = screen.getByRole("switch", {
+      name: "Show context window usage",
+    });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+
+  test("persists an opt-in for the context window indicator", () => {
+    saveShowContextWindowIndicator.mockClear();
+    render(<PreferencesModal open onClose={() => {}} />);
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show context window usage" }),
+    );
+
+    expect(saveShowContextWindowIndicator).toHaveBeenCalledWith(true);
   });
 });

--- a/clients/web/src/domains/settings/components/preferences-modal.tsx
+++ b/clients/web/src/domains/settings/components/preferences-modal.tsx
@@ -4,25 +4,27 @@ import { ShortcutsSections } from "@/domains/settings/keyboard-shortcuts/shortcu
 import { isElectron } from "@/runtime/is-electron";
 import { getLaunchAtLogin, setLaunchAtLogin } from "@/runtime/launch-at-login";
 import { isMacOSBrowser } from "@/runtime/platform-detection";
-import { cmdEnterToSend } from "@/utils/composer-settings";
+import {
+  cmdEnterToSend,
+  showContextWindowIndicator,
+} from "@/utils/composer-settings";
 import { isPointerCoarse } from "@/utils/pointer";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 /**
- * Preferences section for the composer's Enter-key behavior, at parity with
- * the macOS app's "Send with Cmd+Enter" toggle.
+ * Preferences section for composer behavior: the Enter-key mode (at parity
+ * with the macOS app's "Send with Cmd+Enter" toggle) and the opt-in
+ * context-window indicator.
  */
-function ComposerSendSection() {
-  const enabled = cmdEnterToSend.useValue();
+function ComposerSection() {
+  const sendWithModifier = cmdEnterToSend.useValue();
+  const showContextWindow = showContextWindowIndicator.useValue();
 
   // On touch devices the composer never submits on Enter (it always inserts
-  // a newline; sending happens via the send button), so the toggle would be
-  // a no-op control.
-  if (isPointerCoarse()) {
-    return null;
-  }
-
+  // a newline; sending happens via the send button), so that toggle would be
+  // a no-op control. The context-window toggle applies on every surface.
+  const showSendToggle = !isPointerCoarse();
   const modifier = isMacOSBrowser() ? "Cmd" : "Ctrl";
 
   return (
@@ -30,12 +32,20 @@ function ComposerSendSection() {
       <h3 className="text-title-small text-[var(--content-emphasised)]">
         Composer
       </h3>
-      <div className="mt-2">
+      <div className="mt-2 space-y-4">
+        {showSendToggle && (
+          <Toggle
+            checked={sendWithModifier}
+            onChange={cmdEnterToSend.save}
+            label={`Send with ${modifier}+Enter`}
+            helperText={`When enabled, Enter inserts a new line and ${modifier}+Enter sends.`}
+          />
+        )}
         <Toggle
-          checked={enabled}
-          onChange={cmdEnterToSend.save}
-          label={`Send with ${modifier}+Enter`}
-          helperText={`When enabled, Enter inserts a new line and ${modifier}+Enter sends.`}
+          checked={showContextWindow}
+          onChange={showContextWindowIndicator.save}
+          label="Show context window usage"
+          helperText="Adds a ring to the composer tracking how full the context window is. Your assistant compacts its context automatically either way."
         />
       </div>
     </section>
@@ -87,7 +97,7 @@ export interface PreferencesModalProps {
  * Preferences editor opened from the Preferences card on Settings → General.
  * Hosts the shortcut rebinding sections (Electron only — hotkeys drive Electron
  * globalShortcut + menu accelerators with no web/iOS analogue), the composer
- * send toggle, and the Launch at Login toggle. The theme picker is a separate
+ * section, and the Launch at Login toggle. The theme picker is a separate
  * Appearance card on Settings → General.
  */
 export function PreferencesModal({ open, onClose }: PreferencesModalProps) {
@@ -122,7 +132,7 @@ export function PreferencesModal({ open, onClose }: PreferencesModalProps) {
                 </div>
               </section>
             )}
-            <ComposerSendSection />
+            <ComposerSection />
             {isElectron() && <LaunchAtLoginSection />}
           </div>
         </Modal.Body>

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -46,7 +46,6 @@ import { isElectron } from "@/runtime/is-electron";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useIsAuthenticated } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
-import { isPointerCoarse } from "@/utils/pointer";
 import { routes } from "@/utils/routes";
 
 export function GeneralPage() {
@@ -128,12 +127,6 @@ export function GeneralPage() {
   // Mirrors DeleteAccountSection's internal platformHostedOnly gate — it
   // returns null when gated, so the card must not render an empty shell.
   const showDeleteAccount = infraGate !== "gated";
-  // The Preferences modal only has content on Electron (shortcuts, Launch at
-  // Login) or with a fine pointer (the composer send toggle), so its Customize
-  // button and modal are hidden on touch/non-Electron surfaces where the modal
-  // would be empty. The card itself always renders — it hosts the theme picker,
-  // which applies on every platform.
-  const showPreferences = isElectron() || !isPointerCoarse();
 
   return (
     <div className="space-y-4">
@@ -281,14 +274,9 @@ export function GeneralPage() {
         title="Preferences"
         subtitle="Customize how Vellum looks and behaves on this device."
         accessory={
-          showPreferences ? (
-            <Button
-              variant="outlined"
-              onClick={() => setPreferencesOpen(true)}
-            >
-              Customize
-            </Button>
-          ) : undefined
+          <Button variant="outlined" onClick={() => setPreferencesOpen(true)}>
+            Customize
+          </Button>
         }
       >
         <div className="flex flex-col gap-5">
@@ -297,12 +285,10 @@ export function GeneralPage() {
         </div>
       </DetailCard>
 
-      {showPreferences && (
-        <PreferencesModal
-          open={preferencesOpen}
-          onClose={() => setPreferencesOpen(false)}
-        />
-      )}
+      <PreferencesModal
+        open={preferencesOpen}
+        onClose={() => setPreferencesOpen(false)}
+      />
 
       {teleportEnabled && isElectron() && <TeleportCard />}
 

--- a/clients/web/src/utils/composer-settings.ts
+++ b/clients/web/src/utils/composer-settings.ts
@@ -17,3 +17,17 @@ export const cmdEnterToSend = createStorageAccessor<boolean>({
   serialize: String,
   fallback: false,
 });
+
+/**
+ * Opt-in for the composer's context-window fill ring. Off by default: the
+ * assistant compacts its own context, so a gauge climbing toward "full"
+ * reads as an impending failure the user is expected to manage. `/status`
+ * reports the same numbers on demand for anyone who wants them.
+ */
+export const showContextWindowIndicator = createStorageAccessor<boolean>({
+  key: "device:show_context_window_indicator",
+  scope: "device",
+  parse: parseBool,
+  serialize: String,
+  fallback: false,
+});


### PR DESCRIPTION
## Why

Per [this Slack thread](https://vellumai.slack.com/archives/C08GM4RCPTR/p1785219468568909): Rok flagged that showing context-window usage in the composer "could make people nervous as it fills up, especially when it gets full," and noted peers don't surface it. Aaron: *"i'd be down to make it an advanced setting" / "off by default."*

The ring is a gauge the user can't act on — the assistant compacts its own context. Watching it climb toward "full" reads as an impending failure they're expected to manage.

## What

- The composer's context-window ring is **off by default**, enabled via **Settings → General → Preferences → "Show context window usage"**.
- Gate lives inside `ContextWindowIndicator` rather than at the mount site, so any caller inherits the preference.
- Preference is device-scoped localStorage (`device:show_context_window_indicator`) alongside the existing `cmdEnterToSend` composer setting.

Nothing becomes unreachable: `/status` still reports context usage on demand and `/compact` still forces compaction.

## Note for reviewers

The `Clear Context` button lived **only** inside this indicator's mobile bottom sheet, so with the setting off it is no longer reachable on mobile. `/compact` covers the same need and is available everywhere. Flagging in case we want a separate affordance.

One adjacent change: the Preferences modal used to hide itself on touch/non-Electron surfaces because its only content there would have been the fine-pointer Cmd+Enter toggle. The new toggle applies on every surface, so the modal and its Customize button now always render, and the Cmd+Enter toggle is gated individually instead.

## Testing

- New `context-window-indicator.test.tsx` — hidden by default, renders when opted in, stays hidden when opted in but usage is unknown.
- `preferences-modal.test.tsx` — toggle present and unchecked by default; clicking persists the opt-in.
- `bunx tsc --noEmit` clean; ESLint clean on all touched files.
- Baseline-checked the broader suite: `src/domains/settings/` + `src/domains/chat/components/` reports an identical 324 fail / 47 errors both with and without this change (pre-existing cross-file `mock.module` leakage — the files pass individually). This change adds +5 passing tests and no new failures.

Not verified in a live browser — the change is a boolean gate plus a toggle row built from existing design-system components, covered by unit tests in both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)