### PR TITLE
feat(web): stash the takeover avatar surface across the Stripe round-trip

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
@@ -21,6 +21,18 @@ const TRAITS: CharacterTraits = {
   color: "purple",
 };
 
+const OTHER_TRAITS: CharacterTraits = {
+  bodyShape: "square",
+  eyeStyle: "wide",
+  color: "green",
+};
+
+interface AvatarCacheEntry {
+  components: CharacterComponents | null;
+  traits: CharacterTraits | null;
+  customImageUrl: string | null;
+}
+
 beforeEach(() => {
   sessionStorage.clear();
   // Reset the module-level in-memory mirror so it can't leak across tests.
@@ -96,20 +108,43 @@ describe("saveTakeoverAvatarStash / readTakeoverAvatarStash", () => {
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
-  test("a stash with malformed components reads as null and self-clears", () => {
-    sessionStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        assistantId: "a1",
-        components: { bodyShapes: "not-an-array" },
-        traits: null,
-        savedAt: Date.now(),
-      }),
-    );
+  // Every array here is dereferenced unconditionally while rendering, so a
+  // stash missing one crashes the takeover rather than degrading.
+  const MALFORMED_COMPONENTS: Array<[string, unknown]> = [
+    ["non-object components", "not-an-object"],
+    ["a non-array bodyShapes", { ...BUNDLED_COMPONENTS, bodyShapes: "nope" }],
+    ["a non-array eyeStyles", { ...BUNDLED_COMPONENTS, eyeStyles: "nope" }],
+    ["a non-array colors", { ...BUNDLED_COMPONENTS, colors: "nope" }],
+    [
+      "a non-array faceCenterOverrides",
+      { ...BUNDLED_COMPONENTS, faceCenterOverrides: "nope" },
+    ],
+    [
+      "no faceCenterOverrides at all",
+      {
+        bodyShapes: BUNDLED_COMPONENTS.bodyShapes,
+        eyeStyles: BUNDLED_COMPONENTS.eyeStyles,
+        colors: BUNDLED_COMPONENTS.colors,
+      },
+    ],
+  ];
 
-    expect(readTakeoverAvatarStash()).toBeNull();
-    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
-  });
+  for (const [label, components] of MALFORMED_COMPONENTS) {
+    test(`a stash with ${label} reads as null and self-clears`, () => {
+      sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          assistantId: "a1",
+          components,
+          traits: null,
+          savedAt: Date.now(),
+        }),
+      );
+
+      expect(readTakeoverAvatarStash()).toBeNull();
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  }
 
   test("a stash with malformed traits reads as null and self-clears", () => {
     sessionStorage.setItem(
@@ -155,10 +190,12 @@ describe("clearTakeoverAvatarStash", () => {
   });
 });
 
-describe("in-memory fallback when sessionStorage is unavailable", () => {
-  test("the mirror carries the stash past a throwing setItem", () => {
-    // happy-dom's Storage is a Proxy, so overwriting `setItem` on it just
-    // writes a storage entry — swap the whole global instead.
+describe("in-memory mirror on a same-document return", () => {
+  test("the mirror serves the stash back after a throwing setItem", () => {
+    // The native path: checkout opens in an external browser, so the document
+    // is never unloaded and the module is still alive to answer. happy-dom's
+    // Storage is a Proxy, so overwriting `setItem` on it just writes a storage
+    // entry; swap the whole global instead.
     const original = Object.getOwnPropertyDescriptor(
       globalThis,
       "sessionStorage",
@@ -195,15 +232,21 @@ describe("captureTakeoverAvatarStash", () => {
     queryClient = new QueryClient();
   });
 
+  /**
+   * The live query key appends a `supportsManifest` boolean, so a cache can
+   * hold both variants at once; `supportsManifest` and `updatedAt` let a test
+   * control which entry is stale and which order they land in.
+   */
   function seed(
     assistantId: string,
-    data: {
-      components: CharacterComponents | null;
-      traits: CharacterTraits | null;
-      customImageUrl: string | null;
-    },
+    data: AvatarCacheEntry,
+    options?: { supportsManifest?: boolean; updatedAt?: number },
   ) {
-    queryClient.setQueryData([...avatarQueryKey(assistantId), true], data);
+    queryClient.setQueryData(
+      [...avatarQueryKey(assistantId), options?.supportsManifest ?? true],
+      data,
+      { updatedAt: options?.updatedAt },
+    );
   }
 
   /** A stash capture must overwrite or remove, never leave behind. */
@@ -285,6 +328,102 @@ describe("captureTakeoverAvatarStash", () => {
       traits: TRAITS,
       customImageUrl: null,
     });
+    preexistingStash();
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+
+  test("stashes the freshest entry when the stale variant was cached first", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    const now = Date.now();
+    seed(
+      "a1",
+      {
+        components: BUNDLED_COMPONENTS,
+        traits: OTHER_TRAITS,
+        customImageUrl: null,
+      },
+      { supportsManifest: false, updatedAt: now - 60_000 },
+    );
+    seed(
+      "a1",
+      { components: BUNDLED_COMPONENTS, traits: TRAITS, customImageUrl: null },
+      { supportsManifest: true, updatedAt: now },
+    );
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toMatchObject({ traits: TRAITS });
+  });
+
+  test("stashes the freshest entry when the stale variant was cached last", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    const now = Date.now();
+    seed(
+      "a1",
+      { components: BUNDLED_COMPONENTS, traits: TRAITS, customImageUrl: null },
+      { supportsManifest: true, updatedAt: now },
+    );
+    seed(
+      "a1",
+      {
+        components: BUNDLED_COMPONENTS,
+        traits: OTHER_TRAITS,
+        customImageUrl: null,
+      },
+      { supportsManifest: false, updatedAt: now - 60_000 },
+    );
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toMatchObject({ traits: TRAITS });
+  });
+
+  test("a stale custom-image entry does not veto the freshest avatar", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    const now = Date.now();
+    seed(
+      "a1",
+      {
+        components: null,
+        traits: null,
+        customImageUrl: "blob:http://localhost/abc",
+      },
+      { supportsManifest: false, updatedAt: now - 60_000 },
+    );
+    seed(
+      "a1",
+      { components: BUNDLED_COMPONENTS, traits: TRAITS, customImageUrl: null },
+      { supportsManifest: true, updatedAt: now },
+    );
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toMatchObject({
+      assistantId: "a1",
+      traits: TRAITS,
+    });
+  });
+
+  test("a fresh custom-image entry clears a stale drawable one", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    const now = Date.now();
+    seed(
+      "a1",
+      { components: BUNDLED_COMPONENTS, traits: TRAITS, customImageUrl: null },
+      { supportsManifest: false, updatedAt: now - 60_000 },
+    );
+    seed(
+      "a1",
+      {
+        components: null,
+        traits: null,
+        customImageUrl: "blob:http://localhost/abc",
+      },
+      { supportsManifest: true, updatedAt: now },
+    );
     preexistingStash();
 
     captureTakeoverAvatarStash(queryClient);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+
+import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+
+import {
+  captureTakeoverAvatarStash,
+  clearTakeoverAvatarStash,
+  readTakeoverAvatarStash,
+  saveTakeoverAvatarStash,
+} from "./takeover-avatar-stash";
+
+const STORAGE_KEY = "vellum.pro-takeover-avatar";
+
+const TRAITS: CharacterTraits = {
+  bodyShape: "blob",
+  eyeStyle: "default",
+  color: "purple",
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+  // Reset the module-level in-memory mirror so it can't leak across tests.
+  clearTakeoverAvatarStash();
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+});
+
+describe("saveTakeoverAvatarStash / readTakeoverAvatarStash", () => {
+  test("round-trips the payload and stamps savedAt", () => {
+    const before = Date.now();
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+    });
+
+    const stash = readTakeoverAvatarStash();
+    expect(stash).not.toBeNull();
+    expect(stash!.assistantId).toBe("a1");
+    expect(stash!.traits).toEqual(TRAITS);
+    expect(stash!.components.bodyShapes).toEqual(BUNDLED_COMPONENTS.bodyShapes);
+    expect(stash!.savedAt).toBeGreaterThanOrEqual(before);
+    expect(stash!.savedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  test("round-trips null traits", () => {
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: null,
+    });
+
+    expect(readTakeoverAvatarStash()!.traits).toBeNull();
+  });
+
+  test("returns null when nothing is stashed", () => {
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+
+  test("a stash older than 30 minutes reads as null and self-clears", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        assistantId: "a1",
+        components: BUNDLED_COMPONENTS,
+        traits: TRAITS,
+        savedAt: Date.now() - 31 * 60 * 1000,
+      }),
+    );
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  test("a stash just inside the TTL still reads", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        assistantId: "a1",
+        components: BUNDLED_COMPONENTS,
+        traits: TRAITS,
+        savedAt: Date.now() - 29 * 60 * 1000,
+      }),
+    );
+
+    expect(readTakeoverAvatarStash()).toMatchObject({ assistantId: "a1" });
+  });
+
+  test("corrupt JSON reads as null and self-clears", () => {
+    sessionStorage.setItem(STORAGE_KEY, "{not json");
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  test("a stash with malformed components reads as null and self-clears", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        assistantId: "a1",
+        components: { bodyShapes: "not-an-array" },
+        traits: null,
+        savedAt: Date.now(),
+      }),
+    );
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  test("a stash with malformed traits reads as null and self-clears", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        assistantId: "a1",
+        components: BUNDLED_COMPONENTS,
+        traits: { bodyShape: "blob" },
+        savedAt: Date.now(),
+      }),
+    );
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  test("a stash with no assistant id reads as null and self-clears", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        components: BUNDLED_COMPONENTS,
+        traits: null,
+        savedAt: Date.now(),
+      }),
+    );
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("clearTakeoverAvatarStash", () => {
+  test("removes the stash", () => {
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+    });
+    clearTakeoverAvatarStash();
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("in-memory fallback when sessionStorage is unavailable", () => {
+  test("the mirror carries the stash past a throwing setItem", () => {
+    // happy-dom's Storage is a Proxy, so overwriting `setItem` on it just
+    // writes a storage entry — swap the whole global instead.
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    )!;
+    const throwing = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("sessionStorage unavailable");
+      },
+      removeItem: () => {},
+    };
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      get: () => throwing,
+    });
+    try {
+      saveTakeoverAvatarStash({
+        assistantId: "a1",
+        components: BUNDLED_COMPONENTS,
+        traits: TRAITS,
+      });
+
+      expect(readTakeoverAvatarStash()).toMatchObject({ assistantId: "a1" });
+    } finally {
+      Object.defineProperty(globalThis, "sessionStorage", original);
+    }
+  });
+});
+
+describe("captureTakeoverAvatarStash", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  function seed(
+    assistantId: string,
+    data: {
+      components: CharacterComponents | null;
+      traits: CharacterTraits | null;
+      customImageUrl: string | null;
+    },
+  ) {
+    queryClient.setQueryData([...avatarQueryKey(assistantId), true], data);
+  }
+
+  /** A stash capture must overwrite or remove, never leave behind. */
+  function preexistingStash() {
+    saveTakeoverAvatarStash({
+      assistantId: "old",
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+    });
+  }
+
+  test("stashes the active assistant's cached avatar", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    seed("a1", {
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+      customImageUrl: null,
+    });
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toMatchObject({
+      assistantId: "a1",
+      traits: TRAITS,
+    });
+  });
+
+  test("stashes a null-traits avatar", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    seed("a1", {
+      components: BUNDLED_COMPONENTS,
+      traits: null,
+      customImageUrl: null,
+    });
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toMatchObject({
+      assistantId: "a1",
+      traits: null,
+    });
+  });
+
+  test("clears a pre-existing stash when there is no active assistant", () => {
+    preexistingStash();
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+
+  test("clears a pre-existing stash when the avatar is not cached", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    preexistingStash();
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+
+  test("clears a pre-existing stash for a custom-image avatar", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    seed("a1", {
+      components: BUNDLED_COMPONENTS,
+      traits: null,
+      customImageUrl: "blob:http://localhost/abc",
+    });
+    preexistingStash();
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+
+  test("clears a pre-existing stash when components are null", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    seed("a1", {
+      components: null,
+      traits: TRAITS,
+      customImageUrl: null,
+    });
+    preexistingStash();
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
@@ -9,7 +9,7 @@ import { isCharacterTraits } from "@/types/avatar";
  * The render inputs of the active assistant's avatar, captured at the moment a
  * Stripe checkout redirect fires, so the post-checkout takeover can draw the
  * avatar immediately on a cold return instead of holding an empty stage for
- * the 2–3s the live avatar query takes to resolve.
+ * the 2-3s the live avatar query takes to resolve.
  *
  * Stored in sessionStorage (per-tab, survives the Stripe redirect round-trip,
  * dies with the tab) under a 30-minute TTL: a checkout abandoned longer than
@@ -20,18 +20,29 @@ export interface TakeoverAvatarStash {
   components: CharacterComponents;
   /**
    * Null for a `kind: "none"` avatar, which draws the bundled-fallback
-   * creature — so stashing null mirrors the eventual live render.
+   * creature, so stashing null mirrors the eventual live render.
    */
   traits: CharacterTraits | null;
   savedAt: number;
+}
+
+/** The cached avatar-query payload this module reads from. */
+interface CachedAvatar {
+  components: CharacterComponents | null;
+  traits: CharacterTraits | null;
+  customImageUrl: string | null;
 }
 
 const STORAGE_KEY = "vellum.pro-takeover-avatar";
 const MAX_AGE_MS = 30 * 60 * 1000;
 
 /**
- * In-memory mirror of the stash, so an unavailable sessionStorage (private
- * mode, quota, storage disabled) can't silently drop it.
+ * In-memory mirror of the stash, which covers the native return only: on
+ * Electron and iOS, checkout opens in an external browser and this document is
+ * never unloaded, so the module is still alive to serve the stash back. On web
+ * the redirect tears the document down, so a browser whose sessionStorage
+ * throws keeps no stash at all and the takeover draws its breathing
+ * placeholder through the wait instead.
  */
 let inMemoryStash: TakeoverAvatarStash | null = null;
 
@@ -39,20 +50,19 @@ export function saveTakeoverAvatarStash(
   stash: Omit<TakeoverAvatarStash, "savedAt">,
 ): void {
   const stamped: TakeoverAvatarStash = { ...stash, savedAt: Date.now() };
-  // Always keep the memory copy so a throwing sessionStorage can't lose it.
   inMemoryStash = stamped;
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stamped));
   } catch {
-    // sessionStorage may be unavailable (private mode, quota). The in-memory
-    // mirror above preserves the stash — never block the checkout redirect.
+    // sessionStorage may be unavailable (private mode, quota). Never block the
+    // checkout redirect over it.
   }
 }
 
 /**
  * The stashed avatar, or `null` when absent, unparsable, malformed, or older
- * than the TTL — anything unusable is cleared so it can't resurface. Falls
- * back to the in-memory mirror when sessionStorage is unreachable or empty.
+ * than the TTL: anything unusable is cleared so it can't resurface. Falls back
+ * to the in-memory mirror when sessionStorage is unreachable or empty.
  */
 export function readTakeoverAvatarStash(): TakeoverAvatarStash | null {
   let raw: string | null = null;
@@ -60,7 +70,7 @@ export function readTakeoverAvatarStash(): TakeoverAvatarStash | null {
     try {
       raw = sessionStorage.getItem(STORAGE_KEY);
     } catch {
-      // sessionStorage unreachable — fall back to the in-memory mirror.
+      // sessionStorage unreachable, fall back to the in-memory mirror.
       return readInMemoryStash();
     }
   }
@@ -99,7 +109,7 @@ export function clearTakeoverAvatarStash(): void {
  * stash when there is nothing drawable to capture.
  *
  * Every Stripe redirect site calls this, and every call either writes a fresh
- * stash or removes a stale one — so a previous user's (or a previous avatar's)
+ * stash or removes a stale one, so a previous user's (or a previous avatar's)
  * stash can never ride along with a new checkout.
  */
 export function captureTakeoverAvatarStash(queryClient: QueryClient): void {
@@ -109,16 +119,9 @@ export function captureTakeoverAvatarStash(queryClient: QueryClient): void {
     return;
   }
 
-  // Prefix match: the live query key appends a `supportsManifest` boolean, so
-  // this finds the entry whichever variant is cached.
-  const entries = queryClient.getQueriesData<{
-    components: CharacterComponents | null;
-    traits: CharacterTraits | null;
-    customImageUrl: string | null;
-  }>({ queryKey: avatarQueryKey(assistantId) });
-  const data = entries.find(([, value]) => value !== undefined)?.[1];
+  const data = freshestCachedAvatar(queryClient, assistantId);
 
-  // A custom image is a blob URL, dead after the reload — the takeover's
+  // A custom image is a blob URL, dead after the reload, so the takeover's
   // placeholder covers those users instead.
   if (!data || data.customImageUrl != null || data.components == null) {
     clearTakeoverAvatarStash();
@@ -130,6 +133,34 @@ export function captureTakeoverAvatarStash(queryClient: QueryClient): void {
     components: data.components,
     traits: data.traits,
   });
+}
+
+/**
+ * The most recently updated avatar cache entry for an assistant. The live query
+ * key appends a `supportsManifest` boolean, so both variants can sit in the
+ * cache at once and insertion order says nothing about which is current.
+ * Newest data wins: recomputing the flag here would couple this module to the
+ * backwards-compat resolver.
+ */
+function freshestCachedAvatar(
+  queryClient: QueryClient,
+  assistantId: string,
+): CachedAvatar | undefined {
+  const matches = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: avatarQueryKey(assistantId) });
+
+  let freshest: CachedAvatar | undefined;
+  let freshestAt = -Infinity;
+  for (const query of matches) {
+    const data = query.state.data as CachedAvatar | undefined;
+    if (data === undefined || query.state.dataUpdatedAt < freshestAt) {
+      continue;
+    }
+    freshest = data;
+    freshestAt = query.state.dataUpdatedAt;
+  }
+  return freshest;
 }
 
 /**
@@ -148,21 +179,33 @@ function readInMemoryStash(): TakeoverAvatarStash | null {
 }
 
 /**
- * Shape check only — `ChatAvatar` is defensive about component contents, so
- * this rejects garbage rather than deep-guarding the whole component tree.
+ * Shape check only: `ChatAvatar` is defensive about component contents, so this
+ * rejects garbage rather than deep-guarding the whole component tree. Each
+ * array below is dereferenced unconditionally while rendering the creature.
  */
 function isTakeoverAvatarStash(value: unknown): value is TakeoverAvatarStash {
-  if (typeof value !== "object" || value === null) return false;
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
   const stash = value as Record<string, unknown>;
-  if (typeof stash.assistantId !== "string") return false;
-  if (typeof stash.savedAt !== "number") return false;
-  if (stash.traits !== null && !isCharacterTraits(stash.traits)) return false;
+  if (typeof stash.assistantId !== "string") {
+    return false;
+  }
+  if (typeof stash.savedAt !== "number") {
+    return false;
+  }
+  if (stash.traits !== null && !isCharacterTraits(stash.traits)) {
+    return false;
+  }
   const components = stash.components;
-  if (typeof components !== "object" || components === null) return false;
+  if (typeof components !== "object" || components === null) {
+    return false;
+  }
   const parts = components as Record<string, unknown>;
   return (
     Array.isArray(parts.bodyShapes) &&
     Array.isArray(parts.eyeStyles) &&
-    Array.isArray(parts.colors)
+    Array.isArray(parts.colors) &&
+    Array.isArray(parts.faceCenterOverrides)
   );
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
@@ -1,0 +1,168 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { isCharacterTraits } from "@/types/avatar";
+
+/**
+ * The render inputs of the active assistant's avatar, captured at the moment a
+ * Stripe checkout redirect fires, so the post-checkout takeover can draw the
+ * avatar immediately on a cold return instead of holding an empty stage for
+ * the 2–3s the live avatar query takes to resolve.
+ *
+ * Stored in sessionStorage (per-tab, survives the Stripe redirect round-trip,
+ * dies with the tab) under a 30-minute TTL: a checkout abandoned longer than
+ * that shouldn't resurface as a phantom avatar.
+ */
+export interface TakeoverAvatarStash {
+  assistantId: string;
+  components: CharacterComponents;
+  /**
+   * Null for a `kind: "none"` avatar, which draws the bundled-fallback
+   * creature — so stashing null mirrors the eventual live render.
+   */
+  traits: CharacterTraits | null;
+  savedAt: number;
+}
+
+const STORAGE_KEY = "vellum.pro-takeover-avatar";
+const MAX_AGE_MS = 30 * 60 * 1000;
+
+/**
+ * In-memory mirror of the stash, so an unavailable sessionStorage (private
+ * mode, quota, storage disabled) can't silently drop it.
+ */
+let inMemoryStash: TakeoverAvatarStash | null = null;
+
+export function saveTakeoverAvatarStash(
+  stash: Omit<TakeoverAvatarStash, "savedAt">,
+): void {
+  const stamped: TakeoverAvatarStash = { ...stash, savedAt: Date.now() };
+  // Always keep the memory copy so a throwing sessionStorage can't lose it.
+  inMemoryStash = stamped;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stamped));
+  } catch {
+    // sessionStorage may be unavailable (private mode, quota). The in-memory
+    // mirror above preserves the stash — never block the checkout redirect.
+  }
+}
+
+/**
+ * The stashed avatar, or `null` when absent, unparsable, malformed, or older
+ * than the TTL — anything unusable is cleared so it can't resurface. Falls
+ * back to the in-memory mirror when sessionStorage is unreachable or empty.
+ */
+export function readTakeoverAvatarStash(): TakeoverAvatarStash | null {
+  let raw: string | null = null;
+  if (typeof sessionStorage !== "undefined") {
+    try {
+      raw = sessionStorage.getItem(STORAGE_KEY);
+    } catch {
+      // sessionStorage unreachable — fall back to the in-memory mirror.
+      return readInMemoryStash();
+    }
+  }
+  if (!raw) {
+    return readInMemoryStash();
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    clearTakeoverAvatarStash();
+    return null;
+  }
+  if (
+    !isTakeoverAvatarStash(parsed) ||
+    Date.now() - parsed.savedAt > MAX_AGE_MS
+  ) {
+    clearTakeoverAvatarStash();
+    return null;
+  }
+  return parsed;
+}
+
+export function clearTakeoverAvatarStash(): void {
+  inMemoryStash = null;
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // see saveTakeoverAvatarStash
+  }
+}
+
+/**
+ * Capture the active assistant's cached avatar into the stash, or clear the
+ * stash when there is nothing drawable to capture.
+ *
+ * Every Stripe redirect site calls this, and every call either writes a fresh
+ * stash or removes a stale one — so a previous user's (or a previous avatar's)
+ * stash can never ride along with a new checkout.
+ */
+export function captureTakeoverAvatarStash(queryClient: QueryClient): void {
+  const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+  if (!assistantId) {
+    clearTakeoverAvatarStash();
+    return;
+  }
+
+  // Prefix match: the live query key appends a `supportsManifest` boolean, so
+  // this finds the entry whichever variant is cached.
+  const entries = queryClient.getQueriesData<{
+    components: CharacterComponents | null;
+    traits: CharacterTraits | null;
+    customImageUrl: string | null;
+  }>({ queryKey: avatarQueryKey(assistantId) });
+  const data = entries.find(([, value]) => value !== undefined)?.[1];
+
+  // A custom image is a blob URL, dead after the reload — the takeover's
+  // placeholder covers those users instead.
+  if (!data || data.customImageUrl != null || data.components == null) {
+    clearTakeoverAvatarStash();
+    return;
+  }
+
+  saveTakeoverAvatarStash({
+    assistantId,
+    components: data.components,
+    traits: data.traits,
+  });
+}
+
+/**
+ * The in-memory mirror, applying the same TTL as the sessionStorage read so an
+ * abandoned stash can't resurface. Self-clears an expired mirror.
+ */
+function readInMemoryStash(): TakeoverAvatarStash | null {
+  if (!inMemoryStash) {
+    return null;
+  }
+  if (Date.now() - inMemoryStash.savedAt > MAX_AGE_MS) {
+    inMemoryStash = null;
+    return null;
+  }
+  return inMemoryStash;
+}
+
+/**
+ * Shape check only — `ChatAvatar` is defensive about component contents, so
+ * this rejects garbage rather than deep-guarding the whole component tree.
+ */
+function isTakeoverAvatarStash(value: unknown): value is TakeoverAvatarStash {
+  if (typeof value !== "object" || value === null) return false;
+  const stash = value as Record<string, unknown>;
+  if (typeof stash.assistantId !== "string") return false;
+  if (typeof stash.savedAt !== "number") return false;
+  if (stash.traits !== null && !isCharacterTraits(stash.traits)) return false;
+  const components = stash.components;
+  if (typeof components !== "object" || components === null) return false;
+  const parts = components as Record<string, unknown>;
+  return (
+    Array.isArray(parts.bodyShapes) &&
+    Array.isArray(parts.eyeStyles) &&
+    Array.isArray(parts.colors)
+  );
+}


### PR DESCRIPTION
## Summary
- New takeover-avatar-stash module: sessionStorage+memory-mirrored stash of the active assistant's avatar render inputs, 30-min TTL, validated reads
- captureTakeoverAvatarStash(queryClient) gathers the active assistant + cached avatar query and writes-or-clears the stash
- Inert until later PRs consume it

Part of plan: instant-takeover-avatar.md (PR 1 of 5)