### PR TITLE
feat(stt): expose per-provider languageSelection capability via the provider catalog

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29414,6 +29414,11 @@ paths:
                           type: string
                         conversationStreamingMode:
                           type: string
+                        languageSelection:
+                          type: string
+                          enum:
+                            - manual
+                            - auto
                         credentialsGuide:
                           type: string
                       required:

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -137,6 +137,31 @@ describe("STT provider catalog", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Language selection capability
+  // -----------------------------------------------------------------------
+
+  test("languageSelection is set for all providers", () => {
+    for (const entry of listProviderEntries()) {
+      expect(["manual", "auto"]).toContain(entry.languageSelection);
+    }
+  });
+
+  const expectedLanguageSelection = [
+    ["deepgram", "manual"],
+    ["vellum", "manual"],
+    ["xai", "manual"],
+    ["google-gemini", "auto"],
+    ["openai-whisper", "auto"],
+  ] as const;
+
+  test.each(expectedLanguageSelection)(
+    "%s has languageSelection %s",
+    (id, expected) => {
+      expect(getProviderEntry(id)?.languageSelection).toBe(expected);
+    },
+  );
+
+  // -----------------------------------------------------------------------
   // Credential lookup
   // -----------------------------------------------------------------------
 

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -99,6 +99,16 @@ interface SttProviderEntry {
    */
   readonly supportsDiarization: boolean;
 
+  /**
+   * How the provider handles transcription language.
+   *
+   * - `"manual"`: the provider accepts an explicit language parameter and
+   *   defaults to English when omitted; a language picker is meaningful.
+   * - `"auto"`: the provider detects language natively and accepts no
+   *   language parameter; a picker would be a no-op, so clients must hide it.
+   */
+  readonly languageSelection: "manual" | "auto";
+
   /** Guide for obtaining API credentials from this provider. */
   readonly credentialsGuide?: SttCredentialsGuide;
 }
@@ -137,6 +147,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       telephonyMode: "realtime-ws",
       conversationStreamingMode: "realtime-ws",
       supportsDiarization: true,
+      languageSelection: "manual",
       credentialsGuide: {
         description:
           "Sign in to the Deepgram console, navigate to API Keys, and create a new key.",
@@ -163,6 +174,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       telephonyMode: "batch-only",
       conversationStreamingMode: "realtime-ws",
       supportsDiarization: false,
+      languageSelection: "auto",
       credentialsGuide: {
         description:
           "Visit Google AI Studio, sign in with your Google account, and create an API key.",
@@ -188,6 +200,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       telephonyMode: "batch-only",
       conversationStreamingMode: "incremental-batch",
       supportsDiarization: false,
+      languageSelection: "auto",
       credentialsGuide: {
         description:
           "Log in to the OpenAI platform, go to API Keys, and generate a new secret key.",
@@ -213,6 +226,9 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       telephonyMode: "realtime-ws",
       conversationStreamingMode: "realtime-ws",
       supportsDiarization: false,
+      // The relay dials Deepgram nova-3 server-side, which takes an explicit
+      // language parameter.
+      languageSelection: "manual",
     },
   ],
   [
@@ -232,6 +248,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       telephonyMode: "batch-only",
       conversationStreamingMode: "realtime-ws",
       supportsDiarization: true,
+      languageSelection: "manual",
       credentialsGuide: {
         description:
           "Sign in to the xAI console, navigate to API Keys, and create a new key.",

--- a/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
@@ -147,6 +147,19 @@ describe("stt-routes", () => {
     expect(transcribeFile.policy?.requiredScopes).toContain("chat.write");
   });
 
+  // -- Providers list -------------------------------------------------------
+
+  test("providers list includes each provider's languageSelection", async () => {
+    const { handler } = getRoute("stt/providers");
+    const result = (await handler(makeArgs({}))) as {
+      providers: Array<{ id: string; languageSelection: string }>;
+    };
+
+    const byId = new Map(result.providers.map((p) => [p.id, p]));
+    expect(byId.get("deepgram")?.languageSelection).toBe("manual");
+    expect(byId.get("google-gemini")?.languageSelection).toBe("auto");
+  });
+
   // -- Success path ---------------------------------------------------------
 
   test("returns transcribed text with provider and boundary ids", async () => {

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -237,6 +237,7 @@ function handleListProviders() {
     setupHint: e.setupHint,
     apiKeyProviderName: e.credentialProvider,
     conversationStreamingMode: e.conversationStreamingMode,
+    languageSelection: e.languageSelection,
     credentialsGuide: e.credentialsGuide,
   }));
   return { providers };
@@ -440,6 +441,8 @@ export const ROUTES: RouteDefinition[] = [
           setupHint: z.string().optional(),
           apiKeyProviderName: z.string().optional(),
           conversationStreamingMode: z.string().optional(),
+          // Optional on the wire so older generated clients keep validating.
+          languageSelection: z.enum(["manual", "auto"]).optional(),
           credentialsGuide: z.string().optional(),
         }),
       ),


### PR DESCRIPTION
## Summary
- Adds a required `languageSelection: "manual" | "auto"` field to the STT provider catalog (deepgram/vellum/xai manual; gemini/whisper auto)
- Projects it through `GET /v1/stt/providers` so clients can gate language pickers on real capability (old daemons omit the field and clients hide the control)

Part of plan: stt-language-selection.md (PR 2 of 7)