### PR TITLE
feat(skills): deterministic memory parsers for ChatGPT exports and Hermes/OpenClaw memory.db

### DIFF
--- a/skills/assistant-migration/scripts/lib/memory-items.ts
+++ b/skills/assistant-migration/scripts/lib/memory-items.ts
@@ -25,6 +25,37 @@ export function printItemsJson(items: MemoryImportItem[]): void {
   process.stdout.write(JSON.stringify(items, null, 2) + "\n");
 }
 
+/**
+ * Incremental writer for the same JSON array contract as `printItemsJson`,
+ * for parsers whose candidate sets are too large to hold in memory. Items
+ * are serialized one at a time (constant-size buffer per item), so neither
+ * the full array nor a full serialized string ever exists. The emitted
+ * bytes match `printItemsJson` exactly: a 2-space-indented JSON array plus
+ * a trailing newline, parseable as `MemoryImportItem[]`.
+ *
+ * Call `writeItem` per candidate, then `end` exactly once to close the
+ * array.
+ */
+export function createItemsJsonStreamWriter(write: (chunk: string) => void): {
+  writeItem: (item: MemoryImportItem) => void;
+  end: () => void;
+} {
+  let count = 0;
+  return {
+    writeItem(item: MemoryImportItem): void {
+      const body = JSON.stringify(item, null, 2)
+        .split("\n")
+        .map((line) => `  ${line}`)
+        .join("\n");
+      write(count === 0 ? `[\n${body}` : `,\n${body}`);
+      count++;
+    },
+    end(): void {
+      write(count === 0 ? "[]\n" : "\n]\n");
+    },
+  };
+}
+
 const EPOCH_SECONDS_MIN = 1e9; // 2001-09-09
 const EPOCH_SECONDS_MAX = 1e11;
 const EPOCH_MILLIS_MIN = 1e12; // 2001-09-09 in ms

--- a/skills/assistant-migration/scripts/lib/memory-items.ts
+++ b/skills/assistant-migration/scripts/lib/memory-items.ts
@@ -1,0 +1,63 @@
+/**
+ * Normalized interchange type for memory-import candidates produced by the
+ * assistant-migration parsers. Every parser emits a `MemoryImportItem[]`
+ * JSON array on stdout so downstream review/ingest steps can consume a
+ * single shape regardless of source assistant.
+ */
+
+export interface MemoryImportItem {
+  /** The candidate memory text, verbatim from the source. */
+  text: string;
+  /**
+   * Provenance tag matching the concept-page frontmatter convention:
+   * `import:<provider>` (e.g. `import:chatgpt`, `import:hermes`). Imported
+   * pages carry this value in their `source:` frontmatter field.
+   */
+  source: string;
+  /** ISO 8601 timestamp of when the source recorded this item, if known. */
+  origin_date?: string;
+  /** Where in the source the item came from (e.g. `table.column`, `file:key`). */
+  context?: string;
+}
+
+/** Print items as a JSON array on stdout (the stable parser output contract). */
+export function printItemsJson(items: MemoryImportItem[]): void {
+  process.stdout.write(JSON.stringify(items, null, 2) + "\n");
+}
+
+const EPOCH_SECONDS_MIN = 1e9; // 2001-09-09
+const EPOCH_SECONDS_MAX = 1e11;
+const EPOCH_MILLIS_MIN = 1e12; // 2001-09-09 in ms
+const EPOCH_MILLIS_MAX = 1e14;
+
+/**
+ * Best-effort conversion of an epoch- or ISO-looking value to an ISO 8601
+ * string. Returns undefined when the value does not look like a timestamp.
+ */
+export function toIsoDate(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    if (value >= EPOCH_SECONDS_MIN && value < EPOCH_SECONDS_MAX) {
+      return new Date(Math.round(value * 1000)).toISOString();
+    }
+    if (value >= EPOCH_MILLIS_MIN && value < EPOCH_MILLIS_MAX) {
+      return new Date(Math.round(value)).toISOString();
+    }
+    return undefined;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (/^\d{10}(\.\d+)?$/.test(trimmed)) {
+      return toIsoDate(Number(trimmed));
+    }
+    if (/^\d{13}$/.test(trimmed)) {
+      return toIsoDate(Number(trimmed));
+    }
+    if (/^\d{4}-\d{2}-\d{2}([T ].*)?$/.test(trimmed)) {
+      const parsed = new Date(trimmed);
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed.toISOString();
+      }
+    }
+  }
+  return undefined;
+}

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { extractMemoryDb } from "./parse-agent-memory-db.js";
+import { extractMemoryDb, isSecretName } from "./parse-agent-memory-db.js";
 import type { MemoryImportItem } from "./lib/memory-items.js";
 
 let fixtureDir: string;
@@ -26,7 +26,14 @@ beforeAll(() => {
       uuid TEXT,
       title TEXT,
       body TEXT,
+      author TEXT,
+      api_key TEXT,
       updated_at TEXT
+    );
+    CREATE TABLE oauth_tokens (
+      id INTEGER PRIMARY KEY,
+      provider TEXT,
+      access_token TEXT
     );
     CREATE VIRTUAL TABLE memories_fts USING fts5(content);
   `);
@@ -36,8 +43,12 @@ beforeAll(() => {
       "('User works from a home office', NULL)",
   );
   db.exec(
-    "INSERT INTO notes (uuid, title, body, updated_at) VALUES " +
-      "('note-123', 'Project Atlas', 'Atlas launch is planned for spring', '2026-01-15T10:30:00Z')",
+    "INSERT INTO notes (uuid, title, body, author, api_key, updated_at) VALUES " +
+      "('note-123', 'Project Atlas', 'Atlas launch is planned for spring', 'Casey the author', 'sk-FAKE-EXAMPLE-column', '2026-01-15T10:30:00Z')",
+  );
+  db.exec(
+    "INSERT INTO oauth_tokens (provider, access_token) VALUES " +
+      "('example-provider', 'sk-FAKE-EXAMPLE-table')",
   );
   db.exec(
     "INSERT INTO memories_fts (content) VALUES ('User prefers tea over coffee')",
@@ -131,6 +142,106 @@ describe("extractMemoryDb", () => {
     expect(items.length).toBeGreaterThan(0);
     for (const item of items) {
       expect(item.source).toBe("import:openclaw");
+    }
+  });
+
+  test("excludes credential-like tables and reports them as skipped", () => {
+    const { items, census } = extractMemoryDb(fixtureDbPath, "hermes");
+
+    const texts = items.map((i) => i.text);
+    expect(texts).not.toContain("sk-FAKE-EXAMPLE-table");
+    expect(texts).not.toContain("example-provider");
+    for (const item of items) {
+      expect(item.context?.startsWith("oauth_tokens")).toBe(false);
+    }
+
+    const entry = census.find((c) => c.table === "oauth_tokens");
+    expect(entry?.status).toBe("skipped");
+    expect(entry?.reason).toContain("credential-like table name");
+  });
+
+  test("excludes credential-like columns and reports them in the census", () => {
+    const { items, census } = extractMemoryDb(fixtureDbPath, "hermes");
+
+    const texts = items.map((i) => i.text);
+    expect(texts).not.toContain("sk-FAKE-EXAMPLE-column");
+    for (const item of items) {
+      expect(item.context).not.toBe("notes.api_key");
+    }
+
+    const entry = census.find((c) => c.table === "notes");
+    expect(entry?.status).toBe("extracted");
+    expect(entry?.secretColumns).toEqual(["api_key"]);
+  });
+
+  test("does not flag benign names that merely contain secret substrings", () => {
+    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+
+    const texts = items.map((i) => i.text);
+    expect(texts).toContain("Casey the author");
+  });
+
+  test("extracts every row from tables larger than one batch", () => {
+    const bigDbPath = join(fixtureDir, "big-memory.db");
+    const db = new Database(bigDbPath, { create: true });
+    db.exec("CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT)");
+    const insert = db.query("INSERT INTO memories (content) VALUES (?)");
+    const total = 2500;
+    for (let i = 0; i < total; i++) {
+      insert.run(`Fact number ${i}`);
+    }
+    db.close();
+
+    const { items, census } = extractMemoryDb(bigDbPath, "hermes");
+    expect(items.length).toBe(total);
+    const entry = census.find((c) => c.table === "memories");
+    expect(entry?.rows).toBe(total);
+    expect(entry?.items).toBe(total);
+
+    const texts = new Set(items.map((i) => i.text));
+    expect(texts.size).toBe(total);
+    expect(texts.has("Fact number 0")).toBe(true);
+    expect(texts.has(`Fact number ${total - 1}`)).toBe(true);
+  });
+});
+
+describe("isSecretName", () => {
+  test("matches credential-like names across naming conventions", () => {
+    for (const name of [
+      "access_token",
+      "api_key",
+      "api_keys",
+      "oauth_tokens",
+      "apiKey",
+      "PASSWORD",
+      "passwd",
+      "client_secret",
+      "credentials",
+      "cookie_jar",
+      "session_state",
+      "auth_header",
+      "bearer_value",
+      "private_key",
+      "privateKey",
+      "refresh_expiry",
+      "oauth_state",
+    ]) {
+      expect(isSecretName(name)).toBe(true);
+    }
+  });
+
+  test("does not match benign names", () => {
+    for (const name of [
+      "author",
+      "authored_by",
+      "content",
+      "keyboard",
+      "monkeys",
+      "credo",
+      "sessional_notes",
+      "title",
+    ]) {
+      expect(isSecretName(name)).toBe(false);
     }
   });
 });

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import {
   extractMemoryDb,
   isSecretName,
+  isTimestampColumnName,
   redactSecretValues,
 } from "./parse-agent-memory-db.js";
 import {
@@ -303,6 +304,28 @@ describe("createItemsJsonStreamWriter", () => {
     writer.end();
 
     expect(JSON.parse(streamed)).toEqual([]);
+  });
+});
+
+describe("isTimestampColumnName", () => {
+  test("matches timestamp names only on whole segments", () => {
+    for (const name of [
+      "date",
+      "created_at",
+      "createdAt",
+      "updated",
+      "event_ts",
+      "timestamp",
+      "last_modified_time",
+    ]) {
+      expect(isTimestampColumnName(name)).toBe(true);
+    }
+  });
+
+  test("does not match names that merely contain a timestamp word", () => {
+    for (const name of ["candidate", "candidate_text", "timezone", "at"]) {
+      expect(isTimestampColumnName(name)).toBe(false);
+    }
   });
 });
 

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
@@ -5,7 +5,28 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { extractMemoryDb, isSecretName } from "./parse-agent-memory-db.js";
-import type { MemoryImportItem } from "./lib/memory-items.js";
+import {
+  createItemsJsonStreamWriter,
+  type MemoryImportItem,
+} from "./lib/memory-items.js";
+
+/**
+ * Test helper: run the streaming extractor and collect the emitted items,
+ * since production callers stream them instead of accumulating.
+ */
+function collectMemoryDb(
+  dbPath: string,
+  provider: Parameters<typeof extractMemoryDb>[1],
+): {
+  items: MemoryImportItem[];
+  census: ReturnType<typeof extractMemoryDb>["census"];
+} {
+  const items: MemoryImportItem[] = [];
+  const { census } = extractMemoryDb(dbPath, provider, (item) =>
+    items.push(item),
+  );
+  return { items, census };
+}
 
 let fixtureDir: string;
 let fixtureDbPath: string;
@@ -62,7 +83,7 @@ afterAll(() => {
 
 describe("extractMemoryDb", () => {
   test("extracts text-bearing columns as review candidates", () => {
-    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+    const { items } = collectMemoryDb(fixtureDbPath, "hermes");
 
     const texts = items.map((i) => i.text);
     expect(texts).toContain("User prefers tea over coffee");
@@ -77,7 +98,7 @@ describe("extractMemoryDb", () => {
   });
 
   test("records context as table.column", () => {
-    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+    const { items } = collectMemoryDb(fixtureDbPath, "hermes");
 
     const memoryItem = items.find(
       (i) => i.text === "User prefers tea over coffee",
@@ -91,7 +112,7 @@ describe("extractMemoryDb", () => {
   });
 
   test("skips FTS5 virtual and shadow tables", () => {
-    const { items, census } = extractMemoryDb(fixtureDbPath, "hermes");
+    const { items, census } = collectMemoryDb(fixtureDbPath, "hermes");
 
     for (const item of items) {
       expect(item.context?.startsWith("memories_fts")).toBe(false);
@@ -111,7 +132,7 @@ describe("extractMemoryDb", () => {
   });
 
   test("detects origin_date from epoch and ISO timestamp columns", () => {
-    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+    const { items } = collectMemoryDb(fixtureDbPath, "hermes");
 
     const epochItem = items.find(
       (i) => i.text === "User prefers tea over coffee",
@@ -130,7 +151,7 @@ describe("extractMemoryDb", () => {
   });
 
   test("skips identifier-like and timestamp-like values", () => {
-    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+    const { items } = collectMemoryDb(fixtureDbPath, "hermes");
 
     const texts = items.map((i) => i.text);
     expect(texts).not.toContain("note-123");
@@ -138,7 +159,7 @@ describe("extractMemoryDb", () => {
   });
 
   test("tags items with the requested provider", () => {
-    const { items } = extractMemoryDb(fixtureDbPath, "openclaw");
+    const { items } = collectMemoryDb(fixtureDbPath, "openclaw");
     expect(items.length).toBeGreaterThan(0);
     for (const item of items) {
       expect(item.source).toBe("import:openclaw");
@@ -146,7 +167,7 @@ describe("extractMemoryDb", () => {
   });
 
   test("excludes credential-like tables and reports them as skipped", () => {
-    const { items, census } = extractMemoryDb(fixtureDbPath, "hermes");
+    const { items, census } = collectMemoryDb(fixtureDbPath, "hermes");
 
     const texts = items.map((i) => i.text);
     expect(texts).not.toContain("sk-FAKE-EXAMPLE-table");
@@ -161,7 +182,7 @@ describe("extractMemoryDb", () => {
   });
 
   test("excludes credential-like columns and reports them in the census", () => {
-    const { items, census } = extractMemoryDb(fixtureDbPath, "hermes");
+    const { items, census } = collectMemoryDb(fixtureDbPath, "hermes");
 
     const texts = items.map((i) => i.text);
     expect(texts).not.toContain("sk-FAKE-EXAMPLE-column");
@@ -175,7 +196,7 @@ describe("extractMemoryDb", () => {
   });
 
   test("does not flag benign names that merely contain secret substrings", () => {
-    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+    const { items } = collectMemoryDb(fixtureDbPath, "hermes");
 
     const texts = items.map((i) => i.text);
     expect(texts).toContain("Casey the author");
@@ -192,7 +213,7 @@ describe("extractMemoryDb", () => {
     }
     db.close();
 
-    const { items, census } = extractMemoryDb(bigDbPath, "hermes");
+    const { items, census } = collectMemoryDb(bigDbPath, "hermes");
     expect(items.length).toBe(total);
     const entry = census.find((c) => c.table === "memories");
     expect(entry?.rows).toBe(total);
@@ -202,6 +223,41 @@ describe("extractMemoryDb", () => {
     expect(texts.size).toBe(total);
     expect(texts.has("Fact number 0")).toBe(true);
     expect(texts.has(`Fact number ${total - 1}`)).toBe(true);
+  });
+});
+
+describe("createItemsJsonStreamWriter", () => {
+  test("streams the same bytes as a whole-array stringify", () => {
+    const items: MemoryImportItem[] = [
+      { text: "First", source: "import:hermes", context: "memories.content" },
+      {
+        text: "Second",
+        source: "import:hermes",
+        origin_date: "2025-01-01T00:00:00.000Z",
+      },
+    ];
+
+    let streamed = "";
+    const writer = createItemsJsonStreamWriter((chunk) => {
+      streamed += chunk;
+    });
+    for (const item of items) {
+      writer.writeItem(item);
+    }
+    writer.end();
+
+    expect(streamed).toBe(JSON.stringify(items, null, 2) + "\n");
+    expect(JSON.parse(streamed)).toEqual(items);
+  });
+
+  test("emits an empty JSON array when no items are written", () => {
+    let streamed = "";
+    const writer = createItemsJsonStreamWriter((chunk) => {
+      streamed += chunk;
+    });
+    writer.end();
+
+    expect(JSON.parse(streamed)).toEqual([]);
   });
 });
 
@@ -230,6 +286,18 @@ describe("isSecretName", () => {
     }
   });
 
+  test("matches access-key names despite the trailing ss", () => {
+    for (const name of [
+      "accessKey",
+      "access_key",
+      "access_keys",
+      "ACCESS_KEY",
+      "accessKeyId",
+    ]) {
+      expect(isSecretName(name)).toBe(true);
+    }
+  });
+
   test("does not match benign names", () => {
     for (const name of [
       "author",
@@ -240,6 +308,10 @@ describe("isSecretName", () => {
       "credo",
       "sessional_notes",
       "title",
+      "compass",
+      "address",
+      "compass_heading",
+      "home_address",
     ]) {
       expect(isSecretName(name)).toBe(false);
     }
@@ -274,6 +346,44 @@ describe("CLI contract", () => {
     const stderr = result.stderr.toString();
     expect(stderr).toContain("Table census:");
     expect(stderr).toContain("memories");
+  });
+
+  test("streams every row of a multi-batch table as parseable JSON", () => {
+    const bigDbPath = join(fixtureDir, "big-cli-memory.db");
+    const db = new Database(bigDbPath, { create: true });
+    db.exec("CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT)");
+    const insert = db.query("INSERT INTO memories (content) VALUES (?)");
+    const total = 2500;
+    for (let i = 0; i < total; i++) {
+      insert.run(`Fact number ${i}`);
+    }
+    db.close();
+
+    const scriptPath = join(import.meta.dir, "parse-agent-memory-db.ts");
+    const result = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "run",
+        scriptPath,
+        "--file",
+        bigDbPath,
+        "--source",
+        "hermes",
+      ],
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const parsed = JSON.parse(result.stdout.toString()) as MemoryImportItem[];
+    expect(parsed.length).toBe(total);
+    const texts = new Set(parsed.map((i) => i.text));
+    expect(texts.size).toBe(total);
+    expect(texts.has("Fact number 0")).toBe(true);
+    expect(texts.has(`Fact number ${total - 1}`)).toBe(true);
+
+    expect(result.stderr.toString()).toContain(
+      `Total: ${total} review candidates`,
+    );
   });
 
   test("rejects an unsupported --source", () => {

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
@@ -1,0 +1,185 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { extractMemoryDb } from "./parse-agent-memory-db.js";
+import type { MemoryImportItem } from "./lib/memory-items.js";
+
+let fixtureDir: string;
+let fixtureDbPath: string;
+
+beforeAll(() => {
+  fixtureDir = mkdtempSync(join(tmpdir(), "parse-agent-memory-db-"));
+  fixtureDbPath = join(fixtureDir, "memory.db");
+
+  const db = new Database(fixtureDbPath, { create: true });
+  db.exec(`
+    CREATE TABLE memories (
+      id INTEGER PRIMARY KEY,
+      content TEXT,
+      created_at INTEGER
+    );
+    CREATE TABLE notes (
+      id INTEGER PRIMARY KEY,
+      uuid TEXT,
+      title TEXT,
+      body TEXT,
+      updated_at TEXT
+    );
+    CREATE VIRTUAL TABLE memories_fts USING fts5(content);
+  `);
+  db.exec(
+    "INSERT INTO memories (content, created_at) VALUES " +
+      "('User prefers tea over coffee', 1735689600), " +
+      "('User works from a home office', NULL)",
+  );
+  db.exec(
+    "INSERT INTO notes (uuid, title, body, updated_at) VALUES " +
+      "('note-123', 'Project Atlas', 'Atlas launch is planned for spring', '2026-01-15T10:30:00Z')",
+  );
+  db.exec(
+    "INSERT INTO memories_fts (content) VALUES ('User prefers tea over coffee')",
+  );
+  db.close();
+});
+
+afterAll(() => {
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe("extractMemoryDb", () => {
+  test("extracts text-bearing columns as review candidates", () => {
+    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+
+    const texts = items.map((i) => i.text);
+    expect(texts).toContain("User prefers tea over coffee");
+    expect(texts).toContain("User works from a home office");
+    expect(texts).toContain("Project Atlas");
+    expect(texts).toContain("Atlas launch is planned for spring");
+
+    for (const item of items) {
+      expect(item.source).toBe("import:hermes");
+      expect(item.text.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("records context as table.column", () => {
+    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+
+    const memoryItem = items.find(
+      (i) => i.text === "User prefers tea over coffee",
+    );
+    expect(memoryItem?.context).toBe("memories.content");
+
+    const bodyItem = items.find(
+      (i) => i.text === "Atlas launch is planned for spring",
+    );
+    expect(bodyItem?.context).toBe("notes.body");
+  });
+
+  test("skips FTS5 virtual and shadow tables", () => {
+    const { items, census } = extractMemoryDb(fixtureDbPath, "hermes");
+
+    for (const item of items) {
+      expect(item.context?.startsWith("memories_fts")).toBe(false);
+    }
+
+    const ftsEntries = census.filter((c) => c.table.startsWith("memories_fts"));
+    expect(ftsEntries.length).toBeGreaterThan(0);
+    for (const entry of ftsEntries) {
+      expect(entry.status).toBe("skipped");
+    }
+
+    const extractedTables = census
+      .filter((c) => c.status === "extracted")
+      .map((c) => c.table)
+      .sort();
+    expect(extractedTables).toEqual(["memories", "notes"]);
+  });
+
+  test("detects origin_date from epoch and ISO timestamp columns", () => {
+    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+
+    const epochItem = items.find(
+      (i) => i.text === "User prefers tea over coffee",
+    );
+    expect(epochItem?.origin_date).toBe("2025-01-01T00:00:00.000Z");
+
+    const isoItem = items.find(
+      (i) => i.text === "Atlas launch is planned for spring",
+    );
+    expect(isoItem?.origin_date).toBe("2026-01-15T10:30:00.000Z");
+
+    const undatedItem = items.find(
+      (i) => i.text === "User works from a home office",
+    );
+    expect(undatedItem?.origin_date).toBeUndefined();
+  });
+
+  test("skips identifier-like and timestamp-like values", () => {
+    const { items } = extractMemoryDb(fixtureDbPath, "hermes");
+
+    const texts = items.map((i) => i.text);
+    expect(texts).not.toContain("note-123");
+    expect(texts).not.toContain("2026-01-15T10:30:00Z");
+  });
+
+  test("tags items with the requested provider", () => {
+    const { items } = extractMemoryDb(fixtureDbPath, "openclaw");
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.source).toBe("import:openclaw");
+    }
+  });
+});
+
+describe("CLI contract", () => {
+  test("emits valid MemoryImportItem[] JSON on stdout", () => {
+    const scriptPath = join(import.meta.dir, "parse-agent-memory-db.ts");
+    const result = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "run",
+        scriptPath,
+        "--file",
+        fixtureDbPath,
+        "--source",
+        "hermes",
+      ],
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const parsed = JSON.parse(result.stdout.toString()) as MemoryImportItem[];
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+    for (const item of parsed) {
+      expect(typeof item.text).toBe("string");
+      expect(item.source).toBe("import:hermes");
+    }
+
+    const stderr = result.stderr.toString();
+    expect(stderr).toContain("Table census:");
+    expect(stderr).toContain("memories");
+  });
+
+  test("rejects an unsupported --source", () => {
+    const scriptPath = join(import.meta.dir, "parse-agent-memory-db.ts");
+    const result = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "run",
+        scriptPath,
+        "--file",
+        fixtureDbPath,
+        "--source",
+        "unknown-agent",
+      ],
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("unsupported --source");
+  });
+});

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.test.ts
@@ -4,7 +4,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { extractMemoryDb, isSecretName } from "./parse-agent-memory-db.js";
+import {
+  extractMemoryDb,
+  isSecretName,
+  redactSecretValues,
+} from "./parse-agent-memory-db.js";
 import {
   createItemsJsonStreamWriter,
   type MemoryImportItem,
@@ -70,6 +74,12 @@ beforeAll(() => {
   db.exec(
     "INSERT INTO oauth_tokens (provider, access_token) VALUES " +
       "('example-provider', 'sk-FAKE-EXAMPLE-table')",
+  );
+  db.exec(
+    "INSERT INTO memories (content, created_at) VALUES " +
+      "('CI setup note: the runner uses ghp_FAKE0000000000000000000000000000 for checkout', NULL), " +
+      "('Staging login recipe: password=hunter2hunter2hunter2 then run the deploy', NULL), " +
+      "('The word token appears here and jane.doe@example.com is the contact', NULL)",
   );
   db.exec(
     "INSERT INTO memories_fts (content) VALUES ('User prefers tea over coffee')",
@@ -202,6 +212,41 @@ describe("extractMemoryDb", () => {
     expect(texts).toContain("Casey the author");
   });
 
+  test("redacts embedded token shapes and reports counts in the census", () => {
+    const { items, census } = collectMemoryDb(fixtureDbPath, "hermes");
+
+    const ghItem = items.find((i) => i.text.startsWith("CI setup note"));
+    expect(ghItem?.text).toBe(
+      "CI setup note: the runner uses [redacted:github-token] for checkout",
+    );
+
+    const pwItem = items.find((i) => i.text.startsWith("Staging login recipe"));
+    expect(pwItem?.text).toBe(
+      "Staging login recipe: password=[redacted:credential-assignment] then run the deploy",
+    );
+
+    for (const item of items) {
+      expect(item.text).not.toContain("ghp_FAKE");
+      expect(item.text).not.toContain("hunter2");
+    }
+
+    const entry = census.find((c) => c.table === "memories");
+    expect(entry?.status).toBe("extracted");
+    expect(entry?.redactions).toBe(2);
+  });
+
+  test("leaves ordinary prose mentioning tokens or emails untouched", () => {
+    const { items, census } = collectMemoryDb(fixtureDbPath, "hermes");
+
+    const texts = items.map((i) => i.text);
+    expect(texts).toContain(
+      "The word token appears here and jane.doe@example.com is the contact",
+    );
+
+    const entry = census.find((c) => c.table === "notes");
+    expect(entry?.redactions).toBeUndefined();
+  });
+
   test("extracts every row from tables larger than one batch", () => {
     const bigDbPath = join(fixtureDir, "big-memory.db");
     const db = new Database(bigDbPath, { create: true });
@@ -314,6 +359,79 @@ describe("isSecretName", () => {
       "home_address",
     ]) {
       expect(isSecretName(name)).toBe(false);
+    }
+  });
+});
+
+describe("redactSecretValues", () => {
+  test("redacts well-known token shapes with kind-specific placeholders", () => {
+    const cases: [string, string][] = [
+      ["use sk-FAKEFAKEFAKEFAKEFAKE here", "use [redacted:openai-key] here"],
+      [
+        "pat is github_pat_FAKE00000000000000000000",
+        "pat is [redacted:github-token]",
+      ],
+      ["aws id AKIAFAKEFAKEFAKEFAKE", "aws id [redacted:aws-access-key-id]"],
+      ["slack xoxb-FAKE-0000000000-FAKE", "slack [redacted:slack-token]"],
+      [
+        "google AIzaFAKE000000000000000000000000000000",
+        "google [redacted:google-api-key]",
+      ],
+      [
+        "jwt eyJFAKEFAKEFAKE.eyJGAKEFAKEFAKE.FAKESIGFAKESIG here",
+        "jwt [redacted:jwt] here",
+      ],
+      [
+        "header Bearer FAKETOKENFAKETOKENFAKE end",
+        "header [redacted:bearer-token] end",
+      ],
+    ];
+    for (const [input, expected] of cases) {
+      const result = redactSecretValues(input);
+      expect(result.text).toBe(expected);
+      expect(result.redactions).toBe(1);
+    }
+  });
+
+  test("redacts PEM private key blocks as a single span", () => {
+    const input =
+      "backup note\n-----BEGIN PRIVATE KEY-----\nFAKEFAKEFAKEFAKE\n-----END PRIVATE KEY-----\ndone";
+    const result = redactSecretValues(input);
+    expect(result.text).toBe("backup note\n[redacted:private-key]\ndone");
+    expect(result.redactions).toBe(1);
+  });
+
+  test("redacts credential-like assignments even behind a benign key", () => {
+    const result = redactSecretValues(
+      "recipe: api_key=FAKEVALUEFAKEVALUE and more",
+    );
+    expect(result.text).toBe(
+      "recipe: api_key=[redacted:credential-assignment] and more",
+    );
+    expect(result.redactions).toBe(1);
+  });
+
+  test("counts multiple redactions in one text", () => {
+    const result = redactSecretValues(
+      "token=FAKEVALUEFAKEVALUE and sk-FAKEFAKEFAKEFAKEFAKE",
+    );
+    expect(result.text).toBe(
+      "token=[redacted:credential-assignment] and [redacted:openai-key]",
+    );
+    expect(result.redactions).toBe(2);
+  });
+
+  test("does not touch ordinary prose or short values", () => {
+    for (const input of [
+      "The token: is stored safely by the ops team",
+      "Email jane.doe@example.com about the password rotation policy",
+      "password=short",
+      "My favorite phrase is skeleton-key metaphors",
+      "Meeting at 2026-01-15T10:30:00Z about auth flows",
+    ]) {
+      const result = redactSecretValues(input);
+      expect(result.text).toBe(input);
+      expect(result.redactions).toBe(0);
     }
   });
 });

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.ts
@@ -12,8 +12,13 @@
  *
  * FTS5 virtual tables and their shadow tables are skipped: they are
  * rebuildable search indexes, not source data (see references/hermes.md).
- * A per-table census is printed to stderr so the review step can see what
- * was extracted and what was skipped.
+ * Tables and columns with credential-like names (token, api_key, password,
+ * secret, session, and similar) are excluded from extraction entirely so
+ * that live credentials never reach stdout or downstream memory; the
+ * exclusions are reported in the stderr census. Rows are read in batches
+ * over only the candidate columns, so a large database is never
+ * materialized in memory at once. A per-table census is printed to stderr
+ * so the review step can see what was extracted and what was skipped.
  *
  * The database is opened read-only. Point `--file` at a consistent
  * snapshot (`sqlite3 memory.db ".backup snapshot.db"`), never a live DB.
@@ -43,12 +48,81 @@ const IDENTIFIER_COLUMN = /(^|_)(id|uuid|guid|key|hash|checksum)$/i;
 /** FTS5 shadow tables share the virtual table's name plus these suffixes. */
 const FTS5_SHADOW_SUFFIXES = ["data", "idx", "content", "docsize", "config"];
 
+/** Rows fetched per batch so large tables never materialize fully. */
+const ROW_BATCH_SIZE = 1000;
+
+/**
+ * Name segments that mark a table or column as credential-bearing.
+ * Matching is word-boundary aware: names are split into segments on
+ * underscores, other separators, and camelCase boundaries, so "auth"
+ * matches "auth_state" and "userAuth" but not "author".
+ */
+const SECRET_NAME_SEGMENTS = new Set([
+  "token",
+  "apikey",
+  "password",
+  "passwd",
+  "pwd",
+  "secret",
+  "credential",
+  "cred",
+  "cookie",
+  "session",
+  "auth",
+  "bearer",
+  "oauth",
+  "refresh",
+  "privatekey",
+  "jwt",
+]);
+
+/** Adjacent segment pairs that together indicate a credential name. */
+const SECRET_SEGMENT_PAIRS = new Set([
+  "api key",
+  "private key",
+  "access key",
+  "signing key",
+  "encryption key",
+]);
+
+/**
+ * Split a table or column name into lowercase word segments, with a
+ * trailing plural "s" stripped so "tokens" and "api_keys" match the
+ * singular patterns.
+ */
+function nameSegments(name: string): string[] {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment.replace(/s$/, ""));
+}
+
+/** True when a table or column name looks like it holds credentials. */
+export function isSecretName(name: string): boolean {
+  const segments = nameSegments(name);
+  for (const segment of segments) {
+    if (SECRET_NAME_SEGMENTS.has(segment)) {
+      return true;
+    }
+  }
+  for (let i = 0; i + 1 < segments.length; i++) {
+    if (SECRET_SEGMENT_PAIRS.has(`${segments[i]} ${segments[i + 1]}`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export interface TableCensus {
   table: string;
   status: "extracted" | "skipped";
   reason?: string;
   rows?: number;
   items?: number;
+  /** Columns excluded from extraction because their names look credential-bearing. */
+  secretColumns?: string[];
 }
 
 interface SqliteMasterRow {
@@ -105,63 +179,98 @@ export function extractMemoryDb(
         });
         continue;
       }
+      if (isSecretName(table.name)) {
+        census.push({
+          table: table.name,
+          status: "skipped",
+          reason: "credential-like table name (excluded from extraction)",
+        });
+        continue;
+      }
 
       const columns = (
         db.query("SELECT name FROM pragma_table_info(?)").all(table.name) as {
           name: string;
         }[]
       ).map((c) => c.name);
-      const timestampColumns = columns.filter((name) =>
+      const secretColumns = columns.filter((name) => isSecretName(name));
+      const safeColumns = columns.filter((name) => !isSecretName(name));
+      const timestampColumns = safeColumns.filter((name) =>
         TIMESTAMP_COLUMN.test(name),
       );
-      const textCandidateColumns = columns.filter(
+      const textCandidateColumns = safeColumns.filter(
         (name) => !TIMESTAMP_COLUMN.test(name) && !IDENTIFIER_COLUMN.test(name),
       );
 
-      const quoted = `"${table.name.replaceAll('"', '""')}"`;
-      const rows = db.query(`SELECT * FROM ${quoted}`).all() as Record<
-        string,
-        unknown
-      >[];
+      const quoteIdent = (name: string) => `"${name.replaceAll('"', '""')}"`;
+      const quoted = quoteIdent(table.name);
+      const selectColumns = [...textCandidateColumns, ...timestampColumns];
 
+      let rowCount = 0;
       let extracted = 0;
-      for (const row of rows) {
-        let originDate: string | undefined;
-        for (const column of timestampColumns) {
-          originDate = toIsoDate(row[column]);
-          if (originDate) {
+      if (selectColumns.length === 0) {
+        rowCount = (
+          db.query(`SELECT COUNT(*) AS n FROM ${quoted}`).get() as {
+            n: number;
+          }
+        ).n;
+      } else {
+        // Narrow the SELECT to candidate columns and read in batches so
+        // blobs and large tables never materialize fully in memory.
+        const batchQuery = db.query(
+          `SELECT ${selectColumns.map(quoteIdent).join(", ")} FROM ${quoted} LIMIT ${ROW_BATCH_SIZE} OFFSET ?`,
+        );
+        for (let offset = 0; ; offset += ROW_BATCH_SIZE) {
+          const rows = batchQuery.all(offset) as Record<string, unknown>[];
+          rowCount += rows.length;
+
+          for (const row of rows) {
+            let originDate: string | undefined;
+            for (const column of timestampColumns) {
+              originDate = toIsoDate(row[column]);
+              if (originDate) {
+                break;
+              }
+            }
+
+            for (const column of textCandidateColumns) {
+              const value = row[column];
+              if (typeof value !== "string") {
+                continue;
+              }
+              const text = value.trim();
+              if (text.length === 0 || toIsoDate(text) !== undefined) {
+                continue;
+              }
+              const item: MemoryImportItem = {
+                text,
+                source: `import:${provider}`,
+                context: `${table.name}.${column}`,
+              };
+              if (originDate) {
+                item.origin_date = originDate;
+              }
+              items.push(item);
+              extracted++;
+            }
+          }
+
+          if (rows.length < ROW_BATCH_SIZE) {
             break;
           }
         }
-
-        for (const column of textCandidateColumns) {
-          const value = row[column];
-          if (typeof value !== "string") {
-            continue;
-          }
-          const text = value.trim();
-          if (text.length === 0 || toIsoDate(text) !== undefined) {
-            continue;
-          }
-          const item: MemoryImportItem = {
-            text,
-            source: `import:${provider}`,
-            context: `${table.name}.${column}`,
-          };
-          if (originDate) {
-            item.origin_date = originDate;
-          }
-          items.push(item);
-          extracted++;
-        }
       }
 
-      census.push({
+      const entry: TableCensus = {
         table: table.name,
         status: "extracted",
-        rows: rows.length,
+        rows: rowCount,
         items: extracted,
-      });
+      };
+      if (secretColumns.length > 0) {
+        entry.secretColumns = secretColumns;
+      }
+      census.push(entry);
     }
 
     return { items, census };
@@ -225,6 +334,11 @@ function main() {
       process.stderr.write(
         `  extracted: ${entry.table} (${entry.rows} rows, ${entry.items} candidate items)\n`,
       );
+      if (entry.secretColumns && entry.secretColumns.length > 0) {
+        process.stderr.write(
+          `    skipped credential-like columns: ${entry.secretColumns.join(", ")}\n`,
+        );
+      }
     } else {
       process.stderr.write(`  skipped: ${entry.table} (${entry.reason})\n`);
     }

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env bun
+
+/**
+ * Dump memory-import candidates from a Hermes or OpenClaw `memory.db`
+ * SQLite snapshot as `MemoryImportItem[]` JSON on stdout.
+ *
+ * This produces *review candidates*, not final memories. Hermes and
+ * OpenClaw schemas are not standardized across versions, so instead of
+ * assuming table names or columns, the script introspects `sqlite_master`
+ * and dumps the text-bearing columns of every user table. The creator
+ * reviews the candidate inventory before anything is saved to memory.
+ *
+ * FTS5 virtual tables and their shadow tables are skipped: they are
+ * rebuildable search indexes, not source data (see references/hermes.md).
+ * A per-table census is printed to stderr so the review step can see what
+ * was extracted and what was skipped.
+ *
+ * The database is opened read-only. Point `--file` at a consistent
+ * snapshot (`sqlite3 memory.db ".backup snapshot.db"`), never a live DB.
+ *
+ * Usage:
+ *   bun run scripts/parse-agent-memory-db.ts --file /path/to/memory.db --source hermes
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+
+import {
+  printItemsJson,
+  toIsoDate,
+  type MemoryImportItem,
+} from "./lib/memory-items.js";
+
+const SUPPORTED_SOURCES = ["hermes", "openclaw"] as const;
+type SourceProvider = (typeof SUPPORTED_SOURCES)[number];
+
+/** Column names that look like timestamps (feed origin_date, not text). */
+const TIMESTAMP_COLUMN = /(date|time|created|updated|modified|_at$|_ts$)/i;
+
+/** Column names that look like opaque identifiers, not memory text. */
+const IDENTIFIER_COLUMN = /(^|_)(id|uuid|guid|key|hash|checksum)$/i;
+
+/** FTS5 shadow tables share the virtual table's name plus these suffixes. */
+const FTS5_SHADOW_SUFFIXES = ["data", "idx", "content", "docsize", "config"];
+
+export interface TableCensus {
+  table: string;
+  status: "extracted" | "skipped";
+  reason?: string;
+  rows?: number;
+  items?: number;
+}
+
+interface SqliteMasterRow {
+  name: string;
+  sql: string | null;
+}
+
+export function extractMemoryDb(
+  dbPath: string,
+  provider: SourceProvider,
+): { items: MemoryImportItem[]; census: TableCensus[] } {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const tables = db
+      .query("SELECT name, sql FROM sqlite_master WHERE type = 'table'")
+      .all() as SqliteMasterRow[];
+
+    const ftsTables = new Set(
+      tables
+        .filter((t) => /USING\s+fts5\s*\(/i.test(t.sql ?? ""))
+        .map((t) => t.name),
+    );
+    const ftsShadowTables = new Set(
+      [...ftsTables].flatMap((name) =>
+        FTS5_SHADOW_SUFFIXES.map((suffix) => `${name}_${suffix}`),
+      ),
+    );
+
+    const items: MemoryImportItem[] = [];
+    const census: TableCensus[] = [];
+
+    for (const table of tables) {
+      if (table.name.startsWith("sqlite_")) {
+        census.push({
+          table: table.name,
+          status: "skipped",
+          reason: "sqlite internal table",
+        });
+        continue;
+      }
+      if (ftsTables.has(table.name)) {
+        census.push({
+          table: table.name,
+          status: "skipped",
+          reason: "fts5 virtual table (rebuildable index)",
+        });
+        continue;
+      }
+      if (ftsShadowTables.has(table.name)) {
+        census.push({
+          table: table.name,
+          status: "skipped",
+          reason: "fts5 shadow table (rebuildable index)",
+        });
+        continue;
+      }
+
+      const columns = (
+        db.query("SELECT name FROM pragma_table_info(?)").all(table.name) as {
+          name: string;
+        }[]
+      ).map((c) => c.name);
+      const timestampColumns = columns.filter((name) =>
+        TIMESTAMP_COLUMN.test(name),
+      );
+      const textCandidateColumns = columns.filter(
+        (name) => !TIMESTAMP_COLUMN.test(name) && !IDENTIFIER_COLUMN.test(name),
+      );
+
+      const quoted = `"${table.name.replaceAll('"', '""')}"`;
+      const rows = db.query(`SELECT * FROM ${quoted}`).all() as Record<
+        string,
+        unknown
+      >[];
+
+      let extracted = 0;
+      for (const row of rows) {
+        let originDate: string | undefined;
+        for (const column of timestampColumns) {
+          originDate = toIsoDate(row[column]);
+          if (originDate) {
+            break;
+          }
+        }
+
+        for (const column of textCandidateColumns) {
+          const value = row[column];
+          if (typeof value !== "string") {
+            continue;
+          }
+          const text = value.trim();
+          if (text.length === 0 || toIsoDate(text) !== undefined) {
+            continue;
+          }
+          const item: MemoryImportItem = {
+            text,
+            source: `import:${provider}`,
+            context: `${table.name}.${column}`,
+          };
+          if (originDate) {
+            item.origin_date = originDate;
+          }
+          items.push(item);
+          extracted++;
+        }
+      }
+
+      census.push({
+        table: table.name,
+        status: "extracted",
+        rows: rows.length,
+        items: extracted,
+      });
+    }
+
+    return { items, census };
+  } finally {
+    db.close();
+  }
+}
+
+function parseCliArgs(): { filePath: string; source: SourceProvider } {
+  const args = process.argv.slice(2);
+  let filePath: string | null = null;
+  let source: string | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--file" && i + 1 < args.length) {
+      filePath = args[i + 1];
+      i++;
+    } else if (args[i] === "--source" && i + 1 < args.length) {
+      source = args[i + 1];
+      i++;
+    }
+  }
+
+  if (!filePath || !source) {
+    process.stderr.write(
+      "Usage: bun run scripts/parse-agent-memory-db.ts --file <memory.db snapshot> --source <hermes|openclaw>\n",
+    );
+    process.exit(1);
+  }
+  if (!(SUPPORTED_SOURCES as readonly string[]).includes(source)) {
+    process.stderr.write(
+      `Error: unsupported --source "${source}" (expected: ${SUPPORTED_SOURCES.join(", ")})\n`,
+    );
+    process.exit(1);
+  }
+
+  return { filePath, source: source as SourceProvider };
+}
+
+function main() {
+  const { filePath, source } = parseCliArgs();
+
+  if (!existsSync(filePath)) {
+    process.stderr.write(`Error: File not found: ${filePath}\n`);
+    process.exit(1);
+  }
+
+  let result: ReturnType<typeof extractMemoryDb>;
+  try {
+    result = extractMemoryDb(filePath, source);
+  } catch (err) {
+    process.stderr.write(
+      `Error reading database: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+
+  process.stderr.write("Table census:\n");
+  for (const entry of result.census) {
+    if (entry.status === "extracted") {
+      process.stderr.write(
+        `  extracted: ${entry.table} (${entry.rows} rows, ${entry.items} candidate items)\n`,
+      );
+    } else {
+      process.stderr.write(`  skipped: ${entry.table} (${entry.reason})\n`);
+    }
+  }
+  process.stderr.write(
+    `Total: ${result.items.length} review candidates. These are candidates for creator review, not final memories.\n`,
+  );
+
+  printItemsJson(result.items);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.ts
@@ -16,9 +16,11 @@
  * secret, session, and similar) are excluded from extraction entirely so
  * that live credentials never reach stdout or downstream memory; the
  * exclusions are reported in the stderr census. Rows are read in batches
- * over only the candidate columns, so a large database is never
- * materialized in memory at once. A per-table census is printed to stderr
- * so the review step can see what was extracted and what was skipped.
+ * over only the candidate columns, and candidates are streamed to stdout
+ * as they are found, so neither the database rows nor the emitted JSON
+ * array is ever materialized in memory at once. A per-table census is
+ * printed to stderr so the review step can see what was extracted and
+ * what was skipped.
  *
  * The database is opened read-only. Point `--file` at a consistent
  * snapshot (`sqlite3 memory.db ".backup snapshot.db"`), never a live DB.
@@ -31,7 +33,7 @@ import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 
 import {
-  printItemsJson,
+  createItemsJsonStreamWriter,
   toIsoDate,
   type MemoryImportItem,
 } from "./lib/memory-items.js";
@@ -88,7 +90,9 @@ const SECRET_SEGMENT_PAIRS = new Set([
 /**
  * Split a table or column name into lowercase word segments, with a
  * trailing plural "s" stripped so "tokens" and "api_keys" match the
- * singular patterns.
+ * singular patterns. Segments ending in "ss" (access, pass) are not
+ * depluralized: stripping their final "s" would break pair matches
+ * like "access key".
  */
 function nameSegments(name: string): string[] {
   return name
@@ -96,7 +100,9 @@ function nameSegments(name: string): string[] {
     .toLowerCase()
     .split(/[^a-z0-9]+/)
     .filter((segment) => segment.length > 0)
-    .map((segment) => segment.replace(/s$/, ""));
+    .map((segment) =>
+      segment.endsWith("ss") ? segment : segment.replace(/s$/, ""),
+    );
 }
 
 /** True when a table or column name looks like it holds credentials. */
@@ -130,10 +136,16 @@ interface SqliteMasterRow {
   sql: string | null;
 }
 
+/**
+ * Walk every extractable table and hand each candidate to `onItem` as it
+ * is found. Candidates are never accumulated here: the CLI streams them
+ * straight to stdout, and tests collect them in the callback.
+ */
 export function extractMemoryDb(
   dbPath: string,
   provider: SourceProvider,
-): { items: MemoryImportItem[]; census: TableCensus[] } {
+  onItem: (item: MemoryImportItem) => void,
+): { census: TableCensus[]; totalItems: number } {
   const db = new Database(dbPath, { readonly: true });
   try {
     const tables = db
@@ -151,8 +163,8 @@ export function extractMemoryDb(
       ),
     );
 
-    const items: MemoryImportItem[] = [];
     const census: TableCensus[] = [];
+    let totalItems = 0;
 
     for (const table of tables) {
       if (table.name.startsWith("sqlite_")) {
@@ -250,8 +262,9 @@ export function extractMemoryDb(
               if (originDate) {
                 item.origin_date = originDate;
               }
-              items.push(item);
+              onItem(item);
               extracted++;
+              totalItems++;
             }
           }
 
@@ -273,7 +286,7 @@ export function extractMemoryDb(
       census.push(entry);
     }
 
-    return { items, census };
+    return { census, totalItems };
   } finally {
     db.close();
   }
@@ -318,15 +331,23 @@ function main() {
     process.exit(1);
   }
 
+  // Stream the JSON array to stdout item by item so the full candidate
+  // set is never held in memory or serialized as one string.
+  const writer = createItemsJsonStreamWriter((chunk) =>
+    process.stdout.write(chunk),
+  );
   let result: ReturnType<typeof extractMemoryDb>;
   try {
-    result = extractMemoryDb(filePath, source);
+    result = extractMemoryDb(filePath, source, (item) =>
+      writer.writeItem(item),
+    );
   } catch (err) {
     process.stderr.write(
       `Error reading database: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.exit(1);
   }
+  writer.end();
 
   process.stderr.write("Table census:\n");
   for (const entry of result.census) {
@@ -344,10 +365,8 @@ function main() {
     }
   }
   process.stderr.write(
-    `Total: ${result.items.length} review candidates. These are candidates for creator review, not final memories.\n`,
+    `Total: ${result.totalItems} review candidates. These are candidates for creator review, not final memories.\n`,
   );
-
-  printItemsJson(result.items);
 }
 
 if (import.meta.main) {

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.ts
@@ -46,8 +46,39 @@ import {
 const SUPPORTED_SOURCES = ["hermes", "openclaw"] as const;
 type SourceProvider = (typeof SUPPORTED_SOURCES)[number];
 
-/** Column names that look like timestamps (feed origin_date, not text). */
-const TIMESTAMP_COLUMN = /(date|time|created|updated|modified|_at$|_ts$)/i;
+/**
+ * Name segments that mark a column as a timestamp (feeds origin_date, not
+ * text). Matched against whole segments, not substrings: "candidate" and
+ * "timezone" contain "date"/"time" but are not timestamp columns, and a
+ * substring match would silently drop their text from extraction.
+ */
+const TIMESTAMP_NAME_SEGMENTS = new Set([
+  "date",
+  "datetime",
+  "time",
+  "timestamp",
+  "t",
+  "created",
+  "updated",
+  "modified",
+  "at",
+  "ts",
+]);
+
+/** True when a column name's segments mark it as a timestamp column. */
+export function isTimestampColumnName(name: string): boolean {
+  const segments = nameSegments(name);
+  // A lone "at"/"ts" segment only counts as part of a compound name
+  // ("created_at", "event_ts"); a single-segment name must itself be a
+  // timestamp word ("date", "timestamp").
+  if (segments.length === 1) {
+    return (
+      TIMESTAMP_NAME_SEGMENTS.has(segments[0]) &&
+      !["at", "ts"].includes(segments[0])
+    );
+  }
+  return segments.some((segment) => TIMESTAMP_NAME_SEGMENTS.has(segment));
+}
 
 /** Column names that look like opaque identifiers, not memory text. */
 const IDENTIFIER_COLUMN = /(^|_)(id|uuid|guid|key|hash|checksum)$/i;
@@ -332,10 +363,10 @@ export function extractMemoryDb(
       const secretColumns = columns.filter((name) => isSecretName(name));
       const safeColumns = columns.filter((name) => !isSecretName(name));
       const timestampColumns = safeColumns.filter((name) =>
-        TIMESTAMP_COLUMN.test(name),
+        isTimestampColumnName(name),
       );
       const textCandidateColumns = safeColumns.filter(
-        (name) => !TIMESTAMP_COLUMN.test(name) && !IDENTIFIER_COLUMN.test(name),
+        (name) => !isTimestampColumnName(name) && !IDENTIFIER_COLUMN.test(name),
       );
 
       const quoteIdent = (name: string) => `"${name.replaceAll('"', '""')}"`;

--- a/skills/assistant-migration/scripts/parse-agent-memory-db.ts
+++ b/skills/assistant-migration/scripts/parse-agent-memory-db.ts
@@ -15,7 +15,12 @@
  * Tables and columns with credential-like names (token, api_key, password,
  * secret, session, and similar) are excluded from extraction entirely so
  * that live credentials never reach stdout or downstream memory; the
- * exclusions are reported in the stderr census. Rows are read in batches
+ * exclusions are reported in the stderr census. Text values that survive
+ * the name filters are additionally run through a value-level secret
+ * scanner: well-known token shapes and credential-like key=value
+ * assignments are redacted in place (replaced with `[redacted:<kind>]`)
+ * before emission, with per-table redaction counts reported in the
+ * stderr census. Rows are read in batches
  * over only the candidate columns, and candidates are streamed to stdout
  * as they are found, so neither the database rows nor the emitted JSON
  * array is ever materialized in memory at once. A per-table census is
@@ -121,6 +126,123 @@ export function isSecretName(name: string): boolean {
   return false;
 }
 
+/**
+ * Value-level secret scanner for text that already passed the name-based
+ * filters. Credentials can hide in generic text columns (a memory that
+ * says "my key is sk-..." or a JSON settings blob), so each candidate is
+ * scanned for well-known token shapes and credential-like assignments,
+ * and matches are redacted in place.
+ *
+ * Deliberately conservative: only well-known token shapes (recognizable
+ * by prefix/structure) and key=value assignments with a credential-like
+ * key are redacted. There is intentionally NO generic high-entropy
+ * detector: on real memory prose it produces false positives (mangling
+ * ordinary text the user wanted to keep) that are worse than relying on
+ * the creator-review step to catch exotic secret shapes.
+ */
+const SECRET_VALUE_PATTERNS: { kind: string; regex: RegExp }[] = [
+  {
+    kind: "private-key",
+    regex:
+      /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|$)/g,
+  },
+  {
+    kind: "openai-key",
+    regex: /(?<![A-Za-z0-9_-])sk-[A-Za-z0-9_-]{16,}/g,
+  },
+  {
+    kind: "github-token",
+    regex:
+      /(?<![A-Za-z0-9_-])(?:github_pat_[A-Za-z0-9_]{20,}|gh[opsur]_[A-Za-z0-9]{20,})/g,
+  },
+  {
+    kind: "aws-access-key-id",
+    regex: /(?<![A-Za-z0-9])AKIA[0-9A-Z]{16}(?![0-9A-Z])/g,
+  },
+  {
+    kind: "slack-token",
+    regex: /(?<![A-Za-z0-9])xox[abpsr]-[A-Za-z0-9-]{10,}/g,
+  },
+  {
+    kind: "google-api-key",
+    regex: /(?<![A-Za-z0-9_-])AIza[0-9A-Za-z_-]{30,}/g,
+  },
+  {
+    kind: "jwt",
+    regex:
+      /(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?![A-Za-z0-9_-])/g,
+  },
+  {
+    kind: "bearer-token",
+    regex: /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}(?![A-Za-z0-9._~+/=-])/g,
+  },
+];
+
+/**
+ * `key=value` (or `key: value`) assignments where the key is
+ * credential-like (checked against the same name blocklist as tables and
+ * columns via `isSecretName`) and the value is token-like: at least 16
+ * characters with no spaces or quotes. Short or space-containing values
+ * are left alone so ordinary prose ("the token: is stored safely") is
+ * never mangled.
+ */
+const SECRET_ASSIGNMENT_REGEX =
+  /(?<![A-Za-z0-9])([A-Za-z][A-Za-z0-9_.-]{0,63})(\s*[=:]\s*)(["']?)([^\s"'[\]]{16,})/g;
+
+/**
+ * Redact secret-shaped spans in `text`, replacing each match with
+ * `[redacted:<kind>]`. Returns the redacted text and the number of
+ * redacted spans. Assignments are scanned first so a shaped token used
+ * as an assignment value is counted once, and redaction placeholders
+ * contain no token-like characters, so passes never rematch each other's
+ * output.
+ */
+export function redactSecretValues(text: string): {
+  text: string;
+  redactions: number;
+} {
+  let redactions = 0;
+  let out = text;
+
+  // PEM blocks first: they span lines and must be removed whole before
+  // any line-oriented pattern can match inside them.
+  const [pemPattern, ...shapePatterns] = SECRET_VALUE_PATTERNS;
+  out = out.replace(pemPattern.regex, () => {
+    redactions++;
+    return `[redacted:${pemPattern.kind}]`;
+  });
+
+  // Manual exec loop instead of String.replace: when a candidate key is
+  // not credential-like ("recipe: password=..."), scanning must resume
+  // just after the rejected key so the inner assignment is still caught.
+  const assignment = new RegExp(SECRET_ASSIGNMENT_REGEX.source, "g");
+  let assembled = "";
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = assignment.exec(out)) !== null) {
+    const [full, key, sep, quote] = match;
+    if (!isSecretName(key)) {
+      assignment.lastIndex = match.index + key.length;
+      continue;
+    }
+    assembled +=
+      out.slice(last, match.index) +
+      `${key}${sep}${quote}[redacted:credential-assignment]`;
+    last = match.index + full.length;
+    redactions++;
+  }
+  out = assembled + out.slice(last);
+
+  for (const { kind, regex } of shapePatterns) {
+    out = out.replace(regex, () => {
+      redactions++;
+      return `[redacted:${kind}]`;
+    });
+  }
+
+  return { text: out, redactions };
+}
+
 export interface TableCensus {
   table: string;
   status: "extracted" | "skipped";
@@ -129,6 +251,8 @@ export interface TableCensus {
   items?: number;
   /** Columns excluded from extraction because their names look credential-bearing. */
   secretColumns?: string[];
+  /** Secret-shaped spans redacted in place from this table's emitted text. */
+  redactions?: number;
 }
 
 interface SqliteMasterRow {
@@ -220,6 +344,7 @@ export function extractMemoryDb(
 
       let rowCount = 0;
       let extracted = 0;
+      let redacted = 0;
       if (selectColumns.length === 0) {
         rowCount = (
           db.query(`SELECT COUNT(*) AS n FROM ${quoted}`).get() as {
@@ -250,10 +375,15 @@ export function extractMemoryDb(
               if (typeof value !== "string") {
                 continue;
               }
-              const text = value.trim();
-              if (text.length === 0 || toIsoDate(text) !== undefined) {
+              const rawText = value.trim();
+              if (rawText.length === 0 || toIsoDate(rawText) !== undefined) {
                 continue;
               }
+              // Name filters cannot catch credentials stored inside
+              // generic text columns, so redact secret-shaped spans from
+              // the value itself before it reaches stdout.
+              const { text, redactions } = redactSecretValues(rawText);
+              redacted += redactions;
               const item: MemoryImportItem = {
                 text,
                 source: `import:${provider}`,
@@ -282,6 +412,9 @@ export function extractMemoryDb(
       };
       if (secretColumns.length > 0) {
         entry.secretColumns = secretColumns;
+      }
+      if (redacted > 0) {
+        entry.redactions = redacted;
       }
       census.push(entry);
     }
@@ -358,6 +491,11 @@ function main() {
       if (entry.secretColumns && entry.secretColumns.length > 0) {
         process.stderr.write(
           `    skipped credential-like columns: ${entry.secretColumns.join(", ")}\n`,
+        );
+      }
+      if (entry.redactions && entry.redactions > 0) {
+        process.stderr.write(
+          `    redacted ${entry.redactions} secret-like value(s) in place\n`,
         );
       }
     } else {

--- a/skills/assistant-migration/scripts/parse-chatgpt-memory.ts
+++ b/skills/assistant-migration/scripts/parse-chatgpt-memory.ts
@@ -93,6 +93,7 @@ function itemFromRecord(
 function itemsFromMatchedValue(
   value: unknown,
   context: string,
+  depth = 0,
 ): MemoryImportItem[] {
   if (typeof value === "string" && value.trim().length > 0) {
     return [{ text: value.trim(), source: SOURCE, context }];
@@ -113,6 +114,27 @@ function itemsFromMatchedValue(
       }
     }
     return items;
+  }
+  if (value && typeof value === "object") {
+    // An object-shaped memory, e.g. {"memory": {"content": "..."}}: pull
+    // its text-bearing field (with origin_date when a date field is
+    // present). When no text field matches directly, the record may nest
+    // one level deeper, so recurse a single level into its values.
+    const record = value as Record<string, unknown>;
+    const item = itemFromRecord(record, context);
+    if (item) {
+      return [item];
+    }
+    if (depth < 1) {
+      const items: MemoryImportItem[] = [];
+      for (const [key, child] of Object.entries(record)) {
+        if (DATE_FIELDS.includes(key)) {
+          continue;
+        }
+        items.push(...itemsFromMatchedValue(child, context, depth + 1));
+      }
+      return items;
+    }
   }
   return [];
 }

--- a/skills/assistant-migration/scripts/parse-chatgpt-memory.ts
+++ b/skills/assistant-migration/scripts/parse-chatgpt-memory.ts
@@ -39,6 +39,9 @@ import {
   toIsoDate,
   type MemoryImportItem,
 } from "./lib/memory-items.js";
+// The DB parser guards its CLI entry behind import.meta.main, so importing
+// its redaction helper does not execute it.
+import { redactSecretValues } from "./parse-agent-memory-db.js";
 
 const SOURCE = "import:chatgpt";
 
@@ -574,11 +577,24 @@ function main() {
   for (const line of inventory) {
     process.stderr.write(`  ${line.outcome}: ${line.entry} (${line.detail})\n`);
   }
+  // Same value-level guarantee as the DB parser: credential-shaped spans in
+  // saved memories or custom instructions never reach stdout verbatim.
+  let redactionCount = 0;
+  const redactedItems = items.map((item) => {
+    const { text, redactions } = redactSecretValues(item.text);
+    redactionCount += redactions;
+    return redactions > 0 ? { ...item, text } : item;
+  });
+  if (redactionCount > 0) {
+    process.stderr.write(
+      `Redacted ${redactionCount} secret-like value(s) in place.\n`,
+    );
+  }
   process.stderr.write(
-    `Total: ${items.length} review candidates from ${entries.length} entries. Review before saving to memory.\n`,
+    `Total: ${redactedItems.length} review candidates from ${entries.length} entries. Review before saving to memory.\n`,
   );
 
-  printItemsJson(items);
+  printItemsJson(redactedItems);
 }
 
 if (import.meta.main) {

--- a/skills/assistant-migration/scripts/parse-chatgpt-memory.ts
+++ b/skills/assistant-migration/scripts/parse-chatgpt-memory.ts
@@ -1,0 +1,410 @@
+#!/usr/bin/env bun
+
+/**
+ * Scan a ChatGPT account export ZIP for non-conversation memory material
+ * (saved memories, custom instructions / "what ChatGPT should know about
+ * you") and emit `MemoryImportItem[]` JSON on stdout.
+ *
+ * Conversation history is NOT parsed here: that belongs to the
+ * `chatgpt-import` skill. This parser only covers the material described
+ * in references/chatgpt.md under "Non-conversation material".
+ *
+ * ChatGPT does not document a stable filename schema for this material,
+ * so no fixed layout is assumed: every entry in the archive is inspected
+ * and matched by name/content heuristics. A stderr inventory lists which
+ * entries were recognized and which were not, so the creator review step
+ * can audit the coverage.
+ *
+ * Not covered by CI tests: the heuristic surface has no stable upstream
+ * fixture to pin (export layouts vary by account and change over time),
+ * so output is validated by creator review rather than a fixture test.
+ *
+ * Usage:
+ *   bun run scripts/parse-chatgpt-memory.ts --file /path/to/chatgpt-export.zip
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { inflateRawSync } from "node:zlib";
+
+import {
+  printItemsJson,
+  toIsoDate,
+  type MemoryImportItem,
+} from "./lib/memory-items.js";
+
+const SOURCE = "import:chatgpt";
+
+/** JSON keys whose string values look like memories or custom instructions. */
+const MEMORY_KEY =
+  /memor(y|ies)|instruction|about_user|about_model|know_about|should_know|how.*respond|persona/i;
+
+/** Object fields that carry the text of a memory-shaped record. */
+const TEXT_FIELDS = ["content", "memory", "text", "value", "summary", "title"];
+
+/** Object fields that may carry the record's original timestamp. */
+const DATE_FIELDS = [
+  "created_at",
+  "create_time",
+  "updated_at",
+  "update_time",
+  "timestamp",
+  "date",
+];
+
+const MEDIA_EXTENSIONS =
+  /\.(png|jpe?g|gif|webp|svg|mp3|wav|m4a|mp4|webm|pdf|dat|html|css|js)$/i;
+
+const MAX_ENTRY_BYTES = 10 * 1024 * 1024;
+const MAX_WALK_DEPTH = 12;
+
+interface InventoryLine {
+  entry: string;
+  outcome: "recognized" | "skipped";
+  detail: string;
+}
+
+// -- Heuristic content scanning --
+
+function itemFromRecord(
+  record: Record<string, unknown>,
+  context: string,
+): MemoryImportItem | null {
+  for (const field of TEXT_FIELDS) {
+    const value = record[field];
+    if (typeof value === "string" && value.trim().length > 0) {
+      const item: MemoryImportItem = {
+        text: value.trim(),
+        source: SOURCE,
+        context,
+      };
+      for (const dateField of DATE_FIELDS) {
+        const originDate = toIsoDate(record[dateField]);
+        if (originDate) {
+          item.origin_date = originDate;
+          break;
+        }
+      }
+      return item;
+    }
+  }
+  return null;
+}
+
+function itemsFromMatchedValue(
+  value: unknown,
+  context: string,
+): MemoryImportItem[] {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return [{ text: value.trim(), source: SOURCE, context }];
+  }
+  if (Array.isArray(value)) {
+    const items: MemoryImportItem[] = [];
+    for (const element of value) {
+      if (typeof element === "string" && element.trim().length > 0) {
+        items.push({ text: element.trim(), source: SOURCE, context });
+      } else if (element && typeof element === "object") {
+        const item = itemFromRecord(
+          element as Record<string, unknown>,
+          context,
+        );
+        if (item) {
+          items.push(item);
+        }
+      }
+    }
+    return items;
+  }
+  return [];
+}
+
+/** Recursively collect string values under memory/instruction-looking keys. */
+function walkJson(
+  value: unknown,
+  entryName: string,
+  path: string,
+  depth: number,
+  items: MemoryImportItem[],
+): void {
+  if (depth > MAX_WALK_DEPTH || value === null || typeof value !== "object") {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const element of value) {
+      walkJson(element, entryName, path, depth + 1, items);
+    }
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = path ? `${path}.${key}` : key;
+    if (MEMORY_KEY.test(key)) {
+      const matched = itemsFromMatchedValue(child, `${entryName}:${childPath}`);
+      if (matched.length > 0) {
+        items.push(...matched);
+        continue;
+      }
+    }
+    walkJson(child, entryName, childPath, depth + 1, items);
+  }
+}
+
+function scanEntry(name: string, data: Buffer): MemoryImportItem[] {
+  const text = data.toString("utf-8");
+
+  if (name.toLowerCase().endsWith(".json")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new Error("invalid JSON");
+    }
+    const items: MemoryImportItem[] = [];
+    // An entry whose own name signals memories may be a bare array of
+    // memory records with no memory-named key inside.
+    if (MEMORY_KEY.test(name) && Array.isArray(parsed)) {
+      items.push(...itemsFromMatchedValue(parsed, name));
+    }
+    walkJson(parsed, name, "", 0, items);
+    return items;
+  }
+
+  if (name.toLowerCase().endsWith(".txt") && MEMORY_KEY.test(name)) {
+    const trimmed = text.trim();
+    if (trimmed.length > 0) {
+      return [{ text: trimmed, source: SOURCE, context: name }];
+    }
+  }
+
+  return [];
+}
+
+// -- ZIP entry listing (stdlib-only, same approach as chatgpt-import) --
+
+interface ZipEntry {
+  name: string;
+  read: () => Buffer;
+  compressedSize: number;
+}
+
+function listZipEntries(buffer: Buffer): ZipEntry[] {
+  // Find end of central directory record (EOCD signature: 0x06054b50)
+  let eocdOffset = -1;
+  for (let i = buffer.length - 22; i >= 0; i--) {
+    if (
+      buffer[i] === 0x50 &&
+      buffer[i + 1] === 0x4b &&
+      buffer[i + 2] === 0x05 &&
+      buffer[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+  if (eocdOffset === -1) {
+    throw new Error(
+      "Invalid ZIP file: could not find end of central directory",
+    );
+  }
+
+  const centralDirOffset = buffer.readUInt32LE(eocdOffset + 16);
+  const centralDirEntries = buffer.readUInt16LE(eocdOffset + 10);
+
+  const entries: ZipEntry[] = [];
+  let offset = centralDirOffset;
+  for (let i = 0; i < centralDirEntries; i++) {
+    if (
+      buffer[offset] !== 0x50 ||
+      buffer[offset + 1] !== 0x4b ||
+      buffer[offset + 2] !== 0x01 ||
+      buffer[offset + 3] !== 0x02
+    ) {
+      throw new Error("Invalid ZIP central directory entry");
+    }
+
+    const cdCompressedSize = buffer.readUInt32LE(offset + 20);
+    const fileNameLength = buffer.readUInt16LE(offset + 28);
+    const extraLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    const localHeaderOffset = buffer.readUInt32LE(offset + 42);
+    const fileName = buffer
+      .subarray(offset + 46, offset + 46 + fileNameLength)
+      .toString("utf-8");
+
+    if (!fileName.endsWith("/")) {
+      entries.push({
+        name: fileName,
+        compressedSize: cdCompressedSize,
+        read: () =>
+          extractLocalFile(buffer, localHeaderOffset, cdCompressedSize),
+      });
+    }
+
+    offset += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
+function extractLocalFile(
+  buffer: Buffer,
+  offset: number,
+  cdCompressedSize: number,
+): Buffer {
+  if (
+    buffer[offset] !== 0x50 ||
+    buffer[offset + 1] !== 0x4b ||
+    buffer[offset + 2] !== 0x03 ||
+    buffer[offset + 3] !== 0x04
+  ) {
+    throw new Error("Invalid ZIP local file header");
+  }
+
+  const compressionMethod = buffer.readUInt16LE(offset + 8);
+  const localCompressedSize = buffer.readUInt32LE(offset + 18);
+  const compressedSize =
+    cdCompressedSize > 0 ? cdCompressedSize : localCompressedSize;
+  const fileNameLength = buffer.readUInt16LE(offset + 26);
+  const extraLength = buffer.readUInt16LE(offset + 28);
+
+  const dataOffset = offset + 30 + fileNameLength + extraLength;
+  const fileData = buffer.subarray(dataOffset, dataOffset + compressedSize);
+
+  if (compressionMethod === 0) {
+    return Buffer.from(fileData);
+  } else if (compressionMethod === 8) {
+    return inflateRawSync(fileData);
+  } else {
+    throw new Error(`Unsupported ZIP compression method: ${compressionMethod}`);
+  }
+}
+
+// -- Main --
+
+function parseCliArgs(): { filePath: string } {
+  const args = process.argv.slice(2);
+  let filePath: string | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--file" && i + 1 < args.length) {
+      filePath = args[i + 1];
+      i++;
+    }
+  }
+
+  if (!filePath) {
+    process.stderr.write(
+      "Usage: bun run scripts/parse-chatgpt-memory.ts --file <path-to-zip>\n",
+    );
+    process.exit(1);
+  }
+
+  return { filePath };
+}
+
+function main() {
+  const { filePath } = parseCliArgs();
+
+  if (!filePath.endsWith(".zip")) {
+    process.stderr.write(
+      "Error: Only ZIP files are accepted. Please provide the ChatGPT export ZIP file.\n",
+    );
+    process.exit(1);
+  }
+  if (!existsSync(filePath)) {
+    process.stderr.write(`Error: File not found: ${filePath}\n`);
+    process.exit(1);
+  }
+
+  let entries: ZipEntry[];
+  try {
+    entries = listZipEntries(readFileSync(filePath));
+  } catch (err) {
+    process.stderr.write(
+      `Error reading export file: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+
+  const items: MemoryImportItem[] = [];
+  const inventory: InventoryLine[] = [];
+
+  for (const entry of entries) {
+    const baseName = entry.name.split("/").pop() ?? entry.name;
+
+    if (
+      /^conversations\.json$/i.test(baseName) ||
+      /^chat\.html$/i.test(baseName)
+    ) {
+      inventory.push({
+        entry: entry.name,
+        outcome: "skipped",
+        detail: "conversation history (handled by the chatgpt-import skill)",
+      });
+      continue;
+    }
+    if (MEDIA_EXTENSIONS.test(baseName)) {
+      inventory.push({
+        entry: entry.name,
+        outcome: "skipped",
+        detail: "media/asset file",
+      });
+      continue;
+    }
+    if (!/\.(json|txt)$/i.test(baseName)) {
+      inventory.push({
+        entry: entry.name,
+        outcome: "skipped",
+        detail: "unrecognized format",
+      });
+      continue;
+    }
+    if (entry.compressedSize > MAX_ENTRY_BYTES) {
+      inventory.push({
+        entry: entry.name,
+        outcome: "skipped",
+        detail: "entry too large to scan",
+      });
+      continue;
+    }
+
+    let found: MemoryImportItem[];
+    try {
+      found = scanEntry(entry.name, entry.read());
+    } catch (err) {
+      inventory.push({
+        entry: entry.name,
+        outcome: "skipped",
+        detail: `unreadable (${err instanceof Error ? err.message : String(err)})`,
+      });
+      continue;
+    }
+
+    if (found.length > 0) {
+      items.push(...found);
+      inventory.push({
+        entry: entry.name,
+        outcome: "recognized",
+        detail: `${found.length} candidate item(s) via name/content heuristics`,
+      });
+    } else {
+      inventory.push({
+        entry: entry.name,
+        outcome: "skipped",
+        detail: "no memory-like or instruction-like content found",
+      });
+    }
+  }
+
+  process.stderr.write("Export entry inventory:\n");
+  for (const line of inventory) {
+    process.stderr.write(`  ${line.outcome}: ${line.entry} (${line.detail})\n`);
+  }
+  process.stderr.write(
+    `Total: ${items.length} review candidates from ${entries.length} entries. Review before saving to memory.\n`,
+  );
+
+  printItemsJson(items);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/skills/assistant-migration/scripts/parse-chatgpt-memory.ts
+++ b/skills/assistant-migration/scripts/parse-chatgpt-memory.ts
@@ -15,6 +15,14 @@
  * entries were recognized and which were not, so the creator review step
  * can audit the coverage.
  *
+ * The ZIP is read incrementally, never materialized whole: the end of
+ * central directory record is located from a bounded tail read, only the
+ * central directory itself is buffered (kilobytes per thousand entries),
+ * and entry bytes are read and inflated only for entries that pass the
+ * name and size filters. Media files and oversized entries are skipped
+ * without their bytes ever being read, so multi-GB exports parse in
+ * bounded memory.
+ *
  * Not covered by CI tests: the heuristic surface has no stable upstream
  * fixture to pin (export layouts vary by account and change over time),
  * so output is validated by creator review rather than a fixture test.
@@ -23,7 +31,7 @@
  *   bun run scripts/parse-chatgpt-memory.ts --file /path/to/chatgpt-export.zip
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, openSync, readSync } from "node:fs";
 import { inflateRawSync } from "node:zlib";
 
 import {
@@ -199,23 +207,108 @@ function scanEntry(name: string, data: Buffer): MemoryImportItem[] {
   return [];
 }
 
-// -- ZIP entry listing (stdlib-only, same approach as chatgpt-import) --
+// -- Incremental ZIP entry listing (stdlib-only) --
+//
+// The archive is never read whole. Only three regions are ever buffered:
+// a bounded tail (to find the end of central directory record), the
+// central directory itself, and the bytes of individual entries that the
+// caller decides to read. Entries the caller skips (media, oversized)
+// cost zero data reads.
 
 interface ZipEntry {
   name: string;
   read: () => Buffer;
   compressedSize: number;
+  uncompressedSize: number;
 }
 
-function listZipEntries(buffer: Buffer): ZipEntry[] {
-  // Find end of central directory record (EOCD signature: 0x06054b50)
+const EOCD_MIN_SIZE = 22;
+const MAX_ZIP_COMMENT = 0xffff;
+
+/** Read exactly `length` bytes at `position`, or throw. */
+function readAt(fd: number, position: number, length: number): Buffer {
+  const buffer = Buffer.alloc(length);
+  let read = 0;
+  while (read < length) {
+    const n = readSync(fd, buffer, read, length - read, position + read);
+    if (n <= 0) {
+      throw new Error("Invalid ZIP file: unexpected end of file");
+    }
+    read += n;
+  }
+  return buffer;
+}
+
+function readUInt64LE(buffer: Buffer, offset: number): number {
+  const value = buffer.readBigUInt64LE(offset);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("Invalid ZIP file: 64-bit field exceeds safe integer");
+  }
+  return Number(value);
+}
+
+/**
+ * ZIP64 extended information extra field (header id 0x0001): 64-bit
+ * values are stored in extra-field order (uncompressed size, compressed
+ * size, local header offset), but only for the fields whose 32-bit slot
+ * is saturated at 0xffffffff.
+ */
+function applyZip64Extra(
+  extra: Buffer,
+  sizes: {
+    uncompressedSize: number;
+    compressedSize: number;
+    localHeaderOffset: number;
+  },
+): void {
+  let offset = 0;
+  while (offset + 4 <= extra.length) {
+    const headerId = extra.readUInt16LE(offset);
+    const dataSize = extra.readUInt16LE(offset + 2);
+    if (headerId === 0x0001) {
+      let fieldOffset = offset + 4;
+      const fieldEnd = Math.min(offset + 4 + dataSize, extra.length);
+      const take = (): number => {
+        if (fieldOffset + 8 > fieldEnd) {
+          throw new Error("Invalid ZIP file: truncated ZIP64 extra field");
+        }
+        const value = readUInt64LE(extra, fieldOffset);
+        fieldOffset += 8;
+        return value;
+      };
+      if (sizes.uncompressedSize === 0xffffffff) {
+        sizes.uncompressedSize = take();
+      }
+      if (sizes.compressedSize === 0xffffffff) {
+        sizes.compressedSize = take();
+      }
+      if (sizes.localHeaderOffset === 0xffffffff) {
+        sizes.localHeaderOffset = take();
+      }
+      return;
+    }
+    offset += 4 + dataSize;
+  }
+}
+
+function listZipEntries(fd: number, fileSize: number): ZipEntry[] {
+  // Find the end of central directory record (EOCD signature
+  // 0x06054b50) by scanning a bounded tail read: the EOCD is at most
+  // 22 bytes plus a 64 KiB comment from the end of the file.
+  const tailLength = Math.min(fileSize, EOCD_MIN_SIZE + MAX_ZIP_COMMENT);
+  if (tailLength < EOCD_MIN_SIZE) {
+    throw new Error("Invalid ZIP file: too small to contain a ZIP archive");
+  }
+  const tailStart = fileSize - tailLength;
+  const tail = readAt(fd, tailStart, tailLength);
+
   let eocdOffset = -1;
-  for (let i = buffer.length - 22; i >= 0; i--) {
+  for (let i = tail.length - EOCD_MIN_SIZE; i >= 0; i--) {
     if (
-      buffer[i] === 0x50 &&
-      buffer[i + 1] === 0x4b &&
-      buffer[i + 2] === 0x05 &&
-      buffer[i + 3] === 0x06
+      tail[i] === 0x50 &&
+      tail[i + 1] === 0x4b &&
+      tail[i + 2] === 0x05 &&
+      tail[i + 3] === 0x06
     ) {
       eocdOffset = i;
       break;
@@ -227,36 +320,83 @@ function listZipEntries(buffer: Buffer): ZipEntry[] {
     );
   }
 
-  const centralDirOffset = buffer.readUInt32LE(eocdOffset + 16);
-  const centralDirEntries = buffer.readUInt16LE(eocdOffset + 10);
+  let centralDirEntries: number = tail.readUInt16LE(eocdOffset + 10);
+  let centralDirSize: number = tail.readUInt32LE(eocdOffset + 12);
+  let centralDirOffset: number = tail.readUInt32LE(eocdOffset + 16);
+
+  // ZIP64: exports larger than 4 GiB saturate the 32-bit EOCD fields and
+  // store the real values in a ZIP64 EOCD record, located via a fixed
+  // 20-byte locator that immediately precedes the classic EOCD.
+  if (
+    centralDirEntries === 0xffff ||
+    centralDirSize === 0xffffffff ||
+    centralDirOffset === 0xffffffff
+  ) {
+    const locatorStart = tailStart + eocdOffset - 20;
+    if (locatorStart < 0) {
+      throw new Error("Invalid ZIP file: missing ZIP64 EOCD locator");
+    }
+    const locator = readAt(fd, locatorStart, 20);
+    if (locator.readUInt32LE(0) !== 0x07064b50) {
+      throw new Error("Invalid ZIP file: missing ZIP64 EOCD locator");
+    }
+    const zip64EocdOffset = readUInt64LE(locator, 8);
+    const zip64Eocd = readAt(fd, zip64EocdOffset, 56);
+    if (zip64Eocd.readUInt32LE(0) !== 0x06064b50) {
+      throw new Error("Invalid ZIP file: missing ZIP64 EOCD record");
+    }
+    centralDirEntries = readUInt64LE(zip64Eocd, 32);
+    centralDirSize = readUInt64LE(zip64Eocd, 40);
+    centralDirOffset = readUInt64LE(zip64Eocd, 48);
+  }
+
+  // The central directory is tiny relative to the archive (roughly
+  // 50-100 bytes per entry), so buffering it whole is safe.
+  const centralDir = readAt(fd, centralDirOffset, centralDirSize);
 
   const entries: ZipEntry[] = [];
-  let offset = centralDirOffset;
+  let offset = 0;
   for (let i = 0; i < centralDirEntries; i++) {
     if (
-      buffer[offset] !== 0x50 ||
-      buffer[offset + 1] !== 0x4b ||
-      buffer[offset + 2] !== 0x01 ||
-      buffer[offset + 3] !== 0x02
+      centralDir[offset] !== 0x50 ||
+      centralDir[offset + 1] !== 0x4b ||
+      centralDir[offset + 2] !== 0x01 ||
+      centralDir[offset + 3] !== 0x02
     ) {
       throw new Error("Invalid ZIP central directory entry");
     }
 
-    const cdCompressedSize = buffer.readUInt32LE(offset + 20);
-    const fileNameLength = buffer.readUInt16LE(offset + 28);
-    const extraLength = buffer.readUInt16LE(offset + 30);
-    const commentLength = buffer.readUInt16LE(offset + 32);
-    const localHeaderOffset = buffer.readUInt32LE(offset + 42);
-    const fileName = buffer
+    const sizes = {
+      compressedSize: centralDir.readUInt32LE(offset + 20),
+      uncompressedSize: centralDir.readUInt32LE(offset + 24),
+      localHeaderOffset: centralDir.readUInt32LE(offset + 42),
+    };
+    const fileNameLength = centralDir.readUInt16LE(offset + 28);
+    const extraLength = centralDir.readUInt16LE(offset + 30);
+    const commentLength = centralDir.readUInt16LE(offset + 32);
+    const fileName = centralDir
       .subarray(offset + 46, offset + 46 + fileNameLength)
       .toString("utf-8");
+
+    if (
+      sizes.compressedSize === 0xffffffff ||
+      sizes.uncompressedSize === 0xffffffff ||
+      sizes.localHeaderOffset === 0xffffffff
+    ) {
+      const extraStart = offset + 46 + fileNameLength;
+      applyZip64Extra(
+        centralDir.subarray(extraStart, extraStart + extraLength),
+        sizes,
+      );
+    }
 
     if (!fileName.endsWith("/")) {
       entries.push({
         name: fileName,
-        compressedSize: cdCompressedSize,
+        compressedSize: sizes.compressedSize,
+        uncompressedSize: sizes.uncompressedSize,
         read: () =>
-          extractLocalFile(buffer, localHeaderOffset, cdCompressedSize),
+          extractLocalFile(fd, sizes.localHeaderOffset, sizes.compressedSize),
       });
     }
 
@@ -267,31 +407,32 @@ function listZipEntries(buffer: Buffer): ZipEntry[] {
 }
 
 function extractLocalFile(
-  buffer: Buffer,
-  offset: number,
+  fd: number,
+  localHeaderOffset: number,
   cdCompressedSize: number,
 ): Buffer {
+  const header = readAt(fd, localHeaderOffset, 30);
   if (
-    buffer[offset] !== 0x50 ||
-    buffer[offset + 1] !== 0x4b ||
-    buffer[offset + 2] !== 0x03 ||
-    buffer[offset + 3] !== 0x04
+    header[0] !== 0x50 ||
+    header[1] !== 0x4b ||
+    header[2] !== 0x03 ||
+    header[3] !== 0x04
   ) {
     throw new Error("Invalid ZIP local file header");
   }
 
-  const compressionMethod = buffer.readUInt16LE(offset + 8);
-  const localCompressedSize = buffer.readUInt32LE(offset + 18);
+  const compressionMethod = header.readUInt16LE(8);
+  const localCompressedSize = header.readUInt32LE(18);
   const compressedSize =
     cdCompressedSize > 0 ? cdCompressedSize : localCompressedSize;
-  const fileNameLength = buffer.readUInt16LE(offset + 26);
-  const extraLength = buffer.readUInt16LE(offset + 28);
+  const fileNameLength = header.readUInt16LE(26);
+  const extraLength = header.readUInt16LE(28);
 
-  const dataOffset = offset + 30 + fileNameLength + extraLength;
-  const fileData = buffer.subarray(dataOffset, dataOffset + compressedSize);
+  const dataOffset = localHeaderOffset + 30 + fileNameLength + extraLength;
+  const fileData = readAt(fd, dataOffset, compressedSize);
 
   if (compressionMethod === 0) {
-    return Buffer.from(fileData);
+    return fileData;
   } else if (compressionMethod === 8) {
     return inflateRawSync(fileData);
   } else {
@@ -336,10 +477,15 @@ function main() {
     process.exit(1);
   }
 
+  let fd = -1;
   let entries: ZipEntry[];
   try {
-    entries = listZipEntries(readFileSync(filePath));
+    fd = openSync(filePath, "r");
+    entries = listZipEntries(fd, fstatSync(fd).size);
   } catch (err) {
+    if (fd !== -1) {
+      closeSync(fd);
+    }
     process.stderr.write(
       `Error reading export file: ${err instanceof Error ? err.message : String(err)}\n`,
     );
@@ -379,7 +525,10 @@ function main() {
       });
       continue;
     }
-    if (entry.compressedSize > MAX_ENTRY_BYTES) {
+    if (
+      entry.compressedSize > MAX_ENTRY_BYTES ||
+      entry.uncompressedSize > MAX_ENTRY_BYTES
+    ) {
       inventory.push({
         entry: entry.name,
         outcome: "skipped",
@@ -390,6 +539,9 @@ function main() {
 
     let found: MemoryImportItem[];
     try {
+      // Only entries that survived the filters above are ever read; the
+      // read is an on-demand seek into the archive, not a slice of a
+      // whole-file buffer.
       found = scanEntry(entry.name, entry.read());
     } catch (err) {
       inventory.push({
@@ -415,6 +567,8 @@ function main() {
       });
     }
   }
+
+  closeSync(fd);
 
   process.stderr.write("Export entry inventory:\n");
   for (const line of inventory) {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "updatedAt": "2026-07-29T18:42:57.000Z"
     },
     {
       "id": "chat-complex-documents",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T18:53:49.000Z"
+      "updatedAt": "2026-07-29T19:05:50.000Z"
     },
     {
       "id": "chat-complex-documents",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T19:05:50.000Z"
+      "updatedAt": "2026-07-29T19:20:44.000Z"
     },
     {
       "id": "chat-complex-documents",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T18:42:57.000Z"
+      "updatedAt": "2026-07-29T18:53:49.000Z"
     },
     {
       "id": "chat-complex-documents",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1146,7 +1146,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-28T20:26:37.000Z"
+      "updatedAt": "2026-07-28T22:26:01.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T19:20:44.000Z"
+      "updatedAt": "2026-07-29T19:33:00.000Z"
     },
     {
       "id": "chat-complex-documents",


### PR DESCRIPTION
## Summary
- MemoryImportItem interchange type + parse-chatgpt-memory.ts (export ZIP → candidates) + parse-agent-memory-db.ts (SQLite introspection → candidates)
- SQLite parser has a fixture-backed test; catalog regenerated

Part of plan: memory-ingestion.md (PR 8 of 11)