### PR TITLE
Custom-plan checkout deep link: /assistant/checkout carries a configured tier set through signup, Stripe, and hatching

### DIFF
--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -332,6 +332,121 @@ describe("PrivacyScreen — Start navigation", () => {
     expect(target).not.toContain(routes.checkout);
   });
 
+  test("resumes checkout when a pending signup-marked custom intent is present", () => {
+    checkoutIntentValue = {
+      kind: "custom",
+      machineTier: "large",
+      storageTier: "s",
+      creditTier: "credits_50",
+      savedAt: Date.now(),
+      resumeAfterOnboarding: true,
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(`${routes.checkout}?`)).toBe(true);
+    const query = navigatedQuery();
+    // The tier params the checkout route parses back into an upgrade body.
+    expect(query.get("machine_tier")).toBe("large");
+    expect(query.get("storage_tier")).toBe("s");
+    expect(query.get("credit_tier")).toBe("credits_50");
+    expect(query.get("continue")).toBe(
+      `${routes.onboarding.research}?hosting=managed`,
+    );
+  });
+
+  test("a resumed custom config omits the dimensions it leaves unset", () => {
+    checkoutIntentValue = {
+      kind: "custom",
+      machineTier: null,
+      storageTier: "xs",
+      creditTier: null,
+      savedAt: Date.now(),
+      resumeAfterOnboarding: true,
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    const query = navigatedQuery();
+    expect(query.get("storage_tier")).toBe("xs");
+    // Absent, not empty: an empty tier param would fail the checkout parse.
+    expect(query.has("machine_tier")).toBe(false);
+    expect(query.has("credit_tier")).toBe(false);
+  });
+
+  test("proceeds with onboarding when a marked custom stash names no storage tier", () => {
+    // Storage is required on a package-less upgrade, so such a stash names
+    // nothing the checkout route could buy. Fall through rather than hand off
+    // to a route that would only bail back out of the funnel.
+    checkoutIntentValue = {
+      kind: "custom",
+      machineTier: "medium",
+      storageTier: null,
+      creditTier: null,
+      savedAt: Date.now(),
+      resumeAfterOnboarding: true,
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(routes.onboarding.research)).toBe(true);
+    expect(target).not.toContain(routes.checkout);
+  });
+
+  test("drops the carried custom config and proceeds when the pricing funnel is off", () => {
+    takeoverValue = "disabled";
+    checkoutIntentValue = {
+      kind: "custom",
+      machineTier: "medium",
+      storageTier: "m",
+      creditTier: null,
+      savedAt: Date.now(),
+      resumeAfterOnboarding: true,
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(clearCheckoutIntentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(routes.onboarding.research)).toBe(true);
+    expect(target).not.toContain(routes.checkout);
+  });
+
+  test("does NOT resume an unmarked custom intent: onboarding proceeds normally", () => {
+    // The Stripe hand-off rewrites the stash without the marker, so an
+    // unmarked custom intent describes a checkout that already ran.
+    checkoutIntentValue = {
+      kind: "custom",
+      machineTier: "medium",
+      storageTier: "m",
+      creditTier: null,
+      savedAt: Date.now(),
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(routes.onboarding.research)).toBe(true);
+    expect(target).not.toContain(routes.checkout);
+  });
+
   // -- paid post-checkout return bounced here for consent -------------------
   //
   // A checkout return with nothing provisioned is funneled to the hatching

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -16,10 +16,12 @@ import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboardi
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
 import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
 import { CHECKOUT_CONTINUE_PARAM } from "@/lib/billing/checkout-continuation";
+import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 import {
   clearCheckoutIntent,
   readCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
+import { buildCustomCheckoutSearch } from "@/lib/billing/custom-checkout-params";
 import { isLocalMode } from "@/lib/local-mode";
 import { postCheckoutHatchReturnTo } from "@/lib/navigation/navigation-resolver";
 import {
@@ -31,7 +33,7 @@ import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { saveConsent } from "@/lib/consent/consent-persistence";
-import { routes } from "@/utils/routes";
+import { PACKAGE_PARAM, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
 export function PrivacyScreen() {
@@ -114,7 +116,7 @@ export function PrivacyScreen() {
     });
     const onboardingNext = `${destination}${qs ? `?${qs}` : ""}`;
 
-    // A pricing-CTA signup stashes its chosen package (see navigation-resolver
+    // A pricing-CTA signup stashes its chosen plan (see navigation-resolver
     // post-auth). With consent now recorded, resume checkout so payment happens
     // after consent and before the assistant hatches. Resume ONLY a
     // signup-marked intent (`resumeAfterOnboarding`): an ordinary billing-surface
@@ -124,26 +126,23 @@ export function PrivacyScreen() {
     // re-stashing on a Stripe redirect, clearing it on an already-Pro no_op — so
     // this screen just hands off. Resuming only from this explicit Start click —
     // never a render effect — keeps consent and checkout from looping.
-    // A positively-off `marketing-pricing-takeover` drops the dead package and
+    // A positively-off `marketing-pricing-takeover` drops the dead selection and
     // continues onboarding: handing off would bounce through a gated checkout
     // route and out of the funnel before research runs. An unresolved flag still
     // resumes, carrying the onboarding step this click would otherwise have
     // taken: if the flag lands off, checkout returns the user there instead of
     // the plans takeover, so a pending→disabled race stays inside the funnel.
     const checkoutIntent = readCheckoutIntent();
-    if (
-      checkoutIntent?.kind === "package" &&
-      checkoutIntent.resumeAfterOnboarding === true
-    ) {
+    if (checkoutIntent?.resumeAfterOnboarding === true) {
       if (takeover === "disabled") {
         clearCheckoutIntent();
       } else {
-        const checkoutParams = new URLSearchParams({
-          package: checkoutIntent.packageKey,
-          [CHECKOUT_CONTINUE_PARAM]: onboardingNext,
-        });
-        void navigate(`${routes.checkout}?${checkoutParams.toString()}`);
-        return;
+        const checkoutParams = checkoutResumeSearch(checkoutIntent);
+        if (checkoutParams) {
+          checkoutParams.set(CHECKOUT_CONTINUE_PARAM, onboardingNext);
+          void navigate(`${routes.checkout}?${checkoutParams.toString()}`);
+          return;
+        }
       }
     }
 
@@ -259,4 +258,24 @@ export function PrivacyScreen() {
       </div>
     </OnboardingLayout>
   );
+}
+
+/**
+ * The checkout query a signup-marked stash resumes with, or `null` when it
+ * names nothing the checkout route could act on: a custom stash without the
+ * storage tier the upgrade endpoint requires. Only the marker-free
+ * billing-surface saves can write one, and those never resume here.
+ */
+function checkoutResumeSearch(intent: CheckoutIntent): URLSearchParams | null {
+  if (intent.kind === "package") {
+    return new URLSearchParams({ [PACKAGE_PARAM]: intent.packageKey });
+  }
+  if (intent.storageTier === null) {
+    return null;
+  }
+  return buildCustomCheckoutSearch({
+    machineTier: intent.machineTier,
+    storageTier: intent.storageTier,
+    creditTier: intent.creditTier,
+  });
 }

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -31,6 +31,9 @@ const INTENT_KEY = "vellum.pro-checkout-intent";
 // otherwise have taken, so a checkout that doesn't happen resumes the funnel.
 const ONBOARDING_NEXT = "/assistant/onboarding/research?hosting=managed";
 const ONBOARDING_ENTRY = `/assistant/checkout?package=super&continue=${encodeURIComponent(ONBOARDING_NEXT)}`;
+// The package-less encoding: the same funnel carrying a custom tier config.
+const CUSTOM_ENTRY =
+  "/assistant/checkout?machine_tier=large&storage_tier=s&credit_tier=credits_50";
 
 type Captured = { body?: unknown };
 const upgradeCalls: Captured[] = [];
@@ -767,5 +770,111 @@ describe("CheckoutPage", () => {
     takeoverValue = "enabled";
     rerender(makeTree());
     await waitFor(() => expect(upgradeCalls.length).toBe(1));
+  });
+
+  test("a custom tier configuration checks out with no package in the body", async () => {
+    renderCheckout(CUSTOM_ENTRY);
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    // `package` is mutually exclusive with the tier fields server-side, so the
+    // custom body carries the three dimensions and nothing else.
+    expect(upgradeCalls[0]!.body).toEqual({
+      target_plan_id: "pro",
+      confirm: true,
+      machine_tier: "large",
+      storage_tier: "s",
+      credit_tier: "credits_50",
+      return_target: "web",
+    });
+
+    await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
+    // The post-checkout provisioning takeover renders its per-dimension chips
+    // off this stash, so it has to be written before the hand-off.
+    expect(JSON.parse(sessionStorage.getItem(INTENT_KEY)!)).toMatchObject({
+      kind: "custom",
+      machineTier: "large",
+      storageTier: "s",
+      creditTier: "credits_50",
+    });
+  });
+
+  test("omitted machine and credit params check out as the null baseline", async () => {
+    renderCheckout("/assistant/checkout?storage_tier=xs");
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    // Small machine, no credit bundle: the endpoint reads those as explicit
+    // nulls, not as fields to leave off.
+    expect(upgradeCalls[0]!.body).toEqual({
+      target_plan_id: "pro",
+      confirm: true,
+      machine_tier: null,
+      storage_tier: "xs",
+      credit_tier: null,
+      return_target: "web",
+    });
+
+    await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
+    expect(JSON.parse(sessionStorage.getItem(INTENT_KEY)!)).toMatchObject({
+      kind: "custom",
+      machineTier: null,
+      storageTier: "xs",
+      creditTier: null,
+    });
+  });
+
+  test("an explicit package wins over tier params on the same URL", async () => {
+    renderCheckout(
+      "/assistant/checkout?package=super&machine_tier=large&storage_tier=s",
+    );
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    // A body carrying both is a 400, so the client picks one side of the
+    // mutual exclusion rather than passing the conflict along.
+    expect(upgradeCalls[0]!.body).toEqual({
+      target_plan_id: "pro",
+      package: "super",
+      confirm: true,
+      return_target: "web",
+    });
+
+    await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
+    expect(JSON.parse(sessionStorage.getItem(INTENT_KEY)!)).toMatchObject({
+      kind: "package",
+      packageKey: "super",
+    });
+  });
+
+  test("tier params the endpoint would reject bail out and drop the stash", async () => {
+    // Legacy `xxl` storage 400s server-side. A mangled link has to bail rather
+    // than check out some other configuration the user never chose.
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    const { getByTestId } = renderCheckout(
+      "/assistant/checkout?machine_tier=large&storage_tier=xxl",
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+    expect(upgradeCalls.length).toBe(0);
+    expect(openedUrl).toBeNull();
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("a no_op on a custom configuration falls back to plans", async () => {
+    // Already Pro: the upgrade endpoint no-ops instead of minting a session,
+    // for a custom body exactly as it does for a package.
+    upgradeData = { status: "no_op", checkout_url: null, message: "" };
+    const { getByTestId } = renderCheckout(CUSTOM_ENTRY);
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+    expect(openedUrl).toBeNull();
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -1,5 +1,5 @@
 import { Loader2 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -18,6 +18,7 @@ import {
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
+import { parseCustomCheckoutSelection } from "@/lib/billing/custom-checkout-params";
 import { openUrl } from "@/runtime/browser";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { PACKAGE_PARAM, routes } from "@/utils/routes";
@@ -53,7 +54,8 @@ function abandonCheckout() {
 }
 
 /**
- * Deep-link checkout entrypoint (`/assistant/checkout?package=<slug>`). The
+ * Deep-link checkout entrypoint (`/assistant/checkout?package=<slug>`, or
+ * `?machine_tier=&storage_tier=&credit_tier=` for a custom configuration). The
  * marketing pricing CTAs route a chosen Pro package here — reachable by a
  * brand-new user with no assistant yet, so the route sits outside
  * `ActiveAssistantGate` and is exempted from the resolver's no-assistant funnel
@@ -61,7 +63,7 @@ function abandonCheckout() {
  * Stripe.
  *
  * Flow:
- *   - Missing `package` → back to the plans takeover.
+ *   - No package and no valid tier params → back to the plans takeover.
  *   - Gate `"pending"` → hold on the spinner. The platform-session probe has
  *     not answered yet, and a cold reload of this URL is exactly where that
  *     window falls.
@@ -93,6 +95,15 @@ export function CheckoutPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const packageKey = searchParams.get(PACKAGE_PARAM) ?? "";
+  // The package-less encoding of the same funnel: per-dimension tier params.
+  // An explicit `package` wins over them, mirroring the mutual exclusion the
+  // upgrade serializer enforces on the body they turn into. Memoized because
+  // the callbacks below take it as a dependency and `searchParams` is stable
+  // for as long as the location is.
+  const customSelection = useMemo(
+    () => (packageKey ? null : parseCustomCheckoutSelection(searchParams)),
+    [packageKey, searchParams],
+  );
   // Default (session-only) gate: a signed-in platform session reads `"full"`
   // even without an active assistant. See `use-platform-gate.ts`.
   //
@@ -147,12 +158,23 @@ export function CheckoutPage() {
     const returnTarget = checkoutReturnTarget();
     try {
       const result = await mutateAsync({
-        body: {
-          target_plan_id: "pro",
-          package: packageKey,
-          confirm: true,
-          return_target: returnTarget,
-        },
+        // A package resolves its own line items server-side and is mutually
+        // exclusive with the tier fields, so exactly one shape goes out.
+        body: customSelection
+          ? {
+              target_plan_id: "pro",
+              confirm: true,
+              machine_tier: customSelection.machineTier,
+              storage_tier: customSelection.storageTier,
+              credit_tier: customSelection.creditTier,
+              return_target: returnTarget,
+            }
+          : {
+              target_plan_id: "pro",
+              package: packageKey,
+              confirm: true,
+              return_target: returnTarget,
+            },
       });
       if (phaseRef.current !== "running") {
         // A bail settled the attempt while the upgrade was in flight. Drop the
@@ -167,8 +189,17 @@ export function CheckoutPage() {
         // route — see `CheckoutPhase`.
         phaseRef.current = "handed_off";
         // Stash the selection so the post-checkout provisioning screen can show
-        // the purchased package before the subscribe webhook lands.
-        saveCheckoutIntent({ kind: "package", packageKey });
+        // the purchased upgrade before the subscribe webhook lands.
+        saveCheckoutIntent(
+          customSelection
+            ? {
+                kind: "custom",
+                machineTier: customSelection.machineTier,
+                storageTier: customSelection.storageTier,
+                creditTier: customSelection.creditTier,
+              }
+            : { kind: "package", packageKey },
+        );
         captureTakeoverAvatarStash(queryClient);
         setAwaitingReturn(returnTarget === "native");
         void openUrl(result.checkout_url);
@@ -180,7 +211,9 @@ export function CheckoutPage() {
       // an in-place package switch, never Stripe Checkout, so the requested
       // package rides along to plans, which opens that switch from it. A
       // carried continuation owns the destination instead — an onboarding
-      // resume must not divert into the switch modal.
+      // resume must not divert into the switch modal. A custom configuration
+      // names no package, so it lands on the bail target as it always has:
+      // plans has no deep link that reopens a per-dimension configuration.
       phaseRef.current = "settled";
       abandonCheckout();
       navigate(
@@ -196,7 +229,14 @@ export function CheckoutPage() {
       phaseRef.current = "settled";
       setFailed(true);
     }
-  }, [bailTarget, mutateAsync, navigate, packageKey, queryClient]);
+  }, [
+    bailTarget,
+    customSelection,
+    mutateAsync,
+    navigate,
+    packageKey,
+    queryClient,
+  ]);
 
   // The retry the failure and hand-off UIs offer. A failed or abandoned attempt
   // re-runs the upgrade; a missing organization re-runs org resolution instead,
@@ -217,11 +257,12 @@ export function CheckoutPage() {
   }, [orgReadiness, runCheckout]);
 
   useEffect(() => {
-    // No package to check out, a session that can't reach checkout, or the
+    // Nothing to check out (no package and no tier configuration the upgrade
+    // endpoint would accept), a session that can't reach checkout, or the
     // pricing funnel switched off: fall back to the continuation, or to the
     // plans takeover, which owns its own gating and messaging.
     if (
-      !packageKey ||
+      (!packageKey && !customSelection) ||
       gate === "disabled" ||
       gate === "gated" ||
       takeover === "disabled"
@@ -270,6 +311,7 @@ export function CheckoutPage() {
     void runCheckout();
   }, [
     bailTarget,
+    customSelection,
     gate,
     navigate,
     orgReadiness,

--- a/clients/web/src/lib/billing/checkout-intent.test.ts
+++ b/clients/web/src/lib/billing/checkout-intent.test.ts
@@ -156,6 +156,26 @@ describe("readPurchasedCheckoutIntent", () => {
     expect(readPurchasedCheckoutIntent()).toMatchObject({ kind: "custom" });
   });
 
+  test("suppresses a signup-marked custom config: no hand-off ever ran", () => {
+    // The marker means the same thing whatever the intent names: a stash the
+    // Stripe hand-off never rewrote, so nobody paid for what it describes.
+    saveCheckoutIntent({
+      kind: "custom",
+      machineTier: "large",
+      storageTier: "s",
+      creditTier: "credits_50",
+      resumeAfterOnboarding: true,
+    });
+
+    expect(readPurchasedCheckoutIntent()).toBeNull();
+    // The stash itself is untouched: the privacy screen still resumes from it.
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "custom",
+      storageTier: "s",
+      resumeAfterOnboarding: true,
+    });
+  });
+
   test("returns null when nothing is stashed", () => {
     expect(readPurchasedCheckoutIntent()).toBeNull();
   });

--- a/clients/web/src/lib/billing/checkout-intent.ts
+++ b/clients/web/src/lib/billing/checkout-intent.ts
@@ -37,6 +37,8 @@ export type CheckoutIntent =
       storageTier: StorageTierEnum | null;
       creditTier: CreditTierEnum | null;
       savedAt: number;
+      /** The signup carry marker, exactly as on the `package` member above. */
+      resumeAfterOnboarding?: true;
     };
 
 /** `Omit` distributed over each member of a union. */
@@ -105,18 +107,18 @@ export function readCheckoutIntent(): CheckoutIntent | null {
 }
 
 /**
- * The stashed intent when it names a package the user actually paid for, else
- * `null`.
+ * The stashed intent when it names an upgrade the user actually paid for,
+ * else `null`.
  *
  * A stash still carrying `resumeAfterOnboarding` never reached the Stripe
  * hand-off — the hand-off replaces the record without the marker — so it names
- * a package nobody bought. Surfaces that report a purchase to the user read
- * this rather than {@link readCheckoutIntent}, which every bail path would
- * otherwise leave able to render a phantom.
+ * an upgrade nobody bought, whichever kind it is. Surfaces that report a
+ * purchase to the user read this rather than {@link readCheckoutIntent}, which
+ * every bail path would otherwise leave able to render a phantom.
  */
 export function readPurchasedCheckoutIntent(): CheckoutIntent | null {
   const intent = readCheckoutIntent();
-  if (intent?.kind === "package" && intent.resumeAfterOnboarding === true) {
+  if (intent?.resumeAfterOnboarding === true) {
     return null;
   }
   return intent;

--- a/clients/web/src/lib/billing/custom-checkout-params.test.ts
+++ b/clients/web/src/lib/billing/custom-checkout-params.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CustomCheckoutSelection } from "@/lib/billing/custom-checkout-params";
+import {
+  buildCustomCheckoutSearch,
+  parseCustomCheckoutSelection,
+} from "@/lib/billing/custom-checkout-params";
+
+describe("parseCustomCheckoutSelection", () => {
+  test("parses a fully specified configuration", () => {
+    expect(
+      parseCustomCheckoutSelection(
+        new URLSearchParams(
+          "machine_tier=large&storage_tier=s&credit_tier=credits_50",
+        ),
+      ),
+    ).toEqual({
+      machineTier: "large",
+      storageTier: "s",
+      creditTier: "credits_50",
+    });
+  });
+
+  test("omitted machine and credit tiers read as null", () => {
+    expect(
+      parseCustomCheckoutSelection(new URLSearchParams("storage_tier=xs")),
+    ).toEqual({ machineTier: null, storageTier: "xs", creditTier: null });
+  });
+
+  test("returns null when storage_tier is absent", () => {
+    expect(
+      parseCustomCheckoutSelection(
+        new URLSearchParams("machine_tier=medium&credit_tier=credits_10"),
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null for an empty search", () => {
+    expect(parseCustomCheckoutSelection(new URLSearchParams())).toBeNull();
+  });
+
+  test("rejects the legacy storage tiers the serializer 400s", () => {
+    for (const tier of ["xl", "xxl"]) {
+      expect(
+        parseCustomCheckoutSelection(
+          new URLSearchParams(`storage_tier=${tier}`),
+        ),
+      ).toBeNull();
+    }
+  });
+
+  test("rejects the package-only credit tiers", () => {
+    for (const tier of ["credits_45", "credits_115"]) {
+      expect(
+        parseCustomCheckoutSelection(
+          new URLSearchParams(`storage_tier=m&credit_tier=${tier}`),
+        ),
+      ).toBeNull();
+    }
+  });
+
+  test("an invalid machine tier fails the whole parse", () => {
+    expect(
+      parseCustomCheckoutSelection(
+        new URLSearchParams("machine_tier=small&storage_tier=m"),
+      ),
+    ).toBeNull();
+  });
+
+  test("junk values in any dimension fail the whole parse", () => {
+    for (const search of [
+      "storage_tier=huge",
+      "machine_tier=%20&storage_tier=m",
+      "storage_tier=m&credit_tier=credits_9999",
+      "machine_tier=large&storage_tier=s&credit_tier=free",
+    ]) {
+      expect(
+        parseCustomCheckoutSelection(new URLSearchParams(search)),
+      ).toBeNull();
+    }
+  });
+
+  test("a present-but-empty tier param fails the parse", () => {
+    // Never treat a blank value as "unset": the builder omits unset dimensions
+    // outright, so a blank one means the URL was mangled in transit.
+    expect(
+      parseCustomCheckoutSelection(
+        new URLSearchParams("machine_tier=&storage_tier=m"),
+      ),
+    ).toBeNull();
+    expect(
+      parseCustomCheckoutSelection(new URLSearchParams("storage_tier=")),
+    ).toBeNull();
+  });
+
+  test("ignores unrelated params on the checkout URL", () => {
+    expect(
+      parseCustomCheckoutSelection(
+        new URLSearchParams(
+          "storage_tier=l&continue=/assistant/onboarding/research&utm=x",
+        ),
+      ),
+    ).toEqual({ machineTier: null, storageTier: "l", creditTier: null });
+  });
+});
+
+describe("buildCustomCheckoutSearch", () => {
+  test("writes every set dimension", () => {
+    const search = buildCustomCheckoutSearch({
+      machineTier: "xl",
+      storageTier: "l",
+      creditTier: "credits_200",
+    });
+
+    expect(search.toString()).toBe(
+      "machine_tier=xl&storage_tier=l&credit_tier=credits_200",
+    );
+  });
+
+  test("omits the params a null dimension stands for", () => {
+    const search = buildCustomCheckoutSearch({
+      machineTier: null,
+      storageTier: "xs",
+      creditTier: null,
+    });
+
+    expect(search.toString()).toBe("storage_tier=xs");
+    expect(search.has("machine_tier")).toBe(false);
+    expect(search.has("credit_tier")).toBe(false);
+  });
+});
+
+describe("build then parse round-trip", () => {
+  test("preserves every representative selection", () => {
+    const selections: CustomCheckoutSelection[] = [
+      { machineTier: null, storageTier: "xs", creditTier: null },
+      { machineTier: "medium", storageTier: "s", creditTier: null },
+      { machineTier: null, storageTier: "m", creditTier: "credits_25" },
+      { machineTier: "xl", storageTier: "l", creditTier: "credits_200" },
+    ];
+
+    for (const selection of selections) {
+      expect(
+        parseCustomCheckoutSelection(buildCustomCheckoutSearch(selection)),
+      ).toEqual(selection);
+    }
+  });
+});

--- a/clients/web/src/lib/billing/custom-checkout-params.ts
+++ b/clients/web/src/lib/billing/custom-checkout-params.ts
@@ -1,0 +1,98 @@
+import type {
+  CreditTierEnum,
+  MachineTierEnum,
+  StorageTierEnum,
+} from "@/generated/api/types.gen";
+
+/**
+ * A custom Pro configuration carried on the `/assistant/checkout` deep link,
+ * mirroring the upgrade endpoint's per-dimension body. `machineTier: null` is
+ * the small baseline and `creditTier: null` is no credit bundle; `storageTier`
+ * has no null because the serializer requires it on a package-less upgrade.
+ */
+export interface CustomCheckoutSelection {
+  machineTier: MachineTierEnum | null;
+  storageTier: StorageTierEnum;
+  creditTier: CreditTierEnum | null;
+}
+
+// Param names mirror the upgrade serializer's field names, so a checkout URL
+// documents the body it turns into.
+export const CUSTOM_MACHINE_PARAM = "machine_tier";
+export const CUSTOM_STORAGE_PARAM = "storage_tier";
+export const CUSTOM_CREDIT_PARAM = "credit_tier";
+
+const CHECKOUTABLE_MACHINE_TIERS: ReadonlySet<string> =
+  new Set<MachineTierEnum>(["medium", "large", "xl"]);
+
+/** Legacy `xl`/`xxl` are excluded: `validate_storage_tier` 400s on them. */
+const CHECKOUTABLE_STORAGE_TIERS: ReadonlySet<string> =
+  new Set<StorageTierEnum>(["xs", "s", "m", "l"]);
+
+/** `credits_45`/`credits_115` are excluded: they are package-only bundles. */
+const CHECKOUTABLE_CREDIT_TIERS: ReadonlySet<string> = new Set<CreditTierEnum>([
+  "credits_10",
+  "credits_25",
+  "credits_50",
+  "credits_100",
+  "credits_200",
+]);
+
+/**
+ * The custom configuration a checkout URL names, or `null` when it names none
+ * or names one the upgrade endpoint would reject.
+ *
+ * `machine_tier` and `credit_tier` are optional, but a present-and-invalid
+ * value fails the whole parse instead of being dropped: a mangled URL must
+ * bail rather than check out a plan the user never configured.
+ */
+export function parseCustomCheckoutSelection(
+  searchParams: URLSearchParams,
+): CustomCheckoutSelection | null {
+  const storage = searchParams.get(CUSTOM_STORAGE_PARAM);
+  if (storage === null || !isCheckoutableStorageTier(storage)) {
+    return null;
+  }
+
+  const machine = searchParams.get(CUSTOM_MACHINE_PARAM);
+  if (machine !== null && !isCheckoutableMachineTier(machine)) {
+    return null;
+  }
+
+  const credit = searchParams.get(CUSTOM_CREDIT_PARAM);
+  if (credit !== null && !isCheckoutableCreditTier(credit)) {
+    return null;
+  }
+
+  return { machineTier: machine, storageTier: storage, creditTier: credit };
+}
+
+/**
+ * The checkout query string for a selection, omitting the dimensions it leaves
+ * unset. Round-trips through {@link parseCustomCheckoutSelection}.
+ */
+export function buildCustomCheckoutSearch(
+  selection: CustomCheckoutSelection,
+): URLSearchParams {
+  const search = new URLSearchParams();
+  if (selection.machineTier !== null) {
+    search.set(CUSTOM_MACHINE_PARAM, selection.machineTier);
+  }
+  search.set(CUSTOM_STORAGE_PARAM, selection.storageTier);
+  if (selection.creditTier !== null) {
+    search.set(CUSTOM_CREDIT_PARAM, selection.creditTier);
+  }
+  return search;
+}
+
+function isCheckoutableMachineTier(value: string): value is MachineTierEnum {
+  return CHECKOUTABLE_MACHINE_TIERS.has(value);
+}
+
+function isCheckoutableStorageTier(value: string): value is StorageTierEnum {
+  return CHECKOUTABLE_STORAGE_TIERS.has(value);
+}
+
+function isCheckoutableCreditTier(value: string): value is CreditTierEnum {
+  return CHECKOUTABLE_CREDIT_TIERS.has(value);
+}

--- a/clients/web/src/lib/billing/post-auth-checkout.test.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.test.ts
@@ -65,6 +65,83 @@ describe("resolveSignupCheckoutDestination", () => {
     expect(readCheckoutIntent()).toBeNull();
   });
 
+  test("signup on a custom checkout deep link stashes the marked config and routes to privacy", () => {
+    const result = resolveSignupCheckoutDestination({
+      intent: "signup",
+      returnTo:
+        "/assistant/checkout?machine_tier=large&storage_tier=s&credit_tier=credits_50",
+    });
+
+    expect(result).toBe("/assistant/onboarding/privacy");
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "custom",
+      machineTier: "large",
+      storageTier: "s",
+      creditTier: "credits_50",
+      resumeAfterOnboarding: true,
+    });
+  });
+
+  test("a custom link without the optional dimensions stashes them as null", () => {
+    const result = resolveSignupCheckoutDestination({
+      intent: "signup",
+      returnTo: "/assistant/checkout?storage_tier=xs",
+    });
+
+    expect(result).toBe("/assistant/onboarding/privacy");
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "custom",
+      machineTier: null,
+      storageTier: "xs",
+      creditTier: null,
+      resumeAfterOnboarding: true,
+    });
+  });
+
+  test("an explicit package wins over stray tier params", () => {
+    // The upgrade serializer rejects a body carrying both, so the client picks
+    // the same winner it does: the named package.
+    resolveSignupCheckoutDestination({
+      intent: "signup",
+      returnTo: "/assistant/checkout?package=super&storage_tier=m",
+    });
+
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+  });
+
+  test("a checkout link with tiers the endpoint would reject stashes nothing and clears a stale stash", () => {
+    // `xxl` storage 400s server-side, so the link names nothing checkoutable:
+    // treat it like any other non-checkout auth rather than carrying a config
+    // that cannot be bought.
+    saveCheckoutIntent({ kind: "package", packageKey: "abandoned" });
+
+    const result = resolveSignupCheckoutDestination({
+      intent: "signup",
+      returnTo: "/assistant/checkout?storage_tier=xxl",
+    });
+
+    expect(result).toBe("/assistant/onboarding/privacy");
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("login on a custom checkout deep link keeps its returnTo and stashes nothing", () => {
+    const returnTo =
+      "/assistant/checkout?machine_tier=medium&storage_tier=m&credit_tier=credits_25";
+
+    const result = resolveSignupCheckoutDestination({
+      intent: "login",
+      returnTo,
+    });
+
+    // The checkout page itself validates and runs the upgrade for a login.
+    expect(result).toBe(returnTo);
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
   test("login on a checkout deep link keeps its returnTo, stashes nothing, and leaves an existing stash untouched", () => {
     saveCheckoutIntent({ kind: "package", packageKey: "existing" });
 

--- a/clients/web/src/lib/billing/post-auth-checkout.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.ts
@@ -2,64 +2,88 @@ import {
   clearCheckoutIntent,
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
+import {
+  parseCustomCheckoutSelection,
+  type CustomCheckoutSelection,
+} from "@/lib/billing/custom-checkout-params";
 import { PACKAGE_PARAM, routes } from "@/utils/routes";
 
+/** What a checkout deep link asks to buy. */
+type CheckoutDestination =
+  | { kind: "package"; packageKey: string }
+  | { kind: "custom"; selection: CustomCheckoutSelection };
+
 /**
- * Whether a destination is the `/assistant/checkout` deep link, plus the
- * `package` slug it carries (null when absent). The marketing pricing CTAs
- * point here to start Stripe checkout for a chosen package.
+ * What the destination checks out, or `null` when it is not the
+ * `/assistant/checkout` deep link or names nothing that route could act on.
+ * The marketing pricing CTAs point here with either `?package=<slug>` or the
+ * per-dimension tier params of a custom configuration; an explicit package
+ * wins, mirroring the mutual exclusion the upgrade serializer enforces on the
+ * body they turn into.
  */
-function parseCheckoutDestination(destination: string): {
-  isCheckout: boolean;
-  packageKey: string | null;
-} {
+function parseCheckoutDestination(
+  destination: string,
+): CheckoutDestination | null {
   let url: URL;
   try {
     url = new URL(destination, "http://placeholder.invalid");
   } catch {
-    return { isCheckout: false, packageKey: null };
+    return null;
   }
   if (url.pathname !== routes.checkout) {
-    return { isCheckout: false, packageKey: null };
+    return null;
   }
-  return {
-    isCheckout: true,
-    packageKey: url.searchParams.get(PACKAGE_PARAM) || null,
-  };
+  const packageKey = url.searchParams.get(PACKAGE_PARAM) || null;
+  if (packageKey) {
+    return { kind: "package", packageKey };
+  }
+  const selection = parseCustomCheckoutSelection(url.searchParams);
+  return selection ? { kind: "custom", selection } : null;
 }
 
 /**
  * The shared post-auth checkout destination for both the web
  * (`resolvePostAuth`) and native (`resolveNativePostAuthDestination`) paths.
  *
- * A signup that carries a pricing-CTA checkout deep link stashes the package
- * and routes through consent (privacy) first, so the consent screen resumes
- * checkout after onboarding. Any auth that is NOT a checkout deep link
- * discards a stale stash left by an abandoned earlier attempt — external OAuth
- * can't run a cleanup callback, so the next auth entry self-cleans; the stash
- * this flow sets is never touched. A signup otherwise routes to privacy; a
- * login keeps its own `returnTo` and starts checkout directly from there.
+ * A signup that carries a pricing-CTA checkout deep link stashes the plan it
+ * names (a package slug or a custom tier configuration) and routes through
+ * consent (privacy) first, so the consent screen resumes checkout after
+ * onboarding. Any auth that names no checkoutable plan discards a stale stash
+ * left by an abandoned earlier attempt: external OAuth can't run a cleanup
+ * callback, so the next auth entry self-cleans; the stash this flow sets is
+ * never touched. A signup otherwise routes to privacy; a login keeps its own
+ * `returnTo` and starts checkout directly from there.
  */
 export function resolveSignupCheckoutDestination(args: {
   intent: "login" | "signup";
   returnTo: string;
 }): string {
   const { intent, returnTo } = args;
-  const { isCheckout, packageKey } = parseCheckoutDestination(returnTo);
+  const checkout = parseCheckoutDestination(returnTo);
 
-  if (!isCheckout) {
+  if (!checkout) {
     clearCheckoutIntent();
   }
 
   if (intent === "signup") {
-    if (packageKey) {
+    if (checkout) {
       // Mark the stash as signup-originated so only the onboarding privacy
-      // screen resumes it — an ordinary billing-surface stash stays inert here.
-      saveCheckoutIntent({
-        kind: "package",
-        packageKey,
-        resumeAfterOnboarding: true,
-      });
+      // screen resumes it: an ordinary billing-surface stash stays inert here.
+      saveCheckoutIntent(
+        checkout.kind === "package"
+          ? {
+              kind: "package",
+              packageKey: checkout.packageKey,
+              resumeAfterOnboarding: true,
+            }
+          : {
+              kind: "custom",
+              machineTier: checkout.selection.machineTier,
+              storageTier: checkout.selection.storageTier,
+              creditTier: checkout.selection.creditTier,
+              resumeAfterOnboarding: true,
+            },
+      );
     }
     return routes.onboarding.privacy;
   }


### PR DESCRIPTION
Summary:
Extends the marketing checkout funnel (#39161) so `/assistant/checkout` can start a checkout for a fully custom Pro configuration, not just a named package. The marketing /pricing configurator modal (companion PR in vellum-assistant-platform) builds `?machine_tier=&storage_tier=&credit_tier=` links; this PR makes them work end to end: direct entry for signed-in free users, and signup -> consent -> resumed checkout -> Stripe -> provisioning takeover for anonymous visitors.

Changes:
- New `lib/billing/custom-checkout-params.ts`: parse/build codec for the custom tier params, with allowlists that mirror the upgrade serializer exactly (legacy storage `xl`/`xxl` and package-only `credits_45`/`credits_115` rejected; any invalid or empty value fails the whole parse so a mangled URL bails instead of checking out a different plan).
- `checkout-page.tsx`: custom mode alongside package mode; posts `{target_plan_id: "pro", confirm: true, machine_tier, storage_tier, credit_tier}`, stashes a `{kind: "custom"}` checkout intent on Stripe handoff (including the instant-avatar stash capture), and keeps every gate/bail path shared. An explicit `package` param wins over tier params, matching the server's mutual-exclusion rule.
- Signup resume: `parseCheckoutDestination` recognizes custom checkout links, `resolveSignupCheckoutDestination` stashes a marked `{kind: "custom", resumeAfterOnboarding: true}` intent, and the consent screen rebuilds the custom checkout URL (plus the onboarding `continue` param) after signup. `readPurchasedCheckoutIntent` now suppresses any still-marked intent regardless of kind.
- Behavior note: a checkout link that names nothing checkoutable (bare `/assistant/checkout`, or tiers the serializer would 400) is now treated as a non-checkout auth and clears a stale stash.

Testing:
- 111 assertions of new/updated coverage across `custom-checkout-params.test.ts` (13), `checkout-page.test.tsx` (33), `checkout-intent.test.ts` (17), `post-auth-checkout.test.ts` (10), `privacy-screen.test.tsx` (22); regressions green on navigation-resolver (132), billing-onboarding-modal (34), provisioning-state (55), native-auth (9), use-provisioning-credits (14), adjust-plan-modal (26). `tsc --noEmit` and eslint clean on all changed files.
- Not yet browser-verified; the full funnel needs a live platform session (see companion PR for the QA checklist).

Deployment order: merge/deploy this PR BEFORE the companion marketing PR (vellum-assistant-platform: `Jasonnnz/pricing-custom-modal`), whose Continue CTAs emit URLs only this code understands. The whole funnel remains behind the `marketing-pricing-takeover` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
