### PR TITLE
refactor(config): restrict managed-column profile resolution to its intentional callers

### DIFF
--- a/assistant/eslint.config.mjs
+++ b/assistant/eslint.config.mjs
@@ -51,7 +51,7 @@ const eslintConfig = defineConfig([
   },
   // Managed-column profile resolution (`getEffectiveProfile(s)`) resolves
   // default profiles against the vellum column only, ignoring
-  // `llm.defaultProvider` — on a BYO install that is not the body that
+  // `llm.defaultProvider`; on a BYO install that is not the body that
   // dispatches. Runtime code must use `resolveDefaultProfileForProvider` /
   // `getEffectiveProfilesForProvider` instead. The allowlist below is the
   // full set of intentional managed-column consumers: the catalog itself,

--- a/assistant/eslint.config.mjs
+++ b/assistant/eslint.config.mjs
@@ -49,6 +49,39 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
+  // Managed-column profile resolution (`getEffectiveProfile(s)`) resolves
+  // default profiles against the vellum column only, ignoring
+  // `llm.defaultProvider` — on a BYO install that is not the body that
+  // dispatches. Runtime code must use `resolveDefaultProfileForProvider` /
+  // `getEffectiveProfilesForProvider` instead. The allowlist below is the
+  // full set of intentional managed-column consumers: the catalog itself,
+  // hatch-time seeding (writes managed stubs by design), and write-path
+  // validation.
+  {
+    files: ["src/**/*.ts"],
+    ignores: [
+      "src/config/default-profile-catalog.ts",
+      "src/config/seed-inference-profiles.ts",
+      "src/config/inference-profile-validation.ts",
+      "**/__tests__/**",
+      "**/*.test.ts",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/default-profile-catalog.js"],
+              importNames: ["getEffectiveProfile", "getEffectiveProfiles"],
+              message:
+                "Managed-column resolution ignores llm.defaultProvider. Use resolveDefaultProfileForProvider / getEffectiveProfilesForProvider with the parsed config's llm.defaultProvider ?? null.",
+            },
+          ],
+        },
+      ],
+    },
+  },
   // `cli/no-daemon-internals` keeps daemon-internal modules out of the CLI's
   // static import graph, so `assistant …` invocations (including the bash-tool
   // fast path) don't pay the memory cost of loading daemon subsystems. Keep at

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -11,7 +11,6 @@ import {
 } from "../providers/vellum-model-routing.js";
 import { CALL_SITE_DEFAULTS } from "./call-site-defaults.js";
 import {
-  getEffectiveProfile,
   isMatrixProfileKey,
   resolveDefaultProfileForProvider,
 } from "./default-profile-catalog.js";
@@ -57,7 +56,9 @@ import {
  * sits at the top of the chain for every call site.
  *
  * Profile names are resolved against the effective profile catalog
- * (code-defined defaults + workspace `llm.profiles`; see `getEffectiveProfile`).
+ * (code-defined defaults + workspace `llm.profiles`), with default profile
+ * keys resolved through `llm.defaultProvider`'s column of the intent ×
+ * provider matrix (see `resolveDefaultProfileForProvider`).
  * A "mix" profile is expanded to one of its arms by a seeded weighted pick (see
  * `resolveProfileFragment` and `opts.selectionSeed`), uniformly wherever a name
  * is dereferenced. Missing references silently fall through (no throw) so the
@@ -514,8 +515,7 @@ function resolveProfileFragment(
   name: string | undefined,
   llm: z.infer<typeof LLMSchema>,
   opts: ResolveCallSiteOpts,
-  lookupEntry: (name: string) => ProfileEntry | undefined = (n) =>
-    getEffectiveProfile(llm.profiles, n),
+  lookupEntry: (name: string) => ProfileEntry | undefined,
 ): ProfileEntry | undefined {
   if (name == null) {
     return undefined;


### PR DESCRIPTION
## TL;DR

Final PR of the BYO profile-resolution consolidation ([plan papertrail on PR 1, #39392](https://github.com/vellum-ai/vellum-assistant/pull/39392); sweep #39415; wire view #39418). With every runtime call site migrated to install-aware resolution, this closes the door so nothing regresses:

1. **Removes the last silent managed-column fallback**: `resolveProfileFragment`'s `lookupEntry` parameter defaulted to the managed-column lookup — dead on the production path (both callers pass the install-aware lookup) but a footgun for any future caller that omitted the argument. Now required.
2. **Lint-bans new imports** of `getEffectiveProfile` / `getEffectiveProfiles` outside the intentional allowlist: the catalog itself, hatch-time seeding (writes managed stubs by design), and write-path validation. Violations fail `bun run lint` with a message naming the correct replacement.
3. Fixes the resolver's stale doc comment to describe the current resolution path.

## What changes for the user

Nothing. No runtime behavior changes — one dead default parameter removed, one comment fixed, one lint rule added.

## Why this is safe

- Both `resolveProfileFragment` callers already pass `lookupEntry` explicitly; making it required is compile-time-provable dead-code removal (typecheck clean).
- Lint rule verified both ways: a scratch file importing `getEffectiveProfiles` outside the allowlist fails with the expected error (demonstrated during development, then deleted); repo-wide `bun run lint` passes with zero errors.
- Catalog (24) and resolver (77) test suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->