### PR TITLE
fix(web): let the animated avatar draw outside its SVG canvas

### DIFF
--- a/clients/web/src/components/avatar/animated-avatar.test.tsx
+++ b/clients/web/src/components/avatar/animated-avatar.test.tsx
@@ -96,6 +96,22 @@ describe("AnimatedAvatar blink", () => {
   });
 });
 
+describe("AnimatedAvatar canvas", () => {
+  test("lets the body draw outside the SVG box while it moves", () => {
+    const { container } = render(
+      <AnimatedAvatar
+        components={BUNDLED_COMPONENTS}
+        traits={TRAITS}
+        size={240}
+        isAssistantBusy
+      />,
+    );
+
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    expect(svg.style.overflow).toBe("visible");
+  });
+});
+
 describe("AnimatedAvatar streaming morph", () => {
   test("cycles the body path without a React state update", () => {
     const { container } = render(

--- a/clients/web/src/components/avatar/animated-avatar.tsx
+++ b/clients/web/src/components/avatar/animated-avatar.tsx
@@ -321,6 +321,9 @@ export function AnimatedAvatar({
       style={{
         animation: breatheAnimation,
         transformOrigin: "center",
+        // The body fills the viewBox edge to edge, so the busy wobble (±6%) and
+        // the idle twitch draw past it and would otherwise be clipped flat.
+        overflow: "visible",
       }}
     >
       <g


### PR DESCRIPTION
## Summary
- The busy morph wobbles the edge-filling body up to 6% past the viewBox; default svg overflow clipped it flat (obvious at the takeover's 240px)
- overflow: visible on the svg; ancestor crops are unaffected

Part of plan: instant-takeover-avatar.md (PR 5 of 5)