### PR TITLE
fix(tests): align subagent-disposal setup with migration 354

### DIFF
--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantEvent } from "../api/index.js";
+import { getDb } from "../persistence/db-connection.js";
 import { migrateCreateSubagentsTable } from "../persistence/migrations/311-create-subagents-table.js";
+import { migrateAddSubagentParentToolUseId } from "../persistence/migrations/354-add-subagent-parent-tool-use-id.js";
 import { resetTestTables } from "../persistence/raw-query.js";
 import {
   getSubagentRecordById,
@@ -369,6 +371,7 @@ describe("durable record lifetime across disposal paths", () => {
   beforeEach(() => {
     // Idempotent; the table may already exist from a prior run.
     migrateCreateSubagentsTable();
+    migrateAddSubagentParentToolUseId(getDb());
     resetTestTables("subagents");
   });
 
@@ -384,6 +387,7 @@ describe("durable record lifetime across disposal paths", () => {
       sendResultToUser: null,
       status: "completed",
       error: null,
+      parentToolUseId: null,
       createdAt: 1000,
       startedAt: 1001,
       completedAt: 2000,


### PR DESCRIPTION
## Summary
Fixes a cross-PR semantic conflict on the feature branch: #39356 added the required `parentToolUseId` field to `SubagentRecord` and its column to the upsert SQL, while #39358's disposal tests (written pre-merge) still created the table via migration 311 only and used a record literal without the field — 3 test failures + a tsc error visible only on the merged branch.

- Test setup now also runs migration 354
- Record literal gains `parentToolUseId: null`

Part of plan: subagent-running-state-fixes.md (integration fix)