### PR TITLE
feat(gateway): serve approved plugin ingress at /webhooks/plugins/&lt;plugin&gt;/&lt;path&gt;

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -211,6 +211,10 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   // ingress path; not part of the public gateway API
   "/v1/speech/stt/stream",
   "/v1/speech/tts/stream",
+  // Plugin-declared webhooks — which paths exist is decided at runtime by the
+  // installed plugins and the guardian's approvals, so there is no fixed set
+  // to document. The declaration schema is the contract, not this path.
+  "/webhooks/plugins/{param1}/{param2}",
 ]);
 
 // ── Schema paths that don't map to a discrete route definition ──

--- a/gateway/src/channels/plugin-ingress-approvals.test.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.test.ts
@@ -46,7 +46,12 @@ function makeWorkspace(): string {
 }
 
 const ROUTES = [
-  { path: "realtime", kind: "websocket" as const, description: "events" },
+  {
+    path: "realtime",
+    kind: "websocket" as const,
+    signer: "plugin" as const,
+    description: "events",
+  },
 ];
 
 function writePlugin(
@@ -69,36 +74,60 @@ function writePlugin(
 describe("ingressDeclarationDigest", () => {
   it("is stable across route ordering", () => {
     const a = ingressDeclarationDigest([
-      { kind: "http", path: "a" },
-      { kind: "http", path: "b" },
+      { kind: "http", signer: "plugin", path: "a" },
+      { kind: "http", signer: "plugin", path: "b" },
     ]);
     const b = ingressDeclarationDigest([
-      { kind: "http", path: "b" },
-      { kind: "http", path: "a" },
+      { kind: "http", signer: "plugin", path: "b" },
+      { kind: "http", signer: "plugin", path: "a" },
     ]);
     expect(a).toBe(b);
   });
 
   it("ignores a description reword so an approval survives it", () => {
     const before = ingressDeclarationDigest([
-      { kind: "http", path: "a", description: "one" } as never,
+      {
+        kind: "http",
+        signer: "plugin",
+        path: "a",
+        description: "one",
+      } as never,
     ]);
     const after = ingressDeclarationDigest([
-      { kind: "http", path: "a", description: "reworded" } as never,
+      {
+        kind: "http",
+        signer: "plugin",
+        path: "a",
+        description: "reworded",
+      } as never,
     ]);
     expect(after).toBe(before);
   });
 
+  it("changes when the signer changes", () => {
+    // Switching signer changes whose key opens the route, so an approval for
+    // one must not carry over to the other.
+    expect(
+      ingressDeclarationDigest([{ kind: "http", signer: "vellum", path: "a" }]),
+    ).not.toBe(
+      ingressDeclarationDigest([{ kind: "http", signer: "plugin", path: "a" }]),
+    );
+  });
+
   it("changes when reach widens or a transport changes", () => {
-    const base = ingressDeclarationDigest([{ kind: "http", path: "a" }]);
+    const base = ingressDeclarationDigest([
+      { kind: "http", signer: "plugin", path: "a" },
+    ]);
     expect(
       ingressDeclarationDigest([
-        { kind: "http", path: "a" },
-        { kind: "http", path: "b" },
+        { kind: "http", signer: "plugin", path: "a" },
+        { kind: "http", signer: "plugin", path: "b" },
       ]),
     ).not.toBe(base);
     expect(
-      ingressDeclarationDigest([{ kind: "websocket", path: "a" }]),
+      ingressDeclarationDigest([
+        { kind: "websocket", signer: "plugin", path: "a" },
+      ]),
     ).not.toBe(base);
   });
 });

--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -6,6 +6,7 @@ import { listPluginIngressApprovals } from "../db/plugin-ingress-approval-store.
 import { getLogger } from "../logger.js";
 import {
   discoverPluginIngress,
+  PluginIngressCache,
   type DiscoveredPluginIngress,
   type DiscoverPluginIngressOptions,
   type IngressRoute,
@@ -74,13 +75,25 @@ export function resolvePluginIngress(
 }
 
 /**
- * Split an already-performed discovery by approval.
- *
- * Split out so the request path can resolve against {@link
- * PluginIngressCache} rather than re-walking the filesystem per inbound
- * webhook.
+ * Shared TTL cache behind {@link resolveCachedPluginIngress}. Module-global
+ * so every caller sees one snapshot and one refresh schedule.
  */
-export function resolveDiscoveredPluginIngress(
+const ingressCache = new PluginIngressCache();
+
+/**
+ * Approved-ingress view for the request path.
+ *
+ * Reads through the TTL cache rather than re-walking the plugins directory
+ * per inbound webhook, while installs and toggles still take effect without
+ * a gateway restart. Approvals are read from the database each call — the
+ * table is small, and a stale grant is the one thing worth never caching.
+ */
+export function resolveCachedPluginIngress(): PluginIngressResolution {
+  return resolveDiscoveredPluginIngress(ingressCache.get());
+}
+
+/** Split an already-performed discovery by approval. */
+function resolveDiscoveredPluginIngress(
   discovery: PluginIngressDiscovery,
 ): PluginIngressResolution {
   const { plugins, problems } = discovery;

--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -9,6 +9,7 @@ import {
   type DiscoveredPluginIngress,
   type DiscoverPluginIngressOptions,
   type IngressRoute,
+  type PluginIngressDiscovery,
   type PluginIngressProblem,
 } from "./plugin-ingress.js";
 
@@ -69,7 +70,20 @@ export interface PluginIngressResolution {
 export function resolvePluginIngress(
   opts: DiscoverPluginIngressOptions = {},
 ): PluginIngressResolution {
-  const { plugins, problems } = discoverPluginIngress(opts);
+  return resolveDiscoveredPluginIngress(discoverPluginIngress(opts));
+}
+
+/**
+ * Split an already-performed discovery by approval.
+ *
+ * Split out so the request path can resolve against {@link
+ * PluginIngressCache} rather than re-walking the filesystem per inbound
+ * webhook.
+ */
+export function resolveDiscoveredPluginIngress(
+  discovery: PluginIngressDiscovery,
+): PluginIngressResolution {
+  const { plugins, problems } = discovery;
   const approvedDigestByPlugin = new Map(
     listPluginIngressApprovals().map((a) => [a.plugin, a.digest]),
   );

--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -19,15 +19,16 @@ const log = getLogger("plugin-ingress-approvals");
 /**
  * Digest of what a declaration asks for.
  *
- * Covers reach only — each route's transport and path, order-independent.
- * A `description` reword leaves the digest alone, so it does not revoke an
- * approval, while adding a route or changing one's transport does.
+ * Covers reach only — each route's transport, signer, and path,
+ * order-independent. A `description` reword leaves the digest alone, so it
+ * does not revoke an approval, while adding a route, changing one's
+ * transport, or changing whose signature opens it does.
  */
 export function ingressDeclarationDigest(
-  routes: readonly Pick<IngressRoute, "kind" | "path">[],
+  routes: readonly Pick<IngressRoute, "kind" | "path" | "signer">[],
 ): string {
   const canonical = routes
-    .map((route) => `${route.kind} ${route.path}`)
+    .map((route) => `${route.kind} ${route.signer} ${route.path}`)
     .sort()
     .join("\n");
   return createHash("sha256").update(canonical).digest("hex").slice(0, 32);

--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -78,6 +78,42 @@ describe("parsePluginIngressManifest", () => {
     expect(manifest.routes[0]!.path).toBe("realtime");
   });
 
+  it("defaults an undeclared signer to the plugin's own secret", () => {
+    // The safe default: a plugin gets no reach against the platform's key
+    // unless it asks for it and a guardian approves that declaration.
+    const manifest = parsePluginIngressManifest(JSON.parse(VALID));
+    expect(manifest.routes[0]!.signer).toBe("plugin");
+  });
+
+  it("accepts a declared vellum signer", () => {
+    const manifest = parsePluginIngressManifest({
+      routes: [
+        {
+          path: "realtime",
+          kind: "websocket",
+          signer: "vellum",
+          description: "platform-signed events",
+        },
+      ],
+    });
+    expect(manifest.routes[0]!.signer).toBe("vellum");
+  });
+
+  it("rejects an unknown signer", () => {
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [
+          {
+            path: "realtime",
+            kind: "http",
+            signer: "anyone",
+            description: "x",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
   it("rejects an absolute path", () => {
     expect(() =>
       parsePluginIngressManifest({

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -24,6 +24,13 @@ export const PLUGIN_INGRESS_MANIFEST_RELPATH = join("channels", "ingress.json");
 export const IngressRouteKindSchema = z.enum(["http", "websocket"]);
 export type IngressRouteKind = z.infer<typeof IngressRouteKindSchema>;
 
+/**
+ * Party whose `webhook_secret` must have signed an inbound request. Every
+ * public plugin route is signature-checked; this only selects the key.
+ */
+export const IngressSignerSchema = z.enum(["plugin", "vellum"]);
+export type IngressSigner = z.infer<typeof IngressSignerSchema>;
+
 /** Plugin directory name usable as a public URL path segment. */
 const SAFE_PLUGIN_NAME = /^[a-z0-9][a-z0-9._-]*$/i;
 
@@ -74,6 +81,18 @@ export const IngressRouteSchema = z.object({
       message: "path must not contain . or .. segments",
     }),
   kind: IngressRouteKindSchema,
+  /**
+   * Whose secret signs requests to this route.
+   *
+   * `plugin` (the default) verifies against the plugin's own
+   * `webhook_secret`, so a plugin can receive third-party callbacks it has
+   * arranged itself. `vellum` verifies against the platform's
+   * `webhook_secret` — for routes only Vellum calls, which would otherwise
+   * need a per-plugin secret provisioned for a caller we already
+   * authenticate. Declaring it is the plugin's choice; approving it is the
+   * guardian's, which is why it is part of the digest.
+   */
+  signer: IngressSignerSchema.default("plugin"),
   /** Human-readable purpose, surfaced in gateway logs and admin UI. */
   description: z.string().min(1),
 });

--- a/gateway/src/email/verify.ts
+++ b/gateway/src/email/verify.ts
@@ -1,41 +1,15 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { verifyVellumSignature } from "../http/vellum-signature.js";
 
 /**
  * Verify the Vellum-Signature header sent by the Vellum platform.
  *
- * The platform computes: HMAC-SHA256(webhookSecret, rawBody) and sends it as
- *   Vellum-Signature: sha256=<hex-digest>
- *
- * We must compare with a constant-time comparison to avoid timing attacks.
- *
- * This mirrors the WhatsApp webhook signature verification pattern
- * (`X-Hub-Signature-256` header).
+ * The scheme itself lives in `http/vellum-signature.ts`, shared with the
+ * plugin webhook routes so one comparison serves both.
  */
-
-const HEADER_NAME = "vellum-signature";
-
 export function verifyEmailWebhookSignature(
   headers: Headers,
   rawBody: string,
   webhookSecret: string,
 ): boolean {
-  const signatureHeader = headers.get(HEADER_NAME);
-  if (!signatureHeader || !webhookSecret) return false;
-
-  // Header format: "sha256=<hex-digest>"
-  if (!signatureHeader.startsWith("sha256=")) return false;
-  const providedHex = signatureHeader.slice(7);
-
-  const expected = createHmac("sha256", webhookSecret)
-    .update(rawBody, "utf8")
-    .digest("hex");
-
-  // Compare Buffer byte lengths — not string .length — to avoid
-  // timingSafeEqual throwing on non-ASCII input where UTF-16 code unit
-  // count matches but byte length diverges.
-  const providedBuf = Buffer.from(providedHex);
-  const expectedBuf = Buffer.from(expected);
-  if (providedBuf.length !== expectedBuf.length) return false;
-
-  return timingSafeEqual(providedBuf, expectedBuf);
+  return verifyVellumSignature(headers, rawBody, webhookSecret);
 }

--- a/gateway/src/http/routes/channel-ingress.test.ts
+++ b/gateway/src/http/routes/channel-ingress.test.ts
@@ -29,7 +29,12 @@ const created: string[] = [];
 let workspaceDir = "";
 
 const ROUTES = [
-  { path: "realtime", kind: "websocket" as const, description: "events" },
+  {
+    path: "realtime",
+    kind: "websocket" as const,
+    signer: "plugin" as const,
+    description: "events",
+  },
 ];
 
 // Resolve against this test's scratch workspace rather than the ambient one.

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -1,3 +1,5 @@
+import { createHmac } from "node:crypto";
+
 import { describe, expect, it } from "bun:test";
 
 import "../../__tests__/test-preload.js";
@@ -20,8 +22,30 @@ const CONFIG = {
 const ROUTE = {
   path: "realtime",
   kind: "http" as const,
+  signer: "plugin" as const,
   description: "events",
 };
+
+const PLUGIN_SECRET = "plugin-webhook-secret";
+const VELLUM_SECRET = "platform-webhook-secret";
+
+/** Stands in for the credential cache, holding secrets by key. */
+function credentialsFor(entries: Record<string, string>) {
+  return {
+    get: async (key: string) => entries[key],
+  } as unknown as Parameters<
+    typeof createPluginWebhookHandler
+  >[0]["credentials"];
+}
+
+const CREDENTIALS = credentialsFor({
+  "credential/meeting-bot/webhook_secret": PLUGIN_SECRET,
+  "credential/vellum/webhook_secret": VELLUM_SECRET,
+});
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body, "utf8").digest("hex")}`;
+}
 
 function resolution(
   overrides: Partial<PluginIngressResolution> = {},
@@ -31,7 +55,12 @@ function resolution(
 
 /** An approved declaration for `meeting-bot` carrying `routes`. */
 function approvedWith(
-  routes: { path: string; kind: "http" | "websocket"; description: string }[],
+  routes: {
+    path: string;
+    kind: "http" | "websocket";
+    signer: "plugin" | "vellum";
+    description: string;
+  }[],
 ): PluginIngressResolution {
   return resolution({
     approved: [{ plugin: "meeting-bot", routes, digest: "d".repeat(32) }],
@@ -58,8 +87,13 @@ function recordingFetch() {
   return { calls, fetchImpl };
 }
 
-function post(path: string, body = "{}"): Request {
-  return new Request(`http://gateway${path}`, { method: "POST", body });
+/** A signed POST. Pass `secret` to sign with something else, or "" for none. */
+function post(path: string, body = "{}", secret = PLUGIN_SECRET): Request {
+  return new Request(`http://gateway${path}`, {
+    method: "POST",
+    body,
+    headers: secret ? { "vellum-signature": sign(body, secret) } : {},
+  });
 }
 
 describe("approved routes", () => {
@@ -67,6 +101,7 @@ describe("approved routes", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -90,6 +125,7 @@ describe("approved routes", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -110,6 +146,7 @@ describe("the gate", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () =>
         resolution({
           pending: [
@@ -133,6 +170,7 @@ describe("the gate", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -151,6 +189,7 @@ describe("the gate", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -169,6 +208,7 @@ describe("the gate", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -188,6 +228,7 @@ describe("the gate", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -214,6 +255,7 @@ describe("the gate", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([{ ...ROUTE, kind: "websocket" as const }]),
       fetchImpl,
     });
@@ -232,6 +274,7 @@ describe("the gate", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => {
         throw new Error("db unavailable");
       },
@@ -249,11 +292,159 @@ describe("the gate", () => {
   });
 });
 
+describe("signature verification", () => {
+  it("rejects an unsigned request", async () => {
+    // Approval decides which paths exist; it does not say who may call them.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", ""),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects a signature made with the wrong secret", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", "not-the-secret"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects a signature that does not cover this body", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const tampered = new Request(
+      "http://gateway/webhooks/plugins/meeting-bot/realtime",
+      {
+        method: "POST",
+        body: '{"event":"tampered"}',
+        headers: {
+          "vellum-signature": sign('{"event":"joined"}', PLUGIN_SECRET),
+        },
+      },
+    );
+
+    const res = await handle(tampered, "meeting-bot", "realtime");
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("refuses to serve the route at all when no secret is configured", async () => {
+    // Fail closed: a missing secret is a setup mistake, and treating it as
+    // "no signature required" would turn it into an open public endpoint.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: credentialsFor({}),
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(409);
+    expect(calls).toEqual([]);
+  });
+
+  it("verifies a vellum-signed route against the platform secret", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([{ ...ROUTE, signer: "vellum" as const }]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", VELLUM_SECRET),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("does not accept the plugin's own secret on a vellum-signed route", async () => {
+    // Otherwise declaring `signer: "vellum"` would widen rather than narrow
+    // who can reach the route.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([{ ...ROUTE, signer: "vellum" as const }]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", PLUGIN_SECRET),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("does not accept the platform secret on a plugin-signed route", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", VELLUM_SECRET),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+});
+
 describe("payload limits", () => {
   it("rejects a body over the webhook cap without forwarding it", async () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -274,6 +465,7 @@ describe("payload limits", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -303,6 +495,7 @@ describe("payload limits", () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl,
     });
@@ -322,6 +515,7 @@ describe("upstream failures", () => {
   it("reports a runtime that cannot be reached as 502", async () => {
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl: async () => {
         throw new Error("ECONNREFUSED");
@@ -340,6 +534,7 @@ describe("upstream failures", () => {
   it("passes an upstream error status through rather than masking it", async () => {
     const handle = createPluginWebhookHandler({
       config: CONFIG,
+      credentials: CREDENTIALS,
       resolve: () => approvedWith([ROUTE]),
       fetchImpl: async () => new Response("no such route", { status: 404 }),
     });

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "bun:test";
+
+import "../../__tests__/test-preload.js";
+import { initSigningKey } from "../../auth/token-service.js";
+import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
+import type { GatewayConfig } from "../../config.js";
+import { createPluginWebhookHandler } from "./plugin-webhook.js";
+
+// The handler mints a real service token for the upstream hop. Initialising
+// the key beats mocking token-exchange, which is process-wide in bun and
+// would leak into every other suite in the run.
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
+
+const CONFIG = {
+  assistantRuntimeBaseUrl: "http://runtime.test:7821",
+  runtimeTimeoutMs: 1000,
+} as GatewayConfig;
+
+const ROUTE = {
+  path: "realtime",
+  kind: "http" as const,
+  description: "events",
+};
+
+function resolution(
+  overrides: Partial<PluginIngressResolution> = {},
+): PluginIngressResolution {
+  return { approved: [], pending: [], problems: [], ...overrides };
+}
+
+/** An approved declaration for `meeting-bot` carrying `routes`. */
+function approvedWith(
+  routes: { path: string; kind: "http" | "websocket"; description: string }[],
+): PluginIngressResolution {
+  return resolution({
+    approved: [{ plugin: "meeting-bot", routes, digest: "d".repeat(32) }],
+  });
+}
+
+/** Records the upstream call and answers 200. */
+function recordingFetch() {
+  const calls: { url: string; method: string; body: string }[] = [];
+  const fetchImpl = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    calls.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      body:
+        init?.body instanceof ArrayBuffer
+          ? new TextDecoder().decode(init.body)
+          : "",
+    });
+    return new Response("ok", { status: 200 });
+  };
+  return { calls, fetchImpl };
+}
+
+function post(path: string, body = "{}"): Request {
+  return new Request(`http://gateway${path}`, { method: "POST", body });
+}
+
+describe("approved routes", () => {
+  it("forwards to the plugin's route namespace on the runtime", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", '{"event":"joined"}'),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      "http://runtime.test:7821/x/plugins/meeting-bot/realtime",
+    );
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.body).toBe('{"event":"joined"}');
+  });
+
+  it("carries the query string through", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    await handle(
+      post("/webhooks/plugins/meeting-bot/realtime?token=abc"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(calls[0]!.url).toContain("?token=abc");
+  });
+});
+
+describe("the gate", () => {
+  it("404s a route the plugin declares but nobody approved", async () => {
+    // The whole point of the gate: pending is not served.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () =>
+        resolution({
+          pending: [
+            { plugin: "meeting-bot", routes: [ROUTE], digest: "d".repeat(32) },
+          ],
+        }),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(404);
+    expect(calls).toEqual([]);
+  });
+
+  it("404s a plugin with no declaration at all", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/other/realtime"),
+      "other",
+      "realtime",
+    );
+
+    expect(res.status).toBe(404);
+    expect(calls).toEqual([]);
+  });
+
+  it("does not let one plugin's approval serve another's path", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/evil/realtime"),
+      "evil",
+      "realtime",
+    );
+
+    expect(res.status).toBe(404);
+    expect(calls).toEqual([]);
+  });
+
+  it("404s a path the approved declaration does not name", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/admin"),
+      "meeting-bot",
+      "admin",
+    );
+
+    expect(res.status).toBe(404);
+    expect(calls).toEqual([]);
+  });
+
+  it("matches exactly, so an approved path does not carry its subtree", async () => {
+    // Approving `realtime` approved that path, not everything beneath it.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    for (const path of [
+      "realtime/extra",
+      "realtime/../../secret",
+      "realtime%2fextra",
+      "REALTIME",
+      "realtime/",
+    ]) {
+      const res = await handle(
+        post(`/webhooks/plugins/meeting-bot/${path}`),
+        "meeting-bot",
+        path,
+      );
+      expect(res.status).toBe(404);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  it("refuses to serve a websocket-kind route over plain HTTP", async () => {
+    // Approving a WebSocket route did not approve an HTTP one at that path.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([{ ...ROUTE, kind: "websocket" as const }]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(404);
+    expect(calls).toEqual([]);
+  });
+
+  it("fails closed when the approved set cannot be resolved", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => {
+        throw new Error("db unavailable");
+      },
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(500);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("upstream failures", () => {
+  it("reports a runtime that cannot be reached as 502", async () => {
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(502);
+  });
+
+  it("passes an upstream error status through rather than masking it", async () => {
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl: async () => new Response("no such route", { status: 404 }),
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe("no such route");
+  });
+});

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -14,6 +14,7 @@ initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
 const CONFIG = {
   assistantRuntimeBaseUrl: "http://runtime.test:7821",
   runtimeTimeoutMs: 1000,
+  maxWebhookPayloadBytes: 1024,
 } as GatewayConfig;
 
 const ROUTE = {
@@ -79,7 +80,7 @@ describe("approved routes", () => {
     expect(res.status).toBe(200);
     expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe(
-      "http://runtime.test:7821/x/plugins/meeting-bot/realtime",
+      "http://runtime.test:7821/v1/x/plugins/meeting-bot/realtime",
     );
     expect(calls[0]!.method).toBe("POST");
     expect(calls[0]!.body).toBe('{"event":"joined"}');
@@ -245,6 +246,75 @@ describe("the gate", () => {
 
     expect(res.status).toBe(500);
     expect(calls).toEqual([]);
+  });
+});
+
+describe("payload limits", () => {
+  it("rejects a body over the webhook cap without forwarding it", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "x".repeat(2048)),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(413);
+    expect(calls).toEqual([]);
+  });
+
+  it("caps on the streamed bytes, not the Content-Length header", async () => {
+    // The caller is unauthenticated, so Content-Length is attacker-controlled
+    // and absent on chunked requests — a header-only guard would be bypassable.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const oversized = new Request(
+      "http://gateway/webhooks/plugins/meeting-bot/realtime",
+      {
+        method: "POST",
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("x".repeat(2048)));
+            controller.close();
+          },
+        }),
+        // @ts-expect-error -- duplex is required for a streamed request body
+        duplex: "half",
+      },
+    );
+
+    const res = await handle(oversized, "meeting-bot", "realtime");
+
+    expect(res.status).toBe(413);
+    expect(calls).toEqual([]);
+  });
+
+  it("forwards a body at the cap", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "x".repeat(1024)),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls[0]!.body).toHaveLength(1024);
   });
 });
 

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -1,0 +1,103 @@
+/**
+ * Public webhook surface for approved plugin ingress routes.
+ *
+ * This is where the ingress gate stops being bookkeeping: a request is
+ * forwarded to the plugin only when the guardian has approved a declaration
+ * that names exactly this route. Anything else is a 404 — including routes a
+ * plugin declares but nobody has approved, so an unapproved declaration is
+ * indistinguishable from one that was never made.
+ *
+ * Requests arrive from the public internet through the Velay tunnel and are
+ * unauthenticated, like every other handler under `/webhooks/`. Approval
+ * governs which paths exist, not who may call them; a plugin that needs to
+ * know its caller must validate a provider signature or shared secret itself,
+ * the same obligation the Twilio and Mailgun handlers carry.
+ */
+
+import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { proxyForwardToResponse } from "@vellumai/assistant-client";
+
+const log = getLogger("plugin-webhook");
+
+/** Upstream namespace the assistant serves plugin routes from. */
+function pluginRouteUpstreamPath(plugin: string, path: string): string {
+  return `/x/plugins/${plugin}/${path}`;
+}
+
+export interface PluginWebhookHandlerDeps {
+  config: GatewayConfig;
+  /** Approved-ingress view; cached by the caller so this stays off the disk. */
+  resolve: () => PluginIngressResolution;
+  fetchImpl?: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
+}
+
+/**
+ * Handle `/webhooks/plugins/:plugin/:path`.
+ *
+ * The requested path must equal an approved route's declared path. Matching
+ * is exact rather than prefix-based: the digest a guardian approved covers
+ * the paths it listed, so serving `<approved>/anything` would hand out reach
+ * that was never reviewed. Exact matching also disposes of traversal — no
+ * `..` segment equals a declared path — and of percent-encoded spellings,
+ * which fail closed rather than being decoded into a match.
+ */
+export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
+  const { config, resolve, fetchImpl } = deps;
+
+  return async (req: Request, plugin: string, path: string) => {
+    let approved: PluginIngressResolution["approved"];
+    try {
+      approved = resolve().approved;
+    } catch (err) {
+      log.error({ err, plugin }, "Failed to resolve approved plugin ingress");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+
+    const declaration = approved.find((d) => d.plugin === plugin);
+    const route = declaration?.routes.find(
+      // WebSocket routes are declared here but upgraded elsewhere; serving
+      // one over plain HTTP would be a different thing than was approved.
+      (r) => r.kind === "http" && r.path === path,
+    );
+
+    if (!route) {
+      // Deliberately quiet: this path is reachable by anyone on the internet,
+      // so logging every miss at info would hand out a log-flooding lever.
+      log.debug({ plugin, path }, "No approved HTTP ingress route");
+      return Response.json({ error: "Not Found" }, { status: 404 });
+    }
+
+    const upstreamPath = pluginRouteUpstreamPath(plugin, path);
+    const search = new URL(req.url).search;
+    const start = performance.now();
+    const response = await proxyForwardToResponse(req, {
+      baseUrl: config.assistantRuntimeBaseUrl,
+      path: upstreamPath,
+      search: search || undefined,
+      serviceToken: mintServiceToken(),
+      timeoutMs: config.runtimeTimeoutMs,
+      fetchImpl,
+    });
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 500) {
+      log.error(
+        { plugin, path, status: response.status, duration },
+        "Plugin webhook upstream error",
+      );
+    } else if (response.status >= 400) {
+      log.warn(
+        { plugin, path, status: response.status, duration },
+        "Plugin webhook upstream error",
+      );
+    }
+
+    return response;
+  };
+}

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -18,13 +18,23 @@ import type { PluginIngressResolution } from "../../channels/plugin-ingress-appr
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
+import { readLimitedBodyBytes } from "../read-limited-body.js";
 import { proxyForwardToResponse } from "@vellumai/assistant-client";
 
 const log = getLogger("plugin-webhook");
 
-/** Upstream namespace the assistant serves plugin routes from. */
+/** Methods a Request refuses to carry a body for. */
+const METHODS_WITHOUT_BODY = new Set(["GET", "HEAD"]);
+
+/**
+ * Upstream path for a plugin route.
+ *
+ * The `/v1` prefix is load-bearing: the runtime 404s anything outside it
+ * before route matching begins, then strips it and matches the plugin
+ * catch-all `x/:path*` (assistant/src/runtime/routes/user-routes.ts).
+ */
 function pluginRouteUpstreamPath(plugin: string, path: string): string {
-  return `/x/plugins/${plugin}/${path}`;
+  return `/v1/x/plugins/${plugin}/${path}`;
 }
 
 export interface PluginWebhookHandlerDeps {
@@ -73,10 +83,30 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
       return Response.json({ error: "Not Found" }, { status: 404 });
     }
 
+    // Cap the body on the streamed bytes before anything forwards it. The
+    // caller is unauthenticated and Content-Length is attacker-controlled
+    // (and absent on chunked requests), so without this each request could
+    // buffer up to the server-wide maxRequestBodySize. See gateway/AGENTS.md.
+    const body = await readLimitedBodyBytes(req, config.maxWebhookPayloadBytes);
+    if (body.status === "too_large") {
+      log.warn({ plugin, path }, "Plugin webhook payload too large");
+      return Response.json({ error: "Payload Too Large" }, { status: 413 });
+    }
+    if (body.status === "unreadable") {
+      return Response.json({ error: "Bad Request" }, { status: 400 });
+    }
+
     const upstreamPath = pluginRouteUpstreamPath(plugin, path);
     const search = new URL(req.url).search;
     const start = performance.now();
-    const response = await proxyForwardToResponse(req, {
+    // The body is already drained, so hand the proxy a request carrying the
+    // bytes we accepted rather than the consumed original.
+    const forwardable = new Request(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: METHODS_WITHOUT_BODY.has(req.method) ? undefined : body.bytes,
+    });
+    const response = await proxyForwardToResponse(forwardable, {
       baseUrl: config.assistantRuntimeBaseUrl,
       path: upstreamPath,
       search: search || undefined,

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -7,21 +7,47 @@
  * plugin declares but nobody has approved, so an unapproved declaration is
  * indistinguishable from one that was never made.
  *
- * Requests arrive from the public internet through the Velay tunnel and are
- * unauthenticated, like every other handler under `/webhooks/`. Approval
- * governs which paths exist, not who may call them; a plugin that needs to
- * know its caller must validate a provider signature or shared secret itself,
- * the same obligation the Twilio and Mailgun handlers carry.
+ * Requests arrive from the public internet through the Velay tunnel, so
+ * approval alone would only decide which paths exist, not who may call them.
+ * Every request is therefore signature-checked before it is forwarded, and
+ * a route whose secret is missing is refused rather than served unsigned.
+ * The declaration picks whose secret that is — see `IngressRouteSchema.signer`.
  */
 
 import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
+import type { IngressSigner } from "../../channels/plugin-ingress.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
+import { credentialKey } from "../../credential-key.js";
+import {
+  resolveCredentialWithRefresh,
+  verifySecretWithRefresh,
+} from "../../credential-refresh.js";
 import { getLogger } from "../../logger.js";
 import { readLimitedBodyBytes } from "../read-limited-body.js";
+import { verifyVellumSignature } from "../vellum-signature.js";
 import { proxyForwardToResponse } from "@vellumai/assistant-client";
 
 const log = getLogger("plugin-webhook");
+
+/**
+ * Credential holding the secret that signs this route.
+ *
+ * `vellum` routes verify against the platform's own webhook secret — the
+ * same credential the email webhook uses — so a plugin that only ever hears
+ * from Vellum needs no secret of its own. Everything else verifies against
+ * the plugin's, stored under its own service name.
+ *
+ * The field name is fixed for now; making it configurable per plugin is a
+ * later step, along with what the HMAC covers.
+ */
+function signingCredentialKey(plugin: string, signer: IngressSigner): string {
+  return credentialKey(
+    signer === "vellum" ? "vellum" : plugin,
+    "webhook_secret",
+  );
+}
 
 /** Methods a Request refuses to carry a body for. */
 const METHODS_WITHOUT_BODY = new Set(["GET", "HEAD"]);
@@ -41,6 +67,8 @@ export interface PluginWebhookHandlerDeps {
   config: GatewayConfig;
   /** Approved-ingress view; cached by the caller so this stays off the disk. */
   resolve: () => PluginIngressResolution;
+  /** Signing secrets, read through the TTL cache so rotation is picked up. */
+  credentials: CredentialCache | undefined;
   fetchImpl?: (
     input: string | URL | Request,
     init?: RequestInit,
@@ -58,7 +86,7 @@ export interface PluginWebhookHandlerDeps {
  * which fail closed rather than being decoded into a match.
  */
 export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
-  const { config, resolve, fetchImpl } = deps;
+  const { config, resolve, credentials, fetchImpl } = deps;
 
   return async (req: Request, plugin: string, path: string) => {
     let approved: PluginIngressResolution["approved"];
@@ -94,6 +122,38 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
     }
     if (body.status === "unreadable") {
       return Response.json({ error: "Bad Request" }, { status: 400 });
+    }
+
+    // Signature check before the forward, and fail-closed when no secret is
+    // configured: serving a public route unsigned because its secret is
+    // missing would turn a setup mistake into an open endpoint.
+    const secretKey = signingCredentialKey(plugin, route.signer);
+    const secret = await resolveCredentialWithRefresh(credentials, secretKey);
+    if (!secret) {
+      log.warn(
+        { plugin, path, signer: route.signer },
+        "Plugin webhook secret is not configured — rejecting request",
+      );
+      return Response.json(
+        { error: "Webhook secret not configured" },
+        { status: 409 },
+      );
+    }
+
+    const signatureValid = await verifySecretWithRefresh({
+      credentials,
+      key: secretKey,
+      verify: (candidate) =>
+        verifyVellumSignature(req.headers, body.bytes, candidate),
+      log,
+      label: "Plugin webhook signature",
+    });
+    if (!signatureValid) {
+      log.warn(
+        { plugin, path, signer: route.signer },
+        "Plugin webhook signature verification failed",
+      );
+      return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const upstreamPath = pluginRouteUpstreamPath(plugin, path);

--- a/gateway/src/http/vellum-signature.ts
+++ b/gateway/src/http/vellum-signature.ts
@@ -1,0 +1,48 @@
+/**
+ * Verification for the `Vellum-Signature` header.
+ *
+ * The signer computes `HMAC-SHA256(secret, rawBody)` and sends it as
+ * `Vellum-Signature: sha256=<hex-digest>`. The scheme is the platform's, but
+ * nothing about it is platform-specific — plugin webhook routes verify the
+ * same header against the plugin's own secret.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const HEADER_NAME = "vellum-signature";
+const PREFIX = "sha256=";
+
+/**
+ * True when `headers` carries a signature over `rawBody` made with `secret`.
+ *
+ * Pass the raw bytes when you have them: a decoded string round-trips only
+ * for well-formed UTF-8, and a body that is not well-formed would otherwise
+ * be hashed after replacement characters had already altered it.
+ */
+export function verifyVellumSignature(
+  headers: Headers,
+  rawBody: string | Uint8Array,
+  secret: string,
+): boolean {
+  const signatureHeader = headers.get(HEADER_NAME);
+  if (!signatureHeader || !secret) return false;
+  if (!signatureHeader.startsWith(PREFIX)) return false;
+  const providedHex = signatureHeader.slice(PREFIX.length);
+
+  const hmac = createHmac("sha256", secret);
+  if (typeof rawBody === "string") {
+    hmac.update(rawBody, "utf8");
+  } else {
+    hmac.update(rawBody);
+  }
+  const expected = hmac.digest("hex");
+
+  // Compare Buffer byte lengths — not string .length — to avoid
+  // timingSafeEqual throwing on non-ASCII input where UTF-16 code unit
+  // count matches but byte length diverges.
+  const providedBuf = Buffer.from(providedHex);
+  const expectedBuf = Buffer.from(expected);
+  if (providedBuf.length !== expectedBuf.length) return false;
+
+  return timingSafeEqual(providedBuf, expectedBuf);
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -146,8 +146,7 @@ import {
   createChannelIngressRevokeHandler,
 } from "./http/routes/channel-ingress.js";
 import { createPluginWebhookHandler } from "./http/routes/plugin-webhook.js";
-import { resolveDiscoveredPluginIngress } from "./channels/plugin-ingress-approvals.js";
-import { PluginIngressCache } from "./channels/plugin-ingress.js";
+import { resolveCachedPluginIngress } from "./channels/plugin-ingress-approvals.js";
 import {
   createChannelPermissionOverridesListHandler,
   createChannelPermissionOverrideSetHandler,
@@ -608,12 +607,9 @@ async function main() {
     createChannelAdmissionPolicyDeleteHandler();
   const handleChannelIngressApprove = createChannelIngressApproveHandler();
   const handleChannelIngressRevoke = createChannelIngressRevokeHandler();
-  // TTL-cached so an inbound webhook does not re-walk the plugins directory,
-  // while installs and toggles still take effect without a gateway restart.
-  const pluginIngressCache = new PluginIngressCache();
   const handlePluginWebhook = createPluginWebhookHandler({
     config,
-    resolve: () => resolveDiscoveredPluginIngress(pluginIngressCache.get()),
+    resolve: resolveCachedPluginIngress,
   });
   const handleChannelPermissionOverridesList =
     createChannelPermissionOverridesListHandler();

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -145,6 +145,9 @@ import {
   createChannelIngressApproveHandler,
   createChannelIngressRevokeHandler,
 } from "./http/routes/channel-ingress.js";
+import { createPluginWebhookHandler } from "./http/routes/plugin-webhook.js";
+import { resolveDiscoveredPluginIngress } from "./channels/plugin-ingress-approvals.js";
+import { PluginIngressCache } from "./channels/plugin-ingress.js";
 import {
   createChannelPermissionOverridesListHandler,
   createChannelPermissionOverrideSetHandler,
@@ -605,6 +608,13 @@ async function main() {
     createChannelAdmissionPolicyDeleteHandler();
   const handleChannelIngressApprove = createChannelIngressApproveHandler();
   const handleChannelIngressRevoke = createChannelIngressRevokeHandler();
+  // TTL-cached so an inbound webhook does not re-walk the plugins directory,
+  // while installs and toggles still take effect without a gateway restart.
+  const pluginIngressCache = new PluginIngressCache();
+  const handlePluginWebhook = createPluginWebhookHandler({
+    config,
+    resolve: () => resolveDiscoveredPluginIngress(pluginIngressCache.get()),
+  });
   const handleChannelPermissionOverridesList =
     createChannelPermissionOverridesListHandler();
   const handleChannelPermissionOverrideSet =
@@ -695,6 +705,15 @@ async function main() {
     {
       path: "/webhooks/mailgun",
       handler: (req) => handleMailgunWebhook(req),
+    },
+    // Plugin-declared webhooks. Unauthenticated like their neighbours above;
+    // what makes them safe is that only a guardian-approved declaration
+    // creates one, and every other path here 404s. Any method — the plugin's
+    // route module decides which verbs it answers.
+    {
+      path: /^\/webhooks\/plugins\/([^/]+)\/(.+)$/,
+      handler: (req, params) =>
+        handlePluginWebhook(req, params[0]!, params[1]!),
     },
 
     // ── BYO provider registration (auto-verify guardian email) ──

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -610,6 +610,7 @@ async function main() {
   const handlePluginWebhook = createPluginWebhookHandler({
     config,
     resolve: resolveCachedPluginIngress,
+    credentials: credentialCache,
   });
   const handleChannelPermissionOverridesList =
     createChannelPermissionOverridesListHandler();

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -50,7 +50,7 @@ describe("VELAY_ALLOWED_PATHS", () => {
       // Plugin-declared webhooks ride the existing `^/webhooks/` entry. Which
       // of them the gateway actually serves is decided by the approval gate,
       // not by Velay — the tunnel just stops treating the prefix as private.
-      "/webhooks/plugins/meeting-bot/realtime": true,
+      "/webhooks/plugins/example/realtime": true,
       "/v1/audio/some-uuid.mp3": true,
       "/v1/live-voice": true,
       "/v1/stt/stream": true,

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -47,6 +47,10 @@ describe("VELAY_ALLOWED_PATHS", () => {
       "/webhooks/resend": true,
       "/webhooks/mailgun": true,
       "/webhooks/oauth/callback": true,
+      // Plugin-declared webhooks ride the existing `^/webhooks/` entry. Which
+      // of them the gateway actually serves is decided by the approval gate,
+      // not by Velay — the tunnel just stops treating the prefix as private.
+      "/webhooks/plugins/meeting-bot/realtime": true,
       "/v1/audio/some-uuid.mp3": true,
       "/v1/live-voice": true,
       "/v1/stt/stream": true,


### PR DESCRIPTION
## Prompt / plan

Next step after the approval API (#39398). Everything built so far *decided* about ingress; nothing *served* it — an approval landed a row in `plugin_ingress_approvals` and changed no behaviour, because no request path read the approved set. This makes the gate load-bearing.

`/webhooks/plugins/<plugin>/<path>` resolves the approved declarations, verifies the request signature, and forwards to the plugin's route namespace on the runtime (`/v1/x/plugins/<plugin>/<path>`, service-token auth). Everything else is a 404 — including routes a plugin declares that nobody has approved, so a pending declaration is indistinguishable from one that was never made.

**Matching is exact, not prefix-based.** The digest a guardian approved covers the paths it listed, so serving `<approved>/anything` would hand out reach nobody reviewed. That also disposes of two problems for free: no `..` segment equals a declared path, and percent-encoded spellings (`realtime%2fextra`) fail closed rather than being decoded into a match.

**WebSocket-kind routes are declared but not served here.** Approving a `websocket` route did not approve an HTTP one at that path, so the HTTP dispatcher skips them and 404s. That's PR 5 — also why this PR doesn't light up meeting-bot yet: its only declared route is `kind: "websocket"`.

### Signatures

Approval decides which paths exist; it says nothing about who may call them. So every request is verified before it is forwarded: `Vellum-Signature: sha256=<hex>`, HMAC-SHA256 over the raw body — the scheme the platform already uses for email. The comparison moved to `http/vellum-signature.ts` and `email/verify.ts` now delegates to it, rather than a second copy of the same crypto.

A declaration carries `signer`, which selects only the credential:

| `signer` | credential |
| --- | --- |
| `plugin` (default) | `credential/<plugin>/webhook_secret` |
| `vellum` | `credential/vellum/webhook_secret` |

So a plugin can take callbacks it arranged itself, and a plugin that only ever hears from Vellum needs no secret of its own. The field is fixed at `webhook_secret` for now; making it configurable per plugin, and what the HMAC covers, is a later step.

Three decisions inside that, called out because they're the kind that should be argued with:

1. **`signer` is part of the digest.** Changing whose key opens a route changes who can reach it, so an approval for one must not carry over to the other.
2. **The default is `plugin`.** A plugin gets no reach against the platform's key unless it asks and a guardian approves that declaration. Tested both directions, so declaring `vellum` narrows rather than widens.
3. **A missing credential is a 409, not an open route.** Treating "no secret configured" as "no signature required" would turn a setup mistake into a public endpoint.

### Other

Bodies are read via `readLimitedBodyBytes` against `maxWebhookPayloadBytes` before anything forwards them, per `gateway/AGENTS.md` — these callers are unauthenticated and `Content-Length` is attacker-controlled. Resolution runs off a module-global `PluginIngressCache` rather than re-walking the plugins directory per request.

**No Velay allowlist change was needed** — I'd flagged one as part of this step, but `^/webhooks/` already covers the new prefix. Added a positive sample to the allowlist guard test so that's recorded rather than rediscovered.

The route is excluded from the OpenAPI guard with a reason: which paths exist is decided at runtime by the installed plugins and the guardian's approvals, so there is no fixed set to document.

## Test plan

- `gateway/src/http/routes/plugin-webhook.test.ts` — 21 tests. Forwarding: upstream URL, method, body, query string. The gate: pending-not-approved, unknown plugin, cross-plugin, unnamed path, and the subtree cases (`realtime/extra`, `realtime/../../secret`, `realtime%2fextra`, `REALTIME`, `realtime/`) all 404 without reaching upstream; websocket-kind 404s over HTTP; a throwing resolver fails closed at 500. Signatures: unsigned, wrong-secret, and body-tampered all 403; missing credential 409; a `vellum` route verifies against the platform secret and rejects the plugin's, and vice versa. Payload: over-cap 413, at-cap forwarded, streamed body with no `Content-Length` also 413. Upstream: unreachable → 502, upstream 404 passed through.
- Manifest-schema tests for the `signer` default, an explicit `vellum`, and an unknown value; a digest test that changing signer changes the digest.
- 155 pass / 0 fail across the webhook, route-guard, velay, channels, ingress-approval, signature, and store suites. `tsc --noEmit` clean; prettier + eslint clean.
- Note: `bun test src/email/` reports 7 failures in `ingestEmailAttachments` — pre-existing, identical on a clean tree at this base, unrelated to the verifier refactor. `email/verify.test.ts` passes untouched.
- Tests init a real signing key rather than mocking `token-exchange`: `mock.module` is process-wide in bun and leaks into every other suite in the run.

## CLI verb checklist

No new IPC route — this is a public HTTP webhook path. Not applicable.

## Still open after this

- **PR 5** — WebSocket kind (`wsType: "plugin-webhook"`, POST-per-event upstream, serialised per connection), the meeting-bot `routes/realtime.ts`, the `realtimeEndpointUrl()` switch, and `signer: "vellum"` on that declaration.
- **Approving in practice.** The API exists but still has no guardian-authenticated client, so granting ingress today means a manual DB write.
