### PR TITLE
fix(web): render chat-header hamburger and search icons as bare glyphs on the iOS shell

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -113,3 +113,16 @@ describe("ChatLayoutHeader — right cluster", () => {
     expect(toggleCommandPaletteSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("ChatLayoutHeader mobile affordances", () => {
+  test("renders the hamburger and search affordances with their aria wiring", () => {
+    renderHeader({ drawerOpen: false });
+
+    const hamburger = screen.getByRole("button", { name: "Open navigation" });
+    expect(hamburger.getAttribute("aria-expanded")).toBe("false");
+    expect(hamburger.getAttribute("aria-controls")).toBe("chat-side-menu");
+    expect(
+      screen.getByRole("button", { name: "Search (Ctrl+K)" }),
+    ).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -23,6 +23,11 @@ import { useTitleBarStore } from "@/stores/title-bar-store";
 // Off Electron the inset is 0.
 const ELECTRON_TRAFFIC_LIGHT_CLEARANCE = 80;
 
+// iOS shell only: strip the touch-mobile pill fill so the glyph floats
+// bare while keeping the 40x40 tap target and focus ring.
+const NATIVE_IOS_BARE_ICON_BUTTON =
+  "native-ios:bg-transparent native-ios:hover:bg-transparent native-ios:active:bg-transparent";
+
 export interface ChatLayoutHeaderProps {
   isMobile: boolean;
   drawerOpen: boolean;
@@ -107,6 +112,7 @@ export function ChatLayoutHeader({
       iconOnly={<Search />}
       aria-label="Search (Ctrl+K)"
       tooltip="Search (Ctrl+K)"
+      className={NATIVE_IOS_BARE_ICON_BUTTON}
       onClick={handleSearchClick}
     />
   ) : null;
@@ -160,6 +166,7 @@ export function ChatLayoutHeader({
             aria-expanded={drawerOpen}
             aria-controls="chat-side-menu"
             tooltip="Open navigation"
+            className={NATIVE_IOS_BARE_ICON_BUTTON}
             onClick={toggleSidebar}
           />
         ) : (


### PR DESCRIPTION
## Summary

- On the Capacitor iOS shell only, strip the `touch-mobile` circular pill fill from the chat header's mobile hamburger and Search buttons so the glyphs float bare, via a call-site `native-ios:` className merge (rest, hover, and active states all covered so a tap cannot flash the pill back in).
- `expandOnMobile` stays at its default, so the 40x40 tap target, the circular focus ring, and every aria attribute (`aria-label`, `aria-expanded`, `aria-controls`) are unchanged. The desktop `PanelLeft` toggle is untouched. Mobile Safari, desktop web, and Electron are byte-for-byte unchanged because the `data-native-platform="ios"` marker is absent there.
- Added a test pinning that both mobile affordances still render with their aria wiring intact.

Part of plan: ios-capacitor-ui-polish.md (PR 4 of 9)