### PR TITLE
Load older invoices past 100 in the billing invoices table

### DIFF
--- a/clients/web/src/domains/settings/components/invoices-table.test.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.test.tsx
@@ -12,15 +12,20 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type { Invoice, InvoiceListResponse } from "@/generated/api/types.gen";
 
-let listRetrieveCalls = 0;
+let listRetrieveCalls: ({ starting_after?: string } | undefined)[] = [];
 let listResult: InvoiceListResponse = { invoices: [], has_more: false };
+// Pages served for ?starting_after=<cursor> requests, keyed by cursor.
+let nextPages: Record<string, InvoiceListResponse> = {};
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
-  organizationsBillingInvoicesRetrieve: () => {
-    listRetrieveCalls += 1;
+  organizationsBillingInvoicesRetrieve: (options?: {
+    query?: { starting_after?: string };
+  }) => {
+    listRetrieveCalls.push(options?.query);
+    const cursor = options?.query?.starting_after;
     return Promise.resolve({
-      data: listResult,
+      data: cursor ? nextPages[cursor] : listResult,
       response: { ok: true, status: 200 },
     });
   },
@@ -55,8 +60,9 @@ function renderTable(): ReturnType<typeof render> {
 }
 
 beforeEach(() => {
-  listRetrieveCalls = 0;
+  listRetrieveCalls = [];
   listResult = { invoices: [makeInvoice("1"), makeInvoice("2")], has_more: false };
+  nextPages = {};
 });
 
 afterEach(() => {
@@ -74,7 +80,7 @@ describe("InvoicesTable collapse", () => {
     );
     expect(queryByTestId("invoices-table")).toBeNull();
     expect(queryByTestId("invoices-download-all")).toBeNull();
-    expect(listRetrieveCalls).toBe(0);
+    expect(listRetrieveCalls.length).toBe(0);
   });
 
   test("expanding fetches and shows the table; collapsing hides it again", async () => {
@@ -83,7 +89,7 @@ describe("InvoicesTable collapse", () => {
     fireEvent.click(getByTestId("invoices-toggle"));
 
     await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
-    expect(listRetrieveCalls).toBe(1);
+    expect(listRetrieveCalls.length).toBe(1);
     expect(getAllByTestId("invoice-row").length).toBe(2);
     expect(getByTestId("invoices-toggle").textContent).toContain(
       "Hide invoices",
@@ -109,5 +115,60 @@ describe("InvoicesTable collapse", () => {
     await waitFor(() => expect(queryByTestId("invoices-empty")).not.toBeNull());
     // No invoices — the Download all button stays hidden even when expanded.
     expect(queryByTestId("invoices-download-all")).toBeNull();
+  });
+});
+
+describe("InvoicesTable pagination", () => {
+  test("Load more requests the next page with starting_after and renders both pages", async () => {
+    listResult = {
+      invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
+      has_more: true,
+    };
+    nextPages["5"] = {
+      invoices: [makeInvoice("6"), makeInvoice("7")],
+      has_more: false,
+    };
+    const { getByTestId, queryByTestId, getAllByTestId } = renderTable();
+
+    fireEvent.click(getByTestId("invoices-toggle"));
+    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
+
+    // Collapsed to the first 4 rows; Load more only appears once expanded.
+    expect(getAllByTestId("invoice-row").length).toBe(4);
+    expect(queryByTestId("invoices-load-more")).toBeNull();
+
+    fireEvent.click(getByTestId("invoices-show-more"));
+    expect(getAllByTestId("invoice-row").length).toBe(5);
+
+    fireEvent.click(getByTestId("invoices-load-more"));
+
+    await waitFor(() => expect(getAllByTestId("invoice-row").length).toBe(7));
+    expect(listRetrieveCalls.length).toBe(2);
+    expect(listRetrieveCalls[1]).toEqual({ starting_after: "5" });
+
+    // Final page loaded — back to the plain Show less toggle.
+    expect(queryByTestId("invoices-load-more")).toBeNull();
+    expect(getByTestId("invoices-show-more").textContent).toContain(
+      "Show less",
+    );
+  });
+
+  test("Load more is absent when has_more is false", async () => {
+    listResult = {
+      invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
+      has_more: false,
+    };
+    const { getByTestId, queryByTestId } = renderTable();
+
+    fireEvent.click(getByTestId("invoices-toggle"));
+    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
+
+    fireEvent.click(getByTestId("invoices-show-more"));
+
+    expect(queryByTestId("invoices-load-more")).toBeNull();
+    expect(getByTestId("invoices-show-more").textContent).toContain(
+      "Show less",
+    );
+    expect(listRetrieveCalls.length).toBe(1);
   });
 });

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { organizationsBillingInvoicesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import {
@@ -76,15 +76,18 @@ export function InvoicesTable() {
   const [showAll, setShowAll] = useState(false);
   const [isDownloadingAll, setIsDownloadingAll] = useState(false);
 
-  const invoicesQuery = useQuery({
+  const invoicesQuery = useInfiniteQuery({
     // The table hides behind the Show invoices toggle, so don't fetch
     // billing history for a section the user may never open.
     enabled: expanded,
-    queryKey: organizationsBillingInvoicesRetrieveQueryKey(),
-    queryFn: async ({ signal }: { signal: AbortSignal }) => {
+    // Suffix the generated key so it can't collide with a plain-query cache
+    // entry for the same endpoint.
+    queryKey: [...organizationsBillingInvoicesRetrieveQueryKey(), "infinite"],
+    queryFn: async ({ signal, pageParam }) => {
       const { data, response } = await organizationsBillingInvoicesRetrieve({
         throwOnError: false,
         signal,
+        query: pageParam ? { starting_after: pageParam } : undefined,
       });
       if (response?.status === 404) {
         return EMPTY_RESPONSE;
@@ -96,9 +99,12 @@ export function InvoicesTable() {
       }
       return data;
     },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? lastPage.invoices.at(-1)?.id : undefined,
   });
 
-  const invoices = invoicesQuery.data?.invoices ?? [];
+  const invoices = invoicesQuery.data?.pages.flatMap((p) => p.invoices) ?? [];
   const visibleInvoices = showAll
     ? invoices
     : invoices.slice(0, INITIAL_VISIBLE);
@@ -288,17 +294,32 @@ export function InvoicesTable() {
                 </tbody>
               </table>
             </div>
-            {hasMore && (
+            {showAll && invoicesQuery.hasNextPage ? (
               <button
                 type="button"
-                onClick={() => setShowAll((v) => !v)}
-                className="self-start text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
-                data-testid="invoices-show-more"
+                onClick={() => void invoicesQuery.fetchNextPage()}
+                disabled={invoicesQuery.isFetchingNextPage}
+                className="flex items-center gap-2 self-start text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid="invoices-load-more"
               >
-                {showAll
-                  ? "Show less"
-                  : `Show more (${invoices.length - INITIAL_VISIBLE} more)`}
+                {invoicesQuery.isFetchingNextPage && (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                )}
+                Load more
               </button>
+            ) : (
+              hasMore && (
+                <button
+                  type="button"
+                  onClick={() => setShowAll((v) => !v)}
+                  className="self-start text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
+                  data-testid="invoices-show-more"
+                >
+                  {showAll
+                    ? "Show less"
+                    : `Show more (${invoices.length - INITIAL_VISIBLE} more)`}
+                </button>
+              )
             )}
           </>
         )}


### PR DESCRIPTION
## Summary
- Switches InvoicesTable to useInfiniteQuery following the new starting_after cursor, so invoices past the newest 100 are reachable.
- Adds a Load more button (data-testid=invoices-load-more) when has_more is true; single-page behavior is unchanged.
- Adds tests for cursor propagation and Load more visibility.

Part of plan: invoice-pagination-frontend.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->