### PR TITLE
fix(agent): name the failure when a continuation follows a thinking-only max_tokens stall

### DIFF
--- a/assistant/src/__tests__/max-tokens-continue-hook.test.ts
+++ b/assistant/src/__tests__/max-tokens-continue-hook.test.ts
@@ -8,6 +8,9 @@
  *   `messages`; any other stop reason → stop; non-main-agent call sites →
  *   stop; a provider rejection → stop; an entirely-stripped (empty) truncated
  *   turn → stop.
+ * - Which continuation nudge the hook picks: a truncated turn that emitted
+ *   only thinking gets the thinking-only nudge; one that emitted partial
+ *   output keeps the generic continuation.
  * - The per-run budget is split across the two hooks: `post-model-call`
  *   consumes one unit per continue (up to `MAX_TOKENS_AUTO_CONTINUES`) and
  *   the `stop` hook clears the counter on the definitive terminal so the next
@@ -33,6 +36,7 @@ import {
 } from "../plugins/defaults/max-tokens-continue/continue-state-store.js";
 import postModelCall, {
   MAX_TOKENS_CONTINUE_NUDGE_TEXT,
+  MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT,
 } from "../plugins/defaults/max-tokens-continue/hooks/post-model-call.js";
 import stop from "../plugins/defaults/max-tokens-continue/hooks/stop.js";
 import type { ContentBlock } from "../providers/types.js";
@@ -50,6 +54,20 @@ const truncatedText: ContentBlock = {
   type: "text",
   text: "Here is the start of a very long answer that got cut o",
 };
+
+const thinkingBlock: ContentBlock = {
+  type: "thinking",
+  thinking: "Writing SVG code... Writing component markup...",
+  signature: "sig-abc",
+};
+
+/** The nudge text the hook appended after the truncated turn. */
+function appendedNudgeText(ctx: PostModelCallContext): unknown {
+  const nudge = ctx.messages[ctx.messages.length - 1];
+  return nudge?.content[0] && "text" in nudge.content[0]
+    ? nudge.content[0].text
+    : undefined;
+}
 
 function makeCtx(
   overrides: Partial<PostModelCallContext> = {},
@@ -89,6 +107,24 @@ describe("max-tokens-continue NUDGE_TEXT — internal-notice suppression", () =>
       "Continue exactly where you stopped",
     );
   });
+
+  test("the thinking-only nudge names the failure and demands output now", () => {
+    expect(MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT).toContain(
+      INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
+    );
+    expect(
+      MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT.startsWith("<system_notice>"),
+    ).toBe(true);
+    expect(
+      MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT.endsWith("</system_notice>"),
+    ).toBe(true);
+    expect(MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT).toContain(
+      "spent its entire output budget inside thinking",
+    );
+    expect(MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT).toContain(
+      "Do not resume planning",
+    );
+  });
 });
 
 describe("max-tokens-continue post-model-call hook", () => {
@@ -115,6 +151,90 @@ describe("max-tokens-continue post-model-call hook", () => {
       role: "user",
       content: [{ type: "text", text: MAX_TOKENS_CONTINUE_NUDGE_TEXT }],
     });
+  });
+
+  test("thinking-only truncated turn → continue with the thinking-only nudge", async () => {
+    /**
+     * Tests that a turn which burned its whole budget inside thinking is told
+     * so, rather than being invited to resume drafting in thought.
+     */
+    // GIVEN a truncated turn carrying only a thinking block.
+    const ctx = makeCtx({ content: [thinkingBlock] });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN it continues with the thinking-only nudge.
+    expect(ctx.decision).toBe("continue");
+    expect(appendedNudgeText(ctx)).toBe(MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT);
+  });
+
+  test("thinking plus whitespace-only text → thinking-only nudge", async () => {
+    /**
+     * Tests that a blank text block does not count as emitted output.
+     */
+    // GIVEN a truncated turn whose only text block is whitespace.
+    const ctx = makeCtx({
+      content: [thinkingBlock, { type: "text", text: "  \n" }],
+    });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN it still uses the thinking-only nudge.
+    expect(ctx.decision).toBe("continue");
+    expect(appendedNudgeText(ctx)).toBe(MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT);
+  });
+
+  test("thinking plus partial text → generic continuation nudge", async () => {
+    /**
+     * Tests that a turn which did emit output keeps the resume-where-you-left
+     * instruction.
+     */
+    // GIVEN a truncated turn that emitted thinking and partial text.
+    const ctx = makeCtx({ content: [thinkingBlock, truncatedText] });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN it continues with the generic nudge.
+    expect(ctx.decision).toBe("continue");
+    expect(appendedNudgeText(ctx)).toBe(MAX_TOKENS_CONTINUE_NUDGE_TEXT);
+  });
+
+  test("thinking plus a tool call → generic continuation nudge", async () => {
+    /**
+     * Tests that a tool call counts as emitted output.
+     */
+    // GIVEN a truncated turn carrying thinking and a tool call.
+    const ctx = makeCtx({
+      content: [
+        thinkingBlock,
+        { type: "tool_use", id: "tool-1", name: "write_file", input: {} },
+      ],
+    });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN it continues with the generic nudge.
+    expect(ctx.decision).toBe("continue");
+    expect(appendedNudgeText(ctx)).toBe(MAX_TOKENS_CONTINUE_NUDGE_TEXT);
+  });
+
+  test("thinking-only turn on a non-max-tokens stop → untouched", async () => {
+    /**
+     * Tests that the nudge selection never fires outside a max_tokens stop.
+     */
+    // GIVEN a thinking-only turn that ended normally.
+    const ctx = makeCtx({ content: [thinkingBlock], stopReason: "end_turn" });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN nothing is appended.
+    expect(ctx.decision).toBe("stop");
+    expect(ctx.messages).toHaveLength(1);
   });
 
   test("non-max-tokens stop reason → stop", async () => {

--- a/assistant/src/plugins/defaults/max-tokens-continue/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/max-tokens-continue/hooks/post-model-call.ts
@@ -28,9 +28,16 @@
  *   empty remainder leaves nothing to resume from, so the hook lets the turn
  *   end rather than pushing an empty assistant message the provider would
  *   reject.
+ *
+ * The nudge is chosen from the shape of the truncated reply. A reply that
+ * emitted partial output resumes it; a reply that spent the whole budget
+ * inside thinking and emitted nothing gets told so explicitly, because a
+ * generic "continue where you stopped" lets the model resume drafting in
+ * thought and stall the same way on every resume.
  */
 
 import {
+  type ContentBlock,
   type HookFunction,
   INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
   isMaxTokensStopReason,
@@ -50,6 +57,35 @@ export const MAX_TOKENS_CONTINUE_NUDGE_TEXT =
   "<system_notice>Your previous response was cut off because it reached the maximum output length. Continue exactly where you stopped — do not repeat content you already sent and do not start over." +
   INTERNAL_NUDGE_OUTPUT_SUPPRESSION +
   "</system_notice>";
+
+/**
+ * Continuation nudge for a reply that reached the output limit having emitted
+ * only thinking. Shown to the LLM, not the user.
+ */
+export const MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT =
+  "<system_notice>Your previous response spent its entire output budget inside thinking and emitted nothing: no tool call, no text. Do not resume planning and do not restate the plan. Produce the tool call or the reply text now, composing any remaining content directly in the output instead of in thought." +
+  INTERNAL_NUDGE_OUTPUT_SUPPRESSION +
+  "</system_notice>";
+
+/**
+ * Whether the truncated reply is thinking and nothing else: at least one
+ * thinking block, and no block carrying output (a tool call, non-empty text,
+ * or any other emitted content).
+ */
+function isThinkingOnlyStall(content: ContentBlock[]): boolean {
+  let sawThinking = false;
+  for (const block of content) {
+    if (block.type === "thinking" || block.type === "redacted_thinking") {
+      sawThinking = true;
+      continue;
+    }
+    if (block.type === "text" && block.text.trim().length === 0) {
+      continue;
+    }
+    return false;
+  }
+  return sawThinking;
+}
 
 const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   if (ctx.error) {
@@ -75,6 +111,7 @@ const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
     return;
   }
 
+  const thinkingOnly = isThinkingOnlyStall(ctx.content);
   consumeMaxTokensContinueBudget(ctx.conversationId);
   ctx.messages.push({
     role: "assistant",
@@ -82,11 +119,22 @@ const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   });
   ctx.messages.push({
     role: "user",
-    content: [{ type: "text", text: MAX_TOKENS_CONTINUE_NUDGE_TEXT }],
+    content: [
+      {
+        type: "text",
+        text: thinkingOnly
+          ? MAX_TOKENS_THINKING_ONLY_NUDGE_TEXT
+          : MAX_TOKENS_CONTINUE_NUDGE_TEXT,
+      },
+    ],
   });
   ctx.decision = "continue";
   ctx.logger.warn(
-    { plugin: "max-tokens-continue", conversationId: ctx.conversationId },
+    {
+      plugin: "max-tokens-continue",
+      conversationId: ctx.conversationId,
+      thinkingOnly,
+    },
     "Turn truncated at the output token limit — auto-continuing",
   );
 };


### PR DESCRIPTION
## The failure

Measured during #39336's E2E testing. On heavy authoring turns the model repeatedly hit `stop_reason: max_tokens` with a response containing **only a thinking block**: no `tool_use`, no text. The thinking tails read literally "Writing SVG code... Writing component markup...", so the entire artifact was being composed inside thought and none of it survived the stop.

The `max-tokens-continue` default plugin auto-continues these stalls, but its generic nudge ("continue exactly where you stopped") reads as permission to resume drafting in thought, so the stall repeats:

- 3 to 4 consecutive 16k-token thinking-only burns, roughly 4 minutes each, before a retry happened to emit the call in 39s once it stopped planning.
- One earlier run burned about 64k tokens over 35 minutes and produced nothing at all.

## What changes

`max-tokens-continue`'s `post-model-call` hook picks its continuation nudge from the shape of the truncated reply.

Detection predicate (only inside the existing max_tokens / mainAgent / non-empty-content path): at least one `thinking` or `redacted_thinking` block, and no block carrying output. A `tool_use` block, a non-empty `text` block, or any other emitted block disqualifies it; whitespace-only text does not count as output.

Thinking-only stalls get a nudge that names the failure and instructs recovery:

> Your previous response spent its entire output budget inside thinking and emitted nothing: no tool call, no text. Do not resume planning and do not restate the plan. Produce the tool call or the reply text now, composing any remaining content directly in the output instead of in thought.

(wrapped in the same `<system_notice>` envelope and shared `INTERNAL_NUDGE_OUTPUT_SUPPRESSION` clause as the existing nudge). Stalls that did emit partial output keep the existing generic continuation unchanged. The continue budget, the call-site gate, and the empty-content bail are untouched, and the log line carries a `thinkingOnly` field so the two paths are distinguishable in production.

This is detect-and-nudge only. It does not change sampling params, thinking budgets, or the loop.

## Tests

`assistant/src/__tests__/max-tokens-continue-hook.test.ts` extended: thinking-only stall gets the new nudge; thinking plus whitespace-only text still counts as thinking-only; thinking plus partial text and thinking plus a tool call both keep the generic continuation; a thinking-only turn on a non-max_tokens stop is left untouched; plus a shape assertion on the new nudge text. 13 pass, 0 fail. `bun run typecheck:fast`, scoped eslint, and prettier all clean.

Part of #39462

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->