### PR TITLE
fix(gemini): keep function-response Contents free of text and media parts

### DIFF
--- a/assistant/src/providers/gemini/__tests__/to-gemini-contents.test.ts
+++ b/assistant/src/providers/gemini/__tests__/to-gemini-contents.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Gemini rejects a request whose `functionResponse` Content carries any other
+ * kind of part, with the misleading
+ * `Requests ending with a model turn are not supported.` Our agent loop emits
+ * such mixed user messages whenever a tool call errors (`<system_notice>` text
+ * blocks land beside the tool results) or after compaction folds context text
+ * into the tool-result message, so these tests pin the split that keeps the
+ * function-response Content pure.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { ContentBlock, Message } from "../../types.js";
+import { toGeminiContents } from "../to-gemini-contents.js";
+
+const MODEL = "gemini-3.6-flash";
+
+const PNG_BASE64 = "iVBORw0KGgo=";
+
+function userMessage(content: ContentBlock[]): Message {
+  return { role: "user", content };
+}
+
+function assistantMessage(content: ContentBlock[]): Message {
+  return { role: "assistant", content };
+}
+
+function toolUse(id: string, name: string): ContentBlock {
+  return { type: "tool_use", id, name, input: { arg: id } };
+}
+
+function toolResult(
+  toolUseId: string,
+  output: string,
+  contentBlocks?: ContentBlock[],
+): ContentBlock {
+  return {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: output,
+    ...(contentBlocks ? { contentBlocks } : {}),
+  };
+}
+
+describe("toGeminiContents", () => {
+  test("splits the production failure shape into a pure function-response turn", () => {
+    const messages: Message[] = [
+      userMessage([{ type: "text", text: "check my calendar" }]),
+      assistantMessage([
+        {
+          type: "ui_surface",
+          surfaceId: "surface-1",
+          surfaceType: "call_summary",
+        },
+        { type: "text", text: "Looking now." },
+        toolUse("call-1", "list_events"),
+        toolUse("call-2", "read_email"),
+        toolUse("call-3", "search_memory"),
+      ]),
+      userMessage([
+        toolResult("call-1", "ok"),
+        toolResult("call-2", "error"),
+        toolResult("call-3", "ok"),
+        {
+          type: "text",
+          text: "<system_notice>This tool call returned an error.</system_notice>",
+        },
+        {
+          type: "text",
+          text: "<system_notice>Retry budget: 2</system_notice>",
+        },
+      ]),
+    ];
+
+    const contents = toGeminiContents(messages, MODEL);
+
+    expect(contents).toHaveLength(4);
+    expect(contents[0]?.role).toBe("user");
+    expect(contents[0]?.parts).toEqual([{ text: "check my calendar" }]);
+
+    expect(contents[1]?.role).toBe("model");
+    expect(contents[1]?.parts?.map((p) => p.functionCall?.name)).toEqual([
+      undefined,
+      "list_events",
+      "read_email",
+      "search_memory",
+    ]);
+
+    // The function-response Content sits immediately after the model turn and
+    // carries nothing but the responses to that turn's calls.
+    expect(contents[2]?.role).toBe("user");
+    expect(contents[2]?.parts).toHaveLength(3);
+    expect(
+      contents[2]?.parts?.every((part) => Boolean(part.functionResponse)),
+    ).toBe(true);
+    expect(contents[2]?.parts?.map((p) => p.functionResponse?.name)).toEqual([
+      "list_events",
+      "read_email",
+      "search_memory",
+    ]);
+
+    // Everything else the user message carried rides a follow-up user Content,
+    // in original block order.
+    expect(contents[3]).toEqual({
+      role: "user",
+      parts: [
+        {
+          text: "<system_notice>This tool call returned an error.</system_notice>",
+        },
+        { text: "<system_notice>Retry budget: 2</system_notice>" },
+      ],
+    });
+  });
+
+  test("routes tool-result media and sibling text onto the same follow-up Content", () => {
+    const messages: Message[] = [
+      assistantMessage([toolUse("call-1", "screenshot")]),
+      userMessage([
+        toolResult("call-1", "captured", [
+          { type: "text", text: "1280x720" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: PNG_BASE64,
+            },
+          },
+        ]),
+        { type: "text", text: "<system_notice>note</system_notice>" },
+      ]),
+    ];
+
+    const contents = toGeminiContents(messages, MODEL);
+
+    expect(contents).toHaveLength(3);
+    expect(contents[1]?.parts).toEqual([
+      {
+        functionResponse: {
+          name: "screenshot",
+          response: { output: "captured\n1280x720" },
+        },
+      },
+    ]);
+    // Message-level parts come first, then media lifted out of the tool result.
+    expect(contents[2]).toEqual({
+      role: "user",
+      parts: [
+        { text: "<system_notice>note</system_notice>" },
+        { inlineData: { mimeType: "image/png", data: PNG_BASE64 } },
+      ],
+    });
+  });
+
+  test("keeps a tool-result-only user message as a single Content", () => {
+    const messages: Message[] = [
+      assistantMessage([toolUse("call-1", "list_events")]),
+      userMessage([toolResult("call-1", "ok")]),
+    ];
+
+    const contents = toGeminiContents(messages, MODEL);
+
+    expect(contents).toHaveLength(2);
+    expect(contents[1]).toEqual({
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            name: "list_events",
+            response: { output: "ok" },
+          },
+        },
+      ],
+    });
+  });
+
+  test("keeps a plain text user message as a single Content", () => {
+    const contents = toGeminiContents(
+      [userMessage([{ type: "text", text: "hello" }])],
+      MODEL,
+    );
+
+    expect(contents).toEqual([{ role: "user", parts: [{ text: "hello" }] }]);
+  });
+
+  test("keeps text and functionCall together in a model turn", () => {
+    const contents = toGeminiContents(
+      [
+        assistantMessage([
+          { type: "text", text: "one moment" },
+          toolUse("call-1", "list_events"),
+        ]),
+      ],
+      MODEL,
+    );
+
+    expect(contents).toHaveLength(1);
+    expect(contents[0]?.parts).toHaveLength(2);
+    expect(contents[0]?.parts?.[0]?.text).toBe("one moment");
+    expect(contents[0]?.parts?.[1]?.functionCall?.name).toBe("list_events");
+  });
+
+  test("stamps the fallback thought signature on unsigned Gemini 3 tool calls", () => {
+    const contents = toGeminiContents(
+      [
+        assistantMessage([
+          toolUse("call-1", "list_events"),
+          toolUse("call-2", "read_email"),
+        ]),
+      ],
+      MODEL,
+    );
+
+    const parts = contents[0]?.parts ?? [];
+    expect(parts[0]?.thoughtSignature).toBe(
+      "context_engineering_is_the_way_to_go",
+    );
+    expect(parts[1]?.thoughtSignature).toBeUndefined();
+  });
+
+  test("leaves real thought signatures untouched and skips non-Gemini-3 models", () => {
+    const signed = toGeminiContents(
+      [
+        assistantMessage([
+          {
+            type: "tool_use",
+            id: "call-1",
+            name: "list_events",
+            input: {},
+            providerMetadata: {
+              gemini: { thoughtSignature: "real-signature" },
+            },
+          },
+        ]),
+      ],
+      MODEL,
+    );
+    expect(signed[0]?.parts?.[0]?.thoughtSignature).toBe("real-signature");
+
+    const legacy = toGeminiContents(
+      [assistantMessage([toolUse("call-1", "list_events")])],
+      "gemini-2.5-flash",
+    );
+    expect(legacy[0]?.parts?.[0]?.thoughtSignature).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -10,7 +10,6 @@ import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { DAILY_LIMIT_PATTERNS } from "../../util/provider-error-patterns.js";
-import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
@@ -25,11 +24,7 @@ import {
   ContextOverflowError,
   extractOverflowTokensFromMessage,
 } from "../types.js";
-import {
-  base64ByteLength,
-  GEMINI_MAX_INLINE_AUDIO_BYTES,
-  normalizeGeminiAudioMime,
-} from "./inline-media.js";
+import { toGeminiContents } from "./to-gemini-contents.js";
 
 /**
  * Token/context-specific phrases that reliably indicate context-overflow
@@ -38,13 +33,6 @@ import {
  */
 const GEMINI_CONTEXT_OVERFLOW_TOKEN_PATTERNS =
   /token.?count.*exceeds|exceeds.*maximum.*tokens|prompt.?is.?too.?long|too.?many.?(?:input.?)?tokens|input.?too.?long|context.?length.?exceeded/i;
-
-const GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE =
-  "context_engineering_is_the_way_to_go";
-
-function isGemini3Model(model: string): boolean {
-  return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");
-}
 
 const THINKING_LEVEL_BY_NAME: Record<ThinkingLevelName, ThinkingLevel> = {
   minimal: ThinkingLevel.MINIMAL,
@@ -380,7 +368,7 @@ export class GeminiProvider implements Provider {
       : undefined;
 
     try {
-      const geminiContents = this.toGeminiContents(messages, activeModel);
+      const geminiContents = toGeminiContents(messages, activeModel);
 
       const geminiConfig: genai.GenerateContentConfig = {};
 
@@ -604,7 +592,7 @@ export class GeminiProvider implements Provider {
     systemPrompt: string,
     tools?: ToolDefinition[],
   ): Promise<number> {
-    const contents = this.toGeminiContents(messages, this.model);
+    const contents = toGeminiContents(messages, this.model);
     const config: genai.CountTokensConfig = {};
     if (systemPrompt) {
       config.systemInstruction = systemPrompt.replaceAll(
@@ -632,226 +620,5 @@ export class GeminiProvider implements Provider {
       throw new Error("Gemini countTokens returned no totalTokens");
     }
     return res.totalTokens;
-  }
-
-  /** Convert neutral messages to Gemini Content[] format. */
-  private toGeminiContents(
-    messages: Message[],
-    model: string,
-  ): genai.Content[] {
-    // Swap any persisted attachment references back to inline base64 before
-    // building parts, so the transforms below can read `source.data`.
-    messages = resolveMediaReferences(messages);
-    const result: genai.Content[] = [];
-
-    // Build a map from tool_use id → function name so tool_result blocks
-    // can provide the required `name` field on Gemini's FunctionResponse.
-    const toolCallNames = new Map<string, string>();
-    for (const msg of messages) {
-      for (const block of msg.content) {
-        if (block.type === "tool_use") {
-          toolCallNames.set(block.id, block.name);
-        }
-      }
-    }
-
-    for (const msg of messages) {
-      const role = msg.role === "assistant" ? "model" : "user";
-      const { parts, toolResultMediaParts } = this.toGeminiParts(
-        msg.content,
-        toolCallNames,
-        model,
-        role,
-      );
-      if (parts.length > 0) {
-        result.push({ role, parts });
-      }
-      // Gemini requires that a Content with functionResponse parts must not
-      // contain non-functionResponse parts. Emit tool-result images in a
-      // separate user Content entry.
-      if (toolResultMediaParts.length > 0) {
-        result.push({ role: "user", parts: toolResultMediaParts });
-      }
-    }
-
-    return result;
-  }
-
-  /** Convert ContentBlock[] to Gemini Part[] and any tool-result image parts. */
-  private toGeminiParts(
-    blocks: ContentBlock[],
-    toolCallNames: Map<string, string>,
-    model: string,
-    role: "model" | "user",
-  ): { parts: genai.Part[]; toolResultMediaParts: genai.Part[] } {
-    const parts: genai.Part[] = [];
-    const toolResultMediaParts: genai.Part[] = [];
-
-    for (const block of blocks) {
-      switch (block.type) {
-        case "text":
-          parts.push({ text: block.text });
-          break;
-        case "image": {
-          const imageSrc = base64Source(block.source);
-          parts.push({
-            inlineData: {
-              mimeType: imageSrc.media_type,
-              data: imageSrc.data,
-            },
-          });
-          break;
-        }
-        case "file": {
-          const fileSrc = base64Source(block.source);
-          if (this.supportsGeminiInlineFile(fileSrc.media_type)) {
-            // Normalize audio MIME onto Gemini's spelling (e.g. audio/mpeg →
-            // audio/mp3); PDFs pass through unchanged. Guard the 20 MB inline
-            // request limit for audio so an oversize clip degrades to a text
-            // note rather than 400ing the whole request.
-            const audioMime = normalizeGeminiAudioMime(fileSrc.media_type);
-            const rawBytes = base64ByteLength(fileSrc.data);
-            if (audioMime && rawBytes > GEMINI_MAX_INLINE_AUDIO_BYTES) {
-              const approxMb = Math.round(rawBytes / (1024 * 1024));
-              parts.push({
-                text: `[Audio file too large to send inline: ${fileSrc.filename} (${fileSrc.media_type}, ~${approxMb}MB). Gemini's inline request limit is 20MB; this file was omitted. Ask the user for a shorter clip.]`,
-              });
-            } else {
-              parts.push({
-                inlineData: {
-                  mimeType: audioMime ?? fileSrc.media_type,
-                  data: fileSrc.data,
-                },
-              });
-            }
-          } else {
-            const fallback = block.extracted_text?.trim()
-              ? `[Attached file: ${fileSrc.filename} (${fileSrc.media_type})]\n${block.extracted_text}`
-              : `[Attached file: ${fileSrc.filename} (${fileSrc.media_type})]\nNo extracted text available.`;
-            parts.push({ text: fallback });
-          }
-          break;
-        }
-        case "tool_use":
-          {
-            const functionCallPart: genai.Part = {
-              functionCall: {
-                name: block.name,
-                args: block.input,
-              },
-            };
-            const thoughtSignature =
-              block.providerMetadata?.gemini?.thoughtSignature;
-            if (thoughtSignature) {
-              functionCallPart.thoughtSignature = thoughtSignature;
-            }
-            parts.push(functionCallPart);
-          }
-          break;
-        case "tool_result": {
-          let outputText = block.content;
-          if (block.contentBlocks && block.contentBlocks.length > 0) {
-            const extraText = block.contentBlocks
-              .filter(
-                (cb): cb is Extract<ContentBlock, { type: "text" }> =>
-                  cb.type === "text",
-              )
-              .map((cb) => cb.text);
-            if (extraText.length > 0) {
-              outputText = outputText + "\n" + extraText.join("\n");
-            }
-            // Collect images and inline-able audio separately — Gemini rejects
-            // mixing inlineData with functionResponse in the same Content entry.
-            for (const cb of block.contentBlocks) {
-              if (cb.type === "image") {
-                const cbSrc = base64Source(cb.source);
-                toolResultMediaParts.push({
-                  inlineData: {
-                    mimeType: cbSrc.media_type,
-                    data: cbSrc.data,
-                  },
-                });
-              } else if (cb.type === "file") {
-                const cbSrc = base64Source(cb.source);
-                const audioMime = normalizeGeminiAudioMime(cbSrc.media_type);
-                if (
-                  audioMime &&
-                  base64ByteLength(cbSrc.data) <= GEMINI_MAX_INLINE_AUDIO_BYTES
-                ) {
-                  toolResultMediaParts.push({
-                    inlineData: { mimeType: audioMime, data: cbSrc.data },
-                  });
-                } else if (audioMime) {
-                  // Oversize audio: note it in the functionResponse output
-                  // rather than a media part (a text part can't ride the
-                  // separate media Content, and inline audio would blow
-                  // Gemini's request-size limit).
-                  outputText =
-                    outputText +
-                    `\n[Audio too large to send inline: ${cbSrc.filename}. Ask for a shorter clip.]`;
-                }
-                // Non-inline-able file sub-blocks (m4a/opus/pdf) are skipped
-                // here; the tool's text output already conveys the file.
-              }
-            }
-          }
-          parts.push({
-            functionResponse: {
-              name: toolCallNames.get(block.tool_use_id) ?? block.tool_use_id,
-              response: { output: outputText },
-            },
-          });
-          break;
-        }
-        case "server_tool_use":
-          parts.push({ text: `[Web search: ${block.name}]` });
-          break;
-        case "web_search_tool_result":
-          parts.push({ text: "[Web search results]" });
-          break;
-        // thinking, redacted_thinking — not applicable for Gemini
-      }
-    }
-
-    if (role === "model") {
-      this.addGemini3UnsignedToolCallFallback(parts, model);
-    }
-
-    return { parts, toolResultMediaParts };
-  }
-
-  private addGemini3UnsignedToolCallFallback(
-    parts: genai.Part[],
-    model: string,
-  ): void {
-    if (!isGemini3Model(model)) {
-      return;
-    }
-
-    const functionCallParts = parts.filter((part) => part.functionCall);
-    if (functionCallParts.length === 0) {
-      return;
-    }
-
-    const hasRealThoughtSignature = functionCallParts.some((part) =>
-      Boolean(part.thoughtSignature),
-    );
-    if (hasRealThoughtSignature) {
-      return;
-    }
-
-    const firstFunctionCallPart = functionCallParts[0];
-    if (!firstFunctionCallPart) {
-      return;
-    }
-    firstFunctionCallPart.thoughtSignature =
-      GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE;
-  }
-
-  private supportsGeminiInlineFile(mimeType: string): boolean {
-    return (
-      mimeType === "application/pdf" ||
-      normalizeGeminiAudioMime(mimeType) !== null
-    );
   }
 }

--- a/assistant/src/providers/gemini/inline-media.ts
+++ b/assistant/src/providers/gemini/inline-media.ts
@@ -3,10 +3,10 @@
  * it accepts, how our stored MIME types normalize onto Gemini's spelling, the
  * inline-request size ceiling, and the token cost.
  *
- * Imported by both the Gemini serializer (`client.ts`) and the token estimator
- * (`context/token-estimator.ts`) so the two cannot drift — if they disagreed on
- * which audio is sent inline, the context budgeter would mis-count what
- * actually goes on the wire.
+ * Imported by both the Gemini serializer (`to-gemini-contents.ts`) and the
+ * token estimator (`context/token-estimator.ts`) so the two cannot drift: if
+ * they disagreed on which audio is sent inline, the context budgeter would
+ * mis-count what actually goes on the wire.
  *
  * Ref: https://ai.google.dev/gemini-api/docs/audio
  *   - Inline-accepted audio: wav, mp3, aiff, aac, ogg, flac

--- a/assistant/src/providers/gemini/to-gemini-contents.ts
+++ b/assistant/src/providers/gemini/to-gemini-contents.ts
@@ -1,0 +1,269 @@
+/**
+ * Serialization of neutral message history into Gemini's `Content[]` wire
+ * shape.
+ *
+ * The one rule that shapes most of this module: a `Content` carrying
+ * `functionResponse` parts must carry nothing else. Gemini segments turns on
+ * that Content, so any sibling text or `inlineData` part breaks segmentation
+ * and the request is rejected with
+ * `Requests ending with a model turn are not supported.` Our agent loop
+ * routinely produces such mixed user messages (tool results plus
+ * `<system_notice>` text on an errored call, or compaction merging context text
+ * into the tool-result message), so a mixed message is split into a
+ * function-response-only Content followed by a second user Content holding
+ * everything else.
+ */
+
+import type * as genai from "@google/genai";
+
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
+import type { ContentBlock, Message } from "../types.js";
+import {
+  base64ByteLength,
+  GEMINI_MAX_INLINE_AUDIO_BYTES,
+  normalizeGeminiAudioMime,
+} from "./inline-media.js";
+
+const GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE =
+  "context_engineering_is_the_way_to_go";
+
+function isGemini3Model(model: string): boolean {
+  return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");
+}
+
+function supportsGeminiInlineFile(mimeType: string): boolean {
+  return (
+    mimeType === "application/pdf" ||
+    normalizeGeminiAudioMime(mimeType) !== null
+  );
+}
+
+/** Convert neutral messages to Gemini Content[] format. */
+export function toGeminiContents(
+  messages: Message[],
+  model: string,
+): genai.Content[] {
+  // Swap any persisted attachment references back to inline base64 before
+  // building parts, so the transforms below can read `source.data`.
+  const resolved = resolveMediaReferences(messages);
+  const result: genai.Content[] = [];
+
+  // Build a map from tool_use id → function name so tool_result blocks
+  // can provide the required `name` field on Gemini's FunctionResponse.
+  const toolCallNames = new Map<string, string>();
+  for (const msg of resolved) {
+    for (const block of msg.content) {
+      if (block.type === "tool_use") {
+        toolCallNames.set(block.id, block.name);
+      }
+    }
+  }
+
+  for (const msg of resolved) {
+    const role = msg.role === "assistant" ? "model" : "user";
+    const { parts, toolResultMediaParts } = toGeminiParts(
+      msg.content,
+      toolCallNames,
+      model,
+      role,
+    );
+
+    const functionResponseParts = parts.filter((part) => part.functionResponse);
+    if (functionResponseParts.length > 0) {
+      // The function-response Content stays immediately after the model turn
+      // that called the tools, holding nothing but the responses. Everything
+      // else the message carried rides a follow-up user Content: message-level
+      // parts first (in block order), then media lifted out of the tool
+      // results.
+      result.push({ role, parts: functionResponseParts });
+      const followUpParts = [
+        ...parts.filter((part) => !part.functionResponse),
+        ...toolResultMediaParts,
+      ];
+      if (followUpParts.length > 0) {
+        result.push({ role: "user", parts: followUpParts });
+      }
+      continue;
+    }
+
+    if (parts.length > 0) {
+      result.push({ role, parts });
+    }
+    if (toolResultMediaParts.length > 0) {
+      result.push({ role: "user", parts: toolResultMediaParts });
+    }
+  }
+
+  return result;
+}
+
+/** Convert ContentBlock[] to Gemini Part[] and any tool-result image parts. */
+function toGeminiParts(
+  blocks: ContentBlock[],
+  toolCallNames: Map<string, string>,
+  model: string,
+  role: "model" | "user",
+): { parts: genai.Part[]; toolResultMediaParts: genai.Part[] } {
+  const parts: genai.Part[] = [];
+  const toolResultMediaParts: genai.Part[] = [];
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case "text":
+        parts.push({ text: block.text });
+        break;
+      case "image": {
+        const imageSrc = base64Source(block.source);
+        parts.push({
+          inlineData: {
+            mimeType: imageSrc.media_type,
+            data: imageSrc.data,
+          },
+        });
+        break;
+      }
+      case "file": {
+        const fileSrc = base64Source(block.source);
+        if (supportsGeminiInlineFile(fileSrc.media_type)) {
+          // Normalize audio MIME onto Gemini's spelling (e.g. audio/mpeg →
+          // audio/mp3); PDFs pass through unchanged. Guard the 20 MB inline
+          // request limit for audio so an oversize clip degrades to a text
+          // note rather than 400ing the whole request.
+          const audioMime = normalizeGeminiAudioMime(fileSrc.media_type);
+          const rawBytes = base64ByteLength(fileSrc.data);
+          if (audioMime && rawBytes > GEMINI_MAX_INLINE_AUDIO_BYTES) {
+            const approxMb = Math.round(rawBytes / (1024 * 1024));
+            parts.push({
+              text: `[Audio file too large to send inline: ${fileSrc.filename} (${fileSrc.media_type}, ~${approxMb}MB). Gemini's inline request limit is 20MB; this file was omitted. Ask the user for a shorter clip.]`,
+            });
+          } else {
+            parts.push({
+              inlineData: {
+                mimeType: audioMime ?? fileSrc.media_type,
+                data: fileSrc.data,
+              },
+            });
+          }
+        } else {
+          const fallback = block.extracted_text?.trim()
+            ? `[Attached file: ${fileSrc.filename} (${fileSrc.media_type})]\n${block.extracted_text}`
+            : `[Attached file: ${fileSrc.filename} (${fileSrc.media_type})]\nNo extracted text available.`;
+          parts.push({ text: fallback });
+        }
+        break;
+      }
+      case "tool_use":
+        {
+          const functionCallPart: genai.Part = {
+            functionCall: {
+              name: block.name,
+              args: block.input,
+            },
+          };
+          const thoughtSignature =
+            block.providerMetadata?.gemini?.thoughtSignature;
+          if (thoughtSignature) {
+            functionCallPart.thoughtSignature = thoughtSignature;
+          }
+          parts.push(functionCallPart);
+        }
+        break;
+      case "tool_result": {
+        let outputText = block.content;
+        if (block.contentBlocks && block.contentBlocks.length > 0) {
+          const extraText = block.contentBlocks
+            .filter(
+              (cb): cb is Extract<ContentBlock, { type: "text" }> =>
+                cb.type === "text",
+            )
+            .map((cb) => cb.text);
+          if (extraText.length > 0) {
+            outputText = outputText + "\n" + extraText.join("\n");
+          }
+          // Collect images and inline-able audio separately: Gemini rejects
+          // mixing inlineData with functionResponse in the same Content entry.
+          for (const cb of block.contentBlocks) {
+            if (cb.type === "image") {
+              const cbSrc = base64Source(cb.source);
+              toolResultMediaParts.push({
+                inlineData: {
+                  mimeType: cbSrc.media_type,
+                  data: cbSrc.data,
+                },
+              });
+            } else if (cb.type === "file") {
+              const cbSrc = base64Source(cb.source);
+              const audioMime = normalizeGeminiAudioMime(cbSrc.media_type);
+              if (
+                audioMime &&
+                base64ByteLength(cbSrc.data) <= GEMINI_MAX_INLINE_AUDIO_BYTES
+              ) {
+                toolResultMediaParts.push({
+                  inlineData: { mimeType: audioMime, data: cbSrc.data },
+                });
+              } else if (audioMime) {
+                // Oversize audio: note it in the functionResponse output
+                // rather than a media part (a text part can't ride the
+                // separate media Content, and inline audio would blow
+                // Gemini's request-size limit).
+                outputText =
+                  outputText +
+                  `\n[Audio too large to send inline: ${cbSrc.filename}. Ask for a shorter clip.]`;
+              }
+              // Non-inline-able file sub-blocks (m4a/opus/pdf) are skipped
+              // here; the tool's text output already conveys the file.
+            }
+          }
+        }
+        parts.push({
+          functionResponse: {
+            name: toolCallNames.get(block.tool_use_id) ?? block.tool_use_id,
+            response: { output: outputText },
+          },
+        });
+        break;
+      }
+      case "server_tool_use":
+        parts.push({ text: `[Web search: ${block.name}]` });
+        break;
+      case "web_search_tool_result":
+        parts.push({ text: "[Web search results]" });
+        break;
+      // thinking, redacted_thinking: not applicable for Gemini
+    }
+  }
+
+  if (role === "model") {
+    addGemini3UnsignedToolCallFallback(parts, model);
+  }
+
+  return { parts, toolResultMediaParts };
+}
+
+function addGemini3UnsignedToolCallFallback(
+  parts: genai.Part[],
+  model: string,
+): void {
+  if (!isGemini3Model(model)) {
+    return;
+  }
+
+  const functionCallParts = parts.filter((part) => part.functionCall);
+  if (functionCallParts.length === 0) {
+    return;
+  }
+
+  const hasRealThoughtSignature = functionCallParts.some((part) =>
+    Boolean(part.thoughtSignature),
+  );
+  if (hasRealThoughtSignature) {
+    return;
+  }
+
+  const firstFunctionCallPart = functionCallParts[0];
+  if (!firstFunctionCallPart) {
+    return;
+  }
+  firstFunctionCallPart.thoughtSignature =
+    GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE;
+}


### PR DESCRIPTION
## Problem

Gemini conversations die with:

> Gemini API error (400): {"error":{"code":400,"message":"Requests ending with a model turn are not supported.","status":"INVALID_ARGUMENT"}}

Verified from production logs (2026-07-29, gemini-3.6-flash): the failing requests' neutral history is well-formed and **ends with a user message**, so the error text is misleading. The trigger is that the final user message mixes `tool_result` blocks with `text` blocks, which the converter emits as ONE Gemini Content mixing `functionResponse` and text parts. Gemini segments turns on the function-response Content and requires it to carry only the functionResponse parts matching the preceding model call turn; sibling parts break segmentation and the request is rejected.

The agent loop produces exactly that shape whenever a tool call errors (`<system_notice>` text blocks land beside the tool results in the same user message) and after compaction folds context text into the tool-result message. In the observed incident the tool errors were MCP permission denials in a scheduled session (companion fix: #39494), so the conversation could not even report its own failure: every subsequent turn re-sent the mixed Content and 400ed.

The converter already separated media parts out of the functionResponse Content for exactly this reason; text parts were not separated.

## Fix

A user message that yields both functionResponse parts and other parts now emits two Contents:

1. `{ role: "user", parts: [functionResponse...] }` — stays immediately after the model turn that called the tools
2. `{ role: "user", parts: [remaining parts in block order, then media lifted out of tool results] }`

Messages with only tool results, or with none, serialize exactly as before.

The conversion moves out of `GeminiClient`'s private methods into `providers/gemini/to-gemini-contents.ts` (a byte-for-byte lift of the block-conversion switch) so it can be unit tested directly; this provider previously had no conversion tests.

## Testing

- New `to-gemini-contents.test.ts` (7 tests), including the exact failing production shape ([user text], [assistant text+3 tool_use], [user 3 tool_result + 2 text] → 4 Contents with a pure function-response turn). Stubbing the split back out makes the tests fail.
- Regression: `gemini-provider.test.ts` (67), `gemini-count-tokens.test.ts`, `context-overflow-error.test.ts` (29), `cross-provider-web-search.test.ts` (20), `context-token-estimator.test.ts` (31) all pass; `typecheck:fast`, eslint, prettier clean.
- No live-replay validation: no Gemini API key is available locally (the affected assistant is platform-hosted), so the fix is validated by unit tests plus Gemini's documented function-calling constraints.

## Known follow-up (pre-existing, not addressed here)

Running `gemini-provider.test.ts` and `providers/__tests__/context-overflow-error.test.ts` in the same `bun test` invocation fails 4 `detectGeminiContextOverflow` assertions on unmodified main: `mock.module("@google/genai", ...)` leaks a stubbed `ApiError` across files. Each file passes alone. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)