### PR TITLE
feat(web): add Copy conversation ID and Copy group ID to overflow menus

### DIFF
--- a/clients/web/src/domains/chat/chat-conversation-header.tsx
+++ b/clients/web/src/domains/chat/chat-conversation-header.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from "lucide-react";
 import type { ChatHeaderSupplements } from "@/components/layout/chat-layout-slots-store";
 import { ConversationActionsMenu } from "@/domains/chat/components/conversation-actions-menu";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
+import { copyIdToClipboard } from "@/domains/chat/utils/copy-id-to-clipboard";
 import {
   buildMoveToGroupTargets,
   isInCustomGroup,
@@ -112,6 +113,15 @@ export function ChatConversationHeader({
           : undefined
       }
       onCopyConversation={headerSupplements?.onCopyConversation ?? undefined}
+      onCopyConversationId={
+        activeConversation.conversationId
+          ? () =>
+              copyIdToClipboard(
+                activeConversation.conversationId!,
+                "Conversation ID",
+              )
+          : undefined
+      }
       onRefresh={
         headerSupplements?.onRefresh && activeConversation.conversationId != null
           ? headerSupplements.onRefresh

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -30,6 +30,7 @@ import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
 import { PinnedAppNavItem } from "@/domains/chat/components/pinned-app-nav-item";
 import { useDragReorder } from "@/domains/chat/hooks/use-drag-reorder";
 import { SIDEBAR_CONVERSATION_LIMIT, useSidebarState, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state";
+import { copyIdToClipboard } from "@/domains/chat/utils/copy-id-to-clipboard";
 import { channelSectionKey } from "@/domains/chat/utils/sidebar-group-collapse-storage";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { Conversation } from "@/types/conversation-types";
@@ -241,7 +242,11 @@ export function AssistantSideMenu({
   const buildGroupMenu = (
     groupName: string,
     conversations: Conversation[],
-    options?: { onRename?: () => void; onDelete?: () => void },
+    options?: {
+      onRename?: () => void;
+      onDelete?: () => void;
+      onCopyGroupId?: () => void;
+    },
   ): GroupMenuItemsProps => ({
     onMarkAllRead: onMarkAllReadInGroup
       ? () => onMarkAllReadInGroup(conversations)
@@ -255,6 +260,7 @@ export function AssistantSideMenu({
     hasConversations: conversations.length > 0,
     onRename: options?.onRename,
     onDelete: options?.onDelete,
+    onCopyGroupId: options?.onCopyGroupId,
   });
 
   const selectAndClose = useCallback(
@@ -533,6 +539,8 @@ export function AssistantSideMenu({
                           onDelete: onDeleteGroup
                             ? () => onDeleteGroup(group.id)
                             : undefined,
+                          onCopyGroupId: () =>
+                            copyIdToClipboard(group.id, "Group ID"),
                         },
                       );
                       return (

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -212,6 +212,29 @@ describe("renderConversationMenuItems", () => {
     expect(html).toContain("Pin");
     expect(html).toContain("Rename");
   });
+
+  test("renders Copy conversation ID in both variants when wired", () => {
+    for (const variant of ["sidebar", "header"] as const) {
+      const html = renderToStaticMarkup(
+        <>{renderConversationMenuItems({
+          Primitive: Menu as unknown as ConversationMenuPrimitive,
+          variant,
+          onCopyConversationId: () => {},
+        })}</>,
+      );
+      expect(html).toContain("Copy conversation ID");
+    }
+  });
+
+  test("omits Copy conversation ID when not wired", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        onRename: () => {},
+      })}</>,
+    );
+    expect(html).not.toContain("Copy conversation ID");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -149,6 +149,11 @@ export interface ConversationMenuItemsProps {
   onInspect?: () => void;
   /** Copy the full conversation as markdown to the clipboard. */
   onCopyConversation?: () => void;
+  /**
+   * Copy the conversation's id to the clipboard. Lets users paste a precise
+   * reference into chat (the assistant resolves conversation ids directly).
+   */
+  onCopyConversationId?: () => void;
   /** Re-fetch the chat context and reload the current conversation. */
   onRefresh?: () => void;
   /**
@@ -190,6 +195,7 @@ export function renderConversationMenuItems({
   onShareFeedback,
   onInspect,
   onCopyConversation,
+  onCopyConversationId,
   onRefresh,
   channelSourceLink,
   variant = "sidebar",
@@ -302,6 +308,15 @@ export function renderConversationMenuItems({
     </Primitive.Item>
   ) : null;
 
+  const copyConversationIdItem = onCopyConversationId ? (
+    <Primitive.Item
+      leftIcon={<Copy size={14} />}
+      onSelect={onCopyConversationId}
+    >
+      Copy conversation ID
+    </Primitive.Item>
+  ) : null;
+
   if (variant === "header") {
     return (
       <>
@@ -339,6 +354,7 @@ export function renderConversationMenuItems({
         {renameItem}
         {moveToGroupItem}
         {archiveItem}
+        {copyConversationIdItem}
         {inspectItem}
       </>
     );
@@ -367,9 +383,10 @@ export function renderConversationMenuItems({
         </>
       ) : null}
 
-      {inspectItem ? (
+      {copyConversationIdItem || inspectItem ? (
         <>
           <Primitive.Separator />
+          {copyConversationIdItem}
           {inspectItem}
         </>
       ) : null}
@@ -402,6 +419,7 @@ export function renderConversationMenuItemsAsPanelItems({
   onShareFeedback,
   onInspect,
   onCopyConversation,
+  onCopyConversationId,
   onRefresh,
   channelSourceLink,
   variant = "sidebar",
@@ -540,6 +558,16 @@ export function renderConversationMenuItemsAsPanelItems({
       })
     : null;
 
+  const copyConversationIdItem = onCopyConversationId
+    ? buildPanelMenuItem({
+        key: "copy-conversation-id",
+        icon: Copy,
+        label: "Copy conversation ID",
+        run: onCopyConversationId,
+        onClose,
+      })
+    : null;
+
   if (variant === "header") {
     return (
       <>
@@ -580,6 +608,7 @@ export function renderConversationMenuItemsAsPanelItems({
         {renameItem}
         {archiveItem}
         {moveToGroupBlock}
+        {copyConversationIdItem}
         {inspectItem}
       </>
     );
@@ -608,9 +637,10 @@ export function renderConversationMenuItemsAsPanelItems({
         </>
       ) : null}
 
-      {inspectItem ? (
+      {copyConversationIdItem || inspectItem ? (
         <>
           <PanelMenuDivider />
+          {copyConversationIdItem}
           {inspectItem}
         </>
       ) : null}

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/domains/chat/components/thread-status-indicator";
 import type { DragReorderItemProps } from "@/domains/chat/hooks/use-drag-reorder";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
+import { copyIdToClipboard } from "@/domains/chat/utils/copy-id-to-clipboard";
 import {
   buildMoveToGroupTargets,
   isConversationPinned,
@@ -109,6 +110,9 @@ export function buildMenuProps(
     onShareFeedback: ctx.onShareFeedback,
     onInspect:
       ctx.onInspect && hasId ? () => ctx.onInspect?.(conversation) : undefined,
+    onCopyConversationId: hasId
+      ? () => copyIdToClipboard(conversation.conversationId!, "Conversation ID")
+      : undefined,
   };
 }
 

--- a/clients/web/src/domains/chat/components/group-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/group-actions-menu.test.tsx
@@ -30,6 +30,7 @@ const allActions = {
   hasConversations: true,
   onRename: () => {},
   onDelete: () => {},
+  onCopyGroupId: () => {},
 };
 
 async function openMenu(label = "Group actions") {
@@ -55,6 +56,7 @@ describe("hasAnyGroupMenuAction", () => {
   test("true as soon as one callback is wired", () => {
     expect(hasAnyGroupMenuAction({ onMarkAllRead: () => {} })).toBe(true);
     expect(hasAnyGroupMenuAction({ onDelete: () => {} })).toBe(true);
+    expect(hasAnyGroupMenuAction({ onCopyGroupId: () => {} })).toBe(true);
   });
 });
 
@@ -70,6 +72,7 @@ describe("GroupActionsMenu", () => {
       expect(document.body.textContent).toContain("Archive All");
       expect(document.body.textContent).toContain("Rename");
       expect(document.body.textContent).toContain("Delete group");
+      expect(document.body.textContent).toContain("Copy group ID");
     } finally {
       cleanup();
     }

--- a/clients/web/src/domains/chat/components/group-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/group-actions-menu.tsx
@@ -20,6 +20,7 @@
 import {
     Archive,
     CircleCheck,
+    Copy,
     MoreHorizontal,
     Pencil,
     Trash2,
@@ -55,6 +56,11 @@ export interface GroupMenuItemsProps {
   hasConversations?: boolean;
   onRename?: () => void;
   onDelete?: () => void;
+  /**
+   * Copy the group's id to the clipboard. Lets users paste a precise
+   * reference into chat (the assistant resolves group ids directly).
+   */
+  onCopyGroupId?: () => void;
 }
 
 /**
@@ -66,12 +72,14 @@ export function hasAnyGroupMenuAction({
   onArchiveAll,
   onRename,
   onDelete,
+  onCopyGroupId,
 }: GroupMenuItemsProps): boolean {
   return (
     onMarkAllRead != null ||
     onArchiveAll != null ||
     onRename != null ||
-    onDelete != null
+    onDelete != null ||
+    onCopyGroupId != null
   );
 }
 
@@ -83,9 +91,11 @@ export function renderGroupMenuItems({
   hasConversations = false,
   onRename,
   onDelete,
+  onCopyGroupId,
 }: GroupMenuItemsProps & { Primitive: GroupMenuPrimitive }): ReactNode {
   const hasBulkActions = onMarkAllRead != null || onArchiveAll != null;
-  const hasIndividualActions = onRename != null || onDelete != null;
+  const hasIndividualActions =
+    onRename != null || onDelete != null || onCopyGroupId != null;
 
   return (
     <>
@@ -118,6 +128,11 @@ export function renderGroupMenuItems({
           {hasConversations ? "Delete group…" : "Delete group"}
         </Primitive.Item>
       ) : null}
+      {onCopyGroupId ? (
+        <Primitive.Item leftIcon={<Copy size={14} />} onSelect={onCopyGroupId}>
+          Copy group ID
+        </Primitive.Item>
+      ) : null}
     </>
   );
 }
@@ -133,10 +148,12 @@ export function renderGroupMenuItemsAsPanelItems({
   hasConversations = false,
   onRename,
   onDelete,
+  onCopyGroupId,
   onClose,
 }: GroupMenuItemsProps & { onClose: () => void }): ReactNode {
   const hasBulkActions = onMarkAllRead != null || onArchiveAll != null;
-  const hasIndividualActions = onRename != null || onDelete != null;
+  const hasIndividualActions =
+    onRename != null || onDelete != null || onCopyGroupId != null;
 
   return (
     <>
@@ -176,6 +193,15 @@ export function renderGroupMenuItemsAsPanelItems({
             icon: Trash2,
             label: hasConversations ? "Delete group…" : "Delete group",
             run: onDelete,
+            onClose,
+          })
+        : null}
+      {onCopyGroupId
+        ? buildPanelMenuItem({
+            key: "copy-group-id",
+            icon: Copy,
+            label: "Copy group ID",
+            run: onCopyGroupId,
             onClose,
           })
         : null}

--- a/clients/web/src/domains/chat/utils/copy-id-to-clipboard.ts
+++ b/clients/web/src/domains/chat/utils/copy-id-to-clipboard.ts
@@ -1,0 +1,13 @@
+import { toast } from "@vellumai/design-library/components/toast";
+
+/**
+ * Copy an identifier (conversation id, group id) to the clipboard with toast
+ * feedback. Shared by the conversation and group overflow menus so users can
+ * paste a precise reference into chat for the assistant to act on.
+ */
+export function copyIdToClipboard(id: string, label: string): void {
+  navigator.clipboard.writeText(id).then(
+    () => toast.success(`${label} copied to clipboard.`),
+    () => toast.error(`Couldn't copy the ${label.toLowerCase()}.`),
+  );
+}


### PR DESCRIPTION
## TL;DR

Adds "Copy conversation ID" to the conversation overflow/context menus and "Copy group ID" to the custom-group header menus in the web client. Users can now grab a precise id and paste it into chat — the assistant's tools (conversation-groups from #39385, schedule groups from #39388) resolve ids directly, so an id is an unambiguous reference.

## What changes for the user

| Before | After |
| --- | --- |
| No way to see or copy a conversation's id from the UI | "Copy conversation ID" in the sidebar row menu (dropdown + right-click), the conversation header menu, and the mobile bottom sheet |
| No way to see or copy a custom group's id | "Copy group ID" in the custom-group header "…" menu and its right-click menu |
| Referencing a conversation to the assistant relies on titles, which can be ambiguous | Paste the id for an exact reference |

Both items copy to the clipboard and confirm with a toast ("Conversation ID copied to clipboard."); failures surface an error toast.

## Why this is safe

- Read-only actions — nothing mutates state; clipboard write + toast only.
- Each menu keeps its "one source of truth" contract: the item is added to the shared prop shape and rendered by every surface renderer (desktop Menu/ContextMenu, panel/bottom-sheet), so surfaces can't drift. `hasAnyGroupMenuAction` is updated so the guard logic stays consistent.
- "Copy conversation ID" is gated on the row having a `conversationId` (same `hasId` gate as Open in New Window / Inspect).
- One small shared helper (`copy-id-to-clipboard.ts`) serves all call sites — no duplicated clipboard/toast logic.
- Tests extended: menu renderers assert the new items render in both variants (and stay hidden when unwired); `hasAnyGroupMenuAction` covers the new callback. All four menu/row suites pass; `tsc` and eslint clean.

## Notes

- Group ids are copied for custom groups only; system sections (Pinned, Scheduled, …) have well-known stable ids the assistant already knows.
- Four of the touched component files were already prettier-unclean on `main`; I matched local formatting rather than reformatting whole files to keep the diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->