### PR TITLE
fix: drop the stash latch, honest mirror contract, comment accuracy

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -20,6 +20,7 @@ import {
 import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
 import type { LiveVoicePreflightVerdict } from "@/domains/chat/voice/live-voice/live-voice-preflight-api";
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
+import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 // Pure helpers live in `chat-composer-utils` (no mocks needed), so import them
@@ -175,8 +176,11 @@ mock.module("@/lib/backwards-compat/use-supports-live-voice", () => ({
 }));
 
 // Avatar data feeding the voice bar's wave accent. Mocked so the composer
-// renders without a QueryClientProvider (the real hook is React Query).
+// renders without a QueryClientProvider (the real hook is React Query). The
+// real module is spread back in so its other exports survive the mock: the
+// auth store reaches `avatarQueryKey` through the takeover avatar stash.
 mock.module("@/hooks/use-assistant-avatar", () => ({
+  ...assistantAvatarMod,
   useAssistantAvatar: () => ({
     components: null,
     traits: null,

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -207,7 +207,7 @@ beforeEach(() => {
   heldUpgrade = null;
   upgradeData = { status: "redirect", checkout_url: CHECKOUT_URL, message: "" };
   sessionStorage.removeItem(INTENT_KEY);
-  // Also resets the stash module's in-memory mirror, which outlives storage.
+  // The line above only drops the intent key, so clear the avatar stash's own.
   clearTakeoverAvatarStash();
   useResolvedAssistantsStore.setState({
     activeAssistantId: null,

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -31,16 +31,22 @@ import { Button } from "@vellumai/design-library/components/button";
  * - `handed_off` — the package intent is stashed and Stripe is open.
  * - `settled` — terminal: an already-Pro `no_op`, a failed upgrade, or a bail.
  *
- * `handed_off` is the line that matters. Before it, this route owns the stash
- * and a bail clears it; after it, the stash belongs to the post-checkout return
- * trip and nothing here may touch it. Electron and native Capacitor open Stripe
- * without unloading the page, so the route is still mounted to enforce that —
- * and to offer the way out a browser closed short of paying otherwise leaves
- * the user without.
+ * `handed_off` is the line that matters. Before it, this route owns the stashes
+ * and a bail clears them; after it, they belong to the post-checkout return
+ * trip and nothing here may touch them. Electron and native Capacitor open
+ * Stripe without unloading the page, so the route is still mounted to enforce
+ * that — and to offer the way out a browser closed short of paying otherwise
+ * leaves the user without.
  */
 type CheckoutPhase = "idle" | "running" | "handed_off" | "settled";
 
-/** Drops everything an attempt that never reached Stripe left behind. */
+/**
+ * Drops everything an attempt that never reached Stripe left behind. A retry
+ * from the awaiting-return screen re-arms the attempt, so a hand-off followed
+ * by a failing retry forfeits the captured avatar on purpose: that path already
+ * clears the checkout intent, and the cold return falls back to the breathing
+ * placeholder.
+ */
 function abandonCheckout() {
   clearCheckoutIntent();
   clearTakeoverAvatarStash();
@@ -168,9 +174,9 @@ export function CheckoutPage() {
         void openUrl(result.checkout_url);
         return;
       }
-      // `no_op` — already Pro, nothing to provision. Clear the marked stash so
-      // an already-Pro bounce doesn't leave it lingering for its TTL, then hand
-      // off rather than stranding the user on a blank splash.
+      // `no_op` — already Pro, nothing to provision. Clear the stashes so an
+      // already-Pro bounce doesn't leave them lingering for their TTL, then
+      // hand off rather than stranding the user on a blank splash.
       phaseRef.current = "settled";
       abandonCheckout();
       navigate(bailTarget, { replace: true });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -123,7 +123,9 @@ export function BillingOnboardingModal({
 
   // Whether this wizard has actually been opened, so the reset branch below can
   // tell a close from the mount of an instance that is simply rendered closed
-  // (the billing page mounts two of these; only one opens).
+  // (the billing page mounts two of these; only one opens). Its overlap with
+  // `domainsOpenedAt` is deliberate: tying the stash lifecycle to a
+  // domains-freshness fence would couple two unrelated concerns.
   const hasOpenedRef = useRef(false);
 
   useEffect(() => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -188,8 +188,8 @@ function avatarModeFor(
  * body-morph and the reduced-motion gating all come from `AnimatedAvatar`
  * inside `ChatAvatar`.
  *
- * Nothing renders until the target assistant resolves and its avatar query
- * settles. `components ?? fallback`
+ * Nothing renders until something is drawable: the live query settling, or the
+ * stash captured at the Stripe hand-off. `components ?? fallback`
  * synthesizes traits from the first bundled entry of each list — a green blob —
  * so drawing during the fetch shows a different assistant's avatar for a beat,
  * and the takeover is the one surface that reliably mounts cold: the Stripe

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.test.ts
@@ -269,6 +269,38 @@ describe("in-memory mirror on a same-document return", () => {
     }
   });
 
+  test("the mirror serves a stash whose write never reached storage", () => {
+    // The real failure mode: private mode and quota exhaustion break `setItem`
+    // while `getItem` keeps answering, so only the write is lost and a
+    // readable-empty store would otherwise read as absence.
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    )!;
+    const writeFailing = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+      removeItem: () => {},
+    };
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      get: () => writeFailing,
+    });
+    try {
+      saveTakeoverAvatarStash({
+        assistantId: "a1",
+        components: BUNDLED_COMPONENTS,
+        traits: TRAITS,
+      });
+
+      expect(readTakeoverAvatarStash()).toMatchObject({ assistantId: "a1" });
+    } finally {
+      Object.defineProperty(globalThis, "sessionStorage", original);
+    }
+  });
+
   test("the mirror does not resurrect a stash sessionStorage no longer holds", () => {
     // Logout wipes sessionStorage wholesale, so a readable-but-empty store has
     // to read as absence or the previous account's avatar survives the wipe.
@@ -280,6 +312,28 @@ describe("in-memory mirror on a same-document return", () => {
     sessionStorage.clear();
 
     expect(readTakeoverAvatarStash()).toBeNull();
+
+    // That read released the mirror, so the stash cannot come back even once
+    // storage stops answering.
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    )!;
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      get: () => ({
+        getItem: () => {
+          throw new Error("sessionStorage unavailable");
+        },
+        setItem: () => {},
+        removeItem: () => {},
+      }),
+    });
+    try {
+      expect(readTakeoverAvatarStash()).toBeNull();
+    } finally {
+      Object.defineProperty(globalThis, "sessionStorage", original);
+    }
   });
 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-avatar-stash.ts
@@ -45,11 +45,19 @@ const MAX_AGE_MS = 30 * 60 * 1000;
  * throws keeps no stash at all and the takeover draws its breathing
  * placeholder through the wait instead.
  *
- * Served ONLY when sessionStorage is unreachable, never when it is readable and
- * empty: a readable null is authoritative absence, which is what makes logout's
- * blanket `sessionStorage.clear()` able to kill the stash outright.
+ * Served ONLY when sessionStorage is unreachable, or when the last write never
+ * reached it. Otherwise a readable null is authoritative absence, which is what
+ * makes logout's blanket `sessionStorage.clear()` able to kill the stash
+ * outright.
  */
 let inMemoryStash: TakeoverAvatarStash | null = null;
+
+/**
+ * Whether the last write never reached sessionStorage. `setItem` throwing while
+ * `getItem` still answers is the real failure mode (private mode, quota), and
+ * it is the only case where a readable-empty read may fall back to the mirror.
+ */
+let storageWriteFailed = false;
 
 /**
  * Bumped by every write, so a reader that snapshotted the stash can tell its
@@ -77,17 +85,20 @@ export function saveTakeoverAvatarStash(
   version += 1;
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stamped));
+    storageWriteFailed = false;
   } catch {
     // sessionStorage may be unavailable (private mode, quota). Never block the
-    // checkout redirect over it.
+    // checkout redirect over it; the mirror carries the stash instead.
+    storageWriteFailed = true;
   }
 }
 
 /**
  * The stashed avatar, or `null` when absent, unparsable, malformed, or older
  * than the TTL: anything unusable is cleared so it can't resurface. Falls back
- * to the in-memory mirror only when sessionStorage is unreachable; a readable
- * sessionStorage is authoritative, empty included.
+ * to the in-memory mirror only when sessionStorage is unreachable or the last
+ * write never reached it; a readable sessionStorage is otherwise authoritative,
+ * empty included.
  */
 export function readTakeoverAvatarStash(): TakeoverAvatarStash | null {
   if (typeof sessionStorage === "undefined") {
@@ -101,6 +112,12 @@ export function readTakeoverAvatarStash(): TakeoverAvatarStash | null {
     return readInMemoryStash();
   }
   if (!raw) {
+    if (storageWriteFailed) {
+      return readInMemoryStash();
+    }
+    // Readable-empty is authoritative for a stash that did reach storage, so a
+    // logout wipe takes the mirror with it.
+    inMemoryStash = null;
     return null;
   }
 
@@ -123,6 +140,7 @@ export function readTakeoverAvatarStash(): TakeoverAvatarStash | null {
 
 export function clearTakeoverAvatarStash(): void {
   inMemoryStash = null;
+  storageWriteFailed = false;
   version += 1;
   try {
     sessionStorage.removeItem(STORAGE_KEY);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
@@ -8,26 +8,23 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderHook } from "@testing-library/react";
 
+import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
+import type { AvatarData } from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import type { CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { SURFACE_GROUND } from "@/utils/avatar-tone";
 
 /** The id handed to the avatar hook, captured to assert the target rule. */
 let avatarQueryId: string | null | undefined;
 /** The payload the mocked avatar query resolves to, set per test. */
-let avatar: {
-  components: CharacterComponents | null;
-  traits: CharacterTraits | null;
-  customImageUrl: string | null;
-  isLoading: boolean;
-};
+let avatar: AvatarData & { isLoading: boolean };
 mock.module("@/hooks/use-assistant-avatar", () => ({
+  ...assistantAvatarMod,
   useAssistantAvatar: (assistantId: string | null) => {
     avatarQueryId = assistantId;
     return { ...avatar, invalidate: () => {} };
   },
-  avatarQueryKey: (assistantId: string) => ["assistantAvatar", assistantId],
 }));
 
 const { useTakeoverSurface } = await import("./use-takeover-surface");
@@ -281,9 +278,9 @@ describe("avatar stash", () => {
     expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
   });
 
-  test("a target resolving to another assistant mid-flight keeps the drawn stash", () => {
-    // Dropping `ready` here would unmount the creature and restart the
-    // placeholder, so a stash already on screen stays until live data lands.
+  test("a target resolving to another assistant mid-flight withholds the stash", () => {
+    // A mismatch withholds whether it exists at mount or appears mid-flight:
+    // drawing on is drawing the wrong creature at full-viewport scale.
     seedStash("primary-assistant", "purple");
     avatar.isLoading = true;
 
@@ -296,9 +293,8 @@ describe("avatar stash", () => {
 
     rerender({ id: "other-assistant" });
 
-    expect(result.current.ready).toBe(true);
-    expect(result.current.avatar.traits).toEqual(traits("purple"));
-    expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
+    expect(result.current.ready).toBe(false);
+    expect(result.current.tintHex).toBe(SURFACE_GROUND);
 
     avatar = {
       components: BUNDLED_COMPONENTS,
@@ -308,6 +304,7 @@ describe("avatar stash", () => {
     };
     rerender({ id: "other-assistant" });
 
+    expect(result.current.ready).toBe(true);
     expect(result.current.avatar.traits).toEqual(traits("orange"));
     expect(result.current.tintHex.toLowerCase()).toBe(ORANGE_SURFACE);
   });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
-import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import {
+  useAssistantAvatar,
+  type AvatarData,
+} from "@/hooks/use-assistant-avatar";
 import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { SURFACE_GROUND, avatarSurfaceHex } from "@/utils/avatar-tone";
 
@@ -18,12 +20,7 @@ import {
  * Ungated: every field carries whatever was chosen right now, so a consumer
  * must render it only inside a {@link TakeoverSurface.ready} branch.
  */
-export interface TakeoverAvatarInputs {
-  components: CharacterComponents | null;
-  traits: CharacterTraits | null;
-  /** The assistant's uploaded image, drawn as the avatar in place of an SVG. */
-  customImageUrl: string | null;
-}
+export type TakeoverAvatarInputs = AvatarData;
 
 export interface TakeoverSurface {
   /** Opaque #rrggbb to paint the takeover and its exit sheet. */
@@ -77,20 +74,13 @@ export function useTakeoverSurface(
   // `useAssistantAvatar(null)` is a disabled query, which reports
   // `isLoading: false` with no data, so the id has to gate settling too.
   const liveSettled = resolvedId != null && !isLoading;
-  // The id of a stash this surface has already drawn. Latched so the surface
-  // only ever upgrades: a target resolving to a different id mid-flight would
-  // otherwise drop `ready` back to false, unmounting the creature and
-  // restarting the placeholder before the real one lands.
-  const [latchedStashId, setLatchedStashId] = useState<string | null>(null);
   // While the provisioning hook has not named a target the stash may stand in,
   // safe because a stash is only ever captured in a single-assistant org, so
-  // there is no second creature the unresolved target could turn out to be.
-  // Once a target does resolve, only a matching (or already drawn) stash draws.
+  // there is no second creature the unresolved target could turn out to be. A
+  // target that disagrees with the stash withholds either way, whether it is
+  // already resolved at mount or resolves mid-flight.
   const stashUsable =
-    stash != null &&
-    (resolvedId == null ||
-      resolvedId === stash.assistantId ||
-      latchedStashId === stash.assistantId);
+    stash != null && (resolvedId == null || resolvedId === stash.assistantId);
   const liveDrawable =
     liveSettled &&
     (components != null || traits != null || customImageUrl != null);
@@ -98,13 +88,6 @@ export function useTakeoverSurface(
   // daemon erroring while the machine restarts) keeps the stash, which is
   // strictly more truthful than the bundled-green fallback.
   const drawnStash = stashUsable && !liveDrawable ? stash : null;
-
-  const drawnStashId = drawnStash?.assistantId ?? null;
-  useEffect(() => {
-    if (drawnStashId != null) {
-      setLatchedStashId(drawnStashId);
-    }
-  }, [drawnStashId]);
 
   const effectiveComponents = drawnStash ? drawnStash.components : components;
   const effectiveTraits = drawnStash ? drawnStash.traits : traits;

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -359,9 +359,10 @@ body {
   animation: provision-grow-shadow 1.1s cubic-bezier(0.36, 0.02, 0.24, 1) both;
 }
 
-/* The avatar is withheld until its query settles, so it arrives rather than
- * swapping in over a placeholder. The stage has already reserved its height,
- * so this fades in place with nothing moving around it. */
+/* The creature fades in over the placeholder as soon as something is drawable:
+ * the live query settling, or the stash captured at the Stripe hand-off. The
+ * stage has already reserved its height, so this fades in place with nothing
+ * moving around it. */
 @keyframes provision-avatar-reveal {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/clients/web/src/lib/auth/session-cleanup.test.ts
+++ b/clients/web/src/lib/auth/session-cleanup.test.ts
@@ -1,6 +1,19 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import {
+  readTakeoverAvatarStash,
+  saveTakeoverAvatarStash,
+} from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
+import type { CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+
 import { clearUserScopedStorage } from "./session-cleanup";
+
+const STASH_TRAITS: CharacterTraits = {
+  bodyShape: "blob",
+  eyeStyle: "default",
+  color: "purple",
+};
 
 beforeEach(() => {
   localStorage.clear();
@@ -20,6 +33,41 @@ describe("clearUserScopedStorage", () => {
     clearUserScopedStorage();
 
     expect(sessionStorage.length).toBe(0);
+  });
+
+  test("clears a takeover avatar stash whose write never reached storage", () => {
+    // That stash lives only in the module's in-memory mirror, so
+    // `sessionStorage.clear()` cannot reach it and logout has to clear the
+    // module outright.
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    )!;
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      get: () => ({
+        clear: () => {},
+        getItem: () => null,
+        setItem: () => {
+          throw new Error("quota exceeded");
+        },
+        removeItem: () => {},
+      }),
+    });
+    try {
+      saveTakeoverAvatarStash({
+        assistantId: "a1",
+        components: BUNDLED_COMPONENTS,
+        traits: STASH_TRAITS,
+      });
+      expect(readTakeoverAvatarStash()).not.toBeNull();
+
+      clearUserScopedStorage();
+
+      expect(readTakeoverAvatarStash()).toBeNull();
+    } finally {
+      Object.defineProperty(globalThis, "sessionStorage", original);
+    }
   });
 
   test("removes all vellum: prefixed keys from localStorage", () => {

--- a/clients/web/src/lib/auth/session-cleanup.ts
+++ b/clients/web/src/lib/auth/session-cleanup.ts
@@ -22,6 +22,8 @@
  * - https://web.dev/articles/sign-out-best-practices
  */
 
+import { clearTakeoverAvatarStash } from "@/domains/settings/billing/pro-onboarding/takeover-avatar-stash";
+
 const USER_PREFIX = "vellum:";
 
 /**
@@ -65,6 +67,10 @@ function isUserScopedKey(key: string): boolean {
 }
 
 export function clearUserScopedStorage(): void {
+  // The takeover avatar stash can outlive `sessionStorage.clear()` through its
+  // in-memory mirror when the write never reached storage.
+  clearTakeoverAvatarStash();
+
   try {
     sessionStorage.clear();
   } catch {


### PR DESCRIPTION
## Summary
Round-2 self-review remediation for instant-takeover-avatar.md: remove the unscoped ready-latch (capture's solo-org invariant makes it inert; mismatch now withholds), mirror serves only unreachable-storage or failed-write cases with logout clearing it explicitly, type/mock dedup, comment accuracy sweep.