### PR TITLE
docs(web): retarget 0.10.13 backwards-compat gates to 0.11.0

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -167,6 +167,9 @@ Each module owns one feature's old/new split. Current registry:
 | `use-supports-credentials-settings.ts` | `0.10.8`                       | No credentials-page daemon routes or `credential-requests` mint route; the Settings → Credentials tab is hidden and the page renders NotFound | Routes exist; the Credentials tab, page, and one-time credential-link actions render |
 | `use-supports-redacted-credential-chips.ts` | `0.10.10`                 | Sentinel-shaped transcript text renders as plain text (daemon neither mints nor neutralizes sentinels)   | Assistant-message sentinels upgrade to redacted-credential reveal chips                     |
 | `use-supports-noninteractive-voice-turns.ts` | `0.11.0`                 | Voice turns can raise `oauth_connect` surfaces mid-call; the voice room renders its own reachable connect card | Voice turns force `supportsDynamicUi: false` (no mid-call surfaces); the room card stays hidden |
+| `channel-access-controls.ts`        | `0.11.0`                          | Channel list renders without Assistant Access controls (no tier badges, picker, or legend card)           | Two-level Assistant Access picker on the Channels tab, backed by the assistant-side collapse contract |
+| `subagent-recovery.ts`              | `0.11.0`                          | Recovered subagent stubs render from live stream events only (generic label, no history backfill)         | Detail + reconcile routes carry per-child identity; missed-spawn subagents rebuild fully    |
+| `use-supports-image-gen-vellum-provider.ts` | `0.11.0`                  | Vellum image-gen selection persists as legacy `{ mode: "managed" }` with no provider field                | Save path writes `provider: "vellum"`, which the config enum accepts                        |
 
 When you delete a row here, also delete its module, its test, and the now-dead
 legacy branch at the call site.

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.reconcile.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.reconcile.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Tests for the reconcile-on-load path of `useConversationChangeEffects`
- * (LUM-2875): on 0.10.13+ daemons, loading a conversation asks
+ * (LUM-2875): on 0.11.0+ daemons, loading a conversation asks
  * `subagents/reconcile` for every subagent the daemon knows about and
  * materializes store entries for the ones this client never saw spawn.
  * Split from the main test file so the SDK/gate mocks can't perturb the
@@ -132,7 +132,7 @@ describe("useConversationChangeEffects — reconcile-on-load", () => {
     expect(entry?.status).toBe("running");
   });
 
-  test("skips entirely on a pre-0.10.13 daemon", async () => {
+  test("skips entirely on a pre-0.11.0 daemon", async () => {
     recoverySupported = false;
     reconcileResponse = {
       subagents: { "sa-1": { status: "running", label: "x" } },

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
@@ -3,7 +3,7 @@
  *
  * - Reset subagent tracking state (needed for URL-navigation paths that
  *   bypass the `switchConversation` / `startNewConversation` wrappers)
- * - Reconcile-on-load (0.10.13+): materialize store entries for every
+ * - Reconcile-on-load (0.11.0+): materialize store entries for every
  *   subagent the daemon knows about in this conversation, so subagents
  *   whose `subagent_spawned` this client never saw (page reload mid-run,
  *   another device, a store reset) get cards without waiting for their
@@ -54,7 +54,7 @@ export function useConversationChangeEffects(
   // stream event would also recover it via `ensureEntry`, but only when it
   // next emits). Runs as a passive effect, i.e. after the layout reset
   // above, so a conversation change can't wipe what this seeds. Version
-  // gated: pre-0.10.13 daemons return status-only reconcile data, which
+  // gated: pre-0.11.0 daemons return status-only reconcile data, which
   // can't seed a usable entry.
   const supportsRecovery = useSupportsSubagentRecovery();
   useEffect(() => {

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -75,10 +75,10 @@ export interface SubagentEntry {
    * Conversation id passed to the detail fetch. History hydration and
    * reconcile-on-load supply the subagent's OWN conversation id; the live
    * `subagent_event` path stamps the PARENT's (the only id that event
-   * carries). The ambiguity is harmless on 0.10.13+ daemons — the detail
+   * carries). The ambiguity is harmless on 0.11.0+ daemons — the detail
    * route resolves the true conversation from manager state and treats
    * this value as a fallback — and the stamping is version-gated so
-   * pre-0.10.13 daemons are never sent a parent id they'd trust verbatim.
+   * pre-0.11.0 daemons are never sent a parent id they'd trust verbatim.
    */
   conversationId?: string;
   /** StableId of the parent assistant message that spawned this subagent. */
@@ -221,11 +221,11 @@ export interface SubagentActions {
     outputTokens?: number;
     totalCost?: number;
     events: SubagentTimelineEvent[];
-    /** Backfills a stub entry's placeholder label (0.10.13+ daemons). */
+    /** Backfills a stub entry's placeholder label (0.11.0+ daemons). */
     label?: string;
     /**
      * Backfills a stub entry's spawn anchor and registers it in
-     * `byToolUseId` (0.10.13+ daemons), restoring exact message anchoring
+     * `byToolUseId` (0.11.0+ daemons), restoring exact message anchoring
      * for entries recovered without their `subagent_spawned` event.
      */
     parentToolUseId?: string;
@@ -512,7 +512,7 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       subagentId: params.subagentId,
       // Reconcile-driven creation supplies real identity; evidence-driven
       // stubs get a placeholder that the detail fetch backfills on
-      // 0.10.13+ daemons (see `loadDetail`).
+      // 0.11.0+ daemons (see `loadDetail`).
       label: params.label ?? "",
       objective: "",
       status: params.status ?? "running",

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -75,9 +75,9 @@ export interface SubagentEntry {
    * Conversation id passed to the detail fetch. History hydration and
    * reconcile-on-load supply the subagent's OWN conversation id; the live
    * `subagent_event` path stamps the PARENT's (the only id that event
-   * carries). The ambiguity is harmless on 0.11.0+ daemons — the detail
+   * carries). The ambiguity is harmless on 0.11.0+ daemons (the detail
    * route resolves the true conversation from manager state and treats
-   * this value as a fallback — and the stamping is version-gated so
+   * this value as a fallback), and the stamping is version-gated so
    * pre-0.11.0 daemons are never sent a parent id they'd trust verbatim.
    */
   conversationId?: string;

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
@@ -6,7 +6,7 @@
  * dies (the avatar row expands to nothing and the detail panel can't open).
  *
  * The backwards-compat gate decides whether the stub is armed for detail
- * backfill with the parent conversation id: only 0.10.13+ daemons resolve
+ * backfill with the parent conversation id: only 0.11.0+ daemons resolve
  * the subagent's own conversation themselves, so on older daemons the stub
  * must stay un-armed (a fetch with the parent id would parse the parent's
  * messages as the subagent's).
@@ -53,7 +53,7 @@ describe("handleSubagentEvent — unknown subagent id", () => {
     expect(entry?.events).toEqual([]);
   });
 
-  it("materializes an un-armed stub on a pre-0.10.13 daemon", () => {
+  it("materializes an un-armed stub on a pre-0.11.0 daemon", () => {
     selfLookupSupported = false;
 
     handleSubagentEvent(event, ctx);

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -72,7 +72,7 @@ export function handleSubagentEvent(
       ? event.conversationId
       : undefined,
   });
-  // Don't stamp the parent conversation id onto a stub on a pre-0.10.13
+  // Don't stamp the parent conversation id onto a stub on a pre-0.11.0
   // daemon: it would arm the detail auto-fetch with an id the old daemon
   // trusts verbatim, backfilling the PARENT conversation's messages as the
   // subagent's. Known entries keep the historical behavior.

--- a/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
@@ -93,7 +93,7 @@ let daemonSupportsVellumProvider = true;
 mock.module(
   "@/lib/backwards-compat/use-supports-image-gen-vellum-provider",
   () => ({
-    MIN_VERSION: "0.10.13",
+    MIN_VERSION: "0.11.0",
     supportsImageGenVellumProvider: () => daemonSupportsVellumProvider,
   }),
 );

--- a/clients/web/src/lib/backwards-compat/channel-access-controls.test.ts
+++ b/clients/web/src/lib/backwards-compat/channel-access-controls.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 
 // The surface requires the two-level channel contract — the runtime collapse
 // of stored `medium`/`high` cells, the room default for cell-less rooms, and
-// the sensitive-tool floor lift — which ships in 0.10.13. A 0.10.8–0.10.12
+// the sensitive-tool floor lift — which ships in 0.11.0. A 0.10.8–0.10.12
 // assistant serves the channel-permission-overrides routes but honors raw
 // thresholds, so the two-level picker would display "Conservative" for a
 // cell that backend treats as its stored value. `false` = render the
@@ -39,14 +39,14 @@ describe("useSupportsChannelAccessControls", () => {
     expect(result.current).toBe(false);
   });
 
-  test("true on 0.10.13+, the first release carrying the two-level contract", () => {
-    setVersion("0.10.13");
+  test("true on 0.11.0+, the first release carrying the two-level contract", () => {
+    setVersion("0.11.0");
     const { result } = renderHook(() => useSupportsChannelAccessControls());
     expect(result.current).toBe(true);
   });
 
-  test("true for RC builds of the cutover patch", () => {
-    setVersion("0.10.13-rc.1");
+  test("true for RC builds of the cutover release", () => {
+    setVersion("0.11.0-rc.1");
     const { result } = renderHook(() => useSupportsChannelAccessControls());
     expect(result.current).toBe(true);
   });

--- a/clients/web/src/lib/backwards-compat/channel-access-controls.test.ts
+++ b/clients/web/src/lib/backwards-compat/channel-access-controls.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 
 // The surface requires the two-level channel contract — the runtime collapse
 // of stored `medium`/`high` cells, the room default for cell-less rooms, and
-// the sensitive-tool floor lift — which ships in 0.11.0. A 0.10.8–0.10.12
+// the sensitive-tool floor lift, which ships in 0.11.0. A 0.10.8–0.10.12
 // assistant serves the channel-permission-overrides routes but honors raw
 // thresholds, so the two-level picker would display "Conservative" for a
 // cell that backend treats as its stored value. `false` = render the

--- a/clients/web/src/lib/backwards-compat/channel-access-controls.ts
+++ b/clients/web/src/lib/backwards-compat/channel-access-controls.ts
@@ -34,7 +34,7 @@
  */
 import { useAssistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.10.13";
+export const MIN_VERSION = "0.11.0";
 
 /** Render-path gate for the Channels tab's Assistant Access controls. */
 export function useSupportsChannelAccessControls(): boolean {

--- a/clients/web/src/lib/backwards-compat/subagent-recovery.ts
+++ b/clients/web/src/lib/backwards-compat/subagent-recovery.ts
@@ -1,7 +1,7 @@
 /**
  * Backwards-compat gate: subagent recovery for a missed `subagent_spawned`.
  *
- * From assistant 0.10.13 the daemon carries everything a client needs to
+ * From assistant 0.11.0 the daemon carries everything a client needs to
  * rebuild subagent store entries it never saw spawn:
  *
  * - `GET /subagents/:id` resolves the subagent's own conversation id from
@@ -29,7 +29,7 @@ import {
   useAssistantSupports,
 } from "@/lib/backwards-compat/utils";
 
-const MIN_VERSION = "0.10.13";
+const MIN_VERSION = "0.11.0";
 
 /**
  * Snapshot check (safe outside React — stream handlers, store actions):

--- a/clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts
@@ -13,12 +13,12 @@
  * legacy read bridge renders that config as Vellum again, so the choice
  * round-trips.
  *
- * MIN_VERSION targets 0.10.13 — the first release whose image-generation
+ * MIN_VERSION targets 0.11.0 — the first release whose image-generation
  * config enum includes `vellum` (#39109 merged after the 0.10.12 cut).
  */
 import { assistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.10.13";
+export const MIN_VERSION = "0.11.0";
 
 /**
  * Snapshot gate for the save path: whether the active assistant accepts

--- a/clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts
@@ -13,7 +13,7 @@
  * legacy read bridge renders that config as Vellum again, so the choice
  * round-trips.
  *
- * MIN_VERSION targets 0.11.0 — the first release whose image-generation
+ * MIN_VERSION targets 0.11.0: the first release whose image-generation
  * config enum includes `vellum` (#39109 merged after the 0.10.12 cut).
  */
 import { assistantSupports } from "./utils";


### PR DESCRIPTION
## TL;DR

Three web backwards-compat gates (and surrounding comments/tests) documented `0.10.13` as the first release carrying their features. The next release cuts as **0.11.0** — 0.10.13 will never exist. This retargets every 0.10.13 reference to 0.11.0 so gates document a real release. Should land before the 0.11.0 release branch is cut.

## Why this is safe

Gates compare `assistantVersion >= MIN_VERSION`, so a `0.10.13` pin would still have activated correctly on 0.11.0 — **runtime behavior is identical before and after this change**. This is a correctness-of-record fix: per `docs/BACKWARDS_COMPAT.md`, the `MIN_VERSION` + doc comment is what someone deleting the gate later reads to confirm the old path is dead, so it must name the actual first-carrying release.

- No 0.10.13 references remain anywhere in the repo (`grep -rn "0\.10\.13"` across all packages is clean).
- Historical references to real releases (0.10.12 and below) are untouched; ranges like "0.10.8–0.10.12" in prose were re-checked and still read correctly against 0.11.0.
- All four changed test files pass individually (`bun test <file>`); `bunx tsc --noEmit` is clean.

## What changes for the user

Nothing at runtime. For maintainers:

| Surface | Before | After |
| --- | --- | --- |
| `channel-access-controls.ts`, `subagent-recovery.ts`, `use-supports-image-gen-vellum-provider.ts` | `MIN_VERSION = "0.10.13"` — a release that will never ship | `MIN_VERSION = "0.11.0"` — the actual first release carrying each feature |
| Comments in `subagent-store.ts`, `subagent-handlers.ts`, `use-conversation-change-effects.ts` | Describe "0.10.13+" / "pre-0.10.13" daemons | Describe "0.11.0+" / "pre-0.11.0" daemons |
| Tests (channel-access-controls, subagent-handlers, reconcile, image-generation-card) | At-gate cases pin `0.10.13` / `0.10.13-rc.1` | At-gate cases pin `0.11.0` / `0.11.0-rc.1`; `0.10.12` stays the below-gate case |
| `docs/BACKWARDS_COMPAT.md` registry table | The three gates above were missing | Rows added at `0.11.0` |

## Deferred

The registry table in `docs/BACKWARDS_COMPAT.md` is missing ~12 other gates that exist in `src/lib/backwards-compat/` (e.g. `bulk-feed-status`, `events-tail`, `plugins-surface`, `remote-web-pairing-gate`, `use-supports-acp-connect`, `use-supports-bookmarks`, `use-supports-live-voice`, and more). Backfilling those accurately requires reading each gate's contract and wasn't needed for this fix, so it's deferred; this PR only adds rows for the three gates it touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->