### PR TITLE
fix: pair remaining stash clears and trim review-flagged slop

### DIFF
--- a/clients/web/src/domains/settings/billing/assistant-avatar-tile.test.tsx
+++ b/clients/web/src/domains/settings/billing/assistant-avatar-tile.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render } from "@testing-library/react";
 
+import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /** Flipped per-test to hold the avatar query in flight. */
@@ -15,6 +16,7 @@ let avatarLoading = false;
 /** An uploaded avatar image, the simplest resolved avatar to assert on. */
 let avatarCustomImageUrl: string | null = null;
 mock.module("@/hooks/use-assistant-avatar", () => ({
+  ...assistantAvatarMod,
   useAssistantAvatar: () => ({
     components: null,
     traits: null,
@@ -22,7 +24,6 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
     isLoading: avatarLoading,
     invalidate: () => {},
   }),
-  avatarQueryKey: (assistantId: string) => ["assistantAvatar", assistantId],
 }));
 
 const { AssistantAvatarTile } = await import("./assistant-avatar-tile");

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -356,6 +356,11 @@ describe("CheckoutPage", () => {
       packageKey: "super",
       resumeAfterOnboarding: true,
     });
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: AVATAR_TRAITS,
+    });
     const { findByRole, getByTestId } = renderCheckout(
       "/assistant/checkout?package=super",
     );
@@ -367,6 +372,7 @@ describe("CheckoutPage", () => {
       expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
     );
     expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+    expect(readTakeoverAvatarStash()).toBeNull();
   });
 
   test("the error escape resumes the carried onboarding step", async () => {
@@ -473,6 +479,11 @@ describe("CheckoutPage", () => {
       packageKey: "super",
       resumeAfterOnboarding: true,
     });
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: AVATAR_TRAITS,
+    });
     const { getByTestId } = renderCheckout(ONBOARDING_ENTRY);
 
     await waitFor(() =>
@@ -481,6 +492,9 @@ describe("CheckoutPage", () => {
     expect(upgradeCalls.length).toBe(0);
     expect(openedUrl).toBeNull();
     expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+    // The avatar snapshot is stashed for a checkout that never happened, so the
+    // bail drops it alongside the intent.
+    expect(readTakeoverAvatarStash()).toBeNull();
   });
 
   test("the hand-off rewrites a marked stash without the marker", async () => {

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -40,6 +40,12 @@ import { Button } from "@vellumai/design-library/components/button";
  */
 type CheckoutPhase = "idle" | "running" | "handed_off" | "settled";
 
+/** Drops everything an attempt that never reached Stripe left behind. */
+function abandonCheckout() {
+  clearCheckoutIntent();
+  clearTakeoverAvatarStash();
+}
+
 /**
  * Deep-link checkout entrypoint (`/assistant/checkout?package=<slug>`). The
  * marketing pricing CTAs route a chosen Pro package here — reachable by a
@@ -157,7 +163,6 @@ export function CheckoutPage() {
         // Stash the selection so the post-checkout provisioning screen can show
         // the purchased package before the subscribe webhook lands.
         saveCheckoutIntent({ kind: "package", packageKey });
-        // Snapshot the avatar so the takeover can draw it on a cold return.
         captureTakeoverAvatarStash(queryClient);
         setAwaitingReturn(returnTarget === "native");
         void openUrl(result.checkout_url);
@@ -167,8 +172,7 @@ export function CheckoutPage() {
       // an already-Pro bounce doesn't leave it lingering for its TTL, then hand
       // off rather than stranding the user on a blank splash.
       phaseRef.current = "settled";
-      clearCheckoutIntent();
-      clearTakeoverAvatarStash();
+      abandonCheckout();
       navigate(bailTarget, { replace: true });
     } catch {
       if (phaseRef.current !== "running") {
@@ -214,12 +218,12 @@ export function CheckoutPage() {
         return;
       }
       // The attempt is over. Settling it makes an in-flight upgrade's result a
-      // no-op, so a response landing after this can't open Stripe. The stash
-      // goes with it whatever ended the attempt: nothing was bought, and a
+      // no-op, so a response landing after this can't open Stripe. Both stashes
+      // go with it whatever ended the attempt: nothing was bought, and a
       // signup-marked intent left readable for its TTL is one the privacy
       // screen resumes checkout from.
       phaseRef.current = "settled";
-      clearCheckoutIntent();
+      abandonCheckout();
       navigate(bailTarget, { replace: true });
       return;
     }
@@ -268,13 +272,13 @@ export function CheckoutPage() {
         <div className="flex items-center gap-4">
           <Button onClick={retryCheckout}>Try again</Button>
           {/*
-           * Taking the escape ends the attempt, so the stash goes with it.
+           * Taking the escape ends the attempt, so both stashes go with it.
            * Nothing was bought, and a signup-marked intent left behind is one
            * the privacy screen resumes checkout from for the rest of its TTL.
            */}
           <Link
             to={bailTarget}
-            onClick={clearCheckoutIntent}
+            onClick={abandonCheckout}
             className="text-sm text-[var(--content-tertiary)] underline"
           >
             {bailLabel}
@@ -294,7 +298,7 @@ export function CheckoutPage() {
         <div className="flex items-center gap-4">
           <Button onClick={retryCheckout}>Reopen checkout</Button>
           {/*
-           * No `clearCheckoutIntent` here, unlike the failure escape: a
+           * No `abandonCheckout` here, unlike the failure escape: a
            * checkout that reached Stripe may have been paid for, and this page
            * can't tell. The hand-off already rewrote the stash without the
            * signup marker, so leaving it can only help the return trip — it

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -296,7 +296,6 @@ export function PlansPage() {
                 creditTier: body.credit_tier ?? null,
               },
         );
-        // Snapshot the avatar so the takeover can draw it on a cold return.
         captureTakeoverAvatarStash(queryClient);
         openUrl(result.checkout_url);
       } else {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -13,6 +13,7 @@ import * as motionReact from "motion/react";
 
 import { organizationsBillingPlansRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import type { PlanListResponse } from "@/generated/api/types.gen";
+import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
@@ -32,6 +33,7 @@ let avatarTraits: CharacterTraits | null = null;
 /** An uploaded avatar image, which the takeover also blurs behind its content. */
 let avatarCustomImageUrl: string | null = null;
 mock.module("@/hooks/use-assistant-avatar", () => ({
+  ...assistantAvatarMod,
   useAssistantAvatar: (assistantId: string | null) => {
     avatarQueryId = assistantId;
     return {
@@ -42,7 +44,6 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
       invalidate: () => {},
     };
   },
-  avatarQueryKey: (assistantId: string) => ["assistantAvatar", assistantId],
 }));
 
 // `useReducedMotion` reads a cached media-query singleton, so a per-test
@@ -750,18 +751,16 @@ describe("takeover avatar mode", () => {
     );
   });
 
-  for (const state of ["CONFIRMING", "WAITING"] as const) {
-    test(`renders exactly one placeholder in ${state}`, () => {
-      const { container } = renderState({
-        state,
-        assistantId: "primary-assistant",
-      });
-
-      expect(
-        container.querySelectorAll(".provision-avatar-placeholder"),
-      ).toHaveLength(1);
+  test("renders exactly one placeholder", () => {
+    const { container } = renderState({
+      state: "WAITING",
+      assistantId: "primary-assistant",
     });
-  }
+
+    expect(
+      container.querySelectorAll(".provision-avatar-placeholder"),
+    ).toHaveLength(1);
+  });
 
   test("reveals the avatar once the target and the query both settle", () => {
     const { container, getByTestId } = renderState({

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -234,7 +234,7 @@ function TakeoverAvatar({
       }
     >
       <div className="provision-avatar-stage">
-        {/* Keeps the reserved stage from reading as a hole while the avatar is withheld. */}
+        {/* Always rendered, and first, so the creature reveals over it. */}
         <div
           data-testid="provision-avatar-placeholder"
           className={`provision-avatar-placeholder${avatarReady ? " is-resolved" : ""}`}

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -245,7 +245,6 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
               storageTier: selectedStorageTier,
               creditTier: displayCreditTier,
             });
-            // Snapshot the avatar so the takeover can draw it on a cold return.
             captureTakeoverAvatarStash(queryClient);
             void openUrl(data.checkout_url);
             return;

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -472,7 +472,6 @@ beforeEach(() => {
   onboardingResponse = {};
   toastSuccessCalls = [];
   captureStashCalls = 0;
-  takeoverAvatarStash.clearTakeoverAvatarStash();
 });
 
 afterEach(() => {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -271,7 +271,6 @@ function RecommendedUpgrade({
           kind: "package",
           packageKey: recommended.key,
         });
-        // Snapshot the avatar so the takeover can draw it on a cold return.
         captureTakeoverAvatarStash(queryClient);
         // Stripe returns with a `session_id`, which opens the
         // post-checkout Pro onboarding wizard — via the billing page on

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -277,10 +277,9 @@ body {
   height: var(--provision-avatar-size);
   width: calc(var(--provision-avatar-size) * 0.8);
   margin-inline: auto;
-  /* Fallback glow for engines without color-mix() (WKWebView before
-   * iOS 16.2, per the iOS 15.0 deployment target): the takeover is always
-   * dark-themed, so a translucent white stands in for the emphasised mix.
-   * Engines that parse color-mix() take the declaration below instead. */
+  /* Fallback first for engines without color-mix(), see the skeleton-shimmer
+   * note above. The takeover is always dark-themed, so a translucent white
+   * stands in for the emphasised mix. */
   background: radial-gradient(
     closest-side,
     rgba(255, 255, 255, 0.12),


### PR DESCRIPTION
## Summary
Fixes gaps from the plan self-review for instant-takeover-avatar.md: two unpaired checkout-page stash clears, duplicated comments, dead test scaffolding, mock-shape unification.