### PR TITLE
feat(gateway): serve websocket-kind plugin ingress by POSTing frames upstream

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -21,6 +21,10 @@ const ROUTE_PATH_CONSTANTS: Record<string, string> = {
   TWILIO_MEDIA_STREAM_WEBHOOK_PATH,
   TWILIO_STATUS_WEBHOOK_PATH,
   TWILIO_VOICE_WEBHOOK_PATH,
+  // A regex rather than a literal, shared with the WebSocket upgrade branch
+  // so the two halves of the plugin surface cannot disagree. Given here in
+  // the converted form the extractor would have produced from it inline.
+  PLUGIN_WEBHOOK_PATH_PATTERN: "/webhooks/plugins/{param1}/{param2}",
 };
 
 /**

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -129,6 +129,14 @@ export interface PluginIngressDiscovery {
   problems: PluginIngressProblem[];
 }
 
+/**
+ * Matches a public plugin route path, capturing plugin name and route path.
+ * Shared by the HTTP route entry and the WebSocket upgrade branch so the two
+ * halves of the surface cannot come to disagree about its shape.
+ */
+export const PLUGIN_WEBHOOK_PATH_PATTERN =
+  /^\/webhooks\/plugins\/([^/]+)\/(.+)$/;
+
 /** Compose the absolute public path the gateway serves for a route. */
 export function pluginWebhookPath(plugin: string, path: string): string {
   return `${PLUGIN_WEBHOOK_PREFIX}/${plugin}/${path.replace(/^\/+/, "")}`;

--- a/gateway/src/http/routes/plugin-webhook-websocket.test.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.test.ts
@@ -401,6 +401,43 @@ describe("frame delivery", () => {
     expect(calls[0]!.body).toBe('{"event":"joined"}');
   });
 
+  it("sends text frames as a raw content type, not application/json", async () => {
+    // The runtime adapter parses application/json and keeps only objects, so
+    // a bare string or malformed frame would reach the plugin as an empty
+    // body. Text frames must arrive exactly as sent.
+    const seen: { body: unknown; contentType: string }[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      seen.push({ body: init?.body, contentType: headers["content-type"]! });
+      return new Response("", { status: 200 });
+    });
+    const { ws } = fakeSocket(data);
+
+    handlers.message(ws, "not json at all");
+    await settle();
+
+    expect(seen[0]!.contentType).not.toContain("application/json");
+    expect(seen[0]!.body).toBe("not json at all");
+  });
+
+  it("sends binary frames as octet-stream", async () => {
+    const seen: { body: unknown; contentType: string }[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      seen.push({ body: init?.body, contentType: headers["content-type"]! });
+      return new Response("", { status: 200 });
+    });
+    const { ws } = fakeSocket(data);
+
+    handlers.message(ws, new Uint8Array([1, 2, 3]).buffer);
+    await settle();
+
+    expect(seen[0]!.contentType).toBe("application/octet-stream");
+    expect(seen[0]!.body).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
   it("delivers frames one at a time, in order", async () => {
     // The ordering guarantee: the plugin must see `joined` before `left`,
     // which a fan-out of concurrent POSTs would not promise.

--- a/gateway/src/http/routes/plugin-webhook-websocket.test.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.test.ts
@@ -1,0 +1,511 @@
+import { createHmac } from "node:crypto";
+
+import { describe, expect, it } from "bun:test";
+
+import "../../__tests__/test-preload.js";
+import { initSigningKey } from "../../auth/token-service.js";
+import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
+import type { GatewayConfig } from "../../config.js";
+import {
+  createPluginWebhookWebsocketHandler,
+  getPluginWebhookWebsocketHandlers,
+  isPluginWebhookSocketData,
+  type PluginWebhookSocketData,
+} from "./plugin-webhook-websocket.js";
+
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
+
+const CONFIG = {
+  assistantRuntimeBaseUrl: "http://runtime.test:7821",
+  runtimeTimeoutMs: 1000,
+} as GatewayConfig;
+
+const PLUGIN_SECRET = "plugin-webhook-secret";
+const VELLUM_SECRET = "platform-webhook-secret";
+const WS_PATH = "/webhooks/plugins/meeting-bot/realtime";
+
+const ROUTE = {
+  path: "realtime",
+  kind: "websocket" as const,
+  signer: "plugin" as const,
+  description: "events",
+};
+
+function credentialsFor(entries: Record<string, string>) {
+  return {
+    get: async (key: string) => entries[key],
+  } as unknown as Parameters<
+    typeof createPluginWebhookWebsocketHandler
+  >[0]["credentials"];
+}
+
+const CREDENTIALS = credentialsFor({
+  "credential/meeting-bot/webhook_secret": PLUGIN_SECRET,
+  "credential/vellum/webhook_secret": VELLUM_SECRET,
+});
+
+function resolution(
+  overrides: Partial<PluginIngressResolution> = {},
+): PluginIngressResolution {
+  return { approved: [], pending: [], problems: [], ...overrides };
+}
+
+function approvedWith(
+  routes: {
+    path: string;
+    kind: "http" | "websocket";
+    signer: "plugin" | "vellum";
+    description: string;
+  }[],
+): PluginIngressResolution {
+  return resolution({
+    approved: [{ plugin: "meeting-bot", routes, digest: "d".repeat(32) }],
+  });
+}
+
+/** A signed upgrade request. */
+function upgradeRequest(
+  opts: {
+    secret?: string;
+    timestamp?: string;
+    path?: string;
+    upgrade?: boolean;
+    signPath?: string;
+  } = {},
+): Request {
+  const {
+    secret = PLUGIN_SECRET,
+    timestamp = String(Math.floor(Date.now() / 1000)),
+    path = WS_PATH,
+    upgrade = true,
+    signPath = path,
+  } = opts;
+  const headers: Record<string, string> = {};
+  if (upgrade) headers.upgrade = "websocket";
+  if (timestamp) headers["vellum-timestamp"] = timestamp;
+  if (secret) {
+    headers["vellum-signature"] =
+      `sha256=${createHmac("sha256", secret).update(`${timestamp}.${signPath}`, "utf8").digest("hex")}`;
+  }
+  return new Request(`http://gateway${path}`, { headers });
+}
+
+/** A Bun server stand-in that records whether an upgrade was accepted. */
+function fakeServer(accept = true) {
+  const upgrades: PluginWebhookSocketData[] = [];
+  const server = {
+    upgrade: (_req: Request, opts: { data: PluginWebhookSocketData }) => {
+      if (!accept) return false;
+      upgrades.push(opts.data);
+      return true;
+    },
+  } as unknown as import("bun").Server<unknown>;
+  return { server, upgrades };
+}
+
+function makeHandler(
+  overrides: {
+    resolve?: () => PluginIngressResolution;
+    credentials?: ReturnType<typeof credentialsFor>;
+  } = {},
+) {
+  return createPluginWebhookWebsocketHandler({
+    config: CONFIG,
+    resolve: overrides.resolve ?? (() => approvedWith([ROUTE])),
+    credentials: overrides.credentials ?? CREDENTIALS,
+  });
+}
+
+describe("upgrade gate", () => {
+  it("upgrades an approved, signed websocket route", async () => {
+    const handle = makeHandler();
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest(),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res).toBeUndefined();
+    expect(upgrades).toHaveLength(1);
+    expect(upgrades[0]!.plugin).toBe("meeting-bot");
+    expect(isPluginWebhookSocketData(upgrades[0])).toBe(true);
+  });
+
+  it("refuses a non-upgrade request", async () => {
+    const handle = makeHandler();
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({ upgrade: false }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(426);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("404s a declaration nobody approved", async () => {
+    const handle = makeHandler({
+      resolve: () =>
+        resolution({
+          pending: [
+            { plugin: "meeting-bot", routes: [ROUTE], digest: "d".repeat(32) },
+          ],
+        }),
+    });
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest(),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(404);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("404s an http-kind route rather than upgrading it", async () => {
+    // Approving an HTTP route did not approve a socket at that path.
+    const handle = makeHandler({
+      resolve: () => approvedWith([{ ...ROUTE, kind: "http" as const }]),
+    });
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest(),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(404);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("404s a path the declaration does not name", async () => {
+    const handle = makeHandler();
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({ path: "/webhooks/plugins/meeting-bot/admin" }),
+      server,
+      "meeting-bot",
+      "admin",
+    );
+
+    expect(res?.status).toBe(404);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("fails closed when the approved set cannot be resolved", async () => {
+    const handle = makeHandler({
+      resolve: () => {
+        throw new Error("db unavailable");
+      },
+    });
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest(),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(500);
+    expect(upgrades).toEqual([]);
+  });
+});
+
+describe("handshake signature", () => {
+  it("refuses an unsigned handshake", async () => {
+    const handle = makeHandler();
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({ secret: "" }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(403);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("refuses a handshake signed with the wrong secret", async () => {
+    const handle = makeHandler();
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({ secret: "nope" }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(403);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("refuses a stale handshake", async () => {
+    // The timestamp is what stops a captured handshake working forever.
+    const handle = makeHandler();
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({
+        timestamp: String(Math.floor(Date.now() / 1000) - 3600),
+      }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(403);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("refuses a handshake with no timestamp at all", async () => {
+    const handle = makeHandler();
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({ timestamp: "" }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(403);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("refuses a signature minted for a different path", async () => {
+    // Binding the path stops a handshake for one route opening another.
+    const handle = makeHandler();
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({ signPath: "/webhooks/plugins/meeting-bot/other" }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(403);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("refuses the upgrade when no secret is configured", async () => {
+    const handle = makeHandler({ credentials: credentialsFor({}) });
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest(),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(409);
+    expect(upgrades).toEqual([]);
+  });
+
+  it("verifies a vellum-signed route against the platform secret", async () => {
+    const handle = makeHandler({
+      resolve: () => approvedWith([{ ...ROUTE, signer: "vellum" as const }]),
+    });
+    const { server, upgrades } = fakeServer();
+
+    expect(
+      await handle(
+        upgradeRequest({ secret: VELLUM_SECRET }),
+        server,
+        "meeting-bot",
+        "realtime",
+      ),
+    ).toBeUndefined();
+    expect(upgrades).toHaveLength(1);
+
+    const rejected = await handle(
+      upgradeRequest({ secret: PLUGIN_SECRET }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+    expect(rejected?.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Frame delivery
+// ---------------------------------------------------------------------------
+
+/** Socket stand-in capturing close calls. */
+function fakeSocket(data: PluginWebhookSocketData) {
+  const closes: { code: number; reason: string }[] = [];
+  const ws = {
+    data,
+    close: (code: number, reason: string) => closes.push({ code, reason }),
+  } as unknown as import("bun").ServerWebSocket<PluginWebhookSocketData>;
+  return { ws, closes };
+}
+
+function socketData(
+  fetchImpl?: PluginWebhookSocketData["fetchImpl"],
+): PluginWebhookSocketData {
+  return {
+    wsType: "plugin-webhook",
+    config: CONFIG,
+    plugin: "meeting-bot",
+    path: "realtime",
+    queue: [],
+    delivering: false,
+    closed: false,
+    fetchImpl,
+  };
+}
+
+/** Waits for the drain loop to settle. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 50; i++) await Promise.resolve();
+}
+
+describe("frame delivery", () => {
+  it("posts each frame to the plugin's route", async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (url, init) => {
+      calls.push({ url: String(url), body: init?.body });
+      return new Response("", { status: 200 });
+    });
+    const { ws } = fakeSocket(data);
+
+    handlers.message(ws, '{"event":"joined"}');
+    await settle();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      "http://runtime.test:7821/v1/x/plugins/meeting-bot/realtime",
+    );
+    expect(calls[0]!.body).toBe('{"event":"joined"}');
+  });
+
+  it("delivers frames one at a time, in order", async () => {
+    // The ordering guarantee: the plugin must see `joined` before `left`,
+    // which a fan-out of concurrent POSTs would not promise.
+    const started: string[] = [];
+    const finished: string[] = [];
+    let release: (() => void) | undefined;
+
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (_url, init) => {
+      const body = String(init?.body);
+      started.push(body);
+      if (body === "first") {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      }
+      finished.push(body);
+      return new Response("", { status: 200 });
+    });
+    const { ws } = fakeSocket(data);
+
+    handlers.message(ws, "first");
+    handlers.message(ws, "second");
+    await settle();
+
+    // Second must not have started while first is still in flight.
+    expect(started).toEqual(["first"]);
+    release?.();
+    await settle();
+    expect(started).toEqual(["first", "second"]);
+    expect(finished).toEqual(["first", "second"]);
+  });
+
+  it("keeps delivering after a frame fails", async () => {
+    // A failed POST is skipped, not retried — retrying would reorder it
+    // behind frames that already arrived.
+    const seen: string[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (_url, init) => {
+      const body = String(init?.body);
+      seen.push(body);
+      if (body === "boom") throw new Error("upstream down");
+      return new Response("", { status: 200 });
+    });
+    const { ws } = fakeSocket(data);
+
+    handlers.message(ws, "boom");
+    handlers.message(ws, "after");
+    await settle();
+
+    expect(seen).toEqual(["boom", "after"]);
+  });
+
+  it("closes a connection that outruns the buffer", async () => {
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(
+      async () =>
+        new Promise<Response>(() => {
+          /* never settles, so the queue backs up */
+        }),
+    );
+    const { ws, closes } = fakeSocket(data);
+
+    for (let i = 0; i < 150; i++) handlers.message(ws, `frame-${i}`);
+
+    expect(closes).toHaveLength(1);
+    expect(closes[0]!.code).toBe(1008);
+  });
+
+  it("drops undelivered frames when the caller goes away", async () => {
+    const seen: string[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    let release: (() => void) | undefined;
+    const data = socketData(async (_url, init) => {
+      seen.push(String(init?.body));
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return new Response("", { status: 200 });
+    });
+    const { ws } = fakeSocket(data);
+
+    handlers.message(ws, "first");
+    handlers.message(ws, "second");
+    await settle();
+    handlers.close(ws, 1000, "done");
+    release?.();
+    await settle();
+
+    // `second` was still queued when the socket closed, so it never ships.
+    expect(seen).toEqual(["first"]);
+    expect(data.queue).toEqual([]);
+  });
+
+  it("ignores frames that arrive after close", async () => {
+    const seen: string[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (_url, init) => {
+      seen.push(String(init?.body));
+      return new Response("", { status: 200 });
+    });
+    const { ws } = fakeSocket(data);
+
+    handlers.close(ws, 1000, "done");
+    handlers.message(ws, "late");
+    await settle();
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/gateway/src/http/routes/plugin-webhook-websocket.test.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.test.ts
@@ -18,6 +18,7 @@ initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
 const CONFIG = {
   assistantRuntimeBaseUrl: "http://runtime.test:7821",
   runtimeTimeoutMs: 1000,
+  maxWebhookPayloadBytes: 1024,
 } as GatewayConfig;
 
 const PLUGIN_SECRET = "plugin-webhook-secret";
@@ -368,6 +369,7 @@ function socketData(
     plugin: "meeting-bot",
     path: "realtime",
     queue: [],
+    queuedBytes: 0,
     delivering: false,
     closed: false,
     fetchImpl,
@@ -466,6 +468,59 @@ describe("frame delivery", () => {
 
     expect(closes).toHaveLength(1);
     expect(closes[0]!.code).toBe(1008);
+  });
+
+  it("refuses a single frame larger than the webhook payload cap", async () => {
+    // It could never be delivered anyway — the plugin route would reject it
+    // as an oversized webhook body.
+    const seen: string[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (_url, init) => {
+      seen.push(String(init?.body));
+      return new Response("", { status: 200 });
+    });
+    const { ws, closes } = fakeSocket(data);
+
+    handlers.message(ws, "x".repeat(2048));
+    await settle();
+
+    expect(closes).toHaveLength(1);
+    expect(closes[0]!.code).toBe(1008);
+    expect(seen).toEqual([]);
+  });
+
+  it("bounds the queue by bytes, not just frame count", async () => {
+    // 100 frames of Bun's maximum size would be gigabytes, so the count
+    // alone is not a memory bound.
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(
+      async () =>
+        new Promise<Response>(() => {
+          /* never settles, so the queue backs up */
+        }),
+    );
+    const { ws, closes } = fakeSocket(data);
+
+    // Each frame is under the per-frame cap, and there are fewer than
+    // MAX_PENDING_FRAMES of them — only the byte budget can reject these.
+    for (let i = 0; i < 20; i++) handlers.message(ws, "x".repeat(1000));
+
+    expect(closes).toHaveLength(1);
+    expect(closes[0]!.code).toBe(1008);
+    expect(data.queuedBytes).toBe(0);
+  });
+
+  it("releases queued bytes as frames are delivered", async () => {
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async () => new Response("", { status: 200 }));
+    const { ws } = fakeSocket(data);
+
+    handlers.message(ws, "x".repeat(100));
+    handlers.message(ws, "x".repeat(100));
+    await settle();
+
+    expect(data.queue).toEqual([]);
+    expect(data.queuedBytes).toBe(0);
   });
 
   it("drops undelivered frames when the caller goes away", async () => {

--- a/gateway/src/http/routes/plugin-webhook-websocket.test.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.test.ts
@@ -361,7 +361,7 @@ function fakeSocket(data: PluginWebhookSocketData) {
 }
 
 function socketData(
-  fetchImpl?: PluginWebhookSocketData["fetchImpl"],
+  ipcCall?: PluginWebhookSocketData["ipcCall"],
 ): PluginWebhookSocketData {
   return {
     wsType: "plugin-webhook",
@@ -372,7 +372,7 @@ function socketData(
     queuedBytes: 0,
     delivering: false,
     closed: false,
-    fetchImpl,
+    ipcCall,
   };
 }
 
@@ -381,86 +381,55 @@ async function settle(): Promise<void> {
   for (let i = 0; i < 50; i++) await Promise.resolve();
 }
 
+/** A frame carrying `value`, as the caller would send it. */
+function evt(value: string): string {
+  return JSON.stringify({ event: value });
+}
+
 describe("frame delivery", () => {
-  it("posts each frame to the plugin's route", async () => {
-    const calls: { url: string; body: unknown }[] = [];
+  it("hands each frame to the plugin's route over IPC", async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = [];
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (url, init) => {
-      calls.push({ url: String(url), body: init?.body });
-      return new Response("", { status: 200 });
+    const data = socketData(async (method, params) => {
+      calls.push({ method, params });
+      return null;
     });
     const { ws } = fakeSocket(data);
 
-    handlers.message(ws, '{"event":"joined"}');
+    handlers.message(ws, evt("joined"));
     await settle();
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe(
-      "http://runtime.test:7821/v1/x/plugins/meeting-bot/realtime",
-    );
-    expect(calls[0]!.body).toBe('{"event":"joined"}');
-  });
-
-  it("sends text frames as a raw content type, not application/json", async () => {
-    // The runtime adapter parses application/json and keeps only objects, so
-    // a bare string or malformed frame would reach the plugin as an empty
-    // body. Text frames must arrive exactly as sent.
-    const seen: { body: unknown; contentType: string }[] = [];
-    const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (_url, init) => {
-      const headers = init?.headers as Record<string, string>;
-      seen.push({ body: init?.body, contentType: headers["content-type"]! });
-      return new Response("", { status: 200 });
+    expect(calls[0]!.method).toBe("user_route_post");
+    expect(calls[0]!.params).toMatchObject({
+      pathParams: { path: "plugins/meeting-bot/realtime" },
+      body: { event: "joined" },
     });
-    const { ws } = fakeSocket(data);
-
-    handlers.message(ws, "not json at all");
-    await settle();
-
-    expect(seen[0]!.contentType).not.toContain("application/json");
-    expect(seen[0]!.body).toBe("not json at all");
-  });
-
-  it("sends binary frames as octet-stream", async () => {
-    const seen: { body: unknown; contentType: string }[] = [];
-    const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (_url, init) => {
-      const headers = init?.headers as Record<string, string>;
-      seen.push({ body: init?.body, contentType: headers["content-type"]! });
-      return new Response("", { status: 200 });
-    });
-    const { ws } = fakeSocket(data);
-
-    handlers.message(ws, new Uint8Array([1, 2, 3]).buffer);
-    await settle();
-
-    expect(seen[0]!.contentType).toBe("application/octet-stream");
-    expect(seen[0]!.body).toEqual(new Uint8Array([1, 2, 3]));
   });
 
   it("delivers frames one at a time, in order", async () => {
     // The ordering guarantee: the plugin must see `joined` before `left`,
-    // which a fan-out of concurrent POSTs would not promise.
+    // which a fan-out of concurrent calls would not promise.
     const started: string[] = [];
     const finished: string[] = [];
     let release: (() => void) | undefined;
 
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (_url, init) => {
-      const body = String(init?.body);
-      started.push(body);
-      if (body === "first") {
+    const data = socketData(async (_method, params) => {
+      const event = (params!.body as { event: string }).event;
+      started.push(event);
+      if (event === "first") {
         await new Promise<void>((resolve) => {
           release = resolve;
         });
       }
-      finished.push(body);
-      return new Response("", { status: 200 });
+      finished.push(event);
+      return null;
     });
     const { ws } = fakeSocket(data);
 
-    handlers.message(ws, "first");
-    handlers.message(ws, "second");
+    handlers.message(ws, evt("first"));
+    handlers.message(ws, evt("second"));
     await settle();
 
     // Second must not have started while first is still in flight.
@@ -472,58 +441,77 @@ describe("frame delivery", () => {
   });
 
   it("keeps delivering after a frame fails", async () => {
-    // A failed POST is skipped, not retried — retrying would reorder it
+    // A failed call is skipped, not retried — retrying would reorder it
     // behind frames that already arrived.
     const seen: string[] = [];
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (_url, init) => {
-      const body = String(init?.body);
-      seen.push(body);
-      if (body === "boom") throw new Error("upstream down");
-      return new Response("", { status: 200 });
+    const data = socketData(async (_method, params) => {
+      const event = (params!.body as { event: string }).event;
+      seen.push(event);
+      if (event === "boom") throw new Error("assistant unreachable");
+      return null;
     });
     const { ws } = fakeSocket(data);
 
-    handlers.message(ws, "boom");
-    handlers.message(ws, "after");
+    handlers.message(ws, evt("boom"));
+    handlers.message(ws, evt("after"));
     await settle();
 
     expect(seen).toEqual(["boom", "after"]);
   });
 
-  it("closes a connection that outruns the buffer", async () => {
-    const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(
-      async () =>
-        new Promise<Response>(() => {
-          /* never settles, so the queue backs up */
-        }),
-    );
-    const { ws, closes } = fakeSocket(data);
+  it("refuses a frame that is not a JSON object", async () => {
+    // Until the IPC envelope carries raw frames, `body` must be an object.
+    // Queueing anything else would drop it silently at the far end.
+    for (const frame of ["not json", '"a bare string"', "42", "[1,2,3]"]) {
+      const calls: unknown[] = [];
+      const handlers = getPluginWebhookWebsocketHandlers();
+      const data = socketData(async (method) => {
+        calls.push(method);
+        return null;
+      });
+      const { ws, closes } = fakeSocket(data);
 
-    for (let i = 0; i < 150; i++) handlers.message(ws, `frame-${i}`);
+      handlers.message(ws, frame);
+      await settle();
 
-    expect(closes).toHaveLength(1);
-    expect(closes[0]!.code).toBe(1008);
+      expect(closes).toHaveLength(1);
+      expect(closes[0]!.code).toBe(1003);
+      expect(calls).toEqual([]);
+    }
   });
 
-  it("refuses a single frame larger than the webhook payload cap", async () => {
-    // It could never be delivered anyway — the plugin route would reject it
-    // as an oversized webhook body.
-    const seen: string[] = [];
+  it("refuses a binary frame rather than mangling it", async () => {
+    const calls: unknown[] = [];
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (_url, init) => {
-      seen.push(String(init?.body));
-      return new Response("", { status: 200 });
+    const data = socketData(async (method) => {
+      calls.push(method);
+      return null;
     });
     const { ws, closes } = fakeSocket(data);
 
-    handlers.message(ws, "x".repeat(2048));
+    handlers.message(ws, new Uint8Array([1, 2, 3]).buffer);
+    await settle();
+
+    expect(closes[0]!.code).toBe(1003);
+    expect(calls).toEqual([]);
+  });
+
+  it("refuses a single frame larger than the webhook payload cap", async () => {
+    const calls: unknown[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (method) => {
+      calls.push(method);
+      return null;
+    });
+    const { ws, closes } = fakeSocket(data);
+
+    handlers.message(ws, JSON.stringify({ event: "x".repeat(2048) }));
     await settle();
 
     expect(closes).toHaveLength(1);
-    expect(closes[0]!.code).toBe(1008);
-    expect(seen).toEqual([]);
+    expect(closes[0]!.code).toBe(1009);
+    expect(calls).toEqual([]);
   });
 
   it("bounds the queue by bytes, not just frame count", async () => {
@@ -532,7 +520,7 @@ describe("frame delivery", () => {
     const handlers = getPluginWebhookWebsocketHandlers();
     const data = socketData(
       async () =>
-        new Promise<Response>(() => {
+        new Promise<unknown>(() => {
           /* never settles, so the queue backs up */
         }),
     );
@@ -540,20 +528,38 @@ describe("frame delivery", () => {
 
     // Each frame is under the per-frame cap, and there are fewer than
     // MAX_PENDING_FRAMES of them — only the byte budget can reject these.
-    for (let i = 0; i < 20; i++) handlers.message(ws, "x".repeat(1000));
+    for (let i = 0; i < 20; i++) {
+      handlers.message(ws, JSON.stringify({ event: "x".repeat(900) }));
+    }
 
     expect(closes).toHaveLength(1);
     expect(closes[0]!.code).toBe(1008);
     expect(data.queuedBytes).toBe(0);
   });
 
+  it("closes a connection that outruns the buffer", async () => {
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(
+      async () =>
+        new Promise<unknown>(() => {
+          /* never settles */
+        }),
+    );
+    const { ws, closes } = fakeSocket(data);
+
+    for (let i = 0; i < 150; i++) handlers.message(ws, evt(`frame-${i}`));
+
+    expect(closes).toHaveLength(1);
+    expect(closes[0]!.code).toBe(1008);
+  });
+
   it("releases queued bytes as frames are delivered", async () => {
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async () => new Response("", { status: 200 }));
+    const data = socketData(async () => null);
     const { ws } = fakeSocket(data);
 
-    handlers.message(ws, "x".repeat(100));
-    handlers.message(ws, "x".repeat(100));
+    handlers.message(ws, evt("one"));
+    handlers.message(ws, evt("two"));
     await settle();
 
     expect(data.queue).toEqual([]);
@@ -564,17 +570,17 @@ describe("frame delivery", () => {
     const seen: string[] = [];
     const handlers = getPluginWebhookWebsocketHandlers();
     let release: (() => void) | undefined;
-    const data = socketData(async (_url, init) => {
-      seen.push(String(init?.body));
+    const data = socketData(async (_method, params) => {
+      seen.push((params!.body as { event: string }).event);
       await new Promise<void>((resolve) => {
         release = resolve;
       });
-      return new Response("", { status: 200 });
+      return null;
     });
     const { ws } = fakeSocket(data);
 
-    handlers.message(ws, "first");
-    handlers.message(ws, "second");
+    handlers.message(ws, evt("first"));
+    handlers.message(ws, evt("second"));
     await settle();
     handlers.close(ws, 1000, "done");
     release?.();
@@ -586,16 +592,16 @@ describe("frame delivery", () => {
   });
 
   it("ignores frames that arrive after close", async () => {
-    const seen: string[] = [];
+    const seen: unknown[] = [];
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (_url, init) => {
-      seen.push(String(init?.body));
-      return new Response("", { status: 200 });
+    const data = socketData(async (method) => {
+      seen.push(method);
+      return null;
     });
     const { ws } = fakeSocket(data);
 
     handlers.close(ws, 1000, "done");
-    handlers.message(ws, "late");
+    handlers.message(ws, evt("late"));
     await settle();
 
     expect(seen).toEqual([]);

--- a/gateway/src/http/routes/plugin-webhook-websocket.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.ts
@@ -18,7 +18,10 @@ import type { IngressSigner } from "../../channels/plugin-ingress.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
-import { resolveCredentialWithRefresh } from "../../credential-refresh.js";
+import {
+  resolveCredentialWithRefresh,
+  verifySecretWithRefresh,
+} from "../../credential-refresh.js";
 import { getLogger } from "../../logger.js";
 import {
   VELLUM_TIMESTAMP_HEADER,
@@ -33,8 +36,25 @@ const log = getLogger("plugin-webhook-ws");
  * Frames buffered while a delivery is in flight. Matches the STT relay's cap
  * — a caller that outruns the plugin is disconnected rather than allowed to
  * grow the gateway's heap.
+ *
+ * The count alone is not a memory bound: Bun accepts frames far larger than
+ * a webhook payload, so a hundred of them would be gigabytes. Queued bytes
+ * are capped as well, and an oversized single frame is refused outright —
+ * each frame becomes a webhook-sized POST, so `maxWebhookPayloadBytes` is
+ * the size that has to hold.
  */
 const MAX_PENDING_FRAMES = 100;
+
+/** Total bytes a connection may hold queued, across all pending frames. */
+function maxQueuedBytes(config: GatewayConfig): number {
+  return config.maxWebhookPayloadBytes * 8;
+}
+
+function frameByteLength(frame: string | Uint8Array): number {
+  return typeof frame === "string"
+    ? Buffer.byteLength(frame, "utf8")
+    : frame.byteLength;
+}
 
 export type FetchImpl = (
   input: string | URL | Request,
@@ -48,6 +68,8 @@ export type PluginWebhookSocketData = {
   path: string;
   /** Frames waiting on the in-flight delivery. */
   queue: (string | Uint8Array)[];
+  /** Bytes held in {@link queue}, tracked so the cap is on memory not count. */
+  queuedBytes: number;
   /** True while a POST is outstanding, so deliveries stay serialised. */
   delivering: boolean;
   closed: boolean;
@@ -138,7 +160,18 @@ export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
       return new Response("Forbidden", { status: 403 });
     }
     const signed = handshakeSignedPayload(timestamp, new URL(req.url).pathname);
-    if (!verifyVellumSignature(req.headers, signed, secret)) {
+    // Verify through the refresh helper rather than against the value read
+    // above: a secret that rotated while the cache still held the old one
+    // would otherwise fail an upgrade that is actually valid.
+    const signatureValid = await verifySecretWithRefresh({
+      credentials,
+      key: secretKey,
+      verify: (candidate) =>
+        verifyVellumSignature(req.headers, signed, candidate),
+      log,
+      label: "Plugin webhook WS handshake",
+    });
+    if (!signatureValid) {
       log.warn(
         { plugin, path, signer: route.signer },
         "Plugin webhook WS: signature verification failed",
@@ -153,6 +186,7 @@ export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
         plugin,
         path,
         queue: [],
+        queuedBytes: 0,
         delivering: false,
         closed: false,
         fetchImpl,
@@ -221,11 +255,29 @@ async function drain(data: PluginWebhookSocketData): Promise<void> {
   try {
     while (data.queue.length > 0 && !data.closed) {
       const frame = data.queue.shift()!;
+      data.queuedBytes -= frameByteLength(frame);
       await deliverFrame(data, frame);
     }
   } finally {
     data.delivering = false;
   }
+}
+
+/**
+ * Refuse the rest of a connection that has exceeded its budget.
+ *
+ * Marks it closed before asking for the close: `close` is not immediate, and
+ * a caller already outrunning us keeps sending in the meantime. Without this
+ * every one of those frames would close again.
+ */
+function closeOverBudget(
+  ws: import("bun").ServerWebSocket<PluginWebhookSocketData>,
+  reason: string,
+): void {
+  ws.data.closed = true;
+  ws.data.queue = [];
+  ws.data.queuedBytes = 0;
+  ws.close(1008, reason);
 }
 
 export function getPluginWebhookWebsocketHandlers() {
@@ -244,23 +296,41 @@ export function getPluginWebhookWebsocketHandlers() {
       const data = ws.data;
       if (data.closed) return;
 
-      if (data.queue.length >= MAX_PENDING_FRAMES) {
+      const frame =
+        message instanceof ArrayBuffer ? new Uint8Array(message) : message;
+      const size = frameByteLength(frame);
+
+      // A single oversized frame is refused rather than queued: it could
+      // never be delivered anyway, since it exceeds what the plugin's route
+      // accepts as a webhook payload.
+      if (size > data.config.maxWebhookPayloadBytes) {
         log.warn(
-          { plugin: data.plugin, path: data.path },
-          "Plugin webhook frame buffer overflow — closing connection",
+          { plugin: data.plugin, path: data.path, size },
+          "Plugin webhook frame exceeds the webhook payload cap — closing connection",
         );
-        // Mark closed before asking for the close: `close` is not immediate,
-        // and a caller that is already outrunning us will keep sending in the
-        // meantime. Without this every one of those frames closes again.
-        data.closed = true;
-        data.queue = [];
-        ws.close(1008, "Buffer overflow");
+        closeOverBudget(ws, "Frame too large");
         return;
       }
 
-      const frame =
-        message instanceof ArrayBuffer ? new Uint8Array(message) : message;
+      if (
+        data.queue.length >= MAX_PENDING_FRAMES ||
+        data.queuedBytes + size > maxQueuedBytes(data.config)
+      ) {
+        log.warn(
+          {
+            plugin: data.plugin,
+            path: data.path,
+            queued: data.queue.length,
+            queuedBytes: data.queuedBytes,
+          },
+          "Plugin webhook frame buffer overflow — closing connection",
+        );
+        closeOverBudget(ws, "Buffer overflow");
+        return;
+      }
+
       data.queue.push(frame);
+      data.queuedBytes += size;
       void drain(data);
     },
 
@@ -275,6 +345,7 @@ export function getPluginWebhookWebsocketHandlers() {
       // plugin's view should not gain events after the stream ended.
       const dropped = data.queue.length;
       data.queue = [];
+      data.queuedBytes = 0;
       log.info(
         { plugin: data.plugin, path: data.path, code, reason, dropped },
         "Plugin webhook WS closed",

--- a/gateway/src/http/routes/plugin-webhook-websocket.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.ts
@@ -1,0 +1,284 @@
+/**
+ * WebSocket half of the plugin ingress surface.
+ *
+ * A plugin declaring `kind: "websocket"` gets a socket the caller dials, but
+ * plugin routes are HTTP-only — there is no second socket to hand off to. So
+ * the gateway terminates the connection at the edge and POSTs each frame to
+ * the plugin's route, one at a time per connection so the plugin observes
+ * frames in the order they arrived.
+ *
+ * Frames travel upstream; nothing travels back. Giving the plugin's HTTP
+ * response a meaning on the wire would be inventing a protocol neither side
+ * has agreed to, so a non-2xx is logged and the socket is left alone.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
+import type { IngressSigner } from "../../channels/plugin-ingress.js";
+import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
+import { credentialKey } from "../../credential-key.js";
+import { resolveCredentialWithRefresh } from "../../credential-refresh.js";
+import { getLogger } from "../../logger.js";
+import {
+  VELLUM_TIMESTAMP_HEADER,
+  handshakeSignedPayload,
+  timestampWithinTolerance,
+  verifyVellumSignature,
+} from "../vellum-signature.js";
+
+const log = getLogger("plugin-webhook-ws");
+
+/**
+ * Frames buffered while a delivery is in flight. Matches the STT relay's cap
+ * — a caller that outruns the plugin is disconnected rather than allowed to
+ * grow the gateway's heap.
+ */
+const MAX_PENDING_FRAMES = 100;
+
+export type FetchImpl = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type PluginWebhookSocketData = {
+  wsType: "plugin-webhook";
+  config: GatewayConfig;
+  plugin: string;
+  path: string;
+  /** Frames waiting on the in-flight delivery. */
+  queue: (string | Uint8Array)[];
+  /** True while a POST is outstanding, so deliveries stay serialised. */
+  delivering: boolean;
+  closed: boolean;
+  fetchImpl?: FetchImpl;
+};
+
+export function isPluginWebhookSocketData(
+  data: unknown,
+): data is PluginWebhookSocketData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    (data as { wsType?: unknown }).wsType === "plugin-webhook"
+  );
+}
+
+function signingCredentialKey(plugin: string, signer: IngressSigner): string {
+  return credentialKey(
+    signer === "vellum" ? "vellum" : plugin,
+    "webhook_secret",
+  );
+}
+
+export interface PluginWebhookWsDeps {
+  config: GatewayConfig;
+  resolve: () => PluginIngressResolution;
+  credentials: CredentialCache | undefined;
+  fetchImpl?: FetchImpl;
+}
+
+/**
+ * Upgrade handler for `/webhooks/plugins/:plugin/:path`.
+ *
+ * Applies the same gate as the HTTP half — only a guardian-approved
+ * declaration naming exactly this path is served, and only for the
+ * `websocket` kind — then authenticates the handshake before upgrading. An
+ * upgrade cannot be un-done once accepted, so everything is checked first.
+ */
+export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
+  const { config, resolve, credentials, fetchImpl } = deps;
+
+  return async function handleUpgrade(
+    req: Request,
+    server: import("bun").Server<unknown>,
+    plugin: string,
+    path: string,
+  ): Promise<Response | undefined> {
+    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Upgrade Required", { status: 426 });
+    }
+
+    let approved: PluginIngressResolution["approved"];
+    try {
+      approved = resolve().approved;
+    } catch (err) {
+      log.error({ err, plugin }, "Failed to resolve approved plugin ingress");
+      return new Response("Internal Server Error", { status: 500 });
+    }
+
+    const route = approved
+      .find((d) => d.plugin === plugin)
+      ?.routes.find((r) => r.kind === "websocket" && r.path === path);
+    if (!route) {
+      // Quiet for the same reason as the HTTP half: anyone can reach this.
+      log.debug({ plugin, path }, "No approved websocket ingress route");
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const secretKey = signingCredentialKey(plugin, route.signer);
+    const secret = await resolveCredentialWithRefresh(credentials, secretKey);
+    if (!secret) {
+      log.warn(
+        { plugin, path, signer: route.signer },
+        "Plugin webhook secret is not configured — refusing upgrade",
+      );
+      return new Response("Webhook secret not configured", { status: 409 });
+    }
+
+    // A handshake carries no body to sign, so the signature covers the
+    // timestamp and the path instead, and the timestamp bounds how long a
+    // captured handshake stays usable.
+    const timestamp = req.headers.get(VELLUM_TIMESTAMP_HEADER);
+    if (!timestamp || !timestampWithinTolerance(timestamp)) {
+      log.warn(
+        { plugin, path },
+        "Plugin webhook WS: missing or stale timestamp",
+      );
+      return new Response("Forbidden", { status: 403 });
+    }
+    const signed = handshakeSignedPayload(timestamp, new URL(req.url).pathname);
+    if (!verifyVellumSignature(req.headers, signed, secret)) {
+      log.warn(
+        { plugin, path, signer: route.signer },
+        "Plugin webhook WS: signature verification failed",
+      );
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "plugin-webhook",
+        config,
+        plugin,
+        path,
+        queue: [],
+        delivering: false,
+        closed: false,
+        fetchImpl,
+      } satisfies PluginWebhookSocketData,
+    });
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+    return undefined;
+  };
+}
+
+/** POST one frame to the plugin's route. */
+async function deliverFrame(
+  data: PluginWebhookSocketData,
+  frame: string | Uint8Array,
+): Promise<void> {
+  const { config, plugin, path } = data;
+  const doFetch = data.fetchImpl ?? fetch;
+  const url = `${config.assistantRuntimeBaseUrl}/v1/x/plugins/${plugin}/${path}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.runtimeTimeoutMs);
+  try {
+    const response = await doFetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${mintServiceToken()}`,
+        "content-type":
+          typeof frame === "string"
+            ? "application/json"
+            : "application/octet-stream",
+      },
+      // Uint8Array is a valid BodyInit at runtime; the DOM lib types only
+      // admit the ArrayBufferView union it is a member of.
+      body: frame as BodyInit,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      log.warn(
+        { plugin, path, status: response.status },
+        "Plugin webhook frame rejected by plugin route",
+      );
+    }
+    // Drain so the connection is returned to the pool rather than held open
+    // by an unread body.
+    await response.arrayBuffer().catch(() => undefined);
+  } catch (err) {
+    log.warn({ err, plugin, path }, "Plugin webhook frame delivery failed");
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Deliver queued frames one at a time.
+ *
+ * Serialising is the point: the plugin sees `joined` before `left` because
+ * the next POST does not start until the previous one settles. A delivery
+ * that fails is logged and skipped rather than retried — re-sending would
+ * reorder it behind frames that have already arrived.
+ */
+async function drain(data: PluginWebhookSocketData): Promise<void> {
+  if (data.delivering) return;
+  data.delivering = true;
+  try {
+    while (data.queue.length > 0 && !data.closed) {
+      const frame = data.queue.shift()!;
+      await deliverFrame(data, frame);
+    }
+  } finally {
+    data.delivering = false;
+  }
+}
+
+export function getPluginWebhookWebsocketHandlers() {
+  return {
+    open(ws: import("bun").ServerWebSocket<PluginWebhookSocketData>) {
+      log.info(
+        { plugin: ws.data.plugin, path: ws.data.path },
+        "Plugin webhook WS opened",
+      );
+    },
+
+    message(
+      ws: import("bun").ServerWebSocket<PluginWebhookSocketData>,
+      message: string | ArrayBuffer | Uint8Array,
+    ) {
+      const data = ws.data;
+      if (data.closed) return;
+
+      if (data.queue.length >= MAX_PENDING_FRAMES) {
+        log.warn(
+          { plugin: data.plugin, path: data.path },
+          "Plugin webhook frame buffer overflow — closing connection",
+        );
+        // Mark closed before asking for the close: `close` is not immediate,
+        // and a caller that is already outrunning us will keep sending in the
+        // meantime. Without this every one of those frames closes again.
+        data.closed = true;
+        data.queue = [];
+        ws.close(1008, "Buffer overflow");
+        return;
+      }
+
+      const frame =
+        message instanceof ArrayBuffer ? new Uint8Array(message) : message;
+      data.queue.push(frame);
+      void drain(data);
+    },
+
+    close(
+      ws: import("bun").ServerWebSocket<PluginWebhookSocketData>,
+      code: number,
+      reason: string,
+    ) {
+      const data = ws.data;
+      data.closed = true;
+      // Frames not yet delivered are dropped: the caller is gone, and the
+      // plugin's view should not gain events after the stream ended.
+      const dropped = data.queue.length;
+      data.queue = [];
+      log.info(
+        { plugin: data.plugin, path: data.path, code, reason, dropped },
+        "Plugin webhook WS closed",
+      );
+    },
+  };
+}

--- a/gateway/src/http/routes/plugin-webhook-websocket.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.ts
@@ -215,9 +215,14 @@ async function deliverFrame(
       method: "POST",
       headers: {
         authorization: `Bearer ${mintServiceToken()}`,
+        // Deliberately not application/json for text frames: the runtime's
+        // adapter would parse that and keep only JSON *objects*, silently
+        // dropping a bare string, a number, or anything malformed. A raw
+        // content type hands the plugin the frame exactly as it arrived and
+        // lets the plugin decide what it is.
         "content-type":
           typeof frame === "string"
-            ? "application/json"
+            ? "text/plain; charset=utf-8"
             : "application/octet-stream",
       },
       // Uint8Array is a valid BodyInit at runtime; the DOM lib types only

--- a/gateway/src/http/routes/plugin-webhook-websocket.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.ts
@@ -3,16 +3,24 @@
  *
  * A plugin declaring `kind: "websocket"` gets a socket the caller dials, but
  * plugin routes are HTTP-only — there is no second socket to hand off to. So
- * the gateway terminates the connection at the edge and POSTs each frame to
- * the plugin's route, one at a time per connection so the plugin observes
- * frames in the order they arrived.
+ * the gateway terminates the connection at the edge and hands each frame to
+ * the plugin's route over IPC, one at a time per connection so the plugin
+ * observes frames in the order they arrived. IPC rather than a loopback HTTP
+ * hop because the socket is the trust boundary: the assistant does not
+ * re-verify a caller the gateway has already authorised.
  *
- * Frames travel upstream; nothing travels back. Giving the plugin's HTTP
- * response a meaning on the wire would be inventing a protocol neither side
- * has agreed to, so a non-2xx is logged and the socket is left alone.
+ * Frames travel upstream; nothing travels back. Giving the route's response a
+ * meaning on the wire would be inventing a protocol neither side has agreed
+ * to, so a failure is logged and the socket is left alone.
+ *
+ * Today a frame must carry a JSON object. The IPC request envelope can carry
+ * a binary frame — `writeMessage` sends one and the server's reader parses it
+ * — but the server discards it (`void binary` in `assistant-server.ts`) and
+ * the gateway's client still speaks the legacy newline protocol, which has no
+ * binary frame at all. Until that is fixed, anything else is refused at the
+ * socket rather than silently dropped on the way to the plugin.
  */
 
-import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
 import type { IngressSigner } from "../../channels/plugin-ingress.js";
 import type { GatewayConfig } from "../../config.js";
@@ -22,6 +30,7 @@ import {
   resolveCredentialWithRefresh,
   verifySecretWithRefresh,
 } from "../../credential-refresh.js";
+import { ipcCallAssistant } from "../../ipc/assistant-client.js";
 import { getLogger } from "../../logger.js";
 import {
   VELLUM_TIMESTAMP_HEADER,
@@ -40,8 +49,8 @@ const log = getLogger("plugin-webhook-ws");
  * The count alone is not a memory bound: Bun accepts frames far larger than
  * a webhook payload, so a hundred of them would be gigabytes. Queued bytes
  * are capped as well, and an oversized single frame is refused outright —
- * each frame becomes a webhook-sized POST, so `maxWebhookPayloadBytes` is
- * the size that has to hold.
+ * a frame is a webhook-sized request to the plugin, so
+ * `maxWebhookPayloadBytes` is the size that has to hold.
  */
 const MAX_PENDING_FRAMES = 100;
 
@@ -56,10 +65,12 @@ function frameByteLength(frame: string | Uint8Array): number {
     : frame.byteLength;
 }
 
-export type FetchImpl = (
-  input: string | URL | Request,
-  init?: RequestInit,
-) => Promise<Response>;
+/** Signature of {@link ipcCallAssistant}, injectable for tests. */
+export type IpcCall = (
+  method: string,
+  params?: Record<string, unknown>,
+  opts?: { timeoutMs?: number },
+) => Promise<unknown>;
 
 export type PluginWebhookSocketData = {
   wsType: "plugin-webhook";
@@ -70,10 +81,10 @@ export type PluginWebhookSocketData = {
   queue: (string | Uint8Array)[];
   /** Bytes held in {@link queue}, tracked so the cap is on memory not count. */
   queuedBytes: number;
-  /** True while a POST is outstanding, so deliveries stay serialised. */
+  /** True while a delivery is outstanding, so they stay serialised. */
   delivering: boolean;
   closed: boolean;
-  fetchImpl?: FetchImpl;
+  ipcCall?: IpcCall;
 };
 
 export function isPluginWebhookSocketData(
@@ -97,7 +108,7 @@ export interface PluginWebhookWsDeps {
   config: GatewayConfig;
   resolve: () => PluginIngressResolution;
   credentials: CredentialCache | undefined;
-  fetchImpl?: FetchImpl;
+  ipcCall?: IpcCall;
 }
 
 /**
@@ -109,7 +120,7 @@ export interface PluginWebhookWsDeps {
  * upgrade cannot be un-done once accepted, so everything is checked first.
  */
 export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
-  const { config, resolve, credentials, fetchImpl } = deps;
+  const { config, resolve, credentials, ipcCall } = deps;
 
   return async function handleUpgrade(
     req: Request,
@@ -189,7 +200,7 @@ export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
         queuedBytes: 0,
         delivering: false,
         closed: false,
-        fetchImpl,
+        ipcCall,
       } satisfies PluginWebhookSocketData,
     });
     if (!upgraded) {
@@ -199,50 +210,51 @@ export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
   };
 }
 
-/** POST one frame to the plugin's route. */
+/**
+ * The JSON object a frame carries, or null when it does not carry one.
+ *
+ * Until the IPC request envelope can carry raw bytes, `body` is the only way
+ * a frame reaches a route, and it must be an object — `synthesizeRequest`
+ * re-serialises it, and the runtime adapter keeps objects only. Anything else
+ * is undeliverable rather than merely awkward, so the caller refuses it
+ * instead of letting it vanish.
+ */
+function frameAsJsonObject(
+  frame: string | Uint8Array,
+): Record<string, unknown> | null {
+  if (typeof frame !== "string") return null;
+  try {
+    const parsed: unknown = JSON.parse(frame);
+    return parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Hand one frame to the plugin's route over IPC. */
 async function deliverFrame(
   data: PluginWebhookSocketData,
-  frame: string | Uint8Array,
+  body: Record<string, unknown>,
 ): Promise<void> {
   const { config, plugin, path } = data;
-  const doFetch = data.fetchImpl ?? fetch;
-  const url = `${config.assistantRuntimeBaseUrl}/v1/x/plugins/${plugin}/${path}`;
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), config.runtimeTimeoutMs);
+  const call = data.ipcCall ?? ipcCallAssistant;
   try {
-    const response = await doFetch(url, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${mintServiceToken()}`,
-        // Deliberately not application/json for text frames: the runtime's
-        // adapter would parse that and keep only JSON *objects*, silently
-        // dropping a bare string, a number, or anything malformed. A raw
-        // content type hands the plugin the frame exactly as it arrived and
-        // lets the plugin decide what it is.
-        "content-type":
-          typeof frame === "string"
-            ? "text/plain; charset=utf-8"
-            : "application/octet-stream",
+    await call(
+      "user_route_post",
+      {
+        pathParams: { path: `plugins/${plugin}/${path}` },
+        queryParams: {},
+        body,
+        headers: { "content-type": "application/json" },
       },
-      // Uint8Array is a valid BodyInit at runtime; the DOM lib types only
-      // admit the ArrayBufferView union it is a member of.
-      body: frame as BodyInit,
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      log.warn(
-        { plugin, path, status: response.status },
-        "Plugin webhook frame rejected by plugin route",
-      );
-    }
-    // Drain so the connection is returned to the pool rather than held open
-    // by an unread body.
-    await response.arrayBuffer().catch(() => undefined);
+      { timeoutMs: config.runtimeTimeoutMs },
+    );
   } catch (err) {
     log.warn({ err, plugin, path }, "Plugin webhook frame delivery failed");
-  } finally {
-    clearTimeout(timer);
   }
 }
 
@@ -250,7 +262,7 @@ async function deliverFrame(
  * Deliver queued frames one at a time.
  *
  * Serialising is the point: the plugin sees `joined` before `left` because
- * the next POST does not start until the previous one settles. A delivery
+ * the next call does not start until the previous one settles. A delivery
  * that fails is logged and skipped rather than retried — re-sending would
  * reorder it behind frames that have already arrived.
  */
@@ -261,7 +273,10 @@ async function drain(data: PluginWebhookSocketData): Promise<void> {
     while (data.queue.length > 0 && !data.closed) {
       const frame = data.queue.shift()!;
       data.queuedBytes -= frameByteLength(frame);
-      await deliverFrame(data, frame);
+      const body = frameAsJsonObject(frame);
+      // Enqueueing already rejected anything without one; this is a guard,
+      // not a second gate.
+      if (body) await deliverFrame(data, body);
     }
   } finally {
     data.delivering = false;
@@ -269,20 +284,21 @@ async function drain(data: PluginWebhookSocketData): Promise<void> {
 }
 
 /**
- * Refuse the rest of a connection that has exceeded its budget.
+ * Refuse the rest of a connection.
  *
  * Marks it closed before asking for the close: `close` is not immediate, and
  * a caller already outrunning us keeps sending in the meantime. Without this
  * every one of those frames would close again.
  */
-function closeOverBudget(
+function refuse(
   ws: import("bun").ServerWebSocket<PluginWebhookSocketData>,
+  code: number,
   reason: string,
 ): void {
   ws.data.closed = true;
   ws.data.queue = [];
   ws.data.queuedBytes = 0;
-  ws.close(1008, reason);
+  ws.close(code, reason);
 }
 
 export function getPluginWebhookWebsocketHandlers() {
@@ -305,6 +321,23 @@ export function getPluginWebhookWebsocketHandlers() {
         message instanceof ArrayBuffer ? new Uint8Array(message) : message;
       const size = frameByteLength(frame);
 
+      // Refuse what cannot be delivered, rather than queue it and drop it
+      // silently at the far end. 1003 is the code for "received data of a
+      // type this endpoint cannot accept", which is exactly the situation
+      // until the IPC envelope carries raw frames.
+      if (frameAsJsonObject(frame) === null) {
+        log.warn(
+          {
+            plugin: data.plugin,
+            path: data.path,
+            binary: typeof frame !== "string",
+          },
+          "Plugin webhook frame is not a JSON object — closing connection",
+        );
+        refuse(ws, 1003, "Frame must be a JSON object");
+        return;
+      }
+
       // A single oversized frame is refused rather than queued: it could
       // never be delivered anyway, since it exceeds what the plugin's route
       // accepts as a webhook payload.
@@ -313,7 +346,7 @@ export function getPluginWebhookWebsocketHandlers() {
           { plugin: data.plugin, path: data.path, size },
           "Plugin webhook frame exceeds the webhook payload cap — closing connection",
         );
-        closeOverBudget(ws, "Frame too large");
+        refuse(ws, 1009, "Frame too large");
         return;
       }
 
@@ -330,7 +363,7 @@ export function getPluginWebhookWebsocketHandlers() {
           },
           "Plugin webhook frame buffer overflow — closing connection",
         );
-        closeOverBudget(ws, "Buffer overflow");
+        refuse(ws, 1008, "Buffer overflow");
         return;
       }
 

--- a/gateway/src/http/vellum-signature.ts
+++ b/gateway/src/http/vellum-signature.ts
@@ -12,6 +12,41 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 const HEADER_NAME = "vellum-signature";
 const PREFIX = "sha256=";
 
+/** Companion header carrying the unix seconds a handshake was signed at. */
+export const VELLUM_TIMESTAMP_HEADER = "vellum-timestamp";
+
+/**
+ * How stale a signed handshake may be. Matches the Svix tolerance the Resend
+ * webhook uses.
+ */
+const TIMESTAMP_TOLERANCE_SECONDS = 5 * 60;
+
+/**
+ * What a WebSocket handshake signs.
+ *
+ * An upgrade has no body, so signing one would otherwise be signing nothing —
+ * a static value that stays valid forever once captured. Binding the
+ * timestamp and the path instead keeps a captured handshake usable only
+ * briefly, and only against the route it was issued for.
+ */
+export function handshakeSignedPayload(
+  timestamp: string,
+  pathname: string,
+): string {
+  return `${timestamp}.${pathname}`;
+}
+
+/** True when `timestamp` (unix seconds) is close enough to now. */
+export function timestampWithinTolerance(
+  timestamp: string,
+  nowMs: number = Date.now(),
+): boolean {
+  const seconds = Number(timestamp);
+  if (!Number.isFinite(seconds)) return false;
+  const skew = Math.abs(nowMs / 1000 - seconds);
+  return skew <= TIMESTAMP_TOLERANCE_SECONDS;
+}
+
 /**
  * True when `headers` carries a signature over `rawBody` made with `secret`.
  *

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -146,7 +146,13 @@ import {
   createChannelIngressRevokeHandler,
 } from "./http/routes/channel-ingress.js";
 import { createPluginWebhookHandler } from "./http/routes/plugin-webhook.js";
+import {
+  createPluginWebhookWebsocketHandler,
+  getPluginWebhookWebsocketHandlers,
+  isPluginWebhookSocketData,
+} from "./http/routes/plugin-webhook-websocket.js";
 import { resolveCachedPluginIngress } from "./channels/plugin-ingress-approvals.js";
+import { PLUGIN_WEBHOOK_PATH_PATTERN } from "./channels/plugin-ingress.js";
 import {
   createChannelPermissionOverridesListHandler,
   createChannelPermissionOverrideSetHandler,
@@ -505,6 +511,11 @@ async function main() {
   const handleTwilioMediaWs = createTwilioMediaWebsocketHandler(config, {
     configFile: configFileCache,
   });
+  const handlePluginWebhookWs = createPluginWebhookWebsocketHandler({
+    config,
+    resolve: resolveCachedPluginIngress,
+    credentials: credentialCache,
+  });
   const handleSttStreamWs = createSttStreamWebsocketHandler(config);
   const handleLiveVoiceWs = createLiveVoiceWebsocketHandler(config);
   const handleSpeechRelaySttWs = createSpeechRelayUpgradeHandler(
@@ -518,6 +529,7 @@ async function main() {
     { credentials: credentialCache },
   );
   const twilioMediaStreamWebsocketHandlers = getMediaStreamWebsocketHandlers();
+  const pluginWebhookWebsocketHandlers = getPluginWebhookWebsocketHandlers();
   const sttStreamWebsocketHandlers = getSttStreamWebsocketHandlers();
   const liveVoiceWebsocketHandlers = getLiveVoiceWebsocketHandlers();
   const speechRelayWebsocketHandlers = getSpeechRelayWebsocketHandlers();
@@ -703,12 +715,13 @@ async function main() {
       path: "/webhooks/mailgun",
       handler: (req) => handleMailgunWebhook(req),
     },
-    // Plugin-declared webhooks. Unauthenticated like their neighbours above;
-    // what makes them safe is that only a guardian-approved declaration
-    // creates one, and every other path here 404s. Any method — the plugin's
-    // route module decides which verbs it answers.
+    // Plugin-declared webhooks. Public like their neighbours above; what makes
+    // them safe is that only a guardian-approved declaration creates one, every
+    // other path here 404s, and each request is signature-checked. Any method —
+    // the plugin's route module decides which verbs it answers. WebSocket-kind
+    // declarations are upgraded in the pre-router, before this entry is reached.
     {
-      path: /^\/webhooks\/plugins\/([^/]+)\/(.+)$/,
+      path: PLUGIN_WEBHOOK_PATH_PATTERN,
       handler: (req, params) =>
         handlePluginWebhook(req, params[0]!, params[1]!),
     },
@@ -1761,6 +1774,10 @@ async function main() {
           twilioMediaStreamWebsocketHandlers.open(ws as never);
           return;
         }
+        if (isPluginWebhookSocketData(ws.data)) {
+          pluginWebhookWebsocketHandlers.open(ws as never);
+          return;
+        }
         if (isSttStreamSocketData(ws.data)) {
           sttStreamWebsocketHandlers.open(ws as never);
           return;
@@ -1780,6 +1797,10 @@ async function main() {
           twilioMediaStreamWebsocketHandlers.message(ws as never, message);
           return;
         }
+        if (isPluginWebhookSocketData(ws.data)) {
+          pluginWebhookWebsocketHandlers.message(ws as never, message);
+          return;
+        }
         if (isSttStreamSocketData(ws.data)) {
           sttStreamWebsocketHandlers.message(ws as never, message);
           return;
@@ -1797,6 +1818,10 @@ async function main() {
       close(ws, code, reason) {
         if (isMediaStreamSocketData(ws.data)) {
           twilioMediaStreamWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        if (isPluginWebhookSocketData(ws.data)) {
+          pluginWebhookWebsocketHandlers.close(ws as never, code, reason);
           return;
         }
         if (isSttStreamSocketData(ws.data)) {
@@ -2000,6 +2025,23 @@ async function main() {
       const upgradeResult = handleTwilioMediaWs(req, server);
       if (upgradeResult !== undefined) return upgradeResult;
       return undefined as unknown as Response;
+    }
+
+    // Plugin ingress declared as `websocket`. Claimed only for a genuine
+    // upgrade — a plain request to the same path stays with the route table,
+    // where the HTTP half 404s it for not being an approved HTTP route.
+    if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+      const match = url.pathname.match(PLUGIN_WEBHOOK_PATH_PATTERN);
+      if (match) {
+        const upgradeResult = await handlePluginWebhookWs(
+          req,
+          server,
+          match[1]!,
+          match[2]!,
+        );
+        if (upgradeResult !== undefined) return upgradeResult;
+        return undefined as unknown as Response;
+      }
     }
 
     if (url.pathname === "/v1/stt/stream") {


### PR DESCRIPTION
## Prompt / plan

PR 5 of the plugin-ingress arc, after #39430 landed the HTTP half. A plugin can declare `kind: "websocket"`, but until now the gateway 404'd those — including meeting-bot's `realtime`, its only declared route.

Plugin routes are HTTP-only, so there is no second socket to hand a connection off to. The gateway terminates the WebSocket at the edge (`wsType: "plugin-webhook"`, alongside the four that already share that dispatch) and hands each frame to `user_route_post` over IPC.

**Why the gateway is involved at all**, since Velay carries WebSockets: Velay is transport, not a destination. `VelayWebSocketBridge.open()` builds a loopback URL and re-dials the socket against the gateway's own server at the same path, so something must *be* the WebSocket server there — exactly as the HTTP half must exist for Velay-forwarded webhooks. And plugin routes are HTTP-only (`user-route-dispatcher.ts` has no upgrade path), so frames have to become requests somewhere. That conversion is this PR.

**IPC rather than a loopback HTTP hop**, per review: the socket is the trust boundary, so the assistant does not re-verify a caller the gateway has already authorised. `route-adapter.ts` already states this model — the schema ships each route's policy so the gateway enforces it "without maintaining a parallel table".

**One delivery at a time per connection.** The plugin sees `joined` before `left` because the next call does not start until the previous settles; a fan-out would make ordering an accident of latency. A delivery that fails is logged and skipped rather than retried — re-sending would reorder it behind frames that already arrived.

**Frames travel upstream only.** Giving the route's response a meaning on the wire would invent a protocol neither side has agreed to.

### Known limitation, deliberately loud

A frame must carry a JSON object today. The IPC request envelope *can* carry a binary frame — `writeMessage(socket, envelope, binary?)` sends one and the server's reader parses it — but the server discards it (`void binary;`, `assistant-server.ts:388`) and the gateway's client still speaks the legacy newline-delimited protocol, which has no binary frame at all. So `body` is the only way through, and it must be an object.

Rather than let a bare string, a malformed frame, or a binary frame vanish on the way to the plugin, the socket **refuses them with 1003** (unsupported data). A frame stream that silently loses frames is worse than one that fails where you can see it — and it keeps the gap visible until the transport work lands.

That transport work is its own PR next: move `ipcCallAssistant` onto the framed protocol and thread the received `binary` into `rawBody`. `user_route_post` needs no change — `synthesizeRequest` already prefers `args.rawBody`. Fixing it there gives binary to every route, not just plugin webhooks.

### The handshake signature — still needs a platform counterpart

A WebSocket handshake carries no body, so there is nothing to run the existing HMAC over; signing an empty body would mint a credential valid forever once captured. The signature covers `<timestamp>.<pathname>` instead, sent as the usual `Vellum-Signature` with a new `Vellum-Timestamp` header and the 5-minute tolerance the Resend webhook uses. That bounds replay and binds the handshake to one route — but **it is a scheme I chose, not one the platform already speaks**, so the caller side needs agreement in `vellum-assistant-platform` before this carries traffic.

### Other

The path pattern moves to `PLUGIN_WEBHOOK_PATH_PATTERN`, shared by the route table and the upgrade branch. The pre-router claims a request only for a genuine upgrade; a plain request to the same path still falls through to the route table, where the HTTP half 404s it.

## Test plan

- `plugin-webhook-websocket.test.ts` — 24 tests.
  - **Upgrade gate**: approved + signed upgrades; non-upgrade → 426; pending-not-approved → 404; an `http`-kind route → 404 rather than upgrading; unnamed path → 404; a throwing resolver fails closed at 500.
  - **Handshake**: unsigned, wrong-secret, stale timestamp, absent timestamp, and a signature minted for a different path all → 403; missing credential → 409; a `vellum`-signed route verifies against the platform secret and rejects the plugin's.
  - **Delivery**: correct IPC method and params; a blocked first frame provably holds the second (ordering); a failed frame doesn't stall the queue; non-object frames (`not json`, a bare string, a number, an array) and binary frames close at 1003 without calling; an oversized frame closes at 1009; the byte budget trips on 20 under-cap frames (well below `MAX_PENDING_FRAMES`, so only the byte bound can be what rejected them); count overflow closes at 1008; queued bytes return to zero as frames drain; frames still queued when the caller goes away are dropped; frames after close are ignored.
- 164 pass / 0 fail across the websocket, webhook, route-guard, channels, velay, ingress-approval, signature, and store suites. `tsc --noEmit` clean; prettier + eslint clean.
- The overflow test caught a real bug rather than confirming one: the handler kept accepting frames after asking to close, so every subsequent frame closed again. It now marks the connection closed at that point.

## CLI verb checklist

No new IPC route — this calls the existing `user_route_post`. Not applicable.

## Still open after this

- **IPC binary transport** — the next PR, as above.
- **meeting-bot side** — `routes/realtime.ts`, `signer: "vellum"` on the declaration, and switching `realtimeEndpointUrl()` onto the composed Velay path. Separate repo, separate PR.
- **The handshake scheme needs a platform-side counterpart.**
- **Approving in practice** still means a manual DB write.
