### PR TITLE
fix(assistant): register the Telegram callback route for platform-connected local assistants

### DIFF
--- a/assistant/src/__tests__/telegram-config.test.ts
+++ b/assistant/src/__tests__/telegram-config.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../config/loader.js";
 import { credentialKey } from "../security/credential-key.js";
 
 let secureKeyStore: Record<string, string> = {};
@@ -8,9 +14,28 @@ let oauthConnectionStore: Record<
   { id: string; status: string; accountInfo?: string | null }
 > = {};
 const syncCalls: Array<{ provider: string; accountInfo?: string }> = [];
+let platformContextEnabled = false;
 
+const registerCallbackRouteMock = mock(
+  async (callbackPath: string, _type: string) =>
+    `https://gateway.vellum.ai/assistant-123/${callbackPath}`,
+);
+
+// Spread the real module: it is a shared barrel and replacing it wholesale
+// breaks unrelated importers pulled in by the module under test.
+const actualPlatformCallbackRegistration =
+  await import("../inbound/platform-callback-registration.js");
 mock.module("../inbound/platform-callback-registration.js", () => ({
-  registerCallbackRoute: async () => {},
+  ...actualPlatformCallbackRegistration,
+  registerCallbackRoute: registerCallbackRouteMock,
+  resolvePlatformCallbackRegistrationContext: async () => ({
+    isPlatform: false,
+    platformBaseUrl: platformContextEnabled ? "https://api.vellum.ai" : "",
+    assistantId: platformContextEnabled ? "assistant-123" : "",
+    hasAssistantApiKey: platformContextEnabled,
+    authHeader: platformContextEnabled ? "Api-Key secret" : null,
+    enabled: platformContextEnabled,
+  }),
 }));
 
 mock.module("../daemon/handlers/shared.js", () => ({
@@ -77,13 +102,37 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 const originalFetch = globalThis.fetch;
 
-import { getTelegramConfig } from "../daemon/handlers/config-telegram.js";
+const { getTelegramConfig, setTelegramConfig } =
+  await import("../daemon/handlers/config-telegram.js");
+
+function mockTelegramApi(): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/getMe")) {
+      return new Response(
+        JSON.stringify({ ok: true, result: { id: 42, username: "testbot" } }),
+        { status: 200 },
+      );
+    }
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }) as typeof fetch;
+}
+
+function setIngressPublicBaseUrl(url: string): void {
+  const raw = loadRawConfig();
+  setNestedValue(raw, "ingress.publicBaseUrl", url);
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
 
 describe("Telegram config handler", () => {
   beforeEach(() => {
     secureKeyStore = {};
     oauthConnectionStore = {};
     syncCalls.length = 0;
+    platformContextEnabled = false;
+    registerCallbackRouteMock.mockClear();
+    setIngressPublicBaseUrl("");
     globalThis.fetch = originalFetch;
   });
 
@@ -104,5 +153,49 @@ describe("Telegram config handler", () => {
       { provider: "telegram", accountInfo: "@testbot" },
     ]);
     expect(oauthConnectionStore["telegram"]?.accountInfo).toBe("@testbot");
+  });
+
+  // The bug (LUM-2891): registration was gated on IS_PLATFORM, which is only
+  // true on platform pods, so a platform-connected local assistant never
+  // registered the route and Telegram webhooks were never forwarded.
+  test("set registers the platform callback route for a platform-connected local assistant", async () => {
+    platformContextEnabled = true;
+    globalThis.fetch = mockTelegramApi();
+
+    const result = await setTelegramConfig(
+      "123456789:AAtesttoken_testtoken_testtoken_test",
+    );
+
+    expect(result.success).toBe(true);
+    expect(registerCallbackRouteMock).toHaveBeenCalledWith(
+      "webhooks/telegram",
+      "telegram",
+    );
+  });
+
+  test("set does not register a platform callback route when not platform-connected", async () => {
+    globalThis.fetch = mockTelegramApi();
+
+    const result = await setTelegramConfig(
+      "123456789:AAtesttoken_testtoken_testtoken_test",
+    );
+
+    expect(result.success).toBe(true);
+    expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+  });
+
+  // A logged-in local assistant holds platform credentials for the LLM proxy,
+  // so credential presence must not override an explicitly configured ingress.
+  test("set does not register a platform callback route when a public ingress is configured", async () => {
+    platformContextEnabled = true;
+    setIngressPublicBaseUrl("https://abc.ngrok.io");
+    globalThis.fetch = mockTelegramApi();
+
+    const result = await setTelegramConfig(
+      "123456789:AAtesttoken_testtoken_testtoken_test",
+    );
+
+    expect(result.success).toBe(true);
+    expect(registerCallbackRouteMock).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/__tests__/telegram-config.test.ts
+++ b/assistant/src/__tests__/telegram-config.test.ts
@@ -155,9 +155,10 @@ describe("Telegram config handler", () => {
     expect(oauthConnectionStore["telegram"]?.accountInfo).toBe("@testbot");
   });
 
-  // The bug (LUM-2891): registration was gated on IS_PLATFORM, which is only
-  // true on platform pods, so a platform-connected local assistant never
-  // registered the route and Telegram webhooks were never forwarded.
+  // A platform-connected local assistant (IS_PLATFORM unset, valid platform
+  // credentials, no public ingress) receives Telegram webhooks only through
+  // managed platform callbacks, so saving the bot token must register the
+  // route.
   test("set registers the platform callback route for a platform-connected local assistant", async () => {
     platformContextEnabled = true;
     globalThis.fetch = mockTelegramApi();

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
-import { getIsPlatform } from "../../config/env-registry.js";
 import {
   invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
+import { hasWebhookRoutingConfigured } from "../../config/webhook-routing.js";
 import { registerCallbackRoute } from "../../inbound/platform-callback-registration.js";
 import {
   ensureManualTokenConnection,
@@ -249,12 +249,17 @@ export async function setTelegramConfig(
     hasWebhookSecret,
   };
 
-  // When containerized with a platform, register the Telegram callback
-  // route so the platform knows how to forward Telegram webhooks.
-  // This must happen independently of effectiveUrl — in containerized
-  // deployments without ingress.publicBaseUrl, platform callbacks are the
-  // only way to receive Telegram webhooks.
-  if (getIsPlatform()) {
+  // Register the Telegram callback route so the platform knows how to
+  // forward Telegram webhooks. This applies whenever webhooks are delivered
+  // via managed callbacks: platform pods, and platform-connected local
+  // assistants with no public ingress — for both, platform callbacks are the
+  // only way to receive Telegram webhooks. `hasWebhookRoutingConfigured`
+  // encodes the resolution order (a configured ingress wins; an explicit
+  // `ingress.enabled: false` blocks the platform fallback) and is the same
+  // derivation the Telegram status checks read, so registration and reported
+  // status stay in agreement.
+  const { usesManagedCallbacks } = await hasWebhookRoutingConfigured(true);
+  if (usesManagedCallbacks) {
     registerCallbackRoute("webhooks/telegram", "telegram").catch((err) => {
       log.warn({ err }, "Failed to register Telegram platform callback route");
     });

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -252,7 +252,7 @@ export async function setTelegramConfig(
   // Register the Telegram callback route so the platform knows how to
   // forward Telegram webhooks. This applies whenever webhooks are delivered
   // via managed callbacks: platform pods, and platform-connected local
-  // assistants with no public ingress — for both, platform callbacks are the
+  // assistants with no public ingress. For both, platform callbacks are the
   // only way to receive Telegram webhooks. `hasWebhookRoutingConfigured`
   // encodes the resolution order (a configured ingress wins; an explicit
   // `ingress.enabled: false` blocks the platform fallback) and is the same


### PR DESCRIPTION
## TL;DR

On Telegram config save, the platform callback route (`webhooks/telegram`) was only registered when `IS_PLATFORM` was set, i.e. on platform pods. Platform-connected **local** assistants never registered it, so the platform had no route to forward Telegram webhooks to and Telegram messages never arrived, even though the status checks (#39394, LUM-2863) now correctly report a platform callback URL. The registration is now gated on `hasWebhookRoutingConfigured(true)`, the same four-tier derivation the status checks and `webhooks_register` use.

Fixes [LUM-2891](https://linear.app/vellum/issue/LUM-2891).

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| Platform pod saves a bot token | Callback route registered | Unchanged |
| Platform-connected local assistant (no public ingress) saves a bot token | Route never registered; Telegram messages never arrive | Route registered; Telegram messages are forwarded by the platform |
| Local assistant with a configured public ingress (e.g. ngrok) | No platform registration | Unchanged; ingress still wins over platform connectivity |
| Ingress explicitly disabled (`ingress.enabled: false`) | No platform registration | Unchanged; the opt-out is honored, not routed around |
| Not platform-connected, no ingress | No registration | Unchanged |

## Why this is safe

- The gate reuses `hasWebhookRoutingConfigured(true)` from `config/webhook-routing.ts` rather than re-implementing the tier order inline. That helper already encodes the exact resolution order documented in `platform-callback-registration.ts` (platform pods, then configured ingress, then platform credentials, then nothing), calls `resolvePlatformCallbackRegistrationContext()` internally, and is what the Telegram status checks and webhook health sweep read, so registration and reported status cannot diverge.
- The registration call itself stays fire-and-forget with the existing `.catch` plus warn log: a platform-side failure still never fails the config save.
- Platform-pod behavior is equivalent: tier 1 of the helper short-circuits on `IS_PLATFORM` exactly like the old `getIsPlatform()` gate.
- Diff is tight (handler plus its test file only), making this a clean cherry-pick candidate.

## Tests

New unit tests in `telegram-config.test.ts` mirroring the #39394 test shape:

- platform-connected local assistant (not `IS_PLATFORM`, valid platform credentials): route registered (the bug)
- not platform-connected: no registration
- configured public ingress wins over platform connectivity: no registration

The `platform-callback-registration.js` mock now spreads the real module and stubs `resolvePlatformCallbackRegistrationContext`, following the shared-mock-module lesson from #39394.

Verified locally: `telegram-config.test.ts` (4 pass), `webhook-routing.test.ts` (16 pass), `webhook-routes.test.ts` (11 pass), `platform-callback-registration.test.ts` (10 pass), `credential-security-invariants.test.ts` (29 pass), `tsc --noEmit` clean.

## Deferred

- `clearTelegramConfig` does not deregister the platform callback route on disconnect. Deferring is necessary, not just convenient: no deregistration API exists anywhere in the stack (the platform internal gateway exposes register and list only), so the fix is cross-repo (platform endpoint, then assistant client, then the disconnect call site). The stale route is verified inert: disconnect calls Telegram `deleteWebhook` first, and the gateway 401s any request that fails webhook-secret verification (`gateway/src/http/routes/telegram-webhook.ts:78-88`) after the secret is deleted. Tracked in [LUM-2894](https://linear.app/vellum/issue/LUM-2894).

🤖 Generated with [Claude Code](https://claude.com/claude-code)