### PR TITLE
feat(workspace): convert existing BYOK installs to code-defined default profiles

### DIFF
--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Tests for `ensureByokDefaultProfiles` in
+ * `workspace/byok-default-profile-ensure.ts`.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  materializeProfile,
+  resolveDefaultProfileForProvider,
+  USER_PROFILE_TEMPLATES,
+} from "../config/default-profile-catalog.js";
+import type { DefaultProfileProvider } from "../config/default-profile-names.js";
+import type { ProfileEntry } from "../config/schemas/llm.js";
+import { ensureByokDefaultProfiles } from "../workspace/byok-default-profile-ensure.js";
+
+let workspaceDir: string;
+let originalIsPlatform: string | undefined;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-byok-default-profile-ensure-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(configPath(), JSON.stringify(data, null, 2) + "\n");
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath(), "utf-8"));
+}
+
+function llm(): Record<string, unknown> {
+  return readConfig().llm as Record<string, unknown>;
+}
+
+function profiles(): Record<string, Record<string, unknown>> {
+  return llm().profiles as Record<string, Record<string, unknown>>;
+}
+
+function hatchBody(
+  key: "balanced" | "quality-optimized" | "cost-optimized",
+  provider: DefaultProfileProvider,
+): ProfileEntry {
+  const template = USER_PROFILE_TEMPLATES[`custom-${key}`];
+  if (template === undefined) {
+    throw new Error(`No user profile template for custom-${key}`);
+  }
+  return materializeProfile(template, provider, `${provider}-personal`);
+}
+
+/** An unedited anthropic BYOK install as the hatch seeder laid it out. */
+function uneditedByokConfig(): Record<string, unknown> {
+  return {
+    llm: {
+      defaultProvider: { provider: "anthropic" },
+      activeProfile: "custom-balanced",
+      advisorProfile: "custom-quality-optimized",
+      profileOrder: [
+        "balanced",
+        "quality-optimized",
+        "cost-optimized",
+        "custom-balanced",
+        "custom-quality-optimized",
+        "custom-cost-optimized",
+      ],
+      callSites: {
+        subagentSpawn: { profile: "custom-cost-optimized" },
+      },
+      profiles: {
+        balanced: {
+          source: "managed",
+          status: "disabled",
+          label: "Balanced (Managed)",
+        },
+        "quality-optimized": {
+          source: "managed",
+          status: "disabled",
+          label: "Quality (Managed)",
+        },
+        "cost-optimized": {
+          source: "managed",
+          status: "disabled",
+          label: "Speed (Managed)",
+        },
+        "custom-balanced": hatchBody("balanced", "anthropic"),
+        "custom-quality-optimized": hatchBody("quality-optimized", "anthropic"),
+        "custom-cost-optimized": hatchBody("cost-optimized", "anthropic"),
+        "my-mix": {
+          source: "user",
+          label: "My Mix",
+          mix: [
+            { profile: "custom-balanced", weight: 1 },
+            { profile: "custom-quality-optimized", weight: 1 },
+          ],
+        },
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  freshWorkspace();
+  originalIsPlatform = process.env.IS_PLATFORM;
+  delete process.env.IS_PLATFORM;
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+  if (originalIsPlatform === undefined) {
+    delete process.env.IS_PLATFORM;
+  } else {
+    process.env.IS_PLATFORM = originalIsPlatform;
+  }
+});
+
+describe("ensureByokDefaultProfiles", () => {
+  test("converts an unedited install onto the code-defined defaults", () => {
+    writeConfig(uneditedByokConfig());
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles().balanced).toBeUndefined();
+    expect(profiles()["quality-optimized"]).toBeUndefined();
+    expect(profiles()["cost-optimized"]).toBeUndefined();
+    expect(profiles()["custom-balanced"]).toBeUndefined();
+    expect(profiles()["custom-quality-optimized"]).toBeUndefined();
+    expect(profiles()["custom-cost-optimized"]).toBeUndefined();
+
+    expect(llm().activeProfile).toBe("balanced");
+    expect(llm().advisorProfile).toBe("quality-optimized");
+    expect(llm().profileOrder).toEqual([
+      "balanced",
+      "quality-optimized",
+      "cost-optimized",
+    ]);
+    const callSites = llm().callSites as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(callSites.subagentSpawn?.profile).toBe("cost-optimized");
+    expect(profiles()["my-mix"]?.mix).toEqual([
+      { profile: "balanced", weight: 1 },
+      { profile: "quality-optimized", weight: 1 },
+    ]);
+
+    // With the stub gone, the default resolves active and code-defined from
+    // the BYOK provider's catalog column.
+    const resolved = resolveDefaultProfileForProvider(
+      profiles() as Record<string, ProfileEntry>,
+      "balanced",
+      { provider: "anthropic" },
+    );
+    expect(resolved?.source).toBe("managed");
+    expect(resolved?.status).toBeUndefined();
+    expect(resolved?.provider).toBe("anthropic");
+    expect(resolved?.provider_connection).toBe("anthropic-personal");
+  });
+
+  test("second run is a no-op with unchanged file bytes", () => {
+    writeConfig(uneditedByokConfig());
+
+    ensureByokDefaultProfiles(workspaceDir);
+    const first = readFileSync(configPath(), "utf-8");
+    ensureByokDefaultProfiles(workspaceDir);
+    const second = readFileSync(configPath(), "utf-8");
+
+    expect(second).toBe(first);
+  });
+
+  test("a user-edited custom copy survives untouched with its references", () => {
+    const config = uneditedByokConfig();
+    const llmConfig = config.llm as Record<string, unknown>;
+    const profileMap = llmConfig.profiles as Record<
+      string,
+      Record<string, unknown>
+    >;
+    profileMap["custom-balanced"] = {
+      ...profileMap["custom-balanced"],
+      model: "claude-opus-4-6",
+    };
+    writeConfig(config);
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-balanced"]).toEqual({
+      ...hatchBody("balanced", "anthropic"),
+      model: "claude-opus-4-6",
+    });
+    expect(llm().activeProfile).toBe("custom-balanced");
+    expect(llm().profileOrder).toContain("custom-balanced");
+    expect(profiles()["my-mix"]?.mix).toEqual([
+      { profile: "custom-balanced", weight: 1 },
+      { profile: "quality-optimized", weight: 1 },
+    ]);
+
+    expect(profiles()["custom-quality-optimized"]).toBeUndefined();
+    expect(profiles()["custom-cost-optimized"]).toBeUndefined();
+    expect(llm().advisorProfile).toBe("quality-optimized");
+    const callSites = llm().callSites as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(callSites.subagentSpawn?.profile).toBe("cost-optimized");
+  });
+
+  test("label and status differences do not count as edits", () => {
+    const config = uneditedByokConfig();
+    const profileMap = (config.llm as Record<string, unknown>)
+      .profiles as Record<string, Record<string, unknown>>;
+    profileMap["custom-balanced"] = {
+      ...profileMap["custom-balanced"],
+      label: "Balanced (renamed)",
+      status: "disabled",
+    };
+    writeConfig(config);
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-balanced"]).toBeUndefined();
+    expect(llm().activeProfile).toBe("balanced");
+  });
+
+  test("the frozen pre-136 fireworks kimi body converts", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "fireworks" },
+        activeProfile: "custom-cost-optimized",
+        profiles: {
+          "custom-cost-optimized": {
+            source: "user",
+            label: "Speed",
+            description: "Fastest responses at lower cost",
+            maxTokens: 8192,
+            effort: "low",
+            thinking: { enabled: false, streamThinking: false },
+            contextWindow: { maxInputTokens: 200000 },
+            provider: "fireworks",
+            provider_connection: "fireworks-personal",
+            model: "accounts/fireworks/models/kimi-k2p5",
+          },
+        },
+      },
+    });
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-cost-optimized"]).toBeUndefined();
+    expect(llm().activeProfile).toBe("cost-optimized");
+  });
+
+  test("the pre-096 effort-max quality body converts", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        advisorProfile: "custom-quality-optimized",
+        profiles: {
+          "custom-quality-optimized": {
+            ...hatchBody("quality-optimized", "anthropic"),
+            effort: "max",
+          },
+        },
+      },
+    });
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-quality-optimized"]).toBeUndefined();
+    expect(llm().advisorProfile).toBe("quality-optimized");
+  });
+
+  test("no-op on platform installs", () => {
+    process.env.IS_PLATFORM = "true";
+    writeConfig(uneditedByokConfig());
+    const before = readFileSync(configPath(), "utf-8");
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("no-op when the default provider is vellum", () => {
+    const config = uneditedByokConfig();
+    (config.llm as Record<string, unknown>).defaultProvider = {
+      provider: "vellum",
+    };
+    writeConfig(config);
+    const before = readFileSync(configPath(), "utf-8");
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("no-op when llm.defaultProvider is absent or invalid", () => {
+    const config = uneditedByokConfig();
+    delete (config.llm as Record<string, unknown>).defaultProvider;
+    writeConfig(config);
+    const before = readFileSync(configPath(), "utf-8");
+    ensureByokDefaultProfiles(workspaceDir);
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+
+    (config.llm as Record<string, unknown>).defaultProvider = {
+      provider: "not-a-provider",
+    };
+    writeConfig(config);
+    const invalidBefore = readFileSync(configPath(), "utf-8");
+    ensureByokDefaultProfiles(workspaceDir);
+    expect(readFileSync(configPath(), "utf-8")).toBe(invalidBefore);
+  });
+
+  test("tolerates a missing or malformed config without throwing", () => {
+    expect(() => ensureByokDefaultProfiles(workspaceDir)).not.toThrow();
+    expect(existsSync(configPath())).toBe(false);
+
+    writeFileSync(configPath(), "not valid json {{{");
+    expect(() => ensureByokDefaultProfiles(workspaceDir)).not.toThrow();
+
+    writeConfig({ llm: "not-an-object" });
+    expect(() => ensureByokDefaultProfiles(workspaceDir)).not.toThrow();
+  });
+
+  test("a user-source shadow under a default key is left alone", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "openai" },
+        profiles: {
+          balanced: {
+            source: "user",
+            provider: "openai",
+            model: "gpt-5.4",
+          },
+        },
+      },
+    });
+    const before = readFileSync(configPath(), "utf-8");
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("a managed-source default entry with body keys is left alone", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "openai" },
+        profiles: {
+          balanced: {
+            source: "managed",
+            status: "disabled",
+            label: "Balanced (Managed)",
+            model: "gpt-5.4",
+          },
+        },
+      },
+    });
+    const before = readFileSync(configPath(), "utf-8");
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("a custom copy for a different provider is kept", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "openai" },
+        profiles: {
+          "custom-balanced": hatchBody("balanced", "anthropic"),
+        },
+      },
+    });
+    const before = readFileSync(configPath(), "utf-8");
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -61,6 +61,7 @@ import {
 import { APP_VERSION } from "../version.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-thinking-repair.js";
+import { ensureByokDefaultProfiles } from "../workspace/byok-default-profile-ensure.js";
 import { ensureCompleteCustomProfiles } from "../workspace/custom-profile-ensure.js";
 import { ensureDefaultProvider } from "../workspace/default-provider-ensure.js";
 import { startWorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
@@ -521,6 +522,20 @@ export async function runDaemon(): Promise<void> {
     log.warn(
       { err },
       "Default provider ensure pass failed — continuing startup",
+    );
+  }
+
+  // Runs on every boot, after the default-provider ensure (it keys off
+  // llm.defaultProvider) and before custom-profile materialization (so
+  // unedited hatch copies still deep-equal their templates when compared).
+  // See workspace/byok-default-profile-ensure.ts for the full rationale.
+  try {
+    ensureByokDefaultProfiles(getWorkspaceDir());
+    log.info("BYOK default profile ensure pass complete");
+  } catch (err) {
+    log.warn(
+      { err },
+      "BYOK default profile ensure pass failed; continuing startup",
     );
   }
 

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -1,0 +1,295 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  materializeProfile,
+  USER_PROFILE_TEMPLATES,
+} from "../config/default-profile-catalog.js";
+import {
+  DEFAULT_PROFILE_KEYS,
+  type DefaultProfileKey,
+} from "../config/default-profile-names.js";
+import { resolveDefaultConnectionName } from "../config/default-provider-resolution.js";
+import { getIsPlatform } from "../config/env-registry.js";
+import { invalidateConfigCache } from "../config/loader.js";
+import {
+  type DefaultProviderConfig,
+  DefaultProviderSchema,
+} from "../config/schemas/llm.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("byok-default-profile-ensure");
+
+// Converts BYOK installs from the hatch-era profile layout (disabled managed
+// stubs for the default keys plus editable `custom-*` copies) onto the
+// code-defined default profiles: the stubs and unedited copies are removed so
+// `balanced`/`quality-optimized`/`cost-optimized` resolve active and
+// read-only from the default provider's column of the intent x provider
+// matrix, and every named reference to a removed `custom-*` entry is
+// repointed at the bare key. A `custom-*` copy the user edited is kept
+// untouched as an ordinary user profile, references included.
+//
+// This is a boot ensure pass rather than a workspace migration because
+// "unedited" is judged against the live catalog: the primary comparison body
+// is `materializeProfile(USER_PROFILE_TEMPLATES[...])`, which resolves the
+// current per-provider model intents, and migrations are frozen
+// self-contained snapshots that may not import it (see
+// workspace/migrations/AGENTS.md). Running unconditionally each boot (the
+// `ensureDefaultProvider` pattern) also covers configs restored from backups
+// and freshly-hatched installs whose seeder still wrote the legacy layout.
+//
+// Idempotent and write-avoidant: the file is rewritten only when at least one
+// stub or copy was removed.
+
+/**
+ * A hatch stub is a thin managed entry carrying only the workspace-owned
+ * overlay fields; a managed-source entry with any other key (a platform
+ * overlay body) is not a stub and is left alone.
+ */
+const STUB_ONLY_KEYS = new Set(["source", "status", "label"]);
+
+/**
+ * Comparison ignores `label` and `status`: both are workspace-owned overlay
+ * state (BYOK label suffixes, enable/disable toggles), not content edits.
+ */
+const IGNORED_COMPARISON_KEYS = new Set(["label", "status"]);
+
+/**
+ * Frozen hatch-era `custom-*` bodies rewritten in place by a repair
+ * migration, kept as literals migration-style so later template changes
+ * cannot silently widen the match set. The other profile-model migrations
+ * (100, 101, 103, 108, 109, 110, 113, 123) rewrite only the managed default
+ * entries, and 128's stale Grok ids predate `custom-*` seeding entirely, so
+ * none of them contributes a body here.
+ */
+const FROZEN_HATCH_BODIES: Partial<
+  Record<DefaultProfileKey, Record<string, unknown>[]>
+> = {
+  // 136-repair-stale-fireworks-kimi-model-id: fireworks hatches pinned the
+  // then-current latency intent, accounts/fireworks/models/kimi-k2p5. The
+  // migration rewrites the pin to deepseek-v4-flash (today's intent, so the
+  // repaired body matches the current template above), but a config restored
+  // from a pre-136 backup still carries this body.
+  "cost-optimized": [
+    {
+      source: "user",
+      description: "Fastest responses at lower cost",
+      maxTokens: 8192,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 200000 },
+      provider: "fireworks",
+      provider_connection: "fireworks-personal",
+      model: "accounts/fireworks/models/kimi-k2p5",
+    },
+  ],
+};
+
+export function ensureByokDefaultProfiles(workspaceDir: string): void {
+  const configPath = join(workspaceDir, "config.json");
+  if (!existsSync(configPath)) {
+    return;
+  }
+  if (getIsPlatform()) {
+    return;
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return;
+    }
+    config = raw as Record<string, unknown>;
+  } catch {
+    return;
+  }
+
+  const llm = readObject(config.llm);
+  if (llm === null) {
+    return;
+  }
+  const parsedDefault = DefaultProviderSchema.safeParse(llm.defaultProvider);
+  if (!parsedDefault.success || parsedDefault.data.provider === "vellum") {
+    return;
+  }
+  const profiles = readObject(llm.profiles);
+  if (profiles === null) {
+    return;
+  }
+
+  let changed = false;
+
+  // Deleting a thin disabled stub makes the default key resolve active from
+  // the default provider's catalog column (and drops the stub's
+  // "(Managed)"-suffixed label). User-source shadows and managed entries with
+  // body keys are left alone.
+  for (const key of DEFAULT_PROFILE_KEYS) {
+    const entry = readObject(profiles[key]);
+    if (entry === null || entry.source !== "managed") {
+      continue;
+    }
+    if (!Object.keys(entry).every((k) => STUB_ONLY_KEYS.has(k))) {
+      continue;
+    }
+    delete profiles[key];
+    changed = true;
+    log.info(
+      { profile: key },
+      "Removed hatch stub for a default profile; it resolves from the code catalog",
+    );
+  }
+
+  const retired = new Map<string, string>();
+  for (const key of DEFAULT_PROFILE_KEYS) {
+    const name = `custom-${key}`;
+    const entry = readObject(profiles[name]);
+    if (
+      entry === null ||
+      !isKnownUneditedBody(entry, key, parsedDefault.data)
+    ) {
+      continue;
+    }
+    delete profiles[name];
+    retired.set(name, key);
+    changed = true;
+    log.info(
+      { profile: name, replacement: key },
+      "Retired unedited hatch copy of a default profile",
+    );
+  }
+
+  if (retired.size > 0) {
+    repointRetiredReferences(llm, profiles, retired);
+  }
+
+  if (!changed) {
+    return;
+  }
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  // The lifecycle call site runs before the first loadConfig() of this boot;
+  // this guards callers that read config earlier (and future reordering).
+  invalidateConfigCache();
+}
+
+function isKnownUneditedBody(
+  entry: Record<string, unknown>,
+  key: DefaultProfileKey,
+  defaultProvider: DefaultProviderConfig,
+): boolean {
+  const body = comparableBody(entry);
+  return knownHatchBodies(key, defaultProvider).some((known) =>
+    isDeepStrictEqual(body, known),
+  );
+}
+
+function knownHatchBodies(
+  key: DefaultProfileKey,
+  defaultProvider: DefaultProviderConfig,
+): Record<string, unknown>[] {
+  const bodies: Record<string, unknown>[] = [];
+
+  const template = USER_PROFILE_TEMPLATES[`custom-${key}`];
+  if (template !== undefined) {
+    bodies.push(
+      comparableBody(
+        materializeProfile(
+          template,
+          defaultProvider.provider,
+          resolveDefaultConnectionName(defaultProvider),
+        ) as Record<string, unknown>,
+      ),
+    );
+  }
+
+  for (const frozen of FROZEN_HATCH_BODIES[key] ?? []) {
+    if (frozen.provider === defaultProvider.provider) {
+      bodies.push(comparableBody(frozen));
+    }
+  }
+
+  // 096-reduce-quality-profile-effort: hatch seeding produced effort "max"
+  // on this copy until the migration rewrote it to "high". The migration
+  // applied that rewrite regardless of who set the value, so an
+  // effort-"max" variant of any known body counts as equally unedited.
+  if (key === "quality-optimized") {
+    bodies.push(...bodies.map((body) => ({ ...body, effort: "max" })));
+  }
+
+  return bodies;
+}
+
+function comparableBody(
+  entry: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(entry).filter(([k]) => !IGNORED_COMPARISON_KEYS.has(k)),
+  );
+}
+
+/**
+ * Repoint every named reference to a retired `custom-*` entry at its bare
+ * default key: `activeProfile`, `advisorProfile`, call-site `profile`
+ * overrides, and mix arms on remaining profiles. The retired name is removed
+ * from `profileOrder` (the bare key is seeded there on every boot).
+ */
+function repointRetiredReferences(
+  llm: Record<string, unknown>,
+  profiles: Record<string, unknown>,
+  retired: Map<string, string>,
+): void {
+  if (typeof llm.activeProfile === "string" && retired.has(llm.activeProfile)) {
+    llm.activeProfile = retired.get(llm.activeProfile);
+  }
+  if (
+    typeof llm.advisorProfile === "string" &&
+    retired.has(llm.advisorProfile)
+  ) {
+    llm.advisorProfile = retired.get(llm.advisorProfile);
+  }
+
+  const callSites = readObject(llm.callSites);
+  if (callSites !== null) {
+    for (const value of Object.values(callSites)) {
+      const site = readObject(value);
+      if (
+        site !== null &&
+        typeof site.profile === "string" &&
+        retired.has(site.profile)
+      ) {
+        site.profile = retired.get(site.profile);
+      }
+    }
+  }
+
+  for (const value of Object.values(profiles)) {
+    const entry = readObject(value);
+    if (entry === null || !Array.isArray(entry.mix)) {
+      continue;
+    }
+    for (const arm of entry.mix) {
+      const armObj = readObject(arm);
+      if (
+        armObj !== null &&
+        typeof armObj.profile === "string" &&
+        retired.has(armObj.profile)
+      ) {
+        armObj.profile = retired.get(armObj.profile);
+      }
+    }
+  }
+
+  if (Array.isArray(llm.profileOrder)) {
+    llm.profileOrder = (llm.profileOrder as unknown[]).filter(
+      (name) => typeof name !== "string" || !retired.has(name),
+    );
+  }
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- New boot ensure pass ensureByokDefaultProfiles removes the disabled hatch stubs and retires unedited custom-* profile copies on BYOK installs, repointing activeProfile/advisor/call-site/mix/profileOrder references to the code-defined default keys
- User-edited custom-* entries survive untouched as ordinary user profiles
- Runs between ensureDefaultProvider and ensureCompleteCustomProfiles in daemon lifecycle; idempotent and write-avoidant

Part of plan: byok-code-defined-defaults.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->