### PR TITLE
refactor(gateway): extract shared exponential backoff utility

### DIFF
--- a/gateway/src/discord/backoff.ts
+++ b/gateway/src/discord/backoff.ts
@@ -22,6 +22,8 @@
  * 3. **The identify cap is derived from the budget, not chosen for feel.**
  */
 
+import { ExponentialBackoff } from "../util/exponential-backoff.js";
+
 /** Delay before the first reconnect attempt. */
 const BASE_BACKOFF_MS = 1_000;
 
@@ -62,23 +64,26 @@ export const SESSION_STABLE_AFTER_MS = 120_000;
 export type RecoveryKind = "resume" | "identify";
 
 /**
- * Consecutive-failure pacing for reconnects.
- *
- * Stateless with respect to time — the caller owns the timers, so this stays
- * a pure function of attempt count and is testable without waiting.
+ * Consecutive-failure pacing for reconnects: the shared full-jitter
+ * exponential core plus Discord's two rules on top of it, a per-kind delay
+ * ceiling and a reset gated on session stability rather than socket-open.
  */
 export class ReconnectBackoff {
-  private consecutiveFailures = 0;
-  private readonly random: () => number;
+  private readonly backoff: ExponentialBackoff;
 
   /** `random` is injectable so tests can pin the jitter. */
   constructor(random: () => number = Math.random) {
-    this.random = random;
+    this.backoff = new ExponentialBackoff({
+      baseDelayMs: BASE_BACKOFF_MS,
+      maxDelayMs: RESUME_MAX_BACKOFF_MS,
+      jitter: { mode: "full" },
+      random,
+    });
   }
 
   /** Consecutive recovery attempts since the last stable session. */
   get failureCount(): number {
-    return this.consecutiveFailures;
+    return this.backoff.attemptCount;
   }
 
   /**
@@ -90,14 +95,10 @@ export class ReconnectBackoff {
    * identify path at full speed.
    */
   nextDelayMs(kind: RecoveryKind): number {
-    const cap =
-      kind === "identify" ? IDENTIFY_MAX_BACKOFF_MS : RESUME_MAX_BACKOFF_MS;
-    const window = Math.min(
-      BASE_BACKOFF_MS * 2 ** this.consecutiveFailures,
-      cap,
-    );
-    this.consecutiveFailures++;
-    return Math.round(this.random() * window);
+    return this.backoff.nextDelayMs({
+      maxDelayMs:
+        kind === "identify" ? IDENTIFY_MAX_BACKOFF_MS : RESUME_MAX_BACKOFF_MS,
+    });
   }
 
   /**
@@ -105,6 +106,6 @@ export class ReconnectBackoff {
    * is the only thing that clears the backoff.
    */
   noteSessionStable(): void {
-    this.consecutiveFailures = 0;
+    this.backoff.reset();
   }
 }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -11,6 +11,7 @@ import {
   SLACK_THREAD_ALREADY_MUTED,
   SLACK_THREAD_MUTE_SUCCESS,
 } from "../webhook-copy.js";
+import { ExponentialBackoff } from "../util/exponential-backoff.js";
 import {
   CatchupAbortSignal,
   fetchChannelHistorySince,
@@ -147,7 +148,11 @@ export class SlackSocketModeClient {
   private ws: WebSocket | null = null;
   private connecting = false;
   private running = false;
-  private reconnectAttempt = 0;
+  private readonly backoff = new ExponentialBackoff({
+    baseDelayMs: BASE_BACKOFF_MS,
+    maxDelayMs: MAX_BACKOFF_MS,
+    jitter: { mode: "additive", ratio: 0.5 },
+  });
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private dedupCleanupTimer: ReturnType<typeof setInterval> | null = null;
   private store: SlackStore;
@@ -340,7 +345,7 @@ export class SlackSocketModeClient {
       this.reconnectTimer = null;
     }
 
-    this.reconnectAttempt = 0;
+    this.backoff.reset();
 
     const oldWs = this.ws;
     this.ws = null;
@@ -668,7 +673,7 @@ export class SlackSocketModeClient {
 
       ws.addEventListener("open", () => {
         log.info("Slack Socket Mode connected");
-        this.reconnectAttempt = 0;
+        this.backoff.reset();
         // Retry bot identity resolution on every reconnect so a transient
         // auth.test failure at startup is self-healing. Once resolved, the
         // check in resolveBotIdentity short-circuits immediately (no await
@@ -789,7 +794,7 @@ export class SlackSocketModeClient {
         }
         this.ws = null;
         // Reconnect immediately (attempt 0 = minimal backoff)
-        this.reconnectAttempt = 0;
+        this.backoff.reset();
         this.scheduleReconnect();
       }
       return;
@@ -1535,19 +1540,10 @@ export class SlackSocketModeClient {
     if (!this.running) return;
     if (this.reconnectTimer) return;
 
-    const backoff = Math.min(
-      BASE_BACKOFF_MS * Math.pow(2, this.reconnectAttempt),
-      MAX_BACKOFF_MS,
-    );
-    // Add jitter: 0-50% of backoff
-    const jitter = Math.random() * backoff * 0.5;
-    const delay = Math.round(backoff + jitter);
+    const attempt = this.backoff.attemptCount;
+    const delay = this.backoff.nextDelayMs();
 
-    log.info(
-      { attempt: this.reconnectAttempt, delayMs: delay },
-      "Scheduling Socket Mode reconnect",
-    );
-    this.reconnectAttempt++;
+    log.info({ attempt, delayMs: delay }, "Scheduling Socket Mode reconnect");
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;

--- a/gateway/src/util/exponential-backoff.test.ts
+++ b/gateway/src/util/exponential-backoff.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+
+import { ExponentialBackoff } from "./exponential-backoff.js";
+import "../__tests__/test-preload.js";
+
+describe("ExponentialBackoff", () => {
+  test("grows exponentially from the base delay", () => {
+    const backoff = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "additive", ratio: 0 },
+    });
+    expect(backoff.nextDelayMs()).toBe(1_000);
+    expect(backoff.nextDelayMs()).toBe(2_000);
+    expect(backoff.nextDelayMs()).toBe(4_000);
+    expect(backoff.nextDelayMs()).toBe(8_000);
+  });
+
+  test("caps the window at maxDelayMs", () => {
+    const backoff = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "additive", ratio: 0 },
+    });
+    for (let i = 0; i < 40; i++) {
+      backoff.nextDelayMs();
+    }
+    expect(backoff.nextDelayMs()).toBe(30_000);
+  });
+
+  test("a per-call maxDelayMs overrides the constructor ceiling", () => {
+    const backoff = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "additive", ratio: 0 },
+    });
+    for (let i = 0; i < 40; i++) {
+      backoff.nextDelayMs();
+    }
+    expect(backoff.nextDelayMs({ maxDelayMs: 600_000 })).toBe(600_000);
+    expect(backoff.nextDelayMs()).toBe(30_000);
+  });
+
+  test("additive jitter floors the delay at the window", () => {
+    const atZero = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "additive", ratio: 0.5 },
+      random: () => 0,
+    });
+    expect(atZero.nextDelayMs()).toBe(1_000);
+
+    const atOne = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "additive", ratio: 0.5 },
+      random: () => 1,
+    });
+    expect(atOne.nextDelayMs()).toBe(1_500);
+  });
+
+  test("full jitter spreads the delay over the whole window", () => {
+    const atZero = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "full" },
+      random: () => 0,
+    });
+    expect(atZero.nextDelayMs()).toBe(0);
+
+    const atHalf = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "full" },
+      random: () => 0.5,
+    });
+    expect(atHalf.nextDelayMs()).toBe(500);
+  });
+
+  test("reset returns the window to the base delay", () => {
+    const backoff = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "additive", ratio: 0 },
+    });
+    backoff.nextDelayMs();
+    backoff.nextDelayMs();
+    expect(backoff.attemptCount).toBe(2);
+
+    backoff.reset();
+    expect(backoff.attemptCount).toBe(0);
+    expect(backoff.nextDelayMs()).toBe(1_000);
+  });
+
+  test("attemptCount reflects the attempts drawn, not resets alone", () => {
+    const backoff = new ExponentialBackoff({
+      baseDelayMs: 500,
+      maxDelayMs: 30_000,
+      jitter: { mode: "full" },
+      random: () => 1,
+    });
+    expect(backoff.attemptCount).toBe(0);
+    backoff.nextDelayMs();
+    expect(backoff.attemptCount).toBe(1);
+    backoff.nextDelayMs({ maxDelayMs: 10_000 });
+    expect(backoff.attemptCount).toBe(2);
+  });
+
+  test("rounds the delay to whole milliseconds", () => {
+    const backoff = new ExponentialBackoff({
+      baseDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitter: { mode: "additive", ratio: 0.5 },
+      random: () => 0.333,
+    });
+    expect(backoff.nextDelayMs()).toBe(Math.round(1_000 + 0.5 * 0.333 * 1_000));
+  });
+});

--- a/gateway/src/util/exponential-backoff.ts
+++ b/gateway/src/util/exponential-backoff.ts
@@ -1,0 +1,75 @@
+/**
+ * Capped exponential backoff with jitter.
+ *
+ * One counter of consecutive failures drives a delay window of
+ * `min(baseDelayMs * 2^attempts, maxDelayMs)`. Two jitter modes cover the
+ * gateway's reconnect and retry loops:
+ *
+ * - `additive`: delay is the full window plus `ratio * random() * window`,
+ *   so the window is a floor. Used by loops where a single client paces
+ *   itself against its own server allocation (Slack Socket Mode, Velay).
+ * - `full`: delay is uniform over `[0, window)`, spreading retries across
+ *   the whole window. Used where many instances recovering from one
+ *   provider-side outage must not resynchronise (Discord).
+ *
+ * Stateless with respect to time: the caller owns timers and decides when
+ * a connection counts as recovered (via {@link ExponentialBackoff.reset}),
+ * so this stays a pure function of attempt count and is testable without
+ * waiting.
+ */
+
+export type BackoffJitter =
+  | { mode: "full" }
+  | { mode: "additive"; ratio: number };
+
+export type ExponentialBackoffOptions = {
+  /** Window for the first attempt. */
+  baseDelayMs: number;
+  /** Ceiling the window never exceeds. Overridable per call. */
+  maxDelayMs: number;
+  jitter: BackoffJitter;
+  /** Injectable so tests can pin the jitter. */
+  random?: () => number;
+};
+
+export class ExponentialBackoff {
+  private attempts = 0;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly jitter: BackoffJitter;
+  private readonly random: () => number;
+
+  constructor(options: ExponentialBackoffOptions) {
+    this.baseDelayMs = options.baseDelayMs;
+    this.maxDelayMs = options.maxDelayMs;
+    this.jitter = options.jitter;
+    this.random = options.random ?? Math.random;
+  }
+
+  /** Consecutive attempts since the last {@link reset}. */
+  get attemptCount(): number {
+    return this.attempts;
+  }
+
+  /**
+   * Delay before the next attempt, and count it.
+   *
+   * `maxDelayMs` overrides the constructor ceiling for this call only,
+   * for callers whose ceiling depends on the kind of attempt (e.g.
+   * Discord resume vs identify) while one failure counter spans both.
+   */
+  nextDelayMs(overrides?: { maxDelayMs?: number }): number {
+    const cap = overrides?.maxDelayMs ?? this.maxDelayMs;
+    const window = Math.min(this.baseDelayMs * 2 ** this.attempts, cap);
+    this.attempts++;
+    if (this.jitter.mode === "full") {
+      return Math.round(this.random() * window);
+    }
+    return Math.round(window + this.jitter.ratio * this.random() * window);
+  }
+
+  /** Clear the failure counter. The caller decides what counts as recovery. */
+  reset(): void {
+    this.attempts = 0;
+  }
+}

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -8,6 +8,7 @@ import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";
 import { mutateConfigFile } from "../config-file-utils.js";
 import { getLogger } from "../logger.js";
+import { ExponentialBackoff } from "../util/exponential-backoff.js";
 import {
   VELAY_ALLOWED_PATHS_HEADER,
   VELAY_ALLOWED_PATHS_HEADER_VALUE,
@@ -76,17 +77,13 @@ export class VelayTunnelClient {
   private readonly webSocketConstructor: WebSocketConstructorWithOptions;
   private readonly httpBridge: typeof bridgeVelayHttpRequest;
   private readonly webSocketBridge: VelayWebSocketBridge;
-  private readonly baseReconnectDelayMs: number;
-  private readonly maxReconnectDelayMs: number;
-  private readonly reconnectJitterRatio: number;
-  private readonly random: () => number;
+  private readonly backoff: ExponentialBackoff;
   private readonly heartbeatIntervalMs: number;
   private readonly heartbeatReadTimeoutMs: number;
   private readonly timerApi: TimerApi;
   private ws: WebSocket | null = null;
   private running = false;
   private connecting = false;
-  private reconnectAttempt = 0;
   private reconnectTimer: unknown = null;
   private heartbeatTimer: unknown = null;
   private readTimeoutTimer: unknown = null;
@@ -106,13 +103,15 @@ export class VelayTunnelClient {
     this.webSocketBridge = (
       options.webSocketBridgeFactory ?? defaultWebSocketBridgeFactory
     )(options.gatewayLoopbackBaseUrl, (frame) => this.sendFrame(frame));
-    this.baseReconnectDelayMs =
-      options.reconnect?.baseDelayMs ?? BASE_RECONNECT_DELAY_MS;
-    this.maxReconnectDelayMs =
-      options.reconnect?.maxDelayMs ?? MAX_RECONNECT_DELAY_MS;
-    this.reconnectJitterRatio =
-      options.reconnect?.jitterRatio ?? RECONNECT_JITTER_RATIO;
-    this.random = options.reconnect?.random ?? Math.random;
+    this.backoff = new ExponentialBackoff({
+      baseDelayMs: options.reconnect?.baseDelayMs ?? BASE_RECONNECT_DELAY_MS,
+      maxDelayMs: options.reconnect?.maxDelayMs ?? MAX_RECONNECT_DELAY_MS,
+      jitter: {
+        mode: "additive",
+        ratio: options.reconnect?.jitterRatio ?? RECONNECT_JITTER_RATIO,
+      },
+      random: options.reconnect?.random,
+    });
     this.heartbeatIntervalMs =
       options.heartbeat?.intervalMs ?? HEARTBEAT_INTERVAL_MS;
     this.heartbeatReadTimeoutMs =
@@ -134,7 +133,7 @@ export class VelayTunnelClient {
   refreshCredentials(reason = "credentials changed"): void {
     if (!this.running) return;
 
-    this.reconnectAttempt = 0;
+    this.backoff.reset();
     if (this.reconnectTimer) {
       this.timerApi.clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -435,7 +434,7 @@ export class VelayTunnelClient {
 
     await writeManagedPublicBaseUrl(publicUrl, this.options.configFile);
     this.publishedPublicBaseUrl = publicUrl;
-    this.reconnectAttempt = 0;
+    this.backoff.reset();
     log.info({ publicUrl }, "Velay tunnel registered");
   }
 
@@ -571,13 +570,7 @@ export class VelayTunnelClient {
   private scheduleReconnect(): void {
     if (!this.running || this.reconnectTimer) return;
 
-    const backoff = Math.min(
-      this.baseReconnectDelayMs * Math.pow(2, this.reconnectAttempt),
-      this.maxReconnectDelayMs,
-    );
-    const jitter = backoff * this.reconnectJitterRatio * this.random();
-    const delay = Math.round(backoff + jitter);
-    this.reconnectAttempt++;
+    const delay = this.backoff.nextDelayMs();
 
     this.reconnectTimer = this.timerApi.setTimeout(() => {
       this.reconnectTimer = null;
@@ -610,7 +603,7 @@ export class VelayTunnelClient {
     // backoff — otherwise a link minted right after enabling ingress (which
     // also starts the tunnel) stays unreachable for up to the max backoff.
     if (wasDisabled && this.running && !ws && !this.connecting) {
-      this.reconnectAttempt = 0;
+      this.backoff.reset();
       if (this.reconnectTimer) {
         this.timerApi.clearTimeout(this.reconnectTimer);
         this.reconnectTimer = null;


### PR DESCRIPTION
## TL;DR

The Discord, Slack, and Velay clients each carried their own copy of capped exponential backoff with jitter. This extracts the delay computation into a single shared utility, `gateway/src/util/exponential-backoff.ts`, and replaces all three call sites. Per-caller behavior is unchanged.

## Design

`ExponentialBackoff` covers the union of what the three callers need:

- `baseDelayMs` / `maxDelayMs` (Velay configures both via its existing `reconnect` options, which are unchanged)
- Jitter modes: `additive` with a configurable ratio (Slack, Velay) and `full` (Discord)
- Per-call `maxDelayMs` override, for Discord's split resume (30s) vs identify (10min) ceilings over one failure counter
- Injectable `random` for deterministic tests
- `attemptCount` getter and `reset()`

Reset *policy* deliberately stays with each caller, because that is where the three legitimately differ: Slack resets on socket-open, Velay on register/credential refresh/ingress re-enable, Discord only after a session holds stable for 2 minutes (a credential-safety rule documented in `discord/backoff.ts`). Discord's `ReconnectBackoff` remains as a thin domain adapter over the shared core, keeping its identify-budget derivation docs, `noteSessionStable()` semantics, and existing test suite.

## Why this is safe

- The delay formulas are identical before and after: additive mode computes `round(window + ratio * random() * window)`, matching Slack's and Velay's previous inline math; full mode computes `round(random() * window)`, matching Discord's.
- Counter increment order and reset sites are unchanged, verified line by line at all three call sites.
- Velay's public `reconnect` options (`baseDelayMs`, `maxDelayMs`, `jitterRatio`, `random`) are preserved, so its existing tests configure it exactly as before.
- Verified: `bunx tsc --noEmit` clean; per-file `bun test` green for the new utility suite (8 cases), `discord/backoff.test.ts`, `discord/gateway-socket.test.ts`, `velay/client.test.ts`, and all three `slack-socket-mode-*` suites.

## What changes for the user

| Area | Before | After |
| --- | --- | --- |
| Reconnect timing (Slack, Velay, Discord) | Capped exponential backoff with jitter, computed by three private copies | Same delays, computed by one shared utility |
| Velay `reconnect` configuration | `baseDelayMs`, `maxDelayMs`, `jitterRatio`, `random` | Unchanged |
| Discord identify pacing | Full jitter, budget-derived caps, stability-gated reset | Unchanged |

No user-visible behavior changes; this is a drift-prevention refactor per the repo's single-source-of-truth rule.

## Deferred

`telegram/api.ts` and `whatsapp/api.ts` duplicate a larger retry-fetch pipeline (Retry-After parsing plus the attempt loop, with provider-specific error handling interleaved). That is a separate extraction with its own design questions, tracked in a follow-up rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->