### PR TITLE
fix(assistant): record `source` on conversations created by `POST /v1/conversations/import`

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8264,7 +8264,10 @@ paths:
     post:
       operationId: conversations_import_post
       summary: Import conversations
-      description: Import conversations from a standard JSON payload.
+      description:
+        Import conversations from a standard JSON payload. Created conversations record a provenance source of
+        `import:<provider>` derived from the `sourceKey` prefix (e.g. `chatgpt:abc123` -> `import:chatgpt`), or
+        `import:unknown` when no prefix is present.
       tags:
         - conversations
       requestBody:

--- a/assistant/src/__tests__/conversations-import-system-filter.test.ts
+++ b/assistant/src/__tests__/conversations-import-system-filter.test.ts
@@ -4,7 +4,7 @@
  * Covers two behaviors: non-renderable roles are never persisted (the
  * messages store is UI-facing (`ConversationMessage`), so an imported export
  * carrying agent-context `system` rows must land only its `user`/`assistant`
- * turns — the `system` rows are dropped, not persisted), and imported
+ * turns; the `system` rows are dropped, not persisted), and imported
  * conversations carry a provenance `source` derived from the `sourceKey`
  * prefix (`import:<provider>`, or `import:unknown` when absent).
  */
@@ -120,6 +120,40 @@ describe("conversations import provenance source", () => {
     expect(again.imported).toBe(0);
     expect(again.skipped).toBe(1);
     expect(db.select().from(conversations).all()).toHaveLength(1);
+  });
+
+  test("normalizes non-canonical prefixes instead of dropping them", async () => {
+    // GIVEN sourceKeys whose prefixes carry uppercase or underscore characters
+    const body = {
+      conversations: [
+        {
+          sourceKey: "OpenAI:abc",
+          title: "Uppercase prefix",
+          messages: [{ role: "user", content: "hello" }],
+        },
+        {
+          sourceKey: "chat_gpt:def",
+          title: "Underscore prefix",
+          messages: [{ role: "user", content: "hello" }],
+        },
+      ],
+    };
+
+    // WHEN the conversations are imported
+    const result = (await importHandler({
+      body,
+    } as unknown as RouteHandlerArgs)) as { imported: number };
+    expect(result.imported).toBe(2);
+
+    // THEN each prefix is normalized into import:<provider>, not import:unknown
+    const db = getDb();
+    const sources = db
+      .select()
+      .from(conversations)
+      .all()
+      .map((row) => row.source)
+      .sort();
+    expect(sources).toEqual(["import:chat-gpt", "import:openai"]);
   });
 
   test("falls back to import:unknown when sourceKey is absent", async () => {

--- a/assistant/src/__tests__/conversations-import-system-filter.test.ts
+++ b/assistant/src/__tests__/conversations-import-system-filter.test.ts
@@ -1,8 +1,12 @@
 /**
- * Tests that the conversations import route never persists non-renderable
- * roles. The messages store is UI-facing (`ConversationMessage`), so an
- * imported export carrying agent-context `system` rows must land only its
- * `user`/`assistant` turns — the `system` rows are dropped, not persisted.
+ * Route-level tests for the conversations import route.
+ *
+ * Covers two behaviors: non-renderable roles are never persisted (the
+ * messages store is UI-facing (`ConversationMessage`), so an imported export
+ * carrying agent-context `system` rows must land only its `user`/`assistant`
+ * turns — the `system` rows are dropped, not persisted), and imported
+ * conversations carry a provenance `source` derived from the `sourceKey`
+ * prefix (`import:<provider>`, or `import:unknown` when absent).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -80,5 +84,64 @@ describe("conversations import system-row filtering", () => {
         .all()
         .some((m) => m.role === "system"),
     ).toBe(false);
+  });
+});
+
+describe("conversations import provenance source", () => {
+  beforeEach(resetTables);
+
+  test("stamps import:<provider> from a prefixed sourceKey and keeps dedup", async () => {
+    // GIVEN an export whose sourceKey carries a provider prefix
+    const body = {
+      conversations: [
+        {
+          sourceKey: "chatgpt:abc123",
+          title: "ChatGPT import",
+          messages: [{ role: "user", content: "hello" }],
+        },
+      ],
+    };
+
+    // WHEN the conversation is imported
+    const result = (await importHandler({
+      body,
+    } as unknown as RouteHandlerArgs)) as { imported: number };
+    expect(result.imported).toBe(1);
+
+    // THEN the created row records the provider-derived provenance source
+    const db = getDb();
+    const conv = db.select().from(conversations).all()[0];
+    expect(conv.source).toBe("import:chatgpt");
+
+    // AND re-importing the same sourceKey still dedups (no second row)
+    const again = (await importHandler({
+      body,
+    } as unknown as RouteHandlerArgs)) as { imported: number; skipped: number };
+    expect(again.imported).toBe(0);
+    expect(again.skipped).toBe(1);
+    expect(db.select().from(conversations).all()).toHaveLength(1);
+  });
+
+  test("falls back to import:unknown when sourceKey is absent", async () => {
+    // GIVEN an export entry with no sourceKey at all
+    const body = {
+      conversations: [
+        {
+          title: "Prefixless import",
+          messages: [{ role: "user", content: "hello" }],
+        },
+      ],
+    };
+
+    // WHEN the conversation is imported
+    const result = (await importHandler({
+      body,
+    } as unknown as RouteHandlerArgs)) as { imported: number };
+    expect(result.imported).toBe(1);
+
+    // THEN the created row falls back to the unknown-provider source
+    const db = getDb();
+    const conv = db.select().from(conversations).all()[0];
+    expect(conv.source).toBe("import:unknown");
   });
 });

--- a/assistant/src/runtime/routes/conversations-import-routes.ts
+++ b/assistant/src/runtime/routes/conversations-import-routes.ts
@@ -78,6 +78,18 @@ function isRenderableRole(role: string): role is "user" | "assistant" {
   return role === "user" || role === "assistant";
 }
 
+/**
+ * Provenance `source` for an imported conversation. Export tooling prefixes
+ * `sourceKey` with the originating provider (e.g. `chatgpt:abc123`), so a
+ * recognizable prefix maps to `import:<provider>`; anything else falls back
+ * to `import:unknown`. Distinguishes imported rows from the schema default
+ * `"user"` (schema/conversations.ts).
+ */
+function deriveImportSource(sourceKey: string | undefined): string {
+  const prefix = sourceKey?.match(/^([a-z0-9-]+):/)?.[1];
+  return prefix ? `import:${prefix}` : "import:unknown";
+}
+
 // -- Handler --
 
 async function handleConversationsImport({ body }: RouteHandlerArgs) {
@@ -123,8 +135,9 @@ async function handleConversationsImport({ body }: RouteHandlerArgs) {
       const { convCreatedAt, convUpdatedAt, messageTimestamps } =
         resolveTimestamps(conv, messages);
 
+      const source = deriveImportSource(conv.sourceKey);
       const conversation = await withSqliteRetry(
-        () => createConversation(conv.title),
+        () => createConversation({ title: conv.title, source }),
         { op: "conversationsImport.createConversation" },
       );
 
@@ -236,7 +249,11 @@ export const ROUTES: RouteDefinition[] = [
     },
     handler: handleConversationsImport,
     summary: "Import conversations",
-    description: "Import conversations from a standard JSON payload.",
+    description:
+      "Import conversations from a standard JSON payload. Created " +
+      "conversations record a provenance source of `import:<provider>` " +
+      "derived from the `sourceKey` prefix (e.g. `chatgpt:abc123` -> " +
+      "`import:chatgpt`), or `import:unknown` when no prefix is present.",
     tags: ["conversations"],
     requestBody: z.object({
       conversations: z.array(

--- a/assistant/src/runtime/routes/conversations-import-routes.ts
+++ b/assistant/src/runtime/routes/conversations-import-routes.ts
@@ -80,14 +80,23 @@ function isRenderableRole(role: string): role is "user" | "assistant" {
 
 /**
  * Provenance `source` for an imported conversation. Export tooling prefixes
- * `sourceKey` with the originating provider (e.g. `chatgpt:abc123`), so a
- * recognizable prefix maps to `import:<provider>`; anything else falls back
- * to `import:unknown`. Distinguishes imported rows from the schema default
- * `"user"` (schema/conversations.ts).
+ * `sourceKey` with the originating provider (e.g. `chatgpt:abc123`), so the
+ * substring before the first colon is normalized (lowercased, non
+ * `[a-z0-9-]` runs collapsed to `-`) into `import:<provider>`; only keys
+ * with no usable prefix fall back to `import:unknown`. Distinguishes
+ * imported rows from the schema default `"user"` (schema/conversations.ts).
  */
 function deriveImportSource(sourceKey: string | undefined): string {
-  const prefix = sourceKey?.match(/^([a-z0-9-]+):/)?.[1];
-  return prefix ? `import:${prefix}` : "import:unknown";
+  const colonIdx = sourceKey?.indexOf(":") ?? -1;
+  if (sourceKey === undefined || colonIdx <= 0) {
+    return "import:unknown";
+  }
+  const provider = sourceKey
+    .slice(0, colonIdx)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return provider ? `import:${provider}` : "import:unknown";
 }
 
 // -- Handler --


### PR DESCRIPTION
## Summary
- Imported conversations now carry source: import:<provider> derived from the sourceKey prefix (import:unknown fallback)
- Regenerated openapi.yaml; extended import tests

Part of plan: memory-ingestion.md (PR 3 of 11)