### PR TITLE
feat(web): stamp data-native-platform="ios" on html and add a native-ios Tailwind variant + useIsNativeIOS hook

### DIFF
--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -1,6 +1,15 @@
 @import "tailwindcss";
 @import "@vellumai/design-library/tokens.css";
 
+/* Capacitor iOS shell variant. Keys off the data-native-platform marker
+ * set by initNativePlatformAttributes() at boot. Deliberately :is(), not
+ * :where(): the selector must carry :root[attr] specificity (0,3,0 with
+ * the utility class) so native-ios: utilities outrank the design
+ * library's touch-mobile: pill classes, which are single-class rules
+ * inside a media query (0,1,0) and would otherwise win or lose on
+ * emission order. */
+@custom-variant native-ios (&:is(:root[data-native-platform="ios"] *));
+
 /* Base element styles — theme-aware defaults inherited by all descendants. */
 body {
   color: var(--content-default);

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -25,6 +25,7 @@ import { router } from "./routes";
 import "@/lib/api-interceptors";
 import "./index.css";
 
+import { initNativePlatformAttributes } from "@/runtime/native-platform-attributes";
 import { initSafeAreaBridge } from "@/runtime/native-safe-area";
 import { initInputModality } from "@vellumai/design-library";
 
@@ -34,6 +35,7 @@ async function boot() {
   installTranslateDomGuard();
 
   initInputModality();
+  initNativePlatformAttributes();
   await initSafeAreaBridge();
   initSentry();
   initSessionReplay();

--- a/clients/web/src/runtime/native-platform-attributes.test.ts
+++ b/clients/web/src/runtime/native-platform-attributes.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for `initNativePlatformAttributes`.
+ *
+ * The marker is what every `native-ios:` Tailwind utility and iOS-scoped CSS
+ * rule keys off, so these pin that it appears only inside the Capacitor iOS
+ * shell and that repeated calls stay idempotent.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let mockIsNativeIOS = false;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => mockIsNativeIOS,
+}));
+
+const { initNativePlatformAttributes } =
+  await import("@/runtime/native-platform-attributes");
+
+afterEach(() => {
+  mockIsNativeIOS = false;
+  delete document.documentElement.dataset.nativePlatform;
+});
+
+describe("initNativePlatformAttributes", () => {
+  test("leaves the marker unset outside the native iOS shell", () => {
+    initNativePlatformAttributes();
+    expect(document.documentElement.dataset.nativePlatform).toBeUndefined();
+  });
+
+  test("stamps the marker inside the native iOS shell", () => {
+    mockIsNativeIOS = true;
+    initNativePlatformAttributes();
+    expect(document.documentElement.dataset.nativePlatform).toBe("ios");
+  });
+
+  test("is idempotent across repeated calls", () => {
+    mockIsNativeIOS = true;
+    initNativePlatformAttributes();
+    initNativePlatformAttributes();
+    expect(document.documentElement.dataset.nativePlatform).toBe("ios");
+  });
+});

--- a/clients/web/src/runtime/native-platform-attributes.ts
+++ b/clients/web/src/runtime/native-platform-attributes.ts
@@ -1,0 +1,18 @@
+import { isNativeIOS } from "@/runtime/platform-detection";
+
+/**
+ * Stamp the native platform on <html> so CSS can gate Capacitor-iOS-only
+ * styling (the `native-ios` variant in index.css keys off it). Called
+ * synchronously from main.tsx boot() before createRoot so the attribute
+ * is present for the first paint. The attribute write is idempotent, so
+ * no init latch is needed (unlike initInputModality / initSafeAreaBridge,
+ * which register listeners).
+ */
+export function initNativePlatformAttributes(): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  if (isNativeIOS()) {
+    document.documentElement.dataset.nativePlatform = "ios";
+  }
+}

--- a/clients/web/src/runtime/platform-detection.test.ts
+++ b/clients/web/src/runtime/platform-detection.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
 
 let electron = false;
 let nativePlatform = false;
@@ -28,7 +29,8 @@ mock.module("@capacitor/core", () => ({
   Capacitor: { getPlatform: () => nativeOsPlatform },
 }));
 
-const { detectClientOs } = await import("@/runtime/platform-detection");
+const { detectClientOs, useIsNativeIOS } =
+  await import("@/runtime/platform-detection");
 
 const ORIGINAL_UA = navigator.userAgent;
 const IPHONE_UA =
@@ -46,6 +48,7 @@ function setUserAgent(ua: string): void {
 }
 
 afterEach(() => {
+  cleanup();
   electron = false;
   nativePlatform = false;
   nativeOsPlatform = "web";
@@ -94,5 +97,17 @@ describe("detectClientOs", () => {
     nativePlatform = true;
     setUserAgent(IPHONE_UA);
     expect(detectClientOs()).toBe("macos");
+  });
+});
+
+describe("useIsNativeIOS", () => {
+  test("is true inside the Capacitor iOS native shell", () => {
+    nativePlatform = true;
+    nativeOsPlatform = "ios";
+    expect(renderHook(() => useIsNativeIOS()).result.current).toBe(true);
+  });
+
+  test("is false outside a native shell", () => {
+    expect(renderHook(() => useIsNativeIOS()).result.current).toBe(false);
   });
 });

--- a/clients/web/src/runtime/platform-detection.ts
+++ b/clients/web/src/runtime/platform-detection.ts
@@ -306,3 +306,12 @@ export function useIsMacOSWeb(): boolean {
     () => false,
   );
 }
+
+/**
+ * Hydration-safe hook form of `isNativeIOS()`: false on the server and on
+ * the first client render, settles after mount. Use this in JSX instead of
+ * the bare function (docs/CAPACITOR.md) to avoid first-paint flicker.
+ */
+export function useIsNativeIOS(): boolean {
+  return useSyncExternalStore(noop, isNativeIOS, () => false);
+}


### PR DESCRIPTION
## Summary
- `initNativePlatformAttributes()` stamps `data-native-platform="ios"` on `<html>` from `main.tsx` `boot()`, synchronously before `createRoot`, so the marker is present for the first paint. The write is idempotent, so no init latch is needed.
- Adds the `native-ios` Tailwind custom variant in `clients/web/src/index.css`, keyed off that marker. It uses `:is()` (not `:where()`) deliberately so `native-ios:` utilities carry `:root[attr]` specificity and outrank the design library's `touch-mobile:` classes. Verified it compiles to `.native-ios\:bg-transparent:is(:root[data-native-platform="ios"] *)`. The variant lives in the app, not `packages/design-library`, so the shared package stays platform-agnostic.
- Adds `useIsNativeIOS()` to `runtime/platform-detection.ts`, the hydration-safe hook form of `isNativeIOS()` for use in JSX (mirrors `useIsIOSWeb()` / `useIsMacOSWeb()`).

Zero visual change on every platform: no `native-ios:` utility exists yet, so Tailwind emits nothing for the variant, and the attribute is absent outside the Capacitor iOS shell (desktop web, Electron, mobile Safari).

Part of plan: ios-capacitor-ui-polish.md (PR 1 of 9)