### PR TITLE
feat(openai): add GPT-5.6 ChatGPT subscription models

### DIFF
--- a/assistant/src/providers/__tests__/connection-model-compat.test.ts
+++ b/assistant/src/providers/__tests__/connection-model-compat.test.ts
@@ -53,6 +53,9 @@ describe("isConnectionCompatibleWithModel", () => {
 
   test("oauth_subscription connection is compatible with a Codex model", () => {
     const conn = { auth: oauthAuth };
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.6-sol")).toBe(true);
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.6-terra")).toBe(true);
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.6-luna")).toBe(true);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.5")).toBe(true);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.4")).toBe(true);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.4-mini")).toBe(true);

--- a/assistant/src/providers/openai/codex-models.ts
+++ b/assistant/src/providers/openai/codex-models.ts
@@ -1,20 +1,24 @@
 /**
- * Model IDs accepted by the ChatGPT Codex subscription endpoint
+ * Model IDs Vellum allows through the ChatGPT Codex subscription endpoint
  * (`https://chatgpt.com/backend-api/codex`).
  *
  * `oauth_subscription` OpenAI connections hard-route every request to that
- * endpoint, which rejects any model outside this set with HTTP 400. The set
- * gates whether such a connection may serve a given model during auto-
- * resolution of an "Any active OpenAI connection" profile.
+ * endpoint. Because unsupported model IDs return HTTP 400, this manually
+ * maintained compatibility allowlist gates whether such a connection may
+ * serve a given model during auto-resolution of an "Any active OpenAI
+ * connection" profile.
  */
 export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
   "gpt-5.5",
   "gpt-5.4",
   "gpt-5.4-mini",
   "gpt-5.3-codex",
 ]);
 
-/** True when `model` is accepted by the Codex subscription endpoint. */
+/** True when `model` is allowlisted for Codex subscription routing. */
 export function isCodexSubscriptionModel(model: string): boolean {
   return CODEX_SUBSCRIPTION_MODEL_IDS.has(model);
 }

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -1281,6 +1281,9 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
       fireEvent.click(trigger);
       return labels;
     });
+    expect(optionLabels).toContain("GPT-5.6 Sol");
+    expect(optionLabels).toContain("GPT-5.6 Terra");
+    expect(optionLabels).toContain("GPT-5.6 Luna");
     expect(optionLabels).toContain("GPT-5.5");
     expect(optionLabels).not.toContain("GPT-5.5 Pro");
   });

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -26,6 +26,9 @@ import type {
 } from "@/generated/daemon/types.gen";
 
 const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
   "gpt-5.5",
   "gpt-5.4",
   "gpt-5.4-mini",
@@ -44,9 +47,9 @@ function connectionModelsToCatalog(
 /**
  * Whether the current connection restricts a catalog-backed provider to the
  * Codex-compatible subscription model set. A ChatGPT `oauth_subscription`
- * connection only accepts `CODEX_SUBSCRIPTION_MODEL_IDS`, so both the model
- * list and the free-text escape hatch must respect that limit — a typed id
- * the endpoint rejects would otherwise be saveable.
+ * connection is restricted to `CODEX_SUBSCRIPTION_MODEL_IDS`, so both the
+ * model list and the free-text escape hatch must respect that limit — a typed
+ * id the endpoint rejects would otherwise be saveable.
  */
 function restrictsToSubscriptionModels(
   provider: ConnectionProvider | "",


### PR DESCRIPTION
### Summary

- Allow GPT-5.6 Sol, Terra, and Luna through ChatGPT subscription routing.
- Surface the same models in the web profile editor for `oauth_subscription` connections.

### Motivation

PR #37659 added GPT-5.6 Sol, Terra, and Luna to the OpenAI provider catalogs but deliberately left the ChatGPT/Codex subscription path unchanged. As a result, the models were available through managed/API-key OpenAI connections but were filtered out or rejected before a ChatGPT subscription connection could serve them.

### Changes

- Add `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to the assistant's Codex subscription compatibility allowlist.
- Mirror those additions in the web model picker's subscription allowlist.
- Clarify that the assistant constant is a manually maintained Vellum compatibility allowlist, not authoritative endpoint metadata.
- Extend backend and web tests for the added models.

### Live ChatGPT subscription verification

Each model was invoked through an authenticated ChatGPT/Codex session using an ephemeral, read-only Codex CLI run with the prompt `Do not use tools. Reply with exactly OK.`

| Model | Result |
|---|---|
| `gpt-5.6-sol` | Passed; exit 0 and returned `OK` |
| `gpt-5.6-terra` | Passed; exit 0 and returned `OK` |
| `gpt-5.6-luna` | Passed; exit 0 and returned `OK` |
| `gpt-5.5` | Passed; exit 0 and returned `OK` |
| `gpt-5.4` | Passed; exit 0 and returned `OK` |
| `gpt-5.4-mini` | Passed; exit 0 and returned `OK` |
| `gpt-5.3-codex` | Rejected with HTTP 400: `The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.` |

### Test plan

- [x] `cd assistant && bun test src/providers/__tests__/connection-model-compat.test.ts` (9 passed)
- [x] `cd clients/web && bun test src/domains/settings/ai/profile-editor-modal.test.tsx` (44 passed)
- [x] Assistant TypeScript typecheck
- [x] Web TypeScript typecheck
- [x] Targeted ESLint and Prettier checks for all changed files
- [x] `git diff --check`

### Notes for reviewers

- `gpt-5.3-codex` remains in the existing compatibility allowlists even though the live probe above rejected it for this account. Retiring a model changes validation of persisted `provider: "chatgpt"` profiles. A cold-load reproduction confirmed that removing the ID without migration can cause section-level recovery to replace unrelated effective `llm` settings with defaults. Retirement is therefore deferred to a focused follow-up with an append-only workspace migration and explicit stale-profile handling in the editor.
- The assistant and web currently maintain mirrored compatibility sets. This PR keeps the established copies synchronized and limits scope to enabling the three cataloged GPT-5.6 models. Consolidating the policy behind a shared contract is a worthwhile follow-up if maintainers want to establish that architecture.
- macOS and iOS use the shared web client for this UI and do not maintain separate subscription-model allowlists.

### AI usage

AI was used to inspect the routing path, compare the prior catalog PR, run the live model verification matrix, prepare the focused implementation, reproduce automated review concerns, and execute the targeted checks. The working plan was: investigate adding the GPT-5.6 family to ChatGPT OAuth; trace every live allowlist; verify the endpoint-routing comments; test every currently listed subscription model; update only the necessary backend/web lists and tests; and avoid changing persisted-model compatibility without a migration.
