### PR TITLE
fix(web): blur the command palette input at the start of close so the iOS keyboard dismisses earlier

### DIFF
--- a/clients/web/src/components/command-palette/use-command-palette.test.ts
+++ b/clients/web/src/components/command-palette/use-command-palette.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { useCommandPalette } from "@/components/command-palette/use-command-palette";
+import { useCommandPaletteStore } from "@/stores/command-palette-store";
+
+afterEach(() => {
+  cleanup();
+  useCommandPaletteStore.getState().close();
+  for (const input of document.querySelectorAll("input")) {
+    input.remove();
+  }
+});
+
+describe("useCommandPalette", () => {
+  test("blurs the focused element when closing", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    const { result } = renderHook(() => useCommandPalette({ itemCount: 0 }));
+
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.close();
+    });
+
+    expect(document.activeElement).not.toBe(input);
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.query).toBe("");
+  });
+});

--- a/clients/web/src/components/command-palette/use-command-palette.ts
+++ b/clients/web/src/components/command-palette/use-command-palette.ts
@@ -91,6 +91,12 @@ export function useCommandPalette({
   }, [storeOpen]);
 
   const close = useCallback(() => {
+    // Blur first so iOS starts dismissing the keyboard before the palette
+    // leaves the screen; the viewport reflow then overlaps the close
+    // instead of following it.
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     storeClose();
     setQuery("");
     setSelectedIndex(0);


### PR DESCRIPTION
## Summary
- `useCommandPalette.close()` now blurs `document.activeElement` before `storeClose()`, so on the Capacitor iOS shell the keyboard starts animating down while the palette is still mounted instead of only when the focused input unmounts.
- Sits at the single shared choke point, so every close path is covered: the X button (`chat-layout.tsx:1018` -> `commandPalette.close`), Escape and Cmd+K (`use-command-palette.ts` key handler), and item select (`use-command-palette-sections.ts` `closeRef.current()`).
- Not platform gated: on desktop web the input unmounts a frame later anyway and in the Electron floating window the window closes, so the blur is behaviorally invisible there.
- Adds `use-command-palette.test.ts` pinning the blur (verified failing without the change) alongside the existing open/close and query reset behavior.

Part of plan: ios-capacitor-ui-polish.md (PR 7 of 9)