### PR TITLE
feat(platform): add `subscription` and `plans` billing CLI commands

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22640,6 +22640,33 @@ paths:
                   - disconnected
                   - previousBaseUrl
                 additionalProperties: false
+  /v1/platform/plans:
+    get:
+      operationId: platform_plans_get
+      summary: Get the plan catalog with pricing
+      description:
+        "Fetches the platform plan catalog: base and pro plans with pricing (in cents), machine/storage/credit
+        tiers, and packages."
+      tags:
+        - platform
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plans:
+                    type: array
+                    items:
+                      type: object
+                      propertyNames:
+                        type: string
+                      additionalProperties: {}
+                required:
+                  - plans
+                additionalProperties: false
   /v1/platform/status:
     get:
       operationId: platform_status_get
@@ -22691,6 +22718,91 @@ paths:
                   - available
                   - organizationId
                   - userId
+                additionalProperties: false
+  /v1/platform/subscription:
+    get:
+      operationId: platform_subscription_get
+      summary: Get the organization's current plan and subscription state
+      description:
+        Fetches the org's plan (base or pro), subscription status, renewal/period-end dates, cancellation state,
+        selected credit tier, package, and plan-gated entitlements from the platform.
+      tags:
+        - platform
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  planId:
+                    type: string
+                    enum:
+                      - base
+                      - pro
+                  status:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  renewalDate:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  currentPeriodEnd:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  cancelAtPeriodEnd:
+                    type: boolean
+                  cancelAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  selectedCreditTier:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  package:
+                    anyOf:
+                      - type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          version:
+                            type: number
+                          customized:
+                            type: boolean
+                        required:
+                          - key
+                          - name
+                          - version
+                          - customized
+                        additionalProperties: false
+                      - type: "null"
+                  entitlements:
+                    type: object
+                    properties:
+                      managedEmail:
+                        type: boolean
+                      phoneNumber:
+                        type: boolean
+                    required:
+                      - managedEmail
+                      - phoneNumber
+                    additionalProperties: false
+                required:
+                  - planId
+                  - status
+                  - renewalDate
+                  - currentPeriodEnd
+                  - cancelAtPeriodEnd
+                  - cancelAt
+                  - selectedCreditTier
+                  - package
+                  - entitlements
                 additionalProperties: false
   /v1/playground/seed-conversation:
     post:

--- a/assistant/src/cli/commands/platform/__tests__/plans.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/plans.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockCalls: Array<[string, Record<string, unknown>]> = [];
+let mockResponse: unknown = {
+  ok: true,
+  result: {
+    plans: [
+      {
+        id: "base",
+        name: "Base",
+        price_cents: 0,
+        billing_interval: "month",
+        included_features: ["Pay-as-you-go credits"],
+      },
+      {
+        id: "pro",
+        name: "Pro",
+        base_price_cents: 2000,
+        billing_interval: "month",
+        included_features: ["Configurable machine size"],
+      },
+    ],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
+    mockCalls.push([method, params]);
+    return mockResponse;
+  },
+  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
+    throw new Error("exitFromIpcResult called");
+  },
+}));
+
+const { registerPlatformCommand } = await import("../index.js");
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerPlatformCommand(program);
+  return program;
+}
+
+function captureStdout(fn: () => Promise<void>): Promise<string[]> {
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown) => {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  return fn()
+    .then(() => chunks)
+    .finally(() => {
+      process.stdout.write = origWrite;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant platform plans", () => {
+  beforeEach(() => {
+    mockCalls = [];
+    mockResponse = {
+      ok: true,
+      result: {
+        plans: [
+          {
+            id: "base",
+            name: "Base",
+            price_cents: 0,
+            billing_interval: "month",
+            included_features: ["Pay-as-you-go credits"],
+          },
+          {
+            id: "pro",
+            name: "Pro",
+            base_price_cents: 2000,
+            billing_interval: "month",
+            included_features: ["Configurable machine size"],
+          },
+        ],
+      },
+    };
+    process.exitCode = 0;
+  });
+
+  test("calls platform_plans and emits catalog JSON with --json", async () => {
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      await program.parseAsync([
+        "node",
+        "assistant",
+        "platform",
+        "plans",
+        "--json",
+      ]);
+    });
+
+    expect(mockCalls[0][0]).toBe("platform_plans");
+
+    const parsed = JSON.parse(out.join(""));
+    expect(parsed.plans).toHaveLength(2);
+    expect(parsed.plans[0].id).toBe("base");
+    expect(parsed.plans[1].base_price_cents).toBe(2000);
+  });
+
+  test("plain text mode does not emit JSON to stdout", async () => {
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      await program.parseAsync(["node", "assistant", "platform", "plans"]);
+    });
+
+    // Plain-text mode logs via log.info — verify writeOutput (JSON) was NOT called
+    expect(() => JSON.parse(out.join("").trim())).toThrow();
+  });
+});

--- a/assistant/src/cli/commands/platform/__tests__/subscription.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/subscription.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockCalls: Array<[string, Record<string, unknown>]> = [];
+let mockResponse: unknown = {
+  ok: true,
+  result: {
+    planId: "pro",
+    status: "active",
+    renewalDate: "2026-08-01T00:00:00.000Z",
+    currentPeriodEnd: "2026-08-01T00:00:00.000Z",
+    cancelAtPeriodEnd: false,
+    cancelAt: null,
+    selectedCreditTier: "credits_50",
+    package: { key: "super", name: "Super", version: 2, customized: false },
+    entitlements: { managedEmail: true, phoneNumber: false },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
+    mockCalls.push([method, params]);
+    return mockResponse;
+  },
+  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
+    throw new Error("exitFromIpcResult called");
+  },
+}));
+
+const { registerPlatformCommand } = await import("../index.js");
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerPlatformCommand(program);
+  return program;
+}
+
+function captureStdout(fn: () => Promise<void>): Promise<string[]> {
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown) => {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  return fn()
+    .then(() => chunks)
+    .finally(() => {
+      process.stdout.write = origWrite;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant platform subscription", () => {
+  beforeEach(() => {
+    mockCalls = [];
+    mockResponse = {
+      ok: true,
+      result: {
+        planId: "pro",
+        status: "active",
+        renewalDate: "2026-08-01T00:00:00.000Z",
+        currentPeriodEnd: "2026-08-01T00:00:00.000Z",
+        cancelAtPeriodEnd: false,
+        cancelAt: null,
+        selectedCreditTier: "credits_50",
+        package: { key: "super", name: "Super", version: 2, customized: false },
+        entitlements: { managedEmail: true, phoneNumber: false },
+      },
+    };
+    process.exitCode = 0;
+  });
+
+  test("calls platform_subscription and emits plan JSON with --json", async () => {
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      await program.parseAsync([
+        "node",
+        "assistant",
+        "platform",
+        "subscription",
+        "--json",
+      ]);
+    });
+
+    expect(mockCalls[0][0]).toBe("platform_subscription");
+
+    const parsed = JSON.parse(out.join(""));
+    expect(parsed.planId).toBe("pro");
+    expect(parsed.status).toBe("active");
+    expect(parsed.package.name).toBe("Super");
+    expect(parsed.entitlements.managedEmail).toBe(true);
+  });
+
+  test("plain text mode does not emit JSON to stdout", async () => {
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      await program.parseAsync([
+        "node",
+        "assistant",
+        "platform",
+        "subscription",
+      ]);
+    });
+
+    // Plain-text mode logs via log.info — verify writeOutput (JSON) was NOT called
+    expect(() => JSON.parse(out.join("").trim())).toThrow();
+  });
+});

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -21,6 +21,8 @@ assistants.
 Examples:
   $ assistant platform status --json
   $ assistant platform credits --json
+  $ assistant platform subscription --json
+  $ assistant platform plans --json
   $ assistant platform connect
   $ assistant platform disconnect
   $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json`,
@@ -89,6 +91,59 @@ ensure VELLUM_PLATFORM_URL is set and credentials are stored).
 Examples:
   $ assistant platform credits
   $ assistant platform credits --json`,
+    },
+    {
+      name: "subscription",
+      description:
+        "Show the organization's current plan and subscription state",
+      helpText: `
+Fetches the org's plan and subscription state from the platform. Answers
+"what plan am I on?".
+
+Fields:
+  planId              Current plan: "base" or "pro"
+  status              Stripe subscription status (e.g. active, past_due) or
+                      null on the base plan
+  renewalDate         When the current period ends / the plan renews (ISO
+                      8601), or null on the base plan
+  currentPeriodEnd    Same as renewalDate; mirrors the platform field
+  cancelAtPeriodEnd   True when the subscription is set to cancel at period end
+  cancelAt            When the subscription cancels (ISO 8601), or null
+  selectedCreditTier  The selected Pro credit bundle tier, or null
+  package             The named Pro package pin ({ key, name, version,
+                      customized }), or null
+  entitlements        Plan-gated features ({ managedEmail, phoneNumber })
+
+For the credit balance (not the plan), use 'assistant platform credits'. For
+plan pricing, use 'assistant platform plans'.
+
+Requires platform credentials (run 'assistant platform connect' first or
+ensure VELLUM_PLATFORM_URL is set and credentials are stored).
+
+Examples:
+  $ assistant platform subscription
+  $ assistant platform subscription --json`,
+    },
+    {
+      name: "plans",
+      description: "Show the plan catalog with pricing",
+      helpText: `
+Fetches the platform plan catalog. Answers "how much does each plan cost?".
+
+Returns a "plans" array. Each entry has an "id" ("base" or "pro"), "name",
+"billing_interval", and "included_features". The base plan carries
+"price_cents"; the pro plan carries "base_price_cents" plus "machine_tiers",
+"storage_tiers", "credit_tiers", and "packages" (each tier priced in cents).
+
+For the org's OWN plan (not the catalog), use 'assistant platform
+subscription'. For the credit balance, use 'assistant platform credits'.
+
+Requires platform credentials (run 'assistant platform connect' first or
+ensure VELLUM_PLATFORM_URL is set and credentials are stored).
+
+Examples:
+  $ assistant platform plans
+  $ assistant platform plans --json`,
     },
     {
       name: "disconnect",

--- a/assistant/src/cli/commands/platform/index.ts
+++ b/assistant/src/cli/commands/platform/index.ts
@@ -35,6 +35,30 @@ interface PlatformCreditsResult {
   as_of: string;
 }
 
+interface PlatformSubscriptionResult {
+  planId: "base" | "pro";
+  status: string | null;
+  renewalDate: string | null;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  cancelAt: string | null;
+  selectedCreditTier: string | null;
+  package: {
+    key: string;
+    name: string;
+    version: number;
+    customized: boolean;
+  } | null;
+  entitlements: {
+    managedEmail: boolean;
+    phoneNumber: boolean;
+  };
+}
+
+interface PlatformPlansResult {
+  plans: Array<Record<string, unknown>>;
+}
+
 export function registerPlatformCommand(program: Command): void {
   registerCommand(program, {
     name: platformHelp.name,
@@ -122,6 +146,92 @@ export function registerPlatformCommand(program: Command): void {
             log.info(
               `Settled:   $${result.settled.toFixed(2)}   Pending: $${result.pending.toFixed(2)}`,
             );
+          }
+        },
+      );
+
+      // -----------------------------------------------------------------------
+      // subscription
+      // -----------------------------------------------------------------------
+
+      subcommand(platform, "subscription").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
+          const r = await cliIpcCall<PlatformSubscriptionResult>(
+            "platform_subscription",
+            {},
+          );
+          if (!r.ok) {
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          }
+
+          const result = r.result!;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, result);
+          } else {
+            const planLabel = result.planId === "pro" ? "Pro" : "Base";
+            const statusNote = result.status ? ` (${result.status})` : "";
+            log.info(`Plan:   ${planLabel}${statusNote}`);
+            if (result.package) {
+              const customized = result.package.customized
+                ? " (customized)"
+                : "";
+              log.info(`Package: ${result.package.name}${customized}`);
+            }
+            if (result.renewalDate) {
+              const renewalVerb = result.cancelAtPeriodEnd
+                ? "Cancels"
+                : "Renews";
+              log.info(`${renewalVerb}: ${result.renewalDate}`);
+            }
+            if (result.selectedCreditTier) {
+              log.info(`Credit tier: ${result.selectedCreditTier}`);
+            }
+            const ent: string[] = [];
+            if (result.entitlements.managedEmail) {
+              ent.push("managed email");
+            }
+            if (result.entitlements.phoneNumber) {
+              ent.push("phone number");
+            }
+            log.info(
+              `Entitlements: ${ent.length > 0 ? ent.join(", ") : "none"}`,
+            );
+          }
+        },
+      );
+
+      // -----------------------------------------------------------------------
+      // plans
+      // -----------------------------------------------------------------------
+
+      subcommand(platform, "plans").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
+          const r = await cliIpcCall<PlatformPlansResult>("platform_plans", {});
+          if (!r.ok) {
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          }
+
+          const result = r.result!;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, result);
+          } else {
+            for (const plan of result.plans) {
+              const name = String(plan.name ?? plan.id ?? "?");
+              // Base uses `price_cents`; Pro uses `base_price_cents`.
+              const cents = Number(
+                plan.price_cents ?? plan.base_price_cents ?? 0,
+              );
+              const interval = String(plan.billing_interval ?? "month");
+              log.info(`${name}: $${(cents / 100).toFixed(2)}/${interval}`);
+            }
           }
         },
       );

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Platform route handlers for the shared HTTP/IPC route table.
  *
- * Serves six operations:
+ * Serves eight operations:
  *   - platform_status (GET platform/status): aggregates platform context,
  *     credentials, assistant ID, and webhook secret. (Velay tunnel status
  *     lives on the gateway — see gateway_status.)
@@ -15,6 +15,9 @@
  *     registered callback routes for this assistant.
  *   - platform_credits (GET platform/credits): fetches the org's remaining
  *     credit balance from the platform billing summary.
+ *   - platform_subscription (GET platform/subscription): fetches the org's
+ *     current plan, subscription status, and entitlements.
+ *   - platform_plans (GET platform/plans): fetches the plan catalog with pricing.
  */
 
 import { z } from "zod";
@@ -122,6 +125,41 @@ const PlatformCreditsResponseSchema = z.object({
   as_of: z.string(),
 });
 type PlatformCreditsResponse = z.infer<typeof PlatformCreditsResponseSchema>;
+
+const SubscriptionPackageSchema = z.object({
+  key: z.string(),
+  name: z.string(),
+  version: z.number(),
+  customized: z.boolean(),
+});
+
+const PlatformSubscriptionResponseSchema = z.object({
+  planId: z.enum(["base", "pro"]),
+  status: z.string().nullable(),
+  renewalDate: z.string().nullable(),
+  currentPeriodEnd: z.string().nullable(),
+  cancelAtPeriodEnd: z.boolean(),
+  cancelAt: z.string().nullable(),
+  selectedCreditTier: z.string().nullable(),
+  package: SubscriptionPackageSchema.nullable(),
+  entitlements: z.object({
+    managedEmail: z.boolean(),
+    phoneNumber: z.boolean(),
+  }),
+});
+type PlatformSubscriptionResponse = z.infer<
+  typeof PlatformSubscriptionResponseSchema
+>;
+
+// The plan catalog is a large, platform-owned structure (base + pro plans, each
+// with machine/storage/credit tiers and packages). The daemon forwards it as a
+// pass-through so the catalog shape stays owned by the platform and additive
+// changes there don't require a daemon schema bump; only the top-level `plans`
+// envelope is asserted here.
+const PlatformPlansResponseSchema = z.object({
+  plans: z.array(z.record(z.string(), z.unknown())),
+});
+type PlatformPlansResponse = z.infer<typeof PlatformPlansResponseSchema>;
 
 // ---------------------------------------------------------------------------
 // Handlers
@@ -305,39 +343,10 @@ async function handleCallbackRoutesRegister(
 async function handleCallbackRoutesList(
   _args: RouteHandlerArgs,
 ): Promise<CallbackRoutesListResponse> {
-  const context = await resolvePlatformCallbackRegistrationContext();
-
-  if (!context.platformBaseUrl || !context.authHeader) {
-    throw new UnprocessableEntityError(
-      "Platform credentials not available — run 'assistant platform connect' or set VELLUM_PLATFORM_URL",
-    );
-  }
-
-  const url = `${context.platformBaseUrl}/v1/internal/gateway/callback-routes/`;
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      method: "GET",
-      headers: {
-        Authorization: context.authHeader,
-        Accept: "application/json",
-      },
-      signal: AbortSignal.timeout(10_000),
-    });
-  } catch (err) {
-    throw new InternalError(
-      `Failed to list callback routes: ${(err as Error).message}`,
-    );
-  }
-
-  if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    throw new InternalError(
-      `Failed to list callback routes (HTTP ${response.status}): ${detail}`,
-    );
-  }
-
-  const routes = (await response.json()) as Array<{
+  const routes = (await fetchPlatformJson(
+    "/v1/internal/gateway/callback-routes/",
+    "callback routes",
+  )) as Array<{
     id: string;
     assistant_id: string;
     type: string;
@@ -352,39 +361,10 @@ async function handleCallbackRoutesList(
 async function handlePlatformCredits(
   _args: RouteHandlerArgs,
 ): Promise<PlatformCreditsResponse> {
-  const context = await resolvePlatformCallbackRegistrationContext();
-
-  if (!context.platformBaseUrl || !context.authHeader) {
-    throw new UnprocessableEntityError(
-      "Platform credentials not available — run 'assistant platform connect' or set VELLUM_PLATFORM_URL",
-    );
-  }
-
-  const url = `${context.platformBaseUrl}/v1/organizations/billing/summary/`;
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      method: "GET",
-      headers: {
-        Authorization: context.authHeader,
-        Accept: "application/json",
-      },
-      signal: AbortSignal.timeout(10_000),
-    });
-  } catch (err) {
-    throw new InternalError(
-      `Failed to fetch credit balance: ${(err as Error).message}`,
-    );
-  }
-
-  if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    throw new InternalError(
-      `Failed to fetch credit balance (HTTP ${response.status}): ${detail}`,
-    );
-  }
-
-  const summary = (await response.json()) as {
+  const summary = (await fetchPlatformJson(
+    "/v1/organizations/billing/summary/",
+    "credit balance",
+  )) as {
     settled_balance_usd: string;
     pending_compute_usd: string;
     effective_balance_usd: string;
@@ -401,6 +381,108 @@ async function handlePlatformCredits(
     // summary endpoint ever returns one.
     as_of: new Date().toISOString(),
   };
+}
+
+/**
+ * GET a JSON resource from the platform using the assistant's stored platform
+ * credentials. Throws UnprocessableEntityError when credentials are missing and
+ * InternalError on transport / non-2xx failures; `label` names the resource in
+ * those error messages.
+ */
+async function fetchPlatformJson(
+  path: string,
+  label: string,
+): Promise<unknown> {
+  const context = await resolvePlatformCallbackRegistrationContext();
+
+  if (!context.platformBaseUrl || !context.authHeader) {
+    throw new UnprocessableEntityError(
+      "Platform credentials not available — run 'assistant platform connect' or set VELLUM_PLATFORM_URL",
+    );
+  }
+
+  const url = `${context.platformBaseUrl}${path}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: context.authHeader,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    throw new InternalError(
+      `Failed to fetch ${label}: ${(err as Error).message}`,
+    );
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new InternalError(
+      `Failed to fetch ${label} (HTTP ${response.status}): ${detail}`,
+    );
+  }
+
+  return response.json();
+}
+
+async function handlePlatformSubscription(
+  _args: RouteHandlerArgs,
+): Promise<PlatformSubscriptionResponse> {
+  const data = (await fetchPlatformJson(
+    "/v1/organizations/billing/subscription/",
+    "subscription",
+  )) as {
+    plan_id: "base" | "pro";
+    status: string | null;
+    renewal_date: string | null;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+    cancel_at: string | null;
+    selected_credit_tier: string | null;
+    package: {
+      key: string;
+      name: string;
+      version: number;
+      customized: boolean;
+    } | null;
+    entitlements: { managed_email: boolean; phone_number: boolean };
+  };
+
+  return {
+    planId: data.plan_id,
+    status: data.status,
+    renewalDate: data.renewal_date,
+    currentPeriodEnd: data.current_period_end,
+    cancelAtPeriodEnd: data.cancel_at_period_end,
+    cancelAt: data.cancel_at,
+    selectedCreditTier: data.selected_credit_tier,
+    package: data.package
+      ? {
+          key: data.package.key,
+          name: data.package.name,
+          version: data.package.version,
+          customized: data.package.customized,
+        }
+      : null,
+    entitlements: {
+      managedEmail: data.entitlements.managed_email,
+      phoneNumber: data.entitlements.phone_number,
+    },
+  };
+}
+
+async function handlePlatformPlans(
+  _args: RouteHandlerArgs,
+): Promise<PlatformPlansResponse> {
+  const data = (await fetchPlatformJson(
+    "/v1/organizations/billing/plans/",
+    "plan catalog",
+  )) as { plans?: Array<Record<string, unknown>> };
+
+  return { plans: data.plans ?? [] };
 }
 
 // ---------------------------------------------------------------------------
@@ -498,5 +580,35 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["platform"],
     handler: handlePlatformCredits,
     responseBody: PlatformCreditsResponseSchema,
+  },
+  {
+    operationId: "platform_subscription",
+    endpoint: "platform/subscription",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get the organization's current plan and subscription state",
+    description:
+      "Fetches the org's plan (base or pro), subscription status, renewal/period-end dates, cancellation state, selected credit tier, package, and plan-gated entitlements from the platform.",
+    tags: ["platform"],
+    handler: handlePlatformSubscription,
+    responseBody: PlatformSubscriptionResponseSchema,
+  },
+  {
+    operationId: "platform_plans",
+    endpoint: "platform/plans",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get the plan catalog with pricing",
+    description:
+      "Fetches the platform plan catalog: base and pro plans with pricing (in cents), machine/storage/credit tiers, and packages.",
+    tags: ["platform"],
+    handler: handlePlatformPlans,
+    responseBody: PlatformPlansResponseSchema,
   },
 ];

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -230,6 +230,8 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "platform connect",
   "platform status",
   "platform credits",
+  "platform subscription",
+  "platform plans",
   "platform disconnect",
   "platform callback-routes",
   "platform callback-routes register",


### PR DESCRIPTION
## Prompt / plan

Follow-up to the self-knowledge FAQ work (#39365). That PR made the assistant *route* billing questions to a source of truth, but two of them had no runtime data source: "what plan am I on?" and "how much do you cost?". This adds the CLI + daemon surface to answer them, backed by the platform's real billing API (confirmed against `vellum-assistant-platform`: `app/billing/subscription_views.py` and `plan_views.py`).

## Changes

Two new read-only commands under `assistant platform`, each a shared HTTP/IPC route mirroring the existing `platform credits`:

- **`assistant platform subscription`** — `platform_subscription` → `GET /v1/organizations/billing/subscription/`. Reports `planId` (`base`/`pro`), subscription `status`, renewal/period-end, cancellation state, selected credit tier, package pin, and plan-gated entitlements. Answers **"what plan am I on?"**.
- **`assistant platform plans`** — `platform_plans` → `GET /v1/organizations/billing/plans/`. Forwards the plan catalog (base + pro pricing in cents, machine/storage/credit tiers, packages). Answers **"how much does each plan cost?"**. The catalog is platform-owned and large, so the daemon asserts only the top-level `plans` envelope and passes entries through — additive platform changes don't need a daemon schema bump.

Refactor: the credential-guard + fetch + error-mapping pattern was duplicated across `credits`, `callback-routes list`, and the two new handlers. Extracted into `fetchPlatformJson(path, label)` and routed all four through it (removing two inline copies).

Also: registered the two new command paths in the gateway bash risk registry (`command-registry/commands/assistant.ts`), and regenerated `assistant/openapi.yaml`.

## Test plan

- New CLI tests `platform/__tests__/subscription.test.ts` and `plans.test.ts` (mirror `credits.test.ts`); full platform suite: 18 pass across 7 files.
- `route-policy.test.ts` (18 pass) confirms the two new routes carry valid policies.
- Gateway `command-registry.test.ts` (52 pass) confirms the registry addition.
- `bun run typecheck:fast`, `eslint`, and `prettier` clean; `bun run generate:openapi` re-run and committed (570 operations).

## Notes for reviewers

- Naming: `subscription` (the org's own plan) vs `plans` (the catalog), sitting alongside the existing `credits`. Open to `plan`/`pricing` if preferred.
- Both are `settings.read`, `ACTOR_PRINCIPALS` — same policy as `credits`; no risk override needed (matches `status`/`credits`).
- Follow-up worth considering: add explicit routing rows for these commands to the `vellum-self-knowledge` skill's CLI table so the assistant reaches for them by name (they're already discoverable via `assistant platform --help`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WE7j4VV8Wenqs6zmAiznk

---
_Generated by [Claude Code](https://claude.ai/code/session_016WE7j4VV8Wenqs6zmAiznk)_