### PR TITLE
fix(schedule): reap orphaned processes from script-mode schedule runs

### DIFF
--- a/assistant/src/schedule/__tests__/run-script.test.ts
+++ b/assistant/src/schedule/__tests__/run-script.test.ts
@@ -50,6 +50,24 @@ describe("runScript orphan reaping", () => {
     expect(await waitUntilDead(childPid)).toBe(true);
   });
 
+  test("resolves and keeps partial output when an escaped process holds the pipe open", async () => {
+    // Spawning a detached child that inherits stdout mimics a daemonized
+    // process: it leaves the script's process group, so it survives the
+    // sweep while still holding the pipe's write end.
+    const escape =
+      'const p = Bun.spawn(["sleep", "600"], { detached: true, stdout: "inherit" }); p.unref(); console.log(p.pid);';
+    const result = await runScript(`bun -e '${escape}'`, {
+      cwd: tmpdir(),
+      scheduleId: "sched-escape",
+      scheduleRunId: "run-escape",
+    });
+    expect(result.exitCode).toBe(0);
+    const escapeePid = Number(result.stdout.trim());
+    expect(escapeePid).toBeGreaterThan(0);
+    expect(() => process.kill(escapeePid, 0)).not.toThrow();
+    process.kill(escapeePid, "SIGKILL");
+  }, 15_000);
+
   test("reaps background children when the script times out", async () => {
     const result = await runScript("sleep 600 & echo $!; sleep 600", {
       cwd: tmpdir(),

--- a/assistant/src/schedule/__tests__/run-script.test.ts
+++ b/assistant/src/schedule/__tests__/run-script.test.ts
@@ -19,3 +19,47 @@ describe("runScript schedule env injection", () => {
     expect(result.stdout.trim()).toBe("id=sched-abc run=run-xyz");
   });
 });
+
+/** Poll until the pid is gone, since SIGKILL delivery is asynchronous. */
+async function waitUntilDead(pid: number): Promise<boolean> {
+  for (let i = 0; i < 50; i++) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+describe("runScript orphan reaping", () => {
+  test("reaps background children when the script exits normally", async () => {
+    const started = Date.now();
+    const result = await runScript("sleep 600 & echo $!", {
+      cwd: tmpdir(),
+      scheduleId: "sched-reap",
+      scheduleRunId: "run-reap",
+    });
+    // The backgrounded child holds the stdout pipe, so resolving quickly
+    // proves the group sweep closed it rather than the drain timeout firing.
+    expect(Date.now() - started).toBeLessThan(4_000);
+    expect(result.exitCode).toBe(0);
+    const childPid = Number(result.stdout.trim());
+    expect(childPid).toBeGreaterThan(0);
+    expect(await waitUntilDead(childPid)).toBe(true);
+  });
+
+  test("reaps background children when the script times out", async () => {
+    const result = await runScript("sleep 600 & echo $!; sleep 600", {
+      cwd: tmpdir(),
+      scheduleId: "sched-reap-timeout",
+      scheduleRunId: "run-reap-timeout",
+      timeoutMs: 1_000,
+    });
+    expect(result.exitCode).toBe(124);
+    const childPid = Number(result.stdout.trim());
+    expect(childPid).toBeGreaterThan(0);
+    expect(await waitUntilDead(childPid)).toBe(true);
+  });
+});

--- a/assistant/src/schedule/run-script.ts
+++ b/assistant/src/schedule/run-script.ts
@@ -73,9 +73,9 @@ export async function runScript(
   });
 
   // Start consuming streams immediately so buffered output is available even on timeout.
-  // When the process group is killed the pipe fds close and these promises resolve on their own.
-  const stdoutPromise = new Response(proc.stdout).text();
-  const stderrPromise = new Response(proc.stderr).text();
+  // When the process group is killed the pipe fds close and the collectors finish on their own.
+  const stdoutCollector = collectStream(proc.stdout);
+  const stderrCollector = collectStream(proc.stderr);
 
   let timedOut = false;
 
@@ -96,8 +96,8 @@ export async function runScript(
     if (!timedOut) throw err;
     // Collect whatever the process wrote before the group was killed.
     const [stdoutStr, stderrStr] = await drainStreams(
-      stdoutPromise,
-      stderrPromise,
+      stdoutCollector,
+      stderrCollector,
     );
     const stdout = truncate(stdoutStr);
     const timeoutMsg = `Script timed out after ${timeoutMs}ms`;
@@ -117,8 +117,8 @@ export async function runScript(
   killProcessGroup(proc.pid);
 
   const [stdoutStr, stderrStr] = await drainStreams(
-    stdoutPromise,
-    stderrPromise,
+    stdoutCollector,
+    stderrCollector,
   );
   const stdout = truncate(stdoutStr);
   const stderr = truncate(stderrStr);
@@ -144,23 +144,60 @@ function killProcessGroup(pid: number): void {
   }
 }
 
+interface StreamCollector {
+  /** Resolves with the text read so far once the stream ends or is cancelled. */
+  promise: Promise<string>;
+  cancel: () => void;
+}
+
 /**
- * Collect both output streams, giving up on any stream that has not reached
- * EOF within {@link DRAIN_TIMEOUT_MS}.
+ * Read a stream to EOF, accumulating text. `cancel` closes the underlying
+ * pipe fd and settles the promise with whatever was read so far, so a run
+ * never leaves a reader holding the pipe open after it is over.
  */
-function drainStreams(
-  stdoutPromise: Promise<string>,
-  stderrPromise: Promise<string>,
+function collectStream(stream: ReadableStream<Uint8Array>): StreamCollector {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  const promise = (async () => {
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+      }
+    } catch {
+      // Cancelled or the pipe errored; keep what was read.
+    }
+    return text + decoder.decode();
+  })();
+  return {
+    promise,
+    cancel: () => void reader.cancel().catch(() => {}),
+  };
+}
+
+/**
+ * Wait for both output streams, cancelling any stream that has not reached
+ * EOF within {@link DRAIN_TIMEOUT_MS}. Cancelling matters when a process
+ * escaped the group kill and still holds the pipe's write end: without it the
+ * readers would keep the pipe fds alive until that process exits, leaking
+ * two fds per firing of a schedule that leaves such a process behind.
+ */
+async function drainStreams(
+  stdout: StreamCollector,
+  stderr: StreamCollector,
 ): Promise<[string, string]> {
-  const giveUp = (): Promise<string> =>
-    new Promise((resolve) => {
-      const timer = setTimeout(() => resolve(""), DRAIN_TIMEOUT_MS);
-      timer.unref();
-    });
-  return Promise.all([
-    Promise.race([stdoutPromise, giveUp()]),
-    Promise.race([stderrPromise, giveUp()]),
-  ]);
+  const deadline = setTimeout(() => {
+    stdout.cancel();
+    stderr.cancel();
+  }, DRAIN_TIMEOUT_MS);
+  deadline.unref();
+  try {
+    return await Promise.all([stdout.promise, stderr.promise]);
+  } finally {
+    clearTimeout(deadline);
+  }
 }
 
 function truncate(text: string): string {

--- a/assistant/src/schedule/run-script.ts
+++ b/assistant/src/schedule/run-script.ts
@@ -163,7 +163,9 @@ function collectStream(stream: ReadableStream<Uint8Array>): StreamCollector {
     try {
       for (;;) {
         const { done, value } = await reader.read();
-        if (done) break;
+        if (done) {
+          break;
+        }
         text += decoder.decode(value, { stream: true });
       }
     } catch {

--- a/assistant/src/schedule/run-script.ts
+++ b/assistant/src/schedule/run-script.ts
@@ -16,6 +16,14 @@ export const MIN_SCRIPT_TIMEOUT_MS = 1_000;
  * budget in scheduler.ts.
  */
 export const MAX_SCRIPT_TIMEOUT_MS = 30 * 60 * 1000;
+/**
+ * How long to wait for the output pipes to drain after the process group is
+ * killed before giving up (ms). A pipe only reaches EOF once every process
+ * holding its write end has exited, so a child that escaped the group via
+ * setsid could otherwise hold the pipe open forever and wedge the scheduler
+ * tick.
+ */
+const DRAIN_TIMEOUT_MS = 5_000;
 
 export interface ScriptResult {
   exitCode: number;
@@ -29,6 +37,11 @@ export interface ScriptResult {
  * Uses Bun.spawn with /bin/sh so the command string supports pipes,
  * redirects, and shell builtins. Output is truncated to
  * {@link MAX_OUTPUT_BYTES} to keep schedule_runs rows bounded.
+ *
+ * The command runs in its own process group, and the whole group is killed
+ * on timeout and swept after exit, so background children cannot outlive the
+ * run. A child that daemonizes itself with setsid leaves the group and
+ * deliberately survives.
  */
 export async function runScript(
   command: string,
@@ -46,6 +59,7 @@ export async function runScript(
 
   const proc = Bun.spawn(["sh", "-c", command], {
     cwd,
+    detached: true,
     stdout: "pipe",
     stderr: "pipe",
     env: {
@@ -59,7 +73,7 @@ export async function runScript(
   });
 
   // Start consuming streams immediately so buffered output is available even on timeout.
-  // When the process is killed the pipe fds close and these promises resolve on their own.
+  // When the process group is killed the pipe fds close and these promises resolve on their own.
   const stdoutPromise = new Response(proc.stdout).text();
   const stderrPromise = new Response(proc.stderr).text();
 
@@ -68,31 +82,23 @@ export async function runScript(
   const timeoutPromise = new Promise<never>((_, reject) => {
     const timer = setTimeout(() => {
       timedOut = true;
-      proc.kill("SIGKILL");
+      killProcessGroup(proc.pid);
       reject(new Error(`Script timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     timer.unref();
     proc.exited.then(() => clearTimeout(timer));
   });
 
-  /** How long to wait for pipes to drain after SIGKILL before giving up. */
-  const DRAIN_TIMEOUT_MS = 5_000;
-
   let exitCode: number;
   try {
     exitCode = await Promise.race([proc.exited, timeoutPromise]);
   } catch (err) {
     if (!timedOut) throw err;
-    // Collect whatever the process wrote before it was killed.
-    // Race each stream against a short drain window — if a background child
-    // process inherited the pipe fd, the stream would otherwise never reach
-    // EOF and block the scheduler tick indefinitely.
-    const empty = (ms: number): Promise<string> =>
-      new Promise((resolve) => setTimeout(() => resolve(""), ms));
-    const [stdoutStr, stderrStr] = await Promise.all([
-      Promise.race([stdoutPromise, empty(DRAIN_TIMEOUT_MS)]),
-      Promise.race([stderrPromise, empty(DRAIN_TIMEOUT_MS)]),
-    ]);
+    // Collect whatever the process wrote before the group was killed.
+    const [stdoutStr, stderrStr] = await drainStreams(
+      stdoutPromise,
+      stderrPromise,
+    );
     const stdout = truncate(stdoutStr);
     const timeoutMsg = `Script timed out after ${timeoutMs}ms`;
     const stderr = truncate(
@@ -105,8 +111,17 @@ export async function runScript(
     return { exitCode: 124, stdout, stderr };
   }
 
-  const stdout = truncate(await stdoutPromise);
-  const stderr = truncate(await stderrPromise);
+  // Sweep anything the script left running. This reaps orphaned background
+  // children and closes their copies of the pipe fds so the stream reads
+  // below can reach EOF.
+  killProcessGroup(proc.pid);
+
+  const [stdoutStr, stderrStr] = await drainStreams(
+    stdoutPromise,
+    stderrPromise,
+  );
+  const stdout = truncate(stdoutStr);
+  const stderr = truncate(stderrStr);
 
   log.info(
     { command, exitCode, stdoutLen: stdout.length, stderrLen: stderr.length },
@@ -114,6 +129,38 @@ export async function runScript(
   );
 
   return { exitCode, stdout, stderr };
+}
+
+/**
+ * SIGKILL every process in the script's process group. The group is often
+ * already empty, in which case the signal fails with ESRCH and there is
+ * nothing to reap.
+ */
+function killProcessGroup(pid: number): void {
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    // Process group may have already exited.
+  }
+}
+
+/**
+ * Collect both output streams, giving up on any stream that has not reached
+ * EOF within {@link DRAIN_TIMEOUT_MS}.
+ */
+function drainStreams(
+  stdoutPromise: Promise<string>,
+  stderrPromise: Promise<string>,
+): Promise<[string, string]> {
+  const giveUp = (): Promise<string> =>
+    new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(""), DRAIN_TIMEOUT_MS);
+      timer.unref();
+    });
+  return Promise.all([
+    Promise.race([stdoutPromise, giveUp()]),
+    Promise.race([stderrPromise, giveUp()]),
+  ]);
 }
 
 function truncate(text: string): string {


### PR DESCRIPTION
## Summary
- Script-mode schedule commands now run in their own process group (`detached: true`), and the group is SIGKILLed on timeout and swept after exit, so background children can no longer outlive the run.
- This also fixes a scheduler wedge: a background child inheriting the stdout pipe kept the normal-exit path awaiting EOF forever, latching the worker tick permanently. The sweep closes the pipe, and the normal path now shares the same 5s drain fallback as the timeout path.
- A child that daemonizes itself with `setsid` leaves the group and deliberately survives, so scripts that intentionally launch long-lived processes still can.

## Original prompt
Script-mode schedules execute arbitrary shell commands as subprocesses. Asked whether those runs can leave orphaned processes behind, and if so, how to ensure they are reaped when the parent exits. Investigation confirmed orphans in both the timeout and normal-exit cases, plus a permanent schedule-worker hang when a leftover child holds the output pipe, and this PR ships the process-group fix that was worked out.