### PR TITLE
feat(config): BYOK hatches use the code-defined default profiles directly

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -51,6 +51,7 @@ afterAll(() => {
 import {
   getEffectiveProfile,
   getEffectiveProfiles,
+  getEffectiveProfilesForProvider,
   MANAGED_PROFILE_NAMES,
   materializeProfile,
   OS_BETA_PROFILE_TEMPLATE,
@@ -142,7 +143,6 @@ function fullSeededCallSites(): Record<string, Record<string, unknown>> {
 function mergeDefaultConfigAndSeedInferenceProfiles(db?: DrizzleDb): void {
   const defaultConfigMerge = mergeDefaultWorkspaceConfig();
   seedInferenceProfiles({
-    preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
     preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
     isHatch: defaultConfigMerge.hadOverlay,
     db,
@@ -150,12 +150,18 @@ function mergeDefaultConfigAndSeedInferenceProfiles(db?: DrizzleDb): void {
 }
 
 /**
- * The exact thin stub `seedInferenceProfiles` writes for a default profile on
- * a fresh BYOK hatch: no content fields, only the workspace-owned overlays.
+ * Profile names that must stay absent from `llm.profiles` after a BYOK
+ * hatch: the default keys (no disabled stubs) and their `custom-*`
+ * counterparts (no materialized copies).
  */
-function managedStub(label: string): Record<string, unknown> {
-  return { source: "managed", status: "disabled", label: `${label} (Managed)` };
-}
+const LEGACY_HATCH_PROFILE_NAMES = [
+  "balanced",
+  "quality-optimized",
+  "cost-optimized",
+  "custom-balanced",
+  "custom-quality-optimized",
+  "custom-cost-optimized",
+] as const;
 
 function createProviderConnectionsDb(): DrizzleDb {
   const sqlite = new Database(":memory:");
@@ -555,7 +561,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.dataDir).toBeUndefined();
   });
 
-  test("off-platform hatch seeds user anthropic profiles and thin managed stubs", () => {
+  test("off-platform hatch writes no profile entries; defaults resolve through the hatch provider", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -573,34 +579,43 @@ describe("loadConfig startup behavior", () => {
       ) + "\n",
     );
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+    const db = createProviderConnectionsDb();
 
-    mergeDefaultConfigAndSeedInferenceProfiles();
+    mergeDefaultConfigAndSeedInferenceProfiles(db);
     const config = loadConfig();
 
     // `llm.default` is not part of the schema — the overlay blob stays on
     // disk as inert user intent but never reaches the parsed config.
     expect((config.llm as Record<string, unknown>).default).toBeUndefined();
-    // Off-platform: user profiles are active, backed by the user's API key.
-    expect(config.llm.activeProfile).toBe("custom-balanced");
-    expect(config.llm.profiles["custom-balanced"]?.provider).toBe("anthropic");
-    expect(config.llm.profiles["custom-balanced"]?.provider_connection).toBe(
-      "anthropic-personal",
-    );
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.advisorProfile).toBe("quality-optimized");
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     expect(raw.llm.default).toEqual({
       provider: "anthropic",
       model: "claude-opus-4-7",
     });
-    expect(raw.llm.activeProfile).toBe("custom-balanced");
-    // The managed defaults exist only as thin disabled stubs — their content
-    // is code-owned and never written to the workspace.
-    expect(raw.llm.profiles.balanced).toEqual(managedStub("Balanced"));
-    // Default content resolves from the code catalog via the effective view.
-    const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
-    expect(effectiveBalanced?.provider).toBe("vellum");
-    expect(effectiveBalanced?.provider_connection).toBeUndefined();
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.defaultProvider).toEqual({ provider: "anthropic" });
+    // The hatch materializes no profile entries: default content is
+    // code-owned and resolves through `llm.defaultProvider`'s matrix column.
+    for (const name of LEGACY_HATCH_PROFILE_NAMES) {
+      expect(raw.llm.profiles[name]).toBeUndefined();
+    }
+    // The personal connection the BYOK column stamps is created at hatch.
+    expect(getConnection(db, "anthropic-personal")).not.toBeNull();
+
+    // Resolution contract the hatch relies on: the defaults resolve active
+    // through the hatch provider with the personal connection.
+    const effective = getEffectiveProfilesForProvider(
+      raw.llm.profiles,
+      raw.llm.defaultProvider,
+    );
+    expect(effective.balanced?.provider).toBe("anthropic");
+    expect(effective.balanced?.provider_connection).toBe("anthropic-personal");
+    expect(effective.balanced?.model).toBe("claude-sonnet-4-6");
+    expect(effective.balanced?.source).toBe("managed");
+    expect("status" in (effective.balanced ?? {})).toBe(false);
   });
 
   test("on-platform hatch writes no profile entries; defaults resolve from the catalog", () => {
@@ -639,7 +654,7 @@ describe("loadConfig startup behavior", () => {
     expect(effectiveBalanced?.provider_connection).toBeUndefined();
   });
 
-  test("re-hatch from openai to anthropic creates user anthropic profiles off-platform", () => {
+  test("re-hatch from openai to anthropic leaves the user profile untouched and re-anchors the defaults", () => {
     // Pre-seed an OpenAI-style workspace: user-defined custom-balanced profile
     // is active, default is openai. Simulates a workspace that hatched against
     // OpenAI under the pre-1.2 model.
@@ -668,19 +683,25 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-    // Off-platform re-hatch: user profiles are overwritten for the new
-    // provider and custom-balanced becomes active.
-    expect(raw.llm.activeProfile).toBe("custom-balanced");
-    expect(raw.llm.profiles["custom-balanced"].provider).toBe("anthropic");
-    expect(raw.llm.profiles["custom-balanced"].provider_connection).toBe(
-      "anthropic-personal",
+    // Off-platform re-hatch: the default profiles become active, anchored on
+    // the new hatch provider.
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.defaultProvider).toEqual({ provider: "anthropic" });
+    // The pre-existing custom profile is user-owned and never rewritten.
+    expect(raw.llm.profiles["custom-balanced"]).toEqual({
+      source: "user",
+      provider: "openai",
+      model: "gpt-5.4-mini",
+    });
+    // No stubs under the default keys; content resolves through the new
+    // default provider's matrix column.
+    expect(raw.llm.profiles.balanced).toBeUndefined();
+    const effective = getEffectiveProfilesForProvider(
+      raw.llm.profiles,
+      raw.llm.defaultProvider,
     );
-    // The managed defaults get only thin disabled stubs; content stays
-    // code-owned and resolves from the catalog.
-    expect(raw.llm.profiles.balanced).toEqual(managedStub("Balanced"));
-    const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.provider).toBe("vellum");
-    expect(effectiveBalanced?.provider_connection).toBeUndefined();
+    expect(effective.balanced?.provider).toBe("anthropic");
+    expect(effective.balanced?.provider_connection).toBe("anthropic-personal");
   });
 
   test("on-platform re-hatch resets active profile to balanced", () => {
@@ -748,7 +769,7 @@ describe("loadConfig startup behavior", () => {
 
     expect(raw.llm.profiles.placeholder).toBeUndefined();
     expect(raw.llm.profileOrder).not.toContain("placeholder");
-    expect(raw.llm.activeProfile).toBe("custom-balanced");
+    expect(raw.llm.activeProfile).toBe("balanced");
   });
 
   test("boot removes non-dispatchable profile references", () => {
@@ -811,7 +832,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.default.model).toBe("codellama");
   });
 
-  test("off-platform hatch with openai seeds user profiles and thin managed stubs", () => {
+  test("off-platform hatch with openai resolves the defaults through the openai column", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -823,46 +844,26 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    // User profiles for the hatch provider (openai).
-    expect(raw.llm.activeProfile).toBe("custom-balanced");
-    expect(raw.llm.profiles["custom-balanced"].provider).toBe("openai");
-    expect(raw.llm.profiles["custom-balanced"].model).toBe("gpt-5.4-mini");
-    expect(raw.llm.profiles["custom-balanced"].provider_connection).toBe(
-      "openai-personal",
-    );
-    expect(raw.llm.profiles["custom-balanced"].source).toBe("user");
-    expect(raw.llm.profiles["custom-quality-optimized"].provider).toBe(
-      "openai",
-    );
-    expect(raw.llm.profiles["custom-quality-optimized"].model).toBe("gpt-5.4");
-    expect(raw.llm.profiles["custom-cost-optimized"].provider).toBe("openai");
-    expect(raw.llm.profiles["custom-cost-optimized"].model).toBe(
-      "gpt-5.4-nano",
-    );
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.defaultProvider).toEqual({ provider: "openai" });
+    for (const name of LEGACY_HATCH_PROFILE_NAMES) {
+      expect(raw.llm.profiles[name]).toBeUndefined();
+    }
 
-    // The managed defaults exist only as thin disabled stubs on a BYOK hatch.
-    expect(raw.llm.profiles.balanced).toEqual(managedStub("Balanced"));
-    expect(raw.llm.profiles["quality-optimized"]).toEqual(
-      managedStub("Quality"),
+    // The defaults resolve active through the openai column of the matrix,
+    // stamped with the personal connection.
+    const effective = getEffectiveProfilesForProvider(
+      raw.llm.profiles,
+      raw.llm.defaultProvider,
     );
-    expect(raw.llm.profiles["cost-optimized"]).toEqual(managedStub("Speed"));
-
-    // Default content resolves from the code catalog via the effective view.
-    // Balanced serves GLM 5.2 on Fireworks.
-    const effective = getEffectiveProfiles(raw.llm.profiles);
-    expect(effective.balanced?.provider).toBe("vellum");
-    expect(effective.balanced?.provider_connection).toBeUndefined();
-    expect(effective.balanced?.model).toBe("accounts/fireworks/models/glm-5p2");
-    expect(effective.balanced?.effort).toBe("high");
+    expect(effective.balanced?.provider).toBe("openai");
+    expect(effective.balanced?.model).toBe("gpt-5.4-mini");
+    expect(effective.balanced?.provider_connection).toBe("openai-personal");
     expect(effective.balanced?.source).toBe("managed");
-    // Quality pins OpenAI Sol, the most capable managed model.
-    expect(effective["quality-optimized"]?.provider).toBe("vellum");
-    expect(effective["quality-optimized"]?.model).toBe("gpt-5.6-sol");
-    // Speed is served by DeepSeek V4 Flash on Fireworks.
-    expect(effective["cost-optimized"]?.provider).toBe("vellum");
-    expect(effective["cost-optimized"]?.model).toBe(
-      "accounts/fireworks/models/deepseek-v4-flash",
-    );
+    expect(effective["quality-optimized"]?.provider).toBe("openai");
+    expect(effective["quality-optimized"]?.model).toBe("gpt-5.4");
+    expect(effective["cost-optimized"]?.provider).toBe("openai");
+    expect(effective["cost-optimized"]?.model).toBe("gpt-5.4-nano");
   });
 
   test("off-platform boot leaves an existing managed entry byte-identical", () => {
@@ -1281,13 +1282,19 @@ describe("loadConfig startup behavior", () => {
       provider: "anthropic",
       model: "claude-opus-4-7",
     });
-    // Off-platform hatch: user profiles are active; the managed defaults get
-    // only thin disabled stubs.
-    expect(raw.llm.activeProfile).toBe("custom-balanced");
-    expect(raw.llm.profiles["custom-balanced"].provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced).toEqual(managedStub("Balanced"));
-    const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
+    // Off-platform hatch: nothing is materialized; the defaults resolve
+    // through the hatch provider.
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.defaultProvider).toEqual({ provider: "anthropic" });
+    for (const name of LEGACY_HATCH_PROFILE_NAMES) {
+      expect(raw.llm.profiles[name]).toBeUndefined();
+    }
+    const effective = getEffectiveProfilesForProvider(
+      raw.llm.profiles,
+      raw.llm.defaultProvider,
+    );
+    expect(effective.balanced?.provider).toBe("anthropic");
+    expect(effective.balanced?.provider_connection).toBe("anthropic-personal");
   });
 
   test("still quarantines corrupt JSON", () => {
@@ -1312,18 +1319,15 @@ describe("loadConfig startup behavior", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: BYOK-mode seed behavior (issues #2/#3/#4 of the May 12 provider UX
-// queue). Off-platform managed defaults share base labels with the personal
-// "custom-*" profiles (Balanced / Quality / Speed), so the thin stubs written
-// at BYOK hatch time carry a " (Managed)" label suffix and status "disabled"
-// — a fresh BYOK user has no platform auth, so managed defaults must not
-// surface as enabled in the picker on day one. Boots never touch managed
-// entries, so post-hatch user toggles persist — the "never auto-disable BYOK
-// connections" rule applies to RESTART, not to hatch. On platform, no
-// managed entries are written at all; defaults resolve from the code catalog.
+// Tests: BYOK-mode seed behavior. A BYOK hatch writes no profile entries at
+// all: the default names resolve through the hatch provider's column of the
+// intent × provider matrix (via `llm.defaultProvider`), active and
+// connection-stamped. Boots never touch managed entries, so pre-existing
+// stubs and user toggles on them persist until the conversion pass removes
+// them.
 // ---------------------------------------------------------------------------
 
-describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
+describe("seedInferenceProfiles BYOK-mode default profiles", () => {
   beforeEach(() => {
     ensureTestDir();
     const resetPaths = [
@@ -1353,7 +1357,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     invalidateConfigCache();
   });
 
-  test("off-platform hatch suffixes managed profile labels with ' (Managed)'", () => {
+  test("off-platform hatch writes no stubs; defaults resolve active with bare labels", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -1370,28 +1374,24 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
 
     mergeDefaultConfigAndSeedInferenceProfiles();
-    const config = loadConfig();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    // Managed profile labels carry the suffix so they're visibly distinct
-    // from the personal "custom-*" profiles (which retain bare labels).
-    expect(config.llm.profiles.balanced?.label).toBe("Balanced (Managed)");
-    expect(config.llm.profiles["quality-optimized"]?.label).toBe(
-      "Quality (Managed)",
+    // No workspace entries at all: no disabled stubs, no label suffixes, no
+    // custom-* copies. The catalog serves the bare labels, active.
+    expect(raw.llm.profiles).toEqual({});
+    const effective = getEffectiveProfilesForProvider(
+      raw.llm.profiles,
+      raw.llm.defaultProvider,
     );
-    expect(config.llm.profiles["cost-optimized"]?.label).toBe(
-      "Speed (Managed)",
-    );
-
-    // Personal profiles keep their bare labels — they're the daily driver.
-    expect(config.llm.profiles["custom-balanced"]?.label).toBe("Balanced");
+    expect(effective.balanced?.label).toBe("Balanced");
+    expect(effective["quality-optimized"]?.label).toBe("Quality");
+    expect(effective["cost-optimized"]?.label).toBe("Speed");
+    expect("status" in (effective.balanced ?? {})).toBe(false);
+    expect("status" in (effective["quality-optimized"] ?? {})).toBe(false);
+    expect("status" in (effective["cost-optimized"] ?? {})).toBe(false);
   });
 
-  test("off-platform hatch initializes managed profile status to 'disabled'", () => {
-    // On a fresh BYOK hatch the user has no platform auth, so managed
-    // profiles must not surface as enabled in the picker on day one. We
-    // flip the three canonical managed profiles to status="disabled"
-    // ONCE at hatch time. (The complementary "user re-enable persists
-    // across restarts" guarantee is covered by the test further down.)
+  test("off-platform BYOK hatch defaults advisor to quality-optimized", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -1403,34 +1403,11 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
 
-    expect(config.llm.profiles.balanced?.status).toBe("disabled");
-    expect(config.llm.profiles["quality-optimized"]?.status).toBe("disabled");
-    expect(config.llm.profiles["cost-optimized"]?.status).toBe("disabled");
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.advisorProfile).toBe("quality-optimized");
   });
 
-  test("off-platform BYOK hatch defaults advisor to the personal quality profile", () => {
-    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
-    writeFileSync(
-      overlayPath,
-      JSON.stringify({ llm: { default: { provider: "anthropic" } } }, null, 2) +
-        "\n",
-    );
-    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
-
-    mergeDefaultConfigAndSeedInferenceProfiles();
-    const config = loadConfig();
-
-    expect(config.llm.activeProfile).toBe("custom-balanced");
-    expect(config.llm.advisorProfile).toBe("custom-quality-optimized");
-    expect(config.llm.profiles["custom-quality-optimized"]?.provider).toBe(
-      "anthropic",
-    );
-    expect(
-      config.llm.profiles["custom-quality-optimized"]?.provider_connection,
-    ).toBe("anthropic-personal");
-  });
-
-  test("off-platform boot repairs a disabled managed advisor to a personal profile when no active managed replacement exists", () => {
+  test("off-platform boot clears a disabled managed advisor even when a personal profile exists", () => {
     writeConfig({
       llm: {
         advisorProfile: "frontier",
@@ -1477,7 +1454,9 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
 
-    expect(config.llm.advisorProfile).toBe("custom-quality-optimized");
+    // Advisor repair only considers the managed defaults; a user profile is
+    // never auto-selected, so a fully-disabled managed set clears the field.
+    expect(config.llm.advisorProfile).toBeUndefined();
   });
 
   test("platform boot repairs a disabled managed advisor to an active managed profile", () => {

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -30,15 +30,14 @@ import {
  * intent, and each provider that can serve default profiles has a concrete
  * implementation of that intent (model, token budget, effort, thinking).
  * The `vellum` column is the platform-managed implementation; the other
- * columns are the BYOK implementations used to materialize the personal
- * `custom-*` profiles at hatch time.
+ * columns are the BYOK implementations resolved through `llm.defaultProvider`
+ * on off-platform installs.
  *
- * `seedInferenceProfiles` still materializes the `vellum` column into
- * workspace config on every boot, but runtime readers resolve profiles
- * through `getEffectiveProfiles`/`getEffectiveProfile` below, which serve
- * default bodies from this module and overlay only the workspace-owned
- * `label`/`status`/`topP` state. This keeps default profile content
- * updatable by shipping a release — no workspace migration.
+ * Nothing materializes default bodies into workspace config: runtime readers
+ * resolve profiles through `getEffectiveProfiles`/`getEffectiveProfile`
+ * below, which serve default bodies from this module and overlay only the
+ * workspace-owned `label`/`status`/`topP` state. This keeps default profile
+ * content updatable by shipping a release, with no workspace migration.
  */
 
 /**
@@ -135,8 +134,7 @@ const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
  * The BYOK implementation of each default profile intent, shared by every
  * non-vellum provider column. The concrete model resolves per provider from
  * the `intent` via `resolveModelIntent` at materialization time. `provider`
- * is stamped per column (and overridden at hatch time with the user's
- * chosen provider).
+ * is stamped per column.
  */
 const BYOK_PROFILE_IMPLS: Record<
   ProfileMatrixKey,
@@ -209,11 +207,9 @@ export const PROFILE_IMPLS: Record<
 >;
 
 /**
- * Managed profiles, i.e. the `vellum` column keyed by profile name. Seeded
- * into workspace config on every daemon boot; platform overlays
- * (`preserveProfileNames`) take precedence when present. Keyed by the
- * user-facing defaults only — an internal profile is code-resolved and never
- * materialized into workspace config.
+ * Managed profiles, i.e. the `vellum` column keyed by profile name. Keyed by
+ * the user-facing defaults only: an internal profile is code-resolved and
+ * never listed or ordered.
  */
 export const MANAGED_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   Object.fromEntries(
@@ -221,10 +217,11 @@ export const MANAGED_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   );
 
 /**
- * User profile templates, materialized as `custom-*` at hatch time for
- * off-platform installations. The `provider` field is a placeholder — it is
- * overridden at hatch time with the user's chosen provider and personal
- * connection name.
+ * Frozen record of the `custom-*` profile bodies that pre-conversion BYOK
+ * hatches wrote to workspace config (the anthropic column; provider and
+ * connection were overridden per hatch). Consumed by the existing-install
+ * conversion pass as the reference for recognizing unedited copies, which
+ * are safe to remove in favor of the code-resolved defaults.
  */
 export const USER_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   Object.fromEntries(

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -13,13 +13,8 @@ import {
   getEffectiveProfiles,
   MANAGED_PROFILE_NAMES,
   MANAGED_PROFILE_TEMPLATES,
-  materializeProfile,
-  USER_PROFILE_TEMPLATES,
 } from "./default-profile-catalog.js";
-import {
-  DEFAULT_PROFILE_KEYS,
-  DEFAULT_PROFILE_PROVIDERS,
-} from "./default-profile-names.js";
+import { DEFAULT_PROFILE_PROVIDERS } from "./default-profile-names.js";
 import { loadRawConfig, saveRawConfig } from "./loader.js";
 import { isDispatchableProfile } from "./profile-dispatchability.js";
 import type { ProfileEntry } from "./schemas/llm.js";
@@ -31,11 +26,6 @@ export const OS_BETA_FEATURE_FLAG_KEY = "os-beta";
 const MIX_MIN_ARMS = 2;
 
 export type SeedInferenceProfilesOptions = {
-  /**
-   * Profile names supplied by the platform/default overlay for this startup.
-   * Those entries are already on disk and should remain authoritative.
-   */
-  preserveProfileNames?: Iterable<string>;
   preserveActiveProfile?: boolean;
   /** True when a hatch overlay was consumed this startup. */
   isHatch?: boolean;
@@ -51,27 +41,23 @@ export type SeedInferenceProfilesOptions = {
  * whether or not `llm.profiles` carries an entry, so nothing here writes
  * default bodies. Three responsibilities remain:
  *
- * 1. **BYOK hatch stubs**: a fresh off-platform install cannot use the
- *    platform-auth vellum route, so the default profiles get a thin
- *    disabled stub (`{source, status, label}`) that makes the resolver fall
- *    through to the personal `custom-*` profiles. Skipped when the hatch
- *    overlay explicitly selected a managed connection — the defaults then
- *    stay absent and resolve active from the catalog.
+ * 1. **Personal provider connection**: a BYOK hatch creates the
+ *    `<provider>-personal` connection backed by the user's API key in CES.
+ *    The BYOK columns of the intent × provider matrix stamp exactly that
+ *    connection name (via `resolveDefaultConnectionName`), so the default
+ *    profiles dispatch through it.
  *
- * 2. **User profiles** (`custom-balanced`, `custom-quality-optimized`,
- *    `custom-cost-optimized`): materialized once at hatch time for
- *    off-platform installations. Each points at a personal provider
- *    connection backed by the user's API key in CES. Subsequent boots
- *    leave these untouched — the user owns them.
+ * 2. **`llm.defaultProvider`**: written once at hatch time, mirroring the
+ *    platform/managed/BYOK decision, and never overwritten afterward. The
+ *    default profiles resolve through this provider's matrix column.
  *
- * 3. **`llm.defaultProvider`**: written once at hatch time, mirroring the
- *    platform/managed/BYOK decisions above, and never overwritten afterward.
+ * 3. **Active/advisor profile resolution**: hatches activate `balanced`;
+ *    boots repair dangling or disabled selections.
  */
 export function seedInferenceProfiles(
   options: SeedInferenceProfilesOptions = {},
 ): void {
   const config = loadRawConfig();
-  const preservedProfileNames = new Set(options.preserveProfileNames ?? []);
 
   if (config.llm == null || typeof config.llm !== "object") {
     config.llm = {};
@@ -86,48 +72,19 @@ export function seedInferenceProfiles(
   const isPlatform =
     process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
 
-  // BYOK mode = off-platform installs. The user is bringing their own provider
-  // API key; managed profile labels get a " (Managed)" suffix to disambiguate
-  // from the personal "custom-*" profiles that share base labels.
-  const isByokMode = !isPlatform;
-
-  // 1. BYOK hatch stubs. Default profile bodies are code-owned and never
-  //    written here; the only workspace state a default carries is a thin
-  //    managed stub holding the fields the effective view overlays
-  //    (`source`, `status`, `label`). A fresh BYOK hatch disables the
-  //    defaults so the picker doesn't offer an unusable platform-auth route
-  //    on day one — and so the resolver's `custom-*` fallback applies. When
-  //    the hatch overlay explicitly selected a managed connection, no stubs
-  //    are written: the defaults stay absent and resolve active from the
-  //    catalog, so the first post-onboarding message can use the chosen
-  //    managed route. Post-hatch user toggles live on the stub and are never
-  //    touched again.
+  // A hatch overlay that explicitly selected a managed connection routes the
+  // default provider through vellum rather than the entered BYOK key.
   const hatchSelectedManagedConnection = getHatchSelectedManagedConnection(
     llm,
     profiles,
     options,
   );
 
-  if (
-    isByokMode &&
-    options.isHatch &&
-    hatchSelectedManagedConnection === undefined
-  ) {
-    for (const name of DEFAULT_PROFILE_KEYS) {
-      if (readObject(profiles[name])) {
-        continue;
-      }
-      const label = MANAGED_PROFILE_TEMPLATES[name]?.label;
-      profiles[name] = {
-        source: "managed",
-        status: "disabled",
-        ...(typeof label === "string" ? { label: `${label} (Managed)` } : {}),
-      } as ProfileEntry;
-    }
-  }
-
-  // 2. User profiles — only at hatch time for off-platform installations.
-  let userConnectionName: string | undefined;
+  // 1. Personal provider connection: only at hatch time for off-platform
+  //    installations, backed by the user's API key in CES. The BYOK columns
+  //    of the intent × provider matrix stamp `<provider>-personal` (via
+  //    `resolveDefaultConnectionName`), so the connection must exist for the
+  //    default profiles to dispatch.
   let usableHatchProvider: string | undefined;
   if (options.isHatch && !isPlatform) {
     const hatchProvider = readString(readObject(llm.default)?.provider);
@@ -137,41 +94,27 @@ export function seedInferenceProfiles(
       !PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(hatchProvider)
     ) {
       usableHatchProvider = hatchProvider;
-      userConnectionName = `${hatchProvider}-personal`;
+      const userConnectionName = `${hatchProvider}-personal`;
 
-      if (options.db) {
-        if (!getConnection(options.db, userConnectionName)) {
-          const credName = credentialKey(hatchProvider, "api_key");
-          const result = createConnection(options.db, {
-            name: userConnectionName,
-            provider: hatchProvider,
-            auth: { type: "api_key", credential: credName },
-            label: personalConnectionLabel(hatchProvider),
-          });
-          if (!result.ok) {
-            log.warn(
-              { provider: hatchProvider, error: result.error },
-              "Failed to create personal connection during hatch seeding",
-            );
-          }
+      if (options.db && !getConnection(options.db, userConnectionName)) {
+        const credName = credentialKey(hatchProvider, "api_key");
+        const result = createConnection(options.db, {
+          name: userConnectionName,
+          provider: hatchProvider,
+          auth: { type: "api_key", credential: credName },
+          label: personalConnectionLabel(hatchProvider),
+        });
+        if (!result.ok) {
+          log.warn(
+            { provider: hatchProvider, error: result.error },
+            "Failed to create personal connection during hatch seeding",
+          );
         }
-      }
-
-      const provider = hatchProvider as NonNullable<ProfileEntry["provider"]>;
-      for (const [name, template] of Object.entries(USER_PROFILE_TEMPLATES)) {
-        if (preservedProfileNames.has(name)) {
-          continue;
-        }
-        profiles[name] = materializeProfile(
-          template,
-          provider,
-          userConnectionName,
-        );
       }
     }
   }
 
-  // 3. Default provider — hatch only, never overwritten once set. Always
+  // 2. Default provider: hatch only, never overwritten once set. Always
   //    populated — even dangling, so later resolution can prompt the user
   //    for a key explainably rather than hitting an unset branch.
   if (options.isHatch && readObject(llm.defaultProvider) === null) {
@@ -204,17 +147,12 @@ export function seedInferenceProfiles(
     options.preserveActiveProfile === true && requestedActiveExists;
 
   if (!shouldPreserveActiveProfile) {
-    if (options.isHatch) {
-      // Hatch = fresh setup. Pick the right default based on platform mode.
-      llm.activeProfile = userConnectionName ? "custom-balanced" : "balanced";
-    } else if (!requestedActiveExists) {
+    if (options.isHatch || !requestedActiveExists) {
       llm.activeProfile = "balanced";
     }
   }
 
-  // Advisor profile: BYOK hatches default to the strongest personal profile
-  // backed by the entered provider key. Managed-profile hatches and registered
-  // platform installs default to the strongest active managed profile.
+  // Advisor profile: defaults to the strongest active managed default.
   const requestedAdvisorProfile = readString(llm.advisorProfile);
   const requestedAdvisorEntry =
     requestedAdvisorProfile !== undefined
@@ -223,17 +161,15 @@ export function seedInferenceProfiles(
   const requestedAdvisorIsDisabledManaged =
     requestedAdvisorEntry?.source === "managed" &&
     requestedAdvisorEntry.status === "disabled";
-  const preferPersonalAdvisor =
-    userConnectionName !== undefined &&
-    hatchSelectedManagedConnection === undefined;
   if (
     requestedAdvisorProfile === undefined ||
     requestedAdvisorIsDisabledManaged
   ) {
-    const defaultAdvisorProfile = selectDefaultAdvisorProfile(
-      effectiveProfiles,
-      preferPersonalAdvisor,
-    );
+    const defaultAdvisorProfile = firstActiveManagedProfile(effectiveProfiles, [
+      "quality-optimized",
+      "balanced",
+      "cost-optimized",
+    ]);
     if (defaultAdvisorProfile) {
       llm.advisorProfile = defaultAdvisorProfile;
     } else if (requestedAdvisorIsDisabledManaged) {
@@ -250,14 +186,6 @@ export function seedInferenceProfiles(
     if (!orderSet.has(name)) {
       profileOrder.push(name);
       orderSet.add(name);
-    }
-  }
-  if (userConnectionName) {
-    for (const name of Object.keys(USER_PROFILE_TEMPLATES)) {
-      if (!orderSet.has(name)) {
-        profileOrder.push(name);
-        orderSet.add(name);
-      }
     }
   }
   llm.profileOrder = profileOrder;
@@ -391,36 +319,6 @@ function pruneRemovedProfileReferences(
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function selectDefaultAdvisorProfile(
-  profiles: Record<string, Record<string, unknown>>,
-  preferPersonalProfile: boolean,
-): string | undefined {
-  const personal = firstActiveProfile(profiles, [
-    "custom-quality-optimized",
-    "custom-balanced",
-    "custom-cost-optimized",
-  ]);
-  const managed = firstActiveManagedProfile(profiles, [
-    "quality-optimized",
-    "balanced",
-    "cost-optimized",
-  ]);
-  return preferPersonalProfile ? (personal ?? managed) : (managed ?? personal);
-}
-
-function firstActiveProfile(
-  profiles: Record<string, Record<string, unknown>>,
-  names: string[],
-): string | undefined {
-  for (const name of names) {
-    const profile = readObject(profiles[name]);
-    if (profile && profile.status !== "disabled") {
-      return name;
-    }
-  }
-  return undefined;
 }
 
 function firstActiveManagedProfile(

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -474,13 +474,11 @@ export async function runDaemon(): Promise<void> {
   // seeder and persisted alongside schema defaults.
   const defaultConfigMerge = mergeDefaultWorkspaceConfig();
 
-  // Seed inference profiles into the workspace config. Managed Anthropic
-  // profiles are overwritten on every boot so Vellum can push updates.
-  // Off-platform hatches additionally create user profiles + a personal
-  // provider connection for the hatch provider.
+  // Seed inference profiles into the workspace config: active/advisor
+  // resolution plus, on off-platform hatches, `llm.defaultProvider` and a
+  // personal provider connection for the hatch provider.
   try {
     seedInferenceProfiles({
-      preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
       preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
       isHatch: defaultConfigMerge.hadOverlay,
       db: dbReady ? getDb() : undefined,


### PR DESCRIPTION
## Summary
- Stop writing disabled managed stubs and editable custom-* profile copies at BYOK hatch; the default profiles resolve active through llm.defaultProvider's column of the code-owned intent × provider matrix
- Hatch still creates the <provider>-personal connection and stamps llm.defaultProvider; activeProfile is now always "balanced"
- Advisor selection simplified to the managed default list

Part of plan: byok-code-defined-defaults.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->