### PR TITLE
refactor(gateway): extract shared retry/Retry-After machinery from Telegram and WhatsApp APIs

### DIFF
--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -3,6 +3,7 @@ import type { ConfigFileCache } from "../config-file-cache.js";
 import { credentialKey } from "../credential-key.js";
 import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
+import { retryableFetch } from "../util/retryable-fetch.js";
 
 const log = getLogger("telegram-api");
 
@@ -45,148 +46,104 @@ function summarizeFetchError(err: unknown): string {
   return redactTelegramBotTokens(parts.join(" "));
 }
 
-function isRetryable(status: number): boolean {
-  return status === 429 || status >= 500;
+function buildTelegramFailureMessage(
+  method: string,
+  status: number,
+  description: string | undefined,
+  body: string,
+): string {
+  return description
+    ? `Telegram ${method} failed: ${description}`
+    : body
+      ? `Telegram ${method} failed with status ${status}: ${redactTelegramBotTokens(body)}`
+      : `Telegram ${method} failed with status ${status}`;
 }
 
-function computeDelay(
-  attempt: number,
-  initialBackoffMs: number,
-  retryAfterHeader: string | null,
-): number {
-  if (retryAfterHeader) {
-    // Try parsing as numeric seconds first (e.g., "120")
-    const seconds = Number(retryAfterHeader);
-    if (Number.isFinite(seconds) && seconds > 0) {
-      // Clamp to max 32-bit signed int to prevent setTimeout overflow
-      return Math.min(seconds * 1000, 2_147_483_647);
-    }
-
-    // Fall back to HTTP-date format (e.g., "Fri, 31 Dec 1999 23:59:59 GMT")
-    const targetTime = new Date(retryAfterHeader).getTime();
-    if (Number.isFinite(targetTime)) {
-      const delayMs = targetTime - Date.now();
-      if (delayMs > 0) {
-        // Clamp to max 32-bit signed int to prevent setTimeout overflow
-        return Math.min(delayMs, 2_147_483_647);
-      }
-    }
+async function readTelegramErrorBody(response: Response): Promise<{
+  body: string;
+  description: string | undefined;
+  retryAfterParam: number | undefined;
+}> {
+  const body = await response.text().catch(() => "");
+  let description: string | undefined;
+  let retryAfterParam: number | undefined;
+  try {
+    const data = JSON.parse(body) as TelegramApiResponse<unknown>;
+    description = data.description;
+    retryAfterParam = data.parameters?.retry_after;
+  } catch {
+    // Response body is not JSON; the raw text is still returned for messages
   }
-
-  const exponential = initialBackoffMs * Math.pow(2, attempt - 1);
-  // Add jitter: 0–50% of the computed delay
-  const jitter = Math.random() * exponential * 0.5;
-  return exponential + jitter;
+  return { body, description, retryAfterParam };
 }
 
-async function retryableFetch<T>(
+async function retryableTelegramFetch<T>(
   configFile: ConfigFileCache | undefined,
   method: string,
   doFetch: () => Promise<Response>,
 ): Promise<T> {
-  const maxRetries = configFile?.getNumber("telegram", "maxRetries") ?? 3;
-  const initialBackoffMs =
-    configFile?.getNumber("telegram", "initialBackoffMs") ?? 1000;
-
-  let lastError: Error | null = null;
-  let lastRetryAfter: string | null = null;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    if (attempt > 0) {
-      const delay = computeDelay(attempt, initialBackoffMs, lastRetryAfter);
-      log.debug({ attempt, delay, method }, "Retrying Telegram API call");
-      await new Promise((r) => setTimeout(r, delay));
-    }
-
-    lastRetryAfter = null;
-
-    let response: Response;
-    try {
-      response = await doFetch();
-    } catch (err) {
-      const safeError = summarizeFetchError(err);
-      lastError = new Error(`Telegram ${method} request failed: ${safeError}`);
-      log.warn(
-        { error: safeError, attempt, method },
-        "Telegram API fetch failed",
-      );
-      continue;
-    }
-
-    if (!isRetryable(response.status) && !response.ok) {
-      const body = await response.text().catch(() => "");
-      let description: string | undefined;
-      try {
-        const data = JSON.parse(body) as TelegramApiResponse<T>;
-        description = data.description;
-      } catch {
-        // Response body is not JSON — include raw text if available
-      }
-      throw new Error(
-        description
-          ? `Telegram ${method} failed: ${description}`
-          : body
-            ? `Telegram ${method} failed with status ${response.status}: ${redactTelegramBotTokens(body)}`
-            : `Telegram ${method} failed with status ${response.status}`,
-      );
-    }
-
-    if (isRetryable(response.status)) {
-      const body = await response.text().catch(() => "");
-      let description: string | undefined;
-      let retryAfterParam: number | undefined;
-      try {
-        const data = JSON.parse(body) as TelegramApiResponse<T>;
-        description = data.description;
-        retryAfterParam = data.parameters?.retry_after;
-      } catch {
-        // Response body is not JSON
-      }
-      lastRetryAfter =
-        response.headers.get("retry-after") ??
-        (retryAfterParam != null ? String(retryAfterParam) : null);
-      lastError = new Error(
-        description
-          ? `Telegram ${method} failed: ${description}`
-          : body
-            ? `Telegram ${method} failed with status ${response.status}: ${redactTelegramBotTokens(body)}`
-            : `Telegram ${method} failed with status ${response.status}`,
-      );
-      log.warn(
-        {
-          status: response.status,
-          attempt,
-          method,
-          retryAfter: lastRetryAfter,
-        },
-        "Telegram API returned retryable error",
-      );
-      continue;
-    }
-
-    const body = await response.text().catch(() => "");
-    let data: TelegramApiResponse<T>;
-    try {
-      data = JSON.parse(body) as TelegramApiResponse<T>;
-    } catch {
-      throw new Error(
-        body
-          ? `Telegram ${method} failed: unparseable response body: ${redactTelegramBotTokens(body)}`
-          : `Telegram ${method} failed with status ${response.status}: empty response`,
-      );
-    }
-    if (!data.ok || data.result === undefined) {
-      throw new Error(
-        data.description
-          ? `Telegram ${method} failed: ${data.description}`
-          : `Telegram ${method} failed with status ${response.status}`,
-      );
-    }
-
-    return data.result;
-  }
-
-  throw lastError ?? new Error(`Telegram ${method} failed after retries`);
+  return retryableFetch<T>(
+    {
+      provider: "Telegram",
+      operation: method,
+      log,
+      configFile,
+      configSection: "telegram",
+      doFetch,
+    },
+    {
+      summarizeFetchError,
+      throwTerminal: async (response) => {
+        const { body, description } = await readTelegramErrorBody(response);
+        throw new Error(
+          buildTelegramFailureMessage(
+            method,
+            response.status,
+            description,
+            body,
+          ),
+        );
+      },
+      describeRetryable: async (response) => {
+        const { body, description, retryAfterParam } =
+          await readTelegramErrorBody(response);
+        return {
+          retryAfter:
+            response.headers.get("retry-after") ??
+            (retryAfterParam != null ? String(retryAfterParam) : null),
+          error: new Error(
+            buildTelegramFailureMessage(
+              method,
+              response.status,
+              description,
+              body,
+            ),
+          ),
+        };
+      },
+      parseSuccess: async (response) => {
+        const body = await response.text().catch(() => "");
+        let data: TelegramApiResponse<T>;
+        try {
+          data = JSON.parse(body) as TelegramApiResponse<T>;
+        } catch {
+          throw new Error(
+            body
+              ? `Telegram ${method} failed: unparseable response body: ${redactTelegramBotTokens(body)}`
+              : `Telegram ${method} failed with status ${response.status}: empty response`,
+          );
+        }
+        if (!data.ok || data.result === undefined) {
+          throw new Error(
+            data.description
+              ? `Telegram ${method} failed: ${data.description}`
+              : `Telegram ${method} failed with status ${response.status}`,
+          );
+        }
+        return data.result;
+      },
+    },
+  );
 }
 
 export async function callTelegramApi<T>(
@@ -213,7 +170,7 @@ export async function callTelegramApi<T>(
   const timeoutMs =
     opts?.configFile?.getNumber("telegram", "timeoutMs") ?? 15000;
 
-  return retryableFetch<T>(opts?.configFile, method, () =>
+  return retryableTelegramFetch<T>(opts?.configFile, method, () =>
     fetchImpl(`${apiBaseUrl}/bot${botToken}/${method}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -247,7 +204,7 @@ export async function callTelegramApiMultipart<T>(
   const timeoutMs =
     opts?.configFile?.getNumber("telegram", "timeoutMs") ?? 15000;
 
-  return retryableFetch<T>(opts?.configFile, method, () =>
+  return retryableTelegramFetch<T>(opts?.configFile, method, () =>
     fetchImpl(`${apiBaseUrl}/bot${botToken}/${method}`, {
       method: "POST",
       body: form,

--- a/gateway/src/util/retryable-fetch.test.ts
+++ b/gateway/src/util/retryable-fetch.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "bun:test";
+import type pino from "pino";
+import type { ConfigFileCache } from "../config-file-cache.js";
+import {
+  computeRetryDelayMs,
+  isRetryableHttpStatus,
+  retryableFetch,
+} from "./retryable-fetch.js";
+
+const MAX_DELAY_MS = 2_147_483_647;
+
+const noopLog = {
+  debug: () => {},
+  warn: () => {},
+} as unknown as pino.Logger;
+
+function makeConfigFile(values: Record<string, number>): ConfigFileCache {
+  return {
+    getNumber: (_section: string, field: string) => values[field],
+    getString: () => undefined,
+    getBoolean: () => undefined,
+    getRecord: () => undefined,
+  } as unknown as ConfigFileCache;
+}
+
+/** Hooks that fail loudly for paths a given test does not expect to hit. */
+function unusedHooks() {
+  return {
+    throwTerminal: async (): Promise<never> => {
+      throw new Error("unexpected terminal response");
+    },
+    describeRetryable: async () => {
+      throw new Error("unexpected retryable response");
+    },
+    parseSuccess: async (): Promise<never> => {
+      throw new Error("unexpected success response");
+    },
+  };
+}
+
+describe("isRetryableHttpStatus", () => {
+  test("429 and 5xx are retryable", () => {
+    expect(isRetryableHttpStatus(429)).toBe(true);
+    expect(isRetryableHttpStatus(500)).toBe(true);
+    expect(isRetryableHttpStatus(503)).toBe(true);
+    expect(isRetryableHttpStatus(599)).toBe(true);
+  });
+
+  test("2xx and other 4xx are not retryable", () => {
+    expect(isRetryableHttpStatus(200)).toBe(false);
+    expect(isRetryableHttpStatus(400)).toBe(false);
+    expect(isRetryableHttpStatus(401)).toBe(false);
+    expect(isRetryableHttpStatus(404)).toBe(false);
+  });
+});
+
+describe("computeRetryDelayMs", () => {
+  test("numeric Retry-After seconds wins over backoff", () => {
+    expect(computeRetryDelayMs(1, 1000, "120")).toBe(120_000);
+  });
+
+  test("clamps numeric Retry-After to the setTimeout ceiling", () => {
+    expect(computeRetryDelayMs(1, 1000, "99999999999")).toBe(MAX_DELAY_MS);
+  });
+
+  test("HTTP-date Retry-After yields the delta to the target time", () => {
+    const target = new Date(Date.now() + 60_000).toUTCString();
+    const delay = computeRetryDelayMs(1, 1000, target);
+    expect(delay).toBeGreaterThan(50_000);
+    expect(delay).toBeLessThanOrEqual(60_000);
+  });
+
+  test("clamps far-future HTTP-date to the setTimeout ceiling", () => {
+    const delay = computeRetryDelayMs(1, 1000, "Fri, 31 Dec 2999 23:59:59 GMT");
+    expect(delay).toBe(MAX_DELAY_MS);
+  });
+
+  test("past HTTP-date falls back to exponential backoff", () => {
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    const delay = computeRetryDelayMs(1, 1000, past);
+    expect(delay).toBeGreaterThanOrEqual(1000);
+    expect(delay).toBeLessThanOrEqual(1500);
+  });
+
+  test("unparseable header falls back to exponential backoff", () => {
+    const delay = computeRetryDelayMs(1, 1000, "soon");
+    expect(delay).toBeGreaterThanOrEqual(1000);
+    expect(delay).toBeLessThanOrEqual(1500);
+  });
+
+  test("zero and negative Retry-After fall back to exponential backoff", () => {
+    for (const header of ["0", "-5"]) {
+      const delay = computeRetryDelayMs(1, 1000, header);
+      expect(delay).toBeGreaterThanOrEqual(1000);
+      expect(delay).toBeLessThanOrEqual(1500);
+    }
+  });
+
+  test("no header doubles per attempt with 0-50% additive jitter", () => {
+    const first = computeRetryDelayMs(1, 1000, null);
+    expect(first).toBeGreaterThanOrEqual(1000);
+    expect(first).toBeLessThanOrEqual(1500);
+
+    const third = computeRetryDelayMs(3, 1000, null);
+    expect(third).toBeGreaterThanOrEqual(4000);
+    expect(third).toBeLessThanOrEqual(6000);
+  });
+});
+
+describe("retryableFetch", () => {
+  const fastConfig = makeConfigFile({ maxRetries: 3, initialBackoffMs: 1 });
+
+  function options(doFetch: () => Promise<Response>) {
+    return {
+      provider: "Example",
+      operation: "sendThing",
+      log: noopLog,
+      configFile: fastConfig,
+      configSection: "example",
+      doFetch,
+    };
+  }
+
+  test("returns parseSuccess result on first success", async () => {
+    let calls = 0;
+    const result = await retryableFetch<string>(
+      options(async () => {
+        calls++;
+        return new Response('"ok"', { status: 200 });
+      }),
+      {
+        ...unusedHooks(),
+        parseSuccess: async (response) => (await response.json()) as string,
+      },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  test("retries network errors and succeeds", async () => {
+    let calls = 0;
+    const result = await retryableFetch<string>(
+      options(async () => {
+        calls++;
+        if (calls < 3) {
+          throw new Error("connection refused");
+        }
+        return new Response("", { status: 200 });
+      }),
+      {
+        ...unusedHooks(),
+        parseSuccess: async () => "recovered",
+      },
+    );
+    expect(result).toBe("recovered");
+    expect(calls).toBe(3);
+  });
+
+  test("throws the last network error once retries are exhausted", async () => {
+    let calls = 0;
+    await expect(
+      retryableFetch<never>(
+        options(async () => {
+          calls++;
+          throw new Error("connection refused");
+        }),
+        unusedHooks(),
+      ),
+    ).rejects.toThrow("Example sendThing request failed: connection refused");
+    expect(calls).toBe(4);
+  });
+
+  test("uses summarizeFetchError to shape network error messages", async () => {
+    await expect(
+      retryableFetch<never>(
+        {
+          ...options(async () => {
+            throw new Error("secret-token-123");
+          }),
+          configFile: makeConfigFile({ maxRetries: 0, initialBackoffMs: 1 }),
+        },
+        {
+          ...unusedHooks(),
+          summarizeFetchError: () => "[REDACTED]",
+        },
+      ),
+    ).rejects.toThrow("Example sendThing request failed: [REDACTED]");
+  });
+
+  test("retries retryable statuses and records describeRetryable error", async () => {
+    let calls = 0;
+    const seenRetryAfters: Array<string | null> = [];
+    await expect(
+      retryableFetch<never>(
+        options(async () => {
+          calls++;
+          return new Response("busy", { status: 503 });
+        }),
+        {
+          ...unusedHooks(),
+          describeRetryable: async (response) => {
+            seenRetryAfters.push(response.headers.get("retry-after"));
+            return {
+              retryAfter: null,
+              error: new Error(`busy attempt ${calls}`),
+            };
+          },
+        },
+      ),
+    ).rejects.toThrow("busy attempt 4");
+    expect(calls).toBe(4);
+    expect(seenRetryAfters).toHaveLength(4);
+  });
+
+  test("honors maxRetries 0 as a single attempt", async () => {
+    let calls = 0;
+    await expect(
+      retryableFetch<never>(
+        {
+          ...options(async () => {
+            calls++;
+            return new Response("", { status: 500 });
+          }),
+          configFile: makeConfigFile({ maxRetries: 0, initialBackoffMs: 1 }),
+        },
+        {
+          ...unusedHooks(),
+          describeRetryable: async () => ({
+            retryAfter: null,
+            error: new Error("server error"),
+          }),
+        },
+      ),
+    ).rejects.toThrow("server error");
+    expect(calls).toBe(1);
+  });
+
+  test("throws throwTerminal error for non-retryable failures without retrying", async () => {
+    class TerminalError extends Error {}
+    let calls = 0;
+    await expect(
+      retryableFetch<never>(
+        options(async () => {
+          calls++;
+          return new Response("bad request", { status: 400 });
+        }),
+        {
+          ...unusedHooks(),
+          throwTerminal: async (response) => {
+            throw new TerminalError(`terminal ${response.status}`);
+          },
+        },
+      ),
+    ).rejects.toThrow(TerminalError);
+    expect(calls).toBe(1);
+  });
+
+  test("waits per the retryAfter hint from describeRetryable", async () => {
+    let calls = 0;
+    const start = Date.now();
+    await retryableFetch<string>(
+      options(async () => {
+        calls++;
+        if (calls === 1) {
+          return new Response("", { status: 429 });
+        }
+        return new Response("", { status: 200 });
+      }),
+      {
+        ...unusedHooks(),
+        // "1" second is the smallest whole-second hint; keeps the test fast
+        // while still proving the hint (not the 1ms backoff) drove the wait.
+        describeRetryable: async () => ({
+          retryAfter: "1",
+          error: new Error("rate limited"),
+        }),
+        parseSuccess: async () => "done",
+      },
+    );
+    expect(calls).toBe(2);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(950);
+  });
+});

--- a/gateway/src/util/retryable-fetch.ts
+++ b/gateway/src/util/retryable-fetch.ts
@@ -1,0 +1,155 @@
+import type pino from "pino";
+import type { ConfigFileCache } from "../config-file-cache.js";
+
+/** Retryable HTTP statuses: rate limiting and server-side failures. */
+export function isRetryableHttpStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+/** Max 32-bit signed int, the setTimeout ceiling. */
+const MAX_RETRY_DELAY_MS = 2_147_483_647;
+
+/**
+ * Delay before the next retry attempt (1-based).
+ *
+ * A Retry-After hint takes precedence: numeric seconds (e.g. "120") or an
+ * HTTP-date (e.g. "Fri, 31 Dec 1999 23:59:59 GMT"), clamped to the setTimeout
+ * ceiling. Without a usable hint, exponential backoff from initialBackoffMs
+ * with additive jitter of 0-50%.
+ */
+export function computeRetryDelayMs(
+  attempt: number,
+  initialBackoffMs: number,
+  retryAfterHeader: string | null,
+): number {
+  if (retryAfterHeader) {
+    const seconds = Number(retryAfterHeader);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
+    }
+
+    const targetTime = new Date(retryAfterHeader).getTime();
+    if (Number.isFinite(targetTime)) {
+      const delayMs = targetTime - Date.now();
+      if (delayMs > 0) {
+        return Math.min(delayMs, MAX_RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  const exponential = initialBackoffMs * Math.pow(2, attempt - 1);
+  const jitter = Math.random() * exponential * 0.5;
+  return exponential + jitter;
+}
+
+/**
+ * Provider-specific hooks for {@link retryableFetch}. Error shaping (message
+ * text, error classes, secret redaction) stays in the provider module; the
+ * loop only decides when to retry and how long to wait.
+ */
+export interface RetryableFetchHooks<T> {
+  /**
+   * Sanitized one-line summary of a network-level fetch failure, used in the
+   * recorded error and warning log. Defaults to the error's message.
+   */
+  summarizeFetchError?: (err: unknown) => string;
+  /**
+   * Handle a non-retryable, non-ok response (4xx other than 429). Must throw
+   * the provider's terminal error.
+   */
+  throwTerminal: (response: Response) => Promise<never>;
+  /**
+   * Error record and Retry-After hint for a retryable (429/5xx) response.
+   * retryAfter feeds the next attempt's delay; null falls back to exponential
+   * backoff. The error is thrown if this attempt was the last.
+   */
+  describeRetryable: (
+    response: Response,
+  ) => Promise<{ error: Error; retryAfter: string | null }>;
+  /** Parse a successful response into the return value. */
+  parseSuccess: (response: Response) => Promise<T>;
+}
+
+export interface RetryableFetchOptions {
+  /** Provider name for log and error text, e.g. "Telegram". */
+  provider: string;
+  /** API method/operation name for log fields and error text. */
+  operation: string;
+  log: pino.Logger;
+  configFile: ConfigFileCache | undefined;
+  /** Config section holding maxRetries / initialBackoffMs. */
+  configSection: string;
+  doFetch: () => Promise<Response>;
+}
+
+/**
+ * Fetch with retries on network errors, 429, and 5xx. Retry pacing honors the
+ * provider's Retry-After hint via {@link computeRetryDelayMs}; maxRetries
+ * (default 3) and initialBackoffMs (default 1000) come from the provider's
+ * config section.
+ */
+export async function retryableFetch<T>(
+  options: RetryableFetchOptions,
+  hooks: RetryableFetchHooks<T>,
+): Promise<T> {
+  const { provider, operation, log, configFile, configSection, doFetch } =
+    options;
+  const maxRetries = configFile?.getNumber(configSection, "maxRetries") ?? 3;
+  const initialBackoffMs =
+    configFile?.getNumber(configSection, "initialBackoffMs") ?? 1000;
+
+  let lastError: Error | null = null;
+  let lastRetryAfter: string | null = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      const delay = computeRetryDelayMs(
+        attempt,
+        initialBackoffMs,
+        lastRetryAfter,
+      );
+      log.debug({ attempt, delay, operation }, `Retrying ${provider} API call`);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+
+    lastRetryAfter = null;
+
+    let response: Response;
+    try {
+      response = await doFetch();
+    } catch (err) {
+      const summary = hooks.summarizeFetchError
+        ? hooks.summarizeFetchError(err)
+        : err instanceof Error
+          ? err.message
+          : String(err);
+      lastError = new Error(
+        `${provider} ${operation} request failed: ${summary}`,
+      );
+      log.warn(
+        { error: summary, attempt, operation },
+        `${provider} API fetch failed`,
+      );
+      continue;
+    }
+
+    if (isRetryableHttpStatus(response.status)) {
+      const { error, retryAfter } = await hooks.describeRetryable(response);
+      lastRetryAfter = retryAfter;
+      lastError = error;
+      log.warn(
+        { status: response.status, attempt, operation, retryAfter },
+        `${provider} API returned retryable error`,
+      );
+      continue;
+    }
+
+    if (!response.ok) {
+      return hooks.throwTerminal(response);
+    }
+
+    return hooks.parseSuccess(response);
+  }
+
+  throw lastError ?? new Error(`${provider} ${operation} failed after retries`);
+}

--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -3,6 +3,8 @@ import type { ConfigFileCache } from "../config-file-cache.js";
 import { credentialKey } from "../credential-key.js";
 import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
+import type { RetryableFetchHooks } from "../util/retryable-fetch.js";
+import { retryableFetch } from "../util/retryable-fetch.js";
 
 const log = getLogger("whatsapp-api");
 
@@ -27,39 +29,78 @@ interface WhatsAppApiErrorResponse {
   error?: WhatsAppApiErrorDetail;
 }
 
-function isRetryable(status: number): boolean {
-  return status === 429 || status >= 500;
-}
-
-// Auth/permission errors are transient — a token rotation or permission fix
+// Auth/permission errors are transient: a token rotation or permission fix
 // can resolve them within Meta's retry window. These should NOT be treated as
 // non-retryable so the webhook returns 500 and Meta retries the delivery.
 function isAuthError(status: number): boolean {
   return status === 401 || status === 403;
 }
 
-function computeDelay(
-  attempt: number,
-  initialBackoffMs: number,
-  retryAfterHeader: string | null,
-): number {
-  if (retryAfterHeader) {
-    const seconds = Number(retryAfterHeader);
-    if (Number.isFinite(seconds) && seconds > 0) {
-      return Math.min(seconds * 1000, 2_147_483_647);
-    }
-    const targetTime = new Date(retryAfterHeader).getTime();
-    if (Number.isFinite(targetTime)) {
-      const delayMs = targetTime - Date.now();
-      if (delayMs > 0) {
-        return Math.min(delayMs, 2_147_483_647);
-      }
-    }
-  }
+function buildWhatsAppFailureMessage(
+  operation: string,
+  status: number,
+  errorMessage: string | undefined,
+  body: string,
+): string {
+  return errorMessage
+    ? `WhatsApp ${operation} failed: ${errorMessage}`
+    : body
+      ? `WhatsApp ${operation} failed with status ${status}: ${body}`
+      : `WhatsApp ${operation} failed with status ${status}`;
+}
 
-  const exponential = initialBackoffMs * Math.pow(2, attempt - 1);
-  const jitter = Math.random() * exponential * 0.5;
-  return exponential + jitter;
+async function readWhatsAppErrorBody(response: Response): Promise<{
+  body: string;
+  errorMessage: string | undefined;
+}> {
+  const body = await response.text().catch(() => "");
+  let errorMessage: string | undefined;
+  try {
+    const data = JSON.parse(body) as WhatsAppApiErrorResponse;
+    errorMessage = data.error?.message;
+  } catch {
+    // Response body is not JSON; the raw text is still returned for messages
+  }
+  return { body, errorMessage };
+}
+
+function whatsAppErrorHooks(
+  operation: string,
+): Pick<RetryableFetchHooks<never>, "throwTerminal" | "describeRetryable"> {
+  return {
+    throwTerminal: async (response) => {
+      const { body, errorMessage } = await readWhatsAppErrorBody(response);
+      const message = buildWhatsAppFailureMessage(
+        operation,
+        response.status,
+        errorMessage,
+        body,
+      );
+
+      // Auth/permission errors (401/403) are transient: propagate as regular
+      // errors so the webhook returns 500 and Meta retries within its window.
+      // Other 4xx errors (400 invalid media, 404 expired) are terminal.
+      if (isAuthError(response.status)) {
+        throw new Error(message);
+      }
+      throw new WhatsAppNonRetryableError(message);
+    },
+    describeRetryable: async (response) => {
+      const retryAfter = response.headers.get("retry-after");
+      const { body, errorMessage } = await readWhatsAppErrorBody(response);
+      return {
+        retryAfter,
+        error: new Error(
+          buildWhatsAppFailureMessage(
+            operation,
+            response.status,
+            errorMessage,
+            body,
+          ),
+        ),
+      };
+    },
+  };
 }
 
 async function retryableWhatsAppFetch<T>(
@@ -67,92 +108,20 @@ async function retryableWhatsAppFetch<T>(
   operation: string,
   doFetch: () => Promise<Response>,
 ): Promise<T> {
-  const maxRetries = configFile?.getNumber("whatsapp", "maxRetries") ?? 3;
-  const initialBackoffMs =
-    configFile?.getNumber("whatsapp", "initialBackoffMs") ?? 1000;
-
-  let lastError: Error | null = null;
-  let lastRetryAfter: string | null = null;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    if (attempt > 0) {
-      const delay = computeDelay(attempt, initialBackoffMs, lastRetryAfter);
-      log.debug({ attempt, delay, operation }, "Retrying WhatsApp API call");
-      await new Promise((r) => setTimeout(r, delay));
-    }
-
-    lastRetryAfter = null;
-
-    let response: Response;
-    try {
-      response = await doFetch();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      lastError = new Error(`WhatsApp ${operation} request failed: ${message}`);
-      log.warn(
-        { error: message, attempt, operation },
-        "WhatsApp API fetch failed",
-      );
-      continue;
-    }
-
-    if (!isRetryable(response.status) && !response.ok) {
-      const body = await response.text().catch(() => "");
-      let errorMessage: string | undefined;
-      try {
-        const data = JSON.parse(body) as WhatsAppApiErrorResponse;
-        errorMessage = data.error?.message;
-      } catch {
-        // Response body is not JSON — include raw text if available
-      }
-      const message = errorMessage
-        ? `WhatsApp ${operation} failed: ${errorMessage}`
-        : body
-          ? `WhatsApp ${operation} failed with status ${response.status}: ${body}`
-          : `WhatsApp ${operation} failed with status ${response.status}`;
-
-      // Auth/permission errors (401/403) are transient — propagate as regular
-      // errors so the webhook returns 500 and Meta retries within its window.
-      // Other 4xx errors (400 invalid media, 404 expired) are terminal.
-      if (isAuthError(response.status)) {
-        throw new Error(message);
-      }
-      throw new WhatsAppNonRetryableError(message);
-    }
-
-    if (isRetryable(response.status)) {
-      lastRetryAfter = response.headers.get("retry-after");
-      const body = await response.text().catch(() => "");
-      let errorMessage: string | undefined;
-      try {
-        const data = JSON.parse(body) as WhatsAppApiErrorResponse;
-        errorMessage = data.error?.message;
-      } catch {
-        // Response body is not JSON
-      }
-      lastError = new Error(
-        errorMessage
-          ? `WhatsApp ${operation} failed: ${errorMessage}`
-          : body
-            ? `WhatsApp ${operation} failed with status ${response.status}: ${body}`
-            : `WhatsApp ${operation} failed with status ${response.status}`,
-      );
-      log.warn(
-        {
-          status: response.status,
-          attempt,
-          operation,
-          retryAfter: lastRetryAfter,
-        },
-        "WhatsApp API returned retryable error",
-      );
-      continue;
-    }
-
-    return (await response.json()) as T;
-  }
-
-  throw lastError ?? new Error(`WhatsApp ${operation} failed after retries`);
+  return retryableFetch<T>(
+    {
+      provider: "WhatsApp",
+      operation,
+      log,
+      configFile,
+      configSection: "whatsapp",
+      doFetch,
+    },
+    {
+      ...whatsAppErrorHooks(operation),
+      parseSuccess: async (response) => (await response.json()) as T,
+    },
+  );
 }
 
 /** Options bag for optional credential and config cache injection into WhatsApp API calls. */
@@ -447,87 +416,20 @@ async function retryableWhatsAppRawFetch(
   operation: string,
   doFetch: () => Promise<Response>,
 ): Promise<Response> {
-  const maxRetries = configFile?.getNumber("whatsapp", "maxRetries") ?? 3;
-  const initialBackoffMs =
-    configFile?.getNumber("whatsapp", "initialBackoffMs") ?? 1000;
-
-  let lastError: Error | null = null;
-  let lastRetryAfter: string | null = null;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    if (attempt > 0) {
-      const delay = computeDelay(attempt, initialBackoffMs, lastRetryAfter);
-      log.debug({ attempt, delay, operation }, "Retrying WhatsApp API call");
-      await new Promise((r) => setTimeout(r, delay));
-    }
-
-    lastRetryAfter = null;
-
-    let response: Response;
-    try {
-      response = await doFetch();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      lastError = new Error(`WhatsApp ${operation} request failed: ${message}`);
-      log.warn(
-        { error: message, attempt, operation },
-        "WhatsApp API fetch failed",
-      );
-      continue;
-    }
-
-    if (!isRetryable(response.status) && !response.ok) {
-      const body = await response.text().catch(() => "");
-      let errorMessage: string | undefined;
-      try {
-        const data = JSON.parse(body) as WhatsAppApiErrorResponse;
-        errorMessage = data.error?.message;
-      } catch {
-        // Response body is not JSON — include raw text if available
-      }
-      const message = errorMessage
-        ? `WhatsApp ${operation} failed: ${errorMessage}`
-        : body
-          ? `WhatsApp ${operation} failed with status ${response.status}: ${body}`
-          : `WhatsApp ${operation} failed with status ${response.status}`;
-
-      if (isAuthError(response.status)) {
-        throw new Error(message);
-      }
-      throw new WhatsAppNonRetryableError(message);
-    }
-
-    if (isRetryable(response.status)) {
-      lastRetryAfter = response.headers.get("retry-after");
-      const body = await response.text().catch(() => "");
-      let errorMessage: string | undefined;
-      try {
-        const data = JSON.parse(body) as WhatsAppApiErrorResponse;
-        errorMessage = data.error?.message;
-      } catch {
-        // Response body is not JSON
-      }
-      lastError = new Error(
-        errorMessage
-          ? `WhatsApp ${operation} failed: ${errorMessage}`
-          : `WhatsApp ${operation} failed with status ${response.status}`,
-      );
-      log.warn(
-        {
-          status: response.status,
-          attempt,
-          operation,
-          retryAfter: lastRetryAfter,
-        },
-        "WhatsApp API returned retryable error",
-      );
-      continue;
-    }
-
-    return response;
-  }
-
-  throw lastError ?? new Error(`WhatsApp ${operation} failed after retries`);
+  return retryableFetch<Response>(
+    {
+      provider: "WhatsApp",
+      operation,
+      log,
+      configFile,
+      configSection: "whatsapp",
+      doFetch,
+    },
+    {
+      ...whatsAppErrorHooks(operation),
+      parseSuccess: async (response) => response,
+    },
+  );
 }
 
 /**


### PR DESCRIPTION
## TL;DR

`gateway/src/telegram/api.ts` and `gateway/src/whatsapp/api.ts` carried three near-verbatim copies of the same retry machinery (WhatsApp had a second copy for raw binary downloads). Per the repo Single Source of Truth rule, the shared behavior now lives in `gateway/src/util/retryable-fetch.ts`:

- `isRetryableHttpStatus(status)`: 429 or >= 500
- `computeRetryDelayMs(attempt, initialBackoffMs, retryAfterHeader)`: Retry-After as numeric seconds or HTTP-date, clamped to the setTimeout ceiling (2_147_483_647 ms), falling back to exponential backoff with 0-50% additive jitter
- `retryableFetch(options, hooks)`: the retry loop, reading `maxRetries` / `initialBackoffMs` from the provider's config section, with injectable hooks (`summarizeFetchError`, `throwTerminal`, `describeRetryable`, `parseSuccess`)

Provider-specific error shaping stays where it was: Telegram keeps bot-token redaction, the `parameters.retry_after` body fallback, and `ok`/`result` envelope parsing; WhatsApp keeps the 401/403-is-transient rule and `WhatsAppNonRetryableError`.

Note: the Discord `ReconnectBackoff`, Slack, and Velay reconnect loops are intentionally untouched. Discord's pacing is deliberately different (full jitter, session-stability reset, identify-budget math documented in `gateway/src/discord/backoff.ts`), and unifying WebSocket reconnect pacing with HTTP request retries would couple semantics that differ on purpose. That is deferred as a separate design question, not left behind by accident.

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| Telegram/WhatsApp API call succeeds or fails | Retries on network errors, 429, and 5xx with Retry-After-aware backoff | Identical behavior |
| Telegram retry debug/warn logs | Field named `method` | Field named `operation` (matches WhatsApp) |
| WhatsApp media download exhausts retries on 429/5xx | Final error omitted the response body text | Final error includes the body text, same as every other WhatsApp path (this was silent copy drift) |
| Everything else | n/a | No wire-visible or behavioral change |

## Why this is safe

- The delay math, status classification, loop structure, config keys, and defaults are moved verbatim; the two deltas above are log/error-text only.
- Error shaping (message text, error classes, secret redaction) never left the provider modules, so thrown error types and messages that callers match on are unchanged. The WhatsApp webhook's 401/403 vs `WhatsAppNonRetryableError` distinction is preserved.
- New test suite for the shared module (18 tests): Retry-After parsing (numeric, HTTP-date, past date, clamping, garbage), jitter bounds, retry-until-exhausted, terminal short-circuit, `maxRetries: 0`, and that a Retry-After hint actually drives the wait.
- All affected existing suites pass per-file: telegram redaction/send/attachments/webhook-handler/webhook-manager/webhook-route, whatsapp download/webhook. `bunx tsc --noEmit` clean, lint clean, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->