### PR TITLE
fix(assistant): bound rehydrated terminal rows, order subagent-row deletion after conversation delete

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29499,12 +29499,12 @@ paths:
       description:
         "Returns the subagents the assistant knows for a given parent conversation — live, rehydrated, and durably
         recorded, including recently finished runs whose in-memory metadata the retention sweep has already evicted.
-        Durable records live as long as the conversation, so the recorded pass is bounded: every record not in a
-        terminal state is always returned, plus the 20 most recently finished ones. Each entry carries enough detail
-        (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list
-        from scratch, not just refresh statuses. A subagent absent from the response is one the assistant no longer
-        reports, so a client may settle its own stuck-active entries against this snapshot. Only `status` is guaranteed
-        to be present; every other field is optional."
+        Durable records live as long as the conversation, so the snapshot is bounded: every subagent not in a terminal
+        state is always returned, plus the 20 most recently finished ones. Each entry carries enough detail (child
+        conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list from
+        scratch, not just refresh statuses. A subagent absent from the response is one the assistant no longer reports,
+        so a client may settle its own stuck-active entries against this snapshot. Only `status` is guaranteed to be
+        present; every other field is optional."
       tags:
         - subagents
       parameters:

--- a/assistant/src/__tests__/conversation-delete-subagent-rows.test.ts
+++ b/assistant/src/__tests__/conversation-delete-subagent-rows.test.ts
@@ -1,0 +1,125 @@
+/**
+ * A conversation's durable subagent rows are purged only after the conversation
+ * delete commits. The rows are a child's only durable metadata, so dropping
+ * them first would lose them for good when the delete throws — while the
+ * conversation they describe survives, intact for a retried delete.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../daemon/handlers/conversations.js", () => ({
+  cancelGeneration: () => true,
+  clearAllConversations: async () => 0,
+  resolveMetaSlashCommand: () => null,
+  switchConversation: async () => null,
+  undoLastMessage: async () => null,
+}));
+
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { migrateCreateSubagentsTable } from "../persistence/migrations/311-create-subagents-table.js";
+import { migrateAddSubagentParentToolUseId } from "../persistence/migrations/354-add-subagent-parent-tool-use-id.js";
+import { resetTestTables } from "../persistence/raw-query.js";
+import {
+  getSubagentRecordById,
+  type SubagentRecord,
+  upsertSubagentRecord,
+} from "../persistence/subagent-store.js";
+
+await initializeDb();
+
+// Captured before the mock replaces the export, so the happy path still runs
+// the real delete.
+const crud = await import("../persistence/conversation-crud.js");
+const createConversation = crud.createConversation;
+const getConversation = crud.getConversation;
+const realDeleteConversation = crud.deleteConversation;
+
+let failNextDelete = false;
+mock.module("../persistence/conversation-crud.js", () => ({
+  ...crud,
+  deleteConversation: (id: string) => {
+    if (failNextDelete) {
+      throw new Error("simulated delete failure");
+    }
+    return realDeleteConversation(id);
+  },
+}));
+
+const { ROUTES } =
+  await import("../runtime/routes/conversation-management-routes.js");
+const deleteRoute = ROUTES.find((r) => r.operationId === "deleteConversation")!;
+
+function seedRow(id: string, parentConversationId: string): void {
+  const rec: SubagentRecord = {
+    id,
+    parentConversationId,
+    conversationId: `child-conv-${id}`,
+    label: id,
+    objective: "Do something",
+    role: "researcher",
+    isFork: false,
+    sendResultToUser: null,
+    parentToolUseId: null,
+    status: "completed",
+    error: null,
+    createdAt: 1000,
+    startedAt: 1001,
+    completedAt: 2000,
+    inputTokens: 5,
+    outputTokens: 7,
+    estimatedCost: 0.01,
+  };
+  upsertSubagentRecord(rec);
+}
+
+function deleteConversationViaRoute(id: string): Promise<unknown> {
+  return deleteRoute.handler({
+    pathParams: { id },
+    body: {},
+    headers: {},
+  } as Parameters<typeof deleteRoute.handler>[0]) as Promise<unknown>;
+}
+
+describe("DELETE /conversations/:id — subagent row purge order", () => {
+  beforeEach(() => {
+    migrateCreateSubagentsTable();
+    migrateAddSubagentParentToolUseId(getDb());
+    resetTestTables("subagents");
+    failNextDelete = false;
+  });
+
+  test("purges the parent's rows once the delete commits", async () => {
+    const conv = createConversation("subagent-parent");
+    const other = createConversation("unrelated-parent");
+    seedRow("child-a", conv.id);
+    seedRow("child-b", conv.id);
+    seedRow("child-other", other.id);
+
+    await deleteConversationViaRoute(conv.id);
+
+    expect(getConversation(conv.id)).toBeNull();
+    expect(getSubagentRecordById("child-a")).toBeUndefined();
+    expect(getSubagentRecordById("child-b")).toBeUndefined();
+    expect(getSubagentRecordById("child-other")).toBeDefined();
+  });
+
+  test("keeps the rows when the conversation delete throws", async () => {
+    const conv = createConversation("failing-parent");
+    seedRow("child-kept", conv.id);
+    failNextDelete = true;
+
+    await expect(deleteConversationViaRoute(conv.id)).rejects.toThrow(
+      "simulated delete failure",
+    );
+
+    // The conversation is still there for a retried delete, so its children's
+    // only durable metadata has to still be there too.
+    expect(getConversation(conv.id)).not.toBeNull();
+    expect(getSubagentRecordById("child-kept")).toBeDefined();
+  });
+});

--- a/assistant/src/__tests__/subagent-persistence.test.ts
+++ b/assistant/src/__tests__/subagent-persistence.test.ts
@@ -5,7 +5,7 @@ import { migrateCreateSubagentsTable } from "../persistence/migrations/311-creat
 import { migrateAddSubagentParentToolUseId } from "../persistence/migrations/354-add-subagent-parent-tool-use-id.js";
 import { resetTestTables } from "../persistence/raw-query.js";
 import {
-  deleteSubagentRecord,
+  deleteSubagentRecordsByParent,
   loadAllSubagentRecords,
   type SubagentRecord,
   upsertSubagentRecord,
@@ -85,10 +85,15 @@ describe("subagent-store", () => {
     expect(rows[0].outputTokens).toBe(99);
   });
 
-  test("delete removes the record", () => {
+  test("delete by parent removes only that parent's records", () => {
     upsertSubagentRecord(record());
-    deleteSubagentRecord("s1");
-    expect(loadAllSubagentRecords()).toHaveLength(0);
+    upsertSubagentRecord(
+      record({ id: "s2", parentConversationId: "parent-2", label: "other" }),
+    );
+
+    deleteSubagentRecordsByParent("parent-1");
+
+    expect(loadAllSubagentRecords().map((r) => r.id)).toEqual(["s2"]);
   });
 });
 

--- a/assistant/src/__tests__/subagent-reconcile-route.test.ts
+++ b/assistant/src/__tests__/subagent-reconcile-route.test.ts
@@ -290,6 +290,64 @@ describe("reconcileSubagents route", () => {
     );
   });
 
+  test("bounds the live pass after a restart rehydrates every row", () => {
+    for (let i = 0; i < 25; i++) {
+      upsertSubagentRecord(
+        record({
+          id: `sub-done-${i}`,
+          conversationId: `child-conv-done-${i}`,
+          label: `done-${i}`,
+          status: "completed",
+          completedAt: 10_000 + i,
+        }),
+      );
+    }
+    // Rehydration loads every durable row back into memory, terminal ones
+    // included, so for a whole retention window after a restart the live pass
+    // sees exactly the history the durable query bounded.
+    getSubagentManager().rehydrateFromDb();
+
+    const { subagents } = reconcile(PARENT_ID);
+
+    expect(Object.keys(subagents).sort()).toEqual(
+      Array.from({ length: 20 }, (_, i) => `sub-done-${i + 5}`).sort(),
+    );
+  });
+
+  test("never caps out an active child, however old", () => {
+    for (let i = 0; i < 25; i++) {
+      upsertSubagentRecord(
+        record({
+          id: `sub-done-${i}`,
+          conversationId: `child-conv-done-${i}`,
+          label: `done-${i}`,
+          status: "completed",
+          completedAt: 10_000 + i,
+        }),
+      );
+    }
+    upsertSubagentRecord(
+      record({
+        id: "sub-old-active",
+        conversationId: "child-conv-old-active",
+        label: "old-active",
+        status: "running",
+        createdAt: 1,
+        completedAt: null,
+      }),
+    );
+    const manager = getSubagentManager();
+    manager.rehydrateFromDb();
+    // Something is driving this run again, so the live entry is authoritative —
+    // and the oldest child of the parent, which the recency cap must not reach.
+    manager.getState("sub-old-active")!.status = "running";
+
+    const { subagents } = reconcile(PARENT_ID);
+
+    expect(subagents["sub-old-active"].status).toBe("running");
+    expect(Object.keys(subagents)).toHaveLength(21);
+  });
+
   test("omits a durable row whose status is out of enum", () => {
     upsertSubagentRecord(record({ status: "zombie" }));
 

--- a/assistant/src/api/responses/subagent-detail.ts
+++ b/assistant/src/api/responses/subagent-detail.ts
@@ -67,8 +67,9 @@ export const SubagentDetailResponseSchema = z.object({
   label: z.string().optional(),
   /**
    * Tool-use id of the spawning `subagent_spawn` call, from the live manager
-   * state. Lets a recovering client re-anchor the inline card to the exact
-   * spawn tool call (same role as the field on `subagent_spawned`).
+   * state or, once that is gone, the durable record. Lets a recovering client
+   * re-anchor the inline card to the exact spawn tool call (same role as the
+   * field on `subagent_spawned`).
    */
   parentToolUseId: z.string().optional(),
   /**

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -248,12 +248,21 @@ export async function getOrCreateConversation(
  * Abort, dispose, and remove a single in-memory conversation.
  * Use before deleting the DB row so the agent loop can't write to a
  * deleted conversation and trip FK constraints.
+ *
+ * `keepSubagentRecords` leaves the children's durable rows behind for the
+ * caller to delete once its own destructive work has committed — see
+ * `SubagentManager.disposeAllForParent`.
  */
-export function destroyActiveConversation(conversationId: string): void {
+export function destroyActiveConversation(
+  conversationId: string,
+  opts?: { keepSubagentRecords?: boolean },
+): void {
   // Subagent teardown is keyed by parent id, not the live instance — an
   // evicted parent still retains its terminal children, and deleting the
   // conversation must take their records with it.
-  getSubagentManager().disposeAllForParent(conversationId);
+  getSubagentManager().disposeAllForParent(conversationId, undefined, {
+    keepRecords: opts?.keepSubagentRecords === true,
+  });
   const conversation = findConversation(conversationId);
   if (!conversation) {
     return;

--- a/assistant/src/persistence/subagent-store.ts
+++ b/assistant/src/persistence/subagent-store.ts
@@ -200,11 +200,6 @@ export function getSubagentRecordsByParent(
   ).map(rowToRecord);
 }
 
-/** Delete a subagent record once the manager is fully done with it. */
-export function deleteSubagentRecord(id: string): void {
-  rawRun("subagent:deleteRecord", `DELETE FROM subagents WHERE id = ?`, id);
-}
-
 /**
  * Delete every subagent record spawned under `parentConversationId`. A row
  * lives as long as its parent conversation, and the TTL sweep drops a child's

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -67,6 +67,7 @@ import {
 } from "../../persistence/conversation-key-store.js";
 import { enqueueMemoryJob } from "../../persistence/jobs-store.js";
 import { linkRequestLogsToMessage } from "../../persistence/llm-request-log-store.js";
+import { deleteSubagentRecordsByParent } from "../../persistence/subagent-store.js";
 import { deleteSchedule } from "../../schedule/schedule-store.js";
 import { UserError } from "../../util/errors.js";
 import { safeParseRecord } from "../../util/json.js";
@@ -479,8 +480,13 @@ async function handleDeleteConversation({
 
   await cancelScheduleIfLast(resolvedId);
 
-  destroyActiveConversation(resolvedId);
+  // The subagent rows are the children's only durable metadata, so they are
+  // purged after the conversation delete commits: `deleteConversation` can
+  // throw, and dropping them first would lose them for good while leaving the
+  // conversation they describe intact for a retried delete.
+  destroyActiveConversation(resolvedId, { keepSubagentRecords: true });
   const deleted = deleteConversation(resolvedId);
+  deleteSubagentRecordsByParent(resolvedId);
   for (const segId of deleted.segmentIds) {
     enqueueMemoryJob("delete_qdrant_vectors", {
       targetType: "segment",

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -24,7 +24,7 @@ import {
   type SubagentRecord,
 } from "../../persistence/subagent-store.js";
 import { getSubagentManager } from "../../subagent/index.js";
-import { TERMINAL_STATUSES } from "../../subagent/types.js";
+import { type SubagentState, TERMINAL_STATUSES } from "../../subagent/types.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
@@ -271,7 +271,10 @@ function settledDurableStatus(status: SubagentStatus): SubagentStatus {
  * parse is dropped rather than widening the wire type; anything that does parse
  * is settled by `settledDurableStatus`.
  *
- * Only ever called for a row no live manager entry answers for.
+ * The result is only ever OBSERVED for a row no live manager entry answers
+ * for: the detail route reads the record solely when `getState` came back
+ * empty, and the reconcile route calls this for every durable row but lets its
+ * live pass overwrite the ids memory still holds.
  */
 function settledRecordStatus(
   record: SubagentRecord,
@@ -281,13 +284,35 @@ function settledRecordStatus(
 }
 
 /**
- * Cap on the terminal durable rows the reconcile snapshot carries per parent.
- * Rows live as long as the conversation, so an old chat holds every subagent it
- * ever spawned; a client rebuilding its list needs the recent ones, not the
- * full history. Rows that are not terminal are never capped — a client's
+ * Cap on the terminal subagents the reconcile snapshot carries per parent,
+ * applied to the durable pass and the live pass alike. Rows live as long as the
+ * conversation and `SubagentManager.rehydrateFromDb()` loads every one of them
+ * back into memory, so both sides of an old chat hold every subagent it ever
+ * spawned; a client rebuilding its list needs the recent ones, not the full
+ * history. Subagents that are not terminal are never capped — a client's
  * stuck-active entry has to be settled at any age.
  */
 const MAX_RECONCILED_TERMINAL_RECORDS = 20;
+
+/** Recency key shared with the durable query's `COALESCE(completed_at, created_at)`. */
+function settledAt(child: SubagentState): number {
+  return child.completedAt ?? child.createdAt;
+}
+
+function liveReconciledEntry(
+  child: SubagentState,
+): z.infer<typeof ReconciledSubagentSchema> {
+  return {
+    status: child.status,
+    conversationId: child.conversationId,
+    label: child.config.label,
+    objective: child.config.objective,
+    isFork: child.isFork,
+    parentToolUseId: child.config.parentToolUseId,
+    usage: child.usage ? reportableUsage(child.usage) : undefined,
+    error: child.error,
+  };
+}
 
 export const ROUTES: RouteDefinition[] = [
   {
@@ -300,7 +325,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Reconcile subagent live status",
     description:
-      "Returns the subagents the assistant knows for a given parent conversation — live, rehydrated, and durably recorded, including recently finished runs whose in-memory metadata the retention sweep has already evicted. Durable records live as long as the conversation, so the recorded pass is bounded: every record not in a terminal state is always returned, plus the 20 most recently finished ones. Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list from scratch, not just refresh statuses. A subagent absent from the response is one the assistant no longer reports, so a client may settle its own stuck-active entries against this snapshot. Only `status` is guaranteed to be present; every other field is optional.",
+      "Returns the subagents the assistant knows for a given parent conversation — live, rehydrated, and durably recorded, including recently finished runs whose in-memory metadata the retention sweep has already evicted. Durable records live as long as the conversation, so the snapshot is bounded: every subagent not in a terminal state is always returned, plus the 20 most recently finished ones. Each entry carries enough detail (child conversation id, label, objective, token usage, failure reason) for a client to rebuild its subagent list from scratch, not just refresh statuses. A subagent absent from the response is one the assistant no longer reports, so a client may settle its own stuck-active entries against this snapshot. Only `status` is guaranteed to be present; every other field is optional.",
     tags: ["subagents"],
     queryParams: [
       {
@@ -328,7 +353,11 @@ export const ROUTES: RouteDefinition[] = [
       // holds. The retention sweep evicts terminal in-memory metadata while
       // deliberately keeping the row, so a run that completed more than a TTL
       // ago is absent from memory — and a client settling orphans by absence
-      // would rewrite its `completed` entry to `interrupted`.
+      // would rewrite its `completed` entry to `interrupted`. That cover is
+      // bounded rather than total: a completion older than the recent-terminal
+      // window appears in neither pass, so a client settling by absence can
+      // still re-mark it `interrupted`. Acceptable — a run that far back is no
+      // longer surfaced anywhere else either.
       const records = getSubagentRecordsByParent(parentConversationId, {
         terminalStatuses: [...TERMINAL_STATUSES],
         maxTerminal: MAX_RECONCILED_TERMINAL_RECORDS,
@@ -350,17 +379,32 @@ export const ROUTES: RouteDefinition[] = [
         };
       }
 
+      // The live pass carries the same bound. `rehydrateFromDb()` loads every
+      // durable row — terminal ones included — back into the manager, so for a
+      // whole retention window after a restart the in-memory children of an old
+      // parent are exactly as unbounded as the table the query above capped.
+      const liveTerminal: SubagentState[] = [];
       for (const child of manager.getChildrenOf(parentConversationId)) {
-        subagents[child.config.id] = {
-          status: child.status,
-          conversationId: child.conversationId,
-          label: child.config.label,
-          objective: child.config.objective,
-          isFork: child.isFork,
-          parentToolUseId: child.config.parentToolUseId,
-          usage: child.usage ? reportableUsage(child.usage) : undefined,
-          error: child.error,
-        };
+        if (TERMINAL_STATUSES.has(child.status)) {
+          liveTerminal.push(child);
+          continue;
+        }
+        subagents[child.config.id] = liveReconciledEntry(child);
+      }
+      liveTerminal.sort((a, b) => settledAt(b) - settledAt(a));
+      const recentLiveTerminal = new Set(
+        liveTerminal
+          .slice(0, MAX_RECONCILED_TERMINAL_RECORDS)
+          .map((child) => child.config.id),
+      );
+      for (const child of liveTerminal) {
+        const id = child.config.id;
+        // An id the durable pass already surfaced costs nothing to overwrite
+        // with the fresher live state — it is in the payload either way.
+        if (!recentLiveTerminal.has(id) && subagents[id] === undefined) {
+          continue;
+        }
+        subagents[id] = liveReconciledEntry(child);
       }
       return { subagents };
     },

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -22,7 +22,6 @@ import {
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
 import {
   deleteAllSubagentRecords,
-  deleteSubagentRecord,
   deleteSubagentRecordsByParent,
   loadAllSubagentRecords,
   upsertSubagentRecord,
@@ -1032,10 +1031,17 @@ export class SubagentManager {
    * Abort and fully dispose all subagents belonging to a parent conversation,
    * deleting their durable records. Only for parents whose conversation data is
    * going away (deletion, clear-all) — nobody will call subagent_read.
+   *
+   * `keepRecords` tears down the in-memory side only, leaving the rows for the
+   * caller to delete itself. For a caller that has destructive work of its own
+   * still to do: the rows are a subagent's only durable metadata, so dropping
+   * them before that work commits loses them for good if it throws, while the
+   * conversation they describe survives for a retried delete.
    */
   disposeAllForParent(
     parentConversationId: string,
     parentSendToClient?: (msg: AssistantEvent) => void,
+    opts?: { keepRecords?: boolean },
   ): number {
     const count = this.abortAllForParent(
       parentConversationId,
@@ -1050,9 +1056,12 @@ export class SubagentManager {
       }
     }
 
-    // A child the TTL sweep already evicted has no in-memory entry left to
-    // dispose, so its row is only reachable by parent.
-    if (!this.shuttingDown) {
+    // The durable rows are dropped here rather than per child: a subagent's row
+    // lives as long as its parent conversation, and one the TTL sweep already
+    // evicted has no in-memory entry left to dispose, so its row is only
+    // reachable by parent. Shutdown keeps every row so in-flight children can
+    // rehydrate as `interrupted` on the next boot.
+    if (!this.shuttingDown && !opts?.keepRecords) {
       try {
         deleteSubagentRecordsByParent(parentConversationId);
       } catch (err) {
@@ -1215,15 +1224,12 @@ export class SubagentManager {
    * Should be called after the subagent reaches a terminal state
    * and its data is no longer needed.
    *
-   * Durable-row invariant: a subagent's row in the `subagents` table lives as
-   * long as its parent conversation. Only disposals that mean "the parent's
-   * data is going away" (`disposeAllForParent` / `disposeAllForAllParents`)
-   * delete it. The TTL sweep passes `keepRecord` so it frees in-memory
-   * metadata only, leaving the row to answer `getSubagentDetail` for a client
-   * that missed the spawn event; shutdown likewise keeps rows (`shuttingDown`)
-   * so an in-flight subagent can rehydrate as `interrupted` on the next boot.
+   * In-memory only: a subagent's row in the `subagents` table lives as long as
+   * its parent conversation, so it survives this and keeps answering
+   * `getSubagentDetail` for a client that missed the spawn event. Rows are
+   * deleted by parent, from `disposeAllForParent` / `disposeAllForAllParents`.
    */
-  dispose(subagentId: string, opts?: { keepRecord?: boolean }): void {
+  dispose(subagentId: string): void {
     const managed = this.subagents.get(subagentId);
     if (!managed) {
       return;
@@ -1245,17 +1251,6 @@ export class SubagentManager {
       managed.conversation = null;
     }
     this.subagents.delete(subagentId);
-
-    // Drop the durable record only when the caller owns its lifetime — the
-    // parent conversation is going away. The TTL sweep (`keepRecord`) and
-    // shutdown both evict in-memory metadata while leaving the row.
-    if (!this.shuttingDown && !opts?.keepRecord) {
-      try {
-        deleteSubagentRecord(subagentId);
-      } catch (err) {
-        log.warn({ subagentId, err }, "Failed to delete subagent record");
-      }
-    }
 
     // Remove from label index only if it still maps to this subagent
     // (guards against stale delete when a newer subagent reused the label).
@@ -1459,7 +1454,7 @@ export class SubagentManager {
       );
       // Metadata only — the durable row outlives the sweep so a client that
       // missed `subagent_spawned` can still resolve the child conversation.
-      this.dispose(id, { keepRecord: true });
+      this.dispose(id);
     }
     // Stop the timer if there are no more entries to sweep.
     const hasTerminal = [...this.subagents.values()].some(


### PR DESCRIPTION
Self-review remediation (round 3) for the daemon side of the subagent running-state work.

### 1. (P2) Terminal cap bypassed by rehydrated manager state
The reconcile handler ran the bounded durable query (`MAX_RECONCILED_TERMINAL_RECORDS = 20`) and then unconditionally extended the payload from `manager.getChildrenOf()`. Because `rehydrateFromDb()` loads **every** durable row back into `parentToChildren` on restart, the live pass re-introduced the full history for a whole 30-minute retention window — the cap was effectively bypassed post-restart.

Fixed **handler-side**, not memory-side. The memory-side cut (skipping terminal rows in `rehydrateFromDb`) would break real behaviour: `subagent_read` / `subagent_status` / `subagent_abort` / `subagent_message` all resolve through `manager.getState()` and `manager.getByLabel()`, which are backed by the same maps rehydration populates, and `subagent_status` with no id enumerates `getChildrenOf()`. Dropping terminal rows from rehydration would make a completed child unreadable after a restart. See the grep table below.

The live pass now partitions children: non-terminal are always emitted, terminal are sorted by `completedAt ?? createdAt` desc (the same recency key as the durable query's `COALESCE(completed_at, created_at)`) and kept only up to the cap, unioned with the ids the durable pass already surfaced. Active children are never dropped at any age.

### 2. (P2) Durable rows deleted before the parent delete can fail
`handleDeleteConversation` called `destroyActiveConversation()` → `disposeAllForParent` → `deleteSubagentRecordsByParent` **before** `deleteConversation()`, which can throw — leaving the conversation intact for a retry but its children's only durable metadata gone for good.

`disposeAllForParent` takes a `keepRecords` option, threaded through `destroyActiveConversation({ keepSubagentRecords })`. The delete route passes it and calls `deleteSubagentRecordsByParent(resolvedId)` only after `deleteConversation()` returns. The other call sites (`disposeAllForAllParents`, playground `deleteConversationById`) keep today's behaviour.

### 3. (nit) `settledRecordStatus` docstring false at the reconcile call site
Reworded: the result is only ever *observed* for a row no live entry answers for — the reconcile route calls it for every durable row and lets its live pass overwrite the rest.

### 4. (nit) Reconcile comment overclaimed the durable pass's guarantee
The comment now states the bound honestly: recent terminal runs are covered, but a completion older than the recent-terminal window is in neither pass, so a client settling by absence can still re-mark it `interrupted` — acceptable, since such a run is no longer surfaced anywhere.

### 5. (nit) Dead per-id delete in `dispose()`
`dispose()`'s per-id `deleteSubagentRecord` was only reachable from `disposeAllForParent`, which immediately issued the by-parent delete over the same rows (redundant N+1 DELETEs). Dropped, along with the now-vestigial `keepRecord` option; the lifetime doc moved to the by-parent call site. `deleteSubagentRecord` in `subagent-store.ts` had no remaining caller and was removed; its unit test now covers `deleteSubagentRecordsByParent` instead.

### 6. (nit) Stale response-schema docstring
`parentToolUseId` in `subagent-detail.ts` now mirrors the adjacent `label` wording ("…or, once that is gone, the durable record").

### Grep justifying the handler-side cap for fix 1

| Consumer | Depends on rehydrated terminal rows? |
| --- | --- |
| `tools/subagent/read.ts` → `manager.getState()` | **yes** — a completed child would become unreadable after restart |
| `tools/subagent/resolve.ts` → `manager.getByLabel()` | **yes** — label index is populated by rehydration |
| `tools/subagent/status.ts` → `getChildrenOf()` | **yes** — enumerates all children |
| `daemon/conversation.ts:1510` → `getChildrenOf()` | yes |
| `daemon/conversation-evictor.ts:80` → `getChildrenOf()` | yes |
| `runtime/routes/settings-routes.ts:493` → `getState()` | yes |

### Tests
- `subagent-reconcile-route.test.ts` — two new cases: the post-restart payload is bounded to 20 terminal entries, and an old still-active child is never capped out. Both verified to fail without the live-pass cap (26/26 entries instead of 20/21).
- `conversation-delete-subagent-rows.test.ts` (new) — a throwing `deleteConversation` leaves the subagent rows intact for a retried delete; the happy path purges only that parent's rows. Verified to fail without the ordering fix.
- `subagent-persistence.test.ts` — the store's delete unit test retargeted to `deleteSubagentRecordsByParent`.

All green: `subagent-disposal`, `subagent-detail`, `subagent-persistence`, `subagent-reconcile-route`, `subagent-manager-notify`, `subagent-tools`, `subagent-fork-notifications`, `subagent-fork-spawn`, `conversation-delete-schedule-cleanup`, `conversation-delete-missing-logs-db`, `conversation-store`, `conversation-evictor`, `injector-chain`. `bunx tsc --noEmit` clean, eslint clean, `openapi.yaml` regenerated (reconcile description only).

Part of plan: subagent-running-state-fixes.md (self-review remediation r3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
