### PR TITLE
chore(web): declare the iOS keyboard accessory bar hidden at boot

### DIFF
--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -37,10 +37,11 @@ export interface VisibleViewport {
 // keyboard opens and only `visualViewport.height` shrinks, so
 // `innerHeight - vv.height` directly yields the keyboard height.
 //
-// In WKWebView (Capacitor iOS without `@capacitor/keyboard`), the web view
-// frame itself is resized to fit above the keyboard. Both `innerHeight` and
-// `vv.height` shrink together, making `innerHeight - vv.height ≈ 0` even when
-// the keyboard is visible. By comparing against the maximum observed
+// In WKWebView (Capacitor iOS; `@capacitor/keyboard` is installed and left at
+// its default `resize: native` mode), the web view frame itself is resized to
+// fit above the keyboard. Both `innerHeight` and `vv.height` shrink together,
+// making `innerHeight - vv.height ≈ 0` even when the keyboard is visible. By
+// comparing against the maximum observed
 // `innerHeight` — which corresponds to the keyboard-dismissed state — keyboard
 // detection works correctly across both runtimes.
 //
@@ -106,8 +107,9 @@ export function readVisibleViewport(): VisibleViewport | null {
  *
  * In Safari, the soft keyboard shrinks `visualViewport.height` while
  * `window.innerHeight` stays at the full layout viewport. In Capacitor's
- * WKWebView (without `@capacitor/keyboard`), the web view frame itself
- * resizes, shrinking both values together. The `referenceInnerHeight`
+ * WKWebView (with `@capacitor/keyboard` installed at its default
+ * `resize: native` mode), the web view frame itself resizes, shrinking both
+ * values together. The `referenceInnerHeight`
  * approach in `readVisibleViewport` handles both cases — see the module-level
  * comment above it.
  *

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -25,6 +25,7 @@ import { router } from "./routes";
 import "@/lib/api-interceptors";
 import "./index.css";
 
+import { initNativeKeyboard } from "@/runtime/native-keyboard";
 import { initNativePlatformAttributes } from "@/runtime/native-platform-attributes";
 import { initSafeAreaBridge } from "@/runtime/native-safe-area";
 import { initInputModality } from "@vellumai/design-library";
@@ -37,6 +38,7 @@ async function boot() {
   initInputModality();
   initNativePlatformAttributes();
   await initSafeAreaBridge();
+  void initNativeKeyboard();
   initSentry();
   initSessionReplay();
   installConsentRefreshListeners();

--- a/clients/web/src/runtime/native-keyboard.test.ts
+++ b/clients/web/src/runtime/native-keyboard.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for `initNativeKeyboard`.
+ *
+ * These pin the platform gate and the backwards-compat contract: shells built
+ * before `@capacitor/keyboard` was linked reject the call, and boot must not
+ * surface that as an error.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockIsNativeIOS = false;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => mockIsNativeIOS,
+}));
+
+const setAccessoryBarVisible = mock(
+  async (_options: { isVisible: boolean }) => {},
+);
+mock.module("@capacitor/keyboard", () => ({
+  Keyboard: { setAccessoryBarVisible },
+}));
+
+const { initNativeKeyboard } = await import("@/runtime/native-keyboard");
+
+beforeEach(() => {
+  mockIsNativeIOS = false;
+  setAccessoryBarVisible.mockClear();
+});
+
+describe("initNativeKeyboard", () => {
+  test("never touches the plugin outside the native iOS shell", async () => {
+    await initNativeKeyboard();
+    expect(setAccessoryBarVisible).not.toHaveBeenCalled();
+  });
+
+  test("declares the accessory bar hidden inside the native iOS shell", async () => {
+    mockIsNativeIOS = true;
+    await initNativeKeyboard();
+    expect(setAccessoryBarVisible).toHaveBeenCalledTimes(1);
+    expect(setAccessoryBarVisible).toHaveBeenCalledWith({ isVisible: false });
+  });
+
+  test("swallows a rejection from a shell without the plugin", async () => {
+    mockIsNativeIOS = true;
+    setAccessoryBarVisible.mockImplementationOnce(async () => {
+      throw new Error("not implemented");
+    });
+    await initNativeKeyboard();
+    expect(setAccessoryBarVisible).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/runtime/native-keyboard.ts
+++ b/clients/web/src/runtime/native-keyboard.ts
@@ -1,0 +1,27 @@
+import { isNativeIOS } from "@/runtime/platform-detection";
+
+/**
+ * Declare at the JS layer that the iOS keyboard input accessory bar (prev/next
+ * chevrons plus Done) stays hidden.
+ *
+ * This call is not what removes the bar. `@capacitor/keyboard` sets
+ * `hideFormAccessoryBar = YES` unconditionally in its native `load()`
+ * (`Keyboard.m:187`, no config gate), so linking the plugin already hides the
+ * bar on every native build; the call only states that intent explicitly and
+ * pins it against a change to the upstream default.
+ *
+ * Shells built before the plugin was linked never run that `load()`, so they
+ * keep the bar and reject the call with "not implemented"; swallow so the
+ * current web bundle keeps working against them.
+ */
+export async function initNativeKeyboard(): Promise<void> {
+  if (!isNativeIOS()) {
+    return;
+  }
+  try {
+    const { Keyboard } = await import("@capacitor/keyboard");
+    await Keyboard.setAccessoryBarVisible({ isVisible: false });
+  } catch {
+    // Plugin missing from this native build; the bar stays until users update.
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `clients/web/src/runtime/native-keyboard.ts` and calls it fire-and-forget from `boot()`, declaring `setAccessoryBarVisible({ isVisible: false })` at the JS layer. This call is **not** what removes the accessory bar: `@capacitor/keyboard` sets `hideFormAccessoryBar = YES` unconditionally in its native `load()` (`Keyboard.m:187`, no config gate), so simply linking the plugin in #39502 already removed the bar on any native build. The call states that intent explicitly at the JS layer and pins the behavior against a future change to the upstream default.
- Shells built before the plugin was linked never run that `load()`, so they keep the bar and reject the call with "not implemented"; the swallowing catch keeps the current web bundle working against them until users update. Unit test (c) pins that backwards-compat contract.
- Refreshes two now-stale comments in `clients/web/src/hooks/use-visible-viewport.ts` that read "Capacitor iOS **without** `@capacitor/keyboard`". The plugin is now installed and left at its default `resize` mode (`ResizeNative`, `Keyboard.m:169`), which preserves exactly the whole-WKWebView-frame resize the hook's `referenceInnerHeight` math depends on, so the hook's logic is unchanged.

No `plugins.Keyboard` block and no `resize` override were added; the defaults are what the app already depends on. The declaration only reaches a device on a native shell built after #39502 (next TestFlight/App Store build). Desktop web, Electron, and mobile Safari are unaffected (`isNativeIOS()` is false, so the plugin chunk is never even imported).

Part of plan: ios-capacitor-ui-polish.md (PR 6 of 9)