### PR TITLE
feat(skills): `assistant skills companion` CLI for bundling files into managed skills

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -2,11 +2,13 @@ import * as fs from "node:fs";
 import {
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
@@ -16,9 +18,12 @@ const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 
 import { loadSkillCatalog } from "../config/skills.js";
 import {
+  addCompanionFile,
   buildSkillMarkdown,
   createManagedSkill,
   deleteManagedSkill,
+  listCompanionFiles,
+  removeCompanionFile,
   validateCompanionPath,
   validateManagedSkillId,
 } from "../skills/managed-store.js";
@@ -1357,5 +1362,251 @@ describe("YAML metadata round-trip", () => {
     expect(skill!.displayName).toBe("YAML Nested Skill");
     expect(skill!.emoji).toBe("🧪");
     expect(skill!.includes).toEqual(["child-a", "child-b"]);
+  });
+});
+
+describe("companion file CLI store surface", () => {
+  /** Create an assistant-authored managed skill to copy companions into. */
+  function seedAssistantSkill(id: string): void {
+    const result = createManagedSkill({
+      id,
+      name: id,
+      description: `${id} description`,
+      bodyMarkdown: "Body.",
+      author: "assistant",
+    });
+    expect(result.created).toBe(true);
+  }
+
+  test("copies an on-disk source into an assistant-authored skill", () => {
+    seedAssistantSkill("companion-add");
+    const sourcePath = join(TEST_DIR, "proven.py");
+    writeFileSync(sourcePath, "print('proven')\n", "utf-8");
+
+    const result = addCompanionFile({
+      skillId: "companion-add",
+      path: "scripts/proven.py",
+      sourcePath,
+    });
+
+    expect(result.added).toBe(true);
+    expect(
+      readFileSync(
+        join(TEST_DIR, "skills", "companion-add", "scripts", "proven.py"),
+        "utf-8",
+      ),
+    ).toBe("print('proven')\n");
+  });
+
+  test("copies from outside the workspace — source policy is the shell's, not the store's", () => {
+    seedAssistantSkill("companion-outside");
+    const outsideDir = mkdtempSync(join(tmpdir(), "companion-source-"));
+    const sourcePath = join(outsideDir, "outside.py");
+    writeFileSync(sourcePath, "print('outside')\n", "utf-8");
+
+    try {
+      const result = addCompanionFile({
+        skillId: "companion-outside",
+        path: "scripts/outside.py",
+        sourcePath,
+      });
+
+      expect(result.added).toBe(true);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses a skill that is not verifiably assistant-authored", () => {
+    createManagedSkill({
+      id: "companion-user-authored",
+      name: "User Authored",
+      description: "Authored by the user",
+      bodyMarkdown: "Body.",
+      author: "user",
+    });
+    const sourcePath = join(TEST_DIR, "user-authored.py");
+    writeFileSync(sourcePath, "x", "utf-8");
+
+    const result = addCompanionFile({
+      skillId: "companion-user-authored",
+      path: "scripts/x.py",
+      sourcePath,
+    });
+
+    expect(result.added).toBe(false);
+    expect(result.error).toContain("not verifiably assistant-authored");
+    expect(
+      existsSync(
+        join(TEST_DIR, "skills", "companion-user-authored", "scripts", "x.py"),
+      ),
+    ).toBe(false);
+  });
+
+  test("refuses a missing skill", () => {
+    const sourcePath = join(TEST_DIR, "orphan.py");
+    writeFileSync(sourcePath, "x", "utf-8");
+
+    const result = addCompanionFile({
+      skillId: "companion-missing",
+      path: "scripts/x.py",
+      sourcePath,
+    });
+
+    expect(result.added).toBe(false);
+    expect(result.error).toContain("not found");
+  });
+
+  test.each([
+    ["tools.json", "TOOLS.json manifest"],
+    ["TOOLS.json", "case-varied manifest"],
+    ["SKILL.md", "skill body"],
+    ["install-meta.json", "install metadata"],
+  ])("refuses to overwrite the store-owned %s (%s)", (reservedPath) => {
+    seedAssistantSkill("companion-reserved");
+    const sourcePath = join(TEST_DIR, "manifest.json");
+    writeFileSync(sourcePath, '{"tools":[]}', "utf-8");
+
+    const result = addCompanionFile({
+      skillId: "companion-reserved",
+      path: reservedPath,
+      sourcePath,
+      overwrite: true,
+    });
+
+    expect(result.added).toBe(false);
+    expect(result.error).toContain("store-owned file");
+  });
+
+  test("refuses a destination that escapes the skill directory", () => {
+    seedAssistantSkill("companion-escape");
+    const sourcePath = join(TEST_DIR, "escape.py");
+    writeFileSync(sourcePath, "x", "utf-8");
+
+    const result = addCompanionFile({
+      skillId: "companion-escape",
+      path: "../other-skill/scripts/x.py",
+      sourcePath,
+    });
+
+    expect(result.added).toBe(false);
+    expect(result.error).toContain("..");
+  });
+
+  test("refuses to replace an existing companion without overwrite", () => {
+    seedAssistantSkill("companion-clobber");
+    const sourcePath = join(TEST_DIR, "v1.py");
+    writeFileSync(sourcePath, "v1", "utf-8");
+    expect(
+      addCompanionFile({
+        skillId: "companion-clobber",
+        path: "scripts/x.py",
+        sourcePath,
+      }).added,
+    ).toBe(true);
+
+    writeFileSync(sourcePath, "v2", "utf-8");
+    const second = addCompanionFile({
+      skillId: "companion-clobber",
+      path: "scripts/x.py",
+      sourcePath,
+    });
+
+    expect(second.added).toBe(false);
+    expect(second.error).toContain("already exists");
+    expect(
+      readFileSync(
+        join(TEST_DIR, "skills", "companion-clobber", "scripts", "x.py"),
+        "utf-8",
+      ),
+    ).toBe("v1");
+
+    expect(
+      addCompanionFile({
+        skillId: "companion-clobber",
+        path: "scripts/x.py",
+        sourcePath,
+        overwrite: true,
+      }).added,
+    ).toBe(true);
+    expect(
+      readFileSync(
+        join(TEST_DIR, "skills", "companion-clobber", "scripts", "x.py"),
+        "utf-8",
+      ),
+    ).toBe("v2");
+  });
+
+  test("refuses a relative source path", () => {
+    seedAssistantSkill("companion-relative");
+
+    const result = addCompanionFile({
+      skillId: "companion-relative",
+      path: "scripts/x.py",
+      sourcePath: "relative.py",
+    });
+
+    expect(result.added).toBe(false);
+    expect(result.error).toContain("absolute path");
+  });
+
+  test("refuses a directory source", () => {
+    seedAssistantSkill("companion-dir-source");
+    const sourceDir = join(TEST_DIR, "a-directory");
+    mkdirSync(sourceDir, { recursive: true });
+
+    const result = addCompanionFile({
+      skillId: "companion-dir-source",
+      path: "scripts/x.py",
+      sourcePath: sourceDir,
+    });
+
+    expect(result.added).toBe(false);
+    expect(result.error).toContain("not a regular file");
+  });
+
+  test("lists companion files and omits the store-owned files", () => {
+    seedAssistantSkill("companion-list");
+    const sourcePath = join(TEST_DIR, "listed.py");
+    writeFileSync(sourcePath, "12345", "utf-8");
+    addCompanionFile({
+      skillId: "companion-list",
+      path: "scripts/listed.py",
+      sourcePath,
+    });
+
+    const result = listCompanionFiles("companion-list");
+
+    expect("error" in result).toBe(false);
+    const files = (result as { files: { path: string; bytes: number }[] })
+      .files;
+    expect(files).toEqual([{ path: "scripts/listed.py", bytes: 5 }]);
+  });
+
+  test("removes a companion file but never a store-owned file", () => {
+    seedAssistantSkill("companion-remove");
+    const sourcePath = join(TEST_DIR, "removable.py");
+    writeFileSync(sourcePath, "x", "utf-8");
+    addCompanionFile({
+      skillId: "companion-remove",
+      path: "scripts/removable.py",
+      sourcePath,
+    });
+
+    expect(removeCompanionFile("companion-remove", "SKILL.md").removed).toBe(
+      false,
+    );
+    expect(
+      existsSync(join(TEST_DIR, "skills", "companion-remove", "SKILL.md")),
+    ).toBe(true);
+
+    expect(
+      removeCompanionFile("companion-remove", "scripts/removable.py").removed,
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(TEST_DIR, "skills", "companion-remove", "scripts", "removable.py"),
+      ),
+    ).toBe(false);
   });
 });

--- a/assistant/src/cli/commands/__tests__/skills.test.ts
+++ b/assistant/src/cli/commands/__tests__/skills.test.ts
@@ -614,3 +614,136 @@ describe("skills search", () => {
     expect(parsed.community).toHaveLength(0);
   });
 });
+
+// ===========================================================================
+// skills companion
+// ===========================================================================
+
+describe("skills companion", () => {
+  test("add forwards skillId, path and source to skills_companion_add", async () => {
+    mockIpcResults = [
+      { ok: true, result: { path: "/ws/skills/export/scripts/x.py" } },
+    ];
+
+    const { exitCode } = await runCommand([
+      "skills",
+      "companion",
+      "add",
+      "export",
+      "--path",
+      "scripts/x.py",
+      "--from",
+      "/tmp/x.py",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toHaveLength(1);
+    expect(ipcCalls[0]!.method).toBe("skills_companion_add");
+    expect(ipcCalls[0]!.params).toEqual({
+      body: {
+        skillId: "export",
+        path: "scripts/x.py",
+        from: "/tmp/x.py",
+        overwrite: false,
+      },
+    });
+  });
+
+  test("add passes overwrite through", async () => {
+    mockIpcResults = [{ ok: true, result: { path: "/ws/x" } }];
+
+    await runCommand([
+      "skills",
+      "companion",
+      "add",
+      "export",
+      "--path",
+      "scripts/x.py",
+      "--from",
+      "/tmp/x.py",
+      "--overwrite",
+    ]);
+
+    expect(
+      (ipcCalls[0]!.params as { body: { overwrite: boolean } }).body.overwrite,
+    ).toBe(true);
+  });
+
+  test("add surfaces a daemon rejection as a non-zero exit", async () => {
+    mockIpcResults = [
+      {
+        ok: false,
+        error: "not verifiably assistant-authored",
+        statusCode: 400,
+      },
+    ];
+
+    const { exitCode } = await runCommand([
+      "skills",
+      "companion",
+      "add",
+      "hand-written",
+      "--path",
+      "scripts/x.py",
+      "--from",
+      "/tmp/x.py",
+    ]);
+
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("add requires --path and --from", async () => {
+    const missingFrom = await runCommand([
+      "skills",
+      "companion",
+      "add",
+      "export",
+      "--path",
+      "scripts/x.py",
+    ]);
+    expect(missingFrom.exitCode).not.toBe(0);
+    expect(ipcCalls).toHaveLength(0);
+  });
+
+  test("list renders companion files as JSON", async () => {
+    mockIpcResults = [
+      {
+        ok: true,
+        result: { files: [{ path: "scripts/x.py", bytes: 12 }] },
+      },
+    ];
+
+    const { stdout } = await runCommand([
+      "skills",
+      "companion",
+      "list",
+      "export",
+      "--json",
+    ]);
+
+    expect(ipcCalls[0]!.method).toBe("skills_companion_list");
+    expect(JSON.parse(stdout)).toEqual({
+      ok: true,
+      skillId: "export",
+      files: [{ path: "scripts/x.py", bytes: 12 }],
+    });
+  });
+
+  test("remove forwards the companion path", async () => {
+    mockIpcResults = [{ ok: true, result: { removed: true } }];
+
+    await runCommand([
+      "skills",
+      "companion",
+      "remove",
+      "export",
+      "--path",
+      "scripts/x.py",
+    ]);
+
+    expect(ipcCalls[0]!.method).toBe("skills_companion_remove");
+    expect(ipcCalls[0]!.params).toEqual({
+      body: { skillId: "export", path: "scripts/x.py" },
+    });
+  });
+});

--- a/assistant/src/cli/commands/skills.help.ts
+++ b/assistant/src/cli/commands/skills.help.ts
@@ -155,5 +155,111 @@ Examples:
   $ assistant skills add vercel-labs/skills/find-skills
   $ assistant skills add vercel-labs/skills@find-skills --overwrite`,
     },
+    {
+      name: "companion",
+      description:
+        "Manage companion files (scripts, reference docs) inside a managed skill",
+      helpText: `
+Companion files are the files a skill ships alongside its SKILL.md — most often
+a scripts/ helper the skill body invokes. Copy a proven script in with 'add'
+instead of pasting its contents into the skill body, so the skill reruns the
+exact code that worked.
+
+These verbs write only into skills the assistant authored itself (install-meta
+author "assistant"). A skill you wrote by hand is yours to edit directly with
+your own tools; there is deliberately no flag to override that.
+
+Creating the skill itself is a separate operation — see the skill-management
+skill's scaffold_managed_skill tool.
+
+Examples:
+  $ assistant skills companion add export-report --path scripts/export.py --from /tmp/export.py
+  $ assistant skills companion list export-report
+  $ assistant skills companion remove export-report --path scripts/export.py`,
+      subcommands: [
+        {
+          name: "add",
+          args: "<skill-id>",
+          description: "Copy an on-disk file into a managed skill",
+          options: [
+            {
+              flags: "--path <relative-path>",
+              description:
+                "Destination path inside the skill, e.g. scripts/export.py",
+              required: true,
+            },
+            {
+              flags: "--from <absolute-path>",
+              description: "Absolute path of the existing file to copy in",
+              required: true,
+            },
+            {
+              flags: "--overwrite",
+              description: "Replace an existing companion file at --path",
+            },
+            { flags: "--json", description: "Machine-readable JSON output" },
+          ],
+          helpText: `
+Arguments:
+  skill-id   Managed skill to copy into. Run 'assistant skills list' to see
+             managed skills.
+
+Notes:
+  --path is relative to the skill directory and may not escape it or overwrite
+  the store-owned files (SKILL.md, TOOLS.json, install-meta.json, version.json).
+  --from must be an absolute path to a regular file of at most 1 MiB.
+  The skill must be assistant-authored; the command fails otherwise.
+
+Examples:
+  $ assistant skills companion add export-report --path scripts/export.py --from /tmp/export.py
+  $ assistant skills companion add export-report --path scripts/export.py --from /tmp/v2.py --overwrite`,
+        },
+        {
+          name: "list",
+          args: "<skill-id>",
+          description: "List a managed skill's companion files",
+          options: [
+            { flags: "--json", description: "Machine-readable JSON output" },
+          ],
+          helpText: `
+Arguments:
+  skill-id   Managed skill to inspect. Run 'assistant skills list' to see
+             managed skills.
+
+Lists every file in the skill directory except the store-owned files, with its
+size in bytes.
+
+Examples:
+  $ assistant skills companion list export-report
+  $ assistant skills companion list export-report --json`,
+        },
+        {
+          name: "remove",
+          args: "<skill-id>",
+          description: "Delete one companion file from a managed skill",
+          options: [
+            {
+              flags: "--path <relative-path>",
+              description:
+                "Companion file to delete, as shown by 'companion list'",
+              required: true,
+            },
+            { flags: "--json", description: "Machine-readable JSON output" },
+          ],
+          helpText: `
+Arguments:
+  skill-id   Managed skill to delete from. Run 'assistant skills list' to see
+             managed skills.
+
+Notes:
+  Deletes a single file and cannot remove the store-owned files. The skill must
+  be assistant-authored. To delete the whole skill, use
+  'assistant skills uninstall <skill-id>'.
+
+Examples:
+  $ assistant skills companion remove export-report --path scripts/export.py`,
+        },
+      ],
+    },
   ],
 };

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -469,6 +469,96 @@ export function registerSkillsCommand(program: Command): void {
           }
         },
       );
+
+      const companion = subcommand(skills, "companion");
+
+      subcommand(companion, "add").action(
+        async (
+          skillId: string,
+          opts: {
+            path: string;
+            from: string;
+            overwrite?: boolean;
+            json?: boolean;
+          },
+          _cmd,
+        ) => {
+          const json = opts.json ?? false;
+          const r = await cliIpcCall<{ path: string }>("skills_companion_add", {
+            body: {
+              skillId,
+              path: opts.path,
+              from: opts.from,
+              overwrite: opts.overwrite ?? false,
+            },
+          });
+          if (!r.ok)
+            return exitFromCliResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              json,
+            );
+          if (json) {
+            console.log(
+              JSON.stringify({ ok: true, skillId, path: r.result?.path }),
+            );
+          } else {
+            log.info(`Added "${opts.path}" to skill "${skillId}".`);
+          }
+        },
+      );
+
+      subcommand(companion, "list").action(
+        async (skillId: string, opts: { json?: boolean }, _cmd) => {
+          const json = opts.json ?? false;
+          const r = await cliIpcCall<{
+            files: Array<{ path: string; bytes: number }>;
+          }>("skills_companion_list", { body: { skillId } });
+          if (!r.ok)
+            return exitFromCliResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              json,
+            );
+          const files = r.result?.files ?? [];
+          if (json) {
+            console.log(JSON.stringify({ ok: true, skillId, files }));
+            return;
+          }
+          if (files.length === 0) {
+            log.info(`Skill "${skillId}" has no companion files.`);
+            return;
+          }
+          const pathWidth = Math.max(4, ...files.map((f) => f.path.length));
+          log.info(`Companion files in "${skillId}" (${files.length}):\n`);
+          log.info(`  ${"PATH".padEnd(pathWidth)}  BYTES`);
+          for (const file of files) {
+            log.info(`  ${file.path.padEnd(pathWidth)}  ${file.bytes}`);
+          }
+        },
+      );
+
+      subcommand(companion, "remove").action(
+        async (
+          skillId: string,
+          opts: { path: string; json?: boolean },
+          _cmd,
+        ) => {
+          const json = opts.json ?? false;
+          const r = await cliIpcCall<{ removed: boolean }>(
+            "skills_companion_remove",
+            { body: { skillId, path: opts.path } },
+          );
+          if (!r.ok)
+            return exitFromCliResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              json,
+            );
+          if (json) {
+            console.log(JSON.stringify({ ok: true, skillId, path: opts.path }));
+          } else {
+            log.info(`Removed "${opts.path}" from skill "${skillId}".`);
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -63,6 +63,7 @@ import { EVENTS_IPC_METHODS } from "./routes/events-ipc-routes.js";
 import { GUARDIAN_LABEL_IPC_METHODS } from "./routes/guardian-label-ipc-routes.js";
 import { INVITE_IPC_METHODS } from "./routes/invite-ipc-routes.js";
 import { routeDefinitionsToIpcMethods } from "./routes/route-adapter.js";
+import { SKILLS_COMPANION_IPC_METHODS } from "./routes/skills-companion-ipc-routes.js";
 import { ensureSocketPathFree } from "./socket-cleanup.js";
 import { resolveIpcSocketPath } from "./socket-path.js";
 
@@ -215,6 +216,7 @@ export class AssistantIpcServer {
       GUARDIAN_LABEL_IPC_METHODS,
       CONVERSATION_SYNC_IPC_METHODS,
       EVENTS_IPC_METHODS,
+      SKILLS_COMPANION_IPC_METHODS,
     ]) {
       for (const [operationId, handler] of Object.entries(methodMap)) {
         this.methods.set(operationId, handler);

--- a/assistant/src/ipc/routes/__tests__/skills-companion-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/skills-companion-ipc-routes.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Companion-file IPC methods behind `assistant skills companion …`.
+ *
+ * These run against the real managed-skill store (the test preload points
+ * VELLUM_WORKSPACE_DIR at a per-file temp dir), so the assertions cover the
+ * daemon-side contract the CLI depends on: the store's rejections surface as
+ * the right RouteError class, and the ownership gate applies to every caller
+ * — a CLI process carries no request origin, so there is no "interactive"
+ * relaxation to test for.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  BadRequestError,
+  NotFoundError,
+} from "../../../runtime/routes/errors.js";
+import { createManagedSkill } from "../../../skills/managed-store.js";
+import {
+  handleSkillsCompanionAdd,
+  handleSkillsCompanionList,
+  handleSkillsCompanionRemove,
+} from "../skills-companion-ipc-routes.js";
+
+const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+
+function seedAssistantSkill(id: string): void {
+  createManagedSkill({
+    id,
+    name: id,
+    description: `${id} description`,
+    bodyMarkdown: "Body.",
+    author: "assistant",
+    overwrite: true,
+  });
+}
+
+function writeSource(name: string, content = "print('ok')\n"): string {
+  const sourcePath = join(TEST_DIR, name);
+  writeFileSync(sourcePath, content, "utf-8");
+  return sourcePath;
+}
+
+beforeEach(() => {
+  mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
+});
+
+describe("skills_companion_add", () => {
+  test("copies the source and reports the written path", () => {
+    seedAssistantSkill("ipc-add");
+    const from = writeSource("ipc-add.py");
+
+    const result = handleSkillsCompanionAdd({
+      body: { skillId: "ipc-add", path: "scripts/ipc-add.py", from },
+    }) as { added: boolean; path: string };
+
+    expect(result.added).toBe(true);
+    expect(result.path).toContain(join("ipc-add", "scripts", "ipc-add.py"));
+  });
+
+  test("maps a missing skill to NotFound", () => {
+    const from = writeSource("ipc-missing.py");
+
+    expect(() =>
+      handleSkillsCompanionAdd({
+        body: { skillId: "ipc-missing", path: "scripts/x.py", from },
+      }),
+    ).toThrow(NotFoundError);
+  });
+
+  test("maps a rejected destination to BadRequest", () => {
+    seedAssistantSkill("ipc-reserved");
+    const from = writeSource("ipc-reserved.json", "{}");
+
+    expect(() =>
+      handleSkillsCompanionAdd({
+        body: {
+          skillId: "ipc-reserved",
+          path: "TOOLS.json",
+          from,
+          overwrite: true,
+        },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects a user-authored skill regardless of caller", () => {
+    createManagedSkill({
+      id: "ipc-user-authored",
+      name: "User Authored",
+      description: "Hand written",
+      bodyMarkdown: "Body.",
+      author: "user",
+      overwrite: true,
+    });
+    const from = writeSource("ipc-user.py");
+
+    expect(() =>
+      handleSkillsCompanionAdd({
+        body: { skillId: "ipc-user-authored", path: "scripts/x.py", from },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects a malformed request before touching the store", () => {
+    expect(() =>
+      handleSkillsCompanionAdd({ body: { skillId: "ipc-add" } }),
+    ).toThrow();
+  });
+});
+
+describe("skills_companion_list", () => {
+  test("returns companion files without the store-owned files", () => {
+    seedAssistantSkill("ipc-list");
+    handleSkillsCompanionAdd({
+      body: {
+        skillId: "ipc-list",
+        path: "scripts/listed.py",
+        from: writeSource("ipc-listed.py", "12345"),
+      },
+    });
+
+    const result = handleSkillsCompanionList({
+      body: { skillId: "ipc-list" },
+    }) as { files: { path: string; bytes: number }[] };
+
+    expect(result.files).toEqual([{ path: "scripts/listed.py", bytes: 5 }]);
+  });
+});
+
+describe("skills_companion_remove", () => {
+  test("removes a companion file", () => {
+    seedAssistantSkill("ipc-remove");
+    handleSkillsCompanionAdd({
+      body: {
+        skillId: "ipc-remove",
+        path: "scripts/gone.py",
+        from: writeSource("ipc-gone.py"),
+      },
+    });
+
+    const result = handleSkillsCompanionRemove({
+      body: { skillId: "ipc-remove", path: "scripts/gone.py" },
+    }) as { removed: boolean };
+
+    expect(result.removed).toBe(true);
+    expect(
+      (
+        handleSkillsCompanionList({ body: { skillId: "ipc-remove" } }) as {
+          files: unknown[];
+        }
+      ).files,
+    ).toHaveLength(0);
+  });
+
+  test("cannot remove a store-owned file", () => {
+    seedAssistantSkill("ipc-remove-owned");
+
+    expect(() =>
+      handleSkillsCompanionRemove({
+        body: { skillId: "ipc-remove-owned", path: "SKILL.md" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/ipc/routes/skills-companion-ipc-routes.ts
+++ b/assistant/src/ipc/routes/skills-companion-ipc-routes.ts
@@ -1,0 +1,101 @@
+/**
+ * IPC-only companion-file methods behind `assistant skills companion …`.
+ *
+ * Companion files are the reference material a managed skill ships alongside
+ * its SKILL.md — most often a `scripts/` helper the assistant proved works and
+ * wants to rerun verbatim rather than re-derive. Creating the skill itself
+ * stays on the `scaffold_managed_skill` tool, which owns the side effects a
+ * create fans out (capability-memory refresh, skill card, authoring counter,
+ * conversation lineage). Adding a file to a skill that already exists needs
+ * none of them: capability memories derive from frontmatter, and companion
+ * files are read from disk at skill-load time, so a file that lands later is
+ * picked up on the next load.
+ *
+ * No HTTP surface. These verbs write into the workspace skills directory on
+ * behalf of a local caller; the gateway has no reason to reach them, so they
+ * are registered directly on the IPC server (see `assistant-server.ts`) and
+ * never enter the shared `ROUTES` array.
+ */
+
+import { z } from "zod";
+
+import { BadRequestError, NotFoundError } from "../../runtime/routes/errors.js";
+import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
+import {
+  addCompanionFile,
+  listCompanionFiles,
+  removeCompanionFile,
+} from "../../skills/managed-store.js";
+
+const AddParamsSchema = z.object({
+  skillId: z.string().min(1),
+  path: z.string().min(1),
+  from: z.string().min(1),
+  overwrite: z.boolean().optional(),
+});
+
+const ListParamsSchema = z.object({
+  skillId: z.string().min(1),
+});
+
+const RemoveParamsSchema = z.object({
+  skillId: z.string().min(1),
+  path: z.string().min(1),
+});
+
+/**
+ * The store returns a `not found` error for a missing skill and a validation
+ * error for everything else; map the former to 404 so the CLI's exit code
+ * distinguishes "no such skill" from "rejected".
+ */
+function throwStoreError(error: string): never {
+  if (error.includes("not found")) {
+    throw new NotFoundError(error);
+  }
+  throw new BadRequestError(error);
+}
+
+export function handleSkillsCompanionAdd({ body = {} }: RouteHandlerArgs) {
+  const params = AddParamsSchema.parse(body);
+  const result = addCompanionFile({
+    skillId: params.skillId,
+    path: params.path,
+    sourcePath: params.from,
+    overwrite: params.overwrite,
+  });
+  if (!result.added) {
+    throwStoreError(result.error ?? "failed to add companion file");
+  }
+  return { added: true, skillId: params.skillId, path: result.path };
+}
+
+export function handleSkillsCompanionList({ body = {} }: RouteHandlerArgs) {
+  const params = ListParamsSchema.parse(body);
+  const result = listCompanionFiles(params.skillId);
+  if ("error" in result) {
+    throwStoreError(result.error);
+  }
+  return { skillId: params.skillId, files: result.files };
+}
+
+export function handleSkillsCompanionRemove({ body = {} }: RouteHandlerArgs) {
+  const params = RemoveParamsSchema.parse(body);
+  const result = removeCompanionFile(params.skillId, params.path);
+  if (!result.removed) {
+    throwStoreError(result.error ?? "failed to remove companion file");
+  }
+  return { removed: true, skillId: params.skillId, path: params.path };
+}
+
+/**
+ * IPC-only companion-file methods, keyed by IPC operationId. Registered
+ * directly on the assistant IPC server (see `assistant-server.ts`).
+ */
+export const SKILLS_COMPANION_IPC_METHODS: Record<
+  string,
+  (args: RouteHandlerArgs) => unknown
+> = {
+  skills_companion_add: handleSkillsCompanionAdd,
+  skills_companion_list: handleSkillsCompanionList,
+  skills_companion_remove: handleSkillsCompanionRemove,
+};

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   renameSync,
@@ -18,7 +19,7 @@ import { deleteSkillCapabilityNode } from "../plugins/defaults/memory/graph/capa
 import { isDeniedBasename } from "../tools/shared/filesystem/path-policy.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir, getWorkspaceSkillsDir } from "../util/platform.js";
-import { writeInstallMeta } from "./install-meta.js";
+import { readInstallMeta, writeInstallMeta } from "./install-meta.js";
 
 const log = getLogger("managed-store");
 
@@ -472,4 +473,232 @@ export function deleteManagedSkill(id: string): DeleteManagedSkillResult {
   log.info({ id, path: skillDir }, "Deleted managed skill");
 
   return { deleted: true };
+}
+
+// ─── Companion files ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve a managed skill directory for a companion operation, enforcing the
+ * two gates every companion mutation shares: the skill must already exist as a
+ * managed skill, and it must be verifiably assistant-authored.
+ *
+ * The ownership gate is UNCONDITIONAL here, unlike the origin-scoped backstop
+ * in the `scaffold_managed_skill` tool. These functions back an `assistant
+ * skills companion …` CLI verb, and a CLI process carries no request origin:
+ * every provenance signal a caller could present (an env var, a flag) is
+ * written by whoever composed the command line, so an unattended agent could
+ * always choose to present none. Authority must therefore not depend on a
+ * claim — the strict rule applies to every caller, and a human who needs to
+ * drop a file into a skill they authored themselves has a real shell and does
+ * not need this verb.
+ */
+function resolveAssistantAuthoredSkillDir(
+  skillId: string,
+): { skillDir: string } | { error: string } {
+  const validationError = validateManagedSkillId(skillId);
+  if (validationError) {
+    return { error: validationError };
+  }
+
+  const skillDir = getManagedSkillDir(skillId);
+  if (!existsSync(join(skillDir, "SKILL.md"))) {
+    return {
+      error: `Managed skill "${skillId}" not found. Run 'assistant skills list' to see managed skills.`,
+    };
+  }
+
+  // Mirrors the scaffold tool's ownership backstop: `readInstallMeta` returns
+  // null for a skill whose install-meta is missing or corrupt, so gating on an
+  // exact "assistant" author fails closed on user-authored, untagged, and
+  // unverifiable skills alike.
+  if (readInstallMeta(skillDir)?.author !== "assistant") {
+    return {
+      error: `Managed skill "${skillId}" is not verifiably assistant-authored; companion files may only be written into skills the assistant authored.`,
+    };
+  }
+
+  return { skillDir };
+}
+
+export interface AddCompanionFileParams {
+  skillId: string;
+  /** Destination path relative to the skill directory. */
+  path: string;
+  /** Absolute path of the file to copy in. */
+  sourcePath: string;
+  /** Replace an existing companion file at the destination. */
+  overwrite?: boolean;
+}
+
+export interface AddCompanionFileResult {
+  added: boolean;
+  path?: string;
+  error?: string;
+}
+
+/**
+ * Copy an on-disk file into an assistant-authored managed skill as a companion
+ * file (a `scripts/` helper, a reference doc).
+ *
+ * Destination policy is the whole security surface and is unchanged from the
+ * scaffold write path: `validateCompanionPath` keeps the write inside the skill
+ * directory and off the store-owned files (notably TOOLS.json, whose manifest
+ * would let a companion write register executable tools), and the shared
+ * filesystem denylist rejects key-material basenames.
+ *
+ * The SOURCE is read with no path policy of its own, deliberately. Reaching
+ * this function requires shell authority, and what a shell may read is decided
+ * by the bash risk registry — the same classification that governs `cat` and
+ * `cp`, including its escalation for sensitive paths. Re-deciding it here would
+ * fork that policy into a second, weaker copy. The checks below are usability
+ * guards (clear errors for a missing file, a directory, an implausible size),
+ * not a trust boundary.
+ */
+export function addCompanionFile(
+  params: AddCompanionFileParams,
+): AddCompanionFileResult {
+  const resolved = resolveAssistantAuthoredSkillDir(params.skillId);
+  if ("error" in resolved) {
+    return { added: false, error: resolved.error };
+  }
+  const { skillDir } = resolved;
+
+  const { resolvedPath, error } = validateCompanionPath(skillDir, params.path);
+  if (error || !resolvedPath) {
+    return { added: false, error: error ?? "invalid companion file path" };
+  }
+  if (isDeniedBasename(resolvedPath)) {
+    return {
+      added: false,
+      error: `companion file path is a denied filename: "${params.path}"`,
+    };
+  }
+  if (existsSync(resolvedPath)) {
+    if (statSync(resolvedPath).isDirectory()) {
+      return {
+        added: false,
+        error: `companion file path resolves to an existing directory: "${params.path}"`,
+      };
+    }
+    if (!params.overwrite) {
+      return {
+        added: false,
+        error: `companion file "${params.path}" already exists in skill "${params.skillId}". Pass --overwrite to replace it.`,
+      };
+    }
+  }
+
+  if (!params.sourcePath || !isAbsolute(params.sourcePath)) {
+    return {
+      added: false,
+      error: `source must be an absolute path: "${params.sourcePath}"`,
+    };
+  }
+  let sourceStat;
+  try {
+    sourceStat = statSync(params.sourcePath);
+  } catch {
+    return { added: false, error: `source not found: "${params.sourcePath}"` };
+  }
+  if (!sourceStat.isFile()) {
+    return {
+      added: false,
+      error: `source is not a regular file: "${params.sourcePath}"`,
+    };
+  }
+  if (sourceStat.size > MAX_COMPANION_SOURCE_BYTES) {
+    return {
+      added: false,
+      error: `source exceeds ${MAX_COMPANION_SOURCE_BYTES} bytes: "${params.sourcePath}"`,
+    };
+  }
+
+  const content = readFileSync(params.sourcePath, "utf-8");
+  mkdirSync(dirname(resolvedPath), { recursive: true });
+  atomicWriteFile(resolvedPath, content);
+
+  log.info(
+    { id: params.skillId, path: resolvedPath },
+    "Added companion file to managed skill",
+  );
+
+  return { added: true, path: resolvedPath };
+}
+
+export interface CompanionFileEntry {
+  /** Path relative to the skill directory, POSIX-separated. */
+  path: string;
+  bytes: number;
+}
+
+/**
+ * List a managed skill's companion files (everything under the skill directory
+ * except the store-owned top-level files). Read-only, so it applies neither the
+ * ownership gate nor the destination policy.
+ */
+export function listCompanionFiles(
+  skillId: string,
+): { files: CompanionFileEntry[] } | { error: string } {
+  const validationError = validateManagedSkillId(skillId);
+  if (validationError) {
+    return { error: validationError };
+  }
+  const skillDir = getManagedSkillDir(skillId);
+  if (!existsSync(join(skillDir, "SKILL.md"))) {
+    return {
+      error: `Managed skill "${skillId}" not found. Run 'assistant skills list' to see managed skills.`,
+    };
+  }
+
+  const files: CompanionFileEntry[] = [];
+  for (const entry of readdirSync(skillDir, { recursive: true })) {
+    const rel = String(entry).replaceAll(sep, "/");
+    if (RESERVED_COMPANION_NAMES.has(rel.toLowerCase())) {
+      continue;
+    }
+    const absolute = join(skillDir, rel);
+    const stat = statSync(absolute);
+    if (!stat.isFile()) {
+      continue;
+    }
+    files.push({ path: rel, bytes: stat.size });
+  }
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return { files };
+}
+
+/**
+ * Remove one companion file from an assistant-authored managed skill. Shares
+ * the ownership gate and destination policy with {@link addCompanionFile}, so
+ * the store-owned files can never be deleted through this path.
+ */
+export function removeCompanionFile(
+  skillId: string,
+  filePath: string,
+): { removed: boolean; error?: string } {
+  const resolved = resolveAssistantAuthoredSkillDir(skillId);
+  if ("error" in resolved) {
+    return { removed: false, error: resolved.error };
+  }
+
+  const { resolvedPath, error } = validateCompanionPath(
+    resolved.skillDir,
+    filePath,
+  );
+  if (error || !resolvedPath) {
+    return { removed: false, error: error ?? "invalid companion file path" };
+  }
+  if (!existsSync(resolvedPath) || !statSync(resolvedPath).isFile()) {
+    return {
+      removed: false,
+      error: `companion file "${filePath}" not found in skill "${skillId}". Run 'assistant skills companion list ${skillId}' to see companion files.`,
+    };
+  }
+
+  rmSync(resolvedPath);
+  log.info(
+    { id: skillId, path: resolvedPath },
+    "Removed companion file from managed skill",
+  );
+  return { removed: true };
 }

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -1084,6 +1084,33 @@ describe("assistant subcommand classification", () => {
     expect(result.riskLevel).toBe("high");
   });
 
+  test("assistant skills companion add → low (bundles a script into an owned skill)", async () => {
+    const result = await classifier.classify({
+      command:
+        "assistant skills companion add export-report --path scripts/export.py --from /tmp/export.py",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("low");
+  });
+
+  test("assistant skills companion add from a sensitive source → high", async () => {
+    const result = await classifier.classify({
+      command:
+        "assistant skills companion add export-report --path scripts/key.txt --from /home/assistant/.ssh/id_rsa",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("assistant skills companion remove → medium", async () => {
+    const result = await classifier.classify({
+      command:
+        "assistant skills companion remove export-report --path scripts/export.py",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
   test("assistant bash ls → high", async () => {
     const result = await classifier.classify({
       command: "assistant bash ls",

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -275,6 +275,10 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "skills install",
   "skills uninstall",
   "skills add",
+  "skills companion",
+  "skills companion add",
+  "skills companion list",
+  "skills companion remove",
   "status",
   "stt",
   "stt transcribe",
@@ -854,6 +858,28 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "skills install", risk: "high" },
   { path: "skills uninstall", risk: "medium" },
   { path: "skills add", risk: "high" },
+  // `skills install` / `skills add` are high because they fetch and install a
+  // whole skill — arbitrary remote content, including a TOOLS.json manifest
+  // whose executors the daemon dynamically imports. A companion add is a much
+  // smaller action deliberately classified below them: it copies ONE local file
+  // into a skill the assistant already authored, the daemon rejects any
+  // destination outside that skill directory or on the store-owned files
+  // (SKILL.md, TOOLS.json, install-meta.json, version.json), and it can
+  // therefore never register an executable tool. Low is what lets a background
+  // pass bundle a script it just ran without a human in the loop; the arg rule
+  // below re-escalates the sensitive-source case.
+  {
+    path: "skills companion add",
+    risk: "low",
+    reason:
+      "Copies one local file into an assistant-authored skill; cannot register tools",
+  },
+  { path: "skills companion list", risk: "low" },
+  {
+    path: "skills companion remove",
+    risk: "medium",
+    reason: "Deletes a companion file from a managed skill",
+  },
   { path: "stt transcribe", risk: "medium" },
   { path: "tts synthesize", risk: "medium" },
   // Mutates the active provider's voice config (via config_set) — same
@@ -957,5 +983,28 @@ const scheduleCreateArgRules: ArgRule[] = [
 const scheduleCreateNode = getExistingPath(spec, "schedules create");
 scheduleCreateNode.argRules = scheduleCreateArgRules;
 scheduleCreateNode.argSchema = { valueFlags: ["--mode", "--script"] };
+
+// A companion add reads its `--from` source with the caller's own filesystem
+// authority, so what may be read is decided here — the same place `cat` and
+// `cp` are decided — rather than by a second path policy inside the daemon.
+// The pattern mirrors `cat:sensitive`: copying a key, a credentials file, or a
+// dotfile config into a skill folder would persist it where the model reads it
+// back as skill content, so those sources escalate to high and stop being
+// something an unattended pass can do without a human.
+const skillsCompanionAddArgRules: ArgRule[] = [
+  {
+    id: "assistant-skills-companion-add:sensitive-source",
+    flags: ["--from"],
+    valuePattern: "(?:^|/)(?:\\.ssh|\\.gnupg|\\.aws|\\.config|\\.env)\\b",
+    risk: "high",
+    reason: "Copies a sensitive file into a skill folder",
+  },
+];
+const skillsCompanionAddNode = getExistingPath(spec, "skills companion add");
+skillsCompanionAddNode.argRules = skillsCompanionAddArgRules;
+// Both flags consume the next token as a value; declare them so the arg parser
+// pairs `--from <path>` / `--path <rel>` correctly (and so the rule above sees
+// the source path as the flag's value, not as a bare positional).
+skillsCompanionAddNode.argSchema = { valueFlags: ["--from", "--path"] };
 
 export default spec;


### PR DESCRIPTION
## Summary

Adds `assistant skills companion add|list|remove` — a CLI surface for copying an on-disk file into an assistant-authored managed skill (typically a `scripts/` helper the assistant just proved works). Three IPC-only routes (`skills_companion_add|list|remove`) back it, calling new `addCompanionFile` / `listCompanionFiles` / `removeCompanionFile` primitives in `managed-store.ts`.

This is PR 1 of 2. It ships alone and is useful alone; it does **not** change anything about the memory retrospective. See "What this sets up" below.

## Why

Follow-up to the `copy_from` decision on #38922. That PR gave `scaffold_managed_skill` a bespoke `files[].copy_from` field so the retrospective could bundle a script without re-emitting it token for token — and the source-side validation behind it drew nine consecutive Codex findings before the hardening was deliberately reverted (`4772452942`), because each fix narrowed utility until the primary use case was mostly moot.

The alternative raised at the time was "just let it use the CLI." This is that: the copy becomes a CLI verb, and the source-side path policy moves out of the skill store and into the bash risk registry, where it is shared with `cat` and `cp` instead of forked into a second, weaker copy.

## What is enforced, and where

**Destination policy — unchanged, still in the store.** `validateCompanionPath` keeps the write inside the skill directory and off the store-owned files (`SKILL.md`, `TOOLS.json`, `install-meta.json`, `version.json`, case-insensitively). The `TOOLS.json` entry is the load-bearing one: a companion write that could plant a manifest would turn an instruction-only skill into one that registers and dynamically imports executors. Also applies the shared filesystem denylist to the destination basename.

**Ownership — now unconditional.** The scaffold tool's backstop is origin-scoped (`context.requestOrigin === MEMORY_RETROSPECTIVE_ORIGIN`). A CLI process has no request origin, and every provenance signal a caller could present — an env var, a flag — is written by whoever composed the command line, so an unattended caller could always choose to present none. Authority must therefore not depend on a claim: the assistant-authored check applies to **every** caller. A human who wants to drop a file into a skill they wrote by hand has a real shell and does not need this verb; there is deliberately no override flag.

**Source — no path policy in the store, by design.** Reaching these verbs requires shell authority, and what a shell may read is decided by the risk registry. `skills companion add` is classified `low` — one local file into a skill the assistant already owns, unable to register a tool — with an arg rule escalating a sensitive `--from` (`.ssh`, `.gnupg`, `.aws`, `.config`, `.env`) to `high`, mirroring `cat:sensitive`. `companion list` is `low`, `companion remove` is `medium`. The remaining checks on the source (absolute path, regular file, ≤1 MiB) are usability guards for clear errors, not a trust boundary.

Note the classification sits deliberately below its neighbours (`skills install` / `skills add` are `high`) — the reasoning is written into the registry next to the entry, since that is where review should land.

## What this sets up (not in this PR)

A second PR would add `bash` to the memory retrospective's `allowedTools`, rewrite the prompt directive from `copy_from` to this verb, and delete `copy_from` + `validateCompanionSource`. That PR carries a real security decision — granting bash to the fork widens its unattended reach to every `low`-classified command, which is broader than `copy_from`'s workspace+tmp confinement — and is being kept separate so it can be judged on its own. Nothing here commits us to it.

## Test plan

- `assistant`: `bun test src/__tests__/managed-store.test.ts` (97 pass — 12 new covering the ownership gate, reserved-destination via each store-owned name, directory escape, clobber-without-overwrite, relative/directory sources, list/remove), `src/ipc/routes/__tests__/skills-companion-ipc-routes.test.ts` (8 new), `src/cli/commands/__tests__/skills.test.ts` (29 pass, 6 new), `src/cli/__tests__/cli-command-help-coverage.test.ts`, `src/__tests__/scaffold-managed-skill-tool.test.ts` (54 pass, unaffected). Run per file, per CI.
- `gateway`: `bun test src/risk/command-registry.test.ts src/risk/bash-risk-classifier.test.ts src/risk/risk-classifier-parity.test.ts src/__tests__/bash-risk-classifier.test.ts` — 376 pass, including 3 new asserting low / high-on-sensitive-source / medium-on-remove.
- `bun tsc --noEmit` clean in `assistant`. Gateway tsc has pre-existing `@vellumai/service-contracts` resolution errors in unrelated files (stale local packages); nothing in the touched files.

One deliberate test: "copies from outside the workspace — source policy is the shell's, not the store's" pins the removal of source confinement so a future reviewer sees it as intent rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)