### PR TITLE
fix(plugin-api): resolve profile vision support against the default provider

### DIFF
--- a/assistant/src/plugin-api/vision-support.test.ts
+++ b/assistant/src/plugin-api/vision-support.test.ts
@@ -14,6 +14,8 @@ interface MockProfileEntry {
 }
 
 let mockProfiles: Record<string, MockProfileEntry> = {};
+let mockDefaultProvider: { provider: string; connectionName?: string } | null =
+  null;
 
 // Real model catalog — don't mock it, the test exercises real catalog lookups.
 const { doesSupportVision } = await import("./vision-support.js");
@@ -40,16 +42,26 @@ function profile(key: string): ModelProfileInfo {
 function applyConfig(): void {
   setConfig("llm", { profiles: {} });
   const config = getConfig() as { llm: unknown };
-  config.llm = { profiles: mockProfiles };
+  config.llm = {
+    profiles: mockProfiles,
+    ...(mockDefaultProvider != null
+      ? { defaultProvider: mockDefaultProvider }
+      : {}),
+  };
 }
 
-function setMockConfig(profiles: Record<string, MockProfileEntry>) {
+function setMockConfig(
+  profiles: Record<string, MockProfileEntry>,
+  defaultProvider?: { provider: string; connectionName?: string },
+) {
   mockProfiles = profiles;
+  mockDefaultProvider = defaultProvider ?? null;
   applyConfig();
 }
 
 beforeEach(() => {
   mockProfiles = {};
+  mockDefaultProvider = null;
   applyConfig();
 });
 
@@ -144,6 +156,57 @@ describe("doesSupportVision", () => {
       },
     });
     expect(doesSupportVision(profile("mix-profile"))).toBe(false);
+  });
+});
+
+describe("doesSupportVision with a BYO default provider", () => {
+  test("judges a default profile against the default provider's column model", () => {
+    // Managed/vellum column: balanced → glm-5p2 (text-only, supportsVision:
+    // false). Anthropic column: balanced → claude-sonnet-4-6 (supportsVision:
+    // true). The judged model must be the one the BYO install actually runs.
+    setMockConfig({}, { provider: "anthropic" });
+    expect(doesSupportVision(profile("balanced"))).toBe(true);
+  });
+
+  test("without a default provider, a default profile judges the managed column", () => {
+    // Null-reduction: no defaultProvider resolves balanced through the
+    // vellum column (glm-5p2, text-only).
+    setMockConfig({});
+    expect(doesSupportVision(profile("balanced"))).toBe(false);
+  });
+
+  test("mix arms naming a default profile resolve through the same column", () => {
+    setMockConfig(
+      {
+        "mix-profile": {
+          mix: [
+            { profile: "text-arm", weight: 0.5 },
+            { profile: "balanced", weight: 0.5 },
+          ],
+        },
+        "text-arm": {
+          provider: "fireworks",
+          model: "accounts/fireworks/models/glm-5p2",
+        },
+      },
+      { provider: "anthropic" },
+    );
+    // The "balanced" arm resolves to the anthropic column's vision-capable
+    // model, so the mix can route to vision.
+    expect(doesSupportVision(profile("mix-profile"))).toBe(true);
+  });
+
+  test("a user-owned profile is unaffected by the default provider", () => {
+    setMockConfig(
+      {
+        "custom-text": {
+          provider: "fireworks",
+          model: "accounts/fireworks/models/glm-5p2",
+        },
+      },
+      { provider: "anthropic" },
+    );
+    expect(doesSupportVision(profile("custom-text"))).toBe(false);
   });
 });
 

--- a/assistant/src/plugin-api/vision-support.ts
+++ b/assistant/src/plugin-api/vision-support.ts
@@ -8,6 +8,9 @@
  * - a concrete model id (e.g. the provider-reported model that just ran), and
  * - a profile — either a {@link ModelProfileInfo} or a bare profile key —
  *   resolved through `llm.profiles` to an effective `(provider, model)`.
+ *   Default profile keys resolve through `llm.defaultProvider`'s column of the
+ *   intent × provider matrix, so the judged model is the one that actually
+ *   runs on a BYO install.
  *
  * A bare string is tried as a model id first and then as a profile key, so the
  * two callers share one function. Resolution returns `false` when nothing
@@ -16,7 +19,7 @@
  * over silently shipping a raw image to a provider that may reject it.
  */
 
-import { getEffectiveProfile } from "../config/default-profile-catalog.js";
+import { resolveDefaultProfileForProvider } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import {
@@ -68,7 +71,12 @@ function modelVision(model: string): boolean | undefined {
  */
 function profileVision(profileKey: string): boolean | undefined {
   const { llm } = getConfig();
-  const entry = getEffectiveProfile(llm.profiles, profileKey);
+  const defaultProvider = llm.defaultProvider ?? null;
+  const entry = resolveDefaultProfileForProvider(
+    llm.profiles,
+    profileKey,
+    defaultProvider,
+  );
   if (entry == null) {
     return undefined;
   }
@@ -76,7 +84,11 @@ function profileVision(profileKey: string): boolean | undefined {
   if (entry.mix != null) {
     let sawUnknown = false;
     for (const arm of entry.mix) {
-      const armEntry = getEffectiveProfile(llm.profiles, arm.profile);
+      const armEntry = resolveDefaultProfileForProvider(
+        llm.profiles,
+        arm.profile,
+        defaultProvider,
+      );
       const armVision =
         armEntry == null ? undefined : resolveEntryVision(armEntry);
       if (armVision === true) {


### PR DESCRIPTION
## TL;DR

On BYO installs, vision-capability checks for the default profiles (`balanced`, `quality-optimized`, …) judged the **managed/vellum column's model** instead of the model the install actually runs. `doesSupportVision` now resolves default profile keys through `llm.defaultProvider`'s column of the intent × provider matrix — the same resolution the dispatch path already uses.

PR 1 of the BYO profile-resolution consolidation plan (attached below).

## What changes for the user

| Scenario | Before | After |
|---|---|---|
| BYO install (e.g. Anthropic default provider) sends an image on Balanced | Judged against the managed model `glm-5p2` (text-only) → image needlessly captioned to text, even though `claude-sonnet-4-6` (the model that actually runs) accepts images | Judged against the model that actually runs → image passed through |
| BYO install where the actual model is text-only but the managed model has vision | Image wrongly passed through to a model that can't see it | Correctly captioned |
| Managed install | Unchanged | Unchanged |
| User-created custom profiles | Unchanged | Unchanged |

## Why this is safe

- `resolveDefaultProfileForProvider(profiles, key, null)` reduces **exactly** to the previous `getEffectiveProfile` behavior — a null/absent `defaultProvider` (every managed install) is byte-for-byte unaffected, by construction.
- User-owned workspace profiles win over code defaults identically in both variants, so custom profiles are untouched (pinned by a new test).
- Both call sites (direct lookup and mix-arm expansion) move together, so a mix and its arms always resolve against the same column.
- All pre-existing tests pass unchanged; regression surfaces (`image-fallback.test.ts`, `vision-recovery.test.ts`) pass; typecheck clean.

## Test coverage added

The existing suite had zero `defaultProvider` coverage, so this divergence was invisible. New cases: BYO column judgment, null-reduction baseline, mix-arm column consistency, and custom-profile invariance.

<details>
<summary>Full consolidation plan (papertrail)</summary>

# Consolidate BYO profile resolution onto the provider-aware path

## Overview

On BYO installs, ~17 call sites still resolve default profiles through the managed/vellum column (`getEffectiveProfiles` / `getEffectiveProfile` in `assistant/src/config/default-profile-catalog.ts`) instead of the provider-aware variants (`getEffectiveProfilesForProvider` / `resolveDefaultProfileForProvider`) that the dispatch resolver already uses. Result: the `/model` picker, vision checks, plugin profile lists, the config wire view, and several validators show or judge models the user's install will never run. This plan migrates every stale call site onto the provider-aware path and then locks the managed-column functions down so new call sites can't regress.

Safety property shared by every PR: the provider-aware functions are pure and synchronous, the caller passes `llm.defaultProvider ?? null`, and a `null` defaultProvider reduces exactly to the managed-column behavior. Managed installs are byte-for-byte unaffected; only BYO installs change, and only toward what `resolveCallSiteConfig` already dispatches.

Reference implementation for every swap: `assistant/src/runtime/routes/inference-profiles-routes.ts:357` (`config.llm.defaultProvider ?? null` off `getConfigReadOnly()`). Test fixture pattern to copy: the `dp("anthropic")` helper in the `resolveDefaultProfileForProvider` describe block of `assistant/src/config/__tests__/default-profile-catalog.test.ts` (~line 286).

Out of scope (tracked separately): the per-tier BYO mapping feature itself (new `llm` config field + settings UI), surfacing resolved models in the web client, and removing the dead `vision-optimized` intent.

Repo conventions that apply: run tests per-file (`bun test <path>` — batching files causes spurious failures), no rebase/force-push once a PR is under review, comments describe current state only.

Line numbers below are as of `main` @ 45cc60c86c.

## PR 1: Provider-aware vision support

### Depends on
None

### Branch
byo-profile-resolve/pr-1-vision-support

### Title
fix(plugin-api): resolve profile vision support against the default provider

### Files
- assistant/src/plugin-api/vision-support.ts
- assistant/src/plugin-api/vision-support.test.ts

### Implementation steps
1. In `vision-support.ts`, both `getEffectiveProfiles(llm.profiles)` calls (lines 71 and 79 — the direct profile lookup and the mix-arm expansion) become `getEffectiveProfilesForProvider(llm.profiles, llm.defaultProvider ?? null)`. `llm` is already destructured from `getConfig()` in `profileVision`. Both must move together: otherwise a mix's arms resolve against a different column than the mix itself.
2. Update the import from `../config/default-profile-catalog.js` accordingly.
3. In `vision-support.test.ts` (currently has zero `defaultProvider` coverage): add a describe block that sets `llm.defaultProvider = { provider: "anthropic" }` in the config fixture and asserts that `doesSupportVision("balanced")` (and a mix containing `balanced`) is judged against the anthropic column's balanced model, not the managed/vellum column's. Add the inverse case: `defaultProvider` absent → identical results to the existing expectations (the null-reduction property).

### Acceptance criteria
- With `defaultProvider` unset, all pre-existing test expectations pass unchanged.
- With `defaultProvider: { provider: "anthropic" }`, vision judgment for `balanced` / `quality-optimized` uses the anthropic column model per `PROVIDER_MODEL_INTENTS`, verified by the new tests.
- `bun test assistant/src/plugin-api/vision-support.test.ts` passes; `bun test assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts` and `.../vision-recovery.test.ts` pass individually (regression surface — no fixture there sets `defaultProvider`, so they must be unaffected).

## PR 2: Provider-aware connection-delete guard

### Depends on
None

### Branch
byo-profile-resolve/pr-2-connection-guard

### Title
fix(routes): make the connection-delete reference scan provider-aware

### Files
- assistant/src/runtime/routes/inference-provider-connection-routes.ts
- assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts

### Implementation steps
1. At line 513, the reference scan iterates `getEffectiveProfiles(...)` to find profiles whose `provider_connection` names the connection being deleted. Swap to `getEffectiveProfilesForProvider(profiles, dp)` — `dp` from `getDefaultProviderFromConfig(config)` is already in scope at line 490. The provider-aware bodies stamp `provider_connection` via `resolveDefaultConnectionName(dp)`; the managed column does not, which is why the scan currently misses the connection the default profiles actually resolve through.
2. Update the import.
3. In the test file (already `defaultProvider`-aware): add a case — BYO install with `defaultProvider: { provider: "fireworks" }` and a `fireworks-personal` connection; deleting `fireworks-personal` must be rejected, and the rejection payload must list the default profiles as referents. Add a case with an explicit `connectionName` on `defaultProvider` pointing at a second same-provider connection, and assert deleting *that* connection is blocked.

### Acceptance criteria
- Deleting the connection that BYO default profiles resolve through is blocked with the default profiles named as referents.
- `defaultProvider` unset → scan behavior identical to today (null-reduction).
- `bun test assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts` passes.

## PR 3: Provider-aware plugin profile list

### Depends on
None

### Branch
byo-profile-resolve/pr-3-plugin-profiles

### Title
fix(plugin-api): list model profiles through provider-aware resolution

### Files
- assistant/src/plugin-api/model-profiles.ts
- assistant/src/plugin-api/model-profiles.test.ts

### Implementation steps
1. At `model-profiles.ts:23`, swap `getEffectiveProfiles` → `getEffectiveProfilesForProvider(llm.profiles, llm.defaultProvider ?? null)` (`getConfig()` already destructured). This feeds `getModelProfiles()`, so `isDispatchableProfile` stops judging dispatchability against the wrong column on BYO (a default can currently be wrongly hidden from plugins).
2. Update the import.
3. Add `defaultProvider` fixture coverage to `model-profiles.test.ts`: with a BYO provider set, each default profile's reported provider/model comes from that provider's column, and dispatchability is judged against it. Check `assistant/src/__tests__/plugin-api-model-profiles.test.ts` for overlapping assertions and extend it only if it asserts on provider/model values.

### Acceptance criteria
- BYO fixture: listed default profiles carry the default provider's column model, and none are spuriously filtered by `isDispatchableProfile`.
- `defaultProvider` unset → output unchanged.
- `bun test assistant/src/plugin-api/model-profiles.test.ts` and `bun test assistant/src/__tests__/plugin-api-model-profiles.test.ts` pass.

## PR 4: Provider-aware /model picker

### Depends on
None

### Branch
byo-profile-resolve/pr-4-model-picker

### Title
fix(daemon): resolve the /model picker through the default provider

### Files
- assistant/src/daemon/conversation-slash.ts
- assistant/src/__tests__/conversation-slash.test.ts (new)

### Implementation steps
1. At `conversation-slash.ts:139`, swap `getEffectiveProfiles` → `getEffectiveProfilesForProvider(config.llm.profiles, config.llm.defaultProvider ?? null)` — `config` from `getConfig()` is in scope one line above. This fixes both the listing (labels/descriptions shown to the user) and the membership set the switch validates against, which today can disagree with what the resolver dispatches.
2. Update the import.
3. Create `assistant/src/__tests__/conversation-slash.test.ts` (none exists — follow the conventions of `assistant/src/__tests__/conversation-runtime-assembly.test.ts` for config fixture setup). Minimum coverage: (a) with a BYO `defaultProvider`, the picker lists the default profiles with that provider's column bodies; (b) switching to a listed default succeeds; (c) `defaultProvider` unset → listing matches current behavior.

### Acceptance criteria
- Picker listing and switch validation use the same provider-aware set.
- `bun test assistant/src/__tests__/conversation-slash.test.ts` passes.

## PR 5: Provider-aware config wire view (atomic read/write pair)

### Depends on
None

### Branch
byo-profile-resolve/pr-5-config-wire-view

### Title
fix(routes): resolve the config wire overlay and echo-stripping provider-aware

### Files
- assistant/src/runtime/routes/conversation-query-routes.ts
- assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts

### Implementation steps
1. **Write the test first**: a BYO round-trip in `conversation-query-routes.test.ts` (zero `defaultProvider` coverage today). Fixture with `defaultProvider: { provider: "anthropic" }`; `config_get` must return default profiles with anthropic-column bodies; feeding that exact payload back through `config_patch`/`config_set` must strip the managed echoes to a no-op and pass `assertInvariantProfilesPreserved`. This test fails before the swap and pins the read/write contract.
2. These call sites operate on `loadRawConfig()` (untyped), so `llm.defaultProvider` arrives as `unknown`. Parse it once with `DefaultProviderSchema` (import from `assistant/src/config/schemas/llm.ts`) via `safeParse`, yielding `DefaultProviderConfig | null` — do not cast. Add a small local helper if both functions need it.
3. Swap `overlayEffectiveProfilesForWire` (line 869) to `getEffectiveProfilesForProvider` with the parsed value.
4. Swap `normalizeManagedProfileWrites` (line 1003) in the same commit — its contract is "strip fields equal to the current effective **wire** value", so it must agree with step 3 or honest BYO round-trips get rejected. These two must never land separately.
5. Swap the mix-arm validation at line 1736 (`getConfig()` inline there — use the typed `config.llm.defaultProvider ?? null` idiom, no raw parsing needed).
6. Reconcile the imports at lines 143–144 (both managed-column imports go if nothing else in the file still uses them).

### Acceptance criteria
- The new BYO `config_get` → `config_set` round-trip test passes; a pre-swap run of the test demonstrably fails (note it in the PR description).
- `bun test assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts` passes.
- `bun test assistant/src/__tests__/managed-profile-guard.test.ts` passes unchanged (closest existing guard on this write path — already sets `defaultProvider`).

## PR 6: Uniformity sweep — route-layer membership checks and write echoes

### Depends on
None

### Branch
byo-profile-resolve/pr-6-route-membership

### Title
refactor(routes): route profile membership checks and write echoes through provider-aware resolution

### Files
- assistant/src/runtime/routes/conversation-routes.ts
- assistant/src/runtime/routes/inference-send-routes.ts
- assistant/src/runtime/routes/inference-profile-session-handler.ts
- assistant/src/runtime/routes/llm-call-sites-routes.ts
- assistant/src/runtime/routes/inference-profiles-routes.ts
- (matching test files: `__tests__/conversation-management-routes.test.ts`, `__tests__/inference-send-routes.test.ts`, `assistant/src/__tests__/inference-profile-session-handler.test.ts`, `__tests__/llm-call-sites-routes.test.ts`, `__tests__/inference-profiles-routes.test.ts`)

### Implementation steps
Grouped deliberately despite the file count: each change is the identical one-line swap on a names/membership-only read, reviewable as one pattern.
1. `conversation-routes.ts:1452` (validates `inferenceProfile` on conversation create/update): swap, `getConfig()` inline.
2. `inference-send-routes.ts:42` (`--profile` existence check + "Available profiles:" hint): swap, `getConfigReadOnly()` inline. The next block already calls the provider-aware `selectWinningProfile`, so this ends the split-brain between existence check and usability check.
3. `inference-profile-session-handler.ts:148` (sticky-profile membership): swap, `loadConfig()` inline.
4. `llm-call-sites-routes.ts:56` (profile-name dropdown source): swap, `llm` already destructured.
5. `inference-profiles-routes.ts:459` and `:545` (the post-write entry echoes in `handleCreateProfile` / `handleUpdateProfile`): swap the singular `getEffectiveProfile(getConfig().llm.profiles, name)` → `resolveDefaultProfileForProvider(getConfig().llm.profiles, name, getConfig().llm.defaultProvider ?? null)` at both sites, then drop the now-unused `getEffectiveProfile` import at line 21. These handlers reject managed names before the echo, and non-matrix names fall back to identical behavior inside `resolveDefaultProfileForProvider`, so this is behavior-neutral — the point is that PR 8's lint has no allowlist entry for this file. While touching those lines, drop the `as Record<string, unknown>` casts if the return types flow cleanly without them; keep them only if the route return type genuinely needs the widening.
6. Per file, add one minimal `defaultProvider` fixture case asserting the membership set includes the defaults under a BYO provider (names are column-invariant today, so these are cheap pins against future column divergence). For `inference-profiles-routes.ts`, the test file is already `defaultProvider`-aware — add a create-then-echo assertion under a BYO fixture.

### Acceptance criteria
- All six swapped sites compile with no other behavior change; each listed test file passes individually via `bun test <file>`.
- `inference-profiles-routes.ts` no longer imports `getEffectiveProfile` / `getEffectiveProfiles` (grep-clean), so PR 8's lint needs no allowlist entry for it.

## PR 7: Uniformity sweep — non-route consumers

### Depends on
None

### Branch
byo-profile-resolve/pr-7-nonroute-consumers

### Title
refactor(assistant): provider-aware profile resolution for daemon, workflows, and memory consumers

### Files
- assistant/src/daemon/conversation-runtime-assembly.ts
- assistant/src/workflows/leaf-runner.ts
- assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
- assistant/src/tools/workflows/manage-workflows.ts
- (matching test files: `assistant/src/__tests__/conversation-runtime-assembly.test.ts`, `assistant/src/workflows/leaf-runner.test.ts`, `.../memory/src/__tests__/memory-v2-simulate-route.test.ts`, `assistant/src/tools/workflows/run-workflow.test.ts`)

### Implementation steps
1. `conversation-runtime-assembly.ts:234` (`resolveTurnModelProfileLabel` — the `model_profile:` context line): swap; the function already receives `llm: LLMConfig`, so pass `llm.defaultProvider ?? null` with no new threading. (The model half of the line is already resolver-sourced; this aligns the label.)
2. `leaf-runner.ts:331` (`profileExists` gating `WorkflowUnknownProfileError` and the `activeProfile` fallback): this is the one singular-form site — swap `getEffectiveProfile(profiles, name)` → `resolveDefaultProfileForProvider(profiles, name, config.llm.defaultProvider ?? null)`.
3. `memory-v2-routes.ts:524` (router playground `profileOverride` validation): swap, `liveConfig` in scope.
4. `manage-workflows.ts:195` (`list_profiles` action): swap, `llm` destructured. Mirrors PR 6's `llm-call-sites-routes.ts` — the two intentionally stay in sync.
5. Minimal `defaultProvider` fixture case per touched test file, as in PR 6. `run-workflow.test.ts` coverage of `list_profiles` is thin — extend rather than restructure.

### Acceptance criteria
- All four sites compile with no other behavior change; each listed test file passes individually via `bun test <file>`.

## PR 8: Lock down the managed-column API

### Depends on
PR 1, PR 2, PR 3, PR 4, PR 5, PR 6, PR 7

### Branch
byo-profile-resolve/pr-8-lockdown

### Title
refactor(config): restrict managed-column profile resolution to its intentional callers

### Files
- assistant/src/config/llm-resolver.ts
- assistant/eslint.config.mjs (or a new rule in assistant/eslint-rules/)
- assistant/src/config/__tests__/default-profile-catalog.test.ts (only if signatures shift)

### Implementation steps
1. In `llm-resolver.ts`, remove the `getEffectiveProfile` default value on `resolveProfileFragment`'s `lookupEntry` parameter (line ~518) and make the parameter required — both production callers (lines ~280, ~320) already pass the provider-aware `providerAwareEntry`. The default is dead on the production path and is the last silent managed-column fallback. Drop the now-unused import.
2. Fix the stale doc comment at line ~60 that still narrates resolution through `getEffectiveProfile` (the body resolves through `resolveDefaultProfileForProvider`). Describe current state only, per assistant/CLAUDE.md comment rules.
3. Add lint enforcement so new imports of `getEffectiveProfiles` / `getEffectiveProfile` outside the allowlist fail CI. Prefer `no-restricted-imports` with a targeted `overrides` allowlist in `eslint.config.mjs`; if path-scoped allowlisting is awkward there, follow the existing custom-rule precedent in `assistant/eslint-rules/`. Allowlist: `assistant/src/config/default-profile-catalog.ts` itself, `assistant/src/config/seed-inference-profiles.ts` (hatch-time stubs are deliberately managed-column), `assistant/src/config/inference-profile-validation.ts` (write-path validation, deliberate), and test files.
4. Sweep for imports the earlier PRs left unused and remove them.

### Acceptance criteria
- `resolveProfileFragment` has no default lookup; all callers compile.
- A scratch file importing `getEffectiveProfiles` outside the allowlist fails `bun run lint` (demonstrate in the PR description, then delete).
- `bun test assistant/src/config/__tests__/default-profile-catalog.test.ts` and `bun test assistant/src/config/__tests__/llm-resolver.test.ts` (if present) pass.
- `bun run lint` passes repo-wide.


</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->