### PR TITLE
Billing: platform fee label, Base plan card, and upgrade spec chips

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
@@ -1,36 +1,49 @@
 /**
  * Tests for PlanPromoCard: the dark, layout-only "promo" card in the billing
- * Plan section — a centered title, optional one-line blurb, and a single CTA.
- * Verifies it renders the title, blurb, and CTA label; omits the blurb node
- * when no blurb is passed; fires `onCtaClick` on click; shows the pending
- * spinner and blocks the click while pending; and forces the dark palette.
+ * Plan section — a centered title, an optional spec-chip row, and a single CTA.
+ * Verifies it renders the title, the chip labels, and the CTA label; omits the
+ * chip row when no specs are passed; fires `onCtaClick` on click; shows the
+ * pending spinner and blocks the click while pending; and forces the dark
+ * palette.
  */
+
+import { Coins, Computer, HardDrive } from "lucide-react";
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
+import type { PlanSpec } from "./plan-spec";
+
 const { PlanPromoCard } = await import("./plan-promo-card");
+
+const MIGHTY_SPECS: PlanSpec[] = [
+  { icon: Computer, label: "Small Machine" },
+  { icon: Coins, label: "$25 credits" },
+  { icon: HardDrive, label: "10 GB" },
+];
 
 afterEach(() => {
   cleanup();
 });
 
 describe("PlanPromoCard", () => {
-  test("renders the title, blurb, and CTA label", async () => {
+  test("renders the title, spec chips, and CTA label", async () => {
     const { findByRole, findByText } = render(
       <PlanPromoCard
         title="Upgrade to Mighty"
-        blurb="More power and storage"
+        specs={MIGHTY_SPECS}
         ctaLabel="Power Up"
         onCtaClick={() => {}}
       />,
     );
     expect(await findByText("Upgrade to Mighty")).toBeTruthy();
-    expect(await findByText("More power and storage")).toBeTruthy();
+    for (const spec of MIGHTY_SPECS) {
+      expect(await findByText(spec.label)).toBeTruthy();
+    }
     expect(await findByRole("button", { name: "Power Up" })).toBeTruthy();
   });
 
-  test("omits the blurb node when blurb is not provided", () => {
+  test("omits the chip row when specs are not provided", () => {
     const { queryByText } = render(
       <PlanPromoCard
         title="Customize"
@@ -38,7 +51,21 @@ describe("PlanPromoCard", () => {
         onCtaClick={() => {}}
       />,
     );
-    expect(queryByText("More power and storage")).toBeNull();
+    for (const spec of MIGHTY_SPECS) {
+      expect(queryByText(spec.label)).toBeNull();
+    }
+  });
+
+  test("omits the chip row when specs is empty", () => {
+    const { container } = render(
+      <PlanPromoCard
+        title="Customize"
+        specs={[]}
+        ctaLabel="Configure"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(container.querySelector(".flex-wrap")).toBeNull();
   });
 
   test("fires onCtaClick when the CTA is clicked", async () => {

--- a/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Tests for PlanPromoCard: the dark, layout-only "promo" card in the billing
- * Plan section — a centered title, an optional spec-chip row, and a single CTA.
+ * Plan section: a centered title, an optional spec-chip row, and a single CTA.
  * Verifies it renders the title, the chip labels, and the CTA label; omits the
  * chip row when no specs are passed; fires `onCtaClick` on click; shows the
  * pending spinner and blocks the click while pending; and forces the dark

--- a/clients/web/src/domains/settings/billing/plan-promo-card.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.tsx
@@ -20,7 +20,7 @@ export interface PlanPromoCardProps {
 }
 
 /**
- * The dark "promo" card in the billing "Plan" section — a centered title, an
+ * The dark "promo" card in the billing "Plan" section: a centered title, an
  * optional row of spec chips, and a single CTA. Purely presentational: the
  * parent owns the copy, the specs, the pending/disabled state, and the CTA
  * behavior. The forced `data-theme="dark"` scope resolves the semantic tokens

--- a/clients/web/src/domains/settings/billing/plan-promo-card.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.tsx
@@ -1,13 +1,15 @@
 import { Loader2 } from "lucide-react";
 
+import type { PlanSpec } from "@/domains/settings/billing/plan-spec";
+import { SpecChip } from "@/domains/settings/billing/spec-chip";
 import { cn } from "@/utils/misc";
 import { Button } from "@vellumai/design-library/components/button";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 export interface PlanPromoCardProps {
   title: string;
-  /** One-line supporting copy under the title; omitted on the customize variant. */
-  blurb?: string;
+  /** Spec chips under the title; omitted on the customize variant. */
+  specs?: PlanSpec[];
   ctaLabel: string;
   ctaTestId?: string;
   pending?: boolean;
@@ -18,15 +20,16 @@ export interface PlanPromoCardProps {
 }
 
 /**
- * The dark "promo" card in the billing "Plan" section — a centered title,
- * optional one-line blurb, and a single CTA. Purely presentational: the parent
- * owns the copy, the pending/disabled state, and the CTA behavior. The forced
- * `data-theme="dark"` scope resolves the semantic tokens to the mock's dark
- * palette (surface ~#17191C, `--content-secondary` blurb ~#A9B2BB).
+ * The dark "promo" card in the billing "Plan" section — a centered title, an
+ * optional row of spec chips, and a single CTA. Purely presentational: the
+ * parent owns the copy, the specs, the pending/disabled state, and the CTA
+ * behavior. The forced `data-theme="dark"` scope resolves the semantic tokens
+ * to the mock's dark palette (surface ~#17191C, chips on `--surface-overlay`
+ * ~#1C2024). The card is narrow, so the chip row wraps.
  */
 export function PlanPromoCard({
   title,
-  blurb,
+  specs,
   ctaLabel,
   ctaTestId,
   pending = false,
@@ -50,14 +53,12 @@ export function PlanPromoCard({
         >
           {title}
         </Typography>
-        {blurb ? (
-          <Typography
-            as="span"
-            variant="body-small-default"
-            className="text-[var(--content-secondary)]"
-          >
-            {blurb}
-          </Typography>
+        {specs?.length ? (
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            {specs.map((spec) => (
+              <SpecChip key={spec.label} icon={spec.icon} label={spec.label} />
+            ))}
+          </div>
         ) : null}
       </div>
       <Button

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -104,7 +104,7 @@ describe("computeCustomPlanDiff — base checkout (no seed)", () => {
     // base $20 + large $60 + 30 GB $10 + $50 credits.
     expect(diff.totalCents).toBe(2000 + 6000 + 1000 + 5000);
     expect(diff.rows.map((r) => r.label)).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Large machine (4 vCPU, 8 GiB)",
       "30 GB storage",
       "$50 of bundled credits",
@@ -124,7 +124,7 @@ describe("computeCustomPlanDiff — base checkout (no seed)", () => {
     });
 
     expect(diff.rows.map((r) => r.label)).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "No extra credits",

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -104,7 +104,7 @@ describe("computeCustomPlanDiff — base checkout (no seed)", () => {
     // base $20 + large $60 + 30 GB $10 + $50 credits.
     expect(diff.totalCents).toBe(2000 + 6000 + 1000 + 5000);
     expect(diff.rows.map((r) => r.label)).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Large machine (4 vCPU, 8 GiB)",
       "30 GB storage",
       "$50 of bundled credits",
@@ -124,7 +124,7 @@ describe("computeCustomPlanDiff — base checkout (no seed)", () => {
     });
 
     expect(diff.rows.map((r) => r.label)).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "No extra credits",

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -98,7 +98,7 @@ export function computeCustomPlanDiff(input: {
   const rows: CustomPlanDiffRow[] = [
     {
       key: "base",
-      label: `Pro base plan — ${formatMonthly(proPlan.base_price_cents)}`,
+      label: `Platform fee — ${formatMonthly(proPlan.base_price_cents)}`,
       changed: false,
     },
   ];

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -98,7 +98,7 @@ export function computeCustomPlanDiff(input: {
   const rows: CustomPlanDiffRow[] = [
     {
       key: "base",
-      label: `Platform fee — ${formatMonthly(proPlan.base_price_cents)}`,
+      label: `Platform fee: ${formatMonthly(proPlan.base_price_cents)}`,
       changed: false,
     },
   ];

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -468,15 +468,15 @@ describe("CustomPlanModal — base subscriber", () => {
     expect(labels.some((l) => l.startsWith("250 GB"))).toBe(false);
   });
 
-  test("recap opens with just the labeled base fee", () => {
+  test("recap opens with just the labeled platform fee", () => {
     const { getByRole, getByText } = renderPage(freeSubscription());
 
     fireEvent.click(getByRole("button", { name: "Configure" }));
 
-    // Nothing selected yet — the total is the bare base fee, and the recap's
+    // Nothing selected yet — the total is the bare platform fee, and the recap's
     // permanent first row labels where it comes from.
     getByText("$20/mo");
-    getByText("Pro base plan — $20/mo");
+    getByText("Platform fee — $20/mo");
   });
 
   test("recap totals the base price plus the selected tiers", () => {
@@ -494,7 +494,7 @@ describe("CustomPlanModal — base subscriber", () => {
     // Read the recap rows rather than getByText — the machine text also appears
     // in its dropdown trigger and would double-match.
     expect(recapRows()).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Large machine (4 vCPU, 8 GiB)",
       "30 GB storage",
       "$50 of bundled credits",
@@ -599,7 +599,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
 
     // The recap reflects the seeded current tiers.
     expect(recapRows()).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "No extra credits",
@@ -618,7 +618,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     fireEvent.click(getByRole("button", { name: "Configure" }));
 
     expect(recapRows()).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "No extra credits",
@@ -638,7 +638,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     // the new value; every other row keeps its single seeded label.
     expect(strikethroughs()).toEqual(["Medium machine (2.5 vCPU, 5 GiB)"]);
     expect(recapRows()).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)Large machine (4 vCPU, 8 GiB)",
       "10 GB storage",
       "No extra credits",
@@ -838,7 +838,7 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
       (li) => li.textContent?.trim() ?? "",
     );
     expect(rows).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "$25 of bundled credits",
@@ -904,7 +904,7 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     // The held bundle labels its own row rather than claiming the paying
     // subscriber has no credits, and nothing reads as changed on open.
     expect(recapRows()).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "$25 of bundled credits",
@@ -928,7 +928,7 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     expect(continueButton().disabled).toBe(true);
     expect(dropdownTrigger("Storage").textContent).toContain("250 GB");
     expect(recapRows()).toEqual([
-      "Pro base plan — $20/mo",
+      "Platform fee — $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "250 GB storage",
       "No extra credits",

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -473,10 +473,10 @@ describe("CustomPlanModal — base subscriber", () => {
 
     fireEvent.click(getByRole("button", { name: "Configure" }));
 
-    // Nothing selected yet — the total is the bare platform fee, and the recap's
-    // permanent first row labels where it comes from.
+    // Nothing selected yet, so the total is the bare platform fee, and the
+    // recap's permanent first row labels where it comes from.
     getByText("$20/mo");
-    getByText("Platform fee — $20/mo");
+    getByText("Platform fee: $20/mo");
   });
 
   test("recap totals the base price plus the selected tiers", () => {
@@ -494,7 +494,7 @@ describe("CustomPlanModal — base subscriber", () => {
     // Read the recap rows rather than getByText — the machine text also appears
     // in its dropdown trigger and would double-match.
     expect(recapRows()).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Large machine (4 vCPU, 8 GiB)",
       "30 GB storage",
       "$50 of bundled credits",
@@ -599,7 +599,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
 
     // The recap reflects the seeded current tiers.
     expect(recapRows()).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "No extra credits",
@@ -618,7 +618,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     fireEvent.click(getByRole("button", { name: "Configure" }));
 
     expect(recapRows()).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "No extra credits",
@@ -638,7 +638,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     // the new value; every other row keeps its single seeded label.
     expect(strikethroughs()).toEqual(["Medium machine (2.5 vCPU, 5 GiB)"]);
     expect(recapRows()).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)Large machine (4 vCPU, 8 GiB)",
       "10 GB storage",
       "No extra credits",
@@ -838,7 +838,7 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
       (li) => li.textContent?.trim() ?? "",
     );
     expect(rows).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "$25 of bundled credits",
@@ -904,7 +904,7 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     // The held bundle labels its own row rather than claiming the paying
     // subscriber has no credits, and nothing reads as changed on open.
     expect(recapRows()).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
       "$25 of bundled credits",
@@ -928,7 +928,7 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     expect(continueButton().disabled).toBe(true);
     expect(dropdownTrigger("Storage").textContent).toContain("250 GB");
     expect(recapRows()).toEqual([
-      "Platform fee — $20/mo",
+      "Platform fee: $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "250 GB storage",
       "No extra credits",

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -21,8 +21,6 @@ export interface PlanTierCopy {
   recommended?: boolean;
   /** Feature rows appended after the catalog-derived rows. */
   extraFeatures?: readonly string[];
-  /** One-line pitch shown on the billing page's dark "Upgrade to X" card. */
-  upgradeBlurb?: string;
 }
 
 export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
@@ -36,21 +34,18 @@ export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
     cta: "Power Up",
     priceCaption: "Billed monthly",
     recommended: true,
-    upgradeBlurb: "$25 in Credits, more storage and power",
   },
   super: {
     tagline: "Stronger performance for heavier workloads.",
     cta: "Go Super",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],
-    upgradeBlurb: "$45 credits, 3× storage, more power, and email.",
   },
   ultra: {
     tagline: "Built for sustained, high-demand work.",
     cta: "Unleash Ultra",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],
-    upgradeBlurb: "$115 credits, 2x storage, more power, and email.",
   },
 };
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -324,15 +324,18 @@ describe("PlansPage — full catalog render", () => {
   test("renders the headline and all four tier names", () => {
     const html = renderStatic(freeSubscription(), fullCatalog());
     expect(html).toContain("Give your assistant more power");
-    expect(html).toContain("Free");
+    expect(html).toContain("Base");
     expect(html).toContain("Mighty");
     expect(html).toContain("Super");
     expect(html).toContain("Ultra");
   });
 
-  test("formats prices from the catalog totals (and $0 for free)", () => {
+  test("formats prices from the catalog totals (and 'Free' for the base tier)", () => {
     const html = renderStatic(freeSubscription(), fullCatalog());
-    expect(html).toContain("$0/month");
+    // Anchored on the price element: "Free" also appears in CTA copy, so a bare
+    // substring match would pass without the price label rendering at all.
+    expect(html).toContain(">Free</span>");
+    expect(html).not.toContain("$0/month");
     expect(html).toContain("$30/month");
     expect(html).toContain("$100/month");
     expect(html).toContain("$200/month");

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -529,9 +529,9 @@ export function PlansPage() {
         <div className="mt-6 grid w-full max-w-[1312px] grid-cols-1 items-start gap-4 sm:mt-10 sm:grid-cols-2 sm:gap-6 lg:grid-cols-4">
           <PlanColumnCard
             tierKey="free"
-            name="Free"
+            name="Base"
             tagline={freeCopy?.tagline ?? ""}
-            priceLabel="$0/month"
+            priceLabel="Free"
             priceCaption={freeCopy?.priceCaption ?? "Forever"}
             ctaLabel={
               freeRelation === "downgrade"

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -21,6 +21,7 @@ import {
   fireEvent,
   render,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -383,6 +384,43 @@ function renderCard(
   );
 }
 
+/**
+ * The static markup parsed into a detached DOM node, so an assertion can be
+ * scoped to one card. Both cards render spec chips, so a whole-document text
+ * match cannot tell the current card's chips from the promo card's.
+ */
+function renderCardDom(
+  subscription: SubscriptionResponse,
+  plans: PlanListResponse,
+): HTMLElement {
+  const host = document.createElement("div");
+  host.innerHTML = renderCard(subscription, plans);
+  return host;
+}
+
+/** The current-plan card — PlanSpecCard's forced light scope. */
+function currentCard(host: HTMLElement): HTMLElement {
+  const card = host.querySelector<HTMLElement>('[data-theme="light"]');
+  if (!card) {
+    throw new Error("expected a current-plan card");
+  }
+  return card;
+}
+
+/** The recommended card — PlanPromoCard's forced dark scope. */
+function promoCard(host: HTMLElement): HTMLElement {
+  const card = host.querySelector<HTMLElement>('[data-theme="dark"]');
+  if (!card) {
+    throw new Error("expected a recommended promo card");
+  }
+  return card;
+}
+
+/** `packageSpecs` chip labels for the free baseline and each fixture package. */
+const FREE_BASELINE_CHIPS = ["Small Machine", "$0 credits", "4 GB"];
+const MIGHTY_CHIPS = ["Small Machine", "$25 credits", "10 GB"];
+const SUPER_CHIPS = ["Medium Machine", "$45 credits", "30 GB"];
+
 function renderCardInteractive(
   subscription: SubscriptionResponse,
   plans: PlanListResponse,
@@ -498,40 +536,50 @@ describe("PlanCard", () => {
     expect(html).not.toContain("recommended-upgrade-button");
   });
 
-  test("Free current card is chip-less; recommended shows the promo blurb", () => {
-    const html = renderCard(baseSubscription(), basePlansResponse());
-    // The current (Free) card is now a minimal centered card with NO spec chips:
-    // none of the free-baseline chip labels appear.
-    expect(html).not.toContain("$0 credits");
-    expect(html).not.toContain("4 GB");
-    expect(html).not.toContain("Small Machine");
+  test("Free current card is chip-less; recommended shows the package chips", () => {
+    const host = renderCardDom(baseSubscription(), basePlansResponse());
+    // The current (Free) card is a minimal centered card with NO spec chips:
+    // none of the free-baseline chip labels appear inside it.
+    const current = within(currentCard(host));
+    for (const label of FREE_BASELINE_CHIPS) {
+      expect(current.queryByText(label)).toBeNull();
+    }
     // The recommended (Mighty) promo card shows "Upgrade to Mighty" plus the
-    // per-tier blurb, replacing the old summary chip — and carries no tag/chips.
-    expect(html).toContain("Upgrade to Mighty");
-    expect(html).toContain(PLAN_TIER_COPY.mighty.upgradeBlurb!);
-    expect(html).not.toContain("more credits and storage");
-    expect(html).not.toContain("Recommended");
+    // package's spec chips — and carries no tag.
+    const promo = within(promoCard(host));
+    expect(promo.getByText("Upgrade to Mighty")).toBeTruthy();
+    for (const label of MIGHTY_CHIPS) {
+      expect(promo.getByText(label)).toBeTruthy();
+    }
+    expect(promoCard(host).textContent).not.toContain(
+      "more credits and storage",
+    );
+    expect(host.innerHTML).not.toContain("Recommended");
     // The centered free card still shows its "Current Plan" tag.
-    expect(html).toContain("Current Plan");
+    expect(current.getByText("Current Plan")).toBeTruthy();
   });
 
   test("Mighty → Super: current keeps its chips, recommended shows the promo card", () => {
-    const html = renderCard(proMightySubscription(), plansWithSuper());
+    const host = renderCardDom(proMightySubscription(), plansWithSuper());
     // On Mighty, the recommended upgrade is the next catalog package, Super.
-    expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Upgrade to Super");
-    expect(html).toContain(PLAN_TIER_COPY.super.upgradeBlurb!);
+    expect(host.innerHTML).toContain("recommended-upgrade-button");
+    const promo = within(promoCard(host));
+    expect(promo.getByText("Upgrade to Super")).toBeTruthy();
+    for (const label of SUPER_CHIPS) {
+      expect(promo.getByText(label)).toBeTruthy();
+    }
     // The promo card carries no "Recommended" tag and no summary chip.
-    expect(html).not.toContain("Recommended");
-    expect(html).not.toContain("more credits, storage, and a stronger machine");
-    // The current (Mighty) card keeps its absolute chips.
-    expect(html).toContain("$25 credits");
-    expect(html).toContain("10 GB");
-    expect(html).toContain("Small Machine");
-    // The current-plan card shows the actual package name "Mighty" (not the
-    // generic plan name "Pro").
-    expect(html).toContain("plan-card-name");
-    expect(html).toContain("Mighty");
+    expect(host.innerHTML).not.toContain("Recommended");
+    expect(promoCard(host).textContent).not.toContain(
+      "more credits, storage, and a stronger machine",
+    );
+    // The current (Mighty) card keeps its own absolute chips, and names the
+    // actual package ("Mighty"), not the generic plan name "Pro".
+    const current = within(currentCard(host));
+    for (const label of MIGHTY_CHIPS) {
+      expect(current.getByText(label)).toBeTruthy();
+    }
+    expect(current.getByTestId("plan-card-name").textContent).toBe("Mighty");
   });
 
   test("an unpinned Custom sub gets the customize promo card", () => {
@@ -632,19 +680,23 @@ describe("PlanCard", () => {
   });
 
   test("a free user's current card is centered and chip-less", () => {
-    const html = renderCard(baseSubscription(), basePlansResponse());
+    const host = renderCardDom(baseSubscription(), basePlansResponse());
     // The free current card is a minimal centered card: centering classes on the
     // card and its "Current Plan" tag, but NO chips.
-    expect(html).toContain("justify-center");
-    expect(html).toContain("Current Plan");
-    expect(html).not.toContain("$0 credits");
-    expect(html).not.toContain("4 GB");
-    expect(html).not.toContain("Small Machine");
-    // The recommended (Mighty) promo card shows the per-tier blurb, not a chip.
-    expect(html).toContain("Upgrade to Mighty");
-    expect(html).toContain(PLAN_TIER_COPY.mighty.upgradeBlurb!);
-    expect(html).not.toContain("more credits and storage");
-    expect(html).not.toContain("stronger machine");
+    const current = currentCard(host);
+    expect(current.className).toContain("justify-center");
+    expect(within(current).getByText("Current Plan")).toBeTruthy();
+    for (const label of FREE_BASELINE_CHIPS) {
+      expect(within(current).queryByText(label)).toBeNull();
+    }
+    // The recommended (Mighty) promo card shows the package's spec chips.
+    const promo = promoCard(host);
+    expect(within(promo).getByText("Upgrade to Mighty")).toBeTruthy();
+    for (const label of MIGHTY_CHIPS) {
+      expect(within(promo).getByText(label)).toBeTruthy();
+    }
+    expect(promo.textContent).not.toContain("more credits and storage");
+    expect(promo.textContent).not.toContain("stronger machine");
   });
 });
 

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -398,7 +398,7 @@ function renderCardDom(
   return host;
 }
 
-/** The current-plan card — PlanSpecCard's forced light scope. */
+/** The current-plan card: PlanSpecCard's forced light scope. */
 function currentCard(host: HTMLElement): HTMLElement {
   const card = host.querySelector<HTMLElement>('[data-theme="light"]');
   if (!card) {
@@ -407,7 +407,7 @@ function currentCard(host: HTMLElement): HTMLElement {
   return card;
 }
 
-/** The recommended card — PlanPromoCard's forced dark scope. */
+/** The recommended card: PlanPromoCard's forced dark scope. */
 function promoCard(host: HTMLElement): HTMLElement {
   const card = host.querySelector<HTMLElement>('[data-theme="dark"]');
   if (!card) {
@@ -545,7 +545,7 @@ describe("PlanCard", () => {
       expect(current.queryByText(label)).toBeNull();
     }
     // The recommended (Mighty) promo card shows "Upgrade to Mighty" plus the
-    // package's spec chips — and carries no tag.
+    // package's spec chips, and carries no tag.
     const promo = within(promoCard(host));
     expect(promo.getByText("Upgrade to Mighty")).toBeTruthy();
     for (const label of MIGHTY_CHIPS) {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -22,7 +22,6 @@ import {
   type CustomPlanSelection,
 } from "@/domains/settings/billing/plans/custom-plan-modal";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
-import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
 import { packageSpecs } from "@/domains/settings/billing/plan-spec";
 import { PlanSpecCard } from "@/domains/settings/billing/plan-spec-card";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
@@ -351,7 +350,7 @@ function RecommendedUpgrade({
         <PlanPromoCard
           className="lg:flex-[2]"
           title={`Upgrade to ${recommended.name}`}
-          blurb={getPlanTierCopy(recommended.key)?.upgradeBlurb}
+          specs={packageSpecs(recommended)}
           ctaLabel="Upgrade"
           ctaTestId="recommended-upgrade-button"
           pending={isPending}


### PR DESCRIPTION
Three copy/UI fixes to the assistant billing surfaces for pro plans.

## Changes

**1. Custom plan modal — "Platform fee"**
The recap's permanent first row now reads `Platform fee — $20/mo` instead of `Pro base plan — $20/mo` (`custom-plan-diff.ts`).

**2. Plans takeover — first column is "Base / Free"**
The leftmost column card is retitled `Free` → `Base`, and its price label `$0/month` → `Free`, so the block reads **Base / Free / Forever**. `tierKey="free"` is unchanged — it drives the avatar and the upgrade/downgrade relation logic, not display copy.

**3. Recommended upgrade card — spec chips instead of prose**
The billing Plan section's dark "Upgrade to X" card now renders the three catalog-derived `SpecChip`s (machine / credits / storage) via the existing `packageSpecs()`, replacing the hand-written one-line blurb. `PlanPromoCard`'s `blurb?: string` prop becomes `specs?: PlanSpec[]`.

## Note on deleted copy

Removing the blurb left `upgradeBlurb` with zero consumers, so it is deleted from the `PlanTierCopy` interface and all three tier entries rather than left orphaned. The removed strings:

- mighty — `$25 in Credits, more storage and power`
- super — `$45 credits, 3× storage, more power, and email.`
- ultra — `$115 credits, 2x storage, more power, and email.`

## Test scoping

Two existing assertions were matching against the whole rendered document and had to be re-scoped, not merely re-stringed:

- `plan-card.test.tsx` proved "the Free current card is chip-less" with `expect(html).not.toContain("Small Machine")`. Mighty's chips include *Small Machine*, so the promo card's new chips break that assertion legitimately. The chip assertions are now scoped to each card via `within()` on their `data-theme` scopes, and the stale-copy guards run against the promo card's text rather than the document.
- `plans-page.test.tsx` asserted `toContain("Free")` for the card title, which would keep passing after the retitle purely because the CTA reads "Start Free". The price assertion is now anchored on the price element and was confirmed non-vacuous by temporarily restoring `$0/month` and observing the failure.

## Verification

- `bun run test:ci` — 745 passed, 0 failed (745 files, per-file process isolation)
- `bunx tsc --noEmit` — clean
- `eslint` on all changed files — 0 errors; `prettier --check` clean

## Not covered

- **Not browser-verified.** The chips use `--surface-overlay` (`#1C2024`) inside the card's forced dark scope over `--surface-base` (`#17191C`) — a legal token pairing but only a slight lift. If it reads flat in review, the fix is a `tone` prop on `SpecChip`; its background should not change globally, since `PlanSpecCard` shares it under a forced light scope.
- The Free column's CTAs still read "Start Free" / "Downgrade to Free" under a card now titled "Base". Left deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
