### PR TITLE
feat(web): split provisioning target/in-flight checks per dimension

### DIFF
--- a/clients/web/src/lib/billing/provisioning-targets.test.ts
+++ b/clients/web/src/lib/billing/provisioning-targets.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from "bun:test";
 import type { OperationalStatus } from "@/generated/api/types.gen";
 
 import {
+  dimensionTargetsMet,
   isEntitlementRaceVerdict,
   isResizeOperationInFlight,
+  resizeDimensionsInFlight,
   targetsMet,
 } from "./provisioning-targets";
 
@@ -125,6 +127,173 @@ describe("targetsMet", () => {
   });
 });
 
+describe("dimensionTargetsMet", () => {
+  test("null targets leave both dimensions unmet", () => {
+    expect(
+      dimensionTargetsMet(null, { machineSize: "large", storageGib: 50 }),
+    ).toEqual({ machine: false, storage: false });
+  });
+
+  test("a null target dimension is satisfied on its own", () => {
+    expect(
+      dimensionTargetsMet(
+        { machineSize: null, storageGib: 50 },
+        { machineSize: null, storageGib: 10 },
+      ),
+    ).toEqual({ machine: true, storage: false });
+  });
+
+  test("null actuals cannot meet non-null targets", () => {
+    expect(
+      dimensionTargetsMet({ machineSize: "large", storageGib: 50 }, null),
+    ).toEqual({ machine: false, storage: false });
+  });
+
+  test("machine compares by rank, so a larger actual counts", () => {
+    expect(
+      dimensionTargetsMet(
+        { machineSize: "large", storageGib: null },
+        { machineSize: "extra_large", storageGib: null },
+      ).machine,
+    ).toBe(true);
+    expect(
+      dimensionTargetsMet(
+        { machineSize: "large", storageGib: null },
+        { machineSize: "small", storageGib: null },
+      ).machine,
+    ).toBe(false);
+  });
+
+  test("the dimensions are independent: storage can land while machine lags", () => {
+    expect(
+      dimensionTargetsMet(
+        { machineSize: "large", storageGib: 50 },
+        { machineSize: "small", storageGib: 100 },
+      ),
+    ).toEqual({ machine: false, storage: true });
+  });
+
+  test("machine can land while storage lags", () => {
+    expect(
+      dimensionTargetsMet(
+        { machineSize: "large", storageGib: 50 },
+        { machineSize: "large", storageGib: 25 },
+      ),
+    ).toEqual({ machine: true, storage: false });
+  });
+
+  test("targetsMet is the conjunction of the per-dimension flags", () => {
+    const cases: [
+      Parameters<typeof targetsMet>[0],
+      Parameters<typeof targetsMet>[1],
+    ][] = [
+      [null, { machineSize: "large", storageGib: 50 }],
+      [
+        { machineSize: "large", storageGib: 50 },
+        { machineSize: "large", storageGib: 50 },
+      ],
+      [
+        { machineSize: "large", storageGib: 50 },
+        { machineSize: "small", storageGib: 100 },
+      ],
+      [{ machineSize: null, storageGib: null }, null],
+      [{ machineSize: "medium", storageGib: null }, null],
+    ];
+    for (const [targets, actuals] of cases) {
+      const met = dimensionTargetsMet(targets, actuals);
+      expect(targetsMet(targets, actuals)).toBe(
+        targets != null && met.machine && met.storage,
+      );
+    }
+  });
+});
+
+describe("resizeDimensionsInFlight", () => {
+  test("null / undefined status flags nothing", () => {
+    expect(resizeDimensionsInFlight(null)).toEqual({
+      machine: false,
+      storage: false,
+    });
+    expect(resizeDimensionsInFlight(undefined)).toEqual({
+      machine: false,
+      storage: false,
+    });
+  });
+
+  test("a resizing_machine state flags machine only", () => {
+    expect(
+      resizeDimensionsInFlight(opStatus({ state: "resizing_machine" })),
+    ).toEqual({ machine: true, storage: false });
+  });
+
+  test("a resizing_storage state flags storage only", () => {
+    expect(
+      resizeDimensionsInFlight(opStatus({ state: "resizing_storage" })),
+    ).toEqual({ machine: false, storage: true });
+  });
+
+  test("a resize_machine operation flags machine while the state is active", () => {
+    expect(
+      resizeDimensionsInFlight(
+        opStatus({
+          state: "active",
+          active_operation: {
+            operation: "resize_machine",
+            operation_id: "op-1",
+            phase: "WAITING_FOR_READY",
+            started_at: "",
+            updated_at: "",
+            target: {},
+          },
+        }),
+      ),
+    ).toEqual({ machine: true, storage: false });
+  });
+
+  test("a resize_storage operation flags storage while the state is active", () => {
+    expect(
+      resizeDimensionsInFlight(
+        opStatus({
+          state: "active",
+          active_operation: {
+            operation: "resize_storage",
+            operation_id: "op-2",
+            phase: "WAITING_FOR_PVC",
+            started_at: "",
+            updated_at: "",
+            target: {},
+          },
+        }),
+      ),
+    ).toEqual({ machine: false, storage: true });
+  });
+
+  test("an unattributable resize operation flags neither dimension", () => {
+    expect(
+      resizeDimensionsInFlight(
+        opStatus({
+          state: "active",
+          active_operation: {
+            operation: "resize_something_new",
+            operation_id: "op-3",
+            phase: "",
+            started_at: "",
+            updated_at: "",
+            target: {},
+          },
+        }),
+      ),
+    ).toEqual({ machine: false, storage: false });
+  });
+
+  test("an active state with no operation flags neither dimension", () => {
+    expect(resizeDimensionsInFlight(opStatus({ state: "active" }))).toEqual({
+      machine: false,
+      storage: false,
+    });
+  });
+});
+
 describe("isResizeOperationInFlight", () => {
   test("null / undefined status is not in flight", () => {
     expect(isResizeOperationInFlight(null)).toBe(false);
@@ -152,6 +321,24 @@ describe("isResizeOperationInFlight", () => {
             operation: "resize_machine",
             operation_id: "op-1",
             phase: "WAITING_FOR_PVC",
+            started_at: "",
+            updated_at: "",
+            target: {},
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("an unknown resize operation still guards completion globally", () => {
+    expect(
+      isResizeOperationInFlight(
+        opStatus({
+          state: "active",
+          active_operation: {
+            operation: "resize_something_new",
+            operation_id: "op-3",
+            phase: "",
             started_at: "",
             updated_at: "",
             target: {},

--- a/clients/web/src/lib/billing/provisioning-targets.ts
+++ b/clients/web/src/lib/billing/provisioning-targets.ts
@@ -19,27 +19,46 @@ export interface ProvisioningDimensions {
   storageGib: number | null;
 }
 
+/** Per-dimension answer, so callers can act on machine and storage separately. */
+export interface ProvisioningDimensionFlags {
+  machine: boolean;
+  storage: boolean;
+}
+
 /**
- * A dimension with a null target is satisfied (e.g. the Mighty package has no
- * machine tier); a non-null target needs a known actual at or above it.
- * Machine sizes compare by rank, storage by GiB.
+ * Per-dimension target check. A dimension with a null target is satisfied (e.g.
+ * the Mighty package has no machine tier); a non-null target needs a known
+ * actual at or above it. Machine sizes compare by rank, storage by GiB. With no
+ * targets at all nothing is known, so neither dimension is met.
+ */
+export function dimensionTargetsMet(
+  targets: ProvisioningDimensions | null,
+  actuals: ProvisioningDimensions | null,
+): ProvisioningDimensionFlags {
+  if (!targets) {
+    return { machine: false, storage: false };
+  }
+  return {
+    machine:
+      targets.machineSize == null ||
+      (actuals?.machineSize != null &&
+        machineSizeRank(actuals.machineSize) >=
+          machineSizeRank(targets.machineSize)),
+    storage:
+      targets.storageGib == null ||
+      (actuals?.storageGib != null && actuals.storageGib >= targets.storageGib),
+  };
+}
+
+/**
+ * Whether every purchased dimension has landed. Null targets are never met.
  */
 export function targetsMet(
   targets: ProvisioningDimensions | null,
   actuals: ProvisioningDimensions | null,
 ): boolean {
-  if (!targets) {
-    return false;
-  }
-  const machineMet =
-    targets.machineSize == null ||
-    (actuals?.machineSize != null &&
-      machineSizeRank(actuals.machineSize) >=
-        machineSizeRank(targets.machineSize));
-  const storageMet =
-    targets.storageGib == null ||
-    (actuals?.storageGib != null && actuals.storageGib >= targets.storageGib);
-  return machineMet && storageMet;
+  const met = dimensionTargetsMet(targets, actuals);
+  return met.machine && met.storage;
 }
 
 /**
@@ -63,6 +82,27 @@ export function isResizeOperationInFlight(
   }
   const operation = status.active_operation?.operation;
   return typeof operation === "string" && operation.startsWith("resize");
+}
+
+/**
+ * Which dimensions are still rolling out. `isResizeOperationInFlight` matches
+ * any `resize`-prefixed operation so an unknown future resize still guards
+ * completion; this pins the two known dimensions instead, because an operation
+ * it cannot attribute must not hold the wrong dimension pending.
+ */
+export function resizeDimensionsInFlight(
+  status: OperationalStatus | null | undefined,
+): ProvisioningDimensionFlags {
+  if (!status) {
+    return { machine: false, storage: false };
+  }
+  const operation = status.active_operation?.operation;
+  return {
+    machine:
+      status.state === "resizing_machine" || operation === "resize_machine",
+    storage:
+      status.state === "resizing_storage" || operation === "resize_storage",
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add per-dimension `dimensionTargetsMet` and `resizeDimensionsInFlight` helpers
- `targetsMet` now delegates to the per-dimension helper, behavior unchanged
- Groundwork for lighting takeover resource chips one dimension at a time

Part of plan: takeover-credits-chip-and-reveal.md (PR 2 of 7)