### PR TITLE
fix(web): render sidebar close and search icons as bare glyphs on the iOS shell

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -524,6 +524,11 @@ describe("AssistantSideMenu · overlay close affordance", () => {
     expect(overlayHtml).toContain('aria-label="Close navigation"');
     expect(railHtml).not.toContain('aria-label="Close navigation"');
   });
+
+  test("keeps the search affordance in the overlay header", () => {
+    const overlayHtml = renderMenu({ conversations: [], variant: "overlay" });
+    expect(overlayHtml).toContain('aria-label="Search (⌘K)"');
+  });
 });
 
 describe("AssistantSideMenu · section header menus", () => {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -41,6 +41,11 @@ import {
 import { getChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
 import { Button, SideMenu } from "@vellumai/design-library";
 
+// iOS shell only: strip the touch-mobile pill fill so the glyph floats
+// bare while keeping the 40x40 tap target and focus ring.
+const NATIVE_IOS_BARE_ICON_BUTTON =
+  "native-ios:bg-transparent native-ios:hover:bg-transparent native-ios:active:bg-transparent";
+
 /** @deprecated Use {@link SIDEBAR_CONVERSATION_LIMIT} from `use-sidebar-state.ts` */
 export const ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT =
   SIDEBAR_CONVERSATION_LIMIT;
@@ -112,6 +117,7 @@ function SearchButton() {
       iconOnly={<Search />}
       aria-label="Search (⌘K)"
       title="Search (⌘K)"
+      className={NATIVE_IOS_BARE_ICON_BUTTON}
       onClick={handleClick}
     />
   );
@@ -406,6 +412,7 @@ export function AssistantSideMenu({
                 variant="ghost"
                 iconOnly={<X />}
                 aria-label="Close navigation"
+                className={NATIVE_IOS_BARE_ICON_BUTTON}
                 onClick={() => onClose?.()}
               />
               <SearchButton />


### PR DESCRIPTION
## Summary

- Adds a `NATIVE_IOS_BARE_ICON_BUTTON` class constant to `assistant-side-menu.tsx` and applies it to the overlay close (X) button and the sidebar `SearchButton`, stripping the design library's `touch-mobile` pill fill (rest, hover, and active) inside the Capacitor iOS shell only.
- Paint only: `expandOnMobile` stays at its default so the 40x40 tap target, the circular focus ring, and both `aria-label`s are untouched. Desktop web, Electron, and mobile Safari are unchanged because the `data-native-platform="ios"` marker is absent there.
- Verified the mechanism rather than assuming it: Tailwind compiles `native-ios:bg-transparent` to `.native-ios\:bg-transparent:is(:root[data-native-platform="ios"] *)` (0,3,0) and the hover/active forms to (0,4,0), which outrank the `touch-mobile` pill rules at (0,1,0)/(0,2,0) and the ghost variant's own `active:bg-*`; tailwind-merge keeps all three `native-ios:` classes alongside `touch-mobile:h-10 touch-mobile:w-10`, so the tap target survives. The real visual gate is still the iOS simulator.

Part of plan: ios-capacitor-ui-polish.md (PR 3 of 9)