### PR TITLE
feat(monitoring): daily PRAGMA quick_check sample for fleet corruption prevalence

### DIFF
--- a/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
+++ b/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the monitor's quick_check sampler. The corruption seed writes junk
+ * over a b-tree page of a rollback-journal database (WAL would keep the data in
+ * the -wal file, leaving the main file a bare header the check would pass).
+ */
+
+import { closeSync, mkdtempSync, openSync, rmSync, writeSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+
+import { runIntegrityCheck } from "../db-integrity-sample.js";
+
+let dir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "integrity-sample-"));
+  dbPath = join(dir, "test.db");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function seedDb(walMode: boolean): void {
+  const db = new Database(dbPath);
+  try {
+    db.exec(`PRAGMA journal_mode=${walMode ? "WAL" : "DELETE"}`);
+    db.exec("CREATE TABLE t (id TEXT PRIMARY KEY, v TEXT)");
+    const ins = db.prepare("INSERT INTO t (id, v) VALUES (?, ?)");
+    for (let i = 0; i < 200; i++) {
+      ins.run(`k-${i}`, `v-${i}`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+test("returns null when the database does not exist", () => {
+  expect(runIntegrityCheck(dbPath)).toBeNull();
+});
+
+test("reports ok on a healthy database", () => {
+  seedDb(true);
+  const result = runIntegrityCheck(dbPath);
+  expect(result?.ok).toBe(true);
+  expect(result?.errors).toEqual([]);
+  expect(result?.pageCount).toBeGreaterThan(0);
+});
+
+test("reports corruption instead of throwing", () => {
+  seedDb(false);
+  const fd = openSync(dbPath, "r+");
+  try {
+    writeSync(fd, Buffer.alloc(32 * 1024, 0xff), 0, 32 * 1024, 4096);
+  } finally {
+    closeSync(fd);
+  }
+  const result = runIntegrityCheck(dbPath);
+  expect(result?.ok).toBe(false);
+  expect(result?.errors.length).toBeGreaterThan(0);
+});

--- a/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
+++ b/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  assertNotLiveDb(dbPath);
+  assertNotLiveDb(dir);
   rmSync(dir, { recursive: true, force: true });
 });
 

--- a/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
+++ b/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
@@ -1,7 +1,7 @@
 /**
- * Tests for the monitor's quick_check sampler. The corruption seed writes junk
- * over a b-tree page of a rollback-journal database (WAL would keep the data in
- * the -wal file, leaving the main file a bare header the check would pass).
+ * Tests for the quick_check probe. The corruption seed writes junk over a
+ * b-tree page of a rollback-journal database (WAL would keep the data in the
+ * -wal file, leaving the main file a bare header the check would pass).
  */
 
 import { closeSync, mkdtempSync, openSync, rmSync, writeSync } from "node:fs";
@@ -10,7 +10,11 @@ import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, expect, test } from "bun:test";
 
-import { runIntegrityCheck } from "../db-integrity-sample.js";
+import { assertNotLiveDb } from "../../__tests__/assert-not-live-db.js";
+import {
+  type IntegritySampleResult,
+  runIntegrityCheck,
+} from "../db-integrity-check.js";
 
 let dir: string;
 let dbPath: string;
@@ -21,6 +25,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  assertNotLiveDb(dbPath);
   rmSync(dir, { recursive: true, force: true });
 });
 
@@ -38,6 +43,15 @@ function seedDb(walMode: boolean): void {
   }
 }
 
+function corruptDb(): void {
+  const fd = openSync(dbPath, "r+");
+  try {
+    writeSync(fd, Buffer.alloc(32 * 1024, 0xff), 0, 32 * 1024, 4096);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 test("returns null when the database does not exist", () => {
   expect(runIntegrityCheck(dbPath)).toBeNull();
 });
@@ -52,13 +66,21 @@ test("reports ok on a healthy database", () => {
 
 test("reports corruption instead of throwing", () => {
   seedDb(false);
-  const fd = openSync(dbPath, "r+");
-  try {
-    writeSync(fd, Buffer.alloc(32 * 1024, 0xff), 0, 32 * 1024, 4096);
-  } finally {
-    closeSync(fd);
-  }
+  corruptDb();
   const result = runIntegrityCheck(dbPath);
+  expect(result?.ok).toBe(false);
+  expect(result?.errors.length).toBeGreaterThan(0);
+});
+
+test("subprocess entry prints the JSON verdict", () => {
+  seedDb(false);
+  corruptDb();
+  const entry = new URL("../db-integrity-check.ts", import.meta.url).pathname;
+  const proc = Bun.spawnSync({ cmd: ["bun", "run", entry, dbPath] });
+  expect(proc.exitCode).toBe(0);
+  const result = JSON.parse(
+    proc.stdout.toString(),
+  ) as IntegritySampleResult | null;
   expect(result?.ok).toBe(false);
   expect(result?.errors.length).toBeGreaterThan(0);
 });

--- a/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
+++ b/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 
 import { assertNotLiveDb } from "../../__tests__/assert-not-live-db.js";
 import {
+  boundErrors,
   type IntegritySampleResult,
   runIntegrityCheck,
 } from "../db-integrity-check.js";
@@ -70,6 +71,15 @@ test("reports corruption instead of throwing", () => {
   const result = runIntegrityCheck(dbPath);
   expect(result?.ok).toBe(false);
   expect(result?.errors.length).toBeGreaterThan(0);
+});
+
+test("boundErrors caps by UTF-8 bytes without splitting code points", () => {
+  const bounded = boundErrors(Array(20).fill("é".repeat(200)));
+  expect(bounded.length).toBe(10);
+  for (const msg of bounded) {
+    expect(Buffer.byteLength(msg, "utf8")).toBeLessThanOrEqual(160);
+    expect(msg.includes("�")).toBe(false);
+  }
 });
 
 test("subprocess entry prints the JSON verdict", () => {

--- a/assistant/src/monitoring/db-integrity-check.ts
+++ b/assistant/src/monitoring/db-integrity-check.ts
@@ -17,6 +17,21 @@ import { Database } from "bun:sqlite";
 /** Cap on quick_check error rows — a wrecked DB reports thousands. */
 const MAX_ERRORS = 10;
 
+/**
+ * Cap on each error message's length. With MAX_ERRORS rows this bounds the
+ * whole error payload well under the 4096-byte watchdog `detail` limit
+ * (WATCHDOG_DETAIL_MAX_JSON_BYTES) — an oversized detail is silently dropped
+ * by the platform, which would selectively erase the most-corrupted
+ * databases from the prevalence metric.
+ */
+const MAX_ERROR_CHARS = 160;
+
+function boundErrors(messages: string[]): string[] {
+  return messages
+    .slice(0, MAX_ERRORS)
+    .map((m) => (m.length > MAX_ERROR_CHARS ? m.slice(0, MAX_ERROR_CHARS) : m));
+}
+
 export interface IntegritySampleResult {
   ok: boolean;
   errors: string[];
@@ -79,7 +94,7 @@ export function runIntegrityCheck(
     }
     return {
       ok: false,
-      errors: [err instanceof Error ? err.message : String(err)],
+      errors: boundErrors([err instanceof Error ? err.message : String(err)]),
       pageCount: 0,
       durationMs: Date.now() - startedAt,
     };
@@ -93,7 +108,7 @@ export function runIntegrityCheck(
     const healthy = messages.length === 1 && messages[0] === "ok";
     return {
       ok: healthy,
-      errors: healthy ? [] : messages,
+      errors: healthy ? [] : boundErrors(messages),
       pageCount: pageCount(db),
       durationMs: Date.now() - startedAt,
     };
@@ -103,7 +118,7 @@ export function runIntegrityCheck(
     }
     return {
       ok: false,
-      errors: [err instanceof Error ? err.message : String(err)],
+      errors: boundErrors([err instanceof Error ? err.message : String(err)]),
       pageCount: pageCount(db),
       durationMs: Date.now() - startedAt,
     };

--- a/assistant/src/monitoring/db-integrity-check.ts
+++ b/assistant/src/monitoring/db-integrity-check.ts
@@ -1,0 +1,132 @@
+/**
+ * `PRAGMA quick_check` probe for a SQLite database file, runnable as a
+ * standalone subprocess (`bun run db-integrity-check.ts <db-path>`) so the
+ * synchronous page walk never blocks the monitor's event loop. Prints the
+ * JSON-encoded {@link IntegritySampleResult} (or `null`) to stdout.
+ *
+ * quick_check rather than the full `integrity_check` the `assistant db
+ * repair` step runs: quick_check skips the index ↔ table cross-verification,
+ * which is the expensive half on a multi-GB database, while still walking
+ * every page and catching the b-tree damage that makes a database unusable.
+ * A background sweep nobody asked for has to stay cheap.
+ */
+
+import { existsSync } from "node:fs";
+import { Database } from "bun:sqlite";
+
+/** Cap on quick_check error rows — a wrecked DB reports thousands. */
+const MAX_ERRORS = 10;
+
+export interface IntegritySampleResult {
+  ok: boolean;
+  errors: string[];
+  pageCount: number;
+  durationMs: number;
+}
+
+function errCode(err: unknown): unknown {
+  return (err as { code?: unknown }).code;
+}
+
+/**
+ * Lock contention with the daemon (checkpoint restarts, WAL recovery) is not
+ * corruption — mapping it to `ok: false` would inflate the very prevalence
+ * number this probe exists to measure. Busy maps to "no sample" instead.
+ */
+function isBusy(err: unknown): boolean {
+  const code = errCode(err);
+  return code === "SQLITE_BUSY" || code === "SQLITE_LOCKED";
+}
+
+/**
+ * True only for errors that establish structural corruption. Operational
+ * failures (I/O errors, permissions, out-of-memory) say nothing about the
+ * database's integrity and must not count as corrupt samples.
+ */
+function isCorruption(err: unknown): boolean {
+  const code = errCode(err);
+  if (code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB") {
+    return true;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("malformed") || msg.includes("not a database");
+}
+
+/**
+ * Run `PRAGMA quick_check` against `dbPath` on a read-only handle.
+ *
+ * Only genuine corruption signals come back as `ok: false`: quick_check
+ * error rows, or an open/query failure whose error identifies the file as
+ * structurally invalid ("database disk image is malformed", "file is not a
+ * database"). Returns null — "no sample" — when the file does not exist,
+ * the database is locked past the busy timeout, or the failure is
+ * operational (I/O, permissions, memory); the caller stays due and retries
+ * next poll.
+ */
+export function runIntegrityCheck(
+  dbPath: string,
+): IntegritySampleResult | null {
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+  const startedAt = Date.now();
+  let db: Database;
+  try {
+    db = new Database(dbPath, { readonly: true });
+  } catch (err) {
+    if (!isCorruption(err) || isBusy(err)) {
+      return null;
+    }
+    return {
+      ok: false,
+      errors: [err instanceof Error ? err.message : String(err)],
+      pageCount: 0,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+  try {
+    db.exec("PRAGMA busy_timeout=5000");
+    const rows = db
+      .query<{ quick_check: string }, []>(`PRAGMA quick_check(${MAX_ERRORS})`)
+      .all();
+    const messages = rows.map((r) => r.quick_check);
+    const healthy = messages.length === 1 && messages[0] === "ok";
+    return {
+      ok: healthy,
+      errors: healthy ? [] : messages,
+      pageCount: pageCount(db),
+      durationMs: Date.now() - startedAt,
+    };
+  } catch (err) {
+    if (!isCorruption(err) || isBusy(err)) {
+      return null;
+    }
+    return {
+      ok: false,
+      errors: [err instanceof Error ? err.message : String(err)],
+      pageCount: pageCount(db),
+      durationMs: Date.now() - startedAt,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * `PRAGMA page_count` is cheap and works even on damaged DBs (it reads from
+ * the header), but on truly malformed files it can throw too.
+ */
+function pageCount(db: Database): number {
+  try {
+    return (
+      db.query<{ page_count: number }, []>("PRAGMA page_count").get()
+        ?.page_count ?? 0
+    );
+  } catch {
+    return 0;
+  }
+}
+
+if (import.meta.main) {
+  console.log(JSON.stringify(runIntegrityCheck(process.argv[2] ?? "")));
+}

--- a/assistant/src/monitoring/db-integrity-check.ts
+++ b/assistant/src/monitoring/db-integrity-check.ts
@@ -18,18 +18,34 @@ import { Database } from "bun:sqlite";
 const MAX_ERRORS = 10;
 
 /**
- * Cap on each error message's length. With MAX_ERRORS rows this bounds the
- * whole error payload well under the 4096-byte watchdog `detail` limit
- * (WATCHDOG_DETAIL_MAX_JSON_BYTES) — an oversized detail is silently dropped
- * by the platform, which would selectively erase the most-corrupted
- * databases from the prevalence metric.
+ * Cap on each error message's UTF-8 byte length. With MAX_ERRORS rows this
+ * bounds the whole error payload well under the 4096-byte watchdog `detail`
+ * limit (WATCHDOG_DETAIL_MAX_JSON_BYTES) — an oversized detail is silently
+ * dropped by the platform, which would selectively erase the most-corrupted
+ * databases from the prevalence metric. Bytes, not `String.length`: ten
+ * 160-character CJK messages would otherwise serialize to ~4.9 KB.
  */
-const MAX_ERROR_CHARS = 160;
+const MAX_ERROR_BYTES = 160;
 
-function boundErrors(messages: string[]): string[] {
+/** Truncate to at most `maxBytes` of UTF-8 without splitting a code point. */
+function truncateToBytes(s: string, maxBytes: number): string {
+  let bytes = 0;
+  let out = "";
+  for (const ch of s) {
+    const b = Buffer.byteLength(ch, "utf8");
+    if (bytes + b > maxBytes) {
+      break;
+    }
+    out += ch;
+    bytes += b;
+  }
+  return out;
+}
+
+export function boundErrors(messages: string[]): string[] {
   return messages
     .slice(0, MAX_ERRORS)
-    .map((m) => (m.length > MAX_ERROR_CHARS ? m.slice(0, MAX_ERROR_CHARS) : m));
+    .map((m) => truncateToBytes(m, MAX_ERROR_BYTES));
 }
 
 export interface IntegritySampleResult {

--- a/assistant/src/monitoring/db-integrity-sample.ts
+++ b/assistant/src/monitoring/db-integrity-sample.ts
@@ -1,28 +1,28 @@
 /**
- * Periodic `PRAGMA quick_check` sample on the daemon's database, reported as a
- * `db_integrity` watchdog event so the platform can read corruption prevalence
- * across the fleet.
+ * Periodic database integrity sample, reported as a `db_integrity` watchdog
+ * event so the platform can read corruption prevalence across the fleet.
  *
- * Runs in the monitor process, off the daemon's event loop, on a read-only
- * handle — the check never mutates the database. At most one sample per 24h
- * per install (stamped on disk), so the denominator is "installs that reported
- * today" rather than "daemon restarts".
+ * The `PRAGMA quick_check` itself runs in a short-lived subprocess
+ * (`db-integrity-check.ts`) — bun:sqlite's page walk is synchronous, and a
+ * multi-second scan inside this process would stall the resource sampler and
+ * signal handling, the exact things the monitor exists to keep responsive.
+ * The check opens a read-only handle and never mutates the database.
  *
- * We use `quick_check` rather than the full `integrity_check` the `assistant db
- * repair` step runs: quick_check skips the index ↔ table cross-verification,
- * which is the expensive half on a multi-GB database, while still walking every
- * page and catching the b-tree damage that makes a database unusable. A
- * background sweep nobody asked for has to stay cheap.
+ * At most one sample per 24h per install (stamped on disk), so the
+ * denominator is "installs that reported today" rather than "daemon
+ * restarts". The stamp is written only after the event is queued: a failed
+ * enqueue leaves the install due, so it retries next poll instead of
+ * silently dropping out of the day's denominator.
  */
 
 import { existsSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { Database } from "bun:sqlite";
 
 import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { recordWatchdogEvent } from "../telemetry/watchdog-events-store.js";
 import { getLogger } from "../util/logger.js";
 import { getDbPath, getMonitoringDataDir } from "../util/platform.js";
+import type { IntegritySampleResult } from "./db-integrity-check.js";
 
 const log = getLogger("db-integrity-sample");
 
@@ -38,94 +38,36 @@ const POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
 /** Delay before the first attempt, keeping the scan off the boot I/O path. */
 const BOOT_DELAY_MS = 60_000;
 
-/** Cap on quick_check error rows — a wrecked DB reports thousands. */
-const MAX_ERRORS = 10;
+/** Kill switch for a check subprocess wedged on pathological I/O. */
+const CHECK_TIMEOUT_MS = 10 * 60 * 1000;
 
 const STAMP_FILENAME = "db-integrity-last-run-at";
 
-export interface IntegritySampleResult {
-  ok: boolean;
-  errors: string[];
-  pageCount: number;
-  durationMs: number;
-}
-
 /**
- * Lock contention with the daemon (checkpoint restarts, WAL recovery) is not
- * corruption — mapping it to `ok: false` would inflate the very prevalence
- * number this sampler exists to measure. Busy maps to "no sample" instead.
+ * Run the quick_check probe in a subprocess and parse its JSON verdict.
+ * Returns null — "no sample" — on a non-zero exit, unparseable output, or
+ * timeout (the child is killed).
  */
-function isBusy(err: unknown): boolean {
-  const code = (err as { code?: unknown }).code;
-  return code === "SQLITE_BUSY" || code === "SQLITE_LOCKED";
-}
-
-/**
- * Run `PRAGMA quick_check` against `dbPath` on a read-only handle.
- *
- * A database SQLite refuses to open, and a check that throws part-way
- * ("database disk image is malformed"), are both corruption signals, not
- * failures of this function — they come back as `ok: false` with the error
- * message. Returns null when the file does not exist yet or the database is
- * locked past the busy timeout; both mean "no sample", so the caller stays
- * due and retries next poll.
- */
-export function runIntegrityCheck(
+async function runCheckSubprocess(
   dbPath: string,
-): IntegritySampleResult | null {
-  if (!existsSync(dbPath)) {
-    return null;
-  }
-  const startedAt = Date.now();
-  let db: Database;
+): Promise<IntegritySampleResult | null> {
+  const entry = new URL("./db-integrity-check.ts", import.meta.url).pathname;
+  const child = Bun.spawn({
+    cmd: ["bun", "--smol", "run", entry, dbPath],
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const killTimer = setTimeout(() => child.kill(), CHECK_TIMEOUT_MS);
+  killTimer.unref?.();
   try {
-    db = new Database(dbPath, { readonly: true });
-  } catch (err) {
-    if (isBusy(err)) {
+    const stdout = await new Response(child.stdout).text();
+    if ((await child.exited) !== 0) {
       return null;
     }
-    return {
-      ok: false,
-      errors: [err instanceof Error ? err.message : String(err)],
-      pageCount: 0,
-      durationMs: Date.now() - startedAt,
-    };
-  }
-  try {
-    db.exec("PRAGMA busy_timeout=5000");
-    const rows = db
-      .query<{ quick_check: string }, []>(`PRAGMA quick_check(${MAX_ERRORS})`)
-      .all();
-    const messages = rows.map((r) => r.quick_check);
-    return {
-      ok: messages.length === 1 && messages[0] === "ok",
-      errors: messages.length === 1 && messages[0] === "ok" ? [] : messages,
-      pageCount: pageCount(db),
-      durationMs: Date.now() - startedAt,
-    };
-  } catch (err) {
-    if (isBusy(err)) {
-      return null;
-    }
-    return {
-      ok: false,
-      errors: [err instanceof Error ? err.message : String(err)],
-      pageCount: pageCount(db),
-      durationMs: Date.now() - startedAt,
-    };
-  } finally {
-    db.close();
-  }
-}
-
-function pageCount(db: Database): number {
-  try {
-    return (
-      db.query<{ page_count: number }, []>("PRAGMA page_count").get()
-        ?.page_count ?? 0
-    );
+    return JSON.parse(stdout) as IntegritySampleResult | null;
   } catch {
-    return 0;
+    return null;
+  } finally {
+    clearTimeout(killTimer);
   }
 }
 
@@ -143,21 +85,23 @@ function due(): boolean {
 
 /**
  * Sample once if the install is due, emitting one `db_integrity` watchdog
- * event. Never throws. Skips entirely on a confirmed analytics opt-out, where
- * the event would be dropped at record time anyway and the scan would be pure
- * wasted I/O.
+ * event. Never throws. Skips entirely on a confirmed analytics opt-out,
+ * where the event would be dropped at record time anyway and the scan would
+ * be pure wasted I/O.
  */
-export function sampleDbIntegrityIfDue(): void {
+export async function sampleDbIntegrityIfDue(): Promise<void> {
   if (getRawShareAnalytics() === false || !due()) {
     return;
   }
   try {
-    const result = runIntegrityCheck(getDbPath());
-    if (!result) {
+    if (!existsSync(getDbPath())) {
       return; // no database yet — stay due, retry next poll
     }
-    writeFileSync(stampPath(), "");
-    recordWatchdogEvent({
+    const result = await runCheckSubprocess(getDbPath());
+    if (!result) {
+      return; // locked, operational failure, or timeout — stay due
+    }
+    const queued = recordWatchdogEvent({
       checkName: CHECK_NAME,
       value: result.errors.length,
       detail: {
@@ -168,6 +112,9 @@ export function sampleDbIntegrityIfDue(): void {
         errors: result.errors,
       },
     });
+    if (queued) {
+      writeFileSync(stampPath(), "");
+    }
     if (!result.ok) {
       log.warn(
         { errors: result.errors, pageCount: result.pageCount },
@@ -190,9 +137,12 @@ export function startDbIntegritySampler(): void {
   if (process.env.VELLUM_DEV === "1" || pollTimer) {
     return;
   }
-  bootTimer = setTimeout(sampleDbIntegrityIfDue, BOOT_DELAY_MS);
+  bootTimer = setTimeout(() => void sampleDbIntegrityIfDue(), BOOT_DELAY_MS);
   bootTimer.unref?.();
-  pollTimer = setInterval(sampleDbIntegrityIfDue, POLL_INTERVAL_MS);
+  pollTimer = setInterval(
+    () => void sampleDbIntegrityIfDue(),
+    POLL_INTERVAL_MS,
+  );
   pollTimer.unref?.();
 }
 

--- a/assistant/src/monitoring/db-integrity-sample.ts
+++ b/assistant/src/monitoring/db-integrity-sample.ts
@@ -1,0 +1,209 @@
+/**
+ * Periodic `PRAGMA quick_check` sample on the daemon's database, reported as a
+ * `db_integrity` watchdog event so the platform can read corruption prevalence
+ * across the fleet.
+ *
+ * Runs in the monitor process, off the daemon's event loop, on a read-only
+ * handle — the check never mutates the database. At most one sample per 24h
+ * per install (stamped on disk), so the denominator is "installs that reported
+ * today" rather than "daemon restarts".
+ *
+ * We use `quick_check` rather than the full `integrity_check` the `assistant db
+ * repair` step runs: quick_check skips the index ↔ table cross-verification,
+ * which is the expensive half on a multi-GB database, while still walking every
+ * page and catching the b-tree damage that makes a database unusable. A
+ * background sweep nobody asked for has to stay cheap.
+ */
+
+import { existsSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getRawShareAnalytics } from "../platform/consent-cache.js";
+import { recordWatchdogEvent } from "../telemetry/watchdog-events-store.js";
+import { getLogger } from "../util/logger.js";
+import { getDbPath, getMonitoringDataDir } from "../util/platform.js";
+
+const log = getLogger("db-integrity-sample");
+
+/** Watchdog `check_name` carrying the quick_check outcome. */
+const CHECK_NAME = "db_integrity";
+
+/** Minimum spacing between samples on one install. */
+const SAMPLE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** How often the sampler re-tests the 24h stamp (covers long-uptime installs). */
+const POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/** Delay before the first attempt, keeping the scan off the boot I/O path. */
+const BOOT_DELAY_MS = 60_000;
+
+/** Cap on quick_check error rows — a wrecked DB reports thousands. */
+const MAX_ERRORS = 10;
+
+const STAMP_FILENAME = "db-integrity-last-run-at";
+
+export interface IntegritySampleResult {
+  ok: boolean;
+  errors: string[];
+  pageCount: number;
+  durationMs: number;
+}
+
+/**
+ * Lock contention with the daemon (checkpoint restarts, WAL recovery) is not
+ * corruption — mapping it to `ok: false` would inflate the very prevalence
+ * number this sampler exists to measure. Busy maps to "no sample" instead.
+ */
+function isBusy(err: unknown): boolean {
+  const code = (err as { code?: unknown }).code;
+  return code === "SQLITE_BUSY" || code === "SQLITE_LOCKED";
+}
+
+/**
+ * Run `PRAGMA quick_check` against `dbPath` on a read-only handle.
+ *
+ * A database SQLite refuses to open, and a check that throws part-way
+ * ("database disk image is malformed"), are both corruption signals, not
+ * failures of this function — they come back as `ok: false` with the error
+ * message. Returns null when the file does not exist yet or the database is
+ * locked past the busy timeout; both mean "no sample", so the caller stays
+ * due and retries next poll.
+ */
+export function runIntegrityCheck(
+  dbPath: string,
+): IntegritySampleResult | null {
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+  const startedAt = Date.now();
+  let db: Database;
+  try {
+    db = new Database(dbPath, { readonly: true });
+  } catch (err) {
+    if (isBusy(err)) {
+      return null;
+    }
+    return {
+      ok: false,
+      errors: [err instanceof Error ? err.message : String(err)],
+      pageCount: 0,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+  try {
+    db.exec("PRAGMA busy_timeout=5000");
+    const rows = db
+      .query<{ quick_check: string }, []>(`PRAGMA quick_check(${MAX_ERRORS})`)
+      .all();
+    const messages = rows.map((r) => r.quick_check);
+    return {
+      ok: messages.length === 1 && messages[0] === "ok",
+      errors: messages.length === 1 && messages[0] === "ok" ? [] : messages,
+      pageCount: pageCount(db),
+      durationMs: Date.now() - startedAt,
+    };
+  } catch (err) {
+    if (isBusy(err)) {
+      return null;
+    }
+    return {
+      ok: false,
+      errors: [err instanceof Error ? err.message : String(err)],
+      pageCount: pageCount(db),
+      durationMs: Date.now() - startedAt,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function pageCount(db: Database): number {
+  try {
+    return (
+      db.query<{ page_count: number }, []>("PRAGMA page_count").get()
+        ?.page_count ?? 0
+    );
+  } catch {
+    return 0;
+  }
+}
+
+function stampPath(): string {
+  return join(getMonitoringDataDir(), STAMP_FILENAME);
+}
+
+function due(): boolean {
+  try {
+    return Date.now() - statSync(stampPath()).mtimeMs >= SAMPLE_INTERVAL_MS;
+  } catch {
+    return true; // never sampled (or unreadable stamp) — sample now
+  }
+}
+
+/**
+ * Sample once if the install is due, emitting one `db_integrity` watchdog
+ * event. Never throws. Skips entirely on a confirmed analytics opt-out, where
+ * the event would be dropped at record time anyway and the scan would be pure
+ * wasted I/O.
+ */
+export function sampleDbIntegrityIfDue(): void {
+  if (getRawShareAnalytics() === false || !due()) {
+    return;
+  }
+  try {
+    const result = runIntegrityCheck(getDbPath());
+    if (!result) {
+      return; // no database yet — stay due, retry next poll
+    }
+    writeFileSync(stampPath(), "");
+    recordWatchdogEvent({
+      checkName: CHECK_NAME,
+      value: result.errors.length,
+      detail: {
+        ok: result.ok,
+        mode: "quick_check",
+        page_count: result.pageCount,
+        duration_ms: result.durationMs,
+        errors: result.errors,
+      },
+    });
+    if (!result.ok) {
+      log.warn(
+        { errors: result.errors, pageCount: result.pageCount },
+        "Database integrity sample reported corruption",
+      );
+    }
+  } catch (err) {
+    log.warn({ err }, "Database integrity sample failed (non-fatal)");
+  }
+}
+
+let bootTimer: ReturnType<typeof setTimeout> | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the integrity sampler in the monitor process. No-op in dev mode
+ * (VELLUM_DEV=1) and idempotent if already started.
+ */
+export function startDbIntegritySampler(): void {
+  if (process.env.VELLUM_DEV === "1" || pollTimer) {
+    return;
+  }
+  bootTimer = setTimeout(sampleDbIntegrityIfDue, BOOT_DELAY_MS);
+  bootTimer.unref?.();
+  pollTimer = setInterval(sampleDbIntegrityIfDue, POLL_INTERVAL_MS);
+  pollTimer.unref?.();
+}
+
+/** Stop the sampler loop. Idempotent. */
+export function stopDbIntegritySampler(): void {
+  if (bootTimer) {
+    clearTimeout(bootTimer);
+    bootTimer = null;
+  }
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}

--- a/assistant/src/monitoring/db-integrity-sample.ts
+++ b/assistant/src/monitoring/db-integrity-sample.ts
@@ -48,6 +48,14 @@ const STAMP_FILENAME = "db-integrity-last-run-at";
  * Returns null — "no sample" — on a non-zero exit, unparseable output, or
  * timeout (the child is killed).
  */
+/**
+ * The in-flight check subprocess, retained so sampler shutdown can kill it —
+ * a non-detached child survives the monitor's exit and would otherwise hold
+ * its SQLite read snapshot for up to CHECK_TIMEOUT_MS while the daemon
+ * restarts.
+ */
+let activeChild: ReturnType<typeof Bun.spawn> | null = null;
+
 async function runCheckSubprocess(
   dbPath: string,
 ): Promise<IntegritySampleResult | null> {
@@ -56,6 +64,7 @@ async function runCheckSubprocess(
     cmd: ["bun", "--smol", "run", entry, dbPath],
     stdio: ["ignore", "pipe", "ignore"],
   });
+  activeChild = child;
   const killTimer = setTimeout(() => child.kill(), CHECK_TIMEOUT_MS);
   killTimer.unref?.();
   try {
@@ -68,6 +77,7 @@ async function runCheckSubprocess(
     return null;
   } finally {
     clearTimeout(killTimer);
+    activeChild = null;
   }
 }
 
@@ -146,7 +156,7 @@ export function startDbIntegritySampler(): void {
   pollTimer.unref?.();
 }
 
-/** Stop the sampler loop. Idempotent. */
+/** Stop the sampler loop and any in-flight check subprocess. Idempotent. */
 export function stopDbIntegritySampler(): void {
   if (bootTimer) {
     clearTimeout(bootTimer);
@@ -156,4 +166,6 @@ export function stopDbIntegritySampler(): void {
     clearInterval(pollTimer);
     pollTimer = null;
   }
+  activeChild?.kill();
+  activeChild = null;
 }

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -174,6 +174,7 @@ async function main(): Promise<void> {
     recovery?.stop();
     sourceWatch?.stop();
     sampler?.stop();
+    stopDbIntegritySampler();
     cleanupWorkerPidFile(getMonitoringPidPath());
     process.exit(1);
   });
@@ -183,6 +184,7 @@ async function main(): Promise<void> {
     recovery?.stop();
     sourceWatch?.stop();
     sampler?.stop();
+    stopDbIntegritySampler();
     cleanupWorkerPidFile(getMonitoringPidPath());
     process.exit(1);
   });
@@ -191,6 +193,7 @@ async function main(): Promise<void> {
     recovery?.stop();
     sourceWatch?.stop();
     sampler?.stop();
+    stopDbIntegritySampler();
     cleanupWorkerPidFile(getMonitoringPidPath());
   });
 }

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -40,6 +40,10 @@ import {
   startWorkerPidFileGuard,
 } from "../util/worker-process.js";
 import {
+  startDbIntegritySampler,
+  stopDbIntegritySampler,
+} from "./db-integrity-sample.js";
+import {
   type PluginSourceWatchHandle,
   startPluginSourceWatch,
 } from "./plugin-source-watch.js";
@@ -94,6 +98,7 @@ async function main(): Promise<void> {
     recovery?.stop();
     stopConfigSnapshotReporter();
     stopMemoryTierReporter();
+    stopDbIntegritySampler();
     sourceWatch?.stop();
     sampler?.stop();
     // Bounded final telemetry flush, mirroring the daemon's shutdown. This
@@ -154,6 +159,10 @@ async function main(): Promise<void> {
 
   // Emit the coarse memory tier as a periodic per-assistant watchdog heartbeat.
   startMemoryTierReporter();
+
+  // Sample the database's structural integrity (at most daily) so the fleet's
+  // corruption prevalence is measurable.
+  startDbIntegritySampler();
 
   process.on("SIGUSR1", () => {
     log.info("Received SIGUSR1 — refreshing database connections");

--- a/assistant/src/telemetry/watchdog-events-store.ts
+++ b/assistant/src/telemetry/watchdog-events-store.ts
@@ -17,10 +17,13 @@ export interface WatchdogEventRecord {
 /**
  * Record a `watchdog` telemetry event for a watchdog check firing, enqueued
  * on the `telemetry_events` outbox. Consent gating and degraded-mode behavior
- * are `recordTelemetryEvent`'s.
+ * are `recordTelemetryEvent`'s, as is the return value: the queued outbox
+ * row, or null when the event was dropped (opt-out) or could not be stored.
  */
-export function recordWatchdogEvent(record: WatchdogEventRecord): void {
-  recordTelemetryEvent("watchdog", {
+export function recordWatchdogEvent(
+  record: WatchdogEventRecord,
+): { id: string; createdAt: number } | null {
+  return recordTelemetryEvent("watchdog", {
     check_name: record.checkName,
     value: record.value ?? null,
     detail: record.detail ?? null,


### PR DESCRIPTION
## Summary

Adds a `db_integrity` watchdog event emitted from the monitor process: a read-only `PRAGMA quick_check(10)` on the daemon database, at most once per 24h per install (on-disk mtime stamp), boot-delayed 60s with a 6h re-poll for long-uptime installs. Reuses the free-form watchdog telemetry seam (`check_name: "db_integrity"`, `value` = error count, `detail` = ok/mode/page_count/duration_ms/errors), so **no platform serializer change is needed** — fleet-wide corruption prevalence is queryable as soon as this ships.

## Design choices

- **`quick_check`, not `integrity_check`**: the pragma holds one read snapshot for its whole run, and a multi-minute full check on a live WAL database blocks checkpointing while the daemon writes. `quick_check` still walks every page and catches the b-tree damage that bricks an install; what it skips (index↔table drift) is `REINDEX`-repairable. If prevalence warrants, a follow-up can escalate flagged installs to the full check.
- **Busy ≠ corrupt**: `SQLITE_BUSY`/`SQLITE_LOCKED` (checkpoint restarts, WAL recovery) maps to "no sample, stay due, retry next poll" behind a 5s `busy_timeout` — lock contention must not inflate the corruption number this exists to measure.
- **Consent**: skips the scan entirely on a confirmed analytics opt-out (the event would be dropped at record time; the scan would be wasted I/O). Unknown-state records and lets flush-time consent gating decide, matching the outbox contract.
- **Monitor process, not the backup pipeline**: the live daemon DB is the prevalence measure; the gateway backup worker handles opaque `.vbundle` streams. A backup-tick guard ("don't snapshot a corrupt DB") is a possible follow-up, not a metric.

## Testing

- New `db-integrity-sample.test.ts`: healthy DB → ok, junk-overwritten b-tree page → corruption reported without throwing, missing file → null.
- `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExbZkALW6GPbgdKsYTDiAv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->