### PR TITLE
fix(tests): mock supportsSubagentsReconcile where the gate silently disabled reconcile tests

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
@@ -9,6 +9,10 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import { __resetForTesting, publish } from "@/lib/event-bus";
 
+mock.module("@/lib/backwards-compat/subagents-reconcile", () => ({
+  supportsSubagentsReconcile: () => true,
+}));
+
 let getCalls = 0;
 mock.module("@/generated/daemon/sdk.gen", () => ({
   subagentsReconcileGet: async () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
@@ -27,6 +27,10 @@ mock.module("@/lib/backwards-compat/subagent-detail-self-lookup", () => ({
   supportsSubagentDetailSelfLookup: () => selfLookupSupported,
 }));
 
+mock.module("@/lib/backwards-compat/subagents-reconcile", () => ({
+  supportsSubagentsReconcile: () => true,
+}));
+
 let reconcileCalls = 0;
 const reconciledParents: string[] = [];
 mock.module("@/generated/daemon/sdk.gen", () => ({


### PR DESCRIPTION
## Summary
Self-review Pass 2 caught PR #39368 merged with 10 red web tests: the `supportsSubagentsReconcile()` gate (added in the final review cycle) returns false under test because the identity store has no assistant version, so `reconcileFromDaemon` early-returns before touching the mocked SDK. `subagent-store.test.ts` mocked the gate; these two suites were missed.

Part of plan: subagent-running-state-fixes.md (self-review remediation)