### PR TITLE
fix(web): bound client feature flag refreshes

### DIFF
--- a/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
@@ -6,6 +6,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import { cleanup, render, renderHook, waitFor } from "@testing-library/react";
+import { shouldRetryQuery } from "@/utils/query-retry";
 
 const originalFetch = globalThis.fetch;
 
@@ -88,6 +89,47 @@ describe("useClientFeatureFlagSync", () => {
     });
   });
 
+  test("reuses client flags when the hook remounts in the same session", async () => {
+    const queryClient = freshQueryClient();
+    const first = renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    first.unmount();
+
+    renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not retry a rate-limited client flag request", async () => {
+    const rateLimitedFetch = mock(
+      async () => new Response("slow down", { status: 429 }),
+    );
+    globalThis.fetch = rateLimitedFetch as unknown as typeof fetch;
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: shouldRetryQuery,
+          retryDelay: () => 1,
+        },
+      },
+    });
+    renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(FLAG_QUERY_KEY)?.status).toBe("error");
+    });
+    expect(rateLimitedFetch).toHaveBeenCalledTimes(1);
+  });
+
   test("does not fetch platform client flags in remote-gateway mode", async () => {
     window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
     const queryClient = freshQueryClient();
@@ -123,7 +165,6 @@ describe("useClientFeatureFlagSync", () => {
       wrapper: createWrapper(queryClient),
     });
 
-    // The query retries once before giving up, so allow for its backoff.
     await waitFor(
       () => {
         expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);

--- a/clients/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.ts
@@ -10,6 +10,7 @@ import {
   CLIENT_STRING_FLAG_DEFAULTS,
   flagKeyToStoreKey,
 } from "@/lib/feature-flags/feature-flag-catalog";
+import { useClientFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
 import { featureFlagsClientFlagValuesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
@@ -59,6 +60,7 @@ function mapFlags(serverFlags: Record<string, boolean | string>): {
 }
 
 export function useClientFeatureFlagSync(enabled: boolean) {
+  const freshness = useClientFlagQueryFreshness();
   // The client-flag endpoint evaluates against the signed-in user + org, so an
   // authenticated request without `Vellum-Organization-Id` is rejected. The org
   // store hydrates asynchronously after auth, so an authenticated cold load can
@@ -74,10 +76,10 @@ export function useClientFeatureFlagSync(enabled: boolean) {
     queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
     queryFn: ({ signal }) => fetchClientFlagValues(signal),
     enabled: shouldFetch,
-    // Client flags load once per identity-scoped query cache. Actual flag
-    // changes and bounded reconnect catch-up invalidate this query explicitly.
-    staleTime: Infinity,
-    refetchInterval: false,
+    // Push-capable sessions load once per identity-scoped query cache. Actual
+    // flag changes and bounded reconnect catch-up invalidate explicitly.
+    // Assistants before 0.8.5 retain their polling fallback.
+    ...freshness,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     // Inherit the app-wide status-aware retry predicate and exponential delay.

--- a/clients/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.ts
@@ -59,8 +59,11 @@ function mapFlags(serverFlags: Record<string, boolean | string>): {
   return { boolFlags, stringFlags };
 }
 
-export function useClientFeatureFlagSync(enabled: boolean) {
-  const freshness = useClientFlagQueryFreshness();
+export function useClientFeatureFlagSync(
+  enabled: boolean,
+  hasSyncTransport = false,
+) {
+  const freshness = useClientFlagQueryFreshness(hasSyncTransport);
   // The client-flag endpoint evaluates against the signed-in user + org, so an
   // authenticated request without `Vellum-Organization-Id` is rejected. The org
   // store hydrates asynchronously after auth, so an authenticated cold load can
@@ -76,9 +79,9 @@ export function useClientFeatureFlagSync(enabled: boolean) {
     queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
     queryFn: ({ signal }) => fetchClientFlagValues(signal),
     enabled: shouldFetch,
-    // Push-capable sessions load once per identity-scoped query cache. Actual
-    // flag changes and bounded reconnect catch-up invalidate explicitly.
-    // Assistants before 0.8.5 retain their polling fallback.
+    // Push-capable sessions with an attached sync transport load once per
+    // identity-scoped query cache. Older assistants and surfaces without that
+    // transport retain their polling fallback.
     ...freshness,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/clients/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.ts
@@ -3,14 +3,13 @@ import { useQuery } from "@tanstack/react-query";
 
 import { featureFlagsClientFlagValuesRetrieve } from "@/generated/api/sdk.gen";
 import type { ClientFeatureFlagsResponse } from "@/generated/api/types.gen";
-import { assertHasResponse } from "@/utils/api-errors";
+import { assertHasResponse, toApiError } from "@/utils/api-errors";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import {
   CLIENT_FLAG_DEFAULTS,
   CLIENT_STRING_FLAG_DEFAULTS,
   flagKeyToStoreKey,
 } from "@/lib/feature-flags/feature-flag-catalog";
-import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
 import { featureFlagsClientFlagValuesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
@@ -24,17 +23,20 @@ interface ScopedClientFlagValues {
   flags: ClientFeatureFlagsResponse["flags"];
 }
 
-async function fetchClientFlagValues(): Promise<ScopedClientFlagValues> {
+async function fetchClientFlagValues(
+  signal?: AbortSignal,
+): Promise<ScopedClientFlagValues> {
   // Stamp the request with the scope it goes out under. The response is applied
   // from a passive effect, by which point the identity may have moved on, and
   // the stamp is what lets the store tell whose answer it is holding.
   const scopeKey = useClientFeatureFlagStore.getState().scopeKey;
   const { data, error, response } = await featureFlagsClientFlagValuesRetrieve({
     throwOnError: false,
+    signal,
   });
   assertHasResponse(response, error, "Failed to fetch client feature flags");
   if (!response.ok || !data) {
-    throw new Error(`Failed to fetch client feature flags: ${response.status}`);
+    throw toApiError(error, response);
   }
   return { scopeKey, flags: data.flags };
 }
@@ -57,7 +59,6 @@ function mapFlags(serverFlags: Record<string, boolean | string>): {
 }
 
 export function useClientFeatureFlagSync(enabled: boolean) {
-  const freshness = useFlagQueryFreshness();
   // The client-flag endpoint evaluates against the signed-in user + org, so an
   // authenticated request without `Vellum-Organization-Id` is rejected. The org
   // store hydrates asynchronously after auth, so an authenticated cold load can
@@ -71,10 +72,16 @@ export function useClientFeatureFlagSync(enabled: boolean) {
   const shouldFetch = modeAllowsFetch && orgReadiness === "ready";
   const { data, isError } = useQuery({
     queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
-    queryFn: fetchClientFlagValues,
+    queryFn: ({ signal }) => fetchClientFlagValues(signal),
     enabled: shouldFetch,
-    ...freshness,
-    retry: 1,
+    // Client flags load once per identity-scoped query cache. Actual flag
+    // changes and bounded reconnect catch-up invalidate this query explicitly.
+    staleTime: Infinity,
+    refetchInterval: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    // Inherit the app-wide status-aware retry predicate and exponential delay.
+    // It retries transient network/5xx failures and never retries a 429/4xx.
   });
 
   useEffect(() => {

--- a/clients/web/src/hooks/use-feature-flag-bus-sync.test.tsx
+++ b/clients/web/src/hooks/use-feature-flag-bus-sync.test.tsx
@@ -73,9 +73,38 @@ describe("useFeatureFlagBusSync", () => {
     });
     emit(syncEvent([SYNC_TAGS.featureFlagsClient]));
     await waitFor(() => {
-      expect(spy).toHaveBeenCalledWith({
-        queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
+      expect(spy).toHaveBeenCalledWith(
+        {
+          queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
+        },
+        { cancelRefetch: false },
+      );
+    });
+  });
+
+  test("deduplicates bursty client feature flag invalidations", async () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useFeatureFlagBusSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit(syncEvent([SYNC_TAGS.featureFlagsClient]));
+    emit(syncEvent([SYNC_TAGS.featureFlagsClient]));
+    emitOpened("error");
+    emitOpened("watchdog");
+
+    await waitFor(() => {
+      const clientCalls = (
+        spy.mock.calls as unknown as Array<
+          [{ queryKey?: readonly unknown[] }, unknown?]
+        >
+      ).filter(([options]) => {
+        const key = options.queryKey?.[0] as { _id?: string } | undefined;
+        return key?._id === "featureFlagsClientFlagValuesRetrieve";
       });
+      expect(clientCalls).toHaveLength(1);
     });
   });
 
@@ -105,9 +134,12 @@ describe("useFeatureFlagBusSync", () => {
     });
     emitOpened("error");
     await waitFor(() => {
-      expect(spy).toHaveBeenCalledWith({
-        queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
-      });
+      expect(spy).toHaveBeenCalledWith(
+        {
+          queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
+        },
+        { cancelRefetch: false },
+      );
       expect(spy).toHaveBeenCalledWith({
         queryKey: assistantFeatureFlagsGetQueryKey({
           path: { assistant_id: "asst-1" },
@@ -126,9 +158,12 @@ describe("useFeatureFlagBusSync", () => {
     emitOpened("watchdog");
     emitOpened("resume");
     await waitFor(() => {
-      expect(spy).toHaveBeenCalledWith({
-        queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
-      });
+      expect(spy).toHaveBeenCalledWith(
+        {
+          queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
+        },
+        { cancelRefetch: false },
+      );
       expect(spy).toHaveBeenCalledWith({
         queryKey: assistantFeatureFlagsGetQueryKey({
           path: { assistant_id: "asst-1" },

--- a/clients/web/src/hooks/use-feature-flag-bus-sync.test.tsx
+++ b/clients/web/src/hooks/use-feature-flag-bus-sync.test.tsx
@@ -134,7 +134,7 @@ describe("useFeatureFlagBusSync", () => {
     });
   });
 
-  test("does not refresh immediately when an active fetch fails", async () => {
+  test("delays one refresh when an active fetch fails", async () => {
     const queryClient = freshQueryClient();
     let failActiveFetch: ((error: Error) => void) | undefined;
     const activeFetch = new Promise<void>((_, reject) => {
@@ -142,7 +142,7 @@ describe("useFeatureFlagBusSync", () => {
     });
     let isFetching = true;
     queryClient.isFetching = mock(() => (isFetching ? 1 : 0)) as never;
-    const spy = mock(() => activeFetch);
+    const spy = mock(() => (isFetching ? activeFetch : Promise.resolve()));
     queryClient.invalidateQueries = spy as never;
     renderHook(() => useFeatureFlagBusSync("asst-1", true), {
       wrapper: createWrapper(queryClient),
@@ -157,10 +157,30 @@ describe("useFeatureFlagBusSync", () => {
     );
 
     isFetching = false;
-    failActiveFetch?.(new Error("rate limited"));
-    await Promise.resolve();
+    const originalSetTimeout = globalThis.setTimeout;
+    let scheduledRefresh: (() => void) | undefined;
+    let scheduledDelay: number | undefined;
+    globalThis.setTimeout = mock((callback: TimerHandler, delay?: number) => {
+      if (typeof callback === "function") {
+        scheduledRefresh = () => callback();
+      }
+      scheduledDelay = delay;
+      return 1;
+    }) as unknown as typeof setTimeout;
+    try {
+      failActiveFetch?.(new Error("rate limited"));
+      await Promise.resolve();
 
-    expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(scheduledDelay).toBe(30_000);
+
+      globalThis.setTimeout = originalSetTimeout;
+      scheduledRefresh?.();
+      await Promise.resolve();
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
   });
 
   test("invalidates assistant feature flag query prefix on feature-flags:assistant sync tag", async () => {
@@ -227,7 +247,7 @@ describe("useFeatureFlagBusSync", () => {
     });
   });
 
-  test("does NOT invalidate on sse.opened (cause=fresh)", async () => {
+  test("catches up client flags on the initial sse.opened", async () => {
     const queryClient = freshQueryClient();
     const spy = mock(() => Promise.resolve());
     queryClient.invalidateQueries = spy as never;
@@ -235,7 +255,14 @@ describe("useFeatureFlagBusSync", () => {
       wrapper: createWrapper(queryClient),
     });
     emitOpened("fresh");
-    await Promise.resolve();
-    expect(spy).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(
+        {
+          queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
+        },
+        { cancelRefetch: false, throwOnError: false },
+      );
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/hooks/use-feature-flag-bus-sync.test.tsx
+++ b/clients/web/src/hooks/use-feature-flag-bus-sync.test.tsx
@@ -77,7 +77,7 @@ describe("useFeatureFlagBusSync", () => {
         {
           queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
         },
-        { cancelRefetch: false },
+        { cancelRefetch: false, throwOnError: false },
       );
     });
   });
@@ -134,6 +134,35 @@ describe("useFeatureFlagBusSync", () => {
     });
   });
 
+  test("does not refresh immediately when an active fetch fails", async () => {
+    const queryClient = freshQueryClient();
+    let failActiveFetch: ((error: Error) => void) | undefined;
+    const activeFetch = new Promise<void>((_, reject) => {
+      failActiveFetch = reject;
+    });
+    let isFetching = true;
+    queryClient.isFetching = mock(() => (isFetching ? 1 : 0)) as never;
+    const spy = mock(() => activeFetch);
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useFeatureFlagBusSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit(syncEvent([SYNC_TAGS.featureFlagsClient]));
+    expect(spy).toHaveBeenCalledWith(
+      {
+        queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
+      },
+      { cancelRefetch: false, throwOnError: true },
+    );
+
+    isFetching = false;
+    failActiveFetch?.(new Error("rate limited"));
+    await Promise.resolve();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   test("invalidates assistant feature flag query prefix on feature-flags:assistant sync tag", async () => {
     const queryClient = freshQueryClient();
     const spy = mock(() => Promise.resolve());
@@ -164,7 +193,7 @@ describe("useFeatureFlagBusSync", () => {
         {
           queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
         },
-        { cancelRefetch: false },
+        { cancelRefetch: false, throwOnError: false },
       );
       expect(spy).toHaveBeenCalledWith({
         queryKey: assistantFeatureFlagsGetQueryKey({
@@ -188,7 +217,7 @@ describe("useFeatureFlagBusSync", () => {
         {
           queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
         },
-        { cancelRefetch: false },
+        { cancelRefetch: false, throwOnError: false },
       );
       expect(spy).toHaveBeenCalledWith({
         queryKey: assistantFeatureFlagsGetQueryKey({

--- a/clients/web/src/hooks/use-feature-flag-bus-sync.test.tsx
+++ b/clients/web/src/hooks/use-feature-flag-bus-sync.test.tsx
@@ -108,6 +108,32 @@ describe("useFeatureFlagBusSync", () => {
     });
   });
 
+  test("queues one refresh when invalidation races an active fetch", async () => {
+    const queryClient = freshQueryClient();
+    let finishActiveFetch: (() => void) | undefined;
+    const activeFetch = new Promise<void>((resolve) => {
+      finishActiveFetch = resolve;
+    });
+    let isFetching = true;
+    queryClient.isFetching = mock(() => (isFetching ? 1 : 0)) as never;
+    const spy = mock(() => (isFetching ? activeFetch : Promise.resolve()));
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useFeatureFlagBusSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit(syncEvent([SYNC_TAGS.featureFlagsClient]));
+    emit(syncEvent([SYNC_TAGS.featureFlagsClient]));
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    isFetching = false;
+    finishActiveFetch?.();
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   test("invalidates assistant feature flag query prefix on feature-flags:assistant sync tag", async () => {
     const queryClient = freshQueryClient();
     const spy = mock(() => Promise.resolve());

--- a/clients/web/src/hooks/use-feature-flag-bus-sync.ts
+++ b/clients/web/src/hooks/use-feature-flag-bus-sync.ts
@@ -7,11 +7,16 @@
  * - `sse.opened` reconnects (non-fresh) to catch flag changes
  *   missed during the transport gap
  *
+ * Client-flag invalidations are limited to one request per 30 seconds with
+ * one trailing refresh. This bounds reconnect or duplicate-event bursts while
+ * preserving an immediate refresh for the first real change.
+ *
  * References:
  * - EVENT_BUS.md — bus subscription contract
  * - CONVENTIONS.md — domain-first decomposition
  */
 
+import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
@@ -19,6 +24,8 @@ import { assistantFeatureFlagsGetQueryKey } from "@/generated/gateway/@tanstack/
 import { featureFlagsClientFlagValuesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import { SYNC_TAGS } from "@/lib/sync/types";
 import { getClientId } from "@/lib/telemetry/client-identity";
+
+const CLIENT_FLAG_REFRESH_MIN_INTERVAL_MS = 30_000;
 
 /**
  * Subscribes to feature-flag-related sync events via the event bus.
@@ -34,6 +41,54 @@ export function useFeatureFlagBusSync(
   isAssistantActive: boolean,
 ): void {
   const queryClient = useQueryClient();
+  const clientRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const lastClientRefreshAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    lastClientRefreshAtRef.current = null;
+    return () => {
+      if (clientRefreshTimerRef.current) {
+        clearTimeout(clientRefreshTimerRef.current);
+        clientRefreshTimerRef.current = null;
+      }
+    };
+  }, [assistantId, isAssistantActive, queryClient]);
+
+  const invalidateClientFlags = () => {
+    const refresh = () => {
+      clientRefreshTimerRef.current = null;
+      lastClientRefreshAtRef.current = Date.now();
+      void queryClient.invalidateQueries(
+        {
+          queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
+        },
+        // Keep an active request instead of canceling it and starting a
+        // replacement. The query function also forwards its abort signal.
+        { cancelRefetch: false },
+      );
+    };
+    const lastRefreshAt = lastClientRefreshAtRef.current;
+    const elapsed =
+      lastRefreshAt === null
+        ? CLIENT_FLAG_REFRESH_MIN_INTERVAL_MS
+        : Date.now() - lastRefreshAt;
+    if (elapsed >= CLIENT_FLAG_REFRESH_MIN_INTERVAL_MS) {
+      if (clientRefreshTimerRef.current) {
+        clearTimeout(clientRefreshTimerRef.current);
+      }
+      refresh();
+      return;
+    }
+    if (clientRefreshTimerRef.current) {
+      return;
+    }
+    clientRefreshTimerRef.current = setTimeout(
+      refresh,
+      CLIENT_FLAG_REFRESH_MIN_INTERVAL_MS - elapsed,
+    );
+  };
 
   useBusSubscription("sse.event", (envelope) => {
     if (!assistantId || !isAssistantActive) {
@@ -48,9 +103,7 @@ export function useFeatureFlagBusSync(
     }
     for (const tag of event.tags) {
       if (tag === SYNC_TAGS.featureFlagsClient) {
-        void queryClient.invalidateQueries({
-          queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
-        });
+        invalidateClientFlags();
       } else if (tag === SYNC_TAGS.featureFlagsAssistant) {
         void queryClient.invalidateQueries({
           queryKey: assistantFeatureFlagsGetQueryKey({
@@ -68,9 +121,7 @@ export function useFeatureFlagBusSync(
     if (cause === "fresh") {
       return;
     }
-    void queryClient.invalidateQueries({
-      queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
-    });
+    invalidateClientFlags();
     void queryClient.invalidateQueries({
       queryKey: assistantFeatureFlagsGetQueryKey({
         path: { assistant_id: assistantId },

--- a/clients/web/src/hooks/use-feature-flag-bus-sync.ts
+++ b/clients/web/src/hooks/use-feature-flag-bus-sync.ts
@@ -4,13 +4,13 @@
  * Invalidates client and assistant flag TanStack Query caches on:
  * - `sync_changed` events carrying `featureFlagsClient` or
  *   `featureFlagsAssistant` tags
- * - `sse.opened` reconnects (non-fresh) to catch flag changes
- *   missed during the transport gap
+ * - the initial `sse.opened` to catch client flag changes before the stream
+ *   established, plus reconnects to catch changes during transport gaps
  *
  * Client-flag signals are limited to one refresh per 30 seconds with one
  * trailing refresh. A signal that races an active fetch queues one serialized
- * follow-up after it settles, preserving correctness without overlapping
- * requests.
+ * follow-up after success. Failure schedules one cadence-bound trailing
+ * attempt, preserving correctness without overlapping requests.
  *
  * References:
  * - EVENT_BUS.md — bus subscription contract
@@ -34,8 +34,8 @@ const CLIENT_FLAG_REFRESH_MIN_INTERVAL_MS = 30_000;
  * Handles two bus channels:
  * - `sse.event` — routes `featureFlagsClient` and `featureFlagsAssistant`
  *   tags from `sync_changed` events
- * - `sse.opened` — re-invalidates both flag queries on reconnect so
- *   caches re-converge with the daemon
+ * - `sse.opened` — catches up client flags when the stream first establishes
+ *   and re-invalidates both flag queries on reconnect
  */
 export function useFeatureFlagBusSync(
   assistantId: string | null,
@@ -95,14 +95,21 @@ export function useFeatureFlagBusSync(
           }
           refresh();
         };
-        const clearQueuedRefreshAfterFailure = () => {
-          if (generation === clientRefreshGenerationRef.current) {
-            clientRefreshQueuedAfterFetchRef.current = false;
+        const scheduleRefreshAfterFailure = () => {
+          if (generation !== clientRefreshGenerationRef.current) {
+            return;
+          }
+          clientRefreshQueuedAfterFetchRef.current = false;
+          if (!clientRefreshTimerRef.current) {
+            clientRefreshTimerRef.current = setTimeout(
+              refresh,
+              CLIENT_FLAG_REFRESH_MIN_INTERVAL_MS,
+            );
           }
         };
         void invalidation.then(
           refreshAfterSuccess,
-          clearQueuedRefreshAfterFailure,
+          scheduleRefreshAfterFailure,
         );
       }
     };
@@ -155,10 +162,10 @@ export function useFeatureFlagBusSync(
     if (!assistantId || !isAssistantActive) {
       return;
     }
+    invalidateClientFlags();
     if (cause === "fresh") {
       return;
     }
-    invalidateClientFlags();
     void queryClient.invalidateQueries({
       queryKey: assistantFeatureFlagsGetQueryKey({
         path: { assistant_id: assistantId },

--- a/clients/web/src/hooks/use-feature-flag-bus-sync.ts
+++ b/clients/web/src/hooks/use-feature-flag-bus-sync.ts
@@ -80,11 +80,11 @@ export function useFeatureFlagBusSync(
         },
         // Keep an active request instead of canceling it and starting a
         // replacement. The query function also forwards its abort signal.
-        { cancelRefetch: false },
+        { cancelRefetch: false, throwOnError: wasFetching },
       );
       if (wasFetching && !clientRefreshQueuedAfterFetchRef.current) {
         clientRefreshQueuedAfterFetchRef.current = true;
-        const refreshAfterSettle = () => {
+        const refreshAfterSuccess = () => {
           if (generation !== clientRefreshGenerationRef.current) {
             return;
           }
@@ -95,7 +95,15 @@ export function useFeatureFlagBusSync(
           }
           refresh();
         };
-        void invalidation.then(refreshAfterSettle, refreshAfterSettle);
+        const clearQueuedRefreshAfterFailure = () => {
+          if (generation === clientRefreshGenerationRef.current) {
+            clientRefreshQueuedAfterFetchRef.current = false;
+          }
+        };
+        void invalidation.then(
+          refreshAfterSuccess,
+          clearQueuedRefreshAfterFailure,
+        );
       }
     };
     const lastRefreshAt = lastClientRefreshAtRef.current;

--- a/clients/web/src/hooks/use-feature-flag-bus-sync.ts
+++ b/clients/web/src/hooks/use-feature-flag-bus-sync.ts
@@ -7,9 +7,10 @@
  * - `sse.opened` reconnects (non-fresh) to catch flag changes
  *   missed during the transport gap
  *
- * Client-flag invalidations are limited to one request per 30 seconds with
- * one trailing refresh. This bounds reconnect or duplicate-event bursts while
- * preserving an immediate refresh for the first real change.
+ * Client-flag signals are limited to one refresh per 30 seconds with one
+ * trailing refresh. A signal that races an active fetch queues one serialized
+ * follow-up after it settles, preserving correctness without overlapping
+ * requests.
  *
  * References:
  * - EVENT_BUS.md — bus subscription contract
@@ -45,10 +46,19 @@ export function useFeatureFlagBusSync(
     null,
   );
   const lastClientRefreshAtRef = useRef<number | null>(null);
+  const clientRefreshQueuedAfterFetchRef = useRef(false);
+  const clientRefreshGenerationRef = useRef(0);
 
   useEffect(() => {
+    const generation = clientRefreshGenerationRef.current + 1;
+    clientRefreshGenerationRef.current = generation;
     lastClientRefreshAtRef.current = null;
+    clientRefreshQueuedAfterFetchRef.current = false;
     return () => {
+      if (clientRefreshGenerationRef.current === generation) {
+        clientRefreshGenerationRef.current += 1;
+      }
+      clientRefreshQueuedAfterFetchRef.current = false;
       if (clientRefreshTimerRef.current) {
         clearTimeout(clientRefreshTimerRef.current);
         clientRefreshTimerRef.current = null;
@@ -59,15 +69,34 @@ export function useFeatureFlagBusSync(
   const invalidateClientFlags = () => {
     const refresh = () => {
       clientRefreshTimerRef.current = null;
+      const generation = clientRefreshGenerationRef.current;
+      const queryKey = featureFlagsClientFlagValuesRetrieveQueryKey();
+      const wasFetching =
+        queryClient.isFetching({ queryKey, exact: true, type: "active" }) > 0;
       lastClientRefreshAtRef.current = Date.now();
-      void queryClient.invalidateQueries(
+      const invalidation = queryClient.invalidateQueries(
         {
-          queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
+          queryKey,
         },
         // Keep an active request instead of canceling it and starting a
         // replacement. The query function also forwards its abort signal.
         { cancelRefetch: false },
       );
+      if (wasFetching && !clientRefreshQueuedAfterFetchRef.current) {
+        clientRefreshQueuedAfterFetchRef.current = true;
+        const refreshAfterSettle = () => {
+          if (generation !== clientRefreshGenerationRef.current) {
+            return;
+          }
+          clientRefreshQueuedAfterFetchRef.current = false;
+          if (clientRefreshTimerRef.current) {
+            clearTimeout(clientRefreshTimerRef.current);
+            clientRefreshTimerRef.current = null;
+          }
+          refresh();
+        };
+        void invalidation.then(refreshAfterSettle, refreshAfterSettle);
+      }
     };
     const lastRefreshAt = lastClientRefreshAtRef.current;
     const elapsed =

--- a/clients/web/src/lib/backwards-compat/flag-query-freshness.test.tsx
+++ b/clients/web/src/lib/backwards-compat/flag-query-freshness.test.tsx
@@ -70,7 +70,7 @@ describe("useFlagQueryFreshness", () => {
 describe("useClientFlagQueryFreshness", () => {
   test("returns poll options when version is unknown", () => {
     setVersion(null);
-    const { result } = renderHook(() => useClientFlagQueryFreshness(), {
+    const { result } = renderHook(() => useClientFlagQueryFreshness(true), {
       wrapper,
     });
     expect(result.current).toEqual({
@@ -81,7 +81,18 @@ describe("useClientFlagQueryFreshness", () => {
 
   test("returns poll options for assistants on 0.8.4", () => {
     setVersion("0.8.4");
-    const { result } = renderHook(() => useClientFlagQueryFreshness(), {
+    const { result } = renderHook(() => useClientFlagQueryFreshness(true), {
+      wrapper,
+    });
+    expect(result.current).toEqual({
+      staleTime: 5_000,
+      refetchInterval: 5_000,
+    });
+  });
+
+  test("polls when the sync transport is not attached", () => {
+    setVersion("0.8.5");
+    const { result } = renderHook(() => useClientFlagQueryFreshness(false), {
       wrapper,
     });
     expect(result.current).toEqual({
@@ -92,7 +103,7 @@ describe("useClientFlagQueryFreshness", () => {
 
   test("keeps push-capable client flags fresh until invalidated", () => {
     setVersion("0.8.5");
-    const { result } = renderHook(() => useClientFlagQueryFreshness(), {
+    const { result } = renderHook(() => useClientFlagQueryFreshness(true), {
       wrapper,
     });
     expect(result.current).toEqual({

--- a/clients/web/src/lib/backwards-compat/flag-query-freshness.test.tsx
+++ b/clients/web/src/lib/backwards-compat/flag-query-freshness.test.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
-import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
+import {
+  useClientFlagQueryFreshness,
+  useFlagQueryFreshness,
+} from "@/lib/backwards-compat/flag-query-freshness";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -61,5 +64,40 @@ describe("useFlagQueryFreshness", () => {
     act(() => setVersion("0.8.5"));
     expect(result.current.refetchInterval).toBe(false);
     expect(result.current.staleTime).toBe(60_000);
+  });
+});
+
+describe("useClientFlagQueryFreshness", () => {
+  test("returns poll options when version is unknown", () => {
+    setVersion(null);
+    const { result } = renderHook(() => useClientFlagQueryFreshness(), {
+      wrapper,
+    });
+    expect(result.current).toEqual({
+      staleTime: 5_000,
+      refetchInterval: 5_000,
+    });
+  });
+
+  test("returns poll options for assistants on 0.8.4", () => {
+    setVersion("0.8.4");
+    const { result } = renderHook(() => useClientFlagQueryFreshness(), {
+      wrapper,
+    });
+    expect(result.current).toEqual({
+      staleTime: 5_000,
+      refetchInterval: 5_000,
+    });
+  });
+
+  test("keeps push-capable client flags fresh until invalidated", () => {
+    setVersion("0.8.5");
+    const { result } = renderHook(() => useClientFlagQueryFreshness(), {
+      wrapper,
+    });
+    expect(result.current).toEqual({
+      staleTime: Infinity,
+      refetchInterval: false,
+    });
   });
 });

--- a/clients/web/src/lib/backwards-compat/flag-query-freshness.ts
+++ b/clients/web/src/lib/backwards-compat/flag-query-freshness.ts
@@ -2,12 +2,13 @@
  * Backwards-compat gate: feature-flag query freshness.
  *
  * Vellum Assistant 0.8.5 introduced `sync_changed` broadcasts for the
- * two feature-flag tags (PR #31921 / #31932). Web subscribers use
- * those pushes + `sse.opened` reconnect invalidation to keep the flag
- * query caches fresh, so the previous 5s interval poll is redundant.
+ * feature-flag tags (PR #31921 / #31932). Web subscribers use those
+ * pushes + `sse.opened` reconnect invalidation to keep the assistant
+ * flag query cache fresh, so the previous 5s interval poll is redundant.
  *
- * Assistants on 0.8.4 or older have no push path for flags. They still
- * need the poll to stay live.
+ * Assistants on 0.8.4 or older have no push path for assistant flags.
+ * They still need the poll to stay live. Client flags use their own
+ * once-per-session query policy.
  */
 import { useAssistantSupports } from "@/lib/backwards-compat/utils";
 

--- a/clients/web/src/lib/backwards-compat/flag-query-freshness.ts
+++ b/clients/web/src/lib/backwards-compat/flag-query-freshness.ts
@@ -1,14 +1,14 @@
 /**
- * Backwards-compat gate: feature-flag query freshness.
+ * Backwards-compat gates for feature-flag query freshness.
  *
  * Vellum Assistant 0.8.5 introduced `sync_changed` broadcasts for the
- * feature-flag tags (PR #31921 / #31932). Web subscribers use those
- * pushes + `sse.opened` reconnect invalidation to keep the assistant
- * flag query cache fresh, so the previous 5s interval poll is redundant.
+ * feature-flag tags (PR #31921 / #31932). Web subscribers use those pushes
+ * and `sse.opened` reconnect invalidation to keep flag query caches fresh.
  *
- * Assistants on 0.8.4 or older have no push path for assistant flags.
- * They still need the poll to stay live. Client flags use their own
- * once-per-session query policy.
+ * Assistants on 0.8.4 or older have no push path for flags. They retain the
+ * 5-second poll so values still converge. Push-capable client flags stay fresh
+ * indefinitely until an explicit invalidation, while assistant flags use a
+ * 60-second stale window for their existing remount behavior.
  */
 import { useAssistantSupports } from "@/lib/backwards-compat/utils";
 
@@ -22,13 +22,21 @@ export interface FlagQueryFreshness {
   refetchInterval: number | false;
 }
 
-export function useFlagQueryFreshness(): FlagQueryFreshness {
+function useFlagQueryFreshnessFor(pushStaleTime: number): FlagQueryFreshness {
   const supportsPush = useAssistantSupports(MIN_VERSION);
   if (supportsPush) {
-    return { staleTime: PUSH_STALE_MS, refetchInterval: false };
+    return { staleTime: pushStaleTime, refetchInterval: false };
   }
   return {
     staleTime: POLL_INTERVAL_MS,
     refetchInterval: POLL_INTERVAL_MS,
   };
+}
+
+export function useFlagQueryFreshness(): FlagQueryFreshness {
+  return useFlagQueryFreshnessFor(PUSH_STALE_MS);
+}
+
+export function useClientFlagQueryFreshness(): FlagQueryFreshness {
+  return useFlagQueryFreshnessFor(Infinity);
 }

--- a/clients/web/src/lib/backwards-compat/flag-query-freshness.ts
+++ b/clients/web/src/lib/backwards-compat/flag-query-freshness.ts
@@ -6,9 +6,10 @@
  * and `sse.opened` reconnect invalidation to keep flag query caches fresh.
  *
  * Assistants on 0.8.4 or older have no push path for flags. They retain the
- * 5-second poll so values still converge. Push-capable client flags stay fresh
- * indefinitely until an explicit invalidation, while assistant flags use a
- * 60-second stale window for their existing remount behavior.
+ * 5-second poll so values still converge. Push-capable client flags with an
+ * attached sync transport stay fresh indefinitely until an explicit
+ * invalidation, while assistant flags use a 60-second stale window for their
+ * existing remount behavior.
  */
 import { useAssistantSupports } from "@/lib/backwards-compat/utils";
 
@@ -22,9 +23,12 @@ export interface FlagQueryFreshness {
   refetchInterval: number | false;
 }
 
-function useFlagQueryFreshnessFor(pushStaleTime: number): FlagQueryFreshness {
+function useFlagQueryFreshnessFor(
+  pushStaleTime: number,
+  hasSyncTransport = true,
+): FlagQueryFreshness {
   const supportsPush = useAssistantSupports(MIN_VERSION);
-  if (supportsPush) {
+  if (supportsPush && hasSyncTransport) {
     return { staleTime: pushStaleTime, refetchInterval: false };
   }
   return {
@@ -37,6 +41,8 @@ export function useFlagQueryFreshness(): FlagQueryFreshness {
   return useFlagQueryFreshnessFor(PUSH_STALE_MS);
 }
 
-export function useClientFlagQueryFreshness(): FlagQueryFreshness {
-  return useFlagQueryFreshnessFor(Infinity);
+export function useClientFlagQueryFreshness(
+  hasSyncTransport: boolean,
+): FlagQueryFreshness {
+  return useFlagQueryFreshnessFor(Infinity, hasSyncTransport);
 }

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -109,7 +109,6 @@ export function RootLayout() {
   useEffect(() => {
     void setMenuPlatformSession(hasPlatformSession);
   }, [hasPlatformSession]);
-  useClientFeatureFlagSync(!isSessionInitializing);
   useAssistantLifecycle({
     sessionStatus,
     hasPlatformSession,
@@ -127,6 +126,7 @@ export function RootLayout() {
     (s) => s.assistantState.kind,
   );
   const isAssistantActive = assistantStateKind === "active";
+  useClientFeatureFlagSync(!isSessionInitializing, isAssistantActive);
   // Hydrate the assistant identity store (name + version) at the app root so
   // the name is ready on every authenticated route — chat, settings, logs —
   // and the Electron window title / tray / About panel (published below by


### PR DESCRIPTION
## Summary

- load platform client flags once per identity-scoped query cache only when a push-capable assistant has an attached sync transport
- retain the 5-second compatibility poll for assistants before 0.8.5 and for surfaces without the sync transport, including self-hosted, account, and standalone command-palette states
- preserve HTTP status and request cancellation so the shared retry policy backs off transient failures and never retries 429 or other 4xx responses
- coalesce duplicate sync and reconnect invalidations, catch up once when the initial stream opens, and preserve one cadence-bound trailing attempt after a raced fetch failure

## Root cause

The client flag query inherited the assistant flag 5-second polling policy and set `retry: 1`, overriding the shared status-aware retry policy. Feature-flag sync events and non-fresh SSE opens also invalidated the query without a cadence bound. Repeated invalidations could cancel and restart an active TanStack refetch while the HTTP request ignored its abort signal, amplifying reconnect or duplicate-event bursts into overlapping requests and 429 retries.

## Behavior

Assistants on 0.8.5 or newer use push invalidation only where the event bus is attached. The initial stream-open event performs one client-flag catch-up to close the gap before SSE establishment. The first real flag-change signal refreshes immediately, and additional signals within 30 seconds are collapsed into one trailing refresh. If a signal arrives during an active request, the request is retained and exactly one follow-up runs after success. If that request fails, no immediate request is issued; one trailing attempt remains scheduled at the 30-second cadence boundary. Older assistants and surfaces without the event bus keep the existing 5-second poll.

## Validation

- `bun test src/hooks/use-client-feature-flag-sync.test.tsx src/hooks/use-feature-flag-bus-sync.test.tsx src/lib/backwards-compat/flag-query-freshness.test.tsx src/utils/query-retry.test.ts` (40 passed)
- full web `tsc --noEmit`
- focused ESLint and Prettier checks
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->