### PR TITLE
fix(web): reactive reconcile version gate, pre-await orphan candidates, loadDetail terminal guard, hydration identity backfill

### DIFF
--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.test.ts
@@ -217,6 +217,43 @@ describe("reconcileSubagentStoreFromNotifications", () => {
     expect(store().byId["anchored"]?.parentMessageId).toBe("msg-original");
   });
 
+  test("names a blank stub from the notification", () => {
+    // A stub materialized from a bare `subagent_status_changed` has no label
+    // at all; without this it stays blank for the rest of the session.
+    store().ensureEntry({ subagentId: "stub", timestamp: NOW, status: "running" });
+    expect(store().byId["stub"]?.label).toBe("");
+
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [
+        {
+          subagentId: "stub",
+          label: "Audit defenses",
+          status: "running",
+          objective: "Check the locks",
+        },
+      ],
+      PARENT,
+      NOW,
+    );
+
+    expect(store().byId["stub"]?.label).toBe("Audit defenses");
+    expect(store().byId["stub"]?.objective).toBe("Check the locks");
+  });
+
+  test("does not overwrite an identity the entry already has", () => {
+    // `subagent_spawned` is the same source of truth, seen first-hand.
+    spawn("named", "running"); // label === "named"
+    reconcileSubagentStoreFromNotifications(
+      store(),
+      [{ subagentId: "named", label: "Different", status: "running" }],
+      PARENT,
+      NOW,
+    );
+
+    expect(store().byId["named"]?.label).toBe("named");
+  });
+
   test("stamps the parent id on a live entry via the merge path", () => {
     spawn("sub", "running");
     reconcileSubagentStoreFromNotifications(

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
@@ -8,6 +8,7 @@ type SubagentStoreSlice = Pick<
   | "byId"
   | "spawnSubagent"
   | "changeStatus"
+  | "backfillIdentity"
   | "attachParentMessage"
   | "setConversationId"
   | "setParentConversationId"
@@ -19,6 +20,8 @@ export interface SubagentNotificationLike {
   status?: string;
   error?: string;
   conversationId?: string;
+  /** Present from daemons that record it on the notification row. */
+  objective?: string;
   parentMessageId?: string;
 }
 
@@ -61,6 +64,14 @@ export function reconcileSubagentStoreFromNotifications(
       if (parsed.success && shouldApplyStatus(existing.status, parsed.data)) {
         store.changeStatus({ subagentId: n.subagentId, status: parsed.data });
       }
+      // A stub materialized from a bare status event is "known" but blank —
+      // the notification is the first thing to name it. Placeholder yields,
+      // established identity wins.
+      store.backfillIdentity({
+        subagentId: n.subagentId,
+        label: n.label,
+        objective: n.objective,
+      });
       // Entries reconcile materialized carry no parent message id, so nothing
       // has indexed them in `byParent` and the transcript can't place their
       // inline card. The notification is the only source that names the
@@ -76,7 +87,7 @@ export function reconcileSubagentStoreFromNotifications(
       store.spawnSubagent({
         subagentId: n.subagentId,
         label: n.label,
-        objective: "",
+        objective: n.objective ?? "",
         // A notification for an unknown subagent with no parseable status is
         // historical, so a terminal default is the safe read.
         status: parsed.success ? parsed.data : "completed",

--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
@@ -21,8 +21,11 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import { __resetForTesting, publish } from "@/lib/event-bus";
 
+/** Stands in for the assistant version the identity store hydrates async. */
+let reconcileSupported = true;
 mock.module("@/lib/backwards-compat/subagents-reconcile", () => ({
-  supportsSubagentsReconcile: () => true,
+  supportsSubagentsReconcile: () => reconcileSupported,
+  useSupportsSubagentsReconcile: () => reconcileSupported,
 }));
 
 let getCalls = 0;
@@ -67,6 +70,7 @@ function advancePastReconcileWindow() {
 
 beforeEach(() => {
   getCalls = 0;
+  reconcileSupported = true;
   setSystemTime();
   __resetForTesting();
   useSubagentStore.getState().reset();
@@ -94,6 +98,23 @@ describe("useSubagentReconcile", () => {
     mount(ASSISTANT, CONVERSATION, false);
 
     await waitFor(() => expect(getCalls).toBe(0));
+  });
+
+  test("holds the load pass until the assistant version resolves", async () => {
+    // A cold load mounts before the identity fetch lands, so the gate reads
+    // `false` first. Snapshotted once, the conversation-load pass — the only
+    // trigger a silent run has — would be skipped for the whole session.
+    reconcileSupported = false;
+    const { rerender } = mount();
+    await waitFor(() => expect(getCalls).toBe(0));
+
+    reconcileSupported = true;
+    rerender();
+
+    await waitFor(() => expect(getCalls).toBe(1));
+    // And exactly once: a later re-render must not re-fire it.
+    rerender();
+    await waitFor(() => expect(getCalls).toBe(1));
   });
 
   test("reconciles again when the SSE stream reopens on resume", async () => {

--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.ts
@@ -22,12 +22,21 @@
  * subagents to reconcile against. Both triggers fire freely: the store
  * throttles per parent conversation, so a flapping stream costs one round-trip
  * per window rather than one per reopen.
+ *
+ * The version gate is read reactively rather than snapshotted: the assistant
+ * version arrives asynchronously and is cleared on every assistant switch, so
+ * a cold load routinely mounts this hook before it is known. Holding the
+ * conversation-load pass until the version resolves is the difference between
+ * that pass running late and it never running at all — the SSE trigger skips
+ * `"fresh"` opens, and the unknown-id kick only fires for subagents that
+ * stream something.
  */
 
 import { useCallback, useEffect } from "react";
 
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { useSupportsSubagentsReconcile } from "@/lib/backwards-compat/subagents-reconcile";
 import type { BusEventPayload } from "@/lib/event-bus";
 
 type SseOpenedCause = BusEventPayload<"sse.opened">["cause"];
@@ -44,14 +53,26 @@ export function useSubagentReconcile(
   conversationId: string | null,
   conversationExistsOnServer: boolean,
 ): void {
+  const supportsReconcile = useSupportsSubagentsReconcile();
+
   const resync = useCallback(() => {
-    if (!assistantId || !conversationId || !conversationExistsOnServer) {
+    if (
+      !supportsReconcile ||
+      !assistantId ||
+      !conversationId ||
+      !conversationExistsOnServer
+    ) {
       return;
     }
     void useSubagentStore
       .getState()
       .reconcileFromDaemon(assistantId, conversationId);
-  }, [assistantId, conversationId, conversationExistsOnServer]);
+  }, [
+    supportsReconcile,
+    assistantId,
+    conversationId,
+    conversationExistsOnServer,
+  ]);
 
   useEffect(() => {
     resync();

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -1717,6 +1717,45 @@ describe("loadDetail identity backfill", () => {
     expect(getState().byId["sa-1"]?.parentToolUseId).toBe("toolu_original");
     expect(getState().byToolUseId).toBe(byToolUseIdBefore);
   });
+
+  it("never walks a settled entry back to an active status", () => {
+    // The fetch was issued while the run was live; its answer landed after the
+    // terminal event. Nothing further is coming, so a regression here would
+    // strand the card `running` forever.
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      status: "completed",
+      timestamp: NOW,
+    });
+
+    getState().loadDetail({
+      subagentId: "sa-1",
+      events: [],
+      status: "running",
+    });
+
+    expect(getState().byId["sa-1"]?.status).toBe("completed");
+  });
+
+  it("applies a terminal status to a live entry", () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "agent",
+      objective: "",
+      status: "running",
+      timestamp: NOW,
+    });
+
+    getState().loadDetail({
+      subagentId: "sa-1",
+      events: [],
+      status: "completed",
+    });
+
+    expect(getState().byId["sa-1"]?.status).toBe("completed");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -2000,6 +2039,62 @@ describe("reconcileFromDaemon", () => {
     await pending;
 
     expect(getState().byId["sa-late"]?.status).toBe("running");
+  });
+
+  it("leaves an entry hydration materialized mid-flight alone", async () => {
+    // A history page landing during the round-trip describes rows the daemon
+    // was never asked about, so their absence from this response is not
+    // evidence — the next pass, which does see them, decides.
+    reconcileReply = { ok: true, subagents: {} };
+
+    const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    reconcileSubagentStoreFromNotifications(
+      getState(),
+      [{ subagentId: "sa-hydrated", label: "Agent", status: "running" }],
+      "conv-parent",
+      Date.now(),
+    );
+    await pending;
+
+    expect(getState().byId["sa-hydrated"]?.status).toBe("running");
+  });
+
+  it("settles a hydrated row that was already present when the request went out", async () => {
+    // Hydration stamps `spawnedAt` at hydration time, so a row it recovered
+    // moments before the request looks younger than it: the old
+    // `spawnedAt >= requestedAt` heuristic exempted exactly the stuck-`running`
+    // rows this pass exists to settle.
+    setSystemTime(new Date(NOW));
+    reconcileSubagentStoreFromNotifications(
+      getState(),
+      [{ subagentId: "sa-hydrated", label: "Agent", status: "running" }],
+      "conv-parent",
+      Date.now(),
+    );
+    reconcileReply = { ok: true, subagents: {} };
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(getState().byId["sa-hydrated"]?.status).toBe("interrupted");
+  });
+
+  it("leaves a candidate that settled truthfully during the round-trip alone", async () => {
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    reconcileReply = { ok: true, subagents: {} };
+
+    const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    // The terminal event the snapshot predates.
+    getState().changeStatus({ subagentId: "sa-1", status: "completed" });
+    await pending;
+
+    expect(getState().byId["sa-1"]?.status).toBe("completed");
   });
 
   it("leaves an absent entry from another conversation untouched", async () => {

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -680,8 +680,20 @@ async function runReconcile(
   assistantId: string,
   parentConversationId: string,
 ): Promise<void> {
-  const requestedAt = Date.now();
   const generation = resetGeneration;
+  // Absence from the response is only evidence about rows the daemon could
+  // have reported — the ones this conversation already held, still active,
+  // when the request went out. Captured before the await rather than inferred
+  // from `spawnedAt` afterwards: history hydration stamps that field at
+  // hydration time, so a row recovered from an older run looks brand new and
+  // would exempt itself from settling forever.
+  const candidateIds = Object.values(get().byId)
+    .filter(
+      (entry) =>
+        entry.parentConversationId === parentConversationId &&
+        isActiveStatus(entry.status),
+    )
+    .map((entry) => entry.subagentId);
   let snapshot: Record<string, ReconciledSubagent>;
   try {
     const { data, response } = await subagentsReconcileGet({
@@ -722,19 +734,21 @@ async function runReconcile(
     );
   }
 
-  // Settle this conversation's orphans. An entry younger than the request
-  // postdates the snapshot, so its absence proves nothing about it.
+  // Settle this conversation's orphans: a candidate the daemon didn't report
+  // died with it, and no terminal event is ever coming. Re-checked against the
+  // store as it stands now — a terminal event that landed during the
+  // round-trip already settled the row truthfully.
   const { byId, changeStatus } = get();
-  for (const entry of Object.values(byId)) {
+  for (const subagentId of candidateIds) {
+    const entry = byId[subagentId];
     if (
-      entry.parentConversationId !== parentConversationId ||
+      !entry ||
       !isActiveStatus(entry.status) ||
-      entry.spawnedAt >= requestedAt ||
-      Object.hasOwn(snapshot, entry.subagentId)
+      Object.hasOwn(snapshot, subagentId)
     ) {
       continue;
     }
-    changeStatus({ subagentId: entry.subagentId, status: "interrupted" });
+    changeStatus({ subagentId, status: "interrupted" });
   }
 }
 
@@ -993,6 +1007,15 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
         ? params.conversationId
         : existing.conversationId;
 
+    // A detail fetch issued while the run was live answers a round-trip late,
+    // so it can still report `running` for a subagent whose terminal event has
+    // since landed. Same rule as every other out-of-band source: a settled
+    // entry never walks back to active (see `shouldApplyStatus`).
+    const status =
+      params.status && shouldApplyStatus(existing.status, params.status)
+        ? params.status
+        : existing.status;
+
     set({
       byId: {
         ...byId,
@@ -1003,7 +1026,7 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
           // learned from `subagent_spawned` wins (same source of truth).
           label: existing.label || (params.label ?? ""),
           parentToolUseId,
-          status: params.status ?? existing.status,
+          status,
           objective: params.objective ?? existing.objective,
           inputTokens: params.inputTokens ?? existing.inputTokens,
           outputTokens: params.outputTokens ?? existing.outputTokens,

--- a/clients/web/src/lib/backwards-compat/subagents-reconcile.ts
+++ b/clients/web/src/lib/backwards-compat/subagents-reconcile.ts
@@ -12,7 +12,10 @@
  * a bare `{status}` response from 0.10.0–0.10.12 still updates known
  * entries and stubs unknowns.
  */
-import { assistantSupports } from "@/lib/backwards-compat/utils";
+import {
+  assistantSupports,
+  useAssistantSupports,
+} from "@/lib/backwards-compat/utils";
 
 const MIN_VERSION = "0.10.0";
 
@@ -22,4 +25,17 @@ const MIN_VERSION = "0.10.0";
  */
 export function supportsSubagentsReconcile(): boolean {
   return assistantSupports(MIN_VERSION);
+}
+
+/**
+ * Render-time form of the same gate, for the triggers that fire once.
+ *
+ * The version is hydrated asynchronously by the identity fetch and cleared on
+ * every assistant switch, so the snapshot reads `false` for the first moments
+ * of a cold load. A mount effect that captured that answer would skip its
+ * single pass for good; subscribing instead re-runs it the moment the version
+ * lands.
+ */
+export function useSupportsSubagentsReconcile(): boolean {
+  return useAssistantSupports(MIN_VERSION);
 }


### PR DESCRIPTION
Self-review remediation for the subagent run-state work: four integration findings from reading the merged branch end-to-end.

## 1. The mount reconcile was gated on a version that usually hadn't hydrated

`reconcileFromDaemon` snapshots `supportsSubagentsReconcile()`, and `assistantSupports` returns `false` while the identity store has no version — which is the normal state of a cold load (it arrives async and is cleared on assistant switch). `useSubagentReconcile`'s effect deps didn't include the version, so the pass that a silent run depends on never ran: `sse.opened` skips `"fresh"`, and the unknown-id kick only fires for subagents that stream something.

The hook now reads `useSupportsSubagentsReconcile()` — a new reactive re-export beside the snapshot form, so `MIN_VERSION` stays single-sourced — and includes it in the `resync` callback's guard and deps, so the load pass fires the moment the version lands. The store-level snapshot gate stays as defense-in-depth.

## 2. Orphan settling exempted history-hydrated rows

The `entry.spawnedAt >= requestedAt` guard was meant to skip entries spawned after the snapshot, but hydration stamps `spawnedAt` at HYDRATION time. That normally lands after the mount reconcile's `requestedAt`, so every hydrated stuck-`running` row exempted itself from settling — worst on 0.10.0–0.10.12 daemons, where the TTL sweep deleted the durable row and absence is the only signal there is.

`runReconcile` now captures the settling candidates BEFORE the network await (this conversation's active rows as they stood when the request went out) and settles only candidates absent from the response, re-checking at apply time that they still exist and are still active. The `spawnedAt` heuristic is gone.

## 3. `loadDetail` could resurrect a settled entry

`status: params.status ?? existing.status` had no terminal-regression guard, so a detail response served while the run was live could land after a terminal SSE status and flip the card back to `running` — with no further terminal event ever coming. It now applies the shared `shouldApplyStatus`, keeping `existing.status` when the incoming one would walk a settled entry back to active.

## 4. Hydration never repaired identity on existing placeholder stubs

The existing-entry branch of `reconcileSubagentStoreFromNotifications` wrote status, conversation ids and the parent-message anchor but never `label`/`objective`, so a blank `ensureEntry` stub stayed blank forever even when the notification carried the real label. It now calls the store's `backfillIdentity` (placeholder yields, established identity wins), and `SubagentNotificationLike` carries the optional `objective` the wire schema already provides — also used for the fresh-spawn branch, which previously hardcoded `""`.

## Tests

Added to the three suites: version absent at mount → no call, version resolves → exactly one reconcile; a row hydrated mid-flight is untouched while one already present when the request went out settles (and one that settled truthfully during the round-trip is left alone); `loadDetail` terminal→active rejected, live→terminal applied; blank stub named by a notification, established label not overwritten.

`bun run test:ci` green across 11 subagent suites; `bunx tsc --noEmit` and eslint clean on the changed files.

Part of plan: subagent-running-state-fixes.md (self-review remediation r2)
