### PR TITLE
feat(web): hydrate the takeover surface from the avatar stash on cold return

### DIFF
--- a/clients/web/src/domains/settings/billing/assistant-avatar-tile.test.tsx
+++ b/clients/web/src/domains/settings/billing/assistant-avatar-tile.test.tsx
@@ -22,6 +22,7 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
     isLoading: avatarLoading,
     invalidate: () => {},
   }),
+  avatarQueryKey: (assistantId: string) => ["assistantAvatar", assistantId],
 }));
 
 const { AssistantAvatarTile } = await import("./assistant-avatar-tile");

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -71,6 +71,7 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
     isLoading: false,
     invalidate: () => {},
   }),
+  avatarQueryKey: (assistantId: string) => ["assistantAvatar", assistantId],
 }));
 
 // Capture the escape toast so the exit-on-escape path can assert its message;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -42,6 +42,7 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
       invalidate: () => {},
     };
   },
+  avatarQueryKey: (assistantId: string) => ["assistantAvatar", assistantId],
 }));
 
 // `useReducedMotion` reads a cached media-query singleton, so a per-test

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { QueryClient } from "@tanstack/react-query";
 
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
@@ -11,6 +12,7 @@ import {
   clearTakeoverAvatarStash,
   readTakeoverAvatarStash,
   saveTakeoverAvatarStash,
+  takeoverAvatarStashVersion,
 } from "./takeover-avatar-stash";
 
 const STORAGE_KEY = "vellum.pro-takeover-avatar";
@@ -37,8 +39,15 @@ beforeEach(() => {
   sessionStorage.clear();
   // Reset the module-level in-memory mirror so it can't leak across tests.
   clearTakeoverAvatarStash();
-  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  useResolvedAssistantsStore.setState({
+    activeAssistantId: null,
+    assistants: [],
+  });
 });
+
+function assistant(id: string): ResolvedAssistant {
+  return { id, isLocal: false, isPlatformHosted: true };
+}
 
 describe("saveTakeoverAvatarStash / readTakeoverAvatarStash", () => {
   test("round-trips the payload and stamps savedAt", () => {
@@ -190,6 +199,35 @@ describe("clearTakeoverAvatarStash", () => {
   });
 });
 
+describe("takeoverAvatarStashVersion", () => {
+  // A same-document reader snapshots the stash and re-reads when this moves,
+  // so a write that leaves it flat would strand that reader on a stale copy.
+  test("advances on save", () => {
+    const before = takeoverAvatarStashVersion();
+
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+    });
+
+    expect(takeoverAvatarStashVersion()).toBeGreaterThan(before);
+  });
+
+  test("advances on clear", () => {
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+    });
+    const before = takeoverAvatarStashVersion();
+
+    clearTakeoverAvatarStash();
+
+    expect(takeoverAvatarStashVersion()).toBeGreaterThan(before);
+  });
+});
+
 describe("in-memory mirror on a same-document return", () => {
   test("the mirror serves the stash back after a throwing setItem", () => {
     // The native path: checkout opens in an external browser, so the document
@@ -288,6 +326,41 @@ describe("captureTakeoverAvatarStash", () => {
       assistantId: "a1",
       traits: null,
     });
+  });
+
+  test("stashes when the org holds exactly one assistant", () => {
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "a1",
+      assistants: [assistant("a1")],
+    });
+    seed("a1", {
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+      customImageUrl: null,
+    });
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toMatchObject({ assistantId: "a1" });
+  });
+
+  test("clears instead of stashing when a second assistant exists", () => {
+    // The takeover targets the onboarding payload's primary, which need not be
+    // the active assistant, and it draws before that target resolves.
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "a1",
+      assistants: [assistant("a1"), assistant("a2")],
+    });
+    seed("a1", {
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+      customImageUrl: null,
+    });
+    preexistingStash();
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toBeNull();
   });
 
   test("clears a pre-existing stash when there is no active assistant", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
@@ -14,6 +14,11 @@ import { isCharacterTraits } from "@/types/avatar";
  * Stored in sessionStorage (per-tab, survives the Stripe redirect round-trip,
  * dies with the tab) under a 30-minute TTL: a checkout abandoned longer than
  * that shouldn't resurface as a phantom avatar.
+ *
+ * Only ever a single-assistant org's snapshot, since
+ * {@link captureTakeoverAvatarStash} skips orgs holding more than one. That is
+ * what lets the takeover draw it before the target assistant resolves: with
+ * one creature in the org there is no other one it could be aiming at.
  */
 export interface TakeoverAvatarStash {
   assistantId: string;
@@ -46,11 +51,26 @@ const MAX_AGE_MS = 30 * 60 * 1000;
  */
 let inMemoryStash: TakeoverAvatarStash | null = null;
 
+/**
+ * Bumped by every write, so a reader that snapshotted the stash can tell its
+ * copy went stale. Needed because native checkout hands off to an external
+ * browser without unloading the document: the takeover's host is already
+ * mounted when the stash is written, so a once-per-mount read would keep
+ * serving the null it saw before the hand-off.
+ */
+let version = 0;
+
+/** @see {@link version} */
+export function takeoverAvatarStashVersion(): number {
+  return version;
+}
+
 export function saveTakeoverAvatarStash(
   stash: Omit<TakeoverAvatarStash, "savedAt">,
 ): void {
   const stamped: TakeoverAvatarStash = { ...stash, savedAt: Date.now() };
   inMemoryStash = stamped;
+  version += 1;
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stamped));
   } catch {
@@ -97,6 +117,7 @@ export function readTakeoverAvatarStash(): TakeoverAvatarStash | null {
 
 export function clearTakeoverAvatarStash(): void {
   inMemoryStash = null;
+  version += 1;
   try {
     sessionStorage.removeItem(STORAGE_KEY);
   } catch {
@@ -111,10 +132,18 @@ export function clearTakeoverAvatarStash(): void {
  * Every Stripe redirect site calls this, and every call either writes a fresh
  * stash or removes a stale one, so a previous user's (or a previous avatar's)
  * stash can never ride along with a new checkout.
+ *
+ * Orgs holding more than one assistant are skipped: the takeover draws the
+ * onboarding payload's primary, which need not be the active one, and it draws
+ * before that target resolves. Capturing only where the two cannot disagree
+ * costs those orgs the instant avatar and buys the guarantee outright.
  */
 export function captureTakeoverAvatarStash(queryClient: QueryClient): void {
-  const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
-  if (!assistantId) {
+  const { activeAssistantId: assistantId, assistants } =
+    useResolvedAssistantsStore.getState();
+  // Cross-org entries count too: overcounting only forfeits the instant
+  // avatar, undercounting draws the wrong creature.
+  if (!assistantId || assistants.length > 1) {
     clearTakeoverAvatarStash();
     return;
   }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
@@ -261,6 +261,26 @@ describe("avatar stash", () => {
     expect(result.current.tintHex.toLowerCase()).toBe(ORANGE_SURFACE);
   });
 
+  test("picks up a stash written after the hook already mounted", () => {
+    // The native return: checkout opens an external browser, so the billing
+    // modal hosting this hook is mounted (and already read an empty stash)
+    // before the redirect writes one.
+    avatar.isLoading = true;
+
+    const { rerender, result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+    expect(result.current.ready).toBe(false);
+    expect(result.current.tintHex).toBe(SURFACE_GROUND);
+
+    seedStash("primary-assistant", "purple");
+    rerender();
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.avatar.traits).toEqual(traits("purple"));
+    expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
+  });
+
   test("a settle with no data at all keeps the stash", () => {
     // The daemon erroring while the machine restarts settles the query empty.
     // The stashed creature beats falling through to the bundled green one.

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
@@ -27,15 +27,30 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
     avatarQueryId = assistantId;
     return { ...avatar, invalidate: () => {} };
   },
+  avatarQueryKey: (assistantId: string) => ["assistantAvatar", assistantId],
 }));
 
 const { useTakeoverSurface } = await import("./use-takeover-surface");
+// Dynamic like the hook above: a static import is hoisted over `mock.module`,
+// which would load the real avatar hook that the stash module imports.
+const { clearTakeoverAvatarStash, saveTakeoverAvatarStash } = await import(
+  "./takeover-avatar-stash"
+);
 
 const GREEN_SURFACE = "#1d281d";
 const PURPLE_SURFACE = "#29202e";
+const ORANGE_SURFACE = "#332019";
 
 function traits(color: string): CharacterTraits {
   return { bodyShape: "blob", eyeStyle: "default", color };
+}
+
+function seedStash(assistantId: string, color: string): void {
+  saveTakeoverAvatarStash({
+    assistantId,
+    components: BUNDLED_COMPONENTS,
+    traits: traits(color),
+  });
 }
 
 beforeEach(() => {
@@ -47,6 +62,7 @@ beforeEach(() => {
     isLoading: false,
   };
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  clearTakeoverAvatarStash();
 });
 
 describe("target selection", () => {
@@ -175,5 +191,87 @@ describe("resolved surfaces", () => {
     expect(result.current.ready).toBe(true);
     expect(result.current.tintHex.toLowerCase()).toBe(GREEN_SURFACE);
     expect(result.current.backdropImageUrl).toBeNull();
+  });
+});
+
+describe("avatar stash", () => {
+  test("draws the stash while the live query is still in flight", () => {
+    seedStash("primary-assistant", "purple");
+    avatar.isLoading = true;
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.avatar).toEqual({
+      components: BUNDLED_COMPONENTS,
+      traits: traits("purple"),
+      customImageUrl: null,
+    });
+    expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
+    expect(result.current.backdropImageUrl).toBeNull();
+  });
+
+  test("an unnamed target draws the stash rather than withholding", () => {
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "active-assistant",
+    });
+    seedStash("primary-assistant", "purple");
+
+    const { result } = renderHook(() => useTakeoverSurface(null));
+
+    expect(avatarQueryId).toBeNull();
+    expect(result.current.ready).toBe(true);
+    expect(result.current.avatar.traits).toEqual(traits("purple"));
+    expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
+  });
+
+  test("a stash for another assistant never draws", () => {
+    seedStash("other-assistant", "purple");
+    avatar.isLoading = true;
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.ready).toBe(false);
+    expect(result.current.tintHex).toBe(SURFACE_GROUND);
+    expect(result.current.avatar.components).toBeNull();
+  });
+
+  test("live data replaces the stash the moment it lands", () => {
+    seedStash("primary-assistant", "purple");
+    avatar.isLoading = true;
+
+    const { rerender, result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+    expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
+
+    avatar = {
+      components: BUNDLED_COMPONENTS,
+      traits: traits("orange"),
+      customImageUrl: null,
+      isLoading: false,
+    };
+    rerender();
+
+    expect(result.current.avatar.traits).toEqual(traits("orange"));
+    expect(result.current.tintHex.toLowerCase()).toBe(ORANGE_SURFACE);
+  });
+
+  test("a settle with no data at all keeps the stash", () => {
+    // The daemon erroring while the machine restarts settles the query empty.
+    // The stashed creature beats falling through to the bundled green one.
+    seedStash("primary-assistant", "purple");
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.avatar.traits).toEqual(traits("purple"));
+    expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -5,10 +7,13 @@ import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { SURFACE_GROUND, avatarSurfaceHex } from "@/utils/avatar-tone";
 
+import { readTakeoverAvatarStash } from "./takeover-avatar-stash";
+
 /**
- * The target assistant's raw avatar payload, for drawing the creature itself.
- * Ungated: every field carries whatever the query holds right now, so a
- * consumer must render it only inside a {@link TakeoverSurface.ready} branch.
+ * The avatar payload the takeover draws: the live query's once it lands, or the
+ * stash captured at the Stripe hand-off while it resolves.
+ * Ungated: every field carries whatever was chosen right now, so a consumer
+ * must render it only inside a {@link TakeoverSurface.ready} branch.
  */
 export interface TakeoverAvatarInputs {
   components: CharacterComponents | null;
@@ -26,7 +31,7 @@ export interface TakeoverSurface {
    * {@link TakeoverAvatarInputs.customImageUrl}.
    */
   backdropImageUrl: string | null;
-  /** The target resolved and its avatar query settled — safe to draw. */
+  /** Safe to draw: the avatar query settled, or a usable stash stands in. */
   ready: boolean;
   /** Render inputs for the avatar, valid only once `ready`. */
   avatar: TakeoverAvatarInputs;
@@ -37,10 +42,13 @@ export interface TakeoverSurface {
  * it draws, that avatar's render inputs, and the paint derived from it — a deep
  * tint of the character accent, or the custom image to blur behind the content.
  *
- * The surface stays on the hue-neutral {@link SURFACE_GROUND} and withholds the
- * avatar until the query settles. `ChatAvatar` synthesizes fallback traits from
- * the first bundled color, so drawing before the fetch resolves paints green
- * and then jumps to the assistant's real color at full-viewport scale.
+ * Three tiers decide what is drawable, in order: the live avatar query once it
+ * settles with data, else the stash captured at the Stripe hand-off (only for
+ * the same assistant), else nothing. Withholding matters because `ChatAvatar`
+ * synthesizes fallback traits from the first bundled color, so drawing an
+ * unknown avatar paints green and then jumps to the assistant's real color at
+ * full-viewport scale. Until something is drawable the surface stays on the
+ * hue-neutral {@link SURFACE_GROUND}.
  */
 export function useTakeoverSurface(
   assistantId?: string | null,
@@ -53,24 +61,51 @@ export function useTakeoverSurface(
   const resolvedId = assistantId === undefined ? activeId : assistantId;
   const { components, traits, customImageUrl, isLoading } =
     useAssistantAvatar(resolvedId);
+  // Per-mount is enough: the stash is written immediately before a full-page
+  // navigation to Stripe, so every surface that could draw it mounts after.
+  const [stash] = useState(readTakeoverAvatarStash);
+
   // `useAssistantAvatar(null)` is a disabled query, which reports
-  // `isLoading: false` with no data, so the id has to gate readiness too.
-  const ready = resolvedId != null && !isLoading;
+  // `isLoading: false` with no data, so the id has to gate settling too.
+  const liveSettled = resolvedId != null && !isLoading;
+  // While the provisioning hook has not named a target the stash may stand in;
+  // once one resolves, only a matching stash may draw. Either way the wrong
+  // assistant never reaches the screen.
+  const stashUsable =
+    stash != null && (resolvedId == null || resolvedId === stash.assistantId);
+  const liveDrawable =
+    liveSettled &&
+    (components != null || traits != null || customImageUrl != null);
+  // Live data wins the moment it lands. A settle that comes back empty (the
+  // daemon erroring while the machine restarts) keeps the stash, which is
+  // strictly more truthful than the bundled-green fallback.
+  const drawnStash = stashUsable && !liveDrawable ? stash : null;
+
+  const effectiveComponents = drawnStash ? drawnStash.components : components;
+  const effectiveTraits = drawnStash ? drawnStash.traits : traits;
+  // The stash never carries an image: a blob URL is dead after the reload.
+  const effectiveCustomImageUrl = drawnStash ? null : customImageUrl;
+  const ready = liveSettled || stashUsable;
 
   const accent =
-    resolveAvatarAccentHex(components, traits) ??
+    resolveAvatarAccentHex(effectiveComponents, effectiveTraits) ??
     // ChatAvatar draws from `components ?? bundled`, so the surface tints from
     // the same source it does — the first bundled color when the query settles
     // with none — and matches whatever creature is on screen instead of falling
     // through to neutral.
-    (customImageUrl
+    (effectiveCustomImageUrl
       ? null
-      : ((components ?? BUNDLED_COMPONENTS).colors?.[0]?.hex ?? null));
+      : ((effectiveComponents ?? BUNDLED_COMPONENTS).colors?.[0]?.hex ?? null));
 
   return {
     tintHex: ready && accent ? avatarSurfaceHex(accent) : SURFACE_GROUND,
-    backdropImageUrl: ready ? customImageUrl : null,
+    // The stash carries no image, so only a live settle can supply a backdrop.
+    backdropImageUrl: liveSettled ? customImageUrl : null,
     ready,
-    avatar: { components, traits, customImageUrl },
+    avatar: {
+      components: effectiveComponents,
+      traits: effectiveTraits,
+      customImageUrl: effectiveCustomImageUrl,
+    },
   };
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo } from "react";
 
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
@@ -7,7 +7,10 @@ import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { SURFACE_GROUND, avatarSurfaceHex } from "@/utils/avatar-tone";
 
-import { readTakeoverAvatarStash } from "./takeover-avatar-stash";
+import {
+  readTakeoverAvatarStash,
+  takeoverAvatarStashVersion,
+} from "./takeover-avatar-stash";
 
 /**
  * The avatar payload the takeover draws: the live query's once it lands, or the
@@ -61,16 +64,23 @@ export function useTakeoverSurface(
   const resolvedId = assistantId === undefined ? activeId : assistantId;
   const { components, traits, customImageUrl, isLoading } =
     useAssistantAvatar(resolvedId);
-  // Per-mount is enough: the stash is written immediately before a full-page
-  // navigation to Stripe, so every surface that could draw it mounts after.
-  const [stash] = useState(readTakeoverAvatarStash);
+  // Tracking the version, not just mounting once: native checkout opens an
+  // external browser without unloading the page, so the billing modal hosting
+  // this hook is already mounted when the stash is written. Re-reading on the
+  // takeover's open flip is enough; no subscription needed.
+  const stashVersion = takeoverAvatarStashVersion();
+  // Memoized so a sessionStorage re-parse can't hand the avatar a new
+  // `components` identity every render.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- the version IS the dep; it stands in for the module state the read touches
+  const stash = useMemo(() => readTakeoverAvatarStash(), [stashVersion]);
 
   // `useAssistantAvatar(null)` is a disabled query, which reports
   // `isLoading: false` with no data, so the id has to gate settling too.
   const liveSettled = resolvedId != null && !isLoading;
-  // While the provisioning hook has not named a target the stash may stand in;
-  // once one resolves, only a matching stash may draw. Either way the wrong
-  // assistant never reaches the screen.
+  // While the provisioning hook has not named a target the stash may stand in,
+  // safe because a stash is only ever captured in a single-assistant org, so
+  // there is no second creature the unresolved target could turn out to be.
+  // Once a target does resolve, only a matching stash may draw.
   const stashUsable =
     stash != null && (resolvedId == null || resolvedId === stash.assistantId);
   const liveDrawable =


### PR DESCRIPTION
## Summary
- useTakeoverSurface draws the stashed avatar (identity-guarded) while the live query resolves; live data wins the moment it lands
- Tint derives from the same accent path; backdrop stays live-gated
- Four sibling suites that mock `@/hooks/use-assistant-avatar` gained the existing one-line `avatarQueryKey` stub, since the stash module now sits in their import graph (same stub `seed-hatch-avatar.test.ts` and `voice-room.test.tsx` already use). No assertions changed.

Part of plan: instant-takeover-avatar.md (PR 2 of 5)