### PR TITLE
feat(gateway): deliver raw ingress frames and serve vellum-signed routes without approval

### DIFF
--- a/gateway/src/channels/plugin-ingress-approvals.test.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.test.ts
@@ -17,6 +17,7 @@ import {
 import { pluginIngressApprovals } from "../db/schema.js";
 import { PLUGIN_INGRESS_MANIFEST_RELPATH } from "./plugin-ingress.js";
 import {
+  findServableRoute,
   ingressDeclarationDigest,
   resolvePluginIngress,
 } from "./plugin-ingress-approvals.js";
@@ -225,5 +226,76 @@ describe("resolvePluginIngress", () => {
     expect(approved).toEqual([]);
     expect(pending).toEqual([]);
     expect(problems.map((p) => p.plugin)).toEqual(["broken"]);
+  });
+});
+
+describe("findServableRoute", () => {
+  const http = (signer: "plugin" | "vellum") => ({
+    path: "hook",
+    kind: "http" as const,
+    signer,
+    description: "d",
+  });
+
+  function resolution(
+    over: Partial<{
+      approved: { plugin: string; routes: unknown[]; digest: string }[];
+      pending: { plugin: string; routes: unknown[]; digest: string }[];
+    }> = {},
+  ) {
+    return {
+      approved: [],
+      pending: [],
+      problems: [],
+      ...over,
+    } as never;
+  }
+
+  it("serves an approved route", () => {
+    const res = resolution({
+      approved: [
+        { plugin: "p", routes: [http("plugin")], digest: "d".repeat(32) },
+      ],
+    });
+    expect(findServableRoute(res, "p", "hook", "http")?.path).toBe("hook");
+  });
+
+  it("does not serve a plugin-signed route awaiting approval", () => {
+    const res = resolution({
+      pending: [
+        { plugin: "p", routes: [http("plugin")], digest: "d".repeat(32) },
+      ],
+    });
+    expect(findServableRoute(res, "p", "hook", "http")).toBeUndefined();
+  });
+
+  it("serves a vellum-signed route without approval", () => {
+    // Only a caller holding the platform secret can open it, and that trust
+    // was already given when the account was connected.
+    const res = resolution({
+      pending: [
+        { plugin: "p", routes: [http("vellum")], digest: "d".repeat(32) },
+      ],
+    });
+    expect(findServableRoute(res, "p", "hook", "http")?.signer).toBe("vellum");
+  });
+
+  it("still matches on kind and path exactly", () => {
+    const res = resolution({
+      pending: [
+        { plugin: "p", routes: [http("vellum")], digest: "d".repeat(32) },
+      ],
+    });
+    // The exemption is about approval, not about widening reach.
+    expect(findServableRoute(res, "p", "hook", "websocket")).toBeUndefined();
+    expect(findServableRoute(res, "p", "other", "http")).toBeUndefined();
+    expect(findServableRoute(res, "other", "hook", "http")).toBeUndefined();
+  });
+
+  it("serves nothing for a declaration that failed validation", () => {
+    // A malformed manifest lands in `problems`, never in either list, so a
+    // vellum signer cannot smuggle an invalid route through.
+    const res = resolution({});
+    expect(findServableRoute(res, "p", "hook", "http")).toBeUndefined();
   });
 });

--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -10,6 +10,7 @@ import {
   type DiscoveredPluginIngress,
   type DiscoverPluginIngressOptions,
   type IngressRoute,
+  type IngressRouteKind,
   type PluginIngressDiscovery,
   type PluginIngressProblem,
 } from "./plugin-ingress.js";
@@ -47,11 +48,11 @@ export interface ApprovedPluginIngress extends DiscoveredPluginIngress {
 }
 
 export interface PluginIngressResolution {
-  /** Declarations a guardian has approved, and only these may be served. */
+  /** Declarations a guardian has approved. */
   approved: ApprovedPluginIngress[];
   /**
-   * Declarations awaiting a decision. Surfaced so a guardian request can be
-   * raised for them; never served.
+   * Declarations awaiting a decision. Served only where {@link
+   * findServableRoute} says a decision is not required.
    */
   pending: PendingPluginIngress[];
   problems: PluginIngressProblem[];
@@ -126,4 +127,41 @@ function resolveDiscoveredPluginIngress(
   }
 
   return { approved, pending, problems };
+}
+
+/**
+ * The declared route the gateway may serve at `plugin`/`path`, if any.
+ *
+ * Approval is the general gate, with one exception: a route declaring
+ * `signer: "vellum"` is served without it. Such a route only opens to a
+ * caller holding the platform's own webhook secret — us — and the user
+ * already extended that trust when they connected their account, so asking
+ * them to approve it again buys nothing. A route signed by anyone else still
+ * needs a guardian decision, because approval is what establishes who that
+ * signer is allowed to be.
+ *
+ * Note this is reach the plugin can grant itself: a manifest can name a
+ * `vellum`-signed path and have it served unreviewed. What it gets is a path
+ * only Vellum can drive — no authority over the assistant, and nothing a
+ * plugin could not already reach by running its own code.
+ *
+ * Declarations that failed validation are in `problems` and are never
+ * servable, regardless of signer.
+ */
+export function findServableRoute(
+  resolution: PluginIngressResolution,
+  plugin: string,
+  path: string,
+  kind: IngressRouteKind,
+): IngressRoute | undefined {
+  const matches = (routes: readonly IngressRoute[]) =>
+    routes.find((route) => route.kind === kind && route.path === path);
+
+  const approved = resolution.approved.find((d) => d.plugin === plugin);
+  const fromApproved = approved && matches(approved.routes);
+  if (fromApproved) return fromApproved;
+
+  const pending = resolution.pending.find((d) => d.plugin === plugin);
+  const fromPending = pending && matches(pending.routes);
+  return fromPending?.signer === "vellum" ? fromPending : undefined;
 }

--- a/gateway/src/http/routes/plugin-webhook-websocket.test.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.test.ts
@@ -172,6 +172,61 @@ describe("upgrade gate", () => {
     expect(upgrades).toEqual([]);
   });
 
+  it("upgrades a vellum-signed declaration nobody approved", async () => {
+    // Only a caller holding the platform secret can open it, and the user
+    // extended that trust when they connected their account.
+    const handle = makeHandler({
+      resolve: () =>
+        resolution({
+          pending: [
+            {
+              plugin: "meeting-bot",
+              routes: [{ ...ROUTE, signer: "vellum" as const }],
+              digest: "d".repeat(32),
+            },
+          ],
+        }),
+    });
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({ secret: VELLUM_SECRET }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res).toBeUndefined();
+    expect(upgrades).toHaveLength(1);
+  });
+
+  it("still demands the platform signature on an unapproved vellum route", async () => {
+    // Skipping approval did not skip authentication.
+    const handle = makeHandler({
+      resolve: () =>
+        resolution({
+          pending: [
+            {
+              plugin: "meeting-bot",
+              routes: [{ ...ROUTE, signer: "vellum" as const }],
+              digest: "d".repeat(32),
+            },
+          ],
+        }),
+    });
+    const { server, upgrades } = fakeServer();
+
+    const res = await handle(
+      upgradeRequest({ secret: PLUGIN_SECRET }),
+      server,
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res?.status).toBe(403);
+    expect(upgrades).toEqual([]);
+  });
+
   it("404s an http-kind route rather than upgrading it", async () => {
     // Approving an HTTP route did not approve a socket at that path.
     const handle = makeHandler({
@@ -388,10 +443,14 @@ function evt(value: string): string {
 
 describe("frame delivery", () => {
   it("hands each frame to the plugin's route over IPC", async () => {
-    const calls: { method: string; params?: Record<string, unknown> }[] = [];
+    const calls: {
+      method: string;
+      params?: Record<string, unknown>;
+      binary?: Uint8Array;
+    }[] = [];
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (method, params) => {
-      calls.push({ method, params });
+    const data = socketData(async (method, params, opts) => {
+      calls.push({ method, params, binary: opts?.binary });
       return null;
     });
     const { ws } = fakeSocket(data);
@@ -403,8 +462,45 @@ describe("frame delivery", () => {
     expect(calls[0]!.method).toBe("user_route_post");
     expect(calls[0]!.params).toMatchObject({
       pathParams: { path: "plugins/meeting-bot/realtime" },
-      body: { event: "joined" },
     });
+    // The frame travels as the raw body, byte-for-byte.
+    expect(new TextDecoder().decode(calls[0]!.binary)).toBe(evt("joined"));
+  });
+
+  it("delivers a frame that is not JSON at all, unchanged", async () => {
+    // The transport does not decide what a frame means. Anything the caller
+    // sent reaches the plugin as the bytes it sent.
+    const seen: string[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (_method, _params, opts) => {
+      seen.push(new TextDecoder().decode(opts?.binary));
+      return null;
+    });
+    const { ws, closes } = fakeSocket(data);
+
+    for (const frame of ["not json", '"a bare string"', "42", "[1,2,3]"]) {
+      handlers.message(ws, frame);
+    }
+    await settle();
+
+    expect(seen).toEqual(["not json", '"a bare string"', "42", "[1,2,3]"]);
+    expect(closes).toEqual([]);
+  });
+
+  it("delivers a binary frame as the same bytes", async () => {
+    const seen: Uint8Array[] = [];
+    const handlers = getPluginWebhookWebsocketHandlers();
+    const data = socketData(async (_method, _params, opts) => {
+      seen.push(opts!.binary!);
+      return null;
+    });
+    const { ws, closes } = fakeSocket(data);
+
+    handlers.message(ws, new Uint8Array([0, 255, 10, 123]).buffer);
+    await settle();
+
+    expect(seen).toEqual([new Uint8Array([0, 255, 10, 123])]);
+    expect(closes).toEqual([]);
   });
 
   it("delivers frames one at a time, in order", async () => {
@@ -415,8 +511,8 @@ describe("frame delivery", () => {
     let release: (() => void) | undefined;
 
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (_method, params) => {
-      const event = (params!.body as { event: string }).event;
+    const data = socketData(async (_method, _params, opts) => {
+      const event = JSON.parse(new TextDecoder().decode(opts?.binary)).event;
       started.push(event);
       if (event === "first") {
         await new Promise<void>((resolve) => {
@@ -445,8 +541,8 @@ describe("frame delivery", () => {
     // behind frames that already arrived.
     const seen: string[] = [];
     const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (_method, params) => {
-      const event = (params!.body as { event: string }).event;
+    const data = socketData(async (_method, _params, opts) => {
+      const event = JSON.parse(new TextDecoder().decode(opts?.binary)).event;
       seen.push(event);
       if (event === "boom") throw new Error("assistant unreachable");
       return null;
@@ -458,43 +554,6 @@ describe("frame delivery", () => {
     await settle();
 
     expect(seen).toEqual(["boom", "after"]);
-  });
-
-  it("refuses a frame that is not a JSON object", async () => {
-    // Until the IPC envelope carries raw frames, `body` must be an object.
-    // Queueing anything else would drop it silently at the far end.
-    for (const frame of ["not json", '"a bare string"', "42", "[1,2,3]"]) {
-      const calls: unknown[] = [];
-      const handlers = getPluginWebhookWebsocketHandlers();
-      const data = socketData(async (method) => {
-        calls.push(method);
-        return null;
-      });
-      const { ws, closes } = fakeSocket(data);
-
-      handlers.message(ws, frame);
-      await settle();
-
-      expect(closes).toHaveLength(1);
-      expect(closes[0]!.code).toBe(1003);
-      expect(calls).toEqual([]);
-    }
-  });
-
-  it("refuses a binary frame rather than mangling it", async () => {
-    const calls: unknown[] = [];
-    const handlers = getPluginWebhookWebsocketHandlers();
-    const data = socketData(async (method) => {
-      calls.push(method);
-      return null;
-    });
-    const { ws, closes } = fakeSocket(data);
-
-    handlers.message(ws, new Uint8Array([1, 2, 3]).buffer);
-    await settle();
-
-    expect(closes[0]!.code).toBe(1003);
-    expect(calls).toEqual([]);
   });
 
   it("refuses a single frame larger than the webhook payload cap", async () => {
@@ -570,8 +629,8 @@ describe("frame delivery", () => {
     const seen: string[] = [];
     const handlers = getPluginWebhookWebsocketHandlers();
     let release: (() => void) | undefined;
-    const data = socketData(async (_method, params) => {
-      seen.push((params!.body as { event: string }).event);
+    const data = socketData(async (_method, _params, opts) => {
+      seen.push(JSON.parse(new TextDecoder().decode(opts?.binary)).event);
       await new Promise<void>((resolve) => {
         release = resolve;
       });

--- a/gateway/src/http/routes/plugin-webhook-websocket.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.ts
@@ -13,15 +13,14 @@
  * meaning on the wire would be inventing a protocol neither side has agreed
  * to, so a failure is logged and the socket is left alone.
  *
- * Today a frame must carry a JSON object. The IPC request envelope can carry
- * a binary frame — `writeMessage` sends one and the server's reader parses it
- * — but the server discards it (`void binary` in `assistant-server.ts`) and
- * the gateway's client still speaks the legacy newline protocol, which has no
- * binary frame at all. Until that is fixed, anything else is refused at the
- * socket rather than silently dropped on the way to the plugin.
+ * A frame travels as the request's raw body, so the plugin receives exactly
+ * the bytes the caller sent — text or binary, well-formed JSON or not.
  */
 
-import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
+import {
+  findServableRoute,
+  type PluginIngressResolution,
+} from "../../channels/plugin-ingress-approvals.js";
 import type { IngressSigner } from "../../channels/plugin-ingress.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
@@ -30,7 +29,10 @@ import {
   resolveCredentialWithRefresh,
   verifySecretWithRefresh,
 } from "../../credential-refresh.js";
-import { ipcCallAssistant } from "../../ipc/assistant-client.js";
+import {
+  ipcCallAssistant,
+  type IpcCallOptions,
+} from "../../ipc/assistant-client.js";
 import { getLogger } from "../../logger.js";
 import {
   VELLUM_TIMESTAMP_HEADER,
@@ -69,7 +71,7 @@ function frameByteLength(frame: string | Uint8Array): number {
 export type IpcCall = (
   method: string,
   params?: Record<string, unknown>,
-  opts?: { timeoutMs?: number },
+  opts?: IpcCallOptions,
 ) => Promise<unknown>;
 
 export type PluginWebhookSocketData = {
@@ -114,10 +116,10 @@ export interface PluginWebhookWsDeps {
 /**
  * Upgrade handler for `/webhooks/plugins/:plugin/:path`.
  *
- * Applies the same gate as the HTTP half — only a guardian-approved
- * declaration naming exactly this path is served, and only for the
- * `websocket` kind — then authenticates the handshake before upgrading. An
- * upgrade cannot be un-done once accepted, so everything is checked first.
+ * Applies the same gate as the HTTP half — see `findServableRoute` — and only
+ * for the `websocket` kind, then authenticates the handshake before
+ * upgrading. An upgrade cannot be un-done once accepted, so everything is
+ * checked first.
  */
 export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
   const { config, resolve, credentials, ipcCall } = deps;
@@ -132,20 +134,16 @@ export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
       return new Response("Upgrade Required", { status: 426 });
     }
 
-    let approved: PluginIngressResolution["approved"];
+    let route: ReturnType<typeof findServableRoute>;
     try {
-      approved = resolve().approved;
+      route = findServableRoute(resolve(), plugin, path, "websocket");
     } catch (err) {
-      log.error({ err, plugin }, "Failed to resolve approved plugin ingress");
+      log.error({ err, plugin }, "Failed to resolve plugin ingress");
       return new Response("Internal Server Error", { status: 500 });
     }
-
-    const route = approved
-      .find((d) => d.plugin === plugin)
-      ?.routes.find((r) => r.kind === "websocket" && r.path === path);
     if (!route) {
       // Quiet for the same reason as the HTTP half: anyone can reach this.
-      log.debug({ plugin, path }, "No approved websocket ingress route");
+      log.debug({ plugin, path }, "No servable websocket ingress route");
       return new Response("Not Found", { status: 404 });
     }
 
@@ -211,47 +209,34 @@ export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
 }
 
 /**
- * The JSON object a frame carries, or null when it does not carry one.
+ * Hand one frame to the plugin's route over IPC.
  *
- * Until the IPC request envelope can carry raw bytes, `body` is the only way
- * a frame reaches a route, and it must be an object — `synthesizeRequest`
- * re-serialises it, and the runtime adapter keeps objects only. Anything else
- * is undeliverable rather than merely awkward, so the caller refuses it
- * instead of letting it vanish.
+ * The frame travels as the request's raw body, so the plugin receives the
+ * bytes the caller sent — text or binary, well-formed JSON or not. Deciding
+ * what a frame means is the plugin's job, not the transport's.
  */
-function frameAsJsonObject(
-  frame: string | Uint8Array,
-): Record<string, unknown> | null {
-  if (typeof frame !== "string") return null;
-  try {
-    const parsed: unknown = JSON.parse(frame);
-    return parsed !== null &&
-      typeof parsed === "object" &&
-      !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-/** Hand one frame to the plugin's route over IPC. */
 async function deliverFrame(
   data: PluginWebhookSocketData,
-  body: Record<string, unknown>,
+  frame: string | Uint8Array,
 ): Promise<void> {
   const { config, plugin, path } = data;
   const call = data.ipcCall ?? ipcCallAssistant;
+  const bytes =
+    typeof frame === "string" ? new TextEncoder().encode(frame) : frame;
   try {
     await call(
       "user_route_post",
       {
         pathParams: { path: `plugins/${plugin}/${path}` },
         queryParams: {},
-        body,
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type":
+            typeof frame === "string"
+              ? "text/plain; charset=utf-8"
+              : "application/octet-stream",
+        },
       },
-      { timeoutMs: config.runtimeTimeoutMs },
+      { timeoutMs: config.runtimeTimeoutMs, binary: bytes },
     );
   } catch (err) {
     log.warn({ err, plugin, path }, "Plugin webhook frame delivery failed");
@@ -273,10 +258,7 @@ async function drain(data: PluginWebhookSocketData): Promise<void> {
     while (data.queue.length > 0 && !data.closed) {
       const frame = data.queue.shift()!;
       data.queuedBytes -= frameByteLength(frame);
-      const body = frameAsJsonObject(frame);
-      // Enqueueing already rejected anything without one; this is a guard,
-      // not a second gate.
-      if (body) await deliverFrame(data, body);
+      await deliverFrame(data, frame);
     }
   } finally {
     data.delivering = false;
@@ -320,23 +302,6 @@ export function getPluginWebhookWebsocketHandlers() {
       const frame =
         message instanceof ArrayBuffer ? new Uint8Array(message) : message;
       const size = frameByteLength(frame);
-
-      // Refuse what cannot be delivered, rather than queue it and drop it
-      // silently at the far end. 1003 is the code for "received data of a
-      // type this endpoint cannot accept", which is exactly the situation
-      // until the IPC envelope carries raw frames.
-      if (frameAsJsonObject(frame) === null) {
-        log.warn(
-          {
-            plugin: data.plugin,
-            path: data.path,
-            binary: typeof frame !== "string",
-          },
-          "Plugin webhook frame is not a JSON object — closing connection",
-        );
-        refuse(ws, 1003, "Frame must be a JSON object");
-        return;
-      }
 
       // A single oversized frame is refused rather than queued: it could
       // never be delivered anyway, since it exceeds what the plugin's route

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -166,6 +166,65 @@ describe("the gate", () => {
     expect(calls).toEqual([]);
   });
 
+  it("serves a vellum-signed declaration nobody approved", async () => {
+    // Only a caller holding the platform secret can reach it, and the user
+    // extended that trust when they connected their account.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () =>
+        resolution({
+          pending: [
+            {
+              plugin: "meeting-bot",
+              routes: [{ ...ROUTE, signer: "vellum" as const }],
+              digest: "d".repeat(32),
+            },
+          ],
+        }),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", VELLUM_SECRET),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("still demands the platform signature on an unapproved vellum route", async () => {
+    // Skipping approval did not skip authentication.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () =>
+        resolution({
+          pending: [
+            {
+              plugin: "meeting-bot",
+              routes: [{ ...ROUTE, signer: "vellum" as const }],
+              digest: "d".repeat(32),
+            },
+          ],
+        }),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", PLUGIN_SECRET),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
   it("404s a plugin with no declaration at all", async () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -1,11 +1,11 @@
 /**
- * Public webhook surface for approved plugin ingress routes.
+ * Public webhook surface for declared plugin ingress routes.
  *
  * This is where the ingress gate stops being bookkeeping: a request is
- * forwarded to the plugin only when the guardian has approved a declaration
- * that names exactly this route. Anything else is a 404 — including routes a
- * plugin declares but nobody has approved, so an unapproved declaration is
- * indistinguishable from one that was never made.
+ * forwarded only when `findServableRoute` says this exact route may be
+ * served. Anything else is a 404 — including a declaration awaiting
+ * approval, so a route that is not yet servable is indistinguishable from
+ * one that was never declared.
  *
  * Requests arrive from the public internet through the Velay tunnel, so
  * approval alone would only decide which paths exist, not who may call them.
@@ -14,7 +14,10 @@
  * The declaration picks whose secret that is — see `IngressRouteSchema.signer`.
  */
 
-import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
+import {
+  findServableRoute,
+  type PluginIngressResolution,
+} from "../../channels/plugin-ingress-approvals.js";
 import type { IngressSigner } from "../../channels/plugin-ingress.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
@@ -78,10 +81,10 @@ export interface PluginWebhookHandlerDeps {
 /**
  * Handle `/webhooks/plugins/:plugin/:path`.
  *
- * The requested path must equal an approved route's declared path. Matching
- * is exact rather than prefix-based: the digest a guardian approved covers
- * the paths it listed, so serving `<approved>/anything` would hand out reach
- * that was never reviewed. Exact matching also disposes of traversal — no
+ * The requested path must equal a servable route's declared path. Matching
+ * is exact rather than prefix-based: a declaration covers the paths it
+ * listed, so serving `<declared>/anything` would hand out reach nobody
+ * granted. Exact matching also disposes of traversal — no
  * `..` segment equals a declared path — and of percent-encoded spellings,
  * which fail closed rather than being decoded into a match.
  */
@@ -89,25 +92,20 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
   const { config, resolve, credentials, fetchImpl } = deps;
 
   return async (req: Request, plugin: string, path: string) => {
-    let approved: PluginIngressResolution["approved"];
+    let route: ReturnType<typeof findServableRoute>;
     try {
-      approved = resolve().approved;
+      // WebSocket routes are declared here but upgraded elsewhere; serving one
+      // over plain HTTP would be a different thing than was declared.
+      route = findServableRoute(resolve(), plugin, path, "http");
     } catch (err) {
-      log.error({ err, plugin }, "Failed to resolve approved plugin ingress");
+      log.error({ err, plugin }, "Failed to resolve plugin ingress");
       return Response.json({ error: "Internal server error" }, { status: 500 });
     }
-
-    const declaration = approved.find((d) => d.plugin === plugin);
-    const route = declaration?.routes.find(
-      // WebSocket routes are declared here but upgraded elsewhere; serving
-      // one over plain HTTP would be a different thing than was approved.
-      (r) => r.kind === "http" && r.path === path,
-    );
 
     if (!route) {
       // Deliberately quiet: this path is reachable by anyone on the internet,
       // so logging every miss at info would hand out a log-flooding lever.
-      log.debug({ plugin, path }, "No approved HTTP ingress route");
+      log.debug({ plugin, path }, "No servable HTTP ingress route");
       return Response.json({ error: "Not Found" }, { status: 404 });
     }
 


### PR DESCRIPTION
## Prompt / plan

Two changes, both unblocked by #39474 landing the framed IPC transport.

### 1. Frames travel as raw bytes

#39439 had to refuse non-object and binary frames with close code 1003, because `body` was the only way through the IPC envelope and it had to be a JSON object. That restriction existed purely because the transport could not carry the frame — deciding what a frame *means* was never the transport's job.

Frames now go as the request's raw body via `opts.binary`, so a plugin receives exactly the bytes the caller sent: text or binary, well-formed JSON or not. `frameAsJsonObject` and the 1003 refusal are gone.

### 2. Vellum-signed routes are served without approval

Approval had no way to be granted — no CLI verb, no client, nothing in the repo calls the approve API — so every declared route was unreachable in practice. Per review: skip the approval requirement where the webhook comes from us, since a Vellum-signed request is authenticated as Vellum and the user already extended that trust when they connected their account.

Serving now goes through one function, `findServableRoute`, so the rule is stated once and both halves of the surface share it:

- an **approved** declaration is served, as before;
- a declaration awaiting approval is served **only** if the route declares `signer: "vellum"`;
- anything in `problems` (failed validation) is never servable, whatever it declares.

**The exemption is about approval, not authentication.** An unapproved `vellum`-signed route still rejects anything not signed with the platform secret, and still matches kind and path exactly. Tested in both directions on both halves.

**Worth stating plainly**, and it's in the function's doc comment: this is reach a plugin can grant itself. A manifest can name a `vellum`-signed path and have it served unreviewed. What it gets is a path only Vellum can drive — no authority over the assistant, and nothing a plugin could not already reach by running its own code. That seemed the right trade for unblocking the flow, but it is a real widening and I'd rather it be argued with than discovered.

This defers the guardian-request flow further, as intended.

## Test plan

- `findServableRoute` unit tests: approved route served; plugin-signed pending route not served; vellum-signed pending route served; the exemption does not widen kind/path/plugin matching; nothing servable when the declaration failed validation.
- Handler-level, on **both** the HTTP and WebSocket halves: an unapproved vellum-signed declaration is served, and the same route rejects a request signed with the plugin's secret instead of the platform's (403).
- WebSocket delivery: a frame arrives as raw bytes byte-for-byte; frames that are not JSON at all (`not json`, a bare string, a number, an array) are delivered unchanged rather than closing the socket; a binary frame arrives as the same bytes. The ordering, failure-recovery, byte-budget, and close-handling tests are unchanged and still pass.
- 95 pass / 0 fail across the webhook, websocket, and channels suites; 354 pass across the wider gateway sweep. `tsc --noEmit` clean; prettier + eslint clean.
- The 2 failures in that wider sweep (`twilio-voice-webhook`, `channel-verification-session-proxy`) are the long-standing cross-file `mock.module` collisions, unchanged by this branch.

## CLI verb checklist

No new IPC route. Not applicable.

## Still open

- **meeting-bot side** — `routes/realtime.ts`, `signer: "vellum"` on the declaration, and switching `realtimeEndpointUrl()` onto the composed Velay path. Separate repo. With this merged, that declaration is servable the moment it lands, with no approval step.
- **The handshake signature needs a platform-side counterpart** in `vellum-assistant-platform` before this carries real traffic.
- **Guardian-request flow** — still deferred, now with less pressure behind it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ)_