### PR TITLE
fix(web): stop the plans deep link from aborting its own navigations

### DIFF
--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -16,7 +16,7 @@ import {
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
 import { openUrl } from "@/runtime/browser";
 import { useOrganizationStore } from "@/stores/organization-store";
-import { routes } from "@/utils/routes";
+import { PACKAGE_PARAM, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
 /**
@@ -76,7 +76,7 @@ type CheckoutPhase = "idle" | "running" | "handed_off" | "settled";
 export function CheckoutPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const packageKey = searchParams.get("package") ?? "";
+  const packageKey = searchParams.get(PACKAGE_PARAM) ?? "";
   // Default (session-only) gate: a signed-in platform session reads `"full"`
   // even without an active assistant. See `use-platform-gate.ts`.
   //
@@ -167,7 +167,7 @@ export function CheckoutPage() {
       clearCheckoutIntent();
       navigate(
         bailTarget === routes.plans && packageKey
-          ? `${routes.plans}?package=${encodeURIComponent(packageKey)}`
+          ? routes.plansForPackage(packageKey)
           : bailTarget,
         { replace: true },
       );

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -12,8 +12,13 @@
  * The `?package=<key>` deep link reuses that same click handler, so it inherits
  * every guard: it opens the confirm modal for an eligible Pro sub, bails to
  * `?adjust_plan` for an ineligible one, no-ops on the current or an unknown
- * key, and never starts a checkout for a non-Pro user. The param is stripped
+ * key, never starts a checkout for a non-Pro user, and never treats `free` — a
+ * cancellation, not a package — as a switch target. The param is stripped
  * either way and consumed exactly once.
+ *
+ * The last block covers the ordering between the strip and whatever the handler
+ * navigates to. Those are two router navigations, and on the app's route shape
+ * the second aborts the first, so it runs on a data router built to match.
  *
  * Strategy mirrors adjust-plan-modal.test.tsx: mock the generated SDK to
  * capture the upgrade body and return a redirect, mock `openUrl` to capture the
@@ -30,7 +35,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter, useLocation } from "react-router";
+import {
+  createMemoryRouter,
+  MemoryRouter,
+  RouterProvider,
+  useLocation,
+} from "react-router";
 
 import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
@@ -41,6 +51,7 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
   PlanListResponse,
+  ProPlan,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import {
@@ -90,12 +101,16 @@ mock.module("@/runtime/browser", () => ({
 }));
 
 // Force the platform-hosted gate open so the page mounts its pricing body
-// instead of firing the self-hosted / not-ready redirect effect.
+// instead of firing the self-hosted / not-ready redirect effect. Mutable so a
+// test can start with hosting unresolved — the state the deep-link effect waits
+// through — and flip it to ready mid-test.
+let platformHosted = true;
+let lifecycleLoading = false;
 mock.module("@/hooks/use-platform-gate", () => ({
   ...platformGate,
   usePlatformGate: () => "full",
-  useActiveAssistantIsPlatformHosted: () => true,
-  useActiveAssistantLifecycleIsLoading: () => false,
+  useActiveAssistantIsPlatformHosted: () => platformHosted,
+  useActiveAssistantLifecycleIsLoading: () => lifecycleLoading,
 }));
 
 // Render avatar placeholders; skip the lazy compositor bundle in the DOM test.
@@ -134,6 +149,19 @@ function fullCatalog(): PlanListResponse {
         packages: [MIGHTY, SUPER, ULTRA],
       },
     ],
+  };
+}
+
+/** A Pro plan with no packages — what the catalog reads with `pro-packages` off. */
+function emptyPackagesCatalog(): PlanListResponse {
+  const catalog = fullCatalog();
+  return {
+    plans: catalog.plans.map((plan) => {
+      if (plan.id !== "pro") {
+        return plan;
+      }
+      return { ...(plan as ProPlan), packages: [] };
+    }),
   };
 }
 
@@ -199,9 +227,78 @@ function renderPage(
   };
 }
 
+/**
+ * Data-mode harness that mirrors the app's route shape: `/assistant` carries
+ * middleware (`authMiddleware` in `routes.tsx`), and middleware is what keeps
+ * React Router off its synchronous no-loader commit path — so a second
+ * navigation started in the same tick aborts the first. Declarative
+ * `MemoryRouter` cannot reproduce that, which is why the deep-link navigation
+ * tests build a data router instead.
+ *
+ * Returns the ordered list of *committed* locations, which is the observable
+ * that distinguishes a strip that landed from one that was thrown away.
+ */
+function renderRouted(
+  subscription: SubscriptionResponse,
+  entry: string,
+  catalog: PlanListResponse = fullCatalog(),
+) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, refetchOnMount: false },
+    },
+  });
+  client.setQueryData(
+    organizationsBillingSubscriptionRetrieveQueryKey(),
+    subscription,
+  );
+  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), catalog);
+
+  const committed: string[] = [];
+  const record = (location: { pathname: string; search: string }) => {
+    // Emptying the query leaves React Router with a bare "?"; normalize it away
+    // so the sequence reads as the URLs a user would see.
+    const search = location.search === "?" ? "" : location.search;
+    const value = `${location.pathname}${search}`;
+    if (committed[committed.length - 1] !== value) {
+      committed.push(value);
+    }
+  };
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/assistant",
+        middleware: [(_args, next) => next()],
+        HydrateFallback: () => null,
+        children: [
+          { path: "plans", element: <PlansPage /> },
+          { path: "settings/usage", element: <div data-testid="usage-page" /> },
+        ],
+      },
+    ],
+    { initialEntries: [entry], future: { v8_middleware: true } },
+  );
+  record(router.state.location);
+  router.subscribe((state) => record(state.location));
+
+  return {
+    client,
+    committed,
+    router,
+    ...render(
+      <QueryClientProvider client={client}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
+  };
+}
+
 beforeEach(() => {
   upgradeCall = null;
   openedUrl = null;
+  platformHosted = true;
+  lifecycleLoading = false;
   // The stash also keeps an in-memory mirror, so clearing sessionStorage alone
   // leaves a prior test's intent readable.
   clearCheckoutIntent();
@@ -340,18 +437,67 @@ describe("PlansPage — ?package= deep link", () => {
     expect(queryByTestId("confirm-package-switch-button")).toBeNull();
   });
 
-  test("the param is consumed once — a later query settle doesn't reopen the modal", async () => {
-    const { client, findByText, findByRole, getByTestId, queryByTestId } =
+  test("`free` names a cancellation, not a package — it never opens the confirm", async () => {
+    const { getByTestId, queryAllByTestId } = renderPage(
+      proMightySubscription(),
+      "/assistant/plans?package=free",
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toMatch(ON_PLANS_WITHOUT_PARAM),
+    );
+    expect(queryAllByTestId("confirm-free-downgrade-button").length).toBe(0);
+    expect(queryAllByTestId("confirm-package-switch-button").length).toBe(0);
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("the param is consumed once — later subscription changes don't reopen the modal", async () => {
+    // Hold the effect on unresolved hosting so the param survives the first
+    // render; flipping hosting ready is then a real dep change that drives the
+    // one and only consume.
+    platformHosted = false;
+    lifecycleLoading = true;
+    const { client, findByText, findByRole, getByTestId, queryAllByTestId } =
       renderPage(proMightySubscription(), "/assistant/plans?package=super");
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(
+        "/assistant/plans?package=super",
+      ),
+    );
+    expect(queryAllByTestId("confirm-package-switch-button").length).toBe(0);
+
+    act(() => {
+      platformHosted = true;
+      lifecycleLoading = false;
+      // Wakes the subscribed component so the hooks re-read the gate. The
+      // payload has to differ structurally: React Query's structural sharing
+      // keeps the previous reference for a deep-equal one, and no reference
+      // change means no re-render.
+      client.setQueryData(organizationsBillingSubscriptionRetrieveQueryKey(), {
+        ...proMightySubscription(),
+        current_period_end: "2026-08-10T00:00:00Z",
+      });
+    });
 
     await findByText("Upgrade to Super");
     fireEvent.click(await findByRole("button", { name: "Cancel" }));
     await waitFor(() =>
-      expect(queryByTestId("confirm-package-switch-button")).toBeNull(),
+      expect(queryAllByTestId("confirm-package-switch-button").length).toBe(0),
     );
 
-    // A subscription refetch settling re-runs the effect; the one-shot ref (and
-    // the already-stripped URL) keep it from reopening.
+    // `isProUser` is a dependency of the deep-link effect, so dropping to Free
+    // and back to Pro genuinely re-runs it — twice. What keeps the modal closed
+    // is the consumed-param guard, not React skipping the effect.
+    act(() => {
+      client.setQueryData(
+        organizationsBillingSubscriptionRetrieveQueryKey(),
+        freeSubscription(),
+      );
+    });
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toMatch(ON_PLANS_WITHOUT_PARAM),
+    );
     act(() => {
       client.setQueryData(
         organizationsBillingSubscriptionRetrieveQueryKey(),
@@ -362,6 +508,50 @@ describe("PlansPage — ?package= deep link", () => {
     await waitFor(() =>
       expect(getByTestId("loc").textContent).toMatch(ON_PLANS_WITHOUT_PARAM),
     );
-    expect(queryByTestId("confirm-package-switch-button")).toBeNull();
+    expect(queryAllByTestId("confirm-package-switch-button").length).toBe(0);
+    expect(upgradeCall).toBeNull();
+  });
+});
+
+// The param strip and anything `selectTier` navigates to are both router
+// navigations. Starting the second while the first is still pending aborts it,
+// and with middleware on the route tree the first is *always* still pending —
+// so these run on a data router shaped like the app's.
+describe("PlansPage — ?package= deep link navigation", () => {
+  test("the strip commits before the ineligible-Pro bail", async () => {
+    const { committed, router } = renderRouted(
+      { ...proMightySubscription(), cancel_at_period_end: true },
+      "/assistant/plans?package=super",
+    );
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/assistant/settings/usage"),
+    );
+    expect(committed).toEqual([
+      "/assistant/plans?package=super",
+      "/assistant/plans",
+      "/assistant/settings/usage?tab=billing&adjust_plan",
+    ]);
+
+    // Back must never land on the deep link: that entry re-fires the effect and
+    // pushes the user straight out again, with no way onto the plans page.
+    await act(async () => {
+      await router.navigate(-1);
+    });
+    expect(router.state.location.search).not.toContain("package=");
+  });
+
+  test("the strip does not abort the catalog-empty bail", async () => {
+    const { router } = renderRouted(
+      proMightySubscription(),
+      "/assistant/plans?package=super",
+      emptyPackagesCatalog(),
+    );
+
+    await waitFor(() =>
+      expect(
+        `${router.state.location.pathname}${router.state.location.search}`,
+      ).toBe("/assistant/settings/usage?tab=billing&adjust_plan"),
+    );
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -69,7 +69,7 @@ import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
 import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
-import { routes } from "@/utils/routes";
+import { PACKAGE_PARAM, routes } from "@/utils/routes";
 import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button } from "@vellumai/design-library/components/button";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -202,6 +202,9 @@ export function PlansPage() {
   // `?package=<key>` is a one-shot deep link (from marketing / the checkout
   // no-op bail); once acted on it must never re-fire.
   const packageParamConsumedRef = useRef(false);
+  // The requested package, held from the moment the param is stripped until
+  // the stripped URL commits. See the deep-link effects below.
+  const [pendingPackage, setPendingPackage] = useState<string | null>(null);
 
   const subscription = subscriptionQuery.data;
   const proPlan = plansQuery.data?.plans.find(
@@ -332,7 +335,13 @@ export function PlansPage() {
     }
   };
 
-  const selectTier = (tierKey: string) => {
+  // `replaceOnBail` replaces the current history entry when routing to the
+  // billing manage surface instead of pushing. The deep link sets it so the
+  // consumed `?package=` URL leaves no live entry behind for Back to land on.
+  const selectTier = (
+    tierKey: string,
+    options?: { replaceOnBail?: boolean },
+  ) => {
     if (!subscription) {
       return;
     }
@@ -367,7 +376,9 @@ export function PlansPage() {
       // posting a change-package that can only fail (the same fallback the
       // Pro → Free case uses).
       if (!isPackageSwitchEligible(subscription)) {
-        navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
+        navigate(`${routes.settings.usageBilling}&adjust_plan`, {
+          replace: options?.replaceOnBail === true,
+        });
         return;
       }
       setSwitchTarget(pkg);
@@ -385,7 +396,7 @@ export function PlansPage() {
     });
   };
 
-  // The deep-link effect below fires at most once, so it reads the handler
+  // The deep-link effects below act at most once, so they read the handler
   // through a ref rather than depending on an identity that changes every
   // render.
   const selectTierRef = useRef(selectTier);
@@ -395,14 +406,19 @@ export function PlansPage() {
 
   // `?package=<key>` opens the switch flow for the requested package exactly
   // once, reusing `selectTier` so the deep link inherits every guard a click
-  // gets. Non-Pro users get no checkout from a URL — but the param is still
-  // dropped so it can't fire later once they are Pro.
-  const packageParam = searchParams.get("package");
+  // gets. Non-Pro users get no checkout from a URL, and `free` names a
+  // cancellation rather than a package — but the param is dropped either way so
+  // it can't fire later once they are Pro.
+  const packageParam = searchParams.get(PACKAGE_PARAM);
   useEffect(() => {
     if (packageParam == null || packageParamConsumedRef.current) {
       return;
     }
+    // The redirect effect above is already navigating away this tick. Stripping
+    // now would abort it, and its deps never change again, so it would never
+    // re-fire — stranding the user on the spinner.
     if (
+      cannotResolve ||
       !platformReady ||
       !subscriptionQuery.isSuccess ||
       !plansQuery.isSuccess
@@ -410,18 +426,19 @@ export function PlansPage() {
       return;
     }
     packageParamConsumedRef.current = true;
+    if (isProUser && packageParam !== "free") {
+      setPendingPackage(packageParam);
+    }
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
-        next.delete("package");
+        next.delete(PACKAGE_PARAM);
         return next;
       },
       { replace: true },
     );
-    if (isProUser) {
-      selectTierRef.current(packageParam);
-    }
   }, [
+    cannotResolve,
     packageParam,
     platformReady,
     subscriptionQuery.isSuccess,
@@ -429,6 +446,18 @@ export function PlansPage() {
     isProUser,
     setSearchParams,
   ]);
+
+  // The strip above is a router navigation, and `selectTier` may start another
+  // one. Two navigations in the same tick abort each other — with middleware on
+  // the route tree the strip always loses — so wait for the stripped URL to
+  // commit before acting on the held key.
+  useEffect(() => {
+    if (pendingPackage == null || packageParam != null) {
+      return;
+    }
+    setPendingPackage(null);
+    selectTierRef.current(pendingPackage, { replaceOnBail: true });
+  }, [packageParam, pendingPackage]);
 
   let body: ReactNode;
   if (subscription && proPlan && hasPackages) {

--- a/clients/web/src/lib/billing/post-auth-checkout.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.ts
@@ -2,7 +2,7 @@ import {
   clearCheckoutIntent,
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
-import { routes } from "@/utils/routes";
+import { PACKAGE_PARAM, routes } from "@/utils/routes";
 
 /**
  * Whether a destination is the `/assistant/checkout` deep link, plus the
@@ -22,7 +22,10 @@ function parseCheckoutDestination(destination: string): {
   if (url.pathname !== routes.checkout) {
     return { isCheckout: false, packageKey: null };
   }
-  return { isCheckout: true, packageKey: url.searchParams.get("package") || null };
+  return {
+    isCheckout: true,
+    packageKey: url.searchParams.get(PACKAGE_PARAM) || null,
+  };
 }
 
 /**
@@ -52,7 +55,11 @@ export function resolveSignupCheckoutDestination(args: {
     if (packageKey) {
       // Mark the stash as signup-originated so only the onboarding privacy
       // screen resumes it — an ordinary billing-surface stash stays inert here.
-      saveCheckoutIntent({ kind: "package", packageKey, resumeAfterOnboarding: true });
+      saveCheckoutIntent({
+        kind: "package",
+        packageKey,
+        resumeAfterOnboarding: true,
+      });
     }
     return routes.onboarding.privacy;
   }

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -17,6 +17,7 @@ const r = <const T extends string>(path: T): T => path;
 const dyn = (parent: string, id: string): string => `${parent}/${id}`;
 const LOCAL_ADMIN_ORIGIN = "http://localhost:3000";
 const SETTINGS_USAGE_PATH = r("/assistant/settings/usage");
+const PLANS_PATH = r("/assistant/plans");
 
 /**
  * Search param the chat transcript reads on load to scroll to and highlight a
@@ -24,6 +25,15 @@ const SETTINGS_USAGE_PATH = r("/assistant/settings/usage");
  * link producer (settings) and the consumer (chat).
  */
 export const SCROLL_TO_MESSAGE_PARAM = "message";
+
+/**
+ * Search param naming a Pro package. Carried by the checkout deep link
+ * (`/assistant/checkout?package=<slug>`) that the marketing pricing CTAs
+ * target, and by the plans takeover's one-shot switch deep link
+ * ({@link routes.plansForPackage}). Shared by every producer and reader so the
+ * spelling can't drift.
+ */
+export const PACKAGE_PARAM = "package";
 
 export const routes = {
   assistant: r("/assistant"),
@@ -74,7 +84,9 @@ export const routes = {
     relayToken?: string,
   ) => {
     const base = `${dyn(r("/assistant/conversations"), conversationId)}?prompt=${encodeURIComponent(prompt)}`;
-    return relayToken ? `${base}&relay=${encodeURIComponent(relayToken)}` : base;
+    return relayToken
+      ? `${base}&relay=${encodeURIComponent(relayToken)}`
+      : base;
   },
   /**
    * LLM-context inspector for a single conversation. The conversation id
@@ -129,8 +141,7 @@ export const routes = {
    */
   schedules: {
     root: r("/assistant/schedules"),
-    detail: (scheduleId: string) =>
-      dyn(r("/assistant/schedules"), scheduleId),
+    detail: (scheduleId: string) => dyn(r("/assistant/schedules"), scheduleId),
   },
   identity: r("/assistant/identity"),
   /**
@@ -183,7 +194,14 @@ export const routes = {
 
   /** Full-screen pricing takeover ("View Plans") — renders outside ChatLayout
    *  chrome, a sibling of the settings/logs full-screen shells. */
-  plans: r("/assistant/plans"),
+  plans: PLANS_PATH,
+  /**
+   * Plans takeover URL that opens the in-place package-switch flow for `key`
+   * on load. A one-shot deep link: the page consumes the param, strips it, and
+   * routes the key through the same guards a card click gets.
+   */
+  plansForPackage: (key: string) =>
+    `${PLANS_PATH}?${PACKAGE_PARAM}=${encodeURIComponent(key)}`,
 
   /**
    * Deep-link checkout entrypoint. The marketing pricing CTAs route here (via


### PR DESCRIPTION
## Summary

- The `?package=` strip and the navigation `selectTier` starts were issued in the same tick. `router.navigate` aborts the pending navigation first, and `/assistant`'s `middleware: [authMiddleware]` bars React Router's synchronous no-loader commit — so the strip was always discarded. The history entry kept `?package=`, and since the bail was a push, Back returned to it, remounted the page, and pushed the user straight back out. The key is now held in state and acted on only after the stripped URL commits.
- The same collision aborted the pre-existing `cannotResolve` redirect when the catalog is empty (`pro-packages` off). Its deps (`cannotResolve`, `notPlatformHosted`, a memoized `navigate`) never change again, so it never re-fired and the user was stranded on the "Loading plans" spinner. The deep-link effect now stands down while `cannotResolve` is redirecting.
- The ineligible-Pro bail now replaces instead of pushing when it originated from the deep link, so the consumed URL leaves no live history entry even if the strip ever fails again.
- `?package=free` no longer opens the Pro→Free cancellation confirm. The param names a package; `free` is not one. It is still stripped, just not acted on.
- `PACKAGE_PARAM` and `routes.plansForPackage(key)` join the URL registry and replace the hand-built/hand-read `"package"` literals in `checkout-page.tsx`, `plans-page.tsx`, and `post-auth-checkout.ts`.
- `selectTier`'s manage-surface bail now uses `routes.settings.usageBilling` instead of respelling the same URL.

## Tests

Both navigation bugs were reproduced first, on a `createMemoryRouter` data router with middleware on the parent route — declarative `MemoryRouter` structurally cannot show the abort. The tests assert the committed location sequence, not just the final location. The "consumed once" test previously drove `setQueryData` with a deep-equal payload, which changed no dependency and skipped the effect outright; it now holds the effect on unresolved hosting, flips hosting ready to drive the single consume, and then flips `isProUser` twice to prove the effect really re-runs.

Fixes gaps found during self-review of plan pricing-upgrade-path.md