### PR TITLE
feat(web): per-dimension landed signals and machine floor from the provisioning hook

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -146,6 +146,8 @@ let assistantEndpointsFail = false;
 let onboardingFails = false;
 /** Holds the onboarding fetch in flight so isFetching can be observed. */
 let onboardingGate: Deferred | null = null;
+/** Holds the operational-status fetch in flight, mid-poll. */
+let operationalStatusGate: Deferred | null = null;
 let assistantCalls = 0;
 let assistantByIdCalls = 0;
 let operationalStatusCalls = 0;
@@ -233,15 +235,18 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
-  assistantsOperationalStatusDetailRead: () => {
+  assistantsOperationalStatusDetailRead: async () => {
     operationalStatusCalls += 1;
     if (assistantEndpointsFail) {
-      return Promise.reject(new Error("502 Bad Gateway"));
+      throw new Error("502 Bad Gateway");
     }
-    return Promise.resolve({
-      data: operationalStatusResponse,
-      response: { ok: true },
-    });
+    // Read at request time, so a gated fetch answers with the reading the
+    // server held when it started rather than one written while it was out.
+    const data = operationalStatusResponse;
+    if (operationalStatusGate) {
+      await operationalStatusGate.promise;
+    }
+    return { data, response: { ok: true } };
   },
   organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate: () => {
     ensureCalls += 1;
@@ -351,6 +356,7 @@ beforeEach(() => {
   assistantEndpointsFail = false;
   onboardingFails = false;
   onboardingGate = null;
+  operationalStatusGate = null;
   assistantCalls = 0;
   assistantByIdCalls = 0;
   operationalStatusCalls = 0;
@@ -1488,5 +1494,63 @@ describe("useProProvisioning presentation signals", () => {
       expect(latest!.landed).toEqual({ machine: true, storage: true });
     });
     expect(latest!.state).toBe("DONE");
+  }, 20_000);
+
+  test("a status fetch already out when a dimension meets its target does not land it", async () => {
+    // `started` queues the resize on a worker, so the status query can be out
+    // with its pre-resize reading when the assistant poll lands the persisted
+    // target sizes.
+    ensureResponse = makeEnsureResponse("started");
+    const { client } = renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+    subscriptionPlanId = "pro";
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+      timeout: 5000,
+    });
+    expect(latest!.landed).toEqual({ machine: false, storage: false });
+
+    // A status fetch goes out carrying the pre-resize reading, and is still out
+    // when the assistant poll reports the persisted target sizes.
+    const gate = makeDeferred();
+    operationalStatusGate = gate;
+    act(() => {
+      void client.invalidateQueries({ queryKey: STATUS_QUERY_KEY });
+    });
+    await waitFor(() =>
+      expect(client.getQueryState(STATUS_QUERY_KEY)?.fetchStatus).toBe(
+        "fetching",
+      ),
+    );
+
+    assistantResponse = makeAssistant("large", 50);
+    await act(async () => {
+      client.setQueryData(ASSISTANT_QUERY_KEY, assistantResponse);
+    });
+    expect(latest!.landed).toEqual({ machine: false, storage: false });
+
+    // The clock moves on before that fetch answers, so its result stores
+    // strictly after the dimensions read met: it postdates them by
+    // `dataUpdatedAt` alone, though it observed the world before them. It may
+    // not land anything.
+    dateNowOffsetMs += 50;
+    operationalStatusGate = null;
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await waitFor(() =>
+      expect(client.getQueryState(STATUS_QUERY_KEY)?.fetchStatus).toBe("idle"),
+    );
+    expect(latest!.landed).toEqual({ machine: false, storage: false });
+    // The terminal gate compares the same timestamp without the fence and so
+    // takes that reading, which is the asymmetry the flags are stricter than.
+    expect(latest!.state).toBe("DONE");
+
+    // The first fetch that starts after them does land them.
+    await waitForLanded(client, () => {
+      expect(latest!.landed).toEqual({ machine: true, storage: true });
+    });
   }, 20_000);
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -1489,6 +1489,57 @@ describe("useProProvisioning presentation signals", () => {
     });
   }, 20_000);
 
+  test("a lower machine target holds machine pending until the pod downsizes", async () => {
+    subscriptionPlanId = "pro";
+    // Ultra to Super: the package buys a medium machine while the pod is still
+    // large, so the displayed change is a downsize. Grow-only target semantics
+    // read that as met on arrival.
+    onboardingResponse = { ...makeOnboarding(), max_machine_tier: "medium" };
+    assistantResponse = makeAssistant("large", 50);
+    const { client } = renderProbe();
+
+    await waitFor(
+      () =>
+        expect(latest!.targets).toEqual({
+          machineSize: "medium",
+          storageGib: 50,
+        }),
+      { timeout: 5000 },
+    );
+    // Storage landing proves readings are being taken since the actuals, so the
+    // outstanding downsize is the only thing still holding the machine flag.
+    await waitForLanded(client, () => {
+      expect(latest!.landed.storage).toBe(true);
+    });
+    expect(latest!.landed.machine).toBe(false);
+
+    assistantResponse = makeAssistant("medium", 50);
+    await refetchAll(client);
+    await waitForLanded(client, () => {
+      expect(latest!.landed.machine).toBe(true);
+    });
+  }, 20_000);
+
+  test("the same machine target growing is still judged as growth", async () => {
+    subscriptionPlanId = "pro";
+    // Same target, opposite direction: the pod starts below it, so the flag
+    // must keep the grow-only comparison rather than flip to a downsize one.
+    onboardingResponse = { ...makeOnboarding(), max_machine_tier: "medium" };
+    assistantResponse = makeAssistant("small", 50);
+    const { client } = renderProbe();
+
+    await waitForLanded(client, () => {
+      expect(latest!.landed.storage).toBe(true);
+    });
+    expect(latest!.landed.machine).toBe(false);
+
+    assistantResponse = makeAssistant("medium", 50);
+    await refetchAll(client);
+    await waitForLanded(client, () => {
+      expect(latest!.landed.machine).toBe(true);
+    });
+  }, 20_000);
+
   test("a landed flag waits for a status reading taken after the actuals", async () => {
     // `started` queues the resize on a worker, so the status query can still be
     // holding its pre-resize reading when the assistant poll lands the

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -117,6 +117,23 @@ function makeOperationalStatus(
   } as OperationalStatus;
 }
 
+/** A settled state carrying an in-flight resize marker for one dimension. */
+function makeResizeOperationStatus(
+  operation: "resize_machine" | "resize_storage",
+): OperationalStatus {
+  return {
+    ...makeOperationalStatus("active"),
+    active_operation: {
+      operation,
+      operation_id: "op-1",
+      phase: "waiting_for_ready",
+      started_at: "2026-08-01T00:00:00Z",
+      updated_at: "2026-08-01T00:00:00Z",
+      target: {},
+    },
+  } as OperationalStatus;
+}
+
 let subscriptionPlanId: SubscriptionResponse["plan_id"] = "base";
 let onboardingResponse = makeOnboarding();
 let assistantResponse = makeAssistant("small", 10);
@@ -1302,5 +1319,99 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       timeout: 5000,
     });
     expect(latest!.kickError).toBeNull();
+  }, 20_000);
+});
+
+describe("useProProvisioning presentation signals", () => {
+  test("machineFloor is null before onboarding lands and for a real tier", async () => {
+    const { client } = renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+    expect(latest!.machineFloor).toBeNull();
+
+    subscriptionPlanId = "pro";
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+      timeout: 5000,
+    });
+    expect(latest!.targets).toEqual({ machineSize: "large", storageGib: 50 });
+    expect(latest!.machineFloor).toBeNull();
+  });
+
+  test("machineFloor is small when the package carries no machine tier", async () => {
+    subscriptionPlanId = "pro";
+    onboardingResponse = { ...makeOnboarding(), max_machine_tier: null };
+    renderProbe();
+
+    await waitFor(() => expect(latest!.machineFloor).toBe("small"), {
+      timeout: 5000,
+    });
+    // The floor is display only, so it never becomes a machine target.
+    expect(latest!.targets).toEqual({ machineSize: null, storageGib: 50 });
+  });
+
+  test("landed flips per dimension as each target is met", async () => {
+    const { client } = renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+    subscriptionPlanId = "pro";
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+      timeout: 5000,
+    });
+    expect(latest!.landed).toEqual({ machine: false, storage: false });
+
+    // The machine lands first while storage is still growing.
+    assistantResponse = makeAssistant("large", 10);
+    await refetchAll(client);
+    await waitFor(
+      () => expect(latest!.landed).toEqual({ machine: true, storage: false }),
+      { timeout: 5000 },
+    );
+
+    assistantResponse = makeAssistant("large", 50);
+    await refetchAll(client);
+    await waitFor(
+      () => expect(latest!.landed).toEqual({ machine: true, storage: true }),
+      { timeout: 5000 },
+    );
+  }, 20_000);
+
+  test("an in-flight machine resize holds machine pending while storage lands", async () => {
+    const { client } = renderProbe();
+    await reachResizing(client);
+
+    // The platform persists both effective sizes at resize acceptance, so the
+    // actuals meet the targets while the pod is still restarting. Only the
+    // machine marker is in flight, so storage may land ahead of it.
+    assistantResponse = makeAssistant("large", 50);
+    await refetchAll(client);
+    await waitFor(
+      () => expect(latest!.landed).toEqual({ machine: false, storage: true }),
+      { timeout: 5000 },
+    );
+    expect(latest!.state).toBe("RESIZING");
+
+    operationalStatusResponse = makeOperationalStatus("active");
+    await refetchAll(client);
+    await waitFor(
+      () => expect(latest!.landed).toEqual({ machine: true, storage: true }),
+      { timeout: 5000 },
+    );
+  }, 20_000);
+
+  test("an active resize_storage operation holds only the storage flag", async () => {
+    const { client } = renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+    subscriptionPlanId = "pro";
+    assistantResponse = makeAssistant("large", 50);
+    operationalStatusResponse = makeResizeOperationStatus("resize_storage");
+    await refetchAll(client);
+
+    await waitFor(
+      () => expect(latest!.landed).toEqual({ machine: true, storage: false }),
+      { timeout: 5000 },
+    );
   }, 20_000);
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -16,7 +16,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -274,8 +274,18 @@ const { useProProvisioning } = await import("./use-pro-provisioning");
 
 let latest: ProProvisioningResult | null = null;
 
+/**
+ * Run from the probe's layout effect, which fires after a render commits and
+ * before the hook's passive effects. The seam a test needs to start a request
+ * inside that window; it clears itself when it has fired.
+ */
+let onLayoutCommit: (() => void) | null = null;
+
 function Probe({ open = true }: { open?: boolean }) {
   const result = useProProvisioning({ open });
+  useLayoutEffect(() => {
+    onLayoutCommit?.();
+  });
   useEffect(() => {
     latest = result;
   });
@@ -305,6 +315,18 @@ function renderProbe(client = makeClient()) {
 
 async function refetchAll(client: QueryClient) {
   await client.invalidateQueries();
+}
+
+/**
+ * Write to the cache and let the notification reach React. The query cache
+ * schedules its notifications on a timer, so an `act` that only drains
+ * microtasks can return before the render the write implies has happened.
+ */
+async function commitCacheWrite(write: () => void) {
+  await act(async () => {
+    write();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 }
 
 const ASSISTANT_QUERY_KEY = assistantsRetrieveQueryKey({
@@ -370,6 +392,7 @@ beforeEach(() => {
   pendingEnsures = [];
   dateNowOffsetMs = 0;
   latest = null;
+  onLayoutCommit = null;
 });
 
 afterEach(() => {
@@ -1525,15 +1548,85 @@ describe("useProProvisioning presentation signals", () => {
     );
 
     assistantResponse = makeAssistant("large", 50);
-    await act(async () => {
+    await commitCacheWrite(() => {
       client.setQueryData(ASSISTANT_QUERY_KEY, assistantResponse);
     });
     expect(latest!.landed).toEqual({ machine: false, storage: false });
 
     // The clock moves on before that fetch answers, so its result stores
-    // strictly after the dimensions read met: it postdates them by
-    // `dataUpdatedAt` alone, though it observed the world before them. It may
-    // not land anything.
+    // strictly after the dimensions read met: it postdates them in wall-clock
+    // terms, though it observed the world before them. It may not land
+    // anything.
+    dateNowOffsetMs += 50;
+    operationalStatusGate = null;
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    // The terminal gate compares storage times without the fence and so takes
+    // that reading, which is the asymmetry the flags are stricter than. Waiting
+    // for it also proves the reading was fully absorbed before the flags are
+    // asserted to have ignored it.
+    await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
+    expect(latest!.landed).toEqual({ machine: false, storage: false });
+
+    // The first fetch that starts after them does land them.
+    await waitForLanded(client, () => {
+      expect(latest!.landed).toEqual({ machine: true, storage: true });
+    });
+  }, 20_000);
+
+  test("a status refetch starting between the render and the effect does not land a dimension", async () => {
+    // The window a render-time reading cannot see: the hook renders with the
+    // status query idle, a refetch goes out, and only then does the latch
+    // effect run. That request still read the world before the resize marker,
+    // so it may not land anything however late its answer is stored.
+    ensureResponse = makeEnsureResponse("started");
+    const { client } = renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+    subscriptionPlanId = "pro";
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+      timeout: 5000,
+    });
+    expect(latest!.landed).toEqual({ machine: false, storage: false });
+
+    // Settle the status poll first: the window under test is a request that
+    // begins after the render, not one already running when it starts.
+    await act(async () => {
+      await client.refetchQueries({ queryKey: STATUS_QUERY_KEY });
+    });
+    expect(client.getQueryState(STATUS_QUERY_KEY)?.fetchStatus).toBe("idle");
+
+    // Held open so the request is unambiguously still out when the latch
+    // effect runs.
+    const gate = makeDeferred();
+    operationalStatusGate = gate;
+    onLayoutCommit = () => {
+      const assistant = client.getQueryData(ASSISTANT_QUERY_KEY) as
+        | Assistant
+        | undefined;
+      // Only the commit that first carries the target sizes: that is the
+      // render whose passive effect takes the latch.
+      if (assistant?.machine_size !== "large") {
+        return;
+      }
+      onLayoutCommit = null;
+      void client.refetchQueries({ queryKey: STATUS_QUERY_KEY });
+    };
+
+    assistantResponse = makeAssistant("large", 50);
+    await commitCacheWrite(() => {
+      client.setQueryData(ASSISTANT_QUERY_KEY, assistantResponse);
+    });
+    expect(client.getQueryState(STATUS_QUERY_KEY)?.fetchStatus).toBe(
+      "fetching",
+    );
+    expect(latest!.landed).toEqual({ machine: false, storage: false });
+
+    // It answers after the dimensions read met, which is what a fence built on
+    // storage times would take.
     dateNowOffsetMs += 50;
     operationalStatusGate = null;
     await act(async () => {
@@ -1544,11 +1637,8 @@ describe("useProProvisioning presentation signals", () => {
       expect(client.getQueryState(STATUS_QUERY_KEY)?.fetchStatus).toBe("idle"),
     );
     expect(latest!.landed).toEqual({ machine: false, storage: false });
-    // The terminal gate compares the same timestamp without the fence and so
-    // takes that reading, which is the asymmetry the flags are stricter than.
-    expect(latest!.state).toBe("DONE");
 
-    // The first fetch that starts after them does land them.
+    // A reading that starts after the latch does land them.
     await waitForLanded(client, () => {
       expect(latest!.landed).toEqual({ machine: true, storage: true });
     });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -21,6 +21,8 @@ import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import {
+  assistantsOperationalStatusDetailReadQueryKey,
+  assistantsRetrieveQueryKey,
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
@@ -298,6 +300,29 @@ function renderProbe(client = makeClient()) {
 
 async function refetchAll(client: QueryClient) {
   await client.invalidateQueries();
+}
+
+const ASSISTANT_QUERY_KEY = assistantsRetrieveQueryKey({
+  path: { id: "assistant-1" },
+});
+const STATUS_QUERY_KEY = assistantsOperationalStatusDetailReadQueryKey({
+  path: { id: "assistant-1" },
+});
+
+/**
+ * Take operational-status readings until `check` passes. A landed flag holds
+ * its dimension pending until the status has been read since that dimension met
+ * its target, and terminal states stop the hook's own poll, so the readings are
+ * taken by hand rather than waited out.
+ */
+async function waitForLanded(client: QueryClient, check: () => void) {
+  await waitFor(
+    async () => {
+      await client.invalidateQueries({ queryKey: STATUS_QUERY_KEY });
+      check();
+    },
+    { timeout: 5000 },
+  );
 }
 
 /** Drive the hook from a fresh mount to a confirmed-pro RESIZING state. */
@@ -1364,17 +1389,15 @@ describe("useProProvisioning presentation signals", () => {
     // The machine lands first while storage is still growing.
     assistantResponse = makeAssistant("large", 10);
     await refetchAll(client);
-    await waitFor(
-      () => expect(latest!.landed).toEqual({ machine: true, storage: false }),
-      { timeout: 5000 },
-    );
+    await waitForLanded(client, () => {
+      expect(latest!.landed).toEqual({ machine: true, storage: false });
+    });
 
     assistantResponse = makeAssistant("large", 50);
     await refetchAll(client);
-    await waitFor(
-      () => expect(latest!.landed).toEqual({ machine: true, storage: true }),
-      { timeout: 5000 },
-    );
+    await waitForLanded(client, () => {
+      expect(latest!.landed).toEqual({ machine: true, storage: true });
+    });
   }, 20_000);
 
   test("an in-flight machine resize holds machine pending while storage lands", async () => {
@@ -1386,18 +1409,16 @@ describe("useProProvisioning presentation signals", () => {
     // machine marker is in flight, so storage may land ahead of it.
     assistantResponse = makeAssistant("large", 50);
     await refetchAll(client);
-    await waitFor(
-      () => expect(latest!.landed).toEqual({ machine: false, storage: true }),
-      { timeout: 5000 },
-    );
+    await waitForLanded(client, () => {
+      expect(latest!.landed).toEqual({ machine: false, storage: true });
+    });
     expect(latest!.state).toBe("RESIZING");
 
     operationalStatusResponse = makeOperationalStatus("active");
     await refetchAll(client);
-    await waitFor(
-      () => expect(latest!.landed).toEqual({ machine: true, storage: true }),
-      { timeout: 5000 },
-    );
+    await waitForLanded(client, () => {
+      expect(latest!.landed).toEqual({ machine: true, storage: true });
+    });
   }, 20_000);
 
   test("an active resize_storage operation holds only the storage flag", async () => {
@@ -1409,9 +1430,63 @@ describe("useProProvisioning presentation signals", () => {
     operationalStatusResponse = makeResizeOperationStatus("resize_storage");
     await refetchAll(client);
 
-    await waitFor(
-      () => expect(latest!.landed).toEqual({ machine: true, storage: false }),
-      { timeout: 5000 },
-    );
+    await waitForLanded(client, () => {
+      expect(latest!.landed).toEqual({ machine: true, storage: false });
+    });
+  }, 20_000);
+
+  test("the machine floor holds machine pending until the assistant downsizes", async () => {
+    subscriptionPlanId = "pro";
+    onboardingResponse = { ...makeOnboarding(), max_machine_tier: null };
+    // Still above the floor the package settles at: the displayed downsize has
+    // not happened, and the null machine target cannot catch that on its own.
+    assistantResponse = makeAssistant("medium", 50);
+    const { client } = renderProbe();
+
+    await waitFor(() => expect(latest!.machineFloor).toBe("small"), {
+      timeout: 5000,
+    });
+    // Storage landing proves readings are being taken since the actuals, so
+    // the floor is the only thing still holding the machine flag.
+    await waitForLanded(client, () => {
+      expect(latest!.landed.storage).toBe(true);
+    });
+    expect(latest!.landed.machine).toBe(false);
+
+    assistantResponse = makeAssistant("small", 50);
+    await refetchAll(client);
+    await waitForLanded(client, () => {
+      expect(latest!.landed.machine).toBe(true);
+    });
+  }, 20_000);
+
+  test("a landed flag waits for a status reading taken after the actuals", async () => {
+    // `started` queues the resize on a worker, so the status query can still be
+    // holding its pre-resize reading when the assistant poll lands the
+    // persisted target sizes.
+    ensureResponse = makeEnsureResponse("started");
+    const { client } = renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+    subscriptionPlanId = "pro";
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+      timeout: 5000,
+    });
+
+    // Only the assistant query advances here, so nothing has read the world
+    // since the sizes it reports and no flag may land off them.
+    assistantResponse = makeAssistant("large", 50);
+    act(() => {
+      client.setQueryData(ASSISTANT_QUERY_KEY, assistantResponse);
+    });
+    expect(latest!.state).toBe("RESIZING");
+    expect(latest!.landed).toEqual({ machine: false, storage: false });
+
+    // The reading that settles the flow settles the flags with it.
+    await waitForLanded(client, () => {
+      expect(latest!.landed).toEqual({ machine: true, storage: true });
+    });
+    expect(latest!.state).toBe("DONE");
   }, 20_000);
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -27,7 +27,13 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  hashKey,
+  notifyManager,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import {
   assistantsActiveRetrieveOptions,
@@ -84,10 +90,10 @@ const TERMINAL_STATES: readonly ProvisioningStateKind[] = [
 ];
 
 /**
- * When each dimension was first seen to meet what the takeover displays for it
- * with no status fetch out, keyed to the assistant those instants describe. The
- * per-dimension analogue of `targetsMetAt`, feeding the presentation-only
- * landed flags.
+ * The operational-status fetch-start count at the moment each dimension was
+ * first seen to meet what the takeover displays for it, keyed to the assistant
+ * those counts describe. The per-dimension analogue of `targetsMetAt`, feeding
+ * the presentation-only landed flags.
  */
 interface DimensionMetLatch {
   assistantId: string | null;
@@ -224,7 +230,7 @@ export function useProProvisioning({
     string | null
   >(null);
   // The same anchor per dimension, for the landed flags.
-  const [dimensionMetAt, setDimensionMetAt] =
+  const [dimensionMetAtFetch, setDimensionMetAtFetch] =
     useState<DimensionMetLatch>(NO_DIMENSIONS_MET);
   // Latest reconcile failure from any source (auto/escape); cleared by a later
   // success — see runEnsureProvisioned.
@@ -272,7 +278,7 @@ export function useProProvisioning({
     setServerVerdict(null);
     setTargetsMetAt(null);
     setTargetsMetAssistantId(null);
-    setDimensionMetAt(NO_DIMENSIONS_MET);
+    setDimensionMetAtFetch(NO_DIMENSIONS_MET);
     setEnsureError(null);
     setRaceRetryScheduled(false);
     ensureRequestedRef.current = false;
@@ -515,14 +521,56 @@ export function useProProvisioning({
     retry: false,
   });
 
+  const operationalStatusOptions = assistantsOperationalStatusDetailReadOptions(
+    { path: { id: assistantId ?? "unresolved" } },
+  );
   const operationalStatusQuery = useQuery({
-    ...assistantsOperationalStatusDetailReadOptions({
-      path: { id: assistantId ?? "unresolved" },
-    }),
+    ...operationalStatusOptions,
     enabled: open && orgReady && proConfirmed && assistantId != null,
     refetchInterval: pollInterval,
     retry: false,
   });
+
+  // How many operational-status fetches have *started*, and which of those
+  // starts the most recent successful reading belongs to. The query cache
+  // dispatches `fetch` as a request begins and `success` when one lands, both
+  // synchronously, so a subscription counts starts, not completions.
+  //
+  // That distinction is the whole fence below. A request already out when a
+  // dimension latches read the world before the resize marker existed, and no
+  // time its answer is later stored under changes that. Since only starts move
+  // the count, such a request can never advance it past a latch taken while it
+  // was in flight, so where the latch falls relative to the render is moot.
+  //
+  // The ref is the live count, which is what effects read: a count captured
+  // during render is already stale if a request begins before the effect runs.
+  // The state is the render-visible half. It advances only on a successful
+  // reading, so a status query stuck erroring withholds the flags rather than
+  // guessing, and only ever forward, so a landed flag never blinks off when
+  // the next poll goes out. Neither is reset with the wizard: both are
+  // monotonic and the latch is re-taken against the live count.
+  const statusFetchStartsRef = useRef(0);
+  const [lastReadFetchStart, setLastReadFetchStart] = useState(0);
+  const statusQueryHash = hashKey(operationalStatusOptions.queryKey);
+  useEffect(() => {
+    return queryClient.getQueryCache().subscribe((event) => {
+      if (
+        event.type !== "updated" ||
+        event.query.queryHash !== statusQueryHash
+      ) {
+        return;
+      }
+      if (event.action.type === "fetch") {
+        statusFetchStartsRef.current += 1;
+      } else if (event.action.type === "success" && !event.action.manual) {
+        // Which start this reading belongs to has to be read here, before a
+        // later one can move the count. Publishing it through the cache's own
+        // notify queue lands it in the same React commit as the reading.
+        const readStart = statusFetchStartsRef.current;
+        notifyManager.schedule(() => setLastReadFetchStart(readStart));
+      }
+    });
+  }, [queryClient, statusQueryHash]);
 
   const resizeOperationInFlight = isResizeOperationInFlight(
     operationalStatusQuery.data,
@@ -623,30 +671,24 @@ export function useProProvisioning({
   // dimension's marker, or find it retired. Keyed to the provisioning assistant
   // for the reason above.
   //
-  // The instant is only taken while the status query is idle, because
-  // `dataUpdatedAt` records when a response was stored, not when its request
-  // began. A fetch already out when the dimension reads met observed the world
-  // before the resize marker existed, yet storing its answer still advances
-  // `dataUpdatedAt` past the latch. Waiting for idle makes the next advance a
-  // fetch that started after the latch, which is the reading the fence below
-  // asks for.
-  const statusQueryIdle = operationalStatusQuery.fetchStatus === "idle";
+  // What is recorded is the fetch-start count rather than an instant, because
+  // the question the fence asks is when a reading *began*, and that is the only
+  // thing that says whether it could have seen the marker.
   const dimensionMetMatchesAssistant =
-    dimensionMetAt.assistantId === assistantId;
+    dimensionMetAtFetch.assistantId === assistantId;
   useEffect(() => {
     if (!open) {
       return;
     }
-    setDimensionMetAt((prev) => {
+    const startedFetches = statusFetchStartsRef.current;
+    setDimensionMetAtFetch((prev) => {
       const carried =
         prev.assistantId === assistantId ? prev : NO_DIMENSIONS_MET;
-      // Null while a status fetch is out, holding the dimension unlatched.
-      const latchAt = statusQueryIdle ? Date.now() : null;
       const machine = displayTargetsMet.machine
-        ? (carried.machine ?? latchAt)
+        ? (carried.machine ?? startedFetches)
         : null;
       const storage = displayTargetsMet.storage
-        ? (carried.storage ?? latchAt)
+        ? (carried.storage ?? startedFetches)
         : null;
       if (
         prev.assistantId === assistantId &&
@@ -657,7 +699,7 @@ export function useProProvisioning({
       }
       return { assistantId, machine, storage };
     });
-  }, [open, displayTargetsMet, assistantId, statusQueryIdle]);
+  }, [open, displayTargetsMet, assistantId]);
 
   // Pairs the same questions the state machine pairs globally, per dimension.
   // Met-ness alone would not do: the platform persists the effective sizes at
@@ -669,34 +711,36 @@ export function useProProvisioning({
   //
   // These flags are fenced more strictly than the terminal
   // `statusObservedSinceTargetsMet` gate below, which compares `dataUpdatedAt`
-  // against its own latch and so counts a fetch that was already out. That gate
-  // is one-way: reaching a terminal state stops the poll, so a slightly early
-  // completion is absorbed and never visibly reverses. These flags render
-  // continuously, so the same false positive shows a chip checking off and then
-  // regressing to a spinner. That asymmetry is why the stricter fence lives
-  // here and not there.
+  // against its own latch. That is a result-storage time, so it also counts a
+  // fetch that was already out. But that gate is one-way: reaching a terminal
+  // state stops the poll, so a slightly early completion is absorbed and never
+  // visibly reverses. These flags render continuously, so the same false
+  // positive shows a chip checking off and then regressing to a spinner. That
+  // asymmetry is why the stricter fence lives here and not there.
   const landed = useMemo<ProvisioningDimensionFlags>(() => {
     const inFlight = resizeDimensionsInFlight(operationalStatusQuery.data);
-    const statusReadSince = (metAt: number | null) =>
-      metAt != null &&
+    // The reading in hand belongs to a fetch that started after this dimension
+    // latched, so it is the first one that could have seen the marker.
+    const readSinceMet = (metAtFetch: number | null) =>
+      metAtFetch != null &&
       dimensionMetMatchesAssistant &&
-      operationalStatusQuery.dataUpdatedAt > metAt;
+      lastReadFetchStart > metAtFetch;
     return {
       machine:
         displayTargetsMet.machine &&
         !inFlight.machine &&
-        statusReadSince(dimensionMetAt.machine),
+        readSinceMet(dimensionMetAtFetch.machine),
       storage:
         displayTargetsMet.storage &&
         !inFlight.storage &&
-        statusReadSince(dimensionMetAt.storage),
+        readSinceMet(dimensionMetAtFetch.storage),
     };
   }, [
     displayTargetsMet,
-    dimensionMetAt,
+    dimensionMetAtFetch,
     dimensionMetMatchesAssistant,
+    lastReadFetchStart,
     operationalStatusQuery.data,
-    operationalStatusQuery.dataUpdatedAt,
   ]);
 
   // Freeze the first non-null actuals as the before/after "from" side, keyed to

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -127,9 +127,11 @@ export interface ProProvisioningResult {
   /**
    * Per-dimension provisioning progress: a dimension has landed once what the
    * takeover displays for it is met, its own resize is no longer in flight, and
-   * a status fetch that started after that dimension read met has come back. A
-   * machine-less package is measured against `machineFloor` and the actual
-   * size, because its null machine target reads met by definition.
+   * a status fetch that started after that dimension read met has come back.
+   * The machine dimension is measured against the size it is headed for (the
+   * purchased size, or `machineFloor` for a machine-less package) in the
+   * direction it is moving, because the purchased targets only ever grow and a
+   * downsize would otherwise read met before the pod shrank.
    *
    * Presentation only, for per-chip progress; terminal completion still flows
    * exclusively through `deriveProvisioningState`, which can complete the flow
@@ -622,26 +624,49 @@ export function useProProvisioning({
     };
   }, [assistant]);
 
+  const snapshotMatchesAssistant = snapshotAssistantId === assistantId;
+
   // What the takeover displays as met, per dimension. `dimensionTargetsMet`
-  // answers the purchased targets, where a machine-less package has no machine
-  // target at all: null reads met by definition, so the displayed downsize
-  // would report complete before anything downsized. Measure that case against
-  // the floor and the actual size instead. The floor stays out of `targets` for
-  // the reason on `machineFloor`.
+  // answers the purchased targets, which only ever grow, while the takeover
+  // also displays downsizes: a machine-less package has no machine target at
+  // all, so null reads met by definition, and a lower one reads met while the
+  // pod is still larger. Either way the displayed change would report complete
+  // before anything moved. So judge the machine dimension against where it is
+  // actually headed (the purchased size when the package names one, the floor
+  // it settles at otherwise) in the direction the change goes from the size it
+  // started at. The floor stays out of `targets` for the reason on
+  // `machineFloor`.
   const displayTargetsMet = useMemo<ProvisioningDimensionFlags>(() => {
     const met = dimensionTargetsMet(targets, actuals);
-    if (machineFloor == null) {
+    const destination = targets?.machineSize ?? machineFloor;
+    if (destination == null) {
       return met;
     }
+    const actualMachine = actuals?.machineSize ?? null;
+    if (actualMachine == null) {
+      return { ...met, machine: false };
+    }
+    // Before the snapshot latches, and whenever it describes another assistant,
+    // the actuals in hand are themselves the first reading, which narrows the
+    // comparison to "already there" rather than guessing a direction.
+    const startedFrom =
+      (snapshotMatchesAssistant ? actualsSnapshot?.machineSize : null) ??
+      actualMachine;
+    const downsizing =
+      machineSizeRank(destination) < machineSizeRank(startedFrom);
     return {
       ...met,
-      machine:
-        actuals?.machineSize != null &&
-        machineSizeRank(actuals.machineSize) <= machineSizeRank(machineFloor),
+      machine: downsizing
+        ? machineSizeRank(actualMachine) <= machineSizeRank(destination)
+        : machineSizeRank(actualMachine) >= machineSizeRank(destination),
     };
-  }, [targets, actuals, machineFloor]);
-
-  const snapshotMatchesAssistant = snapshotAssistantId === assistantId;
+  }, [
+    targets,
+    actuals,
+    actualsSnapshot,
+    snapshotMatchesAssistant,
+    machineFloor,
+  ]);
 
   // Latch the instant the actuals first read as meeting the targets. The
   // platform creates the resize marker BEFORE it persists the effective sizes,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -41,7 +41,10 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { MachineSizeEnum } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
-import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
+import {
+  allowedMachineSizesForTier,
+  machineSizeRank,
+} from "@/lib/billing/machine-sizes";
 import {
   dimensionTargetsMet,
   isEntitlementRaceVerdict,
@@ -80,6 +83,23 @@ const TERMINAL_STATES: readonly ProvisioningStateKind[] = [
   "CONFIRM_TIMEOUT",
 ];
 
+/**
+ * When each dimension was first seen to meet what the takeover displays for it,
+ * keyed to the assistant those instants describe. The per-dimension analogue of
+ * `targetsMetAt`, feeding the presentation-only landed flags.
+ */
+interface DimensionMetLatch {
+  assistantId: string | null;
+  machine: number | null;
+  storage: number | null;
+}
+
+const NO_DIMENSIONS_MET: DimensionMetLatch = {
+  assistantId: null,
+  machine: null,
+  storage: null,
+};
+
 export interface UseProProvisioningOptions {
   open: boolean;
 }
@@ -98,10 +118,16 @@ export interface ProProvisioningResult {
    */
   machineFloor: MachineSizeEnum | null;
   /**
-   * Per-dimension provisioning progress: a dimension has landed once its target
-   * is met and its own resize is no longer in flight. Presentation only, for
-   * per-chip progress; terminal completion still flows exclusively through
-   * `deriveProvisioningState`.
+   * Per-dimension provisioning progress: a dimension has landed once what the
+   * takeover displays for it is met, its own resize is no longer in flight, and
+   * the operational status has been read since that dimension read met. A
+   * machine-less package is measured against `machineFloor` and the actual
+   * size, because its null machine target reads met by definition.
+   *
+   * Presentation only, for per-chip progress; terminal completion still flows
+   * exclusively through `deriveProvisioningState`, which can complete the flow
+   * before any status reading postdates the actuals. A dimension may therefore
+   * still read pending in DONE, where the state is itself the signal.
    *
    * A machine resize supersedes a storage one in the single per-assistant
    * marker, so storage can read landed while the machine rollout is still
@@ -196,6 +222,9 @@ export function useProProvisioning({
   const [targetsMetAssistantId, setTargetsMetAssistantId] = useState<
     string | null
   >(null);
+  // The same anchor per dimension, for the landed flags.
+  const [dimensionMetAt, setDimensionMetAt] =
+    useState<DimensionMetLatch>(NO_DIMENSIONS_MET);
   // Latest reconcile failure from any source (auto/escape); cleared by a later
   // success — see runEnsureProvisioned.
   const [ensureError, setEnsureError] = useState<unknown>(null);
@@ -242,6 +271,7 @@ export function useProProvisioning({
     setServerVerdict(null);
     setTargetsMetAt(null);
     setTargetsMetAssistantId(null);
+    setDimensionMetAt(NO_DIMENSIONS_MET);
     setEnsureError(null);
     setRaceRetryScheduled(false);
     ensureRequestedRef.current = false;
@@ -543,19 +573,24 @@ export function useProProvisioning({
     };
   }, [assistant]);
 
-  // Pairs the same two questions the state machine pairs globally. Actuals
-  // alone would not do: the platform persists the effective sizes at resize
-  // acceptance, before the pod restarts, so a dimension reads met mid-rollout.
-  // The pairing is also what carries a downgrade, where the null machine target
-  // is trivially met and only the in-flight marker holds the flag false.
-  const landed = useMemo<ProvisioningDimensionFlags>(() => {
+  // What the takeover displays as met, per dimension. `dimensionTargetsMet`
+  // answers the purchased targets, where a machine-less package has no machine
+  // target at all: null reads met by definition, so the displayed downsize
+  // would report complete before anything downsized. Measure that case against
+  // the floor and the actual size instead. The floor stays out of `targets` for
+  // the reason on `machineFloor`.
+  const displayTargetsMet = useMemo<ProvisioningDimensionFlags>(() => {
     const met = dimensionTargetsMet(targets, actuals);
-    const inFlight = resizeDimensionsInFlight(operationalStatusQuery.data);
+    if (machineFloor == null) {
+      return met;
+    }
     return {
-      machine: met.machine && !inFlight.machine,
-      storage: met.storage && !inFlight.storage,
+      ...met,
+      machine:
+        actuals?.machineSize != null &&
+        machineSizeRank(actuals.machineSize) <= machineSizeRank(machineFloor),
     };
-  }, [targets, actuals, operationalStatusQuery.data]);
+  }, [targets, actuals, machineFloor]);
 
   const snapshotMatchesAssistant = snapshotAssistantId === assistantId;
 
@@ -581,6 +616,67 @@ export function useProProvisioning({
       setTargetsMetAssistantId(null);
     }
   }, [open, currentTargetsMet, assistantId, targetsMetMatchesAssistant]);
+
+  // The same latch per dimension, on the same write-order guarantee: a status
+  // reading taken after a dimension read met is the one guaranteed to find that
+  // dimension's marker, or find it retired. Keyed to the provisioning assistant
+  // for the reason above.
+  const dimensionMetMatchesAssistant =
+    dimensionMetAt.assistantId === assistantId;
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setDimensionMetAt((prev) => {
+      const carried =
+        prev.assistantId === assistantId ? prev : NO_DIMENSIONS_MET;
+      const machine = displayTargetsMet.machine
+        ? (carried.machine ?? Date.now())
+        : null;
+      const storage = displayTargetsMet.storage
+        ? (carried.storage ?? Date.now())
+        : null;
+      if (
+        prev.assistantId === assistantId &&
+        prev.machine === machine &&
+        prev.storage === storage
+      ) {
+        return prev;
+      }
+      return { assistantId, machine, storage };
+    });
+  }, [open, displayTargetsMet, assistantId]);
+
+  // Pairs the same questions the state machine pairs globally, per dimension.
+  // Met-ness alone would not do: the platform persists the effective sizes at
+  // resize acceptance, before the pod restarts, so a dimension reads met
+  // mid-rollout. Nor would met-ness plus the marker, because the assistant and
+  // status queries poll independently: in the window where the assistant poll
+  // holds the persisted sizes and the status query still holds its pre-resize
+  // reading, a flag would land and the next poll would take it back.
+  const landed = useMemo<ProvisioningDimensionFlags>(() => {
+    const inFlight = resizeDimensionsInFlight(operationalStatusQuery.data);
+    const statusReadSince = (metAt: number | null) =>
+      metAt != null &&
+      dimensionMetMatchesAssistant &&
+      operationalStatusQuery.dataUpdatedAt > metAt;
+    return {
+      machine:
+        displayTargetsMet.machine &&
+        !inFlight.machine &&
+        statusReadSince(dimensionMetAt.machine),
+      storage:
+        displayTargetsMet.storage &&
+        !inFlight.storage &&
+        statusReadSince(dimensionMetAt.storage),
+    };
+  }, [
+    displayTargetsMet,
+    dimensionMetAt,
+    dimensionMetMatchesAssistant,
+    operationalStatusQuery.data,
+    operationalStatusQuery.dataUpdatedAt,
+  ]);
 
   // Freeze the first non-null actuals as the before/after "from" side, keyed to
   // the assistant it describes. When assistantId changes (e.g. a stale primary

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -84,9 +84,10 @@ const TERMINAL_STATES: readonly ProvisioningStateKind[] = [
 ];
 
 /**
- * When each dimension was first seen to meet what the takeover displays for it,
- * keyed to the assistant those instants describe. The per-dimension analogue of
- * `targetsMetAt`, feeding the presentation-only landed flags.
+ * When each dimension was first seen to meet what the takeover displays for it
+ * with no status fetch out, keyed to the assistant those instants describe. The
+ * per-dimension analogue of `targetsMetAt`, feeding the presentation-only
+ * landed flags.
  */
 interface DimensionMetLatch {
   assistantId: string | null;
@@ -120,7 +121,7 @@ export interface ProProvisioningResult {
   /**
    * Per-dimension provisioning progress: a dimension has landed once what the
    * takeover displays for it is met, its own resize is no longer in flight, and
-   * the operational status has been read since that dimension read met. A
+   * a status fetch that started after that dimension read met has come back. A
    * machine-less package is measured against `machineFloor` and the actual
    * size, because its null machine target reads met by definition.
    *
@@ -621,6 +622,15 @@ export function useProProvisioning({
   // reading taken after a dimension read met is the one guaranteed to find that
   // dimension's marker, or find it retired. Keyed to the provisioning assistant
   // for the reason above.
+  //
+  // The instant is only taken while the status query is idle, because
+  // `dataUpdatedAt` records when a response was stored, not when its request
+  // began. A fetch already out when the dimension reads met observed the world
+  // before the resize marker existed, yet storing its answer still advances
+  // `dataUpdatedAt` past the latch. Waiting for idle makes the next advance a
+  // fetch that started after the latch, which is the reading the fence below
+  // asks for.
+  const statusQueryIdle = operationalStatusQuery.fetchStatus === "idle";
   const dimensionMetMatchesAssistant =
     dimensionMetAt.assistantId === assistantId;
   useEffect(() => {
@@ -630,11 +640,13 @@ export function useProProvisioning({
     setDimensionMetAt((prev) => {
       const carried =
         prev.assistantId === assistantId ? prev : NO_DIMENSIONS_MET;
+      // Null while a status fetch is out, holding the dimension unlatched.
+      const latchAt = statusQueryIdle ? Date.now() : null;
       const machine = displayTargetsMet.machine
-        ? (carried.machine ?? Date.now())
+        ? (carried.machine ?? latchAt)
         : null;
       const storage = displayTargetsMet.storage
-        ? (carried.storage ?? Date.now())
+        ? (carried.storage ?? latchAt)
         : null;
       if (
         prev.assistantId === assistantId &&
@@ -645,7 +657,7 @@ export function useProProvisioning({
       }
       return { assistantId, machine, storage };
     });
-  }, [open, displayTargetsMet, assistantId]);
+  }, [open, displayTargetsMet, assistantId, statusQueryIdle]);
 
   // Pairs the same questions the state machine pairs globally, per dimension.
   // Met-ness alone would not do: the platform persists the effective sizes at
@@ -654,6 +666,15 @@ export function useProProvisioning({
   // status queries poll independently: in the window where the assistant poll
   // holds the persisted sizes and the status query still holds its pre-resize
   // reading, a flag would land and the next poll would take it back.
+  //
+  // These flags are fenced more strictly than the terminal
+  // `statusObservedSinceTargetsMet` gate below, which compares `dataUpdatedAt`
+  // against its own latch and so counts a fetch that was already out. That gate
+  // is one-way: reaching a terminal state stops the poll, so a slightly early
+  // completion is absorbed and never visibly reverses. These flags render
+  // continuously, so the same false positive shows a chip checking off and then
+  // regressing to a spinner. That asymmetry is why the stricter fence lives
+  // here and not there.
   const landed = useMemo<ProvisioningDimensionFlags>(() => {
     const inFlight = resizeDimensionsInFlight(operationalStatusQuery.data);
     const statusReadSince = (metAt: number | null) =>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -126,8 +126,8 @@ export interface ProProvisioningResult {
   machineFloor: MachineSizeEnum | null;
   /**
    * Per-dimension provisioning progress: a dimension has landed once what the
-   * takeover displays for it is met, its own resize is no longer in flight, and
-   * a status fetch that started after that dimension read met has come back.
+   * takeover displays for it is met, it has no resize in flight, and a status
+   * fetch that started after that dimension read met has come back.
    * The machine dimension is measured against the size it is headed for (the
    * purchased size, or `machineFloor` for a machine-less package) in the
    * direction it is moving, because the purchased targets only ever grow and a

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -39,11 +39,15 @@ import {
   organizationsBillingSubscriptionRetrieveOptions,
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
+import type { MachineSizeEnum } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
 import {
+  dimensionTargetsMet,
   isEntitlementRaceVerdict,
   isResizeOperationInFlight,
+  type ProvisioningDimensionFlags,
+  resizeDimensionsInFlight,
 } from "@/lib/billing/provisioning-targets";
 import { useOrganizationStore } from "@/stores/organization-store";
 
@@ -86,6 +90,25 @@ export interface ProProvisioningResult {
   targets: ProvisioningDimensions | null;
   /** First actuals observed, frozen — the "from" side of before/after cards. */
   actualsSnapshot: ProvisioningDimensions | null;
+  /**
+   * Machine size a package with no machine tier settles at, mirroring the
+   * server's ceiling for a null tier. Display only, so the takeover can show
+   * the resulting downsize; it never feeds `targets`, where a non-null machine
+   * size would demand non-null actuals and hang a fresh hatch.
+   */
+  machineFloor: MachineSizeEnum | null;
+  /**
+   * Per-dimension provisioning progress: a dimension has landed once its target
+   * is met and its own resize is no longer in flight. Presentation only, for
+   * per-chip progress; terminal completion still flows exclusively through
+   * `deriveProvisioningState`.
+   *
+   * A machine resize supersedes a storage one in the single per-assistant
+   * marker, so storage can read landed while the machine rollout is still
+   * running. That is honest: the storage grow was accepted, and the machine
+   * flag keeps its own row pending until the rollout converges.
+   */
+  landed: ProvisioningDimensionFlags;
   /**
    * The assistant provisioning targets: the onboarding payload's primary
    * assistant when named, else the active assistant. Drives the actuals and
@@ -495,6 +518,10 @@ export function useProProvisioning({
     };
   }, [onboarding]);
 
+  // Mirrors the server's machine ceiling for a package with no tier.
+  const machineFloor: MachineSizeEnum | null =
+    onboarding != null && onboarding.max_machine_tier == null ? "small" : null;
+
   // The managed-email entitlement alone doesn't make the domain step offerable:
   // the domain POST re-resolves the caller's primary assistant server-side and
   // rejects with 409 when there is none, so the payload must also name one. The
@@ -515,6 +542,20 @@ export function useProProvisioning({
       storageGib: assistant.provisioned_storage_gib ?? null,
     };
   }, [assistant]);
+
+  // Pairs the same two questions the state machine pairs globally. Actuals
+  // alone would not do: the platform persists the effective sizes at resize
+  // acceptance, before the pod restarts, so a dimension reads met mid-rollout.
+  // The pairing is also what carries a downgrade, where the null machine target
+  // is trivially met and only the in-flight marker holds the flag false.
+  const landed = useMemo<ProvisioningDimensionFlags>(() => {
+    const met = dimensionTargetsMet(targets, actuals);
+    const inFlight = resizeDimensionsInFlight(operationalStatusQuery.data);
+    return {
+      machine: met.machine && !inFlight.machine,
+      storage: met.storage && !inFlight.storage,
+    };
+  }, [targets, actuals, operationalStatusQuery.data]);
 
   const snapshotMatchesAssistant = snapshotAssistantId === assistantId;
 
@@ -605,6 +646,8 @@ export function useProProvisioning({
     softWaiting,
     targets,
     actualsSnapshot,
+    machineFloor,
+    landed,
     assistantId,
     domainStepAvailable,
     onboardingSettled,


### PR DESCRIPTION
## Summary
- Expose a per-dimension `landed` signal pairing target-met with not-in-flight, so chips can resolve one dimension at a time
- Expose `machineFloor` for machine-less packages so the takeover can show a real downsize
- Presentation only: completion still flows exclusively through `deriveProvisioningState`

Part of plan: takeover-credits-chip-and-reveal.md (PR 4 of 7)