### PR TITLE
[DEMO ONLY - DO NOT MERGE] Add Debug voice capture export

### DIFF
--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -161,10 +161,7 @@ class MyViewController: CAPBridgeViewController {
     /// launch configuration explicitly opts in. The marker is absent from
     /// Release builds and from ordinary Debug launches.
     private func installVoiceDemoCaptureMarker() {
-        let process = ProcessInfo.processInfo
-        let enabled = process.arguments.contains("-VoiceDemoCapture")
-            || process.environment["VOICE_DEMO_CAPTURE"] == "1"
-        guard enabled,
+        guard VoiceDemoCaptureMode.isEnabled,
               let contentController = webView?.configuration.userContentController
         else { return }
         let script = WKUserScript(

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -144,6 +144,10 @@ class MyViewController: CAPBridgeViewController {
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(NativeAuthPlugin())
         bridge?.registerPluginInstance(NativeBiometricPlugin())
+#if DEBUG
+        bridge?.registerPluginInstance(VoiceDemoCapturePlugin())
+        installVoiceDemoCaptureMarker()
+#endif
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()
@@ -151,6 +155,27 @@ class MyViewController: CAPBridgeViewController {
         installSurfaceOverlayThemeSync()
         installQuoteReplyCapabilityMarker()
     }
+
+#if DEBUG
+    /// Advertise the demo-only capture bridge to the remote web bundle when the
+    /// launch configuration explicitly opts in. The marker is absent from
+    /// Release builds and from ordinary Debug launches.
+    private func installVoiceDemoCaptureMarker() {
+        let process = ProcessInfo.processInfo
+        let enabled = process.arguments.contains("-VoiceDemoCapture")
+            || process.environment["VOICE_DEMO_CAPTURE"] == "1"
+        guard enabled,
+              let contentController = webView?.configuration.userContentController
+        else { return }
+        let script = WKUserScript(
+            source: "window.__vellumVoiceDemoCaptureEnabled = true;",
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        contentController.addUserScript(script)
+        NSLog("[voice-demo-capture] enabled for the next live voice session")
+    }
+#endif
 
     // MARK: - Self-hosted origin navigation
 

--- a/clients/ios/App/App/NativeAuthPlugin.swift
+++ b/clients/ios/App/App/NativeAuthPlugin.swift
@@ -93,7 +93,13 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         // authenticating against a phishing login page rendered inside the
         // system auth sheet — the sheet shows the URL, but a plausible-
         // looking URL could still fool someone.
-        guard NativeAuthPlugin.isAllowedBaseURL(baseURL) else {
+        #if DEBUG
+        let isAllowedBaseURL = NativeAuthPlugin.isAllowedBaseURL(baseURL)
+            || VoiceDemoCaptureMode.isEnabled
+        #else
+        let isAllowedBaseURL = NativeAuthPlugin.isAllowedBaseURL(baseURL)
+        #endif
+        guard isAllowedBaseURL else {
             call.reject("Refusing auth: host \(baseURL.host ?? "<nil>") does not match build target (\(NativeAuthPlugin.allowedAuthHost))")
             return
         }

--- a/clients/ios/App/App/VoiceDemoCapturePlugin.swift
+++ b/clients/ios/App/App/VoiceDemoCapturePlugin.swift
@@ -3,6 +3,14 @@ import AVFAudio
 import Capacitor
 import UIKit
 
+enum VoiceDemoCaptureMode {
+    static var isEnabled: Bool {
+        let process = ProcessInfo.processInfo
+        return process.arguments.contains("-VoiceDemoCapture")
+            || process.environment["VOICE_DEMO_CAPTURE"] == "1"
+    }
+}
+
 @objc(VoiceDemoCapturePlugin)
 public final class VoiceDemoCapturePlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "VoiceDemoCapturePlugin"

--- a/clients/ios/App/App/VoiceDemoCapturePlugin.swift
+++ b/clients/ios/App/App/VoiceDemoCapturePlugin.swift
@@ -1,0 +1,125 @@
+#if DEBUG
+import AVFAudio
+import Capacitor
+import UIKit
+
+@objc(VoiceDemoCapturePlugin)
+public final class VoiceDemoCapturePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "VoiceDemoCapturePlugin"
+    public let jsName = "VoiceDemoCapture"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getAudioRoute", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "exportCapture", returnType: CAPPluginReturnPromise),
+    ]
+
+    private var routeObserver: NSObjectProtocol?
+
+    public override func load() {
+        routeObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.notifyListeners("audioRouteChanged", data: self.audioRoutePayload())
+        }
+    }
+
+    deinit {
+        if let routeObserver {
+            NotificationCenter.default.removeObserver(routeObserver)
+        }
+    }
+
+    @objc public func getAudioRoute(_ call: CAPPluginCall) {
+        call.resolve(audioRoutePayload())
+    }
+
+    @objc public func exportCapture(_ call: CAPPluginCall) {
+        guard let filename = call.getString("filename"), !filename.isEmpty else {
+            call.reject("Missing required option: filename")
+            return
+        }
+        guard let dataBase64 = call.getString("dataBase64"),
+              let archive = Data(base64Encoded: dataBase64)
+        else {
+            call.reject("Voice demo archive is not valid base64")
+            return
+        }
+
+        let safeFilename = URL(fileURLWithPath: filename).lastPathComponent
+        guard safeFilename.hasSuffix(".zip") else {
+            call.reject("Voice demo archive must use a .zip filename")
+            return
+        }
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self else { return }
+            do {
+                let caches = try FileManager.default.url(
+                    for: .cachesDirectory,
+                    in: .userDomainMask,
+                    appropriateFor: nil,
+                    create: true
+                )
+                let directory = caches.appendingPathComponent(
+                    "VoiceDemoCaptures",
+                    isDirectory: true
+                )
+                try FileManager.default.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: true
+                )
+                let archiveURL = directory.appendingPathComponent(safeFilename)
+                try archive.write(to: archiveURL, options: .atomic)
+                NSLog("[voice-demo-capture] bundle URL: %@", archiveURL.path)
+
+                DispatchQueue.main.async {
+                    guard let viewController = self.bridge?.viewController else {
+                        call.reject("Voice demo share sheet has no presenting view controller")
+                        return
+                    }
+                    let activity = UIActivityViewController(
+                        activityItems: [archiveURL],
+                        applicationActivities: nil
+                    )
+                    if let popover = activity.popoverPresentationController {
+                        popover.sourceView = viewController.view
+                        popover.sourceRect = CGRect(
+                            x: viewController.view.bounds.midX,
+                            y: viewController.view.bounds.midY,
+                            width: 1,
+                            height: 1
+                        )
+                        popover.permittedArrowDirections = []
+                    }
+                    viewController.present(activity, animated: true) {
+                        call.resolve(["url": archiveURL.absoluteString])
+                    }
+                }
+            } catch {
+                call.reject("Failed to write voice demo archive: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func audioRoutePayload() -> JSObject {
+        let session = AVAudioSession.sharedInstance()
+        return [
+            "inputs": session.currentRoute.inputs.map(Self.portPayload),
+            "outputs": session.currentRoute.outputs.map(Self.portPayload),
+            "sampleRate": session.sampleRate,
+            "ioBufferDuration": session.ioBufferDuration,
+        ]
+    }
+
+    private static func portPayload(_ port: AVAudioSessionPortDescription) -> JSObject {
+        return [
+            "name": port.portName,
+            "type": port.portType.rawValue,
+            "uid": port.uid,
+            "channelCount": port.channels?.count ?? 0,
+        ]
+    }
+}
+#endif

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -231,6 +231,11 @@ engine.
 3. End live voice. Finalization runs off the audio path and presents the iOS
    share sheet automatically.
 
+To load a local web worktree on a physical device, start its Vite server on the
+LAN and run `ios:setup` with
+`VOICE_DEMO_CAPTURE_SERVER_URL=http://192.168.x.x:3178/assistant`. This
+demo-only override enables cleartext loading for the generated shell.
+
 The Xcode console prints the local archive URL. The shared zip contains a
 `voice-demo-<timestamp>/` folder with `session.json`, `alex.wav`, `pax.wav`,
 `mix.wav`, and `transcript.txt`. Audio files are 48 kHz, 32-bit float WAVs;

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -217,6 +217,26 @@ breakpoint.
   an HTTP target. The placeholder `capacitor-shell/index.html` is also
   what flashes briefly before the remote URL paints.
 
+### Voice demo capture (Debug only)
+
+The iOS shell can export synchronized microphone and assistant tracks from one
+live-voice session. The implementation is compiled only in Debug builds and
+does not change the app's audio-session configuration or create another audio
+engine.
+
+1. Edit the active Debug scheme and add the launch argument
+   `-VoiceDemoCapture` (or set `VOICE_DEMO_CAPTURE=1` in the scheme
+   environment).
+2. Run on the physical device, start live voice, and complete the demo.
+3. End live voice. Finalization runs off the audio path and presents the iOS
+   share sheet automatically.
+
+The Xcode console prints the local archive URL. The shared zip contains a
+`voice-demo-<timestamp>/` folder with `session.json`, `alex.wav`, `pax.wav`,
+`mix.wav`, and `transcript.txt`. Audio files are 48 kHz, 32-bit float WAVs;
+`mix.wav` places Alex on the left and Pax on the right while preserving the
+common session origin and silence.
+
 ## How it's set up
 
 > **Web-side conventions for iOS code paths**: any change to the web app

--- a/clients/web/capacitor.config.ts
+++ b/clients/web/capacitor.config.ts
@@ -46,7 +46,9 @@ function resolveServerUrl(): string {
   return override;
 }
 
-const SERVER_URL = resolveServerUrl();
+const VOICE_DEMO_CAPTURE_SERVER_URL =
+  process.env.VOICE_DEMO_CAPTURE_SERVER_URL?.trim();
+const SERVER_URL = VOICE_DEMO_CAPTURE_SERVER_URL || resolveServerUrl();
 
 const SCHEME_NAMES: Record<string, string> = {
   production: "App",
@@ -65,7 +67,7 @@ const config: CapacitorConfig = {
   webDir: "capacitor-shell",
   server: {
     url: SERVER_URL,
-    cleartext: false,
+    cleartext: VOICE_DEMO_CAPTURE_SERVER_URL?.startsWith("http://") ?? false,
   },
   ios: {
     // Native iOS project lives as a peer to `clients/web/` at `clients/ios/`,

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
@@ -327,6 +327,23 @@ describe("lifecycle", () => {
     expect(batch[799]).toBe(7);
   });
 
+  test("observes the exact pipeline chunk before forwarding it", async () => {
+    const callbacks: string[] = [];
+    const capture = new LiveVoiceAudioCapture({
+      onCapturedChunk: (buffer) => {
+        callbacks.push(`captured:${new Int16Array(buffer)[0]}`);
+      },
+      onChunk: (buffer) => {
+        callbacks.push(`forwarded:${new Int16Array(buffer)[0]}`);
+      },
+    });
+    await capture.start();
+
+    lastWorklet!.port.emit(new Int16Array(800).fill(42).buffer);
+
+    expect(callbacks).toEqual(["captured:42", "forwarded:42"]);
+  });
+
   test("flush() emits the sub-batch tail synchronously and resets", async () => {
     const chunks: ArrayBuffer[] = [];
     const capture = new LiveVoiceAudioCapture({ onChunk: (b) => chunks.push(b) });

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -75,6 +75,12 @@ export type LiveVoiceCaptureResult =
 export interface LiveVoiceAudioCaptureOptions {
   /** Receives each 16 kHz mono Int16 LE PCM chunk as a transferred buffer. */
   onChunk: (buf: ArrayBuffer) => void;
+  /**
+   * Optional observer for the exact PCM chunk delivered to the live-voice
+   * pipeline. Called immediately before `onChunk`; capture observers must copy
+   * synchronously and move any processing or persistence off this callback.
+   */
+  onCapturedChunk?: (buf: ArrayBuffer) => void;
   /** Receives the smoothed RMS amplitude in [0, 1] for UI / barge-in. */
   onAmplitude?: (amplitude: number) => void;
 }
@@ -126,6 +132,7 @@ function classifyError(cause: unknown): LiveVoiceCaptureError {
  */
 export class LiveVoiceAudioCapture {
   private readonly onChunk: (buf: ArrayBuffer) => void;
+  private readonly onCapturedChunk?: (buf: ArrayBuffer) => void;
   private readonly onAmplitude?: (amplitude: number) => void;
 
   private stream: MediaStream | null = null;
@@ -145,6 +152,7 @@ export class LiveVoiceAudioCapture {
 
   constructor(options: LiveVoiceAudioCaptureOptions) {
     this.onChunk = options.onChunk;
+    this.onCapturedChunk = options.onCapturedChunk;
     this.onAmplitude = options.onAmplitude;
   }
 
@@ -235,7 +243,7 @@ export class LiveVoiceAudioCapture {
     if (this.batchLength === 0) return;
     const tail = this.batch.buffer.slice(0, this.batchLength * 2);
     this.batchLength = 0;
-    this.onChunk(tail);
+    this.emitChunk(tail);
   }
 
   /** Copy a worklet quantum into the batch, emitting each full 50ms frame. */
@@ -250,9 +258,23 @@ export class LiveVoiceAudioCapture {
         this.batchLength = 0;
         const full = this.batch;
         this.batch = new Int16Array(BATCH_SAMPLES);
-        this.onChunk(full.buffer);
+        this.emitChunk(full.buffer);
       }
     }
+  }
+
+  private emitChunk(buf: ArrayBuffer): void {
+    if (this.onCapturedChunk) {
+      try {
+        this.onCapturedChunk(buf);
+      } catch (error) {
+        console.warn(
+          "[LiveVoiceAudioCapture] PCM observer failed; continuing voice capture",
+          error,
+        );
+      }
+    }
+    this.onChunk(buf);
   }
 
   /** Computes and forwards the smoothed RMS amplitude for a PCM chunk. */

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -337,6 +337,37 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(player.isPlaying).toBe(true);
   });
 
+  test("reports the decoded buffer schedule and cancellation without changing playback", () => {
+    const observerEvents: string[] = [];
+    const observedContext = new MockAudioContext();
+    const observedPlayer = new LiveVoiceAudioPlayer({
+      audioContextFactory: () =>
+        observedContext as unknown as AudioContextLike,
+      playbackObserver: {
+        onBufferScheduled: ({ id, buffer, delaySeconds }) => {
+          observerEvents.push(
+            `scheduled:${id}:${buffer.length}:${delaySeconds}`,
+          );
+        },
+        onBufferEnded: ({ id, state }) => {
+          observerEvents.push(`ended:${id}:${state}`);
+        },
+      },
+    });
+
+    observedPlayer.enqueue({
+      ...chunk([1, 2, 3, 4], 4),
+      id: "tts-7",
+    });
+    observedPlayer.stop();
+
+    expect(observedContext.sources[0]!.startedAt).toBe(0);
+    expect(observerEvents).toEqual([
+      "scheduled:tts-7:4:0",
+      "ended:tts-7:cancelled",
+    ]);
+  });
+
   test("never schedules in the past after the queue lags currentTime", () => {
     player.enqueue(chunk(new Array(24000).fill(1))); // 1.0s buffer at t=0
     // Advance the clock past the scheduled tail, then enqueue again.

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -44,6 +44,8 @@ import { isNativeIOS } from "@/runtime/platform-detection";
 
 /** A single TTS audio frame as delivered by the live-voice channel. */
 export interface TtsAudioChunk {
+  /** Capture/debug identifier for this wire chunk. */
+  id?: string;
   /**
    * Base64-encoded audio payload. For `audio/pcm` this is raw little-endian
    * 16-bit PCM samples; for container formats it is the encoded container bytes.
@@ -56,6 +58,19 @@ export interface TtsAudioChunk {
   sampleRate: number;
   /** MIME type of the audio payload (e.g. "audio/pcm", "audio/wav"). */
   mimeType: string;
+}
+
+export interface LiveVoiceAudioPlaybackObserver {
+  onBufferScheduled?(event: {
+    id: string;
+    buffer: AudioBuffer;
+    delaySeconds: number;
+  }): void;
+  onBufferEnded?(event: {
+    id: string;
+    state: "completed" | "cancelled";
+    delaySeconds: number;
+  }): void;
 }
 
 /**
@@ -209,11 +224,13 @@ export class LiveVoiceAudioPlayer {
   private readonly createContext: AudioContextFactory;
   private readonly useMediaStreamOutput: boolean;
   private readonly createMediaStreamPlaybackElement: MediaStreamPlaybackElementFactory;
+  private readonly playbackObserver?: LiveVoiceAudioPlaybackObserver;
   private context: AudioContextLike | null = null;
   private mediaStreamOutput: MediaStreamOutputRoute | null = null;
 
   /** Sources currently scheduled (playing or pending). */
-  private activeSources = new Set<AudioBufferSourceNode>();
+  private activeSources = new Map<AudioBufferSourceNode, { id: string }>();
+  private chunkSequence = 0;
 
   /**
    * Absolute `AudioContext.currentTime` at which the next buffer should begin.
@@ -281,6 +298,7 @@ export class LiveVoiceAudioPlayer {
     audioContextFactory?: AudioContextFactory;
     useMediaStreamOutput?: boolean;
     mediaStreamPlaybackElementFactory?: MediaStreamPlaybackElementFactory;
+    playbackObserver?: LiveVoiceAudioPlaybackObserver;
   }) {
     this.createContext =
       options?.audioContextFactory ?? defaultAudioContextFactory;
@@ -288,6 +306,7 @@ export class LiveVoiceAudioPlayer {
     this.createMediaStreamPlaybackElement =
       options?.mediaStreamPlaybackElementFactory ??
       defaultMediaStreamPlaybackElementFactory;
+    this.playbackObserver = options?.playbackObserver;
   }
 
   /** Whether any audio is scheduled, playing, or still decoding. */
@@ -341,7 +360,7 @@ export class LiveVoiceAudioPlayer {
     const buffer = context.createBuffer(1, samples.length, chunk.sampleRate);
     buffer.getChannelData(0).set(samples);
 
-    this.scheduleBuffer(context, buffer);
+    this.scheduleBuffer(context, buffer, this.chunkId(chunk));
   }
 
   /**
@@ -389,7 +408,7 @@ export class LiveVoiceAudioPlayer {
         ) {
           return;
         }
-        this.scheduleBuffer(context, buffer);
+        this.scheduleBuffer(context, buffer, this.chunkId(chunk));
       } finally {
         // A stop() between start and resolution already zeroed the counter (and
         // resolved drain); skip the accounting so we don't go negative.
@@ -404,7 +423,11 @@ export class LiveVoiceAudioPlayer {
   }
 
   /** Connect a decoded buffer to the destination and start it gaplessly. */
-  private scheduleBuffer(context: AudioContextLike, buffer: AudioBuffer): void {
+  private scheduleBuffer(
+    context: AudioContextLike,
+    buffer: AudioBuffer,
+    id: string,
+  ): void {
     const source = context.createBufferSource();
     source.buffer = buffer;
 
@@ -423,10 +446,17 @@ export class LiveVoiceAudioPlayer {
     this.playheadTime = startAt + buffer.duration;
     this.totalScheduledSeconds += buffer.duration;
 
-    this.activeSources.add(source);
+    this.activeSources.set(source, { id });
     source.onended = () => {
       this.handleSourceEnded(source);
     };
+    this.notifyPlaybackObserver(() => {
+      this.playbackObserver?.onBufferScheduled?.({
+        id,
+        buffer,
+        delaySeconds: startAt - context.currentTime,
+      });
+    });
 
     this.playingState = true;
   }
@@ -445,10 +475,17 @@ export class LiveVoiceAudioPlayer {
    */
   stop(): void {
     this.generation += 1;
-    for (const source of this.activeSources) {
+    for (const [source, scheduled] of this.activeSources) {
       // Detach the handler first so stop() doesn't re-enter handleSourceEnded
       // mid-iteration as we mutate the set.
       source.onended = null;
+      this.notifyPlaybackObserver(() => {
+        this.playbackObserver?.onBufferEnded?.({
+          id: scheduled.id,
+          state: "cancelled",
+          delaySeconds: 0,
+        });
+      });
       try {
         source.stop();
       } catch {
@@ -666,11 +703,35 @@ export class LiveVoiceAudioPlayer {
   }
 
   private handleSourceEnded(source: AudioBufferSourceNode): void {
-    if (!this.activeSources.delete(source)) {
+    const scheduled = this.activeSources.get(source);
+    if (!scheduled) {
       return;
     }
+    this.activeSources.delete(source);
+    this.notifyPlaybackObserver(() => {
+      this.playbackObserver?.onBufferEnded?.({
+        id: scheduled.id,
+        state: "completed",
+        delaySeconds: 0,
+      });
+    });
     source.disconnect();
     this.settleIfIdle();
+  }
+
+  private chunkId(chunk: TtsAudioChunk): string {
+    return chunk.id ?? `tts-${++this.chunkSequence}`;
+  }
+
+  private notifyPlaybackObserver(callback: () => void): void {
+    try {
+      callback();
+    } catch (error) {
+      console.warn(
+        "[LiveVoiceAudioPlayer] playback observer failed; continuing playback",
+        error,
+      );
+    }
   }
 
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -93,6 +93,7 @@ import {
   LiveVoiceAudioPlayer,
   type TtsAudioChunk,
 } from "@/domains/chat/voice/live-voice/tts-playback";
+import { VoiceDemoCaptureSession } from "@/domains/chat/voice/live-voice/voice-demo-capture";
 import {
   isLiveVoiceSessionActive,
   minimizeVoiceRoom,
@@ -219,6 +220,7 @@ interface SessionContext {
   client: LiveVoiceChannelClient;
   capture: LiveVoiceAudioCapture;
   player: LiveVoiceAudioPlayer;
+  demoCapture: VoiceDemoCaptureSession | null;
   /** Unsubscribe callbacks for the client event handlers. */
   unsubscribes: Array<() => void>;
   /** Monotonic id; a stale callback whose generation differs is ignored. */
@@ -252,6 +254,10 @@ interface SessionContext {
   forwardingAudio: boolean;
   /** Whether the assistant has sent any TTS audio for the current response. */
   responseAudioStarted: boolean;
+  /** Server turn currently producing assistant text/audio. */
+  currentTurnId: string | null;
+  /** Local speech interval used when manual mode has no server VAD events. */
+  manualSpeechOpen: boolean;
   /**
    * Monotonic counter bumped on every transition into `thinking` (server
    * frame, or hands-free stt-final); identifies which response owns the state.
@@ -342,6 +348,7 @@ export function useLiveVoice(
   const error = useLiveVoiceStore.use.error();
 
   const sessionRef = useRef<SessionContext | null>(null);
+  const demoCaptureRef = useRef<VoiceDemoCaptureSession | null>(null);
 
   // Monotonic count of `start()` calls for this hook instance. `stop()`
   // captures it before its awaits and skips its trailing store reset when a
@@ -420,6 +427,14 @@ export function useLiveVoice(
     disposeStandbyPlayer();
   }, [clearReconnectTimer, disposeStandbyPlayer]);
 
+  const finalizeDemoCapture = useCallback(() => {
+    const demoCapture = demoCaptureRef.current;
+    demoCaptureRef.current = null;
+    if (demoCapture) {
+      void demoCapture.finalizeAndExport();
+    }
+  }, []);
+
   /**
    * Tear down the active session's primitives, clear the ref, and reset the
    * store to idle.
@@ -448,12 +463,14 @@ export function useLiveVoice(
       if (useLiveVoiceStore.getState().state !== "idle") {
         useLiveVoiceStore.getState().reset();
       }
+      finalizeDemoCapture();
       return;
     }
     sessionRef.current = null;
     disposeSessionPrimitives(session);
+    finalizeDemoCapture();
     useLiveVoiceStore.getState().reset();
-  }, [cancelPendingConnection]);
+  }, [cancelPendingConnection, finalizeDemoCapture]);
 
   const stop = useCallback(async () => {
     // A user-initiated stop ends the session outright — drop any pending
@@ -465,6 +482,7 @@ export function useLiveVoice(
     const session = sessionRef.current;
     if (!session) {
       useLiveVoiceStore.getState().reset();
+      finalizeDemoCapture();
       return;
     }
     const startGeneration = startGenerationRef.current;
@@ -478,12 +496,13 @@ export function useLiveVoice(
     // Release the AudioContext, not just the scheduled sources (see teardown).
     await session.player.dispose();
     await session.capture.shutdown();
+    finalizeDemoCapture();
     // A start() that raced the awaits owns the store now (e.g. a second ✕
     // click resets `ending` → idle mid-await, unblocking start()); wiping it
     // here would leave that session's mic hot behind idle UI.
     if (startGenerationRef.current !== startGeneration) return;
     useLiveVoiceStore.getState().reset();
-  }, [cancelPendingConnection]);
+  }, [cancelPendingConnection, finalizeDemoCapture]);
 
   /**
    * Manual turn release ("send now"). Guarded to `listening` so a stray click
@@ -560,7 +579,26 @@ export function useLiveVoice(
   const createPlayer = useCallback(
     () =>
       (
-        optionsRef.current.createPlayer ?? (() => new LiveVoiceAudioPlayer())
+        optionsRef.current.createPlayer ??
+        (() =>
+          new LiveVoiceAudioPlayer({
+            playbackObserver: {
+              onBufferScheduled: ({ id, buffer, delaySeconds }) => {
+                demoCaptureRef.current?.recordAssistantBufferScheduled({
+                  id,
+                  buffer,
+                  delaySeconds,
+                });
+              },
+              onBufferEnded: ({ id, state, delaySeconds }) => {
+                demoCaptureRef.current?.recordAssistantBufferEnded({
+                  id,
+                  state,
+                  delaySeconds,
+                });
+              },
+            },
+          }))
       )(),
     [],
   );
@@ -665,12 +703,15 @@ export function useLiveVoice(
         capture: undefined as unknown as LiveVoiceAudioCapture,
         capturePromise: undefined as unknown as Promise<LiveVoiceCaptureResult>,
         player,
+        demoCapture: demoCaptureRef.current,
         unsubscribes: [],
         generation: 0,
         handsFree: startOptions.handsFree === true,
         captureRunning: false,
         forwardingAudio: false,
         responseAudioStarted: false,
+        currentTurnId: null,
+        manualSpeechOpen: false,
         responseEpoch: 0,
         interruptSent: false,
         releaseInFlight: false,
@@ -687,6 +728,12 @@ export function useLiveVoice(
         opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o))
       )({
         onChunk: (buf) => handleChunk(session, buf),
+        ...(session.demoCapture
+          ? {
+              onCapturedChunk: (buf: ArrayBuffer) =>
+                session.demoCapture?.recordMicrophoneChunk(buf),
+            }
+          : {}),
         onAmplitude: (amplitude) =>
           handleAmplitude(session, amplitude, teardown),
       });
@@ -733,15 +780,24 @@ export function useLiveVoice(
           useLiveVoiceStore.getState().setConversationId(frame.conversationId);
           void finishCaptureStartup(session, teardown);
         }),
-        client.on("speechStarted", () => {
+        client.on("speechStarted", (frame) => {
           if (!live() || !session.handsFree) return;
           // Server VAD heard the user: flush tail playback unconditionally
           // (even mid-`thinking`, when no cancellation follows) and open the
           // next utterance. Speech resuming inside a HELD utterance (semantic
           // endpointing suppressed the boundary) re-fires speech_started for
           // the same utterance — its finalized transcript prefix must stay.
-          if (!session.utteranceOpen) {
+          const opensUtterance = !session.utteranceOpen;
+          if (opensUtterance) {
             useLiveVoiceStore.getState().clearUserTranscripts();
+            session.demoCapture?.recordUserSpeechStarted(
+              `utterance-${frame.seq}`,
+            );
+          }
+          if (session.player.isPlaying) {
+            session.demoCapture?.recordInterruptionStarted(
+              session.currentTurnId ?? undefined,
+            );
           }
           session.utteranceOpen = true;
           flushPlaybackToListening(session);
@@ -749,6 +805,7 @@ export function useLiveVoice(
         client.on("utteranceEnd", () => {
           if (!live() || !session.handsFree) return;
           session.utteranceOpen = false;
+          session.demoCapture?.recordUserSpeechEnded();
           // End of user speech: stamp the client-heard latency start; the
           // response's first tts_audio consumes it (see
           // beginAssistantAudioIfNeeded). Manual mode stamps at the
@@ -760,6 +817,7 @@ export function useLiveVoice(
         client.on("utteranceDiscarded", () => {
           if (!live() || !session.handsFree) return;
           session.utteranceOpen = false;
+          session.demoCapture?.recordUserSpeechEnded();
           // The discarded utterance never becomes a turn — drop its
           // end-of-speech stamp so it can't pair with a later turn's audio.
           session.speechEndedAtMs = null;
@@ -772,6 +830,7 @@ export function useLiveVoice(
         }),
         client.on("sttPartial", (frame) => {
           if (!live()) return;
+          session.demoCapture?.recordUserTranscriptPartial(frame.text);
           const s = useLiveVoiceStore.getState();
           s.setPartialTranscript(frame.text);
           // Manual mode: only while still forwarding (the user's turn) does a
@@ -784,6 +843,7 @@ export function useLiveVoice(
         }),
         client.on("sttFinal", (frame) => {
           if (!live()) return;
+          session.demoCapture?.recordUserTranscriptFinal(frame.text);
           const s = useLiveVoiceStore.getState();
           s.setFinalTranscript(frame.text);
           s.setPartialTranscript("");
@@ -818,8 +878,10 @@ export function useLiveVoice(
           }
           s.setState("thinking");
         }),
-        client.on("thinking", () => {
+        client.on("thinking", (frame) => {
           if (!live()) return;
+          session.currentTurnId = frame.turnId;
+          session.demoCapture?.recordRequestStarted(frame.turnId);
           // New response: reset the per-response transcript and barge-in flags.
           session.responseEpoch += 1;
           session.responseAudioStarted = false;
@@ -849,6 +911,12 @@ export function useLiveVoice(
           // or drag the flushed `listening` back to `thinking`; like
           // `ttsAudio` below, the guard lifts on the next turn.
           if (session.interruptSent) return;
+          if (session.currentTurnId) {
+            session.demoCapture?.recordAssistantTextDelta(
+              session.currentTurnId,
+              frame.text,
+            );
+          }
           const s = useLiveVoiceStore.getState();
           s.appendAssistantTranscript(frame.text);
           const phase = s.state;
@@ -864,7 +932,16 @@ export function useLiveVoice(
           // stt-final reset `interruptSent`).
           if (session.interruptSent) return;
           beginAssistantAudioIfNeeded(session);
+          const chunkId = `tts-${frame.seq}`;
+          session.demoCapture?.recordTtsChunkReceived({
+            id: chunkId,
+            turnId: session.currentTurnId,
+            sampleRate: frame.sampleRate,
+            mimeType: frame.mimeType,
+            byteLength: base64ByteLength(frame.dataBase64),
+          });
           const chunk: TtsAudioChunk = {
+            id: chunkId,
             dataBase64: frame.dataBase64,
             sampleRate: frame.sampleRate,
             mimeType: frame.mimeType,
@@ -876,8 +953,9 @@ export function useLiveVoice(
           markAssistantAudioActive(session);
           useLiveVoiceStore.getState().setState("speaking");
         }),
-        client.on("ttsDone", () => {
+        client.on("ttsDone", (frame) => {
           if (!live()) return;
+          session.demoCapture?.recordAssistantTextFinal(frame.turnId);
           void finishResponseAfterPlayback(session, teardown);
         }),
         client.on("minimizeRoom", () => {
@@ -897,8 +975,9 @@ export function useLiveVoice(
             minimizeVoiceRoom();
           });
         }),
-        client.on("turnCancelled", () => {
+        client.on("turnCancelled", (frame) => {
           if (!live() || !session.handsFree) return;
+          session.demoCapture?.recordInterruptionEnded(frame.turnId);
           // Drop the cancelled turn's bound stamp so the next response's
           // audio can't pair against it. The unbound `speechEndedAtMs` is
           // left alone — it belongs to a newer overlapping utterance whose
@@ -1136,6 +1215,7 @@ export function useLiveVoice(
       reconnectAttemptRef.current = 0;
       initialConnectAttemptRef.current = 0;
       hasReadyRef.current = false;
+      demoCaptureRef.current = VoiceDemoCaptureSession.startIfEnabled();
       await connectSession(assistantId, conversationId, startOptions ?? {});
     },
     [connectSession, clearReconnectTimer],
@@ -1282,6 +1362,17 @@ function handleAmplitude(
   if (
     !muted &&
     !session.handsFree &&
+    !session.manualSpeechOpen &&
+    amplitude >= SPEECH_AMPLITUDE_THRESHOLD
+  ) {
+    session.manualSpeechOpen = true;
+    session.demoCapture?.recordUserSpeechStarted(
+      `manual-utterance-${session.responseEpoch + 1}`,
+    );
+  }
+  if (
+    !muted &&
+    !session.handsFree &&
     amplitude >= BARGE_IN_AMPLITUDE_THRESHOLD
   ) {
     interruptIfSpeaking(session, teardown);
@@ -1333,6 +1424,10 @@ function releasePushToTalk(session: SessionContext): void {
   // gate closes below (re-entry is blocked by releaseInFlight above).
   session.capture.flush();
   session.forwardingAudio = false;
+  if (session.manualSpeechOpen) {
+    session.demoCapture?.recordUserSpeechEnded();
+    session.manualSpeechOpen = false;
+  }
   session.client.pttRelease();
   // End of user speech (manual mode): stamp the client-heard latency start,
   // mirroring the hands-free utterance_end stamp.
@@ -1356,8 +1451,14 @@ function interruptIfSpeaking(
   if (useLiveVoiceStore.getState().state !== "speaking") return;
   if (!session.player.isPlaying || session.interruptSent) return;
   session.interruptSent = true;
+  session.demoCapture?.recordInterruptionStarted(
+    session.currentTurnId ?? undefined,
+  );
   session.player.stop();
   session.client.interrupt();
+  session.demoCapture?.recordInterruptionEnded(
+    session.currentTurnId ?? undefined,
+  );
   teardown();
 }
 
@@ -1378,6 +1479,9 @@ function interruptTurnHandsFree(session: SessionContext): void {
   if (useLiveVoiceStore.getState().state !== "speaking") return;
   if (session.interruptSent) return;
   session.interruptSent = true;
+  session.demoCapture?.recordInterruptionStarted(
+    session.currentTurnId ?? undefined,
+  );
   // The cancelled turn's latency stamp must not pair with a later response.
   session.turnHeardStampMs = null;
   session.client.interrupt();
@@ -1531,4 +1635,9 @@ function finishWithError(
 ): void {
   teardown();
   useLiveVoiceStore.getState().fail(message);
+}
+
+function base64ByteLength(value: string): number {
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((value.length * 3) / 4) - padding);
 }

--- a/clients/web/src/domains/chat/voice/live-voice/voice-demo-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/voice-demo-capture.ts
@@ -1,0 +1,566 @@
+import { registerPlugin, type PluginListenerHandle } from "@capacitor/core";
+
+import {
+  LIVE_VOICE_AUDIO_FORMAT,
+} from "@/domains/chat/voice/live-voice/protocol";
+import {
+  type VoiceDemoAudioRoute,
+  type VoiceDemoAudioSegment,
+  type VoiceDemoEvent,
+  type VoiceDemoFinalizerInput,
+  type VoiceDemoFinalizerResult,
+  type VoiceDemoSessionDocument,
+  type VoiceDemoTranscriptEntry,
+} from "@/domains/chat/voice/live-voice/voice-demo-finalizer";
+import { isNativeIOS } from "@/runtime/platform-detection";
+
+declare global {
+  interface Window {
+    __vellumVoiceDemoCaptureEnabled?: true;
+  }
+}
+
+interface VoiceDemoCapturePlugin {
+  getAudioRoute(): Promise<VoiceDemoAudioRoute>;
+  exportCapture(options: {
+    filename: string;
+    dataBase64: string;
+  }): Promise<{ url: string }>;
+  addListener(
+    eventName: "audioRouteChanged",
+    listener: (route: VoiceDemoAudioRoute) => void,
+  ): Promise<PluginListenerHandle>;
+}
+
+const NativeVoiceDemoCapture =
+  registerPlugin<VoiceDemoCapturePlugin>("VoiceDemoCapture");
+
+interface ScheduledAssistantBuffer {
+  id: string;
+  turnId: string | null;
+  segment: VoiceDemoAudioSegment;
+}
+
+interface ActiveUtterance {
+  id: string;
+  startedT: number;
+}
+
+interface PendingUserTranscript {
+  t: number;
+  text: string;
+}
+
+const EMPTY_AUDIO_ROUTE: VoiceDemoAudioRoute = {
+  inputs: [],
+  outputs: [],
+  sampleRate: 0,
+  ioBufferDuration: 0,
+};
+
+export class VoiceDemoCaptureSession {
+  private readonly sessionId = crypto.randomUUID();
+  private readonly startedAt = new Date();
+  private readonly origin = performance.now();
+  private readonly events: VoiceDemoEvent[] = [];
+  private readonly alexSegments: VoiceDemoAudioSegment[] = [];
+  private readonly paxSegments: VoiceDemoAudioSegment[] = [];
+  private readonly transcriptEntries: VoiceDemoTranscriptEntry[] = [];
+  private readonly assistantTextByTurn = new Map<string, string>();
+  private readonly assistantFirstTokenTurns = new Set<string>();
+  private readonly chunkTurnIds = new Map<string, string | null>();
+  private readonly scheduledAssistantBuffers = new Map<
+    string,
+    ScheduledAssistantBuffer
+  >();
+
+  private audioRoute = EMPTY_AUDIO_ROUTE;
+  private routeListener: PluginListenerHandle | null = null;
+  private activeUtterance: ActiveUtterance | null = null;
+  private lastUserSpeechStartT: number | null = null;
+  private pendingUserTranscript: PendingUserTranscript | null = null;
+  private currentTurnId: string | null = null;
+  private nextAlexT: number | null = null;
+  private eventSequence = 0;
+  private finalizePromise: Promise<void> | null = null;
+
+  static startIfEnabled(): VoiceDemoCaptureSession | null {
+    if (
+      typeof window === "undefined" ||
+      window.__vellumVoiceDemoCaptureEnabled !== true ||
+      !isNativeIOS()
+    ) {
+      return null;
+    }
+    return new VoiceDemoCaptureSession();
+  }
+
+  private constructor() {
+    this.recordEvent({ type: "capture_started" }, 0);
+    this.initializeAudioRouteTracking();
+  }
+
+  get elapsedSeconds(): number {
+    return Math.max(0, (performance.now() - this.origin) / 1000);
+  }
+
+  recordEvent(
+    event: Omit<VoiceDemoEvent, "t"> & { t?: number },
+    t = event.t ?? this.elapsedSeconds,
+  ): void {
+    if (this.finalizePromise) {
+      return;
+    }
+    this.events.push({
+      ...event,
+      t: Math.max(0, t),
+      metadata: {
+        ...event.metadata,
+        sequence: this.eventSequence++,
+      },
+    });
+  }
+
+  recordMicrophoneChunk(buffer: ArrayBuffer): void {
+    if (this.finalizePromise || buffer.byteLength === 0) {
+      return;
+    }
+    const copied = buffer.slice(0);
+    const frameCount = copied.byteLength / Int16Array.BYTES_PER_ELEMENT;
+    const duration = frameCount / LIVE_VOICE_AUDIO_FORMAT.sampleRate;
+    const observedStart = Math.max(0, this.elapsedSeconds - duration);
+    const startT = this.nextAlexT ?? observedStart;
+    const endT = startT + duration;
+    this.nextAlexT = endT;
+    this.alexSegments.push({
+      id: `alex-${this.alexSegments.length + 1}`,
+      startT,
+      endT,
+      sampleRate: LIVE_VOICE_AUDIO_FORMAT.sampleRate,
+      format: "int16",
+      channels: [copied],
+    });
+  }
+
+  recordUserSpeechStarted(id: string): void {
+    if (this.activeUtterance) {
+      return;
+    }
+    const startedT = this.elapsedSeconds;
+    this.activeUtterance = { id, startedT };
+    this.recordEvent({ type: "user_speech_started", id }, startedT);
+  }
+
+  recordUserSpeechEnded(id?: string): void {
+    const utterance = this.activeUtterance;
+    const endedT = this.elapsedSeconds;
+    const utteranceId = id ?? utterance?.id;
+    this.recordEvent(
+      {
+        type: "user_speech_ended",
+        ...(utteranceId ? { id: utteranceId } : {}),
+        ...(utterance ? { endT: endedT } : {}),
+      },
+      endedT,
+    );
+    if (utterance) {
+      this.lastUserSpeechStartT = utterance.startedT;
+    }
+    this.activeUtterance = null;
+  }
+
+  recordUserTranscriptPartial(text: string): void {
+    this.recordEvent({ type: "user_transcript_partial", text });
+  }
+
+  recordUserTranscriptFinal(text: string): void {
+    const t = this.elapsedSeconds;
+    const utteranceT =
+      this.activeUtterance?.startedT ?? this.lastUserSpeechStartT ?? t;
+    this.pendingUserTranscript = { t: utteranceT, text };
+    this.recordEvent({
+      type: "user_transcript_final",
+      text,
+      metadata: { speechStartT: utteranceT },
+    });
+  }
+
+  recordRequestStarted(turnId: string): void {
+    this.currentTurnId = turnId;
+    this.recordEvent({ type: "request_started", id: turnId });
+    const pending = this.pendingUserTranscript;
+    if (pending && pending.text.trim().length > 0) {
+      this.transcriptEntries.push({
+        t: pending.t,
+        speaker: "ALEX",
+        text: pending.text,
+      });
+      this.pendingUserTranscript = null;
+      this.lastUserSpeechStartT = null;
+    }
+  }
+
+  recordAssistantTextDelta(turnId: string, text: string): void {
+    if (!this.assistantFirstTokenTurns.has(turnId)) {
+      this.assistantFirstTokenTurns.add(turnId);
+      this.recordEvent({
+        type: "assistant_first_token",
+        id: turnId,
+        text,
+      });
+    }
+    this.assistantTextByTurn.set(
+      turnId,
+      `${this.assistantTextByTurn.get(turnId) ?? ""}${text}`,
+    );
+    this.recordEvent({
+      type: "assistant_text_delta",
+      id: turnId,
+      text,
+    });
+  }
+
+  recordAssistantTextFinal(turnId: string): void {
+    const text = this.assistantTextByTurn.get(turnId) ?? "";
+    const playbackStartT = this.earliestPlaybackStart(turnId);
+    this.recordEvent({
+      type: "assistant_text_final",
+      id: turnId,
+      text,
+      ...(playbackStartT === null
+        ? {}
+        : { metadata: { playbackStartT } }),
+    });
+    if (text.trim().length > 0) {
+      this.transcriptEntries.push({
+        t: playbackStartT ?? this.elapsedSeconds,
+        speaker: "PAX",
+        text,
+      });
+    }
+  }
+
+  recordTtsChunkReceived(options: {
+    id: string;
+    turnId?: string | null;
+    sampleRate: number;
+    mimeType: string;
+    byteLength: number;
+  }): void {
+    const turnId = options.turnId ?? this.currentTurnId;
+    this.chunkTurnIds.set(options.id, turnId);
+    this.recordEvent({
+      type: "tts_chunk_received",
+      id: options.id,
+      metadata: {
+        turnId,
+        sampleRate: options.sampleRate,
+        mimeType: options.mimeType,
+        byteLength: options.byteLength,
+      },
+    });
+  }
+
+  recordAssistantBufferScheduled(options: {
+    id: string;
+    buffer: AudioBuffer;
+    delaySeconds: number;
+  }): void {
+    if (this.finalizePromise) {
+      return;
+    }
+    const startT = Math.max(0, this.elapsedSeconds + options.delaySeconds);
+    const endT = startT + options.buffer.duration;
+    const channels: ArrayBuffer[] = [];
+    for (
+      let channelIndex = 0;
+      channelIndex < options.buffer.numberOfChannels;
+      channelIndex++
+    ) {
+      channels.push(options.buffer.getChannelData(channelIndex).slice().buffer);
+    }
+    const turnId = this.chunkTurnIds.get(options.id) ?? this.currentTurnId;
+    const segment: VoiceDemoAudioSegment = {
+      id: options.id,
+      startT,
+      endT,
+      sampleRate: options.buffer.sampleRate,
+      format: "float32",
+      channels,
+    };
+    this.paxSegments.push(segment);
+    this.scheduledAssistantBuffers.set(options.id, {
+      id: options.id,
+      turnId,
+      segment,
+    });
+    const metadata = {
+      turnId,
+      scheduledPlaybackT: startT,
+      frameCount: options.buffer.length,
+      sampleRate: options.buffer.sampleRate,
+      channelCount: options.buffer.numberOfChannels,
+      durationSeconds: options.buffer.duration,
+      playbackState: "scheduled",
+    };
+    this.recordEvent({
+      type: "assistant_audio_scheduled",
+      id: options.id,
+      metadata,
+    });
+    this.recordEvent(
+      {
+        type: "assistant_audio_started",
+        id: options.id,
+        metadata: { ...metadata, playbackState: "started" },
+      },
+      startT,
+    );
+  }
+
+  recordAssistantBufferEnded(options: {
+    id: string;
+    state: "completed" | "cancelled";
+    delaySeconds: number;
+  }): void {
+    const scheduled = this.scheduledAssistantBuffers.get(options.id);
+    if (!scheduled) {
+      return;
+    }
+    const observedT = Math.max(0, this.elapsedSeconds + options.delaySeconds);
+    const endT =
+      options.state === "completed"
+        ? scheduled.segment.endT
+        : Math.max(
+            scheduled.segment.startT,
+            Math.min(scheduled.segment.endT, observedT),
+          );
+    scheduled.segment.endT = endT;
+    this.recordEvent(
+      {
+        type: "assistant_audio_ended",
+        id: options.id,
+        endT,
+        metadata: {
+          turnId: scheduled.turnId,
+          playbackState: options.state,
+        },
+      },
+      endT,
+    );
+    this.scheduledAssistantBuffers.delete(options.id);
+  }
+
+  recordInterruptionStarted(id?: string): void {
+    this.recordEvent({
+      type: "interruption_started",
+      ...(id ? { id } : {}),
+    });
+  }
+
+  recordInterruptionEnded(id?: string): void {
+    this.recordEvent({
+      type: "interruption_ended",
+      ...(id ? { id } : {}),
+    });
+  }
+
+  recordCaptureError(error: unknown, phase: string): void {
+    const message =
+      error instanceof Error ? error.message : "Voice demo capture failed";
+    this.recordEvent({
+      type: "capture_error",
+      text: message,
+      metadata: { phase },
+    });
+    console.warn(`[voice-demo-capture] ${phase}: ${message}`);
+  }
+
+  finalizeAndExport(): Promise<void> {
+    if (this.finalizePromise) {
+      return this.finalizePromise;
+    }
+    this.finalizePromise = this.performFinalization();
+    return this.finalizePromise;
+  }
+
+  private async performFinalization(): Promise<void> {
+    const durationSeconds = this.elapsedSeconds;
+    if (this.activeUtterance) {
+      this.events.push({
+        type: "user_speech_ended",
+        id: this.activeUtterance.id,
+        t: durationSeconds,
+        endT: durationSeconds,
+        metadata: { sequence: this.eventSequence++ },
+      });
+      this.activeUtterance = null;
+    }
+    this.events.push({
+      type: "capture_stopped",
+      t: durationSeconds,
+      metadata: { sequence: this.eventSequence++ },
+    });
+    for (const scheduled of this.scheduledAssistantBuffers.values()) {
+      scheduled.segment.endT = Math.max(
+        scheduled.segment.startT,
+        Math.min(scheduled.segment.endT, durationSeconds),
+      );
+    }
+    if (
+      this.pendingUserTranscript &&
+      this.pendingUserTranscript.text.trim().length > 0
+    ) {
+      this.transcriptEntries.push({
+        t: this.pendingUserTranscript.t,
+        speaker: "ALEX",
+        text: this.pendingUserTranscript.text,
+      });
+    }
+
+    const routeListener = this.routeListener;
+    this.routeListener = null;
+    if (routeListener) {
+      await routeListener.remove().catch(() => {});
+    }
+
+    const timestamp = this.startedAt.toISOString().replaceAll(":", "-");
+    const folderName = `voice-demo-${timestamp}`;
+    const session: VoiceDemoSessionDocument = {
+      sessionId: this.sessionId,
+      startedAt: this.startedAt.toISOString(),
+      durationSeconds,
+      audioRoute: this.audioRoute,
+      files: {
+        alex: "alex.wav",
+        pax: "pax.wav",
+        mix: "mix.wav",
+      },
+      events: this.events.toSorted(
+        (left, right) =>
+          left.t - right.t ||
+          eventSequence(left) - eventSequence(right),
+      ),
+    };
+    const input: VoiceDemoFinalizerInput = {
+      folderName,
+      session,
+      alexSegments: this.alexSegments,
+      paxSegments: this.paxSegments,
+      transcriptEntries: this.transcriptEntries,
+    };
+
+    try {
+      const { filename, zip } = await runFinalizerWorker(input);
+      const { url } = await NativeVoiceDemoCapture.exportCapture({
+        filename,
+        dataBase64: arrayBufferToBase64(zip),
+      });
+      console.info(`[voice-demo-capture] exported ${url}`);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Voice demo export failed";
+      console.error(`[voice-demo-capture] export: ${message}`);
+    }
+  }
+
+  private initializeAudioRouteTracking(): void {
+    void NativeVoiceDemoCapture.addListener(
+      "audioRouteChanged",
+      (route) => {
+        this.recordAudioRoute(route);
+      },
+    )
+      .then((listener) => {
+        if (this.finalizePromise) {
+          void listener.remove();
+          return;
+        }
+        this.routeListener = listener;
+      })
+      .catch((error: unknown) => {
+        this.recordCaptureError(error, "audio_route_listener");
+      });
+    void NativeVoiceDemoCapture.getAudioRoute()
+      .then((route) => {
+        this.recordAudioRoute(route);
+      })
+      .catch((error: unknown) => {
+        this.recordCaptureError(error, "audio_route");
+      });
+  }
+
+  private recordAudioRoute(route: VoiceDemoAudioRoute): void {
+    this.audioRoute = route;
+    this.recordEvent({
+      type: "audio_route",
+      metadata: { ...route },
+    });
+  }
+
+  private earliestPlaybackStart(turnId: string): number | null {
+    let earliest: number | null = null;
+    for (const scheduled of this.scheduledAssistantBuffers.values()) {
+      if (scheduled.turnId !== turnId) {
+        continue;
+      }
+      earliest =
+        earliest === null
+          ? scheduled.segment.startT
+          : Math.min(earliest, scheduled.segment.startT);
+    }
+    for (const segment of this.paxSegments) {
+      if (this.chunkTurnIds.get(segment.id) !== turnId) {
+        continue;
+      }
+      earliest =
+        earliest === null ? segment.startT : Math.min(earliest, segment.startT);
+    }
+    return earliest;
+  }
+}
+
+function runFinalizerWorker(
+  input: VoiceDemoFinalizerInput,
+): Promise<Extract<VoiceDemoFinalizerResult, { ok: true }>> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL("./voice-demo-finalizer.worker.ts", import.meta.url),
+      { type: "module" },
+    );
+    worker.onmessage = (event: MessageEvent<VoiceDemoFinalizerResult>) => {
+      worker.terminate();
+      if (event.data.ok) {
+        resolve(event.data);
+      } else {
+        reject(new Error(event.data.message));
+      }
+    };
+    worker.onerror = (event) => {
+      worker.terminate();
+      reject(new Error(event.message || "Voice demo finalizer worker failed"));
+    };
+    const transfer = [
+      ...input.alexSegments.flatMap((segment) => segment.channels),
+      ...input.paxSegments.flatMap((segment) => segment.channels),
+    ];
+    worker.postMessage(input, transfer);
+  });
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize),
+    );
+  }
+  return btoa(binary);
+}
+
+function eventSequence(event: VoiceDemoEvent): number {
+  const sequence = event.metadata?.sequence;
+  return typeof sequence === "number" ? sequence : 0;
+}

--- a/clients/web/src/domains/chat/voice/live-voice/voice-demo-finalizer.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/voice-demo-finalizer.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import {
+  finalizeVoiceDemoCapture,
+  type VoiceDemoFinalizerInput,
+} from "@/domains/chat/voice/live-voice/voice-demo-finalizer";
+
+describe("finalizeVoiceDemoCapture", () => {
+  test("preserves the shared origin and writes aligned mono/stereo float WAVs", async () => {
+    const input: VoiceDemoFinalizerInput = {
+      folderName: "voice-demo-test",
+      session: {
+        sessionId: "session-123",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        durationSeconds: 2,
+        audioRoute: {
+          inputs: [],
+          outputs: [],
+          sampleRate: 48_000,
+          ioBufferDuration: 0.01,
+        },
+        files: {
+          alex: "alex.wav",
+          pax: "pax.wav",
+          mix: "mix.wav",
+        },
+        events: [],
+      },
+      alexSegments: [
+        {
+          id: "alex-1",
+          startT: 0.5,
+          endT: 1.5,
+          sampleRate: 4,
+          format: "int16",
+          channels: [new Int16Array([16_384, 16_384, 16_384, 16_384]).buffer],
+        },
+      ],
+      paxSegments: [
+        {
+          id: "pax-1",
+          startT: 1,
+          endT: 1.5,
+          sampleRate: 4,
+          format: "float32",
+          channels: [new Float32Array([-0.25, -0.25]).buffer],
+        },
+      ],
+      transcriptEntries: [
+        { t: 1, speaker: "PAX", text: "Hello." },
+        { t: 0.5, speaker: "ALEX", text: "Hey." },
+      ],
+    };
+
+    const { filename, zip } = await finalizeVoiceDemoCapture(input);
+
+    expect(filename).toBe("voice-demo-test.zip");
+    const archive = await JSZip.loadAsync(zip);
+    const alex = await archive
+      .file("voice-demo-test/alex.wav")!
+      .async("uint8array");
+    const pax = await archive
+      .file("voice-demo-test/pax.wav")!
+      .async("uint8array");
+    const mix = await archive
+      .file("voice-demo-test/mix.wav")!
+      .async("uint8array");
+    const transcript = await archive
+      .file("voice-demo-test/transcript.txt")!
+      .async("string");
+
+    expect(readWavHeader(alex)).toEqual({
+      format: 3,
+      channels: 1,
+      sampleRate: 48_000,
+      bitsPerSample: 32,
+    });
+    expect(readWavHeader(mix).channels).toBe(2);
+
+    expect(readSample(alex, 0.25, 0, 1)).toBe(0);
+    expect(readSample(alex, 0.75, 0, 1)).toBeCloseTo(0.5, 5);
+    expect(readSample(pax, 0.75, 0, 1)).toBe(0);
+    expect(readSample(pax, 1.25, 0, 1)).toBeCloseTo(-0.25, 5);
+    expect(readSample(mix, 1.25, 0, 2)).toBeCloseTo(0.5, 5);
+    expect(readSample(mix, 1.25, 1, 2)).toBeCloseTo(-0.25, 5);
+    expect(transcript).toBe(
+      "[00:00.500] ALEX: Hey.\n[00:01.000] PAX: Hello.\n",
+    );
+  });
+});
+
+function readWavHeader(bytes: Uint8Array): {
+  format: number;
+  channels: number;
+  sampleRate: number;
+  bitsPerSample: number;
+} {
+  const view = new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength,
+  );
+  return {
+    format: view.getUint16(20, true),
+    channels: view.getUint16(22, true),
+    sampleRate: view.getUint32(24, true),
+    bitsPerSample: view.getUint16(34, true),
+  };
+}
+
+function readSample(
+  bytes: Uint8Array,
+  t: number,
+  channel: number,
+  channelCount: number,
+): number {
+  const frame = Math.round(t * 48_000);
+  const offset = 44 + (frame * channelCount + channel) * 4;
+  return new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength,
+  ).getFloat32(offset, true);
+}

--- a/clients/web/src/domains/chat/voice/live-voice/voice-demo-finalizer.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/voice-demo-finalizer.ts
@@ -1,0 +1,258 @@
+import JSZip from "jszip";
+
+export const VOICE_DEMO_OUTPUT_SAMPLE_RATE = 48_000;
+
+export interface VoiceDemoAudioRoute {
+  inputs: Array<Record<string, unknown>>;
+  outputs: Array<Record<string, unknown>>;
+  sampleRate: number;
+  ioBufferDuration: number;
+}
+
+export interface VoiceDemoEvent {
+  type: string;
+  t: number;
+  endT?: number;
+  id?: string;
+  text?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface VoiceDemoSessionDocument {
+  sessionId: string;
+  startedAt: string;
+  durationSeconds: number;
+  audioRoute: VoiceDemoAudioRoute;
+  files: {
+    alex: "alex.wav";
+    pax: "pax.wav";
+    mix: "mix.wav";
+  };
+  events: VoiceDemoEvent[];
+}
+
+export interface VoiceDemoAudioSegment {
+  id: string;
+  startT: number;
+  endT: number;
+  sampleRate: number;
+  format: "float32" | "int16";
+  channels: ArrayBuffer[];
+}
+
+export interface VoiceDemoTranscriptEntry {
+  t: number;
+  speaker: "ALEX" | "PAX";
+  text: string;
+}
+
+export interface VoiceDemoFinalizerInput {
+  folderName: string;
+  session: VoiceDemoSessionDocument;
+  alexSegments: VoiceDemoAudioSegment[];
+  paxSegments: VoiceDemoAudioSegment[];
+  transcriptEntries: VoiceDemoTranscriptEntry[];
+}
+
+export interface VoiceDemoFinalizerOutput {
+  filename: string;
+  zip: ArrayBuffer;
+}
+
+export type VoiceDemoFinalizerResult =
+  | ({ ok: true } & VoiceDemoFinalizerOutput)
+  | { ok: false; message: string };
+
+export async function finalizeVoiceDemoCapture(
+  input: VoiceDemoFinalizerInput,
+): Promise<VoiceDemoFinalizerOutput> {
+  const frameCount = Math.ceil(
+    input.session.durationSeconds * VOICE_DEMO_OUTPUT_SAMPLE_RATE,
+  );
+  const alex = renderMonoTrack(input.alexSegments, frameCount);
+  const pax = renderMonoTrack(input.paxSegments, frameCount);
+
+  const zip = new JSZip();
+  const folder = zip.folder(input.folderName);
+  if (!folder) {
+    throw new Error("Failed to create voice demo archive folder");
+  }
+
+  folder.file(
+    "session.json",
+    `${JSON.stringify(input.session, null, 2)}\n`,
+  );
+  folder.file(
+    "alex.wav",
+    encodeFloatWav([alex], VOICE_DEMO_OUTPUT_SAMPLE_RATE),
+  );
+  folder.file(
+    "pax.wav",
+    encodeFloatWav([pax], VOICE_DEMO_OUTPUT_SAMPLE_RATE),
+  );
+  folder.file(
+    "mix.wav",
+    encodeFloatWav([alex, pax], VOICE_DEMO_OUTPUT_SAMPLE_RATE),
+  );
+  folder.file(
+    "transcript.txt",
+    formatTranscript(input.transcriptEntries),
+  );
+
+  const bytes = await zip.generateAsync({
+    type: "uint8array",
+    compression: "DEFLATE",
+    compressionOptions: { level: 6 },
+  });
+  const zipBuffer = new Uint8Array(bytes).buffer;
+  return {
+    filename: `${input.folderName}.zip`,
+    zip: zipBuffer,
+  };
+}
+
+export function encodeFloatWav(
+  channels: Float32Array[],
+  sampleRate: number,
+): Uint8Array {
+  if (channels.length === 0) {
+    throw new Error("A WAV file requires at least one channel");
+  }
+  const frameCount = channels[0]?.length ?? 0;
+  if (!channels.every((channel) => channel.length === frameCount)) {
+    throw new Error("WAV channels must have equal frame counts");
+  }
+
+  const bytesPerSample = 4;
+  const blockAlign = channels.length * bytesPerSample;
+  const dataByteLength = frameCount * blockAlign;
+  const output = new Uint8Array(44 + dataByteLength);
+  const view = new DataView(output.buffer);
+
+  writeAscii(output, 0, "RIFF");
+  view.setUint32(4, 36 + dataByteLength, true);
+  writeAscii(output, 8, "WAVE");
+  writeAscii(output, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 3, true);
+  view.setUint16(22, channels.length, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, 32, true);
+  writeAscii(output, 36, "data");
+  view.setUint32(40, dataByteLength, true);
+
+  let offset = 44;
+  for (let frame = 0; frame < frameCount; frame++) {
+    for (const channel of channels) {
+      view.setFloat32(offset, channel[frame] ?? 0, true);
+      offset += bytesPerSample;
+    }
+  }
+  return output;
+}
+
+function renderMonoTrack(
+  segments: VoiceDemoAudioSegment[],
+  frameCount: number,
+): Float32Array {
+  const output = new Float32Array(frameCount);
+  for (const segment of segments) {
+    renderSegment(segment, output);
+  }
+  return output;
+}
+
+function renderSegment(
+  segment: VoiceDemoAudioSegment,
+  output: Float32Array,
+): void {
+  if (
+    segment.channels.length === 0 ||
+    segment.sampleRate <= 0 ||
+    segment.endT <= segment.startT
+  ) {
+    return;
+  }
+
+  const sourceChannels =
+    segment.format === "int16"
+      ? segment.channels.map((buffer) => new Int16Array(buffer))
+      : segment.channels.map((buffer) => new Float32Array(buffer));
+  const sourceFrameCount = Math.min(
+    ...sourceChannels.map((channel) => channel.length),
+  );
+  if (sourceFrameCount === 0) {
+    return;
+  }
+
+  const outputStart = Math.max(
+    0,
+    Math.round(segment.startT * VOICE_DEMO_OUTPUT_SAMPLE_RATE),
+  );
+  const scheduledFrames = Math.ceil(
+    (segment.endT - segment.startT) * VOICE_DEMO_OUTPUT_SAMPLE_RATE,
+  );
+  const sourceFrames = Math.ceil(
+    (sourceFrameCount / segment.sampleRate) *
+      VOICE_DEMO_OUTPUT_SAMPLE_RATE,
+  );
+  const framesToRender = Math.min(
+    scheduledFrames,
+    sourceFrames,
+    output.length - outputStart,
+  );
+  const sourceStep = segment.sampleRate / VOICE_DEMO_OUTPUT_SAMPLE_RATE;
+
+  for (let outputFrame = 0; outputFrame < framesToRender; outputFrame++) {
+    const sourcePosition = outputFrame * sourceStep;
+    const before = Math.min(
+      sourceFrameCount - 1,
+      Math.floor(sourcePosition),
+    );
+    const after = Math.min(sourceFrameCount - 1, before + 1);
+    const fraction = sourcePosition - before;
+    let mono = 0;
+    for (const channel of sourceChannels) {
+      const first = sampleAsFloat(channel, before, segment.format);
+      const second = sampleAsFloat(channel, after, segment.format);
+      mono += first + (second - first) * fraction;
+    }
+    output[outputStart + outputFrame] += mono / sourceChannels.length;
+  }
+}
+
+function sampleAsFloat(
+  channel: Int16Array | Float32Array,
+  index: number,
+  format: VoiceDemoAudioSegment["format"],
+): number {
+  const value = channel[index] ?? 0;
+  return format === "int16" ? value / 0x8000 : value;
+}
+
+function formatTranscript(entries: VoiceDemoTranscriptEntry[]): string {
+  const lines = entries
+    .filter((entry) => entry.text.trim().length > 0)
+    .toSorted((left, right) => left.t - right.t)
+    .map(
+      (entry) =>
+        `[${formatRelativeTime(entry.t)}] ${entry.speaker}: ${entry.text.trim()}`,
+    );
+  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+}
+
+function formatRelativeTime(seconds: number): string {
+  const milliseconds = Math.max(0, Math.round(seconds * 1000));
+  const minutes = Math.floor(milliseconds / 60_000);
+  const secondsWithinMinute = Math.floor((milliseconds % 60_000) / 1000);
+  const millisecondsWithinSecond = milliseconds % 1000;
+  return `${String(minutes).padStart(2, "0")}:${String(secondsWithinMinute).padStart(2, "0")}.${String(millisecondsWithinSecond).padStart(3, "0")}`;
+}
+
+function writeAscii(output: Uint8Array, offset: number, text: string): void {
+  for (let index = 0; index < text.length; index++) {
+    output[offset + index] = text.charCodeAt(index);
+  }
+}

--- a/clients/web/src/domains/chat/voice/live-voice/voice-demo-finalizer.worker.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/voice-demo-finalizer.worker.ts
@@ -1,0 +1,31 @@
+/// <reference lib="webworker" />
+
+import {
+  finalizeVoiceDemoCapture,
+  type VoiceDemoFinalizerInput,
+  type VoiceDemoFinalizerResult,
+} from "@/domains/chat/voice/live-voice/voice-demo-finalizer";
+
+self.onmessage = (event: MessageEvent<VoiceDemoFinalizerInput>) => {
+  void finalizeVoiceDemoCapture(event.data)
+    .then(({ filename, zip }) => {
+      const result: VoiceDemoFinalizerResult = {
+        ok: true,
+        filename,
+        zip,
+      };
+      self.postMessage(result, { transfer: [zip] });
+    })
+    .catch((error: unknown) => {
+      const result: VoiceDemoFinalizerResult = {
+        ok: false,
+        message:
+          error instanceof Error
+            ? error.message
+            : "Voice demo finalization failed",
+      };
+      self.postMessage(result);
+    });
+};
+
+export {};

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -202,6 +202,17 @@ export async function waitForNativeSessionCookie(): Promise<void> {
  * same code works across environments without runtime host sniffing.
  */
 export function installSessionCookies(sessionToken: string): void {
+  if (
+    window.__vellumVoiceDemoCaptureEnabled === true &&
+    !window.location.hostname.endsWith(".vellum.ai")
+  ) {
+    const secure =
+      window.location.protocol === "https:" ? "; secure" : "";
+    document.cookie =
+      `sessionid=${sessionToken}; path=/; samesite=lax; max-age=1209600` +
+      secure;
+    return;
+  }
   // `max-age` makes the cookie persistent. If unspecified, the cookie
   // expires at the end of the session, and users will be required to
   // login again.


### PR DESCRIPTION
## Summary
- add an opt-in `#if DEBUG` iOS voice-demo capture bridge at the existing microphone and TTS playback boundaries
- export synchronized 48 kHz float Alex/Pax tracks, a stereo mix, transcript, and monotonic event timeline
- disposable demo branch for direct Xcode device installation only; do not merge or release

## Original prompt
Add a DEBUG-only iOS Voice Demo Capture mode that exports separately editable microphone and assistant audio plus an exact session timeline, without changing the production audio path. This is strictly for a one-off demo and will never go to production.