### PR TITLE
feat(skills): add conversation-groups bundled skill for sidebar organization

### DIFF
--- a/assistant/src/__tests__/conversation-group-tools.test.ts
+++ b/assistant/src/__tests__/conversation-group-tools.test.ts
@@ -1,0 +1,279 @@
+import type { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  createConversation,
+  getDisplayMetaForConversations,
+} from "../persistence/conversation-crud.js";
+import { ensureGroupMigration } from "../persistence/conversation-group-migration.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { executeConversationGroupCreate } from "../tools/conversation-groups/group_create.js";
+import { executeConversationGroupList } from "../tools/conversation-groups/group_list.js";
+import { executeConversationMoveToGroup } from "../tools/conversation-groups/move_to_group.js";
+import type { ToolContext } from "../tools/types.js";
+
+await initializeDb();
+ensureGroupMigration();
+
+function getRawDb(): Database {
+  return (getDb() as unknown as { $client: Database }).$client;
+}
+
+const ctx: ToolContext = {
+  workingDir: "/tmp",
+  conversationId: "test-conversation",
+  trustClass: "guardian",
+};
+
+function clearState(): void {
+  const raw = getRawDb();
+  raw.run("DELETE FROM conversations");
+  raw.run("DELETE FROM conversation_groups WHERE is_system_group = 0");
+}
+
+function extractGroupId(content: string): string {
+  const match = content.match(/id: ([0-9a-f-]{36})/);
+  expect(match).not.toBeNull();
+  return match![1];
+}
+
+function groupIdOf(conversationId: string): string | null {
+  return (
+    getDisplayMetaForConversations([conversationId]).get(conversationId)
+      ?.groupId ?? null
+  );
+}
+
+// ── conversation_group_list ─────────────────────────────────────────
+
+describe("conversation_group_list tool", () => {
+  beforeEach(clearState);
+
+  test("lists system groups", async () => {
+    const result = await executeConversationGroupList({}, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Pinned (id: system:pinned)");
+    expect(result.content).toContain("Recents (id: system:all)");
+    expect(result.content).toContain("[system group]");
+  });
+
+  test("lists custom groups after creation", async () => {
+    await executeConversationGroupCreate({ name: "Work" }, ctx);
+
+    const result = await executeConversationGroupList({}, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Work");
+  });
+});
+
+// ── conversation_group_create ───────────────────────────────────────
+
+describe("conversation_group_create tool", () => {
+  beforeEach(clearState);
+
+  test("creates a custom group", async () => {
+    const result = await executeConversationGroupCreate(
+      { name: "Travel planning" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Created group "Travel planning"');
+  });
+
+  test("trims the name", async () => {
+    const result = await executeConversationGroupCreate(
+      { name: "  Padded  " },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Created group "Padded"');
+  });
+
+  test("reuses an existing group with the same name (case-insensitive)", async () => {
+    const first = await executeConversationGroupCreate({ name: "Work" }, ctx);
+    const firstId = extractGroupId(first.content);
+
+    const second = await executeConversationGroupCreate({ name: "work" }, ctx);
+    expect(second.isError).toBe(false);
+    expect(second.content).toContain("already exists");
+    expect(second.content).toContain(firstId);
+  });
+
+  test("rejects system group names", async () => {
+    const result = await executeConversationGroupCreate(
+      { name: "pinned" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("system group");
+  });
+
+  test("rejects missing name", async () => {
+    const result = await executeConversationGroupCreate({}, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("name is required");
+  });
+});
+
+// ── conversation_move_to_group ──────────────────────────────────────
+
+describe("conversation_move_to_group tool", () => {
+  beforeEach(clearState);
+
+  test("moves a conversation into a custom group by name", async () => {
+    createConversation({ id: "conv-1", title: "Trip ideas" });
+    await executeConversationGroupCreate({ name: "Travel" }, ctx);
+
+    const result = await executeConversationMoveToGroup(
+      { group: "travel", conversation_id: "conv-1" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Moved "Trip ideas" to group "Travel"');
+    expect(groupIdOf("conv-1")).not.toBe("system:all");
+  });
+
+  test("moves a conversation by group id", async () => {
+    createConversation({ id: "conv-2" });
+    const created = await executeConversationGroupCreate({ name: "Work" }, ctx);
+    const groupId = extractGroupId(created.content);
+
+    const result = await executeConversationMoveToGroup(
+      { group: groupId, conversation_id: "conv-2" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(groupIdOf("conv-2")).toBe(groupId);
+  });
+
+  test("defaults to the current conversation", async () => {
+    createConversation({ id: "test-conversation", title: "This chat" });
+    await executeConversationGroupCreate({ name: "Inbox" }, ctx);
+
+    const result = await executeConversationMoveToGroup(
+      { group: "Inbox" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Moved "This chat" to group "Inbox"');
+  });
+
+  test("moving to Pinned pins the conversation", async () => {
+    createConversation({ id: "conv-pin" });
+
+    const result = await executeConversationMoveToGroup(
+      { group: "Pinned", conversation_id: "conv-pin" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("pinned");
+    expect(groupIdOf("conv-pin")).toBe("system:pinned");
+    const pinned = getRawDb()
+      .query("SELECT is_pinned FROM conversations WHERE id = ?")
+      .get("conv-pin") as { is_pinned: number };
+    expect(pinned.is_pinned).toBe(1);
+  });
+
+  test("preserves display_order across a move", async () => {
+    createConversation({ id: "conv-ord" });
+    getRawDb().run(
+      "UPDATE conversations SET display_order = 7 WHERE id = 'conv-ord'",
+    );
+    await executeConversationGroupCreate({ name: "Ordered" }, ctx);
+
+    const result = await executeConversationMoveToGroup(
+      { group: "Ordered", conversation_id: "conv-ord" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    const row = getRawDb()
+      .query("SELECT display_order FROM conversations WHERE id = ?")
+      .get("conv-ord") as { display_order: number | null };
+    expect(row.display_order).toBe(7);
+  });
+
+  test("no-op when already in the target group", async () => {
+    createConversation({ id: "conv-3", title: "Settled" });
+
+    const result = await executeConversationMoveToGroup(
+      { group: "Recents", conversation_id: "conv-3" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("already in group");
+  });
+
+  test("errors on unknown group with available list", async () => {
+    createConversation({ id: "conv-4" });
+
+    const result = await executeConversationMoveToGroup(
+      { group: "Nonexistent", conversation_id: "conv-4" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No group named "Nonexistent"');
+    expect(result.content).toContain("Available groups:");
+  });
+
+  test("errors on ambiguous group name", async () => {
+    // Two custom groups whose names differ only by case
+    await executeConversationGroupCreate({ name: "Alpha" }, ctx);
+    // Bypass the tool's dedup to create the case-variant directly
+    getRawDb().run(
+      "INSERT INTO conversation_groups (id, name, sort_position, is_system_group, created_at, updated_at) VALUES ('dup-group-id', 'alpha', 99, 0, 0, 0)",
+    );
+    createConversation({ id: "conv-5" });
+
+    const result = await executeConversationMoveToGroup(
+      { group: "ALPHA", conversation_id: "conv-5" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("ambiguous");
+    expect(result.content).toContain("Retry with the group id");
+  });
+
+  test("errors on unknown conversation", async () => {
+    const result = await executeConversationMoveToGroup(
+      { group: "Recents", conversation_id: "missing-conv" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no conversation found");
+  });
+
+  test("notes hidden conversation types", async () => {
+    createConversation({ id: "conv-bg", conversationType: "background" });
+    await executeConversationGroupCreate({ name: "Visible" }, ctx);
+
+    const result = await executeConversationMoveToGroup(
+      { group: "Visible", conversation_id: "conv-bg" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("hidden from the sidebar");
+  });
+
+  test("rejects missing group", async () => {
+    const result = await executeConversationMoveToGroup({}, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("group is required");
+  });
+});

--- a/assistant/src/config/bundled-skills/conversation-groups/SKILL.md
+++ b/assistant/src/config/bundled-skills/conversation-groups/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: conversation-groups
+description: Organize conversations into custom sidebar groups — list groups, create new ones, and file conversations into them
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🗂️"
+  vellum:
+    display-name: "Conversation Groups"
+    category: "productivity"
+---
+
+Organize the user's conversations into sidebar groups. Groups are the sections shown in the conversation sidebar; each conversation belongs to exactly one group.
+
+## Groups
+
+- **Custom groups** are user-defined sections (e.g. "Work", "Travel planning"). Create them with `conversation_group_create` and file conversations with `conversation_move_to_group`.
+- **System groups** are built in and cannot be created, renamed, or deleted:
+  - `system:pinned` (Pinned) — moving a conversation here pins it; moving it elsewhere unpins it.
+  - `system:all` (Recents) — the default ungrouped section. Move a conversation here to "remove" it from a custom group.
+  - `system:scheduled` (Scheduled) and `system:background` (Background) — hold automated conversations. Moving a conversation into these demotes it out of the Recents listing; avoid unless the user explicitly asks.
+
+## Usage
+
+- `conversation_move_to_group` defaults to the **current** conversation, so "file this chat under Work" needs no conversation id.
+- Groups can be referenced by name (case-insensitive) or id. Prefer names; fall back to ids when names are ambiguous.
+- When the user asks to organize their conversations, check the existing groups first (`conversation_group_list`) and reuse a fitting group rather than creating near-duplicates ("Work" vs "Work stuff").
+- Creating a group whose name already exists reuses the existing group instead of creating a duplicate.
+- Moves only affect sidebar organization — no conversation content changes, and every move is reversible.
+- Subagent and background conversations are hidden from the sidebar regardless of group; moving them has no visible effect.

--- a/assistant/src/config/bundled-skills/conversation-groups/TOOLS.json
+++ b/assistant/src/config/bundled-skills/conversation-groups/TOOLS.json
@@ -1,0 +1,58 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "conversation_group_list",
+      "description": "List all conversation sidebar groups in display order, including built-in system groups (Pinned, Scheduled, Background, Recents) and user-defined custom groups. Use this before creating or moving so you reuse an existing group instead of creating a near-duplicate.",
+      "category": "conversations",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      },
+      "executor": "tools/group-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "conversation_group_create",
+      "description": "Create a new custom conversation group (a named section in the conversation sidebar). If a group with the same name already exists (case-insensitive), the existing group is reused and no duplicate is created. System group names (Pinned, Scheduled, Background, Recents) are reserved.",
+      "category": "conversations",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name for the new group as it should appear in the sidebar"
+          }
+        },
+        "required": ["name"]
+      },
+      "executor": "tools/group-create.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "conversation_move_to_group",
+      "description": "Move a conversation into a sidebar group. Defaults to the current conversation when conversation_id is omitted. The group may be referenced by name (case-insensitive) or id. Moving to Pinned pins the conversation; moving to Recents (system:all) removes it from a custom group. Only sidebar organization changes — reversible, no content is affected.",
+      "category": "conversations",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "group": {
+            "type": "string",
+            "description": "Target group name or group id"
+          },
+          "conversation_id": {
+            "type": "string",
+            "description": "Conversation to move. Omit to move the current conversation."
+          }
+        },
+        "required": ["group"]
+      },
+      "executor": "tools/move-to-group.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/conversation-groups/tools/group-create.ts
+++ b/assistant/src/config/bundled-skills/conversation-groups/tools/group-create.ts
@@ -1,0 +1,12 @@
+import { executeConversationGroupCreate } from "../../../../tools/conversation-groups/group_create.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeConversationGroupCreate(input, context);
+}

--- a/assistant/src/config/bundled-skills/conversation-groups/tools/group-list.ts
+++ b/assistant/src/config/bundled-skills/conversation-groups/tools/group-list.ts
@@ -1,0 +1,12 @@
+import { executeConversationGroupList } from "../../../../tools/conversation-groups/group_list.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeConversationGroupList(input, context);
+}

--- a/assistant/src/config/bundled-skills/conversation-groups/tools/move-to-group.ts
+++ b/assistant/src/config/bundled-skills/conversation-groups/tools/move-to-group.ts
@@ -1,0 +1,12 @@
+import { executeConversationMoveToGroup } from "../../../../tools/conversation-groups/move_to_group.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeConversationMoveToGroup(input, context);
+}

--- a/assistant/src/tools/__tests__/conversation-group-tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/conversation-group-tool-input-schemas.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test } from "bun:test";
+
+import type { z } from "zod";
+
+import { conversationGroupCreateInputSchema } from "../conversation-groups/group_create.js";
+import { conversationMoveToGroupInputSchema } from "../conversation-groups/move_to_group.js";
+import { toToolInputSchema } from "../shared/zod-tool-schema.js";
+import { expectNoSchemaDrift } from "./tool-schema-drift-harness.js";
+
+/**
+ * Drift guard between the conversation-groups skill's hand-written
+ * `TOOLS.json` `input_schema`s and the executors' runtime Zod schemas. See
+ * `tool-schema-drift-harness.ts` for what is (and deliberately is not)
+ * compared. `conversation_group_list` takes no input and has no runtime
+ * schema, so it has no entry here.
+ */
+
+const toolsJson = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dir,
+      "../../config/bundled-skills/conversation-groups/TOOLS.json",
+    ),
+    "utf8",
+  ),
+) as Parameters<typeof expectNoSchemaDrift>[1];
+
+const CASES: {
+  name: string;
+  schema: z.ZodType;
+  advertiseRequired?: string[];
+}[] = [
+  {
+    name: "conversation_group_create",
+    schema: conversationGroupCreateInputSchema,
+    advertiseRequired: ["name"],
+  },
+  {
+    name: "conversation_move_to_group",
+    schema: conversationMoveToGroupInputSchema,
+    advertiseRequired: ["group"],
+  },
+];
+
+describe("conversation-groups TOOLS.json ↔ runtime Zod schema drift guard", () => {
+  for (const c of CASES) {
+    test(c.name, () => {
+      expectNoSchemaDrift(
+        {
+          name: c.name,
+          derived: toToolInputSchema(c.schema, {
+            advertiseRequired: c.advertiseRequired,
+          }),
+        },
+        toolsJson,
+      );
+    });
+  }
+});

--- a/assistant/src/tools/conversation-groups/group_create.ts
+++ b/assistant/src/tools/conversation-groups/group_create.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+import { createGroup, listGroups } from "../../persistence/group-crud.js";
+import { publishConversationListChanged } from "../../runtime/sync/resource-sync-events.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of
+ * {@link executeConversationGroupCreate}. Same in-tool pattern and TOOLS.json
+ * drift guard as the other bundled-skill tools. The bespoke non-empty (trim)
+ * check keeps its own error message.
+ */
+export const conversationGroupCreateInputSchema = z.looseObject({
+  name: nullAsOmitted(z.string()),
+});
+
+export async function executeConversationGroupCreate(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const parsedInput = conversationGroupCreateInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult(
+      "conversation_group_create",
+      parsedInput.error,
+    );
+  }
+
+  const name = parsedInput.data.name?.trim();
+  if (!name) {
+    return {
+      content: "Error: name is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  const existing = listGroups().find(
+    (g) => g.name.trim().toLowerCase() === name.toLowerCase(),
+  );
+  if (existing?.isSystemGroup) {
+    return {
+      content: `Error: "${existing.name}" is a built-in system group and cannot be recreated. Move conversations into it directly with conversation_move_to_group.`,
+      isError: true,
+    };
+  }
+  if (existing) {
+    return {
+      content: `Group "${existing.name}" already exists (id: ${existing.id}). Reusing it — no new group was created.`,
+      isError: false,
+    };
+  }
+
+  const group = createGroup(name);
+  publishConversationListChanged("created");
+  return {
+    content: `Created group "${group.name}" (id: ${group.id}). It now appears in the sidebar; use conversation_move_to_group to file conversations into it.`,
+    isError: false,
+  };
+}

--- a/assistant/src/tools/conversation-groups/group_list.ts
+++ b/assistant/src/tools/conversation-groups/group_list.ts
@@ -1,0 +1,20 @@
+import { listGroups } from "../../persistence/group-crud.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+import { formatGroupList } from "./group_shared.js";
+
+export async function executeConversationGroupList(
+  _input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const groups = listGroups();
+  return {
+    content:
+      "Conversation groups (sidebar order):\n" +
+      formatGroupList(groups) +
+      "\n\nSystem groups are built in: Pinned pins a conversation, Recents " +
+      "(system:all) is the default ungrouped section, and Scheduled/" +
+      "Background hold automated conversations. Custom groups are " +
+      "user-defined sections.",
+    isError: false,
+  };
+}

--- a/assistant/src/tools/conversation-groups/group_shared.ts
+++ b/assistant/src/tools/conversation-groups/group_shared.ts
@@ -1,0 +1,52 @@
+import {
+  type ConversationGroupRow,
+  listGroups,
+} from "../../persistence/group-crud.js";
+
+/**
+ * Resolve a model-supplied group reference (id or name) against the current
+ * group list. Name matching is case-insensitive on the trimmed input; an id
+ * match always wins. Returns an error string (for the tool result) when the
+ * reference is missing or ambiguous.
+ */
+export function resolveGroupReference(
+  reference: string,
+): { group: ConversationGroupRow } | { error: string } {
+  const groups = listGroups();
+  const trimmed = reference.trim();
+
+  const byId = groups.find((g) => g.id === trimmed);
+  if (byId) {
+    return { group: byId };
+  }
+
+  const lowered = trimmed.toLowerCase();
+  const byName = groups.filter((g) => g.name.trim().toLowerCase() === lowered);
+  if (byName.length === 1) {
+    return { group: byName[0] };
+  }
+  if (byName.length > 1) {
+    return {
+      error:
+        `Group name "${trimmed}" is ambiguous. Matching groups:\n` +
+        byName.map((g) => `- ${g.name} (id: ${g.id})`).join("\n") +
+        "\nRetry with the group id.",
+    };
+  }
+
+  return {
+    error:
+      `No group named "${trimmed}". Available groups:\n` +
+      formatGroupList(groups) +
+      "\nUse conversation_group_create to create a new group.",
+  };
+}
+
+export function formatGroupList(groups: ConversationGroupRow[]): string {
+  return groups
+    .map(
+      (g) =>
+        `- ${g.name} (id: ${g.id})${g.isSystemGroup ? " [system group]" : ""}`,
+    )
+    .join("\n");
+}

--- a/assistant/src/tools/conversation-groups/move_to_group.ts
+++ b/assistant/src/tools/conversation-groups/move_to_group.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+import {
+  batchSetDisplayOrders,
+  getConversation,
+  getDisplayMetaForConversations,
+} from "../../persistence/conversation-crud.js";
+import { publishConversationListAndMetadataChanged } from "../../runtime/sync/resource-sync-events.js";
+import {
+  invalidToolInputResult,
+  nullAsOmitted,
+} from "../shared/zod-tool-schema.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+import { resolveGroupReference } from "./group_shared.js";
+
+/**
+ * Model-input schema, `safeParse`d at the top of
+ * {@link executeConversationMoveToGroup}. Same in-tool pattern and TOOLS.json
+ * drift guard as the other bundled-skill tools.
+ */
+export const conversationMoveToGroupInputSchema = z.looseObject({
+  group: nullAsOmitted(z.string()),
+  conversation_id: nullAsOmitted(z.string()),
+});
+
+export async function executeConversationMoveToGroup(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const parsedInput = conversationMoveToGroupInputSchema.safeParse(input);
+  if (!parsedInput.success) {
+    return invalidToolInputResult(
+      "conversation_move_to_group",
+      parsedInput.error,
+    );
+  }
+
+  const groupRef = parsedInput.data.group?.trim();
+  if (!groupRef) {
+    return {
+      content: "Error: group is required (a group name or group id)",
+      isError: true,
+    };
+  }
+
+  const resolved = resolveGroupReference(groupRef);
+  if ("error" in resolved) {
+    return { content: `Error: ${resolved.error}`, isError: true };
+  }
+  const group = resolved.group;
+
+  const conversationId =
+    parsedInput.data.conversation_id?.trim() || context.conversationId;
+  const conversation = getConversation(conversationId);
+  if (!conversation) {
+    return {
+      content: `Error: no conversation found with id ${conversationId}`,
+      isError: true,
+    };
+  }
+
+  const label = conversation.title
+    ? `"${conversation.title}"`
+    : `conversation ${conversationId}`;
+
+  const meta = getDisplayMetaForConversations([conversationId]).get(
+    conversationId,
+  );
+  if (meta?.groupId === group.id) {
+    return {
+      content: `${label} is already in group "${group.name}".`,
+      isError: false,
+    };
+  }
+
+  // Preserve the conversation's manual sort slot across the move; only the
+  // group assignment changes.
+  batchSetDisplayOrders([
+    {
+      id: conversationId,
+      displayOrder: meta?.displayOrder ?? null,
+      groupId: group.id,
+    },
+  ]);
+  publishConversationListAndMetadataChanged("reordered", [conversationId]);
+
+  const notes: string[] = [];
+  if (group.id === "system:pinned") {
+    notes.push("It is now pinned.");
+  }
+  if (group.id === "system:scheduled" || group.id === "system:background") {
+    notes.push(
+      `Moving into ${group.name} demotes it out of the Recents listing.`,
+    );
+  }
+  if (conversation.conversationType !== "standard") {
+    notes.push(
+      `Note: this is a ${conversation.conversationType} conversation, which stays hidden from the sidebar regardless of group.`,
+    );
+  }
+
+  return {
+    content: [`Moved ${label} to group "${group.name}".`, ...notes].join(" "),
+    isError: false,
+  };
+}


### PR DESCRIPTION
## TL;DR

Gives the assistant an LLM-facing surface for conversation sidebar groups: a new bundled skill **conversation-groups** with three host-executed tools — list groups, create a custom group, and move a conversation into a group (defaulting to the current conversation). Users can now say "file this chat under Travel" or "make a Work group and put my standup chats in it" and the assistant can actually do it.

## What changes for the user

| Before | After |
| --- | --- |
| Groups exist server-side and in the web sidebar, but the assistant has no way to see or use them | The assistant can list groups (system + custom) on request |
| Creating a group requires the web sidebar UI | Asking the assistant creates the group; duplicate names (case-insensitive) reuse the existing group |
| Filing a conversation requires the web "Move to group" menu | "File this chat under X" moves the current (or any) conversation; group referenced by name or id |
| — | Moving to Pinned pins; moving to Recents un-files; all clients resync immediately |

## Why this is safe

- **No new non-skill tool registrations** — ships as a bundled skill with `TOOLS.json` host executors (same pattern as `followups`), per `assistant/src/tools/AGENTS.md`. Zero system-prompt overhead until the skill loads.
- **No new persistence logic** — moves reuse `batchSetDisplayOrders`, so pin derivation, unknown-group sanitization, and the Scheduled/Background `surfaced_at` demotion semantics stay single-sourced with the existing web "Move to group" path. `display_order` is preserved across moves.
- **Sync parity** — every mutation fires the same `publishConversationListChanged` / `publishConversationListAndMetadataChanged` invalidations the group HTTP routes fire.
- All operations are metadata-only and reversible; the skill exposes no delete/rename (destructive) surface.
- 18 functional tests + a TOOLS.json ↔ Zod schema drift guard (shared harness with followups/phone-calls/acp).

## Deferred (and why)

- **Schedule → custom group**: the scheduler still hard-assigns run conversations to `system:scheduled`, so filing a schedule's conversations somewhere custom won't stick across runs. Follow-up PR threads an optional `groupId` through schedule storage + the schedule tools.
- **Group rename/delete/reorder tools**: delete is destructive, the web UI already covers these, and demand is unproven. Easy to add on the same executors later.
- **Docs-sync manifest entry**: only needed if this skill gets a public docs-reference page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->