### PR TITLE
fix(assistant): let platform-connected assistants register webhook callbacks

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -31549,7 +31549,8 @@ paths:
       summary: Register a webhook callback URL
       description:
         Resolves a stable callback URL for a webhook type. On platform-managed assistants, registers the route with
-        the platform gateway. On self-hosted assistants, uses the configured ingress.publicBaseUrl.
+        the platform gateway. Otherwise uses the configured ingress.publicBaseUrl, falling back to the platform gateway
+        when no ingress is configured and the assistant is connected to the platform.
       tags:
         - webhooks
       requestBody:

--- a/assistant/src/__tests__/platform-callback-registration.test.ts
+++ b/assistant/src/__tests__/platform-callback-registration.test.ts
@@ -7,27 +7,27 @@ let mockPlatformBaseUrl = "";
 let mockPlatformAssistantId = "";
 let mockSecureKeys: Record<string, string> = {};
 
+// Bun shares mocked modules across test files in a combined run, so each mock
+// spreads the real module and overrides only what this file drives. Replacing
+// a module wholesale drops the exports peer tests import from it and breaks
+// their ESM named-import validation whenever this mock wins evaluation.
+const actualEnvRegistry = await import("../config/env-registry.js");
 mock.module("../config/env-registry.js", () => ({
+  ...actualEnvRegistry,
   getIsPlatform: () => mockIsPlatform,
-  // Not called by this test, but the real util/logger.js + util/platform.js
-  // (loaded now that the logger is silent under test instead of mocked)
-  // import these names, and ESM named-import validation requires them.
-  getWorkspaceDirOverride: () => process.env.VELLUM_WORKSPACE_DIR,
-  getDebugStdoutLogs: () => false,
-  getIsContainerized: () => false,
 }));
 
+const actualEnv = await import("../config/env.js");
 mock.module("../config/env.js", () => ({
+  ...actualEnv,
   getPlatformBaseUrl: () => mockPlatformBaseUrl,
   getPlatformAssistantId: () => mockPlatformAssistantId,
 }));
 
+const actualSecureKeys = await import("../security/secure-keys.js");
 mock.module("../security/secure-keys.js", () => ({
+  ...actualSecureKeys,
   getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? undefined,
-  // Bun shares mocked modules across test files in a combined run; peer
-  // tests import this name from the same module, so stub it to keep their
-  // ESM named-import validation satisfied when this mock wins evaluation.
-  deleteSecureKeyAsync: async () => ({ deleted: false }),
 }));
 
 const originalFetch = globalThis.fetch;

--- a/assistant/src/cli/commands/webhooks.help.ts
+++ b/assistant/src/cli/commands/webhooks.help.ts
@@ -13,8 +13,9 @@ Resolves a stable callback URL that external services (Telegram, Twilio,
 email providers, OAuth) should use to reach this assistant.
 
 On platform-managed assistants, this registers a callback route with the
-platform gateway. On self-hosted assistants, it uses the configured
-ingress.publicBaseUrl.
+platform gateway. Otherwise it uses the configured ingress.publicBaseUrl,
+falling back to the platform gateway when no ingress is configured and the
+assistant is connected to the platform.
 
 The webhook path is derived from the type: underscores become path
 separators, prefixed with webhooks/.
@@ -49,8 +50,12 @@ Examples:
       helpText: `
 Resolves a callback URL for the given webhook type. On platform-managed
 assistants (IS_PLATFORM=true), registers a callback route with the platform
-gateway and returns the stable external URL. On self-hosted assistants,
-reads ingress.publicBaseUrl from config and appends the webhook path.
+gateway and returns the stable external URL. Otherwise it reads
+ingress.publicBaseUrl from config and appends the webhook path. That URL is
+either your own tunnel or the Velay tunnel URL the gateway publishes. If no
+ingress is configured and the assistant is connected to the platform
+(via 'assistant platform connect'), it registers a callback route with the
+platform gateway instead of failing.
 
 Arguments:
   type   The webhook type to register. The path is derived automatically:

--- a/assistant/src/runtime/routes/__tests__/webhook-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/webhook-routes.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the webhooks_register route handler's callback-URL
+ * resolution order (LUM-2863).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { InternalError, UnprocessableEntityError } from "../errors.js";
+
+let isPlatform = false;
+let config: Record<string, unknown> = {};
+let platformContextEnabled = false;
+let registerCallbackRouteError: Error | undefined;
+
+const registerCallbackRouteMock = mock(
+  async (callbackPath: string, _type: string, _source?: string) => {
+    if (registerCallbackRouteError) {
+      throw registerCallbackRouteError;
+    }
+    return `https://gateway.vellum.ai/assistant-123/${callbackPath}`;
+  },
+);
+
+// Spread the real modules: these are broad barrels and replacing them wholesale
+// breaks unrelated importers pulled in by the module under test.
+const actualEnvRegistry = await import("../../../config/env-registry.js");
+mock.module("../../../config/env-registry.js", () => ({
+  ...actualEnvRegistry,
+  getIsPlatform: () => isPlatform,
+}));
+
+const actualLoader = await import("../../../config/loader.js");
+mock.module("../../../config/loader.js", () => ({
+  ...actualLoader,
+  getConfig: () => config,
+}));
+
+mock.module("../../../inbound/platform-callback-registration.js", () => ({
+  registerCallbackRoute: registerCallbackRouteMock,
+  resolvePlatformCallbackRegistrationContext: async () => ({
+    isPlatform,
+    platformBaseUrl: "https://api.vellum.ai",
+    assistantId: platformContextEnabled ? "assistant-123" : "",
+    hasAssistantApiKey: platformContextEnabled,
+    authHeader: platformContextEnabled ? "Api-Key secret" : null,
+    enabled: platformContextEnabled,
+  }),
+}));
+
+const { ROUTES } = await import("../webhook-routes.js");
+
+const registerRoute = ROUTES.find(
+  (r) => r.operationId === "webhooks_register",
+)!;
+
+const register = (body: Record<string, unknown>) =>
+  registerRoute.handler({ body });
+
+describe("webhooks_register callback URL resolution", () => {
+  beforeEach(() => {
+    isPlatform = false;
+    config = {};
+    platformContextEnabled = false;
+    registerCallbackRouteError = undefined;
+    registerCallbackRouteMock.mockClear();
+  });
+
+  test("platform pods register with the platform gateway", async () => {
+    isPlatform = true;
+    platformContextEnabled = true;
+
+    expect(await register({ type: "telegram" })).toEqual({
+      callbackUrl: "https://gateway.vellum.ai/assistant-123/webhooks/telegram",
+      type: "telegram",
+      path: "webhooks/telegram",
+      mode: "platform",
+    });
+  });
+
+  // The bug: a local assistant that IS connected to the platform used to fall
+  // through to the self-hosted branch and 422 when it had no public ingress.
+  test("platform-connected local assistant with no ingress gets the platform callback URL", async () => {
+    platformContextEnabled = true;
+
+    expect(await register({ type: "telegram" })).toEqual({
+      callbackUrl: "https://gateway.vellum.ai/assistant-123/webhooks/telegram",
+      type: "telegram",
+      path: "webhooks/telegram",
+      mode: "platform",
+    });
+    expect(registerCallbackRouteMock).toHaveBeenCalledWith(
+      "webhooks/telegram",
+      "telegram",
+      undefined,
+    );
+  });
+
+  test("disconnected local assistant uses the configured publicBaseUrl", async () => {
+    config = { ingress: { publicBaseUrl: "https://abc.ngrok.io" } };
+
+    expect(await register({ type: "telegram" })).toEqual({
+      callbackUrl: "https://abc.ngrok.io/webhooks/telegram",
+      type: "telegram",
+      path: "webhooks/telegram",
+      mode: "self-hosted",
+    });
+    expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+  });
+
+  test("disconnected local assistant with no ingress is still unprocessable", async () => {
+    await expect(register({ type: "telegram" })).rejects.toBeInstanceOf(
+      UnprocessableEntityError,
+    );
+  });
+
+  // A logged-in local assistant holds platform credentials for the LLM proxy,
+  // so credential presence must not override an explicitly configured tunnel.
+  test("a configured publicBaseUrl wins over platform connectivity", async () => {
+    platformContextEnabled = true;
+    config = { ingress: { publicBaseUrl: "https://abc.ngrok.io" } };
+
+    expect(await register({ type: "telegram" })).toMatchObject({
+      callbackUrl: "https://abc.ngrok.io/webhooks/telegram",
+      mode: "self-hosted",
+    });
+    expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+  });
+
+  // The gateway publishes the Velay tunnel URL into ingress.publicBaseUrl, so
+  // a tunneled platform-connected assistant already resolves to a stable
+  // platform-owned URL through the ingress tier.
+  test("a Velay-managed publicBaseUrl resolves through the ingress tier", async () => {
+    platformContextEnabled = true;
+    config = {
+      ingress: {
+        publicBaseUrl: "https://velay.vellum.ai/assistant-123",
+        publicBaseUrlManagedBy: "velay",
+      },
+    };
+
+    expect(await register({ type: "twilio_voice" })).toEqual({
+      callbackUrl:
+        "https://velay.vellum.ai/assistant-123/webhooks/twilio/voice",
+      type: "twilio_voice",
+      path: "webhooks/twilio/voice",
+      mode: "self-hosted",
+    });
+  });
+
+  test("explicitly disabled ingress is not routed around via the platform", async () => {
+    platformContextEnabled = true;
+    config = { ingress: { enabled: false } };
+
+    await expect(register({ type: "telegram" })).rejects.toBeInstanceOf(
+      UnprocessableEntityError,
+    );
+    expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+  });
+
+  test("the source identifier is forwarded to the platform registration", async () => {
+    platformContextEnabled = true;
+
+    await register({ type: "telegram", source: "@my_bot" });
+
+    expect(registerCallbackRouteMock).toHaveBeenCalledWith(
+      "webhooks/telegram",
+      "telegram",
+      "@my_bot",
+    );
+  });
+
+  test("a failed platform registration surfaces as a 500", async () => {
+    platformContextEnabled = true;
+    registerCallbackRouteError = new Error(
+      "Platform callback route registration failed (HTTP 502)",
+    );
+
+    await expect(register({ type: "telegram" })).rejects.toBeInstanceOf(
+      InternalError,
+    );
+  });
+
+  test("a missing platform registration context surfaces as a 422", async () => {
+    platformContextEnabled = true;
+    registerCallbackRouteError = new Error(
+      "Platform callbacks not available — missing platform registration context",
+    );
+
+    await expect(register({ type: "telegram" })).rejects.toBeInstanceOf(
+      UnprocessableEntityError,
+    );
+  });
+
+  test("a path override replaces the derived webhook path", async () => {
+    platformContextEnabled = true;
+
+    expect(
+      await register({ type: "custom", path: "webhooks/my-provider" }),
+    ).toMatchObject({ path: "webhooks/my-provider" });
+  });
+});

--- a/assistant/src/runtime/routes/webhook-routes.ts
+++ b/assistant/src/runtime/routes/webhook-routes.ts
@@ -3,9 +3,8 @@
  *
  * Serves two operations:
  *   - webhooks_register (POST webhooks/register): Resolve a stable callback URL
- *     for a webhook type, registering with the platform gateway on
- *     platform-managed assistants or using the configured ingress.publicBaseUrl
- *     on self-hosted assistants.
+ *     for a webhook type. See `handleWebhooksRegister` for the resolution
+ *     order.
  *   - webhooks_list (GET webhooks): List all webhook callback routes registered
  *     with the platform for this assistant.
  */
@@ -18,7 +17,10 @@ import {
   registerCallbackRoute,
   resolvePlatformCallbackRegistrationContext,
 } from "../../inbound/platform-callback-registration.js";
-import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
+import {
+  getPublicBaseUrl,
+  type IngressConfig,
+} from "../../inbound/public-ingress-urls.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   BadRequestError,
@@ -77,10 +79,66 @@ function deriveWebhookPath(type: string): string {
   return `webhooks/${type.replace(/_/g, "/")}`;
 }
 
+/**
+ * Register `webhookPath` with the platform gateway, mapping failures onto the
+ * route error vocabulary.
+ */
+async function registerWithPlatform(
+  webhookPath: string,
+  type: string,
+  source: string | undefined,
+): Promise<WebhooksRegisterResponse> {
+  let callbackUrl: string;
+  try {
+    callbackUrl = await registerCallbackRoute(webhookPath, type, source);
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg.includes("missing platform registration context")) {
+      throw new UnprocessableEntityError(msg);
+    }
+    throw new InternalError(`Failed to register callback route: ${msg}`);
+  }
+  return { callbackUrl, type, path: webhookPath, mode: "platform" };
+}
+
+/**
+ * True when the user has explicitly switched public ingress off.
+ *
+ * An explicit opt-out is a decision not to accept inbound webhooks at all, so
+ * it must not be silently routed around via platform callbacks. An *absent*
+ * ingress config is merely "not set up yet" and is eligible for the platform
+ * fallback.
+ */
+function isPublicIngressDisabled(config: IngressConfig): boolean {
+  return config.ingress?.enabled === false;
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve a stable callback URL for a webhook type.
+ *
+ * Resolution order:
+ *   1. **Platform pods** (`IS_PLATFORM`) always register with the platform
+ *      gateway: they have no ingress of their own to advertise.
+ *   2. **A configured public ingress wins** for everyone else. That URL is
+ *      either the user's own tunnel (ngrok, a custom domain) or the Velay
+ *      tunnel URL the gateway publishes into `ingress.publicBaseUrl`, so a
+ *      platform-connected local assistant with a live tunnel already resolves
+ *      to a stable platform-owned URL here.
+ *   3. **Platform-connected assistants with no ingress** register with the
+ *      platform gateway rather than failing. Connectivity is decided by
+ *      credentials (platform base URL + assistant ID + assistant API key), not
+ *      by `IS_PLATFORM`, which is only ever true on a platform pod.
+ *
+ * Ingress deliberately precedes platform registration: any logged-in local
+ * assistant holds platform credentials (it needs them for the LLM proxy), so
+ * treating credential presence as "managed" would silently reroute an
+ * explicitly configured self-hosted webhook through the platform. The gateway's
+ * Telegram and email registrars order the same two tiers the same way.
+ */
 async function handleWebhooksRegister(
   args: RouteHandlerArgs,
 ): Promise<WebhooksRegisterResponse> {
@@ -92,39 +150,40 @@ async function handleWebhooksRegister(
 
   const webhookPath =
     (pathOverride as string | undefined) ?? deriveWebhookPath(type as string);
+  const sourceIdentifier = source as string | undefined;
 
   if (getIsPlatform()) {
-    let callbackUrl: string;
-    try {
-      callbackUrl = await registerCallbackRoute(
-        webhookPath,
-        type as string,
-        source as string | undefined,
-      );
-    } catch (err) {
-      const msg = (err as Error).message;
-      if (msg.includes("missing platform registration context")) {
-        throw new UnprocessableEntityError(msg);
-      }
-      throw new InternalError(`Failed to register callback route: ${msg}`);
-    }
-    return { callbackUrl, type, path: webhookPath, mode: "platform" };
+    return registerWithPlatform(webhookPath, type, sourceIdentifier);
   }
 
-  // Self-hosted: use ingress.publicBaseUrl
   const config = getConfig();
-  let baseUrl: string;
-  try {
-    baseUrl = getPublicBaseUrl(config);
-  } catch (err) {
-    throw new UnprocessableEntityError((err as Error).message);
+  if (isPublicIngressDisabled(config)) {
+    throw new UnprocessableEntityError(
+      "Public ingress is disabled. Ask the assistant to enable it, or update it from the Settings page.",
+    );
   }
-  return {
-    callbackUrl: `${baseUrl}/${webhookPath}`,
-    type,
-    path: webhookPath,
-    mode: "self-hosted",
-  };
+
+  let ingressError: Error;
+  try {
+    const baseUrl = getPublicBaseUrl(config);
+    return {
+      callbackUrl: `${baseUrl}/${webhookPath}`,
+      type,
+      path: webhookPath,
+      mode: "self-hosted",
+    };
+  } catch (err) {
+    ingressError = err as Error;
+  }
+
+  // No ingress configured. Fall back to the platform gateway when this
+  // assistant is connected to the platform.
+  const context = await resolvePlatformCallbackRegistrationContext();
+  if (context.enabled) {
+    return registerWithPlatform(webhookPath, type, sourceIdentifier);
+  }
+
+  throw new UnprocessableEntityError(ingressError.message);
 }
 
 async function handleWebhooksList(
@@ -189,7 +248,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Register a webhook callback URL",
     description:
-      "Resolves a stable callback URL for a webhook type. On platform-managed assistants, registers the route with the platform gateway. On self-hosted assistants, uses the configured ingress.publicBaseUrl.",
+      "Resolves a stable callback URL for a webhook type. On platform-managed assistants, registers the route with the platform gateway. Otherwise uses the configured ingress.publicBaseUrl, falling back to the platform gateway when no ingress is configured and the assistant is connected to the platform.",
     tags: ["webhooks"],
     requestBody: WebhooksRegisterRequestSchema,
     responseBody: WebhooksRegisterResponseSchema,


### PR DESCRIPTION
## TL;DR

`webhooks_register` decided "can I use the platform gateway?" by reading `IS_PLATFORM`, an env var set only on platform pods. A local assistant that **is** connected to the Vellum platform therefore never qualified: with no `ingress.publicBaseUrl` configured it fell through to the self-hosted branch and returned 422, despite holding every credential needed to register a stable callback route.

This adds a third resolution tier keyed on platform *connectivity* rather than pod identity. Fixes LUM-2863.

## Resolution order

| # | Condition | Result |
|---|---|---|
| 1 | `IS_PLATFORM` (platform pod) | Register with the platform gateway |
| 2 | A public ingress base URL is configured | `<publicBaseUrl>/<webhookPath>` |
| 3 | No ingress **and** platform-connected | Register with the platform gateway |
| 4 | Neither | 422, as before |

Connectivity in tier 3 means `resolvePlatformCallbackRegistrationContext().enabled`: platform base URL + assistant ID + assistant API key. That predicate already existed and is what `webhooks_list`, `platform_callback_routes_register`, and `platform_status` use.

## Before / after for the user

| Situation | Before | After |
|---|---|---|
| Platform pod | Platform callback URL | Unchanged |
| Local, ngrok/custom tunnel configured | Their tunnel URL | Unchanged |
| Local, platform-connected, Velay tunnel up | Velay tunnel URL (via `ingress.publicBaseUrl`) | Unchanged |
| **Local, platform-connected, no ingress** | **422 "No public base URL configured"** | **Stable platform gateway callback URL** |
| Local, not platform-connected, no ingress | 422 | Unchanged |
| `ingress.enabled: false` | 422 | Unchanged (see below) |

Only the bolded row changes. Every configuration that worked before resolves to the same URL it did before.

## Why ingress still beats platform connectivity

The obvious reading of the ticket is "platform-connected wins". That would be a regression. As `runtime/migrations/origin-mode.ts` already documents, **any** logged-in local assistant holds a platform URL and an `assistant_api_key`, because it needs them for the LLM proxy. Credential presence does not distinguish a managed deployment from a local one, so promoting it above ingress would silently reroute an explicitly configured self-hosted webhook through the platform.

The two existing registrars in `gateway/` order the same two tiers the same way, and `gateway/src/telegram/webhook-manager.ts:148-153` refuses managed registration outside containerized mode for exactly this reason:

> Only fall back to managed callback registration in containerized mode. A local gateway that happens to have stored vellum credentials should not silently reroute Telegram webhooks to the platform.

An explicit `ingress.enabled: false` is treated as "do not accept inbound webhooks", not as "no ingress configured", so it is honored rather than routed around.

## The open question: is the inbound relay email-only?

**It is not email-only.** Velay's tunnel path allowlist (`gateway/src/velay/allowed-paths.ts`) admits `^/webhooks/` wholesale, covering Twilio voice/status/media-stream, Telegram, WhatsApp, email, Resend, Mailgun, and the OAuth callback. Inbound delivery to a local daemon is generic across providers, with per-route signature validation done by the gateway handlers.

Two findings worth recording, because they change how the ticket should be read:

**1. The premise "falls through to ngrok" is inaccurate for the tunneled case.** When the Velay tunnel registers, the gateway writes the tunnel URL into `ingress.publicBaseUrl` and stamps `publicBaseUrlManagedBy: "velay"` (`gateway/src/velay/client.ts:436`, `writeManagedPublicBaseUrl`). A platform-connected local assistant with a live tunnel was therefore **already** getting a stable platform-owned URL through the self-hosted branch. The URL was right; only the `mode` label read `self-hosted`. The real gap is narrower than the ticket describes: it is the assistant with platform credentials and **no** tunnel, which got a hard 422.

**2. The platform-side leg of tier 3 is not verifiable from this repo.** `registerCallbackRoute` posts to `POST {platform}/v1/internal/gateway/callback-routes/register/` and, unlike the gateway's email and Telegram registrars, does **not** send `callback_base_url`. Those registrars send it so the platform points the callback directly at the gateway "rather than routing through the platform proxy". Without it the platform must resolve delivery itself. Whether the platform proxy forwards to a non-pod assistant (presumably via Velay, keyed on assistant ID) lives in `vellum-assistant-platform` and cannot be confirmed here.

Per the scoping instruction, this PR is therefore **assistant-side only**. The daemon now asks the platform for a callback URL in a case where it previously refused to ask at all. If the platform declines, the user gets a clear 422/500 from `registerWithPlatform` instead of a misleading "No public base URL configured". Nothing here assumes the platform leg works, and no gateway or platform change is bundled in.

## Deferred, with reasons

- **`resolveCallbackUrl` still gates on `getIsPlatform()`** (`inbound/platform-callback-registration.ts:181`). This is the same class of bug, but it is the live path for Twilio voice/status (`calls/call-domain.ts`, 6 call sites) and OAuth redirect URIs (`security/oauth2.ts`). Changing it would alter callback URLs for every logged-in local assistant, including ones with a working tunnel. Worth doing, but it needs its own PR with its own verification, and it should land after the platform-side delivery question above is answered. **Recommend filing as a follow-up.**
- **`hasWebhookRoutingConfigured(allowManagedCallbacks)`** (`config/webhook-routing.ts:62`) also keys managed callbacks on `getIsPlatform()`. It feeds channel readiness probes and the Telegram webhook health sweep, which are reporting surfaces, so a stale answer misreports rather than misroutes. Lower priority. **Backlog.**
- **The `mode` field still reports `self-hosted` for a Velay-managed URL.** Accurate as "resolved from ingress config", misleading as "not platform-managed". Renaming it is a wire-contract change to a published response schema for a cosmetic gain. **Backlog.**

## Test plan

New `assistant/src/runtime/routes/__tests__/webhook-routes.test.ts`, 11 cases covering each tier, the precedence rule, the disabled-ingress opt-out, source-identifier passthrough, path override, and both error mappings. Verified as a real regression test: **3 of the 11 fail against the pre-fix handler** and all 11 pass after.

Also fixes cross-file mock pollution in `platform-callback-registration.test.ts`, which replaced `config/env.js`, `config/env-registry.js`, and `security/secure-keys.js` wholesale. Bun shares mocked modules across files in a combined run, so dropping exports broke peer files' ESM named-import validation. That file had accumulated hand-maintained stubs with comments explaining the workaround; spreading the real module removes both the stubs and the failure mode. Confirmed neutral against a same-process baseline (identical 6 fail / 2 errors before and after, from unrelated pre-existing pollution).

`bunx tsc --noEmit`, eslint, and prettier are clean across the assistant package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->