### PR TITLE
fix(web): reconcile identity backfill, hydration anchors, bounded auto-fetch, shared detail predicate

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.test.tsx
@@ -22,6 +22,12 @@ mock.module("@/components/avatar-renderer", () => ({
   AvatarRenderer: () => <div data-testid="avatar" />,
 }));
 
+// Detail addressability is version-gated; pin it on so the open-fetch tests
+// below exercise the parent-only fallback a 0.10.13+ daemon supports.
+mock.module("@/lib/backwards-compat/subagent-detail-self-lookup", () => ({
+  supportsSubagentDetailSelfLookup: () => true,
+}));
+
 mock.module("@/domains/chat/components/subagent-status-badge", () => ({
   StatusBadge: ({ status }: { status: string }) => (
     <div data-testid="status-badge" data-status={status} />
@@ -208,6 +214,59 @@ describe("SubagentDetailPanel — timeline empty state", () => {
     );
     expect(screen.queryByText("No events yet")).toBeNull();
     expect(screen.getByTestId("timeline")).toBeDefined();
+  });
+});
+
+/**
+ * Opening the panel is what pays for a settled subagent's timeline: the
+ * conversation-load auto-fetch only covers live rows, so this is the single
+ * fetch trigger for everything reconcile materializes as terminal.
+ */
+describe("SubagentDetailPanel — detail fetch on open", () => {
+  function requestedIdsFor(entry: Partial<SubagentEntry>): string[] {
+    const requested: string[] = [];
+    render(
+      <SubagentDetailPanel
+        entry={makeEntry(entry)}
+        onClose={noop}
+        onRequestDetail={(id) => requested.push(id)}
+      />,
+    );
+    return requested;
+  }
+
+  test("fetches a settled row with an empty timeline", () => {
+    expect(
+      requestedIdsFor({ status: "completed", conversationId: "conv-child" }),
+    ).toEqual(["sub-1"]);
+  });
+
+  test("fetches a stub that knows only its parent conversation", () => {
+    // The child-semantic `conversationId` is deliberately unset on such a
+    // stub; gating the fetch on it left the panel permanently empty.
+    expect(
+      requestedIdsFor({ conversationId: undefined, parentConversationId: "conv-parent" }),
+    ).toEqual(["sub-1"]);
+  });
+
+  test("does not fetch for an entry no id can address", () => {
+    expect(requestedIdsFor({ conversationId: undefined })).toEqual([]);
+  });
+
+  test("does not fetch for an entry that already has a timeline", () => {
+    expect(
+      requestedIdsFor({
+        conversationId: "conv-child",
+        events: [
+          {
+            id: "te-1",
+            type: "text",
+            content: "hello",
+            timestamp: Date.now(),
+          },
+        ],
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -19,6 +19,7 @@ import {
     formatNumber,
 } from "@/domains/chat/components/metric-card";
 import { StatusBadge } from "@/domains/chat/components/subagent-status-badge";
+import { canAddressSubagentDetail } from "@/domains/chat/store-helpers/subagent-detail-addressability";
 import type { SubagentEntry } from "@/domains/chat/subagent-store";
 import { subagentTraits } from "@/utils/avatar-subagent";
 import { isActiveStatus } from "@/utils/subagent-status";
@@ -210,11 +211,18 @@ export function SubagentDetailPanel({
     setObjectiveOverflows(node.scrollHeight > node.clientHeight);
   }, [entry.subagentId, entry.objective, objectiveExpanded]);
 
+  // The panel is where a settled subagent's timeline is fetched: the
+  // conversation-load auto-fetch only covers live rows, so opening one of the
+  // many terminal rows reconcile materializes is what pays for its detail.
+  // Addressability goes through the shared predicate so a stub that knows only
+  // its parent conversation (0.10.13+ daemons resolve the child themselves)
+  // isn't skipped here while the auto-fetch happily fetches it.
+  const canFetchDetail = canAddressSubagentDetail(entry);
   useEffect(() => {
-    if (onRequestDetail && entry.conversationId && entry.events.length === 0) {
+    if (onRequestDetail && canFetchDetail && entry.events.length === 0) {
       onRequestDetail(entry.subagentId);
     }
-  }, [entry.subagentId, entry.conversationId, entry.events.length, onRequestDetail]);
+  }, [entry.subagentId, canFetchDetail, entry.events.length, onRequestDetail]);
 
   // The selected tool's nested payload, or `undefined` when nothing is selected
   // or the id has no payload (defensive — fall back to the timeline view).

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
@@ -163,6 +163,60 @@ describe("reconcileSubagentStoreFromNotifications", () => {
     expect(entry.parentConversationId).toBe(PARENT);
   });
 
+  test("anchors an entry reconcile recovered to its spawning message", () => {
+    // Reconcile materializes rows with no parent message id at all, so
+    // `byParent` has no bucket for them and the transcript can't place their
+    // inline card. The notification is the only source that names the message.
+    spawn("silent", "completed");
+    expect(useSubagentStore.getState().byParent.size).toBe(0);
+
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [
+        {
+          subagentId: "silent",
+          label: "silent",
+          status: "completed",
+          parentMessageId: "msg-1",
+        },
+      ],
+      PARENT,
+      NOW,
+    );
+
+    expect(store().byId["silent"]?.parentMessageId).toBe("msg-1");
+    expect(
+      useSubagentStore.getState().byParent.get("msg-1")?.map((e) => e.subagentId),
+    ).toEqual(["silent"]);
+  });
+
+  test("leaves an entry already anchored to its message alone", () => {
+    store().spawnSubagent({
+      subagentId: "anchored",
+      label: "anchored",
+      objective: "",
+      timestamp: NOW,
+      status: "running",
+      parentMessageId: "msg-original",
+    });
+
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [
+        {
+          subagentId: "anchored",
+          label: "anchored",
+          status: "running",
+          parentMessageId: "msg-other",
+        },
+      ],
+      PARENT,
+      NOW,
+    );
+
+    expect(store().byId["anchored"]?.parentMessageId).toBe("msg-original");
+  });
+
   test("stamps the parent id on a live entry via the merge path", () => {
     spawn("sub", "running");
     reconcileSubagentStoreFromNotifications(

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
@@ -1,13 +1,14 @@
 import { SubagentStatusSchema } from "@vellumai/assistant-api";
 
 import type { SubagentStore } from "@/domains/chat/subagent-store";
-import { isActiveStatus } from "@/utils/subagent-status";
+import { shouldApplyStatus } from "@/utils/subagent-status";
 
 type SubagentStoreSlice = Pick<
   SubagentStore,
   | "byId"
   | "spawnSubagent"
   | "changeStatus"
+  | "attachParentMessage"
   | "setConversationId"
   | "setParentConversationId"
 >;
@@ -56,17 +57,16 @@ export function reconcileSubagentStoreFromNotifications(
     if (existing) {
       // An unparseable status carries no information about an entry we
       // already hold — keep what SSE or reconcile told us rather than
-      // flipping it terminal. A settled entry likewise never regresses to an
-      // active status on the say-so of a historical notification: reconcile
-      // may have just settled a run whose mid-run "running" notification
-      // still sits in history, and an interrupted run emits no further
-      // terminal event to re-correct the regression.
-      const regressesTerminal =
-        parsed.success &&
-        !isActiveStatus(existing.status) &&
-        isActiveStatus(parsed.data);
-      if (parsed.success && !regressesTerminal) {
+      // flipping it terminal.
+      if (parsed.success && shouldApplyStatus(existing.status, parsed.data)) {
         store.changeStatus({ subagentId: n.subagentId, status: parsed.data });
+      }
+      // Entries reconcile materialized carry no parent message id, so nothing
+      // has indexed them in `byParent` and the transcript can't place their
+      // inline card. The notification is the only source that names the
+      // spawning message.
+      if (n.parentMessageId) {
+        store.attachParentMessage(n.subagentId, n.parentMessageId);
       }
       if (n.conversationId) {
         store.setConversationId(n.subagentId, n.conversationId);

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.test.tsx
@@ -19,6 +19,11 @@
  * 3. The auto-fetch reaches a stub recovered from a missed `subagent_spawned`
  *    that only knows its parent conversation. Such a stub defers live events
  *    until its backfill lands, so nothing else would ever un-stick it.
+ *
+ * 4. The auto-fetch is bounded to rows that can't wait: live ones, and stubs
+ *    deferring their events. Reconcile materializes every subagent the
+ *    conversation ever ran, and a GET per settled row would turn a busy chat's
+ *    load into a request burst; the detail panel fetches those on open.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -140,6 +145,60 @@ describe("useConversationChangeEffects — stub detail auto-fetch", () => {
         "sa-stub",
         "conv-A",
       ),
+    );
+  });
+
+  test("fetches a still-running row whose timeline is empty", async () => {
+    render(<Harness />);
+
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sa-live",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      conversationId: "conv-child",
+      timestamp: NOW,
+    });
+
+    await waitFor(() =>
+      expect(fetchSubagentDetail).toHaveBeenCalledWith(
+        "asst-1",
+        "sa-live",
+        "conv-child",
+      ),
+    );
+  });
+
+  test("does not fetch the settled rows reconcile materializes", async () => {
+    render(<Harness />);
+
+    // A busy chat's history: every one of these carries a child conversation
+    // id and an empty timeline, and none of them is on screen.
+    for (const subagentId of ["sa-1", "sa-2", "sa-3"]) {
+      useSubagentStore.getState().spawnSubagent({
+        subagentId,
+        label: "Agent",
+        objective: "",
+        status: "completed",
+        conversationId: `conv-child-${subagentId}`,
+        timestamp: NOW,
+      });
+    }
+    // A live sibling proves the effect ran at all rather than never firing.
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sa-live",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      conversationId: "conv-child-live",
+      timestamp: NOW,
+    });
+
+    await waitFor(() => expect(fetchSubagentDetail).toHaveBeenCalledTimes(1));
+    expect(fetchSubagentDetail).toHaveBeenCalledWith(
+      "asst-1",
+      "sa-live",
+      "conv-child-live",
     );
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
@@ -3,10 +3,9 @@
  *
  * - Reset subagent tracking state (needed for URL-navigation paths that
  *   bypass the `switchConversation` / `startNewConversation` wrappers)
- * - Auto-fetch detail for subagents reconstructed from conversation history
- *   (entries with a `conversationId` but no events yet) and for stubs
- *   recovered from a missed `subagent_spawned` that are awaiting their
- *   backfill (`hydrationPending`)
+ * - Auto-fetch detail for the subagents that can't wait for a click: the ones
+ *   still running, and the stubs deferring their live events until a backfill
+ *   lands
  *
  * Note: interaction store cleanup (`dismissQuestion`, `resetAll`) is NOT
  * handled here — `switchToConversation()` in `chat-session-store` already
@@ -20,20 +19,29 @@ import {
   useSubagentStore,
   type SubagentEntry,
 } from "@/domains/chat/subagent-store";
+import { canAddressSubagentDetail } from "@/domains/chat/store-helpers/subagent-detail-addressability";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { isActiveStatus } from "@/utils/subagent-status";
 
 /**
- * An entry whose timeline is still empty and that carries an id the daemon can
- * resolve. `hydrationPending` covers the stub armed with only a parent
- * conversation id: `fetchDetailIfNeeded` can address it (0.10.13+ daemons
- * self-resolve the subagent's conversation) even though the child-semantic
- * `conversationId` is deliberately unset. Without it such a stub would defer
- * live events forever waiting on a fetch nothing triggers.
+ * An entry with an empty timeline that the daemon can be asked about, and
+ * that can't afford to wait for the user to open its panel:
+ *
+ * - **Active** — its card is on screen showing live progress, so the timeline
+ *   has to be there before the next event extends it.
+ * - **`hydrationPending`** — it is dropping live events until the backfill
+ *   lands, so nothing else would ever un-stick it.
+ *
+ * A settled entry is deliberately excluded. Reconcile materializes every
+ * subagent the conversation ever ran, and a GET per terminal row turns a busy
+ * chat's load into a request burst for timelines nobody has asked to see; the
+ * detail panel fetches those on open (`onRequestDetail`).
  */
 function needsDetailFetch(entry: SubagentEntry): boolean {
   return (
     entry.events.length === 0 &&
-    Boolean(entry.conversationId || entry.hydrationPending)
+    canAddressSubagentDetail(entry) &&
+    (isActiveStatus(entry.status) || Boolean(entry.hydrationPending))
   );
 }
 

--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
@@ -3,8 +3,20 @@
  * this conversation's subagents. Mocks the generated `subagentsReconcileGet`
  * so each trigger is a countable round-trip; the reconcile's effect on the
  * store is covered by `subagent-store.test.ts`.
+ *
+ * The store throttles per parent conversation, so a trigger that fires inside
+ * the previous one's window is a deliberate no-op. Tests that want a second
+ * round-trip step the clock past it.
  */
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import { __resetForTesting, publish } from "@/lib/event-bus";
@@ -48,14 +60,21 @@ function mount(
   );
 }
 
+/** Step past the store's per-parent reconcile window. */
+function advancePastReconcileWindow() {
+  setSystemTime(new Date(Date.now() + 10_000));
+}
+
 beforeEach(() => {
   getCalls = 0;
+  setSystemTime();
   __resetForTesting();
   useSubagentStore.getState().reset();
 });
 
 afterEach(() => {
   cleanup();
+  setSystemTime();
 });
 
 describe("useSubagentReconcile", () => {
@@ -80,8 +99,26 @@ describe("useSubagentReconcile", () => {
   test("reconciles again when the SSE stream reopens on resume", async () => {
     mount();
     await waitFor(() => expect(getCalls).toBe(1));
+    advancePastReconcileWindow();
 
     publish("sse.opened", { assistantId: ASSISTANT, cause: "resume" });
+
+    await waitFor(() => expect(getCalls).toBe(2));
+  });
+
+  test("a reconnect flap costs one round-trip per window, not one per reopen", async () => {
+    // A stream that drops and re-opens repeatedly used to bypass the kick
+    // throttle entirely: it lives on the store's triggers, not the kick path.
+    mount();
+    await waitFor(() => expect(getCalls).toBe(1));
+
+    for (const cause of ["error", "watchdog", "resume"] as const) {
+      publish("sse.opened", { assistantId: ASSISTANT, cause });
+    }
+    await waitFor(() => expect(getCalls).toBe(1));
+
+    advancePastReconcileWindow();
+    publish("sse.opened", { assistantId: ASSISTANT, cause: "error" });
 
     await waitFor(() => expect(getCalls).toBe(2));
   });

--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.ts
@@ -19,10 +19,12 @@
  *   ring replay.
  *
  * Drafts are excluded — a conversation the server has never seen has no
- * subagents to reconcile against.
+ * subagents to reconcile against. Both triggers fire freely: the store
+ * throttles per parent conversation, so a flapping stream costs one round-trip
+ * per window rather than one per reopen.
  */
 
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
@@ -42,7 +44,7 @@ export function useSubagentReconcile(
   conversationId: string | null,
   conversationExistsOnServer: boolean,
 ): void {
-  useEffect(() => {
+  const resync = useCallback(() => {
     if (!assistantId || !conversationId || !conversationExistsOnServer) {
       return;
     }
@@ -51,18 +53,14 @@ export function useSubagentReconcile(
       .reconcileFromDaemon(assistantId, conversationId);
   }, [assistantId, conversationId, conversationExistsOnServer]);
 
+  useEffect(() => {
+    resync();
+  }, [resync]);
+
   useBusSubscription("sse.opened", ({ assistantId: openedFor, cause }) => {
-    if (!RESYNC_CAUSES.has(cause)) {
+    if (!RESYNC_CAUSES.has(cause) || openedFor !== assistantId) {
       return;
     }
-    if (!assistantId || !conversationId || !conversationExistsOnServer) {
-      return;
-    }
-    if (openedFor !== assistantId) {
-      return;
-    }
-    void useSubagentStore
-      .getState()
-      .reconcileFromDaemon(assistantId, conversationId);
+    resync();
   });
 }

--- a/clients/web/src/domains/chat/store-helpers/subagent-detail-addressability.ts
+++ b/clients/web/src/domains/chat/store-helpers/subagent-detail-addressability.ts
@@ -1,0 +1,47 @@
+/**
+ * Can a subagent entry address its own detail fetch?
+ *
+ * One rule, one spelling — shared by every caller that has to answer it: the
+ * store (arming a stub for backfill, resolving the fetch), the conversation
+ * auto-fetch, and the detail panel's open-fetch. They previously each spelled
+ * their own variant, which is how a stub armed with only a parent conversation
+ * id ended up fetchable by one and invisible to another.
+ */
+
+import { supportsSubagentDetailSelfLookup } from "@/lib/backwards-compat/subagent-detail-self-lookup";
+
+/** The two id fields a detail fetch can be addressed with. */
+export interface SubagentDetailAddress {
+  /** The subagent's own conversation id. */
+  conversationId?: string;
+  /** The conversation whose turn spawned it. */
+  parentConversationId?: string;
+}
+
+/**
+ * The conversation id a detail fetch for `entry` must query, or `undefined`
+ * when nothing at hand can address it.
+ *
+ * The child id works on every daemon. A stub recovered without its
+ * `subagent_spawned` may only know the parent conversation: 0.10.13+ daemons
+ * resolve the subagent's own conversation and treat this parameter as a
+ * fallback, so the parent id is a harmless wire placeholder there. An older
+ * daemon would trust it verbatim and parse the parent's messages as the
+ * subagent's, so below that version a parent-only entry is unaddressable.
+ */
+export function resolveSubagentDetailConversationId(
+  entry: SubagentDetailAddress,
+): string | undefined {
+  if (entry.conversationId) {
+    return entry.conversationId;
+  }
+  if (entry.parentConversationId && supportsSubagentDetailSelfLookup()) {
+    return entry.parentConversationId;
+  }
+  return undefined;
+}
+
+/** Whether a detail fetch for `entry` can be addressed at all. */
+export function canAddressSubagentDetail(entry: SubagentDetailAddress): boolean {
+  return resolveSubagentDetailConversationId(entry) !== undefined;
+}

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock, setSystemTime } from "bun:test";
 import type { SubagentInnerEvent } from "@vellumai/assistant-api";
 
 let selfLookupSupported = true;
@@ -57,6 +57,7 @@ const { useSubagentStore } = await import("@/domains/chat/subagent-store");
 const { reconcileSubagentStoreFromNotifications } = await import(
   "@/domains/chat/hooks/reconcile-subagent-hydration"
 );
+const { useConversationStore } = await import("@/stores/conversation-store");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -68,8 +69,18 @@ function getState() {
 
 const NOW = 1700000000000;
 
+/**
+ * Step the clock past a parent's reconcile window so the next call is a real
+ * round-trip rather than a throttled no-op.
+ */
+function advancePastReconcileWindow() {
+  setSystemTime(new Date(Date.now() + 10_000));
+}
+
 beforeEach(() => {
+  setSystemTime();
   getState().reset();
+  useConversationStore.getState().setActiveConversationId(null);
   selfLookupSupported = true;
   reconcileSupported = true;
   fetchSubagentDetail.mockClear();
@@ -2050,8 +2061,34 @@ describe("reconcileFromDaemon", () => {
     expect(subagentsReconcileGet).toHaveBeenCalledTimes(1);
   });
 
-  it("re-requests once the previous call has settled", async () => {
+  it("re-requests once the previous call has settled and the window reopens", async () => {
     await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    advancePastReconcileWindow();
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(subagentsReconcileGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("throttles a settled trigger that re-fires inside the window", async () => {
+    // An SSE flap: the reopen trigger fires again moments after the mount
+    // pass finished, so single-flight has already let go.
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(subagentsReconcileGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("throttles each parent conversation on its own window", async () => {
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    await getState().reconcileFromDaemon("assistant-1", "conv-other");
+
+    expect(reconcileRequests).toHaveLength(2);
+  });
+
+  it("reopens the window on reset so the next conversation reconciles at once", async () => {
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    getState().reset();
     await getState().reconcileFromDaemon("assistant-1", "conv-parent");
 
     expect(subagentsReconcileGet).toHaveBeenCalledTimes(2);
@@ -2313,5 +2350,294 @@ describe("reconcileFromDaemon", () => {
 
     expect(subagentsReconcileGet).toHaveBeenCalledTimes(2);
     expect(getState().byId["sa-1"]?.label).toBe("Agent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcileFromDaemon — identity backfill onto placeholder rows
+// ---------------------------------------------------------------------------
+
+describe("reconcileFromDaemon identity backfill", () => {
+  it("fills a blank stub's label, objective and spawn anchor", async () => {
+    // The stub a `subagent_status_changed` for an unknown id leaves behind:
+    // "known" to the store, but with nothing to render.
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      status: "running",
+      parentConversationId: "conv-parent",
+    });
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": {
+          status: "running",
+          label: "Audit defenses",
+          objective: "Find the hole",
+          parentToolUseId: "toolu_1",
+        },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.label).toBe("Audit defenses");
+    expect(entry?.objective).toBe("Find the hole");
+    expect(entry?.parentToolUseId).toBe("toolu_1");
+    expect(getState().byToolUseId.get("toolu_1")).toBe("sa-1");
+  });
+
+  it("never overwrites identity the spawn event already established", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "spawn label",
+      objective: "spawn objective",
+      timestamp: NOW,
+      parentToolUseId: "toolu_spawn",
+    });
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": {
+          status: "running",
+          label: "snapshot label",
+          objective: "snapshot objective",
+          parentToolUseId: "toolu_snapshot",
+        },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.label).toBe("spawn label");
+    expect(entry?.objective).toBe("spawn objective");
+    expect(entry?.parentToolUseId).toBe("toolu_spawn");
+    expect(getState().byToolUseId.get("toolu_snapshot")).toBeUndefined();
+  });
+
+  it("leaves the placeholders alone when the snapshot carries no identity", async () => {
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      status: "running",
+      parentConversationId: "conv-parent",
+    });
+    const byToolUseIdBefore = getState().byToolUseId;
+    reconcileReply = { ok: true, subagents: { "sa-1": { status: "running" } } };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    const entry = getState().byId["sa-1"];
+    expect(entry?.label).toBe("");
+    expect(entry?.objective).toBe("");
+    expect(entry?.parentToolUseId).toBeUndefined();
+    expect(getState().byToolUseId).toBe(byToolUseIdBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcileFromDaemon — arming materialized rows against the live stream
+// ---------------------------------------------------------------------------
+
+describe("reconcileFromDaemon hydration arming", () => {
+  const textEvent: SubagentInnerEvent = {
+    type: "assistant_text_delta",
+    text: "live suffix",
+  };
+
+  it("arms a still-running row so its detail replaces the live suffix", async () => {
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": {
+          status: "running",
+          label: "Audit defenses",
+          conversationId: "conv-child",
+        },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    expect(getState().byId["sa-1"]?.hydrationPending).toBe(true);
+
+    // An event that lands while the detail fetch is out. Appending it would
+    // make `loadDetail` keep the one-event suffix over the full history.
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: textEvent,
+      timestamp: NOW + 1,
+    });
+    expect(getState().byId["sa-1"]?.events).toEqual([]);
+
+    getState().loadDetail({
+      subagentId: "sa-1",
+      events: [
+        { id: "e1", type: "text", content: "full", timestamp: NOW },
+        { id: "e2", type: "text", content: "history", timestamp: NOW + 1 },
+      ],
+    });
+
+    expect(getState().byId["sa-1"]?.events).toHaveLength(2);
+    expect(getState().byId["sa-1"]?.hydrationPending).toBe(false);
+  });
+
+  it("leaves a settled row un-armed — nothing races it and nothing fetches it", async () => {
+    reconcileReply = {
+      ok: true,
+      subagents: {
+        "sa-1": {
+          status: "completed",
+          label: "Audit defenses",
+          conversationId: "conv-child",
+        },
+      },
+    };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-1"]?.hydrationPending).toBeUndefined();
+  });
+
+  it("leaves an unaddressable row un-armed on a pre-0.10.13 daemon", async () => {
+    selfLookupSupported = false;
+    reconcileReply = { ok: true, subagents: { "sa-1": { status: "running" } } };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-1"]?.hydrationPending).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureEntry — parent scoping falls back to the conversation on screen
+// ---------------------------------------------------------------------------
+
+describe("ensureEntry parent scoping", () => {
+  it("scopes an id-less stub to the active conversation", () => {
+    useConversationStore.getState().setActiveConversationId("conv-active");
+
+    getState().ensureEntry({ subagentId: "sa-1", timestamp: NOW });
+
+    expect(getState().byId["sa-1"]?.parentConversationId).toBe("conv-active");
+  });
+
+  it("prefers the parent id the evidence carried", () => {
+    useConversationStore.getState().setActiveConversationId("conv-active");
+
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      parentConversationId: "conv-background",
+    });
+
+    expect(getState().byId["sa-1"]?.parentConversationId).toBe(
+      "conv-background",
+    );
+  });
+
+  it("lets reconcile's orphan pass settle a stub it scoped", async () => {
+    // Without the fallback the stub belongs to no conversation: the overlay
+    // shows it in all of them and the per-parent orphan pass settles it in
+    // none.
+    useConversationStore.getState().setActiveConversationId("conv-parent");
+    getState().ensureEntry({
+      subagentId: "sa-1",
+      timestamp: NOW,
+      status: "running",
+    });
+    reconcileReply = { ok: true, subagents: {} };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-1"]?.status).toBe("interrupted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachParentMessage
+// ---------------------------------------------------------------------------
+
+describe("attachParentMessage", () => {
+  it("anchors an unanchored entry and indexes it under the message", () => {
+    // Everything reconcile recovers arrives with no parent message id, so
+    // `byParent` has no bucket for it and the transcript can't place its card.
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      timestamp: NOW,
+    });
+    expect(getState().byParent.size).toBe(0);
+
+    getState().attachParentMessage("sa-1", "msg-1");
+
+    expect(getState().byId["sa-1"]?.parentMessageId).toBe("msg-1");
+    expect(getState().byParent.get("msg-1")).toEqual([
+      getState().byId["sa-1"]!,
+    ]);
+  });
+
+  it("keeps the stable-id bucket pointing at the updated entry", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      timestamp: NOW,
+      parentMessageStableId: "stable-1",
+    });
+
+    getState().attachParentMessage("sa-1", "msg-1");
+
+    const entry = getState().byId["sa-1"]!;
+    expect(getState().byParent.get("stable-1")).toEqual([entry]);
+    expect(getState().byParent.get("msg-1")).toEqual([entry]);
+  });
+
+  it("sorts a message bucket by spawn time", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-late",
+      label: "Late",
+      objective: "",
+      timestamp: NOW + 10,
+      parentMessageId: "msg-1",
+    });
+    getState().spawnSubagent({
+      subagentId: "sa-early",
+      label: "Early",
+      objective: "",
+      timestamp: NOW,
+    });
+
+    getState().attachParentMessage("sa-early", "msg-1");
+
+    expect(
+      getState().byParent.get("msg-1")?.map((e) => e.subagentId),
+    ).toEqual(["sa-early", "sa-late"]);
+  });
+
+  it("is a no-op for an entry already anchored to a message", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      timestamp: NOW,
+      parentMessageId: "msg-original",
+    });
+    const byParentBefore = getState().byParent;
+
+    getState().attachParentMessage("sa-1", "msg-other");
+
+    expect(getState().byId["sa-1"]?.parentMessageId).toBe("msg-original");
+    expect(getState().byParent).toBe(byParentBefore);
+  });
+
+  it("is a no-op for an unknown subagent", () => {
+    const byIdBefore = getState().byId;
+
+    getState().attachParentMessage("sa-missing", "msg-1");
+
+    expect(getState().byId).toBe(byIdBefore);
   });
 });

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -28,12 +28,15 @@ import {
   type SubagentInnerEvent,
 } from "@vellumai/assistant-api";
 import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
-import { isActiveStatus } from "@/utils/subagent-status";
-import { supportsSubagentDetailSelfLookup } from "@/lib/backwards-compat/subagent-detail-self-lookup";
+import { isActiveStatus, shouldApplyStatus } from "@/utils/subagent-status";
 import { supportsSubagentsReconcile } from "@/lib/backwards-compat/subagents-reconcile";
 import { fetchSubagentDetail } from "./fetch-subagent-detail";
 import { mapDetailEvents } from "./map-detail-events";
 import { setToolUseAnchor } from "./store-helpers/by-tool-use-id-index";
+import {
+  canAddressSubagentDetail,
+  resolveSubagentDetailConversationId,
+} from "./store-helpers/subagent-detail-addressability";
 
 // ---------------------------------------------------------------------------
 // State
@@ -181,6 +184,16 @@ export interface SubagentActions {
     parentMessageStableId?: string;
     parentMessageId?: string;
     parentToolUseId?: string;
+    /**
+     * Final tallies for a run materialized after the fact — a reconcile
+     * snapshot carries them alongside the identity. A live spawn omits them
+     * and starts at zero. Supplied on a terminal spawn they also mark the
+     * entry in `terminalUsageIds`, so a late `usage_progress` can't stack on
+     * top of totals that already include it.
+     */
+    inputTokens?: number;
+    outputTokens?: number;
+    totalCost?: number;
   }) => void;
 
   changeStatus: (params: {
@@ -193,19 +206,25 @@ export interface SubagentActions {
   }) => void;
 
   /**
-   * Create a stub entry for a subagent known only from mid-run evidence —
-   * a `subagent_event` or `subagent_status_changed` whose id has no entry
-   * because the `subagent_spawned` event was missed (SSE gap, page reload)
-   * or the store was reset after it arrived. No-op when the entry exists.
+   * Materialize an entry for a subagent this client learned about out of
+   * band — a `subagent_event` / `subagent_status_changed` whose id has no
+   * entry because the `subagent_spawned` was missed (SSE gap, page reload)
+   * or the store was reset after it arrived, or a row from the daemon's
+   * reconcile snapshot. No-op when the entry exists.
    *
-   * The stub is marked `hydrationPending` and left with zero events —
-   * making the detail auto-fetch (`fetchDetailIfNeeded`) backfill the
-   * authoritative label/objective/status/timeline — whenever the ids at hand
-   * can address the subagent's own conversation: either `conversationId`
-   * (the child id, good on every daemon) or, on a daemon that resolves the
-   * subagent's conversation itself, `parentConversationId` as a wire
-   * placeholder. Otherwise the stub renders from whatever streams in — a
-   * generic but functional card.
+   * Whatever identity the evidence carries is applied; the rest falls back to
+   * placeholders (`label: ""`) that the detail fetch or a later, richer
+   * snapshot can backfill. `parentConversationId` falls back to the
+   * conversation on screen — the same guess `requestSubagentReconcile` makes —
+   * because an entry with no parent id is shown by the Active-Subagents
+   * overlay in *every* conversation and is settled by reconcile's orphan pass
+   * in none of them.
+   *
+   * An entry that is still ACTIVE and can address a detail fetch is marked
+   * `hydrationPending`, so the live events that race the backfill are deferred
+   * rather than appended (see the field's doc on `SubagentEntry`). Terminal
+   * rows can't race anything and are deliberately left un-armed: they'd
+   * otherwise drag the whole snapshot through the auto-fetch on every load.
    */
   ensureEntry: (params: {
     subagentId: string;
@@ -213,6 +232,14 @@ export interface SubagentActions {
     conversationId?: string;
     parentConversationId?: string;
     status?: SubagentStatus;
+    label?: string;
+    objective?: string;
+    isFork?: boolean;
+    error?: string;
+    parentToolUseId?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    totalCost?: number;
   }) => void;
 
   receiveEvent: (params: {
@@ -244,6 +271,33 @@ export interface SubagentActions {
      */
     conversationId?: string;
   }) => void;
+
+  /**
+   * Fill in identity a placeholder entry never had — the label, objective and
+   * spawn anchor missing from a stub, or from a row a pre-enrichment daemon
+   * could only report a status for. Placeholder yields, real value wins: a
+   * value the entry already holds is never overwritten, because it came from
+   * the same source of truth (`subagent_spawned`) at first hand. A backfilled
+   * `parentToolUseId` is registered in `byToolUseId` so the transcript can
+   * anchor the inline card to its exact spawn tool call.
+   */
+  backfillIdentity: (params: {
+    subagentId: string;
+    label?: string;
+    objective?: string;
+    parentToolUseId?: string;
+  }) => void;
+
+  /**
+   * Anchor an entry to the assistant message that spawned it and index it
+   * under that id in `byParent`, so the transcript can find it. For entries
+   * materialized without any parent message id — everything reconcile
+   * recovers — history hydration is the first evidence source that names the
+   * spawning message. No-op when the entry is unknown or already anchored;
+   * re-anchoring an optimistic id to its reconciled server id is
+   * `reanchorToMessage`'s job.
+   */
+  attachParentMessage: (subagentId: string, parentMessageId: string) => void;
 
   /**
    * Stamp the subagent's own conversation id, used to fetch detail. No-ops
@@ -297,15 +351,18 @@ export interface SubagentActions {
    * and no terminal event is ever coming.
    *
    * 0.10.13+ daemons return full identity per child (label, objective, child
-   * conversation id, spawn anchor) so unknown ids materialize as complete
-   * rows; older ones return only `status`, which recovers stub-level rows the
-   * detail auto-fetch can still flesh out. Timeline backfill stays with that
-   * auto-fetch — this never touches `events` or `hydrationPending`.
+   * conversation id, spawn anchor) so unknown ids materialize as complete rows
+   * and known placeholder rows are backfilled; older ones return only
+   * `status`, which recovers stub-level rows the detail fetch can still flesh
+   * out. Timeline backfill stays with that fetch — this never touches
+   * `events`.
    *
-   * Concurrent calls for the same parent conversation share one request. A
-   * `reset()` while one is in flight invalidates it — the snapshot describes
-   * the conversation the user just left, so it is dropped rather than merged
-   * into the store that now belongs to a different chat.
+   * Concurrent calls for the same parent conversation share one request, and
+   * every trigger — mount, SSE reopen, unknown-id kick — shares one throttle
+   * window per parent, so an SSE flap loop costs a single round-trip. A
+   * `reset()` while a request is in flight invalidates it (the snapshot
+   * describes the conversation the user just left) and reopens the window for
+   * the conversation now on screen.
    */
   reconcileFromDaemon: (
     assistantId: string,
@@ -415,6 +472,23 @@ function reindexByParentForReanchor(
   return next;
 }
 
+/**
+ * Next `byId` with a single field patched on one entry, or `null` when
+ * nothing would change — the entry is unknown, or already holds that value.
+ * Returning `null` lets the caller skip the `set()` entirely so a per-event
+ * write path doesn't churn store identity.
+ */
+function patchedEntryField<K extends keyof SubagentEntry>(
+  byId: Record<string, SubagentEntry>,
+  subagentId: string,
+  key: K,
+  value: SubagentEntry[K],
+): Record<string, SubagentEntry> | null {
+  const existing = byId[subagentId];
+  if (!existing || existing[key] === value) return null;
+  return { ...byId, [subagentId]: { ...existing, [key]: value } };
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -499,27 +573,54 @@ const reconcileInFlight = new Map<string, Promise<void>>();
  */
 let resetGeneration = 0;
 
-/** Minimum spacing between `requestSubagentReconcile` kicks for one parent. */
+/** Minimum spacing between reconcile round-trips for one parent. */
 const RECONCILE_KICK_INTERVAL_MS = 5_000;
 
 /**
- * Last kick time keyed by parent conversation id, mirroring
+ * Last reconcile time keyed by parent conversation id, mirroring
  * `reconcileInFlight`. Subagent events are routed globally, so a background
- * conversation's kick must not consume the window the conversation on screen
- * needs — a single shared throttle lets either starve the other.
+ * conversation's reconcile must not consume the window the conversation on
+ * screen needs — a single shared throttle lets either starve the other.
  */
 const lastReconcileKickAt = new Map<string, number>();
+
+/**
+ * Take `parentConversationId`'s reconcile slot for this window, reporting
+ * whether it was free. Claiming and testing are one step so two triggers
+ * firing in the same tick can't both pass.
+ */
+function claimReconcileWindow(parentConversationId: string): boolean {
+  const now = Date.now();
+  const lastKickAt = lastReconcileKickAt.get(parentConversationId) ?? 0;
+  if (now - lastKickAt < RECONCILE_KICK_INTERVAL_MS) {
+    return false;
+  }
+  lastReconcileKickAt.set(parentConversationId, now);
+  return true;
+}
 
 /** One child row from the reconcile snapshot; only `status` is guaranteed. */
 type ReconciledSubagent = SubagentsReconcileGetResponse["subagents"][string];
 
+/** The store surface one reconciled row is applied through. */
+type ReconcileApplySlice = Pick<
+  SubagentStore,
+  | "byId"
+  | "ensureEntry"
+  | "changeStatus"
+  | "backfillIdentity"
+  | "setConversationId"
+  | "setParentConversationId"
+>;
+
 /**
  * Apply one child row from the reconcile snapshot. A known entry is refreshed
- * in place; an unknown one is materialized as a full row when the daemon
- * supplied its identity, and as a stub otherwise.
+ * in place — including the identity a placeholder row is still missing, since
+ * a stub created from a bare status event is "known" but blank; an unknown one
+ * is materialized from whatever the daemon supplied.
  */
 function applyReconciledSubagent(
-  store: SubagentStore,
+  store: ReconcileApplySlice,
   subagentId: string,
   info: ReconciledSubagent,
   status: SubagentStatus,
@@ -527,15 +628,12 @@ function applyReconciledSubagent(
 ): void {
   const existing = store.byId[subagentId];
   if (existing) {
-    // The snapshot is a round-trip old, so it can still say `running` for a
-    // subagent whose terminal event has since landed over SSE. Settled entries
-    // only ever move between terminal states.
-    if (isActiveStatus(existing.status) || !isActiveStatus(status)) {
+    if (shouldApplyStatus(existing.status, status)) {
       // Usage and error ride along so an entry whose terminal
       // `subagent_status_changed` was lost still recovers its final totals and
-      // failure reason — the detail auto-fetch won't, since it refuses any
-      // entry that already has events. `changeStatus` preserves what it
-      // already holds when the snapshot omits these.
+      // failure reason — the detail fetch won't, since it refuses any entry
+      // that already has events. `changeStatus` preserves what it already
+      // holds when the snapshot omits these.
       store.changeStatus({
         subagentId,
         status,
@@ -545,6 +643,12 @@ function applyReconciledSubagent(
         totalCost: info.usage?.estimatedCost,
       });
     }
+    store.backfillIdentity({
+      subagentId,
+      label: info.label,
+      objective: info.objective,
+      parentToolUseId: info.parentToolUseId,
+    });
     if (info.conversationId) {
       store.setConversationId(subagentId, info.conversationId);
     }
@@ -552,42 +656,22 @@ function applyReconciledSubagent(
     return;
   }
 
-  if (info.label) {
-    store.spawnSubagent({
-      subagentId,
-      label: info.label,
-      objective: info.objective ?? "",
-      status,
-      isFork: info.isFork,
-      error: info.error,
-      conversationId: info.conversationId,
-      parentConversationId,
-      timestamp: Date.now(),
-      parentToolUseId: info.parentToolUseId,
-    });
-    // A spawn starts every tally at zero, so stamp the snapshot's totals
-    // through `changeStatus` — which also marks a terminal entry so a late
-    // usage event can't double-count on top of them.
-    if (info.usage) {
-      store.changeStatus({
-        subagentId,
-        status,
-        error: info.error,
-        inputTokens: info.usage.inputTokens,
-        outputTokens: info.usage.outputTokens,
-        totalCost: info.usage.estimatedCost,
-      });
-    }
-    return;
-  }
-
-  // Pre-enrichment daemon: `status` is all we get, so fall back to the same
-  // stub the missed-spawn recovery path builds.
+  // A pre-enrichment daemon reports `status` and nothing else, so the row
+  // lands as the same placeholder the missed-spawn recovery path builds.
   store.ensureEntry({
     subagentId,
     timestamp: Date.now(),
-    parentConversationId,
     status,
+    label: info.label,
+    objective: info.objective,
+    isFork: info.isFork,
+    error: info.error,
+    conversationId: info.conversationId,
+    parentConversationId,
+    parentToolUseId: info.parentToolUseId,
+    inputTokens: info.usage?.inputTokens,
+    outputTokens: info.usage?.outputTokens,
+    totalCost: info.usage?.estimatedCost,
   });
 }
 
@@ -614,11 +698,9 @@ async function runReconcile(
     return;
   }
 
-  // The store is global but a snapshot is not: a `reset()` during the
-  // round-trip means the user switched conversation or assistant, so these
-  // rows belong to a context that is no longer on screen. Applying them would
-  // repopulate the fresh store with the previous chat's subagents — and settle
-  // its orphans against the wrong state — so drop the whole step.
+  // A `reset()` during the round-trip means these rows describe a context the
+  // user has already left — drop the whole step rather than repopulate a fresh
+  // store with the previous chat's subagents.
   if (generation !== resetGeneration) {
     return;
   }
@@ -640,11 +722,8 @@ async function runReconcile(
     );
   }
 
-  // Only a successful snapshot is authoritative enough to settle orphans: an
-  // entry this conversation still shows as active that the daemon no longer
-  // knows about died with a restart, and no terminal event is coming. An entry
-  // younger than the request postdates the snapshot, so its absence proves
-  // nothing about it.
+  // Settle this conversation's orphans. An entry younger than the request
+  // postdates the snapshot, so its absence proves nothing about it.
   const { byId, changeStatus } = get();
   for (const entry of Object.values(byId)) {
     if (
@@ -677,9 +756,9 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       status: params.status ?? "pending",
       isFork: params.isFork ?? false,
       error: params.error,
-      inputTokens: 0,
-      outputTokens: 0,
-      totalCost: 0,
+      inputTokens: params.inputTokens ?? 0,
+      outputTokens: params.outputTokens ?? 0,
+      totalCost: params.totalCost ?? 0,
       spawnedAt: params.timestamp,
       events: [],
       conversationId: params.conversationId,
@@ -704,32 +783,60 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       byParent: addEntryToByParent(get().byParent, entry),
       byToolUseId: nextByToolUseId,
     });
+
+    // Mirrors `changeStatus`: totals stamped onto an already-terminal row are
+    // final, so a straggling `usage_progress` must not add to them.
+    if (
+      !isActiveStatus(entry.status) &&
+      (params.inputTokens != null ||
+        params.outputTokens != null ||
+        params.totalCost != null)
+    ) {
+      get().terminalUsageIds.add(params.subagentId);
+    }
   },
 
   ensureEntry: (params) => {
     if (get().byId[params.subagentId]) return;
-    // The child id addresses the subagent's conversation on every daemon. The
-    // parent id only works as a placeholder on a daemon that self-resolves the
-    // subagent's conversation — and even then it stays out of the
-    // child-semantic `conversationId` field.
-    const armsBackfill =
-      Boolean(params.conversationId) ||
-      (Boolean(params.parentConversationId) &&
-        supportsSubagentDetailSelfLookup());
+    // An entry with no parent id at all is scoped to no conversation: the
+    // overlay shows it everywhere and reconcile's per-parent orphan pass
+    // settles it nowhere. A `subagent_status_changed` carries no ids, so fall
+    // back to the conversation on screen.
+    const parentConversationId =
+      params.parentConversationId ??
+      useConversationStore.getState().activeConversationId ??
+      undefined;
+    const status = params.status ?? "running";
 
     get().spawnSubagent({
       subagentId: params.subagentId,
-      // Placeholder identity — the detail fetch backfills the real label
-      // and objective on 0.10.13+ daemons (see `loadDetail`).
-      label: "",
-      objective: "",
-      status: params.status ?? "running",
+      // Placeholder identity when the evidence carries none — the detail
+      // fetch (0.10.13+ daemons) or a later snapshot backfills it.
+      label: params.label ?? "",
+      objective: params.objective ?? "",
+      status,
+      isFork: params.isFork,
+      error: params.error,
       conversationId: params.conversationId,
-      parentConversationId: params.parentConversationId,
+      parentConversationId,
       timestamp: params.timestamp,
+      parentToolUseId: params.parentToolUseId,
+      inputTokens: params.inputTokens,
+      outputTokens: params.outputTokens,
+      totalCost: params.totalCost,
     });
 
-    if (!armsBackfill) return;
+    // Only a live row can have its backfill overtaken by streamed events, and
+    // only an addressable one has a backfill coming at all.
+    if (
+      !isActiveStatus(status) ||
+      !canAddressSubagentDetail({
+        conversationId: params.conversationId,
+        parentConversationId,
+      })
+    ) {
+      return;
+    }
     const { byId } = get();
     const entry = byId[params.subagentId];
     if (!entry) return;
@@ -914,32 +1021,86 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     });
   },
 
-  setConversationId: (subagentId, conversationId) => {
+  backfillIdentity: (params) => {
     const { byId } = get();
-    const existing = byId[subagentId];
-    if (!existing) return;
-    if (existing.conversationId === conversationId) return;
+    const existing = byId[params.subagentId];
+    if (!existing) {
+      return;
+    }
+
+    const label = existing.label || (params.label ?? "");
+    const objective = existing.objective || (params.objective ?? "");
+    const parentToolUseId = existing.parentToolUseId ?? params.parentToolUseId;
+    if (
+      label === existing.label &&
+      objective === existing.objective &&
+      parentToolUseId === existing.parentToolUseId
+    ) {
+      return;
+    }
 
     set({
       byId: {
         ...byId,
-        [subagentId]: { ...existing, conversationId },
+        [params.subagentId]: {
+          ...existing,
+          label,
+          objective,
+          parentToolUseId,
+        },
       },
+      byToolUseId: setToolUseAnchor(
+        get().byToolUseId,
+        parentToolUseId,
+        params.subagentId,
+      ),
     });
   },
 
-  setParentConversationId: (subagentId, parentConversationId) => {
+  attachParentMessage: (subagentId, parentMessageId) => {
     const { byId } = get();
     const existing = byId[subagentId];
-    if (!existing) return;
-    if (existing.parentConversationId === parentConversationId) return;
+    if (!existing || existing.parentMessageId) {
+      return;
+    }
 
+    const updated = { ...existing, parentMessageId };
     set({
-      byId: {
-        ...byId,
-        [subagentId]: { ...existing, parentConversationId },
-      },
+      byId: { ...byId, [subagentId]: updated },
+      // An entry with no stable id was never indexed under one, so re-index
+      // against the message id itself: the stable-bucket pass then finds
+      // nothing to swap and only the message bucket gains the entry.
+      byParent: reindexByParentForReanchor(
+        get().byParent,
+        existing.parentMessageStableId ?? parentMessageId,
+        parentMessageId,
+        new Map([[subagentId, updated]]),
+      ),
     });
+  },
+
+  setConversationId: (subagentId, conversationId) => {
+    const next = patchedEntryField(
+      get().byId,
+      subagentId,
+      "conversationId",
+      conversationId,
+    );
+    if (next) {
+      set({ byId: next });
+    }
+  },
+
+  setParentConversationId: (subagentId, parentConversationId) => {
+    const next = patchedEntryField(
+      get().byId,
+      subagentId,
+      "parentConversationId",
+      parentConversationId,
+    );
+    if (next) {
+      set({ byId: next });
+    }
   },
 
   reanchorToMessage: ({ stableId, messageId }) => {
@@ -996,16 +1157,7 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     const { byId, fetchedAt } = get();
     const entry = byId[subagentId];
     if (!entry) return;
-    // A stub recovered without its `subagent_spawned` may only know the parent
-    // conversation. 0.10.13+ daemons resolve the subagent's own conversation
-    // and treat this parameter as a fallback, so the parent id is a harmless
-    // wire placeholder there; an older daemon would trust it verbatim and
-    // parse the parent's messages as the subagent's.
-    const queryConversationId =
-      entry.conversationId ??
-      (supportsSubagentDetailSelfLookup()
-        ? entry.parentConversationId
-        : undefined);
+    const queryConversationId = resolveSubagentDetailConversationId(entry);
     if (!queryConversationId) return;
     if (entry.events.length > 0) return;
 
@@ -1076,6 +1228,12 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     if (inFlight) {
       return inFlight;
     }
+    // Throttled here rather than at the kick call site so a reconnect loop —
+    // which re-fires the mount and `sse.opened` triggers, not the kick — is
+    // bounded too.
+    if (!claimReconcileWindow(parentConversationId)) {
+      return Promise.resolve();
+    }
 
     const run: Promise<void> = runReconcile(
       get,
@@ -1109,8 +1267,8 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
   },
 
   reset: () => {
-    // A reset means a conversation switch, so the next unknown-id kick should
-    // fire immediately instead of inheriting the previous chat's window.
+    // A reset means a conversation switch, so the next reconcile should fire
+    // immediately instead of inheriting the previous chat's window.
     lastReconcileKickAt.clear();
     // Invalidate every in-flight snapshot (they describe the context being
     // left) and drop them from the single-flight map so a reconcile for the
@@ -1133,12 +1291,11 @@ export const useSubagentStore = createSelectors(useSubagentStoreBase);
 /**
  * Ask the daemon to resync this conversation's subagents, best-effort.
  *
- * For imperative call sites that only hold a reason — the stream handlers hit
- * this when an event names a subagent the store has never seen, which means
- * the client's picture of the run is incomplete. Reads the active assistant
- * from its store (same pattern as `abortSubagent`) and rate-limits to one
- * round-trip per parent per `RECONCILE_KICK_INTERVAL_MS`, so a burst of events
- * for the same missing subagent costs a single fetch.
+ * For the stream handlers, which hit this when an event names a subagent the
+ * store has never seen — the client's picture of the run is incomplete. Reads
+ * the active assistant from its store (same pattern as `abortSubagent`);
+ * `reconcileFromDaemon` decides whether the request actually goes out, so a
+ * burst of events for the same missing subagent costs a single fetch.
  *
  * `parentConversationId` names the conversation to resync. Subagent events are
  * routed globally, so an event for a background conversation must reconcile
@@ -1146,10 +1303,7 @@ export const useSubagentStore = createSelectors(useSubagentStoreBase);
  * hand — `subagent_status_changed` carries none — fall back to the active
  * conversation.
  */
-export function requestSubagentReconcile(
-  reason: string,
-  parentConversationId?: string,
-): void {
+export function requestSubagentReconcile(parentConversationId?: string): void {
   const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
   const targetConversationId =
     parentConversationId ??
@@ -1158,14 +1312,9 @@ export function requestSubagentReconcile(
     return;
   }
 
-  const now = Date.now();
-  const lastKickAt = lastReconcileKickAt.get(targetConversationId) ?? 0;
-  if (now - lastKickAt < RECONCILE_KICK_INTERVAL_MS) {
-    return;
-  }
-  lastReconcileKickAt.set(targetConversationId, now);
-
-  recordDiagnostic("subagent_reconcile_kick", { reason });
+  recordDiagnostic("subagent_reconcile_kick", {
+    reason: "unknown_subagent_id",
+  });
   void useSubagentStoreBase
     .getState()
     .reconcileFromDaemon(assistantId, targetConversationId);

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.test.ts
@@ -251,10 +251,30 @@ describe("handleSubagentStatusChanged — unknown subagent id", () => {
     expect(entry).toBeDefined();
     expect(entry?.status).toBe("completed");
     expect(entry?.inputTokens).toBe(10);
-    // A status event carries no conversation ids at all.
+    // The event carries no conversation ids, and with no conversation on
+    // screen there is nothing to fall back to either.
     expect(entry?.conversationId).toBeUndefined();
     expect(entry?.parentConversationId).toBeUndefined();
     expect(entry?.hydrationPending).toBeUndefined();
+  });
+
+  it("scopes the stub to the conversation on screen", () => {
+    // A status event names no conversation, and an entry with no parent id is
+    // shown by the Active-Subagents overlay in EVERY conversation while
+    // reconcile's per-parent orphan pass settles it in none.
+    useConversationStore.getState().setActiveConversationId(PARENT);
+
+    handleSubagentStatusChanged(
+      { type: "subagent_status_changed", subagentId: "sa-9", status: "running" },
+      ctx,
+    );
+
+    const entry = useSubagentStore.getState().byId["sa-9"];
+    expect(entry?.parentConversationId).toBe(PARENT);
+    // The parent id addresses the backfill on a self-lookup daemon, so the
+    // stub now defers its live events until the fetch lands.
+    expect(entry?.conversationId).toBeUndefined();
+    expect(entry?.hydrationPending).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/subagent-handlers.ts
@@ -36,16 +36,18 @@ export function handleSubagentStatusChanged(
   // was missed (SSE gap, page reload) or the store was reset after it
   // arrived. Materialize a stub so the status lands instead of silently
   // vanishing — a dropped terminal status is how the inline card dies (the
-  // avatar row expands to nothing and the detail panel can't open). The
-  // reconcile kick then recovers the real identity, and any sibling subagent
-  // that streamed nothing at all, a round-trip later.
+  // avatar row expands to nothing and the detail panel can't open). The event
+  // carries no conversation ids at all, so `ensureEntry` scopes the stub to
+  // the conversation on screen. The reconcile kick then recovers the real
+  // identity, and any sibling subagent that streamed nothing at all, a
+  // round-trip later.
   if (!store.byId[event.subagentId]) {
     store.ensureEntry({
       subagentId: event.subagentId,
       timestamp: Date.now(),
       status: event.status,
     });
-    requestSubagentReconcile("unknown_subagent_id");
+    requestSubagentReconcile();
   }
   store.changeStatus({
     subagentId: event.subagentId,
@@ -99,7 +101,7 @@ export function handleSubagentEvent(
     // Reconcile the envelope's OWN parent: this event may belong to a
     // background conversation, whose subagents the active chat's snapshot
     // would say nothing about.
-    requestSubagentReconcile("unknown_subagent_id", parentConversationId);
+    requestSubagentReconcile(parentConversationId);
   }
 
   if (inner.type === "usage_progress") {

--- a/clients/web/src/utils/subagent-status.test.ts
+++ b/clients/web/src/utils/subagent-status.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `shouldApplyStatus` is the one rule two out-of-band evidence sources share —
+ * the `subagents/reconcile` snapshot and history notifications. Both are a
+ * round-trip old, so both can report an active status for a run that has since
+ * settled; letting either land would stick the Active-Subagents overlay and
+ * the Stop control on a subagent that will never emit again.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { SubagentStatus } from "@vellumai/assistant-api";
+
+import { shouldApplyStatus } from "@/utils/subagent-status";
+
+const ACTIVE: SubagentStatus[] = ["running", "pending", "awaiting_input"];
+const TERMINAL: SubagentStatus[] = [
+  "completed",
+  "failed",
+  "aborted",
+  "interrupted",
+];
+
+describe("shouldApplyStatus", () => {
+  test("an active entry accepts anything", () => {
+    for (const existing of ACTIVE) {
+      for (const incoming of [...ACTIVE, ...TERMINAL]) {
+        expect(shouldApplyStatus(existing, incoming)).toBe(true);
+      }
+    }
+  });
+
+  test("a settled entry never regresses to an active status", () => {
+    for (const existing of TERMINAL) {
+      for (const incoming of ACTIVE) {
+        expect(shouldApplyStatus(existing, incoming)).toBe(false);
+      }
+    }
+  });
+
+  test("a settled entry still moves between terminal states", () => {
+    // A truer terminal state — `failed` over a provisional `interrupted` —
+    // must still land.
+    for (const existing of TERMINAL) {
+      for (const incoming of TERMINAL) {
+        expect(shouldApplyStatus(existing, incoming)).toBe(true);
+      }
+    }
+  });
+});

--- a/clients/web/src/utils/subagent-status.ts
+++ b/clients/web/src/utils/subagent-status.ts
@@ -11,6 +11,23 @@ export function isActiveStatus(status: SubagentStatus): boolean {
   return status === "running" || status === "pending" || status === "awaiting_input";
 }
 
+/**
+ * Whether an out-of-band status may overwrite the one the store already holds.
+ *
+ * Both out-of-band sources — the `subagents/reconcile` snapshot and history
+ * notifications — are a round-trip old, so either can still report `running`
+ * for a subagent whose terminal event has since landed over SSE. A settled
+ * entry therefore only ever moves between terminal states: an interrupted run
+ * emits nothing further, so a regression to an active status would stick the
+ * overlay and the Stop control forever.
+ */
+export function shouldApplyStatus(
+  existing: SubagentStatus,
+  incoming: SubagentStatus,
+): boolean {
+  return isActiveStatus(existing) || !isActiveStatus(incoming);
+}
+
 /** Map a SubagentStatus to a semantic color token. */
 export function statusColor(status: SubagentStatus): string {
   switch (status) {


### PR DESCRIPTION
Part of plan: subagent-running-state-fixes.md (self-review remediation)

Web-side remediation for the gaps a self-review found in the subagent run-state
work. Every change is under `clients/web/`.

## Gaps fixed

- **C — reconcile discarded fetched identity for "known" entries.** A stub
  created by `ensureEntry` (blank label, no objective, no spawn anchor) counts
  as known, so the snapshot's real identity was dropped and the row kept a
  blank label forever on 0.10.0–0.10.12 daemons. New `backfillIdentity` action
  applies the same "placeholder yields, real value wins" rule `loadDetail`
  already uses, and registers a backfilled `parentToolUseId` in `byToolUseId`.

- **D — reconcile-materialized rows raced live events.** Rows the snapshot
  materializes for a still-running subagent are now armed `hydrationPending`,
  so events arriving during the detail round-trip are deferred instead of
  making `loadDetail` keep the partial live suffix. Settled rows stay un-armed
  (nothing races them, and arming them would defeat gap H).

- **E — parent-less status stubs became phantom overlay rows.**
  `subagent_status_changed` carries no conversation ids, so its stub had
  `parentConversationId === undefined` — shown by the Active-Subagents overlay
  in *every* conversation and settled by reconcile's per-parent orphan pass in
  none. `ensureEntry` now falls back to the conversation on screen, the same
  guess `requestSubagentReconcile` makes. The undefined-stays-visible grace in
  `useActiveSubagentIds` is kept for the spawn race.

- **F — entries created by reconcile could never gain a transcript anchor.**
  New `attachParentMessage` action re-indexes `byParent` (via the same helper
  `reanchorToMessage` uses); history hydration calls it for an entry that has
  no parent message id yet, which is every row reconcile recovers.

- **H — N-request detail burst on load.** The conversation auto-fetch is now
  bounded to entries that can't wait: active ones and `hydrationPending`
  stubs. Settled rows fetch their timeline when their panel is opened.

- **panel — the panel's own fetch was gated on `entry.conversationId`.** A stub
  armed with only a parent conversation id got no panel-driven fetch, so it
  stayed permanently empty. Both the panel and the auto-fetch now go through
  the shared addressability predicate.

## Consolidations (slop audit)

1. One `canAddressSubagentDetail` / `resolveSubagentDetailConversationId` pair
   in `store-helpers/subagent-detail-addressability.ts`, used by `ensureEntry`
   arming, `fetchDetailIfNeeded`, `needsDetailFetch`, and the panel trigger.
   `hydrationPending` keeps only its receiveEvent-defer job.
2. The terminal-regression guard, previously spelled twice, is now
   `shouldApplyStatus` next to `isActiveStatus`.
3. `setConversationId` / `setParentConversationId` collapse onto a private
   `patchedEntryField` helper; both named actions stay exported.
4. The per-parent throttle moved inside `reconcileFromDaemon`, so the mount and
   `sse.opened` triggers share it with the unknown-id kick — an SSE flap loop
   no longer bypasses it. `reset()` still clears it; single-flight unchanged.
5. `requestSubagentReconcile(parentConversationId?)` — the reason both callers
   passed is inlined at the `recordDiagnostic` call.
6. `spawnSubagent` takes optional usage, so reconcile's materialization stops
   double-writing (spawn + a `changeStatus` with the same status). Terminal
   spawns still mark `terminalUsageIds`.
7. `applyReconciledSubagent` takes a `Pick` slice instead of the whole store,
   matching `reconcile-subagent-hydration.ts`.
8. `useSubagentReconcile`'s two triggers share one `resync` callback.
9. Call-site comments that re-narrated the generation guard / orphan rule are
   trimmed to the point the mechanism's own doc doesn't already make.

## Trade-off worth knowing

Gap H means a settled subagent's inline card reads "0 steps" until its panel is
opened, where it previously auto-fetched on every conversation load. That is
the deliberate exchange for not issuing one GET per historical subagent on
load; opening the card fetches the timeline immediately.

## Verification

- `bun run test:ci` (full web suite)
- `bunx tsc --noEmit`
- `bunx eslint` on every touched file — 0 errors

New/updated coverage: identity backfill (fills a blank stub, never overwrites
a spawned value), reconcile arming (live row armed and its `loadDetail`
replaces the deferred suffix; settled + unaddressable rows un-armed),
active-conversation scoping (stub is settled by a later orphan pass),
`attachParentMessage` (byParent reindex, bucket ordering, no-ops), bounded
auto-fetch (skips settled rows, still fetches the live sibling), panel-open
fetch (settled rows and parent-only stubs), throttle across mount/reopen
(flap → one request per window; per-parent windows; reset reopens), and
`shouldApplyStatus` unit cases.
