### PR TITLE
fix(web): preserve successful hatch choice completion

### DIFF
--- a/clients/web/src/domains/chat/surface-actions.ts
+++ b/clients/web/src/domains/chat/surface-actions.ts
@@ -129,7 +129,6 @@ export async function handleSurfaceAction(
 
   patchTranscriptMessages((prev: DisplayMessage[]) =>
     completeSubmittedSurface(prev, surfaceId, actionId, completionText, {
-      isGuardianDecision,
       ...(isGuardianDecision
         ? { tone: guardianDecisionTone(actionId, result) }
         : {}),

--- a/clients/web/src/domains/chat/utils/send-message-utils.test.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.test.ts
@@ -151,6 +151,70 @@ describe("completeSubmittedSurface", () => {
     );
   });
 
+  it("treats a secondary-styled choice as a successful selection", () => {
+    const messages = [
+      msg({
+        surfaces: [
+          {
+            surfaceId: "s-first-run-scope",
+            surfaceType: "choice",
+            completed: false,
+            data: {},
+            actions: [
+              {
+                id: "scope_work",
+                label: "Help me plan my week",
+                style: "secondary",
+              },
+            ],
+          } as never,
+        ],
+      }),
+    ];
+
+    const result = completeSubmittedSurface(
+      messages,
+      "s-first-run-scope",
+      "scope_work",
+    );
+
+    expect(result[0]!.surfaces![0]!.completed).toBe(true);
+    expect(result[0]!.surfaces![0]!.completionSummary).toBe(
+      "Help me plan my week",
+    );
+  });
+
+  it("preserves an authoritative completion that arrives before the optimistic patch", () => {
+    const messages = [
+      msg({
+        surfaces: [
+          {
+            surfaceId: "s-first-run-scope",
+            surfaceType: "choice",
+            completed: true,
+            completionSummary: 'User chose: "Help me plan my week"',
+            data: {},
+            actions: [
+              {
+                id: "scope_work",
+                label: "Help me plan my week",
+                style: "secondary",
+              },
+            ],
+          } as never,
+        ],
+      }),
+    ];
+
+    expect(
+      completeSubmittedSurface(
+        messages,
+        "s-first-run-scope",
+        "scope_work",
+      ),
+    ).toBe(messages);
+  });
+
   it("leaves non-completing surfaces unchanged", () => {
     const messages = [
       msg({
@@ -195,7 +259,7 @@ describe("completeSubmittedSurface", () => {
       "access-request-req1",
       "apr:req1:leave_unverified",
       replyText,
-      { isGuardianDecision: true, tone: "neutral" },
+      { tone: "neutral" },
     );
 
     const surface = result[0]!.surfaces![0]!;

--- a/clients/web/src/domains/chat/utils/send-message-utils.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.ts
@@ -142,12 +142,6 @@ export function completeSubmittedSurface(
   opts?: {
     /** Explicit completion tone (icon/color); e.g. a denied guardian decision. */
     tone?: SurfaceCompletionTone;
-    /**
-     * Guardian decision (apr:*) completion. These are approve/deny outcomes,
-     * never a plain "Cancelled" — so the secondary-style cancellation heuristic
-     * (which would mislabel a "Deny" button click as "Cancelled") is skipped.
-     */
-    isGuardianDecision?: boolean;
   },
 ): DisplayMessage[] {
   for (let i = prev.length - 1; i >= 0; i--) {
@@ -158,12 +152,12 @@ export function completeSubmittedSurface(
     if (!OPTIMISTIC_COMPLETION_SURFACE_TYPES.includes(surface.surfaceType)) {
       return prev;
     }
+    if (surface.completed) {
+      return prev;
+    }
     const matchedAction = surface.actions?.find((a) => a.id === actionId);
     const isCancellation =
-      !opts?.isGuardianDecision &&
-      (actionId === "cancel" ||
-        actionId === "dismiss" ||
-        matchedAction?.style === "secondary");
+      actionId === "cancel" || actionId === "dismiss";
     const updated = [...prev];
     updated[i] = mapMessageSurfaces(prev[i]!, (s) =>
       s.surfaceId === surfaceId


### PR DESCRIPTION
## Summary
- Treat surface action presentation style as visual-only when deriving optimistic completion, so a non-recommended choice is not marked Cancelled.
- Preserve server-completed surface state when HTTP completion races the SSE event.
- Add regression coverage for newly hatched assistant first-run scope choices.

## Original prompt
- Investigate a report that clicking options in the initial message from a newly hatched assistant rendered the component as Cancelled, identify the root cause, and begin the fix.