### PR TITLE
fix(mcp): honor readOnlyHint annotations when classifying MCP tool risk

### DIFF
--- a/assistant/src/__tests__/mcp-tool-annotations-risk.test.ts
+++ b/assistant/src/__tests__/mcp-tool-annotations-risk.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, jest, mock, test } from "bun:test";
+
+// Mock secure-keys so McpOAuthProvider doesn't try to access the credential store
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: jest.fn().mockResolvedValue(null),
+  setSecureKeyAsync: jest.fn().mockResolvedValue(true),
+  deleteSecureKeyAsync: jest.fn().mockResolvedValue("deleted"),
+}));
+
+mock.module("../config/env-registry.js", () => ({
+  getDebugStdoutLogs: () => false,
+  getIsContainerized: () => false,
+  getIsPlatform: () => false,
+  isPlatformRemote: () => false,
+  getWorkspaceDirOverride: () => undefined,
+  getBackupDirOverride: () => undefined,
+  getBackupKeyPathOverride: () => undefined,
+  getCpuLimit: () => undefined,
+  getMinikubeStorageSize: () => undefined,
+  getProfilerRunId: () => undefined,
+  getProfilerMode: () => undefined,
+  getProfilerMaxBytes: () => undefined,
+  getProfilerMaxRuns: () => undefined,
+  getProfilerMinFreeMb: () => undefined,
+  checkUnrecognizedEnvVars: () => [],
+}));
+
+const { McpClient } = await import("../mcp/client.js");
+const { createMcpTool } = await import("../tools/mcp/mcp-tool-factory.js");
+const { RiskLevel } = await import("../permissions/types.js");
+
+type ServerRisk = "low" | "medium" | "high";
+
+function serverConfig(defaultRiskLevel: ServerRisk) {
+  return {
+    transport: { type: "stdio" as const, command: "echo", args: [] },
+    enabled: true,
+    defaultRiskLevel,
+    maxTools: 100,
+  };
+}
+
+function toolWithAnnotations(readOnlyHint?: boolean) {
+  return {
+    name: "get-summary",
+    description: "Read a summary",
+    inputSchema: { type: "object", properties: {} },
+    ...(readOnlyHint === undefined ? {} : { annotations: { readOnlyHint } }),
+  };
+}
+
+describe("MCP tool risk from readOnlyHint annotations", () => {
+  const fakeManager = { callTool: jest.fn() } as never;
+
+  test("readOnlyHint true on a medium-risk server lowers risk to Low", () => {
+    const tool = createMcpTool(
+      toolWithAnnotations(true),
+      "fathom",
+      serverConfig("medium"),
+      fakeManager,
+    );
+
+    expect(tool.defaultRiskLevel).toBe(RiskLevel.Low);
+  });
+
+  test("readOnlyHint true on a high-risk server leaves risk at High", () => {
+    const tool = createMcpTool(
+      toolWithAnnotations(true),
+      "untrusted",
+      serverConfig("high"),
+      fakeManager,
+    );
+
+    expect(tool.defaultRiskLevel).toBe(RiskLevel.High);
+  });
+
+  test("missing annotations keeps the server default risk", () => {
+    const tool = createMcpTool(
+      toolWithAnnotations(undefined),
+      "fathom",
+      serverConfig("medium"),
+      fakeManager,
+    );
+
+    expect(tool.defaultRiskLevel).toBe(RiskLevel.Medium);
+  });
+
+  test("readOnlyHint false on a low-risk server keeps risk at Low", () => {
+    const tool = createMcpTool(
+      toolWithAnnotations(false),
+      "trusted",
+      serverConfig("low"),
+      fakeManager,
+    );
+
+    expect(tool.defaultRiskLevel).toBe(RiskLevel.Low);
+  });
+});
+
+describe("McpClient.listTools annotations passthrough", () => {
+  test("carries server-declared annotations into McpToolInfo", async () => {
+    const client = new McpClient("test-server");
+
+    const listToolsSpy = jest.fn().mockResolvedValue({
+      tools: [
+        {
+          name: "get-summary",
+          description: "Read a summary",
+          inputSchema: { type: "object", properties: {} },
+          annotations: { readOnlyHint: true, title: "Get summary" },
+        },
+        {
+          name: "delete-recording",
+          description: "Delete a recording",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { client: unknown }).client = {
+      listTools: listToolsSpy,
+    };
+
+    const tools = await client.listTools();
+
+    expect(tools[0]?.annotations).toEqual({
+      readOnlyHint: true,
+      title: "Get summary",
+    });
+    expect(tools[1]?.annotations).toBeUndefined();
+  });
+});

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -3,6 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 
 import { getIsPlatform } from "../config/env-registry.js";
 import type { McpTransport } from "../config/schemas/mcp.js";
@@ -33,10 +34,18 @@ function normalizeInputSchema(
   return { type: "object", properties: {} };
 }
 
+/**
+ * Behavioral hints a server may attach to a tool (MCP `ToolAnnotations`).
+ * Self-reported by the server, so consumers treat them as hints rather than
+ * guarantees.
+ */
+export type McpToolAnnotations = ToolAnnotations;
+
 export interface McpToolInfo {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  annotations?: McpToolAnnotations;
 }
 
 export interface McpCallResult {
@@ -197,6 +206,7 @@ export class McpClient {
       name: tool.name,
       description: tool.description ?? "",
       inputSchema: normalizeInputSchema(tool.inputSchema, tool.name),
+      annotations: tool.annotations,
     }));
   }
 

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -1,4 +1,5 @@
 import type { McpServerConfig } from "../../config/schemas/mcp.js";
+import type { McpToolAnnotations } from "../../mcp/client.js";
 import type { McpServerManager } from "../../mcp/manager.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { toProviderSafeToolName } from "../provider-tool-name.js";
@@ -23,6 +24,29 @@ export interface McpToolMetadata {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  annotations?: McpToolAnnotations;
+}
+
+/**
+ * Resolve the risk level a tool carries.
+ *
+ * `readOnlyHint` is self-reported by the server, so it only refines risk
+ * downward and only for servers the user has already configured below the
+ * high-trust ceiling. Servers left at the default "high" are unaffected, and
+ * the hint never raises risk above the server default.
+ */
+function resolveRiskLevel(
+  metadata: McpToolMetadata,
+  serverConfig: McpServerConfig,
+): RiskLevel {
+  const serverRisk = riskMap[serverConfig.defaultRiskLevel] ?? RiskLevel.High;
+  if (
+    metadata.annotations?.readOnlyHint === true &&
+    serverRisk !== RiskLevel.High
+  ) {
+    return RiskLevel.Low;
+  }
+  return serverRisk;
 }
 
 /**
@@ -36,7 +60,7 @@ export function createMcpTool(
   manager: McpServerManager,
 ): Tool {
   const namespacedName = mcpToolName(serverId, metadata.name);
-  const riskLevel = riskMap[serverConfig.defaultRiskLevel] ?? RiskLevel.High;
+  const riskLevel = resolveRiskLevel(metadata, serverConfig);
   const serverDefinesActivity = schemaDefinesProperty(
     metadata.inputSchema,
     "activity",


### PR DESCRIPTION
## Problem

Scheduled (non-interactive) conversations cannot use read-only MCP tools. A CLI-woken standup workflow calling Fathom's `get_summary` / `get_transcript` hit:

> Permission denied: tool "mcp__fathom__get_transcript" requires user approval but no interactive client is connected.

Every MCP tool inherits its server-wide `defaultRiskLevel` (fathom: `medium`), which sits above the background auto-approve threshold (`low`), so the permission checker auto-denies the prompt in non-interactive sessions. The MCP spec's per-tool `annotations` (including `readOnlyHint`) were discarded entirely in `McpClient.listTools()`.

## Fix

- `McpClient.listTools()` passes `tool.annotations` through into `McpToolInfo`; `McpToolMetadata` carries them to the tool factory.
- `createMcpTool` resolves risk via a new `resolveRiskLevel`: when a tool declares `readOnlyHint: true` **and** the server's configured risk is below the high ceiling, the tool classifies as `Low` risk. Otherwise the server default applies unchanged.

This lets read-only tools from partially-trusted servers auto-approve in guardian/background sessions, while:

- never raising risk above the server default,
- leaving servers at the schema default `high` completely untouched.

## Security note

The MCP SDK docstring warns that clients should never make tool-use decisions from annotations of untrusted servers. This change deliberately scopes the hint's effect: the user's configured `defaultRiskLevel` is the trust declaration, and `high` (the default) means untrusted, where the hint has no effect. The hint only refines risk downward within servers the user already trusts at `medium` or `low`.

## Caveat

If a server does not publish `readOnlyHint` on the wire, its tools keep the server default and non-interactive sessions still deny them; the workaround remains setting the server's `defaultRiskLevel` to `low`.

## Testing

- New `assistant/src/__tests__/mcp-tool-annotations-risk.test.ts`: readOnlyHint+medium→Low, readOnlyHint+high→High, absent+medium→Medium, false+low→Low, plus a `listTools` annotations passthrough test.
- `bun run typecheck:fast` and eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)