### PR TITLE
fix(assistant): route webhook status checks and callback URLs through platform connectivity

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -6,6 +6,8 @@ import { setConfig } from "./helpers/set-config.js";
 let mockSecureKeys: Record<string, string>;
 let mockHasTwilioCredentials: boolean;
 let mockGetIsPlatform: boolean;
+/** Platform credentials present: base URL + assistant ID + assistant API key. */
+let mockPlatformConnected: boolean;
 
 mock.module("../calls/twilio-rest.js", () => ({
   getPhoneNumberSid: async () => null,
@@ -24,7 +26,22 @@ mock.module("../config/env-registry.js", () => ({
   getIsPlatform: () => mockGetIsPlatform,
 }));
 
-mock.module("../inbound/platform-callback-registration.js", () => ({}));
+// Spread the real module: replacing it wholesale drops the exports peer test
+// files import from it, which breaks their named-import validation whenever
+// this mock wins evaluation in a combined run.
+const actualRegistration =
+  await import("../inbound/platform-callback-registration.js");
+mock.module("../inbound/platform-callback-registration.js", () => ({
+  ...actualRegistration,
+  resolvePlatformCallbackRegistrationContext: async () => ({
+    isPlatform: mockGetIsPlatform,
+    platformBaseUrl: "https://api.vellum.ai",
+    assistantId: mockPlatformConnected ? "assistant-123" : "",
+    hasAssistantApiKey: mockPlatformConnected,
+    authHeader: mockPlatformConnected ? "Api-Key secret" : null,
+    enabled: mockPlatformConnected,
+  }),
+}));
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
@@ -85,6 +102,7 @@ describe("ChannelReadinessService", () => {
     mockSecureKeys = {};
     mockHasTwilioCredentials = false;
     mockGetIsPlatform = false;
+    mockPlatformConnected = false;
   });
 
   test("local checks run on every call (no caching of local results)", async () => {
@@ -275,6 +293,94 @@ describe("ChannelReadinessService", () => {
       name: "ingress",
       passed: true,
       message: "Managed platform callback routing is configured",
+    });
+  });
+
+  test("telegram readiness accepts a platform-connected assistant with no ingress", async () => {
+    // LUM-2882: `webhooks register telegram` resolves a platform callback URL
+    // in this configuration, so reporting missing ingress here would hide a
+    // registration that is really in place (or really broken).
+    mockPlatformConnected = true;
+    mockSecureKeys[credentialKey("telegram", "bot_token")] = "123:abc";
+    mockSecureKeys[credentialKey("telegram", "webhook_secret")] = "secret";
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("telegram");
+
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.localChecks).toContainEqual({
+      name: "ingress",
+      passed: true,
+      message: "Managed platform callback routing is configured",
+    });
+  });
+
+  test("phone readiness accepts a platform-connected assistant with no ingress", async () => {
+    mockPlatformConnected = true;
+    mockHasTwilioCredentials = true;
+    setConfig("twilio", { phoneNumber: "+15550123" });
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("phone");
+
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.localChecks).toContainEqual({
+      name: "ingress",
+      passed: true,
+      message: "Managed platform callback routing is configured",
+    });
+  });
+
+  test("configured ingress beats the platform-connected fallback", async () => {
+    // Any logged-in local assistant holds platform credentials for the LLM
+    // proxy. Reporting managed routing here would mislabel a webhook that
+    // `webhooks register` resolves to the self-hosted URL.
+    mockPlatformConnected = true;
+    mockSecureKeys[credentialKey("telegram", "bot_token")] = "123:abc";
+    mockSecureKeys[credentialKey("telegram", "webhook_secret")] = "secret";
+    setConfig("ingress", { publicBaseUrl: "https://tunnel.example.com" });
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("telegram");
+
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.localChecks).toContainEqual({
+      name: "ingress",
+      passed: true,
+      message: "Public ingress URL is configured",
+    });
+  });
+
+  test("explicit ingress opt-out blocks the platform-connected fallback", async () => {
+    // Switching ingress off is a decision not to accept inbound webhooks, not
+    // an invitation to route them through the platform instead.
+    mockPlatformConnected = true;
+    mockSecureKeys[credentialKey("telegram", "bot_token")] = "123:abc";
+    mockSecureKeys[credentialKey("telegram", "webhook_secret")] = "secret";
+    setConfig("ingress", { enabled: false });
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("telegram");
+
+    expect(snapshot.ready).toBe(false);
+    expect(snapshot.reasons).toContainEqual({
+      code: "ingress",
+      text: "No public ingress URL or managed callback route is configured",
+    });
+  });
+
+  test("email readiness ignores platform connectivity", async () => {
+    // Email passes `allowManagedCallbacks: false`, so the managed tiers are
+    // not offered to it and only a real ingress URL counts.
+    mockPlatformConnected = true;
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("email");
+
+    expect(snapshot.localChecks).toContainEqual({
+      name: "ingress",
+      passed: false,
+      message: "Public ingress URL is not configured or disabled",
     });
   });
 

--- a/assistant/src/__tests__/platform-callback-registration.test.ts
+++ b/assistant/src/__tests__/platform-callback-registration.test.ts
@@ -33,8 +33,14 @@ mock.module("../security/secure-keys.js", () => ({
 const originalFetch = globalThis.fetch;
 const originalEnvCredential = process.env.ASSISTANT_API_KEY;
 
-const { registerCallbackRoute, resolvePlatformCallbackRegistrationContext } =
-  await import("../inbound/platform-callback-registration.js");
+const {
+  registerCallbackRoute,
+  resolveCallbackUrl,
+  resolvePlatformCallbackRegistrationContext,
+} = await import("../inbound/platform-callback-registration.js");
+
+const { PublicIngressDisabledError } =
+  await import("../inbound/public-ingress-urls.js");
 
 describe("platform callback registration", () => {
   beforeEach(() => {
@@ -148,5 +154,129 @@ describe("platform callback registration", () => {
     await expect(
       registerCallbackRoute("webhooks/telegram", "telegram"),
     ).resolves.toBe("https://platform.example.com/v1/gateway/callbacks/x/");
+  });
+});
+
+/**
+ * `resolveCallbackUrl` drives Twilio voice/status callbacks and OAuth redirect
+ * URIs. Its tier order has to match `handleWebhooksRegister` in
+ * `runtime/routes/webhook-routes.ts` and `hasWebhookRoutingConfigured` in
+ * `config/webhook-routing.ts` (LUM-2882).
+ */
+describe("resolveCallbackUrl resolution order", () => {
+  const PLATFORM_URL = "https://platform.example.com/v1/gateway/callbacks/x/";
+
+  /** Stand in for a URL builder that cannot resolve a public ingress URL. */
+  function noIngress(): string {
+    throw new Error(
+      "No public base URL configured. Set ingress.publicBaseUrl in config.",
+    );
+  }
+
+  /** Stand in for a URL builder reached while ingress is switched off. */
+  function ingressDisabled(): string {
+    throw new PublicIngressDisabledError();
+  }
+
+  function seedPlatformCredentials(): void {
+    mockSecureKeys[credentialKey("vellum", "platform_base_url")] =
+      "https://platform.example.com";
+    mockSecureKeys[credentialKey("vellum", "platform_assistant_id")] =
+      "11111111-2222-4333-8444-555555555555";
+    mockSecureKeys[credentialKey("vellum", "assistant_api_key")] =
+      "ast-managed-key";
+  }
+
+  let registerCalls: number;
+
+  beforeEach(() => {
+    mockIsPlatform = false;
+    mockPlatformBaseUrl = "";
+    mockPlatformAssistantId = "";
+    mockSecureKeys = {};
+    delete process.env.ASSISTANT_API_KEY;
+    registerCalls = 0;
+    globalThis.fetch = mock(async () => {
+      registerCalls++;
+      return new Response(
+        JSON.stringify({
+          callback_url: PLATFORM_URL,
+          callback_path: "webhooks/twilio/voice",
+          type: "twilio_voice",
+          assistant_id: "11111111-2222-4333-8444-555555555555",
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("platform pods register with the platform gateway", async () => {
+    mockIsPlatform = true;
+    seedPlatformCredentials();
+
+    // The direct supplier is never evaluated on a pod: there is no ingress of
+    // its own to advertise, and evaluating it would throw.
+    await expect(
+      resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
+    ).resolves.toBe(PLATFORM_URL);
+    expect(registerCalls).toBe(1);
+  });
+
+  test("a configured ingress wins over platform connectivity", async () => {
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        () => "https://tunnel.example.com/webhooks/twilio/voice",
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe("https://tunnel.example.com/webhooks/twilio/voice");
+    expect(registerCalls).toBe(0);
+  });
+
+  test("a platform-connected assistant with no ingress registers with the platform", async () => {
+    // LUM-2882: this used to return the direct builder's throw because the
+    // platform branch was gated on IS_PLATFORM, which is only true on a pod.
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
+    ).resolves.toBe(PLATFORM_URL);
+    expect(registerCalls).toBe(1);
+  });
+
+  test("query parameters are appended to the platform URL", async () => {
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice", {
+        callSessionId: "conv-xyz",
+      }),
+    ).resolves.toBe(`${PLATFORM_URL}?callSessionId=conv-xyz`);
+  });
+
+  test("an explicit ingress opt-out is not routed around", async () => {
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        ingressDisabled,
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).rejects.toThrow("Public ingress is disabled");
+    expect(registerCalls).toBe(0);
+  });
+
+  test("without platform credentials the ingress error surfaces unchanged", async () => {
+    await expect(
+      resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
+    ).rejects.toThrow("No public base URL configured");
+    expect(registerCalls).toBe(0);
   });
 });

--- a/assistant/src/config/__tests__/webhook-routing.test.ts
+++ b/assistant/src/config/__tests__/webhook-routing.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for `hasWebhookRoutingConfigured`'s resolution order (LUM-2882).
+ *
+ * The predicate has to agree with `handleWebhooksRegister` in
+ * `runtime/routes/webhook-routes.ts` tier for tier. Where they disagree, the
+ * status surfaces (channel readiness, the Telegram webhook health sweep) report
+ * a state the registration path contradicts, which hides a broken registration
+ * instead of surfacing it. The tier cases here mirror the ones in
+ * `runtime/routes/__tests__/webhook-routes.test.ts`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let isPlatform = false;
+let rawConfig: Record<string, unknown> = {};
+let platformContextEnabled = false;
+
+// Spread the real modules: these are broad barrels and replacing them wholesale
+// breaks unrelated importers pulled in by the module under test.
+const actualEnvRegistry = await import("../env-registry.js");
+mock.module("../env-registry.js", () => ({
+  ...actualEnvRegistry,
+  getIsPlatform: () => isPlatform,
+}));
+
+const actualLoader = await import("../loader.js");
+mock.module("../loader.js", () => ({
+  ...actualLoader,
+  loadRawConfig: () => rawConfig,
+  getConfig: () => rawConfig,
+}));
+
+const actualRegistration =
+  await import("../../inbound/platform-callback-registration.js");
+mock.module("../../inbound/platform-callback-registration.js", () => ({
+  ...actualRegistration,
+  resolvePlatformCallbackRegistrationContext: async () => ({
+    isPlatform,
+    platformBaseUrl: "https://api.vellum.ai",
+    assistantId: platformContextEnabled ? "assistant-123" : "",
+    hasAssistantApiKey: platformContextEnabled,
+    authHeader: platformContextEnabled ? "Api-Key secret" : null,
+    enabled: platformContextEnabled,
+  }),
+}));
+
+const { hasIngressConfigured, hasWebhookRoutingConfigured } =
+  await import("../webhook-routing.js");
+
+describe("hasWebhookRoutingConfigured resolution order", () => {
+  beforeEach(() => {
+    isPlatform = false;
+    rawConfig = {};
+    platformContextEnabled = false;
+  });
+
+  // ── Tier 1: platform pods ────────────────────────────────────────────────
+
+  test("platform pods use managed callbacks", async () => {
+    isPlatform = true;
+
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: true,
+      usesManagedCallbacks: true,
+    });
+  });
+
+  test("platform pods report managed even with an ingress URL configured", async () => {
+    isPlatform = true;
+    rawConfig = { ingress: { publicBaseUrl: "https://tunnel.example.com" } };
+
+    // `handleWebhooksRegister` registers with the platform gateway before it
+    // ever reads the ingress config on a pod, so reporting the ingress URL
+    // here would name a URL no webhook is actually registered against.
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: true,
+      usesManagedCallbacks: true,
+    });
+  });
+
+  // ── Tier 2: a configured ingress wins ────────────────────────────────────
+
+  test("ingress beats the platform-connected fallback", async () => {
+    platformContextEnabled = true;
+    rawConfig = { ingress: { publicBaseUrl: "https://tunnel.example.com" } };
+
+    // Any logged-in local assistant holds platform credentials for the LLM
+    // proxy, so credential presence must not reroute an explicitly configured
+    // self-hosted webhook through the platform.
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: true,
+      usesManagedCallbacks: false,
+    });
+  });
+
+  test("the twilio option resolves ingress before the fallback too", async () => {
+    platformContextEnabled = true;
+    rawConfig = { ingress: { publicBaseUrl: "https://twilio.example.com" } };
+
+    expect(await hasWebhookRoutingConfigured(true, { twilio: true })).toEqual({
+      configured: true,
+      usesManagedCallbacks: false,
+    });
+  });
+
+  test("the twilio option falls back to managed callbacks with no ingress", async () => {
+    platformContextEnabled = true;
+
+    expect(await hasWebhookRoutingConfigured(true, { twilio: true })).toEqual({
+      configured: true,
+      usesManagedCallbacks: true,
+    });
+  });
+
+  // ── Tier 3: platform-connected fallback ──────────────────────────────────
+
+  test("a platform-connected assistant with no ingress uses managed callbacks", async () => {
+    platformContextEnabled = true;
+
+    // The LUM-2882 case: `webhooks register` hands back a platform callback
+    // URL here, so the status surfaces must not report missing ingress.
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: true,
+      usesManagedCallbacks: true,
+    });
+  });
+
+  test("the fallback applies when the ingress URL is present but empty", async () => {
+    platformContextEnabled = true;
+    rawConfig = { ingress: { publicBaseUrl: "" } };
+
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: true,
+      usesManagedCallbacks: true,
+    });
+  });
+
+  test("an explicit ingress.enabled false blocks the fallback", async () => {
+    platformContextEnabled = true;
+    rawConfig = { ingress: { enabled: false } };
+
+    // Opting out is a decision not to accept inbound webhooks at all, not an
+    // invitation to route them through the platform instead.
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: false,
+      usesManagedCallbacks: false,
+    });
+  });
+
+  test("ingress.enabled false blocks the fallback even with a URL configured", async () => {
+    platformContextEnabled = true;
+    rawConfig = {
+      ingress: { enabled: false, publicBaseUrl: "https://tunnel.example.com" },
+    };
+
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: false,
+      usesManagedCallbacks: false,
+    });
+  });
+
+  // ── Tier 4: nothing configured ───────────────────────────────────────────
+
+  test("no ingress and no platform connectivity is not configured", async () => {
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: false,
+      usesManagedCallbacks: false,
+    });
+  });
+
+  // ── allowManagedCallbacks gating ─────────────────────────────────────────
+
+  test("allowManagedCallbacks false hides the platform-connected fallback", async () => {
+    platformContextEnabled = true;
+
+    // Channels that can only be served by a self-hosted ingress pass `false`
+    // and must never be told a managed route stands in for one.
+    expect(await hasWebhookRoutingConfigured(false)).toEqual({
+      configured: false,
+      usesManagedCallbacks: false,
+    });
+  });
+
+  test("allowManagedCallbacks false hides the platform-pod tier", async () => {
+    isPlatform = true;
+
+    expect(await hasWebhookRoutingConfigured(false)).toEqual({
+      configured: false,
+      usesManagedCallbacks: false,
+    });
+  });
+
+  test("allowManagedCallbacks false still honors a configured ingress", async () => {
+    rawConfig = { ingress: { publicBaseUrl: "https://tunnel.example.com" } };
+
+    expect(await hasWebhookRoutingConfigured(false)).toEqual({
+      configured: true,
+      usesManagedCallbacks: false,
+    });
+  });
+});
+
+describe("hasIngressConfigured", () => {
+  beforeEach(() => {
+    isPlatform = false;
+    rawConfig = {};
+    platformContextEnabled = false;
+  });
+
+  test("is unaffected by platform connectivity", () => {
+    platformContextEnabled = true;
+
+    expect(hasIngressConfigured()).toBe(false);
+  });
+
+  test("treats an unset enabled flag with a URL as enabled", () => {
+    rawConfig = { ingress: { publicBaseUrl: "https://tunnel.example.com" } };
+
+    expect(hasIngressConfigured()).toBe(true);
+  });
+
+  test("treats an explicit enabled false as not configured", () => {
+    rawConfig = {
+      ingress: { enabled: false, publicBaseUrl: "https://tunnel.example.com" },
+    };
+
+    expect(hasIngressConfigured()).toBe(false);
+  });
+});

--- a/assistant/src/config/webhook-routing.ts
+++ b/assistant/src/config/webhook-routing.ts
@@ -14,8 +14,10 @@ import {
   resolveTwilioPublicBaseUrl,
 } from "@vellumai/service-contracts/twilio-ingress";
 
+import { resolvePlatformCallbackRegistrationContext } from "../inbound/platform-callback-registration.js";
+import { isPublicIngressDisabled } from "../inbound/public-ingress-urls.js";
 import { getIsPlatform } from "./env-registry.js";
-import { loadRawConfig } from "./loader.js";
+import { getConfig, loadRawConfig } from "./loader.js";
 
 /**
  * True when a public ingress base URL is set and ingress is enabled.
@@ -43,25 +45,64 @@ export function hasIngressConfigured(
 }
 
 /**
- * True when inbound webhooks have somewhere to land: either a self-hosted
- * public ingress URL, or — when `allowManagedCallbacks` is set and this is a
- * platform deployment — the platform's managed callback routes.
+ * True when the user has explicitly switched public ingress off.
+ *
+ * Reads the validated config rather than the raw file so the check matches
+ * what `getPublicBaseUrl` enforces. A config that fails to load is treated as
+ * "not explicitly disabled": absence of a decision is not an opt-out.
  */
-export function hasWebhookRoutingConfigured(
+function isIngressExplicitlyDisabled(): boolean {
+  try {
+    return isPublicIngressDisabled(getConfig());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when inbound webhooks have somewhere to land.
+ *
+ * Mirrors the resolution order `handleWebhooksRegister` uses in
+ * `runtime/routes/webhook-routes.ts`, because the two must agree: a probe that
+ * reports "no ingress" while `webhooks register` hands back a working callback
+ * URL hides a broken registration instead of surfacing it.
+ *
+ *   1. **Platform pods** (`IS_PLATFORM`) always use managed callbacks.
+ *   2. **A configured public ingress wins** for everyone else.
+ *   3. **Platform-connected assistants with no ingress** fall back to managed
+ *      callbacks. Connectivity is decided by credentials (platform base URL +
+ *      assistant ID + assistant API key), not by `IS_PLATFORM`, which is only
+ *      ever true on a platform pod.
+ *   4. Otherwise nothing is configured.
+ *
+ * Ingress deliberately precedes the platform fallback: any logged-in local
+ * assistant holds platform credentials for the LLM proxy, so treating
+ * credential presence as "managed" would misreport an explicitly configured
+ * self-hosted webhook as platform-routed. An explicit `ingress.enabled: false`
+ * is a decision not to accept inbound webhooks at all and blocks the fallback.
+ *
+ * `allowManagedCallbacks` gates both platform tiers: channels that can only be
+ * served by a self-hosted ingress pass `false` and never see them.
+ */
+export async function hasWebhookRoutingConfigured(
   allowManagedCallbacks = false,
   options: { twilio?: boolean } = {},
-): {
+): Promise<{
   configured: boolean;
   usesManagedCallbacks: boolean;
-} {
-  const ingressConfigured = hasIngressConfigured(options);
-  if (ingressConfigured) {
+}> {
+  if (allowManagedCallbacks && getIsPlatform()) {
+    return { configured: true, usesManagedCallbacks: true };
+  }
+
+  if (hasIngressConfigured(options)) {
     return { configured: true, usesManagedCallbacks: false };
   }
 
-  const usesManagedCallbacks = allowManagedCallbacks && getIsPlatform();
-  return {
-    configured: usesManagedCallbacks,
-    usesManagedCallbacks,
-  };
+  if (!allowManagedCallbacks || isIngressExplicitlyDisabled()) {
+    return { configured: false, usesManagedCallbacks: false };
+  }
+
+  const { enabled } = await resolvePlatformCallbackRegistrationContext();
+  return { configured: enabled, usesManagedCallbacks: enabled };
 }

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -21,6 +21,7 @@ import { getIsPlatform } from "../config/env-registry.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
+import { PublicIngressDisabledError } from "./public-ingress-urls.js";
 
 const log = getLogger("platform-callback-registration");
 
@@ -151,18 +152,35 @@ export async function registerCallbackRoute(
 }
 
 /**
- * Resolve a callback URL, registering with the platform when platform-managed.
+ * Resolve a callback URL, registering with the platform when appropriate.
  *
- * When platform callbacks are enabled, registers the route and returns the
- * platform's stable callback URL (optionally with query parameters appended).
- * Otherwise evaluates the lazy direct URL supplier and returns that value.
+ * Resolution order, matching `handleWebhooksRegister` in
+ * `runtime/routes/webhook-routes.ts` and `hasWebhookRoutingConfigured` in
+ * `config/webhook-routing.ts`:
+ *
+ *   1. **Platform pods** (`IS_PLATFORM`) always register with the platform
+ *      gateway: they have no ingress of their own to advertise.
+ *   2. **A configured public ingress wins** for everyone else, so the direct
+ *      supplier is tried first and its value returned when it resolves.
+ *   3. **Platform-connected assistants with no ingress** register with the
+ *      platform gateway rather than surfacing the direct builder's error.
+ *      Connectivity is decided by credentials (platform base URL + assistant
+ *      ID + assistant API key), not by `IS_PLATFORM`, which is only ever true
+ *      on a platform pod.
+ *
+ * An explicit `ingress.enabled: false` is a decision not to accept inbound
+ * webhooks at all, so `PublicIngressDisabledError` propagates instead of being
+ * routed around. Ingress precedes the platform fallback because any logged-in
+ * local assistant holds platform credentials for the LLM proxy: treating
+ * credential presence as "managed" would silently reroute an explicitly
+ * configured self-hosted callback through the platform.
  *
  * The `directUrl` parameter is a **lazy supplier** (a function returning a
  * string) rather than an eagerly-evaluated string. This is critical because
  * the direct URL builders (e.g. `getTwilioVoiceWebhookUrl`) call
  * `getPublicBaseUrl()` which throws when no public ingress URL is configured.
- * In platform-managed environments that rely solely on platform callbacks, the
- * direct URL is never needed — deferring evaluation avoids the throw.
+ * On a platform pod the direct URL is never needed, and deferring evaluation
+ * avoids the throw.
  *
  * @param directUrl - Lazy supplier for the direct callback URL.
  * @param callbackPath - The path to register (e.g. "webhooks/twilio/voice").
@@ -179,7 +197,22 @@ export async function resolveCallbackUrl(
   sourceIdentifier?: string,
 ): Promise<string> {
   if (!getIsPlatform()) {
-    return directUrl();
+    let ingressError: unknown;
+    try {
+      return directUrl();
+    } catch (err) {
+      if (err instanceof PublicIngressDisabledError) {
+        throw err;
+      }
+      ingressError = err;
+    }
+
+    // No ingress configured. Fall back to the platform gateway when this
+    // assistant is connected to the platform.
+    const context = await resolvePlatformCallbackRegistrationContext();
+    if (!context.enabled) {
+      throw ingressError;
+    }
   }
 
   try {
@@ -191,9 +224,10 @@ export async function resolveCallbackUrl(
     }
     return url;
   } catch (err) {
-    // In platform-managed mode there is no local-ingress fallback and
-    // ngrok is not applicable. Surface a clear error so callers (and the
-    // user) understand this is a platform-side issue, not a tunnel problem.
+    // Registration is only attempted once the local ingress has been ruled
+    // out, so there is nothing left to fall back to. Surface a clear error so
+    // callers (and the user) understand this is a platform-side issue, not a
+    // tunnel problem.
     const detail = err instanceof Error ? err.message : String(err);
     throw new Error(
       `Managed callback route registration failed: ${detail}. ` +

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -43,11 +43,41 @@ export interface IngressConfig {
   };
 }
 
-function assertPublicIngressEnabled(config: IngressConfig): void {
-  if (config.ingress?.enabled === false) {
-    throw new Error(
+/**
+ * True when the user has explicitly switched public ingress off.
+ *
+ * An explicit opt-out is a decision not to accept inbound webhooks at all, so
+ * it must not be silently routed around via platform callbacks. An *absent*
+ * ingress config is merely "not set up yet" and is eligible for the platform
+ * fallback, so only a literal `false` counts here.
+ *
+ * Every consumer that offers a platform-callback fallback has to consult this
+ * before falling back, which is why it lives here rather than in each caller.
+ */
+export function isPublicIngressDisabled(config: IngressConfig): boolean {
+  return config.ingress?.enabled === false;
+}
+
+/**
+ * Thrown when a URL builder is asked for a URL while ingress is opted out.
+ *
+ * Distinct from the "no URL configured" error so callers with a
+ * platform-callback fallback can tell the two apart: "not set up yet" is
+ * eligible for the fallback, an explicit opt-out is not. Matching on the
+ * message text would break the moment the copy is reworded.
+ */
+export class PublicIngressDisabledError extends Error {
+  constructor() {
+    super(
       "Public ingress is disabled. Ask the assistant to enable it, or update it from the Settings page.",
     );
+    this.name = "PublicIngressDisabledError";
+  }
+}
+
+function assertPublicIngressEnabled(config: IngressConfig): void {
+  if (isPublicIngressDisabled(config)) {
+    throw new PublicIngressDisabledError();
   }
 }
 
@@ -66,11 +96,15 @@ export function getPublicBaseUrl(config: IngressConfig): string {
 
   const ingressValue = config.ingress?.publicBaseUrl;
   const normalizedIngressValue = normalizePublicBaseUrl(ingressValue);
-  if (normalizedIngressValue) return normalizedIngressValue;
+  if (normalizedIngressValue) {
+    return normalizedIngressValue;
+  }
 
   const ingressEnvValue = getIngressPublicBaseUrl();
   const normalizedIngressEnvValue = normalizePublicBaseUrl(ingressEnvValue);
-  if (normalizedIngressEnvValue) return normalizedIngressEnvValue;
+  if (normalizedIngressEnvValue) {
+    return normalizedIngressEnvValue;
+  }
 
   throw new Error(
     "No public base URL configured. Set ingress.publicBaseUrl in config.",
@@ -90,10 +124,7 @@ export function getTwilioVoiceWebhookUrl(
   config: IngressConfig,
   callSessionId?: string,
 ): string {
-  return buildTwilioVoiceWebhookUrl(
-    getPublicBaseUrl(config),
-    callSessionId,
-  );
+  return buildTwilioVoiceWebhookUrl(getPublicBaseUrl(config), callSessionId);
 }
 
 /**

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -140,14 +140,12 @@ async function checkCredential(
 }
 
 /** Check that public ingress is configured and enabled. */
-function checkIngress(
+async function checkIngress(
   allowManagedCallbacks = false,
   options: { twilio?: boolean } = {},
-): ReadinessCheckResult {
-  const { configured, usesManagedCallbacks } = hasWebhookRoutingConfigured(
-    allowManagedCallbacks,
-    options,
-  );
+): Promise<ReadinessCheckResult> {
+  const { configured, usesManagedCallbacks } =
+    await hasWebhookRoutingConfigured(allowManagedCallbacks, options);
   return check(
     "ingress",
     configured,
@@ -173,7 +171,7 @@ const voiceProbe: ChannelProbe = {
   async runLocalChecks(): Promise<ReadinessCheckResult[]> {
     const hasCreds = await hasTwilioCredentials();
     const hasPhone = !!resolveTwilioPhoneNumber();
-    const ingress = checkIngress(true, { twilio: true });
+    const ingress = await checkIngress(true, { twilio: true });
 
     return [
       check(
@@ -211,7 +209,7 @@ const telegramProbe: ChannelProbe = {
         "webhook_secret",
         "Telegram webhook secret",
       ),
-      checkIngress(true),
+      await checkIngress(true),
     ];
   },
 };
@@ -234,7 +232,7 @@ const emailProbe: ChannelProbe = {
         "Email invite code redemption is enabled",
         "Email invite code redemption is disabled",
       ),
-      checkIngress(),
+      await checkIngress(),
     ];
   },
   async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
@@ -307,7 +305,7 @@ const whatsappProbe: ChannelProbe = {
         "WhatsApp invite code redemption is enabled",
         "WhatsApp invite code redemption is disabled",
       ),
-      checkIngress(),
+      await checkIngress(),
     ];
   },
 };

--- a/assistant/src/runtime/routes/webhook-routes.ts
+++ b/assistant/src/runtime/routes/webhook-routes.ts
@@ -19,7 +19,7 @@ import {
 } from "../../inbound/platform-callback-registration.js";
 import {
   getPublicBaseUrl,
-  type IngressConfig,
+  isPublicIngressDisabled,
 } from "../../inbound/public-ingress-urls.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -99,18 +99,6 @@ async function registerWithPlatform(
     throw new InternalError(`Failed to register callback route: ${msg}`);
   }
   return { callbackUrl, type, path: webhookPath, mode: "platform" };
-}
-
-/**
- * True when the user has explicitly switched public ingress off.
- *
- * An explicit opt-out is a decision not to accept inbound webhooks at all, so
- * it must not be silently routed around via platform callbacks. An *absent*
- * ingress config is merely "not set up yet" and is eligible for the platform
- * fallback.
- */
-function isPublicIngressDisabled(config: IngressConfig): boolean {
-  return config.ingress?.enabled === false;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/telegram/__tests__/webhook-health.test.ts
+++ b/assistant/src/telegram/__tests__/webhook-health.test.ts
@@ -4,10 +4,14 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const secureKeyValues = new Map<string, string>();
 
-let webhookRouting: { configured: boolean; usesManagedCallbacks: boolean } = {
-  configured: true,
-  usesManagedCallbacks: false,
-};
+// Webhook routing is driven through its real inputs rather than by mocking
+// `hasWebhookRoutingConfigured` itself. Stubbing the predicate would have let
+// the sweep and the predicate drift apart unnoticed, which is exactly how
+// LUM-2882 stayed invisible: the predicate stopped matching what
+// `webhooks register` actually does for platform-connected local assistants.
+let ingressConfig: Record<string, unknown> = {};
+let isPlatform = false;
+let platformContextEnabled = false;
 
 type FetchOutcome =
   | { kind: "json"; status?: number; body: unknown }
@@ -34,11 +38,6 @@ mock.module("../../security/credential-key.js", () => ({
     `credential/${service}/${field}`,
 }));
 
-mock.module("../../config/webhook-routing.js", () => ({
-  hasWebhookRoutingConfigured: () => webhookRouting,
-  hasIngressConfigured: () => webhookRouting.configured,
-}));
-
 mock.module("../bot-username.js", () => ({
   getTelegramBotUsername: () => "test_bot",
   getTelegramBotId: () => "123",
@@ -46,8 +45,33 @@ mock.module("../bot-username.js", () => ({
 
 let apiBaseUrl = "https://api.telegram.org";
 
+// Spread the real modules below: these are broad barrels shared with peer test
+// files, and replacing one wholesale drops the exports those files import.
+const actualLoader = await import("../../config/loader.js");
 mock.module("../../config/loader.js", () => ({
-  getConfig: () => ({ telegram: { apiBaseUrl } }),
+  ...actualLoader,
+  getConfig: () => ({ telegram: { apiBaseUrl }, ingress: ingressConfig }),
+  loadRawConfig: () => ({ ingress: ingressConfig }),
+}));
+
+const actualEnvRegistry = await import("../../config/env-registry.js");
+mock.module("../../config/env-registry.js", () => ({
+  ...actualEnvRegistry,
+  getIsPlatform: () => isPlatform,
+}));
+
+const actualRegistration =
+  await import("../../inbound/platform-callback-registration.js");
+mock.module("../../inbound/platform-callback-registration.js", () => ({
+  ...actualRegistration,
+  resolvePlatformCallbackRegistrationContext: async () => ({
+    isPlatform,
+    platformBaseUrl: "https://api.vellum.ai",
+    assistantId: platformContextEnabled ? "assistant-123" : "",
+    hasAssistantApiKey: platformContextEnabled,
+    authHeader: platformContextEnabled ? "Api-Key secret" : null,
+    enabled: platformContextEnabled,
+  }),
 }));
 
 // Mirrors the real `emitNotificationSignal` contract: it swallows pipeline
@@ -121,7 +145,9 @@ beforeEach(() => {
   secureKeyValues.clear();
   secureKeyValues.set(BOT_TOKEN_KEY, "12345:test-token");
   secureKeyValues.set(WEBHOOK_SECRET_KEY, "s3cret");
-  webhookRouting = { configured: true, usesManagedCallbacks: false };
+  ingressConfig = { publicBaseUrl: "https://example.test" };
+  isPlatform = false;
+  platformContextEnabled = false;
   setWebhookInfo({ url: WEBHOOK_URL, pending_update_count: 0 });
   fetchCallCount = 0;
   fetchedUrls.length = 0;
@@ -158,7 +184,7 @@ describe("gating", () => {
   });
 
   test("does not run when no webhook routing is configured", async () => {
-    webhookRouting = { configured: false, usesManagedCallbacks: false };
+    ingressConfig = {};
 
     const result = await runTelegramWebhookHealthCheck();
 
@@ -167,8 +193,45 @@ describe("gating", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
+  test("does not run when public ingress is explicitly disabled", async () => {
+    // An opt-out means no inbound webhook is expected at all, so the sweep has
+    // nothing to verify even though platform credentials are present.
+    ingressConfig = { enabled: false };
+    platformContextEnabled = true;
+
+    const result = await runTelegramWebhookHealthCheck();
+
+    expect(result.status).toBe("skipped");
+    expect(fetchCallCount).toBe(0);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("runs for a platform-connected local assistant with no ingress", async () => {
+    // LUM-2882: `webhooks register telegram` registers a platform callback
+    // route in this exact configuration, so a broken registration is real and
+    // the sweep has to verify it rather than skip.
+    ingressConfig = {};
+    platformContextEnabled = true;
+    setWebhookInfo({
+      url: WEBHOOK_URL,
+      last_error_date: unixSecondsAgo(30),
+      last_error_message: "Wrong response from the webhook: 404 Not Found",
+    });
+
+    const result = await runTelegramWebhookHealthCheck();
+
+    expect(result.status).toBe("delivery_failing");
+    expect(fetchCallCount).toBeGreaterThan(0);
+    expect(emittedSignals).toHaveLength(1);
+    // The callback route is platform-owned, so the self-hosted remediation
+    // (point config at a new tunnel URL) does not apply.
+    expect(result.detail).not.toContain("assistant config set");
+    expect(result.detail).toContain("contact support");
+  });
+
   test("runs when platform-managed callbacks stand in for public ingress", async () => {
-    webhookRouting = { configured: true, usesManagedCallbacks: true };
+    isPlatform = true;
+    ingressConfig = {};
     setWebhookInfo({
       url: WEBHOOK_URL,
       last_error_date: unixSecondsAgo(30),

--- a/assistant/src/telegram/webhook-health.ts
+++ b/assistant/src/telegram/webhook-health.ts
@@ -191,7 +191,7 @@ export async function checkTelegramWebhookHealth(): Promise<TelegramWebhookHealt
   }
 
   const { configured, usesManagedCallbacks } =
-    hasWebhookRoutingConfigured(true);
+    await hasWebhookRoutingConfigured(true);
   if (!configured) {
     return {
       status: "skipped",


### PR DESCRIPTION
## TL;DR

PR #39394 taught `webhooks_register` a third resolution tier: a local, platform-connected assistant with no public ingress registers with the platform gateway instead of returning 422. The predicates that *report on* that same question were left on the old `IS_PLATFORM`-only gate, so in exactly the newly supported configuration they contradicted the route. This syncs them, preserving #39394's tier order exactly.

Fixes LUM-2882

## Why

Two places asked "can this deployment receive webhooks?" and answered with `allowManagedCallbacks && getIsPlatform()`. `IS_PLATFORM` is only ever true on a platform pod, so a logged-in local assistant never matched.

**Part 1 (Codex P2 on #39394).** `hasWebhookRoutingConfigured` feeds both channel readiness and the Telegram webhook health sweep. So `webhooks register telegram` returned a working platform callback URL while `/v1/channels/readiness` reported missing ingress and the health sweep (LUM-2862's new detection) skipped verification entirely. A broken registration was **invisible** for that config, which is the one case the sweep exists to catch.

**Part 2 (deferred out of #39394 by its author).** `resolveCallbackUrl` had the identical gate. It drives Twilio voice/status callbacks and OAuth redirect URIs.

## Before / after

Configuration: local assistant (`IS_PLATFORM` unset), platform-connected (platform base URL + assistant ID + assistant API key), **no** `ingress.publicBaseUrl`.

| Surface | Before | After |
| --- | --- | --- |
| `webhooks register telegram` | platform callback URL (since #39394) | unchanged |
| `/v1/channels/readiness` (telegram, phone) | "No public ingress URL or managed callback route is configured", `ready: false` | "Managed platform callback routing is configured", `ready: true` |
| Telegram webhook health sweep | skipped, never verifies | verifies; alerts with the platform-appropriate remediation |
| `resolveCallbackUrl` (Twilio status, OAuth redirect) | throws "No public base URL configured" | returns the platform callback URL |

Unchanged everywhere else: a configured ingress still wins over platform connectivity, and an explicit `ingress.enabled: false` is still honored as "do not accept inbound webhooks" rather than routed around.

## Why this is safe

- **Tier order is #39394's, unchanged**: `IS_PLATFORM` → configured ingress → platform-connected fallback → not configured. Platform connectivity was deliberately *not* promoted above ingress: any logged-in local assistant holds platform credentials for the LLM proxy, so treating credential presence as "managed" would silently reroute an explicitly configured self-hosted webhook through the platform.
- **The opt-out is preserved on every path**, including the two new ones, and is covered by tests.
- **`allowManagedCallbacks` still gates both platform tiers**, so channels that can only be served by a self-hosted ingress (email, WhatsApp) see no behavior change at all.
- **No new import cycles**: `bun run lint:circular` reports 186 before and after, and none of the touched modules appear in any cycle.
- The one behavior change outside the target config is cosmetic: on a platform pod that *also* has an ingress URL set, readiness now says "Managed platform callback routing is configured" instead of naming the ingress URL. That matches what `webhooks_register` actually does on a pod (it registers with the platform before ever reading ingress config), so the old message named a URL no webhook was registered against.

## Async ripple

`resolvePlatformCallbackRegistrationContext()` is async and the predicates were sync. Rather than caching or duplicating the resolver, `hasWebhookRoutingConfigured` and `checkIngress` became async. Every call site was already inside an `async` function, so the ripple is four added `await`s and no restructuring.

## Incidental refactor

`isPublicIngressDisabled` was a local copy in `webhook-routes.ts`; it moves to `public-ingress-urls.ts` beside the code that enforces it, and `webhook-routes.ts` now imports it.

The disabled case throws a typed `PublicIngressDisabledError`. `resolveCallbackUrl` calls a lazy direct-URL supplier and has to tell "user opted out" (do not fall back) apart from "not set up yet" (fall back) *from the thrown error*, since it cannot see the config the caller closed over. Matching on message text would break the moment the copy is reworded. The message itself is unchanged.

Also added braces to two pre-existing braceless `if` returns in `getPublicBaseUrl` (AGENTS.md control-flow rule, file already being edited).

## Tests

New `assistant/src/config/__tests__/webhook-routing.test.ts` covers all four tiers, both `allowManagedCallbacks` settings, ingress-beats-fallback, and both `ingress.enabled: false` variants. Extended: readiness (new tier, ingress-wins, opt-out, and email confirming `allowManagedCallbacks: false` is unaffected), the Telegram sweep, and `resolveCallbackUrl` (six cases including query-param passthrough and opt-out).

I verified the new tests are not vacuous: reverting just the tier-3 branch fails 4 of them.

**The Telegram health test previously mocked `hasWebhookRoutingConfigured` itself**, which is precisely why the sweep and the predicate could drift apart unnoticed. It now drives the real predicate through its inputs (config + credentials), so this class of divergence fails the test instead of shipping.

Ran: `typecheck` (clean), `lint` (0 errors), `lint:circular` (no new cycles), `prettier --check` (clean), and each affected test file individually: 195 tests, 0 failures. The repo runner isolates each test file in its own process because `mock.module` is process-global, so per-file is how CI runs them. I could not run the full local suite: it dies in fixture setup connecting to `~/.vellum/workspace/ces.sock`, and it fails identically on unmodified `origin/main` sources, so that is an environment prerequisite rather than anything in this diff. CI will cover it.

## What was NOT done

I found five more `getIsPlatform()`-only gates in this same family. None are clearly low-risk, so I am enumerating rather than fixing them:

1. **`calls/voice-ingress-preflight.ts:46`, the one that matters most.** All three `resolveCallbackUrl` call sites in `call-domain.ts` (lines 413, 920, 1052) sit behind `preflightVoiceIngress()`, which still fails with "Outbound voice calls require public ingress" for this exact config. **So Part 2's fix does not yet reach outbound voice calls**. It reaches OAuth redirect URIs and `syncTwilioWebhooks` (phone-number-level webhook config), which are not behind the preflight. Fixing it would newly *permit* calls that are blocked today, and the preflight returns a `publicBaseUrl` that downstream media-stream setup consumes, so it needs its own change with its own testing. Worth doing next.
2. `daemon/handlers/config-telegram.ts:257`: auto-registers the Telegram callback route only when `IS_PLATFORM`. Same class; a platform-connected local assistant never gets the route registered from the config handler. Worth doing.
3. `daemon/handlers/config-ingress.ts:37`: `getIngressConfigResult` reports `managedCallbacks: false` for this config, so the Settings UI and the assistant LLM see a state `webhooks register` contradicts. Same class as Part 1; needs a decision on which credential source to synthesize the URL from (it reads env, not stored credentials).
4. `security/oauth2.ts:786` and 5. `mcp/client.ts:102`: both choose `gateway` vs `loopback` OAuth callback transport. Arguably **not** broken: loopback is a legitimate, working choice for a local assistant, so flipping these to gateway would be a behavior change without a clear bug. Listing for completeness; I would leave them.

Happy to file follow-ups for 1-3 if you want them tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->