### PR TITLE
Billing: name the base tier consistently in the downgrade flow

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/free-downgrade-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/free-downgrade-confirm-modal.tsx
@@ -19,8 +19,8 @@ export interface FreeDowngradeConfirmModalProps {
 }
 
 /**
- * Reconfirm dialog for cancelling Pro ("Downgrade to Free") from the plans
- * takeover. Mirrors the adjust-plan modal's "Downgrade to Base?" step: it lists
+ * Reconfirm dialog for cancelling Pro ("Downgrade to Base") from the plans
+ * takeover. Mirrors the adjust-plan modal's step of the same name: it lists
  * the Pro features that will be lost before handing off to the Stripe billing
  * portal, where the actual cancellation happens. Layout-only — the parent owns
  * the portal mutation.
@@ -44,7 +44,7 @@ export function FreeDowngradeConfirmModal({
     >
       <Modal.Content size="md" hideCloseButton>
         <Modal.Header>
-          <Modal.Title icon={AlertTriangle}>Downgrade to Free?</Modal.Title>
+          <Modal.Title icon={AlertTriangle}>Downgrade to Base?</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Typography
@@ -78,7 +78,7 @@ export function FreeDowngradeConfirmModal({
             disabled={pending}
             data-testid="confirm-free-downgrade-button"
           >
-            Downgrade to Free
+            Downgrade to Base
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -387,7 +387,7 @@ describe("PlansPage checkout — base subscriber", () => {
 });
 
 describe("PlansPage checkout — Pro subscriber", () => {
-  // Below Mighty, Free reads "Downgrade to Free". Downgrading a Pro org to the
+  // Below Mighty, Base reads "Downgrade to Base". Downgrading a Pro org to the
   // Free plan is a subscription cancellation, not a package switch — clicking it
   // opens a confirm step (then the Stripe billing portal, the same destination
   // as the adjust-plan modal's "Downgrade to Base"). The full confirm → portal
@@ -397,7 +397,7 @@ describe("PlansPage checkout — Pro subscriber", () => {
   test("a Free downgrade CTA never starts a Stripe checkout", () => {
     const { getByRole } = renderPage(proMightySubscription());
 
-    fireEvent.click(getByRole("button", { name: "Downgrade to Free" }));
+    fireEvent.click(getByRole("button", { name: "Downgrade to Base" }));
 
     expect(upgradeCall).toBeNull();
     expect(readCheckoutIntent()).toBeNull();

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -405,7 +405,7 @@ describe("PlansPage — current-plan state", () => {
     // Only the Mighty column is the current plan.
     expect(count(html, /Current Plan/g)).toBe(1);
     // Free sits below Mighty, so its CTA becomes a downgrade.
-    expect(html).toContain("Downgrade to Free");
+    expect(html).toContain("Downgrade to Base");
     expect(html).not.toContain("Start Free");
     // Super and Ultra sit above Mighty, so they keep their upgrade CTAs.
     expect(html).toContain("Go Super");
@@ -604,10 +604,10 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     const { findByRole, findByText, findByTestId, getByTestId } =
       renderInteractive(proSuperSubscription());
 
-    // Below Super, Free reads "Downgrade to Free". Clicking it opens the confirm
+    // Below Super, Base reads "Downgrade to Base". Clicking it opens the confirm
     // dialog — not an immediate portal redirect.
-    fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
-    await findByText("Downgrade to Free?");
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Base" }));
+    await findByText("Downgrade to Base?");
     expect(openedUrl).toBeNull();
     expect(portalSessionCall).toBeNull();
 
@@ -628,12 +628,12 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     const { findByRole, findByText, getByRole, queryByText } =
       renderInteractive(proSuperSubscription());
 
-    fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
-    await findByText("Downgrade to Free?");
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Base" }));
+    await findByText("Downgrade to Base?");
 
     // The confirm dialog's Cancel closes it without creating a portal session.
     fireEvent.click(getByRole("button", { name: "Cancel" }));
-    await waitFor(() => expect(queryByText("Downgrade to Free?")).toBeNull());
+    await waitFor(() => expect(queryByText("Downgrade to Base?")).toBeNull());
     expect(portalSessionCall).toBeNull();
     expect(openedUrl).toBeNull();
   });
@@ -648,8 +648,8 @@ describe("PlansPage — Pro package switch (change-package)", () => {
       { plans },
     );
 
-    fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
-    await findByText("Downgrade to Free?");
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Base" }));
+    await findByText("Downgrade to Base?");
     await findByText("Managed email");
     await findByText("Custom domain");
   });
@@ -662,7 +662,7 @@ describe("PlansPage — Pro package switch (change-package)", () => {
       proMightySubscription(),
     );
 
-    fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Base" }));
     fireEvent.click(await findByTestId("confirm-free-downgrade-button"));
 
     // The portal request is in flight and never settles: every other plan
@@ -857,7 +857,7 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
   test("a Custom sub's Free card is a downgrade and no named card is current", () => {
     const html = renderStatic(proCustomizedMightySubscription(), fullCatalog());
     // Pro → Free is always a downgrade.
-    expect(html).toContain("Downgrade to Free");
+    expect(html).toContain("Downgrade to Base");
     expect(html).not.toContain("Start Free");
     // A Custom sub has no catalog rank, so no named column card is its current
     // plan. The Custom row's own current-plan tag is gated on the onboarding

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -672,7 +672,7 @@ export function PlansPage() {
             priceCaption={freeCopy?.priceCaption ?? "Forever"}
             ctaLabel={
               freeRelation === "downgrade"
-                ? downgradeLabel("Free")
+                ? downgradeLabel("Base")
                 : (freeCopy?.cta ?? "Start Free")
             }
             features={FREE_FEATURES}


### PR DESCRIPTION
Follow-up to #39412, which has now merged. This branch is rebased onto `main`.

## Why

#39412 retitles the plans takeover's first column from "Free" to "Base". Its downgrade CTA still read **"Downgrade to Free"**, sitting directly under a heading that says "Base" and next to a sibling CTA reading "Downgrade to Mighty" (every other column names itself).

The rest of the app already settled on "Base" for this action:

- `plan-card-content.tsx:339` renders `Downgrade to Base`
- `adjust-plan-modal.tsx:502` renders `Downgrade to Base?`
- `downgrade-reconfirm-modal.tsx:33` renders `Downgrade to Base?`

The plans takeover was the outlier, so this is a consistency fix rather than new naming.

## Changes

- `plans-page.tsx` — the free column's downgrade CTA becomes `downgradeLabel("Base")`.
- `free-downgrade-confirm-modal.tsx` — the dialog that CTA opens is retitled `Downgrade to Base?` and its confirm button `Downgrade to Base`. Changing only the CTA would have moved the mismatch one click downstream instead of removing it.
- Test expectations updated in `plans-page.test.tsx` (11) and `plans-page-checkout.test.tsx` (2), plus two comments that described the card as "Free".

Not touched: the catalog plan's API name is still `Free` (`id: "base"`), and the free column's non-downgrade CTA still reads "Start Free", which works as an action rather than a plan name.

## Verification

- `bun run test:ci` — 745 passed, 0 failed
- `bunx tsc --noEmit` — clean
- `eslint` on all changed files — clean
- No em dashes on any added line (per AGENTS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
