### PR TITLE
docs(web): retarget the per-chat plugin gates from 0.11.0 to 0.12.0

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -170,6 +170,8 @@ Each module owns one feature's old/new split. Current registry:
 | `channel-access-controls.ts`        | `0.11.0`                          | Channel list renders without Assistant Access controls (no tier badges, picker, or legend card)           | Two-level Assistant Access picker on the Channels tab, backed by the assistant-side collapse contract |
 | `subagent-recovery.ts`              | `0.11.0`                          | Recovered subagent stubs render from live stream events only (generic label, no history backfill)         | Detail + reconcile routes carry per-child identity; missed-spawn subagents rebuild fully    |
 | `use-supports-image-gen-vellum-provider.ts` | `0.11.0`                  | Vellum image-gen selection persists as legacy `{ mode: "managed" }` with no provider field                | Save path writes `provider: "vellum"`, which the config enum accepts                        |
+| `use-supports-new-chat-plugins.ts`  | `0.12.0`                          | New-chat plugin picker hidden; the send path omits the per-chat plugin set (older daemons ignore it)      | Picker renders and the send path includes the per-chat plugin set the daemon applies        |
+| `use-supports-inchat-plugin-edit.ts` | `0.12.0`                         | In-chat plugin pill hidden; the conversation GET omits `enabledPlugins` so per-chat scope is unreadable   | Pill renders the conversation's plugin scope and edits it via `PUT /conversations/:id/enabledplugins` |
 
 When you delete a row here, also delete its module, its test, and the now-dead
 legacy branch at the call site.

--- a/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 });
 
 // Exhaustive semver truth-table lives in `utils.test.ts`. Here we verify the
-// boundary on each side of MIN_VERSION (0.11.0 — the release that ships the
+// boundary on each side of MIN_VERSION (0.12.0, the release that ships the
 // manage-plugins surface) plus the conservative-on-unknown policy,
 // exercised through the public hook.
 describe("useSupportsInchatPluginEdit", () => {
@@ -28,16 +28,16 @@ describe("useSupportsInchatPluginEdit", () => {
     expect(readGate(null)).toBe(false);
   });
 
-  test("reads false below 0.11.0 (incl. 0.10.7, 0.10.9)", () => {
+  test("reads false below 0.12.0 (incl. 0.11.0, 0.11.1)", () => {
+    expect(readGate("0.11.1")).toBe(false);
+    expect(readGate("0.11.0")).toBe(false);
     expect(readGate("0.10.9")).toBe(false);
-    expect(readGate("0.10.7")).toBe(false);
-    expect(readGate("0.10.6")).toBe(false);
     expect(readGate("0.9.0")).toBe(false);
   });
 
-  test("reads true for assistants on 0.11.0+", () => {
-    expect(readGate("0.11.0")).toBe(true);
-    expect(readGate("0.11.1")).toBe(true);
+  test("reads true for assistants on 0.12.0+", () => {
+    expect(readGate("0.12.0")).toBe(true);
+    expect(readGate("0.12.1")).toBe(true);
     expect(readGate("1.0.0")).toBe(true);
   });
 

--- a/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.ts
@@ -10,14 +10,15 @@
  * so the pill would misrepresent per-chat state — keep it hidden until the
  * active assistant is known to support it. Conservative on unknown.
  *
- * MIN_VERSION targets 0.11.0 — the manage-plugins surface (this in-chat pill
+ * MIN_VERSION targets 0.12.0. The manage-plugins surface (this in-chat pill
  * plus the new-chat plugin picker) ships in that release, so the gate holds
- * until the active assistant is on 0.11.0 or newer, keeping the pill hidden on
- * every older assistant until the surface lands.
+ * until the active assistant is on 0.12.0 or newer, keeping the pill hidden on
+ * every older assistant until the surface lands, including on 0.11.x, which
+ * cuts without it.
  */
 import { useAssistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.11.0";
+export const MIN_VERSION = "0.12.0";
 
 /**
  * Returns `true` when the active assistant exposes the standalone

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 });
 
 // Exhaustive truth-table for the underlying semver gate lives in
-// `utils.test.ts`. Here we verify the boundary on each side of 0.11.0
+// `utils.test.ts`. Here we verify the boundary on each side of 0.12.0
 // plus the conservative-on-unknown policy, exercised through the public
 // hook and the awaiting send-path variant. (The snapshot read is a
 // private helper; it is covered via these exported entry points.)
@@ -36,16 +36,16 @@ describe("useSupportsNewChatPlugins", () => {
     expect(readGateViaHook(null)).toBe(false);
   });
 
-  test("reads false for assistants below 0.11.0 (incl. 0.10.7, 0.10.9)", () => {
+  test("reads false for assistants below 0.12.0 (incl. 0.11.0, 0.11.1)", () => {
+    expect(readGateViaHook("0.11.1")).toBe(false);
+    expect(readGateViaHook("0.11.0")).toBe(false);
     expect(readGateViaHook("0.10.9")).toBe(false);
-    expect(readGateViaHook("0.10.7")).toBe(false);
-    expect(readGateViaHook("0.10.6")).toBe(false);
     expect(readGateViaHook("0.9.0")).toBe(false);
   });
 
-  test("reads true for assistants on 0.11.0+", () => {
-    expect(readGateViaHook("0.11.0")).toBe(true);
-    expect(readGateViaHook("0.11.1")).toBe(true);
+  test("reads true for assistants on 0.12.0+", () => {
+    expect(readGateViaHook("0.12.0")).toBe(true);
+    expect(readGateViaHook("0.12.1")).toBe(true);
     expect(readGateViaHook("1.0.0")).toBe(true);
   });
 
@@ -62,7 +62,7 @@ describe("resolveSupportsNewChatPlugins", () => {
   });
 
   test("resolves true for a supported daemon once the version is known", async () => {
-    setVersion("0.11.0");
+    setVersion("0.12.0");
     expect(await resolveSupportsNewChatPlugins()).toBe(true);
   });
 });

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
@@ -19,12 +19,11 @@
  * on the send path so the decision awaits version hydration rather than
  * optimistically assuming support.
  *
- * MIN_VERSION targets 0.11.0 — the manage-plugins surface (this new-chat
+ * MIN_VERSION targets 0.12.0. The manage-plugins surface (this new-chat
  * picker plus the in-chat plugin pill) ships in that release, so the gate
- * holds until the active assistant is on 0.11.0 or newer. That keeps the
+ * holds until the active assistant is on 0.12.0 or newer. That keeps the
  * picker and send-path inclusion hidden on every older assistant until
- * the surface lands; bump MIN_VERSION to the release that finalizes
- * per-chat plugin selection when it is ready.
+ * the surface lands, including on 0.11.x, which cuts without it.
  */
 import {
   assistantSupports,
@@ -32,7 +31,7 @@ import {
   whenAssistantVersionKnown,
 } from "./utils";
 
-export const MIN_VERSION = "0.11.0";
+export const MIN_VERSION = "0.12.0";
 
 /**
  * Returns `true` when the active assistant accepts the per-chat plugin


### PR DESCRIPTION
## Prompt / plan

"There is a plugin per conversation flag that's gated on 0.11.0 that we should bump to 0.12.0."

The per-conversation plugin feature is guarded by two backwards-compat gates that their own docstrings describe as one surface ("the manage-plugins surface: this new-chat picker plus the in-chat plugin pill"), both previously at `0.11.0`:

- `use-supports-new-chat-plugins.ts` (per-chat plugin selection, incl. the send-path inclusion)
- `use-supports-inchat-plugin-edit.ts` (the in-chat pill that reads/edits a conversation's plugin scope)

Both moved to `0.12.0`, since leaving one behind would half-enable the surface on a 0.11.x assistant. If only one of them was meant to move, say which and I'll revert the other.

Gates compare `assistantVersion >= MIN_VERSION`, so the only behavior change is that 0.11.x assistants keep the legacy path: picker hidden, send path omits the per-chat plugin set, pill hidden. Prose in both modules and their tests was updated to describe the real first-carrying release, with em dashes dropped from the touched lines per the root `AGENTS.md` rule.

Also registers both gates in the `BACKWARDS_COMPAT.md` registry table, which they were missing from.

## Test plan

- `bun test src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts` — 10 pass, 0 fail (boundary cases retargeted: 0.11.0/0.11.1 now read `false`, 0.12.0/0.12.1 read `true`).
- Pre-commit hook ran eslint + `tsc --noEmit` for `clients/web/` — both clean.
- The plugin call-site suites (`new-chat-plugins`, `inchat-plugin-pill`, `use-chat-header-registration`) have 18 pre-existing failures on this branch's base commit; verified identical counts with the change stashed, so they are unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKHkR5ZYhTuN3UZBmWAubc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKHkR5ZYhTuN3UZBmWAubc)_