### PR TITLE
fix(web): never render storage as shrinking; show the machine floor on machine-less packages

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -497,8 +497,8 @@ describe("stalled", () => {
     expect(container.querySelectorAll(".lucide-arrow-right").length).toBe(1);
   });
 
-  test("both dimensions unchanged render singular with no arrows", () => {
-    const { getByText, container } = renderState({
+  test("an unchanged machine renders singular while unchanged storage is dropped", () => {
+    const { getByText, queryByText, container } = renderState({
       state: "STALLED",
       targets: { machineSize: "medium", storageGib: 30 },
       fromSnapshot: { machineSize: "medium", storageGib: 30 },
@@ -506,9 +506,10 @@ describe("stalled", () => {
 
     expect(getByText("Machine")).toBeTruthy();
     expect(getByText("Medium")).toBeTruthy();
-    expect(getByText("Storage")).toBeTruthy();
-    expect(getByText("30 GB")).toBeTruthy();
-    // Nothing changed, so neither chip draws a current→new arrow.
+    // Storage only renders when it grows, so an unchanged tier has no chip.
+    expect(queryByText("Storage")).toBeNull();
+    expect(queryByText("30 GB")).toBeNull();
+    // Nothing changed, so the machine chip draws no current→new arrow.
     expect(container.querySelector(".lucide-arrow-right")).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
@@ -83,15 +83,15 @@ describe("buildResourceChanges", () => {
     expect(changes[1].from).toBeUndefined();
   });
 
-  test("omits `from` when the snapshot equals the target", () => {
+  test("omits `from` on machine when the snapshot equals the target", () => {
     const changes = buildResourceChanges({
       targets,
       fromSnapshot: { machineSize: "large", storageGib: 50 },
       credits: null,
     });
 
+    expect(changes.map((c) => c.key)).toEqual(["machine"]);
     expect(changes[0].from).toBeUndefined();
-    expect(changes[1].from).toBeUndefined();
   });
 
   test("includes `from` when the snapshot differs from the target", () => {
@@ -103,5 +103,97 @@ describe("buildResourceChanges", () => {
 
     expect(changes[0].from).toBe("Small");
     expect(changes[1].from).toBe("10 GB");
+  });
+
+  test("omits storage when the target equals the snapshot", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: 30 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+      credits: null,
+    });
+
+    expect(changes).toEqual([]);
+  });
+
+  test("omits storage when the target is below the snapshot", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: 10 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+      credits: null,
+    });
+
+    expect(changes).toEqual([]);
+  });
+
+  test("renders storage when the snapshot is null", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: 10 },
+      fromSnapshot: { machineSize: null, storageGib: null },
+      credits: null,
+    });
+
+    expect(changes).toEqual([
+      { key: "storage", label: "Storage", from: undefined, to: "10 GB" },
+    ]);
+  });
+
+  test("renders storage when it grows", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: 30 },
+      fromSnapshot: { machineSize: null, storageGib: 10 },
+      credits: null,
+    });
+
+    expect(changes).toEqual([
+      { key: "storage", label: "Storage", from: "10 GB", to: "30 GB" },
+    ]);
+  });
+
+  test("renders the machine floor when the snapshot machine differs", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: null },
+      fromSnapshot: { machineSize: "medium", storageGib: 30 },
+      machineFloor: "small",
+      credits: null,
+    });
+
+    expect(changes).toEqual([
+      { key: "machine", label: "Machine", from: "Medium", to: "Small" },
+    ]);
+  });
+
+  test("omits the machine floor when the pod already sits at the floor", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: null },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+      machineFloor: "small",
+      credits: null,
+    });
+
+    expect(changes).toEqual([]);
+  });
+
+  test("omits the machine floor when the snapshot machine is null", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: null },
+      fromSnapshot: { machineSize: null, storageGib: null },
+      machineFloor: "small",
+      credits: null,
+    });
+
+    expect(changes).toEqual([]);
+  });
+
+  test("ignores the machine floor when the target machineSize is set", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: "large", storageGib: null },
+      fromSnapshot: { machineSize: "medium", storageGib: null },
+      machineFloor: "small",
+      credits: null,
+    });
+
+    expect(changes).toEqual([
+      { key: "machine", label: "Machine", from: "Medium", to: "Large" },
+    ]);
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
@@ -1,5 +1,6 @@
 import { SIZE_LABEL } from "@/lib/billing/machine-sizes";
 
+import type { MachineSizeEnum } from "@/generated/api/types.gen";
 import type { ProvisioningDimensions } from "./provisioning-machine";
 
 export type ResourceChangeKey = "machine" | "storage" | "credits";
@@ -17,13 +18,30 @@ export interface ResourceChange {
  * machine → storage → credits to mirror the chip order in provisioning-state.
  * A dimension is included only when it has something to show; `from` is present
  * only when the pre-resize snapshot differs from the target.
+ *
+ * Storage renders only when it grows. PVCs never shrink (vembda raises on a
+ * decrease and Kubernetes cannot reduce a claim), so a lowered BILLED storage
+ * tier leaves the volume exactly where it is, and `30 GB → 10 GB` would claim a
+ * data loss that never happens. A null snapshot is the fresh-hatch case and
+ * still renders.
+ *
+ * `machineFloor` is display-only. It covers machine-less packages, whose null
+ * machine target otherwise drops the machine row entirely, and it mirrors the
+ * server's `_machine_tier_ceiling_size(None) == "small"`. It must never feed
+ * `targetsMet`: a non-null machine target requires non-null actuals and hangs
+ * the upgrade takeover on a fresh hatch. The floor row also needs a real
+ * difference on the from-side, because a null machine target is trivially met
+ * and a pod already at or below the ceiling gets no cap marker created
+ * server-side, so a floor row without that difference arrives pre-checked and
+ * asserts a downsize that never ran.
  */
 export function buildResourceChanges(input: {
   targets: ProvisioningDimensions;
   fromSnapshot: ProvisioningDimensions;
+  machineFloor?: MachineSizeEnum | null;
   credits: { from: string; to: string } | null;
 }): ResourceChange[] {
-  const { targets, fromSnapshot, credits } = input;
+  const { targets, fromSnapshot, machineFloor, credits } = input;
   const changes: ResourceChange[] = [];
 
   if (targets.machineSize != null) {
@@ -37,15 +55,29 @@ export function buildResourceChanges(input: {
           : undefined,
       to: SIZE_LABEL[targets.machineSize],
     });
+  } else if (
+    machineFloor != null &&
+    fromSnapshot.machineSize != null &&
+    fromSnapshot.machineSize !== machineFloor
+  ) {
+    changes.push({
+      key: "machine",
+      label: "Machine",
+      from: SIZE_LABEL[fromSnapshot.machineSize],
+      to: SIZE_LABEL[machineFloor],
+    });
   }
 
-  if (targets.storageGib != null) {
+  if (
+    targets.storageGib != null &&
+    (fromSnapshot.storageGib == null ||
+      targets.storageGib > fromSnapshot.storageGib)
+  ) {
     changes.push({
       key: "storage",
       label: "Storage",
       from:
-        fromSnapshot.storageGib != null &&
-        fromSnapshot.storageGib !== targets.storageGib
+        fromSnapshot.storageGib != null
           ? `${fromSnapshot.storageGib} GB`
           : undefined,
       to: `${targets.storageGib} GB`,


### PR DESCRIPTION
## Summary
- Storage rows render only when storage actually grows, since PVCs never shrink and a lowered billed tier must not read as data loss
- Add a display-only machine floor so machine-less packages can show a real downsize without touching `targetsMet`
- The floor row is suppressed unless the snapshot shows a genuine difference, so it can never arrive pre-checked

Part of plan: takeover-credits-chip-and-reveal.md (PR 3 of 7)