### PR TITLE
fix(gateway): complete Telegram setWebhook handshake for platform-connected local assistants (LUM-2899)

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -66,7 +66,7 @@ Slack is **not** handled by this skill. For Slack setup, load the **slack-app-se
 
 ### Telegram
 
-Telegram uses a bot token (not OAuth). Load the **telegram-setup** skill, which uses a managed platform callback route in containerized deployments and falls back to **public-ingress** locally when needed:
+Telegram uses a bot token (not OAuth). Load the **telegram-setup** skill, which uses a managed platform callback route on platform-connected assistants (managed pods and local assistants alike) and falls back to **public-ingress** for self-hosted setups when needed:
 
 - First run `assistant platform status --json`. If it shows managed callback routing is available, tell the user you will use the platform callback route and skip ngrok/public-ingress.
 - Call `skill_load` with `skill: "telegram-setup"` to load the dependency skill.

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -40,7 +40,7 @@ Before using any messaging tool, verify that the platform is connected by callin
 
 ### Public Ingress (required for Telegram)
 
-Telegram setup requires webhook routing, but it does **not** always require ngrok. Before suggesting public ingress for Telegram, check managed callback availability with `assistant platform status --json`. If that reports `isPlatform: true` with a non-empty `assistantId` and `available: true`, use the platform callback route flow and do not prompt for ngrok. Only use the **public-ingress** skill for local assistants that genuinely need a public gateway URL. Slack uses Socket Mode and does not require public ingress. Gmail/Outlook on the desktop app uses a loopback callback and does not require public ingress; the channel path (Path B in the vellum-oauth-integrations skill) handles public ingress internally when needed.
+Telegram setup requires webhook routing, but it does **not** always require ngrok. Before suggesting public ingress for Telegram, check managed callback availability with `assistant platform status --json`. If that reports `available: true` with a non-empty `assistantId`, use the platform callback route flow and do not prompt for ngrok; this applies to managed pods and platform-connected local assistants alike, so do not require `isPlatform: true`. Only use the **public-ingress** skill for local assistants that genuinely need a public gateway URL. Slack uses Socket Mode and does not require public ingress. Gmail/Outlook on the desktop app uses a loopback callback and does not require public ingress; the channel path (Path B in the vellum-oauth-integrations skill) handles public ingress internally when needed.
 
 ### Email Connection Flow
 

--- a/assistant/src/config/webhook-routing.ts
+++ b/assistant/src/config/webhook-routing.ts
@@ -83,6 +83,14 @@ function isIngressExplicitlyDisabled(): boolean {
  *
  * `allowManagedCallbacks` gates both platform tiers: channels that can only be
  * served by a self-hosted ingress pass `false` and never see them.
+ *
+ * The gateway's Telegram webhook reconciler implements this same resolution
+ * order when deciding what URL to hand Telegram's setWebhook
+ * (`resolveExpectedTelegramWebhookUrl` in
+ * `gateway/src/telegram/webhook-manager.ts`). The two must stay in agreement:
+ * a tier this derivation reports as configured but the reconciler declines
+ * leaves Telegram setup reporting success while no webhook is ever registered
+ * (LUM-2899). Change the tiers in both places or not at all.
  */
 export async function hasWebhookRoutingConfigured(
   allowManagedCallbacks = false,

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -366,7 +366,8 @@ describe("reconcileTelegramWebhook", () => {
     expect((calls[2].body as any).secret_token).toBe("test-webhook-secret");
   });
 
-  test("skips managed callback fallback when ingress is explicitly disabled", async () => {
+  test("deregisters the webhook instead of using the managed callback fallback when ingress is explicitly disabled", async () => {
+    const calls: string[] = [];
     const caches = makeCaches({
       ingressUrl: undefined,
       ingressEnabled: false,
@@ -375,18 +376,54 @@ describe("reconcileTelegramWebhook", () => {
       platformAssistantId: "11111111-2222-4333-8444-555555555555",
     });
 
-    fetchMock = mock(async () => new Response("", { status: 200 }));
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.includes("/deleteWebhook")) {
+        calls.push("deleteWebhook");
+        return makeTelegramResponse(true);
+      }
+      calls.push(`unexpected:${url}`);
+      return new Response("Not found", { status: 404 });
+    });
 
     await reconcileTelegramWebhook(caches);
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(calls).toEqual(["deleteWebhook"]);
   });
 
-  test("skips reconciliation when ingress is explicitly disabled even with an ingress URL", async () => {
+  test("deregisters the webhook when ingress is explicitly disabled even with an ingress URL", async () => {
+    const calls: string[] = [];
     const caches = makeCaches({ ingressEnabled: false });
 
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.includes("/deleteWebhook")) {
+        calls.push("deleteWebhook");
+        return makeTelegramResponse(true);
+      }
+      calls.push(`unexpected:${url}`);
+      return new Response("Not found", { status: 404 });
+    });
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toEqual(["deleteWebhook"]);
+  });
+
+  test("does not call Telegram when ingress is disabled but credentials are absent", async () => {
     fetchMock = mock(async () => new Response("", { status: 200 }));
 
+    const caches = makeCaches({ ingressEnabled: false, botToken: undefined });
     await reconcileTelegramWebhook(caches);
 
     expect(fetchMock).not.toHaveBeenCalled();

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -21,6 +21,7 @@ const { reconcileTelegramWebhook } =
 afterEach(() => {
   fetchMock = mock(async () => new Response());
   delete process.env.IS_CONTAINERIZED;
+  delete process.env.IS_PLATFORM;
   delete process.env.VELLUM_PLATFORM_URL;
   delete process.env.ASSISTANT_API_KEY;
 });
@@ -81,8 +82,9 @@ function makeCaches(
     },
     getNumber: () => undefined,
     getBoolean: (section: string, key: string) => {
-      if (section === "ingress" && key === "enabled")
+      if (section === "ingress" && key === "enabled") {
         return opts.ingressEnabled;
+      }
       return undefined;
     },
     getRecord: () => undefined,
@@ -421,6 +423,62 @@ describe("reconcileTelegramWebhook", () => {
     await reconcileTelegramWebhook(caches);
 
     expect(calls).toEqual(["deleteWebhook"]);
+  });
+
+  test("ignores ingress.enabled false on platform pods and registers the managed callback route", async () => {
+    const calls: string[] = [];
+    process.env.IS_PLATFORM = "true";
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      ingressEnabled: false,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "ast-managed-key",
+      platformAssistantId: "11111111-2222-4333-8444-555555555555",
+    });
+
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.includes("/callback-routes/register/")) {
+        calls.push("registerCallbackRoute");
+        return new Response(
+          JSON.stringify({
+            callback_url:
+              "https://platform.example.com/v1/gateway/callbacks/11111111-2222-4333-8444-555555555555/webhooks/telegram/",
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.includes("/deleteWebhook")) {
+        calls.push("deleteWebhook");
+        return makeTelegramResponse(true);
+      }
+      if (url.includes("/getWebhookInfo")) {
+        calls.push("getWebhookInfo");
+        return makeTelegramResponse({
+          url: "",
+          has_custom_certificate: false,
+          pending_update_count: 0,
+        });
+      }
+      if (url.includes("/setWebhook")) {
+        calls.push("setWebhook");
+        return makeTelegramResponse(true);
+      }
+      return new Response("Not found", { status: 404 });
+    });
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toEqual([
+      "registerCallbackRoute",
+      "getWebhookInfo",
+      "setWebhook",
+    ]);
   });
 
   test("does not call Telegram when ingress is disabled but credentials are absent", async () => {

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -398,7 +398,10 @@ describe("reconcileTelegramWebhook", () => {
 
   test("deregisters the webhook when ingress is explicitly disabled even with an ingress URL", async () => {
     const calls: string[] = [];
-    const caches = makeCaches({ ingressEnabled: false });
+    const caches = makeCaches({
+      ingressEnabled: false,
+      ingressUrl: "https://example.ngrok.io",
+    });
 
     fetchMock = mock(async (input: string | URL | Request) => {
       const url =

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -39,6 +39,7 @@ function makeCaches(
     botToken?: string | null;
     webhookSecret?: string | null;
     ingressUrl?: string | null;
+    ingressEnabled?: boolean;
     platformBaseUrl?: string | null;
     assistantApiKey?: string | null;
     platformAssistantId?: string | null;
@@ -79,7 +80,11 @@ function makeCaches(
       return undefined;
     },
     getNumber: () => undefined,
-    getBoolean: () => undefined,
+    getBoolean: (section: string, key: string) => {
+      if (section === "ingress" && key === "enabled")
+        return opts.ingressEnabled;
+      return undefined;
+    },
     getRecord: () => undefined,
     refreshNow: () => {},
   } as unknown as ConfigFileCache;
@@ -293,6 +298,98 @@ describe("reconcileTelegramWebhook", () => {
       "https://platform.example.com/v1/gateway/callbacks/11111111-2222-4333-8444-555555555555/webhooks/telegram/",
     );
     expect((calls[2].body as any).secret_token).toBe("test-webhook-secret");
+  });
+
+  test("registers a managed callback route without IS_CONTAINERIZED when platform credentials are present (LUM-2899)", async () => {
+    const calls: { method: string; body: unknown }[] = [];
+    // IS_CONTAINERIZED deliberately unset: a platform-connected local
+    // assistant must complete the setWebhook handshake for the managed
+    // callback mode that `hasWebhookRoutingConfigured` reports as configured.
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "ast-managed-key",
+      platformAssistantId: "11111111-2222-4333-8444-555555555555",
+    });
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (
+          url ===
+          "https://platform.example.com/v1/internal/gateway/callback-routes/register/"
+        ) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          calls.push({ method: "registerCallbackRoute", body });
+          return new Response(
+            JSON.stringify({
+              callback_url:
+                "https://platform.example.com/v1/gateway/callbacks/11111111-2222-4333-8444-555555555555/webhooks/telegram/",
+            }),
+            {
+              status: 201,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.includes("/getWebhookInfo")) {
+          calls.push({ method: "getWebhookInfo", body: null });
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          calls.push({ method: "setWebhook", body });
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].method).toBe("registerCallbackRoute");
+    expect(calls[1].method).toBe("getWebhookInfo");
+    expect(calls[2].method).toBe("setWebhook");
+    expect((calls[2].body as any).url).toBe(
+      "https://platform.example.com/v1/gateway/callbacks/11111111-2222-4333-8444-555555555555/webhooks/telegram/",
+    );
+    expect((calls[2].body as any).secret_token).toBe("test-webhook-secret");
+  });
+
+  test("skips managed callback fallback when ingress is explicitly disabled", async () => {
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      ingressEnabled: false,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "ast-managed-key",
+      platformAssistantId: "11111111-2222-4333-8444-555555555555",
+    });
+
+    fetchMock = mock(async () => new Response("", { status: 200 }));
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("skips reconciliation when ingress is explicitly disabled even with an ingress URL", async () => {
+    const caches = makeCaches({ ingressEnabled: false });
+
+    fetchMock = mock(async () => new Response("", { status: 200 }));
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("registers via env assistant key and credential cache for assistant ID", async () => {

--- a/gateway/src/feature-flag-resolver.ts
+++ b/gateway/src/feature-flag-resolver.ts
@@ -40,7 +40,7 @@ export function isFeatureFlagEnabled(key: string): boolean {
   return !!getFeatureFlagValue(key);
 }
 
-function isPlatformMode(): boolean {
+export function isPlatformMode(): boolean {
   const v = process.env.IS_PLATFORM?.trim().toLowerCase();
   return v === "true" || v === "1";
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2636,6 +2636,21 @@ async function main() {
         );
       });
 
+      // Vellum credentials are load-bearing for the Telegram webhook URL when
+      // the managed callback fallback applies: a platform connection arriving
+      // or rotating after Telegram setup must repoint Telegram at the managed
+      // callback route without waiting for an unrelated Telegram or ingress
+      // change, or a system wake. Skipped when telegram credentials changed in
+      // the same event, since that branch already reconciled above.
+      if (telegramReady && !changed.has("telegram")) {
+        reconcileTelegramWebhook(telegramCaches).catch((err) => {
+          log.error(
+            { err },
+            "Failed to reconcile Telegram webhook after vellum credential change",
+          );
+        });
+      }
+
       // Force an immediate per-assistant feature-flag re-sync. A `vellum`
       // credential change means a warm-pool claim / key rotation / late
       // provisioning — the assistant identity the platform evaluates flags

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -143,7 +143,9 @@ async function resolveExpectedTelegramWebhookUrl(
   // (LUM-2899).
   //
   //   1. An explicit `ingress.enabled: false` is a decision not to accept
-  //      inbound webhooks at all; it blocks both tiers below.
+  //      inbound webhooks at all; it precedes both tiers below and actively
+  //      deregisters, so `reconcileTelegramWebhook` handles it before calling
+  //      this resolver.
   //   2. A configured public ingress URL wins (a self-hosted tunnel, or the
   //      Velay-published URL while the tunnel is registered).
   //   3. Platform-connected assistants (platform pods and local assistants
@@ -151,10 +153,6 @@ async function resolveExpectedTelegramWebhookUrl(
   //      route. `registerManagedTelegramCallbackRoute` self-gates on platform
   //      features and credential presence, so a gateway with no platform
   //      context resolves to undefined and reconciliation skips.
-  if (caches?.configFile?.getBoolean("ingress", "enabled") === false) {
-    return undefined;
-  }
-
   let ingressUrl: string | undefined;
   if (caches?.configFile) {
     ingressUrl = caches.configFile.getString("ingress", "publicBaseUrl");
@@ -200,6 +198,24 @@ export async function reconcileTelegramWebhook(
     return;
   }
 
+  const apiOpts = caches?.credentials
+    ? { credentials: caches.credentials, configFile: caches?.configFile }
+    : undefined;
+
+  // An explicit `ingress.enabled: false` must actively deregister, not just
+  // skip: Telegram keeps delivering to the last registered webhook URL until
+  // deleteWebhook (or a replacement setWebhook) runs, and the gateway's
+  // /webhooks/telegram route does not consult this flag. deleteWebhook is
+  // idempotent, and pending updates are deliberately kept so re-enabling
+  // ingress does not lose queued messages.
+  if (caches?.configFile?.getBoolean("ingress", "enabled") === false) {
+    await callTelegramApi("deleteWebhook", {}, apiOpts);
+    log.info(
+      "Telegram webhook deregistered: public ingress is explicitly disabled",
+    );
+    return;
+  }
+
   let expectedUrl: string | undefined;
   try {
     expectedUrl = await resolveExpectedTelegramWebhookUrl(caches);
@@ -221,10 +237,6 @@ export async function reconcileTelegramWebhook(
     );
     return;
   }
-
-  const apiOpts = caches?.credentials
-    ? { credentials: caches.credentials, configFile: caches?.configFile }
-    : undefined;
 
   const info = await callTelegramApi<WebhookInfo>(
     "getWebhookInfo",

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -2,7 +2,10 @@ import type { CredentialCache } from "../credential-cache.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import { credentialKey } from "../credential-key.js";
 import { fetchImpl } from "../fetch.js";
-import { arePlatformFeaturesEnabled } from "../feature-flag-resolver.js";
+import {
+  arePlatformFeaturesEnabled,
+  isPlatformMode,
+} from "../feature-flag-resolver.js";
 import { callTelegramApi } from "./api.js";
 import { getLogger } from "../logger.js";
 
@@ -145,7 +148,7 @@ async function resolveExpectedTelegramWebhookUrl(
   //   1. An explicit `ingress.enabled: false` is a decision not to accept
   //      inbound webhooks at all; it precedes both tiers below and actively
   //      deregisters, so `reconcileTelegramWebhook` handles it before calling
-  //      this resolver.
+  //      this resolver. Platform pods are exempt (see the comment there).
   //   2. A configured public ingress URL wins (a self-hosted tunnel, or the
   //      Velay-published URL while the tunnel is registered).
   //   3. Platform-connected assistants (platform pods and local assistants
@@ -208,7 +211,16 @@ export async function reconcileTelegramWebhook(
   // /webhooks/telegram route does not consult this flag. deleteWebhook is
   // idempotent, and pending updates are deliberately kept so re-enabling
   // ingress does not lose queued messages.
-  if (caches?.configFile?.getBoolean("ingress", "enabled") === false) {
+  //
+  // Platform pods are exempt: `hasWebhookRoutingConfigured` resolves the
+  // IS_PLATFORM tier ahead of the explicit-disable check because a pod has no
+  // self-owned ingress to disable, so honoring a stray flag here would delete
+  // the pod's only delivery path while the daemon still reports the channel
+  // as configured (the LUM-2899 divergence in mirror image).
+  if (
+    !isPlatformMode() &&
+    caches?.configFile?.getBoolean("ingress", "enabled") === false
+  ) {
     await callTelegramApi("deleteWebhook", {}, apiOpts);
     log.info(
       "Telegram webhook deregistered: public ingress is explicitly disabled",

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -135,6 +135,26 @@ async function registerManagedTelegramCallbackRoute(
 async function resolveExpectedTelegramWebhookUrl(
   caches?: WebhookManagerCaches,
 ): Promise<string | undefined> {
+  // Resolution order mirrors `hasWebhookRoutingConfigured` in
+  // assistant/src/config/webhook-routing.ts, which is what the daemon's
+  // Telegram config handler and readiness probes report to the user. The two
+  // must agree: a mode that derivation reports as configured but this
+  // resolver declines makes setup report success while setWebhook never runs
+  // (LUM-2899).
+  //
+  //   1. An explicit `ingress.enabled: false` is a decision not to accept
+  //      inbound webhooks at all; it blocks both tiers below.
+  //   2. A configured public ingress URL wins (a self-hosted tunnel, or the
+  //      Velay-published URL while the tunnel is registered).
+  //   3. Platform-connected assistants (platform pods and local assistants
+  //      holding vellum credentials) fall back to a managed platform callback
+  //      route. `registerManagedTelegramCallbackRoute` self-gates on platform
+  //      features and credential presence, so a gateway with no platform
+  //      context resolves to undefined and reconciliation skips.
+  if (caches?.configFile?.getBoolean("ingress", "enabled") === false) {
+    return undefined;
+  }
+
   let ingressUrl: string | undefined;
   if (caches?.configFile) {
     ingressUrl = caches.configFile.getString("ingress", "publicBaseUrl");
@@ -143,13 +163,6 @@ async function resolveExpectedTelegramWebhookUrl(
   if (ingressUrl) {
     const baseUrl = ingressUrl.replace(/\/+$/, "");
     return `${baseUrl}/${TELEGRAM_CALLBACK_PATH}`;
-  }
-
-  // Only fall back to managed callback registration in containerized mode.
-  // A local gateway that happens to have stored vellum credentials should not
-  // silently reroute Telegram webhooks to the platform.
-  if (!process.env.IS_CONTAINERIZED) {
-    return undefined;
   }
 
   return registerManagedTelegramCallbackRoute(caches);

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -35,7 +35,7 @@
     },
     "messaging": {
       "docsSlug": "messaging",
-      "sha256": "bbe48449dc1d19d176ba0bf16988107a8b92eea74dac37e9d05e433947727315"
+      "sha256": "9062a5e7844c17fa099600a760df31608388b8f57d7cd3aef75b50a127b4402d"
     },
     "phone-calls": {
       "docsSlug": "phone-calls",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -35,7 +35,7 @@
     },
     "messaging": {
       "docsSlug": "messaging",
-      "sha256": "9062a5e7844c17fa099600a760df31608388b8f57d7cd3aef75b50a127b4402d"
+      "sha256": "c6f265b9d8bdef9d84b5b5cef3ca19b5cf0a1f270fd64bf4b0f94d9172d23657"
     },
     "phone-calls": {
       "docsSlug": "phone-calls",


### PR DESCRIPTION
Fixes [LUM-2899](https://linear.app/vellum/issue/LUM-2899).

## TL;DR

On a platform-connected local assistant (no `IS_CONTAINERIZED`, no public ingress URL), Telegram setup reported success but the channel was silently dead. The daemon's derivation (`hasWebhookRoutingConfigured`) reports managed platform callbacks as the configured webhook mode and registers the platform callback route, but the gateway reconciler, the only component that ever calls Telegram's `setWebhook`, refused the managed-callback fallback unless `IS_CONTAINERIZED` was set. Telegram was never pointed at any URL.

The gateway reconciler now mirrors the derivation's documented tier order:

1. An explicit `ingress.enabled: false` actively deregisters the webhook via `deleteWebhook` (the user opted out of inbound webhooks, and Telegram would otherwise keep delivering to the last registered URL). Pending updates are kept so re-enabling ingress does not lose queued messages. Platform pods are exempt, matching the derivation where the `IS_PLATFORM` tier resolves first: a pod has no self-owned ingress to disable, so a stray flag must not delete its only delivery path.
2. A configured `ingress.publicBaseUrl` wins (self-hosted tunnel, or the Velay-published URL).
3. Otherwise, fall back to registering a managed platform callback route whenever platform credentials are available, regardless of `IS_CONTAINERIZED`.

The `IS_CONTAINERIZED` gate dated from #21226 (March 2026), before the platform-connected fallback tier became the documented intended behavior. Twilio, OAuth (`resolveCallbackUrl`), and email (`registerEmailCallbackRoute`) already follow the tier order with no containerized gate; the Telegram reconciler was the one holdout. Both sides now cross-reference each other in comments (`webhook-manager.ts` and `webhook-routing.ts`) so the "these two must agree" invariant is visible from either file.

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| Local assistant, platform-connected, no ingress URL | Setup says success; Telegram never receives `setWebhook`; messages silently never arrive; health sweep misleadingly says a webhook it never registered is missing | Setup says success and the gateway points Telegram at the stable platform callback URL; messages flow through the platform callback route |
| Local assistant with `ingress.enabled: false` | Gateway could still register a webhook if a stale `publicBaseUrl` remained in config, and a webhook registered before the opt-out kept delivering | Webhook actively deregistered via `deleteWebhook` on the next reconcile, matching what the daemon derivation reports (platform pods exempt; their tier resolves to managed callbacks first) |
| Platform pods / Docker (`IS_CONTAINERIZED`) | Managed callback registration + `setWebhook` | Unchanged (existing tests kept as-is to prove it) |
| Local self-hosted with configured ingress URL | Webhook registered against the configured URL | Unchanged (ingress tier still wins) |

## Why this is safe

- The managed fallback is not a new code path: `registerManagedTelegramCallbackRoute` is the same function containerized deployments have used since March, and it self-gates on `arePlatformFeaturesEnabled()` plus platform base URL + assistant API key + assistant ID. A gateway with no platform context resolves to `undefined` and skips reconciliation exactly as before.
- The concern that motivated the original gate (silently rerouting an explicitly self-hosted setup through the platform) is already handled by tier order: a configured ingress URL always wins, and `ingress.enabled: false` is now honored as a hard opt-out on the gateway side too, matching the daemon derivation.
- If the platform cannot forward to a given assistant (no Velay tunnel), this converts a silent failure into a detected one: `setWebhook` succeeds, delivery errors surface in Telegram's `getWebhookInfo`, and the existing 5-minute health sweep alerts the guardian instead of the channel staying dark with no signal.
- New regression test covers the exact LUM-2899 scenario (platform credentials, no ingress URL, `IS_CONTAINERIZED` unset), plus three tests pinning the `ingress.enabled: false` opt-out: active deregistration with and without an ingress URL, and no Telegram call when credentials are absent. All 15 tests in the file pass; gateway and assistant typechecks are clean.

Also updated: the messaging skill's Telegram section described the managed callback route as containerized-only, which this PR makes untrue; the wording now says platform-connected. The docs-sync fingerprint for the messaging skill was re-recorded per the bundled-skills process. The public docs page for the messaging skill (vellum.ai/docs/skills-reference/messaging, authored in vellum-assistant-platform) should get the same wording check.

## Deferred

**Velay URL oscillation for the registered Telegram webhook** (to be filed in Linear separately):

On Velay-backed assistants, `reconcileTelegramWebhook` fires on telegram credential changes, on vellum credential changes, on non-Velay ingress config changes, and on system wake, and it registers whatever URL tier resolution produces at that moment. The Velay client writes its published URL into `ingress.publicBaseUrl` on tunnel registration and clears it on every reconnect, so depending on timing the registered webhook URL can oscillate between the raw Velay URL (tier 2, when the tunnel happens to be registered) and the stable platform callback URL (tier 3, when it is not). The config watcher already skips Telegram reconciliation for Velay-only `publicBaseUrl` churn (`isOnlyVelayPublicBaseUrlChange`), but wake- and credential-triggered reconciles still capture whichever URL is present. Candidate fix: prefer the stable platform callback URL over the Velay-published URL for Telegram specifically, since the platform callback URL survives tunnel flaps while the Velay URL does not. Needs a decision on whether other channels that consume `ingress.publicBaseUrl` (Twilio webhook sync, email callback registration) want the same preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
