### PR TITLE
feat(web): fetch subagent detail on group expand; loading state instead of '0 steps'

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.test.tsx
@@ -8,7 +8,7 @@
  * plus a "Collapse" toggle; and "Collapse" returns to the summary.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { cleanup, fireEvent, render, within } from "@testing-library/react";
 
 import { SubagentSpawnGroup } from "@/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group";
@@ -53,6 +53,27 @@ describe("SubagentSpawnGroup", () => {
     // Badges present, but the expanded list rows are not yet rendered.
     expect(queryAllByTestId("subagent-avatar-badge")).toHaveLength(3);
     expect(queryAllByTestId("inline-process-card")).toHaveLength(0);
+  });
+
+  test("expanding fetches the group's detail and still expands", async () => {
+    const ids = spawnIds(3);
+    const { getByTestId, findAllByTestId } = render(
+      <SubagentSpawnGroup subagentIds={ids} />,
+    );
+
+    const spy = spyOn(
+      useSubagentStore.getState(),
+      "fetchGroupDetail",
+    ).mockImplementation(() => {});
+
+    fireEvent.click(getByTestId("subagent-avatar-row-details"));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(ids);
+    // The expand still happens — the fetch is a side-effect, not a gate.
+    expect(await findAllByTestId("inline-process-card")).toHaveLength(3);
+
+    spy.mockRestore();
   });
 
   test("Details expands to the row list plus a Collapse toggle", async () => {

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
@@ -10,6 +10,7 @@ import { Typography } from "@vellumai/design-library";
 import { SubagentAvatarRow } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
 import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
 import { InlineProcessCardRow } from "@/domains/chat/process-registry/inline-process-card-row";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
 
 export interface SubagentSpawnGroupProps {
   subagentIds: string[];
@@ -25,6 +26,15 @@ export function SubagentSpawnGroup({
   // Default collapsed — the avatar summary is the resting state in the mocks.
   const [expanded, setExpanded] = useState(false);
   const reduce = useReducedMotion();
+
+  // Expanding is the first moment the user asks to see this group's timelines,
+  // so fetch each member's detail now — bounded to the handful in this group,
+  // not the whole conversation on load. Settled cards with no events show a
+  // loading state until this lands, then their real steps (see `detailSettled`).
+  const handleExpand = () => {
+    setExpanded(true);
+    useSubagentStore.getState().fetchGroupDetail(subagentIds);
+  };
 
   if (subagentIds.length === 0) return null;
 
@@ -44,7 +54,7 @@ export function SubagentSpawnGroup({
         >
           <SubagentAvatarRow
             subagentIds={subagentIds}
-            onExpand={() => setExpanded(true)}
+            onExpand={handleExpand}
           />
         </motion.div>
       ) : (

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -100,6 +100,86 @@ describe("computeSubagentCardData — state derivation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Loading state — terminal card whose detail hasn't been fetched yet
+// ---------------------------------------------------------------------------
+
+describe("computeSubagentCardData — unfetched-timeline loading state", () => {
+  test("terminal addressable entry with 0 events and !detailSettled → loading, no step count", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        conversationId: "conv-child",
+        events: [],
+        detailSettled: false,
+      }),
+    );
+    expect(data.state).toBe("loading");
+    expect(data.stepCount).toBe("");
+    expect(data.currentStepTitle).toBe("Loading");
+    expect(data.currentStepInfo).toBe("Research Agent");
+    expect(data.steps).toEqual([]);
+  });
+
+  test("once detailSettled with 0 events → resting empty state, not loading", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        conversationId: "conv-child",
+        events: [],
+        detailSettled: true,
+      }),
+    );
+    expect(data.state).toBe("complete");
+    expect(data.currentStepTitle).toBe("Finished");
+    expect(data.stepCount).toBe("0 steps");
+  });
+
+  test("terminal entry with events shows its steps, not loading", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        conversationId: "conv-child",
+        // No detailSettled flag — events alone prove the timeline is loaded.
+        events: [makeEvent({ type: "text", content: "hello" })],
+      }),
+    );
+    expect(data.state).toBe("complete");
+    expect(data.steps).toHaveLength(1);
+    expect(data.stepCount).toBe("1 step");
+  });
+
+  test("active entry with 0 events is NOT forced to loading (keeps Working)", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "running",
+        conversationId: "conv-child",
+        events: [],
+      }),
+    );
+    // Running still maps to a `loading` visual state, but it must go through
+    // the normal streaming path — not the unfetched-timeline branch.
+    expect(data.state).toBe("loading");
+    expect(data.currentStepTitle).toBe("Working");
+  });
+
+  test("non-addressable terminal entry (old daemon, no conversation id) is NOT stuck loading", () => {
+    const data = computeSubagentCardData(
+      makeEntry({
+        status: "completed",
+        // No conversationId and no parentConversationId → unaddressable.
+        conversationId: undefined,
+        parentConversationId: undefined,
+        events: [],
+        detailSettled: false,
+      }),
+    );
+    expect(data.state).toBe("complete");
+    expect(data.currentStepTitle).toBe("Finished");
+    expect(data.stepCount).toBe("0 steps");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Step mapping
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -37,7 +37,9 @@ import {
   type SubagentTimelineEvent,
 } from "@/domains/chat/subagent-store";
 import { useSubagentSteps } from "@/domains/chat/subagent-step-projection";
+import { canAddressSubagentDetail } from "@/domains/chat/store-helpers/subagent-detail-addressability";
 import type { SubagentStatus } from "@vellumai/assistant-api";
+import { isActiveStatus } from "@/utils/subagent-status";
 import { deriveStepLabelFromName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
 import { truncate } from "@/domains/chat/utils/truncate";
@@ -530,6 +532,33 @@ export function deriveSubagentCardData(
   entry: SubagentEntry,
   { steps, toolMeta }: { steps: ToolCallCardStep[]; toolMeta: Array<ToolMeta | undefined> },
 ): ToolCallCardData {
+  // A settled (terminal) entry whose timeline hasn't been fetched yet: don't
+  // claim "0 steps" — the subagent DID have steps, they just haven't loaded.
+  // Render a loading state until the fetch lands (see `detailSettled`), at
+  // which point the honest truth (its steps, or a resting empty state) takes
+  // over. `!isActiveStatus` so live cards keep their streaming "Working" state;
+  // `canAddressSubagentDetail` so a card on an old daemon that can never fetch
+  // falls back to today's behavior instead of spinning forever;
+  // `events.length === 0` so an already-loaded card is untouched.
+  const isLoadingDetail =
+    !isActiveStatus(entry.status) &&
+    canAddressSubagentDetail(entry) &&
+    entry.events.length === 0 &&
+    !entry.detailSettled;
+
+  if (isLoadingDetail) {
+    return {
+      state: "loading",
+      currentStepTitle: "Loading",
+      currentStepInfo: entry.label,
+      // Empty so the card chrome renders no step-count pill (the shell hides
+      // "", "0 …", and "1 …"); a real count follows once the fetch settles.
+      stepCount: "",
+      steps,
+      carouselItems: [],
+    };
+  }
+
   const state = deriveCardState(entry.status);
   const { currentStepTitle, currentStepInfo } = deriveCurrentStep(
     entry,

--- a/clients/web/src/domains/chat/subagent-store.test.ts
+++ b/clients/web/src/domains/chat/subagent-store.test.ts
@@ -70,6 +70,9 @@ const { reconcileSubagentStoreFromNotifications } = await import(
   "@/domains/chat/hooks/reconcile-subagent-hydration"
 );
 const { useConversationStore } = await import("@/stores/conversation-store");
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -100,6 +103,7 @@ beforeEach(() => {
   setSystemTime();
   getState().reset();
   useConversationStore.getState().setActiveConversationId(null);
+  useResolvedAssistantsStore.getState().setActiveAssistantId(null);
   selfLookupSupported = true;
   reconcileSupported = true;
   fetchSubagentDetail.mockClear();
@@ -1833,6 +1837,169 @@ describe("fetchDetailIfNeeded conversation id", () => {
     await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
 
     expect(fetchSubagentDetail).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchDetailIfNeeded — detailSettled marks a completed fetch
+// ---------------------------------------------------------------------------
+
+describe("fetchDetailIfNeeded detailSettled", () => {
+  function spawnTerminal(id: string) {
+    getState().spawnSubagent({
+      subagentId: id,
+      label: "Agent",
+      objective: "",
+      status: "completed",
+      conversationId: "conv-child",
+      timestamp: NOW,
+    });
+  }
+
+  it("sets detailSettled on a success (events) fetch", async () => {
+    spawnTerminal("sa-1");
+    fetchSubagentDetail.mockResolvedValueOnce({
+      status: "completed",
+      events: [{ type: "text", content: "hello" }],
+    } as never);
+
+    await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
+
+    const entry = getState().byId["sa-1"]!;
+    expect(entry.detailSettled).toBe(true);
+    expect(entry.events.length).toBeGreaterThan(0);
+  });
+
+  it("sets detailSettled on an empty-result fetch", async () => {
+    spawnTerminal("sa-1");
+    fetchSubagentDetail.mockResolvedValueOnce({
+      status: "completed",
+      events: [],
+    } as never);
+
+    await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
+
+    const entry = getState().byId["sa-1"]!;
+    expect(entry.detailSettled).toBe(true);
+    expect(entry.events).toEqual([]);
+  });
+
+  it("sets detailSettled on a failed fetch", async () => {
+    spawnTerminal("sa-1");
+    // Default mock resolves to null (fetch failure).
+    await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
+
+    expect(getState().byId["sa-1"]?.detailSettled).toBe(true);
+  });
+
+  it("is a no-op when the entry was disposed mid-flight", async () => {
+    spawnTerminal("sa-1");
+    fetchSubagentDetail.mockImplementationOnce(async () => {
+      // The conversation switches away while the fetch is outstanding.
+      getState().reset();
+      return null;
+    });
+
+    await getState().fetchDetailIfNeeded("assistant-1", "sa-1");
+
+    expect(getState().byId["sa-1"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchGroupDetail
+// ---------------------------------------------------------------------------
+
+describe("fetchGroupDetail", () => {
+  function spawnAddressable(id: string) {
+    getState().spawnSubagent({
+      subagentId: id,
+      label: "Agent",
+      objective: "",
+      status: "completed",
+      conversationId: `conv-${id}`,
+      timestamp: NOW,
+    });
+  }
+
+  it("fetches once per addressable unfetched id in the group", async () => {
+    useResolvedAssistantsStore.getState().setActiveAssistantId("assistant-1");
+    spawnAddressable("sa-1");
+    spawnAddressable("sa-2");
+
+    getState().fetchGroupDetail(["sa-1", "sa-2"]);
+    // Fire-and-forget: let the queued fetches settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchSubagentDetail).toHaveBeenCalledTimes(2);
+    expect(fetchSubagentDetail).toHaveBeenCalledWith(
+      "assistant-1",
+      "sa-1",
+      "conv-sa-1",
+    );
+    expect(fetchSubagentDetail).toHaveBeenCalledWith(
+      "assistant-1",
+      "sa-2",
+      "conv-sa-2",
+    );
+  });
+
+  it("is a no-op when there is no active assistant", async () => {
+    // beforeEach leaves the active assistant null.
+    spawnAddressable("sa-1");
+
+    getState().fetchGroupDetail(["sa-1"]);
+    await Promise.resolve();
+
+    expect(fetchSubagentDetail).not.toHaveBeenCalled();
+  });
+
+  it("skips ids that already have events", async () => {
+    useResolvedAssistantsStore.getState().setActiveAssistantId("assistant-1");
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      status: "completed",
+      conversationId: "conv-sa-1",
+      timestamp: NOW,
+    });
+    // Give it a timeline so `fetchDetailIfNeeded` bails.
+    getState().receiveEvent({
+      subagentId: "sa-1",
+      event: { type: "assistant_text_delta", content: "hi" } as never,
+      timestamp: NOW,
+    });
+
+    getState().fetchGroupDetail(["sa-1"]);
+    await Promise.resolve();
+
+    expect(fetchSubagentDetail).not.toHaveBeenCalled();
+  });
+
+  it("skips a non-addressable id (no conversation id) but still fetches its peers", async () => {
+    useResolvedAssistantsStore.getState().setActiveAssistantId("assistant-1");
+    // sa-1 has no conversationId and no parentConversationId → unaddressable.
+    getState().spawnSubagent({
+      subagentId: "sa-1",
+      label: "Agent",
+      objective: "",
+      status: "completed",
+      timestamp: NOW,
+    });
+    spawnAddressable("sa-2");
+
+    getState().fetchGroupDetail(["sa-1", "sa-2"]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchSubagentDetail).toHaveBeenCalledTimes(1);
+    expect(fetchSubagentDetail).toHaveBeenCalledWith(
+      "assistant-1",
+      "sa-2",
+      "conv-sa-2",
+    );
   });
 });
 

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -118,6 +118,13 @@ export interface SubagentEntry {
    * append-only instead of dropping forever.
    */
   hydrationPending?: boolean;
+  /**
+   * True once a detail fetch for this entry has completed at least once —
+   * success, empty, or failure. Until then, a terminal entry with no events is
+   * presumed to have an unloaded timeline and renders as loading rather than
+   * "0 steps".
+   */
+  detailSettled?: boolean;
 }
 
 export interface SubagentState {
@@ -347,6 +354,18 @@ export interface SubagentActions {
    * Clears the marker on failure or empty events so callers can retry.
    */
   fetchDetailIfNeeded: (assistantId: string, subagentId: string) => Promise<void>;
+
+  /**
+   * Fetch detail for every subagent in a spawn group — the handful the user
+   * just expanded — so their terminal cards can replace the loading state with
+   * their real timeline. Reads the active assistant from
+   * `useResolvedAssistantsStore` (same pattern as `abortSubagent` /
+   * `requestSubagentReconcile`). Fire-and-forget: `fetchDetailIfNeeded` dedups
+   * via `fetchedAt` and bails when events already exist, so calling it for
+   * already-loaded or still-active ids is a safe no-op. No-op when there's no
+   * active assistant.
+   */
+  fetchGroupDetail: (subagentIds: string[]) => void;
 
   /**
    * Rebuild this conversation's subagent rows from the daemon's live
@@ -1225,6 +1244,22 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       queryConversationId,
     );
 
+    // Whatever the outcome — a real timeline, an empty one, or a failed
+    // fetch — the detail fetch has now completed at least once. Marking the
+    // entry `detailSettled` lets a terminal card with no events stop rendering
+    // as loading and show the honest truth (its steps, or a resting empty
+    // state). A no-op when the entry was disposed mid-flight (a `reset()` on a
+    // conversation switch).
+    const settled = patchedEntryField(
+      get().byId,
+      subagentId,
+      "detailSettled",
+      true,
+    );
+    if (settled) {
+      set({ byId: settled });
+    }
+
     const clearMarker = () => {
       const next = new Map(get().fetchedAt);
       next.delete(subagentId);
@@ -1265,6 +1300,16 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
       parentToolUseId: detail.parentToolUseId,
       conversationId: detail.conversationId,
     });
+  },
+
+  fetchGroupDetail: (subagentIds) => {
+    const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+    if (!assistantId) {
+      return;
+    }
+    for (const id of subagentIds) {
+      void get().fetchDetailIfNeeded(assistantId, id);
+    }
   },
 
   reconcileFromDaemon: (


### PR DESCRIPTION
Refines the settled-card trade-off: expanding a subagent group now fetches its members' detail (bounded to the group, still no load-time burst), and a terminal card with an unloaded timeline shows a loading state instead of a misleading '0 steps' until the fetch lands. Part of plan: subagent-running-state-fixes.md (UX refinement).

## What changed
- **Store** (`subagent-store.ts`): new `detailSettled?: boolean` on `SubagentEntry`, set true in every terminal path of `fetchDetailIfNeeded` (success/empty/failure) via a `patchedEntryField` no-op-safe patch; new `fetchGroupDetail(ids)` action that reads the active assistant and fires `fetchDetailIfNeeded` per id (dedup/no-op safe).
- **Card** (`use-subagent-card-data.ts`): early loading branch in `deriveSubagentCardData` when `!isActiveStatus && canAddressSubagentDetail && events.length === 0 && !detailSettled` → `state: "loading"`, empty `stepCount` (shell hides it), `currentStepTitle: "Loading"`.
- **Component** (`subagent-spawn-group.tsx`): expand handler also calls `fetchGroupDetail(subagentIds)`.

Tests added across all three suites. `tsc` clean, eslint clean (0 errors), touched + adjacent subagent suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)