### PR TITLE
feat(web): open the provisioning takeover on package downgrades

### DIFF
--- a/clients/web/src/domains/onboarding/purchased-provisioning.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.ts
@@ -22,7 +22,7 @@ import {
   organizationsBillingSubscriptionOnboardingRetrieve,
   organizationsBillingSubscriptionRetrieve,
 } from "@/generated/api/sdk.gen";
-import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
+import { machineCeilingForTier } from "@/lib/billing/machine-sizes";
 import {
   isEntitlementRaceVerdict,
   isResizeOperationInFlight,
@@ -202,8 +202,7 @@ export async function awaitPurchasedProvisioning(
       const data = onboarding.data;
       if (data) {
         targets = {
-          machineSize:
-            allowedMachineSizesForTier(data.max_machine_tier).at(-1) ?? null,
+          machineSize: machineCeilingForTier(data.max_machine_tier),
           storageGib: data.selected_storage_gib ?? null,
         };
       }

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -215,6 +215,7 @@ type CapturedResizeContext = {
   fromSnapshot: { machineSize: string | null; storageGib: number | null };
   credits: { fromTier: string | null; toTier: string | null } | null;
   direction: string;
+  canLowerResources: boolean;
 };
 let takeoverResizeContext: CapturedResizeContext | undefined;
 mock.module(
@@ -654,6 +655,9 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
     expect(takeoverResizeContext?.direction).toBe("downgrade");
+    // Mighty names no machine tier, so the pod is capped to the floor: met
+    // targets can't stand in for "nothing was owed" here.
+    expect(takeoverResizeContext?.canLowerResources).toBe(true);
     expect(toastSuccessCalls).toEqual([]);
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(upgradeCall).toBeNull();
@@ -674,6 +678,8 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
     expect(takeoverResizeContext?.direction).toBe("upgrade");
+    // Ultra raises the ceiling, so the fast no-op inference is kept.
+    expect(takeoverResizeContext?.canLowerResources).toBe(false);
     // The sub holds no bundle and Ultra pins one, so the tier move is threaded.
     expect(takeoverResizeContext?.credits).toEqual({
       fromTier: null,
@@ -1066,6 +1072,9 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
     expect(takeover.getAttribute("data-mode")).toBe("resize");
     // No rank to compare against, so the takeover states a neutral change.
     expect(takeoverResizeContext?.direction).toBe("change");
+    // And for the same reason its own ceiling can sit anywhere relative to the
+    // target's, so the switch has to prove the restart rather than assume none.
+    expect(takeoverResizeContext?.canLowerResources).toBe(true);
     expect(upgradeCall).toBeNull();
   });
 
@@ -1365,6 +1374,8 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     });
     // A per-dimension edit can move dimensions in both directions at once.
     expect(takeoverResizeContext?.direction).toBe("change");
+    // Medium → Large raises the ceiling, so nothing has to shrink.
+    expect(takeoverResizeContext?.canLowerResources).toBe(false);
     expect(upgradeCall).toBeNull();
   });
 
@@ -1397,7 +1408,60 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
       fromTier: null,
       toTier: "credits_50",
     });
+    // Credits are not a provisioned resource and no ceiling moved, so the
+    // takeover keeps the inference that lets met targets resolve it straight
+    // away. The neutral "change" direction must not cost it that.
+    expect(takeoverResizeContext?.canLowerResources).toBe(false);
     expect(upgradeCall).toBeNull();
+  });
+
+  test("a storage-only Continue keeps the fast no-op inference", async () => {
+    // Volumes only ever grow, so a storage edit can't lower a ceiling either.
+    const { findByRole, findByTestId } = renderInteractive(
+      proMightySubscription(),
+      { plans: customCatalog() },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    selectOption("Storage", "30 GB");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(storageTierCall).not.toBeNull());
+    expect(storageTierCall!.body).toEqual({ storage_tier: "s" });
+    expect(machineTierCall).toBeNull();
+    expect(creditTierCall).toBeNull();
+
+    await findByTestId("resize-takeover");
+    expect(takeoverResizeContext?.canLowerResources).toBe(false);
+  });
+
+  test("a machine downgrade makes the takeover prove the restart", async () => {
+    // The sub holds a Large ceiling and drops to Medium, so the server caps the
+    // pod down. A machine downgrade owes no grow, so it opens the takeover only
+    // alongside the credit change here, and while that takeover is up the
+    // cap-down is rolling out with its targets already reading met.
+    const { findByRole, findByTestId } = renderInteractive(
+      proMightySubscription(),
+      {
+        plans: customCatalog(),
+        onboardingData: onboarding({ max_machine_tier: "large" }),
+      },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    selectOption("Machine size", "Medium machine (2.5 vCPU, 5 GiB)");
+    selectOption("Credit bundle", "50 credits");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(machineTierCall).not.toBeNull());
+    expect(machineTierCall!.body).toEqual({ machine_tier: "medium" });
+
+    await findByTestId("resize-takeover");
+    // The copy stays neutral; only the ceiling question flips.
+    expect(takeoverResizeContext?.direction).toBe("change");
+    expect(takeoverResizeContext?.canLowerResources).toBe(true);
   });
 
   test("a machine-only Continue threads no credits chip", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -81,8 +81,8 @@ let creditTierCall: Captured | null = null;
 let openedUrl: string | null = null;
 // When non-null, the change-machine-tier call rejects — drives the failure path.
 let machineTierError: unknown = null;
-// Success-toast messages captured from the mocked toast module — lets the
-// downgrade path assert its confirmation toast without rendering the Toaster.
+// Success-toast messages captured from the mocked toast module, so a path can
+// assert exactly which confirmations fired without rendering the Toaster.
 const toastSuccessCalls: string[] = [];
 // When false, the change-package promise never settles — used to observe the
 // in-flight (pending) disabled state.
@@ -214,6 +214,7 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 type CapturedResizeContext = {
   fromSnapshot: { machineSize: string | null; storageGib: number | null };
   credits: { fromTier: string | null; toTier: string | null } | null;
+  direction: string;
 };
 let takeoverResizeContext: CapturedResizeContext | undefined;
 mock.module(
@@ -630,7 +631,7 @@ afterEach(() => {
 });
 
 describe("PlansPage — Pro package switch (change-package)", () => {
-  test("Super → Mighty downgrade confirms, then calls change-package without opening the takeover", async () => {
+  test("Super → Mighty downgrade confirms, then calls change-package and opens the takeover", async () => {
     const { findByRole, findByTestId, getByTestId, queryByTestId } =
       renderInteractive(proSuperSubscription());
 
@@ -645,13 +646,15 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     await waitFor(() => expect(changePackageCall).not.toBeNull());
     expect(changePackageCall!.body).toEqual({ package: "mighty" });
 
-    // A downgrade caps the machine down immediately, so the dialog closes on a
-    // success toast and the provisioning takeover never opens.
+    // A downgrade caps the machine down and restarts the pod like any other
+    // switch, so it watches the same takeover, with no fire-and-forget toast.
     await waitFor(() =>
       expect(queryByTestId("confirm-package-switch-button")).toBeNull(),
     );
-    expect(toastSuccessCalls).toEqual(["Downgraded to Mighty."]);
-    expect(queryByTestId("resize-takeover")).toBeNull();
+    const takeover = await findByTestId("resize-takeover");
+    expect(takeover.getAttribute("data-mode")).toBe("resize");
+    expect(takeoverResizeContext?.direction).toBe("downgrade");
+    expect(toastSuccessCalls).toEqual([]);
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(upgradeCall).toBeNull();
   });
@@ -670,6 +673,7 @@ describe("PlansPage — Pro package switch (change-package)", () => {
 
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
+    expect(takeoverResizeContext?.direction).toBe("upgrade");
     // The sub holds no bundle and Ultra pins one, so the tier move is threaded.
     expect(takeoverResizeContext?.credits).toEqual({
       fromTier: null,
@@ -1060,6 +1064,8 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
     expect(changePackageCall!.body).toEqual({ package: "mighty" });
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
+    // No rank to compare against, so the takeover states a neutral change.
+    expect(takeoverResizeContext?.direction).toBe("change");
     expect(upgradeCall).toBeNull();
   });
 
@@ -1357,6 +1363,8 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
       machineSize: "large",
       storageGib: 10,
     });
+    // A per-dimension edit can move dimensions in both directions at once.
+    expect(takeoverResizeContext?.direction).toBe("change");
     expect(upgradeCall).toBeNull();
   });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -548,7 +548,8 @@ function renderInteractive(
     seedOnboarding = true,
   }: {
     plans?: PlanListResponse;
-    onboardingData?: OnboardingStateResponse;
+    /** Null models a read that settled with no payload, e.g. one that failed. */
+    onboardingData?: OnboardingStateResponse | null;
     /** False leaves the onboarding query to fetch, so it mounts unsettled. */
     seedOnboarding?: boolean;
   } = {},
@@ -661,6 +662,25 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     expect(toastSuccessCalls).toEqual([]);
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(upgradeCall).toBeNull();
+  });
+
+  test("an unread current tier is treated as able to lower, not as the floor", async () => {
+    // A failed onboarding read settles `currentReady` while leaving every
+    // dimension null, and a null machine tier is what a machine-less package
+    // reports. Ranking that null would read a Super sub as sitting on the
+    // floor and hand a real downgrade the inference only a raise earns.
+    const { findByRole, findByTestId } = renderInteractive(
+      proSuperSubscription(),
+      { onboardingData: null },
+    );
+
+    fireEvent.click(
+      await findByRole("button", { name: "Downgrade to Mighty" }),
+    );
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+    await findByTestId("resize-takeover");
+
+    expect(takeoverResizeContext?.canLowerResources).toBe(true);
   });
 
   test("Super → Ultra upgrade confirms, then calls change-package with the ultra key", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -37,6 +37,7 @@ import {
   BillingOnboardingModal,
   type ResizeTakeoverContext,
 } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
+import type { TakeoverDirection } from "@/domains/settings/billing/pro-onboarding/takeover-copy";
 import { captureTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
 import { usePreferredOrActiveAssistant } from "@/domains/settings/billing/pro-onboarding/use-preferred-or-active-assistant";
 import { findCreditTier } from "@/domains/settings/billing/pro-onboarding/use-provisioning-credits";
@@ -92,6 +93,15 @@ const DOCS_URL = "https://www.vellum.ai/docs/pricing";
 // How long the `?package=` deep link waits for its forced re-read of the
 // billing data before deciding on whatever the cache already holds.
 const DEEP_LINK_REFRESH_TIMEOUT_MS = 8_000;
+
+// How the takeover describes a package switch. The neutral "switch" relation is
+// a Custom sub, which has no catalog rank to compare against the target, so its
+// move has no knowable direction and the copy must not claim one.
+const TAKEOVER_DIRECTION: Record<SwitchRelation, TakeoverDirection> = {
+  upgrade: "upgrade",
+  downgrade: "downgrade",
+  switch: "change",
+};
 
 // The screen is a wall of creature avatars; warm the bundled component chunk at
 // module load so they resolve before first paint instead of popping in.
@@ -593,12 +603,23 @@ export function PlansPage() {
       },
     });
 
+    // A Custom sub (currentTierKey null) can't be ranked against the target, so
+    // it stays direction-neutral ("switch"); a clean-pinned sub gets the
+    // directional up/down relation. Drives the confirm copy and, once
+    // confirmed, the takeover's.
+    const switchRelation: SwitchRelation = switchTarget
+      ? currentTierKey === null
+        ? "switch"
+        : tierRelation(currentTierKey, switchTarget.key) === "downgrade"
+          ? "downgrade"
+          : "upgrade"
+      : "upgrade";
+
     const confirmSwitch = async () => {
       if (!switchTarget) {
         return;
       }
       const target = switchTarget;
-      const relation = tierRelation(currentTierKey, target.key);
       const before = capturePlanBefore();
       const result = await changePackage(target.key);
       if (!result) {
@@ -612,38 +633,22 @@ export function PlansPage() {
         toast.success("You're already on this plan.");
         return;
       }
-      // status === "ok": only an upgrade grows the machine, so only it needs
-      // the resize/provisioning takeover. A downgrade caps the machine down
-      // immediately server-side with no apply/restart step, so just confirm it.
-      // A Custom-sub switch has unknown direction, so it lands here as "upgrade"
-      // and opens the takeover — the provisioning step is grow-only/idempotent
-      // server-side, so it is the safe default when direction is unknown.
-      if (relation === "downgrade") {
-        toast.success(`Downgraded to ${target.name}.`);
-      } else {
-        const toCreditTier = (target.credit_tier ??
-          null) as CreditTierEnum | null;
-        setResizeContext({
-          fromSnapshot: before.fromSnapshot,
-          credits:
-            toCreditTier !== before.creditTier
-              ? { fromTier: before.creditTier, toTier: toCreditTier }
-              : null,
-        });
-        setResizeTakeoverOpen(true);
-      }
+      // status === "ok": every direction restarts the pod, a downgrade included
+      // (the server caps the machine down and the resize rolls out from there),
+      // so all of them watch the provisioning takeover. The direction only
+      // steers the copy.
+      const toCreditTier = (target.credit_tier ??
+        null) as CreditTierEnum | null;
+      setResizeContext({
+        fromSnapshot: before.fromSnapshot,
+        credits:
+          toCreditTier !== before.creditTier
+            ? { fromTier: before.creditTier, toTier: toCreditTier }
+            : null,
+        direction: TAKEOVER_DIRECTION[switchRelation],
+      });
+      setResizeTakeoverOpen(true);
     };
-
-    // A Custom sub (currentTierKey null) can't be ranked against the target, so
-    // the confirm copy stays direction-neutral ("switch"); a clean-pinned sub
-    // gets the directional up/down copy.
-    const switchRelation: SwitchRelation = switchTarget
-      ? currentTierKey === null
-        ? "switch"
-        : tierRelation(currentTierKey, switchTarget.key) === "downgrade"
-          ? "downgrade"
-          : "upgrade"
-      : "upgrade";
 
     const startCustomCheckout = (selection: CustomPlanSelection) =>
       startCheckout({
@@ -672,6 +677,9 @@ export function PlansPage() {
           credits: result.creditChanged
             ? { fromTier: before.creditTier, toTier: selection.creditTier }
             : null,
+          // A per-dimension edit can raise one dimension and lower another, so
+          // it has no single direction to state.
+          direction: "change",
         });
         setResizeTakeoverOpen(true);
       } else {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -202,6 +202,7 @@ export function PlansPage() {
     isPending: changeTiersPending,
     current,
     currentReady,
+    currentKnown,
     primaryAssistantId,
   } = useChangeTiers({ enabled: platformReady });
   // Native iOS keeps Checkout inside an in-app sheet, so the page holds
@@ -630,11 +631,16 @@ export function PlansPage() {
       // credits are not a provisioned resource at all.
       //
       // A Custom sub has no catalog rank, so its own ceiling can sit anywhere
-      // relative to the target's, and an unread ceiling can't be ranked at all.
-      // Neither may claim the fast inference.
+      // relative to the target's, and an unranked ceiling can't be compared at
+      // all. Neither may claim the fast inference. `currentKnown` is what
+      // separates a tier that is absent from one that was never read: a failed
+      // onboarding read settles `currentReady` while leaving `machineTier`
+      // null, which is indistinguishable from a package that names no machine
+      // and would rank an Ultra sub as if it sat on the floor.
       const canLowerResources =
         currentTierKey === null ||
         !currentReady ||
+        !currentKnown ||
         lowersMachineCeiling(current.machineTier, target.machine_tier);
       const result = await changePackage(target.key);
       if (!result) {
@@ -681,11 +687,11 @@ export function PlansPage() {
       const before = capturePlanBefore();
       // The modal seeds from `current`, so the machine tier it is moving away
       // from is read here rather than guessed. A credit-only or storage-only
-      // edit leaves the ceiling alone and keeps its fast no-op inference.
-      const canLowerResources = lowersMachineCeiling(
-        current.machineTier,
-        selection.machineTier,
-      );
+      // edit leaves the ceiling alone and keeps its fast no-op inference, while
+      // a tier that was never read cannot be ranked and so cannot claim it.
+      const canLowerResources =
+        !currentKnown ||
+        lowersMachineCeiling(current.machineTier, selection.machineTier);
       const result = await changeTiers(selection);
       if (!result) {
         // The hook toasted; keep the modal open so the user can retry.

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -74,7 +74,10 @@ import {
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
 import { creditTierKeyUsd } from "@/lib/billing/credit-tiers";
-import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
+import {
+  lowersMachineCeiling,
+  MACHINE_TIER_LABEL,
+} from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
 import { PACKAGE_PARAM, routes } from "@/utils/routes";
@@ -621,6 +624,18 @@ export function PlansPage() {
       }
       const target = switchTarget;
       const before = capturePlanBefore();
+      // Whether the switch can cap the pod's machine down, which is what
+      // decides if targets that read met can stand in for "nothing was owed".
+      // Only the machine ceiling moves that way: a volume never shrinks, and
+      // credits are not a provisioned resource at all.
+      //
+      // A Custom sub has no catalog rank, so its own ceiling can sit anywhere
+      // relative to the target's, and an unread ceiling can't be ranked at all.
+      // Neither may claim the fast inference.
+      const canLowerResources =
+        currentTierKey === null ||
+        !currentReady ||
+        lowersMachineCeiling(current.machineTier, target.machine_tier);
       const result = await changePackage(target.key);
       if (!result) {
         // The hook already toasted; keep the confirm dialog open so the user
@@ -646,6 +661,7 @@ export function PlansPage() {
             ? { fromTier: before.creditTier, toTier: toCreditTier }
             : null,
         direction: TAKEOVER_DIRECTION[switchRelation],
+        canLowerResources,
       });
       setResizeTakeoverOpen(true);
     };
@@ -663,6 +679,13 @@ export function PlansPage() {
     // the upgrade/checkout endpoint no-ops for an active Pro sub.
     const applyCustomTierChange = async (selection: CustomPlanSelection) => {
       const before = capturePlanBefore();
+      // The modal seeds from `current`, so the machine tier it is moving away
+      // from is read here rather than guessed. A credit-only or storage-only
+      // edit leaves the ceiling alone and keeps its fast no-op inference.
+      const canLowerResources = lowersMachineCeiling(
+        current.machineTier,
+        selection.machineTier,
+      );
       const result = await changeTiers(selection);
       if (!result) {
         // The hook toasted; keep the modal open so the user can retry.
@@ -680,6 +703,7 @@ export function PlansPage() {
           // A per-dimension edit can raise one dimension and lower another, so
           // it has no single direction to state.
           direction: "change",
+          canLowerResources,
         });
         setResizeTakeoverOpen(true);
       } else {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -1206,6 +1206,7 @@ describe("BillingOnboardingModal — resize mode", () => {
         fromSnapshot: { machineSize: "small", storageGib: 10 },
         credits: { fromTier: "credits_25", toTier: "credits_50" },
         direction: "upgrade",
+        canLowerResources: false,
       },
       plans: plansWithCredits(),
     });
@@ -1239,6 +1240,7 @@ describe("BillingOnboardingModal — resize mode", () => {
         fromSnapshot: { machineSize: "medium", storageGib: 30 },
         credits: null,
         direction: "upgrade",
+        canLowerResources: false,
       },
     });
 
@@ -1269,6 +1271,7 @@ describe("BillingOnboardingModal — resize mode", () => {
         fromSnapshot: { machineSize: null, storageGib: 30 },
         credits: null,
         direction: "upgrade",
+        canLowerResources: false,
       },
     });
 
@@ -1552,6 +1555,87 @@ describe("BillingOnboardingModal — resize mode", () => {
   }, 20_000);
 });
 
+describe("BillingOnboardingModal (in-place custom change)", () => {
+  /**
+   * A per-dimension edit always reads "change", whichever way its dimensions
+   * move, so the copy direction says nothing about whether a ceiling can drop.
+   * These two run identical fixtures and differ only in that answer.
+   */
+  function creditOnlyFixtures() {
+    subscriptionPlanId = "pro";
+    // The pod already sits at the targets: a credit edit buys no machine and no
+    // disk, so there is nothing for it to converge on.
+    onboardingResponse = makeOnboarding({
+      max_machine_tier: "medium",
+      selected_storage_gib: 10,
+      domain_setup_available: false,
+    });
+    assistantResponse = makeAssistant("medium", 10);
+    operationalStatusResponse = makeOperationalStatus("active");
+  }
+
+  test("a credit-only change settles without waiting on a server verdict", async () => {
+    creditOnlyFixtures();
+    // The reconcile is held for the whole test, so no verdict can ever land.
+    // Nothing but the client's own reading of the targets can resolve this.
+    let releaseEnsure = () => {};
+    ensureHold = new Promise<void>((resolve) => {
+      releaseEnsure = () => resolve();
+    });
+    const { getByText, queryByText } = renderModal({
+      mode: "resize",
+      resizeContext: {
+        fromSnapshot: { machineSize: "medium", storageGib: 10 },
+        credits: { fromTier: "credits_25", toTier: "credits_45" },
+        direction: "change",
+        canLowerResources: false,
+      },
+      plans: plansWithCredits(),
+    });
+
+    await waitFor(() => expect(getByText("You're all set!")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    expect(getByText("Your plan changes are live.")).toBeTruthy();
+    // It resolved rather than riding the stall clock out to a snag.
+    expect(queryByText("Updating your assistant…")).toBeNull();
+    expect(queryByText("We hit a snag updating your assistant")).toBeNull();
+    releaseEnsure();
+  }, 20_000);
+
+  test("the same change with a droppable ceiling still holds the wait", async () => {
+    creditOnlyFixtures();
+    let releaseEnsure = () => {};
+    ensureHold = new Promise<void>((resolve) => {
+      releaseEnsure = () => resolve();
+    });
+    const { client, getByText, queryByText } = renderModal({
+      mode: "resize",
+      resizeContext: {
+        fromSnapshot: { machineSize: "medium", storageGib: 10 },
+        credits: { fromTier: "credits_25", toTier: "credits_45" },
+        direction: "change",
+        canLowerResources: true,
+      },
+      plans: plansWithCredits(),
+    });
+
+    await waitFor(() => expect(ensureCalls).toBeGreaterThan(0), {
+      timeout: 5000,
+    });
+    await client.invalidateQueries();
+    await client.invalidateQueries();
+
+    await waitFor(
+      () => expect(getByText("Updating your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    expect(queryByText("Your plan is ready")).toBeNull();
+    expect(queryByText("You're all set!")).toBeNull();
+    releaseEnsure();
+  }, 20_000);
+});
+
 describe("BillingOnboardingModal (package downgrade)", () => {
   test("holds the wait while nothing has yet observed the restart", async () => {
     // The race a downgrade has to survive. Mighty names no machine tier and the
@@ -1578,6 +1662,7 @@ describe("BillingOnboardingModal (package downgrade)", () => {
         fromSnapshot: { machineSize: "medium", storageGib: 10 },
         credits: { fromTier: "credits_45", toTier: "credits_25" },
         direction: "downgrade",
+        canLowerResources: true,
       },
       plans: plansWithCredits(),
     });
@@ -1633,6 +1718,7 @@ describe("BillingOnboardingModal (package downgrade)", () => {
         fromSnapshot: { machineSize: "medium", storageGib: 10 },
         credits: { fromTier: "credits_45", toTier: "credits_25" },
         direction: "downgrade",
+        canLowerResources: true,
       },
       plans: plansWithCredits(),
     });
@@ -1698,6 +1784,7 @@ describe("BillingOnboardingModal (package downgrade)", () => {
         fromSnapshot: { machineSize: "small", storageGib: 10 },
         credits: { fromTier: "credits_45", toTier: "credits_25" },
         direction: "downgrade",
+        canLowerResources: true,
       },
       plans: plansWithCredits(),
     });
@@ -1725,6 +1812,7 @@ describe("BillingOnboardingModal (package downgrade)", () => {
         fromSnapshot: { machineSize: "small", storageGib: 10 },
         credits: { fromTier: "credits_25", toTier: "credits_45" },
         direction: "upgrade",
+        canLowerResources: false,
       },
       plans: plansWithCredits(),
     });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -238,6 +238,8 @@ let ensureCalls = 0;
 let ensureResponse = makeEnsureResponse("started");
 /** When set, the reconcile rejects with this error body (e.g. the 503). */
 let ensureError: unknown = null;
+/** When set, reconcile responses hold until this promise resolves. */
+let ensureHold: Promise<void> | null = null;
 /** Domains list the modal-level resize query reads; empty by default. */
 let domainsResponse: PaginatedAssistantDomainList = makeDomains(false);
 /** Counts modal-level domains fetches so tests can assert it never fires. */
@@ -285,7 +287,8 @@ mock.module("@/generated/api/sdk.gen", () => ({
     if (ensureError != null) {
       return Promise.reject(ensureError);
     }
-    return Promise.resolve({ data: ensureResponse, response: { ok: true } });
+    const result = { data: ensureResponse, response: { ok: true } };
+    return ensureHold ? ensureHold.then(() => result) : Promise.resolve(result);
   },
   assistantsDomainsList: () => {
     domainsCalls += 1;
@@ -371,6 +374,7 @@ beforeEach(() => {
   ensureCalls = 0;
   ensureResponse = makeEnsureResponse("started");
   ensureError = null;
+  ensureHold = null;
   domainsResponse = makeDomains(false);
   domainsCalls = 0;
   domainsFails = false;
@@ -929,7 +933,7 @@ describe("BillingOnboardingModal", () => {
       () =>
         expect(
           getByText(
-            "Your payment went through safely — this can take a minute.",
+            "Your payment went through safely. This can take a minute.",
           ),
         ).toBeTruthy(),
       { timeout: TEST_CONFIRM_TIMEOUT_MS + 3000 },
@@ -1549,6 +1553,69 @@ describe("BillingOnboardingModal — resize mode", () => {
 });
 
 describe("BillingOnboardingModal (package downgrade)", () => {
+  test("holds the wait while nothing has yet observed the restart", async () => {
+    // The race a downgrade has to survive. Mighty names no machine tier and the
+    // volume keeps its size, so the targets read met from the first render;
+    // meanwhile the status query has not seen the restart and the reconcile has
+    // not answered. Nothing has observed the pod going down, so nothing may say
+    // it is back up: completing here would unlock chat against a gateway that
+    // is still coming up.
+    subscriptionPlanId = "pro";
+    onboardingResponse = makeOnboarding({
+      max_machine_tier: null,
+      selected_storage_gib: 10,
+      domain_setup_available: false,
+    });
+    assistantResponse = makeAssistant("medium", 10);
+    operationalStatusResponse = makeOperationalStatus("active");
+    let releaseEnsure = () => {};
+    ensureHold = new Promise<void>((resolve) => {
+      releaseEnsure = () => resolve();
+    });
+    const { client, getByText, queryByText } = renderModal({
+      mode: "resize",
+      resizeContext: {
+        fromSnapshot: { machineSize: "medium", storageGib: 10 },
+        credits: { fromTier: "credits_45", toTier: "credits_25" },
+        direction: "downgrade",
+      },
+      plans: plansWithCredits(),
+    });
+
+    // The reconcile has been asked and is still out.
+    await waitFor(() => expect(ensureCalls).toBeGreaterThan(0), {
+      timeout: 5000,
+    });
+    await client.invalidateQueries();
+    await client.invalidateQueries();
+
+    await waitFor(
+      () => expect(getByText("Updating your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    expect(queryByText("Your plan is ready")).toBeNull();
+    expect(queryByText("You're all set!")).toBeNull();
+
+    // The restart surfaces, so there is finally something to observe.
+    operationalStatusResponse = makeOperationalStatus("resizing_machine");
+    await client.invalidateQueries();
+    await waitFor(
+      () => expect(getByText("Updating your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    await client.invalidateQueries();
+
+    // The cap lands and the marker retires, which resolves the flow properly:
+    // DONE, not the "nothing to do" terminal.
+    assistantResponse = makeAssistant("small", 10);
+    operationalStatusResponse = makeOperationalStatus("active");
+    await client.invalidateQueries();
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    releaseEnsure();
+  }, 20_000);
+
   test("Super → Mighty states the credit drop, the machine cap and no storage row", async () => {
     subscriptionPlanId = "pro";
     // Mighty names no machine tier, so the pod is capped down to the floor and

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -176,7 +176,19 @@ function makeEnsureResponse(
   };
 }
 
-/** A pro catalog with a `credits_50` tier the terminal credits chip resolves. */
+/** A credit tier the chip can price from the catalog rather than its key. */
+function creditTier(usd: number) {
+  return {
+    tier: `credits_${usd}`,
+    label: `$${usd} credits/mo`,
+    credits_usd: usd,
+    price_cents: usd * 100,
+    lookup_key: `credits_${usd}_key`,
+    legacy: false,
+  };
+}
+
+/** A pro catalog holding every credit tier the chip assertions move between. */
 function plansWithCredits(): PlanListResponse {
   return {
     plans: [
@@ -189,16 +201,7 @@ function plansWithCredits(): PlanListResponse {
         included_features: [],
         machine_tiers: [],
         storage_tiers: [],
-        credit_tiers: [
-          {
-            tier: "credits_50",
-            label: "$50 credits/mo",
-            credits_usd: 50,
-            price_cents: 5000,
-            lookup_key: "credits_50_key",
-            legacy: false,
-          },
-        ],
+        credit_tiers: [creditTier(25), creditTier(45), creditTier(50)],
         packages: [],
       },
     ],
@@ -871,7 +874,7 @@ describe("BillingOnboardingModal", () => {
     expect(queryByText("Continue in the background?")).toBeNull();
     expect(
       queryByText(
-        "Your assistant is still upgrading. Chatting won't be available until it finishes — you can keep waiting here, or continue and we'll let you know when it's ready.",
+        "Your assistant is still upgrading. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
       ),
     ).toBeNull();
     expect(queryByText("Continue")).toBeNull();
@@ -912,7 +915,7 @@ describe("BillingOnboardingModal", () => {
     // The FetchErrorState UI and its go-to-billing action still render and act.
     expect(
       getByText(
-        "We hit a problem checking your subscription. Your upgrade may still be processing — return to billing to refresh.",
+        "We hit a problem checking your subscription. Your upgrade may still be processing. Return to billing to refresh.",
       ),
     ).toBeTruthy();
     fireEvent.click(getByTestId("onboarding-go-to-billing"));
@@ -1198,6 +1201,7 @@ describe("BillingOnboardingModal — resize mode", () => {
       resizeContext: {
         fromSnapshot: { machineSize: "small", storageGib: 10 },
         credits: { fromTier: "credits_25", toTier: "credits_50" },
+        direction: "upgrade",
       },
       plans: plansWithCredits(),
     });
@@ -1230,6 +1234,7 @@ describe("BillingOnboardingModal — resize mode", () => {
       resizeContext: {
         fromSnapshot: { machineSize: "medium", storageGib: 30 },
         credits: null,
+        direction: "upgrade",
       },
     });
 
@@ -1259,6 +1264,7 @@ describe("BillingOnboardingModal — resize mode", () => {
       resizeContext: {
         fromSnapshot: { machineSize: null, storageGib: 30 },
         credits: null,
+        direction: "upgrade",
       },
     });
 
@@ -1539,5 +1545,151 @@ describe("BillingOnboardingModal — resize mode", () => {
     // The re-fire for B is what unblocks routing — a boolean latch would have
     // skipped it and left B's fresh cache never crossing the fence.
     expect(domainsCalls).toBeGreaterThan(callsAfterActive);
+  }, 20_000);
+});
+
+describe("BillingOnboardingModal (package downgrade)", () => {
+  test("Super → Mighty states the credit drop, the machine cap and no storage row", async () => {
+    subscriptionPlanId = "pro";
+    // Mighty names no machine tier, so the pod is capped down to the floor and
+    // its storage stays exactly where it is.
+    onboardingResponse = makeOnboarding({
+      max_machine_tier: null,
+      selected_storage_gib: 10,
+      domain_setup_available: false,
+    });
+    assistantResponse = makeAssistant("medium", 10);
+    operationalStatusResponse = makeOperationalStatus("resizing_machine");
+    const { client, getByTestId, getByText, queryByTestId } = renderModal({
+      mode: "resize",
+      resizeContext: {
+        fromSnapshot: { machineSize: "medium", storageGib: 10 },
+        credits: { fromTier: "credits_45", toTier: "credits_25" },
+        direction: "downgrade",
+      },
+      plans: plansWithCredits(),
+    });
+
+    // Nothing here calls the change an upgrade.
+    await waitFor(
+      () => expect(getByText("Updating your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+
+    // Credits apply the moment the change is accepted, so that chip is already
+    // checked while the machine is still rolling out.
+    await waitFor(() => expect(getByTestId("chip-credits")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    const credits = getByTestId("chip-credits");
+    expect(credits.textContent).toContain("$45/mo");
+    expect(credits.textContent).toContain("$25/mo");
+    expect(within(credits).getByTestId("chip-check")).toBeTruthy();
+
+    const machine = getByTestId("chip-machine");
+    expect(machine.textContent).toContain("Medium");
+    expect(machine.textContent).toContain("Small");
+    expect(within(machine).getByTestId("chip-spinner")).toBeTruthy();
+    // The volume keeps its size, so there is no storage move to state.
+    expect(queryByTestId("chip-storage")).toBeNull();
+
+    // The cap lands and the resize marker retires.
+    assistantResponse = makeAssistant("small", 10);
+    operationalStatusResponse = makeOperationalStatus("active");
+    await client.invalidateQueries();
+
+    await waitFor(
+      () =>
+        expect(
+          within(getByTestId("chip-machine")).getByTestId("chip-check"),
+        ).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    await waitFor(() => expect(getByText("You're all set!")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    expect(getByText("Your plan changes are live.")).toBeTruthy();
+  }, 20_000);
+
+  test("a pod already below the new ceiling gets no machine row at all", async () => {
+    // Divergent state: the sub was billed a Medium ceiling while the pod had
+    // long since settled at Small. Switching to Mighty drops the ceiling to the
+    // floor the pod is already at, so the server's cap skips it and no resize
+    // marker is ever created. A machine row here would arrive pre-checked and
+    // assert a downsize that never ran.
+    subscriptionPlanId = "pro";
+    onboardingResponse = makeOnboarding({
+      max_machine_tier: null,
+      selected_storage_gib: 10,
+      domain_setup_available: false,
+    });
+    assistantResponse = makeAssistant("small", 10);
+    ensureResponse = makeEnsureResponse("already_done");
+    const { getByTestId, getByText, queryByTestId } = renderModal({
+      mode: "resize",
+      resizeContext: {
+        fromSnapshot: { machineSize: "small", storageGib: 10 },
+        credits: { fromTier: "credits_45", toTier: "credits_25" },
+        direction: "downgrade",
+      },
+      plans: plansWithCredits(),
+    });
+
+    // Nothing is outstanding, so the flow resolves rather than hanging on a
+    // dimension that never moves.
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    expect(queryByTestId("chip-machine")).toBeNull();
+    expect(getByTestId("chip-credits").textContent).toContain("$25/mo");
+  }, 20_000);
+
+  test("Mighty → Super shows all three chips, storage pending until the grow lands", async () => {
+    subscriptionPlanId = "pro";
+    onboardingResponse = makeOnboarding({
+      max_machine_tier: "medium",
+      selected_storage_gib: 30,
+      domain_setup_available: false,
+    });
+    assistantResponse = makeAssistant("small", 10);
+    const { client, getByTestId, getByText } = renderModal({
+      mode: "resize",
+      resizeContext: {
+        fromSnapshot: { machineSize: "small", storageGib: 10 },
+        credits: { fromTier: "credits_25", toTier: "credits_45" },
+        direction: "upgrade",
+      },
+      plans: plansWithCredits(),
+    });
+
+    await waitFor(
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    await waitFor(() => expect(getByTestId("chip-storage")).toBeTruthy(), {
+      timeout: 5000,
+    });
+
+    const storage = getByTestId("chip-storage");
+    expect(storage.textContent).toContain("10 GB");
+    expect(storage.textContent).toContain("30 GB");
+    expect(within(storage).getByTestId("chip-spinner")).toBeTruthy();
+    const machine = getByTestId("chip-machine");
+    expect(machine.textContent).toContain("Small");
+    expect(machine.textContent).toContain("Medium");
+    const credits = getByTestId("chip-credits");
+    expect(credits.textContent).toContain("$25/mo");
+    expect(credits.textContent).toContain("$45/mo");
+
+    assistantResponse = makeAssistant("medium", 30);
+    await client.invalidateQueries();
+
+    await waitFor(
+      () =>
+        expect(
+          within(getByTestId("chip-storage")).getByTestId("chip-check"),
+        ).toBeTruthy(),
+      { timeout: 5000 },
+    );
   }, 20_000);
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -32,6 +32,7 @@ import {
 } from "./provisioning-state";
 import { clearTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
 import { TakeoverBackdrop } from "./takeover-backdrop";
+import { takeoverCopy, type TakeoverDirection } from "./takeover-copy";
 import { useAssistantDomains } from "./use-assistant-domains";
 import { useProProvisioning } from "./use-pro-provisioning";
 import type { CreditTierChange } from "./use-provisioning-credits";
@@ -78,6 +79,8 @@ export interface ResizeTakeoverContext {
   fromSnapshot: ProvisioningDimensions;
   /** The credit tiers the change moves between; null when it left them alone. */
   credits: CreditTierChange | null;
+  /** Which way the change goes, which every surface here writes its copy to. */
+  direction: TakeoverDirection;
 }
 
 export interface BillingOnboardingModalProps {
@@ -199,6 +202,11 @@ export function BillingOnboardingModal({
 
   const { targets, assistantId, domainStepAvailable, onboardingSettled } =
     provisioning;
+
+  // Only an in-place change can go anywhere but up, and only it threads a
+  // context; checkout and a context-less resize mount both read as an upgrade.
+  const direction = isResize ? resizeContext?.direction : undefined;
+  const copy = takeoverCopy(direction);
 
   // An in-place change lands before this mounts, so its actuals already read
   // post-change and the captured snapshot is the only honest from-side.
@@ -358,12 +366,12 @@ export function BillingOnboardingModal({
     provisioning.kickProvisioning();
     toast.info(
       provisioning.kickError != null
-        ? "We'll retry your upgrade in the background."
-        : "Your upgrade continues in the background.",
+        ? copy.backgroundRetryToast
+        : copy.backgroundExitToast,
     );
     setBackgroundConfirmOpen(false);
     onClose();
-  }, [provisioning, onClose]);
+  }, [provisioning, onClose, copy]);
 
   // Cancelling keeps the user on the takeover, still waiting on the upgrade.
   const cancelBackgroundExit = useCallback(() => {
@@ -481,7 +489,7 @@ export function BillingOnboardingModal({
         // after the wizard has advanced past provisioning.
         open={backgroundConfirmOpen && machineBusy}
         title="Continue in the background?"
-        message="Your assistant is still upgrading. Chatting won't be available until it finishes — you can keep waiting here, or continue and we'll let you know when it's ready."
+        message={copy.backgroundConfirmMessage}
         confirmLabel="Continue"
         cancelLabel="Keep waiting"
         onConfirm={confirmBackgroundExit}
@@ -493,11 +501,14 @@ export function BillingOnboardingModal({
   function renderStep() {
     if (step === "provisioning") {
       if (provisioning.confirmError || provisioning.targetsError) {
-        return <FetchErrorState onGoToBilling={onClose} />;
+        return (
+          <FetchErrorState onGoToBilling={onClose} direction={direction} />
+        );
       }
       return (
         <ProvisioningState
           state={provisioning.state}
+          direction={direction}
           softWaiting={provisioning.softWaiting}
           intent={intent}
           creditsChange={isResize ? resizeContext?.credits : undefined}
@@ -532,6 +543,6 @@ export function BillingOnboardingModal({
       );
     }
 
-    return <CompleteState assistantId={assistantId} />;
+    return <CompleteState assistantId={assistantId} direction={direction} />;
   }
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -81,6 +81,13 @@ export interface ResizeTakeoverContext {
   credits: CreditTierChange | null;
   /** Which way the change goes, which every surface here writes its copy to. */
   direction: TakeoverDirection;
+  /**
+   * Whether the change can lower a resource ceiling, so the pod has to shrink
+   * before it is ready. Separate from `direction`, which is copy only: a
+   * per-dimension edit reads "change" whichever way its dimensions move, and one
+   * that only touches credits owes no provisioning at all.
+   */
+  canLowerResources: boolean;
 }
 
 export interface BillingOnboardingModalProps {
@@ -137,14 +144,19 @@ export function BillingOnboardingModal({
   // context; checkout and a context-less resize mount both read as an upgrade.
   const direction = isResize ? resizeContext?.direction : undefined;
   const copy = takeoverCopy(direction);
+  // For the same reason, only an in-place change can lower a ceiling. Checkout
+  // and a context-less resize mount only ever raise them.
+  const canLowerResources = isResize
+    ? resizeContext?.canLowerResources === true
+    : false;
 
   // The hook owns the on-open subscription/onboarding cache invalidation and
   // every provisioning poll; it keeps tracking across step changes so a
   // backgrounded resize still resolves while the user sets up their domain. It
-  // takes the direction because a change that can lower the ceilings meets
-  // them before anything moves, so it needs positive evidence of the restart
-  // before it may complete.
-  const provisioning = useProProvisioning({ open, direction });
+  // takes the ceiling question because a change that can lower a ceiling meets
+  // its targets before anything moves, so it needs positive evidence of the
+  // restart before it may complete.
+  const provisioning = useProProvisioning({ open, canLowerResources });
 
   // Whether this wizard has actually been opened, so the reset branch below can
   // tell a close from the mount of an instance that is simply rendered closed

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -133,10 +133,18 @@ export function BillingOnboardingModal({
   // chatting stays unavailable until the upgrade finishes.
   const [backgroundConfirmOpen, setBackgroundConfirmOpen] = useState(false);
 
+  // Only an in-place change can go anywhere but up, and only it threads a
+  // context; checkout and a context-less resize mount both read as an upgrade.
+  const direction = isResize ? resizeContext?.direction : undefined;
+  const copy = takeoverCopy(direction);
+
   // The hook owns the on-open subscription/onboarding cache invalidation and
   // every provisioning poll; it keeps tracking across step changes so a
-  // backgrounded resize still resolves while the user sets up their domain.
-  const provisioning = useProProvisioning({ open });
+  // backgrounded resize still resolves while the user sets up their domain. It
+  // takes the direction because a change that can lower the ceilings meets
+  // them before anything moves, so it needs positive evidence of the restart
+  // before it may complete.
+  const provisioning = useProProvisioning({ open, direction });
 
   // Whether this wizard has actually been opened, so the reset branch below can
   // tell a close from the mount of an instance that is simply rendered closed
@@ -202,11 +210,6 @@ export function BillingOnboardingModal({
 
   const { targets, assistantId, domainStepAvailable, onboardingSettled } =
     provisioning;
-
-  // Only an in-place change can go anywhere but up, and only it threads a
-  // context; checkout and a context-less resize mount both read as an upgrade.
-  const direction = isResize ? resizeContext?.direction : undefined;
-  const copy = takeoverCopy(direction);
 
   // An in-place change lands before this mounts, so its actuals already read
   // post-change and the captured snapshot is the only honest from-side.

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.test.tsx
@@ -63,6 +63,12 @@ describe("CompleteState heading and creatures", () => {
     expect(getByText("Enjoy the new found power.")).toBeTruthy();
   });
 
+  test("a plan change states what landed instead of new found power", () => {
+    const { getByText } = render(<CompleteState direction="downgrade" />);
+    expect(getByText("You're all set!")).toBeTruthy();
+    expect(getByText("Your plan changes are live.")).toBeTruthy();
+  });
+
   test("renders the full six-creature corner layer, aria-hidden", () => {
     const { getByTestId, getAllByTestId } = render(<CompleteState />);
     expect(getAllByTestId("creature-avatar")).toHaveLength(6);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -6,13 +6,17 @@ import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
 import { CreatureCorners, WizardCardHeading } from "./primitives";
+import { takeoverCopy, type TakeoverDirection } from "./takeover-copy";
 import { usePreferredOrActiveAssistant } from "./use-preferred-or-active-assistant";
 
 export function CompleteState({
   assistantId,
+  direction,
 }: {
   /** The provisioning target assistant (onboarding primary, else active). */
   assistantId?: string | null;
+  /** Which way the change that just landed went. */
+  direction?: TakeoverDirection;
 }) {
   const navigate = useNavigate();
   const isOrgReady = useIsOrgReady();
@@ -27,7 +31,7 @@ export function CompleteState({
       <div className="relative flex w-full flex-col items-center">
         <WizardCardHeading
           title="You're all set!"
-          subtitle="Enjoy the new found power."
+          subtitle={takeoverCopy(direction).completeSubtitle}
         />
 
         <div className="mt-10 flex w-full flex-col items-center gap-10">

--- a/clients/web/src/domains/settings/billing/pro-onboarding/error-states.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/error-states.tsx
@@ -4,11 +4,15 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import { IconBadge } from "./primitives";
+import { takeoverCopy, type TakeoverDirection } from "./takeover-copy";
 
 export function FetchErrorState({
   onGoToBilling,
+  direction,
 }: {
   onGoToBilling: () => void;
+  /** Which way the change whose billing reads failed was going. */
+  direction?: TakeoverDirection;
 }) {
   return (
     <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
@@ -22,8 +26,7 @@ export function FetchErrorState({
           as="p"
           className="text-[var(--content-secondary)]"
         >
-          We hit a problem checking your subscription. Your upgrade may still be
-          processing — return to billing to refresh.
+          {takeoverCopy(direction).fetchErrorBody}
         </Typography>
       </div>
       <Button

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
@@ -394,6 +394,120 @@ describe("deriveProvisioningState — an in-flight resize blocks completion", ()
   });
 });
 
+describe("deriveProvisioningState: met targets only prove a no-op on the way up", () => {
+  // A change that can lower the ceilings meets them from its very first render:
+  // a machine-less package carries no machine target at all, and storage never
+  // shrinks. So targets-met says nothing about whether the pod has restarted,
+  // and only the server may declare there was nothing to do.
+  //
+  // The whole block runs with the pod still at its pre-change size, which is
+  // exactly what a Super → Mighty cap-down looks like before it lands.
+  const downgrade = {
+    targetsProveNoop: false,
+    targets: { machineSize: null, storageGib: 10 },
+    actuals: { machineSize: "medium" as const, storageGib: 10 },
+    initialActuals: null,
+  };
+
+  test("no verdict yet with met targets holds the wait instead of NOT_APPLICABLE", () => {
+    expect(deriveProvisioningState(baseInput(downgrade))).toEqual({
+      state: "WAITING",
+      softWaiting: false,
+    });
+  });
+
+  test("a failed reconcile rides the stall clock out to STALLED", () => {
+    // The endpoint erroring leaves the verdict null, so the flow waits rather
+    // than claiming a restart it never observed.
+    expect(
+      deriveProvisioningState(
+        baseInput({ ...downgrade, msSinceWatchStart: PROVISION_STALL_MS }),
+      ).state,
+    ).toBe("STALLED");
+  });
+
+  test("not_applicable still declares the no-op", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ ...downgrade, serverVerdict: "not_applicable" }),
+      ).state,
+    ).toBe("NOT_APPLICABLE");
+  });
+
+  test("already_done still completes", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ ...downgrade, serverVerdict: "already_done" }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  // A status reading taken after the targets read met is the upgrade path's
+  // proof that the rollout is over, and it rests on the same grow-only footing:
+  // the marker is created before the sizes are persisted, so met targets
+  // postdate it. A change that never has to grow meets its targets before the
+  // resize is requested at all, so that reading can precede the marker and
+  // proves nothing. Only a marker the client watched appear does.
+  test("started stays RESIZING despite a post-actuals status reading", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          ...downgrade,
+          serverVerdict: "started",
+          statusObservedSinceTargetsMet: true,
+        }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("in_progress stays RESIZING despite a post-actuals status reading", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          ...downgrade,
+          serverVerdict: "in_progress",
+          statusObservedSinceTargetsMet: true,
+        }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("a watched marker still completes a provisional verdict", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          ...downgrade,
+          serverVerdict: "in_progress",
+          sawOperation: true,
+        }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("an observed resize that cleared still completes", () => {
+    expect(
+      deriveProvisioningState(baseInput({ ...downgrade, sawOperation: true }))
+        .state,
+    ).toBe("DONE");
+  });
+
+  test("the same inputs on the way up still read NOT_APPLICABLE", () => {
+    // The flag is the only difference, so every upgrade path is untouched.
+    expect(
+      deriveProvisioningState(
+        baseInput({ ...downgrade, targetsProveNoop: true }),
+      ).state,
+    ).toBe("NOT_APPLICABLE");
+  });
+
+  test("omitting the flag keeps today's behaviour", () => {
+    const { targetsProveNoop: _omitted, ...withoutFlag } = downgrade;
+    expect(deriveProvisioningState(baseInput(withoutFlag)).state).toBe(
+      "NOT_APPLICABLE",
+    );
+  });
+});
+
 describe("deriveProvisioningState — a provisional verdict needs a post-actuals status reading", () => {
   // The assistant and operational-status queries poll independently, so the
   // assistant poll can land the target sizes while the status query still holds

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
@@ -67,6 +67,16 @@ export interface DeriveProvisioningInput {
    * unaffected.
    */
   statusObservedSinceTargetsMet?: boolean;
+  /**
+   * Whether met targets are themselves evidence that nothing was owed. True
+   * for a change that only ever raises the ceilings: the assistant sitting at
+   * or above what was bought then really does mean there is no work. False for
+   * one that can lower them, where the targets read met from the first render
+   * (a machine-less package has no machine target at all, and storage never
+   * shrinks) and so prove nothing. Defaults to true, which is what
+   * post-checkout onboarding always is.
+   */
+  targetsProveNoop?: boolean;
 }
 
 export interface ProvisioningSnapshot {
@@ -89,6 +99,7 @@ export function deriveProvisioningState(
     confirmExpired,
     serverVerdict = null,
     statusObservedSinceTargetsMet = true,
+    targetsProveNoop = true,
   } = input;
 
   if (planId !== "pro") {
@@ -132,12 +143,20 @@ export function deriveProvisioningState(
   // rolling out — the guard above holds) or finds it retired (genuinely
   // converged). A resize we watched appear and clear is equally good evidence.
   //
+  // That write-order argument runs on the same grow-only footing as the
+  // targets themselves, so it is only available where met targets prove a
+  // no-op. A change that can lower the ceilings meets them before the resize is
+  // even requested, so the reading it anchors can precede the marker entirely
+  // and says nothing about the rollout. There, only a marker the client watched
+  // appear counts.
+  //
   // `already_done` stays terminal on its own because the server checked the
   // marker itself — `collect_pro_provisioning_state` combines targets-met AND
   // no-active-operation before it answers that.
   const provisionalVerdict =
     serverVerdict === "started" || serverVerdict === "in_progress";
-  const rolloutConfirmedOver = sawOperation || statusObservedSinceTargetsMet;
+  const rolloutConfirmedOver =
+    sawOperation || (targetsProveNoop && statusObservedSinceTargetsMet);
 
   if (!resizeOperationInFlight) {
     // Outside a provisional verdict: DONE-by-actuals still wins over a stale
@@ -146,8 +165,9 @@ export function deriveProvisioningState(
     // seen, disambiguate by the first actuals ever observed: if they were below
     // the targets, a resize must have run → DONE. NOT_APPLICABLE is reserved
     // for first-observed actuals that already met the targets (null
-    // initialActuals means the current actuals ARE the first observation — the
-    // hook freezes them as the snapshot one render later).
+    // initialActuals means the current actuals ARE the first observation, since
+    // the hook freezes them as the snapshot one render later), and only where
+    // met targets can prove a no-op at all.
     const completed = provisionalVerdict
       ? rolloutConfirmedOver
       : operationObserved ||
@@ -160,7 +180,20 @@ export function deriveProvisioningState(
       }
       // An uncorroborated provisional verdict keeps observing (falls through to
       // RESIZING) rather than completing or declaring there was nothing to do.
-      if (!provisionalVerdict) {
+      //
+      // Where met targets prove nothing, only the server may declare the no-op.
+      // A change that can lower the ceilings meets them from its very first
+      // render (a machine-less package carries no machine target, and storage
+      // never shrinks), so completing here would say "ready" while the pod is
+      // still restarting. A verdict that has not landed yet, or a reconcile
+      // that failed outright, falls through instead: the flow holds in
+      // WAITING/RESIZING and the stall clock is the backstop, so a failed
+      // reconcile costs the user a 90s wait ending in STALLED with a retry.
+      // An honest spinner beats claiming a restart finished when it has not.
+      if (
+        !provisionalVerdict &&
+        (targetsProveNoop || serverVerdict === "not_applicable")
+      ) {
         return { state: "NOT_APPLICABLE", softWaiting: false };
       }
     } else {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -846,7 +846,7 @@ describe("confirm_timeout", () => {
 
     expect(getByText("Still confirming your upgrade")).toBeTruthy();
     expect(
-      getByText("Your payment went through safely — this can take a minute."),
+      getByText("Your payment went through safely. This can take a minute."),
     ).toBeTruthy();
     fireEvent.click(getByTestId("onboarding-retry"));
     expect(onRetry).toHaveBeenCalledTimes(1);
@@ -873,6 +873,20 @@ describe("direction", () => {
       expect(getByText(expected)).toBeTruthy();
       unmount();
     }
+  });
+
+  test("a downgrade confirm timeout reassures without claiming a payment", () => {
+    // A net package decrease is credited against the next invoice, so nothing
+    // may have been charged at all.
+    const { getByText, queryByText } = renderState({
+      state: "CONFIRM_TIMEOUT",
+      direction: "downgrade",
+    });
+
+    expect(
+      getByText("Your plan change was submitted. This can take a minute."),
+    ).toBeTruthy();
+    expect(queryByText(/payment/i)).toBeNull();
   });
 
   test("a downgrade snag reads as a plan change, error message and all", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -855,6 +855,56 @@ describe("confirm_timeout", () => {
   });
 });
 
+describe("direction", () => {
+  test("a downgrade never claims an upgrade in any phase", () => {
+    const phases: Array<[ProvisioningStateProps["state"], string]> = [
+      ["CONFIRMING", "Confirming your plan change…"],
+      ["WAITING", "Updating your assistant…"],
+      ["RESIZING", "Updating your assistant…"],
+      ["CONFIRM_TIMEOUT", "Still confirming your plan change"],
+    ];
+    for (const [state, expected] of phases) {
+      const { getByText, unmount } = renderState({
+        state,
+        direction: "downgrade",
+        targets: { machineSize: "small", storageGib: null },
+        fromSnapshot: { machineSize: "medium", storageGib: null },
+      });
+      expect(getByText(expected)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  test("a downgrade snag reads as a plan change, error message and all", () => {
+    const { getByText } = renderState({
+      state: "STALLED",
+      direction: "downgrade",
+      escapeAvailable: true,
+      kickError: {},
+    });
+
+    expect(getByText("We hit a snag updating your assistant")).toBeTruthy();
+    expect(
+      getByText(
+        "Retry in the background and we'll keep working on your plan change.",
+      ),
+    ).toBeTruthy();
+  });
+
+  test("a direction-unknown change reads the same as a downgrade", () => {
+    const { getByText } = renderState({
+      state: "WAITING",
+      direction: "change",
+    });
+    expect(getByText("Updating your assistant…")).toBeTruthy();
+  });
+
+  test("an omitted direction keeps the upgrade wording", () => {
+    const { getByText } = renderState({ state: "WAITING" });
+    expect(getByText("Upgrading your assistant…")).toBeTruthy();
+  });
+});
+
 describe("escape hatch", () => {
   test("renders the background-continue button only when available", () => {
     const onEscape = mock(() => {});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -807,7 +807,7 @@ export function ProvisioningState({
         <>
           <Copy
             status={copy.confirmTimeoutStatus}
-            caption="Your payment went through safely — this can take a minute."
+            caption={copy.confirmTimeoutCaption}
           />
           <div className="flex items-center gap-2 pt-1">
             <Button

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -36,6 +36,7 @@ import {
   type ResourceChangeKey,
 } from "./resource-changes";
 import { TakeoverBackdrop } from "./takeover-backdrop";
+import { takeoverCopy, type TakeoverDirection } from "./takeover-copy";
 import {
   useProvisioningCredits,
   useResizeCreditsChange,
@@ -107,6 +108,8 @@ const RESOURCE_CHIP_ICON: Record<ResourceChangeKey, LucideIcon> = {
 
 export interface ProvisioningStateProps {
   state: ProvisioningStateKind;
+  /** Which way the change goes; selects the phase copy. */
+  direction?: TakeoverDirection;
   /** Softens the waiting sub-copy once the grace period has elapsed. */
   softWaiting: boolean;
   /** The checkout selection stashed before the Stripe redirect. */
@@ -596,6 +599,7 @@ function IntentChips({ intent }: { intent: CheckoutIntent }) {
 
 export function ProvisioningState({
   state,
+  direction,
   softWaiting,
   intent,
   creditsChange,
@@ -614,6 +618,7 @@ export function ProvisioningState({
   dwellMs = PROVISION_MIN_DWELL_MS,
   phaseMinMs = PROVISION_PHASE_MIN_MS,
 }: ProvisioningStateProps) {
+  const copy = takeoverCopy(direction);
   const onCelebrationEndRef = useRef(onCelebrationEnd);
   useEffect(() => {
     onCelebrationEndRef.current = onCelebrationEnd;
@@ -722,7 +727,7 @@ export function ProvisioningState({
       return (
         <>
           <Copy
-            status="Confirming your upgrade…"
+            status={copy.confirmingStatus}
             caption="This might take a couple seconds."
           />
           {intent && <IntentChips intent={intent} />}
@@ -735,7 +740,7 @@ export function ProvisioningState({
       return (
         <>
           <Copy
-            status="Upgrading your assistant…"
+            status={copy.waitingStatus}
             caption={
               softWaiting
                 ? "Still working — this can take a minute or two."
@@ -779,16 +784,11 @@ export function ProvisioningState({
         <>
           <Copy
             status={
-              snag
-                ? "We hit a snag upgrading your assistant"
-                : "This is taking longer than expected"
+              snag ? copy.snagStatus : "This is taking longer than expected"
             }
             caption={
               snag
-                ? extractOnboardingErrorMessage(
-                    kickError,
-                    "Retry in the background — we'll keep working on your upgrade.",
-                  )
+                ? extractOnboardingErrorMessage(kickError, copy.snagCaption)
                 : "This may take a couple of minutes."
             }
           />
@@ -802,7 +802,7 @@ export function ProvisioningState({
       return (
         <>
           <Copy
-            status="Still confirming your upgrade"
+            status={copy.confirmTimeoutStatus}
             caption="Your payment went through safely — this can take a minute."
           />
           <div className="flex items-center gap-2 pt-1">

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -788,7 +788,11 @@ export function ProvisioningState({
             }
             caption={
               snag
-                ? extractOnboardingErrorMessage(kickError, copy.snagCaption)
+                ? extractOnboardingErrorMessage(
+                    kickError,
+                    copy.snagCaption,
+                    direction,
+                  )
                 : "This may take a couple of minutes."
             }
           />

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-copy.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-copy.test.ts
@@ -20,6 +20,9 @@ describe("takeoverCopy", () => {
     );
     expect(copy.confirmingStatus).toBe("Confirming your upgrade…");
     expect(copy.confirmTimeoutStatus).toBe("Still confirming your upgrade");
+    expect(copy.confirmTimeoutCaption).toBe(
+      "Your payment went through safely. This can take a minute.",
+    );
     expect(copy.backgroundConfirmMessage).toBe(
       "Your assistant is still upgrading. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
     );
@@ -44,6 +47,11 @@ describe("takeoverCopy", () => {
     );
     expect(copy.confirmingStatus).toBe("Confirming your plan change…");
     expect(copy.confirmTimeoutStatus).toBe("Still confirming your plan change");
+    // A net package decrease is credited toward the next invoice, so there may
+    // have been no payment to reassure anyone about.
+    expect(copy.confirmTimeoutCaption).toBe(
+      "Your plan change was submitted. This can take a minute.",
+    );
     expect(copy.backgroundConfirmMessage).toBe(
       "Your assistant is still updating. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
     );
@@ -73,6 +81,14 @@ describe("takeoverCopy", () => {
       const strings = Object.values(takeoverCopy(direction));
       const mentionsUpgrade = strings.some((s) => /upgrad/i.test(s));
       expect(mentionsUpgrade).toBe(direction === "upgrade");
+    }
+  });
+
+  test("only the upgrade direction claims a payment", () => {
+    for (const direction of DIRECTIONS) {
+      const strings = Object.values(takeoverCopy(direction));
+      const mentionsPayment = strings.some((s) => /payment/i.test(s));
+      expect(mentionsPayment).toBe(direction === "upgrade");
     }
   });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-copy.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-copy.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the takeover's direction-dependent copy table. The strings
+ * themselves are the contract here, so they are asserted literally: every other
+ * suite reads them through `takeoverCopy`, and this is the one place a wording
+ * change has to be made deliberately.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { takeoverCopy, type TakeoverDirection } from "./takeover-copy";
+
+const DIRECTIONS: TakeoverDirection[] = ["upgrade", "downgrade", "change"];
+
+describe("takeoverCopy", () => {
+  test("an upgrade names the upgrade throughout", () => {
+    const copy = takeoverCopy("upgrade");
+    expect(copy.waitingStatus).toBe("Upgrading your assistant…");
+    expect(copy.snagStatus).toBe("We hit a snag upgrading your assistant");
+    expect(copy.snagCaption).toBe(
+      "Retry in the background and we'll keep working on your upgrade.",
+    );
+    expect(copy.confirmingStatus).toBe("Confirming your upgrade…");
+    expect(copy.confirmTimeoutStatus).toBe("Still confirming your upgrade");
+    expect(copy.backgroundConfirmMessage).toBe(
+      "Your assistant is still upgrading. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
+    );
+    expect(copy.backgroundExitToast).toBe(
+      "Your upgrade continues in the background.",
+    );
+    expect(copy.backgroundRetryToast).toBe(
+      "We'll retry your upgrade in the background.",
+    );
+    expect(copy.completeSubtitle).toBe("Enjoy the new found power.");
+    expect(copy.fetchErrorBody).toBe(
+      "We hit a problem checking your subscription. Your upgrade may still be processing. Return to billing to refresh.",
+    );
+  });
+
+  test("a downgrade states a plan change, never an upgrade", () => {
+    const copy = takeoverCopy("downgrade");
+    expect(copy.waitingStatus).toBe("Updating your assistant…");
+    expect(copy.snagStatus).toBe("We hit a snag updating your assistant");
+    expect(copy.snagCaption).toBe(
+      "Retry in the background and we'll keep working on your plan change.",
+    );
+    expect(copy.confirmingStatus).toBe("Confirming your plan change…");
+    expect(copy.confirmTimeoutStatus).toBe("Still confirming your plan change");
+    expect(copy.backgroundConfirmMessage).toBe(
+      "Your assistant is still updating. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
+    );
+    expect(copy.backgroundExitToast).toBe(
+      "Your plan change continues in the background.",
+    );
+    expect(copy.backgroundRetryToast).toBe(
+      "We'll retry your plan change in the background.",
+    );
+    expect(copy.completeSubtitle).toBe("Your plan changes are live.");
+    expect(copy.fetchErrorBody).toBe(
+      "We hit a problem checking your subscription. Your plan change may still be processing. Return to billing to refresh.",
+    );
+  });
+
+  test("a direction-unknown change reads exactly like a downgrade", () => {
+    expect(takeoverCopy("change")).toEqual(takeoverCopy("downgrade"));
+  });
+
+  test("an absent direction falls back to the upgrade wording", () => {
+    expect(takeoverCopy()).toEqual(takeoverCopy("upgrade"));
+    expect(takeoverCopy(undefined)).toEqual(takeoverCopy("upgrade"));
+  });
+
+  test("only the upgrade direction says 'upgrade' anywhere", () => {
+    for (const direction of DIRECTIONS) {
+      const strings = Object.values(takeoverCopy(direction));
+      const mentionsUpgrade = strings.some((s) => /upgrad/i.test(s));
+      expect(mentionsUpgrade).toBe(direction === "upgrade");
+    }
+  });
+
+  test("no string carries an em dash", () => {
+    // Escaped rather than literal: the repo bans the character itself, and the
+    // pre-ship diff check greps for it.
+    const EM_DASH = "\u2014";
+    for (const direction of DIRECTIONS) {
+      for (const value of Object.values(takeoverCopy(direction))) {
+        expect(value).not.toContain(EM_DASH);
+      }
+    }
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-copy.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-copy.ts
@@ -26,6 +26,12 @@ export interface TakeoverCopy {
   confirmingStatus: string;
   /** CONFIRM_TIMEOUT heading, once that read has run out of patience. */
   confirmTimeoutStatus: string;
+  /**
+   * CONFIRM_TIMEOUT caption. Reassures that the change itself is safe, so it
+   * may only name money where money was certainly taken: a net package
+   * decrease lands as a credit toward the next invoice, with no payment at all.
+   */
+  confirmTimeoutCaption: string;
   /** Body of the confirm that gates the background exit. */
   backgroundConfirmMessage: string;
   /** Toast on a clean background exit. */
@@ -45,6 +51,8 @@ const UPGRADE: TakeoverCopy = {
     "Retry in the background and we'll keep working on your upgrade.",
   confirmingStatus: "Confirming your upgrade…",
   confirmTimeoutStatus: "Still confirming your upgrade",
+  confirmTimeoutCaption:
+    "Your payment went through safely. This can take a minute.",
   backgroundConfirmMessage:
     "Your assistant is still upgrading. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
   backgroundExitToast: "Your upgrade continues in the background.",
@@ -61,6 +69,8 @@ const PLAN_CHANGE: TakeoverCopy = {
     "Retry in the background and we'll keep working on your plan change.",
   confirmingStatus: "Confirming your plan change…",
   confirmTimeoutStatus: "Still confirming your plan change",
+  confirmTimeoutCaption:
+    "Your plan change was submitted. This can take a minute.",
   backgroundConfirmMessage:
     "Your assistant is still updating. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
   backgroundExitToast: "Your plan change continues in the background.",

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-copy.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-copy.ts
@@ -1,0 +1,88 @@
+/**
+ * Direction-dependent copy for the provisioning takeover and the surfaces that
+ * bracket it: the background-exit confirm and its toasts, the completion card,
+ * and the billing fetch-error card.
+ *
+ * A downgrade and a direction-unknown switch read identically. Neither can
+ * claim an upgrade, and "plan change" is the one phrase that covers a step down
+ * and a sideways move without guessing which one happened.
+ */
+
+/**
+ * Which way the change the takeover is watching goes. "change" is the neutral
+ * variant for a move with no knowable direction, e.g. a Custom sub switching to
+ * a stock package.
+ */
+export type TakeoverDirection = "upgrade" | "downgrade" | "change";
+
+export interface TakeoverCopy {
+  /** WAITING / RESIZING heading, while the machine rolls out. */
+  waitingStatus: string;
+  /** STALLED heading once a reconcile failure has been captured. */
+  snagStatus: string;
+  /** STALLED caption when the captured failure carries no message of its own. */
+  snagCaption: string;
+  /** CONFIRMING heading, while the subscription read catches up. */
+  confirmingStatus: string;
+  /** CONFIRM_TIMEOUT heading, once that read has run out of patience. */
+  confirmTimeoutStatus: string;
+  /** Body of the confirm that gates the background exit. */
+  backgroundConfirmMessage: string;
+  /** Toast on a clean background exit. */
+  backgroundExitToast: string;
+  /** Toast on a background exit that is also retrying a failed reconcile. */
+  backgroundRetryToast: string;
+  /** Subtitle of the terminal completion card. */
+  completeSubtitle: string;
+  /** Body of the card shown when the billing reads themselves fail. */
+  fetchErrorBody: string;
+}
+
+const UPGRADE: TakeoverCopy = {
+  waitingStatus: "Upgrading your assistant…",
+  snagStatus: "We hit a snag upgrading your assistant",
+  snagCaption:
+    "Retry in the background and we'll keep working on your upgrade.",
+  confirmingStatus: "Confirming your upgrade…",
+  confirmTimeoutStatus: "Still confirming your upgrade",
+  backgroundConfirmMessage:
+    "Your assistant is still upgrading. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
+  backgroundExitToast: "Your upgrade continues in the background.",
+  backgroundRetryToast: "We'll retry your upgrade in the background.",
+  completeSubtitle: "Enjoy the new found power.",
+  fetchErrorBody:
+    "We hit a problem checking your subscription. Your upgrade may still be processing. Return to billing to refresh.",
+};
+
+const PLAN_CHANGE: TakeoverCopy = {
+  waitingStatus: "Updating your assistant…",
+  snagStatus: "We hit a snag updating your assistant",
+  snagCaption:
+    "Retry in the background and we'll keep working on your plan change.",
+  confirmingStatus: "Confirming your plan change…",
+  confirmTimeoutStatus: "Still confirming your plan change",
+  backgroundConfirmMessage:
+    "Your assistant is still updating. Chatting won't be available until it finishes. You can keep waiting here, or continue and we'll let you know when it's ready.",
+  backgroundExitToast: "Your plan change continues in the background.",
+  backgroundRetryToast: "We'll retry your plan change in the background.",
+  completeSubtitle: "Your plan changes are live.",
+  fetchErrorBody:
+    "We hit a problem checking your subscription. Your plan change may still be processing. Return to billing to refresh.",
+};
+
+const COPY: Record<TakeoverDirection, TakeoverCopy> = {
+  upgrade: UPGRADE,
+  downgrade: PLAN_CHANGE,
+  change: PLAN_CHANGE,
+};
+
+/**
+ * Every string the takeover surfaces render for one direction. An absent
+ * direction reads as an upgrade, which is what post-checkout onboarding always
+ * is and the safest thing to say when a caller states nothing.
+ */
+export function takeoverCopy(
+  direction: TakeoverDirection = "upgrade",
+): TakeoverCopy {
+  return COPY[direction];
+}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -1045,6 +1045,46 @@ describe("useProProvisioning", () => {
     expect(latest!.state).not.toBe("NOT_APPLICABLE");
   }, 20_000);
 
+  test("readings taken while closed do not qualify the next open", async () => {
+    // The cache subscription outlives the takeover and the lifecycle poller
+    // keeps this query warm, so readings can keep landing after a close. If
+    // those counted, the next open would treat a cached marker as watched.
+    const client = makeClient();
+    subscriptionPlanId = "pro";
+    operationalStatusResponse = makeOperationalStatus("active");
+    assistantResponse = makeAssistant("large", 50);
+    const { setOpen } = renderProbe(client, true);
+
+    await waitFor(() => expect(latest!.assistantId).toBe("assistant-1"), {
+      timeout: 5000,
+    });
+    await refetchAll(client);
+    await act(async () => setOpen(false));
+
+    // The takeover's own query is disabled while closed, but the lifecycle
+    // poller holds the same key and keeps reading. Model that other consumer
+    // directly: it catches a resize belonging to something else entirely and
+    // leaves the marker in the shared cache.
+    await act(async () => {
+      await client.fetchQuery({
+        queryKey: STATUS_QUERY_KEY,
+        queryFn: () => makeResizeOperationStatus("resize_machine"),
+      });
+    });
+
+    await act(async () => setOpen(true));
+    await waitFor(() => expect(latest!.assistantId).toBe("assistant-1"), {
+      timeout: 5000,
+    });
+
+    // The reopened takeover has watched nothing yet, so the cached marker is
+    // not its evidence and it cannot complete off a later healthy reading.
+    operationalStatusResponse = makeOperationalStatus("active");
+    await refetchAll(client);
+    expect(latest!.state).not.toBe("DONE");
+    expect(latest!.state).not.toBe("NOT_APPLICABLE");
+  }, 20_000);
+
   test("a marker watched on the fallback assistant is not evidence for the primary", async () => {
     // Under a change that can lower the ceilings, a watched marker is the only
     // evidence the completion gate accepts, so an unkeyed latch would let the

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -281,8 +281,14 @@ let latest: ProProvisioningResult | null = null;
  */
 let onLayoutCommit: (() => void) | null = null;
 
-function Probe({ open = true }: { open?: boolean }) {
-  const result = useProProvisioning({ open });
+function Probe({
+  open = true,
+  canLowerResources = false,
+}: {
+  open?: boolean;
+  canLowerResources?: boolean;
+}) {
+  const result = useProProvisioning({ open, canLowerResources });
   useLayoutEffect(() => {
     onLayoutCommit?.();
   });
@@ -298,10 +304,10 @@ function makeClient() {
   });
 }
 
-function renderProbe(client = makeClient()) {
+function renderProbe(client = makeClient(), canLowerResources = false) {
   const ui = (open = true) => (
     <QueryClientProvider client={client}>
-      <Probe open={open} />
+      <Probe open={open} canLowerResources={canLowerResources} />
     </QueryClientProvider>
   );
   const view = render(ui());
@@ -1012,6 +1018,68 @@ describe("useProProvisioning", () => {
     });
   }, 20_000);
 
+  test("a marker watched on the fallback assistant is not evidence for the primary", async () => {
+    // Under a change that can lower the ceilings, a watched marker is the only
+    // evidence the completion gate accepts, so an unkeyed latch would let the
+    // fallback assistant's unrelated resize complete the primary's downsize.
+    const client = makeClient();
+    // Hold the on-open refetch so the stale cached primary (A) is tracked
+    // first, then re-keys to the fresh one (B).
+    const gate = makeDeferred();
+    onboardingGate = gate;
+    client.setQueryData(
+      organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+      { ...makeOnboarding(), primary_assistant_id: "assistant-A" },
+      { updatedAt: realDateNow() - 60_000 },
+    );
+    subscriptionPlanId = "pro";
+    onboardingResponse = {
+      ...makeOnboarding(),
+      primary_assistant_id: "assistant-B",
+    };
+    // The fence holds the stale primary off, so the active assistant is the
+    // tracked fallback. It is mid-resize; the primary B sits at the targets with
+    // no marker of its own, which is what a pre-marker downgrade looks like.
+    operationalStatusResponse = makeOperationalStatus("resizing_machine");
+    assistantResponse = {
+      ...makeAssistant("large", 50),
+      id: "assistant-active",
+    };
+    assistantsById["assistant-A"] = {
+      ...makeAssistant("large", 50),
+      id: "assistant-A",
+    };
+    assistantsById["assistant-B"] = {
+      ...makeAssistant("large", 50),
+      id: "assistant-B",
+    };
+    renderProbe(client, true);
+
+    // Latch the marker while the fallback is the tracked assistant.
+    await waitFor(() => expect(latest!.assistantId).toBe("assistant-active"), {
+      timeout: 5000,
+    });
+    await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+      timeout: 5000,
+    });
+
+    // Re-key to the primary, whose own status carries no operation at all.
+    operationalStatusResponse = makeOperationalStatus("active");
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await waitFor(() => expect(latest!.assistantId).toBe("assistant-B"), {
+      timeout: 5000,
+    });
+    await refetchAll(client);
+
+    // The fallback's marker belongs to another assistant, so it cannot stand in
+    // as the primary's rollout evidence and the wait holds.
+    expect(latest!.state).not.toBe("DONE");
+    expect(latest!.state).not.toBe("NOT_APPLICABLE");
+  }, 20_000);
+
   test("assistantId changing mid-open re-captures the snapshot against the new assistant", async () => {
     subscriptionPlanId = "pro";
     onboardingResponse = {
@@ -1656,8 +1724,7 @@ describe("useProProvisioning presentation signals", () => {
     operationalStatusGate = gate;
     onLayoutCommit = () => {
       const assistant = client.getQueryData(ASSISTANT_QUERY_KEY) as
-        | Assistant
-        | undefined;
+        Assistant | undefined;
       // Only the commit that first carries the target sizes: that is the
       // render whose passive effect takes the latch.
       if (assistant?.machine_size !== "large") {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -1018,6 +1018,33 @@ describe("useProProvisioning", () => {
     });
   }, 20_000);
 
+  test("a marker cached before this open is not evidence for this change", async () => {
+    // The lifecycle poller shares this query key, so the cache can already hold
+    // a marker from an earlier resize on this same assistant. Adopting it would
+    // let a finished resize vouch for one that has not started.
+    const client = makeClient();
+    client.setQueryData(
+      STATUS_QUERY_KEY,
+      makeResizeOperationStatus("resize_machine"),
+      { updatedAt: realDateNow() - 60_000 },
+    );
+    subscriptionPlanId = "pro";
+    // Every fresh read reports no operation at all, so the only marker that
+    // ever existed is the cached one.
+    operationalStatusResponse = makeOperationalStatus("active");
+    assistantResponse = makeAssistant("large", 50);
+    renderProbe(client, true);
+
+    await waitFor(() => expect(latest!.assistantId).toBe("assistant-1"), {
+      timeout: 5000,
+    });
+    await refetchAll(client);
+    await refetchAll(client);
+
+    expect(latest!.state).not.toBe("DONE");
+    expect(latest!.state).not.toBe("NOT_APPLICABLE");
+  }, 20_000);
+
   test("a marker watched on the fallback assistant is not evidence for the primary", async () => {
     // Under a change that can lower the ceilings, a watched marker is the only
     // evidence the completion gate accepts, so an unkeyed latch would let the

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -265,6 +265,11 @@ export function useProProvisioning({
   const [sawOperationAssistantId, setSawOperationAssistantId] = useState<
     string | null
   >(null);
+  // How many operational-status readings have actually landed during this open.
+  // Cached data is served without a success event, so it never moves this,
+  // which is what separates a marker this takeover watched from one the cache
+  // was already holding. Read where the latch above is gated.
+  const [statusReadsThisOpen, setStatusReadsThisOpen] = useState(0);
   const [actualsSnapshot, setActualsSnapshot] =
     useState<ProvisioningDimensions | null>(null);
   // The assistant the frozen snapshot describes, so it can be re-captured when
@@ -291,6 +296,7 @@ export function useProProvisioning({
     setResumedAt(null);
     setSawOperation(false);
     setSawOperationAssistantId(null);
+    setStatusReadsThisOpen(0);
     setActualsSnapshot(null);
     setSnapshotAssistantId(null);
     setTracking(true);
@@ -586,7 +592,10 @@ export function useProProvisioning({
         // later one can move the count. Publishing it through the cache's own
         // notify queue lands it in the same React commit as the reading.
         const readStart = statusFetchStartsRef.current;
-        notifyManager.schedule(() => setLastReadFetchStart(readStart));
+        notifyManager.schedule(() => {
+          setLastReadFetchStart(readStart);
+          setStatusReadsThisOpen((count) => count + 1);
+        });
       }
     });
   }, [queryClient, statusQueryHash]);
@@ -595,12 +604,24 @@ export function useProProvisioning({
     operationalStatusQuery.data,
   );
 
+  // Only a reading that landed during this open can testify about this change.
+  // The status query is keyed the way the lifecycle poller keys it, so its
+  // cache can already hold a marker left by an earlier resize on this very
+  // assistant, and react-query serves that the moment the takeover mounts.
+  // Adopting it would let a finished resize vouch for one that has not started.
+  //
+  // Landed readings are counted rather than compared against a fetch-start
+  // floor, because the query subscribes ahead of the cache listener here and
+  // its first fetch start is never seen. Cached data arrives with no success
+  // event at all, which is exactly the distinction this needs.
+  const statusReadBelongsToThisOpen = statusReadsThisOpen > 0;
+
   useEffect(() => {
-    if (resizeOperationInFlight) {
+    if (resizeOperationInFlight && statusReadBelongsToThisOpen) {
       setSawOperation(true);
       setSawOperationAssistantId(assistantId);
     }
-  }, [resizeOperationInFlight, assistantId]);
+  }, [resizeOperationInFlight, statusReadBelongsToThisOpen, assistantId]);
   const sawOperationMatchesAssistant = sawOperationAssistantId === assistantId;
 
   const onboarding = onboardingQuery.data;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -265,11 +265,6 @@ export function useProProvisioning({
   const [sawOperationAssistantId, setSawOperationAssistantId] = useState<
     string | null
   >(null);
-  // How many operational-status readings have actually landed during this open.
-  // Cached data is served without a success event, so it never moves this,
-  // which is what separates a marker this takeover watched from one the cache
-  // was already holding. Read where the latch above is gated.
-  const [statusReadsThisOpen, setStatusReadsThisOpen] = useState(0);
   const [actualsSnapshot, setActualsSnapshot] =
     useState<ProvisioningDimensions | null>(null);
   // The assistant the frozen snapshot describes, so it can be re-captured when
@@ -296,7 +291,6 @@ export function useProProvisioning({
     setResumedAt(null);
     setSawOperation(false);
     setSawOperationAssistantId(null);
-    setStatusReadsThisOpen(0);
     setActualsSnapshot(null);
     setSnapshotAssistantId(null);
     setTracking(true);
@@ -592,36 +586,34 @@ export function useProProvisioning({
         // later one can move the count. Publishing it through the cache's own
         // notify queue lands it in the same React commit as the reading.
         const readStart = statusFetchStartsRef.current;
+        // A marker only counts as this takeover's evidence when it arrives in a
+        // reading that landed here: the query cache outlives the takeover and
+        // the lifecycle poller keeps it warm, so its stored value can be a
+        // marker from an earlier resize on this same assistant. Reading the
+        // marker off the delivered payload rather than off rendered state ties
+        // the evidence to the reading that carried it, so neither a cached
+        // value nor a later re-render can stand in for one.
+        const watchedMarker =
+          open && isResizeOperationInFlight(event.action.data);
         notifyManager.schedule(() => {
           setLastReadFetchStart(readStart);
-          setStatusReadsThisOpen((count) => count + 1);
+          if (watchedMarker) {
+            setSawOperation(true);
+            setSawOperationAssistantId(assistantId);
+          }
         });
       }
     });
-  }, [queryClient, statusQueryHash]);
+  }, [queryClient, statusQueryHash, open, assistantId]);
 
   const resizeOperationInFlight = isResizeOperationInFlight(
     operationalStatusQuery.data,
   );
 
-  // Only a reading that landed during this open can testify about this change.
-  // The status query is keyed the way the lifecycle poller keys it, so its
-  // cache can already hold a marker left by an earlier resize on this very
-  // assistant, and react-query serves that the moment the takeover mounts.
-  // Adopting it would let a finished resize vouch for one that has not started.
-  //
-  // Landed readings are counted rather than compared against a fetch-start
-  // floor, because the query subscribes ahead of the cache listener here and
-  // its first fetch start is never seen. Cached data arrives with no success
-  // event at all, which is exactly the distinction this needs.
-  const statusReadBelongsToThisOpen = statusReadsThisOpen > 0;
-
-  useEffect(() => {
-    if (resizeOperationInFlight && statusReadBelongsToThisOpen) {
-      setSawOperation(true);
-      setSawOperationAssistantId(assistantId);
-    }
-  }, [resizeOperationInFlight, statusReadBelongsToThisOpen, assistantId]);
+  // `sawOperation` is latched from the reading itself, in the cache listener
+  // above, so nothing here needs to re-observe it. It stays keyed to the
+  // assistant it was watched on, because the fallback-to-primary re-key can
+  // move the watch mid-open.
   const sawOperationMatchesAssistant = sawOperationAssistantId === assistantId;
 
   const onboarding = onboardingQuery.data;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -257,6 +257,14 @@ export function useProProvisioning({
   // verdict or an error into the next open's session.
   const ensureGenerationRef = useRef(0);
   const [sawOperation, setSawOperation] = useState(false);
+  // The assistant whose marker was watched. Until the onboarding payload names
+  // a primary the hook polls the active-assistant fallback, so a marker can be
+  // observed on one assistant and the watch then re-keyed to another. An
+  // unkeyed latch would carry that unrelated marker across as evidence that a
+  // downsize on the new assistant had already rolled out.
+  const [sawOperationAssistantId, setSawOperationAssistantId] = useState<
+    string | null
+  >(null);
   const [actualsSnapshot, setActualsSnapshot] =
     useState<ProvisioningDimensions | null>(null);
   // The assistant the frozen snapshot describes, so it can be re-captured when
@@ -282,6 +290,7 @@ export function useProProvisioning({
     setProConfirmedAt(null);
     setResumedAt(null);
     setSawOperation(false);
+    setSawOperationAssistantId(null);
     setActualsSnapshot(null);
     setSnapshotAssistantId(null);
     setTracking(true);
@@ -589,8 +598,10 @@ export function useProProvisioning({
   useEffect(() => {
     if (resizeOperationInFlight) {
       setSawOperation(true);
+      setSawOperationAssistantId(assistantId);
     }
-  }, [resizeOperationInFlight]);
+  }, [resizeOperationInFlight, assistantId]);
+  const sawOperationMatchesAssistant = sawOperationAssistantId === assistantId;
 
   const onboarding = onboardingQuery.data;
   const targets = useMemo<ProvisioningDimensions | null>(() => {
@@ -808,7 +819,10 @@ export function useProProvisioning({
     // snapshot from a prior target must never drive the before/after verdict.
     initialActuals: snapshotMatchesAssistant ? actualsSnapshot : null,
     resizeOperationInFlight,
-    sawOperation,
+    // Same rule as the snapshot: a marker watched on a prior target says
+    // nothing about this one, and under a downward change it is the only
+    // evidence the completion gate accepts.
+    sawOperation: sawOperation && sawOperationMatchesAssistant,
     msSinceWatchStart,
     confirmExpired,
     serverVerdict,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -67,6 +67,7 @@ import {
   type ProvisioningStateKind,
   targetsMet,
 } from "./provisioning-machine";
+import type { TakeoverDirection } from "./takeover-copy";
 import {
   ENSURE_PROVISIONED_RACE_RETRY_MS,
   PRO_POLL_INTERVAL_MS,
@@ -109,6 +110,11 @@ const NO_DIMENSIONS_MET: DimensionMetLatch = {
 
 export interface UseProProvisioningOptions {
   open: boolean;
+  /**
+   * Which way the change being watched goes. Absent reads as an upgrade, which
+   * is what post-checkout onboarding always is.
+   */
+  direction?: TakeoverDirection;
 }
 
 export interface ProProvisioningResult {
@@ -192,6 +198,7 @@ export interface ProProvisioningResult {
 
 export function useProProvisioning({
   open,
+  direction,
 }: UseProProvisioningOptions): ProProvisioningResult {
   const queryClient = useQueryClient();
   // Every query here is org-scoped (needs the Vellum-Organization-Id header).
@@ -787,6 +794,10 @@ export function useProProvisioning({
   const watchStartedAt = resumedAt ?? proConfirmedAt;
   const msSinceWatchStart =
     watchStartedAt == null ? null : Math.max(0, now - watchStartedAt);
+  // Only a change that never lowers the ceilings keeps "targets met" and
+  // "nothing to provision" equivalent. A downgrade, and a move whose direction
+  // nobody knows, both meet their targets before anything has moved.
+  const targetsProveNoop = direction == null || direction === "upgrade";
   const { state, softWaiting } = deriveProvisioningState({
     planId: proConfirmed ? "pro" : observedPlanId,
     targets,
@@ -810,6 +821,7 @@ export function useProProvisioning({
       targetsMetAt != null &&
       targetsMetMatchesAssistant &&
       operationalStatusQuery.dataUpdatedAt > targetsMetAt,
+    targetsProveNoop,
   });
 
   const isTerminal = TERMINAL_STATES.includes(state);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -48,7 +48,8 @@ import {
 import type { MachineSizeEnum } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import {
-  allowedMachineSizesForTier,
+  MACHINE_FLOOR_SIZE,
+  machineCeilingForTier,
   machineSizeRank,
 } from "@/lib/billing/machine-sizes";
 import {
@@ -67,7 +68,6 @@ import {
   type ProvisioningStateKind,
   targetsMet,
 } from "./provisioning-machine";
-import type { TakeoverDirection } from "./takeover-copy";
 import {
   ENSURE_PROVISIONED_RACE_RETRY_MS,
   PRO_POLL_INTERVAL_MS,
@@ -111,10 +111,11 @@ const NO_DIMENSIONS_MET: DimensionMetLatch = {
 export interface UseProProvisioningOptions {
   open: boolean;
   /**
-   * Which way the change being watched goes. Absent reads as an upgrade, which
-   * is what post-checkout onboarding always is.
+   * Whether the change being watched can lower a resource ceiling, which is the
+   * only thing that stops met targets from standing in for "nothing was owed".
+   * Absent reads as false, which is what post-checkout onboarding always is.
    */
-  direction?: TakeoverDirection;
+  canLowerResources?: boolean;
 }
 
 export interface ProProvisioningResult {
@@ -198,7 +199,7 @@ export interface ProProvisioningResult {
 
 export function useProProvisioning({
   open,
-  direction,
+  canLowerResources = false,
 }: UseProProvisioningOptions): ProProvisioningResult {
   const queryClient = useQueryClient();
   // Every query here is org-scoped (needs the Vellum-Organization-Id header).
@@ -600,15 +601,16 @@ export function useProProvisioning({
       // No machine tier on the package (e.g. Mighty), or a tier this bundle
       // doesn't know, yields no machine target; the machine treats a null
       // dimension as satisfied, so version skew never computes a wrong target.
-      machineSize:
-        allowedMachineSizesForTier(onboarding.max_machine_tier).at(-1) ?? null,
+      machineSize: machineCeilingForTier(onboarding.max_machine_tier),
       storageGib: onboarding.selected_storage_gib ?? null,
     };
   }, [onboarding]);
 
   // Mirrors the server's machine ceiling for a package with no tier.
   const machineFloor: MachineSizeEnum | null =
-    onboarding != null && onboarding.max_machine_tier == null ? "small" : null;
+    onboarding != null && onboarding.max_machine_tier == null
+      ? MACHINE_FLOOR_SIZE
+      : null;
 
   // The managed-email entitlement alone doesn't make the domain step offerable:
   // the domain POST re-resolves the caller's primary assistant server-side and
@@ -795,9 +797,9 @@ export function useProProvisioning({
   const msSinceWatchStart =
     watchStartedAt == null ? null : Math.max(0, now - watchStartedAt);
   // Only a change that never lowers the ceilings keeps "targets met" and
-  // "nothing to provision" equivalent. A downgrade, and a move whose direction
-  // nobody knows, both meet their targets before anything has moved.
-  const targetsProveNoop = direction == null || direction === "upgrade";
+  // "nothing to provision" equivalent. One that can lower them meets its
+  // targets before anything has moved.
+  const targetsProveNoop = !canLowerResources;
   const { state, softWaiting } = deriveProvisioningState({
     planId: proConfirmed ? "pro" : observedPlanId,
     targets,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/utils.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractOnboardingErrorMessage } from "./utils";
+
+const FALLBACK = "fallback caption";
+
+describe("extractOnboardingErrorMessage", () => {
+  test("maps a known code to its stock message", () => {
+    expect(
+      extractOnboardingErrorMessage({ error: "subdomain_taken" }, FALLBACK),
+    ).toBe("That subdomain is already taken. Try another.");
+  });
+
+  test("an upgrade keeps the upgrade wording", () => {
+    expect(
+      extractOnboardingErrorMessage(
+        { error: "provisioning_submission_failed" },
+        FALLBACK,
+        "upgrade",
+      ),
+    ).toBe("We couldn't queue your upgrade just now. Try again in a moment.");
+  });
+
+  test("an omitted direction reads as an upgrade", () => {
+    expect(
+      extractOnboardingErrorMessage(
+        { error: "provisioning_submission_failed" },
+        FALLBACK,
+      ),
+    ).toBe("We couldn't queue your upgrade just now. Try again in a moment.");
+  });
+
+  test("a downgrade never claims an upgrade", () => {
+    // The reconcile these codes come from runs the same way for a downgrade, so
+    // a stalled downgrade can surface them from the retry.
+    for (const code of [
+      "provisioning_submission_failed",
+      "no_provisionable_assistants",
+    ]) {
+      const message = extractOnboardingErrorMessage(
+        { error: code },
+        FALLBACK,
+        "downgrade",
+      );
+      expect(message).not.toContain("upgrade");
+      expect(message).not.toBe(FALLBACK);
+    }
+  });
+
+  test("a direction-unknown change reads the same as a downgrade", () => {
+    expect(
+      extractOnboardingErrorMessage(
+        { error: "no_provisionable_assistants" },
+        FALLBACK,
+        "change",
+      ),
+    ).toBe(
+      extractOnboardingErrorMessage(
+        { error: "no_provisionable_assistants" },
+        FALLBACK,
+        "downgrade",
+      ),
+    );
+  });
+
+  test("a code with no direction variant keeps one message either way", () => {
+    expect(
+      extractOnboardingErrorMessage(
+        { error: "no_active_pro" },
+        FALLBACK,
+        "downgrade",
+      ),
+    ).toBe("We couldn't confirm your Pro plan yet. Try again in a moment.");
+  });
+
+  test("falls back when the error carries no usable message", () => {
+    expect(extractOnboardingErrorMessage({}, FALLBACK, "downgrade")).toBe(
+      FALLBACK,
+    );
+    expect(extractOnboardingErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
@@ -1,3 +1,5 @@
+import type { TakeoverDirection } from "./takeover-copy";
+
 export const DOMAIN_EXIT_DELAY_MS = 800;
 
 export const PRO_POLL_INTERVAL_MS = 1000;
@@ -44,14 +46,32 @@ export const ONBOARDING_ERROR_CODE_MESSAGES: Record<string, string> = {
     "We couldn't find an assistant to upgrade yet. Try again in a moment.",
 };
 
+/**
+ * The codes whose stock message names an upgrade, reworded for a takeover that
+ * is watching something else. The reconcile these come from runs the same way
+ * for a downgrade, so without this a stalled downgrade offers to retry and then
+ * reports a failure to queue "your upgrade".
+ */
+const PLAN_CHANGE_ERROR_CODE_MESSAGES: Record<string, string> = {
+  provisioning_submission_failed:
+    "We couldn't queue your plan change just now. Try again in a moment.",
+  no_provisionable_assistants:
+    "We couldn't find an assistant to update yet. Try again in a moment.",
+};
+
 export function extractOnboardingErrorMessage(
   error: unknown,
   fallback: string,
+  direction: TakeoverDirection = "upgrade",
 ): string {
   if (error && typeof error === "object") {
     const rec = error as Record<string, unknown>;
     if (typeof rec.error === "string") {
-      const mapped = ONBOARDING_ERROR_CODE_MESSAGES[rec.error];
+      const mapped =
+        (direction === "upgrade"
+          ? undefined
+          : PLAN_CHANGE_ERROR_CODE_MESSAGES[rec.error]) ??
+        ONBOARDING_ERROR_CODE_MESSAGES[rec.error];
       if (mapped) {
         return mapped;
       }

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -326,6 +326,27 @@ describe("useChangeTiers", () => {
     expect(result.current.currentKnown).toBe(true);
   });
 
+  test("currentKnown is false when the tiers predate the subscription", async () => {
+    // Both queries sit in cache for `staleTime` without refetching, so the
+    // subscription can be refreshed on its own and leave the tiers describing
+    // the plan before it. Nothing about the onboarding query itself looks wrong
+    // in that window; only the pairing does.
+    const { result, client } = setup();
+    expect(result.current.currentKnown).toBe(true);
+
+    // Re-seed the same payload as an older read. Nothing about it changes
+    // except its vintage, which is the entire defect.
+    act(() => {
+      client.setQueryData(ONBOARDING_KEY, onboardingFixture, {
+        updatedAt: Date.now() - 60_000,
+      });
+    });
+
+    await waitFor(() => expect(result.current.currentKnown).toBe(false));
+    // The tiers still read fine on their own, which is what hides this.
+    expect(result.current.current.machineTier).not.toBeNull();
+  });
+
   test("currentKnown is false while cached tiers are being re-read", async () => {
     // A background refetch keeps `isSuccess` true over the old payload, so the
     // tiers stay readable while a fresher answer is already on its way.

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -9,7 +9,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
 import type {
@@ -31,6 +31,7 @@ let onboardingFixture: OnboardingStateResponse | null = null;
 let plansFixture: PlanListResponse | null = null;
 // When true, the onboarding query stays pending (its first load never lands).
 let onboardingHangs = false;
+let onboardingFails = false;
 
 /** Pro catalog whose machine tiers carry the prices used to rank up/downgrades. */
 function proPlans(): PlanListResponse {
@@ -94,9 +95,17 @@ mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   organizationsBillingSubscriptionOnboardingRetrieveOptions: () => ({
     queryKey: ONBOARDING_KEY,
     // When `onboardingHangs`, never resolves — models the first onboarding load
-    // still in flight so `currentReady` can be exercised.
-    queryFn: () =>
-      onboardingHangs ? new Promise(() => {}) : onboardingFixture,
+    // still in flight so `currentReady` can be exercised. When
+    // `onboardingFails`, rejects, which settles the query with no data at all.
+    queryFn: () => {
+      if (onboardingHangs) {
+        return new Promise(() => {});
+      }
+      if (onboardingFails) {
+        return Promise.reject(new Error("onboarding read failed"));
+      }
+      return onboardingFixture;
+    },
   }),
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey: () =>
     ONBOARDING_KEY,
@@ -226,6 +235,7 @@ describe("useChangeTiers", () => {
     storageImpl = async () => ({});
     creditImpl = async () => ({});
     onboardingHangs = false;
+    onboardingFails = false;
     subscriptionFetches = 0;
     subscriptionFixture = proSubscription();
     onboardingFixture = onboarding();
@@ -298,6 +308,29 @@ describe("useChangeTiers", () => {
   test("currentReady is true once the onboarding data is present", () => {
     const { result } = setup();
     expect(result.current.currentReady).toBe(true);
+  });
+
+  test("currentKnown is false when the onboarding read failed", async () => {
+    // The read settles, so `currentReady` says go, but every dimension behind
+    // it is null. A caller ranking the machine tier must not read that null as
+    // the machine-less floor.
+    onboardingFails = true;
+    const { result } = setup({ seedOnboarding: false });
+    await waitFor(() => expect(result.current.currentReady).toBe(true));
+    expect(result.current.currentKnown).toBe(false);
+    expect(result.current.current.machineTier).toBeNull();
+  });
+
+  test("currentKnown is true once the onboarding payload is in hand", () => {
+    const { result } = setup();
+    expect(result.current.currentKnown).toBe(true);
+  });
+
+  test("currentKnown is true for a base sub (no onboarding to read)", () => {
+    subscriptionFixture = proSubscription({ plan_id: "base" });
+    onboardingHangs = true;
+    const { result } = setup({ seedOnboarding: false });
+    expect(result.current.currentKnown).toBe(true);
   });
 
   test("currentReady is true for a base sub (no onboarding to await)", () => {

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -326,6 +326,21 @@ describe("useChangeTiers", () => {
     expect(result.current.currentKnown).toBe(true);
   });
 
+  test("currentKnown is false while cached tiers are being re-read", async () => {
+    // A background refetch keeps `isSuccess` true over the old payload, so the
+    // tiers stay readable while a fresher answer is already on its way.
+    const { result, client } = setup();
+    expect(result.current.currentKnown).toBe(true);
+
+    onboardingHangs = true;
+    act(() => {
+      void client.refetchQueries({ queryKey: ONBOARDING_KEY });
+    });
+
+    await waitFor(() => expect(result.current.currentKnown).toBe(false));
+    expect(result.current.current.machineTier).not.toBeNull();
+  });
+
   test("currentKnown is false when a refetch fails over cached tiers", async () => {
     // React Query keeps the previous payload when a refetch fails, so the tiers
     // stay readable while no longer describing the sub. Ranking them is as

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -222,7 +222,7 @@ function setup({
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client }, children);
   const { result } = renderHook(() => useChangeTiers({ enabled }), { wrapper });
-  return { result, invalidatedKeys, events };
+  return { result, invalidatedKeys, events, client };
 }
 
 describe("useChangeTiers", () => {
@@ -324,6 +324,23 @@ describe("useChangeTiers", () => {
   test("currentKnown is true once the onboarding payload is in hand", () => {
     const { result } = setup();
     expect(result.current.currentKnown).toBe(true);
+  });
+
+  test("currentKnown is false when a refetch fails over cached tiers", async () => {
+    // React Query keeps the previous payload when a refetch fails, so the tiers
+    // stay readable while no longer describing the sub. Ranking them is as
+    // wrong as ranking nulls, just harder to see.
+    const { result, client } = setup();
+    expect(result.current.currentKnown).toBe(true);
+
+    onboardingFails = true;
+    await act(async () => {
+      await client.refetchQueries({ queryKey: ONBOARDING_KEY });
+    });
+
+    await waitFor(() => expect(result.current.currentKnown).toBe(false));
+    // The stale tiers are still readable, which is what makes this dangerous.
+    expect(result.current.current.machineTier).not.toBeNull();
   });
 
   test("currentKnown is true for a base sub (no onboarding to read)", () => {

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -180,10 +180,13 @@ export function useChangeTiers({
   // that first load settles (success or error) — an error leaves the tiers null,
   // which the caller safely reads as "not representable" and routes to manage.
   const currentReady = !onPro || !onboardingQuery.isPending;
-  // Settling covers a read that FAILED, which leaves every dimension null. The
-  // payload actually being in hand is the only thing that separates "this
-  // package names no machine" from "we could not read the machine at all".
-  const currentKnown = !onPro || onboardingQuery.data != null;
+  // Two ways the tiers can lie, and both have to be excluded. A read that
+  // FAILED leaves every dimension null, which is indistinguishable from a
+  // package that names no machine. And a refetch that fails keeps the previous
+  // payload, so the tiers can be real but stale, which ranks just as wrongly.
+  // So the read must have both succeeded and produced something.
+  const currentKnown =
+    !onPro || (onboardingQuery.isSuccess && onboardingQuery.data != null);
 
   const isPending =
     changeMachineTierMutation.isPending ||

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -78,6 +78,15 @@ export interface UseChangeTiersResult {
    */
   currentReady: boolean;
   /**
+   * Whether `current`'s server-read dimensions were actually READ: for a Pro
+   * sub, the onboarding payload behind them is in hand. `currentReady` only
+   * says that read settled, so it is true for one that failed, and a failed
+   * read leaves `machineTier` null, which is exactly what a package naming no
+   * machine reports. Callers that rank the machine tier must consult this and
+   * treat an unread tier as unknown rather than as the machine-less floor.
+   */
+  currentKnown: boolean;
+  /**
    * The assistant the server provisions against, from the same onboarding
    * payload `current` reads. Null while that payload is absent, or when the org
    * names no primary; callers fall back to the active assistant, which is how
@@ -171,6 +180,10 @@ export function useChangeTiers({
   // that first load settles (success or error) — an error leaves the tiers null,
   // which the caller safely reads as "not representable" and routes to manage.
   const currentReady = !onPro || !onboardingQuery.isPending;
+  // Settling covers a read that FAILED, which leaves every dimension null. The
+  // payload actually being in hand is the only thing that separates "this
+  // package names no machine" from "we could not read the machine at all".
+  const currentKnown = !onPro || onboardingQuery.data != null;
 
   const isPending =
     changeMachineTierMutation.isPending ||
@@ -320,6 +333,7 @@ export function useChangeTiers({
     current,
     eligible,
     currentReady,
+    currentKnown,
     primaryAssistantId: onboardingQuery.data?.primary_assistant_id ?? null,
   };
 }

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -180,13 +180,25 @@ export function useChangeTiers({
   // that first load settles (success or error) — an error leaves the tiers null,
   // which the caller safely reads as "not representable" and routes to manage.
   const currentReady = !onPro || !onboardingQuery.isPending;
-  // Two ways the tiers can lie, and both have to be excluded. A read that
-  // FAILED leaves every dimension null, which is indistinguishable from a
-  // package that names no machine. And a refetch that fails keeps the previous
-  // payload, so the tiers can be real but stale, which ranks just as wrongly.
-  // So the read must have both succeeded and produced something.
+  // Whether these tiers can be trusted to describe the sub right now, which is
+  // stricter than `currentReady` and exists because ranking a wrong machine
+  // tier silently grants a downgrade the no-op inference only a raise earns.
+  //
+  // Every state the query can be in that does not answer "yes":
+  //   - never loaded: no payload, every dimension null
+  //   - loaded with no payload: a successful read of nothing, same nulls
+  //   - failed outright: same nulls, and null is what a machine-less package
+  //     legitimately reports, so it cannot be told apart from one
+  //   - failed over cached data: payload retained, real but no longer current
+  //   - re-reading cached data: payload retained and possibly about to change
+  // Only a settled, successful, non-empty read that nothing is currently
+  // superseding says these tiers are the sub's. Callers treat everything else
+  // as unrankable, which costs a fast path and never costs correctness.
   const currentKnown =
-    !onPro || (onboardingQuery.isSuccess && onboardingQuery.data != null);
+    !onPro ||
+    (onboardingQuery.isSuccess &&
+      onboardingQuery.data != null &&
+      !onboardingQuery.isFetching);
 
   const isPending =
     changeMachineTierMutation.isPending ||

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -191,14 +191,23 @@ export function useChangeTiers({
   //     legitimately reports, so it cannot be told apart from one
   //   - failed over cached data: payload retained, real but no longer current
   //   - re-reading cached data: payload retained and possibly about to change
-  // Only a settled, successful, non-empty read that nothing is currently
-  // superseding says these tiers are the sub's. Callers treat everything else
-  // as unrankable, which costs a fast path and never costs correctness.
+  //
+  // A settled read is still not enough on its own, because these tiers are
+  // ranked against a subscription read from a different query. The client holds
+  // both for `staleTime` without refetching, so a subscription refreshed on its
+  // own can be paired with onboarding describing the plan before it: a fresh
+  // Ultra sub beside a cached machine-less payload ranks a step down as a step
+  // up. The two have to be read from the same moment or later, so the payload
+  // must not predate the subscription it is being compared against.
+  //
+  // Callers treat everything else as unrankable, which costs a fast path and
+  // never costs correctness.
   const currentKnown =
     !onPro ||
     (onboardingQuery.isSuccess &&
       onboardingQuery.data != null &&
-      !onboardingQuery.isFetching);
+      !onboardingQuery.isFetching &&
+      onboardingQuery.dataUpdatedAt >= subscriptionQuery.dataUpdatedAt);
 
   const isPending =
     changeMachineTierMutation.isPending ||

--- a/clients/web/src/lib/billing/machine-sizes.test.ts
+++ b/clients/web/src/lib/billing/machine-sizes.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import {
   allowedMachineSizesForTier,
+  lowersMachineCeiling,
+  MACHINE_FLOOR_SIZE,
   MACHINE_SIZE_ORDER,
+  machineCeilingForTier,
   machineSizeRank,
   SIZE_DESCRIPTION,
   SIZE_LABEL,
@@ -56,5 +59,60 @@ describe("machine-sizes", () => {
     for (let i = 1; i < ranks.length; i++) {
       expect(ranks[i]).toBeGreaterThan(ranks[i - 1]);
     }
+  });
+});
+
+describe("machineCeilingForTier", () => {
+  test("resolves a known tier to its largest allowed size", () => {
+    expect(machineCeilingForTier("medium")).toBe("medium");
+    expect(machineCeilingForTier("large")).toBe("large");
+    expect(machineCeilingForTier("xl")).toBe("extra_large");
+  });
+
+  test("resolves a tier naming no machine to no ceiling", () => {
+    expect(machineCeilingForTier(null)).toBeNull();
+    expect(machineCeilingForTier(undefined)).toBeNull();
+  });
+
+  test("resolves a tier this bundle doesn't know to no ceiling", () => {
+    expect(machineCeilingForTier("gargantuan")).toBeNull();
+  });
+});
+
+describe("lowersMachineCeiling", () => {
+  test("a step down the tier ladder lowers the ceiling", () => {
+    expect(lowersMachineCeiling("xl", "large")).toBe(true);
+    expect(lowersMachineCeiling("large", "medium")).toBe(true);
+  });
+
+  test("a step up, or no step at all, does not", () => {
+    expect(lowersMachineCeiling("medium", "large")).toBe(false);
+    expect(lowersMachineCeiling("large", "xl")).toBe(false);
+    expect(lowersMachineCeiling("large", "large")).toBe(false);
+  });
+
+  test("moving to a tier naming no machine drops to the floor", () => {
+    // A machine-less package (Mighty) settles at the floor, so anything above
+    // it shrinks and the floor itself stays put.
+    expect(lowersMachineCeiling("medium", null)).toBe(true);
+    expect(lowersMachineCeiling(null, null)).toBe(false);
+  });
+
+  test("moving off a tier naming no machine only ever raises", () => {
+    expect(lowersMachineCeiling(null, "medium")).toBe(false);
+    expect(lowersMachineCeiling(null, "xl")).toBe(false);
+  });
+
+  test("the floor is the size a machine-less tier resolves to", () => {
+    // The comparison above rests on this, and `machineFloor` in the
+    // provisioning hook displays the same size.
+    expect(MACHINE_SIZE_ORDER[0]).toBe(MACHINE_FLOOR_SIZE);
+  });
+
+  test("a tier it cannot rank reads as able to lower, on either side", () => {
+    // Guessing here would hand the fast no-op inference to a move that may
+    // really be shrinking the pod.
+    expect(lowersMachineCeiling("gargantuan", "medium")).toBe(true);
+    expect(lowersMachineCeiling("medium", "gargantuan")).toBe(true);
   });
 });

--- a/clients/web/src/lib/billing/machine-sizes.ts
+++ b/clients/web/src/lib/billing/machine-sizes.ts
@@ -76,6 +76,51 @@ export function machineSizeRank(size: MachineSizeEnum): number {
   return MACHINE_SIZE_ORDER.indexOf(size);
 }
 
+/**
+ * The size the server settles a package that names no machine tier at, and so
+ * the ceiling it caps such a package's pod to.
+ */
+export const MACHINE_FLOOR_SIZE: MachineSizeEnum = "small";
+
+/**
+ * The largest size a tier permits: the ceiling the server caps a pod to. Null
+ * when the tier names no machine, or is one this bundle doesn't recognize.
+ */
+export function machineCeilingForTier(
+  tier: string | null | undefined,
+): MachineSizeEnum | null {
+  return allowedMachineSizesForTier(tier).at(-1) ?? null;
+}
+
+/**
+ * Whether moving between two machine tiers can force the pod to shrink: the
+ * ceiling it is headed for ranks below the one it is leaving.
+ *
+ * A tier of null names no machine, so it resolves to the floor the server caps
+ * such a package to. A non-null tier this bundle cannot rank resolves to
+ * nothing at all, and reads as able to shrink: a move that can't be ranked must
+ * not be granted the inference that only a raise has earned.
+ */
+export function lowersMachineCeiling(
+  fromTier: string | null | undefined,
+  toTier: string | null | undefined,
+): boolean {
+  const from = tierCeilingRank(fromTier);
+  const to = tierCeilingRank(toTier);
+  if (from == null || to == null) {
+    return true;
+  }
+  return to < from;
+}
+
+function tierCeilingRank(tier: string | null | undefined): number | null {
+  if (tier == null) {
+    return machineSizeRank(MACHINE_FLOOR_SIZE);
+  }
+  const ceiling = machineCeilingForTier(tier);
+  return ceiling == null ? null : machineSizeRank(ceiling);
+}
+
 export function buildMachineSizeOptions(
   sizes: MachineSizeEnum[],
   currentSize: MachineSizeEnum | null | undefined,


### PR DESCRIPTION
## Summary

- A confirmed package downgrade now opens the resize takeover instead of toasting: the server caps the machine down and restarts the pod either way, so the restart is worth watching. Every `status === "ok"` switch threads a `ResizeTakeoverContext` and opens the takeover.
- New `takeover-copy.ts` lookup keyed by `TakeoverDirection` (`upgrade` | `downgrade` | `change`) owns every direction-dependent string: the wait/confirm/snag/timeout headings, the background-exit confirm and its two toasts, the completion subtitle and the fetch-error body. A downgrade and a direction-unknown Custom switch both read as a plan change; checkout defaults to `upgrade`, so its copy is byte-identical.
- Scenario coverage for the downgrade shape: Super to Mighty shows the credit drop checked from first paint, the machine cap pending behind a live `resize_machine`, and no storage row; a pod already at the new floor gets no machine row at all; Mighty to Super still shows all three chips with storage pending until the grow lands.

Part of plan: takeover-credits-chip-and-reveal.md (PR 7 of 7)