### PR TITLE
Sync platform OpenAPI spec for paginated invoice list

### DIFF
--- a/clients/web/openapi-schemas/platform-source.json
+++ b/clients/web/openapi-schemas/platform-source.json
@@ -1,4 +1,4 @@
 {
   "sourceRepo": "vellum-ai/vellum-assistant-platform",
-  "sourceSha": "afc5af179b389565b0ee955a18aff477ab4a465e"
+  "sourceSha": "17eab07b3b43777726a92bd412c2c79a93298fcb"
 }

--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -4356,7 +4356,7 @@ paths:
   /v1/organizations/billing/invoices/:
     get:
       operationId: organizations_billing_invoices_retrieve
-      description: Return the org's Stripe invoices, newest first.
+      description: Return one page of the org's Stripe invoices, newest first.
       parameters:
       - in: header
         name: Vellum-Organization-Id
@@ -4365,6 +4365,12 @@ paths:
           format: uuid
         description: Required if using Cookie-based or X-Session-Token authentication
           methods.
+      - in: query
+        name: starting_after
+        schema:
+          type: string
+        description: 'Cursor: return invoices older than the invoice with this id
+          (from the previous page''s last entry).'
       tags:
       - organizations
       security:
@@ -4379,6 +4385,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/InvoiceListResponse'
           description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
+          description: Invalid or expired starting_after cursor.
       x-vellum-api-clients:
       - platform
   /v1/organizations/billing/invoices/download/:
@@ -7399,7 +7411,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Invoice'
+        has_more:
+          type: boolean
+          description: True if older invoices exist beyond this page. Pass the last
+            invoice's id as ?starting_after= to fetch the next page.
       required:
+      - has_more
       - invoices
     LiveVoiceTokenRequestRequest:
       type: object

--- a/clients/web/src/domains/settings/components/invoices-table.test.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.test.tsx
@@ -13,7 +13,7 @@ import * as sdkGen from "@/generated/api/sdk.gen";
 import type { Invoice, InvoiceListResponse } from "@/generated/api/types.gen";
 
 let listRetrieveCalls = 0;
-let listResult: InvoiceListResponse = { invoices: [] };
+let listResult: InvoiceListResponse = { invoices: [], has_more: false };
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -56,7 +56,7 @@ function renderTable(): ReturnType<typeof render> {
 
 beforeEach(() => {
   listRetrieveCalls = 0;
-  listResult = { invoices: [makeInvoice("1"), makeInvoice("2")] };
+  listResult = { invoices: [makeInvoice("1"), makeInvoice("2")], has_more: false };
 });
 
 afterEach(() => {
@@ -99,7 +99,7 @@ describe("InvoicesTable collapse", () => {
   });
 
   test("empty billing history shows the empty state only once expanded", async () => {
-    listResult = { invoices: [] };
+    listResult = { invoices: [], has_more: false };
     const { getByTestId, queryByTestId } = renderTable();
 
     expect(queryByTestId("invoices-empty")).toBeNull();

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -24,7 +24,7 @@ import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-const EMPTY_RESPONSE: InvoiceListResponse = { invoices: [] };
+const EMPTY_RESPONSE: InvoiceListResponse = { invoices: [], has_more: false };
 
 const INITIAL_VISIBLE = 4;
 


### PR DESCRIPTION
## Summary
- Syncs openapi-schemas/platform.yaml and platform-source.json from platform commit 17eab07b3b43 (verbatim from automated sync PR #39485, which this supersedes): adds the starting_after cursor param and required has_more field to the invoices list endpoint.
- Adds has_more: false to the EMPTY_RESPONSE literal and test fixtures that the newly-required field broke.
- Note: the HeyAPI react-query plugin did NOT emit organizationsBillingInvoicesRetrieveInfiniteOptions for the invoices operation (starting_after is not in its pagination keyword list). PR 2 will build the infinite query manually, which it does not depend on the helper for.

Part of plan: invoice-pagination-frontend.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->