### PR TITLE
refactor(assistant): validate the host app-control result body via parseBody

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -13621,6 +13621,7 @@ paths:
               properties:
                 requestId:
                   type: string
+                  minLength: 1
                   description: Pending app-control request ID
                 state:
                   type: string

--- a/assistant/src/__tests__/host-app-control-routes.test.ts
+++ b/assistant/src/__tests__/host-app-control-routes.test.ts
@@ -239,6 +239,98 @@ describe("handleHostAppControlResult", () => {
     ).toThrow(BadRequestError);
   });
 
+  test("malformed body (empty requestId): throws BadRequestError", () => {
+    expect(() =>
+      handleHostAppControlResult({ body: { requestId: "", state: "running" } }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("malformed body (non-string requestId): throws BadRequestError", () => {
+    expect(() =>
+      handleHostAppControlResult({ body: { requestId: 42, state: "running" } }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("malformed body (wrong-typed optional): throws BadRequestError", () => {
+    expect(() =>
+      handleHostAppControlResult({
+        body: { requestId: "abc", state: "running", pngBase64: 123 },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("malformed body (windowBounds not an object): throws BadRequestError", () => {
+    expect(() =>
+      handleHostAppControlResult({
+        body: { requestId: "abc", state: "running", windowBounds: "nope" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("malformed body (windowBounds missing a side): throws BadRequestError", () => {
+    expect(() =>
+      handleHostAppControlResult({
+        body: {
+          requestId: "abc",
+          state: "running",
+          windowBounds: { x: 1, y: 2, width: 800 },
+        },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("malformed body (non-numeric windowBounds side): throws BadRequestError", () => {
+    expect(() =>
+      handleHostAppControlResult({
+        body: {
+          requestId: "abc",
+          state: "running",
+          windowBounds: { x: 1, y: 2, width: "800", height: 600 },
+        },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("validates before consuming the pending interaction", async () => {
+    const requestId = "ac-req-invalid-stays";
+    pending.set(requestId, {
+      conversationId: "conv-1",
+      kind: "host_app_control",
+    });
+
+    await handleHostAppControlResult({
+      body: { requestId, state: "exploded" },
+    }).catch(() => {
+      // expected
+    });
+
+    expect(pending.has(requestId)).toBe(true);
+  });
+
+  test("unknown keys are stripped, not rejected (client passthrough result)", async () => {
+    const requestId = "ac-req-extra-keys";
+    const conversationId = "conv-extra";
+    pending.set(requestId, { conversationId, kind: "host_app_control" });
+
+    const resolveCalls: Array<{ payload: unknown }> = [];
+    conversations.set(conversationId, {
+      conversationId,
+      hostAppControlProxy: {
+        resolve(_rid, payload) {
+          resolveCalls.push({ payload });
+        },
+      },
+    });
+
+    const result = await handleHostAppControlResult({
+      body: { requestId, state: "running", helperDiagnostics: { pid: 4242 } },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(resolveCalls).toHaveLength(1);
+    expect(resolveCalls[0].payload).toEqual({ requestId, state: "running" });
+  });
+
   test("payload omits undefined optional fields (no leaking undefined keys)", async () => {
     const requestId = "ac-req-min";
     const conversationId = "conv-min";

--- a/assistant/src/runtime/routes/host-app-control-routes.ts
+++ b/assistant/src/runtime/routes/host-app-control-routes.ts
@@ -27,23 +27,54 @@ import {
 import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import { BadRequestError, ForbiddenError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
-const VALID_STATES: ReadonlySet<HostAppControlState> = new Set([
+/**
+ * States the client may report. `satisfies` keeps this tuple a subset of
+ * {@link HostAppControlState}, so the wire enum cannot drift past the type.
+ */
+const APP_CONTROL_STATES = [
   "running",
   "missing",
   "minimized",
-]);
+] as const satisfies readonly HostAppControlState[];
+
+/**
+ * Body of `POST /v1/host-app-control-result`, declared as the route's
+ * `requestBody` and parsed by the handler, so the OpenAPI contract and the
+ * runtime check are one schema rather than two hand-kept copies.
+ *
+ * Unknown keys are stripped rather than rejected: the macOS executor forwards
+ * its helper's result through a `.passthrough()` schema, so extra fields can
+ * legitimately ride along.
+ */
+const HostAppControlResultBodySchema = z.object({
+  requestId: z.string().min(1).describe("Pending app-control request ID"),
+  state: z
+    .enum(APP_CONTROL_STATES)
+    .describe("Lifecycle state of the targeted application"),
+  pngBase64: z
+    .string()
+    .describe("Base64 PNG screenshot of the targeted app window")
+    .optional(),
+  windowBounds: z
+    .object({
+      x: z.number(),
+      y: z.number(),
+      width: z.number(),
+      height: z.number(),
+    })
+    .optional(),
+  executionResult: z.string().optional(),
+  executionError: z.string().optional(),
+});
 
 // ---------------------------------------------------------------------------
 // POST /v1/host-app-control-result
 // ---------------------------------------------------------------------------
 
 async function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
-  if (!body || typeof body !== "object") {
-    throw new BadRequestError("Request body is required");
-  }
-
   const {
     requestId,
     state,
@@ -51,24 +82,7 @@ async function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
     windowBounds,
     executionResult,
     executionError,
-  } = body as {
-    requestId?: string;
-    state?: string;
-    pngBase64?: string;
-    windowBounds?: { x: number; y: number; width: number; height: number };
-    executionResult?: string;
-    executionError?: string;
-  };
-
-  if (!requestId || typeof requestId !== "string") {
-    throw new BadRequestError("requestId is required");
-  }
-
-  if (!state || !VALID_STATES.has(state as HostAppControlState)) {
-    throw new BadRequestError(
-      "state must be one of: running, missing, minimized",
-    );
-  }
+  } = parseBody(HostAppControlResultBodySchema, body);
 
   // Late-delivery tolerance: if the pending interaction is already gone (the
   // proxy timed out, the conversation was disposed, etc.), accept the post
@@ -115,7 +129,7 @@ async function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
 
   const payload: HostAppControlResultPayload = {
     requestId,
-    state: state as HostAppControlState,
+    state,
     ...(pngBase64 !== undefined ? { pngBase64 } : {}),
     ...(windowBounds !== undefined ? { windowBounds } : {}),
     ...(executionResult !== undefined ? { executionResult } : {}),
@@ -145,26 +159,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Resolve a pending host app-control request by requestId. Returns 200 even when no pending interaction matches (late delivery is tolerated).",
     tags: ["host"],
-    requestBody: z.object({
-      requestId: z.string().describe("Pending app-control request ID"),
-      state: z
-        .enum(["running", "missing", "minimized"])
-        .describe("Lifecycle state of the targeted application"),
-      pngBase64: z
-        .string()
-        .describe("Base64 PNG screenshot of the targeted app window")
-        .optional(),
-      windowBounds: z
-        .object({
-          x: z.number(),
-          y: z.number(),
-          width: z.number(),
-          height: z.number(),
-        })
-        .optional(),
-      executionResult: z.string().optional(),
-      executionError: z.string().optional(),
-    }),
+    requestBody: HostAppControlResultBodySchema,
     responseBody: z.object({
       accepted: z.boolean(),
     }),


### PR DESCRIPTION
## TL;DR

`POST /v1/host-app-control-result` validated its body with a `body as {...}` cast plus two hand-rolled guards, so only `requestId` and `state` were actually checked at runtime. This swaps that for the shared `parseBody()` helper against the route's own declared `requestBody` schema, so every field is validated and malformed input returns a 400 instead of flowing into handler logic.

LUM-2793, continuing the per-route rollout from #39051 and #39052.

## What changed

The route's inline `requestBody` schema is hoisted into a named const (`HostAppControlResultBodySchema`) and used in both places: as the route's declared `requestBody`, and as the argument to `parseBody()`. The wire contract and the runtime check are now one schema rather than two hand-kept copies.

That removes all three `body as {...}` cast sites, plus the now-dead `VALID_STATES` set and the `state as HostAppControlState` re-cast, since `state` comes out of the parse already narrowed to the enum.

`VALID_STATES` was typed `ReadonlySet<HostAppControlState>`, which caught schema-to-type drift. The replacement `APP_CONTROL_STATES` tuple preserves that guard via `as const satisfies readonly HostAppControlState[]`.

## Before / after for the user

| Body posted by the client | Before | After |
| --- | --- | --- |
| Valid result | 200, forwarded to the proxy | Unchanged |
| Extra unknown keys | 200, extra keys stripped | Unchanged (schema is deliberately non-strict) |
| Missing or blank `requestId`, bad `state` | 400 | Unchanged (400, different message text) |
| `windowBounds: "nope"` | 200, a string reached the proxy through a field typed as a bounds object | 400 |
| `windowBounds` missing `height` | 200, malformed bounds forwarded | 400 |
| `pngBase64: 123` | 200, a number forwarded through a string field | 400 |

## Why this is safe

- The macOS client is the only caller. Its `APP_CONTROL_RESULT_SCHEMA` in `clients/macos/src/main/executors/host-app-control-executor.ts` is field-identical to the route schema (same `state` enum, same optional fields, same `windowBounds` shape), so every result it posts still validates.
- That client schema is `.passthrough()` and the executor spreads the helper's result (`{ requestId, ...result }`), so extra keys can legitimately ride along. The route schema is therefore left non-strict on purpose: unknown keys are stripped, exactly as the old destructuring did. There is a test covering this.
- The only OpenAPI delta is `minLength: 1` on `requestId`, which documents the empty-string rejection the old `!requestId` guard already performed. The regenerated spec is included.
- Every newly rejected case is a previously unvalidated field reaching the awaiting proxy with the wrong runtime type.
- `parseBody` throws `BadRequestError`, which both the HTTP and IPC adapters already map to 400.

## Tests

Added to `assistant/src/__tests__/host-app-control-routes.test.ts`: blank and non-string `requestId`, wrong-typed `pngBase64`, three `windowBounds` shape violations, a check that validation happens before the pending interaction is consumed, and a check that unknown keys are stripped rather than rejected.

That file goes from 22 to 30 passing tests. `bunx tsc --noEmit`, eslint, and prettier are all clean.

## Deferred, and a suggestion

Nothing is deferred from this route.

Worth flagging for the rollout as a whole: the same cast-and-guard shape (`Request body is required` / `requestId is required` followed by a `body as {...}`) still appears in at least `host-cu-routes.ts`, `host-file-routes.ts`, `guardian-action-routes.ts`, `approval-routes.ts`, `secret-routes.ts`, `credential-routes.ts`, and `channel-verification-routes.ts`. Each is the same mechanical edit as this one. If the rollout is going to reach all of them anyway, a single sweep is probably cheaper than a ticket per route, and it would close the validation gap everywhere at once rather than leaving a shrinking set of unvalidated boundaries. Happy to do that as a follow-up if useful.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->