### PR TITLE
feat(web): add the curated STT spoken-language catalog

### DIFF
--- a/clients/web/src/lib/stt/language-catalog.test.ts
+++ b/clients/web/src/lib/stt/language-catalog.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  STT_LANGUAGES,
+  STT_MULTI_CODE,
+  suggestedLanguageForLocale,
+} from "./language-catalog";
+
+describe("STT_LANGUAGES", () => {
+  test("has exactly 11 entries", () => {
+    expect(STT_LANGUAGES).toHaveLength(11);
+  });
+
+  test("the multi description names all 10 supported languages", () => {
+    const multi = STT_LANGUAGES.find(
+      (option) => option.code === STT_MULTI_CODE,
+    );
+    expect(multi).toBeDefined();
+    const description = multi?.description ?? "";
+    expect(description).toContain("English");
+    expect(description).toContain("Spanish");
+    expect(description).toContain("French");
+    expect(description).toContain("German");
+    expect(description).toContain("Hindi");
+    expect(description).toContain("Russian");
+    expect(description).toContain("Portuguese");
+    expect(description).toContain("Japanese");
+    expect(description).toContain("Italian");
+    expect(description).toContain("Dutch");
+  });
+});
+
+describe("suggestedLanguageForLocale", () => {
+  test("returns null for English locales", () => {
+    expect(suggestedLanguageForLocale("en-US")).toBeNull();
+  });
+
+  test("returns null for undefined", () => {
+    expect(suggestedLanguageForLocale(undefined)).toBeNull();
+  });
+
+  test("returns null for the empty string", () => {
+    expect(suggestedLanguageForLocale("")).toBeNull();
+  });
+
+  test("returns null for a subtag outside the catalog", () => {
+    expect(suggestedLanguageForLocale("ta-IN")).toBeNull();
+  });
+
+  test("returns multi for a supported non-English locale", () => {
+    expect(suggestedLanguageForLocale("hi-IN")).toBe(STT_MULTI_CODE);
+  });
+
+  test("normalizes case", () => {
+    expect(suggestedLanguageForLocale("HI")).toBe(STT_MULTI_CODE);
+  });
+
+  test("takes the primary subtag of a regional locale", () => {
+    expect(suggestedLanguageForLocale("pt-BR")).toBe(STT_MULTI_CODE);
+  });
+});

--- a/clients/web/src/lib/stt/language-catalog.ts
+++ b/clients/web/src/lib/stt/language-catalog.ts
@@ -1,0 +1,66 @@
+/**
+ * Curated spoken-language catalog for STT settings.
+ *
+ * The set is exactly Deepgram nova-3's `multi` (code-switching) roster,
+ * because the managed relay pins nova-3. Extending it requires verifying
+ * nova-3 monolingual support in Deepgram's docs first.
+ */
+
+export interface SttLanguageOption {
+  code: string;
+  label: string;
+  nativeLabel?: string;
+  description?: string;
+}
+
+/** Sentinel meaning "unset / provider default": recognition defaults to English. */
+export const STT_LANGUAGE_DEFAULT_CODE = "";
+
+export const STT_MULTI_CODE = "multi";
+
+export const STT_LANGUAGES: readonly SttLanguageOption[] = [
+  {
+    code: STT_LANGUAGE_DEFAULT_CODE,
+    label: "English (default)",
+    description: "Speech recognition defaults to English.",
+  },
+  {
+    code: STT_MULTI_CODE,
+    label: "Multilingual",
+    description:
+      "Follows you between languages mid-sentence: English, Spanish, French, German, Hindi, Russian, Portuguese, Japanese, Italian, and Dutch.",
+  },
+  { code: "es", label: "Spanish", nativeLabel: "Español" },
+  { code: "fr", label: "French", nativeLabel: "Français" },
+  { code: "de", label: "German", nativeLabel: "Deutsch" },
+  { code: "hi", label: "Hindi", nativeLabel: "हिन्दी" },
+  { code: "ru", label: "Russian", nativeLabel: "Русский" },
+  { code: "pt", label: "Portuguese", nativeLabel: "Português" },
+  { code: "ja", label: "Japanese", nativeLabel: "日本語" },
+  { code: "it", label: "Italian", nativeLabel: "Italiano" },
+  { code: "nl", label: "Dutch", nativeLabel: "Nederlands" },
+];
+
+/**
+ * Suggested STT language for a browser locale (`navigator.language`), or
+ * `null` when no suggestion applies (English, empty, or outside the catalog).
+ *
+ * A non-English-locale speaker talking to an English-speaking assistant is
+ * exactly the code-switching case, so the suggestion is `multi`, not the
+ * locale's monolingual code.
+ */
+export function suggestedLanguageForLocale(
+  navigatorLanguage: string | undefined,
+): string | null {
+  if (!navigatorLanguage) {
+    return null;
+  }
+  const primarySubtag = navigatorLanguage.toLowerCase().split("-")[0];
+  if (primarySubtag === "en") {
+    return null;
+  }
+  const inCatalog = STT_LANGUAGES.some(
+    (option) => option.code === primarySubtag,
+  );
+  return inCatalog ? STT_MULTI_CODE : null;
+}


### PR DESCRIPTION
## Summary
- New static catalog `src/lib/stt/language-catalog.ts`: default-English sentinel, `multi` code-switching entry (description names all 10 supported languages), and 9 monolingual options with native labels
- `suggestedLanguageForLocale()` maps a non-English browser locale in the supported set to the `multi` suggestion
- Additive only; consumed by later PRs in the plan

Part of plan: stt-language-selection.md (PR 3 of 7)