### PR TITLE
fix: restore migration 355 registration and schedule docs fingerprint, both lost in the v0.11.0 merge

### DIFF
--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -462,6 +462,7 @@ import { migrateScheduleSkillScriptHandoff } from "./migrations/351-schedule-ski
 import { migrateDropScheduleSkillScriptHandoff } from "./migrations/352-drop-schedule-skill-script-handoff.js";
 import { migrateAddLlmUsageConversationType } from "./migrations/353-add-llm-usage-conversation-type.js";
 import { migrateBackfillAppConversationLineage } from "./migrations/354-backfill-app-conversation-lineage.js";
+import { migrateAddScheduleGroupId } from "./migrations/355-add-schedule-group-id.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1481,4 +1482,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateDropScheduleSkillScriptHandoff,
   migrateAddLlmUsageConversationType,
   migrateBackfillAppConversationLineage,
+  migrateAddScheduleGroupId,
 ];

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "0720e01d6702c62c6511bd328c05e5990e939c731a4b2cdf1f94aaedd8f46b78"
+      "sha256": "629b5815eb736b46f1af5faf57a5a74788e3b43bbf08371c654eddc3f788557d"
     },
     "skill-management": {
       "docsSlug": "skill-management",


### PR DESCRIPTION
Two independent regressions from the same release merge, both restoring what #39388 had.

## Bug 1 — migration 355 unregistered

`assistant/src/persistence/migrations/355-add-schedule-group-id.ts` adds `cron_jobs.group_id`, which the schedule sidebar-group feature (#39388) writes and reads through `resolveScheduleConversationGroupId` in `schedule-store.ts`.

#39388 both added the migration file **and** registered it in `migrationSteps`. The release merge `6cc0273a6c` ("Release v0.11.0", #39456) dropped the registration while keeping the file — a conflict resolution that silently lost two lines.

On `main` today:

```
$ git grep -n "355-add-schedule-group-id" origin/main -- assistant/src
(no output)
```

## Consequences

1. **The migration never runs.** `ALTER TABLE cron_jobs ADD COLUMN group_id TEXT` is unreachable, so any daemon that did not already pick up the column from a pre-merge build has no `group_id` — and the schedule sidebar-group feature fails at runtime on those installs.

2. **`conversation-delete-schedule-cleanup.test.ts` fails on `main`** — 5 tests, all with `SQLiteError: table cron_jobs has no column named group_id`. The Drizzle schema declares the column (added by #39388) but the migration that creates it never runs, so every insert into `cron_jobs` throws. Verified locally: 0 pass / 5 fail without this change, 5 pass / 0 fail with it.

3. **`bun run lint:unused` fails on `main`.** knip reports the file as unreachable because nothing imports it:

   ```
   Unused files (1)
   src/persistence/migrations/355-add-schedule-group-id.ts
   ```

   Every assistant PR's `Lint` job inherits that failure. `ci-main-assistant.yaml` does not run `lint:unused`, which is why the regression was not caught at merge time.

### Fix

Restore the import and the `migrationSteps` entry exactly as #39388 had them. The migration is idempotent (`tableHasColumn`-guarded), so daemons that already have the column from a pre-merge build are unaffected — the `ALTER` is skipped.

## Bug 2 — schedule docs-sync fingerprint regressed

Same merge, same shape: #39388 changed the schedule SKILL.md (new "Conversation Group" section) and re-recorded its docs-sync fingerprint to `629b…`. The release merge kept main's SKILL.md but regressed the manifest entry (`scripts/skill-docs-sync.manifest.json`) to the pre-#39388 hash `0720…`. Since then `skill-docs-sync-guard.test.ts` fails on `main` — this is the `Test` failure the first CI run of this PR surfaced.

Verified by hashing the SKILL.md across revs with the script's own normalization: `origin/main` = `629b…` (matches what the manifest said *before* the merge), `8c19941a7a^` = `0720…` (what the merge regressed it to).

### Fix

`bun run scripts/check-skill-docs-sync.ts --write`, which reproduces `629b…` byte-for-byte — i.e. this re-records exactly the acknowledgment #39388's author already made, not a new reconcile decision. The public docs page gets a matching Configuration bullet for the sidebar-group feature in a separate vellum-assistant-platform PR (the page lives in that repo).

## Testing

- `conversation-delete-schedule-cleanup.test.ts` — 5 pass, 0 fail (5 fail on `main`).
- `skill-docs-sync-guard.test.ts` — 1 pass, 0 fail (fails on `main`).
- `bun run lint:unused` — clean (was failing on `main`).
- `bunx tsc --noEmit`, `bun run lint`, `prettier --check` — clean.
- `schedule-tools.test.ts` + `db-schedule-syntax-migration.test.ts` — 100 pass, 0 fail.

## Follow-up worth considering (not in this PR)

`lint:unused` runs only in `pr-assistant.yaml`, not `ci-main-assistant.yaml`. A release merge can therefore introduce this exact class of regression without any job failing. Adding it to the main workflow would have caught this at merge.

Found while working on an unrelated telemetry change (#39457), whose `Lint` job fails on this inherited breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsQqt2aDQ8r1hAatYchwia
