### PR TITLE
docs(gateway): document the vellum-signed approval exception at the schema

### DIFF
--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -134,16 +134,16 @@ function resolveDiscoveredPluginIngress(
  *
  * Approval is the general gate, with one exception: a route declaring
  * `signer: "vellum"` is served without it. Such a route only opens to a
- * caller holding the platform's own webhook secret — us — and the user
- * already extended that trust when they connected their account, so asking
+ * caller holding the platform's own webhook secret, which is to say us, and
+ * the user extended that trust when they connected their account, so asking
  * them to approve it again buys nothing. A route signed by anyone else still
  * needs a guardian decision, because approval is what establishes who that
  * signer is allowed to be.
  *
  * Note this is reach the plugin can grant itself: a manifest can name a
  * `vellum`-signed path and have it served unreviewed. What it gets is a path
- * only Vellum can drive — no authority over the assistant, and nothing a
- * plugin could not already reach by running its own code.
+ * only Vellum can drive, carrying no authority over the assistant and
+ * nothing a plugin could not already reach by running its own code.
  *
  * Declarations that failed validation are in `problems` and are never
  * servable, regardless of signer.
@@ -159,7 +159,9 @@ export function findServableRoute(
 
   const approved = resolution.approved.find((d) => d.plugin === plugin);
   const fromApproved = approved && matches(approved.routes);
-  if (fromApproved) return fromApproved;
+  if (fromApproved) {
+    return fromApproved;
+  }
 
   const pending = resolution.pending.find((d) => d.plugin === plugin);
   const fromPending = pending && matches(pending.routes);

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -86,11 +86,17 @@ export const IngressRouteSchema = z.object({
    *
    * `plugin` (the default) verifies against the plugin's own
    * `webhook_secret`, so a plugin can receive third-party callbacks it has
-   * arranged itself. `vellum` verifies against the platform's
-   * `webhook_secret` — for routes only Vellum calls, which would otherwise
-   * need a per-plugin secret provisioned for a caller we already
-   * authenticate. Declaring it is the plugin's choice; approving it is the
-   * guardian's, which is why it is part of the digest.
+   * arranged itself, and a guardian decides whether that route is served.
+   *
+   * `vellum` verifies against the platform's `webhook_secret`, for routes
+   * only Vellum calls, which would otherwise need a per-plugin secret
+   * provisioned for a caller we already authenticate. Such a route is
+   * served without a guardian approval: the trust it relies on was given
+   * when the account was connected. See `findServableRoute` in
+   * `plugin-ingress-approvals.ts` for the rule and what it concedes.
+   *
+   * Either way the signer is part of the digest, so a plugin cannot move a
+   * route between the two without the change being visible.
    */
   signer: IngressSignerSchema.default("plugin"),
   /** Human-readable purpose, surfaced in gateway logs and admin UI. */

--- a/gateway/src/http/routes/plugin-webhook-websocket.ts
+++ b/gateway/src/http/routes/plugin-webhook-websocket.ts
@@ -14,7 +14,7 @@
  * to, so a failure is logged and the socket is left alone.
  *
  * A frame travels as the request's raw body, so the plugin receives exactly
- * the bytes the caller sent — text or binary, well-formed JSON or not.
+ * the bytes the caller sent: text or binary, well-formed JSON or not.
  */
 
 import {
@@ -116,7 +116,7 @@ export interface PluginWebhookWsDeps {
 /**
  * Upgrade handler for `/webhooks/plugins/:plugin/:path`.
  *
- * Applies the same gate as the HTTP half — see `findServableRoute` — and only
+ * Applies the same gate as the HTTP half (see `findServableRoute`) and only
  * for the `websocket` kind, then authenticates the handshake before
  * upgrading. An upgrade cannot be un-done once accepted, so everything is
  * checked first.
@@ -212,7 +212,7 @@ export function createPluginWebhookWebsocketHandler(deps: PluginWebhookWsDeps) {
  * Hand one frame to the plugin's route over IPC.
  *
  * The frame travels as the request's raw body, so the plugin receives the
- * bytes the caller sent — text or binary, well-formed JSON or not. Deciding
+ * bytes the caller sent: text or binary, well-formed JSON or not. Deciding
  * what a frame means is the plugin's job, not the transport's.
  */
 async function deliverFrame(

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -3,7 +3,7 @@
  *
  * This is where the ingress gate stops being bookkeeping: a request is
  * forwarded only when `findServableRoute` says this exact route may be
- * served. Anything else is a 404 — including a declaration awaiting
+ * served. Anything else is a 404, including a declaration awaiting
  * approval, so a route that is not yet servable is indistinguishable from
  * one that was never declared.
  *
@@ -84,9 +84,9 @@ export interface PluginWebhookHandlerDeps {
  * The requested path must equal a servable route's declared path. Matching
  * is exact rather than prefix-based: a declaration covers the paths it
  * listed, so serving `<declared>/anything` would hand out reach nobody
- * granted. Exact matching also disposes of traversal — no
- * `..` segment equals a declared path — and of percent-encoded spellings,
- * which fail closed rather than being decoded into a match.
+ * granted. Exact matching also disposes of traversal, since no `..` segment
+ * equals a declared path, and of percent-encoded spellings, which fail
+ * closed rather than being decoded into a match.
  */
 export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
   const { config, resolve, credentials, fetchImpl } = deps;


### PR DESCRIPTION
## Prompt / plan

Cleanup of the Codex findings left on #39480 after it merged. Three of the four; the content-type one you said to skip.

**The one that mattered: contradictory security documentation.** `IngressRouteSchema.signer` still told manifest authors that "approving it is the guardian's" choice, for both signers. That is the opposite of what the gateway now enforces for `vellum` routes, and the schema doc is where a plugin author actually looks. Someone reading it would have had the wrong contract for the one field that decides whether their route needs review.

It now describes both signers separately, states plainly that a `vellum`-signed route is served without a guardian approval and why, and points at `findServableRoute` for the rule and what it concedes. The digest note stays, since it applies to both.

**Braces** around the single-statement `if` in `findServableRoute`, per the control-flow rule. Worth noting why lint did not catch it: the ESLint `curly` rule is set to `error` in `assistant/` and `clients/web/` but not in `gateway/`, so this path relies on review. Codex was right to flag it.

**Em dashes** removed from the comments this arc added in the approval and webhook handlers. Scoped to the seven lines #39480 introduced, per AGENTS.md: "Existing text is not swept retroactively. Fix em dashes on lines you are already changing and leave the rest alone." Older em dashes in these same files are left alone deliberately.

No behaviour change; comments, one brace pair, and punctuation.

## Test plan

- 95 pass / 0 fail across the channels, webhook, and websocket suites.
- `tsc --noEmit` clean; prettier + eslint clean.

## CLI verb checklist

No new routes. Not applicable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ)_