### PR TITLE
feat(skills): discover skills shipped by default plugins

### DIFF
--- a/assistant/src/config/__tests__/default-plugin-skill-discovery.test.ts
+++ b/assistant/src/config/__tests__/default-plugin-skill-discovery.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for default-plugin resident skill discovery.
+ *
+ * A default plugin ships inside the assistant's own source tree
+ * (`plugins/defaults/<dir>/`) rather than under `<workspaceDir>/plugins/`, so
+ * its `skills/` directory is enumerated from the compiled-in tree. The walk
+ * takes its roots as an argument so these tests can drive it against a temp
+ * tree instead of adding fixture plugins to `src/`.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getDefaultPluginSkillRoots } from "../../plugins/defaults/main.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
+import { discoverPluginResidentSkills } from "../skills.js";
+
+let tempRoot: string;
+
+/**
+ * Create `<tempRoot>/<dirName>/skills/<id>/SKILL.md` for each skill and return
+ * the root descriptor the discovery walk consumes.
+ */
+function defaultPluginRoot(
+  dirName: string,
+  skills: Array<{ id: string; skillMd?: string }>,
+): { pluginName: string; skillsDir: string } {
+  const skillsDir = join(tempRoot, dirName, "skills");
+  for (const skill of skills) {
+    const skillDir = join(skillsDir, skill.id);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      skill.skillMd ??
+        `---\nname: ${skill.id}\ndescription: Description for ${skill.id}.\n---\n\nBody for ${skill.id}.\n`,
+    );
+  }
+  return { pluginName: `default-${dirName}`, skillsDir };
+}
+
+/** Install a workspace plugin shipping the given skills. */
+function writeWorkspacePlugin(dirName: string, skillIds: string[]): void {
+  const pluginDir = join(getWorkspacePluginsDir(), dirName);
+  mkdirSync(pluginDir, { recursive: true });
+  writeFileSync(
+    join(pluginDir, "package.json"),
+    JSON.stringify({ name: dirName, version: "1.0.0" }),
+  );
+  for (const id of skillIds) {
+    const skillDir = join(pluginDir, "skills", id);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---\nname: ${id}\ndescription: Workspace plugin copy of ${id}.\n---\n\nBody.\n`,
+    );
+  }
+}
+
+/** Write the `.disabled` sentinel the CLI writes for `pluginName`. */
+function disablePlugin(pluginName: string): void {
+  const dir = join(getWorkspacePluginsDir(), pluginName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".disabled"), "");
+}
+
+describe("default plugin resident skills", () => {
+  beforeEach(() => {
+    const pluginsDir = getWorkspacePluginsDir();
+    if (existsSync(pluginsDir)) {
+      rmSync(pluginsDir, { recursive: true, force: true });
+    }
+    tempRoot = mkdtempSync(join(tmpdir(), "default-plugin-skills-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  test("surfaces a default plugin's resident skill, owned by its default- name", () => {
+    const root = defaultPluginRoot("fixture", [{ id: "qa-fixture-skill" }]);
+
+    const skills = discoverPluginResidentSkills([root]);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.id).toBe("qa-fixture-skill");
+    expect(skills[0]!.source).toBe("plugin");
+    expect(skills[0]!.owner).toEqual({
+      kind: "plugin",
+      id: "default-fixture",
+    });
+    expect(skills[0]!.description).toBe("Description for qa-fixture-skill.");
+  });
+
+  test("hides a default plugin's skills when the plugin is disabled", () => {
+    const root = defaultPluginRoot("fixture", [{ id: "qa-fixture-skill" }]);
+    disablePlugin("default-fixture");
+
+    expect(discoverPluginResidentSkills([root])).toEqual([]);
+  });
+
+  test("an installed plugin's skill of the same id overrides the default one", () => {
+    const root = defaultPluginRoot("fixture", [
+      { id: "qa-shared-skill" },
+      { id: "qa-default-only" },
+    ]);
+    writeWorkspacePlugin("installed-fixture", ["qa-shared-skill"]);
+
+    const skills = discoverPluginResidentSkills([root]);
+    const shared = skills.filter((skill) => skill.id === "qa-shared-skill");
+
+    expect(shared).toHaveLength(1);
+    expect(shared[0]!.owner).toEqual({
+      kind: "plugin",
+      id: "installed-fixture",
+    });
+    // The default plugin's other skills are unaffected by the override.
+    expect(
+      skills.find((skill) => skill.id === "qa-default-only")?.owner,
+    ).toEqual({ kind: "plugin", id: "default-fixture" });
+  });
+
+  test("skips a malformed SKILL.md and still surfaces its valid siblings", () => {
+    const root = defaultPluginRoot("fixture", [
+      { id: "qa-malformed-skill", skillMd: "No frontmatter here.\n" },
+      { id: "qa-missing-description", skillMd: "---\nname: x\n---\n\nBody.\n" },
+      { id: "qa-valid-skill" },
+    ]);
+
+    const skills = discoverPluginResidentSkills([root]);
+
+    expect(skills.map((skill) => skill.id)).toEqual(["qa-valid-skill"]);
+  });
+
+  test("getDefaultPluginSkillRoots reports no roots until a default plugin ships skills", () => {
+    // Every root it reports must be a `default-`-prefixed plugin name; today no
+    // default plugin ships a `skills/` directory, so the set is empty.
+    for (const root of getDefaultPluginSkillRoots()) {
+      expect(root.pluginName).toMatch(/^default-[a-z0-9-]+$/);
+    }
+    expect(getDefaultPluginSkillRoots()).toEqual([]);
+  });
+});

--- a/assistant/src/config/__tests__/default-plugin-skill-discovery.test.ts
+++ b/assistant/src/config/__tests__/default-plugin-skill-discovery.test.ts
@@ -20,7 +20,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { getDefaultPluginSkillRoots } from "../../plugins/defaults/main.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
-import { discoverPluginResidentSkills } from "../skills.js";
+import {
+  discoverDefaultPluginResidentSkills,
+  discoverPluginResidentSkills,
+  mergePluginResidentSkills,
+} from "../skills.js";
 
 let tempRoot: string;
 
@@ -86,7 +90,7 @@ describe("default plugin resident skills", () => {
   test("surfaces a default plugin's resident skill, owned by its default- name", () => {
     const root = defaultPluginRoot("fixture", [{ id: "qa-fixture-skill" }]);
 
-    const skills = discoverPluginResidentSkills([root]);
+    const skills = discoverDefaultPluginResidentSkills([root]);
 
     expect(skills).toHaveLength(1);
     expect(skills[0]!.id).toBe("qa-fixture-skill");
@@ -102,7 +106,7 @@ describe("default plugin resident skills", () => {
     const root = defaultPluginRoot("fixture", [{ id: "qa-fixture-skill" }]);
     disablePlugin("default-fixture");
 
-    expect(discoverPluginResidentSkills([root])).toEqual([]);
+    expect(discoverDefaultPluginResidentSkills([root])).toEqual([]);
   });
 
   test("an installed plugin's skill of the same id overrides the default one", () => {
@@ -112,7 +116,12 @@ describe("default plugin resident skills", () => {
     ]);
     writeWorkspacePlugin("installed-fixture", ["qa-shared-skill"]);
 
-    const skills = discoverPluginResidentSkills([root]);
+    // The installed side comes from the real zero-arg discovery (the shipped
+    // defaults tree contributes nothing), the default side from the fixture.
+    const skills = mergePluginResidentSkills(
+      discoverDefaultPluginResidentSkills([root]),
+      discoverPluginResidentSkills(),
+    );
     const shared = skills.filter((skill) => skill.id === "qa-shared-skill");
 
     expect(shared).toHaveLength(1);
@@ -133,7 +142,7 @@ describe("default plugin resident skills", () => {
       { id: "qa-valid-skill" },
     ]);
 
-    const skills = discoverPluginResidentSkills([root]);
+    const skills = discoverDefaultPluginResidentSkills([root]);
 
     expect(skills.map((skill) => skill.id)).toEqual(["qa-valid-skill"]);
   });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -18,6 +18,8 @@ import {
 
 import { z } from "zod";
 
+import { getDefaultPluginSkillRoots } from "../plugins/defaults/main.js";
+import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { parseFrontmatterFields } from "../skills/frontmatter.js";
 import type { InlineCommandExpansion } from "../skills/inline-command-expansions.js";
 import { parseInlineCommandExpansions } from "../skills/inline-command-expansions.js";
@@ -67,9 +69,10 @@ const SkillMetadataSchema = z
  * - `workspace`: user-authored skill living in a conversation's working dir.
  * - `extra`: third-party directory roots passed via `loadSkillCatalog`'s
  *   `extraDirs` argument (primarily for tests).
- * - `plugin`: shipped on disk inside an installed plugin at
- *   `<workspaceDir>/plugins/<name>/skills/<id>/SKILL.md`, attributed back to
- *   the owning plugin via its `owner` descriptor.
+ * - `plugin`: shipped on disk inside a plugin — an installed one at
+ *   `<workspaceDir>/plugins/<name>/skills/<id>/SKILL.md`, or an in-process
+ *   default at `plugins/defaults/<dir>/skills/<id>/SKILL.md` — attributed back
+ *   to the owning plugin via its `owner` descriptor.
  */
 export type SkillSource =
   | "bundled"
@@ -95,7 +98,8 @@ export interface SkillSummary {
    * Ownership descriptor identifying the extension that ships this skill,
    * reusing the same {@link OwnerInfo} model the tool registry uses. Set only
    * for `source: "plugin"` skills — `{ kind: "plugin", id: <plugin dir name> }`
-   * — attributing them to the installed plugin under `<workspaceDir>/plugins/`.
+   * for an installed plugin under `<workspaceDir>/plugins/`, `{ kind:
+   * "plugin", id: "default-<dir>" }` for an in-process default plugin.
    */
   owner?: OwnerInfo;
   /** Parsed tool manifest metadata, if the skill has a valid TOOLS.json. */
@@ -743,13 +747,91 @@ function hasLoadablePluginManifest(pluginDir: string): boolean {
 }
 
 /**
- * Discover skills shipped on disk inside installed plugins. Each installed
- * plugin — a directory under `<workspaceDir>/plugins/` recognized by
- * {@link hasLoadablePluginManifest} — may ship skills at `skills/<id>/SKILL.md`.
- * Returned summaries are attributed to the owning plugin via their `owner`
- * descriptor (`{ kind: "plugin", id: <plugin dir name> }`).
+ * Discover skills shipped on disk by the in-process default plugins. A default
+ * plugin lives in the assistant's own source tree rather than under
+ * `<workspaceDir>/plugins/`, so its skills are enumerated from the roots
+ * {@link getDefaultPluginSkillRoots} reports (`defaults/<dir>/skills/`) instead
+ * of a workspace scan — there is no `package.json` gate because a default
+ * plugin's manifest is the one the daemon compiles in.
+ *
+ * `roots` is injectable so tests can exercise the walk against a temp tree; in
+ * production it is always the shipped defaults tree.
+ *
+ * A default plugin's disabled sentinel lives in the workspace and is keyed by
+ * its `default-<dir>` name, so the gate is {@link isPluginDisabled} at read
+ * time — the same read-time check the hook, tool, and route surfaces use, so a
+ * CLI toggle applies on the next turn without a daemon restart.
  */
-function discoverPluginResidentSkills(): SkillSummary[] {
+function discoverDefaultPluginResidentSkills(
+  roots: readonly { pluginName: string; skillsDir: string }[],
+): SkillSummary[] {
+  const summaries: SkillSummary[] = [];
+  for (const { pluginName, skillsDir } of roots) {
+    if (isPluginDisabled(pluginName)) {
+      continue;
+    }
+    for (const directory of discoverSkillDirectories(skillsDir)) {
+      const skill = readSkillFromDirectory(directory, skillsDir, "plugin");
+      if (!skill) {
+        continue;
+      }
+      summaries.push({
+        ...skillSummaryFromDefinition(skill, "plugin"),
+        owner: { kind: "plugin", id: pluginName },
+      });
+    }
+  }
+  return summaries;
+}
+
+/**
+ * Discover skills shipped on disk inside plugins: the in-process defaults in
+ * the assistant's source tree and the installed plugins under
+ * `<workspaceDir>/plugins/` (a directory recognized by
+ * {@link hasLoadablePluginManifest}), each of which may ship skills at
+ * `skills/<id>/SKILL.md`. Returned summaries are attributed to the owning
+ * plugin via their `owner` descriptor — `{ kind: "plugin", id: <plugin dir
+ * name> }` for an installed plugin, `{ kind: "plugin", id: "default-<dir>" }`
+ * for a default one.
+ *
+ * Default-plugin skills sit BELOW installed-plugin skills: an installed plugin
+ * shipping a skill of the same id shadows the default one, so a user can
+ * replace a first-party skill by installing a plugin that redefines it, the
+ * same direction as the catalog's overall extra → bundled → plugin → managed →
+ * workspace ordering. Shadowed defaults are dropped here rather than left for
+ * the catalog's first-wins `seenIds` pass, which would otherwise let whichever
+ * group is emitted first win.
+ *
+ * `defaultPluginSkillRoots` is injectable for tests; production callers use the
+ * shipped defaults tree.
+ */
+export function discoverPluginResidentSkills(
+  defaultPluginSkillRoots: readonly {
+    pluginName: string;
+    skillsDir: string;
+  }[] = getDefaultPluginSkillRoots(),
+): SkillSummary[] {
+  const defaultSkills = discoverDefaultPluginResidentSkills(
+    defaultPluginSkillRoots,
+  );
+  const installedSkills = discoverInstalledPluginResidentSkills();
+  const installedIds = new Set(installedSkills.map((skill) => skill.id));
+
+  const survivingDefaults = defaultSkills.filter((skill) => {
+    if (!installedIds.has(skill.id)) {
+      return true;
+    }
+    log.info(
+      { id: skill.id, pluginName: skill.owner?.id },
+      "Installed plugin skill overrides default plugin skill",
+    );
+    return false;
+  });
+
+  return [...survivingDefaults, ...installedSkills];
+}
+
+function discoverInstalledPluginResidentSkills(): SkillSummary[] {
   const pluginsDir = getWorkspacePluginsDir();
   if (!existsSync(pluginsDir)) {
     return [];
@@ -975,10 +1057,12 @@ export function loadSkillCatalog(
     catalog.push(skill);
   }
 
-  // Discover skills shipped on disk inside installed plugins. They sit above
-  // bundled/extra but below managed and workspace so a user-authored
-  // filesystem skill can override a plugin-provided skill by declaring the
-  // same id under `$VELLUM_WORKSPACE_DIR/skills/`.
+  // Discover skills shipped on disk inside plugins — in-process defaults and
+  // installed plugins alike. They sit above bundled/extra but below managed and
+  // workspace so a user-authored filesystem skill can override a
+  // plugin-provided skill by declaring the same id under
+  // `$VELLUM_WORKSPACE_DIR/skills/`. Precedence *within* the plugin source
+  // (installed over default) is resolved by the discovery pass.
   const pluginSkills = discoverPluginResidentSkills();
   for (const skill of pluginSkills) {
     if (seenIds.has(skill.id)) {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -762,7 +762,7 @@ function hasLoadablePluginManifest(pluginDir: string): boolean {
  * time, the same read-time check the hook, tool, and route surfaces use, so a
  * CLI toggle applies on the next turn without a daemon restart.
  */
-function discoverDefaultPluginResidentSkills(
+export function discoverDefaultPluginResidentSkills(
   roots: readonly { pluginName: string; skillsDir: string }[],
 ): SkillSummary[] {
   const summaries: SkillSummary[] = [];
@@ -802,19 +802,23 @@ function discoverDefaultPluginResidentSkills(
  * the catalog's first-wins `seenIds` pass, which would otherwise let whichever
  * group is emitted first win.
  *
- * `defaultPluginSkillRoots` is injectable for tests; production callers use the
- * shipped defaults tree.
  */
-export function discoverPluginResidentSkills(
-  defaultPluginSkillRoots: readonly {
-    pluginName: string;
-    skillsDir: string;
-  }[] = getDefaultPluginSkillRoots(),
-): SkillSummary[] {
-  const defaultSkills = discoverDefaultPluginResidentSkills(
-    defaultPluginSkillRoots,
+export function discoverPluginResidentSkills(): SkillSummary[] {
+  return mergePluginResidentSkills(
+    discoverDefaultPluginResidentSkills(getDefaultPluginSkillRoots()),
+    discoverInstalledPluginResidentSkills(),
   );
-  const installedSkills = discoverInstalledPluginResidentSkills();
+}
+
+/**
+ * Merge the two plugin skill groups, dropping any default-plugin skill whose
+ * id an installed plugin also ships. Kept separate from the discovery walks so
+ * the shadowing rule is testable with synthetic summaries.
+ */
+export function mergePluginResidentSkills(
+  defaultSkills: readonly SkillSummary[],
+  installedSkills: readonly SkillSummary[],
+): SkillSummary[] {
   const installedIds = new Set(installedSkills.map((skill) => skill.id));
 
   const survivingDefaults = defaultSkills.filter((skill) => {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -69,9 +69,9 @@ const SkillMetadataSchema = z
  * - `workspace`: user-authored skill living in a conversation's working dir.
  * - `extra`: third-party directory roots passed via `loadSkillCatalog`'s
  *   `extraDirs` argument (primarily for tests).
- * - `plugin`: shipped on disk inside a plugin — an installed one at
+ * - `plugin`: shipped on disk inside a plugin: an installed one at
  *   `<workspaceDir>/plugins/<name>/skills/<id>/SKILL.md`, or an in-process
- *   default at `plugins/defaults/<dir>/skills/<id>/SKILL.md` — attributed back
+ *   default at `plugins/defaults/<dir>/skills/<id>/SKILL.md`, attributed back
  *   to the owning plugin via its `owner` descriptor.
  */
 export type SkillSource =
@@ -751,7 +751,7 @@ function hasLoadablePluginManifest(pluginDir: string): boolean {
  * plugin lives in the assistant's own source tree rather than under
  * `<workspaceDir>/plugins/`, so its skills are enumerated from the roots
  * {@link getDefaultPluginSkillRoots} reports (`defaults/<dir>/skills/`) instead
- * of a workspace scan — there is no `package.json` gate because a default
+ * of a workspace scan; there is no `package.json` gate because a default
  * plugin's manifest is the one the daemon compiles in.
  *
  * `roots` is injectable so tests can exercise the walk against a temp tree; in
@@ -759,7 +759,7 @@ function hasLoadablePluginManifest(pluginDir: string): boolean {
  *
  * A default plugin's disabled sentinel lives in the workspace and is keyed by
  * its `default-<dir>` name, so the gate is {@link isPluginDisabled} at read
- * time — the same read-time check the hook, tool, and route surfaces use, so a
+ * time, the same read-time check the hook, tool, and route surfaces use, so a
  * CLI toggle applies on the next turn without a daemon restart.
  */
 function discoverDefaultPluginResidentSkills(
@@ -790,7 +790,7 @@ function discoverDefaultPluginResidentSkills(
  * `<workspaceDir>/plugins/` (a directory recognized by
  * {@link hasLoadablePluginManifest}), each of which may ship skills at
  * `skills/<id>/SKILL.md`. Returned summaries are attributed to the owning
- * plugin via their `owner` descriptor — `{ kind: "plugin", id: <plugin dir
+ * plugin via their `owner` descriptor: `{ kind: "plugin", id: <plugin dir
  * name> }` for an installed plugin, `{ kind: "plugin", id: "default-<dir>" }`
  * for a default one.
  *
@@ -1057,7 +1057,7 @@ export function loadSkillCatalog(
     catalog.push(skill);
   }
 
-  // Discover skills shipped on disk inside plugins — in-process defaults and
+  // Discover skills shipped on disk inside plugins, in-process defaults and
   // installed plugins alike. They sit above bundled/extra but below managed and
   // workspace so a user-authored filesystem skill can override a
   // plugin-provided skill by declaring the same id under

--- a/assistant/src/plugins/defaults/main.ts
+++ b/assistant/src/plugins/defaults/main.ts
@@ -149,3 +149,34 @@ export function getDefaultPluginRouteRoots(): {
   }
   return roots;
 }
+
+/**
+ * Enumerate default plugins that ship a `skills/` directory, keyed by their
+ * plugin name (`default-<directory-name>`, e.g. `default-platform-hosted`).
+ * Each `skillsDir` holds the plugin's resident skills at `<id>/SKILL.md`, the
+ * same layout an installed plugin uses under
+ * `<workspaceDir>/plugins/<name>/skills/`.
+ *
+ * That name is the key a default plugin's `.disabled` sentinel and per-chat
+ * scoping are keyed by, so a caller gates a root's skills with
+ * `isPluginDisabled(pluginName)`.
+ */
+export function getDefaultPluginSkillRoots(): {
+  pluginName: string;
+  skillsDir: string;
+}[] {
+  const roots: { pluginName: string; skillsDir: string }[] = [];
+  for (const entry of readdirSync(DEFAULTS_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const skillsDir = join(DEFAULTS_DIR, entry.name, "skills");
+    if (existsSync(skillsDir) && statSync(skillsDir).isDirectory()) {
+      roots.push({
+        pluginName: DEFAULT_PLUGIN_NAMESPACE_PREFIX + entry.name,
+        skillsDir,
+      });
+    }
+  }
+  return roots;
+}


### PR DESCRIPTION
## The gap

`loadSkillCatalog()` builds from five sources, and its plugin-resident source scanned only `getWorkspacePluginsDir()`. The in-process default plugins live in the assistant's own source tree (`assistant/src/plugins/defaults/<dir>/`), which that scan never touches — so a default plugin shipping `skills/<id>/SKILL.md` contributed **nothing**, silently. Its hooks, tools, and routes load fine; only its skills vanish, with no warning to diagnose from.

## The fix

- `getDefaultPluginSkillRoots()` in `plugins/defaults/main.ts` — a near-copy of the existing `getDefaultPluginRouteRoots()`: readdir the defaults tree from `import.meta.dir` and return `{ pluginName: "default-<dir>", skillsDir }` for each plugin that ships a `skills/` directory. Safe for the same reason routes are: the assistant ships its source hierarchy as-is.
- Plugin-resident discovery in `config/skills.ts` now walks those roots in addition to the workspace scan. Each skill dir with a valid `SKILL.md` becomes a `SkillSummary` with `source: "plugin"` and `owner: { kind: "plugin", id: "default-<dir>" }`, so per-chat plugin scoping (`filterSkillsByEnabledPlugins`) already routes it correctly — `getEffectiveEnabledPluginSet` unions the `default-*` names.
- Disabled gating is `isPluginDisabled("default-<dir>")` at read time, matching the hook/tool/route surfaces: the sentinel is the workspace file keyed by manifest name (`<workspace>/plugins/default-<dir>/.disabled`), **not** a `.disabled` file in the source tree, so a CLI toggle applies on the next turn without a restart.

## Precedence

Unchanged across sources: `extra` → `bundled` → `plugin` → `managed` → `workspace`.

Within the `plugin` source, **installed plugins outrank defaults**: an installed plugin shipping the same skill id shadows the default one, so a user can replace a first-party skill by installing a plugin that redefines it — the same direction as the catalog's overall ordering. Shadowed defaults are dropped in the discovery pass (with a log line) rather than left to the catalog's first-wins `seenIds` sweep, which would otherwise hand the win to whichever group happened to be emitted first.

## Tests

`discoverPluginResidentSkills()` takes the default roots as an injectable argument (defaulting to `getDefaultPluginSkillRoots()`), so tests drive the walk against a temp tree instead of adding throwaway fixture plugins under `src/`. New `config/__tests__/default-plugin-skill-discovery.test.ts` covers:

- discovery + `owner` stamping with the `default-<dir>` id
- disabled filtering, through the real `isPluginDisabled` against the per-test temp workspace
- installed-plugin same-id override (and that the default's other skills are untouched)
- malformed `SKILL.md` (no frontmatter / missing `description`) skipped, valid siblings still surfaced
- `getDefaultPluginSkillRoots()` returns `[]` cleanly today — no default plugin ships skills on `main`

Also green: `plugin-resident-skill-discovery.test.ts`, `plugin-import-boundary-reverse-guard.test.ts`, `default-plugin-names-guard.test.ts`, `default-plugin-routes.test.ts`, `skills.test.ts`, `available-skills.test.ts`, `skill-load-plugin-scope.test.ts`, `skills-files-catalog-fallback.test.ts`, plus `typecheck:fast` and lint.

The new `skills.ts` → `plugins/defaults/main.ts` import stays inside the reverse import-boundary guard's exemption for host-level shared modules directly under `defaults/` (baseline unchanged).

## Why now

Prerequisite for follow-up work on #39336 — a default plugin there wants to ship a skill, which today would be invisible.

Caught by @dvargasfuertes during review of #39336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->