### PR TITLE
refactor(gateway): replace resolveAssistant with an identity guard

### DIFF
--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import { LOCAL_ASSISTANT_ID } from "../assistant-id.js";
-import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import {
+  hasRoutableIdentity,
+  LOCAL_ROUTE,
+  resolveAssistantByPhoneNumber,
+} from "../routing/resolve-assistant.js";
 import type { GatewayConfig } from "../config.js";
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
@@ -29,124 +33,75 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-describe("resolveAssistant", () => {
-  test("resolves by conversation_id match", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "99001", assistantId: "assistant-a" },
-        { type: "actor_id", key: "55001", assistantId: "assistant-b" },
-      ],
-    });
-
-    const result = resolveAssistant(config, "99001", "55001");
-    expect(isRejection(result)).toBe(false);
-    if (!isRejection(result)) {
-      expect(result.assistantId).toBe("assistant-a");
-      expect(result.routeSource).toBe("conversation_id");
-    }
+describe("LOCAL_ROUTE", () => {
+  test("names the local assistant", () => {
+    expect(LOCAL_ROUTE.assistantId).toBe(LOCAL_ASSISTANT_ID);
+    expect(LOCAL_ROUTE.routeSource).toBe("default");
   });
 
-  test("falls back to actor_id when conversation_id does not match", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "99999", assistantId: "assistant-a" },
-        { type: "actor_id", key: "55001", assistantId: "assistant-b" },
-      ],
-    });
+  test("is frozen so a caller cannot mutate the shared route", () => {
+    expect(Object.isFrozen(LOCAL_ROUTE)).toBe(true);
+  });
+});
 
-    const result = resolveAssistant(config, "99001", "55001");
-    expect(isRejection(result)).toBe(false);
-    if (!isRejection(result)) {
-      expect(result.assistantId).toBe("assistant-b");
-      expect(result.routeSource).toBe("actor_id");
-    }
+describe("hasRoutableIdentity", () => {
+  test("accepts an event with either identity present", () => {
+    expect(hasRoutableIdentity("99001", "55001")).toBe(true);
+    expect(hasRoutableIdentity("99001", undefined)).toBe(true);
+    expect(hasRoutableIdentity(undefined, "55001")).toBe(true);
   });
 
-  test("falls back to the local assistant when no explicit match", () => {
-    const config = makeConfig();
-
-    const result = resolveAssistant(config, "99001", "55001");
-    expect(isRejection(result)).toBe(false);
-    if (!isRejection(result)) {
-      expect(result.assistantId).toBe(LOCAL_ASSISTANT_ID);
-      expect(result.routeSource).toBe("default");
-    }
-  });
-
-  test("conversation_id takes priority over actor_id for same assistant", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "actor_id", key: "55001", assistantId: "assistant-user" },
-        {
-          type: "conversation_id",
-          key: "99001",
-          assistantId: "assistant-chat",
-        },
-      ],
-    });
-
-    const result = resolveAssistant(config, "99001", "55001");
-    expect(isRejection(result)).toBe(false);
-    if (!isRejection(result)) {
-      expect(result.assistantId).toBe("assistant-chat");
-      expect(result.routeSource).toBe("conversation_id");
-    }
-  });
-
-  test("rejects a no-identity event", () => {
-    // Fail-closed: an event with neither a conversation nor an actor id has
-    // nothing to route on, so it must reject rather than fall through to the
-    // local assistant. This is the only rejection resolveAssistant produces.
-    const config = makeConfig();
-
+  test("rejects an event with neither identity", () => {
+    // Fail-closed: nothing to bind a conversation on, nothing to classify
+    // trust against. Empty strings count as absent.
     for (const [conversationId, actorId] of [
       ["", ""],
       [undefined, undefined],
       ["", undefined],
       [undefined, ""],
     ] as const) {
-      const result = resolveAssistant(config, conversationId, actorId);
-      expect(isRejection(result)).toBe(true);
-      if (isRejection(result)) {
-        expect(result.reason).toContain("No routable identity");
-      }
+      expect(hasRoutableIdentity(conversationId, actorId)).toBe(false);
     }
   });
+});
 
-  test("still resolves when only one identity is present and matches a route", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "99001", assistantId: "assistant-a" },
-        { type: "actor_id", key: "55001", assistantId: "assistant-b" },
-      ],
+describe("resolveAssistantByPhoneNumber", () => {
+  const config = makeConfig();
+
+  function cacheWith(mapping: Record<string, string> | undefined) {
+    return {
+      getRecord: () => mapping,
+    } as unknown as Parameters<typeof resolveAssistantByPhoneNumber>[2];
+  }
+
+  test("resolves the assistant whose configured number was dialed", () => {
+    const result = resolveAssistantByPhoneNumber(
+      config,
+      "+12015550101",
+      cacheWith({ "ast-a": "+12015550101", "ast-b": "+12015550102" }),
+    );
+    expect(result).toEqual({
+      assistantId: "ast-a",
+      routeSource: "phone_number",
     });
-
-    // Missing actor, conversation matches.
-    const byConversation = resolveAssistant(config, "99001", undefined);
-    expect(isRejection(byConversation)).toBe(false);
-    if (!isRejection(byConversation)) {
-      expect(byConversation.assistantId).toBe("assistant-a");
-    }
-
-    // Missing conversation, actor matches.
-    const byActor = resolveAssistant(config, undefined, "55001");
-    expect(isRejection(byActor)).toBe(false);
-    if (!isRejection(byActor)) {
-      expect(byActor.assistantId).toBe("assistant-b");
-    }
   });
 
-  test("resolves locally when one identity is present but unrouted", () => {
-    // A valid-but-unrouted event (real identity, no explicit route) still
-    // resolves — only the no-identity case is rejected. Whether it is then
-    // admitted is the admission floor's call, not routing's.
-    const config = makeConfig();
+  test("returns undefined when no configured number matches", () => {
+    const result = resolveAssistantByPhoneNumber(
+      config,
+      "+12015550199",
+      cacheWith({ "ast-a": "+12015550101" }),
+    );
+    expect(result).toBeUndefined();
+  });
 
-    const result = resolveAssistant(config, "C-unrouted", undefined);
-    expect(isRejection(result)).toBe(false);
-    if (!isRejection(result)) {
-      expect(result.assistantId).toBe(LOCAL_ASSISTANT_ID);
-      expect(result.routeSource).toBe("default");
-    }
+  test("returns undefined when no mapping is configured", () => {
+    expect(
+      resolveAssistantByPhoneNumber(
+        config,
+        "+12015550101",
+        cacheWith(undefined),
+      ),
+    ).toBeUndefined();
   });
 });

--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -435,17 +435,10 @@ describe("normalizeSlackAppMention with display name", () => {
         { status: 200, headers: { "content-type": "application/json" } },
       );
     });
-
-    const config = makeConfig();
     const event = makeEvent({ user: "U_WITH_NAME" });
 
     // First call: cache miss, fires background fetch, no display name yet
-    const result1 = normalizeSlackAppMention(
-      event,
-      "evt-dn-1a",
-      config,
-      "xoxb-test",
-    );
+    const result1 = normalizeSlackAppMention(event, "evt-dn-1a", "xoxb-test");
     expect(result1).not.toBeNull();
     expect(result1!.event.actor.displayName).toBeUndefined();
 
@@ -453,12 +446,7 @@ describe("normalizeSlackAppMention with display name", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     // Second call: cache hit, display name populated
-    const result2 = normalizeSlackAppMention(
-      event,
-      "evt-dn-1b",
-      config,
-      "xoxb-test",
-    );
+    const result2 = normalizeSlackAppMention(event, "evt-dn-1b", "xoxb-test");
     expect(result2).not.toBeNull();
     expect(result2!.event.actor.displayName).toBe("Test U");
     expect(result2!.event.actor.username).toBe("testuser");
@@ -481,19 +469,12 @@ describe("normalizeSlackAppMention with display name", () => {
         { status: 200, headers: { "content-type": "application/json" } },
       );
     });
-
-    const config = makeConfig();
     const event = makeEvent({ user: "U_PREWARM" });
 
     // Pre-warm the cache with an explicit async call
     await resolveSlackUser("U_PREWARM", "xoxb-test");
 
-    const result = normalizeSlackAppMention(
-      event,
-      "evt-dn-pw",
-      config,
-      "xoxb-test",
-    );
+    const result = normalizeSlackAppMention(event, "evt-dn-pw", "xoxb-test");
     expect(result).not.toBeNull();
     expect(result!.event.actor.displayName).toBe("Test U");
     expect(result!.event.actor.username).toBe("testuser");
@@ -519,7 +500,6 @@ describe("normalizeSlackAppMention with display name", () => {
         { status: 200, headers: { "content-type": "application/json" } },
       );
     });
-
     const config = makeConfig();
     const event = makeEvent({ user: "U_WITH_TZ" });
     await resolveSlackUser("U_WITH_TZ", "xoxb-test");
@@ -527,7 +507,6 @@ describe("normalizeSlackAppMention with display name", () => {
     const result = normalizeSlackAppMention(
       event,
       "evt-tz-forward",
-      config,
       "xoxb-test",
     );
     expect(result).not.toBeNull();
@@ -564,8 +543,6 @@ describe("normalizeSlackAppMention with display name", () => {
         { status: 200, headers: { "content-type": "application/json" } },
       );
     });
-
-    const config = makeConfig();
     const event = makeEvent({
       text: "<@U123BOT> <@ULEO> please look",
     });
@@ -574,7 +551,6 @@ describe("normalizeSlackAppMention with display name", () => {
     const result = normalizeSlackAppMention(
       event,
       "evt-mention-cache",
-      config,
       undefined,
       { userLabels: userInfo ? { ULEO: userInfo.displayName } : {} },
     );
@@ -591,8 +567,6 @@ describe("normalizeSlackAppMention with display name", () => {
     fetchMock = mock(async () => {
       return new Response("", { status: 500 });
     });
-
-    const config = makeConfig();
     const event = makeEvent({
       text: "<@U123BOT> <@UFAIL> please look",
     });
@@ -601,7 +575,6 @@ describe("normalizeSlackAppMention with display name", () => {
     const result = normalizeSlackAppMention(
       event,
       "evt-mention-fallback",
-      config,
       undefined,
       { userLabels: userInfo ? { UFAIL: userInfo.displayName } : {} },
     );
@@ -615,9 +588,8 @@ describe("normalizeSlackAppMention with display name", () => {
   });
 
   test("omits displayName when bot token is not configured", () => {
-    const config = makeConfig();
     const event = makeEvent();
-    const result = normalizeSlackAppMention(event, "evt-dn-2", config);
+    const result = normalizeSlackAppMention(event, "evt-dn-2");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.displayName).toBeUndefined();
@@ -628,15 +600,8 @@ describe("normalizeSlackAppMention with display name", () => {
     fetchMock = mock(async () => {
       return new Response("", { status: 500 });
     });
-
-    const config = makeConfig();
     const event = makeEvent();
-    const result = normalizeSlackAppMention(
-      event,
-      "evt-dn-3",
-      config,
-      "xoxb-test",
-    );
+    const result = normalizeSlackAppMention(event, "evt-dn-3", "xoxb-test");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.displayName).toBeUndefined();

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -12,32 +12,6 @@ import type {
   SlackDirectMessageEvent,
   SlackMessageChangedEvent,
 } from "../slack/message-schemas.js";
-import type { GatewayConfig } from "../config.js";
-
-function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
-    assistantRuntimeBaseUrl: "http://localhost:7821",
-    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-    logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: {
-      telegram: 50 * 1024 * 1024,
-      slack: 100 * 1024 * 1024,
-      whatsapp: 16 * 1024 * 1024,
-      default: 50 * 1024 * 1024,
-    },
-    maxAttachmentConcurrency: 3,
-    maxWebhookPayloadBytes: 1048576,
-    port: 7830,
-    routingEntries: [],
-    runtimeInitialBackoffMs: 500,
-    runtimeMaxRetries: 2,
-    runtimeProxyRequireAuth: false,
-    runtimeTimeoutMs: 30000,
-    shutdownDrainMs: 5000,
-    trustProxy: false,
-    ...overrides,
-  } as GatewayConfig;
-}
 
 function makeEvent(
   overrides: Partial<SlackAppMentionEvent> = {},
@@ -54,9 +28,8 @@ function makeEvent(
 
 describe("normalizeSlackAppMention", () => {
   test("normalizes app_mention event with sourceChannel 'slack'", async () => {
-    const config = makeConfig();
     const event = makeEvent();
-    const result = await normalizeSlackAppMention(event, "evt-001", config);
+    const result = await normalizeSlackAppMention(event, "evt-001");
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
@@ -64,66 +37,55 @@ describe("normalizeSlackAppMention", () => {
   });
 
   test("sets conversationExternalId to event.channel", async () => {
-    const config = makeConfig();
     const event = makeEvent({ channel: "C_MY_CHANNEL" });
-    const result = await normalizeSlackAppMention(event, "evt-002", config);
+    const result = await normalizeSlackAppMention(event, "evt-002");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.conversationExternalId).toBe("C_MY_CHANNEL");
   });
 
   test("externalMessageId uses client_msg_id when present", async () => {
-    const config = makeConfig();
     const event = makeEvent({ client_msg_id: "cmid-abc" });
-    const result = await normalizeSlackAppMention(event, "evt-003", config);
+    const result = await normalizeSlackAppMention(event, "evt-003");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.externalMessageId).toBe("cmid-abc");
   });
 
   test("externalMessageId falls back to ts when client_msg_id is absent", async () => {
-    const config = makeConfig();
     const event = makeEvent({
       client_msg_id: undefined,
       ts: "1700000000.000100",
     });
-    const result = await normalizeSlackAppMention(event, "evt-004", config);
+    const result = await normalizeSlackAppMention(event, "evt-004");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.externalMessageId).toBe("1700000000.000100");
   });
 
   test("renders the bot's mention using the resolved label", async () => {
-    const config = makeConfig();
     const event = makeEvent({ text: "<@U123BOT> hello world" });
-    const result = await normalizeSlackAppMention(
-      event,
-      "evt-005",
-      config,
-      undefined,
-      { userLabels: { U123BOT: "vex" } },
-    );
+    const result = await normalizeSlackAppMention(event, "evt-005", undefined, {
+      userLabels: { U123BOT: "vex" },
+    });
 
     expect(result).not.toBeNull();
     expect(result!.event.message.content).toBe("@vex hello world");
   });
 
   test("renders the bot's mention with the unknown-user fallback when unresolved", async () => {
-    const config = makeConfig();
     const event = makeEvent({ text: "<@U123BOT>" });
-    const result = await normalizeSlackAppMention(event, "evt-006", config);
+    const result = await normalizeSlackAppMention(event, "evt-006");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.content).toBe("@unknown-user");
   });
 
   test("renders bot and human mentions side by side", async () => {
-    const config = makeConfig();
     const event = makeEvent({ text: "<@UBOT> <@ULEO> can you check?" });
     const result = await normalizeSlackAppMention(
       event,
       "evt-mention-label",
-      config,
       undefined,
       { userLabels: { UBOT: "vex", ULEO: "leo" } },
     );
@@ -133,13 +95,8 @@ describe("normalizeSlackAppMention", () => {
   });
 
   test("renders unresolved user mentions with the unknown-user fallback", async () => {
-    const config = makeConfig();
     const event = makeEvent({ text: "<@UBOT> <@UUNKNOWN> can you check?" });
-    const result = await normalizeSlackAppMention(
-      event,
-      "evt-unknown-mention",
-      config,
-    );
+    const result = await normalizeSlackAppMention(event, "evt-unknown-mention");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.content).toBe(
@@ -148,65 +105,56 @@ describe("normalizeSlackAppMention", () => {
   });
 
   test("thread_ts is preserved in return value", async () => {
-    const config = makeConfig();
     const event = makeEvent({ thread_ts: "1700000000.000050" });
-    const result = await normalizeSlackAppMention(event, "evt-007", config);
+    const result = await normalizeSlackAppMention(event, "evt-007");
 
     expect(result).not.toBeNull();
     expect(result!.threadTs).toBe("1700000000.000050");
   });
 
   test("threadTs falls back to ts when thread_ts is not present", async () => {
-    const config = makeConfig();
     const event = makeEvent({ thread_ts: undefined, ts: "1700000000.000100" });
-    const result = await normalizeSlackAppMention(event, "evt-008", config);
+    const result = await normalizeSlackAppMention(event, "evt-008");
 
     expect(result).not.toBeNull();
     expect(result!.threadTs).toBe("1700000000.000100");
   });
 
   test("actor.actorExternalId is set to event.user", async () => {
-    const config = makeConfig();
     const event = makeEvent({ user: "U_SENDER_42" });
-    const result = await normalizeSlackAppMention(event, "evt-009", config);
+    const result = await normalizeSlackAppMention(event, "evt-009");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.actorExternalId).toBe("U_SENDER_42");
   });
 
   test("channel field is set in return value", async () => {
-    const config = makeConfig();
     const event = makeEvent({ channel: "C_RETURN_CHAN" });
-    const result = await normalizeSlackAppMention(event, "evt-010", config);
+    const result = await normalizeSlackAppMention(event, "evt-010");
 
     expect(result).not.toBeNull();
     expect(result!.channel).toBe("C_RETURN_CHAN");
   });
 
   test("source.updateId is set to eventId", async () => {
-    const config = makeConfig();
     const event = makeEvent();
-    const result = await normalizeSlackAppMention(event, "my-event-id", config);
+    const result = await normalizeSlackAppMention(event, "my-event-id");
 
     expect(result).not.toBeNull();
     expect(result!.event.source.updateId).toBe("my-event-id");
   });
 
   test("resolves an unrouted mention to the local assistant", async () => {
-    const config = makeConfig({
-      routingEntries: [],
-    });
     const event = makeEvent();
-    const result = await normalizeSlackAppMention(event, "evt-011", config);
+    const result = await normalizeSlackAppMention(event, "evt-011");
 
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
   });
 
   test("raw event is included in the result", async () => {
-    const config = makeConfig();
     const event = makeEvent();
-    const result = await normalizeSlackAppMention(event, "evt-012", config);
+    const result = await normalizeSlackAppMention(event, "evt-012");
 
     expect(result).not.toBeNull();
     expect(result!.event.raw).toEqual(
@@ -245,14 +193,12 @@ function makeChannelMessageEvent(
 
 describe("Slack inbound mention rendering", () => {
   test("direct messages render mentions without stripping the bot mention", () => {
-    const config = makeConfig();
     const event = makeDirectMessageEvent({
       text: "<@UBOT> <@ULEO> hello",
     });
     const result = normalizeSlackDirectMessage(
       event,
       "evt-dm-render",
-      config,
       undefined,
       { userLabels: { UBOT: "assistant", ULEO: "leo" } },
     );
@@ -264,14 +210,12 @@ describe("Slack inbound mention rendering", () => {
   });
 
   test("channel messages render bot and human mentions inline", () => {
-    const config = makeConfig();
     const event = makeChannelMessageEvent({
       text: "<@UBOT> <@ULEO> hello",
     });
     const result = normalizeSlackChannelMessage(
       event,
       "evt-channel-render",
-      config,
       undefined,
       { userLabels: { UBOT: "vex", ULEO: "leo" } },
     );
@@ -283,14 +227,12 @@ describe("Slack inbound mention rendering", () => {
   });
 
   test("channel messages render with unknown-user fallback when bot label is missing", () => {
-    const config = makeConfig();
     const event = makeChannelMessageEvent({
       text: "<@UBOT> <@ULEO> hello",
     });
     const result = normalizeSlackChannelMessage(
       event,
       "evt-channel-fallback-render",
-      config,
       undefined,
       { userLabels: { ULEO: "leo" } },
     );
@@ -300,7 +242,6 @@ describe("Slack inbound mention rendering", () => {
   });
 
   test("message edits render bot and human mentions and preserve edit metadata", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_USER123",
@@ -308,7 +249,7 @@ describe("Slack inbound mention rendering", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-edit-render", config, {
+    const result = normalizeSlackMessageEdit(event, "evt-edit-render", {
       userLabels: { UBOT: "vex", ULEO: "leo" },
     });
 
@@ -340,9 +281,8 @@ function makeMessageChangedEvent(
 
 describe("normalizeSlackMessageEdit", () => {
   test("normalizes message_changed event with isEdit: true", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent();
-    const result = normalizeSlackMessageEdit(event, "evt-100", config);
+    const result = normalizeSlackMessageEdit(event, "evt-100");
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
@@ -351,9 +291,8 @@ describe("normalizeSlackMessageEdit", () => {
   });
 
   test("uses eventId as externalMessageId for edit dedup", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent();
-    const result = normalizeSlackMessageEdit(event, "evt-101", config);
+    const result = normalizeSlackMessageEdit(event, "evt-101");
 
     expect(result).not.toBeNull();
     // Each edit gets a unique externalMessageId (eventId) so successive edits aren't deduped
@@ -363,11 +302,10 @@ describe("normalizeSlackMessageEdit", () => {
   });
 
   test("returns null when edited message has no user", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: { text: "no user", ts: "1700000000.000100" },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-102", config);
+    const result = normalizeSlackMessageEdit(event, "evt-102");
 
     expect(result).toBeNull();
   });
@@ -377,7 +315,6 @@ describe("normalizeSlackMessageEdit", () => {
   // performs that check — an edit from the bot's own user ID normalizes
   // successfully. The pipeline filter is tested in socket-mode tests.
   test("does not filter edits by bot user (handled upstream)", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_BOT",
@@ -385,14 +322,13 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-103", config);
+    const result = normalizeSlackMessageEdit(event, "evt-103");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.actorExternalId).toBe("U_BOT");
   });
 
   test("renders bot mention in edited text", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_USER123",
@@ -400,7 +336,7 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-104", config, {
+    const result = normalizeSlackMessageEdit(event, "evt-104", {
       userLabels: { U123BOT: "vex" },
     });
 
@@ -409,7 +345,6 @@ describe("normalizeSlackMessageEdit", () => {
   });
 
   test("sets actor.actorExternalId from edited message user", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_EDITOR",
@@ -417,14 +352,13 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-105", config);
+    const result = normalizeSlackMessageEdit(event, "evt-105");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.actorExternalId).toBe("U_EDITOR");
   });
 
   test("threadTs uses edited message thread_ts when present", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_USER123",
@@ -433,16 +367,15 @@ describe("normalizeSlackMessageEdit", () => {
         thread_ts: "1700000000.000050",
       },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-106", config);
+    const result = normalizeSlackMessageEdit(event, "evt-106");
 
     expect(result).not.toBeNull();
     expect(result!.threadTs).toBe("1700000000.000050");
   });
 
   test("threadTs falls back to edited message ts when no thread_ts", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent();
-    const result = normalizeSlackMessageEdit(event, "evt-107", config);
+    const result = normalizeSlackMessageEdit(event, "evt-107");
 
     expect(result).not.toBeNull();
     // Falls back to edited.ts (not the wrapper event.ts)
@@ -450,16 +383,14 @@ describe("normalizeSlackMessageEdit", () => {
   });
 
   test("DM edit without thread_ts omits threadTs", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({ channel_type: "im" });
-    const result = normalizeSlackMessageEdit(event, "evt-dm-edit-1", config);
+    const result = normalizeSlackMessageEdit(event, "evt-dm-edit-1");
 
     expect(result).not.toBeNull();
     expect(result!.threadTs).toBeUndefined();
   });
 
   test("DM edit with thread_ts preserves threadTs", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       channel_type: "im",
       message: {
@@ -469,54 +400,45 @@ describe("normalizeSlackMessageEdit", () => {
         thread_ts: "1700000000.000050",
       },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-dm-edit-2", config);
+    const result = normalizeSlackMessageEdit(event, "evt-dm-edit-2");
 
     expect(result).not.toBeNull();
     expect(result!.threadTs).toBe("1700000000.000050");
   });
 
   test("DM edits use default assistant when channel is not in routing table", () => {
-    const config = makeConfig({
-      routingEntries: [],
-    });
     const event = makeMessageChangedEvent({ channel_type: "im" });
-    const result = normalizeSlackMessageEdit(event, "evt-108", config);
+    const result = normalizeSlackMessageEdit(event, "evt-108");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.isEdit).toBe(true);
   });
 
   test("resolves an unrouted non-DM edit to the local assistant", () => {
-    const config = makeConfig({
-      routingEntries: [],
-    });
     const event = makeMessageChangedEvent({ channel_type: "channel" });
-    const result = normalizeSlackMessageEdit(event, "evt-109", config);
+    const result = normalizeSlackMessageEdit(event, "evt-109");
 
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
   });
 
   test("sets chatType to channel for non-DM edits", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({ channel_type: "channel" });
-    const result = normalizeSlackMessageEdit(event, "evt-110", config);
+    const result = normalizeSlackMessageEdit(event, "evt-110");
 
     expect(result).not.toBeNull();
     expect(result!.event.source.chatType).toBe("channel");
   });
 
   test("does not set chatType for DM edits", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({ channel_type: "im" });
-    const result = normalizeSlackMessageEdit(event, "evt-111", config);
+    const result = normalizeSlackMessageEdit(event, "evt-111");
 
     expect(result).not.toBeNull();
     expect(result!.event.source.chatType).toBeUndefined();
   });
 
   test("returns null for metadata-only mutation on a never-edited message", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_USER123",
@@ -529,17 +451,12 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(
-      event,
-      "evt-metadata-only-1",
-      config,
-    );
+    const result = normalizeSlackMessageEdit(event, "evt-metadata-only-1");
 
     expect(result).toBeNull();
   });
 
   test("returns null for metadata-only mutation on an already-edited message", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_USER123",
@@ -554,17 +471,12 @@ describe("normalizeSlackMessageEdit", () => {
         edited: { user: "U_USER123", ts: "1700000000.000150" },
       },
     });
-    const result = normalizeSlackMessageEdit(
-      event,
-      "evt-metadata-only-2",
-      config,
-    );
+    const result = normalizeSlackMessageEdit(event, "evt-metadata-only-2");
 
     expect(result).toBeNull();
   });
 
   test("returns null for metadata-only mutation in a DM", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       channel: "D_DM_CHANNEL",
       channel_type: "im",
@@ -579,17 +491,12 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(
-      event,
-      "evt-metadata-only-dm",
-      config,
-    );
+    const result = normalizeSlackMessageEdit(event, "evt-metadata-only-dm");
 
     expect(result).toBeNull();
   });
 
   test("forwards first user edit when message.edited becomes set", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_USER123",
@@ -603,7 +510,7 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-real-edit-1", config);
+    const result = normalizeSlackMessageEdit(event, "evt-real-edit-1");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.content).toContain(
@@ -613,7 +520,6 @@ describe("normalizeSlackMessageEdit", () => {
   });
 
   test("forwards rich-text-only edit when text is identical but edited.ts changes", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
         user: "U_USER123",
@@ -627,22 +533,17 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(
-      event,
-      "evt-rich-text-edit",
-      config,
-    );
+    const result = normalizeSlackMessageEdit(event, "evt-rich-text-edit");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.isEdit).toBe(true);
   });
 
   test("forwards edit when previous_message is missing (cannot prove no-op)", () => {
-    const config = makeConfig();
     const event = makeMessageChangedEvent();
     expect(event.previous_message).toBeUndefined();
 
-    const result = normalizeSlackMessageEdit(event, "evt-no-prev", config);
+    const result = normalizeSlackMessageEdit(event, "evt-no-prev");
     expect(result).not.toBeNull();
     expect(result!.event.message.isEdit).toBe(true);
   });

--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -1,32 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { normalizeSlackReactionAdded } from "../slack/reaction-normalizer.js";
 import type { SlackReactionEvent } from "../slack/message-schemas.js";
-import type { GatewayConfig } from "../config.js";
-
-function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
-    assistantRuntimeBaseUrl: "http://localhost:7821",
-    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-    logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: {
-      telegram: 50 * 1024 * 1024,
-      slack: 100 * 1024 * 1024,
-      whatsapp: 16 * 1024 * 1024,
-      default: 50 * 1024 * 1024,
-    },
-    maxAttachmentConcurrency: 3,
-    maxWebhookPayloadBytes: 1048576,
-    port: 7830,
-    routingEntries: [],
-    runtimeInitialBackoffMs: 500,
-    runtimeMaxRetries: 2,
-    runtimeProxyRequireAuth: false,
-    runtimeTimeoutMs: 30000,
-    shutdownDrainMs: 5000,
-    trustProxy: false,
-    ...overrides,
-  } as GatewayConfig;
-}
 
 function makeReactionEvent(
   overrides?: Partial<SlackReactionEvent>,
@@ -47,13 +21,8 @@ function makeReactionEvent(
 
 describe("normalizeSlackReactionAdded", () => {
   test("normalizes a reaction_added event with callbackData", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C123", assistantId: "ast-1" },
-      ],
-    });
     const event = makeReactionEvent();
-    const result = normalizeSlackReactionAdded(event, "ev-1", config);
+    const result = normalizeSlackReactionAdded(event, "ev-1");
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
@@ -65,13 +34,8 @@ describe("normalizeSlackReactionAdded", () => {
   });
 
   test("encodes emoji name in callbackData", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C123", assistantId: "ast-1" },
-      ],
-    });
     const event = makeReactionEvent({ reaction: "white_check_mark" });
-    const result = normalizeSlackReactionAdded(event, "ev-2", config);
+    const result = normalizeSlackReactionAdded(event, "ev-2");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.callbackData).toBe(
@@ -83,20 +47,18 @@ describe("normalizeSlackReactionAdded", () => {
   // not by the normalizer. This test verifies the normalizer no longer
   // performs that check — it normalizes successfully regardless of user.
   test("does not filter reactions by bot user (handled upstream)", () => {
-    const config = makeConfig();
     const event = makeReactionEvent({ user: "BOT1" });
-    const result = normalizeSlackReactionAdded(event, "ev-3", config);
+    const result = normalizeSlackReactionAdded(event, "ev-3");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.actorExternalId).toBe("BOT1");
   });
 
   test("resolves unrouted DM channels to the local assistant", () => {
-    const config = makeConfig();
     const event = makeReactionEvent({
       item: { type: "message", channel: "D999", ts: "111.222" },
     });
-    const result = normalizeSlackReactionAdded(event, "ev-6", config);
+    const result = normalizeSlackReactionAdded(event, "ev-6");
 
     expect(result).not.toBeNull();
     expect(result!.channel).toBe("D999");
@@ -105,24 +67,18 @@ describe("normalizeSlackReactionAdded", () => {
   test("resolves unrouted public channels to the local assistant", () => {
     // Previously dropped here because the unmapped policy rejected them. The
     // gateway now normalizes them and lets the admission floor decide.
-    const config = makeConfig();
     const event = makeReactionEvent({
       item: { type: "message", channel: "C999", ts: "111.222" },
     });
-    const result = normalizeSlackReactionAdded(event, "ev-6b", config);
+    const result = normalizeSlackReactionAdded(event, "ev-6b");
 
     expect(result).not.toBeNull();
     expect(result!.channel).toBe("C999");
   });
 
   test("generates unique externalMessageId including reaction name and user", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C123", assistantId: "ast-1" },
-      ],
-    });
     const event = makeReactionEvent({ reaction: "alarm_clock" });
-    const result = normalizeSlackReactionAdded(event, "ev-7", config);
+    const result = normalizeSlackReactionAdded(event, "ev-7");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.externalMessageId).toBe(
@@ -131,15 +87,10 @@ describe("normalizeSlackReactionAdded", () => {
   });
 
   test("two users reacting same emoji produce different externalMessageIds", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C123", assistantId: "ast-1" },
-      ],
-    });
     const event1 = makeReactionEvent({ user: "U001" });
     const event2 = makeReactionEvent({ user: "U002" });
-    const result1 = normalizeSlackReactionAdded(event1, "ev-8a", config);
-    const result2 = normalizeSlackReactionAdded(event2, "ev-8b", config);
+    const result1 = normalizeSlackReactionAdded(event1, "ev-8a");
+    const result2 = normalizeSlackReactionAdded(event2, "ev-8b");
 
     expect(result1).not.toBeNull();
     expect(result2).not.toBeNull();

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -860,8 +860,8 @@ describe("SlackSocketModeClient thread tracking", () => {
       expect(emitted[0].event.source.updateId).toBe("Ev-actor-routed-followup");
       expect(emitted[0].threadTs).toBe(threadTs);
       expect(emitted[0].routing).toEqual({
-        assistantId: "ast-actor",
-        routeSource: "actor_id",
+        assistantId: LOCAL_ASSISTANT_ID,
+        routeSource: "default",
       });
 
       // A human with no explicit actor route replying in the armed thread is
@@ -2115,7 +2115,7 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       await run();
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.message.callbackData).toBe("reaction:eyes");
-      expect(emitted[0].routing.assistantId).toBe("ast-actor");
+      expect(emitted[0].routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
     } finally {
       rawDb.close();
     }
@@ -2155,7 +2155,7 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       await run();
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.message.isEdit).toBe(true);
-      expect(emitted[0].routing.assistantId).toBe("ast-actor");
+      expect(emitted[0].routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
     } finally {
       rawDb.close();
     }
@@ -2192,7 +2192,7 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       await run();
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.message.callbackData).toBe("message_deleted");
-      expect(emitted[0].routing.assistantId).toBe("ast-actor");
+      expect(emitted[0].routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
     } finally {
       rawDb.close();
     }

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -56,9 +56,6 @@ export const REFRESH_INACTIVITY_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 /** Suggest refresh at 80% of access token TTL. */
 export const REFRESH_AFTER_FRACTION = 0.8;
 
-/** The daemon's internal assistant scope identifier. */
-const DAEMON_INTERNAL_ASSISTANT_ID = LOCAL_ASSISTANT_ID;
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -104,9 +101,7 @@ function uuid(): string {
 }
 
 export function getExternalAssistantId(): string {
-  return (
-    process.env.VELLUM_ASSISTANT_NAME?.trim() || DAEMON_INTERNAL_ASSISTANT_ID
-  );
+  return process.env.VELLUM_ASSISTANT_NAME?.trim() || LOCAL_ASSISTANT_ID;
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/email/inbound-pipeline.ts
+++ b/gateway/src/email/inbound-pipeline.ts
@@ -6,7 +6,7 @@ import { resolveCredentialWithRefresh } from "../credential-refresh.js";
 import { recordDenialReplyIfAllowed } from "../db/denial-reply-rate-limiter.js";
 import type { StringDedupCache } from "../dedup-cache.js";
 import { handleInbound } from "../handlers/handle-inbound.js";
-import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import { hasRoutableIdentity } from "../routing/resolve-assistant.js";
 import {
   handleCircuitBreakerError,
   processInboundResult,
@@ -151,20 +151,15 @@ export async function runEmailInboundPipeline(
     `${label} webhook received`,
   );
 
-  const routing = resolveAssistant(
-    config,
-    gatewayEvent.message.conversationExternalId,
-    senderAddress,
-  );
-
-  if (isRejection(routing)) {
+  if (
+    !hasRoutableIdentity(
+      gatewayEvent.message.conversationExternalId,
+      senderAddress,
+    )
+  ) {
     log.warn(
-      {
-        from: senderAddress,
-        to: recipientAddress,
-        reason: routing.reason,
-      },
-      `Routing rejected inbound ${label} email`,
+      { from: senderAddress, to: recipientAddress },
+      `Dropped inbound ${label} email — no routable identity`,
     );
     mark();
     return Response.json({ ok: true });
@@ -194,7 +189,6 @@ export async function runEmailInboundPipeline(
       }),
       replyCallbackUrl: undefined,
       traceId,
-      routingOverride: routing,
       // Provider SPF/DKIM/DMARC verdict (from the normalizer). `false` collapses
       // a forged `From:` out of guardian/trusted_contact; `undefined` is a no-op.
       senderAuthenticated,

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -13,7 +13,10 @@ import {
   canonicalizeInboundIdentity,
   canonicalSenderIdFor,
 } from "../verification/identity.js";
-import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import {
+  hasRoutableIdentity,
+  LOCAL_ROUTE,
+} from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
 import {
   forwardToRuntime,
@@ -49,7 +52,7 @@ export type HandleInboundOptions = {
   transportMetadata?: TransportMetadataOverrides;
   replyCallbackUrl?: string;
   traceId?: string;
-  /** When provided, skip resolveAssistant() and use this pre-resolved route. */
+  /** When provided, use this pre-resolved route instead of LOCAL_ROUTE. */
   routingOverride?: RouteResult;
   /** Extra fields merged into sourceMetadata (e.g. commandIntent). */
   sourceMetadata?: Partial<SourceMetadata>;
@@ -113,28 +116,24 @@ export async function handleInbound(
     };
   }
 
-  const routing =
-    options?.routingOverride ??
-    resolveAssistant(
-      config,
+  if (
+    !hasRoutableIdentity(
       event.message.conversationExternalId,
       event.actor.actorExternalId,
-    );
-
-  if (isRejection(routing)) {
+    )
+  ) {
     log.info(
-      {
-        conversationExternalId: event.message.conversationExternalId,
-        reason: routing.reason,
-      },
-      "Inbound event rejected by routing",
+      { conversationExternalId: event.message.conversationExternalId },
+      "Inbound event dropped — no routable identity",
     );
     return {
       forwarded: false,
       rejected: true,
-      rejectionReason: routing.reason,
+      rejectionReason: "no_routable_identity",
     };
   }
+
+  const routing = options?.routingOverride ?? LOCAL_ROUTE;
 
   const displayName = event.actor.displayName || event.actor.username;
 

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -17,10 +17,7 @@ import { verifyEmailWebhookSignature } from "../../email/verify.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { readLimitedBody } from "../read-limited-body.js";
-import {
-  resolveAssistant,
-  isRejection,
-} from "../../routing/resolve-assistant.js";
+import { hasRoutableIdentity } from "../../routing/resolve-assistant.js";
 import {
   handleCircuitBreakerError,
   interceptedReply,
@@ -129,23 +126,15 @@ export function createEmailWebhookHandler(
       "Email webhook received",
     );
 
-    // Resolve routing using the recipient address as both conversation
-    // and actor ID — the standard routing chain will check explicit
-    // routes first, then fall back to the default assistant.
-    const routing = resolveAssistant(
-      config,
-      event.message.conversationExternalId,
-      event.actor.actorExternalId,
-    );
-
-    if (isRejection(routing)) {
+    if (
+      !hasRoutableIdentity(
+        event.message.conversationExternalId,
+        event.actor.actorExternalId,
+      )
+    ) {
       tlog.warn(
-        {
-          from: event.actor.actorExternalId,
-          to: recipientAddress,
-          reason: routing.reason,
-        },
-        "Routing rejected inbound email",
+        { from: event.actor.actorExternalId, to: recipientAddress },
+        "Dropped inbound email — no routable identity",
       );
       // No way to reply to the sender for rejected emails — just log
       dedupCache.mark(eventId);
@@ -198,7 +187,6 @@ export function createEmailWebhookHandler(
         }),
         replyCallbackUrl: undefined, // Email replies use `assistant email send` tool (no /deliver/email)
         traceId,
-        routingOverride: routing,
         senderAuthenticated,
         sourceMetadata: {
           emailProvider: "platform",

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -54,8 +54,6 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 /** Pair tokens are valid for 24 hours — covers extended sessions and SSE reconnects. */
 const PAIR_TOKEN_TTL_SECONDS = 86400;
 
-const DAEMON_INTERNAL_ASSISTANT_ID = LOCAL_ASSISTANT_ID;
-
 // ---------------------------------------------------------------------------
 // Rate limiter (dedicated, per-peer)
 // ---------------------------------------------------------------------------
@@ -169,9 +167,7 @@ function auditDeny(
 // ---------------------------------------------------------------------------
 
 function getExternalAssistantId(): string {
-  return (
-    process.env.VELLUM_ASSISTANT_NAME?.trim() || DAEMON_INTERNAL_ASSISTANT_ID
-  );
+  return process.env.VELLUM_ASSISTANT_NAME?.trim() || LOCAL_ASSISTANT_ID;
 }
 
 export async function handlePair(

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -11,10 +11,7 @@ import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { readLimitedBody } from "../read-limited-body.js";
 import { RejectionRateLimiter } from "../../rejection-rate-limiter.js";
-import {
-  resolveAssistant,
-  isRejection,
-} from "../../routing/resolve-assistant.js";
+import { hasRoutableIdentity } from "../../routing/resolve-assistant.js";
 import {
   AttachmentValidationError,
   CircuitBreakerOpenError,
@@ -321,18 +318,14 @@ export function createTelegramWebhookHandler(
     // Handle /start command — forward to runtime as a channel command intent
     const startCmd = parseTelegramStartCommand(normalized.message.content);
     if (startCmd !== null) {
-      const startRouting = resolveAssistant(
-        config,
-        normalized.message.conversationExternalId,
-        normalized.actor.actorExternalId,
-      );
-
-      if (isRejection(startRouting)) {
+      if (
+        !hasRoutableIdentity(
+          normalized.message.conversationExternalId,
+          normalized.actor.actorExternalId,
+        )
+      ) {
         tlog.warn(
-          {
-            chatId: normalized.message.conversationExternalId,
-            reason: startRouting.reason,
-          },
+          { chatId: normalized.message.conversationExternalId },
           "Routing rejected /start command",
         );
         if (
@@ -503,19 +496,15 @@ export function createTelegramWebhookHandler(
 
     // Handle /new command — reset conversation before it reaches the runtime
     if (isNewCommand(normalized.message.content)) {
-      const routing = resolveAssistant(
-        config,
-        normalized.message.conversationExternalId,
-        normalized.actor.actorExternalId,
-      );
-
-      if (isRejection(routing)) {
+      if (
+        !hasRoutableIdentity(
+          normalized.message.conversationExternalId,
+          normalized.actor.actorExternalId,
+        )
+      ) {
         tlog.warn(
-          {
-            chatId: normalized.message.conversationExternalId,
-            reason: routing.reason,
-          },
-          "Routing rejected /new command",
+          { chatId: normalized.message.conversationExternalId },
+          "Dropped /new command — no routable identity",
         );
         if (
           rejectionLimiter.shouldSend(normalized.message.conversationExternalId)
@@ -566,12 +555,10 @@ export function createTelegramWebhookHandler(
 
     // Check routing early so we can gate attachments
     const chatId = normalized.message.conversationExternalId;
-    const routing = resolveAssistant(
-      config,
+    const routable = hasRoutableIdentity(
       chatId,
       normalized.actor.actorExternalId,
     );
-    const routable = !isRejection(routing);
 
     // Download and upload attachments if present (skip for edits and callback
     // queries — edits only update text, callbacks have no media to process)

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -9,11 +9,7 @@ import {
   forwardTwilioVoiceWebhook,
   resolvePublicBaseWssUrl,
 } from "../../runtime/client.js";
-import {
-  resolveAssistant,
-  resolveAssistantByPhoneNumber,
-  isRejection,
-} from "../../routing/resolve-assistant.js";
+import { resolveAssistantByPhoneNumber } from "../../routing/resolve-assistant.js";
 import {
   validateTwilioWebhookRequest,
   type TwilioValidationCaches,
@@ -86,36 +82,16 @@ export function createTwilioVoiceWebhookHandler(
           "Resolved assistant by phone number for inbound call",
         );
       } else {
-        // Phone-number lookup missed — fall through to standard routing
-        // instead of silently forwarding with no assistant ID.
-        const fallbackRouting = resolveAssistant(
-          config,
-          params.From,
-          params.From,
+        // Phone-number lookup missed. Voice lines are intentionally open, so
+        // answer on the local assistant rather than dropping the call — a
+        // caller-ID-withheld (anonymous) call has no `From` to route on at
+        // all. The callee is still protected by the `phone` admission floor
+        // checked above.
+        assistantId = LOCAL_ASSISTANT_ID;
+        log.info(
+          { from: params.From, to: params.To },
+          "Inbound call routed to the local assistant",
         );
-
-        if (isRejection(fallbackRouting)) {
-          // The only rejection resolveAssistant produces is a missing
-          // identity, which here means a caller-ID-withheld (anonymous) call.
-          // Voice lines are intentionally open, so answer it on the local
-          // assistant rather than dropping it; the callee is still protected
-          // by the `phone` admission floor checked above.
-          assistantId = LOCAL_ASSISTANT_ID;
-          log.info(
-            { to: params.To },
-            "Anonymous inbound call routed to the local assistant",
-          );
-        } else {
-          assistantId = fallbackRouting.assistantId;
-          log.info(
-            {
-              assistantId,
-              routeSource: fallbackRouting.routeSource,
-              from: params.From,
-            },
-            "Resolved assistant via fallback routing for inbound call",
-          );
-        }
       }
 
       // ── Gateway-owned voice verification ────────────────────────────

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -13,10 +13,7 @@ import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { readLimitedBody } from "../read-limited-body.js";
 import { RejectionRateLimiter } from "../../rejection-rate-limiter.js";
-import {
-  resolveAssistant,
-  isRejection,
-} from "../../routing/resolve-assistant.js";
+import { hasRoutableIdentity } from "../../routing/resolve-assistant.js";
 import {
   AttachmentValidationError,
   uploadAttachment,
@@ -185,16 +182,14 @@ export function createWhatsAppWebhookHandler(
         );
       });
 
-      // Resolve routing once so we can gate further operations on it
-      const routing = resolveAssistant(config, from, from);
+      // `from` is both conversation and actor for WhatsApp, so a single
+      // identity check gates every downstream operation.
+      const routable = hasRoutableIdentity(from, from);
 
       // Handle /new command — reset conversation before it reaches the runtime
       if (isNewCommand(event.message.content)) {
-        if (isRejection(routing)) {
-          tlog.warn(
-            { from, reason: routing.reason },
-            "Routing rejected /new command",
-          );
+        if (!routable) {
+          tlog.warn({ from }, "Dropped /new command — no routable identity");
           sendWhatsAppReply(
             config,
             from,
@@ -223,10 +218,10 @@ export function createWhatsAppWebhookHandler(
         continue;
       }
 
-      if (isRejection(routing)) {
+      if (!routable) {
         tlog.warn(
-          { from, reason: routing.reason },
-          "Routing rejected inbound WhatsApp message",
+          { from },
+          "Dropped inbound WhatsApp message — no routable identity",
         );
         if (rejectionLimiter.shouldSend(from)) {
           sendWhatsAppReply(
@@ -378,7 +373,6 @@ export function createWhatsAppWebhookHandler(
           transportMetadata: buildWhatsAppTransportMetadata(),
           replyCallbackUrl: `${config.gatewayInternalBaseUrl}/deliver/whatsapp`,
           traceId,
-          routingOverride: routing,
         });
 
         const processed = processInboundResult(

--- a/gateway/src/routing/resolve-assistant.ts
+++ b/gateway/src/routing/resolve-assistant.ts
@@ -2,66 +2,49 @@ import { LOCAL_ASSISTANT_ID } from "../assistant-id.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { GatewayConfig } from "../config.js";
 import { getLogger } from "../logger.js";
-import type { RoutingOutcome } from "./types.js";
+import type { RouteResult } from "./types.js";
 
 const log = getLogger("routing");
 
-export function resolveAssistant(
-  config: GatewayConfig,
+/**
+ * The route every identified inbound event takes.
+ *
+ * A gateway process fronts exactly one daemon at a fixed
+ * `assistantRuntimeBaseUrl`, and the inbound wire payload carries no assistant
+ * id, so routing has nothing left to choose. Whether a sender is allowed
+ * through is a separate decision made downstream against the channel's
+ * admission floor — see "Channel Trust Classification & Admission Policy" in
+ * gateway/CLAUDE.md.
+ */
+export const LOCAL_ROUTE: RouteResult = Object.freeze({
+  assistantId: LOCAL_ASSISTANT_ID,
+  routeSource: "default",
+});
+
+/**
+ * Fail-closed identity backstop.
+ *
+ * An event carrying neither a conversation nor an actor id has nothing to bind
+ * a conversation on and nothing to classify trust against, so it is dropped
+ * rather than attributed to the local assistant. Ingress handlers validate the
+ * identity fields they key on as well; this is the shared rule behind them.
+ */
+export function hasRoutableIdentity(
   conversationId: string | undefined,
   actorId: string | undefined,
-): RoutingOutcome {
-  // Priority 0: no identity at all → nothing to route on, so a malformed event
-  // with neither a conversation nor an actor is dropped rather than attributed
-  // to the local assistant. This is the only rejection this function produces;
-  // callers are expected to validate identity too, and this is the fail-closed
-  // backstop behind them.
-  if (!conversationId && !actorId) {
-    log.info(
-      { conversationId, actorId },
-      "No routable identity on event, rejecting",
-    );
-    return { rejected: true, reason: "No routable identity on this event" };
-  }
-
-  // Priority 1: explicit conversation_id route
-  for (const entry of config.routingEntries) {
-    if (entry.type === "conversation_id" && entry.key === conversationId) {
-      log.debug(
-        { conversationId, assistantId: entry.assistantId },
-        "Resolved by conversation_id",
-      );
-      return { assistantId: entry.assistantId, routeSource: "conversation_id" };
-    }
-  }
-
-  // Priority 2: explicit actor_id route
-  for (const entry of config.routingEntries) {
-    if (entry.type === "actor_id" && entry.key === actorId) {
-      log.debug(
-        { actorId, assistantId: entry.assistantId },
-        "Resolved by actor_id",
-      );
-      return { assistantId: entry.assistantId, routeSource: "actor_id" };
-    }
-  }
-
-  // Priority 3: the local assistant. A gateway process fronts exactly one
-  // daemon, so any event carrying a routable identity belongs to it — there is
-  // no second backend an unmatched event could have been meant for. Admission
-  // is decided downstream on trust class (see the admission-policy floor in
-  // gateway/CLAUDE.md), not here on whether a routing entry happened to exist.
-  log.debug(
-    { conversationId, actorId, assistantId: LOCAL_ASSISTANT_ID },
-    "Resolved to the local assistant",
+): boolean {
+  if (conversationId || actorId) return true;
+  log.info(
+    { conversationId, actorId },
+    "No routable identity on event, dropping",
   );
-  return { assistantId: LOCAL_ASSISTANT_ID, routeSource: "default" };
+  return false;
 }
 
 /**
  * Resolve the assistant by looking up the inbound "To" phone number in
  * the per-assistant phone number mapping. Returns undefined when no match
- * is found, letting callers fall through to the standard routing chain.
+ * is found, letting callers fall through to {@link LOCAL_ROUTE}.
  *
  * Reads the mapping from ConfigFileCache when available.
  */
@@ -69,7 +52,7 @@ export function resolveAssistantByPhoneNumber(
   _config: GatewayConfig,
   toNumber: string,
   configFileCache?: ConfigFileCache,
-): RoutingOutcome | undefined {
+): RouteResult | undefined {
   const mapping = configFileCache?.getRecord("twilio", "assistantPhoneNumbers");
   if (!mapping) return undefined;
 
@@ -83,10 +66,4 @@ export function resolveAssistantByPhoneNumber(
   }
 
   return undefined;
-}
-
-export function isRejection(
-  outcome: RoutingOutcome,
-): outcome is { rejected: true; reason: string } {
-  return "rejected" in outcome && outcome.rejected === true;
 }

--- a/gateway/src/routing/types.ts
+++ b/gateway/src/routing/types.ts
@@ -2,10 +2,3 @@ export type RouteResult = {
   assistantId: string;
   routeSource: "conversation_id" | "actor_id" | "default" | "phone_number";
 };
-
-export type RouteRejection = {
-  rejected: true;
-  reason: string;
-};
-
-export type RoutingOutcome = RouteResult | RouteRejection;

--- a/gateway/src/slack/block-actions-normalizer.ts
+++ b/gateway/src/slack/block-actions-normalizer.ts
@@ -2,8 +2,10 @@ import {
   slackBlockActionsPayloadSchema,
   type NormalizedSlackEvent,
 } from "./message-schemas.js";
-import type { GatewayConfig } from "../config.js";
-import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import {
+  hasRoutableIdentity,
+  LOCAL_ROUTE,
+} from "../routing/resolve-assistant.js";
 
 /**
  * Normalize a Slack `block_actions` interactive payload into the gateway's
@@ -18,7 +20,6 @@ import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 export function normalizeSlackBlockActions(
   payload: unknown,
   envelopeId: string,
-  config: GatewayConfig,
 ): NormalizedSlackEvent | null {
   const parsed = slackBlockActionsPayloadSchema.safeParse(payload);
   if (!parsed.success) return null;
@@ -38,8 +39,7 @@ export function normalizeSlackBlockActions(
   const channelId = data.channel?.id;
   if (!channelId) return null;
 
-  const routing = resolveAssistant(config, channelId, userId);
-  if (isRejection(routing)) return null;
+  if (!hasRoutableIdentity(channelId, userId)) return null;
 
   const messageTs = data.message?.ts;
   // Use action_ts (unique per click) to prevent dedup collisions when
@@ -73,7 +73,7 @@ export function normalizeSlackBlockActions(
       },
       raw: payload as Record<string, unknown>,
     },
-    routing,
+    routing: LOCAL_ROUTE,
     // Prefer the thread root so follow-up messages land in the original
     // conversation thread, not a reply's sub-thread.
     threadTs: data.message?.thread_ts ?? messageTs ?? envelopeId,

--- a/gateway/src/slack/message-change-normalizer.ts
+++ b/gateway/src/slack/message-change-normalizer.ts
@@ -8,8 +8,10 @@ import {
   renderSlackInboundText,
   type SlackTextRenderContext,
 } from "./render-text.js";
-import type { GatewayConfig } from "../config.js";
-import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import {
+  hasRoutableIdentity,
+  LOCAL_ROUTE,
+} from "../routing/resolve-assistant.js";
 
 /**
  * Normalize a Slack `message_changed` event into the gateway's canonical
@@ -29,7 +31,6 @@ import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 export function normalizeSlackMessageEdit(
   event: unknown,
   eventId: string,
-  config: GatewayConfig,
   renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
   const parsed = slackMessageChangedEventSchema.safeParse(event);
@@ -52,8 +53,7 @@ export function normalizeSlackMessageEdit(
   const channel = changed.channel;
 
   const isDm = isSlackDmChannel(channel, changed.channel_type);
-  const routing = resolveAssistant(config, channel, edited.user);
-  if (isRejection(routing)) return null;
+  if (!hasRoutableIdentity(channel, edited.user)) return null;
 
   const content = renderSlackInboundText(edited.text ?? "", renderContext);
 
@@ -84,7 +84,7 @@ export function normalizeSlackMessageEdit(
       },
       raw: rawEvent,
     },
-    routing,
+    routing: LOCAL_ROUTE,
     // For DMs without a thread, omit threadTs so the reply goes directly in conversation.
     // For channels (or DMs already in a thread), fall back to edited.ts.
     ...(isDm && !edited.thread_ts
@@ -113,7 +113,6 @@ export function normalizeSlackMessageEdit(
 export function normalizeSlackMessageDelete(
   event: unknown,
   eventId: string,
-  config: GatewayConfig,
 ): NormalizedSlackEvent | null {
   const parsed = slackMessageDeletedEventSchema.safeParse(event);
   if (!parsed.success) return null;
@@ -130,8 +129,7 @@ export function normalizeSlackMessageDelete(
   const actorId = deleted.previous_message?.user ?? "slack-system";
 
   const isDm = isSlackDmChannel(channel, deleted.channel_type);
-  const routing = resolveAssistant(config, channel, actorId);
-  if (isRejection(routing)) return null;
+  if (!hasRoutableIdentity(channel, actorId)) return null;
 
   const previousThreadTs = deleted.previous_message?.thread_ts;
 
@@ -161,7 +159,7 @@ export function normalizeSlackMessageDelete(
       },
       raw: rawEvent,
     },
-    routing,
+    routing: LOCAL_ROUTE,
     // Preserve thread context so downstream handling stays scoped to the
     // original conversation thread when applicable.
     ...(previousThreadTs ? { threadTs: previousThreadTs } : {}),

--- a/gateway/src/slack/message-normalizer.ts
+++ b/gateway/src/slack/message-normalizer.ts
@@ -10,9 +10,10 @@ import {
 } from "./render-text.js";
 import { slackUserActorFields, slackBotSenderInfo } from "./actor.js";
 import { extractSlackAttachments, extractSlackFileMap } from "./attachments.js";
-import type { GatewayConfig } from "../config.js";
-import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
-import type { RouteResult } from "../routing/types.js";
+import {
+  hasRoutableIdentity,
+  LOCAL_ROUTE,
+} from "../routing/resolve-assistant.js";
 
 /**
  * Normalize a Slack DM (`message` with `channel_type: "im"`) into the
@@ -37,7 +38,7 @@ type SlackMessageShape = {
 
 /**
  * Shared construction for the plain-message family (`app_mention` / DM /
- * channel). Each caller owns its own guards, routing, and identity extraction;
+ * channel). Each caller owns its own guards and identity extraction;
  * this builds the canonical normalized event they all produce, so the three
  * public normalizers stay thin variant wrappers.
  */
@@ -45,7 +46,6 @@ function buildNormalizedSlackMessage(
   event: SlackMessageEvent,
   rawEvent: Record<string, unknown>,
   eventId: string,
-  routing: RouteResult,
   channel: string,
   actorId: string,
   shape: SlackMessageShape,
@@ -120,7 +120,7 @@ function buildNormalizedSlackMessage(
       },
       raw: rawEvent,
     },
-    routing,
+    routing: LOCAL_ROUTE,
     ...(threadTs ? { threadTs } : {}),
     channel,
     ...(slackFiles ? { slackFiles } : {}),
@@ -131,7 +131,6 @@ function buildNormalizedSlackMessage(
 export function normalizeSlackDirectMessage(
   event: unknown,
   eventId: string,
-  config: GatewayConfig,
   botToken?: string,
   renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
@@ -144,14 +143,12 @@ export function normalizeSlackDirectMessage(
   if (msg.subtype && msg.subtype !== "file_share") return null;
   if (!msg.user || !msg.channel || !msg.ts) return null;
 
-  const routing = resolveAssistant(config, msg.channel, msg.user);
-  if (isRejection(routing)) return null;
+  if (!hasRoutableIdentity(msg.channel, msg.user)) return null;
 
   return buildNormalizedSlackMessage(
     msg,
     event as Record<string, unknown>,
     eventId,
-    routing,
     msg.channel,
     msg.user,
     { chatType: "im", stampTeam: false, fallbackThreadToTs: false },
@@ -173,7 +170,6 @@ export function normalizeSlackDirectMessage(
 export function normalizeSlackChannelMessage(
   event: unknown,
   eventId: string,
-  config: GatewayConfig,
   botToken?: string,
   renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
@@ -185,14 +181,12 @@ export function normalizeSlackChannelMessage(
   if (msg.subtype && msg.subtype !== "file_share") return null;
   if (!msg.user || !msg.channel || !msg.ts) return null;
 
-  const routing = resolveAssistant(config, msg.channel, msg.user);
-  if (isRejection(routing)) return null;
+  if (!hasRoutableIdentity(msg.channel, msg.user)) return null;
 
   return buildNormalizedSlackMessage(
     msg,
     event as Record<string, unknown>,
     eventId,
-    routing,
     msg.channel,
     msg.user,
     { chatType: "channel", stampTeam: true, fallbackThreadToTs: true },
@@ -210,7 +204,6 @@ export function normalizeSlackChannelMessage(
 export function normalizeSlackAppMention(
   event: unknown,
   eventId: string,
-  config: GatewayConfig,
   botToken?: string,
   renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
@@ -220,14 +213,12 @@ export function normalizeSlackAppMention(
 
   if (!msg.user || !msg.channel || !msg.ts) return null;
 
-  const routing = resolveAssistant(config, msg.channel, msg.user);
-  if (isRejection(routing)) return null;
+  if (!hasRoutableIdentity(msg.channel, msg.user)) return null;
 
   return buildNormalizedSlackMessage(
     msg,
     event as Record<string, unknown>,
     eventId,
-    routing,
     msg.channel,
     msg.user,
     { stampTeam: true, fallbackThreadToTs: true },

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -24,14 +24,6 @@ import type {
   SlackMessageDeletedEvent,
   SlackFile,
 } from "./message-schemas.js";
-import type { GatewayConfig } from "../config.js";
-
-function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
-  return {
-    routingEntries: [],
-    ...overrides,
-  } as GatewayConfig;
-}
 
 function makeBlockActionsPayload(
   overrides?: Partial<{
@@ -106,9 +98,8 @@ function makeReactionRemovedEvent(
 
 describe("normalizeSlackBlockActions", () => {
   it("normalizes a block_actions payload with callbackData", () => {
-    const config = makeConfig();
     const payload = makeBlockActionsPayload();
-    const result = normalizeSlackBlockActions(payload, "env-1", config);
+    const result = normalizeSlackBlockActions(payload, "env-1");
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
@@ -128,7 +119,6 @@ describe("normalizeSlackBlockActions", () => {
   });
 
   it("uses thread root timestamp when message is a threaded reply", () => {
-    const config = makeConfig();
     const payload = makeBlockActionsPayload();
     // Simulate a button click on a message that lives inside a thread
     payload.message = {
@@ -136,7 +126,7 @@ describe("normalizeSlackBlockActions", () => {
       thread_ts: "1234567890.000001",
       text: "Choose an option",
     };
-    const result = normalizeSlackBlockActions(payload, "env-thread", config);
+    const result = normalizeSlackBlockActions(payload, "env-thread");
 
     expect(result).not.toBeNull();
     // threadTs should be the thread root, not the clicked message's ts
@@ -144,23 +134,21 @@ describe("normalizeSlackBlockActions", () => {
   });
 
   it("falls back to message ts when no thread_ts is present", () => {
-    const config = makeConfig();
     const payload = makeBlockActionsPayload();
-    const result = normalizeSlackBlockActions(payload, "env-no-thread", config);
+    const result = normalizeSlackBlockActions(payload, "env-no-thread");
 
     expect(result).not.toBeNull();
     expect(result!.threadTs).toBe("1234567890.123456");
   });
 
   it("generates unique externalMessageId per click via action_ts", () => {
-    const config = makeConfig();
     const payload1 = makeBlockActionsPayload();
     payload1.actions![0].action_ts = "1000000000.000001";
     const payload2 = makeBlockActionsPayload();
     payload2.actions![0].action_ts = "1000000000.000002";
 
-    const result1 = normalizeSlackBlockActions(payload1, "env-same", config);
-    const result2 = normalizeSlackBlockActions(payload2, "env-same", config);
+    const result1 = normalizeSlackBlockActions(payload1, "env-same");
+    const result2 = normalizeSlackBlockActions(payload2, "env-same");
 
     expect(result1).not.toBeNull();
     expect(result2).not.toBeNull();
@@ -170,12 +158,11 @@ describe("normalizeSlackBlockActions", () => {
   });
 
   it("falls back to action_id when value is undefined", () => {
-    const config = makeConfig();
     const payload = makeBlockActionsPayload({
       actionValue: undefined as unknown as string,
     });
     payload.actions![0].value = undefined;
-    const result = normalizeSlackBlockActions(payload, "env-2", config);
+    const result = normalizeSlackBlockActions(payload, "env-2");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.callbackData).toBe("approve_btn");
@@ -183,28 +170,25 @@ describe("normalizeSlackBlockActions", () => {
   });
 
   it("returns null when actions array is empty", () => {
-    const config = makeConfig();
     const payload = makeBlockActionsPayload();
     payload.actions = [];
-    const result = normalizeSlackBlockActions(payload, "env-3", config);
+    const result = normalizeSlackBlockActions(payload, "env-3");
 
     expect(result).toBeNull();
   });
 
   it("returns null when user ID is missing", () => {
-    const config = makeConfig();
     const payload = makeBlockActionsPayload();
     payload.user = { id: "", username: "alice" };
-    const result = normalizeSlackBlockActions(payload, "env-4", config);
+    const result = normalizeSlackBlockActions(payload, "env-4");
 
     expect(result).toBeNull();
   });
 
   it("returns null when channel is missing", () => {
-    const config = makeConfig();
     const payload = makeBlockActionsPayload();
     payload.channel = undefined;
-    const result = normalizeSlackBlockActions(payload, "env-5", config);
+    const result = normalizeSlackBlockActions(payload, "env-5");
 
     expect(result).toBeNull();
   });
@@ -214,13 +198,8 @@ describe("normalizeSlackBlockActions", () => {
   // isn't in the routing table the click must still reach the assistant rather
   // than being silently dropped.
   it("resolves an unrouted DM channel to the local assistant", () => {
-    const config = makeConfig();
     const payload = makeBlockActionsPayload({ channelId: "D999" });
-    const result = normalizeSlackBlockActions(
-      payload,
-      "env-dm-fallback",
-      config,
-    );
+    const result = normalizeSlackBlockActions(payload, "env-dm-fallback");
 
     expect(result).not.toBeNull();
     expect(result!.channel).toBe("D999");
@@ -228,36 +207,22 @@ describe("normalizeSlackBlockActions", () => {
     expect(result!.routing.routeSource).toBe("default");
   });
 
-  it("uses explicit routing for a DM channel that is in the routing table", () => {
+  it("resolves a DM channel that is in the routing table to the local assistant", () => {
     // The DM fallback only fires when routing rejects; an explicit
     // conversation_id route for the DM channel must still win.
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "D789", assistantId: "explicit-ast" },
-      ],
-    });
     const payload = makeBlockActionsPayload({ channelId: "D789" });
-    const result = normalizeSlackBlockActions(
-      payload,
-      "env-dm-explicit",
-      config,
-    );
+    const result = normalizeSlackBlockActions(payload, "env-dm-explicit");
 
     expect(result).not.toBeNull();
-    expect(result!.routing.assistantId).toBe("explicit-ast");
-    expect(result!.routing.routeSource).toBe("conversation_id");
+    expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
+    expect(result!.routing.routeSource).toBe("default");
   });
 
   it("resolves an unrouted non-DM channel to the local assistant", () => {
     // Public channels used to keep strict routing and drop unrouted clicks.
     // They now normalize like DMs; the admission floor decides admittance.
-    const config = makeConfig();
     const payload = makeBlockActionsPayload({ channelId: "C456" });
-    const result = normalizeSlackBlockActions(
-      payload,
-      "env-non-dm-reject",
-      config,
-    );
+    const result = normalizeSlackBlockActions(payload, "env-non-dm-reject");
 
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
@@ -265,12 +230,10 @@ describe("normalizeSlackBlockActions", () => {
 });
 
 describe("block_actions tolerant validation", () => {
-  const config = makeConfig();
-
   it("drops a non-object payload instead of throwing", () => {
-    expect(normalizeSlackBlockActions("nope", "env-x1", config)).toBeNull();
-    expect(normalizeSlackBlockActions(null, "env-x2", config)).toBeNull();
-    expect(normalizeSlackBlockActions(42, "env-x3", config)).toBeNull();
+    expect(normalizeSlackBlockActions("nope", "env-x1")).toBeNull();
+    expect(normalizeSlackBlockActions(null, "env-x2")).toBeNull();
+    expect(normalizeSlackBlockActions(42, "env-x3")).toBeNull();
   });
 
   it("collapses a non-array actions field and drops the payload", () => {
@@ -283,7 +246,6 @@ describe("block_actions tolerant validation", () => {
         actions: "not-an-array",
       },
       "env-x4",
-      config,
     );
 
     expect(result).toBeNull();
@@ -299,7 +261,6 @@ describe("block_actions tolerant validation", () => {
         actions: [{ type: "button" }],
       },
       "env-x5",
-      config,
     );
 
     expect(result).toBeNull();
@@ -314,7 +275,6 @@ describe("block_actions tolerant validation", () => {
         actions: [{ action_id: "approve", type: "button" }],
       },
       "env-x6",
-      config,
     );
 
     expect(result).toBeNull();
@@ -329,7 +289,6 @@ describe("block_actions tolerant validation", () => {
         actions: [{ action_id: "approve", type: "button" }],
       },
       "env-x7",
-      config,
     );
 
     expect(result).toBeNull();
@@ -347,7 +306,6 @@ describe("block_actions tolerant validation", () => {
         ],
       },
       "env-x8",
-      config,
     );
 
     expect(result).not.toBeNull();
@@ -365,7 +323,7 @@ describe("block_actions tolerant validation", () => {
       ],
       unexpected_field: "surprise",
     };
-    const result = normalizeSlackBlockActions(payload, "env-x9", config);
+    const result = normalizeSlackBlockActions(payload, "env-x9");
 
     expect(result).not.toBeNull();
     expect(result!.event.raw).toEqual(payload);
@@ -374,9 +332,8 @@ describe("block_actions tolerant validation", () => {
 
 describe("normalizeSlackReactionAdded", () => {
   it("normalizes a reaction_added event with callbackData", () => {
-    const config = makeConfig();
     const event = makeReactionAddedEvent();
-    const result = normalizeSlackReactionAdded(event, "evt-1", config);
+    const result = normalizeSlackReactionAdded(event, "evt-1");
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
@@ -393,44 +350,39 @@ describe("normalizeSlackReactionAdded", () => {
   });
 
   it("returns null when user is missing", () => {
-    const config = makeConfig();
     const event = makeReactionAddedEvent({ user: "" });
-    const result = normalizeSlackReactionAdded(event, "evt-2", config);
+    const result = normalizeSlackReactionAdded(event, "evt-2");
 
     expect(result).toBeNull();
   });
 
   it("returns null when item channel is missing", () => {
-    const config = makeConfig();
     const event = makeReactionAddedEvent();
     event.item.channel = "";
-    const result = normalizeSlackReactionAdded(event, "evt-3", config);
+    const result = normalizeSlackReactionAdded(event, "evt-3");
 
     expect(result).toBeNull();
   });
 
   it("returns null when item ts is missing", () => {
-    const config = makeConfig();
     const event = makeReactionAddedEvent();
     event.item.ts = "";
-    const result = normalizeSlackReactionAdded(event, "evt-4", config);
+    const result = normalizeSlackReactionAdded(event, "evt-4");
 
     expect(result).toBeNull();
   });
 
   it("resolves an unrouted reaction to the local assistant", () => {
-    const config = makeConfig();
     const event = makeReactionAddedEvent();
-    const result = normalizeSlackReactionAdded(event, "evt-5", config);
+    const result = normalizeSlackReactionAdded(event, "evt-5");
 
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
   });
 
   it("uses the reaction name in callbackData", () => {
-    const config = makeConfig();
     const event = makeReactionAddedEvent({ reaction: "white_check_mark" });
-    const result = normalizeSlackReactionAdded(event, "evt-6", config);
+    const result = normalizeSlackReactionAdded(event, "evt-6");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.callbackData).toBe(
@@ -444,22 +396,17 @@ describe("normalizeSlackReactionAdded", () => {
     // gate on thread tracking — that filter lives in socket-mode.ts.
     // Verify the normalizer happily produces a valid event for an arbitrary
     // public-channel message ts when routing matches the channel.
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C500", assistantId: "ast-1" },
-      ],
-    });
     const event = makeReactionAddedEvent({
       channelId: "C500",
       messageTs: "1700000000.999999",
     });
-    const result = normalizeSlackReactionAdded(event, "evt-expand", config);
+    const result = normalizeSlackReactionAdded(event, "evt-expand");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.callbackData).toBe("reaction:thumbsup");
     expect(result!.channel).toBe("C500");
     expect(result!.threadTs).toBe("1700000000.999999");
-    expect(result!.routing.assistantId).toBe("ast-1");
+    expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
     expect(result!.event.message.externalMessageId).toBe(
       "C500:1700000000.999999:thumbsup:U123",
     );
@@ -468,9 +415,8 @@ describe("normalizeSlackReactionAdded", () => {
 
 describe("normalizeSlackReactionRemoved", () => {
   it("normalizes a reaction_removed event with reaction_removed: prefix", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent();
-    const result = normalizeSlackReactionRemoved(event, "evt-r-1", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-1");
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
@@ -489,9 +435,8 @@ describe("normalizeSlackReactionRemoved", () => {
   });
 
   it("uses the reaction name in callbackData", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent({ reaction: "white_check_mark" });
-    const result = normalizeSlackReactionRemoved(event, "evt-r-2", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-2");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.callbackData).toBe(
@@ -500,27 +445,24 @@ describe("normalizeSlackReactionRemoved", () => {
   });
 
   it("returns null when user is missing", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent({ user: "" });
-    const result = normalizeSlackReactionRemoved(event, "evt-r-3", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-3");
 
     expect(result).toBeNull();
   });
 
   it("returns null when item channel is missing", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent();
     event.item.channel = "";
-    const result = normalizeSlackReactionRemoved(event, "evt-r-4", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-4");
 
     expect(result).toBeNull();
   });
 
   it("returns null when item ts is missing", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent();
     event.item.ts = "";
-    const result = normalizeSlackReactionRemoved(event, "evt-r-5", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-5");
 
     expect(result).toBeNull();
   });
@@ -528,30 +470,27 @@ describe("normalizeSlackReactionRemoved", () => {
   // Self-authored reactions are now filtered upstream in processEventPayload,
   // not by the normalizer.
   it("does not filter reactions by bot user (handled upstream)", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent({ user: "UBOT" });
-    const result = normalizeSlackReactionRemoved(event, "evt-r-6", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-6");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.actorExternalId).toBe("UBOT");
   });
 
   it("resolves an unrouted public-channel reaction removal to the local assistant", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent();
-    const result = normalizeSlackReactionRemoved(event, "evt-r-7", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-7");
 
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
   });
 
   it("resolves unrouted DM channels to the local assistant", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent({
       channelId: "D999",
       messageTs: "111.222",
     });
-    const result = normalizeSlackReactionRemoved(event, "evt-r-8", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-8");
 
     expect(result).not.toBeNull();
     expect(result!.channel).toBe("D999");
@@ -561,12 +500,11 @@ describe("normalizeSlackReactionRemoved", () => {
   });
 
   it("normalizes reaction_removed in a DM channel", () => {
-    const config = makeConfig();
     const event = makeReactionRemovedEvent({
       channelId: "D789",
       messageTs: "1700000000.000001",
     });
-    const result = normalizeSlackReactionRemoved(event, "evt-r-9", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-9");
 
     expect(result).not.toBeNull();
     expect(result!.channel).toBe("D789");
@@ -582,19 +520,14 @@ describe("normalizeSlackReactionRemoved", () => {
     // Filter expansion: PR 3 admits reactions on any subscribed channel,
     // not just tracked bot-thread messages. Verify the removed normalizer
     // produces a valid event for an arbitrary public-channel message ts.
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C500", assistantId: "ast-1" },
-      ],
-    });
     const event = makeReactionRemovedEvent({
       channelId: "C500",
       messageTs: "1700000000.999999",
     });
-    const result = normalizeSlackReactionRemoved(event, "evt-r-10", config);
+    const result = normalizeSlackReactionRemoved(event, "evt-r-10");
 
     expect(result).not.toBeNull();
-    expect(result!.routing.assistantId).toBe("ast-1");
+    expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
     expect(result!.event.message.externalMessageId).toBe(
       "C500:1700000000.999999:thumbsup:U123:removed",
     );
@@ -603,7 +536,6 @@ describe("normalizeSlackReactionRemoved", () => {
   it("produces a different externalMessageId than reaction_added for the same emoji+user+message", () => {
     // Critical for dedup: an add followed by a remove of the same emoji by
     // the same user on the same message must not collide on externalMessageId.
-    const config = makeConfig();
     const addEvent = makeReactionAddedEvent({
       reaction: "fire",
       messageTs: "111.222",
@@ -612,11 +544,10 @@ describe("normalizeSlackReactionRemoved", () => {
       reaction: "fire",
       messageTs: "111.222",
     });
-    const addResult = normalizeSlackReactionAdded(addEvent, "evt-add", config);
+    const addResult = normalizeSlackReactionAdded(addEvent, "evt-add");
     const removeResult = normalizeSlackReactionRemoved(
       removeEvent,
       "evt-remove",
-      config,
     );
 
     expect(addResult).not.toBeNull();
@@ -628,16 +559,12 @@ describe("normalizeSlackReactionRemoved", () => {
 });
 
 describe("reaction event tolerant validation", () => {
-  const config = makeConfig();
-
   it("drops a non-object payload instead of throwing", () => {
     // The socket frame is unvalidated JSON.parse output; a scalar where an
     // object is expected must be dropped at the boundary, not crash the batch.
-    expect(
-      normalizeSlackReactionAdded("not-an-object", "evt-x1", config),
-    ).toBeNull();
-    expect(normalizeSlackReactionAdded(null, "evt-x2", config)).toBeNull();
-    expect(normalizeSlackReactionAdded(42, "evt-x3", config)).toBeNull();
+    expect(normalizeSlackReactionAdded("not-an-object", "evt-x1")).toBeNull();
+    expect(normalizeSlackReactionAdded(null, "evt-x2")).toBeNull();
+    expect(normalizeSlackReactionAdded(42, "evt-x3")).toBeNull();
   });
 
   it("collapses a non-object item to undefined and drops the event", () => {
@@ -652,7 +579,6 @@ describe("reaction event tolerant validation", () => {
         item: "bogus",
       },
       "evt-x4",
-      config,
     );
 
     expect(result).toBeNull();
@@ -667,7 +593,6 @@ describe("reaction event tolerant validation", () => {
         item: { type: "message", channel: "C456", ts: "1700000000.000100" },
       },
       "evt-x5",
-      config,
     );
 
     expect(result).toBeNull();
@@ -684,7 +609,6 @@ describe("reaction event tolerant validation", () => {
         item: { type: "message", channel: "C456", ts: "1700000000.000100" },
       },
       "evt-x5a",
-      config,
     );
 
     expect(result).toBeNull();
@@ -699,7 +623,6 @@ describe("reaction event tolerant validation", () => {
         item: { type: "message", channel: "C456", ts: "1700000000.000100" },
       },
       "evt-x5b",
-      config,
     );
 
     expect(result).toBeNull();
@@ -717,7 +640,6 @@ describe("reaction event tolerant validation", () => {
         item: { type: "message", channel: "C456", ts: { nested: true } },
       },
       "evt-x6",
-      config,
     );
 
     expect(result).toBeNull();
@@ -734,7 +656,7 @@ describe("reaction event tolerant validation", () => {
       unexpected_field: "surprise",
       nested_extra: { a: 1 },
     };
-    const result = normalizeSlackReactionAdded(payload, "evt-x7", config);
+    const result = normalizeSlackReactionAdded(payload, "evt-x7");
 
     expect(result).not.toBeNull();
     expect(result!.event.raw).toEqual(payload);
@@ -746,9 +668,8 @@ describe("reaction event tolerant validation", () => {
 
 describe("DM threading", () => {
   it("non-threaded DM has no threadTs", () => {
-    const config = makeConfig();
     const event = makeDmEvent();
-    const result = normalizeSlackDirectMessage(event, "evt-dm-1", config);
+    const result = normalizeSlackDirectMessage(event, "evt-dm-1");
 
     expect(result).not.toBeNull();
     expect(result!.event.source.chatType).toBe("im");
@@ -757,9 +678,8 @@ describe("DM threading", () => {
   });
 
   it("threaded DM preserves threadTs", () => {
-    const config = makeConfig();
     const event = makeDmEvent({ thread_ts: "1700000000.000050" });
-    const result = normalizeSlackDirectMessage(event, "evt-dm-2", config);
+    const result = normalizeSlackDirectMessage(event, "evt-dm-2");
 
     expect(result).not.toBeNull();
     expect(result!.event.source.chatType).toBe("im");
@@ -770,7 +690,6 @@ describe("DM threading", () => {
 
 describe("Slack text rendering in normalized message content", () => {
   it("renders channel refs from render context channel labels", () => {
-    const config = makeConfig();
     const event = makeAppMentionEvent({
       text: "<@UBOT> please continue in <#CFEEDBACK>",
     });
@@ -778,7 +697,6 @@ describe("Slack text rendering in normalized message content", () => {
     const result = normalizeSlackAppMention(
       event,
       "evt-channel-label",
-      config,
       undefined,
       {
         userLabels: { UBOT: "assistant" },
@@ -794,16 +712,11 @@ describe("Slack text rendering in normalized message content", () => {
   });
 
   it("falls back to unknown-channel when no channel label is available", () => {
-    const config = makeConfig();
     const event = makeChannelEvent({
       text: "please continue in <#CUNKNOWN>",
     });
 
-    const result = normalizeSlackChannelMessage(
-      event,
-      "evt-channel-fallback",
-      config,
-    );
+    const result = normalizeSlackChannelMessage(event, "evt-channel-fallback");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.content).toBe(
@@ -871,7 +784,6 @@ function makeAppMentionEvent(
 describe("attachment extraction in normalize functions", () => {
   describe("normalizeSlackDirectMessage", () => {
     it("populates attachments with type 'image' for image files", () => {
-      const config = makeConfig();
       const event = makeDmEvent({
         files: [
           makeSlackFile({
@@ -886,7 +798,7 @@ describe("attachment extraction in normalize functions", () => {
           }),
         ],
       });
-      const result = normalizeSlackDirectMessage(event, "evt-1", config);
+      const result = normalizeSlackDirectMessage(event, "evt-1");
 
       expect(result).not.toBeNull();
       expect(result!.event.message.attachments).toHaveLength(2);
@@ -913,7 +825,6 @@ describe("attachment extraction in normalize functions", () => {
     });
 
     it("populates attachments with type 'document' for non-image files", () => {
-      const config = makeConfig();
       const event = makeDmEvent({
         files: [
           makeSlackFile({
@@ -924,7 +835,7 @@ describe("attachment extraction in normalize functions", () => {
           }),
         ],
       });
-      const result = normalizeSlackDirectMessage(event, "evt-2", config);
+      const result = normalizeSlackDirectMessage(event, "evt-2");
 
       expect(result).not.toBeNull();
       expect(result!.event.message.attachments).toHaveLength(1);
@@ -938,7 +849,6 @@ describe("attachment extraction in normalize functions", () => {
     });
 
     it("filters out files missing download URLs", () => {
-      const config = makeConfig();
       const event = makeDmEvent({
         files: [
           makeSlackFile({ id: "F004" }),
@@ -949,7 +859,7 @@ describe("attachment extraction in normalize functions", () => {
           }),
         ],
       });
-      const result = normalizeSlackDirectMessage(event, "evt-3", config);
+      const result = normalizeSlackDirectMessage(event, "evt-3");
 
       expect(result).not.toBeNull();
       // Only F004 has download URLs
@@ -960,9 +870,8 @@ describe("attachment extraction in normalize functions", () => {
     });
 
     it("omits attachments field when files is empty", () => {
-      const config = makeConfig();
       const event = makeDmEvent({ files: [] });
-      const result = normalizeSlackDirectMessage(event, "evt-4", config);
+      const result = normalizeSlackDirectMessage(event, "evt-4");
 
       expect(result).not.toBeNull();
       expect(result!.event.message.attachments).toBeUndefined();
@@ -970,9 +879,8 @@ describe("attachment extraction in normalize functions", () => {
     });
 
     it("omits attachments field when files is undefined", () => {
-      const config = makeConfig();
       const event = makeDmEvent();
-      const result = normalizeSlackDirectMessage(event, "evt-5", config);
+      const result = normalizeSlackDirectMessage(event, "evt-5");
 
       expect(result).not.toBeNull();
       expect(result!.event.message.attachments).toBeUndefined();
@@ -982,7 +890,6 @@ describe("attachment extraction in normalize functions", () => {
 
   describe("normalizeSlackChannelMessage", () => {
     it("populates attachments for channel messages with files", () => {
-      const config = makeConfig();
       const event = makeChannelEvent({
         files: [
           makeSlackFile({
@@ -992,7 +899,7 @@ describe("attachment extraction in normalize functions", () => {
           }),
         ],
       });
-      const result = normalizeSlackChannelMessage(event, "evt-ch-1", config);
+      const result = normalizeSlackChannelMessage(event, "evt-ch-1");
 
       expect(result).not.toBeNull();
       expect(result!.event.message.attachments).toHaveLength(1);
@@ -1011,7 +918,6 @@ describe("attachment extraction in normalize functions", () => {
   describe("file_share subtype handling", () => {
     describe("normalizeSlackDirectMessage", () => {
       it("normalizes DM with file_share subtype and files", () => {
-        const config = makeConfig();
         const event = makeDmEvent({
           subtype: "file_share",
           files: [
@@ -1022,7 +928,7 @@ describe("attachment extraction in normalize functions", () => {
             }),
           ],
         });
-        const result = normalizeSlackDirectMessage(event, "evt-fs-1", config);
+        const result = normalizeSlackDirectMessage(event, "evt-fs-1");
 
         expect(result).not.toBeNull();
         expect(result!.event.message.attachments).toHaveLength(1);
@@ -1033,7 +939,6 @@ describe("attachment extraction in normalize functions", () => {
       });
 
       it("normalizes DM file_share mentions without stripping the bot mention", () => {
-        const config = makeConfig();
         const event = makeDmEvent({
           subtype: "file_share",
           text: "<@UBOT> <@ULEO> shared this",
@@ -1048,7 +953,6 @@ describe("attachment extraction in normalize functions", () => {
         const result = normalizeSlackDirectMessage(
           event,
           "evt-fs-mentions-dm",
-          config,
           undefined,
           { userLabels: { UBOT: "assistant", ULEO: "leo" } },
         );
@@ -1065,9 +969,8 @@ describe("attachment extraction in normalize functions", () => {
       });
 
       it("normalizes DM with file_share subtype without files", () => {
-        const config = makeConfig();
         const event = makeDmEvent({ subtype: "file_share" });
-        const result = normalizeSlackDirectMessage(event, "evt-fs-2", config);
+        const result = normalizeSlackDirectMessage(event, "evt-fs-2");
 
         expect(result).not.toBeNull();
         expect(result!.event.message.content).toBe("hello");
@@ -1075,9 +978,8 @@ describe("attachment extraction in normalize functions", () => {
       });
 
       it("drops DM with bot_message subtype", () => {
-        const config = makeConfig();
         const event = makeDmEvent({ subtype: "bot_message" });
-        const result = normalizeSlackDirectMessage(event, "evt-fs-3", config);
+        const result = normalizeSlackDirectMessage(event, "evt-fs-3");
 
         expect(result).toBeNull();
       });
@@ -1085,7 +987,6 @@ describe("attachment extraction in normalize functions", () => {
 
     describe("normalizeSlackChannelMessage", () => {
       it("normalizes channel message with file_share subtype and files", () => {
-        const config = makeConfig();
         const event = makeChannelEvent({
           subtype: "file_share",
           files: [
@@ -1096,7 +997,7 @@ describe("attachment extraction in normalize functions", () => {
             }),
           ],
         });
-        const result = normalizeSlackChannelMessage(event, "evt-fs-4", config);
+        const result = normalizeSlackChannelMessage(event, "evt-fs-4");
 
         expect(result).not.toBeNull();
         expect(result!.event.message.attachments).toHaveLength(1);
@@ -1106,7 +1007,6 @@ describe("attachment extraction in normalize functions", () => {
       });
 
       it("normalizes channel file_share mentions and renders the bot mention", () => {
-        const config = makeConfig();
         const event = makeChannelEvent({
           subtype: "file_share",
           text: "<@UBOT> <@ULEO> shared this",
@@ -1121,7 +1021,6 @@ describe("attachment extraction in normalize functions", () => {
         const result = normalizeSlackChannelMessage(
           event,
           "evt-fs-mentions-channel",
-          config,
           undefined,
           { userLabels: { UBOT: "vex", ULEO: "leo" } },
         );
@@ -1142,9 +1041,8 @@ describe("attachment extraction in normalize functions", () => {
       });
 
       it("normalizes channel message with file_share subtype without files", () => {
-        const config = makeConfig();
         const event = makeChannelEvent({ subtype: "file_share" });
-        const result = normalizeSlackChannelMessage(event, "evt-fs-5", config);
+        const result = normalizeSlackChannelMessage(event, "evt-fs-5");
 
         expect(result).not.toBeNull();
         expect(result!.event.message.content).toBe("hello");
@@ -1152,9 +1050,8 @@ describe("attachment extraction in normalize functions", () => {
       });
 
       it("drops channel message with bot_message subtype", () => {
-        const config = makeConfig();
         const event = makeChannelEvent({ subtype: "bot_message" });
-        const result = normalizeSlackChannelMessage(event, "evt-fs-6", config);
+        const result = normalizeSlackChannelMessage(event, "evt-fs-6");
 
         expect(result).toBeNull();
       });
@@ -1163,7 +1060,6 @@ describe("attachment extraction in normalize functions", () => {
 
   describe("normalizeSlackAppMention", () => {
     it("populates attachments for app mention events with files", () => {
-      const config = makeConfig();
       const event = makeAppMentionEvent({
         files: [
           makeSlackFile({
@@ -1174,7 +1070,7 @@ describe("attachment extraction in normalize functions", () => {
           }),
         ],
       });
-      const result = normalizeSlackAppMention(event, "evt-am-1", config);
+      const result = normalizeSlackAppMention(event, "evt-am-1");
 
       expect(result).not.toBeNull();
       expect(result!.event.message.attachments).toHaveLength(1);
@@ -1230,13 +1126,11 @@ function makeMessageChangedEvent(
 }
 
 describe("message event tolerant validation", () => {
-  const config = makeConfig();
-
   it("drops non-object message payloads instead of throwing", () => {
-    expect(normalizeSlackDirectMessage("nope", "evt-t1", config)).toBeNull();
-    expect(normalizeSlackDirectMessage(null, "evt-t2", config)).toBeNull();
-    expect(normalizeSlackChannelMessage(42, "evt-t3", config)).toBeNull();
-    expect(normalizeSlackAppMention(null, "evt-t4", config)).toBeNull();
+    expect(normalizeSlackDirectMessage("nope", "evt-t1")).toBeNull();
+    expect(normalizeSlackDirectMessage(null, "evt-t2")).toBeNull();
+    expect(normalizeSlackChannelMessage(42, "evt-t3")).toBeNull();
+    expect(normalizeSlackAppMention(null, "evt-t4")).toBeNull();
   });
 
   it("renders empty content for a non-string DM text instead of crashing", () => {
@@ -1253,7 +1147,6 @@ describe("message event tolerant validation", () => {
         text: 12345,
       },
       "evt-t5",
-      config,
     );
 
     expect(result).not.toBeNull();
@@ -1270,7 +1163,6 @@ describe("message event tolerant validation", () => {
         text: { rich: "obj" },
       },
       "evt-t6",
-      config,
     );
 
     expect(result).not.toBeNull();
@@ -1287,7 +1179,6 @@ describe("message event tolerant validation", () => {
         text: "hi",
       },
       "evt-t7",
-      config,
     );
 
     expect(result).toBeNull();
@@ -1303,7 +1194,6 @@ describe("message event tolerant validation", () => {
         text: "hi",
       },
       "evt-t8",
-      config,
     );
 
     expect(result).toBeNull();
@@ -1321,7 +1211,6 @@ describe("message event tolerant validation", () => {
         files: "not-an-array",
       },
       "evt-t9",
-      config,
     );
 
     expect(result).not.toBeNull();
@@ -1338,7 +1227,7 @@ describe("message event tolerant validation", () => {
       text: "hi",
       unexpected_field: "surprise",
     };
-    const result = normalizeSlackChannelMessage(payload, "evt-t10", config);
+    const result = normalizeSlackChannelMessage(payload, "evt-t10");
 
     expect(result).not.toBeNull();
     expect(result!.event.raw).toEqual(payload);
@@ -1357,7 +1246,6 @@ describe("message event tolerant validation", () => {
         text: "hi",
       },
       "evt-t11",
-      config,
     );
 
     expect(result).toBeNull();
@@ -1368,11 +1256,6 @@ describe("normalizeSlackMessageEdit", () => {
   it("normalizes an edit in a subscribed channel (not DM, not bot thread)", () => {
     // Bot is subscribed to the channel via a conversation_id routing entry —
     // this is the case PR 4 expanded the gateway filter to admit.
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C456", assistantId: "ast-2" },
-      ],
-    });
     const event = makeMessageChangedEvent({
       channel: "C456",
       channelType: "channel",
@@ -1382,15 +1265,15 @@ describe("normalizeSlackMessageEdit", () => {
     });
     const eventId = "Ev0XYZ";
 
-    const result = normalizeSlackMessageEdit(event, eventId, config);
+    const result = normalizeSlackMessageEdit(event, eventId);
 
     expect(result).not.toBeNull();
     expect(result!.event.message.isEdit).toBe(true);
     expect(result!.event.message.conversationExternalId).toBe("C456");
     expect(result!.event.actor.actorExternalId).toBe("U123");
     expect(result!.event.source.chatType).toBe("channel");
-    expect(result!.routing.assistantId).toBe("ast-2");
-    expect(result!.routing.routeSource).toBe("conversation_id");
+    expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
+    expect(result!.routing.routeSource).toBe("default");
 
     // PR 3 invariant: source.messageId is the original Slack ts (the lookup
     // key the daemon uses to find the prior message), and externalMessageId
@@ -1404,17 +1287,12 @@ describe("normalizeSlackMessageEdit", () => {
   });
 
   it("uses message ts as threadTs for top-level channel edits", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C456", assistantId: "ast-2" },
-      ],
-    });
     const event = makeMessageChangedEvent({
       channel: "C456",
       channelType: "channel",
       messageTs: "1700000000.000100",
     });
-    const result = normalizeSlackMessageEdit(event, "Ev1", config);
+    const result = normalizeSlackMessageEdit(event, "Ev1");
 
     expect(result).not.toBeNull();
     // For channel edits without a thread_ts, fall back to the message ts so
@@ -1424,18 +1302,13 @@ describe("normalizeSlackMessageEdit", () => {
   });
 
   it("preserves thread_ts on a threaded channel edit", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C456", assistantId: "ast-2" },
-      ],
-    });
     const event = makeMessageChangedEvent({
       channel: "C456",
       channelType: "channel",
       messageTs: "1700000000.000150",
       threadTs: "1700000000.000050",
     });
-    const result = normalizeSlackMessageEdit(event, "Ev2", config);
+    const result = normalizeSlackMessageEdit(event, "Ev2");
 
     expect(result).not.toBeNull();
     expect(result!.threadTs).toBe("1700000000.000050");
@@ -1445,14 +1318,11 @@ describe("normalizeSlackMessageEdit", () => {
   it("resolves an edit in an unrouted non-DM channel to the local assistant", () => {
     // Previously dropped as unroutable; the gateway now normalizes it and
     // leaves the admittance decision to the admission floor.
-    const config = makeConfig({
-      routingEntries: [],
-    });
     const event = makeMessageChangedEvent({
       channel: "C999",
       channelType: "channel",
     });
-    const result = normalizeSlackMessageEdit(event, "Ev3", config);
+    const result = normalizeSlackMessageEdit(event, "Ev3");
 
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
@@ -1460,20 +1330,14 @@ describe("normalizeSlackMessageEdit", () => {
 
   // Self-authored edits are now filtered upstream in processEventPayload.
   it("does not filter edits by bot user (handled upstream)", () => {
-    const config = makeConfig({
-      routingEntries: [
-        { type: "conversation_id", key: "C456", assistantId: "ast-2" },
-      ],
-    });
     const event = makeMessageChangedEvent({ user: "UBOT" });
-    const result = normalizeSlackMessageEdit(event, "Ev4", config);
+    const result = normalizeSlackMessageEdit(event, "Ev4");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.actorExternalId).toBe("UBOT");
   });
 
   it("infers DM from channel ID prefix when channel_type is absent", () => {
-    const config = makeConfig();
     // Build the event directly so `channel_type` is truly absent — the
     // makeMessageChangedEvent helper coalesces undefined back to "channel".
     const event: SlackMessageChangedEvent = {
@@ -1494,7 +1358,7 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     };
-    const result = normalizeSlackMessageEdit(event, "Ev5", config);
+    const result = normalizeSlackMessageEdit(event, "Ev5");
 
     // Previously this needed the DM-prefix fallback to survive the unmapped
     // reject policy; it now resolves locally like any other identified event.
@@ -1531,7 +1395,6 @@ function makeMessageDeletedEvent(
 
 describe("normalizeSlackMessageDelete", () => {
   it("normalizes a DM delete with the message_deleted sentinel", () => {
-    const config = makeConfig();
     const event = makeMessageDeletedEvent({
       channel: "D789",
       channel_type: "im",
@@ -1541,7 +1404,7 @@ describe("normalizeSlackMessageDelete", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageDelete(event, "evt-del-dm", config);
+    const result = normalizeSlackMessageDelete(event, "evt-del-dm");
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
@@ -1560,9 +1423,8 @@ describe("normalizeSlackMessageDelete", () => {
   });
 
   it("normalizes a channel delete with the message_deleted sentinel", () => {
-    const config = makeConfig();
     const event = makeMessageDeletedEvent();
-    const result = normalizeSlackMessageDelete(event, "evt-del-ch", config);
+    const result = normalizeSlackMessageDelete(event, "evt-del-ch");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.callbackData).toBe("message_deleted");
@@ -1577,7 +1439,6 @@ describe("normalizeSlackMessageDelete", () => {
   });
 
   it("preserves threadTs from the previous_message thread root", () => {
-    const config = makeConfig();
     const event = makeMessageDeletedEvent({
       previous_message: {
         user: "U123",
@@ -1586,35 +1447,29 @@ describe("normalizeSlackMessageDelete", () => {
         thread_ts: "1700000000.000050",
       },
     });
-    const result = normalizeSlackMessageDelete(event, "evt-del-thr", config);
+    const result = normalizeSlackMessageDelete(event, "evt-del-thr");
 
     expect(result).not.toBeNull();
     expect(result!.threadTs).toBe("1700000000.000050");
   });
 
   it("returns null when deleted_ts is missing", () => {
-    const config = makeConfig();
     const event = makeMessageDeletedEvent({
       deleted_ts: undefined as unknown as string,
     });
-    const result = normalizeSlackMessageDelete(event, "evt-del-bad", config);
+    const result = normalizeSlackMessageDelete(event, "evt-del-bad");
 
     expect(result).toBeNull();
   });
 
   it("falls back to a synthetic actor when previous_message.user is missing", () => {
-    const config = makeConfig();
     const event = makeMessageDeletedEvent({
       previous_message: {
         text: "[no user]",
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageDelete(
-      event,
-      "evt-del-no-user",
-      config,
-    );
+    const result = normalizeSlackMessageDelete(event, "evt-del-no-user");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.actorExternalId).toBe("slack-system");
@@ -1623,45 +1478,30 @@ describe("normalizeSlackMessageDelete", () => {
   it("resolves an unrouted channel delete to the local assistant", () => {
     // Previously dropped by the unmapped reject policy. Admission, not
     // routing, now decides whether an unrouted channel is allowed through.
-    const config = makeConfig();
     const event = makeMessageDeletedEvent();
-    const result = normalizeSlackMessageDelete(
-      event,
-      "evt-del-noroute",
-      config,
-    );
+    const result = normalizeSlackMessageDelete(event, "evt-del-noroute");
 
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
   });
 
   it("resolves DM deletes to the local assistant when the channel is unrouted", () => {
-    const config = makeConfig();
     const event = makeMessageDeletedEvent({
       channel: "D789",
       channel_type: "im",
     });
-    const result = normalizeSlackMessageDelete(
-      event,
-      "evt-del-dm-default",
-      config,
-    );
+    const result = normalizeSlackMessageDelete(event, "evt-del-dm-default");
 
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe(LOCAL_ASSISTANT_ID);
   });
 
   it("infers DM from channel ID prefix when channel_type is absent", () => {
-    const config = makeConfig();
     const event = makeMessageDeletedEvent({
       channel: "D789",
       channel_type: undefined,
     });
-    const result = normalizeSlackMessageDelete(
-      event,
-      "evt-del-dm-infer",
-      config,
-    );
+    const result = normalizeSlackMessageDelete(event, "evt-del-dm-infer");
 
     // Previously this needed the DM-prefix fallback to survive the unmapped
     // reject policy; it now resolves locally like any other identified event.
@@ -1674,7 +1514,6 @@ describe("normalizeSlackMessageDelete", () => {
   it("does not filter deletes by bot user (handled upstream)", () => {
     // Self-authored deletes are filtered in processEventPayload's single
     // self-filter, not in the normalizer.
-    const config = makeConfig();
     const event = makeMessageDeletedEvent({
       channel: "D789",
       channel_type: "im",
@@ -1685,7 +1524,7 @@ describe("normalizeSlackMessageDelete", () => {
       },
     });
     // Self-authored deletes are now filtered upstream in processEventPayload.
-    const result = normalizeSlackMessageDelete(event, "evt-del-self", config);
+    const result = normalizeSlackMessageDelete(event, "evt-del-self");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.actorExternalId).toBe("UBOT");
@@ -1693,15 +1532,13 @@ describe("normalizeSlackMessageDelete", () => {
 });
 
 describe("message edit/delete tolerant validation", () => {
-  const config = makeConfig();
-
   it("drops non-object edit/delete payloads instead of throwing", () => {
     // Socket frames are unvalidated JSON.parse output; a scalar where an object
     // is expected must be dropped at the boundary, not crash the batch.
-    expect(normalizeSlackMessageEdit("nope", "evt-me1", config)).toBeNull();
-    expect(normalizeSlackMessageEdit(null, "evt-me2", config)).toBeNull();
-    expect(normalizeSlackMessageDelete(42, "evt-md1", config)).toBeNull();
-    expect(normalizeSlackMessageDelete(null, "evt-md2", config)).toBeNull();
+    expect(normalizeSlackMessageEdit("nope", "evt-me1")).toBeNull();
+    expect(normalizeSlackMessageEdit(null, "evt-me2")).toBeNull();
+    expect(normalizeSlackMessageDelete(42, "evt-md1")).toBeNull();
+    expect(normalizeSlackMessageDelete(null, "evt-md2")).toBeNull();
   });
 
   it("collapses a non-object edit message to undefined and drops the event", () => {
@@ -1713,7 +1550,6 @@ describe("message edit/delete tolerant validation", () => {
         message: "not-an-object",
       },
       "evt-me3",
-      config,
     );
 
     expect(result).toBeNull();
@@ -1727,7 +1563,6 @@ describe("message edit/delete tolerant validation", () => {
         message: { user: "U123", text: "hi", ts: "1700000000.000100" },
       },
       "evt-me4",
-      config,
     );
 
     expect(result).toBeNull();
@@ -1742,7 +1577,6 @@ describe("message edit/delete tolerant validation", () => {
         message: { user: "U123", text: "hi", ts: { bogus: true } },
       },
       "evt-me5",
-      config,
     );
 
     expect(result).toBeNull();
@@ -1759,7 +1593,6 @@ describe("message edit/delete tolerant validation", () => {
         message: { user: "U123", ts: "1700000000.000100" },
       },
       "evt-me6",
-      config,
     );
 
     expect(result).not.toBeNull();
@@ -1775,7 +1608,7 @@ describe("message edit/delete tolerant validation", () => {
       message: { user: "U123", text: "hi", ts: "1700000000.000100" },
       unexpected_field: "surprise",
     };
-    const result = normalizeSlackMessageEdit(payload, "evt-me7", config);
+    const result = normalizeSlackMessageEdit(payload, "evt-me7");
 
     expect(result).not.toBeNull();
     expect(result!.event.raw).toEqual(payload);
@@ -1790,7 +1623,6 @@ describe("message edit/delete tolerant validation", () => {
         deleted_ts: "1700000000.000100",
       },
       "evt-md3",
-      config,
     );
 
     expect(result).toBeNull();
@@ -1805,7 +1637,7 @@ describe("message edit/delete tolerant validation", () => {
       previous_message: { user: "U123", text: "gone", ts: "1700000000.000100" },
       unexpected_field: "surprise",
     };
-    const result = normalizeSlackMessageDelete(payload, "evt-md4", config);
+    const result = normalizeSlackMessageDelete(payload, "evt-md4");
 
     expect(result).not.toBeNull();
     expect(result!.event.raw).toEqual(payload);
@@ -1821,18 +1653,16 @@ describe("message edit/delete tolerant validation", () => {
 describe("source.threadId propagation", () => {
   describe("normalizeSlackDirectMessage", () => {
     it("populates source.threadId when thread_ts is present", () => {
-      const config = makeConfig();
       const event = makeDmEvent({ thread_ts: "1700000000.111111" });
-      const result = normalizeSlackDirectMessage(event, "evt-tid-1", config);
+      const result = normalizeSlackDirectMessage(event, "evt-tid-1");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBe("1700000000.111111");
     });
 
     it("omits source.threadId when thread_ts is absent", () => {
-      const config = makeConfig();
       const event = makeDmEvent();
-      const result = normalizeSlackDirectMessage(event, "evt-tid-2", config);
+      const result = normalizeSlackDirectMessage(event, "evt-tid-2");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBeUndefined();
@@ -1841,18 +1671,16 @@ describe("source.threadId propagation", () => {
 
   describe("normalizeSlackChannelMessage", () => {
     it("populates source.threadId when thread_ts is present", () => {
-      const config = makeConfig();
       const event = makeChannelEvent({ thread_ts: "1700000000.222222" });
-      const result = normalizeSlackChannelMessage(event, "evt-tid-3", config);
+      const result = normalizeSlackChannelMessage(event, "evt-tid-3");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBe("1700000000.222222");
     });
 
     it("omits source.threadId when thread_ts is absent (top-level channel message)", () => {
-      const config = makeConfig();
       const event = makeChannelEvent();
-      const result = normalizeSlackChannelMessage(event, "evt-tid-4", config);
+      const result = normalizeSlackChannelMessage(event, "evt-tid-4");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBeUndefined();
@@ -1861,18 +1689,16 @@ describe("source.threadId propagation", () => {
 
   describe("normalizeSlackAppMention", () => {
     it("populates source.threadId when thread_ts is present", () => {
-      const config = makeConfig();
       const event = makeAppMentionEvent({ thread_ts: "1700000000.333333" });
-      const result = normalizeSlackAppMention(event, "evt-tid-5", config);
+      const result = normalizeSlackAppMention(event, "evt-tid-5");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBe("1700000000.333333");
     });
 
     it("omits source.threadId when thread_ts is absent", () => {
-      const config = makeConfig();
       const event = makeAppMentionEvent();
-      const result = normalizeSlackAppMention(event, "evt-tid-6", config);
+      const result = normalizeSlackAppMention(event, "evt-tid-6");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBeUndefined();
@@ -1881,27 +1707,24 @@ describe("source.threadId propagation", () => {
 
   describe("actor team ID capture", () => {
     it("captures event.team as actor.teamId for channel messages", () => {
-      const config = makeConfig();
       const event = makeChannelEvent({ team: "T999" });
-      const result = normalizeSlackChannelMessage(event, "evt-team-1", config);
+      const result = normalizeSlackChannelMessage(event, "evt-team-1");
 
       expect(result).not.toBeNull();
       expect(result!.event.actor.teamId).toBe("T999");
     });
 
     it("captures event.team as actor.teamId for app mentions", () => {
-      const config = makeConfig();
       const event = makeAppMentionEvent({ team: "T999" });
-      const result = normalizeSlackAppMention(event, "evt-team-2", config);
+      const result = normalizeSlackAppMention(event, "evt-team-2");
 
       expect(result).not.toBeNull();
       expect(result!.event.actor.teamId).toBe("T999");
     });
 
     it("omits actor.teamId when the event carries no team", () => {
-      const config = makeConfig();
       const event = makeChannelEvent();
-      const result = normalizeSlackChannelMessage(event, "evt-team-3", config);
+      const result = normalizeSlackChannelMessage(event, "evt-team-3");
 
       expect(result).not.toBeNull();
       expect(result!.event.actor.teamId).toBeUndefined();
@@ -1910,11 +1733,10 @@ describe("source.threadId propagation", () => {
 
   describe("normalizeSlackReactionAdded", () => {
     it("populates source.threadId with the reacted message's ts", () => {
-      const config = makeConfig();
       const event = makeReactionAddedEvent({
         messageTs: "1700000000.444444",
       });
-      const result = normalizeSlackReactionAdded(event, "evt-tid-7", config);
+      const result = normalizeSlackReactionAdded(event, "evt-tid-7");
 
       expect(result).not.toBeNull();
       // Reactions route replies against the reacted message, so threadId
@@ -1926,40 +1748,29 @@ describe("source.threadId propagation", () => {
 
   describe("normalizeSlackMessageEdit", () => {
     it("populates source.threadId for channel edits inside a thread", () => {
-      const config = makeConfig({
-        routingEntries: [
-          { type: "conversation_id", key: "C456", assistantId: "ast-2" },
-        ],
-      });
       const event = makeMessageChangedEvent({
         threadTs: "1700000000.555555",
       });
-      const result = normalizeSlackMessageEdit(event, "evt-tid-8", config);
+      const result = normalizeSlackMessageEdit(event, "evt-tid-8");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBe("1700000000.555555");
     });
 
     it("omits source.threadId for channel edits with no thread", () => {
-      const config = makeConfig({
-        routingEntries: [
-          { type: "conversation_id", key: "C456", assistantId: "ast-2" },
-        ],
-      });
       const event = makeMessageChangedEvent();
-      const result = normalizeSlackMessageEdit(event, "evt-tid-9", config);
+      const result = normalizeSlackMessageEdit(event, "evt-tid-9");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBeUndefined();
     });
 
     it("omits source.threadId for DM edits with no thread", () => {
-      const config = makeConfig();
       const event = makeMessageChangedEvent({
         channel: "D789",
         channelType: "im",
       });
-      const result = normalizeSlackMessageEdit(event, "evt-tid-10", config);
+      const result = normalizeSlackMessageEdit(event, "evt-tid-10");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBeUndefined();
@@ -1968,23 +1779,21 @@ describe("source.threadId propagation", () => {
 
   describe("normalizeSlackBlockActions", () => {
     it("populates source.threadId when message.thread_ts is present", () => {
-      const config = makeConfig();
       const payload = makeBlockActionsPayload();
       payload.message = {
         ts: "1234567890.999999",
         thread_ts: "1234567890.000001",
         text: "Choose an option",
       };
-      const result = normalizeSlackBlockActions(payload, "env-tid-1", config);
+      const result = normalizeSlackBlockActions(payload, "env-tid-1");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBe("1234567890.000001");
     });
 
     it("omits source.threadId when message.thread_ts is absent", () => {
-      const config = makeConfig();
       const payload = makeBlockActionsPayload();
-      const result = normalizeSlackBlockActions(payload, "env-tid-2", config);
+      const result = normalizeSlackBlockActions(payload, "env-tid-2");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBeUndefined();
@@ -1993,7 +1802,6 @@ describe("source.threadId propagation", () => {
 
   describe("normalizeSlackMessageDelete", () => {
     it("populates source.threadId for deletes of threaded messages", () => {
-      const config = makeConfig();
       const event = makeMessageDeletedEvent({
         previous_message: {
           user: "U123",
@@ -2002,16 +1810,15 @@ describe("source.threadId propagation", () => {
           thread_ts: "parent_ts",
         },
       });
-      const result = normalizeSlackMessageDelete(event, "evt-tid-11", config);
+      const result = normalizeSlackMessageDelete(event, "evt-tid-11");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBe("parent_ts");
     });
 
     it("omits source.threadId for deletes of top-level messages", () => {
-      const config = makeConfig();
       const event = makeMessageDeletedEvent();
-      const result = normalizeSlackMessageDelete(event, "evt-tid-12", config);
+      const result = normalizeSlackMessageDelete(event, "evt-tid-12");
 
       expect(result).not.toBeNull();
       expect(result!.event.source.threadId).toBeUndefined();
@@ -2021,7 +1828,6 @@ describe("source.threadId propagation", () => {
 
 describe("bot sender classification", () => {
   it("marks a DM from another bot as a bot sender", () => {
-    const config = makeConfig();
     const event = makeDmEvent({
       user: "UBOT99",
       bot_id: "B0AGENT",
@@ -2032,7 +1838,7 @@ describe("bot sender classification", () => {
         team_id: "T0EXAMPLE",
       },
     });
-    const result = normalizeSlackDirectMessage(event, "evt-bot-1", config);
+    const result = normalizeSlackDirectMessage(event, "evt-bot-1");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.isBot).toBe(true);
@@ -2045,12 +1851,11 @@ describe("bot sender classification", () => {
   });
 
   it("marks a channel message from another bot as a bot sender", () => {
-    const config = makeConfig();
     const event = makeChannelEvent({
       user: "UBOT99",
       bot_id: "B0AGENT",
     });
-    const result = normalizeSlackChannelMessage(event, "evt-bot-2", config);
+    const result = normalizeSlackChannelMessage(event, "evt-bot-2");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.isBot).toBe(true);
@@ -2058,13 +1863,12 @@ describe("bot sender classification", () => {
   });
 
   it("marks an app_mention from another bot as a bot sender", () => {
-    const config = makeConfig();
     const event = makeAppMentionEvent({
       user: "UBOT99",
       bot_id: "B0AGENT",
       bot_profile: { name: "Peer Assistant" },
     });
-    const result = normalizeSlackAppMention(event, "evt-bot-3", config);
+    const result = normalizeSlackAppMention(event, "evt-bot-3");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.isBot).toBe(true);
@@ -2075,12 +1879,7 @@ describe("bot sender classification", () => {
   });
 
   it("does not mark a human sender as a bot", () => {
-    const config = makeConfig();
-    const result = normalizeSlackDirectMessage(
-      makeDmEvent(),
-      "evt-bot-4",
-      config,
-    );
+    const result = normalizeSlackDirectMessage(makeDmEvent(), "evt-bot-4");
 
     expect(result).not.toBeNull();
     expect(result!.event.actor.isBot).toBeUndefined();
@@ -2111,13 +1910,11 @@ describe("slackBotContactNote", () => {
 
 describe("enrichNormalizedActor", () => {
   it("classifies an is_bot-only sender as a bot after profile resolution", () => {
-    const config = makeConfig();
     // No bot_id on the event and no cached profile — normalization alone
     // cannot detect the bot.
     const normalized = normalizeSlackDirectMessage(
       makeDmEvent({ user: "UBOT99" }),
       "evt-enrich-1",
-      config,
     );
     expect(normalized).not.toBeNull();
     expect(normalized!.botSender).toBeUndefined();
@@ -2134,11 +1931,9 @@ describe("enrichNormalizedActor", () => {
   });
 
   it("does not classify a human sender as a bot", () => {
-    const config = makeConfig();
     const normalized = normalizeSlackDirectMessage(
       makeDmEvent(),
       "evt-enrich-2",
-      config,
     );
     expect(normalized).not.toBeNull();
 
@@ -2153,7 +1948,6 @@ describe("enrichNormalizedActor", () => {
   });
 
   it("preserves an existing botSender derived from bot_id", () => {
-    const config = makeConfig();
     const normalized = normalizeSlackDirectMessage(
       makeDmEvent({
         user: "UBOT99",
@@ -2161,7 +1955,6 @@ describe("enrichNormalizedActor", () => {
         bot_profile: { name: "Peer Assistant", app_id: "A0EXAMPLE" },
       }),
       "evt-enrich-3",
-      config,
     );
     expect(normalized).not.toBeNull();
 
@@ -2194,9 +1987,8 @@ describe("DM app_context", () => {
   };
 
   it("carries the entities the sender had open", () => {
-    const config = makeConfig();
     const event = makeDmEvent({ app_context: { entities: [CHANNEL_ENTITY] } });
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-1", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-1");
 
     expect(result).not.toBeNull();
     expect(result!.event.source.appContext).toEqual({
@@ -2211,12 +2003,11 @@ describe("DM app_context", () => {
   });
 
   it("preserves entity order, which Slack sends by relevance", () => {
-    const config = makeConfig();
     const second = { type: "slack#/types/channel_id", value: "C0SECOND" };
     const event = makeDmEvent({
       app_context: { entities: [CHANNEL_ENTITY, second] },
     });
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-2", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-2");
 
     expect(
       result!.event.source.appContext?.entities.map((e) => e.value),
@@ -2224,33 +2015,26 @@ describe("DM app_context", () => {
   });
 
   it("omits appContext when the sender had nothing open", () => {
-    const config = makeConfig();
     // Slack sends an empty context object rather than dropping the field.
     const event = makeDmEvent({ app_context: {} });
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-3", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-3");
 
     expect(result!.event.source.appContext).toBeUndefined();
   });
 
   it("omits appContext when Slack sends no context at all", () => {
-    const config = makeConfig();
-    const result = normalizeSlackDirectMessage(
-      makeDmEvent(),
-      "evt-ctx-4",
-      config,
-    );
+    const result = normalizeSlackDirectMessage(makeDmEvent(), "evt-ctx-4");
 
     expect(result!.event.source.appContext).toBeUndefined();
   });
 
   it("drops a malformed context rather than failing the message", () => {
-    const config = makeConfig();
     // A DM whose context is garbage must still deliver — the message is the
     // payload, the context is an enrichment.
     const event = makeDmEvent({
       app_context: { entities: "not-an-array" },
     } as unknown as Partial<SlackDirectMessageEvent>);
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-5", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-5");
 
     expect(result).not.toBeNull();
     expect(result!.event.message.content).toBeTruthy();
@@ -2258,7 +2042,6 @@ describe("DM app_context", () => {
   });
 
   it("drops only the malformed entity, keeping its valid siblings", () => {
-    const config = makeConfig();
     // One bad entity must not take the usable ones with it: the message would
     // still deliver, but "summarize this" would go unresolved with the answer
     // sitting right there in the payload.
@@ -2271,7 +2054,7 @@ describe("DM app_context", () => {
         ],
       },
     } as unknown as Partial<SlackDirectMessageEvent>);
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-9", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-9");
 
     expect(result!.event.source.appContext?.entities).toEqual([
       {
@@ -2283,18 +2066,16 @@ describe("DM app_context", () => {
   });
 
   it("omits the context when every entity is malformed", () => {
-    const config = makeConfig();
     const event = makeDmEvent({
       app_context: { entities: [{ type: "slack#/types/channel_id" }] },
     } as unknown as Partial<SlackDirectMessageEvent>);
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-10", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-10");
 
     expect(result).not.toBeNull();
     expect(result!.event.source.appContext).toBeUndefined();
   });
 
   it("carries a message_context entity, whose value is an object not an id", () => {
-    const config = makeConfig();
     // The thread/message case — the one that resolves "summarise this". Its
     // `value` is an object, so a string-only schema silently drops it.
     const event = makeDmEvent({
@@ -2311,7 +2092,7 @@ describe("DM app_context", () => {
         ],
       },
     });
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-7", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-7");
 
     expect(result!.event.source.appContext?.entities[0]).toEqual({
       type: "slack#/types/message_context",
@@ -2321,13 +2102,12 @@ describe("DM app_context", () => {
   });
 
   it("carries enterprise_id when Slack sends one", () => {
-    const config = makeConfig();
     const event = makeDmEvent({
       app_context: {
         entities: [{ ...CHANNEL_ENTITY, enterprise_id: "E0GRID" }],
       },
     });
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-8", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-8");
 
     expect(result!.event.source.appContext?.entities[0]).toMatchObject({
       enterpriseId: "E0GRID",
@@ -2335,9 +2115,8 @@ describe("DM app_context", () => {
   });
 
   it("keeps the raw context verbatim on the event", () => {
-    const config = makeConfig();
     const event = makeDmEvent({ app_context: { entities: [CHANNEL_ENTITY] } });
-    const result = normalizeSlackDirectMessage(event, "evt-ctx-6", config);
+    const result = normalizeSlackDirectMessage(event, "evt-ctx-6");
 
     expect((result!.event.raw as Record<string, unknown>).app_context).toEqual({
       entities: [CHANNEL_ENTITY],

--- a/gateway/src/slack/reaction-normalizer.ts
+++ b/gateway/src/slack/reaction-normalizer.ts
@@ -3,8 +3,10 @@ import {
   type SlackReactionEvent,
   type NormalizedSlackEvent,
 } from "./message-schemas.js";
-import type { GatewayConfig } from "../config.js";
-import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import {
+  hasRoutableIdentity,
+  LOCAL_ROUTE,
+} from "../routing/resolve-assistant.js";
 
 /**
  * Shared normalizer for Slack reaction events. Both `reaction_added` and
@@ -15,7 +17,6 @@ function normalizeSlackReaction(
   event: SlackReactionEvent,
   rawEvent: Record<string, unknown>,
   eventId: string,
-  config: GatewayConfig,
   op: "added" | "removed",
 ): NormalizedSlackEvent | null {
   // `reaction` is load-bearing: it forms the `callbackData` and part of the
@@ -34,8 +35,7 @@ function normalizeSlackReaction(
 
   const channel = event.item.channel;
 
-  const routing = resolveAssistant(config, channel, event.user);
-  if (isRejection(routing)) return null;
+  if (!hasRoutableIdentity(channel, event.user)) return null;
 
   const prefix = op === "added" ? "reaction" : "reaction_removed";
   const callbackData = `${prefix}:${event.reaction}`;
@@ -69,7 +69,7 @@ function normalizeSlackReaction(
       },
       raw: rawEvent,
     },
-    routing,
+    routing: LOCAL_ROUTE,
     threadTs: event.item.ts,
     channel,
   };
@@ -86,7 +86,6 @@ function normalizeSlackReaction(
 export function normalizeSlackReactionAdded(
   event: unknown,
   eventId: string,
-  config: GatewayConfig,
 ): NormalizedSlackEvent | null {
   const parsed = slackReactionEventSchema.safeParse(event);
   if (!parsed.success) return null;
@@ -94,7 +93,6 @@ export function normalizeSlackReactionAdded(
     parsed.data,
     event as Record<string, unknown>,
     eventId,
-    config,
     "added",
   );
 }
@@ -110,7 +108,6 @@ export function normalizeSlackReactionAdded(
 export function normalizeSlackReactionRemoved(
   event: unknown,
   eventId: string,
-  config: GatewayConfig,
 ): NormalizedSlackEvent | null {
   const parsed = slackReactionEventSchema.safeParse(event);
   if (!parsed.success) return null;
@@ -118,7 +115,6 @@ export function normalizeSlackReactionRemoved(
     parsed.data,
     event as Record<string, unknown>,
     eventId,
-    config,
     "removed",
   );
 }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1130,43 +1130,24 @@ export class SlackSocketModeClient {
 
     let normalized: NormalizedSlackEvent | null;
     if (isReactionAdded) {
-      normalized = normalizeSlackReactionAdded(
-        event,
-        eventId,
-        this.config.gatewayConfig,
-      );
+      normalized = normalizeSlackReactionAdded(event, eventId);
     } else if (isReactionRemoved) {
-      normalized = normalizeSlackReactionRemoved(
-        event,
-        eventId,
-        this.config.gatewayConfig,
-      );
+      normalized = normalizeSlackReactionRemoved(event, eventId);
     } else if (isAppMention) {
       normalized = normalizeSlackAppMention(
         event,
         eventId,
-        this.config.gatewayConfig,
         this.config.botToken,
         renderContext,
       );
     } else if (isMessageChanged) {
-      normalized = normalizeSlackMessageEdit(
-        event,
-        eventId,
-        this.config.gatewayConfig,
-        renderContext,
-      );
+      normalized = normalizeSlackMessageEdit(event, eventId, renderContext);
     } else if (isMessageDeleted) {
-      normalized = normalizeSlackMessageDelete(
-        event,
-        eventId,
-        this.config.gatewayConfig,
-      );
+      normalized = normalizeSlackMessageDelete(event, eventId);
     } else if (isActiveThreadReply) {
       normalized = normalizeSlackChannelMessage(
         event,
         eventId,
-        this.config.gatewayConfig,
         this.config.botToken,
         renderContext,
       );
@@ -1174,7 +1155,6 @@ export class SlackSocketModeClient {
       normalized = normalizeSlackDirectMessage(
         event,
         eventId,
-        this.config.gatewayConfig,
         this.config.botToken,
         renderContext,
       );
@@ -1475,7 +1455,6 @@ export class SlackSocketModeClient {
     const normalized = normalizeSlackBlockActions(
       payload,
       envelopeId ?? "unknown",
-      this.config.gatewayConfig,
     );
     if (normalized) {
       this.onEvent(normalized);


### PR DESCRIPTION
## Prompt / plan

Follow-up to #39454, addressing the two review comments left on it:

- [`guardian-bootstrap.ts:60`](https://github.com/vellum-ai/vellum-assistant/pull/39454#discussion_r3674521299) — "Can we just delete this `DAEMON_INTERNAL_ASSISTANT_ID` too?"
- [`resolve-assistant.ts:9`](https://github.com/vellum-ai/vellum-assistant/pull/39454#discussion_r3674540222) — "I believe we could likely delete this method too"

Both yes.

`resolveAssistant` had one job left after #39454: return the local assistant unless the event carried no identity at all. That's a boolean question wearing an outcome union, so it becomes one:

- **`hasRoutableIdentity(conversationId, actorId)`** — the fail-closed backstop, behavior unchanged, still the only reason an event is dropped here.
- **`LOCAL_ROUTE`** — the frozen route every identified event takes.

`isRejection`, `RouteRejection`, and `RoutingOutcome` go with it. Ingress handlers now read as a guard plus a constant rather than unwrapping a union that could only ever hold one shape. `resolveAssistantByPhoneNumber` stays — Twilio still resolves a real per-number assistant — and narrows from `RoutingOutcome` to `RouteResult`.

The `DAEMON_INTERNAL_ASSISTANT_ID = LOCAL_ASSISTANT_ID` aliases in `guardian-bootstrap.ts` and `pair.ts` were pure indirection, inlined.

**Knock-on cleanup:** with routing gone, `config` was dead in all six Slack normalizers. Dropped the parameter rather than underscore-prefixing it.

### Two things worth a reviewer's attention

**`routingEntries` no longer selects an assistant.** It could not meaningfully do so — the gateway fronts one daemon and `RuntimeInboundPayload` carries no assistant id — so a `conversation_id`/`actor_id` entry now contributes its key but not its `assistantId`. Tests asserting an entry's assistantId were updated to `LOCAL_ASSISTANT_ID`.

**`routingEntries` itself stays, and is not vestigial.** This surprised me while scoping the deletion: `socket-mode.ts` reads `conversation_id` entries as a *Slack channel-subscription list* — `isChannelSubscribed` (`:487`, reaction admission) and reconnect catch-up enumeration (`:1306`) both depend on it. Deleting the field would have silently degraded Slack rather than being a pure cleanup. Replacing that overload with a real subscription config is separate work, not folded in here.

## Test plan

- `tsc --noEmit` clean for `gateway/`; the 10 remaining errors are the pre-existing `ArrayBufferLike`/websocket typing issues, verified identical on a clean baseline and in files this PR doesn't touch.
- Full gateway suite: **631 failures vs a 644 main baseline, zero new** (`comm -13` on sorted failing-test-name lists).
- **All twelve touched suites also run in isolation, all green** — resolve-assistant (7), slack/normalize (129), slack-normalize (39), slack-reaction-normalize (7), slack-display-name (20), socket-mode-thread-tracking (40), socket-mode-catchup (18), telegram-webhook (15), telegram-webhook-handler (15), whatsapp-webhook (19), email-webhook (23), twilio-voice-webhook (19).

That last step is deliberate. Name-diffing the full run **cannot see a regression inside a file that was already failing**, which is exactly how #39454's socket-mode breakage reached CI. Running each touched suite alone is the check that catches it; it found 10 real assertion breaks in this PR that the diff reported as clean.

One combined-run artifact worth noting: running 8 Slack/Telegram suites in a single `bun test` process produces a `downloadAttachment` mock leak (2 errors). It reproduces identically on `main`, and each file passes alone.

## Not addressed here

The two Codex P1s on #39454 are still open and are **not** cleanup — both are consequences of removing the reject path in that PR, and both need admission ordering changes in the webhook pipeline rather than edits to this diff:

1. `/new` reaches `handleNewCommand()` before `handleInbound()`, so neither the `no_one` kill switch nor the runtime trust floor runs before `resetConversation()` mutates state.
2. Attachment download/upload happens before `handleInbound()`, so a denied message can still consume persistent storage.

Happy to take those next if you want them prioritized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ga7B6XfAAMzr3QSFV5jpw

---
_Generated by [Claude Code](https://claude.ai/code/session_011ga7B6XfAAMzr3QSFV5jpw)_