### PR TITLE
fix(assistant): delete durable subagent rows with their parent, bound the reconcile snapshot, unify route helpers

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29497,12 +29497,14 @@ paths:
       operationId: subagents_reconcile_get
       summary: Reconcile subagent live status
       description:
-        Returns every subagent the assistant knows for a given parent conversation — live, rehydrated, and durably
-        recorded, including terminal runs whose in-memory metadata the retention sweep has already evicted. Each entry
-        carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to
-        rebuild its subagent list from scratch, not just refresh statuses. A subagent absent from the response is one
-        the assistant has no knowledge of at all, so a client may settle its own stuck-active entries against this
-        snapshot. Only `status` is guaranteed to be present; every other field is optional.
+        "Returns the subagents the assistant knows for a given parent conversation — live, rehydrated, and durably
+        recorded, including recently finished runs whose in-memory metadata the retention sweep has already evicted.
+        Durable records live as long as the conversation, so the recorded pass is bounded: every record not in a
+        terminal state is always returned, plus the 20 most recently finished ones. Each entry carries enough detail
+        (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list
+        from scratch, not just refresh statuses. A subagent absent from the response is one the assistant no longer
+        reports, so a client may settle its own stuck-active entries against this snapshot. Only `status` is guaranteed
+        to be present; every other field is optional."
       tags:
         - subagents
       parameters:

--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -48,11 +48,20 @@ mock.module("../subagent/index.js", () => ({
 /** Subagents that survive only in durable records, keyed by subagent id. */
 const durableRecords = new Map<
   string,
-  { conversationId: string; label: string; status: string }
+  {
+    conversationId: string;
+    label: string;
+    status: string;
+    parentToolUseId?: string | null;
+  }
 >();
 
+// The mock replaces the whole module for the process, so every export the
+// routes file imports from it has to be present — a missing one reads as
+// `undefined` and only fails when a route calls it.
 mock.module("../persistence/subagent-store.js", () => ({
   getSubagentRecordById: (id: string) => durableRecords.get(id),
+  getSubagentRecordsByParent: () => [],
 }));
 
 import type { MessageRow } from "../persistence/conversation-crud.js";
@@ -237,6 +246,7 @@ interface DetailResponse {
   status?: string;
   label?: string;
   conversationId?: string;
+  parentToolUseId?: string;
 }
 
 function fetchDetail(id: string, conversationId?: string): DetailResponse {
@@ -371,6 +381,68 @@ describe("getSubagentDetail route resolution", () => {
     expect(result.conversationId).toBe("odd-child-conv");
     expect(result.label).toBe("Odd label");
     expect(result.status).toBeUndefined();
+  });
+
+  test("carries the durable spawn anchor for an evicted subagent", () => {
+    // Without the record fallback the anchor is lost the moment the sweep (or a
+    // restart) drops the live state, and the client's card can never re-attach
+    // to the tool call that spawned it.
+    seedConversation("anchored-child-conv", "anchored transcript");
+    durableRecords.set("sub-anchored", {
+      conversationId: "anchored-child-conv",
+      label: "Anchored label",
+      status: "completed",
+      parentToolUseId: "toolu-anchor",
+    });
+
+    expect(fetchDetail("sub-anchored", "parent-conv").parentToolUseId).toBe(
+      "toolu-anchor",
+    );
+  });
+
+  test("omits the spawn anchor when the durable row has none", () => {
+    seedConversation("unanchored-child-conv", "unanchored transcript");
+    durableRecords.set("sub-unanchored", {
+      conversationId: "unanchored-child-conv",
+      label: "Unanchored label",
+      status: "completed",
+      parentToolUseId: null,
+    });
+
+    expect(
+      fetchDetail("sub-unanchored", "parent-conv").parentToolUseId,
+    ).toBeUndefined();
+  });
+
+  test("reports cost-only usage that a token-count check would drop", () => {
+    seedConversation("cost-only-conv", "cost only transcript");
+    usageByConversation.set("cost-only-conv", {
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0.002,
+    });
+    liveSubagents.set("sub-cost-only", {
+      conversationId: "cost-only-conv",
+      status: "completed",
+      config: { label: "Cost only" },
+    });
+
+    expect(fetchDetail("sub-cost-only").usage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0.002,
+    });
+  });
+
+  test("omits usage entirely for a child that has spent nothing", () => {
+    seedConversation("free-conv", "free transcript");
+    liveSubagents.set("sub-free", {
+      conversationId: "free-conv",
+      status: "completed",
+      config: { label: "Free" },
+    });
+
+    expect(fetchDetail("sub-free").usage).toBeUndefined();
   });
 
   test("uses the query param when the daemon knows nothing about the subagent", () => {

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -7,6 +7,7 @@ import { migrateAddSubagentParentToolUseId } from "../persistence/migrations/354
 import { resetTestTables } from "../persistence/raw-query.js";
 import {
   getSubagentRecordById,
+  loadAllSubagentRecords,
   type SubagentRecord,
   upsertSubagentRecord,
 } from "../persistence/subagent-store.js";
@@ -375,10 +376,13 @@ describe("durable record lifetime across disposal paths", () => {
     resetTestTables("subagents");
   });
 
-  function seedRecord(id: string): void {
+  function seedRecord(
+    id: string,
+    parentConversationId = "parent-sess-1",
+  ): void {
     const rec: SubagentRecord = {
       id,
-      parentConversationId: "parent-sess-1",
+      parentConversationId,
       conversationId: "conv-sub-1",
       label: "Test subagent",
       objective: "Do something",
@@ -442,6 +446,46 @@ describe("durable record lifetime across disposal paths", () => {
     expect(getSubagentRecordById("sub-parent-gone")).toBeUndefined();
 
     asInternals(manager).stopSweep();
+  });
+
+  test("disposeAllForParent deletes rows the sweep already evicted", () => {
+    const manager = new SubagentManager();
+    seedRecord("sub-swept-then-deleted");
+    seedRecord("sub-other-parent", "parent-sess-2");
+    injectFakeSubagent(
+      manager,
+      "sub-swept-then-deleted",
+      makeState("sub-swept-then-deleted", { status: "completed" }),
+      undefined,
+      null,
+    );
+    asInternals(manager).subagents.get(
+      "sub-swept-then-deleted",
+    )!.retainedUntil = Date.now() - 1000; // expired
+
+    // The sweep frees the in-memory entry, so `parentToChildren` no longer
+    // names this child — only a by-parent delete can still reach its row.
+    asInternals(manager).sweepTerminal();
+    expect(getSubagentRecordById("sub-swept-then-deleted")).toBeDefined();
+
+    manager.disposeAllForParent("parent-sess-1");
+
+    expect(getSubagentRecordById("sub-swept-then-deleted")).toBeUndefined();
+    // Another parent's rows are untouched.
+    expect(getSubagentRecordById("sub-other-parent")).toBeDefined();
+
+    asInternals(manager).stopSweep();
+  });
+
+  test("clear-all deletes rows for a parent with no live children", () => {
+    const manager = new SubagentManager();
+    seedRecord("sub-orphan-row", "parent-sess-3");
+
+    // No in-memory entry at all, so `parentToChildren` holds no key for this
+    // parent and iterating it would skip the row entirely.
+    manager.disposeAllForAllParents();
+
+    expect(loadAllSubagentRecords()).toHaveLength(0);
   });
 
   test("shutdown disposal keeps the row for rehydration", () => {

--- a/assistant/src/__tests__/subagent-reconcile-route.test.ts
+++ b/assistant/src/__tests__/subagent-reconcile-route.test.ts
@@ -252,6 +252,44 @@ describe("reconcileSubagents route", () => {
     expect(reconcile(PARENT_ID).subagents["sub-1"].status).toBe("running");
   });
 
+  test("bounds the durable pass to the most recent terminal runs", () => {
+    // Rows live as long as the conversation, so an old chat holds every
+    // subagent it ever spawned — the snapshot must not ship the lot.
+    for (let i = 0; i < 25; i++) {
+      upsertSubagentRecord(
+        record({
+          id: `sub-done-${i}`,
+          conversationId: `child-conv-done-${i}`,
+          label: `done-${i}`,
+          status: "completed",
+          completedAt: 10_000 + i,
+        }),
+      );
+    }
+    // An unsettled row is never dropped, however old: the client's stuck-active
+    // entry has to be settled no matter how much finished work came after it.
+    upsertSubagentRecord(
+      record({
+        id: "sub-stale-active",
+        conversationId: "child-conv-stale",
+        label: "stale-active",
+        status: "running",
+        createdAt: 1,
+        completedAt: null,
+      }),
+    );
+
+    const { subagents } = reconcile(PARENT_ID);
+
+    expect(subagents["sub-stale-active"].status).toBe("interrupted");
+    const terminalIds = Object.keys(subagents)
+      .filter((id) => id !== "sub-stale-active")
+      .sort();
+    expect(terminalIds).toEqual(
+      Array.from({ length: 20 }, (_, i) => `sub-done-${i + 5}`).sort(),
+    );
+  });
+
   test("omits a durable row whose status is out of enum", () => {
     upsertSubagentRecord(record({ status: "zombie" }));
 

--- a/assistant/src/persistence/migrations/311-create-subagents-table.ts
+++ b/assistant/src/persistence/migrations/311-create-subagents-table.ts
@@ -12,9 +12,11 @@ import { getSqlite } from "../db-connection.js";
  * from the child conversation's messages) and mark any that were still in
  * flight as `interrupted` rather than silently orphaning them.
  *
- * Rows are written on spawn and on every status transition, and deleted when
- * the manager disposes the subagent during normal operation (TTL sweep or
- * parent eviction) — never on shutdown, so in-flight rows survive the restart.
+ * Rows are written on spawn and on every status transition, and live as long as
+ * the parent conversation: only the disposal paths that mean the parent's data
+ * is going away (conversation deletion, clear-all) delete them. The retention
+ * sweep frees a terminal subagent's in-memory metadata while leaving its row,
+ * and shutdown keeps rows too, so in-flight runs survive the restart.
  *
  * Idempotent (`IF NOT EXISTS`). No backfill — pre-existing subagents predate
  * the table and were already only in-memory.

--- a/assistant/src/persistence/migrations/354-add-subagent-parent-tool-use-id.ts
+++ b/assistant/src/persistence/migrations/354-add-subagent-parent-tool-use-id.ts
@@ -11,9 +11,10 @@ const COLUMN_DEFINITION = "parent_tool_use_id TEXT";
  * spawned the subagent. `SubagentManager` carries it on `SubagentConfig` so
  * the `subagent_spawned` event and the reconcile/detail routes can anchor an
  * inline subagent card to the exact spawn tool call. Persisting it keeps that
- * anchor resolvable after `rehydrateFromDb()` rebuilds children from this
- * table, so a client reloading after an assistant restart still lands the card
- * on the right tool call.
+ * anchor resolvable once the live state is gone: `rehydrateFromDb()` restores
+ * it onto rebuilt children, and both routes read it straight off the row for a
+ * subagent the retention sweep has already evicted — so a client reloading
+ * after an assistant restart still lands the card on the right tool call.
  *
  * Nullable with no backfill: the id is only known at spawn time and rows
  * written before this column existed have no surviving record of it, so they

--- a/assistant/src/persistence/subagent-store.ts
+++ b/assistant/src/persistence/subagent-store.ts
@@ -161,22 +161,68 @@ export function getSubagentRecordById(id: string): SubagentRecord | undefined {
 }
 
 /**
- * Every subagent record spawned under `parentConversationId`. Durable rows
- * outlive the manager's in-memory metadata — the TTL sweep evicts terminal
- * entries with `keepRecord: true` — so this is the only way to enumerate a
- * parent's subagents that completed long enough ago to have been swept.
+ * Subagent records spawned under `parentConversationId`. Durable rows outlive
+ * the manager's in-memory metadata — the TTL sweep evicts terminal entries with
+ * `keepRecord: true` — so this is the only way to enumerate a parent's
+ * subagents that finished long enough ago to have been swept.
+ *
+ * Rows live as long as the parent conversation, so a long-lived chat
+ * accumulates them without limit and the result is bounded: every row whose
+ * status is NOT in `bound.terminalStatuses` is returned (an unsettled row
+ * matters at any age), plus the `bound.maxTerminal` most recently finished
+ * terminal rows. Recency is `completed_at` falling back to `created_at`, since
+ * a row settled at rehydration records no completion time.
+ *
+ * The terminal status set is supplied by the caller so this layer stays
+ * decoupled from the subagent domain's status enum.
  */
 export function getSubagentRecordsByParent(
   parentConversationId: string,
+  bound: { terminalStatuses: readonly string[]; maxTerminal: number },
 ): SubagentRecord[] {
+  const placeholders = bound.terminalStatuses.map(() => "?").join(", ");
   return rawAll<SubagentRow>(
     "subagent:getByParent",
-    `SELECT * FROM subagents WHERE parent_conversation_id = ?`,
+    `SELECT * FROM subagents
+       WHERE parent_conversation_id = ? AND status NOT IN (${placeholders})
+     UNION ALL
+     SELECT * FROM (
+       SELECT * FROM subagents
+         WHERE parent_conversation_id = ? AND status IN (${placeholders})
+         ORDER BY COALESCE(completed_at, created_at) DESC
+         LIMIT ?
+     )`,
     parentConversationId,
+    ...bound.terminalStatuses,
+    parentConversationId,
+    ...bound.terminalStatuses,
+    bound.maxTerminal,
   ).map(rowToRecord);
 }
 
 /** Delete a subagent record once the manager is fully done with it. */
 export function deleteSubagentRecord(id: string): void {
   rawRun("subagent:deleteRecord", `DELETE FROM subagents WHERE id = ?`, id);
+}
+
+/**
+ * Delete every subagent record spawned under `parentConversationId`. A row
+ * lives as long as its parent conversation, and the TTL sweep drops a child's
+ * in-memory entry while keeping the row — so deleting by id alone strands the
+ * swept children when the parent goes away. Served by
+ * `idx_subagents_parent_conversation_id`.
+ */
+export function deleteSubagentRecordsByParent(
+  parentConversationId: string,
+): void {
+  rawRun(
+    "subagent:deleteRecordsByParent",
+    `DELETE FROM subagents WHERE parent_conversation_id = ?`,
+    parentConversationId,
+  );
+}
+
+/** Delete every subagent record. For clear-all, when all chat data goes away. */
+export function deleteAllSubagentRecords(): void {
+  rawRun("subagent:deleteAllRecords", `DELETE FROM subagents`);
 }

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -21,6 +21,7 @@ import { getConversationUsageTotals } from "../../persistence/llm-usage-store.js
 import {
   getSubagentRecordById,
   getSubagentRecordsByParent,
+  type SubagentRecord,
 } from "../../persistence/subagent-store.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { TERMINAL_STATUSES } from "../../subagent/types.js";
@@ -169,6 +170,32 @@ export function parseSubagentMessages(
   return { subagentId, objective, events };
 }
 
+/**
+ * The usage worth putting on the wire, shared by the detail and reconcile
+ * routes. A child that has spent nothing reports no usage at all — an all-zero
+ * snapshot tells a client nothing its own tally doesn't already say. Cost with
+ * no counted tokens is still spend, so all three fields must be empty before
+ * the field is dropped.
+ */
+function reportableUsage(usage: {
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+}): z.infer<typeof SubagentUsageStatsSchema> | undefined {
+  if (
+    usage.inputTokens <= 0 &&
+    usage.outputTokens <= 0 &&
+    usage.estimatedCost <= 0
+  ) {
+    return undefined;
+  }
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    estimatedCost: usage.estimatedCost,
+  };
+}
+
 function getSubagentDetail(
   subagentId: string,
   conversationId: string,
@@ -183,8 +210,8 @@ function getSubagentDetail(
     { subagentId, eventCount: result.events.length },
     "getSubagentDetail: parsed events",
   );
-  const usage = getConversationUsageTotals(conversationId);
-  if (usage.inputTokens > 0 || usage.outputTokens > 0) {
+  const usage = reportableUsage(getConversationUsageTotals(conversationId));
+  if (usage) {
     result.usage = usage;
   }
   return result;
@@ -238,28 +265,29 @@ function settledDurableStatus(status: SubagentStatus): SubagentStatus {
 }
 
 /**
- * A child that has spent nothing reports no usage at all, matching the detail
- * route — an all-zero snapshot tells a client nothing its own tally doesn't
- * already say.
+ * The status to report for a durable row, or `undefined` when the caller should
+ * omit the field. `SubagentRecord.status` is an untyped column while both route
+ * contracts are the closed `SubagentStatusSchema` enum, so a value that doesn't
+ * parse is dropped rather than widening the wire type; anything that does parse
+ * is settled by `settledDurableStatus`.
+ *
+ * Only ever called for a row no live manager entry answers for.
  */
-function reconciledUsage(usage: {
-  inputTokens: number;
-  outputTokens: number;
-  estimatedCost: number;
-}): z.infer<typeof SubagentUsageStatsSchema> | undefined {
-  if (
-    usage.inputTokens <= 0 &&
-    usage.outputTokens <= 0 &&
-    usage.estimatedCost <= 0
-  ) {
-    return undefined;
-  }
-  return {
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    estimatedCost: usage.estimatedCost,
-  };
+function settledRecordStatus(
+  record: SubagentRecord,
+): SubagentStatus | undefined {
+  const parsed = SubagentStatusSchema.safeParse(record.status);
+  return parsed.success ? settledDurableStatus(parsed.data) : undefined;
 }
+
+/**
+ * Cap on the terminal durable rows the reconcile snapshot carries per parent.
+ * Rows live as long as the conversation, so an old chat holds every subagent it
+ * ever spawned; a client rebuilding its list needs the recent ones, not the
+ * full history. Rows that are not terminal are never capped — a client's
+ * stuck-active entry has to be settled at any age.
+ */
+const MAX_RECONCILED_TERMINAL_RECORDS = 20;
 
 export const ROUTES: RouteDefinition[] = [
   {
@@ -272,7 +300,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Reconcile subagent live status",
     description:
-      "Returns every subagent the assistant knows for a given parent conversation — live, rehydrated, and durably recorded, including terminal runs whose in-memory metadata the retention sweep has already evicted. Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list from scratch, not just refresh statuses. A subagent absent from the response is one the assistant has no knowledge of at all, so a client may settle its own stuck-active entries against this snapshot. Only `status` is guaranteed to be present; every other field is optional.",
+      "Returns the subagents the assistant knows for a given parent conversation — live, rehydrated, and durably recorded, including recently finished runs whose in-memory metadata the retention sweep has already evicted. Durable records live as long as the conversation, so the recorded pass is bounded: every record not in a terminal state is always returned, plus the 20 most recently finished ones. Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list from scratch, not just refresh statuses. A subagent absent from the response is one the assistant no longer reports, so a client may settle its own stuck-active entries against this snapshot. Only `status` is guaranteed to be present; every other field is optional.",
     tags: ["subagents"],
     queryParams: [
       {
@@ -301,24 +329,23 @@ export const ROUTES: RouteDefinition[] = [
       // deliberately keeping the row, so a run that completed more than a TTL
       // ago is absent from memory — and a client settling orphans by absence
       // would rewrite its `completed` entry to `interrupted`.
-      for (const record of getSubagentRecordsByParent(parentConversationId)) {
-        // `SubagentRecord.status` is an untyped column; the response contract
-        // is the closed enum, so drop what doesn't parse rather than widening
-        // the wire type.
-        const status = SubagentStatusSchema.safeParse(record.status);
-        if (!status.success) {
+      const records = getSubagentRecordsByParent(parentConversationId, {
+        terminalStatuses: [...TERMINAL_STATUSES],
+        maxTerminal: MAX_RECONCILED_TERMINAL_RECORDS,
+      });
+      for (const record of records) {
+        const status = settledRecordStatus(record);
+        if (!status) {
           continue;
         }
         subagents[record.id] = {
-          // Coerced here, before the live pass below overwrites any id the
-          // manager also holds — so only genuinely orphaned rows keep it.
-          status: settledDurableStatus(status.data),
+          status,
           conversationId: record.conversationId,
           label: record.label,
           objective: record.objective,
           isFork: record.isFork,
           parentToolUseId: record.parentToolUseId ?? undefined,
-          usage: reconciledUsage(record),
+          usage: reportableUsage(record),
           error: record.error ?? undefined,
         };
       }
@@ -331,7 +358,7 @@ export const ROUTES: RouteDefinition[] = [
           objective: child.config.objective,
           isFork: child.isFork,
           parentToolUseId: child.config.parentToolUseId,
-          usage: child.usage ? reconciledUsage(child.usage) : undefined,
+          usage: child.usage ? reportableUsage(child.usage) : undefined,
           error: child.error,
         };
       }
@@ -367,15 +394,9 @@ export const ROUTES: RouteDefinition[] = [
       const state = manager.getState(pathParams!.id);
       // Durable rows outlive manager state — the TTL sweep evicts in-memory
       // metadata but keeps the row, and after a restart the row answers until
-      // `rehydrateFromDb()` runs — so they supply the conversation, label and
-      // status once the live state is gone.
+      // `rehydrateFromDb()` runs — so they supply the conversation, label,
+      // status and spawn anchor once the live state is gone.
       const record = state ? undefined : getSubagentRecordById(pathParams!.id);
-      // `SubagentRecord.status` is an untyped column; the response contract is
-      // the closed `SubagentStatusSchema` enum. Drop anything that doesn't
-      // parse rather than widening the wire type.
-      const recordStatus = record
-        ? SubagentStatusSchema.safeParse(record.status)
-        : undefined;
 
       // Prefer the authoritative child-conversation id the daemon holds.
       // Clients recovering from a missed `subagent_spawned` only know the
@@ -392,15 +413,11 @@ export const ROUTES: RouteDefinition[] = [
       return {
         ...getSubagentDetail(pathParams!.id, conversationId),
         conversationId,
-        // `record` is only read when the manager has no state, so a
-        // record-derived status is by definition orphaned and gets settled.
         status:
-          state?.status ??
-          (recordStatus?.success
-            ? settledDurableStatus(recordStatus.data)
-            : undefined),
+          state?.status ?? (record ? settledRecordStatus(record) : undefined),
         label: state?.config.label ?? record?.label,
-        parentToolUseId: state?.config.parentToolUseId,
+        parentToolUseId:
+          state?.config.parentToolUseId ?? record?.parentToolUseId ?? undefined,
       };
     },
   },

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -21,7 +21,9 @@ import {
 } from "../daemon/conversation-registry.js";
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
 import {
+  deleteAllSubagentRecords,
   deleteSubagentRecord,
+  deleteSubagentRecordsByParent,
   loadAllSubagentRecords,
   upsertSubagentRecord,
 } from "../persistence/subagent-store.js";
@@ -1012,6 +1014,18 @@ export class SubagentManager {
     for (const parentId of [...this.parentToChildren.keys()]) {
       this.disposeAllForParent(parentId);
     }
+    // `parentToChildren` only names parents that still hold in-memory children,
+    // and the TTL sweep drops a child's entry while keeping its row — so a
+    // parent whose children were all swept has no key to iterate. Clearing the
+    // table is the only way to take every retained row with the data it
+    // belongs to.
+    if (!this.shuttingDown) {
+      try {
+        deleteAllSubagentRecords();
+      } catch (err) {
+        log.warn({ err }, "Failed to delete subagent records");
+      }
+    }
   }
 
   /**
@@ -1033,6 +1047,19 @@ export class SubagentManager {
       // Use snapshot since dispose mutates the set.
       for (const childId of [...children]) {
         this.dispose(childId);
+      }
+    }
+
+    // A child the TTL sweep already evicted has no in-memory entry left to
+    // dispose, so its row is only reachable by parent.
+    if (!this.shuttingDown) {
+      try {
+        deleteSubagentRecordsByParent(parentConversationId);
+      } catch (err) {
+        log.warn(
+          { parentConversationId, err },
+          "Failed to delete subagent records for parent",
+        );
       }
     }
 


### PR DESCRIPTION
Part of plan: subagent-running-state-fixes.md (self-review remediation)

Fixes the daemon-side gaps found reviewing the subagent run-state branch.

## Gap B — durable-row leak on parent deletion

Since the TTL sweep started calling `dispose(id, { keepRecord: true })`, a swept child's row survives while its `parentToChildren` entry does not. `disposeAllForParent()` iterates only that map and there is no FK cascade, so deleting the parent conversation orphaned those rows forever — `rehydrateFromDb()` reloads every row each boot and re-sweeps it with `keepRecord`, so the leak is permanent. A parent whose children were *all* swept has no map key at all, so clear-all skipped its rows entirely.

- `persistence/subagent-store.ts`: add `deleteSubagentRecordsByParent()` (served by `idx_subagents_parent_conversation_id`) and `deleteAllSubagentRecords()`.
- `subagent/manager.ts`: `disposeAllForParent()` ends with the by-parent delete and `disposeAllForAllParents()` clears the table, both guarded by `!this.shuttingDown` to match `dispose()`'s invariant, and both best-effort like the manager's other persistence calls.

## Gap G — detail route dropped the durable spawn anchor

The detail handler returned `parentToolUseId: state?.config.parentToolUseId` with no record fallback while the reconcile route had one, so after a restart or a sweep the web client's `loadDetail` anchor backfill could never fire. Now `state?.config.parentToolUseId ?? record?.parentToolUseId ?? undefined`, reusing the lookup the handler already performs.

## Gap H — unbounded reconcile snapshot

Rows now live as long as the conversation, so `getSubagentRecordsByParent` shipped a parent's entire subagent history on every conversation load. The durable pass is bounded in SQL: every row whose status is not terminal is always returned (a stuck-active client entry has to be settled at any age), plus the 20 most recently finished terminal rows, ordered by `COALESCE(completed_at, created_at) DESC`. Route description updated to describe the bound.

## Consolidations (slop audit)

1. The two routes disagreed on when to omit `usage` — detail checked token counts, reconcile checked all three fields. One `reportableUsage()` helper now serves both, on the reconcile rule, so cost-only spend surfaces on the detail route too.
2. `SubagentStatusSchema.safeParse(record.status)` → skip / `settledDurableStatus` was duplicated with near-verbatim comments; extracted as `settledRecordStatus()`, commented once.
3. Migration 311's doc claimed rows are deleted by the TTL sweep and parent eviction — false since `keepRecord`. Rewritten to name parent deletion only. Migration 354's doc now reflects that both routes read the anchor off the row.
4. `subagent-detail.test.ts` mocked `subagent-store.js` with only `getSubagentRecordById`, leaving the other export the routes file imports `undefined` under the process-global mock. Every imported export is mocked now.

## Tests

- `subagent-disposal`: sweep a terminal child (row retained) → `disposeAllForParent` deletes it and leaves another parent's rows alone; clear-all deletes rows for a parent with no live children.
- `subagent-reconcile-route`: 25 terminal rows + 1 stale active row → response carries the active row plus the 20 most recent terminal ones.
- `subagent-detail`: evicted-subagent detail carries the record's `parentToolUseId` (and omits it when the row has none); cost-only usage is reported, all-zero usage is omitted.

Validated per-file: `subagent-disposal` (17), `subagent-detail` (19), `subagent-reconcile-route` (13), `subagent-persistence` (7), `subagent-notify-parent` (19), `conversation-store-ephemeral`, `conversation-delete-schedule-cleanup` — all green. `bunx tsc --noEmit` clean, eslint + prettier clean, `openapi.yaml` regenerated (reconcile description only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)