### PR TITLE
fix: repair v0.11.0 merge-back damage to main (Lint/TypeCheck/Build/Test all red)

### DIFF
--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -462,6 +462,7 @@ import { migrateScheduleSkillScriptHandoff } from "./migrations/351-schedule-ski
 import { migrateDropScheduleSkillScriptHandoff } from "./migrations/352-drop-schedule-skill-script-handoff.js";
 import { migrateAddLlmUsageConversationType } from "./migrations/353-add-llm-usage-conversation-type.js";
 import { migrateBackfillAppConversationLineage } from "./migrations/354-backfill-app-conversation-lineage.js";
+import { migrateAddScheduleGroupId } from "./migrations/355-add-schedule-group-id.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1481,4 +1482,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateDropScheduleSkillScriptHandoff,
   migrateAddLlmUsageConversationType,
   migrateBackfillAppConversationLineage,
+  migrateAddScheduleGroupId,
 ];

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -408,7 +408,9 @@ export function useConversationLoader({
       // per-conversation process stores — wiping them kills the inline
       // cards of still-running subagents, which only repopulate from live
       // SSE events (LUM-2875).
-      if (key === useConversationStore.getState().activeConversationId) return;
+      if (key === useConversationStore.getState().activeConversationId) {
+        return;
+      }
       useSubagentStore.getState().reset();
       useWorkflowStore.getState().reset();
       void navigate(routes.conversation(key));

--- a/clients/web/src/domains/chat/subagent-store.ts
+++ b/clients/web/src/domains/chat/subagent-store.ts
@@ -706,14 +706,6 @@ const useSubagentStoreBase = create<SubagentStore>()((set, get) => ({
           )
         : get().byToolUseId;
 
-    // Backfill the spawn anchor for a recovered stub and register it in the
-    // tool-use index so the inline card re-anchors to its exact spawn call.
-    const parentToolUseId = existing.parentToolUseId ?? params.parentToolUseId;
-    const nextByToolUseId =
-      parentToolUseId && !existing.parentToolUseId
-        ? setToolUseAnchor(get().byToolUseId, parentToolUseId, params.subagentId)
-        : get().byToolUseId;
-
     set({
       byId: {
         ...byId,

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "0720e01d6702c62c6511bd328c05e5990e939c731a4b2cdf1f94aaedd8f46b78"
+      "sha256": "629b5815eb736b46f1af5faf57a5a74788e3b43bbf08371c654eddc3f788557d"
     },
     "skill-management": {
       "docsSlug": "skill-management",


### PR DESCRIPTION
## TL;DR

Main's CI is red since the v0.11.0 release merge-back (#39456): the merge dropped and duplicated hunks across four files. Every open PR inherits the failures through its merge ref (that's how it surfaced — on #39453). This PR restores exactly what the merge lost; no behavior changes beyond returning main to its intended pre-merge state.

## What broke and the repair

| File | Damage | Repair |
| --- | --- | --- |
| `assistant/src/persistence/steps.ts` | Migration **355-add-schedule-group-id** registration deleted (the migration file itself survived), while the schedule-group code from #39388 kept writing `cron_jobs.group_id` → every schedule-family assistant test fails with `SQLiteError: table cron_jobs has no column named group_id` | Restore the import + step entry |
| `clients/web/src/domains/chat/subagent-store.ts` | The recovered-stub spawn-anchor backfill block appears **twice** → TS2451 redeclare; breaks Type Check, the web Build, and the web Storybook build | Delete the duplicate (kept the prettier-formatted first copy) |
| `clients/web/src/domains/chat/hooks/use-conversation-loader.ts` | Braceless `if … return;` guard — `curly` has been at error level since #39429 | Add braces |
| `scripts/skill-docs-sync.manifest.json` | Merge kept main's **newer** schedule SKILL.md (with the #39388 Conversation Group section) but recorded the release branch's **older** fingerprint → `skill-docs-sync-guard` fails | `check-skill-docs-sync.ts --write` — regenerates to the exact pre-merge hash `629b5815…`, i.e. pure restoration, no docs-drift acknowledged |

## Why this is safe

Every change restores content that was already reviewed and merged to main before #39456 (the migration registration and manifest hash from #39388; the single-copy backfill block from the subagent-recovery work) or is a lint-mandated brace with no behavior change. Verified locally: `clients/web` tsc + lint (0 errors) + `vite build`, and the previously failing test files (`conversation-delete-schedule-cleanup`, `run-due-schedules`, `schedule-routes`, `wake-intent-hooks`, `task-memory-cleanup`, `skill-docs-sync-guard`) all pass.

## Worth checking separately

The same merge may have mangled other hunks that don't trip CI. Whoever owns the release flow may want to audit #39456's diff against the release branch + pre-merge main — the four above were found by chasing CI failures, not by an exhaustive sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->