### PR TITLE
build(web): always regenerate the OpenAPI client on postinstall

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -873,13 +873,13 @@ bun run openapi-ts
 Generated output lives in `src/generated/api/` (gitignored). Codegen runs
 automatically via [npm lifecycle hooks](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts):
 
-- **`postinstall`** — runs after every `bun install`; always regenerates
+- **`postinstall`**: runs after every `bun install`; always regenerates
   (~2s, idempotent) so a stale `src/generated/` from an older checkout or
   worktree can't survive an install and cause phantom `tsc` errors that
   never reproduce in CI.
-- **`predev`** — runs before every `bun run dev`; regenerates so the
+- **`predev`**: runs before every `bun run dev`; regenerates so the
   client stays in sync with the committed specs.
-- **`pretypecheck`** — runs before every `bun run typecheck`; regenerates
+- **`pretypecheck`**: runs before every `bun run typecheck`; regenerates
   for the same reason. A bare `bunx tsc --noEmit` bypasses this hook, so
   prefer `bun run typecheck`.
 

--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -873,10 +873,15 @@ bun run openapi-ts
 Generated output lives in `src/generated/api/` (gitignored). Codegen runs
 automatically via [npm lifecycle hooks](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts):
 
-- **`postinstall`** — runs after every `bun install`; generates the client
-  when `src/generated/` doesn't exist yet (first-time bootstrap).
-- **`predev`** — runs before every `bun run dev`; always regenerates so
-  the client stays in sync with the committed specs.
+- **`postinstall`** — runs after every `bun install`; always regenerates
+  (~2s, idempotent) so a stale `src/generated/` from an older checkout or
+  worktree can't survive an install and cause phantom `tsc` errors that
+  never reproduce in CI.
+- **`predev`** — runs before every `bun run dev`; regenerates so the
+  client stays in sync with the committed specs.
+- **`pretypecheck`** — runs before every `bun run typecheck`; regenerates
+  for the same reason. A bare `bunx tsc --noEmit` bypasses this hook, so
+  prefer `bun run typecheck`.
 
 No manual codegen step is needed — `bun install` + `bun run dev` triggers
 these hooks automatically. Vellum maintainers using the internal `vel`

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -18,7 +18,7 @@
     "audit:cross-domain:check": "node scripts/audit-cross-domain-imports.mjs --check",
     "pretypecheck": "bun run openapi-ts",
     "typecheck": "bunx tsc --noEmit",
-    "postinstall": "test -d src/generated || bun run openapi-ts",
+    "postinstall": "bun run openapi-ts",
     "openapi-ts": "bun run scripts/transform-daemon-spec.ts && bun run scripts/transform-gateway-spec.ts && openapi-ts",
     "ios:setup": "bunx cap sync ios && cd ../ios/App && xcodegen generate --spec project.yml",
     "ios:open": "bun run ios:setup && open ../ios/App/App.xcodeproj",


### PR DESCRIPTION
## TL;DR

`clients/web`'s `postinstall` only ran OpenAPI codegen when `src/generated/` was **missing**, so a stale generated client survived every `bun install`. Anyone running a bare `bunx tsc --noEmit` (which bypasses the `pretypecheck` hook) then hit phantom type errors that never reproduce in CI. This makes `postinstall` regenerate unconditionally and documents all three codegen hooks in `CONVENTIONS.md`.

## Context

Latest instance: after #39431 added the `keenable` web-search provider to `assistant/openapi.yaml`, worktrees whose `src/generated/daemon/types.gen.ts` predated it failed `bunx tsc --noEmit` with TS2322/TS2769 in `debug-api.test.ts` — while CI (which regenerates before typecheck) stayed green. [LUM-2141](https://linear.app/vellum/issue/LUM-2141/appsweb-typecheck-should-regenerate-the-openapi-client-to-prevent) closed this gap for `bun run typecheck` via `pretypecheck` (#32972) but left `postinstall` gated on `test -d src/generated` (from #31222).

## What changes for the user

| | Before | After |
|---|---|---|
| `bun install` with no `src/generated/` | Generates client (first-time bootstrap) | Same |
| `bun install` with a **stale** `src/generated/` | Keeps the stale client; bare `tsc` fails with phantom errors | Regenerates; bare `tsc` matches CI |
| `bun install` wall-clock | — | +~2s (measured 1.7s codegen; install with codegen totals 2.0s) |
| `bun run dev` / `bun run typecheck` / CI | Already regenerate | Unchanged |

## Why this is safe

- **Codegen is idempotent and cheap** — same rationale LUM-2141 used to add `pretypecheck`; measured 1.7s wall for all four jobs, and output is byte-identical when specs haven't changed (verified: clean `git status` after regen).
- **All inputs are committed** — `platform.yaml`/`auth.yaml` are vendored, and `daemon.json`/`gateway.json` derive from the committed `assistant/openapi.yaml` and gateway sources, so codegen works on any checkout (this was already true: the old guard fell through to full codegen on fresh clones).
- **Published tarballs unaffected** — with `src/generated/` absent, the old guard already attempted codegen, so the failure surface for a hypothetical trusted-dependency install is unchanged; bun doesn't run lifecycle scripts for untrusted deps regardless.
- **Verified end-to-end**: planted a stale marker in `types.gen.ts`, ran `bun install` at the workspace root — marker gone, client regenerated, `bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->