### PR TITLE
fix(web): hide themed scrollbars inside the Capacitor iOS shell

### DIFF
--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -572,13 +572,15 @@ body {
  * ::-webkit-scrollbar above replaces WKWebView's auto-hiding overlay
  * indicator with an always-visible bar, which reads as broken on iOS.
  * Scrolling and momentum are unaffected. The
- * :root[data-native-platform="ios"] prefix outranks the :root * and
+ * :root[data-native-platform="ios"] prefix covers both the document
+ * scrollbar and every inner scroller, and outranks the :root * and
  * [data-theme] scrollbar rules above on specificity. */
 :root[data-native-platform="ios"],
 :root[data-native-platform="ios"] * {
   scrollbar-width: none;
 }
 
+:root[data-native-platform="ios"]::-webkit-scrollbar,
 :root[data-native-platform="ios"] ::-webkit-scrollbar {
   display: none;
   width: 0;

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -568,6 +568,23 @@ body {
   background-clip: padding-box;
 }
 
+/* Capacitor iOS shell: hide scrollbars entirely. Styling
+ * ::-webkit-scrollbar above replaces WKWebView's auto-hiding overlay
+ * indicator with an always-visible bar, which reads as broken on iOS.
+ * Scrolling and momentum are unaffected. The
+ * :root[data-native-platform="ios"] prefix outranks the :root * and
+ * [data-theme] scrollbar rules above on specificity. */
+:root[data-native-platform="ios"],
+:root[data-native-platform="ios"] * {
+  scrollbar-width: none;
+}
+
+:root[data-native-platform="ios"] ::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .busy-indicator {
     animation: none;


### PR DESCRIPTION
## Summary

- Adds one iOS-scoped block to `clients/web/src/index.css` that sets `scrollbar-width: none` and hides the `::-webkit-scrollbar` family under `:root[data-native-platform="ios"]`, the marker PR 1 stamps on `<html>` at boot.
- Root cause: the global themed-scrollbar rules replace WKWebView's auto-hiding overlay indicator with an always-rendered 8px bar, which reads as broken on iOS. One root-scoped block covers all 84+ scroll containers plus the design-library scroll primitives (side menu, modal, bottom sheet, dropdown, resizable panel, markdown message, scroll shadow) instead of per-component classes.
- Desktop web, Electron, and mobile Safari are unchanged: the attribute is absent there, so the new rules never match. `sandbox-bridge.ts` and the ad-hoc `[scrollbar-width:none]` usages are untouched.

Verified the production bundle emits the rules in the right cascade position, and confirmed no `scrollbar-gutter` or `offsetWidth - clientWidth` math exists in either package, so hiding the indicator cannot shift layout or break scroll math. iOS simulator check is the real acceptance gate and is still outstanding.

Part of plan: ios-capacitor-ui-polish.md (PR 2 of 9)