### PR TITLE
polish(web): make the Assistant Access key scannable (LUM-2905)

### DIFF
--- a/clients/web/src/domains/channels/components/channel-trust-floor-section.tsx
+++ b/clients/web/src/domains/channels/components/channel-trust-floor-section.tsx
@@ -57,7 +57,7 @@ export function ChannelTrustFloorSection({
         // (e.g. `no_one`) policy and let the user overwrite it.
         <Typography
           as="span"
-          variant="body-small-default"
+          variant="body-small-lighter"
           className="text-[color:var(--content-tertiary)]"
         >
           Loading…
@@ -65,7 +65,7 @@ export function ChannelTrustFloorSection({
       ) : error ? (
         <Typography
           as="span"
-          variant="body-small-default"
+          variant="body-small-lighter"
           className="text-[color:var(--content-negative)]"
         >
           Couldn’t load this setting. Try reopening this page.
@@ -83,7 +83,7 @@ export function ChannelTrustFloorSection({
           </div>
           <Typography
             as="span"
-            variant="body-small-default"
+            variant="body-small-lighter"
             className="text-[color:var(--content-tertiary)]"
           >
             {descriptions[value]}

--- a/clients/web/src/domains/channels/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-list.tsx
@@ -218,7 +218,7 @@ export function SlackChannelList({
     <div className="flex flex-col gap-3 p-4">
       <Typography
         as="p"
-        variant="body-small-default"
+        variant="body-small-lighter"
         className="text-[color:var(--content-tertiary)]"
       >
         {presenceHint}
@@ -226,7 +226,7 @@ export function SlackChannelList({
       {loading ? (
         <Typography
           as="span"
-          variant="body-small-default"
+          variant="body-small-lighter"
           className="text-[color:var(--content-tertiary)]"
         >
           Loading…
@@ -234,7 +234,7 @@ export function SlackChannelList({
       ) : error ? (
         <Typography
           as="span"
-          variant="body-small-default"
+          variant="body-small-lighter"
           className="text-[color:var(--content-negative)]"
         >
           Couldn’t load channels. Try reopening this page.
@@ -289,7 +289,7 @@ export function SlackChannelList({
           {visibleChannels.length === 0 ? (
             <Typography
               as="span"
-              variant="body-small-default"
+              variant="body-small-lighter"
               className="py-4 text-center text-[color:var(--content-tertiary)]"
             >
               No channels match.

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -1,5 +1,3 @@
-import { Link } from "react-router";
-
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import {
@@ -9,13 +7,12 @@ import {
 } from "@/domains/channels/slack-channel-overrides";
 import { TierDot } from "@/domains/channels/components/tier-picker";
 import type { RiskThreshold } from "@/utils/threshold-presets";
-import { routes } from "@/utils/routes";
 
 /**
  * One line per level, all on the single lookup-depth axis: how much the
  * assistant does on its own when answering other people before checking with
- * the owner. The per-level lines carry the whole explanation (LUM-2905) — the
- * line above them only says who the levels apply to.
+ * the owner. The per-level lines are the whole key (LUM-2905) — the card
+ * header carries the Trust Rules pointer.
  *
  * Grounded in what a channel cell can actually delegate
  * (`assistant/src/tools/tool-approval-handler.ts` → `isChannelLiftable`): only
@@ -45,21 +42,28 @@ export interface SlackChannelTierLegendProps {
 }
 
 /**
- * Always-visible Assistant Access key in the default-access card footer: the
- * levels themselves — each name over its {@link tierDescription} line, which
- * carries the full meaning — then one line of scope (who the levels apply to,
- * plus the Trust Rules link). No heading: the rows above the footer already
- * establish what is being picked. Everything renders on screen — no hover
- * tooltip — so the meaning is reachable on touch; the copy stays terse so the
- * key scans (LUM-2905). The level the global default resolves to is marked
- * "· default", matching the per-row picker so the two read together.
+ * Always-visible Assistant Access key in the default-access card footer: only
+ * the levels themselves, each name over its {@link tierDescription} line,
+ * which carries the full meaning. No heading and no scope line: the rows
+ * above the footer already establish what is being picked, and the "applies
+ * to other people in the channel" scope fact from #39143 was deliberately
+ * traded away for brevity in LUM-2905 — restore a scope line here if that
+ * confusion resurfaces. Everything renders on screen — no hover tooltip — so
+ * the meaning is reachable on touch. The level the global default resolves to
+ * is marked "· default", matching the per-row picker so the two read
+ * together.
+ *
+ * The key lists levels most-permissive-first (Conservative before Strict) so
+ * the usual default reads first; the picker menu keeps preset order, which is
+ * fine because each key entry names its level.
  */
 export function SlackChannelTierLegend({ defaultTier }: SlackChannelTierLegendProps) {
   const shownDefault = channelTierBehavesAs(defaultTier ?? undefined) ?? null;
+  const legendTiers = [...CHANNEL_TIER_VALUES].reverse();
   return (
     <div className="flex flex-col gap-2 px-4 py-3">
       <ul className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
-        {CHANNEL_TIER_VALUES.map((tier) => {
+        {legendTiers.map((tier) => {
           const meta = CAPABILITY_TIER_META[tier];
           return (
             <li key={tier} className="flex flex-col gap-0.5">
@@ -78,9 +82,12 @@ export function SlackChannelTierLegend({ defaultTier }: SlackChannelTierLegendPr
                   </Typography>
                 ) : null}
               </span>
+              {/* body-small-lighter, not -default: these lines wrap, and the
+                  -default/-emphasised variants are line-height-1 single-line
+                  label styles (tokens.css). */}
               <Typography
                 as="span"
-                variant="body-small-default"
+                variant="body-small-lighter"
                 className="text-[color:var(--content-tertiary)]"
               >
                 {tierDescription(tier)}
@@ -89,20 +96,6 @@ export function SlackChannelTierLegend({ defaultTier }: SlackChannelTierLegendPr
           );
         })}
       </ul>
-      <Typography
-        as="p"
-        variant="body-small-default"
-        className="text-[color:var(--content-tertiary)]"
-      >
-        For other people in the channel — you keep your global setting.{" "}
-        <Link
-          to={routes.settings.privacy}
-          className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
-        >
-          Trust Rules
-        </Link>{" "}
-        fine-tune when it asks.
-      </Typography>
     </div>
   );
 }

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -12,25 +12,25 @@ import type { RiskThreshold } from "@/utils/threshold-presets";
 import { routes } from "@/utils/routes";
 
 /**
- * Full per-level help copy, framed around what the assistant does on its own
- * when answering other people in the channel. Rendered inline under each name
- * in the key, so the meaning is on screen without hovering — plain text (not
- * JSX) because it interpolates the assistant name. The terse
- * `CAPABILITY_TIER_META.sublabel` is the picker's short form, not used here.
+ * One short line per level, all on the single lookup-depth axis: how much the
+ * assistant does on its own when answering other people before checking with
+ * the owner. Fuller than the picker's `CAPABILITY_TIER_META.sublabel`, but
+ * deliberately not an explainer — the footer carries the shared boundary, so
+ * each line only has to say what runs without asking.
  *
  * Grounded in what a channel cell can actually delegate
  * (`assistant/src/tools/tool-approval-handler.ts` → `isChannelLiftable`): only
  * non-executing side effects in the assistant's own workspace — reads, public
- * `web_fetch`, and ordinary in-workspace file writes. "Take notes" describes
+ * `web_fetch`, and ordinary in-workspace file writes. "Takes notes" describes
  * those writes without implying documents: the document tools run on the host
  * and stay on the capability floor. Everything the footer names is floored at
  * every level, so the two levels differ only in whether that narrow set runs
  * on its own or asks first.
  */
-function tierDescription(tier: RiskThreshold, assistantName: string): string {
+function tierDescription(tier: RiskThreshold): string {
   return tier === "none"
-    ? `${assistantName} replies, but asks you before doing anything else, even a web search.`
-    : `${assistantName} can look things up and take notes on its own: web searches, public web pages, and reading and writing files in its own workspace.`;
+    ? "Replies, but asks first for anything else."
+    : "Looks things up and takes notes on its own.";
 }
 
 export interface SlackChannelTierLegendProps {
@@ -46,11 +46,13 @@ export interface SlackChannelTierLegendProps {
 
 /**
  * Always-visible Assistant Access key in the default-access card footer: a
- * heading, who the levels apply to, every level as its name over the full
- * {@link tierDescription} sentence, then the boundary that holds at every
- * level. Everything renders on screen — no hover tooltip — so the meaning is
- * reachable on touch. The level the global default resolves to is marked
- * "· default", matching the per-row picker so the two read together.
+ * heading, one paragraph of shared context (who the levels apply to, then the
+ * boundary that holds at every level), and last the levels themselves — each
+ * name over its short {@link tierDescription} line — so the key ends on the
+ * actual choice. Everything renders on screen — no hover tooltip — so the
+ * meaning is reachable on touch; the copy stays terse so the key scans
+ * (LUM-2905). The level the global default resolves to is marked "· default",
+ * matching the per-row picker so the two read together.
  */
 export function SlackChannelTierLegend({
   assistantName,
@@ -67,8 +69,17 @@ export function SlackChannelTierLegend({
         variant="body-small-default"
         className="text-[color:var(--content-tertiary)]"
       >
-        Applies to other people in the channel — your own requests use your
-        global Assistant Access.
+        For other people in the channel — your own requests follow your global
+        setting. Whatever the level, {assistantName} always asks first before
+        running code, changing how it works, reaching your computer or
+        connected accounts, or using skills you haven&rsquo;t vetted. Your{" "}
+        <Link
+          to={routes.settings.privacy}
+          className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
+        >
+          Trust Rules
+        </Link>{" "}
+        fine-tune when it asks.
       </Typography>
       <ul className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
         {CHANNEL_TIER_VALUES.map((tier) => {
@@ -95,29 +106,12 @@ export function SlackChannelTierLegend({
                 variant="body-small-default"
                 className="text-[color:var(--content-tertiary)]"
               >
-                {tierDescription(tier, assistantName)}
+                {tierDescription(tier)}
               </Typography>
             </li>
           );
         })}
       </ul>
-      <Typography
-        as="p"
-        variant="body-small-default"
-        className="text-[color:var(--content-tertiary)]"
-      >
-        Whatever the level, nothing in this room lets {assistantName} run code,
-        change how it works, reach your computer or your connected accounts, or
-        use skills you haven&rsquo;t vetted. Those always come to you first.
-        Your{" "}
-        <Link
-          to={routes.settings.privacy}
-          className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
-        >
-          Trust Rules
-        </Link>{" "}
-        fine-tune when it asks.
-      </Typography>
     </div>
   );
 }

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -11,18 +11,18 @@ import type { RiskThreshold } from "@/utils/threshold-presets";
 /**
  * One line per level, all on the single lookup-depth axis: how much the
  * assistant does on its own when answering other people before checking with
- * the owner. The per-level lines are the whole key (LUM-2905) — the card
+ * the owner. The per-level lines are the whole key (LUM-2905); the card
  * header carries the Trust Rules pointer.
  *
  * Grounded in what a channel cell can actually delegate
  * (`assistant/src/tools/tool-approval-handler.ts` → `isChannelLiftable`): only
- * non-executing side effects in the assistant's own workspace — reads, public
- * `web_fetch`, and ordinary in-workspace file writes. "Takes notes" describes
+ * non-executing side effects in the assistant's own workspace (reads, public
+ * `web_fetch`, and ordinary in-workspace file writes). "Takes notes" describes
  * those writes without implying documents: the document tools run on the host
  * and stay on the capability floor.
  *
  * The capability floor (code, the owner's computer or accounts, unvetted
- * skills always escalate) compresses to "asks first for anything bigger" —
+ * skills always escalate) compresses to "asks first for anything bigger":
  * accurate without the inventory, and it keeps the two lines the same weight:
  * both name what runs on its own, then that everything else asks.
  */
@@ -36,7 +36,7 @@ export interface SlackChannelTierLegendProps {
   /**
    * The level the owner's global setting resolves to, marked "· default" in
    * the key so it lines up with the rows (which name the same level). `null`
-   * while unknown — no level is marked.
+   * while unknown; no level is marked.
    */
   defaultTier: RiskThreshold | null;
 }
@@ -47,8 +47,8 @@ export interface SlackChannelTierLegendProps {
  * which carries the full meaning. No heading and no scope line: the rows
  * above the footer already establish what is being picked, and the "applies
  * to other people in the channel" scope fact from #39143 was deliberately
- * traded away for brevity in LUM-2905 — restore a scope line here if that
- * confusion resurfaces. Everything renders on screen — no hover tooltip — so
+ * traded away for brevity in LUM-2905; restore a scope line here if that
+ * confusion resurfaces. Everything renders on screen (no hover tooltip) so
  * the meaning is reachable on touch. The level the global default resolves to
  * is marked "· default", matching the per-row picker so the two read
  * together.

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -12,30 +12,30 @@ import type { RiskThreshold } from "@/utils/threshold-presets";
 import { routes } from "@/utils/routes";
 
 /**
- * One short line per level, all on the single lookup-depth axis: how much the
+ * One line per level, all on the single lookup-depth axis: how much the
  * assistant does on its own when answering other people before checking with
- * the owner. Fuller than the picker's `CAPABILITY_TIER_META.sublabel`, but
- * deliberately not an explainer — the footer carries the shared boundary, so
- * each line only has to say what runs without asking.
+ * the owner. The per-level lines carry the whole explanation (LUM-2905) — the
+ * line above them only says who the levels apply to.
  *
  * Grounded in what a channel cell can actually delegate
  * (`assistant/src/tools/tool-approval-handler.ts` → `isChannelLiftable`): only
  * non-executing side effects in the assistant's own workspace — reads, public
  * `web_fetch`, and ordinary in-workspace file writes. "Takes notes" describes
  * those writes without implying documents: the document tools run on the host
- * and stay on the capability floor. Everything the footer names is floored at
- * every level, so the two levels differ only in whether that narrow set runs
- * on its own or asks first.
+ * and stay on the capability floor.
+ *
+ * The capability floor (code, the owner's computer or accounts, unvetted
+ * skills always escalate) compresses to "asks first for anything bigger" —
+ * accurate without the inventory, and it keeps the two lines the same weight:
+ * both name what runs on its own, then that everything else asks.
  */
 function tierDescription(tier: RiskThreshold): string {
   return tier === "none"
-    ? "Replies, but asks first for anything else."
-    : "Looks things up and takes notes on its own.";
+    ? "Replies, but asks first for anything else, even a web search."
+    : "Looks things up and takes notes on its own; asks first for anything bigger.";
 }
 
 export interface SlackChannelTierLegendProps {
-  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
-  assistantName: string;
   /**
    * The level the owner's global setting resolves to, marked "· default" in
    * the key so it lines up with the rows (which name the same level). `null`
@@ -45,42 +45,19 @@ export interface SlackChannelTierLegendProps {
 }
 
 /**
- * Always-visible Assistant Access key in the default-access card footer: a
- * heading, one paragraph of shared context (who the levels apply to, then the
- * boundary that holds at every level), and last the levels themselves — each
- * name over its short {@link tierDescription} line — so the key ends on the
- * actual choice. Everything renders on screen — no hover tooltip — so the
- * meaning is reachable on touch; the copy stays terse so the key scans
- * (LUM-2905). The level the global default resolves to is marked "· default",
- * matching the per-row picker so the two read together.
+ * Always-visible Assistant Access key in the default-access card footer: the
+ * levels themselves — each name over its {@link tierDescription} line, which
+ * carries the full meaning — then one line of scope (who the levels apply to,
+ * plus the Trust Rules link). No heading: the rows above the footer already
+ * establish what is being picked. Everything renders on screen — no hover
+ * tooltip — so the meaning is reachable on touch; the copy stays terse so the
+ * key scans (LUM-2905). The level the global default resolves to is marked
+ * "· default", matching the per-row picker so the two read together.
  */
-export function SlackChannelTierLegend({
-  assistantName,
-  defaultTier,
-}: SlackChannelTierLegendProps) {
+export function SlackChannelTierLegend({ defaultTier }: SlackChannelTierLegendProps) {
   const shownDefault = channelTierBehavesAs(defaultTier ?? undefined) ?? null;
   return (
     <div className="flex flex-col gap-2 px-4 py-3">
-      <Typography as="span" variant="body-small-emphasised">
-        Assistant Access levels
-      </Typography>
-      <Typography
-        as="p"
-        variant="body-small-default"
-        className="text-[color:var(--content-tertiary)]"
-      >
-        For other people in the channel — your own requests follow your global
-        setting. Whatever the level, {assistantName} always asks first before
-        running code, changing how it works, reaching your computer or
-        connected accounts, or using skills you haven&rsquo;t vetted. Your{" "}
-        <Link
-          to={routes.settings.privacy}
-          className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
-        >
-          Trust Rules
-        </Link>{" "}
-        fine-tune when it asks.
-      </Typography>
       <ul className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
         {CHANNEL_TIER_VALUES.map((tier) => {
           const meta = CAPABILITY_TIER_META[tier];
@@ -112,6 +89,20 @@ export function SlackChannelTierLegend({
           );
         })}
       </ul>
+      <Typography
+        as="p"
+        variant="body-small-default"
+        className="text-[color:var(--content-tertiary)]"
+      >
+        For other people in the channel — you keep your global setting.{" "}
+        <Link
+          to={routes.settings.privacy}
+          className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
+        >
+          Trust Rules
+        </Link>{" "}
+        fine-tune when it asks.
+      </Typography>
     </div>
   );
 }

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
@@ -124,10 +124,7 @@ export function SlackChannelTypeDefaults({
         })}
       </Card.Body>
       <Card.Footer className="p-0">
-        <SlackChannelTierLegend
-          assistantName={assistantName}
-          defaultTier={globalDefaultTier}
-        />
+        <SlackChannelTierLegend defaultTier={globalDefaultTier} />
       </Card.Footer>
     </Card.Root>
   );

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
@@ -1,4 +1,5 @@
 import { Hash, MessageSquare } from "lucide-react";
+import { Link } from "react-router";
 
 import { Card } from "@vellumai/design-library/components/card";
 import { ListRow } from "@vellumai/design-library/components/list-row";
@@ -8,6 +9,7 @@ import { SlackChannelTierLegend } from "@/domains/channels/components/slack-chan
 import { TierPicker } from "@/domains/channels/components/tier-picker";
 import type { ChannelDefaultBucket } from "@/domains/channels/slack-channel-overrides";
 import type { RiskThreshold } from "@/utils/threshold-presets";
+import { routes } from "@/utils/routes";
 
 interface BucketRow {
   bucket: ChannelDefaultBucket;
@@ -78,13 +80,22 @@ export function SlackChannelTypeDefaults({
       <Card.Header>
         <div className="flex flex-col gap-1">
           Default access
+          {/* body-small-lighter: this subtitle wraps to two lines, and
+              body-small-default is a line-height-1 single-line label style. */}
           <Typography
             as="p"
-            variant="body-small-default"
+            variant="body-small-lighter"
             className="text-[color:var(--content-tertiary)]"
           >
             How much {assistantName} does on its own, by conversation type.
-            Individual channels can override this below.
+            Individual channels can override this below, and{" "}
+            <Link
+              to={routes.settings.privacy}
+              className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
+            >
+              Trust Rules
+            </Link>{" "}
+            fine-tune when it asks.
           </Typography>
         </div>
       </Card.Header>

--- a/clients/web/src/domains/channels/slack-channel-overrides.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.ts
@@ -65,7 +65,7 @@ interface CapabilityTierMeta {
   label: string;
   /**
    * Short qualifier shown as the picker option's tooltip. Frames how much the
-   * assistant does on its own before checking with the owner — reads/answers
+   * assistant does on its own before checking with the owner: reads/answers
    * only, since writes/sends/spends always escalate. The slightly fuller
    * per-tier line lives in the legend (`SlackChannelTierLegend`).
    */

--- a/clients/web/src/domains/channels/slack-channel-overrides.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.ts
@@ -64,11 +64,10 @@ interface CapabilityTierMeta {
   /** Preset name, straight from the matching global Assistant Access preset. */
   label: string;
   /**
-   * Short qualifier shown beside the label in the picker and the legend key.
-   * Frames how much the assistant does on its own before checking with the
-   * owner — reads/answers only, since writes/sends/spends always escalate. The
-   * full per-tier sentence lives in the legend (`SlackChannelTierLegend`); it
-   * interpolates the assistant name, so it can't be a static string here.
+   * Short qualifier shown as the picker option's tooltip. Frames how much the
+   * assistant does on its own before checking with the owner — reads/answers
+   * only, since writes/sends/spends always escalate. The slightly fuller
+   * per-tier line lives in the legend (`SlackChannelTierLegend`).
    */
   sublabel: string;
   tone: TagTone;


### PR DESCRIPTION
Fixes LUM-2905.

## TL;DR

The Default Access card's "Assistant Access levels" legend was a wall of text. It's now just the two levels, one line each, with the Trust Rules pointer folded into the card header. While in there, fixed a typography-variant bug (single-line label style used for wrapping prose) across the whole Channels page.

## What changes for the user

| Before | After |
| --- | --- |
| "Assistant Access levels" heading + "Applies to other people…" subtitle above the key | Both removed; the key is just the two levels |
| Strict: "Example Assistant replies, but asks you before doing anything else, even a web search." | "Replies, but asks first for anything else, even a web search." |
| Conservative: "Example Assistant can look things up and take notes on its own: web searches, public web pages, and reading and writing files in its own workspace." | "Looks things up and takes notes on its own; asks first for anything bigger." |
| Three-sentence disclaimer enumerating the capability floor, with the Trust Rules link | Floor folds into Conservative's "asks first for anything bigger"; Trust Rules joins the card header: "Individual channels can override this below, and Trust Rules fine-tune when it asks." |
| Key ordered Strict, Conservative | Conservative (the usual default) first; the picker menu keeps preset order |
| Wrapping helper text across the page rendered at line-height 1 (cramped) | Wrapping prose (tier lines, card subtitle, /invite hint, trust-floor descriptions, loading/error texts) uses `body-small-lighter` (12/18px), the design system's multi-line small variant |

## Why it's safe

- Copy, ordering, and typography-variant changes only; no behavior, routing, or persistence changes. `SlackChannelTierLegend` loses its now-unused `assistantName` prop.
- Keeps the accuracy constraints from #39143: both tier lines stay on the single lookup-depth axis and nothing claims an action auto-approves that doesn't (the capability floor compresses to "asks first for anything bigger"). The "applies to other people in the channel" scope fact was deliberately dropped for brevity; the component docstring records where to restore it if that confusion resurfaces.
- Everything still renders on screen (no hover tooltip), preserving the touch-reachability decision from #39101/#39143.
- The typography sweep touches only `Typography` `variant` props: wrapping prose moves to `body-small-lighter`; true single-line labels (section headings, the "· default" marker, filter pills) keep their label variants. All colors and link styling already use design tokens, matching the design library's own patterns.
- Also fixed the stale `sublabel` docstring in `slack-channel-overrides.ts` (it claimed the legend renders the sublabel; only the picker tooltip does).
- Review feedback addressed: em dashes removed from all JSDoc rewritten by this PR, per the AGENTS.md em-dash rule. Pre-existing em dashes on untouched lines are left alone per the no-retroactive-sweep clause.
- Verified: `tsc --noEmit` clean, lint clean on touched files, channels-domain tests pass per-file, and every state checked visually in Storybook (Default Access card + channel list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)