### PR TITLE
Give the SPA shell Open Graph tags so shared links unfurl

### DIFF
--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -11,30 +11,26 @@
   <title>Vellum Assistant</title>
 
   <!--
-    Open Graph / Twitter card fallback for the whole SPA.
+    Open Graph fallback for every SPA route.
 
-    nginx serves this one file for every client-side route (/account/signup,
-    /account/login, /assistant/...), so these tags are necessarily generic —
-    there is no server render that could vary them per route. They exist so a
-    shared sign-up or app link renders a branded card in Slack, iMessage,
-    WhatsApp, LinkedIn, and X instead of a bare URL. The marketing site is
-    server-rendered by Next.js and supplies its own per-page tags.
+    nginx serves this one file for all client-side routes (/account/signup,
+    /account/login, /assistant/...), so these tags are the only link preview
+    metadata those routes have. They are generic by necessity: one static file
+    backs every route. The marketing site is server rendered and supplies its
+    own per-route tags.
 
-    Two things to preserve when editing:
+    URLs must be absolute and on the www host. This file is also served from
+    assistant.* hosts and loaded inside the Capacitor WKWebView, where a
+    relative path resolves against a host that has no such asset. The apex
+    `vellum.ai` 308-redirects, and some unfurlers drop a redirecting og:image.
 
-    - URLs must be absolute and on the canonical www host. This file is also
-      served from assistant.* hosts and loaded inside the Capacitor WKWebView,
-      where a relative path resolves against a host that has no such asset.
-      Do not point at the apex `vellum.ai` either — it 308-redirects, and
-      several unfurlers drop an og:image that redirects.
-    - No `og:url`. It would have to name a single route, and unfurlers treat it
-      as the canonical target — a link to /account/signup would then unfurl as
-      whichever route we hardcoded. Omitting it lets each crawler use the URL
-      it actually fetched.
+    No `og:url`: it can only name one route, and unfurlers treat it as the
+    canonical target, so every link would unfurl as whichever route was
+    hardcoded. Omitting it lets each crawler use the URL it fetched.
 
-    `noindex, nofollow` above is intentional and unrelated: the app shell must
-    stay out of search results. The link-preview crawlers are allowed through
-    by a dedicated group in the marketing site's robots.txt.
+    `noindex, nofollow` above is intentional and separate: the shell stays out
+    of search results. Link preview crawlers reach it via a dedicated group in
+    the marketing site's robots.txt.
   -->
   <meta name="description" content="An assistant that knows you deeply, evolves alongside you, and belongs to no one else. Powered by memory that remembers the way you do." />
   <meta property="og:site_name" content="Vellum" />

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -9,6 +9,51 @@
   <link rel="icon" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <title>Vellum Assistant</title>
+
+  <!--
+    Open Graph / Twitter card fallback for the whole SPA.
+
+    nginx serves this one file for every client-side route (/account/signup,
+    /account/login, /assistant/...), so these tags are necessarily generic —
+    there is no server render that could vary them per route. They exist so a
+    shared sign-up or app link renders a branded card in Slack, iMessage,
+    WhatsApp, LinkedIn, and X instead of a bare URL. The marketing site is
+    server-rendered by Next.js and supplies its own per-page tags.
+
+    Two things to preserve when editing:
+
+    - URLs must be absolute and on the canonical www host. This file is also
+      served from assistant.* hosts and loaded inside the Capacitor WKWebView,
+      where a relative path resolves against a host that has no such asset.
+      Do not point at the apex `vellum.ai` either — it 308-redirects, and
+      several unfurlers drop an og:image that redirects.
+    - No `og:url`. It would have to name a single route, and unfurlers treat it
+      as the canonical target — a link to /account/signup would then unfurl as
+      whichever route we hardcoded. Omitting it lets each crawler use the URL
+      it actually fetched.
+
+    `noindex, nofollow` above is intentional and unrelated: the app shell must
+    stay out of search results. The link-preview crawlers are allowed through
+    by a dedicated group in the marketing site's robots.txt.
+  -->
+  <meta name="description" content="An assistant that knows you deeply, evolves alongside you, and belongs to no one else. Powered by memory that remembers the way you do." />
+  <meta property="og:site_name" content="Vellum" />
+  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:title" content="Vellum: Your Personal Intelligence" />
+  <meta property="og:description" content="An assistant that knows you deeply, evolves alongside you, and belongs to no one else. Powered by memory that remembers the way you do." />
+  <meta property="og:image" content="https://www.vellum.ai/og-cover-v2.jpg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="Vellum: Your Personal Intelligence" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@vellum_ai" />
+  <meta name="twitter:creator" content="@vellum_ai" />
+  <meta name="twitter:title" content="Vellum: Your Personal Intelligence" />
+  <meta name="twitter:description" content="An assistant that knows you deeply, evolves alongside you, and belongs to no one else. Powered by memory that remembers the way you do." />
+  <meta name="twitter:image" content="https://www.vellum.ai/og-cover-v2.jpg" />
+  <meta name="twitter:image:alt" content="Vellum: Your Personal Intelligence" />
+
   <script src="/theme-init.js"></script>
 </head>
 <body>

--- a/clients/web/src/shell-metadata.test.ts
+++ b/clients/web/src/shell-metadata.test.ts
@@ -5,9 +5,9 @@ import { describe, expect, test } from "bun:test";
 
 /**
  * nginx serves `index.html` for every SPA route, so the Open Graph tags in it
- * are the *only* link-preview metadata `/account/signup`, `/account/login`,
- * and `/assistant/...` will ever have. These tests pin that contract — the
- * tags are easy to drop by accident and the loss is invisible until someone
+ * are the *only* link preview metadata `/account/signup`, `/account/login`,
+ * and `/assistant/...` will ever have. These tests pin that contract. The tags
+ * are easy to drop by accident, and the loss stays invisible until someone
  * pastes a link somewhere and gets a bare URL.
  */
 const INDEX_HTML = readFileSync(
@@ -33,7 +33,7 @@ function nameTag(name: string): string | null {
 const EXPECTED_TITLE = "Vellum: Your Personal Intelligence";
 const EXPECTED_IMAGE = "https://www.vellum.ai/og-cover-v2.jpg";
 
-describe("SPA shell — Open Graph metadata", () => {
+describe("SPA shell: Open Graph metadata", () => {
   test("declares the tags an unfurler needs for a large image card", () => {
     expect(ogTag("og:title")).toBe(EXPECTED_TITLE);
     expect(ogTag("og:description")).toBeTruthy();
@@ -73,8 +73,8 @@ describe("SPA shell — Open Graph metadata", () => {
     }
   });
 
-  // og:url would have to name one route, and unfurlers treat it as canonical —
-  // a /account/signup link would unfurl as whichever route we hardcoded.
+  // og:url can only name one route, and unfurlers treat it as canonical, so a
+  // /account/signup link would unfurl as whichever route was hardcoded.
   test("omits og:url so each crawler uses the URL it fetched", () => {
     expect(ogTag("og:url")).toBeNull();
   });

--- a/clients/web/src/shell-metadata.test.ts
+++ b/clients/web/src/shell-metadata.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, expect, test } from "bun:test";
+
+/**
+ * nginx serves `index.html` for every SPA route, so the Open Graph tags in it
+ * are the *only* link-preview metadata `/account/signup`, `/account/login`,
+ * and `/assistant/...` will ever have. These tests pin that contract — the
+ * tags are easy to drop by accident and the loss is invisible until someone
+ * pastes a link somewhere and gets a bare URL.
+ */
+const INDEX_HTML = readFileSync(
+  path.join(import.meta.dir, "..", "index.html"),
+  "utf8"
+);
+
+const doc = new DOMParser().parseFromString(INDEX_HTML, "text/html");
+
+function ogTag(property: string): string | null {
+  return (
+    doc.querySelector(`meta[property="${property}"]`)?.getAttribute("content") ??
+    null
+  );
+}
+
+function nameTag(name: string): string | null {
+  return (
+    doc.querySelector(`meta[name="${name}"]`)?.getAttribute("content") ?? null
+  );
+}
+
+const EXPECTED_TITLE = "Vellum: Your Personal Intelligence";
+const EXPECTED_IMAGE = "https://www.vellum.ai/og-cover-v2.jpg";
+
+describe("SPA shell — Open Graph metadata", () => {
+  test("declares the tags an unfurler needs for a large image card", () => {
+    expect(ogTag("og:title")).toBe(EXPECTED_TITLE);
+    expect(ogTag("og:description")).toBeTruthy();
+    expect(ogTag("og:image")).toBe(EXPECTED_IMAGE);
+    expect(ogTag("og:type")).toBe("website");
+    expect(ogTag("og:site_name")).toBe("Vellum");
+  });
+
+  test("declares the image dimensions so cards render on first share", () => {
+    expect(ogTag("og:image:width")).toBe("1200");
+    expect(ogTag("og:image:height")).toBe("630");
+    expect(ogTag("og:image:alt")).toBe(EXPECTED_TITLE);
+  });
+
+  test("declares a matching Twitter card", () => {
+    expect(nameTag("twitter:card")).toBe("summary_large_image");
+    expect(nameTag("twitter:site")).toBe("@vellum_ai");
+    expect(nameTag("twitter:title")).toBe(EXPECTED_TITLE);
+    expect(nameTag("twitter:description")).toBeTruthy();
+    expect(nameTag("twitter:image")).toBe(EXPECTED_IMAGE);
+  });
+
+  test("og and twitter descriptions agree with the meta description", () => {
+    const description = nameTag("description");
+    expect(description).toBeTruthy();
+    expect(ogTag("og:description")).toBe(description);
+    expect(nameTag("twitter:description")).toBe(description);
+  });
+
+  // This file is also served from assistant.* hosts and loaded inside the
+  // Capacitor WKWebView, where a relative path resolves against a host with no
+  // such asset. The apex vellum.ai 308-redirects and some unfurlers drop a
+  // redirecting image.
+  test("image URLs are absolute and on the canonical www host", () => {
+    for (const url of [ogTag("og:image"), nameTag("twitter:image")]) {
+      expect(url).toMatch(/^https:\/\/www\.vellum\.ai\//);
+    }
+  });
+
+  // og:url would have to name one route, and unfurlers treat it as canonical —
+  // a /account/signup link would unfurl as whichever route we hardcoded.
+  test("omits og:url so each crawler uses the URL it fetched", () => {
+    expect(ogTag("og:url")).toBeNull();
+  });
+
+  // Previews are enabled via a dedicated link-preview-bot group in the
+  // marketing site's robots.txt, not by making the app shell indexable.
+  test("keeps the app shell out of the search index", () => {
+    expect(nameTag("robots")).toBe("noindex, nofollow");
+  });
+});


### PR DESCRIPTION
## Problem

nginx serves `clients/web/index.html` for **every** SPA route, so this one file is the only link preview metadata `/account/signup`, `/account/login`, and `/assistant/*` will ever have. It had none at all.

Verified against production:

```
$ curl -sL https://www.vellum.ai/signup   # 308 to /account/signup
<title>Vellum Assistant</title>
# ...zero og: or twitter: tags
```

A link to the sign-up page pasted into Slack, iMessage, WhatsApp, LinkedIn, or X rendered as a bare URL.

## Change

Adds the branded card to `index.html`: `og:title`/`description`/`image` (plus `width`/`height`/`alt`), `og:type`, `og:site_name`, `og:locale`, a matching `summary_large_image` Twitter card, and a `meta description`.

Two choices worth preserving (both documented inline and pinned by tests):

1. **URLs are absolute and on the canonical www host.** This file is also served from `assistant.*` hosts and loaded inside the Capacitor WKWebView, where a relative path resolves against a host that has no such asset. Not the apex `vellum.ai` either, since it 308-redirects and some unfurlers drop a redirecting image.
2. **No `og:url`.** It can only name a single route, and unfurlers treat it as canonical, so a `/account/signup` link would unfurl as whichever route got hardcoded. Omitting it lets each crawler use the URL it actually fetched.

`noindex, nofollow` is unchanged. The app shell should stay out of search results, which is a separate concern from unfurling.

## Verification

- `bun run build`: confirmed the tags survive Vite's HTML transform into `dist/index.html`.
- The pinned `og:image` is live and does **not** redirect: `curl -sSI https://www.vellum.ai/og-cover-v2.jpg` returns `200`, `image/jpeg`, 91KB, 1200x630, `num_redirects=0`.
- 7 new tests parse `index.html` with happy-dom and pin the tag set, the absolute-www-host rule, the deliberate `og:url` omission, and that `noindex` is retained.
- `eslint` clean. All CI checks green.

## Companion PR (required)

Previews also need the platform's `robots.txt` to stop blocking the unfurlers on `/account/`: **vellum-ai/vellum-assistant-platform#9549**.

Neither PR is sufficient alone. That one makes the page reachable by unfurlers, this one gives it something to read. Order does not matter; the preview appears once both ship.

## Known limitation

One static file backs every route, so these tags are generic by necessity. The sign-up page gets a branded Vellum card, not sign-up-specific copy. Per-route tags would need SSR or a multi-page build.
