### PR TITLE
Adjust-plan modal card reflects the sub's real plan and specs

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -11,9 +11,9 @@ import type { ProPlan } from "@/generated/api/types.gen";
 import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
 
 import {
+  currentPlanFeatures,
   currentTierRows,
   machineLabel,
-  nonTierFeatures,
   packageHighlights,
   packageSpecs,
 } from "./plan-spec";
@@ -154,6 +154,12 @@ describe("machineLabel", () => {
 describe("currentTierRows", () => {
   const proPlan = {
     id: "pro",
+    // `machine_tiers` is required on ProPlan and is consulted for the machine
+    // label, so the fixture carries it even where a test doesn't exercise it.
+    machine_tiers: [
+      { tier: "medium", label: "Medium" },
+      { tier: "large", label: "Large" },
+    ],
     credit_tiers: [
       { tier: "credits_50", label: "50 credits", credits_usd: 50 },
       { tier: "credits_25", label: "25 credits", credits_usd: 25 },
@@ -238,6 +244,21 @@ describe("currentTierRows", () => {
     ).toBe("Credit bundle");
   });
 
+  test("uses the catalog label for a tier the static map does not know", () => {
+    // The tier picker renders the server label, so the card has to agree
+    // rather than surfacing the raw identifier.
+    const withNewTier = {
+      ...proPlan,
+      machine_tiers: [{ tier: "xxl", label: "XXL" }],
+    } as unknown as ProPlan;
+    expect(
+      currentTierRows(
+        tiers({ machineTier: "xxl" as CurrentTiers["machineTier"] }),
+        withNewTier,
+      )[0],
+    ).toBe("XXL Machine");
+  });
+
   test("passes an unmapped machine tier through rather than dropping it", () => {
     expect(
       currentTierRows(
@@ -248,37 +269,63 @@ describe("currentTierRows", () => {
   });
 });
 
-describe("nonTierFeatures", () => {
-  // The four rows the platform catalog serves for Pro today.
+describe("currentPlanFeatures", () => {
   const CATALOG = [
     "Pay-as-you-go and bundled credits",
     "Configurable machine size",
     "Configurable storage",
     "Assistant email & subdomain",
   ];
+  const proPlan = {
+    id: "pro",
+    included_features: CATALOG,
+    machine_tiers: [{ tier: "large", label: "Large" }],
+    credit_tiers: [
+      { tier: "credits_50", label: "50 credits", credits_usd: 50 },
+    ],
+  } as unknown as ProPlan;
 
-  test("drops the rows the real tier values supersede", () => {
-    expect(nonTierFeatures(CATALOG)).toEqual(["Assistant email & subdomain"]);
+  const full: CurrentTiers = {
+    machineTier: "large",
+    storageTier: "s",
+    storageGib: 30,
+    creditTier: "credits_50",
+  };
+
+  test("replaces every capability row it has a real value for", () => {
+    expect(currentPlanFeatures(full, proPlan)).toEqual([
+      "Large Machine",
+      "30 GB",
+      "50 credits/mo",
+      "Assistant email & subdomain",
+    ]);
+  });
+
+  test("keeps the pay-as-you-go row when the sub holds no bundle", () => {
+    // Without this the card would say nothing at all about credits, dropping a
+    // capability the plan still has.
+    expect(currentPlanFeatures({ ...full, creditTier: null }, proPlan)).toEqual([
+      "Large Machine",
+      "30 GB",
+      "Pay-as-you-go and bundled credits",
+      "Assistant email & subdomain",
+    ]);
+  });
+
+  test("keeps the storage row when the GiB is unresolved", () => {
+    expect(currentPlanFeatures({ ...full, storageGib: null }, proPlan)).toEqual([
+      "Large Machine",
+      "50 credits/mo",
+      "Configurable storage",
+      "Assistant email & subdomain",
+    ]);
   });
 
   test("carries through an entitlement the platform adds later", () => {
-    // The regression this guards: a client-side mirror of the platform
-    // constant would silently drop any row it did not already know about.
-    expect(nonTierFeatures([...CATALOG, "Priority support"])).toEqual([
-      "Assistant email & subdomain",
-      "Priority support",
-    ]);
-  });
-
-  test("keeps a renamed capability row rather than dropping it", () => {
-    // Redundant next to the real value, but visible. Failing open beats
-    // silently omitting an entitlement the subscriber actually has.
-    expect(nonTierFeatures(["Configurable compute size"])).toEqual([
-      "Configurable compute size",
-    ]);
-  });
-
-  test("returns an empty list for an empty catalog", () => {
-    expect(nonTierFeatures([])).toEqual([]);
+    const extended = {
+      ...proPlan,
+      included_features: [...CATALOG, "Priority support"],
+    } as unknown as ProPlan;
+    expect(currentPlanFeatures(full, extended)).toContain("Priority support");
   });
 });

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -7,7 +7,15 @@ import {
   FREE_STORAGE_GIB,
 } from "@/domains/settings/billing/plan-tier-meta";
 
-import { machineLabel, packageHighlights, packageSpecs } from "./plan-spec";
+import type { ProPlan } from "@/generated/api/types.gen";
+import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
+
+import {
+  currentTierRows,
+  machineLabel,
+  packageHighlights,
+  packageSpecs,
+} from "./plan-spec";
 
 describe("packageSpecs", () => {
   test("uses the free/base baseline for a null package", () => {
@@ -139,5 +147,77 @@ describe("machineLabel", () => {
     expect(machineLabel({ machine_size: "extra_large" } as ProPackage)).toBe(
       "Extra Large",
     );
+  });
+});
+
+describe("currentTierRows", () => {
+  const proPlan = {
+    id: "pro",
+    credit_tiers: [
+      { tier: "credits_50", label: "50 credits", credits_usd: 50 },
+      { tier: "credits_25", label: "25 credits", credits_usd: 25 },
+    ],
+  } as unknown as ProPlan;
+
+  const tiers = (over: Partial<CurrentTiers> = {}): CurrentTiers => ({
+    machineTier: "large",
+    storageTier: "s",
+    storageGib: 30,
+    creditTier: "credits_50",
+    ...over,
+  });
+
+  test("labels all three dimensions from the sub's own tiers", () => {
+    expect(currentTierRows(tiers(), proPlan)).toEqual([
+      "Large Machine",
+      "30 GB",
+      "50 credits",
+    ]);
+  });
+
+  test("falls back to the standard small machine when no paid tier is held", () => {
+    expect(currentTierRows(tiers({ machineTier: null }), proPlan)[0]).toBe(
+      "Small Machine",
+    );
+  });
+
+  test("drops storage rather than guessing when the GiB is unresolved", () => {
+    expect(currentTierRows(tiers({ storageGib: null }), proPlan)).toEqual([
+      "Large Machine",
+      "50 credits",
+    ]);
+  });
+
+  test("drops the credit row entirely when no bundle is held", () => {
+    expect(currentTierRows(tiers({ creditTier: null }), proPlan)).toEqual([
+      "Large Machine",
+      "30 GB",
+    ]);
+  });
+
+  test("prices a held bundle off the tier key when the catalog dropped it", () => {
+    // A delisted tier has no catalog label, but the sub still pays for it, so
+    // the amount is recovered from the `credits_<usd>` key.
+    expect(
+      currentTierRows(tiers({ creditTier: "credits_115" }), proPlan)[2],
+    ).toBe("115 credits");
+  });
+
+  test("falls back to a generic bundle label for an unparseable tier key", () => {
+    expect(
+      currentTierRows(
+        tiers({ creditTier: "legacy_bundle" as CurrentTiers["creditTier"] }),
+        proPlan,
+      )[2],
+    ).toBe("Credit bundle");
+  });
+
+  test("passes an unmapped machine tier through rather than dropping it", () => {
+    expect(
+      currentTierRows(
+        tiers({ machineTier: "xxl" as CurrentTiers["machineTier"] }),
+        proPlan,
+      )[0],
+    ).toBe("xxl Machine");
   });
 });

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -13,6 +13,7 @@ import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
 import {
   currentTierRows,
   machineLabel,
+  nonTierFeatures,
   packageHighlights,
   packageSpecs,
 } from "./plan-spec";
@@ -219,5 +220,40 @@ describe("currentTierRows", () => {
         proPlan,
       )[0],
     ).toBe("xxl Machine");
+  });
+});
+
+describe("nonTierFeatures", () => {
+  // The four rows the platform catalog serves for Pro today.
+  const CATALOG = [
+    "Pay-as-you-go and bundled credits",
+    "Configurable machine size",
+    "Configurable storage",
+    "Assistant email & subdomain",
+  ];
+
+  test("drops the rows the real tier values supersede", () => {
+    expect(nonTierFeatures(CATALOG)).toEqual(["Assistant email & subdomain"]);
+  });
+
+  test("carries through an entitlement the platform adds later", () => {
+    // The regression this guards: a client-side mirror of the platform
+    // constant would silently drop any row it did not already know about.
+    expect(nonTierFeatures([...CATALOG, "Priority support"])).toEqual([
+      "Assistant email & subdomain",
+      "Priority support",
+    ]);
+  });
+
+  test("keeps a renamed capability row rather than dropping it", () => {
+    // Redundant next to the real value, but visible. Failing open beats
+    // silently omitting an entitlement the subscriber actually has.
+    expect(nonTierFeatures(["Configurable compute size"])).toEqual([
+      "Configurable compute size",
+    ]);
+  });
+
+  test("returns an empty list for an empty catalog", () => {
+    expect(nonTierFeatures([])).toEqual([]);
   });
 });

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -171,7 +171,7 @@ describe("currentTierRows", () => {
     expect(currentTierRows(tiers(), proPlan)).toEqual([
       "Large Machine",
       "30 GB",
-      "50 credits",
+      "50 credits/mo",
     ]);
   });
 
@@ -184,7 +184,7 @@ describe("currentTierRows", () => {
   test("drops storage rather than guessing when the GiB is unresolved", () => {
     expect(currentTierRows(tiers({ storageGib: null }), proPlan)).toEqual([
       "Large Machine",
-      "50 credits",
+      "50 credits/mo",
     ]);
   });
 
@@ -200,7 +200,7 @@ describe("currentTierRows", () => {
     // the amount is recovered from the `credits_<usd>` key.
     expect(
       currentTierRows(tiers({ creditTier: "credits_115" }), proPlan)[2],
-    ).toBe("115 credits");
+    ).toBe("115 credits/mo");
   });
 
   test("falls back to a generic bundle label for an unparseable tier key", () => {

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -204,6 +204,31 @@ describe("currentTierRows", () => {
     ).toBe("115 credits/mo");
   });
 
+  test("ignores a catalog label that already carries a cadence", () => {
+    // The row is composed from `credits_usd`, so a server label formatted as
+    // "$50 credits/mo" cannot double up into "50 credits/mo/mo".
+    const cadenced = {
+      id: "pro",
+      credit_tiers: [
+        { tier: "credits_50", label: "$50 credits/mo", credits_usd: 50 },
+      ],
+    } as unknown as ProPlan;
+    expect(currentTierRows(tiers(), cadenced)[2]).toBe("50 credits/mo");
+  });
+
+  test("renders a zero-credit bundle rather than treating it as absent", () => {
+    const freeBundle = {
+      id: "pro",
+      credit_tiers: [{ tier: "credits_0", label: "None", credits_usd: 0 }],
+    } as unknown as ProPlan;
+    expect(
+      currentTierRows(
+        tiers({ creditTier: "credits_0" as CurrentTiers["creditTier"] }),
+        freeBundle,
+      )[2],
+    ).toBe("0 credits/mo");
+  });
+
   test("falls back to a generic bundle label for an unparseable tier key", () => {
     expect(
       currentTierRows(

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -132,17 +132,20 @@ export function currentTierRows(
     rows.push(`${current.storageGib} GB`);
   }
   if (current.creditTier != null) {
-    // A held/deprecated credit tier absent from the catalog can't resolve to a
-    // catalog label; derive the amount from the tier key (credits_<usd>) so the
-    // paid bundle still shows instead of being silently dropped.
-    const usd = current.creditTier.match(/^credits_(\d+)$/)?.[1];
-    const label =
-      findCreditTier(proPlan, current.creditTier)?.label ??
-      (usd != null ? `${usd} credits` : null);
+    // Built from the structured `credits_usd` rather than `CreditTier.label`:
+    // the label is server-owned copy, so composing a cadence onto it would read
+    // as "50 credits/mo/mo" the day it starts carrying one itself.
+    //
+    // A held/deprecated tier absent from the catalog has no structured amount,
+    // so it falls back to the tier key (credits_<usd>) and the paid bundle
+    // still shows instead of being silently dropped.
+    const catalogUsd = findCreditTier(proPlan, current.creditTier)?.credits_usd;
+    const keyUsd = current.creditTier.match(/^credits_(\d+)$/)?.[1];
+    const usd = catalogUsd ?? (keyUsd != null ? Number(keyUsd) : null);
     // Credits refresh every month, unlike the machine and storage rows, which
     // are standing capacity. A bundle whose amount can't be resolved at all
     // stays generic rather than claiming a cadence for an unknown quantity.
-    rows.push(label != null ? `${label}/mo` : "Credit bundle");
+    rows.push(usd != null ? `${usd} credits/mo` : "Credit bundle");
   }
   return rows;
 }

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -5,13 +5,19 @@ import {
   FREE_STORAGE_GIB,
 } from "@/domains/settings/billing/plan-tier-meta";
 import type { ProPackage } from "@/domains/settings/billing/package-types";
+import { findCreditTier } from "@/domains/settings/billing/pro-onboarding/use-provisioning-credits";
+import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
 import {
   creditRowLabel,
   formatDollars,
   storageRowLabel,
 } from "@/domains/settings/components/tier-pricing";
-import type { MachineSizeEnum } from "@/generated/api/types.gen";
-import { SIZE_DESCRIPTION, SIZE_LABEL } from "@/lib/billing/machine-sizes";
+import type { MachineSizeEnum, ProPlan } from "@/generated/api/types.gen";
+import {
+  MACHINE_TIER_LABEL,
+  SIZE_DESCRIPTION,
+  SIZE_LABEL,
+} from "@/lib/billing/machine-sizes";
 
 /** A single spec chip: an icon and its label. */
 export interface PlanSpec {
@@ -75,4 +81,47 @@ export function packageHighlights(
     creditRowLabel(credits),
     ...extra,
   ];
+}
+
+/**
+ * Pro entitlements that no tier encodes, so `currentTierRows` cannot derive
+ * them. Mirrors the non-tier entries of `_PRO_INCLUDED_FEATURES` in platform
+ * `django/app/billing/plan_views.py`; the tier-derived entries there are
+ * deliberately superseded by the subscriber's real values.
+ */
+export const PRO_NON_TIER_FEATURES = ["Assistant email & subdomain"];
+
+/**
+ * Spec rows for a Pro sub's own tier configuration, e.g.
+ * `["Medium Machine", "30 GB", "50 credits"]`. Unlike `packageSpecs`, which
+ * describes a stock package, this describes what the subscriber actually holds,
+ * so it also covers a Custom sub whose tiers match no package.
+ *
+ * A dimension with no resolvable value is dropped rather than guessed: only the
+ * machine falls back, to the standard-small baseline that a package with no paid
+ * machine tier runs on. Callers must not invoke this before the tier reads have
+ * settled, or an unresolved config renders as that baseline.
+ */
+export function currentTierRows(
+  current: CurrentTiers,
+  proPlan: ProPlan,
+): string[] {
+  const machine = current.machineTier
+    ? (MACHINE_TIER_LABEL[current.machineTier] ?? current.machineTier)
+    : STANDARD_MACHINE_LABEL;
+  const rows = [`${machine} Machine`];
+  if (current.storageGib != null) {
+    rows.push(`${current.storageGib} GB`);
+  }
+  if (current.creditTier != null) {
+    // A held/deprecated credit tier absent from the catalog can't resolve to a
+    // catalog label; derive the amount from the tier key (credits_<usd>) so the
+    // paid bundle still shows instead of being silently dropped.
+    const usd = current.creditTier.match(/^credits_(\d+)$/)?.[1];
+    rows.push(
+      findCreditTier(proPlan, current.creditTier)?.label ??
+        (usd != null ? `${usd} credits` : "Credit bundle"),
+    );
+  }
+  return rows;
 }

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -118,10 +118,13 @@ export function currentTierRows(
     // catalog label; derive the amount from the tier key (credits_<usd>) so the
     // paid bundle still shows instead of being silently dropped.
     const usd = current.creditTier.match(/^credits_(\d+)$/)?.[1];
-    rows.push(
+    const label =
       findCreditTier(proPlan, current.creditTier)?.label ??
-        (usd != null ? `${usd} credits` : "Credit bundle"),
-    );
+      (usd != null ? `${usd} credits` : null);
+    // Credits refresh every month, unlike the machine and storage rows, which
+    // are standing capacity. A bundle whose amount can't be resolved at all
+    // stays generic rather than claiming a cadence for an unknown quantity.
+    rows.push(label != null ? `${label}/mo` : "Credit bundle");
   }
   return rows;
 }

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -84,30 +84,16 @@ export function packageHighlights(
 }
 
 /**
- * The catalog's generic capability rows that a subscriber's real tier values
- * supersede: "Configurable machine size" says nothing once the card can say
- * "Large Machine". Matched against `ProPlan.included_features`.
- *
- * Recognizing a row here only removes it. A renamed or newly added catalog
- * feature therefore survives into the card, which reads as redundant next to
- * the real value at worst; the alternative, listing the entitlements to keep,
- * would silently drop anything the platform adds.
+ * The catalog capability row each tier dimension replaces. A row is only
+ * dropped when its dimension actually produced a concrete value: a sub holding
+ * no credit bundle keeps "Pay-as-you-go and bundled credits", which is still
+ * true of its plan and is the only thing left saying so.
  */
-const TIER_SUPERSEDED_FEATURES = new Set([
-  "Pay-as-you-go and bundled credits",
-  "Configurable machine size",
-  "Configurable storage",
-]);
-
-/**
- * The catalog features that survive alongside the real tier rows, i.e. the Pro
- * entitlements no tier encodes (an assistant email and subdomain today). Taken
- * from the live catalog rather than a client-side mirror of the platform
- * constant, so an entitlement the API adds shows up without a web change.
- */
-export function nonTierFeatures(included: readonly string[]): string[] {
-  return included.filter((feature) => !TIER_SUPERSEDED_FEATURES.has(feature));
-}
+const CAPABILITY_ROW = {
+  machine: "Configurable machine size",
+  storage: "Configurable storage",
+  credits: "Pay-as-you-go and bundled credits",
+} as const;
 
 /**
  * Spec rows for a Pro sub's own tier configuration, e.g.
@@ -124,8 +110,13 @@ export function currentTierRows(
   current: CurrentTiers,
   proPlan: ProPlan,
 ): string[] {
+  // Static map first, so casing stays stable for the tiers this bundle knows;
+  // then the catalog's own label, so a tier the platform adds reads the same
+  // here as it does in the tier picker; the raw key only as a last resort.
   const machine = current.machineTier
-    ? (MACHINE_TIER_LABEL[current.machineTier] ?? current.machineTier)
+    ? (MACHINE_TIER_LABEL[current.machineTier] ??
+      proPlan.machine_tiers.find((t) => t.tier === current.machineTier)?.label ??
+      current.machineTier)
     : STANDARD_MACHINE_LABEL;
   const rows = [`${machine} Machine`];
   if (current.storageGib != null) {
@@ -148,4 +139,31 @@ export function currentTierRows(
     rows.push(usd != null ? `${usd} credits/mo` : "Credit bundle");
   }
   return rows;
+}
+
+/**
+ * The full checklist for a current Pro subscriber: their real tier rows, then
+ * every catalog feature those rows did not replace.
+ *
+ * The surviving rows come from the live catalog rather than a client-side
+ * mirror, so an entitlement the platform adds appears with no web change, and a
+ * dimension the sub has no concrete value for keeps its generic capability row
+ * instead of vanishing.
+ */
+export function currentPlanFeatures(
+  current: CurrentTiers,
+  proPlan: ProPlan,
+): string[] {
+  // The machine row always renders, falling back to the small baseline.
+  const superseded = new Set<string>([CAPABILITY_ROW.machine]);
+  if (current.storageGib != null) {
+    superseded.add(CAPABILITY_ROW.storage);
+  }
+  if (current.creditTier != null) {
+    superseded.add(CAPABILITY_ROW.credits);
+  }
+  return [
+    ...currentTierRows(current, proPlan),
+    ...proPlan.included_features.filter((f) => !superseded.has(f)),
+  ];
 }

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -84,12 +84,30 @@ export function packageHighlights(
 }
 
 /**
- * Pro entitlements that no tier encodes, so `currentTierRows` cannot derive
- * them. Mirrors the non-tier entries of `_PRO_INCLUDED_FEATURES` in platform
- * `django/app/billing/plan_views.py`; the tier-derived entries there are
- * deliberately superseded by the subscriber's real values.
+ * The catalog's generic capability rows that a subscriber's real tier values
+ * supersede: "Configurable machine size" says nothing once the card can say
+ * "Large Machine". Matched against `ProPlan.included_features`.
+ *
+ * Recognizing a row here only removes it. A renamed or newly added catalog
+ * feature therefore survives into the card, which reads as redundant next to
+ * the real value at worst; the alternative, listing the entitlements to keep,
+ * would silently drop anything the platform adds.
  */
-export const PRO_NON_TIER_FEATURES = ["Assistant email & subdomain"];
+const TIER_SUPERSEDED_FEATURES = new Set([
+  "Pay-as-you-go and bundled credits",
+  "Configurable machine size",
+  "Configurable storage",
+]);
+
+/**
+ * The catalog features that survive alongside the real tier rows, i.e. the Pro
+ * entitlements no tier encodes (an assistant email and subdomain today). Taken
+ * from the live catalog rather than a client-side mirror of the platform
+ * constant, so an entitlement the API adds shows up without a web change.
+ */
+export function nonTierFeatures(included: readonly string[]): string[] {
+  return included.filter((feature) => !TIER_SUPERSEDED_FEATURES.has(feature));
+}
 
 /**
  * Spec rows for a Pro sub's own tier configuration, e.g.

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -928,7 +928,7 @@ describe("PlansPage — Custom row current-plan marker", () => {
     });
 
     await findByText("Your Current Plan");
-    await findByText("Medium Machine · 10 GB · 50 credits");
+    await findByText("Medium Machine · 10 GB · 50 credits/mo");
   });
 
   test("a legacy/unpinned Pro sub sees the Custom row marked current with a tier summary", async () => {
@@ -938,7 +938,7 @@ describe("PlansPage — Custom row current-plan marker", () => {
     });
 
     await findByText("Your Current Plan");
-    await findByText("Medium Machine · 10 GB · 50 credits");
+    await findByText("Medium Machine · 10 GB · 50 credits/mo");
   });
 
   test("a custom sub holding a deprecated credit tier shows a derived credit label", async () => {
@@ -950,7 +950,7 @@ describe("PlansPage — Custom row current-plan marker", () => {
     );
 
     await findByText("Your Current Plan");
-    await findByText("Medium Machine · 10 GB · 45 credits");
+    await findByText("Medium Machine · 10 GB · 45 credits/mo");
   });
 
   test("a clean-pinned Pro sub sees no marker on the Custom row", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -12,8 +12,8 @@ import {
   tierRelation,
 } from "@/domains/settings/billing/package-types";
 import {
+  currentTierRows,
   machineLabel,
-  STANDARD_MACHINE_LABEL,
 } from "@/domains/settings/billing/plan-spec";
 import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
 import {
@@ -35,7 +35,6 @@ import {
 } from "@/domains/settings/billing/plans/plans-copy";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { captureTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
-import { findCreditTier } from "@/domains/settings/billing/pro-onboarding/use-provisioning-credits";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
@@ -67,7 +66,6 @@ import {
 } from "@/hooks/use-platform-gate";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
-import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
 import { PACKAGE_PARAM, routes } from "@/utils/routes";
@@ -120,30 +118,11 @@ function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
 
 /**
  * A one-line recap of a custom sub's current tiers for the Custom row, e.g.
- * "Medium Machine · 30 GB · 50 credits". The machine reads from the tier label
- * map (or the standard-machine baseline), storage from the resolved GiB, and
- * the credit label from the live catalog's `CreditTier.label`; a dimension with
- * no value is dropped. The wording mirrors `packageSpecs` in `plan-spec.ts`.
+ * "Medium Machine · 30 GB · 50 credits". Row wording is shared with the
+ * adjust-plan modal's current-plan card via `currentTierRows`.
  */
 function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
-  const machine = current.machineTier
-    ? (MACHINE_TIER_LABEL[current.machineTier] ?? current.machineTier)
-    : STANDARD_MACHINE_LABEL;
-  const parts = [`${machine} Machine`];
-  if (current.storageGib != null) {
-    parts.push(`${current.storageGib} GB`);
-  }
-  if (current.creditTier != null) {
-    // A held/deprecated credit tier absent from the catalog can't resolve to a
-    // catalog label; derive the amount from the tier key (credits_<usd>) so the
-    // paid bundle still shows instead of being silently dropped.
-    const usd = current.creditTier.match(/^credits_(\d+)$/)?.[1];
-    parts.push(
-      findCreditTier(proPlan, current.creditTier)?.label ??
-        (usd != null ? `${usd} credits` : "Credit bundle"),
-    );
-  }
-  return parts.join(" · ");
+  return currentTierRows(current, proPlan).join(" · ");
 }
 
 /**

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -1130,6 +1130,29 @@ describe("AdjustPlanModal current plan: name and real tier rows", () => {
     expect(text).not.toContain("Pay-as-you-go and bundled credits");
   });
 
+  test("keeps the pay-as-you-go row for a sub holding no credit bundle", async () => {
+    // No bundle means no concrete credit row, so the catalog's pay-as-you-go
+    // entitlement has to survive; otherwise the card says nothing at all about
+    // credits for a plan that still has them.
+    renderModal(
+      subscription("pro", null, { cancel_at_period_end: true }),
+      realKeyedPlansResponse(),
+      undefined,
+      REAL_ONBOARDING,
+    );
+
+    await waitFor(() => {
+      if (!(document.body.textContent ?? "").includes("Large Machine")) {
+        throw new Error("real rows not rendered yet");
+      }
+    });
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("Pay-as-you-go and bundled credits");
+    expect(text).not.toContain("Configurable machine size");
+    expect(text).not.toContain("Configurable storage");
+  });
+
   test("carries through a non-tier entitlement the catalog adds", async () => {
     // The real spec rows replace only the generic capability copy. Anything
     // else the catalog lists is an entitlement no tier encodes, so it has to

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -1008,3 +1008,208 @@ describe("AdjustPlanModal credit bundle — selector order", () => {
     ).toBeTruthy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Current-plan identity: real package name and real tier rows
+// ---------------------------------------------------------------------------
+
+/**
+ * A catalog keyed by the real `MachineTierEnum` / `StorageTierEnum` values
+ * ('medium' | 'large' | 'xl', 'xs' | 's' | ...), unlike `proPlansResponse`'s
+ * older fictional keys. The current-plan rows label the machine off
+ * `MACHINE_TIER_LABEL`, which is keyed by the real enum, so these tests need a
+ * catalog a real subscription could actually point at.
+ */
+function realKeyedPlansResponse(): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "base",
+        name: "Base",
+        base_price_cents: 0,
+        base_lookup_key: "base",
+        billing_interval: "month",
+        included_features: ["Pay-as-you-go credits"],
+      },
+      {
+        id: "pro",
+        name: "Pro",
+        base_price_cents: 1000,
+        base_lookup_key: "pro_base",
+        billing_interval: "month",
+        machine_tiers: [
+          {
+            tier: "medium",
+            label: "Medium",
+            price_cents: 3500,
+            lookup_key: "medium_lk",
+            cpu_limit: "2500m",
+            memory_gib: 5,
+            description: "Medium machine (2.5 vCPU, 5 GiB)",
+          },
+          {
+            tier: "large",
+            label: "Large",
+            price_cents: 6000,
+            lookup_key: "large_lk",
+            cpu_limit: "4",
+            memory_gib: 8,
+            description: "Large machine (4 vCPU, 8 GiB)",
+          },
+        ],
+        storage_tiers: [
+          {
+            tier: "xs",
+            label: "10 GiB",
+            price_cents: 500,
+            storage_gib: 10,
+            lookup_key: "xs_lk",
+            legacy: false,
+          },
+          {
+            tier: "s",
+            label: "30 GiB",
+            price_cents: 1000,
+            storage_gib: 30,
+            lookup_key: "s_lk",
+            legacy: false,
+          },
+        ],
+        included_features: [
+          "Pay-as-you-go and bundled credits",
+          "Configurable machine size",
+          "Configurable storage",
+          "Assistant email & subdomain",
+        ],
+        credit_tiers: CREDIT_TIERS,
+      },
+    ],
+  } as unknown as PlanListResponse;
+}
+
+/** A Pro sub on the `large` machine with 30 GiB storage and a $50 bundle. */
+const REAL_ONBOARDING: OnboardingData = {
+  max_machine_tier: "large",
+  selected_storage_tier: "s",
+  selected_storage_gib: 30,
+};
+
+function planNames(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-testid="modal-plan-name"]'),
+  ).map((n) => n.textContent?.trim() ?? "");
+}
+
+describe("AdjustPlanModal current plan: name and real tier rows", () => {
+  test("a clean-pinned sub reads its package name and its own tier rows", async () => {
+    renderModal(
+      subscription("pro", "credits_50", {
+        cancel_at_period_end: true,
+        package: { key: "super", name: "Super", version: 1, customized: false },
+      }),
+      realKeyedPlansResponse(),
+      undefined,
+      REAL_ONBOARDING,
+    );
+
+    await waitFor(() => {
+      if (!planNames().includes("Super")) {
+        throw new Error("package name not rendered yet");
+      }
+    });
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("Large Machine");
+    expect(text).toContain("30 GB");
+    expect(text).toContain("50 credits");
+    // The non-tier entitlement survives; the three tier-derived generic bullets
+    // are superseded by the subscriber's real values.
+    expect(text).toContain("Assistant email & subdomain");
+    expect(text).not.toContain("Configurable machine size");
+    expect(text).not.toContain("Configurable storage");
+    expect(text).not.toContain("Pay-as-you-go and bundled credits");
+  });
+
+  test("a customized pin reads 'Custom' but still shows its real tier rows", async () => {
+    renderModal(
+      subscription("pro", "credits_50", {
+        cancel_at_period_end: true,
+        package: { key: "super", name: "Super", version: 1, customized: true },
+      }),
+      realKeyedPlansResponse(),
+      undefined,
+      REAL_ONBOARDING,
+    );
+
+    await waitFor(() => {
+      if (!planNames().includes("Custom")) {
+        throw new Error("custom name not rendered yet");
+      }
+    });
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("Large Machine");
+    expect(text).toContain("30 GB");
+    expect(text).not.toContain("Super");
+  });
+
+  test("an unpinned legacy sub reads 'Custom'", async () => {
+    renderModal(
+      subscription("pro", "credits_50", { cancel_at_period_end: true }),
+      realKeyedPlansResponse(),
+      undefined,
+      REAL_ONBOARDING,
+    );
+
+    await waitFor(() => {
+      if (!planNames().includes("Custom")) {
+        throw new Error("custom name not rendered yet");
+      }
+    });
+  });
+
+  test("a base user sees the Pro card as a generic offer, not as their plan", async () => {
+    renderModal(subscription("base", null), realKeyedPlansResponse());
+
+    await waitFor(() => {
+      if (!planNames().includes("Pro")) {
+        throw new Error("catalog name not rendered yet");
+      }
+    });
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("Configurable machine size");
+    expect(text).not.toContain("Large Machine");
+    // Never "Custom": a base user has no Pro package to describe.
+    expect(planNames()).not.toContain("Custom");
+  });
+
+  test("an errored onboarding read keeps generic copy instead of describing a paid sub as Small", async () => {
+    // The onboarding query is deliberately unseeded: it fires, the unmocked SDK
+    // fn rejects, and with retry:false it settles into an error. Every tier then
+    // reads null, so an `isLoading`-only gate would open and label this paying
+    // subscriber with the standard-small baseline.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    client.setQueryData(
+      organizationsBillingSubscriptionRetrieveQueryKey(),
+      subscription("pro", "credits_50", { cancel_at_period_end: true }),
+    );
+    client.setQueryData(
+      organizationsBillingPlansRetrieveQueryKey(),
+      realKeyedPlansResponse(),
+    );
+    const { findByTestId } = render(
+      <QueryClientProvider client={client}>
+        <AdjustPlanModal open onClose={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    await findByTestId("modal-pro-price-unavailable");
+
+    const text = document.body.textContent ?? "";
+    expect(text).not.toContain("Small Machine");
+    expect(text).toContain("Configurable machine size");
+  });
+});

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -1130,6 +1130,34 @@ describe("AdjustPlanModal current plan: name and real tier rows", () => {
     expect(text).not.toContain("Pay-as-you-go and bundled credits");
   });
 
+  test("carries through a non-tier entitlement the catalog adds", async () => {
+    // The real spec rows replace only the generic capability copy. Anything
+    // else the catalog lists is an entitlement no tier encodes, so it has to
+    // survive rather than be dropped by a client-side allowlist.
+    const plans = realKeyedPlansResponse();
+    const pro = (plans.plans as unknown as { included_features: string[] }[])[1];
+    pro.included_features = [...pro.included_features, "Priority support"];
+
+    renderModal(
+      subscription("pro", "credits_50", { cancel_at_period_end: true }),
+      plans,
+      undefined,
+      REAL_ONBOARDING,
+    );
+
+    await waitFor(() => {
+      const text = document.body.textContent ?? "";
+      if (!text.includes("Large Machine")) {
+        throw new Error("real rows not rendered yet");
+      }
+    });
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("Priority support");
+    expect(text).toContain("Assistant email & subdomain");
+    expect(text).not.toContain("Configurable machine size");
+  });
+
   test("a customized pin reads 'Custom' but still shows its real tier rows", async () => {
     renderModal(
       subscription("pro", "credits_50", {

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -1121,7 +1121,7 @@ describe("AdjustPlanModal current plan: name and real tier rows", () => {
     const text = document.body.textContent ?? "";
     expect(text).toContain("Large Machine");
     expect(text).toContain("30 GB");
-    expect(text).toContain("50 credits");
+    expect(text).toContain("50 credits/mo");
     // The non-tier entitlement survives; the three tier-derived generic bullets
     // are superseded by the subscriber's real values.
     expect(text).toContain("Assistant email & subdomain");

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -4,6 +4,11 @@ import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { captureTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
+import { proPackageDisplayName } from "@/domains/settings/billing/package-types";
+import {
+  currentTierRows,
+  PRO_NON_TIER_FEATURES,
+} from "@/domains/settings/billing/plan-spec";
 import {
   buildPortalReturnSnapshot,
   formatGraceDate,
@@ -154,6 +159,31 @@ export function AdjustPlanModal({
   const displayCreditTier: CreditTierEnum | null =
     selectedCreditTier === undefined ? currentCreditTier : selectedCreditTier;
   const selectedCreditPriceCents = priceForCredit(displayCreditTier);
+
+  // The Pro card names the sub's real plan and lists its real tiers, so it
+  // agrees with the billing plan card whose Manage button opens this modal.
+  const planDisplayName = proPackageDisplayName(subscriptionQuery.data?.package);
+  // Rows come from the current tiers, not the picker selection: the card states
+  // what the sub holds, while the picker and the price delta express a pending
+  // change. Gated on `isSuccess` rather than a loading flag because the machine
+  // and storage tiers live on the onboarding read: while it is pending OR after
+  // it errors, every tier reads null, which is indistinguishable from a
+  // machine-less package and would describe a paid sub as the small baseline.
+  const currentPlanFeatures =
+    onPro && onboardingQuery.isSuccess && proPlan
+      ? [
+          ...currentTierRows(
+            {
+              machineTier: currentMachineTier,
+              storageTier: currentStorageTier,
+              storageGib: currentStorageGib,
+              creditTier: currentCreditTier,
+            },
+            proPlan,
+          ),
+          ...PRO_NON_TIER_FEATURES,
+        ]
+      : null;
 
   // Disable storage tiers below current (downgrades not allowed).
   const machineTiersForPicker = proPlan?.machine_tiers ?? [];
@@ -612,6 +642,8 @@ export function AdjustPlanModal({
                             plan={plan}
                             isCurrent={planIsCurrent}
                             onPro={onPro}
+                            planDisplayName={planDisplayName}
+                            currentPlanFeatures={currentPlanFeatures}
                             cancelAtPeriodEnd={cancelAtPeriodEnd}
                             isCanceled={isCanceled}
                             cancelDate={cancelDate}

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -5,10 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { captureTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
 import { proPackageDisplayName } from "@/domains/settings/billing/package-types";
-import {
-  currentTierRows,
-  PRO_NON_TIER_FEATURES,
-} from "@/domains/settings/billing/plan-spec";
+import { currentTierRows } from "@/domains/settings/billing/plan-spec";
 import {
   buildPortalReturnSnapshot,
   formatGraceDate,
@@ -169,20 +166,17 @@ export function AdjustPlanModal({
   // and storage tiers live on the onboarding read: while it is pending OR after
   // it errors, every tier reads null, which is indistinguishable from a
   // machine-less package and would describe a paid sub as the small baseline.
-  const currentPlanFeatures =
+  const currentSpecRows =
     onPro && onboardingQuery.isSuccess && proPlan
-      ? [
-          ...currentTierRows(
-            {
-              machineTier: currentMachineTier,
-              storageTier: currentStorageTier,
-              storageGib: currentStorageGib,
-              creditTier: currentCreditTier,
-            },
-            proPlan,
-          ),
-          ...PRO_NON_TIER_FEATURES,
-        ]
+      ? currentTierRows(
+          {
+            machineTier: currentMachineTier,
+            storageTier: currentStorageTier,
+            storageGib: currentStorageGib,
+            creditTier: currentCreditTier,
+          },
+          proPlan,
+        )
       : null;
 
   // Disable storage tiers below current (downgrades not allowed).
@@ -643,7 +637,7 @@ export function AdjustPlanModal({
                             isCurrent={planIsCurrent}
                             onPro={onPro}
                             planDisplayName={planDisplayName}
-                            currentPlanFeatures={currentPlanFeatures}
+                            currentSpecRows={currentSpecRows}
                             cancelAtPeriodEnd={cancelAtPeriodEnd}
                             isCanceled={isCanceled}
                             cancelDate={cancelDate}

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { captureTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
 import { proPackageDisplayName } from "@/domains/settings/billing/package-types";
-import { currentTierRows } from "@/domains/settings/billing/plan-spec";
+import { currentPlanFeatures } from "@/domains/settings/billing/plan-spec";
 import {
   buildPortalReturnSnapshot,
   formatGraceDate,
@@ -166,9 +166,9 @@ export function AdjustPlanModal({
   // and storage tiers live on the onboarding read: while it is pending OR after
   // it errors, every tier reads null, which is indistinguishable from a
   // machine-less package and would describe a paid sub as the small baseline.
-  const currentSpecRows =
+  const planFeatures =
     onPro && onboardingQuery.isSuccess && proPlan
-      ? currentTierRows(
+      ? currentPlanFeatures(
           {
             machineTier: currentMachineTier,
             storageTier: currentStorageTier,
@@ -637,7 +637,7 @@ export function AdjustPlanModal({
                             isCurrent={planIsCurrent}
                             onPro={onPro}
                             planDisplayName={planDisplayName}
-                            currentSpecRows={currentSpecRows}
+                            currentPlanFeatures={planFeatures}
                             cancelAtPeriodEnd={cancelAtPeriodEnd}
                             isCanceled={isCanceled}
                             cancelDate={cancelDate}

--- a/clients/web/src/domains/settings/components/plan-card-content.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-content.tsx
@@ -14,6 +14,7 @@ import { Card } from "@vellumai/design-library/components/card";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
+import { nonTierFeatures } from "@/domains/settings/billing/plan-spec";
 import { minTierPriceCents } from "./adjust-plan-utils";
 import { CreditBundlePicker } from "./credit-bundle-picker";
 import { PlanFeatureList } from "./plan-feature-list";
@@ -26,8 +27,8 @@ export interface PlanCardContentProps {
   onPro: boolean;
   /** The sub's real plan name ("Mighty" / "Custom"); used on the current Pro card. */
   planDisplayName: string;
-  /** The sub's real tier rows; null until the tier reads settle. */
-  currentPlanFeatures: string[] | null;
+  /** The sub's real machine/storage/credit rows; null until the tier reads settle. */
+  currentSpecRows: string[] | null;
   cancelAtPeriodEnd: boolean;
   isCanceled: boolean;
   cancelDate: string | null;
@@ -68,7 +69,7 @@ export function PlanCardContent({
   isCurrent,
   onPro,
   planDisplayName,
-  currentPlanFeatures,
+  currentSpecRows,
   cancelAtPeriodEnd,
   isCanceled,
   cancelDate,
@@ -248,8 +249,14 @@ export function PlanCardContent({
           </div>
           <PlanFeatureList
             features={
-              showsRealPlan && currentPlanFeatures
-                ? currentPlanFeatures
+              showsRealPlan && currentSpecRows
+                ? // The real values replace the catalog's generic capability
+                  // rows; everything else the catalog lists is an entitlement
+                  // no tier encodes, so it carries through untouched.
+                  [
+                    ...currentSpecRows,
+                    ...nonTierFeatures(plan.included_features),
+                  ]
                 : plan.included_features
             }
             variant="checklist"

--- a/clients/web/src/domains/settings/components/plan-card-content.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-content.tsx
@@ -24,6 +24,10 @@ export interface PlanCardContentProps {
   plan: PlanCatalogEntry;
   isCurrent: boolean;
   onPro: boolean;
+  /** The sub's real plan name ("Mighty" / "Custom"); used on the current Pro card. */
+  planDisplayName: string;
+  /** The sub's real tier rows; null until the tier reads settle. */
+  currentPlanFeatures: string[] | null;
   cancelAtPeriodEnd: boolean;
   isCanceled: boolean;
   cancelDate: string | null;
@@ -63,6 +67,8 @@ export function PlanCardContent({
   plan,
   isCurrent,
   onPro,
+  planDisplayName,
+  currentPlanFeatures,
   cancelAtPeriodEnd,
   isCanceled,
   cancelDate,
@@ -107,6 +113,10 @@ export function PlanCardContent({
   const proPickerShown =
     isProCard && (!isCurrent || (isCurrent && proTierChangeMode));
   const showProTierChange = isProCard && isCurrent && proTierChangeMode;
+  // Only the card describing a plan the user actually holds goes concrete. To a
+  // base user the Pro card is an offer, so it keeps the generic catalog name and
+  // capability copy alongside its "From $X/mo" price.
+  const showsRealPlan = isProCard && isCurrent;
 
   return (
     <Card.Root className="flex flex-col bg-[var(--surface-base)]">
@@ -123,8 +133,12 @@ export function PlanCardContent({
             )}
           </span>
           <div className="flex min-h-6 items-center gap-2">
-            <Typography as="h3" variant="title-small">
-              {plan.name}
+            <Typography
+              as="h3"
+              variant="title-small"
+              data-testid="modal-plan-name"
+            >
+              {showsRealPlan ? planDisplayName : plan.name}
             </Typography>
             {isCurrent && <Tag tone="positive">Current</Tag>}
           </div>
@@ -233,7 +247,11 @@ export function PlanCardContent({
             )}
           </div>
           <PlanFeatureList
-            features={plan.included_features}
+            features={
+              showsRealPlan && currentPlanFeatures
+                ? currentPlanFeatures
+                : plan.included_features
+            }
             variant="checklist"
           />
           {isProCard && !creditTiersEnabled && (

--- a/clients/web/src/domains/settings/components/plan-card-content.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-content.tsx
@@ -14,7 +14,6 @@ import { Card } from "@vellumai/design-library/components/card";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
-import { nonTierFeatures } from "@/domains/settings/billing/plan-spec";
 import { minTierPriceCents } from "./adjust-plan-utils";
 import { CreditBundlePicker } from "./credit-bundle-picker";
 import { PlanFeatureList } from "./plan-feature-list";
@@ -27,8 +26,8 @@ export interface PlanCardContentProps {
   onPro: boolean;
   /** The sub's real plan name ("Mighty" / "Custom"); used on the current Pro card. */
   planDisplayName: string;
-  /** The sub's real machine/storage/credit rows; null until the tier reads settle. */
-  currentSpecRows: string[] | null;
+  /** The sub's real specs plus the catalog rows they don't replace; null until the tier reads settle. */
+  currentPlanFeatures: string[] | null;
   cancelAtPeriodEnd: boolean;
   isCanceled: boolean;
   cancelDate: string | null;
@@ -69,7 +68,7 @@ export function PlanCardContent({
   isCurrent,
   onPro,
   planDisplayName,
-  currentSpecRows,
+  currentPlanFeatures,
   cancelAtPeriodEnd,
   isCanceled,
   cancelDate,
@@ -249,14 +248,8 @@ export function PlanCardContent({
           </div>
           <PlanFeatureList
             features={
-              showsRealPlan && currentSpecRows
-                ? // The real values replace the catalog's generic capability
-                  // rows; everything else the catalog lists is an entitlement
-                  // no tier encodes, so it carries through untouched.
-                  [
-                    ...currentSpecRows,
-                    ...nonTierFeatures(plan.included_features),
-                  ]
+              showsRealPlan && currentPlanFeatures
+                ? currentPlanFeatures
                 : plan.included_features
             }
             variant="checklist"


### PR DESCRIPTION
## Problem

The right-hand card in the "Your Assistant, Your Way" modal (`AdjustPlanModal`) is built entirely from the plan **catalog** entry for `pro`, so it always reads "Pro" with generic capability copy. It never consults `subscription.package` — even though the billing plan card whose **Manage** button opens this modal already resolves the real name via `proPackageDisplayName`. The modal contradicted the card behind it.

Most visible in the cancellation flow: a user deciding whether to keep their plan saw nothing concrete about what they were about to lose.

## Change

For a plan the user actually holds:

| | Before | After |
|---|---|---|
| Title | `Pro` | `Super` / `Mighty` / `Custom` |
| Bullets | Configurable machine size, Configurable storage, Pay-as-you-go and bundled credits | Large Machine, 30 GB, 50 credits, Assistant email & subdomain |

No new API calls — every field was already fetched by the modal.

- **`plan-spec.ts`** — new `currentTierRows()`. This is `plans-page.tsx`'s existing `customCurrentSummary` body promoted to a shared array-returning helper (it already handled the delisted-credit-tier case). `customCurrentSummary` now delegates to it, so the takeover's Custom row and this card cannot drift.
- **`adjust-plan-modal.tsx`** — resolves the name via the same `proPackageDisplayName` the billing card uses, so the two agree by construction.
- **`plan-card-content.tsx`** — guarded by `isProCard && isCurrent`.

## Two decisions worth reviewing

**Gated on `isSuccess`, not `isLoading`.** `isLoading` also goes false on *error*, at which point every tier reads `null` — indistinguishable from a machine-less package — so a paying subscriber would have been labeled with the standard-small baseline. There is a regression test for exactly this path.

**A base user still sees generic copy.** To them the Pro card is an *offer*, not a description of what they hold, so it keeps the catalog name and its "From $X/mo" price.

## Not in scope

- **Routing is unchanged.** The cancelled-sub → this-modal path is intentional and test-pinned: `isPackageSwitchEligible` explicitly gates out `cancel_at_period_end` because the takeover cannot act on a cancelling sub (every change 409s server-side). This modal is the "Keep your Plan" recovery surface.
- **Crown icon kept.** Swapping in `PlanTierAvatar` would match the billing card, but it falls back to `TIER_TRAITS.free` for unknown keys, so a Custom sub would render the *free* creature and visually demote a paying user.
- The billing-page card still shows no spec chips for Custom subs. The same new helper would enable it; separate surface, separate PR.

## Testing

- `bun run test:ci` — **763/763 test files pass**. Typecheck clean, lint 0 errors.
- 12 new tests: 7 unit (`plan-spec.test.ts`), 5 integration covering clean pin → real name, customized pin → "Custom" with real specs, unpinned legacy, base-user offer, and errored onboarding.
- Mutation-tested: with the feature disabled, exactly the 3 behavior-asserting tests fail and the 2 regression guards still pass.
- `plans-page.test.tsx` passes unchanged (41 tests), confirming the extraction is behavior-preserving.

Note: the existing modal fixtures used fictional tier keys (`machine_large`, `storage_20`) rather than the real enums (`large`, `s`). Since `MACHINE_TIER_LABEL` is keyed by the real enum, the new tests use a correctly-keyed catalog rather than rewriting fixtures many passing tests depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)