### PR TITLE
fix(daemon): tolerate transient SQLite contention in the conversation usage-totals write

### DIFF
--- a/assistant/src/__tests__/conversation-usage.test.ts
+++ b/assistant/src/__tests__/conversation-usage.test.ts
@@ -7,6 +7,15 @@ const updateConversationUsageCalls: Array<{
   estimatedCost: number;
 }> = [];
 
+let updateConversationUsageFailures = 0;
+let updateConversationUsageFailureCode = "SQLITE_BUSY";
+
+function sqliteError(code: string): Error {
+  const err = new Error("database is locked") as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
 mock.module("../persistence/conversation-crud.js", () => ({
   setConversationProcessingStartedAt: () => {},
   isConversationProcessing: () => false,
@@ -16,6 +25,10 @@ mock.module("../persistence/conversation-crud.js", () => ({
     outputTokens: number,
     estimatedCost: number,
   ) => {
+    if (updateConversationUsageFailures > 0) {
+      updateConversationUsageFailures--;
+      throw sqliteError(updateConversationUsageFailureCode);
+    }
     updateConversationUsageCalls.push({
       conversationId,
       inputTokens,
@@ -35,6 +48,7 @@ import { UsageTrackingProvider } from "../providers/usage-tracking.js";
 import type { PricingUsage } from "../usage/types.js";
 import { resolvePricingForUsageWithOverrides } from "../util/pricing.js";
 import { setConfig } from "./helpers/set-config.js";
+import { waitFor } from "./helpers/wait-for.js";
 
 await initializeDb();
 
@@ -63,6 +77,8 @@ describe("recordUsage", () => {
     const db = getDb();
     db.run(`DELETE FROM llm_usage_events`);
     updateConversationUsageCalls.length = 0;
+    updateConversationUsageFailures = 0;
+    updateConversationUsageFailureCode = "SQLITE_BUSY";
   });
 
   test("applies fast mode pricing when any response has speed: fast", () => {
@@ -422,6 +438,149 @@ describe("recordUsage", () => {
       inferenceProfile: null,
       inferenceProfileSource: "default",
     });
+  });
+
+  test("transient SQLITE_BUSY on the totals write never escapes and retries persist the totals", async () => {
+    const usageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+    // Sync attempt fails, first background retry fails, second succeeds.
+    updateConversationUsageFailures = 2;
+
+    recordUsage(
+      {
+        conversationId: "conv-busy-1",
+        providerName: "openai",
+        usageStats,
+      },
+      100,
+      20,
+      "gpt-4o",
+      () => {},
+      "main_agent",
+    );
+
+    // The throwing write must not have escaped into the caller, and the
+    // in-memory accumulator must already reflect the event.
+    expect(usageStats.inputTokens).toBe(100);
+    expect(usageStats.outputTokens).toBe(20);
+
+    await waitFor(() => updateConversationUsageCalls.length === 1, {
+      timeoutMs: 3_000,
+    });
+    expect(updateConversationUsageCalls[0]).toMatchObject({
+      conversationId: "conv-busy-1",
+      inputTokens: 100,
+      outputTokens: 20,
+    });
+  });
+
+  test("exhausted retries are tolerated and the next usage event self-heals the totals", async () => {
+    const usageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+    // More failures than the sync attempt (1) plus the retry chain's
+    // initial-plus-3-retries budget (4), so the first event's write is
+    // dropped entirely.
+    updateConversationUsageFailures = 100;
+
+    recordUsage(
+      {
+        conversationId: "conv-busy-2",
+        providerName: "openai",
+        usageStats,
+      },
+      100,
+      20,
+      "gpt-4o",
+      () => {},
+      "main_agent",
+    );
+
+    await waitFor(() => updateConversationUsageFailures === 95, {
+      timeoutMs: 3_000,
+    });
+    // Give the chain a beat to settle after its final failure.
+    await Bun.sleep(50);
+    expect(updateConversationUsageCalls).toHaveLength(0);
+
+    updateConversationUsageFailures = 0;
+    recordUsage(
+      {
+        conversationId: "conv-busy-2",
+        providerName: "openai",
+        usageStats,
+      },
+      50,
+      10,
+      "gpt-4o",
+      () => {},
+      "main_agent",
+    );
+
+    // The second event's write carries the cumulative totals, healing the
+    // dropped first write.
+    await waitFor(() => updateConversationUsageCalls.length === 1, {
+      timeoutMs: 3_000,
+    });
+    expect(updateConversationUsageCalls[0]).toMatchObject({
+      conversationId: "conv-busy-2",
+      inputTokens: 150,
+      outputTokens: 30,
+    });
+  });
+
+  test("a usage event landing mid-retry coalesces and stale totals never overwrite newer ones", async () => {
+    const usageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+    // Sync attempt and the first two background attempts fail, leaving the
+    // chain alive in backoff while the second event lands.
+    updateConversationUsageFailures = 3;
+
+    const ctx = {
+      conversationId: "conv-busy-3",
+      providerName: "openai",
+      usageStats,
+    };
+    recordUsage(ctx, 100, 20, "gpt-4o", () => {}, "main_agent");
+    recordUsage(ctx, 50, 10, "gpt-4o", () => {}, "main_agent");
+
+    await waitFor(
+      () =>
+        updateConversationUsageCalls.some(
+          (call) => call.inputTokens === 150 && call.outputTokens === 30,
+        ),
+      { timeoutMs: 3_000 },
+    );
+    // Wait out any straggling coalesced write, then confirm nothing stale
+    // landed after the cumulative totals.
+    await Bun.sleep(300);
+    const last = updateConversationUsageCalls.at(-1);
+    expect(last).toMatchObject({
+      conversationId: "conv-busy-3",
+      inputTokens: 150,
+      outputTokens: 30,
+    });
+  });
+
+  test("a non-retryable write error is tolerated without retrying", async () => {
+    const usageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+    updateConversationUsageFailures = 1;
+    updateConversationUsageFailureCode = "SQLITE_CORRUPT";
+
+    recordUsage(
+      {
+        conversationId: "conv-corrupt-1",
+        providerName: "openai",
+        usageStats,
+      },
+      100,
+      20,
+      "gpt-4o",
+      () => {},
+      "main_agent",
+    );
+
+    // No background chain: the failure budget is spent on the sync attempt
+    // and nothing retries afterwards.
+    await Bun.sleep(300);
+    expect(updateConversationUsageCalls).toHaveLength(0);
+    expect(usageStats.inputTokens).toBe(100);
   });
 
   test("NaN token counts never reach persistence and a poisoned total self-heals", () => {

--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -17,6 +17,10 @@ import {
   resolvePricingForUsageWithOverrides,
   usesAnthropicPricingRules,
 } from "../util/pricing.js";
+import {
+  isRetryableSqliteError,
+  withSqliteRetry,
+} from "../util/sqlite-retry.js";
 import type { UsageStats } from "./message-protocol.js";
 
 const log = getLogger("conversation-usage");
@@ -166,6 +170,83 @@ function resolveAttribution(
     : resolveUsageAttribution(attribution);
 }
 
+interface PendingUsageWrite {
+  /** Most recent context for this conversation; every attempt persists it. */
+  latest: UsageContext;
+  /** A usage event arrived while the chain was draining; one trailing write owed. */
+  dirty: boolean;
+}
+
+const pendingUsageWrites = new Map<string, PendingUsageWrite>();
+
+/**
+ * Persist the conversation row's cumulative usage totals, tolerating SQLite
+ * write contention. Usage accounting is post-turn bookkeeping — a concurrent
+ * bulk writer (e.g. a retrospective fork copy) holding the write lock past
+ * `busy_timeout` must never surface as a failed turn, so no error escapes.
+ *
+ * The first attempt runs synchronously (the common, uncontended path). On a
+ * transient `SQLITE_BUSY`/`SQLITE_IOERR` it falls back to a background
+ * {@link withSqliteRetry} chain, single-flight per conversation: events that
+ * land mid-chain coalesce into one trailing write instead of racing it, so a
+ * delayed retry can never overwrite newer totals with older ones. Totals are
+ * absolute values read from the live {@link UsageStats} accumulator at
+ * statement time, which makes coalescing lossless and a fully dropped write
+ * self-healing on the next usage event.
+ */
+function persistUsageTotals(ctx: UsageContext): void {
+  const pending = pendingUsageWrites.get(ctx.conversationId);
+  if (pending) {
+    pending.latest = ctx;
+    pending.dirty = true;
+    return;
+  }
+  try {
+    writeUsageTotals(ctx);
+    return;
+  } catch (err) {
+    if (!isRetryableSqliteError(err)) {
+      log.warn(
+        { err, conversationId: ctx.conversationId },
+        "Failed to persist conversation usage totals (non-fatal)",
+      );
+      return;
+    }
+  }
+  const entry: PendingUsageWrite = { latest: ctx, dirty: false };
+  pendingUsageWrites.set(ctx.conversationId, entry);
+  void retryUsageWrite(entry);
+}
+
+function writeUsageTotals(target: UsageContext): void {
+  updateConversationUsage(
+    target.conversationId,
+    target.usageStats.inputTokens,
+    target.usageStats.outputTokens,
+    target.usageStats.estimatedCost,
+  );
+}
+
+async function retryUsageWrite(entry: PendingUsageWrite): Promise<void> {
+  const conversationId = entry.latest.conversationId;
+  try {
+    await withSqliteRetry(() => writeUsageTotals(entry.latest), {
+      op: "conversation:updateUsage",
+      context: { conversationId },
+    });
+  } catch (err) {
+    log.warn(
+      { err, conversationId },
+      "Failed to persist conversation usage totals after retries; totals self-heal on the next usage event (non-fatal)",
+    );
+  } finally {
+    pendingUsageWrites.delete(conversationId);
+    if (entry.dirty) {
+      persistUsageTotals(entry.latest);
+    }
+  }
+}
+
 export function recordUsage(
   ctx: UsageContext,
   inputTokens: number,
@@ -233,12 +314,7 @@ export function recordUsage(
       ? ctx.usageStats.estimatedCost
       : 0) + estimatedCost;
 
-  updateConversationUsage(
-    ctx.conversationId,
-    ctx.usageStats.inputTokens,
-    ctx.usageStats.outputTokens,
-    ctx.usageStats.estimatedCost,
-  );
+  persistUsageTotals(ctx);
   onEvent({
     type: "usage_update",
     conversationId: ctx.conversationId,


### PR DESCRIPTION
## Summary
- `recordUsage` now persists conversation usage totals through a contention-tolerant path: the first write attempt stays synchronous, and a transient `SQLITE_BUSY`/`SQLITE_IOERR` falls back to a background `withSqliteRetry` chain instead of throwing into the agent loop — post-turn bookkeeping can no longer surface as a user-visible "Processing failed: database is locked" turn failure after the reply already completed.
- The background chain is single-flight per conversation with coalescing: usage events landing mid-chain fold into one trailing write of the latest totals, so a delayed retry can never overwrite newer totals with older ones. Totals are absolute values read from the live accumulator at statement time, so a fully dropped write self-heals on the next usage event (same posture as the persisted-seq anchor and turn-outcome stamp).
- Regression tests: transient-busy retry persists totals, exhausted retries are tolerated and self-heal on the next event, mid-chain coalescing leaves no stale overwrite, and non-retryable errors are tolerated without retrying.

## Original prompt
Observed live on a long-running instance: a background retrospective fork-copy held the SQLite write lock in 10–14s batches while a conversation turn completed; the daemon's 5s busy_timeout expired and the unprotected `updateConversationUsage` call in the agent loop's usage bookkeeping threw `SQLITE_BUSY`, failing the turn in the client UI even though the reply had fully generated and persisted. Request: wrap the usage-totals write in the same withSqliteRetry + tolerate-and-warn pattern used by sibling post-turn writes so usage accounting never fails a completed turn, with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)