### PR TITLE
fix(web): make TierPicker onReset reachable when the default is unresolved

### DIFF
--- a/clients/web/src/domains/channels/components/tier-picker.test.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import {
+  TierPicker,
+  type TierPickerProps,
+} from "@/domains/channels/components/tier-picker";
+
+// CHANNEL_TIER_VALUES preset labels: "none" is Strict, "low" is Conservative.
+const STRICT = "Strict";
+const CONSERVATIVE = "Conservative";
+
+function renderPicker(props: Partial<TierPickerProps> = {}) {
+  const onTierChange = mock((_tier: string) => {});
+  const onReset = mock(() => {});
+  render(
+    <TierPicker
+      tier={undefined}
+      defaultTier={null}
+      onTierChange={onTierChange}
+      onReset={onReset}
+      aria-label="Assistant Access in #general"
+      {...props}
+    />,
+  );
+  return { onTierChange, onReset };
+}
+
+function openMenu(): HTMLElement[] {
+  const trigger = document.querySelector<HTMLElement>(
+    '[data-slot="dropdown-trigger"]',
+  );
+  if (!trigger) {
+    throw new Error("No dropdown trigger rendered");
+  }
+  fireEvent.click(trigger);
+  return Array.from(document.querySelectorAll<HTMLElement>('[role="option"]'));
+}
+
+function optionLabeled(options: HTMLElement[], label: string): HTMLElement {
+  const match = options.find((el) => el.textContent?.startsWith(label));
+  if (!match) {
+    const seen = options.map((el) => el.textContent).join(", ");
+    throw new Error(`No option labeled "${label}" (saw: ${seen})`);
+  }
+  return match;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TierPicker with a resolved default", () => {
+  test("marks the default level and offers no separate Default entry", () => {
+    renderPicker({ defaultTier: "low" });
+    const options = openMenu();
+    expect(options).toHaveLength(2);
+    expect(optionLabeled(options, CONSERVATIVE).textContent).toContain(
+      "default",
+    );
+    expect(
+      options.some((el) => el.textContent?.startsWith("Default")),
+    ).toBeFalse();
+  });
+
+  test("selecting the default-marked level resets instead of pinning", () => {
+    const { onTierChange, onReset } = renderPicker({
+      tier: "none",
+      defaultTier: "low",
+    });
+    fireEvent.click(optionLabeled(openMenu(), CONSERVATIVE));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onTierChange).not.toHaveBeenCalled();
+  });
+
+  test("selecting a non-default level pins it", () => {
+    const { onTierChange, onReset } = renderPicker({ defaultTier: "low" });
+    fireEvent.click(optionLabeled(openMenu(), STRICT));
+    expect(onTierChange).toHaveBeenCalledWith("none");
+    expect(onReset).not.toHaveBeenCalled();
+  });
+
+  test("a medium default collapses to the level it behaves as", () => {
+    const { onTierChange, onReset } = renderPicker({ defaultTier: "medium" });
+    const options = openMenu();
+    expect(optionLabeled(options, CONSERVATIVE).textContent).toContain(
+      "default",
+    );
+    fireEvent.click(optionLabeled(options, CONSERVATIVE));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onTierChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("TierPicker with an unresolved default (defaultTier null)", () => {
+  test("carries an explicit Default entry and marks no level", () => {
+    renderPicker({ tier: "low" });
+    const options = openMenu();
+    expect(options).toHaveLength(3);
+    expect(options[0]?.textContent).toStartWith("Default");
+    expect(
+      options.some((el) => el.textContent?.includes("default")),
+    ).toBeFalse();
+  });
+
+  test("selecting Default resets an explicit override", () => {
+    const { onTierChange, onReset } = renderPicker({ tier: "low" });
+    fireEvent.click(optionLabeled(openMenu(), "Default"));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onTierChange).not.toHaveBeenCalled();
+  });
+
+  test("selecting Default on a cell-less scope still resets, never writes", () => {
+    const { onTierChange, onReset } = renderPicker();
+    fireEvent.click(optionLabeled(openMenu(), "Default"));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onTierChange).not.toHaveBeenCalled();
+  });
+
+  test("selecting a level pins it", () => {
+    const { onTierChange, onReset } = renderPicker({ tier: "low" });
+    fireEvent.click(optionLabeled(openMenu(), STRICT));
+    expect(onTierChange).toHaveBeenCalledWith("none");
+    expect(onReset).not.toHaveBeenCalled();
+  });
+
+  test("re-selecting the current level pins rather than guessing a reset", () => {
+    // The picker cannot know whether the unresolved default matches the
+    // current level, and clearing the cell on a guess could silently change
+    // effective access once the default resolves. Only the explicit Default
+    // entry resets.
+    const { onTierChange, onReset } = renderPicker({ tier: "low" });
+    fireEvent.click(optionLabeled(openMenu(), CONSERVATIVE));
+    expect(onTierChange).toHaveBeenCalledWith("low");
+    expect(onReset).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/channels/components/tier-picker.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.tsx
@@ -10,6 +10,14 @@ import {
 } from "@/domains/channels/slack-channel-overrides";
 import type { RiskThreshold } from "@/utils/threshold-presets";
 
+/**
+ * Menu value for the explicit "Default" entry shown while the default is
+ * unresolved. Never collides with a {@link RiskThreshold} value.
+ */
+const DEFAULT_ENTRY = "__default__";
+
+type TierOptionValue = RiskThreshold | typeof DEFAULT_ENTRY;
+
 /** Small accent dot, colored per tier via `CAPABILITY_TIER_META.dotColor`. */
 export function TierDot({ color }: { color: string }) {
   return (
@@ -27,7 +35,9 @@ export interface TierPickerProps {
   /**
    * The tier this scope falls through to when it has no cell of its own — the
    * level shown with a muted "default" marker. `null` while still unknown, in
-   * which case no level is marked and the trigger shows a "Default" placeholder.
+   * which case no level is marked, the trigger shows a "Default" placeholder,
+   * and the menu carries an explicit "Default" entry so {@link onReset} stays
+   * reachable.
    */
   defaultTier: RiskThreshold | null;
   disabled?: boolean;
@@ -50,6 +60,13 @@ export interface TierPickerProps {
  *
  * A stored `medium`/`high` cell is shown as the level it behaves as, so the
  * picker never displays a level it cannot offer.
+ *
+ * While the default is unresolved (`defaultTier` null) no level can carry the
+ * marker, and the picker cannot tell which level the default resolves to, so
+ * selecting a level always pins it. The menu instead carries an explicit
+ * "Default" entry that clears this scope's cell: the one selection that means
+ * "follow the default" without guessing at a level, keeping {@link onReset}
+ * reachable in this state.
  */
 export function TierPicker({
   tier,
@@ -61,7 +78,7 @@ export function TierPicker({
 }: TierPickerProps) {
   const effectiveTier = channelTierBehavesAs(tier ?? defaultTier ?? undefined);
   const shownDefault = channelTierBehavesAs(defaultTier ?? undefined) ?? null;
-  const options: DropdownOption<RiskThreshold>[] = CHANNEL_TIER_VALUES.map(
+  const options: DropdownOption<TierOptionValue>[] = CHANNEL_TIER_VALUES.map(
     (value) => ({
       value,
       label: CAPABILITY_TIER_META[value].label,
@@ -73,11 +90,22 @@ export function TierPicker({
       tooltip: CAPABILITY_TIER_META[value].sublabel,
     }),
   );
+  if (shownDefault === null) {
+    options.unshift({
+      value: DEFAULT_ENTRY,
+      label: "Default",
+      // Invisible dot so the label aligns with the level rows.
+      icon: <TierDot color="transparent" />,
+      tooltip: "follows the default level",
+    });
+  }
 
-  const handleChange = (next: RiskThreshold) => {
+  const handleChange = (next: TierOptionValue) => {
     // Picking the level the default resolves to means "follow the default",
-    // which is the absence of a cell — clear it rather than pinning an equal one.
-    if (next === shownDefault) {
+    // which is the absence of a cell: clear it rather than pinning an equal
+    // one. The explicit "Default" entry is that same choice for when the
+    // default is unresolved and no level carries the marker.
+    if (next === DEFAULT_ENTRY || next === shownDefault) {
       onReset();
     } else {
       onTierChange(next);
@@ -85,7 +113,7 @@ export function TierPicker({
   };
 
   return (
-    <Dropdown<RiskThreshold>
+    <Dropdown<TierOptionValue>
       value={effectiveTier ?? ""}
       onChange={handleChange}
       options={options}


### PR DESCRIPTION
## TL;DR

When the Slack tier picker's `defaultTier` is null (the effective default is unknown to the client), the `onReset` branch was unreachable: every menu selection wrote a permission cell, and a user trying to restore "follow the default" on an overridden channel could only pin another override. The picker now shows an explicit "Default" menu entry in that state which calls `onReset()`. Behavior with a resolved default is unchanged.

Fixes LUM-2895

## The design, and why not the literal comparison fix

`defaultTier` is null exactly when the client does not know what the default resolves to: the resolve query is still pending or errored, the global-thresholds fetch failed, or the gateway predates the resolve route (the 0.10.7 band 404s it deterministically, leaving the state permanent). In that state the component cannot detect "the user selected the tier that matches the effective default", so the ticket's literal comparison cannot be implemented. Guessing is worse than the bug: treating a re-select of the displayed level as a reset would delete a pinned `Strict` cell and silently broaden effective access to `Conservative` if the hidden default resolves that way.

The fix keeps the picker's core contract (there is always exactly one menu selection that means "follow the default"):

- **Default resolved**: the level the default maps to carries the muted "default" marker; selecting it calls `onReset()`. Unchanged, and there is still no separate "Default" entry.
- **Default unresolved** (`defaultTier` null): no level can carry the marker, so the menu adds an explicit "Default" entry that calls `onReset()`. Selecting a level still pins it, because pinning is the only write that guarantees the level the user chose.

`onReset` flows to `onTierReset` / `onBucketReset` in `use-channel-permission-overrides`, which already no-op when no cell exists, so selecting "Default" on an un-overridden row costs no round-trip.

## What changes for the user

| Situation | Before | After |
| --- | --- | --- |
| Channel has an override, default still loading / unavailable | No menu choice clears the override; any selection writes a cell | A "Default" entry clears the override and the channel follows the default again |
| Channel has no override, default unknown | Any selection pins a cell | Same for levels; picking "Default" is a safe no-op |
| Default known (normal case) | Level with "default" marker resets; others pin | Unchanged |

## Why this is safe

- The unresolved-default state previously had no reset path at all, so no existing user flow is removed or reinterpreted; the new entry only appears when the marker cannot.
- Selecting a level never silently resets: effective access can only change when the user picks "Default", which names exactly what it does.
- New `tier-picker.test.tsx` covers both states (9 tests): marker + reset semantics with a resolved default (including the `medium` collapse), the Default entry's presence and reset behavior with a null default, and a regression test that re-selecting the current level still pins rather than guessing a reset.
- `bunx tsc --noEmit` reports only the 7 errors already present on the base commit (verified via stash); lint is clean for the touched files.

## Verification

- `bun test src/domains/channels/components/tier-picker.test.tsx` (9 pass)
- Adjacent files re-run individually: `slack-channel-list.test.ts`, `assistant-channels-list.test.tsx`, `slack-channel-overrides.test.ts` (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->