### PR TITLE
fix(routes): resolve the config wire overlay and echo-stripping provider-aware

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1197,6 +1197,59 @@ describe("code-owned default profiles — wire view and write normalization", ()
   });
 });
 
+describe("code-owned default profiles — BYO default provider wire view", () => {
+  // With llm.defaultProvider set, the wire view must show the column of the
+  // intent × provider matrix that actually dispatches — not the vellum
+  // column — and the write path must echo-strip against that same view or an
+  // honest GET → write round-trip is rejected.
+  test("GET materializes the default provider's column for default profiles", async () => {
+    seedRawConfig({
+      llm: { defaultProvider: { provider: "anthropic" }, profiles: {} },
+    });
+    const response = (await getRoute.handler({})) as Record<string, any>;
+    const wireBalanced = response.llm.profiles.balanced;
+    expect(wireBalanced.provider).toBe("anthropic");
+    expect(wireBalanced.model).toBe("claude-sonnet-4-6");
+    expect(wireBalanced.provider_connection).toBe("anthropic-personal");
+    expect(response.llm.profiles["quality-optimized"].provider).toBe(
+      "anthropic",
+    );
+  });
+
+  test("GET → PATCH round-trip of the BYO wire view is accepted and keeps disk stubs thin", async () => {
+    seedRawConfig({
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        profiles: { balanced: { source: "managed", status: "disabled" } },
+      },
+    });
+    const response = (await getRoute.handler({})) as Record<string, any>;
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: response.llm.profiles } },
+    });
+    expect(result).toHaveProperty("llm");
+    expectOneCommitCycle();
+    expect(savedProfile("balanced")).toEqual({
+      source: "managed",
+      status: "disabled",
+    });
+    // Echoes of absent defaults reduce to a no-op managed stub.
+    expect(savedProfile("quality-optimized")).toEqual({ source: "managed" });
+  });
+
+  test("GET → SET llm round-trip of the BYO wire view is accepted", async () => {
+    seedRawConfig({
+      llm: { defaultProvider: { provider: "anthropic" }, profiles: {} },
+    });
+    const response = (await getRoute.handler({})) as Record<string, any>;
+    const result = await setRoute.handler({
+      body: { path: "llm", value: response.llm },
+    });
+    expect(result).toHaveProperty("ok");
+    expect(savedProfile("balanced")).toEqual({ source: "managed" });
+  });
+});
+
 describe("code-owned default profiles — leaf SET source stamping", () => {
   test("a leaf SET creating a managed entry stamps the managed marker", async () => {
     seedRawConfig({ llm: { profiles: {} } });

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -140,10 +140,10 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
 };
 
 import {
-  getEffectiveProfile,
-  getEffectiveProfiles,
+  getEffectiveProfilesForProvider,
   INVARIANT_PROFILE_NAMES,
   MANAGED_PROFILE_NAMES,
+  resolveDefaultProfileForProvider,
 } from "../../config/default-profile-catalog.js";
 import { DEFAULT_PROFILE_KEYS } from "../../config/default-profile-names.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -851,10 +851,20 @@ function handleGetConfig() {
  * profile view (code-catalog default bodies + workspace overlays). Default
  * profile CONTENT is code-owned and the workspace holds at most a thin stub,
  * but clients (settings UI, sticky-profile pickers) need the full bodies to
- * render labels/models — so the wire view materializes them. Wire-only:
+ * render labels/models — so the wire view materializes them, resolved through
+ * `llm.defaultProvider`'s column of the intent × provider matrix so a BYO
+ * install sees the provider/model that actually dispatches. Wire-only:
  * `normalizeManagedProfileWrites` reduces echoed bodies back to the
  * workspace-owned fields on the write paths, so a `config get` →
- * `config set` round-trip never persists catalog content.
+ * `config set` round-trip never persists catalog content — the two must
+ * resolve through the same column or honest round-trips are rejected.
+ *
+ * `defaultProvider` deliberately comes from the parsed config, not the raw
+ * object this function mutates: the schema's `.catch(undefined)` shields the
+ * matrix lookup from an invalid persisted value, which a raw read would feed
+ * straight into resolution. The raw profiles and the cached parse cannot
+ * disagree on `defaultProvider` — every write path that touches it
+ * invalidates the config cache.
  */
 function overlayEffectiveProfilesForWire(config: unknown): void {
   const root = readPlainObject(config);
@@ -866,8 +876,9 @@ function overlayEffectiveProfilesForWire(config: unknown): void {
   if (!existingLlm) {
     root.llm = llm;
   }
-  llm.profiles = getEffectiveProfiles(
+  llm.profiles = getEffectiveProfilesForProvider(
     readPlainObject(llm.profiles) as Record<string, ProfileEntry> | undefined,
+    getConfig().llm.defaultProvider ?? null,
   );
 }
 
@@ -999,8 +1010,15 @@ export function normalizeManagedProfileWrites(patch: unknown): void {
       continue;
     }
 
+    // Must resolve through the same provider column as
+    // `overlayEffectiveProfilesForWire`, or an echo of the wire view would
+    // not match `effective` and an honest round-trip would be rejected.
     const effective = readPlainObject(
-      getEffectiveProfile(currentProfiles, name),
+      resolveDefaultProfileForProvider(
+        currentProfiles,
+        name,
+        getConfig().llm.defaultProvider ?? null,
+      ),
     );
     for (const key of Object.keys(entry)) {
       if (key === "source" || key === "status") {
@@ -1733,7 +1751,11 @@ async function handleReplaceInferenceProfile({
     }
     // Validate arms against the effective view (matches the resolver and
     // `LLMSchema.superRefine`), not the raw workspace record.
-    const existingProfiles = getEffectiveProfiles(getConfig().llm.profiles);
+    const { llm: parsedLlm } = getConfig();
+    const existingProfiles = getEffectiveProfilesForProvider(
+      parsedLlm.profiles,
+      parsedLlm.defaultProvider ?? null,
+    );
     parsed.data.mix.forEach((arm, index) => {
       if (arm.profile === name) {
         throw new BadRequestError(


### PR DESCRIPTION
## TL;DR

The user-facing fix of the BYO profile-resolution consolidation ([plan papertrail on PR 1, #39392](https://github.com/vellum-ai/vellum-assistant/pull/39392)). Background: the default profiles (Balanced/Quality/Speed) resolve to a concrete provider+model in two possible ways — the **managed body** (what a Vellum-managed install runs) or the **BYO body** for the user's own default provider (what a bring-your-own-key install runs). Dispatch already picks the right one per install. But `config_get` — the web client's **only** source of profile data — always reported the managed body. So on a BYO install, the settings UI described models the install never runs. This PR makes the config wire view (and its write-path counterpart) report the same body dispatch uses.

## What this does NOT change

- **Which model any request runs on. Anywhere, for anyone.** Dispatch is untouched; this changes what's *reported*, to match what already *runs*.
- **Anything at all on managed installs.** With no BYO default provider (or one explicitly set to Vellum), the new resolution returns a byte-identical body — verified for both cases, and pinned by the 75 pre-existing guard tests passing unchanged.

## What changes (BYO installs only)

| Scenario | Before | After |
|---|---|---|
| Manage Profiles modal | Defaults show the managed body, e.g. "GLM 5.2 hosted by Vellum" on an install whose Balanced actually runs Claude via the user's Anthropic key | Shows the provider/model that actually runs |
| Attaching an image | The client's vision gate judges the managed model's vision capability — can wrongly block or allow image attachments (client-side sibling of #39392) | Judges the model that actually runs |
| `assistant config get` → `config set` round-trip | Works (read and write sides both used the managed body, consistently) | Works (both sides now use the install-aware body, consistently) |

## Why the read and write sides move together

`normalizeManagedProfileWrites` strips fields from incoming writes when they equal the current *wire* value — that's what lets an honest `config get` → `config set` round-trip through while real edit attempts are rejected. If only the read side changed, a BYO client's round-trip would stop matching and get rejected with a 400. The two swaps are one commit, and the new BYO round-trip tests in `managed-profile-guard.test.ts` pin the pairing — notably, every pre-existing round-trip test runs without a BYO provider configured, so a future read-side-only change would pass CI without these.

## Implementation notes

- The new wire-view test demonstrably fails before the swap (verified during development).
- `defaultProvider` is read from the **parsed** config, not the raw file: raw values are persisted unvalidated, and feeding a junk value into resolution would 500 every `config_get`; the schema's `.catch(undefined)` shields the parsed path by design. A code comment documents this.
- The mix-arm validation swap in the same file is verified inert (identical name sets) — consistency only.
- Web client checked: the `provider_connection === "vellum"` display branch in `manage-profiles-list-item.tsx` can't misfire on the new BYO stamps (`"<provider>-personal"` never equals `"vellum"`, and `vellum` is a reserved connection name).

## Accepted trade-off + known residual

- The wire body now varies with `llm.defaultProvider`, so a client echoing a profiles map cached from before a default-provider switch would get a 400 at echo-strip. No current web write path echoes managed bodies (verified), so this is latent; documented rather than engineered around.
- Out of scope: `status` can still disagree with dispatch on BYO hatch installs (a disabled stub shows Disabled while the resolver treats it as runnable) — same divergence class, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
