### PR TITLE
feat(memory): declare `source` and `origin_date` provenance fields in concept-page frontmatter

### DIFF
--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/page-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/page-store.test.ts
@@ -241,6 +241,37 @@ describe("writePage + readPage round-trip", () => {
     expect(read!.frontmatter.status).toBe("cc-draft");
   });
 
+  test("round-trips the provenance fields (source, origin_date)", async () => {
+    // Imported/backfilled pages carry `source: import:<provider>` and an
+    // `origin_date:` for original chronology. Both are declared (not
+    // passthrough) so they parse with a real type and survive the
+    // renderPageContent write -> readPage round-trip.
+    const page = makePage({
+      slug: "imported-page",
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        ref_urls: [],
+        source: "import:chatgpt",
+        origin_date: "2023-04-01",
+      },
+    });
+    await writePage(workspaceDir, page);
+
+    const read = await readPage(workspaceDir, "imported-page");
+    expect(read).not.toBeNull();
+    expect(read!.frontmatter.source).toBe("import:chatgpt");
+    expect(read!.frontmatter.origin_date).toBe("2023-04-01");
+
+    // The rendered file carries both keys in its frontmatter block.
+    const raw = readFileSync(
+      join(workspaceDir, "memory", "concepts", "imported-page.md"),
+      "utf-8",
+    );
+    expect(raw).toMatch(/source: "?import:chatgpt"?/);
+    expect(raw).toMatch(/origin_date: "?2023-04-01"?/);
+  });
+
   test("renders frontmatter at the top with --- delimiters", async () => {
     const page = makePage();
     await writePage(workspaceDir, page);

--- a/assistant/src/plugins/defaults/memory/substrate/types.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/types.ts
@@ -68,6 +68,18 @@ export const ConceptPageFrontmatterSchema = z
     // card surface so state-shaped questions can select the page. Distinct
     // from `status:` (the article-model draft marker, e.g. "cc-draft").
     current: z.string().optional(),
+    // Page-level provenance tag for pages not authored by consolidation;
+    // convention `import:<provider>` (e.g. `import:chatgpt`, `import:fathom`).
+    // Absent on organically consolidated pages. Distinct from the leaked
+    // `sources` (plural) passthrough key seen in migrated corpora.
+    source: z.string().optional(),
+    // ISO 8601 date (or datetime) the page's content originally dates from,
+    // for imported/backfilled material. Consumed by the page index as the
+    // page's *effective recency* (`freshAt`); does NOT affect the maintain
+    // job's mtime-based re-embed delta. Migrated corpora already carry leaked
+    // passthrough keys like `date`/`as_of`: `origin_date` is the declared,
+    // consumed field; the leaked keys stay inert.
+    origin_date: z.string().optional(),
   })
   // `.passthrough()`, NOT `.strict()`: tolerate unknown frontmatter keys instead
   // of throwing. Migrated/converted corpora carry leaked source-page fields the

--- a/assistant/src/plugins/defaults/memory/substrate/types.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/types.ts
@@ -74,11 +74,11 @@ export const ConceptPageFrontmatterSchema = z
     // `sources` (plural) passthrough key seen in migrated corpora.
     source: z.string().optional(),
     // ISO 8601 date (or datetime) the page's content originally dates from,
-    // for imported/backfilled material. Consumed by the page index as the
-    // page's *effective recency* (`freshAt`); does NOT affect the maintain
-    // job's mtime-based re-embed delta. Migrated corpora already carry leaked
-    // passthrough keys like `date`/`as_of`: `origin_date` is the declared,
-    // consumed field; the leaked keys stay inert.
+    // for imported/backfilled material whose file mtime reflects when it was
+    // written to this workspace rather than when its content was true.
+    // Migrated corpora already carry leaked passthrough keys like
+    // `date`/`as_of`: `origin_date` is the declared field; the leaked keys
+    // stay inert.
     origin_date: z.string().optional(),
   })
   // `.passthrough()`, NOT `.strict()`: tolerate unknown frontmatter keys instead


### PR DESCRIPTION
## Summary
- Declares `source:` (import:<provider> provenance tag) and `origin_date:` (original-chronology ISO date) as typed optional fields in ConceptPageFrontmatterSchema
- Round-trip test through writePage/readPage/renderPageContent

Part of plan: memory-ingestion.md (PR 1 of 11)