### PR TITLE
fix: invoices table pagination review gaps

### DIFF
--- a/clients/web/src/domains/settings/components/invoices-table.test.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.test.tsx
@@ -12,10 +12,12 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type { Invoice, InvoiceListResponse } from "@/generated/api/types.gen";
 
-let listRetrieveCalls: ({ starting_after?: string } | undefined)[] = [];
-let listResult: InvoiceListResponse = { invoices: [], has_more: false };
+let listRetrieveCalls: ({ starting_after?: string } | undefined)[];
+let listResult: InvoiceListResponse;
 // Pages served for ?starting_after=<cursor> requests, keyed by cursor.
-let nextPages: Record<string, InvoiceListResponse> = {};
+let nextPages: Record<string, InvoiceListResponse>;
+// When set, ?starting_after= requests fail with this HTTP status.
+let nextPageErrorStatus: number | null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -24,6 +26,12 @@ mock.module("@/generated/api/sdk.gen", () => ({
   }) => {
     listRetrieveCalls.push(options?.query);
     const cursor = options?.query?.starting_after;
+    if (cursor && nextPageErrorStatus !== null) {
+      return Promise.resolve({
+        data: undefined,
+        response: { ok: false, status: nextPageErrorStatus },
+      });
+    }
     return Promise.resolve({
       data: cursor ? nextPages[cursor] : listResult,
       response: { ok: true, status: 200 },
@@ -63,6 +71,7 @@ beforeEach(() => {
   listRetrieveCalls = [];
   listResult = { invoices: [makeInvoice("1"), makeInvoice("2")], has_more: false };
   nextPages = {};
+  nextPageErrorStatus = null;
 });
 
 afterEach(() => {
@@ -146,7 +155,7 @@ describe("InvoicesTable pagination", () => {
     expect(listRetrieveCalls.length).toBe(2);
     expect(listRetrieveCalls[1]).toEqual({ starting_after: "5" });
 
-    // Final page loaded — back to the plain Show less toggle.
+    // Final page loaded, so Load more disappears and Show less remains.
     expect(queryByTestId("invoices-load-more")).toBeNull();
     expect(getByTestId("invoices-show-more").textContent).toContain(
       "Show less",
@@ -170,5 +179,92 @@ describe("InvoicesTable pagination", () => {
       "Show less",
     );
     expect(listRetrieveCalls.length).toBe(1);
+  });
+
+  test("Show less stays available and works while more server pages remain", async () => {
+    listResult = {
+      invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
+      has_more: true,
+    };
+    const { getByTestId, queryByTestId, getAllByTestId } = renderTable();
+
+    fireEvent.click(getByTestId("invoices-toggle"));
+    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
+
+    fireEvent.click(getByTestId("invoices-show-more"));
+
+    // Expanded with more pages on the server: Show less and Load more
+    // render together instead of Load more replacing the toggle.
+    expect(getByTestId("invoices-show-more").textContent).toContain(
+      "Show less",
+    );
+    expect(queryByTestId("invoices-load-more")).not.toBeNull();
+
+    fireEvent.click(getByTestId("invoices-show-more"));
+
+    expect(getAllByTestId("invoice-row").length).toBe(4);
+    expect(getByTestId("invoices-show-more").textContent).toContain(
+      "Show more (1 more)",
+    );
+    expect(queryByTestId("invoices-load-more")).toBeNull();
+  });
+
+  test("a failed Load more keeps loaded rows and shows an inline retry", async () => {
+    listResult = {
+      invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
+      has_more: true,
+    };
+    nextPageErrorStatus = 400;
+    const { getByTestId, queryByTestId, queryByText, getAllByTestId } =
+      renderTable();
+
+    fireEvent.click(getByTestId("invoices-toggle"));
+    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
+    fireEvent.click(getByTestId("invoices-show-more"));
+
+    fireEvent.click(getByTestId("invoices-load-more"));
+
+    await waitFor(() =>
+      expect(queryByTestId("invoices-load-more-error")).not.toBeNull(),
+    );
+    // Page 1 rows survive the page 2 failure; no full-panel error.
+    expect(getAllByTestId("invoice-row").length).toBe(5);
+    expect(queryByText("Failed to load invoices.")).toBeNull();
+
+    // Retry refetches loaded pages and clears the inline error.
+    nextPageErrorStatus = null;
+    fireEvent.click(getByTestId("invoices-load-more-retry"));
+    await waitFor(() =>
+      expect(queryByTestId("invoices-load-more-error")).toBeNull(),
+    );
+    expect(getAllByTestId("invoice-row").length).toBe(5);
+  });
+
+  test("a short first page with has_more still offers Load more", async () => {
+    listResult = {
+      invoices: [makeInvoice("1"), makeInvoice("2")],
+      has_more: true,
+    };
+    nextPages["2"] = {
+      invoices: ["3", "4", "5"].map(makeInvoice),
+      has_more: false,
+    };
+    const { getByTestId, queryByTestId, getAllByTestId } = renderTable();
+
+    fireEvent.click(getByTestId("invoices-toggle"));
+    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
+
+    // Two rows, nothing hidden locally, but the server has more:
+    // Load more must render so the rest is reachable.
+    expect(queryByTestId("invoices-show-more")).toBeNull();
+    fireEvent.click(getByTestId("invoices-load-more"));
+
+    await waitFor(() => expect(getAllByTestId("invoice-row").length).toBe(4));
+    // Once appended rows exceed the collapsed window, the normal
+    // Show more toggle takes over.
+    expect(getByTestId("invoices-show-more").textContent).toContain(
+      "Show more (1 more)",
+    );
+    expect(queryByTestId("invoices-load-more")).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -16,6 +16,11 @@ import {
 } from "@/generated/api/sdk.gen";
 import type { InvoiceListResponse } from "@/generated/api/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
+import {
+  ApiError,
+  assertHasResponse,
+  extractErrorMessage,
+} from "@/utils/api-errors";
 import { formatFriendlyDate } from "@/utils/format-date";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
@@ -80,21 +85,24 @@ export function InvoicesTable() {
     // The table hides behind the Show invoices toggle, so don't fetch
     // billing history for a section the user may never open.
     enabled: expanded,
-    // Suffix the generated key so it can't collide with a plain-query cache
-    // entry for the same endpoint.
-    queryKey: [...organizationsBillingInvoicesRetrieveQueryKey(), "infinite"],
+    queryKey: organizationsBillingInvoicesRetrieveQueryKey(),
     queryFn: async ({ signal, pageParam }) => {
-      const { data, response } = await organizationsBillingInvoicesRetrieve({
-        throwOnError: false,
-        signal,
-        query: pageParam ? { starting_after: pageParam } : undefined,
-      });
+      const { data, error, response } =
+        await organizationsBillingInvoicesRetrieve({
+          throwOnError: false,
+          signal,
+          query: pageParam ? { starting_after: pageParam } : undefined,
+        });
       if (response?.status === 404) {
         return EMPTY_RESPONSE;
       }
-      if (!response?.ok || !data) {
-        throw new Error(
-          `Failed to load invoices (${response?.status ?? "network error"})`,
+      assertHasResponse(response, error, "Failed to load invoices.");
+      if (!response.ok || !data) {
+        // ApiError carries the HTTP status so the global retry predicate can
+        // skip retrying 4xx, notably the stale starting_after cursor 400.
+        throw new ApiError(
+          response.status,
+          extractErrorMessage(error, response, "Failed to load invoices."),
         );
       }
       return data;
@@ -108,7 +116,12 @@ export function InvoicesTable() {
   const visibleInvoices = showAll
     ? invoices
     : invoices.slice(0, INITIAL_VISIBLE);
-  const hasMore = invoices.length > INITIAL_VISIBLE;
+  const hasHiddenRows = invoices.length > INITIAL_VISIBLE;
+  const showVisibilityToggle = showAll || hasHiddenRows;
+  // "Load more" renders whenever every locally loaded row is already visible
+  // but the server still has more, so remaining invoices are always reachable.
+  const showLoadMore =
+    (showAll || !hasHiddenRows) && invoicesQuery.hasNextPage;
 
   async function downloadAllInvoices(): Promise<void> {
     setIsDownloadingAll(true);
@@ -195,7 +208,7 @@ export function InvoicesTable() {
               Loading invoices...
             </Typography>
           </div>
-        ) : invoicesQuery.isError ? (
+        ) : invoicesQuery.isError && !invoicesQuery.data ? (
           <Notice tone="error">Failed to load invoices.</Notice>
         ) : invoices.length === 0 ? (
           <Typography
@@ -294,32 +307,59 @@ export function InvoicesTable() {
                 </tbody>
               </table>
             </div>
-            {showAll && invoicesQuery.hasNextPage ? (
-              <button
-                type="button"
-                onClick={() => void invoicesQuery.fetchNextPage()}
-                disabled={invoicesQuery.isFetchingNextPage}
-                className="flex items-center gap-2 self-start text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
-                data-testid="invoices-load-more"
-              >
-                {invoicesQuery.isFetchingNextPage && (
-                  <Loader2 className="h-4 w-4 animate-spin" />
+            {(showVisibilityToggle || showLoadMore) && (
+              <div className="flex flex-wrap items-center gap-4 self-start">
+                {showVisibilityToggle && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAll((v) => !v)}
+                    className="text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
+                    data-testid="invoices-show-more"
+                  >
+                    {showAll
+                      ? "Show less"
+                      : `Show more (${invoices.length - INITIAL_VISIBLE} more)`}
+                  </button>
                 )}
-                Load more
-              </button>
-            ) : (
-              hasMore && (
-                <button
-                  type="button"
-                  onClick={() => setShowAll((v) => !v)}
-                  className="self-start text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
-                  data-testid="invoices-show-more"
-                >
-                  {showAll
-                    ? "Show less"
-                    : `Show more (${invoices.length - INITIAL_VISIBLE} more)`}
-                </button>
-              )
+                {showLoadMore && (
+                  <button
+                    type="button"
+                    onClick={() => void invoicesQuery.fetchNextPage()}
+                    disabled={invoicesQuery.isFetchingNextPage}
+                    className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
+                    data-testid="invoices-load-more"
+                  >
+                    {invoicesQuery.isFetchingNextPage && (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    )}
+                    Load more
+                  </button>
+                )}
+                {invoicesQuery.isFetchNextPageError && (
+                  <div
+                    className="flex items-center gap-2"
+                    data-testid="invoices-load-more-error"
+                  >
+                    <Typography
+                      as="span"
+                      variant="body-small-default"
+                      className="text-[color:var(--content-negative)]"
+                    >
+                      Failed to load more invoices.
+                    </Typography>
+                    <button
+                      type="button"
+                      // refetch() recomputes cursors from fresh pages, so it
+                      // also recovers from a stale starting_after cursor.
+                      onClick={() => void invoicesQuery.refetch()}
+                      className="text-body-small-default text-[var(--content-tertiary)] underline transition-colors hover:text-[var(--content-secondary)]"
+                      data-testid="invoices-load-more-retry"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                )}
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for invoice-pagination-frontend.md (self-review + external bot feedback on #39498).

- Show less is now always available while expanded; Load more renders alongside it, and a short first page with has_more no longer strands unreachable invoices.
- A failed Load more keeps already-loaded rows visible with an inline retry; the queryFn throws ApiError so the stale-cursor 400 is no longer retried against the 4xx policy.
- Cleanups: drop the obsolete infinite query-key suffix, dead test initializers, and an em dash comment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->