### PR TITLE
feat(web): capture the takeover avatar stash before every Stripe redirect

### DIFF
--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -22,6 +22,8 @@ import * as platformGateMod from "@/hooks/use-platform-gate";
 import type { PlatformGateStateWithPending } from "@/hooks/use-platform-gate";
 import * as takeoverMod from "@/hooks/use-marketing-pricing-takeover";
 import type { MarketingPricingTakeoverState } from "@/hooks/use-marketing-pricing-takeover";
+import type { CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
 const INTENT_KEY = "vellum.pro-checkout-intent";
@@ -112,7 +114,33 @@ mock.module("@/hooks/use-marketing-pricing-takeover", () => ({
 }));
 
 const { useOrganizationStore } = await import("@/stores/organization-store");
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
+const { avatarQueryKey } = await import("@/hooks/use-assistant-avatar");
+const {
+  clearTakeoverAvatarStash,
+  readTakeoverAvatarStash,
+  saveTakeoverAvatarStash,
+} = await import("./pro-onboarding/takeover-avatar-stash");
 const { CheckoutPage } = await import("./checkout-page");
+
+const AVATAR_TRAITS: CharacterTraits = {
+  bodyShape: "blob",
+  eyeStyle: "default",
+  color: "purple",
+};
+
+/**
+ * The cached avatar the hand-off snapshots. The live query key appends a
+ * `supportsManifest` boolean, so the seed has to carry one too.
+ */
+function seedCachedAvatar(client: QueryClient, assistantId: string) {
+  client.setQueryData([...avatarQueryKey(assistantId), true], {
+    components: BUNDLED_COMPONENTS,
+    traits: AVATAR_TRAITS,
+    customImageUrl: null,
+  });
+}
 
 function LocationProbe() {
   const location = useLocation();
@@ -179,6 +207,9 @@ beforeEach(() => {
   heldUpgrade = null;
   upgradeData = { status: "redirect", checkout_url: CHECKOUT_URL, message: "" };
   sessionStorage.removeItem(INTENT_KEY);
+  // Also resets the stash module's in-memory mirror, which outlives storage.
+  clearTakeoverAvatarStash();
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
 
 afterEach(() => {
@@ -186,8 +217,11 @@ afterEach(() => {
 });
 
 describe("CheckoutPage", () => {
-  test("valid package + full gate fires the upgrade, stashes intent, opens Stripe", async () => {
-    renderCheckout("/assistant/checkout?package=super");
+  test("valid package + full gate fires the upgrade, stashes intent and avatar, opens Stripe", async () => {
+    const client = freshQueryClient();
+    seedCachedAvatar(client, "a1");
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    render(checkoutTree("/assistant/checkout?package=super", client));
 
     await waitFor(() => expect(upgradeCalls.length).toBe(1));
     expect(upgradeCalls[0]!.body).toEqual({
@@ -206,6 +240,9 @@ describe("CheckoutPage", () => {
       kind: "package",
       packageKey: "super",
     });
+    // The avatar goes with it, so the post-checkout takeover can draw the
+    // creature on a cold return instead of holding an empty stage.
+    expect(readTakeoverAvatarStash()?.assistantId).toBe("a1");
   });
 
   test("holds the upgrade while org is resolving, then fires once it hydrates", async () => {
@@ -281,6 +318,11 @@ describe("CheckoutPage", () => {
       packageKey: "super",
       resumeAfterOnboarding: true,
     });
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: AVATAR_TRAITS,
+    });
     const { getByTestId } = renderCheckout("/assistant/checkout?package=super");
 
     await waitFor(() => expect(upgradeCalls.length).toBe(1));
@@ -289,6 +331,9 @@ describe("CheckoutPage", () => {
     );
     expect(openedUrl).toBeNull();
     expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+    // The avatar snapshot is stashed for a checkout return that is no longer
+    // coming, so it goes out with the intent.
+    expect(readTakeoverAvatarStash()).toBeNull();
   });
 
   test("an error renders the retry UI, and Try again re-fires the upgrade", async () => {

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -2,8 +2,12 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import {
+  captureTakeoverAvatarStash,
+  clearTakeoverAvatarStash,
+} from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
 import { organizationsBillingSubscriptionUpgradeCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
 import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
@@ -108,6 +112,7 @@ export function CheckoutPage() {
   const bailLabel =
     bailTarget === routes.plans ? "View plans" : "Continue setup";
 
+  const queryClient = useQueryClient();
   const { mutateAsync } = useMutation(
     organizationsBillingSubscriptionUpgradeCreateMutation(),
   );
@@ -152,6 +157,8 @@ export function CheckoutPage() {
         // Stash the selection so the post-checkout provisioning screen can show
         // the purchased package before the subscribe webhook lands.
         saveCheckoutIntent({ kind: "package", packageKey });
+        // Snapshot the avatar so the takeover can draw it on a cold return.
+        captureTakeoverAvatarStash(queryClient);
         setAwaitingReturn(returnTarget === "native");
         void openUrl(result.checkout_url);
         return;
@@ -161,6 +168,7 @@ export function CheckoutPage() {
       // off rather than stranding the user on a blank splash.
       phaseRef.current = "settled";
       clearCheckoutIntent();
+      clearTakeoverAvatarStash();
       navigate(bailTarget, { replace: true });
     } catch {
       if (phaseRef.current !== "running") {
@@ -169,7 +177,7 @@ export function CheckoutPage() {
       phaseRef.current = "settled";
       setFailed(true);
     }
-  }, [bailTarget, mutateAsync, navigate, packageKey]);
+  }, [bailTarget, mutateAsync, navigate, packageKey, queryClient]);
 
   // The retry the failure and hand-off UIs offer. A failed or abandoned attempt
   // re-runs the upgrade; a missing organization re-runs org resolution instead,

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -35,6 +35,13 @@ import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
 import * as platformGateMod from "@/hooks/use-platform-gate";
 import * as toastMod from "@vellumai/design-library/components/toast";
+import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import {
+  clearTakeoverAvatarStash,
+  readTakeoverAvatarStash,
+} from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
 import {
   organizationsBillingPlansRetrieveQueryKey,
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
@@ -513,14 +520,18 @@ function renderInteractive(
     organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
     onboardingData,
   );
-  return render(
-    <MemoryRouter initialEntries={["/assistant/plans"]}>
-      <QueryClientProvider client={client}>
-        <PlansPage />
-      </QueryClientProvider>
-      <LocationProbe />
-    </MemoryRouter>,
-  );
+  return {
+    // Exposed so the checkout test can seed the avatar cache the stash reads.
+    client,
+    ...render(
+      <MemoryRouter initialEntries={["/assistant/plans"]}>
+        <QueryClientProvider client={client}>
+          <PlansPage />
+        </QueryClientProvider>
+        <LocationProbe />
+      </MemoryRouter>,
+    ),
+  };
 }
 
 beforeEach(() => {
@@ -544,6 +555,9 @@ beforeEach(() => {
   onboardingFixture = null;
   toastSuccessCalls.length = 0;
   takeoverResizeCredits = undefined;
+  // The stash and the assistants store are module-level globals, so reset both.
+  clearTakeoverAvatarStash();
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
 
 afterEach(() => {
@@ -683,7 +697,13 @@ describe("PlansPage — Pro package switch (change-package)", () => {
   });
 
   test("base user CTA starts Stripe checkout, not change-package", async () => {
-    const { findByRole } = renderInteractive(freeSubscription());
+    const { client, findByRole } = renderInteractive(freeSubscription());
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    client.setQueryData([...avatarQueryKey("a1"), true], {
+      components: BUNDLED_COMPONENTS,
+      traits: null,
+      customImageUrl: null,
+    });
 
     fireEvent.click(await findByRole("button", { name: "Go Super" }));
 
@@ -695,6 +715,8 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     });
     await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
     expect(changePackageCall).toBeNull();
+    // The redirect snapshots the avatar so the takeover can draw it on return.
+    expect(readTakeoverAvatarStash()?.assistantId).toBe("a1");
   });
 
   test("the confirm CTA is disabled while a switch is pending", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -34,6 +34,7 @@ import {
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
+import { captureTakeoverAvatarStash } from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
 import { findCreditTier } from "@/domains/settings/billing/pro-onboarding/use-provisioning-credits";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
@@ -295,6 +296,8 @@ export function PlansPage() {
                 creditTier: body.credit_tier ?? null,
               },
         );
+        // Snapshot the avatar so the takeover can draw it on a cold return.
+        captureTakeoverAvatarStash(queryClient);
         openUrl(result.checkout_url);
       } else {
         await queryClient.invalidateQueries({

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -31,6 +31,7 @@ import type {
   PlanListResponse,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
+import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
 import { readCheckoutIntent, saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
@@ -64,6 +65,7 @@ let avatarComponents: CharacterComponents | null = null;
 let avatarTraits: CharacterTraits | null = null;
 let avatarCustomImageUrl: string | null = null;
 mock.module("@/hooks/use-assistant-avatar", () => ({
+  ...assistantAvatarMod,
   useAssistantAvatar: () => ({
     components: avatarComponents,
     traits: avatarTraits,
@@ -285,6 +287,11 @@ const { BillingOnboardingModal } = await import("./billing-onboarding-modal");
 const { TAKEOVER_SURFACE, TAKEOVER_SURFACE_VAR } = await import(
   "./provisioning-state"
 );
+const {
+  clearTakeoverAvatarStash,
+  readTakeoverAvatarStash,
+  saveTakeoverAvatarStash,
+} = await import("./takeover-avatar-stash");
 
 /**
  * Fast celebration dwell. Long enough for waitFor (50ms polls) to reliably
@@ -351,6 +358,9 @@ beforeEach(() => {
   dateNowOffsetMs = 0;
   toastInfoCalls.length = 0;
   sessionStorage.clear();
+  // Resets the stash module's in-memory mirror, which sessionStorage.clear()
+  // leaves behind.
+  clearTakeoverAvatarStash();
 });
 
 afterEach(() => {
@@ -419,8 +429,13 @@ describe("BillingOnboardingModal", () => {
     expect(queryByText("Super package")).toBeNull();
   });
 
-  test("domain_setup_available false skips straight to complete and clears the intent stash", async () => {
+  test("domain_setup_available false skips straight to complete and clears the intent and avatar stashes", async () => {
     saveCheckoutIntent({ kind: "package", packageKey: "super" });
+    saveTakeoverAvatarStash({
+      assistantId: "assistant-1",
+      components: BUNDLED_COMPONENTS,
+      traits: null,
+    });
     subscriptionPlanId = "pro";
     onboardingResponse = makeOnboarding({ domain_setup_available: false });
     const { client, getByText, queryByText } = renderModal();
@@ -443,6 +458,7 @@ describe("BillingOnboardingModal", () => {
     });
     expect(queryByText("Assistant Email")).toBeNull();
     expect(readCheckoutIntent()).toBeNull();
+    expect(readTakeoverAvatarStash()).toBeNull();
     // Checkout mode never fires the modal-level domains query.
     expect(domainsCalls).toBe(0);
   });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -31,6 +31,7 @@ import {
   TAKEOVER_SURFACE,
   TAKEOVER_SURFACE_VAR,
 } from "./provisioning-state";
+import { clearTakeoverAvatarStash } from "./takeover-avatar-stash";
 import { TakeoverBackdrop } from "./takeover-backdrop";
 import { useAssistantDomains } from "./use-assistant-domains";
 import { useProProvisioning } from "./use-pro-provisioning";
@@ -147,7 +148,10 @@ export function BillingOnboardingModal({
   );
 
   useEffect(() => {
-    if (step === "complete") clearCheckoutIntent();
+    if (step === "complete") {
+      clearCheckoutIntent();
+      clearTakeoverAvatarStash();
+    }
   }, [step]);
 
   // Domain/email/guardian registration must run while the assistant's machine

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -86,9 +86,16 @@ mock.module("@/runtime/browser", () => ({
 }));
 
 import {
+  clearTakeoverAvatarStash,
+  readTakeoverAvatarStash,
+} from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
+import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import {
   clearCheckoutIntent,
   readCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { AdjustPlanModal } from "./adjust-plan-modal";
 
 const CREDIT_TIERS: CreditTier[] = [
@@ -265,6 +272,8 @@ beforeEach(() => {
   // The stash also keeps an in-memory mirror, so clearing sessionStorage alone
   // leaves a prior test's intent readable.
   clearCheckoutIntent();
+  clearTakeoverAvatarStash();
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
 
 afterEach(() => {
@@ -311,10 +320,17 @@ describe("AdjustPlanModal credit bundle — upgrade", () => {
 describe("AdjustPlanModal upgrade — checkout intent stash", () => {
   test("stashes the selected tiers before redirecting to Stripe checkout", async () => {
     upgradeResponse = { checkout_url: "https://checkout.example.com/session" };
-    const { getByTestId } = renderModal(
+    const { getByTestId, client } = renderModal(
       subscription("base", null),
       proPlansResponse(CREDIT_TIERS),
     );
+    // The live avatar key appends a `supportsManifest` boolean.
+    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    client.setQueryData([...avatarQueryKey("a1"), true], {
+      components: BUNDLED_COMPONENTS,
+      traits: { bodyShape: "blob", eyeStyle: "default", color: "purple" },
+      customImageUrl: null,
+    });
 
     fireEvent.click(getByTestId("modal-upgrade-to-pro-button"));
 
@@ -332,6 +348,9 @@ describe("AdjustPlanModal upgrade — checkout intent stash", () => {
       storageTier: "storage_10",
       creditTier: null,
     });
+    // The avatar snapshot rides along so the takeover can draw it on a cold
+    // return, before the live avatar query resolves.
+    expect(readTakeoverAvatarStash()?.assistantId).toBe("a1");
   });
 
   test("does not stash when the upgrade response has no checkout URL", async () => {

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { captureTakeoverAvatarStash } from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
 import {
     buildPortalReturnSnapshot,
     formatGraceDate,
@@ -244,6 +245,8 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
               storageTier: selectedStorageTier,
               creditTier: displayCreditTier,
             });
+            // Snapshot the avatar so the takeover can draw it on a cold return.
+            captureTakeoverAvatarStash(queryClient);
             void openUrl(data.checkout_url);
             return;
           }

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -45,6 +45,7 @@ import {
   makeSuperPackage,
   makeUltraPackage,
 } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
+import * as takeoverAvatarStash from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
 import { routes } from "@/utils/routes";
 
 // Capture navigate() targets so the action-button wiring can be asserted
@@ -156,6 +157,19 @@ mock.module("@/runtime/browser", () => ({
   },
   openUrlFinishedListener: () => () => {},
 }));
+
+// Count the avatar snapshot the checkout redirect takes; the real capture reads
+// the resolved-assistants store, which these DOM tests never drive.
+let captureStashCalls = 0;
+mock.module(
+  "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash",
+  () => ({
+    ...takeoverAvatarStash,
+    captureTakeoverAvatarStash: () => {
+      captureStashCalls += 1;
+    },
+  }),
+);
 
 const { PlanCard } = await import("./plan-card");
 
@@ -457,6 +471,8 @@ beforeEach(() => {
   changeStorageTierCall = null;
   onboardingResponse = {};
   toastSuccessCalls = [];
+  captureStashCalls = 0;
+  takeoverAvatarStash.clearTakeoverAvatarStash();
 });
 
 afterEach(() => {
@@ -1297,6 +1313,8 @@ describe("PlanCard recommended upgrade — change-package", () => {
       }
     });
     expect(openedUrl).toBe("https://checkout.example.com/session");
+    // The redirect snapshots the avatar so the takeover can draw it on return.
+    expect(captureStashCalls).toBe(1);
     expect(upgradeCall?.body).toMatchObject({
       target_plan_id: "pro",
       package: "mighty",

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -25,6 +25,7 @@ import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/pack
 import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
 import { packageSpecs } from "@/domains/settings/billing/plan-spec";
 import { PlanSpecCard } from "@/domains/settings/billing/plan-spec-card";
+import { captureTakeoverAvatarStash } from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
 import {
   formatGraceDate,
@@ -270,6 +271,8 @@ function RecommendedUpgrade({
           kind: "package",
           packageKey: recommended.key,
         });
+        // Snapshot the avatar so the takeover can draw it on a cold return.
+        captureTakeoverAvatarStash(queryClient);
         // Stripe returns with a `session_id`, which opens the
         // post-checkout Pro onboarding wizard — via the billing page on
         // web, via the `billing/checkout-complete` deep link on macOS.


### PR DESCRIPTION
## Summary
- captureTakeoverAvatarStash fires beside saveCheckoutIntent at all four Stripe redirect sites (checkout page, plans page, plan card, adjust modal)
- Stash cleared with the checkout intent (wizard complete, no_op bail)

Part of plan: instant-takeover-avatar.md (PR 4 of 5)