### PR TITLE
docs(agents): never use em dashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,16 @@ Proactively remove unused code during every change. Remove code your change make
 
 Default to no comment — bias aggressively toward terseness and rely on good naming. Follow the commenting density of the surrounding code.
 
+## Em Dashes
+
+Never use em dashes (`—`). Use a period, comma, colon, parentheses, or a plain hyphen instead.
+
+This covers everything you write: user-facing copy, code comments, documentation, commit messages, and PR descriptions.
+
+**User-facing copy is the strict case.** The assistant's own system prompt already forbids em dashes (`assistant/src/prompts/templates/SOUL.md`), so a UI string that uses one is written in a different voice from the assistant standing next to it. Treat any string a user can read (product copy, error messages, notifications, seeded prompts, API descriptions) as a hard no.
+
+Existing text is not swept retroactively. Fix em dashes on lines you are already changing and leave the rest alone.
+
 ## Control-Flow Braces
 
 Wrap every `if` / `else` / `for` / `while` / `do…while` body in braces, even a single-statement one-liner. Braces make control flow easy to scan — the block boundary is explicit — and close a common footgun: a second line added under a braceless condition reads as if it sits inside the branch but runs unconditionally. The ESLint `curly` rule flags this in both `assistant/` and `clients/web/` (currently at `warn`); it is fully auto-fixable, so add braces to any control statement you touch.


### PR DESCRIPTION
## What

Adds an **Em Dashes** section to the root `AGENTS.md`, next to the existing Code Comments rule:

> Never use em dashes (`—`). Use a period, comma, colon, parentheses, or a plain hyphen instead.

It covers everything written in this repo (copy, comments, docs, commit messages, PR descriptions), with user-facing copy called out as the strict case.

## Why here, and why now

The product already holds this line in exactly one place: the assistant's own system prompt forbids em dashes in everything it says.

`assistant/src/prompts/templates/SOUL.md:119`
```
Never use em-dash characters. Use periods, commas, colons, or normal dashes instead.
```

Nothing carried that rule across to the code we write around the assistant, so UI strings drift into a voice the assistant itself is forbidden from using. A user reading an em dash in a product string and none in the assistant's reply is reading two different authors.

## Not retroactive

Stated explicitly in the rule: fix em dashes on lines you are already changing, and leave the rest alone. A repo-wide sweep would touch thousands of comment lines for no reader benefit and would bury real changes in review. `AGENTS.md` itself still contains em dashes in its older sections for the same reason.

## Scope

Documentation only. No code, no behavior, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)