### PR TITLE
feat(account): forward campaign attribution on the provider redirect

### DIFF
--- a/clients/web/src/domains/account/social-auth.test.ts
+++ b/clients/web/src/domains/account/social-auth.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildProviderRedirectFields,
+  readAttributionParams,
+} from "@/domains/account/social-auth";
+
+const ORIGIN = "https://www.vellum.ai";
+const CALLBACK = "/account/provider/callback";
+
+function fields(attribution?: Record<string, string>) {
+  return buildProviderRedirectFields("workos", CALLBACK, ORIGIN, {
+    intent: "signup",
+    ...(attribution ? { attribution } : {}),
+  });
+}
+
+describe("readAttributionParams", () => {
+  test("collects the params a paid-social landing carries", () => {
+    const collected = readAttributionParams(
+      "?utm_source=ig&utm_medium=paid-social&utm_campaign=personal-ai&fbclid=abc123",
+    );
+
+    expect(collected).toEqual({
+      utm_source: "ig",
+      utm_medium: "paid-social",
+      utm_campaign: "personal-ai",
+      fbclid: "abc123",
+    });
+  });
+
+  test("collects nothing for an organic arrival", () => {
+    expect(readAttributionParams("?returnTo=%2Fassistant")).toEqual({});
+  });
+
+  test("bounds an oversized value", () => {
+    const collected = readAttributionParams(`?fbclid=${"x".repeat(5000)}`);
+
+    expect(collected["fbclid"]).toHaveLength(512);
+  });
+});
+
+describe("buildProviderRedirectFields", () => {
+  test("forwards attribution so the backend can read it without the cookie", () => {
+    const built = fields({ utm_source: "ig", fbclid: "abc123" });
+
+    expect(built["utm_source"]).toBe("ig");
+    expect(built["fbclid"]).toBe("abc123");
+  });
+
+  test("keeps the existing fields intact", () => {
+    const built = fields({ utm_source: "ig" });
+
+    expect(built["provider"]).toBe("workos");
+    expect(built["callback_url"]).toBe(`${ORIGIN}${CALLBACK}`);
+    expect(built["process"]).toBe("login");
+    expect(built["intent"]).toBe("signup");
+  });
+
+  test("omits attribution keys entirely when there are none", () => {
+    const built = fields();
+
+    expect(built["utm_source"]).toBeUndefined();
+    expect(built["fbclid"]).toBeUndefined();
+  });
+
+  test("a crafted landing URL cannot redirect the flow elsewhere", () => {
+    const built = fields({
+      provider: "evil",
+      callback_url: "https://evil.example/steal",
+      process: "connect",
+      utm_source: "ig",
+    } as Record<string, string>);
+
+    // Only allowlisted attribution keys are copied; the reserved fields keep
+    // the values the caller set.
+    expect(built["provider"]).toBe("workos");
+    expect(built["callback_url"]).toBe(`${ORIGIN}${CALLBACK}`);
+    expect(built["process"]).toBe("login");
+    expect(built["utm_source"]).toBe("ig");
+  });
+});

--- a/clients/web/src/domains/account/social-auth.ts
+++ b/clients/web/src/domains/account/social-auth.ts
@@ -30,10 +30,61 @@ export const PROVIDER_REDIRECT_PATH =
 // Provider redirect (synchronous form POST)
 // ---------------------------------------------------------------------------
 
+/**
+ * Marketing attribution params the backend accepts on the redirect POST.
+ *
+ * Mirrors the keys `read_request_attribution` reads off the request in
+ * `django/config/middleware/marketing_attribution.py`.
+ */
+const ATTRIBUTION_PARAMS: readonly string[] = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "msclkid",
+  "fbclid",
+  "ttclid",
+  "li_fat_id",
+  "twclid",
+];
+
+/** Server truncates per-field; this only bounds what we put on the wire. */
+const ATTRIBUTION_VALUE_MAX_LENGTH = 512;
+
+/**
+ * Attribution params present on the current URL, carried here from the
+ * campaign landing page.
+ *
+ * Attribution normally rides the `vellum_utm` cookie, but that cookie is set
+ * by the marketing site's middleware and does not survive a social in-app
+ * browser (Instagram, Facebook) handing off to the system browser — the new
+ * cookie jar never saw it, so paid-social signups arrive unattributed.
+ * URL params do survive that handoff, and the backend falls back to reading
+ * them off the request when the cookie is missing, so forwarding them here
+ * gives the flow a cookie-free path to attribution.
+ */
+export function readAttributionParams(search: string): Record<string, string> {
+  const params = new URLSearchParams(search);
+  const collected: Record<string, string> = {};
+  for (const key of ATTRIBUTION_PARAMS) {
+    const value = params.get(key);
+    if (value) {
+      collected[key] = value.slice(0, ATTRIBUTION_VALUE_MAX_LENGTH);
+    }
+  }
+  return collected;
+}
+
 export interface ProviderRedirectOptions {
   readonly intent?: ProviderIntent;
   /** Pre-fill the WorkOS AuthKit email field (and email-first flows). */
   readonly loginHint?: string;
+  /** Campaign attribution to forward, from {@link readAttributionParams}. */
+  readonly attribution?: Record<string, string>;
 }
 
 /**
@@ -59,6 +110,15 @@ export function buildProviderRedirectFields(
   }
   if (options.loginHint) {
     fields["login_hint"] = options.loginHint;
+  }
+  // Assigned before the reserved fields above would be reachable, but written
+  // after them so a crafted `?provider=` or `?callback_url=` on the landing
+  // URL can never override the redirect target.
+  for (const key of ATTRIBUTION_PARAMS) {
+    const value = options.attribution?.[key];
+    if (value) {
+      fields[key] = value;
+    }
   }
 
   return fields;
@@ -110,12 +170,14 @@ export async function startProviderRedirect(
 
   form.action = `${origin}${PROVIDER_REDIRECT_PATH}`;
 
-  const fields = buildProviderRedirectFields(
-    providerId,
-    callbackUrl,
-    origin,
-    options,
-  );
+  const fields = buildProviderRedirectFields(providerId, callbackUrl, origin, {
+    ...options,
+    // Read here rather than threaded from each screen so every entry point
+    // forwards attribution: the landing page carries it in the URL precisely
+    // because the cookie may not have survived the browser handoff.
+    attribution:
+      options.attribution ?? readAttributionParams(window.location.search),
+  });
   fields["csrfmiddlewaretoken"] = csrfToken;
 
   for (const [name, value] of Object.entries(fields)) {


### PR DESCRIPTION
Companion to vellum-ai/vellum-assistant-platform#9597. Together they fix Meta signups arriving unattributed.

## Prompt / plan

Attribution rides the `vellum_utm` cookie set by the marketing site's middleware. The Instagram and Facebook in-app browsers hand off to the system browser to complete OAuth, and **that browser's cookie jar never saw the cookie** — so the signup lands with empty `utm_source` and Meta campaigns report as `direct`. In prod, exactly 5 attribution rows have ever carried a Meta source; 3 of those are internal test accounts.

URL params survive that handoff, because they travel with the navigation rather than the cookie jar. The marketing site now carries attribution onto the signup link (the companion PR); this side reads it off the current URL and includes it in the provider-redirect form POST.

The backend closes the loop already: `read_request_attribution` reads the cookie first and falls back to attribution params on the request, so a redirect POST carrying `utm_source` / `fbclid` is attributed with no cookie involved anywhere.

## Decisions worth review

- **Read inside `startProviderRedirect`, not threaded from each screen.** Every entry point then forwards it — which matters because the landing page put it in the URL precisely on the assumption the cookie may not have survived. `startProviderRedirect` already reads `window.location.origin`, so reading `.search` there is consistent.
- **Attribution fields are written after `provider` / `callback_url` / `process`**, and only allowlisted keys are copied, so a crafted landing URL (`?provider=evil&callback_url=…`) cannot retarget the redirect. There's a test pinning this.
- **Values are bounded before going on the wire.** The server truncates per-field regardless; this just avoids putting an unbounded reflected value into a form POST.

## Test plan

- `bun test src/domains/account/social-auth.test.ts` — 7 pass. Covers param collection, bounding an oversized value, field forwarding, existing fields untouched, nothing added for organic arrivals, and that a crafted URL cannot override the redirect target.
- `bun run test:ci` — 763 test files, 0 failed.
- `bunx tsc --noEmit` — clean.
- `bun run lint` — 0 errors.

## Merge order

Either order is safe. Before the platform PR lands there is nothing in the URL to read, so no fields are added and behavior is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUmZCccK9XZca5LTaDh9mL)_