### PR TITLE
feat(web): give the takeover's empty avatar stage a breathing placeholder

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -735,7 +735,7 @@ describe("takeover avatar mode", () => {
     // of the assistant's real avatar.
     avatarLoading = true;
 
-    const { container } = renderState({
+    const { container, getByTestId } = renderState({
       state: "WAITING",
       assistantId: "primary-assistant",
     });
@@ -743,15 +743,36 @@ describe("takeover avatar mode", () => {
     expect(container.querySelector(".provision-avatar-reveal")).toBeNull();
     // The stage still reserves its height, so nothing moves when it arrives.
     expect(container.querySelector(".provision-avatar-stage")).toBeTruthy();
+    // …and the placeholder breathes in the meantime rather than leaving a hole.
+    expect(getByTestId("provision-avatar-placeholder").className).not.toContain(
+      "is-resolved",
+    );
   });
 
+  for (const state of ["CONFIRMING", "WAITING"] as const) {
+    test(`renders exactly one placeholder in ${state}`, () => {
+      const { container } = renderState({
+        state,
+        assistantId: "primary-assistant",
+      });
+
+      expect(
+        container.querySelectorAll(".provision-avatar-placeholder"),
+      ).toHaveLength(1);
+    });
+  }
+
   test("reveals the avatar once the target and the query both settle", () => {
-    const { container } = renderState({
+    const { container, getByTestId } = renderState({
       state: "WAITING",
       assistantId: "primary-assistant",
     });
 
     expect(container.querySelector(".provision-avatar-reveal")).toBeTruthy();
+    // The placeholder fades out on the same beat the creature arrives on.
+    expect(getByTestId("provision-avatar-placeholder").className).toContain(
+      "is-resolved",
+    );
   });
 
   test("keeps waiting while the target assistant is still unknown", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -234,6 +234,11 @@ function TakeoverAvatar({
       }
     >
       <div className="provision-avatar-stage">
+        {/* Keeps the reserved stage from reading as a hole while the avatar is withheld. */}
+        <div
+          data-testid="provision-avatar-placeholder"
+          className={`provision-avatar-placeholder${avatarReady ? " is-resolved" : ""}`}
+        />
         <div className="provision-avatar-layer">
           <div className="provision-avatar-current">
             <div className="provision-avatar-strain">

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -277,6 +277,15 @@ body {
   height: var(--provision-avatar-size);
   width: calc(var(--provision-avatar-size) * 0.8);
   margin-inline: auto;
+  /* Fallback glow for engines without color-mix() (WKWebView before
+   * iOS 16.2, per the iOS 15.0 deployment target): the takeover is always
+   * dark-themed, so a translucent white stands in for the emphasised mix.
+   * Engines that parse color-mix() take the declaration below instead. */
+  background: radial-gradient(
+    closest-side,
+    rgba(255, 255, 255, 0.12),
+    transparent 72%
+  );
   background: radial-gradient(
     closest-side,
     color-mix(in srgb, var(--content-emphasised) 12%, transparent),

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -267,6 +267,37 @@ body {
   height: calc(var(--provision-avatar-size) * var(--provision-avatar-growth));
 }
 
+/* While the avatar is withheld, an identity-neutral glow breathes on the
+ * creature's resting footprint so the reserved stage doesn't read as a hole.
+ * Centering is `margin-inline`, not a translate — the breathe owns `transform`. */
+.provision-avatar-placeholder {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  height: var(--provision-avatar-size);
+  width: calc(var(--provision-avatar-size) * 0.8);
+  margin-inline: auto;
+  background: radial-gradient(
+    closest-side,
+    color-mix(in srgb, var(--content-emphasised) 12%, transparent),
+    transparent 72%
+  );
+  transform-origin: bottom center;
+  transition: opacity var(--provision-reveal) ease-out;
+  animation: provision-placeholder-breathe 2.6s ease-in-out infinite;
+}
+
+@keyframes provision-placeholder-breathe {
+  0%, 100% { transform: scale(0.94); opacity: 0.65; }
+  50% { transform: scale(1.05); opacity: 1; }
+}
+
+/* Fades out on the same beat the creature reveals on, then costs nothing. */
+.provision-avatar-placeholder.is-resolved {
+  opacity: 0;
+  animation: none;
+}
+
 .provision-avatar-layer {
   position: absolute;
   inset-inline: 0;
@@ -348,6 +379,15 @@ body {
   }
 
   .provision-surface-settle {
+    transition: none;
+  }
+
+  /* A static glow still marks where the creature lands. */
+  .provision-avatar-placeholder {
+    animation: none;
+  }
+
+  .provision-avatar-placeholder.is-resolved {
     transition: none;
   }
 }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -269,7 +269,7 @@ body {
 
 /* While the avatar is withheld, an identity-neutral glow breathes on the
  * creature's resting footprint so the reserved stage doesn't read as a hole.
- * Centering is `margin-inline`, not a translate — the breathe owns `transform`. */
+ * Centering is `margin-inline`, not a translate: the breathe owns `transform`. */
 .provision-avatar-placeholder {
   position: absolute;
   inset-inline: 0;


### PR DESCRIPTION
## Summary
- Identity-neutral breathing glow fills the takeover's reserved avatar stage while the creature is withheld
- Fades out on the same 250ms beat the avatar reveals on; reduced-motion gets a static glow

Part of plan: instant-takeover-avatar.md (PR 3 of 5)