### PR TITLE
feat(web): land the Capacitor iOS shell on a new chat draft at cold launch

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -24,6 +24,7 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { isNativeIOS } from "@/runtime/platform-detection";
 import { useConversationStore } from "@/stores/conversation-store";
 import { haptic } from "@/utils/haptics";
 import { routes } from "@/utils/routes";
@@ -290,6 +291,7 @@ export function useConversationLoader({
   // recent* fetch failed (we still have last-known-good data to land on).
   // -------------------------------------------------------------------------
   const lastAppliedUrlConversationIdRef = useRef<string | null>(null);
+  const newChatDraftConversationIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (assistantStateKind !== "active") {
       return;
@@ -300,16 +302,25 @@ export function useConversationLoader({
 
     const explicitConversationId = urlConversationId;
 
+    // The Capacitor iOS shell cold-launches into a fresh draft instead of
+    // resuming a conversation. Held in a ref so effect re-runs reuse the key.
+    let newChatDraftConversationId: string | null = null;
+    if (isNativeIOS()) {
+      newChatDraftConversationIdRef.current ??= createDraftConversationId();
+      newChatDraftConversationId = newChatDraftConversationIdRef.current;
+    }
+
     // Only the "resume last-viewed" / "land on latest foreground" fallbacks
-    // read the fetched list. An explicit URL key, an onboarding draft, or the
-    // existing in-memory selection all resolve without it — so the chat
-    // transcript the user opened renders immediately instead of blocking on
-    // the sidebar's conversation-list API.
+    // read the fetched list. An explicit URL key, an onboarding draft, the
+    // existing in-memory selection, or a new-chat draft all resolve without
+    // it, so the chat transcript the user opened renders immediately instead
+    // of blocking on the sidebar's conversation-list API.
     const needsConversationList = !(
       explicitConversationId != null ||
       searchParams.get("onboarding") === "1" ||
       (assistantIdRef.current === assistantId &&
-        useConversationStore.getState().activeConversationId != null)
+        useConversationStore.getState().activeConversationId != null) ||
+      newChatDraftConversationId != null
     );
     if (needsConversationList && conversationListIsPending) {
       return;
@@ -346,6 +357,7 @@ export function useConversationLoader({
     const key = resolveBootstrappedConversationId({
       queryParamKey: explicitConversationId,
       onboardingDraftConversationId,
+      newChatDraftConversationId,
       currentConversationId:
         useConversationStore.getState().activeConversationId,
       currentAssistantId: assistantIdRef.current,

--- a/clients/web/src/domains/chat/utils/conversation-selection.test.ts
+++ b/clients/web/src/domains/chat/utils/conversation-selection.test.ts
@@ -149,4 +149,86 @@ describe("resolveBootstrappedConversationId", () => {
       }),
     ).toBe("new-latest");
   });
+
+  describe("newChatDraftConversationId", () => {
+    test("replaces both resume fallbacks on cold load", () => {
+      expect(
+        resolveBootstrappedConversationId({
+          queryParamKey: null,
+          newChatDraftConversationId: "new-chat-draft",
+          currentConversationId: null,
+          currentAssistantId: null,
+          nextAssistantId: "asst-1",
+          storedConversationId: "old-visible",
+          defaultConversationId: "new-latest",
+          conversations,
+        }),
+      ).toBe("new-chat-draft");
+    });
+
+    test("loses to an explicit URL conversation key", () => {
+      expect(
+        resolveBootstrappedConversationId({
+          queryParamKey: "from-url",
+          newChatDraftConversationId: "new-chat-draft",
+          currentConversationId: null,
+          currentAssistantId: null,
+          nextAssistantId: "asst-1",
+          storedConversationId: "old-visible",
+          defaultConversationId: "new-latest",
+          conversations,
+        }),
+      ).toBe("from-url");
+    });
+
+    test("loses to the onboarding draft", () => {
+      expect(
+        resolveBootstrappedConversationId({
+          queryParamKey: null,
+          onboardingDraftConversationId: "onboarding-draft",
+          newChatDraftConversationId: "new-chat-draft",
+          currentConversationId: null,
+          currentAssistantId: null,
+          nextAssistantId: "asst-1",
+          storedConversationId: "old-visible",
+          defaultConversationId: "new-latest",
+          conversations,
+        }),
+      ).toBe("onboarding-draft");
+    });
+
+    test("loses to an existing same-assistant in-memory selection", () => {
+      expect(
+        resolveBootstrappedConversationId({
+          queryParamKey: null,
+          newChatDraftConversationId: "new-chat-draft",
+          currentConversationId: "old-visible",
+          currentAssistantId: "asst-1",
+          nextAssistantId: "asst-1",
+          storedConversationId: "old-visible",
+          defaultConversationId: "new-latest",
+          conversations,
+        }),
+      ).toBe("old-visible");
+    });
+
+    test("leaves cold-load resume unchanged when absent or null", () => {
+      const args = {
+        queryParamKey: null,
+        currentConversationId: null,
+        currentAssistantId: null,
+        nextAssistantId: "asst-1",
+        storedConversationId: "old-visible",
+        defaultConversationId: "new-latest",
+        conversations,
+      };
+      expect(resolveBootstrappedConversationId(args)).toBe("old-visible");
+      expect(
+        resolveBootstrappedConversationId({
+          ...args,
+          newChatDraftConversationId: null,
+        }),
+      ).toBe("old-visible");
+    });
+  });
 });

--- a/clients/web/src/domains/chat/utils/conversation-selection.ts
+++ b/clients/web/src/domains/chat/utils/conversation-selection.ts
@@ -3,6 +3,11 @@ import type { Conversation } from "@/types/conversation-types";
 interface ResolveBootstrappedConversationIdArgs {
   queryParamKey: string | null;
   onboardingDraftConversationId?: string | null;
+  /**
+   * Client-minted draft key for platforms that cold-launch into a new chat
+   * (the Capacitor iOS shell). Absent everywhere else.
+   */
+  newChatDraftConversationId?: string | null;
   currentConversationId: string | null;
   currentAssistantId: string | null;
   nextAssistantId: string;
@@ -60,11 +65,22 @@ function isStoredConversationSelectable(
  * the in-memory selection so manual refresh does not jump to whatever
  * conversation is newest. On a cold load, resume the last persisted key only if
  * the server still lists it as a foreground conversation; background/scheduled
- * conversations require an explicit URL selection.
+ * conversations require an explicit URL selection. A new-chat draft key, when
+ * supplied, replaces both resume fallbacks so the platform lands on an empty
+ * composer instead.
+ *
+ * Precedence, highest first:
+ *   1. `queryParamKey` (explicit URL selection)
+ *   2. `onboardingDraftConversationId`
+ *   3. `currentConversationId` (same-assistant in-memory selection)
+ *   4. `newChatDraftConversationId`
+ *   5. `storedConversationId` (last viewed, if still selectable)
+ *   6. `defaultConversationId`
  */
 export function resolveBootstrappedConversationId({
   queryParamKey,
   onboardingDraftConversationId,
+  newChatDraftConversationId,
   currentConversationId,
   currentAssistantId,
   nextAssistantId,
@@ -82,6 +98,10 @@ export function resolveBootstrappedConversationId({
 
   if (currentAssistantId === nextAssistantId && currentConversationId) {
     return currentConversationId;
+  }
+
+  if (newChatDraftConversationId) {
+    return newChatDraftConversationId;
   }
 
   if (


### PR DESCRIPTION
## Summary
- `resolveBootstrappedConversationId` gains an optional `newChatDraftConversationId`. It sits BELOW (1) explicit URL conversation id, (2) onboarding draft, and (3) same-assistant in-memory selection, and ABOVE (4) stored last-viewed and (5) `defaultConversationId`, so it replaces only the two resume fallbacks. Push-notification taps and deep links are unaffected (they resolve through precedence 1). The option is optional and defaults to absent, so every existing test stays green unedited and desktop web / Electron behavior is byte-identical.
- `use-conversation-loader.ts` mints the draft id at most once per mount via a ref (mirroring `onboardingDraftConversationIdRef`) and only when the plain `isNativeIOS()` is true. The gate lives inside the bootstrap-routing effect, so the plain function, not a hook, is correct. The `needsConversationList` short-circuit is extended so the iOS new-chat path does not block first paint on the sidebar conversation-list fetch; the non-iOS path still requires the list exactly as today.
- New cases in the existing `conversation-selection.test.ts` pin all five precedence relationships. No `use-conversation-loader.test.ts` was created (testing that hook directly needs heavy mocking).

Accepted tradeoffs: (a) each iOS cold open writes the throwaway draft id into `vellum:lastViewedConversation:<assistantId>`, which is harmless because `isStoredConversationSelectable` rejects ids absent from the conversation list, so web and Electron still fall back to latest-foreground; (b) a composer draft typed in the previously-viewed conversation is no longer auto-surfaced on reopen, though it is still stored and reappears on navigating back.

Verification: `bun test src/domains/chat/utils/conversation-selection.test.ts` (14 pass), `bunx tsc --noEmit`, and `bun run lint` (0 errors) all pass. iOS simulator cold launch remains the real acceptance gate.

Part of plan: ios-capacitor-ui-polish.md (PR 9 of 9)