### PR TITLE
fix(providers): retire serverless-dead Fireworks kimi-k2p5 from defaults; repair stamped configs

### DIFF
--- a/assistant/src/__tests__/config-get-vision-flag.test.ts
+++ b/assistant/src/__tests__/config-get-vision-flag.test.ts
@@ -40,7 +40,7 @@ describe("GET /v1/config profile vision enrichment", () => {
     seedProfiles({
       "test-no-vision": {
         provider: "fireworks",
-        model: "accounts/fireworks/models/kimi-k2p5",
+        model: "accounts/fireworks/models/glm-5p2",
       },
     });
 

--- a/assistant/src/__tests__/workspace-migration-136-repair-stale-fireworks-kimi-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-136-repair-stale-fireworks-kimi-model-id.test.ts
@@ -1,0 +1,139 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repairStaleFireworksKimiModelIdMigration } from "../workspace/migrations/136-repair-stale-fireworks-kimi-model-id.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+const STALE = "accounts/fireworks/models/kimi-k2p5";
+const REPLACEMENT = "accounts/fireworks/models/deepseek-v4-flash";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-136-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("136-repair-stale-fireworks-kimi-model-id migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(repairStaleFireworksKimiModelIdMigration.id).toBe(
+      "136-repair-stale-fireworks-kimi-model-id",
+    );
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
+      "136-repair-stale-fireworks-kimi-model-id",
+    );
+  });
+
+  test("repairs the stale ID in default, call sites, and profiles", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: STALE },
+        callSites: {
+          recall: { model: STALE, maxTokens: 4096 },
+          heartbeat: { model: `${STALE}-tuned` },
+          malformed: STALE,
+        },
+        profiles: {
+          "cost-optimized": { provider: "vellum", model: STALE },
+          legacy: { model: STALE },
+        },
+      },
+    });
+
+    repairStaleFireworksKimiModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.maxTokens).toBe(4096);
+    // Non-exact matches and malformed leaves are untouched.
+    expect(llm.callSites.heartbeat.model).toBe(`${STALE}-tuned`);
+    expect(llm.callSites.malformed).toBe(STALE);
+    // Managed profiles stamped provider "vellum" carry Fireworks model IDs.
+    expect(llm.profiles["cost-optimized"].model).toBe(REPLACEMENT);
+    expect(llm.profiles.legacy.model).toBe(REPLACEMENT);
+  });
+
+  test("leaves fragments with an explicit other provider untouched", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai-compatible", model: STALE },
+        profiles: {
+          byo: { provider: "openai-compatible", model: STALE },
+        },
+      },
+    });
+
+    repairStaleFireworksKimiModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(STALE);
+    expect(llm.profiles.byo.model).toBe(STALE);
+  });
+
+  test("is idempotent and a no-op without the stale ID", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: STALE },
+        profiles: { fine: { provider: "fireworks", model: REPLACEMENT } },
+      },
+    });
+
+    repairStaleFireworksKimiModelIdMigration.run(workspaceDir);
+    const first = readConfig();
+    repairStaleFireworksKimiModelIdMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(first);
+
+    const llm = first.llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.profiles.fine.model).toBe(REPLACEMENT);
+  });
+
+  test("handles missing config, missing llm block, and invalid JSON", () => {
+    // No config.json at all.
+    expect(() =>
+      repairStaleFireworksKimiModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeConfig({ theme: "dark" });
+    repairStaleFireworksKimiModelIdMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ theme: "dark" });
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    expect(() =>
+      repairStaleFireworksKimiModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -881,20 +881,10 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
           cacheReadPer1mTokens: 0.26,
         },
       },
-      {
-        id: "accounts/fireworks/models/kimi-k2p5",
-        displayName: "Kimi K2.5",
-        contextWindowTokens: 256000,
-        maxOutputTokens: 32768,
-        supportsThinking: false,
-        supportsCaching: false,
-        supportsVision: false,
-        supportsToolUse: true,
-        pricing: {
-          inputPer1mTokens: 0.6,
-          outputPer1mTokens: 2.5,
-        },
-      },
+      // Kimi K2.5 (accounts/fireworks/models/kimi-k2p5) was removed on
+      // 2026-07-28: Fireworks withdrew its serverless deployment, so
+      // chat/completions calls 404 ("not found, inaccessible, and/or not
+      // deployed"). Migration 136 repairs configs still pinning it.
       {
         id: "accounts/fireworks/models/minimax-m3",
         displayName: "MiniMax M3",
@@ -964,7 +954,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
     ],
-    defaultModel: "accounts/fireworks/models/kimi-k2p5",
+    defaultModel: "accounts/fireworks/models/deepseek-v4-flash",
     apiKeyUrl: "https://fireworks.ai/account/api-keys",
     apiKeyPlaceholder: "fw_...",
   },

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -881,10 +881,10 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
           cacheReadPer1mTokens: 0.26,
         },
       },
-      // Kimi K2.5 (accounts/fireworks/models/kimi-k2p5) was removed on
-      // 2026-07-28: Fireworks withdrew its serverless deployment, so
+      // Kimi K2.5 (accounts/fireworks/models/kimi-k2p5) is intentionally
+      // absent: Fireworks serves it on-demand/dedicated only, so serverless
       // chat/completions calls 404 ("not found, inaccessible, and/or not
-      // deployed"). Migration 136 repairs configs still pinning it.
+      // deployed").
       {
         id: "accounts/fireworks/models/minimax-m3",
         displayName: "MiniMax M3",

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -36,7 +36,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   },
   fireworks: {
     balanced: "accounts/fireworks/models/minimax-m3",
-    "latency-optimized": "accounts/fireworks/models/kimi-k2p5",
+    "latency-optimized": "accounts/fireworks/models/deepseek-v4-flash",
     "quality-optimized": "accounts/fireworks/models/kimi-k2p6",
     "vision-optimized": "accounts/fireworks/models/kimi-k2p6",
   },

--- a/assistant/src/workspace/migrations/136-repair-stale-fireworks-kimi-model-id.ts
+++ b/assistant/src/workspace/migrations/136-repair-stale-fireworks-kimi-model-id.ts
@@ -34,9 +34,14 @@ export const repairStaleFireworksKimiModelIdMigration: WorkspaceMigration = {
       return;
     }
 
+    // Read outside the parse catch: a transient filesystem error (EIO,
+    // EACCES) must reach the runner so the migration retries, while
+    // malformed JSON is a permanent state this migration cannot repair.
+    const rawText = readFileSync(configPath, "utf-8");
+
     let config: Record<string, unknown>;
     try {
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      const raw = JSON.parse(rawText);
       if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
         return;
       }
@@ -80,6 +85,9 @@ export const repairStaleFireworksKimiModelIdMigration: WorkspaceMigration = {
     writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
     renameSync(tmpPath, configPath);
   },
+  // The exact-match rewrite is idempotent, so a transient failure (full
+  // disk, I/O error) is safe to retry on later startups.
+  retryFailedCheckpoint: true,
   down(_workspaceDir: string): void {
     // Forward-only: reintroducing the stale model ID would break Fireworks
     // calls.

--- a/assistant/src/workspace/migrations/136-repair-stale-fireworks-kimi-model-id.ts
+++ b/assistant/src/workspace/migrations/136-repair-stale-fireworks-kimi-model-id.ts
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Repair the stale Fireworks Kimi K2.5 model ID in workspace LLM config.
+ *
+ * Fireworks withdrew the serverless deployment of
+ * `accounts/fireworks/models/kimi-k2p5` (the model page now lists it as
+ * on-demand/dedicated only), so serverless chat/completions calls fail with
+ * a 404 "Model not found, inaccessible, and/or not deployed". The ID was
+ * seeded widely: it was the Fireworks `latency-optimized` intent and the
+ * Fireworks provider default, and older migrations (038/040/054/066/073)
+ * stamped it into call sites, so affected assistants throw
+ * model-not-found on every message routed through those entries
+ * (ATL-1164, ATL-1167, ATL-1144, ATL-1142).
+ *
+ * Repair known LLM config leaves where clients write model IDs —
+ * `llm.default`, `llm.callSites.*`, and `llm.profiles.*` — only on an
+ * exact stale match, replacing with `accounts/fireworks/models/
+ * deepseek-v4-flash` (the same latency-intent replacement the managed
+ * catalog already made, verified serverless-servable).
+ *
+ * Provider guard: the stale ID was a catalog entry owned by the
+ * `fireworks` provider and also appears in managed profiles stamped
+ * `provider: "vellum"` (which route Fireworks-account model IDs through
+ * the managed proxy). A fragment is repaired when its `provider` is
+ * `"fireworks"`, `"vellum"`, or absent; an explicit other provider (e.g.
+ * an `openai-compatible` endpoint serving a model by the same name) is
+ * left untouched.
+ */
+export const repairStaleFireworksKimiModelIdMigration: WorkspaceMigration = {
+  id: "136-repair-stale-fireworks-kimi-model-id",
+  description:
+    "Repair stale Fireworks accounts/fireworks/models/kimi-k2p5 model ID in workspace LLM config",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return;
+      }
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) {
+      return;
+    }
+
+    let changed = false;
+
+    changed = repairFragment(readObject(llm.default)) || changed;
+
+    const callSites = readObject(llm.callSites);
+    if (callSites !== null) {
+      for (const rawConfig of Object.values(callSites)) {
+        changed = repairFragment(readObject(rawConfig)) || changed;
+      }
+    }
+
+    const profiles = readObject(llm.profiles);
+    if (profiles !== null) {
+      for (const rawProfile of Object.values(profiles)) {
+        changed = repairFragment(readObject(rawProfile)) || changed;
+      }
+    }
+
+    if (!changed) {
+      return;
+    }
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: reintroducing the stale model ID would break Fireworks
+    // calls.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const STALE_MODEL_ID = "accounts/fireworks/models/kimi-k2p5";
+const REPLACEMENT_MODEL_ID = "accounts/fireworks/models/deepseek-v4-flash";
+const REPAIRABLE_PROVIDERS = new Set(["fireworks", "vellum"]);
+
+function repairFragment(fragment: Record<string, unknown> | null): boolean {
+  if (fragment === null) {
+    return false;
+  }
+  if (fragment.model !== STALE_MODEL_ID) {
+    return false;
+  }
+  if (
+    fragment.provider !== undefined &&
+    !REPAIRABLE_PROVIDERS.has(fragment.provider as string)
+  ) {
+    return false;
+  }
+  fragment.model = REPLACEMENT_MODEL_ID;
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/136-repair-stale-fireworks-kimi-model-id.ts
+++ b/assistant/src/workspace/migrations/136-repair-stale-fireworks-kimi-model-id.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { WorkspaceMigration } from "./types.js";
@@ -6,24 +6,18 @@ import type { WorkspaceMigration } from "./types.js";
 /**
  * Repair the stale Fireworks Kimi K2.5 model ID in workspace LLM config.
  *
- * Fireworks withdrew the serverless deployment of
- * `accounts/fireworks/models/kimi-k2p5` (the model page now lists it as
- * on-demand/dedicated only), so serverless chat/completions calls fail with
- * a 404 "Model not found, inaccessible, and/or not deployed". The ID was
- * seeded widely: it was the Fireworks `latency-optimized` intent and the
- * Fireworks provider default, and older migrations (038/040/054/066/073)
- * stamped it into call sites, so affected assistants throw
- * model-not-found on every message routed through those entries
- * (ATL-1164, ATL-1167, ATL-1144, ATL-1142).
+ * `accounts/fireworks/models/kimi-k2p5` has no serverless deployment on
+ * Fireworks (on-demand/dedicated only), so serverless chat/completions
+ * calls fail with a 404 "Model not found, inaccessible, and/or not
+ * deployed". Existing configs can still pin the ID in `llm.default`,
+ * `llm.callSites.*`, and `llm.profiles.*`.
  *
- * Repair known LLM config leaves where clients write model IDs
- * (`llm.default`, `llm.callSites.*`, and `llm.profiles.*`) only on an
- * exact stale match, replacing with `accounts/fireworks/models/
- * deepseek-v4-flash` (the same latency-intent replacement the managed
- * catalog already made, verified serverless-servable).
+ * Repair those leaves only on an exact stale match, replacing with
+ * `accounts/fireworks/models/deepseek-v4-flash`, the catalog's current
+ * Fireworks latency-intent model.
  *
- * Provider guard: the stale ID was a catalog entry owned by the
- * `fireworks` provider and also appears in managed profiles stamped
+ * Provider guard: the stale ID belongs to the `fireworks` provider and
+ * also appears in managed profiles stamped
  * `provider: "vellum"` (which route Fireworks-account model IDs through
  * the managed proxy). A fragment is repaired when its `provider` is
  * `"fireworks"`, `"vellum"`, or absent; an explicit other provider (e.g.
@@ -78,7 +72,13 @@ export const repairStaleFireworksKimiModelIdMigration: WorkspaceMigration = {
       return;
     }
 
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    // Write-then-rename so an interrupted write cannot leave config.json
+    // truncated: a torn in-place write would parse as invalid JSON on the
+    // retry, which the catch above treats as "nothing to do", letting the
+    // runner checkpoint the migration as completed against a corrupt file.
+    const tmpPath = `${configPath}.migration-136.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+    renameSync(tmpPath, configPath);
   },
   down(_workspaceDir: string): void {
     // Forward-only: reintroducing the stale model ID would break Fireworks

--- a/assistant/src/workspace/migrations/136-repair-stale-fireworks-kimi-model-id.ts
+++ b/assistant/src/workspace/migrations/136-repair-stale-fireworks-kimi-model-id.ts
@@ -16,8 +16,8 @@ import type { WorkspaceMigration } from "./types.js";
  * model-not-found on every message routed through those entries
  * (ATL-1164, ATL-1167, ATL-1144, ATL-1142).
  *
- * Repair known LLM config leaves where clients write model IDs —
- * `llm.default`, `llm.callSites.*`, and `llm.profiles.*` — only on an
+ * Repair known LLM config leaves where clients write model IDs
+ * (`llm.default`, `llm.callSites.*`, and `llm.profiles.*`) only on an
  * exact stale match, replacing with `accounts/fireworks/models/
  * deepseek-v4-flash` (the same latency-intent replacement the managed
  * catalog already made, verified serverless-servable).
@@ -87,7 +87,7 @@ export const repairStaleFireworksKimiModelIdMigration: WorkspaceMigration = {
 };
 
 // ---------------------------------------------------------------------------
-// Helpers — self-contained per workspace migrations AGENTS.md
+// Helpers: self-contained per workspace migrations AGENTS.md
 // ---------------------------------------------------------------------------
 
 const STALE_MODEL_ID = "accounts/fireworks/models/kimi-k2p5";

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -133,6 +133,7 @@ import { webSearchModeToProviderMigration } from "./132-web-search-mode-to-provi
 import { collapseProviderConnectionsMigration } from "./133-collapse-provider-connections.js";
 import { imageGenerationModeToProviderMigration } from "./134-image-generation-mode-to-provider.js";
 import { copySubstrateTunablesMigration } from "./135-copy-substrate-tunables.js";
+import { repairStaleFireworksKimiModelIdMigration } from "./136-repair-stale-fireworks-kimi-model-id.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -281,4 +282,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   collapseProviderConnectionsMigration,
   imageGenerationModeToProviderMigration,
   copySubstrateTunablesMigration,
+  repairStaleFireworksKimiModelIdMigration,
 ];

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -325,8 +325,8 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 131_072,
       supportsThinking: true,
     },
-    // Kimi K2.5 (kimi-k2p5) removed 2026-07-28: Fireworks withdrew its
-    // serverless deployment, so calls 404. Mirrors the daemon catalog.
+    // Kimi K2.5 (kimi-k2p5) is intentionally absent: Fireworks serves it
+    // on-demand/dedicated only, so serverless calls 404.
     {
       id: "accounts/fireworks/models/minimax-m3",
       displayName: "MiniMax M3",

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -325,13 +325,8 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 131_072,
       supportsThinking: true,
     },
-    {
-      id: "accounts/fireworks/models/kimi-k2p5",
-      displayName: "Kimi K2.5",
-      contextWindowTokens: 256_000,
-      defaultContextWindowTokens: 200_000,
-      maxOutputTokens: 32_768,
-    },
+    // Kimi K2.5 (kimi-k2p5) removed 2026-07-28: Fireworks withdrew its
+    // serverless deployment, so calls 404. Mirrors the daemon catalog.
     {
       id: "accounts/fireworks/models/minimax-m3",
       displayName: "MiniMax M3",
@@ -935,7 +930,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   openai: "gpt-5.5",
   gemini: "gemini-2.5-flash",
   ollama: "llama3.2",
-  fireworks: "accounts/fireworks/models/kimi-k2p5",
+  fireworks: "accounts/fireworks/models/deepseek-v4-flash",
   together: "MiniMaxAI/MiniMax-M3",
   openrouter: "x-ai/grok-4.20",
   "vercel-ai-gateway": "anthropic/claude-sonnet-4.6",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -722,7 +722,7 @@
         "linkLabel": "Open Fireworks Dashboard"
       },
       "supportsPlatformAuth": true,
-      "defaultModel": "accounts/fireworks/models/kimi-k2p5",
+      "defaultModel": "accounts/fireworks/models/deepseek-v4-flash",
       "models": [
         {
           "id": "accounts/fireworks/models/kimi-k3",
@@ -774,22 +774,6 @@
             "inputPer1mTokens": 1.4,
             "outputPer1mTokens": 4.4,
             "cacheReadPer1mTokens": 0.26
-          }
-        },
-        {
-          "id": "accounts/fireworks/models/kimi-k2p5",
-          "displayName": "Kimi K2.5",
-          "contextWindowTokens": 256000,
-          "maxOutputTokens": 32768,
-          "defaultContextWindowTokens": 200000,
-          "longContextMode": "native-model",
-          "supportsThinking": false,
-          "supportsCaching": false,
-          "supportsVision": false,
-          "supportsToolUse": true,
-          "pricing": {
-            "inputPer1mTokens": 0.6,
-            "outputPer1mTokens": 2.5
           }
         },
         {


### PR DESCRIPTION
## Summary
- `accounts/fireworks/models/kimi-k2p5` no longer has a serverless deployment on Fireworks ([model page](https://fireworks.ai/models/fireworks/kimi-k2p5) lists it as on-demand only), so every serverless `chat/completions` call 404s. Verified live with the platform key: kimi-k2p5 → 404 "Model not found, inaccessible, and/or not deployed"; kimi-k2p6, deepseek-v4-flash, minimax-m3 → 200.
- The managed catalog's Speed profile was already remapped to deepseek-v4-flash, but two live references kept shipping the dead model: the Fireworks `latency-optimized` intent (`model-intents.ts`) and the Fireworks provider `defaultModel` (`model-catalog.ts`). Both now point at `deepseek-v4-flash`; the dead model is removed from the catalog listing.
- New workspace migration `136-repair-stale-fireworks-kimi-model-id` (modeled on 128) rewrites config.json entries still pinning the stale ID — `llm.default`, `llm.callSites.*`, `llm.profiles.*` — when the fragment's provider is `fireworks`, `vellum`, or absent. Older migrations (038/040/054/066/073) stamped the ID into existing configs, and the boot-time backfill never repairs present values, so without this the ATL-1164/1167/1144/1142/1145 cluster (managed Speed profile failing every message) persists indefinitely.

## Original prompt
Triage analysis of the Self-Service KPI queue found 7 of 10 model-routing tickets trace to one root cause: the managed "cost-optimized" (Speed) profile resolving to `accounts/fireworks/models/kimi-k2p5`, which Fireworks no longer serves serverless. The catalog default had been fixed but the intent matrix and provider defaultModel still referenced the dead model, and users' stamped configs had no repair path. Requested: remap both live references to deepseek-v4-flash and add a repair migration for existing configs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->