### PR TITLE
fix: harden takeover avatar stash capture, latch, and lifecycle

### DIFF
--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -209,7 +209,11 @@ beforeEach(() => {
   sessionStorage.removeItem(INTENT_KEY);
   // Also resets the stash module's in-memory mirror, which outlives storage.
   clearTakeoverAvatarStash();
-  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  useResolvedAssistantsStore.setState({
+    activeAssistantId: null,
+    assistants: [],
+    assistantsHydrated: false,
+  });
 });
 
 afterEach(() => {
@@ -220,7 +224,12 @@ describe("CheckoutPage", () => {
   test("valid package + full gate fires the upgrade, stashes intent and avatar, opens Stripe", async () => {
     const client = freshQueryClient();
     seedCachedAvatar(client, "a1");
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    // Capture only stashes for a hydrated list holding exactly one assistant.
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "a1",
+      assistants: [{ id: "a1", isLocal: false, isPlatformHosted: true }],
+      assistantsHydrated: true,
+    });
     render(checkoutTree("/assistant/checkout?package=super", client));
 
     await waitFor(() => expect(upgradeCalls.length).toBe(1));

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -557,7 +557,11 @@ beforeEach(() => {
   takeoverResizeCredits = undefined;
   // The stash and the assistants store are module-level globals, so reset both.
   clearTakeoverAvatarStash();
-  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  useResolvedAssistantsStore.setState({
+    activeAssistantId: null,
+    assistants: [],
+    assistantsHydrated: false,
+  });
 });
 
 afterEach(() => {
@@ -698,7 +702,12 @@ describe("PlansPage — Pro package switch (change-package)", () => {
 
   test("base user CTA starts Stripe checkout, not change-package", async () => {
     const { client, findByRole } = renderInteractive(freeSubscription());
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    // Capture only stashes for a hydrated list holding exactly one assistant.
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "a1",
+      assistants: [{ id: "a1", isLocal: false, isPlatformHosted: true }],
+      assistantsHydrated: true,
+    });
     client.setQueryData([...avatarQueryKey("a1"), true], {
       components: BUNDLED_COMPONENTS,
       traits: null,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -73,7 +73,6 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
     isLoading: false,
     invalidate: () => {},
   }),
-  avatarQueryKey: (assistantId: string) => ["assistantAvatar", assistantId],
 }));
 
 // Capture the escape toast so the exit-on-escape path can assert its message;
@@ -320,11 +319,11 @@ function renderModal({
     client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
   }
   const onClose = mock(() => {});
-  const view = render(
+  const tree = (open: boolean) => (
     <MemoryRouter>
       <QueryClientProvider client={client}>
         <BillingOnboardingModal
-          open
+          open={open}
           onClose={onClose}
           dwellMs={TEST_DWELL_MS}
           phaseMinMs={0}
@@ -332,9 +331,12 @@ function renderModal({
           resizeCredits={resizeCredits}
         />
       </QueryClientProvider>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
-  return { client, onClose, ...view };
+  const view = render(tree(true));
+  /** Flips `open` to false, which is what the parent does on close. */
+  const close = () => view.rerender(tree(false));
+  return { client, onClose, close, ...view };
 }
 
 beforeEach(() => {
@@ -359,8 +361,8 @@ beforeEach(() => {
   dateNowOffsetMs = 0;
   toastInfoCalls.length = 0;
   sessionStorage.clear();
-  // Resets the stash module's in-memory mirror, which sessionStorage.clear()
-  // leaves behind.
+  // Also resets the stash module's in-memory mirror, which sessionStorage.clear()
+  // leaves in place (it is simply never served while storage is readable).
   clearTakeoverAvatarStash();
 });
 
@@ -430,7 +432,7 @@ describe("BillingOnboardingModal", () => {
     expect(queryByText("Super package")).toBeNull();
   });
 
-  test("domain_setup_available false skips straight to complete and clears the intent and avatar stashes", async () => {
+  test("domain_setup_available false skips straight to complete, clearing the intent there and the avatar stash on close", async () => {
     saveCheckoutIntent({ kind: "package", packageKey: "super" });
     saveTakeoverAvatarStash({
       assistantId: "assistant-1",
@@ -439,7 +441,7 @@ describe("BillingOnboardingModal", () => {
     });
     subscriptionPlanId = "pro";
     onboardingResponse = makeOnboarding({ domain_setup_available: false });
-    const { client, getByText, queryByText } = renderModal();
+    const { client, close, getByText, queryByText } = renderModal();
 
     await waitFor(
       () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
@@ -459,9 +461,14 @@ describe("BillingOnboardingModal", () => {
     });
     expect(queryByText("Assistant Email")).toBeNull();
     expect(readCheckoutIntent()).toBeNull();
-    expect(readTakeoverAvatarStash()).toBeNull();
+    // The stash outlives the step flip: the exit sheet still paints from the
+    // surface it feeds, so clearing here would slide that tint mid-fade.
+    expect(readTakeoverAvatarStash()).not.toBeNull();
     // Checkout mode never fires the modal-level domains query.
     expect(domainsCalls).toBe(0);
+
+    close();
+    expect(readTakeoverAvatarStash()).toBeNull();
   });
 
   test(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -121,8 +121,14 @@ export function BillingOnboardingModal({
   // backgrounded resize still resolves while the user sets up their domain.
   const provisioning = useProProvisioning({ open });
 
+  // Whether this wizard has actually been opened, so the reset branch below can
+  // tell a close from the mount of an instance that is simply rendered closed
+  // (the billing page mounts two of these; only one opens).
+  const hasOpenedRef = useRef(false);
+
   useEffect(() => {
     if (open) {
+      hasOpenedRef.current = true;
       setIntent(isResize ? null : readPurchasedCheckoutIntent());
       // Fence the domains freshness check to this open before any domains fetch
       // can land, so a pre-open cached list never reads as fresh.
@@ -138,6 +144,13 @@ export function BillingOnboardingModal({
     setDisplayedPhase(null);
     setDomainsOpenedAt(null);
     setBackgroundConfirmOpen(false);
+    if (hasOpenedRef.current) {
+      hasOpenedRef.current = false;
+      // On close, not at the complete step: the takeover's exit sheet still
+      // paints from this surface, so bumping the stash version mid-fade would
+      // slide an otherwise-empty avatar query's tint to bundled green.
+      clearTakeoverAvatarStash();
+    }
   }, [open, isResize]);
 
   useEffect(
@@ -150,7 +163,6 @@ export function BillingOnboardingModal({
   useEffect(() => {
     if (step === "complete") {
       clearCheckoutIntent();
-      clearTakeoverAvatarStash();
     }
   }, [step]);
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { QueryClient } from "@tanstack/react-query";
 
+import type { AvatarData } from "@/hooks/use-assistant-avatar";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import type { CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
 import {
@@ -29,12 +30,6 @@ const OTHER_TRAITS: CharacterTraits = {
   color: "green",
 };
 
-interface AvatarCacheEntry {
-  components: CharacterComponents | null;
-  traits: CharacterTraits | null;
-  customImageUrl: string | null;
-}
-
 beforeEach(() => {
   sessionStorage.clear();
   // Reset the module-level in-memory mirror so it can't leak across tests.
@@ -42,11 +37,21 @@ beforeEach(() => {
   useResolvedAssistantsStore.setState({
     activeAssistantId: null,
     assistants: [],
+    assistantsHydrated: false,
   });
 });
 
 function assistant(id: string): ResolvedAssistant {
   return { id, isLocal: false, isPlatformHosted: true };
+}
+
+/** A hydrated list holding exactly one assistant: the only shape capture stashes. */
+function soloOrg(id: string): void {
+  useResolvedAssistantsStore.setState({
+    activeAssistantId: id,
+    assistants: [assistant(id)],
+    assistantsHydrated: true,
+  });
 }
 
 describe("saveTakeoverAvatarStash / readTakeoverAvatarStash", () => {
@@ -229,7 +234,7 @@ describe("takeoverAvatarStashVersion", () => {
 });
 
 describe("in-memory mirror on a same-document return", () => {
-  test("the mirror serves the stash back after a throwing setItem", () => {
+  test("the mirror serves the stash back when sessionStorage throws", () => {
     // The native path: checkout opens in an external browser, so the document
     // is never unloaded and the module is still alive to answer. happy-dom's
     // Storage is a Proxy, so overwriting `setItem` on it just writes a storage
@@ -239,7 +244,9 @@ describe("in-memory mirror on a same-document return", () => {
       "sessionStorage",
     )!;
     const throwing = {
-      getItem: () => null,
+      getItem: () => {
+        throw new Error("sessionStorage unavailable");
+      },
       setItem: () => {
         throw new Error("sessionStorage unavailable");
       },
@@ -261,6 +268,19 @@ describe("in-memory mirror on a same-document return", () => {
       Object.defineProperty(globalThis, "sessionStorage", original);
     }
   });
+
+  test("the mirror does not resurrect a stash sessionStorage no longer holds", () => {
+    // Logout wipes sessionStorage wholesale, so a readable-but-empty store has
+    // to read as absence or the previous account's avatar survives the wipe.
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+    });
+    sessionStorage.clear();
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
 });
 
 describe("captureTakeoverAvatarStash", () => {
@@ -277,7 +297,7 @@ describe("captureTakeoverAvatarStash", () => {
    */
   function seed(
     assistantId: string,
-    data: AvatarCacheEntry,
+    data: AvatarData,
     options?: { supportsManifest?: boolean; updatedAt?: number },
   ) {
     queryClient.setQueryData(
@@ -297,7 +317,7 @@ describe("captureTakeoverAvatarStash", () => {
   }
 
   test("stashes the active assistant's cached avatar", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     seed("a1", {
       components: BUNDLED_COMPONENTS,
       traits: TRAITS,
@@ -313,7 +333,7 @@ describe("captureTakeoverAvatarStash", () => {
   });
 
   test("stashes a null-traits avatar", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     seed("a1", {
       components: BUNDLED_COMPONENTS,
       traits: null,
@@ -332,6 +352,7 @@ describe("captureTakeoverAvatarStash", () => {
     useResolvedAssistantsStore.setState({
       activeAssistantId: "a1",
       assistants: [assistant("a1")],
+      assistantsHydrated: true,
     });
     seed("a1", {
       components: BUNDLED_COMPONENTS,
@@ -344,12 +365,51 @@ describe("captureTakeoverAvatarStash", () => {
     expect(readTakeoverAvatarStash()).toMatchObject({ assistantId: "a1" });
   });
 
+  test("clears instead of stashing before the list has hydrated", () => {
+    // A persisted `activeAssistantId` reads through pre-hydration, so a list
+    // that happens to show one assistant proves nothing about the org yet.
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "a1",
+      assistants: [assistant("a1")],
+      assistantsHydrated: false,
+    });
+    seed("a1", {
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+      customImageUrl: null,
+    });
+    preexistingStash();
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+
+  test("clears instead of stashing when the hydrated list is empty", () => {
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "a1",
+      assistants: [],
+      assistantsHydrated: true,
+    });
+    seed("a1", {
+      components: BUNDLED_COMPONENTS,
+      traits: TRAITS,
+      customImageUrl: null,
+    });
+    preexistingStash();
+
+    captureTakeoverAvatarStash(queryClient);
+
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+
   test("clears instead of stashing when a second assistant exists", () => {
     // The takeover targets the onboarding payload's primary, which need not be
     // the active assistant, and it draws before that target resolves.
     useResolvedAssistantsStore.setState({
       activeAssistantId: "a1",
       assistants: [assistant("a1"), assistant("a2")],
+      assistantsHydrated: true,
     });
     seed("a1", {
       components: BUNDLED_COMPONENTS,
@@ -372,7 +432,7 @@ describe("captureTakeoverAvatarStash", () => {
   });
 
   test("clears a pre-existing stash when the avatar is not cached", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     preexistingStash();
 
     captureTakeoverAvatarStash(queryClient);
@@ -381,7 +441,7 @@ describe("captureTakeoverAvatarStash", () => {
   });
 
   test("clears a pre-existing stash for a custom-image avatar", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     seed("a1", {
       components: BUNDLED_COMPONENTS,
       traits: null,
@@ -395,7 +455,7 @@ describe("captureTakeoverAvatarStash", () => {
   });
 
   test("clears a pre-existing stash when components are null", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     seed("a1", {
       components: null,
       traits: TRAITS,
@@ -409,7 +469,7 @@ describe("captureTakeoverAvatarStash", () => {
   });
 
   test("stashes the freshest entry when the stale variant was cached first", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     const now = Date.now();
     seed(
       "a1",
@@ -432,7 +492,7 @@ describe("captureTakeoverAvatarStash", () => {
   });
 
   test("stashes the freshest entry when the stale variant was cached last", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     const now = Date.now();
     seed(
       "a1",
@@ -455,7 +515,7 @@ describe("captureTakeoverAvatarStash", () => {
   });
 
   test("a stale custom-image entry does not veto the freshest avatar", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     const now = Date.now();
     seed(
       "a1",
@@ -481,7 +541,7 @@ describe("captureTakeoverAvatarStash", () => {
   });
 
   test("a fresh custom-image entry clears a stale drawable one", () => {
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    soloOrg("a1");
     const now = Date.now();
     seed(
       "a1",

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
@@ -1,9 +1,12 @@
 import type { QueryClient } from "@tanstack/react-query";
 
-import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import { avatarQueryKey, type AvatarData } from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
-import { isCharacterTraits } from "@/types/avatar";
+import {
+  isCharacterTraits,
+  type CharacterComponents,
+  type CharacterTraits,
+} from "@/types/avatar";
 
 /**
  * The render inputs of the active assistant's avatar, captured at the moment a
@@ -15,10 +18,10 @@ import { isCharacterTraits } from "@/types/avatar";
  * dies with the tab) under a 30-minute TTL: a checkout abandoned longer than
  * that shouldn't resurface as a phantom avatar.
  *
- * Only ever a single-assistant org's snapshot, since
- * {@link captureTakeoverAvatarStash} skips orgs holding more than one. That is
- * what lets the takeover draw it before the target assistant resolves: with
- * one creature in the org there is no other one it could be aiming at.
+ * Only ever the snapshot of an org positively known to hold one assistant,
+ * since {@link captureTakeoverAvatarStash} skips every other case. That is what
+ * lets the takeover draw it before the target assistant resolves: with one
+ * creature in the org there is no other one it could be aiming at.
  */
 export interface TakeoverAvatarStash {
   assistantId: string;
@@ -31,13 +34,6 @@ export interface TakeoverAvatarStash {
   savedAt: number;
 }
 
-/** The cached avatar-query payload this module reads from. */
-interface CachedAvatar {
-  components: CharacterComponents | null;
-  traits: CharacterTraits | null;
-  customImageUrl: string | null;
-}
-
 const STORAGE_KEY = "vellum.pro-takeover-avatar";
 const MAX_AGE_MS = 30 * 60 * 1000;
 
@@ -48,6 +44,10 @@ const MAX_AGE_MS = 30 * 60 * 1000;
  * the redirect tears the document down, so a browser whose sessionStorage
  * throws keeps no stash at all and the takeover draws its breathing
  * placeholder through the wait instead.
+ *
+ * Served ONLY when sessionStorage is unreachable, never when it is readable and
+ * empty: a readable null is authoritative absence, which is what makes logout's
+ * blanket `sessionStorage.clear()` able to kill the stash outright.
  */
 let inMemoryStash: TakeoverAvatarStash | null = null;
 
@@ -57,6 +57,10 @@ let inMemoryStash: TakeoverAvatarStash | null = null;
  * browser without unloading the document: the takeover's host is already
  * mounted when the stash is written, so a once-per-mount read would keep
  * serving the null it saw before the hand-off.
+ *
+ * Read during render with no subscription, so a bump only lands on the next
+ * externally-triggered render; the takeover's open flip guarantees one on the
+ * path that matters.
  */
 let version = 0;
 
@@ -82,20 +86,22 @@ export function saveTakeoverAvatarStash(
 /**
  * The stashed avatar, or `null` when absent, unparsable, malformed, or older
  * than the TTL: anything unusable is cleared so it can't resurface. Falls back
- * to the in-memory mirror when sessionStorage is unreachable or empty.
+ * to the in-memory mirror only when sessionStorage is unreachable; a readable
+ * sessionStorage is authoritative, empty included.
  */
 export function readTakeoverAvatarStash(): TakeoverAvatarStash | null {
-  let raw: string | null = null;
-  if (typeof sessionStorage !== "undefined") {
-    try {
-      raw = sessionStorage.getItem(STORAGE_KEY);
-    } catch {
-      // sessionStorage unreachable, fall back to the in-memory mirror.
-      return readInMemoryStash();
-    }
+  if (typeof sessionStorage === "undefined") {
+    return readInMemoryStash();
+  }
+  let raw: string | null;
+  try {
+    raw = sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    // sessionStorage unreachable, fall back to the in-memory mirror.
+    return readInMemoryStash();
   }
   if (!raw) {
-    return readInMemoryStash();
+    return null;
   }
 
   let parsed: unknown;
@@ -129,21 +135,26 @@ export function clearTakeoverAvatarStash(): void {
  * Capture the active assistant's cached avatar into the stash, or clear the
  * stash when there is nothing drawable to capture.
  *
- * Every Stripe redirect site calls this, and every call either writes a fresh
- * stash or removes a stale one, so a previous user's (or a previous avatar's)
- * stash can never ride along with a new checkout.
+ * Every pro-checkout redirect site calls this, and every call either writes a
+ * fresh stash or removes a stale one, so a previous user's (or a previous
+ * avatar's) stash can never ride along with a new checkout.
  *
- * Orgs holding more than one assistant are skipped: the takeover draws the
- * onboarding payload's primary, which need not be the active one, and it draws
- * before that target resolves. Capturing only where the two cannot disagree
- * costs those orgs the instant avatar and buys the guarantee outright.
+ * Only a hydrated list holding exactly one assistant is captured: the takeover
+ * draws the onboarding payload's primary, which need not be the active one, and
+ * it draws before that target resolves. Capturing only where the two cannot
+ * disagree costs everyone else the instant avatar and buys the guarantee
+ * outright.
  */
 export function captureTakeoverAvatarStash(queryClient: QueryClient): void {
-  const { activeAssistantId: assistantId, assistants } =
-    useResolvedAssistantsStore.getState();
-  // Cross-org entries count too: overcounting only forfeits the instant
-  // avatar, undercounting draws the wrong creature.
-  if (!assistantId || assistants.length > 1) {
+  const {
+    activeAssistantId: assistantId,
+    assistants,
+    assistantsHydrated,
+  } = useResolvedAssistantsStore.getState();
+  // The single-assistant org has to be positively known: the list starts empty
+  // while a persisted `activeAssistantId` already reads through, so an
+  // unhydrated read cannot tell a solo org from a multi-assistant one.
+  if (!assistantId || !assistantsHydrated || assistants.length !== 1) {
     clearTakeoverAvatarStash();
     return;
   }
@@ -174,15 +185,15 @@ export function captureTakeoverAvatarStash(queryClient: QueryClient): void {
 function freshestCachedAvatar(
   queryClient: QueryClient,
   assistantId: string,
-): CachedAvatar | undefined {
+): AvatarData | undefined {
   const matches = queryClient
     .getQueryCache()
     .findAll({ queryKey: avatarQueryKey(assistantId) });
 
-  let freshest: CachedAvatar | undefined;
+  let freshest: AvatarData | undefined;
   let freshestAt = -Infinity;
   for (const query of matches) {
-    const data = query.state.data as CachedAvatar | undefined;
+    const data = query.state.data as AvatarData | undefined;
     if (data === undefined || query.state.dataUpdatedAt < freshestAt) {
       continue;
     }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
@@ -281,6 +281,37 @@ describe("avatar stash", () => {
     expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
   });
 
+  test("a target resolving to another assistant mid-flight keeps the drawn stash", () => {
+    // Dropping `ready` here would unmount the creature and restart the
+    // placeholder, so a stash already on screen stays until live data lands.
+    seedStash("primary-assistant", "purple");
+    avatar.isLoading = true;
+
+    const { rerender, result } = renderHook(
+      ({ id }: { id?: string | null }) => useTakeoverSurface(id),
+      { initialProps: { id: null } as { id?: string | null } },
+    );
+    expect(result.current.ready).toBe(true);
+    expect(result.current.avatar.traits).toEqual(traits("purple"));
+
+    rerender({ id: "other-assistant" });
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.avatar.traits).toEqual(traits("purple"));
+    expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
+
+    avatar = {
+      components: BUNDLED_COMPONENTS,
+      traits: traits("orange"),
+      customImageUrl: null,
+      isLoading: false,
+    };
+    rerender({ id: "other-assistant" });
+
+    expect(result.current.avatar.traits).toEqual(traits("orange"));
+    expect(result.current.tintHex.toLowerCase()).toBe(ORANGE_SURFACE);
+  });
+
   test("a settle with no data at all keeps the stash", () => {
     // The daemon erroring while the machine restarts settles the query empty.
     // The stashed creature beats falling through to the bundled green one.

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
@@ -77,12 +77,20 @@ export function useTakeoverSurface(
   // `useAssistantAvatar(null)` is a disabled query, which reports
   // `isLoading: false` with no data, so the id has to gate settling too.
   const liveSettled = resolvedId != null && !isLoading;
+  // The id of a stash this surface has already drawn. Latched so the surface
+  // only ever upgrades: a target resolving to a different id mid-flight would
+  // otherwise drop `ready` back to false, unmounting the creature and
+  // restarting the placeholder before the real one lands.
+  const [latchedStashId, setLatchedStashId] = useState<string | null>(null);
   // While the provisioning hook has not named a target the stash may stand in,
   // safe because a stash is only ever captured in a single-assistant org, so
   // there is no second creature the unresolved target could turn out to be.
-  // Once a target does resolve, only a matching stash may draw.
+  // Once a target does resolve, only a matching (or already drawn) stash draws.
   const stashUsable =
-    stash != null && (resolvedId == null || resolvedId === stash.assistantId);
+    stash != null &&
+    (resolvedId == null ||
+      resolvedId === stash.assistantId ||
+      latchedStashId === stash.assistantId);
   const liveDrawable =
     liveSettled &&
     (components != null || traits != null || customImageUrl != null);
@@ -90,6 +98,13 @@ export function useTakeoverSurface(
   // daemon erroring while the machine restarts) keeps the stash, which is
   // strictly more truthful than the bundled-green fallback.
   const drawnStash = stashUsable && !liveDrawable ? stash : null;
+
+  const drawnStashId = drawnStash?.assistantId ?? null;
+  useEffect(() => {
+    if (drawnStashId != null) {
+      setLatchedStashId(drawnStashId);
+    }
+  }, [drawnStashId]);
 
   const effectiveComponents = drawnStash ? drawnStash.components : components;
   const effectiveTraits = drawnStash ? drawnStash.traits : traits;
@@ -109,8 +124,7 @@ export function useTakeoverSurface(
 
   return {
     tintHex: ready && accent ? avatarSurfaceHex(accent) : SURFACE_GROUND,
-    // The stash carries no image, so only a live settle can supply a backdrop.
-    backdropImageUrl: liveSettled ? customImageUrl : null,
+    backdropImageUrl: ready ? effectiveCustomImageUrl : null,
     ready,
     avatar: {
       components: effectiveComponents,

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -273,7 +273,11 @@ beforeEach(() => {
   // leaves a prior test's intent readable.
   clearCheckoutIntent();
   clearTakeoverAvatarStash();
-  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  useResolvedAssistantsStore.setState({
+    activeAssistantId: null,
+    assistants: [],
+    assistantsHydrated: false,
+  });
 });
 
 afterEach(() => {
@@ -324,8 +328,13 @@ describe("AdjustPlanModal upgrade — checkout intent stash", () => {
       subscription("base", null),
       proPlansResponse(CREDIT_TIERS),
     );
-    // The live avatar key appends a `supportsManifest` boolean.
-    useResolvedAssistantsStore.setState({ activeAssistantId: "a1" });
+    // The live avatar key appends a `supportsManifest` boolean, and capture only
+    // stashes for a hydrated list holding exactly one assistant.
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "a1",
+      assistants: [{ id: "a1", isLocal: false, isPlatformHosted: true }],
+      assistantsHydrated: true,
+    });
     client.setQueryData([...avatarQueryKey("a1"), true], {
       components: BUNDLED_COMPONENTS,
       traits: { bodyShape: "blob", eyeStyle: "default", color: "purple" },

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -16,7 +16,8 @@ export function avatarQueryKey(assistantId: string) {
   return [AVATAR_QUERY_KEY_PREFIX, assistantId] as const;
 }
 
-interface AvatarData {
+/** The shape cached under {@link avatarQueryKey}; read directly by cache consumers. */
+export interface AvatarData {
   components: CharacterComponents | null;
   traits: CharacterTraits | null;
   customImageUrl: string | null;


### PR DESCRIPTION
## Summary
Fixes gaps from the plan self-review for instant-takeover-avatar.md: hydration-aware capture guard, monotonic ready latch, clear-on-close, readable-null mirror contract, doc/type cleanups.