### PR TITLE
fix(chat): profile switch on a brand-new conversation no longer 404s

### DIFF
--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -273,7 +273,7 @@ import { ComposerSettingsMenu } from "@/domains/chat/components/composer-setting
 import { useConversationStore } from "@/stores/conversation-store";
 import type { Conversation } from "@/types/conversation-types";
 import { ApiError } from "@/utils/api-errors";
-import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
 
 /** The config payload most cases mount against: one profile, "Smart". */
 const SMART_CONFIG = {
@@ -1089,9 +1089,12 @@ describe("Profile selection on a draft stub conversation (ATL-1136)", () => {
     // draft id — which has no server row yet, so a PUT against it would 404.
     useConversationStore.getState().setActiveConversationId("draft-xyz");
     const qc = createQueryClient();
-    qc.setQueryData(conversationsQueryKey("assistant-1"), [
-      { conversationId: "draft-xyz", draft: true } as Conversation,
-    ]);
+    qc.setQueryData(conversationListQueryKey("assistant-1"), {
+      conversations: [
+        { conversationId: "draft-xyz", draft: true } as Conversation,
+      ],
+      hasMore: false,
+    });
     renderMenu({ props: { conversationId: "draft-xyz" }, queryClient: qc });
 
     await waitFor(() =>

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -271,7 +271,9 @@ import { ComposerSettingsMenu } from "@/domains/chat/components/composer-setting
 // Real store (not mocked) — the component reads the draft conversation id and
 // the pending-profile stash from it.
 import { useConversationStore } from "@/stores/conversation-store";
+import type { Conversation } from "@/types/conversation-types";
 import { ApiError } from "@/utils/api-errors";
+import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
 
 /** The config payload most cases mount against: one profile, "Smart". */
 const SMART_CONFIG = {
@@ -1075,5 +1077,39 @@ describe("compact composer collapse", () => {
       true,
       false,
     ]);
+  });
+});
+
+describe("Profile selection on a draft stub conversation (ATL-1136)", () => {
+  test("stashes the selection instead of PUTting against the unminted id", async () => {
+    // Guard against a hanging/altered config impl leaking from a prior test.
+    configGetMock.mockImplementation(async () => ({ data: SMART_CONFIG }));
+    // First send in flight: the optimistic draft stub is in the foreground
+    // list cache, so the composer's `conversationId` prop is the client-minted
+    // draft id — which has no server row yet, so a PUT against it would 404.
+    useConversationStore.getState().setActiveConversationId("draft-xyz");
+    const qc = createQueryClient();
+    qc.setQueryData(conversationsQueryKey("assistant-1"), [
+      { conversationId: "draft-xyz", draft: true } as Conversation,
+    ]);
+    renderMenu({ props: { conversationId: "draft-xyz" }, queryClient: qc });
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Smart").length).toBeGreaterThan(0),
+    );
+    const smart = screen
+      .getAllByTestId("menu-item")
+      .find((b) => b.textContent?.includes("Smart"));
+    fireEvent.click(smart!);
+
+    // The selection lands in the stash (the send path / mint-time re-key
+    // applies it), with no network write and no error toast.
+    await waitFor(() => {
+      expect(
+        useConversationStore.getState().pendingDraftProfiles.get("draft-xyz"),
+      ).toBe("smart");
+    });
+    expect(inferenceprofilePut).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -196,14 +196,17 @@ export function ComposerSettingsMenu({
   // while the real/draft id lives in the conversation store. If the user
   // already picked a model for that id, the selection is stashed there (not
   // written to the global default) — reflect it so the checkmark survives a
-  // remount and matches what the first message / promotion will apply. See
+  // remount and matches what the first message / promotion will apply. A
+  // defined prop can also carry a stash: a draft stub's id (no server row
+  // yet), or a loaded row whose promotion hasn't landed. In both cases the
+  // stash is the latest intent, so it wins there too. See
   // `pendingDraftProfiles` in `conversation-store`.
   const activeConversationId = useConversationStore.use.activeConversationId();
   const pendingDraftProfiles = useConversationStore.use.pendingDraftProfiles();
-  const draftProfileSelection =
-    !conversationId && activeConversationId
-      ? (pendingDraftProfiles.get(activeConversationId) ?? null)
-      : null;
+  const stashKey = conversationId ?? activeConversationId;
+  const draftProfileSelection = stashKey
+    ? (pendingDraftProfiles.get(stashKey) ?? null)
+    : null;
 
   const profileActiveKey =
     optimisticActiveProfile ?? draftProfileSelection ?? serverEffectiveProfile;
@@ -406,6 +409,22 @@ export function ComposerSettingsMenu({
         // optimistic checkmark rather than leave it stranded.
         setOptimisticActiveProfile(lastConfirmedProfileRef.current);
         return false;
+      }
+
+      // A draft stub (optimistically prepended on first send, `draft: true`)
+      // has no server row yet — a PUT against its client-minted id 404s
+      // (ATL-1136). Stash like the no-row branch above; the send path forwards
+      // the stash, and `use-send-message` re-keys it to the server-minted id
+      // so the promotion effect persists it once the real row exists.
+      if (
+        findConversation(queryClient, assistantId, capturedConversationId)
+          ?.draft
+      ) {
+        useConversationStore
+          .getState()
+          .setPendingDraftProfile(capturedConversationId, name);
+        lastConfirmedProfileRef.current = name;
+        return true;
       }
 
       // A direct selection supersedes any stash recorded for this conversation

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -248,7 +248,10 @@ export function ComposerSettingsMenu({
   // persist the stash as a per-conversation override. Draft stubs (`draft:
   // true`, added optimistically on first send) are skipped — the send path owns
   // their stash and applies it to the conversation it mints.
-  const promotingProfileRef = useRef<Set<string>>(new Set());
+  // Keyed by conversation id, holding the in-flight promotion promise so a
+  // direct selection can serialize behind it (see handleProfileSelect). The
+  // promise never rejects — failures are swallowed below.
+  const promotingProfileRef = useRef<Map<string, Promise<void>>>(new Map());
   useEffect(() => {
     if (!conversationId) {
       return;
@@ -264,8 +267,7 @@ export function ComposerSettingsMenu({
       return;
     }
     const id = conversationId;
-    promotingProfileRef.current.add(id);
-    void (async () => {
+    const promotion = (async () => {
       try {
         await conversationsByIdInferenceprofilePut({
           path: { assistant_id: assistantId, id },
@@ -294,6 +296,7 @@ export function ComposerSettingsMenu({
         promotingProfileRef.current.delete(id);
       }
     })();
+    promotingProfileRef.current.set(id, promotion);
   }, [conversationId, assistantId, pendingDraftProfiles, queryClient]);
 
   // ---------------------------------------------------------------------------
@@ -434,6 +437,16 @@ export function ComposerSettingsMenu({
       useConversationStore
         .getState()
         .clearPendingDraftProfile(capturedConversationId);
+
+      // Serialize behind an in-flight promotion PUT for this conversation:
+      // if the older promotion write landed after ours, the persisted
+      // override would silently revert to the stashed value. The promotion
+      // promise never rejects, so awaiting it is safe.
+      const inflightPromotion =
+        promotingProfileRef.current.get(capturedConversationId);
+      if (inflightPromotion) {
+        await inflightPromotion;
+      }
 
       try {
         await conversationsByIdInferenceprofilePut({

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -1008,6 +1008,24 @@ export function useSendMessage({
               replace: true,
             });
           }
+        } else if (resolvedId && isDraft) {
+          // Legacy (pre-0.8.6) assistants echo the client-minted draft id
+          // back, so the re-key above is skipped. The row is persisted
+          // server-side now — a profile picked while the POST was in flight
+          // still sits in the stash, and nothing would push it: the row's
+          // draft flag only clears via the async list refetch, which doesn't
+          // touch the promotion effect's deps. Clear the flag and re-set the
+          // stash entry (a Map-identity change) so the composer's promotion
+          // effect re-runs and persists the selection (ATL-1136).
+          const stashedProfile = useConversationStore
+            .getState()
+            .pendingDraftProfiles.get(activeConversationId);
+          if (stashedProfile !== undefined) {
+            resolveDraftKey(queryClient, assistantId, activeConversationId, activeConversationId);
+            useConversationStore
+              .getState()
+              .setPendingDraftProfile(activeConversationId, stashedProfile);
+          }
         }
 
         void refreshConversations();

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -1014,14 +1014,20 @@ export function useSendMessage({
           // server-side now — a profile picked while the POST was in flight
           // still sits in the stash, and nothing would push it: the row's
           // draft flag only clears via the async list refetch, which doesn't
-          // touch the promotion effect's deps. Clear the flag and re-set the
-          // stash entry (a Map-identity change) so the composer's promotion
-          // effect re-runs and persists the selection (ATL-1136).
+          // touch the promotion effect's deps. Clear the flag, then clear and
+          // re-set the stash entry — `setPendingDraftProfile` no-ops on an
+          // unchanged value, so a clear/set pair is needed to change the Map
+          // identity the promotion effect depends on. Whether or not React
+          // batches the pair into one render, the effect re-runs with the
+          // stash present and persists the selection (ATL-1136).
           const stashedProfile = useConversationStore
             .getState()
             .pendingDraftProfiles.get(activeConversationId);
           if (stashedProfile !== undefined) {
             resolveDraftKey(queryClient, assistantId, activeConversationId, activeConversationId);
+            useConversationStore
+              .getState()
+              .clearPendingDraftProfile(activeConversationId);
             useConversationStore
               .getState()
               .setPendingDraftProfile(activeConversationId, stashedProfile);

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -449,8 +449,17 @@ export function useSendMessage({
       // The draft's stashed profile (if any) has now been persisted on the
       // minted conversation; drop this draft's entry so it can't re-apply to a
       // later send. Cleared only on success — a failed draft send keeps the
-      // stash so a retry still carries the chosen profile.
-      if (inferenceProfileForSend) {
+      // stash so a retry still carries the chosen profile — and only while the
+      // stash still holds the value that was sent: a newer selection made
+      // mid-flight must survive so the mint-time re-key below can carry it to
+      // the minted conversation.
+      if (
+        inferenceProfileForSend &&
+        useConversationStore
+          .getState()
+          .pendingDraftProfiles.get(requestConversationId) ===
+          inferenceProfileForSend
+      ) {
         useConversationStore
           .getState()
           .clearPendingDraftProfile(requestConversationId);
@@ -966,6 +975,22 @@ export function useSendMessage({
             activeConversationId,
             newConversationId,
           );
+
+          // A profile picked while the mint was in flight is stashed under the
+          // draft id after the POST already read the stash — re-key it to the
+          // minted id so the composer's promotion effect persists it now that
+          // the real row exists (ATL-1136).
+          const stashedProfile = useConversationStore
+            .getState()
+            .pendingDraftProfiles.get(activeConversationId);
+          if (stashedProfile !== undefined) {
+            useConversationStore
+              .getState()
+              .setPendingDraftProfile(newConversationId, stashedProfile);
+            useConversationStore
+              .getState()
+              .clearPendingDraftProfile(activeConversationId);
+          }
 
           // Only update active view state if the user is still on this conversation.
           if (


### PR DESCRIPTION
## Summary
- Switching the inference profile right after the first send in a brand-new conversation hit `PUT /v1/conversations/:id/inference-profile` with the optimistic draft stub's client-minted id, which has no server row on server-mint (0.8.6+) assistants — the request 404'd and showed the red "Failed to switch profile. Please try again." toast (ATL-1136).
- `handleProfileSelect` now treats a `draft: true` stub like the existing no-row branch: it stashes the selection in `pendingDraftProfiles` instead of PUTting. When the server-minted id resolves, `use-send-message` re-keys the stash to the minted id so the composer's existing promotion effect persists it, and the clear-on-success is equality-guarded so a selection made mid-flight isn't wiped before the re-key.
- The server endpoint's strict 404 is intentionally unchanged, and the greeting conversation stays ephemeral/unpersisted — persisting on switch would reintroduce the stray `/greeting` sidebar row (LUM-2789).

## Original prompt
Fix ATL-1136: switching the inference profile on a brand-new (empty) conversation fails with a red "Failed to switch profile" banner because the placeholder conversation is never persisted, so the switch endpoint 404s. The ask was the smallest, cleanest fix that also keeps LUM-2789 (stray `/greeting` conversation in the sidebar) resolved — i.e. without persisting placeholder/greeting conversations server-side.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->