### PR TITLE
feat(web): from-to credits chip in the takeover, one format for checkout and in-place changes

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -505,14 +505,21 @@ function LocationProbe() {
   return <div data-testid="loc">{location.pathname + location.search}</div>;
 }
 
-/** An assistant whose pod sits at `machineSize`, the machine chip's from-side. */
-function makeAssistant(id: string, machineSize: MachineSizeEnum): Assistant {
+/**
+ * An assistant whose pod sits at `machineSize` on a `provisionedStorageGib`
+ * volume, the two resource from-sides the chips read.
+ */
+function makeAssistant(
+  id: string,
+  machineSize: MachineSizeEnum,
+  provisionedStorageGib = 10,
+): Assistant {
   return {
     id,
     name: "Casey",
     handle: "casey",
     machine_size: machineSize,
-    provisioned_storage_gib: 10,
+    provisioned_storage_gib: provisionedStorageGib,
   } as Assistant;
 }
 
@@ -692,6 +699,9 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     // value the page can read once the await resolves is already post-change.
     // Model that by flipping each fixture to its post-change value before the
     // switch is confirmed: only a capture taken ahead of the await survives it.
+    // The disk carries 25 GB while the billed tier reads 30, the spread a
+    // volume keeps after its tier was lowered. The chip must state the disk.
+    assistantFixture = makeAssistant("assistant-primary", "medium", 25);
     const { findByRole, findByTestId } = renderInteractive(
       { ...proSuperSubscription(), selected_credit_tier: "credits_45" },
       {
@@ -717,7 +727,7 @@ describe("PlansPage — Pro package switch (change-package)", () => {
       max_machine_tier: "large",
       selected_storage_gib: 60,
     });
-    assistantFixture = makeAssistant("assistant-primary", "large");
+    assistantFixture = makeAssistant("assistant-primary", "large", 60);
 
     fireEvent.click(await findByRole("button", { name: "Unleash Ultra" }));
     fireEvent.click(await findByTestId("confirm-package-switch-button"));
@@ -725,7 +735,7 @@ describe("PlansPage — Pro package switch (change-package)", () => {
 
     expect(takeoverResizeContext?.fromSnapshot).toEqual({
       machineSize: "medium",
-      storageGib: 30,
+      storageGib: 25,
     });
     expect(takeoverResizeContext?.credits).toEqual({
       fromTier: "credits_45",
@@ -1342,7 +1352,7 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
       fromTier: null,
       toTier: "credits_50",
     });
-    // The pod's own size is the machine from-side, not the billing ceiling.
+    // The pod's own machine and disk are the from-sides, not the billed tiers.
     expect(takeoverResizeContext?.fromSnapshot).toEqual({
       machineSize: "large",
       storageGib: 10,

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -55,6 +55,8 @@ import {
   makeUltraPackage,
 } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 import type {
+  Assistant,
+  MachineSizeEnum,
   OnboardingStateResponse,
   PackageChangeResponse,
   PlanListResponse,
@@ -99,6 +101,12 @@ let changePackageError: unknown = null;
 let subscriptionFixture: SubscriptionResponse | null = null;
 let plansFixture: PlanListResponse | null = null;
 let onboardingFixture: OnboardingStateResponse | null = null;
+// The assistant the machine from-side is read off, plus a log of how it was
+// asked for, so the primary-then-active resolution can be asserted.
+let assistantFixture: Assistant | null = null;
+let activeAssistantFixture: Assistant | null = null;
+const assistantByIdCalls: (string | null)[] = [];
+let activeAssistantCalls = 0;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -153,6 +161,17 @@ mock.module("@/generated/api/sdk.gen", () => ({
     Promise.resolve({ data: plansFixture, response: { ok: true } }),
   organizationsBillingSubscriptionOnboardingRetrieve: () =>
     Promise.resolve({ data: onboardingFixture, response: { ok: true } }),
+  assistantsRetrieve: (opts: { path?: { id?: string } }) => {
+    assistantByIdCalls.push(opts.path?.id ?? null);
+    return Promise.resolve({ data: assistantFixture, response: { ok: true } });
+  },
+  assistantsActiveRetrieve: () => {
+    activeAssistantCalls += 1;
+    return Promise.resolve({
+      data: activeAssistantFixture,
+      response: { ok: true },
+    });
+  },
 }));
 
 mock.module("@/runtime/browser", () => ({
@@ -183,23 +202,27 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 // The full loading → "You're all set!" flow is owned by
 // billing-onboarding-modal.test.tsx's resize-mode suite.
 //
-// Captures the credit tier the page threads in so the credit-change confirmation
-// (and the switch path's deliberate omission of it) can be asserted directly.
-let takeoverResizeCredits: string | null | undefined;
+// Captures the context the page threads in, so the pre-change from-sides (and
+// the switch path's omission of an unchanged bundle) can be asserted directly.
+type CapturedResizeContext = {
+  fromSnapshot: { machineSize: string | null; storageGib: number | null };
+  credits: { fromTier: string | null; toTier: string | null } | null;
+};
+let takeoverResizeContext: CapturedResizeContext | undefined;
 mock.module(
   "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal",
   () => ({
     BillingOnboardingModal: ({
       open,
       mode,
-      resizeCredits,
+      resizeContext,
     }: {
       open: boolean;
       mode?: string;
-      resizeCredits?: string | null;
+      resizeContext?: CapturedResizeContext;
     }) => {
       if (open) {
-        takeoverResizeCredits = resizeCredits;
+        takeoverResizeContext = resizeContext;
       }
       return open ? (
         <div data-testid="resize-takeover" data-mode={mode ?? "checkout"} />
@@ -475,6 +498,17 @@ function LocationProbe() {
   return <div data-testid="loc">{location.pathname + location.search}</div>;
 }
 
+/** An assistant whose pod sits at `machineSize`, the machine chip's from-side. */
+function makeAssistant(id: string, machineSize: MachineSizeEnum): Assistant {
+  return {
+    id,
+    name: "Casey",
+    handle: "casey",
+    machine_size: machineSize,
+    provisioned_storage_gib: 10,
+  } as Assistant;
+}
+
 /** Onboarding state carrying a Pro sub's current machine/storage tiers. */
 function onboarding(
   overrides: Partial<OnboardingStateResponse> = {},
@@ -556,8 +590,12 @@ beforeEach(() => {
   subscriptionFixture = null;
   plansFixture = null;
   onboardingFixture = null;
+  assistantFixture = makeAssistant("assistant-primary", "medium");
+  activeAssistantFixture = makeAssistant("assistant-active", "large");
+  assistantByIdCalls.length = 0;
+  activeAssistantCalls = 0;
   toastSuccessCalls.length = 0;
-  takeoverResizeCredits = undefined;
+  takeoverResizeContext = undefined;
   // The stash and the assistants store are module-level globals, so reset both.
   clearTakeoverAvatarStash();
   useResolvedAssistantsStore.setState({
@@ -612,10 +650,111 @@ describe("PlansPage — Pro package switch (change-package)", () => {
 
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
-    // The switch path sources no bundle, so it threads none — a stale value
-    // from a prior custom change must never surface on this takeover.
-    expect(takeoverResizeCredits).toBeUndefined();
+    // The sub holds no bundle and Ultra pins one, so the tier move is threaded.
+    expect(takeoverResizeContext?.credits).toEqual({
+      fromTier: null,
+      toTier: "credits_115",
+    });
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+  });
+
+  test("a switch that leaves the bundle alone threads no credits chip", async () => {
+    // Super pins credits_45 and the sub already holds it, so there is no move to
+    // state and the chip is dropped.
+    const { findByRole, findByTestId } = renderInteractive({
+      ...proMightySubscription(),
+      selected_credit_tier: "credits_45",
+    });
+
+    fireEvent.click(await findByRole("button", { name: "Go Super" }));
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+    await findByTestId("resize-takeover");
+
+    expect(takeoverResizeContext?.credits).toBeNull();
+  });
+
+  test("a package switch hands the takeover the pre-change machine, storage and bundle", async () => {
+    // The server caps the machine before change-package answers, and the hook
+    // then invalidates the subscription and onboarding reads, so every "current"
+    // value the page can read once the await resolves is already post-change.
+    // Model that by flipping each fixture to its post-change value before the
+    // switch is confirmed: only a capture taken ahead of the await survives it.
+    const { findByRole, findByTestId } = renderInteractive(
+      { ...proSuperSubscription(), selected_credit_tier: "credits_45" },
+      {
+        onboardingData: onboarding({
+          primary_assistant_id: "assistant-primary",
+          selected_storage_gib: 30,
+        }),
+      },
+    );
+    // Let the by-id assistant read land before the pod grows.
+    await waitFor(() => expect(assistantByIdCalls.length).toBeGreaterThan(0));
+
+    changePackageData = {
+      status: "ok",
+      package: { key: "ultra", name: "Ultra", version: 1, customized: false },
+    };
+    subscriptionFixture = {
+      ...proSuperSubscription(),
+      selected_credit_tier: "credits_115",
+    };
+    onboardingFixture = onboarding({
+      primary_assistant_id: "assistant-primary",
+      max_machine_tier: "large",
+      selected_storage_gib: 60,
+    });
+    assistantFixture = makeAssistant("assistant-primary", "large");
+
+    fireEvent.click(await findByRole("button", { name: "Unleash Ultra" }));
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+    await findByTestId("resize-takeover");
+
+    expect(takeoverResizeContext?.fromSnapshot).toEqual({
+      machineSize: "medium",
+      storageGib: 30,
+    });
+    expect(takeoverResizeContext?.credits).toEqual({
+      fromTier: "credits_45",
+      toTier: "credits_115",
+    });
+  });
+
+  test("the machine from-side reads the onboarding payload's primary assistant", async () => {
+    // The takeover watches the primary-then-active assistant, so the chip's
+    // from-side has to describe that same pod. In a multi-assistant org the
+    // active one is a different machine.
+    const { findByRole, findByTestId } = renderInteractive(
+      proSuperSubscription(),
+      {
+        onboardingData: onboarding({
+          primary_assistant_id: "assistant-primary",
+        }),
+      },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Unleash Ultra" }));
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+    await findByTestId("resize-takeover");
+
+    expect(assistantByIdCalls).toContain("assistant-primary");
+    expect(activeAssistantCalls).toBe(0);
+    // "medium" is the primary's size; the active assistant reads "large".
+    expect(takeoverResizeContext?.fromSnapshot.machineSize).toBe("medium");
+  });
+
+  test("with no primary named the from-side falls back to the active assistant", async () => {
+    const { findByRole, findByTestId } = renderInteractive(
+      proSuperSubscription(),
+      { onboardingData: onboarding({ primary_assistant_id: null }) },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Unleash Ultra" }));
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+    await findByTestId("resize-takeover");
+
+    expect(assistantByIdCalls).toEqual([]);
+    expect(takeoverResizeContext?.fromSnapshot.machineSize).toBe("large");
   });
 
   test("Pro → Free downgrade confirms first, then opens the Stripe billing portal", async () => {
@@ -1153,8 +1292,17 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     // (which no-ops for active Pro) is never touched.
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
-    // The bundle changed alongside the machine, so it's threaded through too.
-    expect(takeoverResizeCredits).toBe("credits_50");
+    // The bundle changed alongside the machine, so the tier move is threaded
+    // through too, from the pre-change tier the sub held.
+    expect(takeoverResizeContext?.credits).toEqual({
+      fromTier: null,
+      toTier: "credits_50",
+    });
+    // The pod's own size is the machine from-side, not the billing ceiling.
+    expect(takeoverResizeContext?.fromSnapshot).toEqual({
+      machineSize: "large",
+      storageGib: 10,
+    });
     expect(upgradeCall).toBeNull();
   });
 
@@ -1181,10 +1329,30 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     // a readable confirmation moment.
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
-    // The applied bundle is threaded through so the takeover can confirm it —
-    // the credit-only path never reaches the WAITING credits chip.
-    expect(takeoverResizeCredits).toBe("credits_50");
+    // The tier move is threaded through so the takeover can state it; a
+    // credit-only change resolves straight to the terminal phase.
+    expect(takeoverResizeContext?.credits).toEqual({
+      fromTier: null,
+      toTier: "credits_50",
+    });
     expect(upgradeCall).toBeNull();
+  });
+
+  test("a machine-only Continue threads no credits chip", async () => {
+    const { findByRole, findByTestId } = renderInteractive(
+      proMightySubscription(),
+      { plans: customCatalog() },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(machineTierCall).not.toBeNull());
+    await findByTestId("resize-takeover");
+    expect(creditTierCall).toBeNull();
+    expect(takeoverResizeContext?.credits).toBeNull();
   });
 
   // Configure always opens the in-place custom modal for a Pro sub, whatever the

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -101,6 +101,9 @@ let changePackageError: unknown = null;
 let subscriptionFixture: SubscriptionResponse | null = null;
 let plansFixture: PlanListResponse | null = null;
 let onboardingFixture: OnboardingStateResponse | null = null;
+// When non-null the onboarding read waits on this before answering, which holds
+// the query unsettled the way a cold load does.
+let onboardingHold: Promise<void> | null = null;
 // The assistant the machine from-side is read off, plus a log of how it was
 // asked for, so the primary-then-active resolution can be asserted.
 let assistantFixture: Assistant | null = null;
@@ -159,8 +162,12 @@ mock.module("@/generated/api/sdk.gen", () => ({
     Promise.resolve({ data: subscriptionFixture, response: { ok: true } }),
   organizationsBillingPlansRetrieve: () =>
     Promise.resolve({ data: plansFixture, response: { ok: true } }),
-  organizationsBillingSubscriptionOnboardingRetrieve: () =>
-    Promise.resolve({ data: onboardingFixture, response: { ok: true } }),
+  organizationsBillingSubscriptionOnboardingRetrieve: () => {
+    const result = { data: onboardingFixture, response: { ok: true } };
+    return onboardingHold
+      ? onboardingHold.then(() => result)
+      : Promise.resolve(result);
+  },
   assistantsRetrieve: (opts: { path?: { id?: string } }) => {
     assistantByIdCalls.push(opts.path?.id ?? null);
     return Promise.resolve({ data: assistantFixture, response: { ok: true } });
@@ -529,9 +536,12 @@ function renderInteractive(
   {
     plans = fullCatalog(),
     onboardingData = onboarding(),
+    seedOnboarding = true,
   }: {
     plans?: PlanListResponse;
     onboardingData?: OnboardingStateResponse;
+    /** False leaves the onboarding query to fetch, so it mounts unsettled. */
+    seedOnboarding?: boolean;
   } = {},
 ) {
   subscriptionFixture = subscription;
@@ -553,10 +563,12 @@ function renderInteractive(
     subscription,
   );
   client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
-  client.setQueryData(
-    organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
-    onboardingData,
-  );
+  if (seedOnboarding) {
+    client.setQueryData(
+      organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+      onboardingData,
+    );
+  }
   return {
     // Exposed so the checkout test can seed the avatar cache the stash reads.
     client,
@@ -590,6 +602,7 @@ beforeEach(() => {
   subscriptionFixture = null;
   plansFixture = null;
   onboardingFixture = null;
+  onboardingHold = null;
   assistantFixture = makeAssistant("assistant-primary", "medium");
   activeAssistantFixture = makeAssistant("assistant-active", "large");
   assistantByIdCalls.length = 0;
@@ -741,6 +754,37 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     expect(activeAssistantCalls).toBe(0);
     // "medium" is the primary's size; the active assistant reads "large".
     expect(takeoverResizeContext?.fromSnapshot.machineSize).toBe("medium");
+  });
+
+  test("an unsettled onboarding read never resolves the from-side to the active assistant", async () => {
+    // On a cold load the onboarding payload has not answered, so no primary is
+    // named yet. Reading through to the active assistant in that window returns
+    // a real machine size for the wrong pod in a multi-assistant org, and the
+    // capture then states it for the life of the takeover.
+    let releaseOnboarding = () => {};
+    onboardingHold = new Promise<void>((resolve) => {
+      releaseOnboarding = resolve;
+    });
+    const { findByRole, findByTestId } = renderInteractive(
+      proSuperSubscription(),
+      { seedOnboarding: false },
+    );
+
+    const cta = await findByRole("button", { name: "Unleash Ultra" });
+    expect(assistantByIdCalls).toEqual([]);
+    expect(activeAssistantCalls).toBe(0);
+
+    fireEvent.click(cta);
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+    // Let the post-change invalidation refetches settle so the takeover opens.
+    releaseOnboarding();
+    await findByTestId("resize-takeover");
+
+    // Unknown, not the active assistant's "large". Storage has the same window.
+    expect(takeoverResizeContext?.fromSnapshot).toEqual({
+      machineSize: null,
+      storageGib: null,
+    });
   });
 
   test("with no primary named the from-side falls back to the active assistant", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -72,6 +72,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
+import { creditTierKeyUsd } from "@/lib/billing/credit-tiers";
 import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
@@ -140,9 +141,9 @@ function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
   }
   if (current.creditTier != null) {
     // A held/deprecated credit tier absent from the catalog can't resolve to a
-    // catalog label; derive the amount from the tier key (credits_<usd>) so the
-    // paid bundle still shows instead of being silently dropped.
-    const usd = current.creditTier.match(/^credits_(\d+)$/)?.[1];
+    // catalog label; fall back to the amount its key names so the paid bundle
+    // still shows instead of being silently dropped.
+    const usd = creditTierKeyUsd(current.creditTier);
     parts.push(
       findCreditTier(proPlan, current.creditTier)?.label ??
         (usd != null ? `${usd} credits` : "Credit bundle"),

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -33,8 +33,12 @@ import {
   downgradeLabel,
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
-import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
+import {
+  BillingOnboardingModal,
+  type ResizeTakeoverContext,
+} from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { captureTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
+import { usePreferredOrActiveAssistant } from "@/domains/settings/billing/pro-onboarding/use-preferred-or-active-assistant";
 import { findCreditTier } from "@/domains/settings/billing/pro-onboarding/use-provisioning-credits";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
@@ -60,6 +64,7 @@ import type {
   ProPlan,
   SubscriptionUpgradeRequestRequest,
 } from "@/generated/api/types.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import {
   useActiveAssistantIsPlatformHosted,
   useActiveAssistantLifecycleIsLoading,
@@ -183,6 +188,7 @@ export function PlansPage() {
     isPending: changeTiersPending,
     current,
     currentReady,
+    primaryAssistantId,
   } = useChangeTiers({ enabled: platformReady });
   // Native iOS keeps Checkout inside an in-app sheet, so the page holds
   // pre-checkout data until the sheet closes.
@@ -199,10 +205,11 @@ export function PlansPage() {
   // the grow-only resize the platform already fired server-side (no redundant
   // client-driven resize).
   const [resizeTakeoverOpen, setResizeTakeoverOpen] = useState(false);
-  // The credit tier applied by an in-place change, threaded to the takeover's
-  // terminal confirmation. See `ProvisioningStateProps.resizeCredits`.
-  const [resizeCreditTier, setResizeCreditTier] = useState<
-    CreditTierEnum | null | undefined
+  // What the plan looked like before the in-place change this takeover is
+  // watching. Captured pre-dispatch, because every read here reports the applied
+  // change once it returns. See `ResizeTakeoverContext`.
+  const [resizeContext, setResizeContext] = useState<
+    ResizeTakeoverContext | undefined
   >(undefined);
   // `?package=<key>` is a one-shot deep link (from marketing / the checkout
   // no-op bail); once acted on it must never re-fire.
@@ -222,6 +229,19 @@ export function PlansPage() {
   const packages = proPlan?.packages ?? [];
   const hasPackages = packages.length > 0;
   const isProUser = subscription?.plan_id === "pro";
+
+  // The pod whose `machine_size` an in-place change moves, resolved the way the
+  // takeover resolves the assistant it watches: the onboarding payload's primary
+  // when it names one, else the active assistant. Both sides of a machine chip
+  // must describe the same machine in a multi-assistant org. The real size is
+  // what makes that chip honest: a cap that finds the pod already at or below
+  // the new ceiling skips it and creates no resize marker, so a ceiling-derived
+  // from-side would draw a downsize that never runs.
+  const orgReady = useIsOrgReady();
+  const assistant = usePreferredOrActiveAssistant(
+    primaryAssistantId,
+    platformReady && orgReady && isProUser,
+  );
 
   // A Custom sub (unpinned or customized) has no meaningful catalog rank, so
   // it has no current tier: every named card is offered as a switch target —
@@ -540,12 +560,28 @@ export function PlansPage() {
       portalMutation.mutate({});
     };
 
+    /**
+     * The plan's from-sides as they stand at the moment of the call. Both
+     * in-place paths take this BEFORE they dispatch: the server caps the machine
+     * before it answers and the mutation hooks then invalidate the subscription
+     * and onboarding queries `current` derives from, so every read afterwards
+     * reports the change that just landed.
+     */
+    const capturePlanBefore = () => ({
+      creditTier: current.creditTier,
+      fromSnapshot: {
+        machineSize: assistant?.machine_size ?? null,
+        storageGib: current.storageGib,
+      },
+    });
+
     const confirmSwitch = async () => {
       if (!switchTarget) {
         return;
       }
       const target = switchTarget;
       const relation = tierRelation(currentTierKey, target.key);
+      const before = capturePlanBefore();
       const result = await changePackage(target.key);
       if (!result) {
         // The hook already toasted; keep the confirm dialog open so the user
@@ -567,8 +603,15 @@ export function PlansPage() {
       if (relation === "downgrade") {
         toast.success(`Downgraded to ${target.name}.`);
       } else {
-        // The switch path owes no credit confirmation; clear any prior tier.
-        setResizeCreditTier(undefined);
+        const toCreditTier = (target.credit_tier ??
+          null) as CreditTierEnum | null;
+        setResizeContext({
+          fromSnapshot: before.fromSnapshot,
+          credits:
+            toCreditTier !== before.creditTier
+              ? { fromTier: before.creditTier, toTier: toCreditTier }
+              : null,
+        });
         setResizeTakeoverOpen(true);
       }
     };
@@ -596,6 +639,7 @@ export function PlansPage() {
     // Active Pro orgs edit their tiers in place via the change-tier endpoints;
     // the upgrade/checkout endpoint no-ops for an active Pro sub.
     const applyCustomTierChange = async (selection: CustomPlanSelection) => {
+      const before = capturePlanBefore();
       const result = await changeTiers(selection);
       if (!result) {
         // The hook toasted; keep the modal open so the user can retry.
@@ -604,10 +648,13 @@ export function PlansPage() {
       setCustomPlanOpen(false);
       if (result.needsResize || result.creditChanged) {
         // Both a resize and a credit-only change open the takeover; thread the
-        // applied tier only when credits actually changed.
-        setResizeCreditTier(
-          result.creditChanged ? selection.creditTier : undefined,
-        );
+        // tier move only when credits actually changed.
+        setResizeContext({
+          fromSnapshot: before.fromSnapshot,
+          credits: result.creditChanged
+            ? { fromTier: before.creditTier, toTier: selection.creditTier }
+            : null,
+        });
         setResizeTakeoverOpen(true);
       } else {
         toast.success("Plan updated.");
@@ -761,11 +808,11 @@ export function PlansPage() {
           open={resizeTakeoverOpen}
           onClose={() => {
             setResizeTakeoverOpen(false);
-            // Fail-safe: clear the tier so a stale credit chip can't resurface
-            // if an open path forgot to set it.
-            setResizeCreditTier(undefined);
+            // Fail-safe: drop the captured context so stale chips can't
+            // resurface if an open path forgot to set it.
+            setResizeContext(undefined);
           }}
-          resizeCredits={resizeCreditTier}
+          resizeContext={resizeContext}
         />
 
         <p className="mt-6 text-center text-[12px] font-medium text-[var(--content-tertiary)] sm:mt-10">

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -575,12 +575,20 @@ export function PlansPage() {
      * before it answers and the mutation hooks then invalidate the subscription
      * and onboarding queries `current` derives from, so every read afterwards
      * reports the change that just landed.
+     *
+     * Both resource dimensions come off the assistant rather than the billed
+     * tiers, which is what the takeover compares them against. A volume never
+     * shrinks, so an org that lowered its storage tier keeps the larger disk
+     * while `selected_storage_gib` reports the smaller billed one: raising the
+     * tier again would draw a move from a size the disk left long ago, and a
+     * raise that stays under the retained size would draw a growth that never
+     * happens.
      */
     const capturePlanBefore = () => ({
       creditTier: current.creditTier,
       fromSnapshot: {
         machineSize: assistant?.machine_size ?? null,
-        storageGib: current.storageGib,
+        storageGib: assistant?.provisioned_storage_gib ?? null,
       },
     });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -237,10 +237,19 @@ export function PlansPage() {
   // what makes that chip honest: a cap that finds the pod already at or below
   // the new ceiling skips it and creates no resize marker, so a ceiling-derived
   // from-side would draw a downsize that never runs.
+  //
+  // Held until `currentReady`, because `primaryAssistantId` rides the same
+  // onboarding read: asking earlier resolves a null id to the ACTIVE assistant,
+  // which is a different pod in a multi-assistant org, and that real-but-wrong
+  // size is what the takeover then states for the life of the change.
+  // `currentReady` also settles when that read errors, so a failed onboarding
+  // fetch falls back to the active assistant rather than holding the read off
+  // forever. Nothing downstream is gated on this resolving: a plan change the
+  // user asked for must not wait on an assistant read.
   const orgReady = useIsOrgReady();
   const assistant = usePreferredOrActiveAssistant(
     primaryAssistantId,
-    platformReady && orgReady && isProUser,
+    platformReady && orgReady && isProUser && currentReady,
   );
 
   // A Custom sub (unpinned or customized) has no meaningful catalog rank, so

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -1248,6 +1248,34 @@ describe("BillingOnboardingModal — resize mode", () => {
     expect(getByTestId("chip-storage").textContent).toContain("30 GB");
   });
 
+  test("a captured from-side with an unknown dimension falls back to the actuals", async () => {
+    // The capture is per dimension: a machine read that had not settled when
+    // the change was dispatched leaves that one null, and pinning the whole
+    // from-side to the capture would freeze it null and drop the chip's
+    // from-side for good.
+    subscriptionPlanId = "pro";
+    const { getByTestId, getByText } = renderModal({
+      mode: "resize",
+      resizeContext: {
+        fromSnapshot: { machineSize: null, storageGib: 30 },
+        credits: null,
+      },
+    });
+
+    await waitFor(
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+
+    // Machine falls back to the actuals snapshot (Small); storage keeps the
+    // captured 30 GB rather than the assistant's live 10 GB.
+    await waitFor(
+      () => expect(getByTestId("chip-machine").textContent).toContain("Small"),
+      { timeout: 5000 },
+    );
+    expect(getByTestId("chip-storage").textContent).toContain("30 GB");
+  });
+
   test("a resize mount with no captured context keeps the actuals snapshot", async () => {
     // The billing page's resize mount threads none, so its from-sides still come
     // from the pre-resize actuals.

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -37,7 +37,6 @@ import {
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type {
   Assistant,
-  CreditTierEnum,
   EnsureProvisionedResponse,
   OnboardingStateResponse,
   OperationalStatus,
@@ -54,6 +53,7 @@ import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import * as toastMod from "@vellumai/design-library/components/toast";
 
+import type { ResizeTakeoverContext } from "./billing-onboarding-modal";
 import * as proOnboardingUtils from "./utils";
 
 /** Shrunk so the confirm-timeout test doesn't wait out the real 10s poll. */
@@ -319,11 +319,11 @@ const TEST_DWELL_MS = 250;
 
 function renderModal({
   mode,
-  resizeCredits,
+  resizeContext,
   plans,
 }: {
   mode?: "checkout" | "resize";
-  resizeCredits?: CreditTierEnum | null;
+  resizeContext?: ResizeTakeoverContext;
   plans?: PlanListResponse;
 } = {}) {
   const client = new QueryClient({
@@ -344,7 +344,7 @@ function renderModal({
           dwellMs={TEST_DWELL_MS}
           phaseMinMs={0}
           mode={mode}
-          resizeCredits={resizeCredits}
+          resizeContext={resizeContext}
         />
       </QueryClientProvider>
     </MemoryRouter>
@@ -1191,11 +1191,14 @@ describe("BillingOnboardingModal — resize mode", () => {
     expect(queryByText("Super package")).toBeNull();
   });
 
-  test("confirms an applied credit bundle on the terminal phase", async () => {
+  test("carries a threaded credit change from the wait through to the terminal phase", async () => {
     subscriptionPlanId = "pro";
-    const { client, getByText } = renderModal({
+    const { client, getByTestId, getByText } = renderModal({
       mode: "resize",
-      resizeCredits: "credits_50",
+      resizeContext: {
+        fromSnapshot: { machineSize: "small", storageGib: 10 },
+        credits: { fromTier: "credits_25", toTier: "credits_50" },
+      },
       plans: plansWithCredits(),
     });
 
@@ -1203,15 +1206,67 @@ describe("BillingOnboardingModal — resize mode", () => {
       () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
+    // One credits surface: the chip is on screen for the whole wait, not held
+    // back for the terminal phase.
+    expect(getByTestId("chip-credits").textContent).toContain("$25/mo");
 
     assistantResponse = makeAssistant("large", 50);
     await client.invalidateQueries();
     await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
       timeout: 5000,
     });
-    // The threaded bundle is confirmed on the terminal phase — a credit change
-    // never reaches the WAITING credits chip, so this is its only surface.
-    expect(getByText("$50 credits/mo")).toBeTruthy();
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("$25/mo");
+    expect(chip.textContent).toContain("$50/mo");
+  });
+
+  test("resize mode draws its from-sides from the captured context, not live actuals", async () => {
+    // The change lands before this mounts, so what the assistant reports can
+    // already be the post-change machine. Only the captured snapshot still knows
+    // where the change started, and it has to win.
+    subscriptionPlanId = "pro";
+    const { getByTestId, getByText } = renderModal({
+      mode: "resize",
+      resizeContext: {
+        fromSnapshot: { machineSize: "medium", storageGib: 30 },
+        credits: null,
+      },
+    });
+
+    await waitFor(
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+
+    // The live assistant reads Small / 10 GB; the captured snapshot is what the
+    // chips state.
+    await waitFor(
+      () => expect(getByTestId("chip-machine").textContent).toContain("Medium"),
+      { timeout: 5000 },
+    );
+    expect(getByTestId("chip-machine").textContent).not.toContain("Small");
+    expect(getByTestId("chip-storage").textContent).toContain("30 GB");
+  });
+
+  test("a resize mount with no captured context keeps the actuals snapshot", async () => {
+    // The billing page's resize mount threads none, so its from-sides still come
+    // from the pre-resize actuals.
+    subscriptionPlanId = "pro";
+    const { getByTestId, getByText, queryByTestId } = renderModal({
+      mode: "resize",
+    });
+
+    await waitFor(
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+
+    // The from-side appears once the actuals snapshot latches.
+    await waitFor(
+      () => expect(getByTestId("chip-machine").textContent).toContain("Small"),
+      { timeout: 5000 },
+    );
+    expect(queryByTestId("chip-credits")).toBeNull();
   });
 
   test("waits for a domains answer fresh for this open, not a stale cached one", async () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -9,7 +9,6 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 
 import { assistantsDomainsListQueryKey } from "@/generated/api/@tanstack/react-query.gen";
-import type { CreditTierEnum } from "@/generated/api/types.gen";
 import {
   clearCheckoutIntent,
   readPurchasedCheckoutIntent,
@@ -35,6 +34,7 @@ import { clearTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
 import { TakeoverBackdrop } from "./takeover-backdrop";
 import { useAssistantDomains } from "./use-assistant-domains";
 import { useProProvisioning } from "./use-pro-provisioning";
+import type { CreditTierChange } from "./use-provisioning-credits";
 import { useTakeoverSurface } from "./use-takeover-surface";
 
 type WizardStep = "provisioning" | "domain" | "complete";
@@ -67,6 +67,19 @@ const EMPTY_DIMENSIONS: ProvisioningDimensions = {
   storageGib: null,
 };
 
+/**
+ * What an in-place plan change knows about the state it left behind. The
+ * platform applies the change before the takeover mounts, so every "current"
+ * value the takeover can read is already the post-change one; the caller
+ * captures these before it dispatches the change and hands them over.
+ */
+export interface ResizeTakeoverContext {
+  /** Machine and storage as they stood before the change was dispatched. */
+  fromSnapshot: ProvisioningDimensions;
+  /** The credit tiers the change moves between; null when it left them alone. */
+  credits: CreditTierChange | null;
+}
+
 export interface BillingOnboardingModalProps {
   open: boolean;
   onClose: () => void;
@@ -83,11 +96,12 @@ export interface BillingOnboardingModalProps {
    */
   mode?: "checkout" | "resize";
   /**
-   * Resize mode only: the credit tier applied by an in-place change, forwarded
-   * to the takeover. Ignored in checkout mode, where credits ride the stashed
-   * intent instead. See `ProvisioningStateProps.resizeCredits`.
+   * Resize mode only: what the change looked like before it was dispatched.
+   * Ignored in checkout mode, where the from-sides come from the pre-resize
+   * actuals snapshot and credits ride the stashed intent. A resize mount that
+   * omits it falls back to that same snapshot and renders no credits chip.
    */
-  resizeCredits?: CreditTierEnum | null;
+  resizeContext?: ResizeTakeoverContext;
 }
 
 export function BillingOnboardingModal({
@@ -96,7 +110,7 @@ export function BillingOnboardingModal({
   dwellMs,
   phaseMinMs,
   mode = "checkout",
-  resizeCredits,
+  resizeContext,
 }: BillingOnboardingModalProps) {
   const isResize = mode === "resize";
   const queryClient = useQueryClient();
@@ -466,9 +480,17 @@ export function BillingOnboardingModal({
           state={provisioning.state}
           softWaiting={provisioning.softWaiting}
           intent={intent}
-          resizeCredits={isResize ? resizeCredits : undefined}
+          creditsChange={isResize ? resizeContext?.credits : undefined}
           targets={targets ?? EMPTY_DIMENSIONS}
-          fromSnapshot={provisioning.actualsSnapshot ?? EMPTY_DIMENSIONS}
+          // An in-place change lands before this mounts, so its actuals already
+          // read post-change and the captured snapshot is the only honest
+          // from-side. Checkout's resize fires after the mount, so its actuals
+          // snapshot genuinely predates the change.
+          fromSnapshot={
+            (isResize ? resizeContext?.fromSnapshot : null) ??
+            provisioning.actualsSnapshot ??
+            EMPTY_DIMENSIONS
+          }
           machineFloor={provisioning.machineFloor}
           landed={provisioning.landed}
           celebrating={routingSettled}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -200,6 +200,26 @@ export function BillingOnboardingModal({
   const { targets, assistantId, domainStepAvailable, onboardingSettled } =
     provisioning;
 
+  // An in-place change lands before this mounts, so its actuals already read
+  // post-change and the captured snapshot is the only honest from-side.
+  // Checkout's resize fires after the mount, so its actuals snapshot genuinely
+  // predates the change.
+  //
+  // Each dimension resolves on its own: a capture taken while one of its own
+  // reads was still unsettled carries a null for that dimension alone, and
+  // pinning the whole from-side to that capture freezes it null for the life of
+  // the takeover. Falling back to the actuals degrades honestly,
+  // because for an in-place change those actuals already describe the
+  // post-change state, so the dimension reads from == to and drops out of the
+  // row entirely. A missing chip beats a chip stating a move that never
+  // happened.
+  const capturedFrom = isResize ? resizeContext?.fromSnapshot : undefined;
+  const actualsFrom = provisioning.actualsSnapshot;
+  const fromSnapshot: ProvisioningDimensions = {
+    machineSize: capturedFrom?.machineSize ?? actualsFrom?.machineSize ?? null,
+    storageGib: capturedFrom?.storageGib ?? actualsFrom?.storageGib ?? null,
+  };
+
   // The takeover and the sheet that covers it on the way out paint from one
   // surface: the tint published as a custom property, plus the same blurred
   // backdrop a custom-image avatar shows — so the handoff can't cross-fade a
@@ -482,15 +502,7 @@ export function BillingOnboardingModal({
           intent={intent}
           creditsChange={isResize ? resizeContext?.credits : undefined}
           targets={targets ?? EMPTY_DIMENSIONS}
-          // An in-place change lands before this mounts, so its actuals already
-          // read post-change and the captured snapshot is the only honest
-          // from-side. Checkout's resize fires after the mount, so its actuals
-          // snapshot genuinely predates the change.
-          fromSnapshot={
-            (isResize ? resizeContext?.fromSnapshot : null) ??
-            provisioning.actualsSnapshot ??
-            EMPTY_DIMENSIONS
-          }
+          fromSnapshot={fromSnapshot}
           machineFloor={provisioning.machineFloor}
           landed={provisioning.landed}
           celebrating={routingSettled}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -676,6 +676,47 @@ describe("done / not_applicable", () => {
     expect(within(chip).getByTestId("chip-check")).toBeTruthy();
   });
 
+  test("not_applicable states the credit move alone, whatever the live targets carry", () => {
+    // The provisioning targets carry the tier ceiling, so a Super/Ultra sub has
+    // a non-null machine target even for a credit-only change. Nothing is being
+    // provisioned in this phase, so only the credit move belongs on screen.
+    const { getByTestId, queryByTestId } = renderState({
+      state: "NOT_APPLICABLE",
+      targets: { machineSize: "large", storageGib: 100 },
+      fromSnapshot: { machineSize: null, storageGib: null },
+      creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
+    });
+
+    expect(getByTestId("chip-credits")).toBeTruthy();
+    expect(queryByTestId("chip-machine")).toBeNull();
+    expect(queryByTestId("chip-storage")).toBeNull();
+  });
+
+  test("not_applicable with nothing but resource targets renders no row at all", () => {
+    const { queryByTestId } = renderState({
+      state: "NOT_APPLICABLE",
+      targets: { machineSize: "large", storageGib: 100 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+    });
+
+    expect(queryByTestId("resource-chips")).toBeNull();
+  });
+
+  test("done still renders the resource chips alongside credits", () => {
+    // The credits-only narrowing is scoped to NOT_APPLICABLE; DONE reports the
+    // provisioning that actually ran.
+    const { getByTestId } = renderState({
+      state: "DONE",
+      targets: { machineSize: "large", storageGib: 100 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+      creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
+    });
+
+    expect(getByTestId("chip-machine")).toBeTruthy();
+    expect(getByTestId("chip-storage")).toBeTruthy();
+    expect(getByTestId("chip-credits")).toBeTruthy();
+  });
+
   test("not_applicable renders a dropped bundle as a move to $0", () => {
     // "No extra credits" is an endpoint of the change like any other, so the
     // chip prices it rather than falling back to a bare status word.
@@ -764,37 +805,33 @@ describe("stalled", () => {
     expect(queryByText("Continue in the background")).toBeNull();
   });
 
-  test("an unchanged machine dimension renders singular while storage still arrows", () => {
-    const { getByText, getAllByText, container } = renderState({
+  test("an unchanged machine dimension drops out while storage still arrows", () => {
+    const { getByText, queryByTestId, container } = renderState({
       state: "STALLED",
       targets: { machineSize: "medium", storageGib: 100 },
       fromSnapshot: { machineSize: "medium", storageGib: 30 },
     });
 
-    // Machine is unchanged: the label appears once (target only), never as a
-    // "Medium → Medium" self-arrow.
-    expect(getByText("Machine")).toBeTruthy();
-    expect(getAllByText("Medium").length).toBe(1);
+    // The pod is already at the target size, so nothing is being resized there
+    // and the chip would claim work that never runs.
+    expect(queryByTestId("chip-machine")).toBeNull();
     // Storage changed: both endpoints render, with a single from→to arrow.
     expect(getByText("30 GB")).toBeTruthy();
     expect(getByText("100 GB")).toBeTruthy();
     expect(container.querySelectorAll(".lucide-arrow-right").length).toBe(1);
   });
 
-  test("an unchanged machine renders singular while unchanged storage is dropped", () => {
-    const { getByText, queryByText, container } = renderState({
+  test("an unchanged machine and unchanged storage leave no chip row", () => {
+    const { queryByText, queryByTestId } = renderState({
       state: "STALLED",
       targets: { machineSize: "medium", storageGib: 30 },
       fromSnapshot: { machineSize: "medium", storageGib: 30 },
     });
 
-    expect(getByText("Machine")).toBeTruthy();
-    expect(getByText("Medium")).toBeTruthy();
+    expect(queryByTestId("resource-chips")).toBeNull();
+    expect(queryByText("Machine")).toBeNull();
     // Storage only renders when it grows, so an unchanged tier has no chip.
     expect(queryByText("Storage")).toBeNull();
-    expect(queryByText("30 GB")).toBeNull();
-    // Nothing changed, so the machine chip draws no current→new arrow.
-    expect(container.querySelector(".lucide-arrow-right")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -290,7 +290,7 @@ describe("waiting / resizing", () => {
     ).toBeTruthy();
   });
 
-  test("renders a 0 → label credits chip when the catalog resolves a label", () => {
+  test("renders a checkout credits chip as a monthly rate from $0", () => {
     const { getByText } = renderState({
       state: "WAITING",
       intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
@@ -299,8 +299,23 @@ describe("waiting / resizing", () => {
     });
 
     expect(getByText("Credits")).toBeTruthy();
-    expect(getByText("0")).toBeTruthy();
-    expect(getByText("$50 credits/mo")).toBeTruthy();
+    expect(getByText("$0/mo")).toBeTruthy();
+    expect(getByText("$50/mo")).toBeTruthy();
+  });
+
+  test("an in-place credit change renders the same from-to rate, in either direction", () => {
+    // One format for checkout and for a switch: the chip states the move, so a
+    // downgrade reads as plainly as an upgrade.
+    const { getByTestId } = renderState({
+      state: "WAITING",
+      creditsChange: { fromTier: "credits_50", toTier: "credits_25" },
+      targets: { machineSize: null, storageGib: null },
+      fromSnapshot: { machineSize: null, storageGib: null },
+    });
+
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("$50/mo");
+    expect(chip.textContent).toContain("$25/mo");
   });
 
   test("omits the credits chip when the catalog can't resolve a label", () => {
@@ -336,7 +351,7 @@ describe("waiting / resizing", () => {
       expect(getByText("Storage")).toBeTruthy();
       expect(getByText("100 GB")).toBeTruthy();
       expect(getByText("Credits")).toBeTruthy();
-      expect(getByText("$50 credits/mo")).toBeTruthy();
+      expect(getByText("$50/mo")).toBeTruthy();
       // One row holds all three; there is no sibling row to wrap onto.
       const row = chipRow(container);
       expect(within(row).getAllByTestId(CHIP_TESTID).length).toBe(3);
@@ -561,7 +576,7 @@ describe("chip fit at narrow widths", () => {
     const cases: Array<[string, string, string]> = [
       ["chip-machine", "Machine", "Large"],
       ["chip-storage", "Storage", "100 GB"],
-      ["chip-credits", "Credits", "$50 credits/mo"],
+      ["chip-credits", "Credits", "$50/mo"],
     ];
 
     for (const [key, label, value] of cases) {
@@ -628,7 +643,7 @@ describe("done / not_applicable", () => {
     expect(onCelebrationEnd).not.toHaveBeenCalled();
   });
 
-  test("not_applicable renders the plan-ready status without chips or an Apply button", async () => {
+  test("not_applicable renders the plan-ready status with nothing to show and no Apply button", async () => {
     const onCelebrationEnd = mock(() => {});
     const { getByText, queryByText, queryByTestId } = renderState({
       state: "NOT_APPLICABLE",
@@ -638,49 +653,55 @@ describe("done / not_applicable", () => {
     });
 
     expect(getByText("Your plan is ready")).toBeTruthy();
+    // No targets and no credit change, so the row has no chip to build.
+    expect(queryByTestId("resource-chips")).toBeNull();
     expect(queryByText("Machine")).toBeNull();
     expect(queryByText("Storage")).toBeNull();
     expect(queryByTestId("provisioning-apply")).toBeNull();
     await waitFor(() => expect(onCelebrationEnd).toHaveBeenCalledTimes(1));
   });
 
-  test("not_applicable confirms an applied credit bundle with the catalog label", () => {
-    // A credit-only in-place change owes no resize, so it lands here — the only
-    // surface where its bundle can be confirmed (the WAITING credits chip never
-    // shows).
-    const { getByText } = renderState({
+  test("not_applicable carries the credits chip, checked, in the same format", () => {
+    // A credit-only in-place change owes no resize, so it lands here, and this
+    // is the one surface where it can state what changed.
+    const { getByText, getByTestId } = renderState({
       state: "NOT_APPLICABLE",
-      resizeCredits: "credits_50",
+      creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
     });
 
     expect(getByText("Your plan is ready")).toBeTruthy();
-    expect(getByText("Credits")).toBeTruthy();
-    expect(getByText("$50 credits/mo")).toBeTruthy();
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("$25/mo");
+    expect(chip.textContent).toContain("$50/mo");
+    expect(within(chip).getByTestId("chip-check")).toBeTruthy();
   });
 
-  test("not_applicable falls back to plain copy when the bundle can't resolve", () => {
-    // "No extra credits" (null tier) still counts as a change, so it confirms
-    // without a catalog label rather than leaving the phase blank.
-    const { getByText, queryByText } = renderState({
+  test("not_applicable renders a dropped bundle as a move to $0", () => {
+    // "No extra credits" is an endpoint of the change like any other, so the
+    // chip prices it rather than falling back to a bare status word.
+    const { getByTestId } = renderState({
       state: "NOT_APPLICABLE",
-      resizeCredits: null,
+      creditsChange: { fromTier: "credits_50", toTier: null },
     });
 
-    expect(getByText("Credits updated")).toBeTruthy();
-    expect(queryByText(/credits\/mo/)).toBeNull();
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("$50/mo");
+    expect(chip.textContent).toContain("$0/mo");
   });
 
-  test("done confirms an applied credit bundle alongside the target chips", () => {
-    const { getByText } = renderState({
+  test("done carries the credits chip alongside the resource chips", () => {
+    const { getByText, getByTestId } = renderState({
       state: "DONE",
       targets: { machineSize: "large", storageGib: 100 },
       fromSnapshot: { machineSize: "small", storageGib: 30 },
-      resizeCredits: "credits_50",
+      creditsChange: { fromTier: null, toTier: "credits_50" },
     });
 
     expect(getByText("All done!")).toBeTruthy();
     expect(getByText("Large")).toBeTruthy();
-    expect(getByText("$50 credits/mo")).toBeTruthy();
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("$0/mo");
+    expect(chip.textContent).toContain("$50/mo");
   });
 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -16,10 +16,8 @@ import {
 } from "react";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
-import type {
-  CreditTierEnum,
-  MachineSizeEnum,
-} from "@/generated/api/types.gen";
+import { formatMonthly } from "@/domains/settings/components/tier-pricing";
+import type { MachineSizeEnum } from "@/generated/api/types.gen";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import type { ProvisioningDimensionFlags } from "@/lib/billing/provisioning-targets";
@@ -39,8 +37,9 @@ import {
 } from "./resource-changes";
 import { TakeoverBackdrop } from "./takeover-backdrop";
 import {
-  useCreditTierLabel,
   useProvisioningCredits,
+  useResizeCreditsChange,
+  type CreditTierChange,
 } from "./use-provisioning-credits";
 import { useTakeoverSurface } from "./use-takeover-surface";
 import { useHeldPhase } from "./use-held-phase";
@@ -113,15 +112,13 @@ export interface ProvisioningStateProps {
   /** The checkout selection stashed before the Stripe redirect. */
   intent: CheckoutIntent | null;
   /**
-   * The credit tier just applied by an in-place resize change, threaded from
-   * the plans page so the terminal phase can confirm a credit-bundle change —
-   * a credit-only change skips WAITING/RESIZING, where the checkout-driven
-   * credits chip lives, so this is its only surface. `undefined` = no credit
-   * change (omit the chip); a tier or explicit `null` ("No extra credits") =
-   * show the confirmation. Distinct from `intent` on purpose: resize mode never
-   * reads the checkout intent, so a stale one can't leak in here.
+   * Resize mode only: the credit tiers an in-place change moves between,
+   * captured by the plans page before the change landed. `null` or `undefined`
+   * means the change left the bundle alone and the credits chip is dropped.
+   * Distinct from `intent` on purpose: resize mode never reads the checkout
+   * intent, so a stale one can't leak in here.
    */
-  resizeCredits?: CreditTierEnum | null;
+  creditsChange?: CreditTierChange | null;
   targets: ProvisioningDimensions;
   /** Pre-resize actuals rendered as the "from" side of the resource chips. */
   fromSnapshot: ProvisioningDimensions;
@@ -452,8 +449,8 @@ function chipDone(
 /**
  * The takeover's resource chips: every applicable change as a `{current} ->
  * {new}` chip (machine and storage from `targets`, `fromSnapshot` and the
- * display-only `machineFloor`; credits from the catalog with a fixed `0`
- * current for the base-to-pro upgrade).
+ * display-only `machineFloor`; credits as a from-to monthly rate, `$0/mo` on
+ * the from-side for a base-to-pro checkout).
  *
  * All of them render together from the first paint of the wait, each carrying
  * its own progress: dimmed with a spinner while its dimension is still moving,
@@ -474,6 +471,7 @@ function chipDone(
  */
 function ResourceChangeChips({
   intent,
+  creditsChange,
   targets,
   fromSnapshot,
   machineFloor,
@@ -481,18 +479,30 @@ function ResourceChangeChips({
   allDone = false,
 }: {
   intent: CheckoutIntent | null;
+  creditsChange?: CreditTierChange | null;
   targets: ProvisioningDimensions;
   fromSnapshot: ProvisioningDimensions;
   machineFloor?: MachineSizeEnum | null;
   landed?: ProvisioningDimensionFlags;
   allDone?: boolean;
 }) {
-  const creditsLabel = useProvisioningCredits(intent);
+  // Checkout reads the stashed intent, an in-place change carries its own
+  // tiers, and a takeover runs in exactly one of those modes, so at most one of
+  // these resolves.
+  const checkoutCredits = useProvisioningCredits(intent);
+  const inPlaceCredits = useResizeCreditsChange(creditsChange);
+  const credits = checkoutCredits ?? inPlaceCredits;
   const changes = buildResourceChanges({
     targets,
     fromSnapshot,
     machineFloor,
-    credits: creditsLabel ? { from: "0", to: creditsLabel } : null,
+    credits:
+      credits != null
+        ? {
+            from: formatMonthly(credits.fromUsd * 100),
+            to: formatMonthly(credits.toUsd * 100),
+          }
+        : null,
   });
 
   const completed = changes
@@ -580,7 +590,7 @@ export function ProvisioningState({
   state,
   softWaiting,
   intent,
-  resizeCredits,
+  creditsChange,
   targets,
   fromSnapshot,
   machineFloor,
@@ -596,11 +606,6 @@ export function ProvisioningState({
   dwellMs = PROVISION_MIN_DWELL_MS,
   phaseMinMs = PROVISION_PHASE_MIN_MS,
 }: ProvisioningStateProps) {
-  // `undefined` = no credit change; a tier or explicit null both surface the
-  // terminal confirmation (see the `resizeCredits` prop).
-  const showCreditConfirmation = resizeCredits !== undefined;
-  const creditConfirmationLabel = useCreditTierLabel(resizeCredits ?? null);
-
   const onCelebrationEndRef = useRef(onCelebrationEnd);
   useEffect(() => {
     onCelebrationEndRef.current = onCelebrationEnd;
@@ -690,37 +695,13 @@ export function ProvisioningState({
     return (
       <ResourceChangeChips
         intent={intent}
+        creditsChange={creditsChange}
         targets={targets}
         fromSnapshot={fromSnapshot}
         machineFloor={machineFloor}
         landed={landed}
         allDone={allDone}
       />
-    );
-  }
-
-  // Confirmation chip for a credit-only (or credit-inclusive) in-place change,
-  // shown on the terminal phase. Resolves to the catalog label ("$50
-  // credits/mo") when known, matching the WAITING credits chip; falls back to
-  // a plain "Credits updated" for the "No extra credits" choice or before the
-  // catalog resolves, so the terminal phase is never left blank.
-  function creditConfirmationChip() {
-    if (!showCreditConfirmation) {
-      return null;
-    }
-    return (
-      <ChipRow>
-        {creditConfirmationLabel != null ? (
-          <DimensionChip
-            icon={RESOURCE_CHIP_ICON.credits}
-            label="Credits"
-            to={creditConfirmationLabel}
-            done
-          />
-        ) : (
-          <TextChip label="Credits updated" />
-        )}
-      </ChipRow>
     );
   }
 
@@ -760,16 +741,17 @@ export function ProvisioningState({
         <>
           <Copy status="All done!" />
           {resourceChips(true)}
-          {creditConfirmationChip()}
         </>
       );
     }
 
     if (heldState === "NOT_APPLICABLE") {
+      // Terminal for a change that owes no provisioning, a credit-only switch
+      // above all, so the chips are its one statement of what changed.
       return (
         <>
           <Copy status="Your plan is ready" />
-          {creditConfirmationChip()}
+          {resourceChips(true)}
         </>
       );
     }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -468,6 +468,9 @@ function chipDone(
  * `allDone` is the terminal phase, where the state itself is the signal for
  * every dimension. The from-to arrow survives it, so one chip format covers
  * every phase the row appears in.
+ *
+ * `creditsOnly` narrows the row to the credit move, for a phase that owes no
+ * machine or storage work at all.
  */
 function ResourceChangeChips({
   intent,
@@ -477,6 +480,7 @@ function ResourceChangeChips({
   machineFloor,
   landed,
   allDone = false,
+  creditsOnly = false,
 }: {
   intent: CheckoutIntent | null;
   creditsChange?: CreditTierChange | null;
@@ -485,6 +489,7 @@ function ResourceChangeChips({
   machineFloor?: MachineSizeEnum | null;
   landed?: ProvisioningDimensionFlags;
   allDone?: boolean;
+  creditsOnly?: boolean;
 }) {
   // Checkout reads the stashed intent, an in-place change carries its own
   // tiers, and a takeover runs in exactly one of those modes, so at most one of
@@ -492,7 +497,7 @@ function ResourceChangeChips({
   const checkoutCredits = useProvisioningCredits(intent);
   const inPlaceCredits = useResizeCreditsChange(creditsChange);
   const credits = checkoutCredits ?? inPlaceCredits;
-  const changes = buildResourceChanges({
+  const built = buildResourceChanges({
     targets,
     fromSnapshot,
     machineFloor,
@@ -504,6 +509,9 @@ function ResourceChangeChips({
           }
         : null,
   });
+  const changes = creditsOnly
+    ? built.filter((change) => change.key === "credits")
+    : built;
 
   const completed = changes
     .filter((change) => allDone || chipDone(change.key, landed))
@@ -691,7 +699,10 @@ export function ProvisioningState({
   }
 
   /** The resource row; `allDone` is the terminal phase forcing every check on. */
-  function resourceChips(allDone = false) {
+  function resourceChips({
+    allDone = false,
+    creditsOnly = false,
+  }: { allDone?: boolean; creditsOnly?: boolean } = {}) {
     return (
       <ResourceChangeChips
         intent={intent}
@@ -701,6 +712,7 @@ export function ProvisioningState({
         machineFloor={machineFloor}
         landed={landed}
         allDone={allDone}
+        creditsOnly={creditsOnly}
       />
     );
   }
@@ -740,18 +752,20 @@ export function ProvisioningState({
       return (
         <>
           <Copy status="All done!" />
-          {resourceChips(true)}
+          {resourceChips({ allDone: true })}
         </>
       );
     }
 
     if (heldState === "NOT_APPLICABLE") {
       // Terminal for a change that owes no provisioning, a credit-only switch
-      // above all, so the chips are its one statement of what changed.
+      // above all, so the credit move is its one statement of what changed. No
+      // machine or storage work is outstanding here by construction, so a
+      // resource chip could only report a dimension that stayed put.
       return (
         <>
           <Copy status="Your plan is ready" />
-          {resourceChips(true)}
+          {resourceChips({ allDone: true, creditsOnly: true })}
         </>
       );
     }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
@@ -83,15 +83,63 @@ describe("buildResourceChanges", () => {
     expect(changes[1].from).toBeUndefined();
   });
 
-  test("omits `from` on machine when the snapshot equals the target", () => {
+  test("omits machine when the snapshot already equals the target", () => {
     const changes = buildResourceChanges({
       targets,
       fromSnapshot: { machineSize: "large", storageGib: 50 },
       credits: null,
     });
 
-    expect(changes.map((c) => c.key)).toEqual(["machine"]);
-    expect(changes[0].from).toBeUndefined();
+    expect(changes).toEqual([]);
+  });
+
+  test("keeps a credit-only change free of a machine row", () => {
+    // The live targets carry the tier ceiling, so the machine target is non-null
+    // for any paid tier even when the change never touched the machine.
+    const changes = buildResourceChanges({
+      targets: { machineSize: "large", storageGib: 50 },
+      fromSnapshot: { machineSize: "large", storageGib: 50 },
+      credits: { from: "$25/mo", to: "$50/mo" },
+    });
+
+    expect(changes.map((c) => c.key)).toEqual(["credits"]);
+  });
+
+  test("keeps a storage-only change free of a machine row", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: "medium", storageGib: 50 },
+      fromSnapshot: { machineSize: "medium", storageGib: 10 },
+      credits: null,
+    });
+
+    expect(changes).toEqual([
+      { key: "storage", label: "Storage", from: "10 GB", to: "50 GB" },
+    ]);
+  });
+
+  test("renders machine with no from-side when the snapshot machine is null", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: "large", storageGib: null },
+      fromSnapshot: { machineSize: null, storageGib: null },
+      credits: null,
+    });
+
+    expect(changes).toEqual([
+      { key: "machine", label: "Machine", from: undefined, to: "Large" },
+    ]);
+  });
+
+  test("ignores the machine floor when the target machine is met, not just set", () => {
+    // A non-null machine target reserves the row; the floor branch stays
+    // reserved for the machine-less packages that have no target at all.
+    const changes = buildResourceChanges({
+      targets: { machineSize: "medium", storageGib: null },
+      fromSnapshot: { machineSize: "medium", storageGib: null },
+      machineFloor: "small",
+      credits: null,
+    });
+
+    expect(changes).toEqual([]);
   });
 
   test("includes `from` when the snapshot differs from the target", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
@@ -19,6 +19,13 @@ export interface ResourceChange {
  * A dimension is included only when it has something to show; `from` is present
  * only when the pre-resize snapshot differs from the target.
  *
+ * Machine renders only when it moves. A snapshot equal to the target describes
+ * a pod that stays exactly where it is, and a chip for it asserts a resize that
+ * never runs; the live targets carry the tier ceiling, which is non-null for
+ * any paid tier, so a credit-only or storage-only change would otherwise paint
+ * a machine row out of nothing. A null snapshot is the fresh-hatch (or
+ * not-yet-read) case and still renders, with no from-side.
+ *
  * Storage renders only when it grows. PVCs never shrink (vembda raises on a
  * decrease and Kubernetes cannot reduce a claim), so a lowered BILLED storage
  * tier leaves the volume exactly where it is, and `30 GB → 10 GB` would claim a
@@ -45,16 +52,17 @@ export function buildResourceChanges(input: {
   const changes: ResourceChange[] = [];
 
   if (targets.machineSize != null) {
-    changes.push({
-      key: "machine",
-      label: "Machine",
-      from:
-        fromSnapshot.machineSize != null &&
-        fromSnapshot.machineSize !== targets.machineSize
-          ? SIZE_LABEL[fromSnapshot.machineSize]
-          : undefined,
-      to: SIZE_LABEL[targets.machineSize],
-    });
+    if (fromSnapshot.machineSize !== targets.machineSize) {
+      changes.push({
+        key: "machine",
+        label: "Machine",
+        from:
+          fromSnapshot.machineSize != null
+            ? SIZE_LABEL[fromSnapshot.machineSize]
+            : undefined,
+        to: SIZE_LABEL[targets.machineSize],
+      });
+    }
   } else if (
     machineFloor != null &&
     fromSnapshot.machineSize != null &&

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -1,7 +1,8 @@
 /**
- * Tests for `useProvisioningCredits`. The plan catalog is seeded straight into
- * the React Query cache so `useQuery` resolves synchronously without a fetch —
- * mirrors the `plan-card.test.tsx` `setQueryData` pattern.
+ * Tests for the credits resolution behind the takeover's from-to chip. The plan
+ * catalog is seeded straight into the React Query cache so `useQuery` resolves
+ * synchronously without a fetch, mirroring the `plan-card.test.tsx`
+ * `setQueryData` pattern.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -9,8 +10,16 @@ import { renderHook } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
 import { organizationsBillingPlansRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
-import type { PlanListResponse } from "@/generated/api/types.gen";
+import type {
+  CreditTierEnum,
+  PlanListResponse,
+} from "@/generated/api/types.gen";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
+
+import type {
+  CreditsChange,
+  CreditTierChange,
+} from "./use-provisioning-credits";
 
 // Drives the org-readiness gate — the plans lookup must stay idle until the
 // organization store hydrates, or it fires without a `Vellum-Organization-Id`.
@@ -19,7 +28,7 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
 }));
 
-const { useProvisioningCredits, useCreditTierLabel } =
+const { useProvisioningCredits, useResizeCreditsChange } =
   await import("./use-provisioning-credits");
 
 /** A pro-plan catalog with a `credits_50` tier and a Mighty package on it. */
@@ -65,16 +74,16 @@ function plansResponse(): PlanListResponse {
             total_price_cents: 4000,
           },
           {
-            key: "orphan",
-            name: "Orphan",
+            key: "tierless",
+            name: "Tierless",
             description: "",
             version: 1,
             machine_tier: null,
             storage_tier: "xs",
-            credit_tier: "credits_999",
+            credit_tier: "credits_50",
             machine_size: null,
             storage_gib: 10,
-            credits_usd: 30,
+            credits_usd: null,
             include_platform_fee: false,
             base_price_cents: 4000,
             machine_price_cents: 0,
@@ -88,10 +97,10 @@ function plansResponse(): PlanListResponse {
   };
 }
 
-function renderWithClient(
-  intent: CheckoutIntent | null,
+function withClient<T>(
+  hook: () => T,
   plans?: PlanListResponse,
-): { value: string | null; client: QueryClient } {
+): { value: T; client: QueryClient } {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -100,16 +109,15 @@ function renderWithClient(
   }
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client }, children);
-  const value = renderHook(() => useProvisioningCredits(intent), { wrapper })
-    .result.current;
-  return { value, client };
+  return { value: renderHook(hook, { wrapper }).result.current, client };
 }
 
-function renderCredits(
-  intent: CheckoutIntent | null,
-  plans?: PlanListResponse,
-): string | null {
-  return renderWithClient(intent, plans).value;
+/** "idle" unless the plans query actually went out. */
+function plansFetchStatus(client: QueryClient): string {
+  return (
+    client.getQueryState(organizationsBillingPlansRetrieveQueryKey())
+      ?.fetchStatus ?? "idle"
+  );
 }
 
 describe("useProvisioningCredits", () => {
@@ -117,28 +125,31 @@ describe("useProvisioningCredits", () => {
     orgReady = true;
   });
 
+  function renderCredits(
+    intent: CheckoutIntent | null,
+    plans?: PlanListResponse,
+  ): CreditsChange | null {
+    return withClient(() => useProvisioningCredits(intent), plans).value;
+  }
+
   test("holds the plans lookup until the org is ready", () => {
     orgReady = false;
-    const { value, client } = renderWithClient({
-      kind: "package",
-      packageKey: "mighty",
-      savedAt: 0,
-    });
+    const { value, client } = withClient(() =>
+      useProvisioningCredits({
+        kind: "package",
+        packageKey: "mighty",
+        savedAt: 0,
+      }),
+    );
 
     expect(value).toBeNull();
-    expect(
-      client.getQueryState(organizationsBillingPlansRetrieveQueryKey())
-        ?.fetchStatus ?? "idle",
-    ).toBe("idle");
+    expect(plansFetchStatus(client)).toBe("idle");
   });
 
   test("holds the plans lookup when there is no intent", () => {
-    const { client } = renderWithClient(null);
+    const { client } = withClient(() => useProvisioningCredits(null));
 
-    expect(
-      client.getQueryState(organizationsBillingPlansRetrieveQueryKey())
-        ?.fetchStatus ?? "idle",
-    ).toBe("idle");
+    expect(plansFetchStatus(client)).toBe("idle");
   });
 
   test("returns null for a null intent", () => {
@@ -151,22 +162,22 @@ describe("useProvisioningCredits", () => {
     ).toBeNull();
   });
 
-  test("resolves a package's credit tier label", () => {
+  test("resolves a package's credits from $0, since the base plan bundles none", () => {
     expect(
       renderCredits(
         { kind: "package", packageKey: "mighty", savedAt: 0 },
         plansResponse(),
       ),
-    ).toBe("$50 credits/mo");
+    ).toEqual({ fromUsd: 0, toUsd: 50 });
   });
 
-  test("falls back to the package's credits_usd when no tier matches", () => {
+  test("falls back to the package's credit tier when it carries no credits_usd", () => {
     expect(
       renderCredits(
-        { kind: "package", packageKey: "orphan", savedAt: 0 },
+        { kind: "package", packageKey: "tierless", savedAt: 0 },
         plansResponse(),
       ),
-    ).toBe("30 credits");
+    ).toEqual({ fromUsd: 0, toUsd: 50 });
   });
 
   test("returns null for an unknown package key", () => {
@@ -178,7 +189,7 @@ describe("useProvisioningCredits", () => {
     ).toBeNull();
   });
 
-  test("resolves a custom intent's credit tier label", () => {
+  test("resolves a custom intent's credit tier", () => {
     expect(
       renderCredits(
         {
@@ -190,7 +201,7 @@ describe("useProvisioningCredits", () => {
         },
         plansResponse(),
       ),
-    ).toBe("$50 credits/mo");
+    ).toEqual({ fromUsd: 0, toUsd: 50 });
   });
 
   test("returns null for a custom intent without credits", () => {
@@ -209,58 +220,70 @@ describe("useProvisioningCredits", () => {
   });
 });
 
-describe("useCreditTierLabel", () => {
+describe("useResizeCreditsChange", () => {
   beforeEach(() => {
     orgReady = true;
   });
 
-  function renderLabel(
-    creditTier: Parameters<typeof useCreditTierLabel>[0],
+  function renderChange(
+    change: CreditTierChange | null | undefined,
     plans?: PlanListResponse,
-  ): { value: string | null; client: QueryClient } {
-    const client = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    if (plans) {
-      client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
-    }
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client }, children);
-    const value = renderHook(() => useCreditTierLabel(creditTier), { wrapper })
-      .result.current;
-    return { value, client };
+  ): CreditsChange | null {
+    return withClient(() => useResizeCreditsChange(change), plans).value;
   }
 
-  test("resolves a credit tier's catalog label", () => {
-    expect(renderLabel("credits_50", plansResponse()).value).toBe(
-      "$50 credits/mo",
-    );
-  });
-
-  test("returns null while the catalog is unresolved", () => {
-    expect(renderLabel("credits_50").value).toBeNull();
-  });
-
-  test("returns null for a tier absent from the catalog", () => {
-    expect(renderLabel("credits_100", plansResponse()).value).toBeNull();
-  });
-
-  test("returns null — and holds the lookup — for a null tier", () => {
-    const { value, client } = renderLabel(null, plansResponse());
-    expect(value).toBeNull();
+  test("resolves both sides from the catalog", () => {
     expect(
-      client.getQueryState(organizationsBillingPlansRetrieveQueryKey())
-        ?.fetchStatus ?? "idle",
-    ).toBe("idle");
+      renderChange({ fromTier: null, toTier: "credits_50" }, plansResponse()),
+    ).toEqual({ fromUsd: 0, toUsd: 50 });
+  });
+
+  test("reads a dropped bundle as a move down to $0", () => {
+    // "No extra credits" is a real endpoint of the change, not a missing side.
+    expect(
+      renderChange({ fromTier: "credits_50", toTier: null }, plansResponse()),
+    ).toEqual({ fromUsd: 50, toUsd: 0 });
+  });
+
+  test("reads a held tier the catalog no longer lists off its key", () => {
+    // A grandfathered bundle is absent from the offered tiers, so the catalog
+    // can't price it; its key carries the dollars.
+    expect(
+      renderChange(
+        { fromTier: "credits_115", toTier: "credits_50" },
+        plansResponse(),
+      ),
+    ).toEqual({ fromUsd: 115, toUsd: 50 });
+  });
+
+  test("omits the chip when a tier carries no resolvable amount", () => {
+    // Version skew: the server names a tier this bundle's enum doesn't list and
+    // whose key holds no dollar figure. A wrong number is worse than no chip.
+    const skewedTier = "credits_unlimited" as unknown as CreditTierEnum;
+    expect(
+      renderChange(
+        { fromTier: skewedTier, toTier: "credits_50" },
+        plansResponse(),
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null and holds the lookup with no change threaded", () => {
+    const { value, client } = withClient(
+      () => useResizeCreditsChange(undefined),
+      plansResponse(),
+    );
+
+    expect(value).toBeNull();
+    expect(plansFetchStatus(client)).toBe("idle");
   });
 
   test("holds the lookup until the org is ready", () => {
     orgReady = false;
-    const { value, client } = renderLabel("credits_50");
-    expect(value).toBeNull();
-    expect(
-      client.getQueryState(organizationsBillingPlansRetrieveQueryKey())
-        ?.fetchStatus ?? "idle",
-    ).toBe("idle");
+    const { client } = withClient(() =>
+      useResizeCreditsChange({ fromTier: null, toTier: "credits_50" }),
+    );
+
+    expect(plansFetchStatus(client)).toBe("idle");
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -4,17 +4,34 @@ import { organizationsBillingPlansRetrieveOptions } from "@/generated/api/@tanst
 import type {
   CreditTier,
   CreditTierEnum,
-  PlanCatalogEntry,
   ProPlan,
 } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 
 /**
- * Finds a Pro plan's `credit_tiers` entry for a tier — the single source of the
- * credit-tier lookup shared by the label helpers here and the plans-page custom
- * row summary. Returns undefined for a null/undefined tier or when the tier
- * can't be resolved (no Pro plan, no matching tier).
+ * A credit bundle change as monthly dollar amounts. Both sides always carry a
+ * number: "No extra credits" is $0, not an absent side.
+ */
+export interface CreditsChange {
+  fromUsd: number;
+  toUsd: number;
+}
+
+/**
+ * The credit tiers an in-place plan change moves between. `null` on either side
+ * is the explicit "No extra credits" choice.
+ */
+export interface CreditTierChange {
+  fromTier: CreditTierEnum | null;
+  toTier: CreditTierEnum | null;
+}
+
+/**
+ * Finds a Pro plan's `credit_tiers` entry for a tier, the single source of the
+ * credit-tier lookup shared by the dollar resolution here and the plans-page
+ * custom row summary. Returns undefined for a null/undefined tier or when the
+ * tier can't be resolved (no Pro plan, no matching tier).
  */
 export function findCreditTier(
   proPlan: ProPlan | undefined,
@@ -27,78 +44,92 @@ export function findCreditTier(
 }
 
 /**
- * Resolves a credit tier's catalog label from the Pro plan's `credit_tiers`.
- * Returns null for a null/undefined tier or when the tier can't be resolved
- * (catalog still loading, no Pro plan, no matching tier).
+ * The Pro plan from the shared plan catalog. Reads the same query
+ * `plans-page.tsx` uses, so React Query dedupes when the takeover follows a page
+ * that already fetched it.
+ *
+ * Without a ready org the request carries no `Vellum-Organization-Id` and fails,
+ * caching a rejection that would leave the chip unresolved once the org does
+ * hydrate. The sibling provisioning queries gate the same way.
  */
-function creditTierLabel(
-  plans: PlanCatalogEntry[] | undefined,
-  tier: CreditTierEnum | null | undefined,
-): string | null {
-  const proPlan = plans?.find((p): p is ProPlan => p.id === "pro");
-  return findCreditTier(proPlan, tier)?.label ?? null;
+function useProPlan(enabled: boolean): ProPlan | undefined {
+  const orgReady = useIsOrgReady();
+  const { data } = useQuery({
+    ...organizationsBillingPlansRetrieveOptions(),
+    enabled: orgReady && enabled,
+  });
+  return data?.plans.find((p): p is ProPlan => p.id === "pro");
 }
 
 /**
- * Resolves the human-readable monthly-credit label for the purchased plan from
- * the shared plan catalog, so the provisioning takeover can render a
- * `0 → {credits}` chip for the base→pro upgrade. Reads the same query
- * `plans-page.tsx` uses, so React Query dedupes when the takeover follows a page
- * that already fetched it. Returns null while the catalog loads, when the intent
- * carries no credits, or when the label can't be resolved. Display-only.
+ * The monthly dollars a credit tier bundles. A null tier is the "No extra
+ * credits" choice and costs nothing. A held or legacy tier the catalog no longer
+ * lists still carries its amount in its key (`credits_<usd>`), so the key
+ * answers where the catalog can't. Anything else stays unresolved, so the chip
+ * is dropped rather than rendering a wrong number.
+ */
+function creditTierUsd(
+  proPlan: ProPlan | undefined,
+  tier: CreditTierEnum | null,
+): number | null {
+  if (tier == null) {
+    return 0;
+  }
+  const catalogUsd = findCreditTier(proPlan, tier)?.credits_usd;
+  if (catalogUsd != null) {
+    return catalogUsd;
+  }
+  const keyUsd = tier.match(/^credits_(\d+)$/)?.[1];
+  return keyUsd != null ? Number(keyUsd) : null;
+}
+
+/**
+ * The credits a post-Stripe checkout buys, as a from-to dollar pair. The base
+ * plan bundles none, so the from-side is $0. Returns null while the catalog
+ * loads, when the intent carries no credits, or when the amount can't be
+ * resolved, and the chip is omitted. Display-only.
  */
 export function useProvisioningCredits(
   intent: CheckoutIntent | null,
-): string | null {
-  const orgReady = useIsOrgReady();
-  // Without a ready org the request carries no `Vellum-Organization-Id` and
-  // fails, caching a rejection that would leave the chip unresolved once the
-  // org does hydrate. The sibling provisioning queries gate the same way.
-  const { data } = useQuery({
-    ...organizationsBillingPlansRetrieveOptions(),
-    enabled: orgReady && intent != null,
-  });
+): CreditsChange | null {
+  const proPlan = useProPlan(intent != null);
 
-  if (intent == null) {
+  if (intent == null || proPlan == null) {
     return null;
   }
 
-  const proPlan = data?.plans.find((p): p is ProPlan => p.id === "pro");
-  if (proPlan == null) {
-    return null;
-  }
-
+  let toUsd: number | null | undefined;
   if (intent.kind === "package") {
     const pkg = proPlan.packages.find((p) => p.key === intent.packageKey);
-    const label = findCreditTier(proPlan, pkg?.credit_tier)?.label;
-    if (label != null) {
-      return label;
-    }
-    return pkg?.credits_usd != null ? `${pkg.credits_usd} credits` : null;
+    toUsd =
+      pkg?.credits_usd ??
+      findCreditTier(proPlan, pkg?.credit_tier)?.credits_usd;
+  } else {
+    toUsd = findCreditTier(proPlan, intent.creditTier)?.credits_usd;
   }
 
-  return creditTierLabel(data?.plans, intent.creditTier);
+  return toUsd != null ? { fromUsd: 0, toUsd } : null;
 }
 
 /**
- * Resolves a single credit tier's human-readable label from the shared plan
- * catalog, for the in-place resize takeover's terminal "credits updated" chip.
- * Mirrors `useProvisioningCredits`'s custom-intent resolution but takes the tier
- * directly — the resize path threads the just-applied tier, not a stashed
- * checkout intent. Returns null while the catalog loads, when no tier is given
- * (e.g. the "No extra credits" choice), or when the tier can't be resolved.
- * Display-only.
+ * The credits an in-place plan change moves between, as a from-to dollar pair.
+ * Both endpoints come from the tiers the plans page captured before the change
+ * landed, so the chip states the move rather than the outcome. Returns null when
+ * no credit change is threaded or when either side can't be resolved, and the
+ * chip is omitted. Display-only.
  */
-export function useCreditTierLabel(
-  creditTier: CreditTierEnum | null | undefined,
-): string | null {
-  const orgReady = useIsOrgReady();
-  // Gate the same way the sibling provisioning queries do: without a ready org
-  // the request carries no `Vellum-Organization-Id` and fails.
-  const { data } = useQuery({
-    ...organizationsBillingPlansRetrieveOptions(),
-    enabled: orgReady && creditTier != null,
-  });
+export function useResizeCreditsChange(
+  change: CreditTierChange | null | undefined,
+): CreditsChange | null {
+  const proPlan = useProPlan(change != null);
 
-  return creditTierLabel(data?.plans, creditTier);
+  if (change == null) {
+    return null;
+  }
+  const fromUsd = creditTierUsd(proPlan, change.fromTier);
+  const toUsd = creditTierUsd(proPlan, change.toTier);
+  if (fromUsd == null || toUsd == null) {
+    return null;
+  }
+  return { fromUsd, toUsd };
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
+import { creditTierKeyUsd } from "@/lib/billing/credit-tiers";
 
 /**
  * A credit bundle change as monthly dollar amounts. Both sides always carry a
@@ -63,10 +64,10 @@ function useProPlan(enabled: boolean): ProPlan | undefined {
 
 /**
  * The monthly dollars a credit tier bundles. A null tier is the "No extra
- * credits" choice and costs nothing. A held or legacy tier the catalog no longer
- * lists still carries its amount in its key (`credits_<usd>`), so the key
- * answers where the catalog can't. Anything else stays unresolved, so the chip
- * is dropped rather than rendering a wrong number.
+ * credits" choice and costs nothing, and the catalog prices everything it
+ * lists; a tier it doesn't falls back to the amount its key names. Anything
+ * else stays unresolved, so the chip is dropped rather than rendering a wrong
+ * number.
  */
 function creditTierUsd(
   proPlan: ProPlan | undefined,
@@ -75,12 +76,7 @@ function creditTierUsd(
   if (tier == null) {
     return 0;
   }
-  const catalogUsd = findCreditTier(proPlan, tier)?.credits_usd;
-  if (catalogUsd != null) {
-    return catalogUsd;
-  }
-  const keyUsd = tier.match(/^credits_(\d+)$/)?.[1];
-  return keyUsd != null ? Number(keyUsd) : null;
+  return findCreditTier(proPlan, tier)?.credits_usd ?? creditTierKeyUsd(tier);
 }
 
 /**

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -254,6 +254,19 @@ describe("useChangeTiers", () => {
     expect(result.current.eligible).toBe(true);
   });
 
+  test("exposes the onboarding payload's primary assistant", () => {
+    onboardingFixture = onboarding({ primary_assistant_id: "assistant-7" });
+    const { result } = setup();
+    expect(result.current.primaryAssistantId).toBe("assistant-7");
+  });
+
+  test("reports no primary assistant while the payload is absent", () => {
+    // Callers fall back to the active assistant here, which is how the
+    // provisioning takeover resolves its own target.
+    const { result } = setup({ seedOnboarding: false });
+    expect(result.current.primaryAssistantId).toBeNull();
+  });
+
   test("is ineligible when the sub is cancelling", () => {
     subscriptionFixture = proSubscription({ cancel_at_period_end: true });
     const { result } = setup();

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -77,6 +77,13 @@ export interface UseChangeTiersResult {
    * "not representable" — a false negative would misroute an eligible sub.
    */
   currentReady: boolean;
+  /**
+   * The assistant the server provisions against, from the same onboarding
+   * payload `current` reads. Null while that payload is absent, or when the org
+   * names no primary; callers fall back to the active assistant, which is how
+   * the provisioning takeover resolves its own target.
+   */
+  primaryAssistantId: string | null;
 }
 
 /**
@@ -307,5 +314,12 @@ export function useChangeTiers({
     return { needsResize, creditChanged: creditSucceeded };
   };
 
-  return { changeTiers, isPending, current, eligible, currentReady };
+  return {
+    changeTiers,
+    isPending,
+    current,
+    eligible,
+    currentReady,
+    primaryAssistantId: onboardingQuery.data?.primary_assistant_id ?? null,
+  };
 }

--- a/clients/web/src/lib/billing/credit-tiers.test.ts
+++ b/clients/web/src/lib/billing/credit-tiers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { creditTierKeyUsd } from "./credit-tiers";
+
+describe("creditTierKeyUsd", () => {
+  test("reads the amount a catalog-listed tier key names", () => {
+    expect(creditTierKeyUsd("credits_25")).toBe(25);
+    expect(creditTierKeyUsd("credits_115")).toBe(115);
+  });
+
+  test("prices a held tier the catalog no longer lists", () => {
+    expect(creditTierKeyUsd("credits_50")).toBe(50);
+  });
+
+  test("returns null for the absence of a tier", () => {
+    expect(creditTierKeyUsd(null)).toBeNull();
+    expect(creditTierKeyUsd(undefined)).toBeNull();
+  });
+
+  test("returns null for a key that names no amount", () => {
+    expect(creditTierKeyUsd("credits")).toBeNull();
+    expect(creditTierKeyUsd("credits_")).toBeNull();
+    expect(creditTierKeyUsd("credits_pro")).toBeNull();
+    expect(creditTierKeyUsd("credits_25_extra")).toBeNull();
+    expect(creditTierKeyUsd("legacy_25")).toBeNull();
+  });
+});

--- a/clients/web/src/lib/billing/credit-tiers.ts
+++ b/clients/web/src/lib/billing/credit-tiers.ts
@@ -1,0 +1,12 @@
+/**
+ * The monthly dollar amount a credit tier key names. Tier keys are shaped
+ * `credits_<usd>`, so a held or legacy tier the plan catalog no longer lists
+ * still carries its own amount and can be priced without it. Returns null for
+ * any key not in that shape, and callers decide what to show instead.
+ */
+export function creditTierKeyUsd(
+  tier: string | null | undefined,
+): number | null {
+  const usd = tier?.match(/^credits_(\d+)$/)?.[1];
+  return usd != null ? Number(usd) : null;
+}


### PR DESCRIPTION
## Summary
- One credits surface: every takeover phase renders the same from-to `$X/mo` chip, landed from first paint
- In-place switches capture true pre-change from-sides for machine, storage and credits before the mutation lands
- The machine from-side is the pod's real `machine_size` for the same assistant the takeover watches, not the billing ceiling
- `resizeCredits`, `showCreditConfirmation`, `creditConfirmationChip` and `useCreditTierLabel` are retired

Part of plan: takeover-credits-chip-and-reveal.md (PR 6 of 7)