### PR TITLE
refactor(memory): extract `tryAcquireLock`/`releaseLock` into `substrate/consolidation-lock.ts`

### DIFF
--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-lock.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-lock.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for `substrate/consolidation-lock.ts`.
+ *
+ * Coverage matrix:
+ *   - Free lock → acquired; payload records `<pid> <timestamp>`.
+ *   - Held by a live PID within the TTL → refused with the holder string,
+ *     and the live holder's file is left in place.
+ *   - Holder PID not running → stale takeover.
+ *   - Holder older than the TTL despite a live PID (container PID-1
+ *     collision) → stale takeover.
+ *   - Empty / corrupted payload → stale takeover.
+ *   - `releaseLock` removes the file and is a no-op when it is absent.
+ *   - `getConsolidationLockPath` resolves the frozen
+ *     `.v2-state/consolidation.lock` path.
+ *
+ * Tests use temp dirs (mkdtemp) and never touch `~/.vellum/`.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getConsolidationLockPath,
+  releaseLock,
+  STALE_LOCK_TTL_MS,
+  tryAcquireLock,
+} from "../consolidation-lock.js";
+
+let memoryDir: string;
+let lockPath: string;
+
+beforeEach(() => {
+  memoryDir = mkdtempSync(join(tmpdir(), "consolidation-lock-test-"));
+  lockPath = getConsolidationLockPath(memoryDir);
+  // Tests that seed a pre-existing holder write the lock file directly, so
+  // the `.v2-state` dir (normally created by `tryAcquireLock` itself) must
+  // exist up front.
+  mkdirSync(dirname(lockPath), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(memoryDir, { recursive: true, force: true });
+});
+
+describe("getConsolidationLockPath", () => {
+  test("resolves the frozen .v2-state/consolidation.lock path", () => {
+    expect(lockPath).toBe(join(memoryDir, ".v2-state", "consolidation.lock"));
+  });
+});
+
+describe("tryAcquireLock", () => {
+  test("acquires a free lock and records the holder's PID and timestamp", () => {
+    const before = Date.now();
+    expect(tryAcquireLock(lockPath)).toBeNull();
+
+    // The payload is `<pid> <timestamp>` so a crashed run leaves a
+    // diagnosable trace.
+    const [pid, timestamp] = readFileSync(lockPath, "utf-8").trim().split(" ");
+    expect(Number.parseInt(pid, 10)).toBe(process.pid);
+    expect(Number.parseInt(timestamp, 10)).toBeGreaterThanOrEqual(before);
+  });
+
+  test("appends the advisory holder tag after the PID and timestamp", () => {
+    expect(tryAcquireLock(lockPath, "ingest:123")).toBeNull();
+
+    const parts = readFileSync(lockPath, "utf-8").trim().split(" ");
+    expect(parts).toHaveLength(3);
+    expect(Number.parseInt(parts[0], 10)).toBe(process.pid);
+    expect(parts[2]).toBe("ingest:123");
+  });
+
+  test("refuses with the holder string when held by a live PID within the TTL", () => {
+    // GIVEN a lock seeded with the current process's PID and a fresh
+    // timestamp, so the liveness probe sees a running holder AND the lock is
+    // younger than the stale TTL.
+    const holder = `${process.pid} ${Date.now()}`;
+    writeFileSync(lockPath, `${holder}\n`);
+
+    // WHEN a second acquire attempts the lock, THEN it reports the holder
+    // rather than taking over, AND the live holder's file is untouched.
+    expect(tryAcquireLock(lockPath)).toBe(holder);
+    expect(readFileSync(lockPath, "utf-8")).toBe(`${holder}\n`);
+  });
+
+  test("takes over a stale lock whose holder PID is not running", () => {
+    // PID 999999 is above every platform's PID range, so the liveness probe
+    // reports the holder dead.
+    writeFileSync(lockPath, "999999 1700000000000\n");
+
+    expect(tryAcquireLock(lockPath)).toBeNull();
+
+    // The stale file was replaced by this process's own lock.
+    expect(readFileSync(lockPath, "utf-8")).toStartWith(`${process.pid} `);
+  });
+
+  test("takes over a lock from a live PID once it is older than the TTL (container PID-1 collision)", () => {
+    // GIVEN a lock held by a live PID (the current process stands in for the
+    // restarted PID-1 daemon) with a timestamp beyond the stale TTL. Without
+    // the TTL, the liveness probe alone could never reclaim it.
+    const ancient = Date.now() - STALE_LOCK_TTL_MS - 1;
+    writeFileSync(lockPath, `${process.pid} ${ancient}\n`);
+
+    expect(tryAcquireLock(lockPath)).toBeNull();
+    expect(readFileSync(lockPath, "utf-8")).not.toContain(`${ancient}`);
+  });
+
+  test("treats an empty / corrupted payload as stale and takes over", () => {
+    // The only writer produces `<pid> <timestamp>`, so an empty file is
+    // corruption from a partial write that crashed mid-flush.
+    writeFileSync(lockPath, "");
+
+    expect(tryAcquireLock(lockPath)).toBeNull();
+    expect(readFileSync(lockPath, "utf-8")).toStartWith(`${process.pid} `);
+  });
+});
+
+describe("releaseLock", () => {
+  test("removes the lock file", () => {
+    expect(tryAcquireLock(lockPath)).toBeNull();
+    releaseLock(lockPath);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("is a no-op when the lock file is absent", () => {
+    expect(existsSync(lockPath)).toBe(false);
+    expect(() => releaseLock(lockPath)).not.toThrow();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-job.ts
@@ -70,15 +70,8 @@
  * treats it as a retryable failure.
  */
 
-import {
-  closeSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  unlinkSync,
-  writeSync,
-} from "node:fs";
-import { dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import {
   isMemoryV3Live,
@@ -98,9 +91,14 @@ import {
 } from "../../../../persistence/jobs-store.js";
 import { runBackgroundJob } from "../../../../runtime/background-job-runner.js";
 import { formatBufferTimestamp } from "../graph/tool-handlers.js";
-import { isProcessAlive } from "../host-utils.js";
 import { getLogger } from "../logging.js";
 import { getWorkspaceDir } from "../paths.js";
+import {
+  CONSOLIDATION_TIMEOUT_MS,
+  getConsolidationLockPath,
+  releaseLock,
+  tryAcquireLock,
+} from "./consolidation-lock.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./constants.js";
 import { getPageIndex, type PageParseFailure } from "./page-index.js";
 import { resolveConsolidationPrompt } from "./prompts/consolidation.js";
@@ -151,33 +149,6 @@ const CONSOLIDATION_ALLOWED_TOOLS: readonly string[] = [
   "delete_memory_page",
   "recall",
 ];
-
-/**
- * Hard timeout for the consolidation run. Consolidation reads the buffer,
- * rewrites several files, and re-encodes essentials/threads — generous
- * upper bound so a slow run isn't killed mid-edit, but bounded so a stuck
- * provider can't pin the worker indefinitely.
- */
-const CONSOLIDATION_TIMEOUT_MS = 15 * 60 * 1000;
-
-/**
- * Age past which a lock held by an apparently-live PID is taken over anyway.
- *
- * The PID-liveness probe alone is not sufficient in containers: the daemon
- * runs as PID 1, so after a container restart `isProcessAlive(1)` reports the
- * NEW daemon as alive even though it is not the process that wrote the lock.
- * PID-1 collision means a lock left behind by a crashed/restarted run can
- * never be declared stale by liveness alone, and consolidation wedges
- * permanently (every scheduled run skips with `locked`).
- *
- * A lock older than this TTL is treated as abandoned regardless of PID
- * liveness. The bound is a large multiple of the run's hard timeout — the
- * lock timestamp is written at acquire time and a run can hold the lock for
- * at most `CONSOLIDATION_TIMEOUT_MS`, so a TTL well above that can never fire
- * against a legitimately in-flight run while still recovering a wedged lock
- * within a couple of scheduled passes.
- */
-const STALE_LOCK_TTL_MS = 4 * CONSOLIDATION_TIMEOUT_MS;
 
 /**
  * Durable checkpoint tracking consecutive consolidation run failures.
@@ -338,8 +309,7 @@ export async function memoryV2ConsolidateJob(
   }
 
   const memoryDir = join(getWorkspaceDir(), "memory");
-  // FROZEN: `memory/.v2-state/` is a persisted workspace path — never rename.
-  const lockPath = join(memoryDir, ".v2-state", "consolidation.lock");
+  const lockPath = getConsolidationLockPath(memoryDir);
   const bufferPath = join(memoryDir, "buffer.md");
 
   // Step 1: acquire lock. Bails immediately if another consolidation is
@@ -664,182 +634,4 @@ function countNonEmptyLines(content: string): number {
     return 0;
   }
   return content.split("\n").filter((line) => line.trim().length > 0).length;
-}
-
-/**
- * Atomically create the lock file with `wx` (O_CREAT | O_EXCL) flags. Returns
- * `null` on success, or the current holder string (file contents, typically
- * `pid timestamp`) when the file already exists and the holder is still alive.
- *
- * Stale-lock takeover: if the file exists but its holder is stale (PID not
- * running, payload corrupt, or — for the container PID-1 collision — older
- * than the TTL; see {@link holderStaleReason}), unlink the stale file and
- * retry the create exactly once. This recovers automatically from a crashed
- * or restarted daemon that died with the lock held — otherwise every
- * subsequent scheduled consolidation would skip with `locked` indefinitely
- * until an operator manually removed the file.
- *
- * The simple takeover-then-retry is safe here (unlike `snapshot-lock.ts`'s
- * full rename-aside dance) because only the assistant's jobs worker calls
- * this lock, and at most one assistant process runs per workspace at any
- * time. A holder with an unparseable / empty payload is treated as stale —
- * the only writers ever produce a `<pid> <timestamp>` line, so an
- * unparseable file is corruption from a partial write that crashed.
- */
-function tryAcquireLock(lockPath: string): string | null {
-  // The workspace migration seeds `memory/.v2-state/`, but tests and
-  // ad-hoc workspaces may not have it yet. `mkdirSync({ recursive: true })`
-  // is idempotent, so the call is cheap when the dir already exists.
-  mkdirSync(dirname(lockPath), { recursive: true });
-
-  const firstHolder = tryCreate(lockPath);
-  if (firstHolder === null) {
-    return null;
-  }
-  const staleReason = holderStaleReason(firstHolder);
-  if (staleReason === null) {
-    return firstHolder;
-  }
-
-  log.info(
-    { lockPath, holder: firstHolder, reason: staleReason },
-    "consolidation: taking over stale lock",
-  );
-  try {
-    unlinkSync(lockPath);
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code !== "ENOENT") {
-      log.warn(
-        { err, lockPath },
-        "consolidation: failed to unlink stale lock; reporting as locked",
-      );
-      return firstHolder;
-    }
-  }
-  // After unlink, the next `wx` create should succeed. If a third party
-  // raced in and re-acquired (vanishingly unlikely with one writer per
-  // workspace), surface their holder string rather than overwriting.
-  return tryCreate(lockPath);
-}
-
-/**
- * Atomically create the lock file. Returns `null` on success, or the holder
- * string read from the file when it already exists (`"unknown"` if the read
- * itself fails). Rethrows any non-EEXIST errno from `openSync`.
- */
-function tryCreate(lockPath: string): string | null {
-  let fd: number;
-  try {
-    fd = openSync(lockPath, "wx");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
-      throw err;
-    }
-    try {
-      return readFileSync(lockPath, "utf-8").trim() || "unknown";
-    } catch {
-      return "unknown";
-    }
-  }
-  try {
-    writeSync(fd, `${process.pid} ${Date.now()}\n`);
-  } catch {
-    // best-effort — payload is advisory, the file's existence is the lock
-  } finally {
-    try {
-      closeSync(fd);
-    } catch {
-      // best-effort
-    }
-  }
-  return null;
-}
-
-/**
- * Why a lock holder is considered stale, for diagnosable takeover logs:
- *   - `unparseable`: empty / corrupt payload (partial write from a crash).
- *   - `pid_dead`: the holder's PID is no longer running.
- *   - `expired`: the lock is older than {@link STALE_LOCK_TTL_MS} even though
- *     its PID still appears alive — the PID-1 collision case in containers.
- */
-type StaleReason = "unparseable" | "pid_dead" | "expired";
-
-/**
- * Parse a `<pid> <timestamp>` holder payload (see `tryCreate`'s write).
- * Returns `null` when the PID cannot be parsed; a missing/garbled timestamp
- * yields `timestamp: null` so a partial payload still gives us the PID.
- */
-function parseHolder(
-  holder: string,
-): { pid: number; timestamp: number | null } | null {
-  const match = /^(\d+)(?:\s+(\d+))?/.exec(holder);
-  if (!match) {
-    return null;
-  }
-  const pid = Number.parseInt(match[1], 10);
-  if (!Number.isFinite(pid) || pid <= 0) {
-    return null;
-  }
-  const timestamp =
-    match[2] !== undefined ? Number.parseInt(match[2], 10) : null;
-  return {
-    pid,
-    timestamp:
-      timestamp !== null && Number.isFinite(timestamp) ? timestamp : null,
-  };
-}
-
-/**
- * Classify a holder string, returning the reason it is stale or `null` when
- * the lock is held by a live process and must be respected.
- *
- * Takeover triggers, in order:
- *   1. Unparseable / empty / `"unknown"` payload → `unparseable`. The only
- *      writer is `tryCreate`, so corruption is a partial write from a crashed
- *      prior holder, not a live writer mid-flush.
- *   2. PID not running → `pid_dead`. The fast path for a crashed daemon (or a
- *      different process now occupying that PID on a normal host).
- *   3. Lock older than {@link STALE_LOCK_TTL_MS} → `expired`. Required because
- *      the daemon runs as PID 1 in containers: after a restart the new daemon
- *      is also PID 1, so the liveness probe alone reports the holder as alive
- *      forever and could never reclaim an abandoned lock. The TTL is far above
- *      the run's hard timeout, so it never fires against an in-flight run.
- */
-function holderStaleReason(holder: string): StaleReason | null {
-  const parsed = parseHolder(holder);
-  if (parsed === null) {
-    return "unparseable";
-  }
-  if (!isProcessAlive(parsed.pid)) {
-    return "pid_dead";
-  }
-  if (
-    parsed.timestamp !== null &&
-    Date.now() - parsed.timestamp > STALE_LOCK_TTL_MS
-  ) {
-    return "expired";
-  }
-  return null;
-}
-
-/**
- * Idempotent unlink of the lock file. Called from the `finally` block so a
- * crash in the run path doesn't leave the lock stranded. ENOENT is swallowed
- * because the lock may have been released by an operator or never created
- * (acquire failed before reaching the lock-write step).
- */
-function releaseLock(lockPath: string): void {
-  try {
-    unlinkSync(lockPath);
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {
-      return;
-    }
-    log.warn(
-      { err, lockPath },
-      "consolidation: failed to release lock (best-effort)",
-    );
-  }
 }

--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
@@ -1,6 +1,6 @@
 // SUBSTRATE (v2+v3).
 /**
- * Memory substrate — the single-process consolidation lock.
+ * Memory substrate: the single-process consolidation lock.
  *
  * Serializes bulk writers of the `memory/` files so two overlapping passes
  * can't fight over the same corpus.
@@ -58,7 +58,7 @@ export const STALE_LOCK_TTL_MS = 4 * CONSOLIDATION_TIMEOUT_MS;
 
 /** The consolidation lock's location under a workspace's `memory/` dir. */
 export function getConsolidationLockPath(memoryDir: string): string {
-  // FROZEN: `memory/.v2-state/` is a persisted workspace path — never rename.
+  // FROZEN: `memory/.v2-state/` is a persisted workspace path; never rename.
   return join(memoryDir, ".v2-state", "consolidation.lock");
 }
 

--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
@@ -1,0 +1,250 @@
+// SUBSTRATE (v2+v3).
+/**
+ * Memory substrate — the single-process consolidation lock.
+ *
+ * Serializes bulk writers of the `memory/` files so two overlapping passes
+ * can't fight over the same corpus.
+ *
+ * The lock is a `wx`-created file at `memory/.v2-state/consolidation.lock`
+ * containing the holder's PID + timestamp (plus an optional advisory tag), so
+ * a crashed run leaves a diagnosable trace. A stale lock is taken over
+ * automatically on the next acquire (single-writer per workspace): when the
+ * holder's PID is no longer running, or — because the daemon runs as PID 1 in
+ * containers and a restarted daemon collides with the dead holder's PID —
+ * when the lock is older than {@link STALE_LOCK_TTL_MS}.
+ */
+
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { isProcessAlive } from "../host-utils.js";
+import { getLogger } from "../logging.js";
+
+const log = getLogger("memory-v2-consolidate");
+
+/**
+ * Hard timeout for the consolidation run. Consolidation reads the buffer,
+ * rewrites several files, and re-encodes essentials/threads — generous
+ * upper bound so a slow run isn't killed mid-edit, but bounded so a stuck
+ * provider can't pin the worker indefinitely.
+ */
+export const CONSOLIDATION_TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * Age past which a lock held by an apparently-live PID is taken over anyway.
+ *
+ * The PID-liveness probe alone is not sufficient in containers: the daemon
+ * runs as PID 1, so after a container restart `isProcessAlive(1)` reports the
+ * NEW daemon as alive even though it is not the process that wrote the lock.
+ * PID-1 collision means a lock left behind by a crashed/restarted run can
+ * never be declared stale by liveness alone, and consolidation wedges
+ * permanently (every scheduled run skips with `locked`).
+ *
+ * A lock older than this TTL is treated as abandoned regardless of PID
+ * liveness. The bound is a large multiple of the run's hard timeout — the
+ * lock timestamp is written at acquire time and a run can hold the lock for
+ * at most `CONSOLIDATION_TIMEOUT_MS`, so a TTL well above that can never fire
+ * against a legitimately in-flight run while still recovering a wedged lock
+ * within a couple of scheduled passes.
+ */
+export const STALE_LOCK_TTL_MS = 4 * CONSOLIDATION_TIMEOUT_MS;
+
+/** The consolidation lock's location under a workspace's `memory/` dir. */
+export function getConsolidationLockPath(memoryDir: string): string {
+  // FROZEN: `memory/.v2-state/` is a persisted workspace path — never rename.
+  return join(memoryDir, ".v2-state", "consolidation.lock");
+}
+
+/**
+ * Atomically create the lock file with `wx` (O_CREAT | O_EXCL) flags. Returns
+ * `null` on success, or the current holder string (file contents, typically
+ * `pid timestamp`) when the file already exists and the holder is still alive.
+ *
+ * `holderTag` is an optional advisory suffix appended after the PID and
+ * timestamp (payload `<pid> <timestamp> <tag>`) so operators can tell which
+ * writer holds the lock; stale classification ignores it.
+ *
+ * Stale-lock takeover: if the file exists but its holder is stale (PID not
+ * running, payload corrupt, or — for the container PID-1 collision — older
+ * than the TTL; see {@link holderStaleReason}), unlink the stale file and
+ * retry the create exactly once. This recovers automatically from a crashed
+ * or restarted daemon that died with the lock held — otherwise every
+ * subsequent scheduled consolidation would skip with `locked` indefinitely
+ * until an operator manually removed the file.
+ *
+ * The simple takeover-then-retry is safe here (unlike `snapshot-lock.ts`'s
+ * full rename-aside dance) because only the assistant's jobs worker calls
+ * this lock, and at most one assistant process runs per workspace at any
+ * time. A holder with an unparseable / empty payload is treated as stale —
+ * the only writers ever produce a `<pid> <timestamp>` line, so an
+ * unparseable file is corruption from a partial write that crashed.
+ */
+export function tryAcquireLock(
+  lockPath: string,
+  holderTag?: string,
+): string | null {
+  // The workspace migration seeds `memory/.v2-state/`, but tests and
+  // ad-hoc workspaces may not have it yet. `mkdirSync({ recursive: true })`
+  // is idempotent, so the call is cheap when the dir already exists.
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  const firstHolder = tryCreate(lockPath, holderTag);
+  if (firstHolder === null) {
+    return null;
+  }
+  const staleReason = holderStaleReason(firstHolder);
+  if (staleReason === null) {
+    return firstHolder;
+  }
+
+  log.info(
+    { lockPath, holder: firstHolder, reason: staleReason },
+    "consolidation: taking over stale lock",
+  );
+  try {
+    unlinkSync(lockPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      log.warn(
+        { err, lockPath },
+        "consolidation: failed to unlink stale lock; reporting as locked",
+      );
+      return firstHolder;
+    }
+  }
+  // After unlink, the next `wx` create should succeed. If a third party
+  // raced in and re-acquired (vanishingly unlikely with one writer per
+  // workspace), surface their holder string rather than overwriting.
+  return tryCreate(lockPath, holderTag);
+}
+
+/**
+ * Atomically create the lock file. Returns `null` on success, or the holder
+ * string read from the file when it already exists (`"unknown"` if the read
+ * itself fails). Rethrows any non-EEXIST errno from `openSync`.
+ */
+function tryCreate(lockPath: string, holderTag?: string): string | null {
+  let fd: number;
+  try {
+    fd = openSync(lockPath, "wx");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw err;
+    }
+    try {
+      return readFileSync(lockPath, "utf-8").trim() || "unknown";
+    } catch {
+      return "unknown";
+    }
+  }
+  try {
+    const tagSuffix = holderTag === undefined ? "" : ` ${holderTag}`;
+    writeSync(fd, `${process.pid} ${Date.now()}${tagSuffix}\n`);
+  } catch {
+    // best-effort — payload is advisory, the file's existence is the lock
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      // best-effort
+    }
+  }
+  return null;
+}
+
+/**
+ * Why a lock holder is considered stale, for diagnosable takeover logs:
+ *   - `unparseable`: empty / corrupt payload (partial write from a crash).
+ *   - `pid_dead`: the holder's PID is no longer running.
+ *   - `expired`: the lock is older than {@link STALE_LOCK_TTL_MS} even though
+ *     its PID still appears alive — the PID-1 collision case in containers.
+ */
+type StaleReason = "unparseable" | "pid_dead" | "expired";
+
+/**
+ * Parse a `<pid> <timestamp>` holder payload (see `tryCreate`'s write).
+ * Returns `null` when the PID cannot be parsed; a missing/garbled timestamp
+ * yields `timestamp: null` so a partial payload still gives us the PID.
+ */
+function parseHolder(
+  holder: string,
+): { pid: number; timestamp: number | null } | null {
+  const match = /^(\d+)(?:\s+(\d+))?/.exec(holder);
+  if (!match) {
+    return null;
+  }
+  const pid = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return null;
+  }
+  const timestamp =
+    match[2] !== undefined ? Number.parseInt(match[2], 10) : null;
+  return {
+    pid,
+    timestamp:
+      timestamp !== null && Number.isFinite(timestamp) ? timestamp : null,
+  };
+}
+
+/**
+ * Classify a holder string, returning the reason it is stale or `null` when
+ * the lock is held by a live process and must be respected.
+ *
+ * Takeover triggers, in order:
+ *   1. Unparseable / empty / `"unknown"` payload → `unparseable`. The only
+ *      writer is `tryCreate`, so corruption is a partial write from a crashed
+ *      prior holder, not a live writer mid-flush.
+ *   2. PID not running → `pid_dead`. The fast path for a crashed daemon (or a
+ *      different process now occupying that PID on a normal host).
+ *   3. Lock older than {@link STALE_LOCK_TTL_MS} → `expired`. Required because
+ *      the daemon runs as PID 1 in containers: after a restart the new daemon
+ *      is also PID 1, so the liveness probe alone reports the holder as alive
+ *      forever and could never reclaim an abandoned lock. The TTL is far above
+ *      the run's hard timeout, so it never fires against an in-flight run.
+ */
+function holderStaleReason(holder: string): StaleReason | null {
+  const parsed = parseHolder(holder);
+  if (parsed === null) {
+    return "unparseable";
+  }
+  if (!isProcessAlive(parsed.pid)) {
+    return "pid_dead";
+  }
+  if (
+    parsed.timestamp !== null &&
+    Date.now() - parsed.timestamp > STALE_LOCK_TTL_MS
+  ) {
+    return "expired";
+  }
+  return null;
+}
+
+/**
+ * Idempotent unlink of the lock file. Called from the caller's `finally`
+ * block so a crash in the run path doesn't leave the lock stranded. ENOENT is
+ * swallowed
+ * because the lock may have been released by an operator or never created
+ * (acquire failed before reaching the lock-write step).
+ */
+export function releaseLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return;
+    }
+    log.warn(
+      { err, lockPath },
+      "consolidation: failed to release lock (best-effort)",
+    );
+  }
+}

--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
@@ -9,8 +9,8 @@
  * containing the holder's PID + timestamp (plus an optional advisory tag), so
  * a crashed run leaves a diagnosable trace. A stale lock is taken over
  * automatically on the next acquire (single-writer per workspace): when the
- * holder's PID is no longer running, or — because the daemon runs as PID 1 in
- * containers and a restarted daemon collides with the dead holder's PID —
+ * holder's PID is no longer running, or (because the daemon runs as PID 1 in
+ * containers and a restarted daemon collides with the dead holder's PID)
  * when the lock is older than {@link STALE_LOCK_TTL_MS}.
  */
 
@@ -31,7 +31,7 @@ const log = getLogger("memory-v2-consolidate");
 
 /**
  * Hard timeout for the consolidation run. Consolidation reads the buffer,
- * rewrites several files, and re-encodes essentials/threads — generous
+ * rewrites several files, and re-encodes essentials/threads: generous
  * upper bound so a slow run isn't killed mid-edit, but bounded so a stuck
  * provider can't pin the worker indefinitely.
  */
@@ -48,7 +48,7 @@ export const CONSOLIDATION_TIMEOUT_MS = 15 * 60 * 1000;
  * permanently (every scheduled run skips with `locked`).
  *
  * A lock older than this TTL is treated as abandoned regardless of PID
- * liveness. The bound is a large multiple of the run's hard timeout — the
+ * liveness. The bound is a large multiple of the run's hard timeout: the
  * lock timestamp is written at acquire time and a run can hold the lock for
  * at most `CONSOLIDATION_TIMEOUT_MS`, so a TTL well above that can never fire
  * against a legitimately in-flight run while still recovering a wedged lock
@@ -72,17 +72,17 @@ export function getConsolidationLockPath(memoryDir: string): string {
  * writer holds the lock; stale classification ignores it.
  *
  * Stale-lock takeover: if the file exists but its holder is stale (PID not
- * running, payload corrupt, or — for the container PID-1 collision — older
+ * running, payload corrupt, or (for the container PID-1 collision) older
  * than the TTL; see {@link holderStaleReason}), unlink the stale file and
  * retry the create exactly once. This recovers automatically from a crashed
- * or restarted daemon that died with the lock held — otherwise every
+ * or restarted daemon that died with the lock held; otherwise every
  * subsequent scheduled consolidation would skip with `locked` indefinitely
  * until an operator manually removed the file.
  *
  * The simple takeover-then-retry is safe here (unlike `snapshot-lock.ts`'s
  * full rename-aside dance) because only the assistant's jobs worker calls
  * this lock, and at most one assistant process runs per workspace at any
- * time. A holder with an unparseable / empty payload is treated as stale —
+ * time. A holder with an unparseable / empty payload is treated as stale:
  * the only writers ever produce a `<pid> <timestamp>` line, so an
  * unparseable file is corruption from a partial write that crashed.
  */
@@ -149,7 +149,7 @@ function tryCreate(lockPath: string, holderTag?: string): string | null {
     const tagSuffix = holderTag === undefined ? "" : ` ${holderTag}`;
     writeSync(fd, `${process.pid} ${Date.now()}${tagSuffix}\n`);
   } catch {
-    // best-effort — payload is advisory, the file's existence is the lock
+    // best-effort: payload is advisory, the file's existence is the lock
   } finally {
     try {
       closeSync(fd);
@@ -165,7 +165,7 @@ function tryCreate(lockPath: string, holderTag?: string): string | null {
  *   - `unparseable`: empty / corrupt payload (partial write from a crash).
  *   - `pid_dead`: the holder's PID is no longer running.
  *   - `expired`: the lock is older than {@link STALE_LOCK_TTL_MS} even though
- *     its PID still appears alive — the PID-1 collision case in containers.
+ *     its PID still appears alive (the PID-1 collision case in containers).
  */
 type StaleReason = "unparseable" | "pid_dead" | "expired";
 


### PR DESCRIPTION
## Summary
- Pure refactor: moves the consolidation lock (acquire/release, stale takeover, frozen path) into a shared substrate module for the upcoming ingest service
- New dedicated lock tests

Part of plan: memory-ingestion.md (PR 4 of 11)