### PR TITLE
refactor(assistant): resolve profile call sites through the provider-aware path

### DIFF
--- a/assistant/src/__tests__/conversation-slash.test.ts
+++ b/assistant/src/__tests__/conversation-slash.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getConfig } from "../config/loader.js";
+import { setConfig } from "./helpers/set-config.js";
+
+// ─── Fixture config ─────────────────────────────────────────────────────────
+
+let mockLlm: Record<string, unknown> = {};
+
+const { resolveSlash } = await import("../daemon/conversation-slash.js");
+
+/**
+ * Install the current fixture `llm` config for real. A schema-valid baseline
+ * is seeded first so the loader caches a config object; `llm` is then
+ * overwritten on that live cached object so fixtures reach the resolver
+ * exactly as authored.
+ */
+function applyConfig(): void {
+  setConfig("llm", { profiles: {} });
+  const config = getConfig() as { llm: unknown };
+  config.llm = mockLlm;
+}
+
+beforeEach(() => {
+  mockLlm = { profiles: {} };
+  applyConfig();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("/model list", () => {
+  test("lists the code-catalog defaults", async () => {
+    const result = await resolveSlash("/model");
+    expect(result.kind).toBe("unknown");
+    const message = (result as { message: string }).message;
+    expect(message).toContain("`balanced`");
+    expect(message).toContain("`quality-optimized`");
+    expect(message).toContain("`cost-optimized`");
+  });
+
+  test("default profile descriptions follow the default provider's column", async () => {
+    // The BYOK and vellum columns carry different description strings for
+    // quality-optimized and cost-optimized; the listing must show the column
+    // that actually dispatches on this install.
+    mockLlm = {
+      profiles: {},
+      defaultProvider: { provider: "anthropic" },
+    };
+    applyConfig();
+
+    const message = ((await resolveSlash("/model")) as { message: string })
+      .message;
+    expect(message).toContain("Best results with the most capable model");
+    expect(message).toContain("Fastest responses at lower cost");
+    expect(message).not.toContain("(DeepSeek V4 Flash)");
+  });
+
+  test("descriptions use the managed column without a default provider", async () => {
+    const message = ((await resolveSlash("/model")) as { message: string })
+      .message;
+    expect(message).toContain(
+      "High-quality results with the most capable model",
+    );
+    expect(message).toContain(
+      "Fastest responses at lower cost (DeepSeek V4 Flash)",
+    );
+  });
+});
+
+describe("/model switch", () => {
+  test("rejects an unknown profile with the available set", async () => {
+    const result = await resolveSlash("/model nope");
+    expect(result.kind).toBe("unknown");
+    const message = (result as { message: string }).message;
+    expect(message).toContain("`nope` not found");
+    expect(message).toContain("`balanced`");
+  });
+
+  test("validates against the same set under a BYO default provider", async () => {
+    mockLlm = {
+      profiles: {},
+      defaultProvider: { provider: "anthropic" },
+    };
+    applyConfig();
+
+    const result = await resolveSlash("/model nope");
+    expect((result as { message: string }).message).toContain(
+      "`nope` not found",
+    );
+  });
+});

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -15,7 +15,7 @@ import {
   resolveAppDir,
 } from "../apps/app-store.js";
 import { type ChannelId, parseInterfaceId } from "../channels/types.js";
-import { getEffectiveProfile } from "../config/default-profile-catalog.js";
+import { resolveDefaultProfileForProvider } from "../config/default-profile-catalog.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { isMemoryV3Live } from "../config/memory-v3-gate.js";
@@ -231,7 +231,11 @@ export function resolveTurnModelProfileLabel(
   if (modelProfileNoticeKey == null) {
     return null;
   }
-  const profileEntry = getEffectiveProfile(llm.profiles, modelProfileNoticeKey);
+  const profileEntry = resolveDefaultProfileForProvider(
+    llm.profiles,
+    modelProfileNoticeKey,
+    llm.defaultProvider ?? null,
+  );
   const resolved = resolveCallSiteConfig(callSite, llm, {
     overrideProfile: modelProfileNoticeKey,
     selectionSeed,

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -1,5 +1,5 @@
 import type { InterfaceId } from "../channels/types.js";
-import { getEffectiveProfiles } from "../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../config/default-profile-catalog.js";
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import {
@@ -136,7 +136,10 @@ async function resolveModelCommand(
   parse: ModelCommandParse,
 ): Promise<SlashResolution> {
   const config = getConfig();
-  const profiles = getEffectiveProfiles(config.llm.profiles);
+  const profiles = getEffectiveProfilesForProvider(
+    config.llm.profiles,
+    config.llm.defaultProvider ?? null,
+  );
   const profileNames = orderProfileKeys(profiles, config.llm.profileOrder);
   const activeProfile = config.llm.activeProfile;
 

--- a/assistant/src/plugin-api/model-profiles.test.ts
+++ b/assistant/src/plugin-api/model-profiles.test.ts
@@ -17,6 +17,7 @@ interface MockProfileEntry {
 let mockProfiles: Record<string, MockProfileEntry> = {};
 let mockActiveProfile: string | undefined;
 let mockProfileOrder: string[] | undefined;
+let mockDefaultProvider: { provider: string } | undefined;
 
 const { getModelProfiles } = await import("./model-profiles.js");
 
@@ -34,6 +35,7 @@ function listProfiles(): ReturnType<typeof getModelProfiles> {
     profiles: mockProfiles,
     activeProfile: mockActiveProfile,
     profileOrder: mockProfileOrder,
+    defaultProvider: mockDefaultProvider,
   };
   return getModelProfiles();
 }
@@ -44,6 +46,7 @@ beforeEach(() => {
   mockProfiles = {};
   mockActiveProfile = undefined;
   mockProfileOrder = undefined;
+  mockDefaultProvider = undefined;
 });
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -134,6 +137,31 @@ describe("getModelProfiles", () => {
       expect(profile.isDisabled).toBe(false);
       expect(profile.isMix).toBe(false);
     }
+  });
+
+  test("default profile descriptions follow the default provider's column", () => {
+    // The BYOK and vellum columns of the profile matrix carry different
+    // description strings for quality-optimized and cost-optimized; the
+    // listed description must come from the column that actually dispatches.
+    mockDefaultProvider = { provider: "anthropic" };
+
+    const result = listProfiles();
+    expect(result.find((p) => p.key === "quality-optimized")?.description).toBe(
+      "Best results with the most capable model",
+    );
+    expect(result.find((p) => p.key === "cost-optimized")?.description).toBe(
+      "Fastest responses at lower cost",
+    );
+  });
+
+  test("default profile descriptions use the managed column without a default provider", () => {
+    const result = listProfiles();
+    expect(result.find((p) => p.key === "quality-optimized")?.description).toBe(
+      "High-quality results with the most capable model",
+    );
+    expect(result.find((p) => p.key === "cost-optimized")?.description).toBe(
+      "Fastest responses at lower cost (DeepSeek V4 Flash)",
+    );
   });
 
   test("marks the active profile with isActive", () => {

--- a/assistant/src/plugin-api/model-profiles.ts
+++ b/assistant/src/plugin-api/model-profiles.ts
@@ -1,4 +1,4 @@
-import { getEffectiveProfiles } from "../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
 import { isDispatchableProfile } from "../config/profile-dispatchability.js";
 import { orderProfileKeys } from "../config/profile-order.js";
@@ -20,7 +20,10 @@ import type { ModelProfileInfo } from "./types.js";
 export function getModelProfiles(): ModelProfileInfo[] {
   const { llm } = getConfig();
   const { activeProfile } = llm;
-  const profiles = getEffectiveProfiles(llm.profiles);
+  const profiles = getEffectiveProfilesForProvider(
+    llm.profiles,
+    llm.defaultProvider ?? null,
+  );
   const result: ModelProfileInfo[] = [];
   for (const key of orderProfileKeys(profiles, llm.profileOrder)) {
     const entry = profiles[key];

--- a/assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
-import { getEffectiveProfiles } from "../../../../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../../../../config/default-profile-catalog.js";
 import { loadConfig } from "../../../../config/loader.js";
 import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
@@ -521,7 +521,10 @@ export async function handleSimulateRouter({
   // through (the resolver tolerates missing override-profile references by
   // design, but the playground wants the user to know they typo'd).
   if (profileOverride !== undefined) {
-    const profiles = getEffectiveProfiles(liveConfig.llm?.profiles);
+    const profiles = getEffectiveProfilesForProvider(
+      liveConfig.llm?.profiles,
+      liveConfig.llm?.defaultProvider ?? null,
+    );
     if (!Object.prototype.hasOwnProperty.call(profiles, profileOverride)) {
       const available = Object.keys(profiles).sort();
       const hint =

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -39,7 +39,7 @@ import {
   supportsHostProxy,
 } from "../../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import {
@@ -1449,7 +1449,11 @@ export async function handleSendMessage(
     );
   }
   if (requestedInferenceProfile !== undefined) {
-    const profiles = getEffectiveProfiles(getConfig().llm.profiles);
+    const { llm } = getConfig();
+    const profiles = getEffectiveProfilesForProvider(
+      llm.profiles,
+      llm.defaultProvider ?? null,
+    );
     if (
       !Object.prototype.hasOwnProperty.call(profiles, requestedInferenceProfile)
     ) {

--- a/assistant/src/runtime/routes/inference-profile-session-handler.ts
+++ b/assistant/src/runtime/routes/inference-profile-session-handler.ts
@@ -14,7 +14,7 @@
 
 import { randomUUID } from "node:crypto";
 
-import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
@@ -145,7 +145,11 @@ export async function setInferenceProfileSession({
   }
 
   // --- Validate profile ---
-  const profiles = getEffectiveProfiles(loadConfig().llm?.profiles);
+  const { llm } = loadConfig();
+  const profiles = getEffectiveProfilesForProvider(
+    llm?.profiles,
+    llm?.defaultProvider ?? null,
+  );
   if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
     throw new BadRequestError(
       `Profile "${profile}" is not defined in llm.profiles`,

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -18,7 +18,6 @@
 import { z } from "zod";
 
 import {
-  getEffectiveProfile,
   getEffectiveProfilesForProvider,
   MANAGED_PROFILE_NAMES,
   resolveDefaultProfileForProvider,
@@ -456,8 +455,11 @@ async function handleCreateProfile({ body = {} }: RouteHandlerArgs) {
   return {
     ok: true as const,
     name,
-    entry: (getEffectiveProfile(getConfig().llm.profiles, name) ??
-      entry) as Record<string, unknown>,
+    entry: (resolveDefaultProfileForProvider(
+      getConfig().llm.profiles,
+      name,
+      getConfig().llm.defaultProvider ?? null,
+    ) ?? entry) as Record<string, unknown>,
     warnings,
   };
 }
@@ -542,8 +544,11 @@ async function handleUpdateProfile({
   return {
     ok: true as const,
     name,
-    entry: (getEffectiveProfile(getConfig().llm.profiles, name) ??
-      merged) as Record<string, unknown>,
+    entry: (resolveDefaultProfileForProvider(
+      getConfig().llm.profiles,
+      name,
+      getConfig().llm.defaultProvider ?? null,
+    ) ?? merged) as Record<string, unknown>,
     warnings,
   };
 }

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -10,7 +10,7 @@
 
 import { z } from "zod";
 
-import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
 import {
   getDefaultProviderFromConfig,
   resolveDefaultConnectionName,
@@ -509,8 +509,14 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
     }
   }
 
-  // llm.profiles.*: only ProfileEntry has provider_connection.
-  const profiles = getEffectiveProfiles(config.llm?.profiles);
+  // llm.profiles.*: only ProfileEntry has provider_connection. Resolved
+  // provider-aware so the scan sees the same bodies the runtime resolver
+  // produces: on a BYO install the default profiles carry the
+  // `provider_connection` they actually dispatch through. Today every name
+  // the defaults can stamp is also caught by the `llm.defaultProvider` guard
+  // above; this keeps the scan a faithful backstop rather than one that
+  // silently skips the defaults.
+  const profiles = getEffectiveProfilesForProvider(config.llm?.profiles, dp);
   const referencingProfiles = Object.entries(profiles)
     .filter(
       ([, p]) => (p as Record<string, unknown>).provider_connection === name,

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 
-import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
 import type { ResolutionFallbackReason } from "../../config/llm-resolver.js";
 import { selectWinningProfile } from "../../config/llm-resolver.js";
 import { getConfigReadOnly } from "../../config/loader.js";
@@ -39,7 +39,11 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
 
   // Validate --profile against the configured profile catalog.
   if (profile !== undefined) {
-    const profiles = getEffectiveProfiles(getConfigReadOnly().llm?.profiles);
+    const { llm } = getConfigReadOnly();
+    const profiles = getEffectiveProfilesForProvider(
+      llm?.profiles,
+      llm?.defaultProvider ?? null,
+    );
     if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
       const available = Object.keys(profiles).sort();
       const hint =

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { loadConfig } from "../../config/loader.js";
 import {
@@ -53,7 +53,10 @@ export type LlmProfilesListResult = z.infer<
 
 async function handleListProfiles(): Promise<LlmProfilesListResult> {
   const { llm } = loadConfig();
-  const profiles = getEffectiveProfiles(llm?.profiles);
+  const profiles = getEffectiveProfilesForProvider(
+    llm?.profiles,
+    llm?.defaultProvider ?? null,
+  );
   return {
     profiles: Object.keys(profiles).sort(),
     activeProfile:

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -15,7 +15,7 @@
 
 import { z } from "zod";
 
-import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
@@ -192,7 +192,10 @@ export async function executeManageWorkflows(
       // workspace-wide active profile. Read-only — leaves use this to pick a
       // valid `profile` for `run_workflow` (an unknown profile throws).
       const { llm } = loadConfig();
-      const profiles = getEffectiveProfiles(llm?.profiles);
+      const profiles = getEffectiveProfilesForProvider(
+        llm?.profiles,
+        llm?.defaultProvider ?? null,
+      );
       return {
         content: JSON.stringify({
           profiles: Object.keys(profiles).sort(),

--- a/assistant/src/workflows/leaf-runner.ts
+++ b/assistant/src/workflows/leaf-runner.ts
@@ -43,7 +43,7 @@ import { z } from "zod";
 
 import { type AgentEvent, AgentLoop } from "../agent/loop.js";
 import type { AssistantEvent } from "../api/index.js";
-import { getEffectiveProfile } from "../config/default-profile-catalog.js";
+import { resolveDefaultProfileForProvider } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
 import { isMemoryEnabled } from "../config/memory-v3-gate.js";
 import { isPersonalMemoryAllowed } from "../daemon/trust-context.js";
@@ -328,7 +328,14 @@ function validateProfile(profile: string): string {
 }
 
 function profileExists(profile: string): boolean {
-  return getEffectiveProfile(getConfig().llm.profiles, profile) != null;
+  const { llm } = getConfig();
+  return (
+    resolveDefaultProfileForProvider(
+      llm.profiles,
+      profile,
+      llm.defaultProvider ?? null,
+    ) != null
+  );
 }
 
 /**


### PR DESCRIPTION
## TL;DR

Part of the BYO profile-resolution consolidation ([plan papertrail on PR 1, #39392](https://github.com/vellum-ai/vellum-assistant/pull/39392)). Background: the default profiles (Balanced/Quality/Speed) resolve to a concrete provider+model in two possible ways — the **managed body** (what a Vellum-managed install runs) or the **BYO body** for the user's own default provider (what a bring-your-own-key install runs). The runtime dispatcher already picks the right one per install; these 12 call sites always read the managed body regardless. This PR points them all at the same install-aware resolution the dispatcher uses.

## What this does NOT change

- **Which model any request runs on. Anywhere, for anyone.** Dispatch already resolved install-aware before this PR; these are read/validation surfaces only.
- **Anything at all on managed installs.** With no BYO default provider configured, the new resolution call returns the exact same code path and objects as the old one — not equivalent, identical. Every pre-existing test (none of which configure a BYO provider) passes unchanged.

## What changes (BYO installs only)

Two description strings: `/model` and the plugin profile list now show the BYO body's Quality/Speed descriptions — so Speed stops saying "(DeepSeek V4 Flash)", a model those installs don't run. That's the entire user-visible diff.

Everything else in this PR is verified-inert consistency work (details per site below): the sites only read fields that are identical in both bodies (profile names, labels, status), or sit behind guards that already handle the case. They're migrated anyway so a follow-up lint rule can ban the install-blind lookup entirely and nothing new regresses.

## Sites

**Observable (descriptions only):** `plugin-api/model-profiles.ts`, `daemon/conversation-slash.ts` — pinned by new tests (BYO + managed baselines).

**Verified inert:** `runtime/routes/inference-provider-connection-routes.ts` (delete-guard scan — every name it could newly catch is already blocked by the `llm.defaultProvider` guard above it), `runtime/routes/conversation-routes.ts`, `runtime/routes/inference-send-routes.ts`, `runtime/routes/inference-profile-session-handler.ts`, `runtime/routes/llm-call-sites-routes.ts` (name-set membership checks — the name set is identical in both bodies), `runtime/routes/inference-profiles-routes.ts` (post-write echoes — managed names rejected upstream), `daemon/conversation-runtime-assembly.ts` (label only — identical in both bodies), `workflows/leaf-runner.ts`, `plugins/defaults/memory/src/memory-v2-routes.ts`, `tools/workflows/manage-workflows.ts` (name sets).

## Testing

- New `src/__tests__/conversation-slash.test.ts` (the `/model` picker had no coverage): listing + switch under both a BYO default provider and none.
- `model-profiles.test.ts`: description assertions for both install types.
- All 12 touched files' existing suites pass individually (72+11+5+18+6+24+21+6+204+23+8+5); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
