### PR TITLE
fix(web): reconnect reconcile bypasses the kick throttle; orphan pass re-checks parent ownership; kick diagnostic tracks real reconciles

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.test.tsx
@@ -4,9 +4,9 @@
  * so each trigger is a countable round-trip; the reconcile's effect on the
  * store is covered by `subagent-store.test.ts`.
  *
- * The store throttles per parent conversation, so a trigger that fires inside
- * the previous one's window is a deliberate no-op. Tests that want a second
- * round-trip step the clock past it.
+ * The store throttles the conversation-load pass per parent conversation, but
+ * not a reopen: a stream replaced after a drop is the one that may have lost a
+ * terminal status, so its reconcile is issued inside the window too.
  */
 import {
   afterEach,
@@ -63,11 +63,6 @@ function mount(
   );
 }
 
-/** Step past the store's per-parent reconcile window. */
-function advancePastReconcileWindow() {
-  setSystemTime(new Date(Date.now() + 10_000));
-}
-
 beforeEach(() => {
   getCalls = 0;
   reconcileSupported = true;
@@ -120,26 +115,34 @@ describe("useSubagentReconcile", () => {
   test("reconciles again when the SSE stream reopens on resume", async () => {
     mount();
     await waitFor(() => expect(getCalls).toBe(1));
-    advancePastReconcileWindow();
 
     publish("sse.opened", { assistantId: ASSISTANT, cause: "resume" });
 
     await waitFor(() => expect(getCalls).toBe(2));
   });
 
-  test("a reconnect flap costs one round-trip per window, not one per reopen", async () => {
-    // A stream that drops and re-opens repeatedly used to bypass the kick
-    // throttle entirely: it lives on the store's triggers, not the kick path.
+  test("reconciles on a reopen inside the load pass's throttle window", async () => {
+    // The dropped stream may have straddled a terminal status, and nothing
+    // retries a reconcile the window swallowed — the row stays `running`
+    // forever. The reactive version gate makes this the common case: the load
+    // pass often runs late, moments before the reopen.
+    mount();
+    await waitFor(() => expect(getCalls).toBe(1));
+
+    publish("sse.opened", { assistantId: ASSISTANT, cause: "error" });
+
+    await waitFor(() => expect(getCalls).toBe(2));
+  });
+
+  test("a flap that reopens repeatedly in one tick costs one round-trip", async () => {
+    // Bypassing the throttle doesn't mean one request per reopen: the store
+    // single-flights per parent conversation.
     mount();
     await waitFor(() => expect(getCalls).toBe(1));
 
     for (const cause of ["error", "watchdog", "resume"] as const) {
       publish("sse.opened", { assistantId: ASSISTANT, cause });
     }
-    await waitFor(() => expect(getCalls).toBe(1));
-
-    advancePastReconcileWindow();
-    publish("sse.opened", { assistantId: ASSISTANT, cause: "error" });
 
     await waitFor(() => expect(getCalls).toBe(2));
   });

--- a/clients/web/src/domains/chat/hooks/use-subagent-reconcile.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-reconcile.ts
@@ -19,9 +19,12 @@
  *   ring replay.
  *
  * Drafts are excluded — a conversation the server has never seen has no
- * subagents to reconcile against. Both triggers fire freely: the store
- * throttles per parent conversation, so a flapping stream costs one round-trip
- * per window rather than one per reopen.
+ * subagents to reconcile against. Both triggers fire freely; the store decides
+ * what actually goes out. A conversation-load pass is throttled per parent, so
+ * a re-run costs nothing, while a reopen is issued even inside that window:
+ * the stream it replaces is the one that may have dropped the terminal status,
+ * and a reconcile skipped there is never retried. Reopens landing together
+ * still collapse into a single round-trip.
  *
  * The version gate is read reactively rather than snapshotted: the assistant
  * version arrives asynchronously and is cleared on every assistant switch, so
@@ -34,7 +37,10 @@
 
 import { useCallback, useEffect } from "react";
 
-import { useSubagentStore } from "@/domains/chat/subagent-store";
+import {
+  type SubagentReconcileTrigger,
+  useSubagentStore,
+} from "@/domains/chat/subagent-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useSupportsSubagentsReconcile } from "@/lib/backwards-compat/subagents-reconcile";
 import type { BusEventPayload } from "@/lib/event-bus";
@@ -55,33 +61,36 @@ export function useSubagentReconcile(
 ): void {
   const supportsReconcile = useSupportsSubagentsReconcile();
 
-  const resync = useCallback(() => {
-    if (
-      !supportsReconcile ||
-      !assistantId ||
-      !conversationId ||
-      !conversationExistsOnServer
-    ) {
-      return;
-    }
-    void useSubagentStore
-      .getState()
-      .reconcileFromDaemon(assistantId, conversationId);
-  }, [
-    supportsReconcile,
-    assistantId,
-    conversationId,
-    conversationExistsOnServer,
-  ]);
+  const resync = useCallback(
+    (trigger: SubagentReconcileTrigger) => {
+      if (
+        !supportsReconcile ||
+        !assistantId ||
+        !conversationId ||
+        !conversationExistsOnServer
+      ) {
+        return;
+      }
+      void useSubagentStore
+        .getState()
+        .reconcileFromDaemon(assistantId, conversationId, trigger);
+    },
+    [
+      supportsReconcile,
+      assistantId,
+      conversationId,
+      conversationExistsOnServer,
+    ],
+  );
 
   useEffect(() => {
-    resync();
+    resync("mount");
   }, [resync]);
 
   useBusSubscription("sse.opened", ({ assistantId: openedFor, cause }) => {
     if (!RESYNC_CAUSES.has(cause) || openedFor !== assistantId) {
       return;
     }
-    resync();
+    resync("reopen");
   });
 }

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -52,6 +52,18 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   subagentsByIdAbortPost: mock(async () => ({ data: undefined, response: { ok: true } })),
 }));
 
+const actualDiagnostics = await import("@/lib/diagnostics");
+const recordedDiagnostics: Array<{
+  kind: string;
+  details: Record<string, unknown>;
+}> = [];
+mock.module("@/lib/diagnostics", () => ({
+  ...actualDiagnostics,
+  recordDiagnostic: (kind: string, details: Record<string, unknown> = {}) => {
+    recordedDiagnostics.push({ kind, details });
+  },
+}));
+
 const { useSubagentStore } = await import("@/domains/chat/subagent-store");
 // Imported after the SDK mock so it binds to the same mocked store module.
 const { reconcileSubagentStoreFromNotifications } = await import(
@@ -77,6 +89,13 @@ function advancePastReconcileWindow() {
   setSystemTime(new Date(Date.now() + 10_000));
 }
 
+/** Every `subagent_reconcile_kick` recorded since the current test started. */
+function reconcileKicks() {
+  return recordedDiagnostics.filter(
+    (event) => event.kind === "subagent_reconcile_kick",
+  );
+}
+
 beforeEach(() => {
   setSystemTime();
   getState().reset();
@@ -87,6 +106,7 @@ beforeEach(() => {
   subagentsReconcileGet.mockClear();
   reconcileRequests.length = 0;
   reconcileReply = { ok: true, subagents: {} };
+  recordedDiagnostics.length = 0;
 });
 
 // ---------------------------------------------------------------------------
@@ -2187,6 +2207,95 @@ describe("reconcileFromDaemon", () => {
     await getState().reconcileFromDaemon("assistant-1", "conv-parent");
 
     expect(subagentsReconcileGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("issues a reopen-triggered reconcile inside the window", async () => {
+    // The dropped stream may have straddled a terminal status, and a reconcile
+    // skipped here is never retried — the row would stay `running` forever.
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent", "reopen");
+
+    expect(subagentsReconcileGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("still shares one request between concurrent reopens", async () => {
+    await Promise.all([
+      getState().reconcileFromDaemon("assistant-1", "conv-parent", "reopen"),
+      getState().reconcileFromDaemon("assistant-1", "conv-parent", "reopen"),
+    ]);
+
+    expect(subagentsReconcileGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a reopen take the window so the reconnect's load pass is a no-op", async () => {
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent", "reopen");
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(subagentsReconcileGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps each parent's reopen on its own window", async () => {
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent", "reopen");
+    await getState().reconcileFromDaemon("assistant-1", "conv-other");
+
+    expect(reconcileRequests).toHaveLength(2);
+  });
+
+  it("does not settle a candidate re-parented mid-round-trip", async () => {
+    // `ensureEntry` guesses the conversation on screen as parent, so a later
+    // `subagent_event` can re-attribute the stub. This response describes the
+    // conversation it asked about, not the one the row now belongs to.
+    getState().spawnSubagent({
+      subagentId: "sa-moved",
+      label: "Agent",
+      objective: "",
+      status: "running",
+      parentConversationId: "conv-parent",
+      timestamp: NOW,
+    });
+    reconcileReply = { ok: true, subagents: {} };
+
+    const pending = getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    getState().setParentConversationId("sa-moved", "conv-other");
+    await pending;
+
+    expect(getState().byId["sa-moved"]?.status).toBe("running");
+  });
+
+  it("records no kick diagnostic when the assistant predates the route", async () => {
+    reconcileSupported = false;
+
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+
+    expect(reconcileKicks()).toHaveLength(0);
+  });
+
+  it("records one kick diagnostic per round-trip, tagged with its trigger", async () => {
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent");
+    // Throttled and single-flighted calls issue nothing, so they record
+    // nothing.
+    await Promise.all([
+      getState().reconcileFromDaemon("assistant-1", "conv-parent"),
+      getState().reconcileFromDaemon("assistant-1", "conv-parent", "unknown_id"),
+    ]);
+    await getState().reconcileFromDaemon("assistant-1", "conv-parent", "reopen");
+
+    expect(reconcileKicks().map((event) => event.details.trigger)).toEqual([
+      "mount",
+      "reopen",
+    ]);
+  });
+
+  it("tags an unknown-id kick with its own trigger", async () => {
+    await getState().reconcileFromDaemon(
+      "assistant-1",
+      "conv-parent",
+      "unknown_id",
+    );
+
+    expect(reconcileKicks()).toEqual([
+      { kind: "subagent_reconcile_kick", details: { trigger: "unknown_id" } },
+    ]);
   });
 
   it("skips an item whose status is not a known subagent status", async () => {

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -170,6 +170,17 @@ export const EMPTY_SUBAGENT_ENTRIES: readonly SubagentEntry[] = [];
 // Actions
 // ---------------------------------------------------------------------------
 
+/**
+ * What asked for a reconcile. Decides whether the call is throttled and rides
+ * along on the `subagent_reconcile_kick` diagnostic so the field tells which
+ * trigger is actually recovering runs.
+ *
+ * - `"mount"` — conversation load (or the version gate resolving after it).
+ * - `"reopen"` — an SSE stream replaced after a drop; never throttled.
+ * - `"unknown_id"` — a stream event named a subagent the store doesn't hold.
+ */
+export type SubagentReconcileTrigger = "mount" | "reopen" | "unknown_id";
+
 export interface SubagentActions {
   spawnSubagent: (params: {
     subagentId: string;
@@ -357,16 +368,20 @@ export interface SubagentActions {
    * out. Timeline backfill stays with that fetch — this never touches
    * `events`.
    *
-   * Concurrent calls for the same parent conversation share one request, and
-   * every trigger — mount, SSE reopen, unknown-id kick — shares one throttle
-   * window per parent, so an SSE flap loop costs a single round-trip. A
-   * `reset()` while a request is in flight invalidates it (the snapshot
-   * describes the conversation the user just left) and reopens the window for
-   * the conversation now on screen.
+   * Concurrent calls for the same parent conversation always share one
+   * request. Beyond that, `"mount"` and `"unknown_id"` share one throttle
+   * window per parent; `"reopen"` bypasses it. A reopen replaces a stream that
+   * may have dropped a terminal status, so throttling it away is how a row
+   * stays `running` forever — the miss is unrecoverable, whereas a throttled
+   * mount pass has already been covered by the round-trip that took the
+   * window. A `reset()` while a request is in flight invalidates it (the
+   * snapshot describes the conversation the user just left) and reopens the
+   * window for the conversation now on screen.
    */
   reconcileFromDaemon: (
     assistantId: string,
     parentConversationId: string,
+    trigger?: SubagentReconcileTrigger,
   ) => Promise<void>;
 
   /**
@@ -573,7 +588,7 @@ const reconcileInFlight = new Map<string, Promise<void>>();
  */
 let resetGeneration = 0;
 
-/** Minimum spacing between reconcile round-trips for one parent. */
+/** Minimum spacing between one parent's throttled reconcile round-trips. */
 const RECONCILE_KICK_INTERVAL_MS = 5_000;
 
 /**
@@ -585,17 +600,25 @@ const RECONCILE_KICK_INTERVAL_MS = 5_000;
 const lastReconcileKickAt = new Map<string, number>();
 
 /**
+ * Open a fresh window for `parentConversationId` without testing the current
+ * one — for a trigger that issues its round-trip regardless, so the throttled
+ * triggers still measure their spacing from the last real request.
+ */
+function stampReconcileWindow(parentConversationId: string): void {
+  lastReconcileKickAt.set(parentConversationId, Date.now());
+}
+
+/**
  * Take `parentConversationId`'s reconcile slot for this window, reporting
  * whether it was free. Claiming and testing are one step so two triggers
  * firing in the same tick can't both pass.
  */
 function claimReconcileWindow(parentConversationId: string): boolean {
-  const now = Date.now();
   const lastKickAt = lastReconcileKickAt.get(parentConversationId) ?? 0;
-  if (now - lastKickAt < RECONCILE_KICK_INTERVAL_MS) {
+  if (Date.now() - lastKickAt < RECONCILE_KICK_INTERVAL_MS) {
     return false;
   }
-  lastReconcileKickAt.set(parentConversationId, now);
+  stampReconcileWindow(parentConversationId);
   return true;
 }
 
@@ -737,12 +760,16 @@ async function runReconcile(
   // Settle this conversation's orphans: a candidate the daemon didn't report
   // died with it, and no terminal event is ever coming. Re-checked against the
   // store as it stands now — a terminal event that landed during the
-  // round-trip already settled the row truthfully.
+  // round-trip already settled the row truthfully, and ownership is re-tested
+  // because a stub `ensureEntry` attributed to the conversation on screen can
+  // be re-parented by a later `subagent_event`. This response says nothing
+  // about a row that now belongs to a different conversation.
   const { byId, changeStatus } = get();
   for (const subagentId of candidateIds) {
     const entry = byId[subagentId];
     if (
       !entry ||
+      entry.parentConversationId !== parentConversationId ||
       !isActiveStatus(entry.status) ||
       Object.hasOwn(snapshot, subagentId)
     ) {
@@ -1240,7 +1267,11 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     });
   },
 
-  reconcileFromDaemon: (assistantId, parentConversationId) => {
+  reconcileFromDaemon: (
+    assistantId,
+    parentConversationId,
+    trigger = "mount",
+  ) => {
     // Single choke point for every trigger (mount, SSE reopen, unknown-id
     // kick): assistants older than 0.10.0 don't serve the route, and the
     // triggers re-fire on every reopen — gate rather than 404 repeatedly.
@@ -1251,13 +1282,24 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
     if (inFlight) {
       return inFlight;
     }
-    // Throttled here rather than at the kick call site so a reconnect loop —
-    // which re-fires the mount and `sse.opened` triggers, not the kick — is
-    // bounded too.
-    if (!claimReconcileWindow(parentConversationId)) {
+    // Throttled here rather than at the kick call site so a mount pass that
+    // re-runs when the version gate resolves is bounded too. A reopen is
+    // exempt: the stream it replaces may have dropped the terminal status this
+    // pass exists to recover, and a dropped reopen is never retried. It still
+    // stamps the window, so the reconnect's own mount pass doesn't double-fire,
+    // and single-flight above still collapses a burst of reopens into one
+    // request. `sse.opened` only publishes for a stream that genuinely
+    // established, so this is bounded by the transport's reconnect backoff.
+    if (trigger === "reopen") {
+      stampReconcileWindow(parentConversationId);
+    } else if (!claimReconcileWindow(parentConversationId)) {
       return Promise.resolve();
     }
 
+    // Recorded here rather than at the kick call site so the count tracks
+    // round-trips actually issued — not calls the version gate, the window or
+    // single-flight turned into a no-op.
+    recordDiagnostic("subagent_reconcile_kick", { trigger });
     const run: Promise<void> = runReconcile(
       get,
       assistantId,
@@ -1335,10 +1377,7 @@ export function requestSubagentReconcile(parentConversationId?: string): void {
     return;
   }
 
-  recordDiagnostic("subagent_reconcile_kick", {
-    reason: "unknown_subagent_id",
-  });
   void useSubagentStoreBase
     .getState()
-    .reconcileFromDaemon(assistantId, targetConversationId);
+    .reconcileFromDaemon(assistantId, targetConversationId, "unknown_id");
 }


### PR DESCRIPTION
Self-review remediation (r3) for the web side of the subagent running-state fixes. Three findings from the r2 review of `subagent-store.ts` / `use-subagent-reconcile.ts`.

## 1. (P1) The relocated 5s reconcile throttle dropped the first reconnect reconcile with no retry

Moving the throttle into `reconcileFromDaemon` put *every* trigger through `claimReconcileWindow`. An `sse.opened` reopen (cause `error`/`watchdog`/`resume`) landing within 5s of the conversation-load pass became `Promise.resolve()` — no pending flag, no timer, no retry. If the dropped stream straddled a terminal `subagent_status_changed`, the subagent stays `running` forever: the exact failure this branch exists to fix. The r2 reactive version gate widens the window, since the load pass now often runs late.

Fixed with the **priority path**: `reconcileFromDaemon` takes a `SubagentReconcileTrigger` (`"mount" | "reopen" | "unknown_id"`), threaded from `useSubagentReconcile`'s mount effect and `sse.opened` handler and from `requestSubagentReconcile`. A `"reopen"` skips `claimReconcileWindow` but still dedups through `reconcileInFlight`, so a burst of reopens in one tick is still a single round-trip. It *stamps* the window (`stampReconcileWindow`) so the reconnect's own load pass doesn't double-fire. Mount and unknown-id kicks keep the throttle unchanged.

Chosen over the trailing-edge variant because it needs no new timer or pending flag (nothing extra for `reset()` to clear, no risk of a stale timer firing into a switched conversation) and it recovers a stuck row immediately rather than up to 5s later. Volume stays bounded: `sse.opened` only publishes for a stream that genuinely established, so reopens are already spaced by the transport's reconnect backoff.

## 2. (functional) Orphan pass lost its post-await parent-ownership re-check

The pre-await candidate snapshot filters on `entry.parentConversationId === parentConversationId`, but the post-await settle loop only re-checked existence + `isActiveStatus` + `Object.hasOwn(snapshot, id)` — it dropped the parent comparison the old inline code had. Since `ensureEntry` guesses the active conversation as parent and a later `subagent_event` can re-attribute a stub via `setParentConversationId`, a stale response could settle a row that has since been re-parented to a different conversation (also reachable between two concurrent per-parent reconciles). Added `entry.parentConversationId !== parentConversationId` back into the `continue` condition.

## 3. (nit/observability) The `subagent_reconcile_kick` diagnostic no longer tracked reconciles

It sat in `requestSubagentReconcile`, where it fired even when the version gate short-circuited (pre-0.10.0 daemon) or the window / in-flight map dedup'd the call, and its `reason` had been reduced to a constant. Moved to where the round-trip is actually issued inside `reconcileFromDaemon`, tagged with the `trigger` from fix 1. Now: nothing recorded for a gated, throttled or coalesced call; one record per real reconcile, saying which trigger caused it.

## Tests

`subagent-store.test.ts` — reopen reconciles inside the window; concurrent reopens still coalesce to one request; a reopen takes the window so the following load pass is a no-op; per-parent keying preserved; a candidate re-parented mid-round-trip is not settled; no kick diagnostic behind the version gate; one per real reconcile with its trigger.

`use-subagent-reconcile.test.tsx` — a reopen inside the load pass's window still reconciles; a flap that reopens repeatedly in one tick costs one round-trip.

Both new-behavior suites verified to fail against the pre-fix code.

`bun run test:ci` (3 files) green, `bunx tsc --noEmit` clean, eslint on changed files reports only pre-existing `curly` warnings.

Part of plan: subagent-running-state-fixes.md (self-review remediation r3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)