### PR TITLE
test(cli): keep plugin publish tests off the network

### DIFF
--- a/assistant/src/cli/lib/__tests__/publish-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/publish-plugin.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -50,6 +51,45 @@ function makePluginDir(
     writeFileSync(join(dir, "skills", "my-skill"), "content");
   }
   return dir;
+}
+
+/**
+ * Build a plugin directory backed by a git repo that `resolveGitContext` can
+ * read without touching the network.
+ *
+ * `origin` is a filesystem path under `github.com/<owner>/<repo>.git`, which
+ * satisfies the GitHub-remote match while keeping every git invocation local.
+ * Nothing exists at that path, so the reachability probe resolves offline in
+ * milliseconds and `resolveGitContext` applies its documented fallback of
+ * treating an unanswerable probe as pushed. Pointing `origin` at a real
+ * github.com URL instead makes the probe a live network call, which is slow
+ * and can block on a credential prompt.
+ */
+function makeGitPluginDir(): { dir: string; cleanup: () => void } {
+  const base = mkdtempSync(join(tmpdir(), "publish-"));
+  const remote = join(base, "github.com", "test", "test-plugin.git");
+
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+    // Belt to the local-path suspenders: git must fail rather than wait on a
+    // terminal for credentials.
+    GIT_TERMINAL_PROMPT: "0",
+  };
+  const git = (cwd: string, args: string[]): void => {
+    execFileSync("git", args, { cwd, stdio: "ignore", env });
+  };
+
+  const dir = makePluginDir(base, validPkg, { hooks: true });
+  git(dir, ["init", "--quiet"]);
+  git(dir, ["add", "-A"]);
+  git(dir, ["-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "init"]);
+  git(dir, ["remote", "add", "origin", remote]);
+
+  return { dir, cleanup: () => rmSync(base, { recursive: true, force: true }) };
 }
 
 const validPkg: Partial<ParsedPackageJson> = {
@@ -339,36 +379,25 @@ describe("formatValidationResult", () => {
 
 describe("runPublish", () => {
   it("returns false on denied confirmation without submitting", async () => {
-    const dir = makePluginDir(tmpdir(), validPkg, { hooks: true });
-    // Initialize a git repo so resolveGitContext doesn't fail
-    const { execSync } = await import("node:child_process");
-    const gitEnv = {
-      ...process.env,
-      GIT_AUTHOR_NAME: "Test",
-      GIT_AUTHOR_EMAIL: "test@test.com",
-      GIT_COMMITTER_NAME: "Test",
-      GIT_COMMITTER_EMAIL: "test@test.com",
-    };
-    execSync("git init && git add -A && git commit -m init", {
-      cwd: dir,
-      stdio: "ignore",
-      env: gitEnv,
-    });
-    execSync("git remote add origin https://github.com/test/test-plugin.git", {
-      cwd: dir,
-      stdio: "ignore",
-      env: gitEnv,
-    });
+    const { dir, cleanup } = makeGitPluginDir();
 
+    let confirmed = false;
     const ok = await runPublish(
       { path: dir, force: false, json: false },
       {
-        confirmPrompt: async () => "denied",
+        confirmPrompt: async () => {
+          confirmed = true;
+          return "denied";
+        },
       },
     );
 
     expect(ok).toBe(false);
-    rmSync(dir, { recursive: true });
+    // The flow has to reach the confirmation step for the assertion above to
+    // mean anything: an earlier short-circuit (validation, git resolution)
+    // also returns false.
+    expect(confirmed).toBe(true);
+    cleanup();
   });
 
   it("returns true on --print without submitting", async () => {


### PR DESCRIPTION
De-flakes the CI failure in [run 30403432815](https://github.com/vellum-ai/vellum-assistant/actions/runs/30403432815/job/90423345001?pr=39428): `publish-plugin.test.ts` -> `runPublish > returns false on denied confirmation without submitting` timed out at 5000.94ms and left a dangling git process.

Test-only. No production code changes.

## Prompt / plan

Prompt: "we need to address this failure: <link to the failing job>", then "make this a test only PR, we just want to make this test less flaky".

The fixture set `origin` to `https://github.com/test/test-plugin.git`, so `resolveGitContext`'s `git ls-remote origin <sha>` reachability probe ran as a real network call against a repository that does not exist. On the runner that call stalled past bun's 5s test timeout. The payload the test prints shows up in the job log *after* the timeout, because bun keeps the timed-out promise running, which is why the test looks like it both failed on time and ran to completion. Locally the probe either resolves fast or gets rewritten by a proxy, so the flake only surfaced in CI.

Fix: point `origin` at a filesystem path under `github.com/<owner>/<repo>.git`. It still satisfies the GitHub-remote match in `resolveGitContext`, but the probe now resolves offline in single-digit milliseconds and takes the documented fallback that treats an unanswerable probe as pushed, which is the same branch CI reached after its stall. `GIT_TERMINAL_PROMPT=0` rules out a credential prompt regardless.

The test also asserts the confirmation prompt was reached. Without that, any earlier short-circuit satisfies `expect(ok).toBe(false)`, so it passed for the wrong reason in environments that rewrite github.com URLs, where git resolution failed before the prompt the test means to exercise.

## Test plan

- `bun test src/cli/lib/__tests__/publish-plugin.test.ts` -> 22 pass, 0 fail, ~200ms (was a 5s timeout), run repeatedly with no network access.
- `bunx tsc --noEmit` and `eslint` clean.

## Follow-up (not in this PR)

While tracing the stall I found that `git ls-remote <remote> <sha>` cannot answer "is this commit pushed": ls-remote matches ref *names*, so a commit SHA matches nothing and the command returns empty output for every commit, pushed or not (verified against a bare repo with the commit definitely pushed). `pushed` is therefore only ever true via the `catch` branch, i.e. when the probe fails. Worth a separate look, kept out of this PR to keep it test-only.

Note: the failing job is on #39428, the cherry-pick PR onto `release/v0.11.0`. This lands on `main`, so it needs a cherry-pick onto the release branch to green that PR.
