### PR TITLE
fix(web): remove the "Your Groups" heading from the sidebar

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -127,6 +127,8 @@ function SearchButton() {
  *     • Show more/less — page through recent conversations
  *     • Channel ▾      — one collapsible section per origin channel
  *                        (Slack, Telegram, WhatsApp, …)
+ *     • ───────────────
+ *     • Group ▾        — one collapsible section per custom group
  *   Footer
  *     • caller-provided tip card (SidebarTipCard) — hidden on the collapsed rail
  *     • ───────────────
@@ -514,48 +516,46 @@ export function AssistantSideMenu({
               {sidebar.customGroups.length > 0 ? (
                 <>
                   <SideMenu.Separator />
-                  <SideMenu.Section title="Your Groups">
-                    <CollapsibleNavSection.Root
-                      type="multiple"
-                      className="gap-3"
-                      value={sidebar.effectiveOpenCustomGroups}
-                      onValueChange={sidebar.onOpenCustomGroupsChange}
-                    >
-                      {sidebar.customGroups.map((group) => {
-                        const groupMenu = buildGroupMenu(
-                          group.name,
-                          group.conversations,
-                          {
-                            onRename: onRenameGroup
-                              ? () => onRenameGroup(group.id)
-                              : undefined,
-                            onDelete: onDeleteGroup
-                              ? () => onDeleteGroup(group.id)
-                              : undefined,
-                          },
-                        );
-                        return (
-                          <ConversationNavSection
-                            key={group.id}
-                            value={group.id}
-                            label={group.name}
-                            /* The "…" button and the header's right-click menu
-                               both render from `groupMenu`. */
-                            trailing={
-                              <GroupActionsMenu
-                                label={group.name}
-                                {...groupMenu}
-                              />
-                            }
-                            groupMenu={groupMenu}
-                            items={group.conversations}
-                            dragSection={`group:${group.id}`}
-                            collapsedIndicator={collapsedActivityDot(group.conversations)}
-                          />
-                        );
-                      })}
-                    </CollapsibleNavSection.Root>
-                  </SideMenu.Section>
+                  <CollapsibleNavSection.Root
+                    type="multiple"
+                    className="gap-3"
+                    value={sidebar.effectiveOpenCustomGroups}
+                    onValueChange={sidebar.onOpenCustomGroupsChange}
+                  >
+                    {sidebar.customGroups.map((group) => {
+                      const groupMenu = buildGroupMenu(
+                        group.name,
+                        group.conversations,
+                        {
+                          onRename: onRenameGroup
+                            ? () => onRenameGroup(group.id)
+                            : undefined,
+                          onDelete: onDeleteGroup
+                            ? () => onDeleteGroup(group.id)
+                            : undefined,
+                        },
+                      );
+                      return (
+                        <ConversationNavSection
+                          key={group.id}
+                          value={group.id}
+                          label={group.name}
+                          /* The "…" button and the header's right-click menu
+                             both render from `groupMenu`. */
+                          trailing={
+                            <GroupActionsMenu
+                              label={group.name}
+                              {...groupMenu}
+                            />
+                          }
+                          groupMenu={groupMenu}
+                          items={group.conversations}
+                          dragSection={`group:${group.id}`}
+                          collapsedIndicator={collapsedActivityDot(group.conversations)}
+                        />
+                      );
+                    })}
+                  </CollapsibleNavSection.Root>
                 </>
               ) : null}
             </>


### PR DESCRIPTION
## TL;DR

Removes the redundant "Your Groups" heading above custom conversation groups in the sidebar. The groups already sit below a divider, so the heading was duplicate visual chrome.

## What changes for the user

| Before | After |
| --- | --- |
| Sidebar shows a divider, then a "Your Groups" heading, then the custom groups | Sidebar shows a divider, then the custom groups directly |
| Custom groups indented under a labeled section wrapper | Custom groups align with the built-in sections (Pinned, Chats, channels) |

## Why this is safe

- Pure JSX unwrap: the `SideMenu.Section` wrapper existed only to render the title. The collapsible accordion inside it — open/close state, rename/delete menus, drag-reorder, activity dots — is untouched and moves up one level unchanged.
- The divider above the groups is kept, so the visual separation from the built-in sections remains.
- Custom groups render through the same shared components as every other sidebar section (`ConversationNavSection` / `CollapsibleNavSection`); no component behavior changed.
- Type-check, ESLint, and the sidebar-state tests pass. `SideMenu.Section` remains available in the design library (it has its own tests there).

## Deferred

Two follow-ups investigated alongside this change, deferred as separate PRs since they touch different layers (DB migration + tool surface respectively): custom group icons (which would also fix custom groups being absent from the collapsed rail), and letting the assistant file conversations into groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->