### PR TITLE
feat(account): report signup and login arrivals to the funnel ledger

### DIFF
--- a/clients/web/src/domains/account/hooks/use-funnel-page-view.test.ts
+++ b/clients/web/src/domains/account/hooks/use-funnel-page-view.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+let native = false;
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => native,
+}));
+
+const { useFunnelPageView } = await import(
+  "@/domains/account/hooks/use-funnel-page-view"
+);
+
+const SIGNUP = "/account/signup";
+
+let fetchMock: ReturnType<typeof mock>;
+let originalFetch: typeof globalThis.fetch;
+let originalLocation: PropertyDescriptor | undefined;
+
+function setHostname(hostname: string): void {
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, hostname },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  native = false;
+  // Captured before the first override so `afterEach` can put the real
+  // `window.location` back. Leaking a vellum.ai hostname into the rest of the
+  // suite makes every later auth-page test fire a real beacon.
+  originalLocation ??= Object.getOwnPropertyDescriptor(window, "location");
+  setHostname("www.vellum.ai");
+  originalFetch = globalThis.fetch;
+  fetchMock = mock(async () => new Response(null, { status: 204 }));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  if (originalLocation) {
+    Object.defineProperty(window, "location", originalLocation);
+  }
+});
+
+function bodyOf(call: unknown[]): { path?: string } {
+  const init = call[1] as RequestInit;
+  return JSON.parse(String(init.body)) as { path?: string };
+}
+
+describe("useFunnelPageView", () => {
+  test("reports the arrival to the platform ledger endpoint", () => {
+    renderHook(() => useFunnelPageView(SIGNUP, true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0] as unknown[];
+    expect(call[0]).toBe("/api/funnel/view");
+    expect(bodyOf(call).path).toBe(SIGNUP);
+  });
+
+  test("sends cookies so the platform can resolve the HttpOnly visitor id", () => {
+    renderHook(() => useFunnelPageView(SIGNUP, true));
+
+    const init = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    expect(init.credentials).toBe("same-origin");
+  });
+
+  test("survives the navigation to the OAuth provider", () => {
+    renderHook(() => useFunnelPageView(SIGNUP, true));
+
+    const init = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit;
+    expect(init.keepalive).toBe(true);
+  });
+
+  test("does not report until the visitor actually reaches the screen", () => {
+    const { rerender } = renderHook(
+      ({ enabled }) => useFunnelPageView(SIGNUP, enabled),
+      { initialProps: { enabled: false } },
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("one arrival is one ledger entry across re-renders", () => {
+    const { rerender } = renderHook(() => useFunnelPageView(SIGNUP, true));
+
+    rerender();
+    rerender();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("stays out of the native funnel, which resolves a different origin", () => {
+    native = true;
+
+    renderHook(() => useFunnelPageView(SIGNUP, true));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test.each(["assistant.acme-corp.internal", "localhost"])(
+    "skips %s, where the platform endpoint does not exist",
+    (hostname) => {
+      setHostname(hostname);
+
+      renderHook(() => useFunnelPageView(SIGNUP, true));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("a failed beacon never surfaces to the auth screen", () => {
+    fetchMock = mock(async () => {
+      throw new Error("network down");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    expect(() =>
+      renderHook(() => useFunnelPageView(SIGNUP, true)),
+    ).not.toThrow();
+  });
+});

--- a/clients/web/src/domains/account/hooks/use-funnel-page-view.ts
+++ b/clients/web/src/domains/account/hooks/use-funnel-page-view.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from "react";
+
+import { isNativePlatform } from "@/runtime/native-auth";
+import { isVellumDomain } from "@/utils/domains";
+
+/** Platform route that appends to the marketing page-view ledger. */
+const FUNNEL_BEACON_ENDPOINT = "/api/funnel/view";
+
+/**
+ * Report that a visitor reached an SPA-served auth page.
+ *
+ * The marketing page-view ledger is written by the platform's Next.js
+ * middleware, but `/account/*` is routed to the static SPA by ingress and
+ * served by nginx from this bundle, so that middleware never runs for these
+ * routes. Without this beacon the funnel is dark between the marketing landing
+ * page and the created user, and campaign drop-off can't be pinned to either
+ * the landing page or the signup step.
+ *
+ * The visitor id lives in the `HttpOnly` `vellum_vid` cookie, which this app
+ * cannot read. The beacon therefore reports only *which* page was reached and
+ * lets the platform resolve the visitor server-side from the cookie it can
+ * see — which is also why this is a same-origin request rather than a log line.
+ */
+export function useFunnelPageView(path: string, enabled: boolean): void {
+  const reportedPath = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    // Guards React's double-invoked effects in development, and any re-render
+    // that doesn't change `path` — one arrival should be one ledger entry.
+    if (reportedPath.current === path) {
+      return;
+    }
+    // Native signups are a separate funnel and resolve against a different
+    // origin. Off a vellum.ai host (self-hosted, local dev) the endpoint
+    // doesn't exist, so skip rather than fire a request that always fails.
+    if (isNativePlatform()) {
+      return;
+    }
+    if (!isVellumDomain(window.location.hostname)) {
+      return;
+    }
+
+    reportedPath.current = path;
+
+    void fetch(FUNNEL_BEACON_ENDPOINT, {
+      method: "POST",
+      // The platform resolves `vellum_vid` from the request cookies.
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path }),
+      // The next click leaves for the OAuth provider; without this the
+      // in-flight beacon is cancelled on navigation and the arrival is lost.
+      keepalive: true,
+    }).catch(() => {
+      // Telemetry must never surface to the user or break the auth screen.
+    });
+  }, [path, enabled]);
+}

--- a/clients/web/src/domains/account/pages/login-page.tsx
+++ b/clients/web/src/domains/account/pages/login-page.tsx
@@ -9,6 +9,7 @@ import {
   LoginErrorText,
   LoginHeading,
 } from "@/domains/account/components/login-shell";
+import { useFunnelPageView } from "@/domains/account/hooks/use-funnel-page-view";
 import { useReturnToShortCircuit } from "@/domains/account/hooks/use-return-to-short-circuit";
 import {
   PROVIDER_ID,
@@ -169,6 +170,9 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
 export function LoginPage() {
   const isNative = useIsNativePlatform();
   const shortCircuit = useReturnToShortCircuit();
+  // Only a visitor who reaches the screen is a funnel arrival — an existing
+  // session that short-circuits straight to `returnTo` is not.
+  useFunnelPageView(routes.account.login, shortCircuit.kind === "proceed");
 
   if (shortCircuit.kind === "wait") {
     return isNative ? (

--- a/clients/web/src/domains/account/pages/signup-page.tsx
+++ b/clients/web/src/domains/account/pages/signup-page.tsx
@@ -1,7 +1,9 @@
 import { AuthWaitSpinner } from "@/domains/account/components/auth-wait-spinner";
 import { SignupScreen } from "@/domains/account/components/signup-screen";
 import { SignupShell } from "@/domains/account/components/signup-shell";
+import { useFunnelPageView } from "@/domains/account/hooks/use-funnel-page-view";
 import { useReturnToShortCircuit } from "@/domains/account/hooks/use-return-to-short-circuit";
+import { routes } from "@/utils/routes";
 
 /**
  * Signup entry. Renders the branded sign-up screen for everyone: a rotating
@@ -15,6 +17,9 @@ import { useReturnToShortCircuit } from "@/domains/account/hooks/use-return-to-s
  */
 export function SignupPage() {
   const shortCircuit = useReturnToShortCircuit();
+  // Only a visitor who reaches the screen is a funnel arrival — an existing
+  // session that short-circuits straight to `returnTo` is not.
+  useFunnelPageView(routes.account.signup, shortCircuit.kind === "proceed");
 
   if (shortCircuit.kind === "wait") {
     return (


### PR DESCRIPTION
Companion to vellum-ai/vellum-assistant-platform#9577, which adds the `/api/funnel/view` endpoint this calls. **Merge the platform PR first** — until it lands, this beacon posts to a route that doesn't exist (failures are swallowed, so nothing breaks, but nothing is recorded either).

## Prompt / plan

Investigating why Meta ad UTMs weren't appearing on `/admin/top-of-funnel`, the analysis kept hitting the same wall: **there is no data for the signup step.** For the current Instagram campaign the platform can see 13,367 UTM-tagged landings on `/personal-ai` and ~3 signups carrying Meta attribution — with no way to tell whether visitors bounced on the landing page or dropped at the signup form. Those are different problems with different fixes.

The cause is architectural. The marketing page-view ledger is written by the platform's Next.js middleware, but ingress routes `/account` to the static SPA and nginx serves those paths from this bundle, so that middleware never runs for them. The first attempt at a fix lived in the platform middleware and was dead code for exactly this reason.

## Approach

`useFunnelPageView` posts to the platform's `/api/funnel/view` on arrival at the signup and login screens. The endpoint resolves the visitor server-side and appends the ledger entry; this side only reports *which* page was reached.

**Why a request and not client-side analytics or a log line:** the visitor id lives in the `HttpOnly` `vellum_vid` cookie, which this app cannot read. Only a server that can see the cookie is able to attribute the arrival, so it has to round-trip.

Decisions worth review:

- **Fires only on `kind: "proceed"`.** An existing session that short-circuits straight to `returnTo` never reached the screen and isn't a funnel arrival.
- **Skipped on native.** iOS signups are a separate funnel and resolve against a different origin.
- **Skipped off a vellum.ai host**, so self-hosted deployments and local dev don't fire at an endpoint that isn't there.
- **`keepalive: true`.** The next click leaves for the OAuth provider; without it the in-flight beacon is cancelled on navigation and the arrival is lost.
- **Failures swallowed.** Telemetry must never surface on an auth screen.

No new UI, so no design-library surface is involved.

## Test plan

- `bun test src/domains/account/hooks/use-funnel-page-view.test.ts` — 9 pass. Covers endpoint and payload, cookie forwarding, the enabled gate, once-per-arrival across re-renders, both skip conditions, and that a failing beacon doesn't throw.
- `bun run test:ci` — 762 test files, 0 failed.
- `bunx tsc --noEmit` — clean.
- `bun run lint` — 0 errors.

One thing the test suite caught that's worth flagging: the hook test overrides `window.location` to exercise the hostname gate, and an earlier revision didn't restore it. That leaked a `vellum.ai` hostname into the rest of the suite and made every later auth-page test fire a real network beacon (`ECONNREFUSED` noise, verified absent on a clean tree). The descriptor is now captured and restored in `afterEach`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUmZCccK9XZca5LTaDh9mL)_