### PR TITLE
telemetry: emit subagent role and spawn mode so delegated LLM spend is separable

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -2024,6 +2024,61 @@ describe("queryUnreportedUsageEvents", () => {
     expect(events[1].parentTurnIndex).toBeNull();
   });
 
+  // -------------------------------------------------------------------------
+  // Delegated-work decomposition (subagentRole + subagentSpawnMode). Every
+  // subagent variety emits under `llm_call_site = "subagentSpawn"`, so these
+  // two orthogonal columns — stamped on the conversation row at spawn — are
+  // what make advisor consults, forks and regular spawns separable.
+  // -------------------------------------------------------------------------
+
+  test("surfaces subagentRole and subagentSpawnMode from the child conversation", () => {
+    const db = getDb();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, parent_conversation_id, subagent_role, subagent_spawn_mode) VALUES ('advisor-child', 'background', 1000, 1000, 'parent-1', 'advisor', 'advisor_consult')`,
+    );
+    insertEventAt(2000, { conversationId: "advisor-child" });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].subagentRole).toBe("advisor");
+    expect(events[0].subagentSpawnMode).toBe("advisor_consult");
+  });
+
+  test("role and spawn mode are independent — a general subagent can be regular or forked", () => {
+    const db = getDb();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, subagent_role, subagent_spawn_mode) VALUES ('plain-child', 'background', 1000, 1000, 'general', 'regular')`,
+    );
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, subagent_role, subagent_spawn_mode) VALUES ('forked-child', 'background', 1000, 1000, 'general', 'fork')`,
+    );
+    insertEventAt(2000, { conversationId: "plain-child" });
+    insertEventAt(3000, { conversationId: "forked-child" });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(2);
+    expect(events[0].subagentRole).toBe("general");
+    expect(events[0].subagentSpawnMode).toBe("regular");
+    expect(events[1].subagentRole).toBe("general");
+    expect(events[1].subagentSpawnMode).toBe("fork");
+  });
+
+  test("subagent fields are null for ordinary conversations and no-conversation events", () => {
+    const db = getDb();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('conv-plain', 'standard', 500, 500)`,
+    );
+    insertEventAt(1000, { conversationId: "conv-plain" });
+    insertEventAt(2000, { conversationId: null });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(2);
+    expect(events[0].subagentRole).toBeNull();
+    expect(events[0].subagentSpawnMode).toBeNull();
+    expect(events[1].subagentRole).toBeNull();
+    expect(events[1].subagentSpawnMode).toBeNull();
+  });
+
   test("surfaces llmCallCount on unreported events", () => {
     insertEventAt(1000, { llmCallCount: 4 });
     insertEventAt(2000, {});

--- a/assistant/src/__tests__/subagent-spawn-tool-fork.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-tool-fork.test.ts
@@ -301,6 +301,63 @@ describe("subagent_spawn fork parameter", () => {
     }
   });
 
+  // Spawn mode is what makes delegated LLM spend separable: every variety
+  // emits under `llm_call_site = "subagentSpawn"`, so the mode declared here
+  // is the only thing distinguishing a fresh spawn from a context-inheriting
+  // fork downstream.
+  test("declares spawnMode 'fork' for a forked spawn", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+
+    let capturedConfig: Record<string, unknown> | undefined;
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "fork-mode-id";
+    };
+
+    clearConversations();
+    setConversation("spawn-mode-parent", {
+      messages: FAKE_PARENT_MESSAGES,
+      getCurrentSystemPrompt: () => "You are a helpful assistant.",
+    } as any);
+
+    try {
+      await executeSubagentSpawn(
+        { label: "Forked", objective: "Continue", fork: true },
+        makeContext("spawn-mode-parent", { sendToClient: () => {} }),
+      );
+
+      expect(capturedConfig!.spawnMode).toBe("fork");
+    } finally {
+      manager.spawn = originalSpawn;
+      clearConversations();
+    }
+  });
+
+  test("declares spawnMode 'regular' for a non-forked spawn", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+
+    let capturedConfig: Record<string, unknown> | undefined;
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "regular-mode-id";
+    };
+
+    try {
+      await executeSubagentSpawn(
+        { label: "Plain", objective: "Do work", role: "researcher" },
+        makeContext("spawn-mode-conv", { sendToClient: () => {} }),
+      );
+
+      expect(capturedConfig!.spawnMode).toBe("regular");
+      // Role and spawn mode are orthogonal dimensions — both are recorded.
+      expect(capturedConfig!.role).toBe("researcher");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
   test("error when parent conversation cannot be resolved", async () => {
     // Empty store — findConversation will return undefined.
     clearConversations();

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1674,6 +1674,10 @@ describe("Subagent advisor-role consult", () => {
       expect(captured.current).toBeDefined();
       expect(captured.current!.config.fork).toBe(true);
       expect(captured.current!.config.role).toBe("advisor");
+      // The advisor is a ROLE, not an `LLMCallSiteEnum` value — its usage
+      // lands under `subagentSpawn` like any other subagent. The declared
+      // spawn mode is what separates it from a plain fork in cost telemetry.
+      expect(captured.current!.config.spawnMode).toBe("advisor_consult");
       // Framing embeds the executor prompt as advisor system prompt context.
       expect(captured.current!.config.systemPromptOverride).toContain(
         "PARENT SYSTEM PROMPT",

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -5295,6 +5295,12 @@ export async function defaultSpawnBackgroundContinuation(args: {
       objective: args.objective,
       fork: true,
       sendResultToUser: false,
+      // Distinct spawn mode so this unattended continuation is separable in
+      // cost telemetry from a tool-initiated fork. Mechanically both are
+      // forks, but they come from different call sites with different cost
+      // profiles, and lumping them together is what made delegated spend
+      // opaque in the first place.
+      spawnMode: "voice_continuation",
       // Full subagent abilities: the continuation runs like any other
       // background subagent, so it can genuinely finish build-shaped work
       // (JARVIS-1354). Side effects are governed by the standard

--- a/assistant/src/persistence/conversation-bootstrap.ts
+++ b/assistant/src/persistence/conversation-bootstrap.ts
@@ -29,6 +29,19 @@ export interface BootstrapConversationOptions {
    * implies no history inheritance.
    */
   parentConversationId?: string;
+  /**
+   * Role the subagent that owns this conversation was spawned with. Persisted
+   * on the conversation row (not only on the ephemeral `subagents` row) so
+   * usage telemetry can attribute delegated spend per role long after the
+   * subagent record is disposed.
+   */
+  subagentRole?: string;
+  /**
+   * How the subagent that owns this conversation was spawned (`regular`,
+   * `fork`, `advisor_consult`, `voice_continuation`). Orthogonal to
+   * {@link subagentRole}; persisted for the same reason.
+   */
+  subagentSpawnMode?: string;
 }
 
 /**
@@ -63,6 +76,10 @@ export async function bootstrapConversation(
         }),
         ...(opts.parentConversationId && {
           parentConversationId: opts.parentConversationId,
+        }),
+        ...(opts.subagentRole && { subagentRole: opts.subagentRole }),
+        ...(opts.subagentSpawnMode && {
+          subagentSpawnMode: opts.subagentSpawnMode,
         }),
       }),
     { op: "bootstrapConversation" },

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -912,6 +912,14 @@ export function createConversation(
          * `forkParentConversationId` it implies no history inheritance.
          */
         parentConversationId?: string;
+        /**
+         * Role of the subagent that owns this conversation, and how it was
+         * spawned. Persisted here (not only on the ephemeral `subagents` row)
+         * so usage telemetry can decompose delegated spend by variety long
+         * after the subagent record is disposed. See migration 356.
+         */
+        subagentRole?: string;
+        subagentSpawnMode?: string;
       },
 ) {
   const db = getDb();
@@ -955,6 +963,8 @@ export function createConversation(
     scheduleJobId: opts.scheduleJobId ?? null,
     forkParentConversationId: opts.forkParentConversationId ?? null,
     parentConversationId: opts.parentConversationId ?? null,
+    subagentRole: opts.subagentRole ?? null,
+    subagentSpawnMode: opts.subagentSpawnMode ?? null,
     // Snapshot↔stream alignment baseline, captured at the creation instant.
     // 0 (nothing stamped yet this process) is stored as NULL so `/messages`
     // reports null and the client cold-starts rather than aligning to seq 0.

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -258,6 +258,20 @@ export interface UnreportedUsageEvent extends UsageEvent {
    * Null when there's no parent conversation.
    */
   parentTurnIndex: number | null;
+  /**
+   * Role of the subagent that owns this LLM call's conversation, from
+   * `SUBAGENT_ROLE_REGISTRY`. Null for every LLM call that did not run inside
+   * a subagent conversation, and for subagent conversations created before
+   * migration 356 whose `subagents` row had already been disposed.
+   */
+  subagentRole: string | null;
+  /**
+   * How that subagent was spawned (`regular` / `fork` / `advisor_consult` /
+   * `voice_continuation`). Orthogonal to `subagentRole`: the role selects the
+   * child's capabilities, the spawn mode selects its context inheritance and
+   * lifecycle. Null under the same conditions as `subagentRole`.
+   */
+  subagentSpawnMode: string | null;
 }
 
 export function queryUnreportedUsageEvents(
@@ -357,6 +371,11 @@ export function queryUnreportedUsageEvents(
       // the cutoff (child creation for subagent spawns, fork boundary
       // message for retrospective forks). Same eligibility filter as
       // `turnIndex` above.
+      // Stamped on the conversation row at spawn (migration 356) rather than
+      // joined from `subagents`, whose rows are deleted on dispose while this
+      // watermark query can trail far behind after an ingest outage.
+      subagentRole: conversations.subagentRole,
+      subagentSpawnMode: conversations.subagentSpawnMode,
       parentTurnIndex: sql<number | null>`(
         CASE WHEN ${parentIdSql} IS NULL THEN NULL
         ELSE (
@@ -399,6 +418,8 @@ export function queryUnreportedUsageEvents(
     parentConversationId: row.parentConversationId,
     parentTurnIndex:
       row.parentTurnIndex === null ? null : Number(row.parentTurnIndex),
+    subagentRole: row.subagentRole,
+    subagentSpawnMode: row.subagentSpawnMode,
   }));
 }
 

--- a/assistant/src/persistence/migrations/356-add-conversation-subagent-kind.test.ts
+++ b/assistant/src/persistence/migrations/356-add-conversation-subagent-kind.test.ts
@@ -1,0 +1,159 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateAddConversationSubagentKind } from "./356-add-conversation-subagent-kind.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-356 shape: only the columns the migration and tests touch. The
+  // `subagents` table (migration 311) always precedes 356 in the step order
+  // and is the backfill source.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE subagents (
+      id TEXT PRIMARY KEY,
+      parent_conversation_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      is_fork INTEGER NOT NULL
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function kindOf(
+  sqlite: Database,
+  conversationId: string,
+): { role: unknown; mode: unknown } {
+  const row = sqlite
+    .query(
+      "SELECT subagent_role, subagent_spawn_mode FROM conversations WHERE id = ?",
+    )
+    .get(conversationId) as {
+    subagent_role: unknown;
+    subagent_spawn_mode: unknown;
+  };
+  return { role: row.subagent_role, mode: row.subagent_spawn_mode };
+}
+
+function columnInfo(sqlite: Database) {
+  return sqlite.query("PRAGMA table_info(conversations)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+describe("migration 356: conversations subagent role / spawn mode", () => {
+  test("adds both columns, nullable", () => {
+    const { sqlite, db } = createTestDb();
+    const before = columnInfo(sqlite).map((c) => c.name);
+    expect(before).not.toContain("subagent_role");
+    expect(before).not.toContain("subagent_spawn_mode");
+
+    migrateAddConversationSubagentKind(db);
+
+    for (const name of ["subagent_role", "subagent_spawn_mode"]) {
+      const column = columnInfo(sqlite).find((c) => c.name === name);
+      expect(column).toBeDefined();
+      expect(column?.notnull).toBe(0);
+    }
+  });
+
+  test("existing non-subagent rows read back null", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at)
+      VALUES ('conv-1', 1000, 1000)
+    `);
+
+    migrateAddConversationSubagentKind(db);
+
+    expect(kindOf(sqlite, "conv-1")).toEqual({ role: null, mode: null });
+  });
+
+  test("round-trips an insert that sets the new columns", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAddConversationSubagentKind(db);
+
+    sqlite.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at, subagent_role, subagent_spawn_mode)
+      VALUES ('child-1', 2000, 2000, 'researcher', 'regular')
+    `);
+
+    expect(kindOf(sqlite, "child-1")).toEqual({
+      role: "researcher",
+      mode: "regular",
+    });
+  });
+
+  test("backfills role and derives spawn mode from surviving subagents rows", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at) VALUES
+        ('sub-regular', 1000, 1000),
+        ('sub-fork', 2000, 2000),
+        ('sub-advisor', 3000, 3000),
+        ('plain-conv', 4000, 4000);
+      INSERT INTO subagents (id, parent_conversation_id, conversation_id, role, is_fork) VALUES
+        ('s1', 'parent-a', 'sub-regular', 'coder', 0),
+        ('s2', 'parent-b', 'sub-fork', 'general', 1),
+        ('s3', 'parent-c', 'sub-advisor', 'advisor', 1);
+    `);
+
+    migrateAddConversationSubagentKind(db);
+
+    expect(kindOf(sqlite, "sub-regular")).toEqual({
+      role: "coder",
+      mode: "regular",
+    });
+    expect(kindOf(sqlite, "sub-fork")).toEqual({
+      role: "general",
+      mode: "fork",
+    });
+    // The advisor is a role, so the derived mode must be `advisor_consult`
+    // rather than the bare `fork` its `is_fork` flag would otherwise imply.
+    expect(kindOf(sqlite, "sub-advisor")).toEqual({
+      role: "advisor",
+      mode: "advisor_consult",
+    });
+    // Conversations with no surviving subagents row stay unattributed.
+    expect(kindOf(sqlite, "plain-conv")).toEqual({ role: null, mode: null });
+  });
+
+  test("backfill does not overwrite already-stamped values", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAddConversationSubagentKind(db);
+    sqlite.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at, subagent_role, subagent_spawn_mode)
+      VALUES ('stamped', 1000, 1000, 'general', 'voice_continuation');
+      INSERT INTO subagents (id, parent_conversation_id, conversation_id, role, is_fork)
+      VALUES ('s1', 'parent-stale', 'stamped', 'general', 1);
+    `);
+
+    migrateAddConversationSubagentKind(db);
+
+    expect(kindOf(sqlite, "stamped")).toEqual({
+      role: "general",
+      mode: "voice_continuation",
+    });
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateAddConversationSubagentKind(db);
+    expect(() => migrateAddConversationSubagentKind(db)).not.toThrow();
+
+    const names = columnInfo(sqlite).map((c) => c.name);
+    expect(names.filter((n) => n === "subagent_role")).toHaveLength(1);
+    expect(names.filter((n) => n === "subagent_spawn_mode")).toHaveLength(1);
+  });
+});

--- a/assistant/src/persistence/migrations/356-add-conversation-subagent-kind.ts
+++ b/assistant/src/persistence/migrations/356-add-conversation-subagent-kind.ts
@@ -1,0 +1,79 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const ROLE_COLUMN = "subagent_role";
+const SPAWN_MODE_COLUMN = "subagent_spawn_mode";
+
+/**
+ * Add `subagent_role` and `subagent_spawn_mode` columns to `conversations`.
+ *
+ * Both are nullable, free-form strings describing the subagent that owns the
+ * conversation: the role it was spawned with (`general`, `researcher`,
+ * `coder`, `planner`, `investigator`, `advisor`) and how it was spawned
+ * (`regular`, `fork`, `advisor_consult`, `voice_continuation`). NULL for
+ * every conversation that is not a subagent.
+ *
+ * Together they make delegated LLM spend separable. Every subagent variety —
+ * a fire-and-forget spawn, a context-inheriting fork, and an advisor consult
+ * — emits usage under `llm_call_site = "subagentSpawn"` in a child
+ * conversation, so the largest descendant cost bucket could not be
+ * decomposed. The advisor in particular is a ROLE, not a call site.
+ *
+ * Denormalized onto `conversations` rather than joined from `subagents` at
+ * telemetry-flush time because `subagents` rows are deleted on dispose (TTL
+ * sweep ~30 minutes after the run goes terminal) while usage telemetry
+ * flushes on a watermark that can trail arbitrarily far behind after an
+ * ingest outage. Same rationale that put `parent_conversation_id` here
+ * (migration 342). No index: these are projected alongside an existing
+ * primary-key join, never filtered on.
+ *
+ * Backfills from the `subagents` table (migration 311) for subagents that
+ * have not yet been disposed, which links unflushed usage rows of
+ * pre-migration subagents. The spawn mode is derived from the surviving
+ * `role` / `is_fork` columns; long-disposed subagents have no surviving
+ * linkage anywhere and correctly stay NULL. The derivation cannot recover
+ * `voice_continuation` (the live-voice continuation is an unlabelled fork
+ * pre-migration), so those rows backfill as `fork` — a small, bounded
+ * inaccuracy confined to the backfill window.
+ *
+ * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
+ * TABLE` and the checkpoint write doesn't cause a duplicate-column error on
+ * the next boot, and the backfill only fills NULL rows for the same reason.
+ */
+export function migrateAddConversationSubagentKind(database: DrizzleDb): void {
+  if (!tableHasColumn(database, "conversations", ROLE_COLUMN)) {
+    database.run(`ALTER TABLE conversations ADD COLUMN ${ROLE_COLUMN} TEXT`);
+  }
+  if (!tableHasColumn(database, "conversations", SPAWN_MODE_COLUMN)) {
+    database.run(
+      `ALTER TABLE conversations ADD COLUMN ${SPAWN_MODE_COLUMN} TEXT`,
+    );
+  }
+  database.run(`
+    UPDATE conversations
+    SET subagent_role = (
+      SELECT s.role FROM subagents s
+      WHERE s.conversation_id = conversations.id
+    )
+    WHERE subagent_role IS NULL
+      AND EXISTS (
+        SELECT 1 FROM subagents s WHERE s.conversation_id = conversations.id
+      )
+  `);
+  database.run(`
+    UPDATE conversations
+    SET subagent_spawn_mode = (
+      SELECT CASE
+        WHEN s.role = 'advisor' THEN 'advisor_consult'
+        WHEN s.is_fork = 1 THEN 'fork'
+        ELSE 'regular'
+      END
+      FROM subagents s
+      WHERE s.conversation_id = conversations.id
+    )
+    WHERE subagent_spawn_mode IS NULL
+      AND EXISTS (
+        SELECT 1 FROM subagents s WHERE s.conversation_id = conversations.id
+      )
+  `);
+}

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -45,6 +45,32 @@ export const conversations = sqliteTable(
      * conversations not spawned by another conversation.
      */
     parentConversationId: text("parent_conversation_id"),
+    /**
+     * Role the subagent that owns this conversation was spawned with, from
+     * `SUBAGENT_ROLE_REGISTRY` (`general`, `researcher`, `coder`, `planner`,
+     * `investigator`, `advisor`). NULL for every conversation that is not a
+     * subagent.
+     *
+     * Denormalized here rather than read from the `subagents` table at
+     * telemetry-flush time on purpose: `subagents` rows are deleted on
+     * dispose (TTL sweep ~30 minutes after the run goes terminal), while
+     * usage telemetry flushes on a watermark that can trail arbitrarily far
+     * behind after an ingest outage. Stamping the conversation row — the same
+     * rationale that put `parent_conversation_id` here — makes the
+     * attribution durable for the life of the usage row.
+     */
+    subagentRole: text("subagent_role"),
+    /**
+     * How the subagent that owns this conversation was spawned — context
+     * inheritance and lifecycle, orthogonal to {@link subagentRole}:
+     * `regular` (fire-and-forget `subagent_spawn`, fresh objective-only
+     * context), `fork` (`subagent_spawn` with `fork: true`, inherits the
+     * parent transcript), `advisor_consult` (synchronous tool-less advisor
+     * consult the parent turn blocks on), `voice_continuation` (silent
+     * read-only live-voice continuation of an interrupted turn). NULL for
+     * every conversation that is not a subagent.
+     */
+    subagentSpawnMode: text("subagent_spawn_mode"),
     isAutoTitle: integer("is_auto_title").notNull().default(1),
     scheduleJobId: text("schedule_job_id"),
     lastMessageAt: integer("last_message_at"),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -462,6 +462,7 @@ import { migrateScheduleSkillScriptHandoff } from "./migrations/351-schedule-ski
 import { migrateDropScheduleSkillScriptHandoff } from "./migrations/352-drop-schedule-skill-script-handoff.js";
 import { migrateAddLlmUsageConversationType } from "./migrations/353-add-llm-usage-conversation-type.js";
 import { migrateBackfillAppConversationLineage } from "./migrations/354-backfill-app-conversation-lineage.js";
+import { migrateAddConversationSubagentKind } from "./migrations/356-add-conversation-subagent-kind.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1481,4 +1482,11 @@ export const migrationSteps: MigrationStep[] = [
   migrateDropScheduleSkillScriptHandoff,
   migrateAddLlmUsageConversationType,
   migrateBackfillAppConversationLineage,
+  {
+    name: "migrateAddConversationSubagentKind",
+    run: migrateAddConversationSubagentKind,
+    // The backfill reads the `subagents` table (migration 311), so that table
+    // must exist and be checkpointed first.
+    dependsOn: ["migrateCreateSubagentsTable"],
+  },
 ];

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -27,6 +27,9 @@ mock.module("../registry.js", () => ({
 // ── Imports (after mocks) ───────────────────────────────────────────────────
 
 import { CODE_DEFAULT_PROFILE_ENTRIES } from "../../config/default-profile-catalog.js";
+import { getDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { resetSubagentAttributionCacheForTests } from "../../usage/subagent-attribution.js";
 import { RetryProvider } from "../retry.js";
 import type {
   Message,
@@ -186,6 +189,70 @@ describe("RetryProvider — callSite resolution", () => {
         "X-Vellum-LLM-Call-Site-Label"
       ],
     ).toBeUndefined();
+  });
+
+  // Delegated-work attribution on the authoritative billing path. Every
+  // subagent variety shares `llm_call_site = "subagentSpawn"`, so these two
+  // orthogonal headers are what let rated usage be decomposed by variety.
+  test("forwards subagent role and spawn mode headers for a subagent conversation", async () => {
+    await initializeDb();
+    resetSubagentAttributionCacheForTests();
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, subagent_role, subagent_spawn_mode)
+       VALUES ('conv-retry-advisor', 'background', 1000, 1000, 'advisor', 'advisor_consult')`,
+    );
+    setLlmConfig({
+      callSites: { subagentSpawn: { provider: "openai", model: "gpt-sub" } },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("openai", (options) => {
+        seen = options;
+      }),
+      { forwardUsageAttributionHeaders: true },
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: {
+        callSite: "subagentSpawn",
+        conversationId: "conv-retry-advisor",
+      },
+    });
+
+    const headers = (seen?.config as Record<string, unknown>)
+      .usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Subagent-Role"]).toBe("advisor");
+    expect(headers["X-Vellum-Subagent-Spawn-Mode"]).toBe("advisor_consult");
+  });
+
+  test("omits subagent headers for a conversation that is not a subagent", async () => {
+    await initializeDb();
+    resetSubagentAttributionCacheForTests();
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at)
+       VALUES ('conv-retry-plain', 'standard', 1000, 1000)`,
+    );
+    setLlmConfig({
+      callSites: { subagentSpawn: { provider: "openai", model: "gpt-sub" } },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("openai", (options) => {
+        seen = options;
+      }),
+      { forwardUsageAttributionHeaders: true },
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "subagentSpawn", conversationId: "conv-retry-plain" },
+    });
+
+    const headers = (seen?.config as Record<string, unknown>)
+      .usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Subagent-Role"]).toBeUndefined();
+    expect(headers["X-Vellum-Subagent-Spawn-Mode"]).toBeUndefined();
   });
 
   test("omits attribution headers by default for direct provider transports", async () => {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -4,6 +4,7 @@ import {
   resolveUsageAttribution,
   sanitizeUsageMetadataValue,
 } from "../usage/attribution.js";
+import { resolveSubagentAttribution } from "../usage/subagent-attribution.js";
 import { ProviderError, type ProviderErrorReason } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -41,6 +42,12 @@ const USAGE_ATTRIBUTION_HEADER_NAMES = {
   resolvedProvider: "X-Vellum-Resolved-Provider",
   resolvedModel: "X-Vellum-Resolved-Model",
   resolvedMixArm: "X-Vellum-Resolved-Mix-Arm",
+  // Delegated-work attribution. Every subagent variety shares
+  // `llm_call_site = "subagentSpawn"`, so on the authoritative billing path
+  // these two orthogonal dimensions are the only way to tell an advisor
+  // consult from a fork from a regular spawn.
+  subagentRole: "X-Vellum-Subagent-Role",
+  subagentSpawnMode: "X-Vellum-Subagent-Spawn-Mode",
 } as const;
 
 /** Providers whose transports consume `promptCacheKey` (OpenAI Responses
@@ -414,6 +421,10 @@ function normalizeSendMessageOptions(
     // downstream as a wire-format field.
     delete nextConfig.callSite;
     if (normalizeOptions.forwardUsageAttributionHeaders === true) {
+      // Read from the conversation row rather than the live SubagentManager:
+      // the row is durable and the lookup is a memoized primary-key read that
+      // can never throw, so billing attribution cannot destabilize dispatch.
+      const subagent = resolveSubagentAttribution(config.conversationId);
       const usageAttributionHeaders = buildUsageAttributionHeaders({
         callSite: attribution.callSite,
         appliedProfile: attribution.appliedProfile,
@@ -421,6 +432,8 @@ function normalizeSendMessageOptions(
         resolvedProvider: attribution.resolvedProvider,
         resolvedModel: attribution.resolvedModel,
         resolvedMixArm: attribution.resolvedMixArm,
+        subagentRole: subagent.subagentRole,
+        subagentSpawnMode: subagent.subagentSpawnMode,
       });
       if (Object.keys(usageAttributionHeaders).length > 0) {
         nextConfig.usageAttributionHeaders = usageAttributionHeaders;
@@ -746,6 +759,8 @@ function buildUsageAttributionHeaders(input: {
   resolvedProvider: string;
   resolvedModel: string;
   resolvedMixArm: string | null;
+  subagentRole: string | null;
+  subagentSpawnMode: string | null;
 }): Record<string, string> {
   const headers: Record<string, string> = {};
   addSanitizedHeader(
@@ -779,6 +794,16 @@ function buildUsageAttributionHeaders(input: {
     headers,
     USAGE_ATTRIBUTION_HEADER_NAMES.resolvedMixArm,
     input.resolvedMixArm,
+  );
+  addSanitizedHeader(
+    headers,
+    USAGE_ATTRIBUTION_HEADER_NAMES.subagentRole,
+    input.subagentRole,
+  );
+  addSanitizedHeader(
+    headers,
+    USAGE_ATTRIBUTION_HEADER_NAMES.subagentSpawnMode,
+    input.subagentSpawnMode,
   );
   return headers;
 }

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -42,6 +42,7 @@ import {
   SUBAGENT_ROLE_REGISTRY,
   type SubagentConfig,
   type SubagentRole,
+  type SubagentSpawnMode,
   type SubagentState,
   type SubagentStatus,
   TERMINAL_STATUSES,
@@ -370,14 +371,29 @@ export class SubagentManager {
     }
     const roleConfig = SUBAGENT_ROLE_REGISTRY[role];
 
+    // ── Resolve spawn mode ───────────────────────────────────────────
+    // The spawning call site is the only layer that can tell an advisor
+    // consult or a live-voice continuation apart from a plain fork, so it
+    // declares its mode. The fallback is mechanical rather than NULL: a
+    // future call site that forgets still records honest context-inheritance
+    // shape instead of dropping out of the telemetry breakdown entirely.
+    const spawnMode: SubagentSpawnMode =
+      config.spawnMode ?? (isFork ? "fork" : "regular");
+
     // ── Create conversation ─────────────────────────────────────────
     const subagentId = uuid();
+    // `subagentRole` / `subagentSpawnMode` are stamped on the conversation
+    // row, not just the `subagents` row, because `subagents` rows are deleted
+    // on dispose while usage telemetry flushes on a watermark that can trail
+    // far behind. See migration 356.
     const conversationRecord = await bootstrapConversation({
       conversationType: "background",
       source: "subagent",
       origin: "subagent",
       systemHint: `Subagent: ${config.label}`,
       parentConversationId: config.parentConversationId,
+      subagentRole: role,
+      subagentSpawnMode: spawnMode,
     });
 
     // ── Build conversation dependencies ─────────────────────────────

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -50,6 +50,19 @@ export interface SubagentConfig {
   /** Optional role for the subagent. Defaults handled by consumers. */
   role?: SubagentRole;
   /**
+   * How this subagent was spawned — the call site and its context/lifecycle
+   * shape. Stamped onto the child conversation row and emitted as
+   * `subagent_spawn_mode` on `llm_usage` telemetry so delegated spend is
+   * separable per variety.
+   *
+   * Set by the spawning call site, which is the only layer that knows: the
+   * manager cannot tell an advisor consult from a plain fork, nor a live-voice
+   * continuation from a tool-initiated one. Omitting it falls back to the
+   * mechanical `fork ? "fork" : "regular"`, so a future call site that forgets
+   * still lands on an honest value rather than NULL.
+   */
+  spawnMode?: SubagentSpawnMode;
+  /**
    * When true, side-effecting tools (send/write/delete/purchase, host commands)
    * are refused for this subagent regardless of trust class — the executor
    * rejects any such dispatch and the tool is kept off the model's tool surface.
@@ -141,6 +154,34 @@ export type SubagentRole =
   | "planner"
   | "investigator"
   | "advisor";
+
+// ── Spawn modes ──────────────────────────────────────────────────────────
+
+/**
+ * How a subagent was spawned. Orthogonal to {@link SubagentRole}: the role
+ * selects the tool allowlist and system-prompt preamble (what the child may
+ * do), the spawn mode selects context inheritance and lifecycle (how many
+ * input tokens the child starts with, and whether the parent blocks on it).
+ * A fork's inherited parent transcript is the dominant input-token driver and
+ * is independent of which role ran, which is why neither field subsumes the
+ * other.
+ *
+ * - `regular` — fire-and-forget `subagent_spawn`, fresh objective-only context.
+ * - `fork` — `subagent_spawn` with `fork: true`, inherits the parent transcript.
+ * - `advisor_consult` — synchronous, tool-less advisor consult on the advisor
+ *   profile; the parent turn blocks on it and returns its guidance inline.
+ * - `voice_continuation` — silent, read-only live-voice background
+ *   continuation of an interrupted turn.
+ *
+ * Mirrored on the wire as `llm_usage.subagent_spawn_mode`, which is an OPEN
+ * string set on the platform side: adding a value here needs no coordinated
+ * platform release.
+ */
+export type SubagentSpawnMode =
+  | "regular"
+  | "fork"
+  | "advisor_consult"
+  | "voice_continuation";
 
 export interface SubagentRoleConfig {
   /**

--- a/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
+++ b/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
@@ -43,6 +43,8 @@ const llmUsage: LlmUsageTelemetryEvent = {
   // Zero is legitimate (wire bound is min(0)): a subagent can be spawned
   // before the parent's first real user turn.
   parent_turn_index: 0,
+  subagent_role: "advisor",
+  subagent_spawn_mode: "advisor_consult",
   provider: "anthropic",
   model: "claude-fable-5",
   input_tokens: 1200,

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -281,6 +281,12 @@ const usageSource = simpleSource(
     turn_index: e.turnIndex,
     parent_conversation_id: e.parentConversationId,
     parent_turn_index: e.parentTurnIndex,
+    // Delegated-work decomposition. Every subagent variety shares
+    // `llm_call_site = "subagentSpawn"`; these two orthogonal dimensions are
+    // what make advisor consults, forks, and regular spawns separable. Null
+    // for the vast majority of calls, which are not delegated at all.
+    subagent_role: e.subagentRole,
+    subagent_spawn_mode: e.subagentSpawnMode,
     provider: e.provider,
     model: e.model,
     input_tokens: e.inputTokens,

--- a/assistant/src/telemetry/telemetry-wire.generated.ts
+++ b/assistant/src/telemetry/telemetry-wire.generated.ts
@@ -95,6 +95,8 @@ export const llmUsageTelemetryEventSchema = z.object({
     .nullable()
     .optional(),
   parent_turn_index: z.number().int().min(0).nullable().optional(),
+  subagent_role: z.string().trim().min(1).max(64).nullable().optional(),
+  subagent_spawn_mode: z.string().trim().min(1).max(64).nullable().optional(),
 });
 export type LlmUsageTelemetryEvent = z.infer<
   typeof llmUsageTelemetryEventSchema

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -114,6 +114,23 @@ export interface LlmUsageTelemetryEvent extends TelemetryEventBase {
    * parent conversation.
    */
   parent_turn_index: number | null;
+  /**
+   * Role the subagent that owns this event's conversation was spawned with
+   * (`general`, `researcher`, `coder`, `planner`, `investigator`, `advisor`).
+   * The advisor is a ROLE, not an `LLMCallSiteEnum` value, so this is the only
+   * thing that tells an advisor consult apart from a regular subagent — both
+   * emit under `llm_call_site = "subagentSpawn"`. Null when the LLM call did
+   * not run inside a subagent conversation.
+   */
+  subagent_role: string | null;
+  /**
+   * How that subagent was spawned: `regular`, `fork`, `advisor_consult`, or
+   * `voice_continuation`. Orthogonal to `subagent_role` — the role selects the
+   * child's capabilities, the spawn mode selects its context inheritance and
+   * lifecycle (a fork's inherited transcript dominates its input tokens
+   * regardless of role). Null under the same condition as `subagent_role`.
+   */
+  subagent_spawn_mode: string | null;
   provider: string;
   model: string;
   input_tokens: number;

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -260,6 +260,8 @@ type UnreportedUsageEventFixture = UsageEvent & {
   turnIndex: number | null;
   parentConversationId: string | null;
   parentTurnIndex: number | null;
+  subagentRole: string | null;
+  subagentSpawnMode: string | null;
 };
 
 function makeUsageEvent(
@@ -290,6 +292,8 @@ function makeUsageEvent(
     turnIndex: 1,
     parentConversationId: null,
     parentTurnIndex: null,
+    subagentRole: null,
+    subagentSpawnMode: null,
     llmCallCount: 1,
     ...overrides,
   };

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -212,6 +212,11 @@ export async function executeSubagentSpawn(
         // Regular forks omit the role so they default to general; the advisor
         // role is special-cased earlier via runAdvisorConsult, not here.
         ...(!fork && role ? { role: role as SubagentRole } : {}),
+        // Declare the spawn mode so delegated LLM spend is separable in
+        // telemetry: every variety shares `llm_call_site = "subagentSpawn"`,
+        // and a fork's inherited transcript costs very differently from a
+        // fresh objective-only spawn.
+        spawnMode: fork ? "fork" : "regular",
         ...(inheritedOverrideProfile
           ? { overrideProfile: inheritedOverrideProfile }
           : {}),
@@ -327,6 +332,10 @@ async function runAdvisorConsult(args: {
           sendResultToUser: false,
           role: "advisor",
           fork: true,
+          // The advisor is a ROLE, not an `LLMCallSiteEnum` value — its usage
+          // lands under `subagentSpawn` like any other subagent. This is what
+          // makes advisor consults separable from regular forks in telemetry.
+          spawnMode: "advisor_consult",
           parentMessages: sanitizedMessages,
           systemPromptOverride: buildAdvisorSystem(parentSystemPrompt),
           ...(overrideProfile ? { overrideProfile } : {}),

--- a/assistant/src/usage/__tests__/subagent-attribution.test.ts
+++ b/assistant/src/usage/__tests__/subagent-attribution.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import {
+  resetSubagentAttributionCacheForTests,
+  resolveSubagentAttribution,
+} from "../subagent-attribution.js";
+
+await initializeDb();
+
+let counter = 0;
+
+function insertConversation(opts: {
+  subagentRole?: string;
+  subagentSpawnMode?: string;
+}): string {
+  counter += 1;
+  const id = `conv-attr-${counter}`;
+  const db = getDb();
+  db.run(
+    `INSERT INTO conversations (id, conversation_type, created_at, updated_at, subagent_role, subagent_spawn_mode)
+     VALUES ('${id}', 'background', 1000, 1000, ${
+       opts.subagentRole === undefined ? "NULL" : `'${opts.subagentRole}'`
+     }, ${
+       opts.subagentSpawnMode === undefined
+         ? "NULL"
+         : `'${opts.subagentSpawnMode}'`
+     })`,
+  );
+  return id;
+}
+
+describe("resolveSubagentAttribution", () => {
+  beforeEach(() => {
+    resetSubagentAttributionCacheForTests();
+  });
+
+  test("returns the stamped role and spawn mode for a subagent conversation", () => {
+    const id = insertConversation({
+      subagentRole: "advisor",
+      subagentSpawnMode: "advisor_consult",
+    });
+
+    expect(resolveSubagentAttribution(id)).toEqual({
+      subagentRole: "advisor",
+      subagentSpawnMode: "advisor_consult",
+    });
+  });
+
+  test("returns nulls for an ordinary conversation", () => {
+    const id = insertConversation({});
+
+    expect(resolveSubagentAttribution(id)).toEqual({
+      subagentRole: null,
+      subagentSpawnMode: null,
+    });
+  });
+
+  test("returns nulls without a conversation id", () => {
+    expect(resolveSubagentAttribution(undefined)).toEqual({
+      subagentRole: null,
+      subagentSpawnMode: null,
+    });
+    expect(resolveSubagentAttribution("")).toEqual({
+      subagentRole: null,
+      subagentSpawnMode: null,
+    });
+  });
+
+  test("returns nulls for an unknown conversation and does not cache the miss", () => {
+    // The columns are stamped at conversation creation, so a miss means the
+    // row has not landed yet — caching it would pin an empty result.
+    expect(resolveSubagentAttribution("conv-not-yet")).toEqual({
+      subagentRole: null,
+      subagentSpawnMode: null,
+    });
+
+    const db = getDb();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, subagent_role, subagent_spawn_mode)
+       VALUES ('conv-not-yet', 'background', 1000, 1000, 'coder', 'regular')`,
+    );
+
+    expect(resolveSubagentAttribution("conv-not-yet")).toEqual({
+      subagentRole: "coder",
+      subagentSpawnMode: "regular",
+    });
+  });
+
+  test("memoizes a resolved conversation", () => {
+    const id = insertConversation({
+      subagentRole: "general",
+      subagentSpawnMode: "fork",
+    });
+    expect(resolveSubagentAttribution(id).subagentSpawnMode).toBe("fork");
+
+    // The columns are immutable after creation, so a later write must not be
+    // observable — proving the second call did not hit the database.
+    const db = getDb();
+    db.run(
+      `UPDATE conversations SET subagent_spawn_mode = 'regular' WHERE id = '${id}'`,
+    );
+
+    expect(resolveSubagentAttribution(id).subagentSpawnMode).toBe("fork");
+    resetSubagentAttributionCacheForTests();
+    expect(resolveSubagentAttribution(id).subagentSpawnMode).toBe("regular");
+  });
+});

--- a/assistant/src/usage/subagent-attribution.ts
+++ b/assistant/src/usage/subagent-attribution.ts
@@ -56,26 +56,11 @@ export function resolveSubagentAttribution(
     return cached;
   }
 
-  let row: { subagent_role: string | null; subagent_spawn_mode: string | null };
-  try {
-    const found = rawGet<{
-      subagent_role: string | null;
-      subagent_spawn_mode: string | null;
-    }>(
-      "usage:subagentAttribution",
-      `SELECT subagent_role, subagent_spawn_mode FROM conversations WHERE id = ?`,
-      conversationId,
-    );
-    if (!found) {
-      // No row (yet). Deliberately NOT cached: caching a miss would pin an
-      // empty result for a conversation whose row lands moments later.
-      return NOT_A_SUBAGENT;
-    }
-    row = found;
-  } catch (err) {
-    // Includes the pre-migration case (column absent) and any DB-unavailable
-    // context such as unit tests that exercise the provider stack alone.
-    log.debug({ err, conversationId }, "Subagent attribution lookup failed");
+  const row = readRow(conversationId);
+  if (!row) {
+    // Either no row yet, or the read failed. Deliberately NOT cached: caching
+    // a miss would pin an empty result for a conversation whose row lands
+    // moments later, or for the whole process after one transient DB error.
     return NOT_A_SUBAGENT;
   }
 
@@ -91,6 +76,30 @@ export function resolveSubagentAttribution(
   }
   cache.set(conversationId, attribution);
   return attribution;
+}
+
+interface ConversationSubagentRow {
+  subagent_role: string | null;
+  subagent_spawn_mode: string | null;
+}
+
+/**
+ * Read the two columns, or `null` when the conversation has no row or the
+ * read fails. Failure covers the pre-migration case (columns absent) and any
+ * DB-unavailable context, such as a unit test exercising the provider stack
+ * alone — attribution must never be able to take a model request down.
+ */
+function readRow(conversationId: string): ConversationSubagentRow | null {
+  try {
+    return rawGet<ConversationSubagentRow>(
+      "usage:subagentAttribution",
+      `SELECT subagent_role, subagent_spawn_mode FROM conversations WHERE id = ?`,
+      conversationId,
+    );
+  } catch (err) {
+    log.debug({ err, conversationId }, "Subagent attribution lookup failed");
+    return null;
+  }
 }
 
 /** Test seam — drops every memoized entry. */

--- a/assistant/src/usage/subagent-attribution.ts
+++ b/assistant/src/usage/subagent-attribution.ts
@@ -1,0 +1,99 @@
+import { rawGet } from "../persistence/raw-query.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("subagent-attribution");
+
+/**
+ * The two delegated-work attribution dimensions carried on a conversation:
+ * the subagent role it was spawned with, and how it was spawned. Both null
+ * for a conversation that is not a subagent.
+ */
+export interface SubagentAttribution {
+  subagentRole: string | null;
+  subagentSpawnMode: string | null;
+}
+
+const NOT_A_SUBAGENT: SubagentAttribution = {
+  subagentRole: null,
+  subagentSpawnMode: null,
+};
+
+/**
+ * Bound on the memo below. Both columns are stamped once at conversation
+ * creation and never updated, so a hit is always correct and the only cost of
+ * a bounded cache is an occasional re-read. Sized to comfortably cover the
+ * conversations resident in one process without becoming a memory concern.
+ */
+const MAX_CACHED_CONVERSATIONS = 2048;
+
+/**
+ * Insertion-ordered memo. `Map` iteration order is insertion order, so
+ * dropping the first key evicts the oldest entry — sufficient for a lookup
+ * whose values are immutable and whose miss cost is a single primary-key read.
+ */
+const cache = new Map<string, SubagentAttribution>();
+
+/**
+ * Resolve the delegated-work attribution for a conversation, for forwarding on
+ * the runtime proxy's `X-Vellum-Subagent-*` headers.
+ *
+ * Reads the columns stamped at spawn time (migration 356) rather than the
+ * `subagents` table: `subagents` rows are deleted on dispose, and the billing
+ * path must not depend on a row that may already be gone.
+ *
+ * Never throws. This runs on the provider dispatch hot path and attribution
+ * must never be able to take a model request down — any failure degrades to
+ * "no attribution", which is exactly how the platform treats a missing header.
+ */
+export function resolveSubagentAttribution(
+  conversationId: string | undefined,
+): SubagentAttribution {
+  if (conversationId === undefined || conversationId.length === 0) {
+    return NOT_A_SUBAGENT;
+  }
+  const cached = cache.get(conversationId);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let row: { subagent_role: string | null; subagent_spawn_mode: string | null };
+  try {
+    const found = rawGet<{
+      subagent_role: string | null;
+      subagent_spawn_mode: string | null;
+    }>(
+      "usage:subagentAttribution",
+      `SELECT subagent_role, subagent_spawn_mode FROM conversations WHERE id = ?`,
+      conversationId,
+    );
+    if (!found) {
+      // No row (yet). Deliberately NOT cached: caching a miss would pin an
+      // empty result for a conversation whose row lands moments later.
+      return NOT_A_SUBAGENT;
+    }
+    row = found;
+  } catch (err) {
+    // Includes the pre-migration case (column absent) and any DB-unavailable
+    // context such as unit tests that exercise the provider stack alone.
+    log.debug({ err, conversationId }, "Subagent attribution lookup failed");
+    return NOT_A_SUBAGENT;
+  }
+
+  const attribution: SubagentAttribution = {
+    subagentRole: row.subagent_role,
+    subagentSpawnMode: row.subagent_spawn_mode,
+  };
+  if (cache.size >= MAX_CACHED_CONVERSATIONS) {
+    const oldest = cache.keys().next();
+    if (!oldest.done) {
+      cache.delete(oldest.value);
+    }
+  }
+  cache.set(conversationId, attribution);
+  return attribution;
+}
+
+/** Test seam — drops every memoized entry. */
+export function resetSubagentAttributionCacheForTests(): void {
+  cache.clear();
+}


### PR DESCRIPTION
## ⚠️ Merge order — read first

**Platform serializer merges FIRST: vellum-ai/vellum-assistant-platform#9586. This PR merges LAST.**

The platform ingest endpoint silently skips events that fail their serializer: the batch still returns 200, the daemon acks and deletes its outbox rows, and the data is gone with no error anywhere. A daemon emitter shipped before its platform serializer loses every event it records in the gap.

Between the two, the automatic `sync-telemetry-wire.yaml` workflow opens a PR here with the regenerated wire module. This PR carries the same two-line addition to `telemetry-wire.generated.ts` so it type-checks standalone; merge the sync PR first if it lands, and take its version.

## Why

Every subagent variety emits usage under `llm_call_site = "subagentSpawn"` in a child conversation, so delegated spend arrives downstream as one opaque bucket — the single largest descendant cost bucket in prod. The advisor is not a distinct `LLMCallSiteEnum` value at all; it is a subagent **role** that branches in `tools/subagent/spawn.ts` to a synchronous, context-inheriting fork on `llm.advisorProfile`. Downstream, the only handle on it today is `inference_profile = 'quality-optimized'` — a proxy, not an identity.

## What is emitted

Two orthogonal dimensions on `llm_usage`:

| Field | Meaning | Values |
| --- | --- | --- |
| `subagent_role` | The child's capability profile from `SUBAGENT_ROLE_REGISTRY` | `general`, `researcher`, `coder`, `planner`, `investigator`, `advisor` |
| `subagent_spawn_mode` | How it was spawned — context inheritance + lifecycle | `regular`, `fork`, `advisor_consult`, `voice_continuation` |

Neither subsumes the other. `subagent_spawn` never forwards a role for forks (they default to `general`, to keep the KV cache aligned with the parent), so the mode is the only thing separating a general fork from a general regular spawn — and a fork's inherited parent transcript dominates its input tokens regardless of which role ran.

The four spawn call sites now declare their own mode:

- `tools/subagent/spawn.ts` → `fork ? "fork" : "regular"`
- `tools/subagent/spawn.ts` advisor branch → `"advisor_consult"`
- `live-voice/live-voice-session.ts` background continuation → `"voice_continuation"`

Only the call site can distinguish these — the manager sees `fork: true` for all three of the latter. `SubagentManager.spawn` falls back to the mechanical `fork ? "fork" : "regular"` when a caller omits `spawnMode`, so a future call site that forgets still records an honest value rather than dropping out of the breakdown.

## Where the values live: migration 356

Both are denormalized onto the `conversations` row at spawn time rather than joined from `subagents` at telemetry-flush time.

`subagents` rows are **deleted on dispose** (`SubagentManager.dispose`, driven by a 30-minute terminal-retention TTL sweep), while `queryUnreportedUsageEvents` flushes on a watermark that can trail arbitrarily far behind after an ingest outage. Joining `subagents` would silently yield NULL attribution for exactly the backlogs where cost analysis matters most.

`conversations` is durable, and the flush query **already LEFT JOINs it** for `conversation_type` / `parent_conversation_id` — so this is two extra projected columns on an existing primary-key join, no new read. It is the same rationale that put `parent_conversation_id` on `conversations` (migration 342).

Migration 356 is idempotent (`tableHasColumn`-guarded, NULL-only backfill) and backfills from surviving `subagents` rows, deriving the mode from `role` / `is_fork` (`advisor` → `advisor_consult`). It cannot recover `voice_continuation` retroactively — pre-migration those are unlabelled forks and backfill as `fork`. That inaccuracy is bounded to the backfill window.

No index: these columns are projected alongside an existing join, never filtered on.

## Runtime-proxy attribution headers

`X-Vellum-Subagent-Role` / `X-Vellum-Subagent-Spawn-Mode` are forwarded from `RetryProvider` when `forwardUsageAttributionHeaders` is on. Daemon telemetry `cost` is an estimate; the runtime proxy is billed truth, so the decomposition is worth having on both paths.

`usage/subagent-attribution.ts` resolves them from the conversation row with a bounded, insertion-ordered memo. The columns are immutable after conversation creation, so a hit is always correct. The lookup **never throws** — any failure (pre-migration column, DB unavailable, provider-only unit test) degrades to "no attribution", which is exactly how the platform treats a missing header. A miss is deliberately not cached, so a lookup that races the conversation insert is not pinned empty.

The matching platform-side accept list is in vellum-ai/vellum-assistant-platform#9586.

## Testing

- `356-add-conversation-subagent-kind.test.ts` (new): both columns added nullable, non-subagent rows read null, round-trip, backfill derives all three modes (including `advisor` → `advisor_consult`), backfill does not overwrite stamped values, idempotent re-run.
- `usage/__tests__/subagent-attribution.test.ts` (new): resolves stamped values, nulls for ordinary/absent conversations, memoizes, does not cache a miss.
- `llm-usage-store.test.ts`: the flush query surfaces both columns, role and mode are independent, nulls for ordinary and no-conversation events.
- `retry-callsite.test.ts`: headers forwarded for a subagent conversation, omitted for a plain one.
- `subagent-spawn-tool-fork.test.ts` / `subagent-tools.test.ts`: each call site declares the right mode.
- `bunx tsc --noEmit`, `bun run lint`, `prettier --check` all clean. Targeted suites (`src/telemetry`, `src/persistence`, `src/usage`, `src/subagent`, plus conversation/subagent/provider-usage tests in `src/__tests__`) show the same pass/fail counts as `origin/main` on this machine — the residual local failures are pre-existing environment/isolation issues, unchanged by this PR.

## Not in this PR

Admin dashboard charts (platform repo). There is no data until this rolls out; the chart work is tracked as a follow-up on vellum-ai/vellum-assistant-platform#9542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsQqt2aDQ8r1hAatYchwia
