### PR TITLE
fix(web): target the group-icons gate at 0.11.1, the next scheduled cut

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -172,7 +172,7 @@ Each module owns one feature's old/new split. Current registry:
 | `use-supports-image-gen-vellum-provider.ts` | `0.11.0`                  | Vellum image-gen selection persists as legacy `{ mode: "managed" }` with no provider field                | Save path writes `provider: "vellum"`, which the config enum accepts                        |
 | `use-supports-new-chat-plugins.ts`  | `0.12.0`                          | New-chat plugin picker hidden; the send path omits the per-chat plugin set (older daemons ignore it)      | Picker renders and the send path includes the per-chat plugin set the daemon applies        |
 | `use-supports-inchat-plugin-edit.ts` | `0.12.0`                         | In-chat plugin pill hidden; the conversation GET omits `enabledPlugins` so per-chat scope is unreadable   | Pill renders the conversation's plugin scope and edits it via `PUT /conversations/:id/enabledplugins` |
-| `use-supports-group-icons.ts`       | `0.12.0`                          | Group rows carry no `icon` field; the group create/rename dialog is name-only and group writes omit `icon` | Groups persist a nullable icon name; the dialog shows an icon picker and group writes include `icon` |
+| `use-supports-group-icons.ts`       | `0.11.1`                          | Group rows carry no `icon` field; the group create/rename dialog is name-only and group writes omit `icon` | Groups persist a nullable icon name; the dialog shows an icon picker and group writes include `icon` |
 
 When you delete a row here, also delete its module, its test, and the now-dead
 legacy branch at the call site.

--- a/clients/web/src/lib/backwards-compat/use-supports-group-icons.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-group-icons.test.ts
@@ -25,16 +25,16 @@ describe("useSupportsGroupIcons", () => {
     expect(check("")).toBe(false);
   });
 
-  test("returns true at exactly MIN_VERSION (0.12.0)", () => {
-    expect(check("0.12.0")).toBe(true);
+  test("returns true at exactly MIN_VERSION (0.11.1)", () => {
+    expect(check("0.11.1")).toBe(true);
   });
 
   test("returns true for dev builds ahead of MIN_VERSION", () => {
-    expect(check("0.12.0-dev.202607281200.abc1234")).toBe(true);
+    expect(check("0.11.1-dev.202607281200.abc1234")).toBe(true);
   });
 
   test("returns true for versions above MIN_VERSION", () => {
-    expect(check("0.12.1")).toBe(true);
+    expect(check("0.11.2")).toBe(true);
     expect(check("1.0.0")).toBe(true);
   });
 
@@ -45,6 +45,6 @@ describe("useSupportsGroupIcons", () => {
 
   test("returns false for unparseable versions", () => {
     expect(check("not-a-version")).toBe(false);
-    expect(check("0.12")).toBe(false);
+    expect(check("0.11")).toBe(false);
   });
 });

--- a/clients/web/src/lib/backwards-compat/use-supports-group-icons.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-group-icons.ts
@@ -15,7 +15,7 @@
  */
 import { useAssistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.12.0";
+export const MIN_VERSION = "0.11.1";
 
 /**
  * Returns `true` when the active assistant persists group icons. Subscribes

--- a/clients/web/src/lib/backwards-compat/use-supports-group-icons.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-group-icons.ts
@@ -12,6 +12,11 @@
  *
  * Reading needs no gate: an older daemon simply omits `icon` from
  * `GET /v1/groups` and the sidebar falls back to its default rendering.
+ *
+ * MIN_VERSION names the next scheduled cut from main. A hotfix release
+ * branches from the latest release tag instead, so a hotfix that claims
+ * this version number would NOT carry the feature; if that happens,
+ * retarget this gate to the next scheduled cut's number.
  */
 import { useAssistantSupports } from "./utils";
 


### PR DESCRIPTION
## TL;DR

#39389 merged with the group-icons backwards-compat gate at `MIN_VERSION 0.12.0`. That number assumed the next release after 0.11.0 is a minor bump, but scheduled cuts default to a patch bump (`NEXT_RELEASE_BUMP`), so the first release carrying group icons is **0.11.1**. This retargets the gate, its test, and the docs registry row.

## Why this is safe

Gates compare `assistantVersion >= MIN_VERSION`, so this only changes behavior for future 0.11.1 daemons: at `0.12.0` they would have kept the name-only dialog despite fully supporting icons; at `0.11.1` the picker lights up with the release that ships the feature. Released 0.11.0 daemons (which lack the icon column) stay below the gate either way.

## What changes for the user

| Surface | Before | After |
| --- | --- | --- |
| Web app against a 0.11.1 daemon | Icon picker hidden until 0.12.0 | Icon picker available |
| Web app against 0.11.0 or older | Name-only dialog | Unchanged |

If #39389's feature ends up excluded from the 0.11.1 cut after all, this gate must move again to whatever release first carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->