### PR TITLE
feat(web): STT language selector on the speech-to-text settings form

### DIFF
--- a/clients/web/src/components/speech/stt-provider-form.tsx
+++ b/clients/web/src/components/speech/stt-provider-form.tsx
@@ -167,21 +167,22 @@ export function SttProviderForm({
     isLanguageSelectable,
     selectLanguage,
   } = useSttLanguageSelection(assistantId);
-  // The hook's availability describes the daemon's CONFIGURED provider, but
-  // the form can sit on a different unsaved DRAFT choice, so the picker also
-  // gates on the daemon id it would steer: the draft's mapping, except that a
-  // daemon provider the dropdown can't represent (e.g. xai via CLI) renders
-  // as a placeholder while the daemon keeps running it, so until the user
-  // drafts a real change that provider is the one a language pick hot-applies
-  // to. The client-only native choice has no daemon mapping (its recognizer
-  // never reads `services.stt.language`), so it resolves to undefined and the
-  // capability check below hides the picker.
+  // A language pick hot-applies to the daemon's CONFIGURED provider, so the
+  // picker binds to that provider and hides while the dropdown holds an
+  // unsaved draft of a different one: offering the draft's languages would
+  // write a value the still-active provider may ignore (e.g. Multilingual
+  // drafted for Vellum while xAI runs, whose resolver drops "multi"). With
+  // no pending draft, the steered id is the daemon's own provider when the
+  // dropdown can't represent it (e.g. xai via CLI renders as a placeholder),
+  // otherwise the selection's mapping. The client-only native choice has no
+  // daemon mapping (its recognizer never reads `services.stt.language`), so
+  // it resolves to undefined and the capability check below hides the
+  // picker.
   const languageDaemonProviderId = useMemo(() => {
-    if (
-      daemonSttProvider &&
-      !CARD_ID_BY_DAEMON_PROVIDER[daemonSttProvider] &&
-      draftProvider === serverProvider
-    ) {
+    if (draftProvider !== serverProvider) {
+      return undefined;
+    }
+    if (daemonSttProvider && !CARD_ID_BY_DAEMON_PROVIDER[daemonSttProvider]) {
       return daemonSttProvider;
     }
     return STT_DAEMON_PROVIDER[draftProvider]?.provider;

--- a/clients/web/src/components/speech/stt-provider-form.tsx
+++ b/clients/web/src/components/speech/stt-provider-form.tsx
@@ -32,6 +32,8 @@ import {
   MACOS_NATIVE_STT_PROVIDER_ID,
   STT_PROVIDERS,
 } from "@/lib/provider-catalogs";
+import { STT_LANGUAGES } from "@/lib/stt/language-catalog";
+import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 
 /**
  * The speech-to-text provider + API key form: provider choice, key entry, and
@@ -155,6 +157,14 @@ export function SttProviderForm({
   const daemonHasProvider = !!daemonSttProvider;
 
   const [draftProvider, setDraftProvider] = useDraftOverride(serverProvider);
+  // Spoken-language pick, shown only when the daemon reports the configured
+  // provider as manually language-selectable. Hot-applies through the hook,
+  // independent of this form's Save.
+  const {
+    available: languageAvailable,
+    currentCode: languageCode,
+    selectLanguage,
+  } = useSttLanguageSelection(assistantId);
   const [apiKeyText, setApiKeyText] = useState("");
   const [providerHasKey, setProviderHasKey] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -342,6 +352,27 @@ export function SttProviderForm({
           aria-label="STT provider"
         />
       </div>
+
+      {languageAvailable && (
+        <div className="space-y-1">
+          <label className="block text-body-small-default text-[var(--content-tertiary)]">
+            Spoken language
+          </label>
+          <Dropdown
+            value={languageCode}
+            onChange={selectLanguage}
+            options={STT_LANGUAGES.map((l) => ({
+              value: l.code,
+              label: l.nativeLabel ? `${l.label} (${l.nativeLabel})` : l.label,
+              tooltip: l.description,
+            }))}
+            aria-label="Spoken language"
+          />
+          <p className="text-body-small-default text-[var(--content-tertiary)]">
+            Applies from your next spoken turn.
+          </p>
+        </div>
+      )}
 
       {requiresApiKey && (
         <div className="space-y-1">

--- a/clients/web/src/components/speech/stt-provider-form.tsx
+++ b/clients/web/src/components/speech/stt-provider-form.tsx
@@ -158,21 +158,39 @@ export function SttProviderForm({
   const daemonHasProvider = !!daemonSttProvider;
 
   const [draftProvider, setDraftProvider] = useDraftOverride(serverProvider);
-  // Spoken-language pick, shown only when the daemon reports the configured
-  // provider as manually language-selectable. Hot-applies through the hook,
-  // independent of this form's Save.
+  // Spoken-language pick, shown only when the daemon reports the provider it
+  // would steer as manually language-selectable. Hot-applies through the
+  // hook, independent of this form's Save.
   const {
     available: languageAvailable,
     currentCode: languageCode,
+    isLanguageSelectable,
     selectLanguage,
   } = useSttLanguageSelection(assistantId);
-  // The hook's availability describes the daemon's provider, but the form can
-  // sit on the client-only native choice (before or after Save) while the
-  // daemon still reports its own default. The native recognizer never reads
-  // `services.stt.language`, so the picker hides whenever the form shows a
-  // provider with no daemon mapping rather than offering a language the
-  // recognizer ignores.
-  const draftUsesDaemonStt = !!STT_DAEMON_PROVIDER[draftProvider];
+  // The hook's availability describes the daemon's CONFIGURED provider, but
+  // the form can sit on a different unsaved DRAFT choice, so the picker also
+  // gates on the daemon id it would steer: the draft's mapping, except that a
+  // daemon provider the dropdown can't represent (e.g. xai via CLI) renders
+  // as a placeholder while the daemon keeps running it, so until the user
+  // drafts a real change that provider is the one a language pick hot-applies
+  // to. The client-only native choice has no daemon mapping (its recognizer
+  // never reads `services.stt.language`), so it resolves to undefined and the
+  // capability check below hides the picker.
+  const languageDaemonProviderId = useMemo(() => {
+    if (
+      daemonSttProvider &&
+      !CARD_ID_BY_DAEMON_PROVIDER[daemonSttProvider] &&
+      draftProvider === serverProvider
+    ) {
+      return daemonSttProvider;
+    }
+    return STT_DAEMON_PROVIDER[draftProvider]?.provider;
+  }, [daemonSttProvider, draftProvider, serverProvider]);
+  // Unknown and absent probe entries read as false, hiding the control
+  // rather than offering a language its provider ignores.
+  const draftLanguageSelectable =
+    !!languageDaemonProviderId &&
+    isLanguageSelectable(languageDaemonProviderId);
   const [apiKeyText, setApiKeyText] = useState("");
   const [providerHasKey, setProviderHasKey] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -361,7 +379,7 @@ export function SttProviderForm({
         />
       </div>
 
-      {languageAvailable && draftUsesDaemonStt && (
+      {languageAvailable && draftLanguageSelectable && (
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Spoken language
@@ -369,7 +387,10 @@ export function SttProviderForm({
           <Dropdown
             value={languageCode}
             onChange={selectLanguage}
-            options={sttLanguageOptionsFor(languageCode).map((l) => ({
+            options={sttLanguageOptionsFor(
+              languageCode,
+              languageDaemonProviderId ?? "",
+            ).map((l) => ({
               value: l.code,
               label: l.nativeLabel ? `${l.label} (${l.nativeLabel})` : l.label,
               tooltip: l.description,

--- a/clients/web/src/components/speech/stt-provider-form.tsx
+++ b/clients/web/src/components/speech/stt-provider-form.tsx
@@ -32,7 +32,7 @@ import {
   MACOS_NATIVE_STT_PROVIDER_ID,
   STT_PROVIDERS,
 } from "@/lib/provider-catalogs";
-import { STT_LANGUAGES } from "@/lib/stt/language-catalog";
+import { sttLanguageOptionsFor } from "@/lib/stt/language-catalog";
 import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 
 /**
@@ -135,7 +135,8 @@ export function SttProviderForm({
   // `services.stt` falls under the ConfigGetResponse index signature
   // (`unknown`), so narrow it explicitly to read the provider.
   const daemonStt = daemonConfig?.services?.stt as
-    { provider?: string; mode?: string } | undefined;
+    | { provider?: string; mode?: string }
+    | undefined;
   // A config written by the legacy mode toggle marks managed via `mode` while
   // `provider` holds the BYOK restore value — the daemon routes it to Vellum,
   // so the form must render it as Vellum too.
@@ -165,6 +166,13 @@ export function SttProviderForm({
     currentCode: languageCode,
     selectLanguage,
   } = useSttLanguageSelection(assistantId);
+  // The hook's availability describes the daemon's provider, but the form can
+  // sit on the client-only native choice (before or after Save) while the
+  // daemon still reports its own default. The native recognizer never reads
+  // `services.stt.language`, so the picker hides whenever the form shows a
+  // provider with no daemon mapping rather than offering a language the
+  // recognizer ignores.
+  const draftUsesDaemonStt = !!STT_DAEMON_PROVIDER[draftProvider];
   const [apiKeyText, setApiKeyText] = useState("");
   const [providerHasKey, setProviderHasKey] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -353,7 +361,7 @@ export function SttProviderForm({
         />
       </div>
 
-      {languageAvailable && (
+      {languageAvailable && draftUsesDaemonStt && (
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Spoken language
@@ -361,7 +369,7 @@ export function SttProviderForm({
           <Dropdown
             value={languageCode}
             onChange={selectLanguage}
-            options={STT_LANGUAGES.map((l) => ({
+            options={sttLanguageOptionsFor(languageCode).map((l) => ({
               value: l.code,
               label: l.nativeLabel ? `${l.label} (${l.nativeLabel})` : l.label,
               tooltip: l.description,

--- a/clients/web/src/components/speech/use-managed-voice-selection.ts
+++ b/clients/web/src/components/speech/use-managed-voice-selection.ts
@@ -19,23 +19,25 @@
  * unavailable, `available` is false and the surfaces render no picker.
  */
 
-import { useCallback, useMemo, useRef, useState } from "react";
-
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-
-import { toast } from "@vellumai/design-library/components/toast";
+import { useQuery } from "@tanstack/react-query";
 
 import {
   configGetOptions,
-  configGetQueryKey,
   ttsProvidersGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
-import { configPatch } from "@/generated/daemon/sdk.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import {
   useManagedVoices,
   type ManagedVoiceOption,
 } from "@/lib/tts/use-managed-voices";
+
+import { useSerializedConfigSelection } from "@/components/speech/use-serialized-config-selection";
+
+// Module-level so `select` identity only tracks real state (see
+// `useSerializedConfigSelection`).
+const buildVoicePatchBody = (model: string) => ({
+  services: { tts: { providers: { vellum: { model } } } },
+});
 
 export interface UseManagedVoiceSelection {
   /** True only when this assistant is managed and its daemon offers voice selection. */
@@ -70,7 +72,6 @@ export function useManagedVoiceSelection(
 ): UseManagedVoiceSelection {
   const isOrgReady = useIsOrgReady();
   const enabled = isOrgReady && !!assistantId;
-  const queryClient = useQueryClient();
 
   const { data: providerCatalog } = useQuery({
     ...ttsProvidersGetOptions({ path: { assistant_id: assistantId ?? "" } }),
@@ -113,66 +114,22 @@ export function useManagedVoiceSelection(
   // "not managed", which would flash the BYO state on every mount.
   const isByok = enabled && !!daemonConfig && !isManaged;
 
-  const [selecting, setSelecting] = useState(false);
-  // The voice a pick is heading for, held until its write has landed in config.
-  // Auditioning voices in a row is the point of the picker, and a check mark
-  // that waits out a round trip reads as a dropped click.
-  const [pendingModel, setPendingModel] = useState<string | null>(null);
+  const configuredModel =
+    daemonTts?.providers?.vellum?.model ??
+    defaultModel ??
+    voices[0]?.model ??
+    "";
 
-  const currentModel = useMemo(() => {
-    const configured = daemonTts?.providers?.vellum?.model;
-    return pendingModel ?? configured ?? defaultModel ?? voices[0]?.model ?? "";
-  }, [pendingModel, daemonTts, defaultModel, voices]);
-
-  // Writes run one at a time in click order, and only the newest one settles the
-  // UI. Concurrent PATCHes of the same config field can arrive out of order —
-  // config would then keep whichever landed last rather than what was clicked
-  // last, and the first response back would clear `selecting` while a later
-  // write was still in flight.
-  const writeChain = useRef<Promise<void>>(Promise.resolve());
-  const latestWrite = useRef(0);
-
-  const selectModel = useCallback(
-    (model: string) => {
-      if (!assistantId || model === currentModel) {
-        return;
-      }
-      const seq = ++latestWrite.current;
-      setPendingModel(model);
-      setSelecting(true);
-      writeChain.current = writeChain.current.then(async () => {
-        try {
-          const { response } = await configPatch({
-            path: { assistant_id: assistantId },
-            body: { services: { tts: { providers: { vellum: { model } } } } },
-            throwOnError: false,
-          });
-          if (!response?.ok) {
-            toast.error("Couldn't change the voice just now — try again.");
-            return;
-          }
-          // Refetch config so `currentModel` reflects the write. The running
-          // session picks the new voice up from config on its next turn.
-          await queryClient.invalidateQueries({
-            queryKey: configGetQueryKey({
-              path: { assistant_id: assistantId },
-            }),
-          });
-        } catch {
-          toast.error("Couldn't change the voice just now — try again.");
-        } finally {
-          // Superseded writes leave the state alone: the pick they'd revert to
-          // is not the one the user is waiting on. Dropping the pending model
-          // here also reverts a failed write to whatever config actually holds.
-          if (seq === latestWrite.current) {
-            setPendingModel(null);
-            setSelecting(false);
-          }
-        }
-      });
-    },
-    [assistantId, currentModel, queryClient],
-  );
+  const {
+    currentValue: currentModel,
+    selecting,
+    select: selectModel,
+  } = useSerializedConfigSelection({
+    assistantId,
+    configuredValue: configuredModel,
+    buildPatchBody: buildVoicePatchBody,
+    failureMessage: "Couldn't change the voice just now — try again.",
+  });
 
   return {
     available,

--- a/clients/web/src/components/speech/use-managed-voice-selection.ts
+++ b/clients/web/src/components/speech/use-managed-voice-selection.ts
@@ -128,7 +128,7 @@ export function useManagedVoiceSelection(
     assistantId,
     configuredValue: configuredModel,
     buildPatchBody: buildVoicePatchBody,
-    failureMessage: "Couldn't change the voice just now — try again.",
+    failureMessage: "Couldn't change the voice just now. Try again.",
   });
 
   return {

--- a/clients/web/src/components/speech/use-serialized-config-selection.ts
+++ b/clients/web/src/components/speech/use-serialized-config-selection.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared optimistic-write engine for the speech pickers (`use-managed-voice-
+ * selection`, `use-stt-language-selection`). Each picker persists one config
+ * value via `config_patch` and needs the same write discipline, so it lives
+ * here once: an optimistic pending value, serialized writes, a latest-write
+ * guard, config invalidation, and a failure toast.
+ *
+ * The caller keeps ownership of everything value-shaped: how the configured
+ * value is derived from config, what body a value patches to, and the
+ * failure copy. This hook only owns the write lifecycle.
+ */
+
+import { useCallback, useRef, useState } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@vellumai/design-library/components/toast";
+
+import { configGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { configPatch } from "@/generated/daemon/sdk.gen";
+
+type ConfigPatchBody = NonNullable<Parameters<typeof configPatch>[0]>["body"];
+
+export interface UseSerializedConfigSelection {
+  /**
+   * The currently-selected value: the pick a write is still carrying, else
+   * the caller's `configuredValue`. Holding the pick until its write has
+   * landed keeps the surface responsive: a check mark that waits out a round
+   * trip reads as a dropped click.
+   */
+  currentValue: string;
+  /** A write is in flight. Stays true until the newest one settles. */
+  selecting: boolean;
+  /**
+   * Persist a value. Safe to call again before the last one lands, writes
+   * are serialized in call order. A pick equal to `currentValue` is a no-op.
+   */
+  select: (value: string) => void;
+}
+
+export function useSerializedConfigSelection({
+  assistantId,
+  configuredValue,
+  buildPatchBody,
+  failureMessage,
+}: {
+  assistantId: string | null;
+  /**
+   * The caller's config-derived value (config field, defaults, display
+   * normalization). `currentValue` reads as this whenever no pick is in
+   * flight.
+   */
+  configuredValue: string;
+  /**
+   * Maps a picked value to the `config_patch` body that persists it. Must be
+   * referentially stable (module-level or memoized) so `select` identity only
+   * tracks real state.
+   */
+  buildPatchBody: (value: string) => ConfigPatchBody;
+  /** Toast copy shown when a write fails or rejects. */
+  failureMessage: string;
+}): UseSerializedConfigSelection {
+  const queryClient = useQueryClient();
+
+  const [selecting, setSelecting] = useState(false);
+  // The value a pick is heading for, held until its write has landed in
+  // config.
+  const [pendingValue, setPendingValue] = useState<string | null>(null);
+
+  const currentValue = pendingValue ?? configuredValue;
+
+  // Writes run one at a time in click order, and only the newest one settles
+  // the UI. Concurrent PATCHes of the same config field can arrive out of
+  // order: config would then keep whichever landed last rather than what was
+  // clicked last, and the first response back would clear `selecting` while
+  // a later write was still in flight.
+  const writeChain = useRef<Promise<void>>(Promise.resolve());
+  const latestWrite = useRef(0);
+
+  const select = useCallback(
+    (value: string) => {
+      if (!assistantId || value === currentValue) {
+        return;
+      }
+      const seq = ++latestWrite.current;
+      setPendingValue(value);
+      setSelecting(true);
+      writeChain.current = writeChain.current.then(async () => {
+        try {
+          const { response } = await configPatch({
+            path: { assistant_id: assistantId },
+            body: buildPatchBody(value),
+            throwOnError: false,
+          });
+          if (!response?.ok) {
+            toast.error(failureMessage);
+            return;
+          }
+          // Refetch config so `currentValue` reflects the write. The running
+          // session picks the new value up from config on its next turn.
+          await queryClient.invalidateQueries({
+            queryKey: configGetQueryKey({
+              path: { assistant_id: assistantId },
+            }),
+          });
+        } catch {
+          toast.error(failureMessage);
+        } finally {
+          // Superseded writes leave the state alone: the pick they'd revert
+          // to is not the one the user is waiting on. Dropping the pending
+          // value here also reverts a failed write to whatever config holds.
+          if (seq === latestWrite.current) {
+            setPendingValue(null);
+            setSelecting(false);
+          }
+        }
+      });
+    },
+    [assistantId, currentValue, buildPatchBody, failureMessage, queryClient],
+  );
+
+  return { currentValue, selecting, select };
+}

--- a/clients/web/src/components/speech/use-stt-language-selection.test.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for `useSttLanguageSelection`:
+ *
+ *   1. Capability gating: unavailable when the daemon omits
+ *      `languageSelection` (old daemon) or reports the configured provider
+ *      as `"auto"`; available for a `"manual"` provider.
+ *   2. Writes: a pick issues exactly one `services.stt.language` PATCH;
+ *      rapid picks serialize in call order; the default pick writes the
+ *      explicit `"en"` fallback (config_patch cannot delete the key) and
+ *      `"en"` reads back as the default code.
+ *
+ * Generated daemon bindings are mocked with controllable data, mirroring
+ * `speech-to-text-card.test.tsx`; the QueryClientProvider is real.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => true,
+}));
+
+const ASSISTANT_ID = "asst-test";
+
+// Controllable daemon responses the mocked query factories resolve to.
+// `initialData` makes them available synchronously on mount, mirroring how
+// the real queries would already be cached.
+let daemonConfigData: { services: Record<string, unknown> } = { services: {} };
+let providerCatalogData: {
+  providers: {
+    id: string;
+    displayName: string;
+    languageSelection?: "manual" | "auto";
+  }[];
+} = { providers: [] };
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  configGetOptions: () => ({
+    queryKey: ["config-get-test"],
+    queryFn: () => Promise.resolve(daemonConfigData),
+    initialData: daemonConfigData,
+  }),
+  configGetQueryKey: () => ["config-get-test"],
+  sttProvidersGetOptions: () => ({
+    queryKey: ["stt-providers-test"],
+    queryFn: () => Promise.resolve(providerCatalogData),
+    initialData: providerCatalogData,
+  }),
+}));
+
+// Capture the language PATCHes. `deferPatches` switches configPatch to
+// manually-resolved promises so the serialization test can observe ordering.
+interface SdkCall {
+  path?: unknown;
+  body?: unknown;
+}
+const configPatchCalls: SdkCall[] = [];
+let deferPatches = false;
+let patchResolvers: ((v: {
+  response: { ok: boolean; status: number };
+}) => void)[] = [];
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  configPatch: (opts: SdkCall) => {
+    configPatchCalls.push(opts);
+    if (deferPatches) {
+      return new Promise((resolve) => patchResolvers.push(resolve));
+    }
+    return Promise.resolve({ response: { ok: true, status: 200 } });
+  },
+}));
+
+const { useSttLanguageSelection } =
+  await import("@/components/speech/use-stt-language-selection");
+
+function renderSelection() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderHook(() => useSttLanguageSelection(ASSISTANT_ID), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children),
+  });
+}
+
+describe("useSttLanguageSelection", () => {
+  beforeEach(() => {
+    configPatchCalls.length = 0;
+    deferPatches = false;
+    patchResolvers = [];
+    daemonConfigData = { services: {} };
+    providerCatalogData = { providers: [] };
+  });
+
+  test("unavailable when the daemon omits languageSelection (old daemon)", () => {
+    daemonConfigData = { services: { stt: { provider: "deepgram" } } };
+    providerCatalogData = {
+      providers: [{ id: "deepgram", displayName: "Deepgram" }],
+    };
+
+    const { result } = renderSelection();
+    expect(result.current.available).toBe(false);
+  });
+
+  test("unavailable when the configured provider auto-detects", () => {
+    daemonConfigData = { services: { stt: { provider: "google-gemini" } } };
+    providerCatalogData = {
+      providers: [
+        { id: "google-gemini", displayName: "Gemini", languageSelection: "auto" },
+        { id: "deepgram", displayName: "Deepgram", languageSelection: "manual" },
+      ],
+    };
+
+    const { result } = renderSelection();
+    expect(result.current.available).toBe(false);
+  });
+
+  test("available for a manually language-selectable provider", () => {
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    providerCatalogData = {
+      providers: [
+        { id: "vellum", displayName: "Vellum", languageSelection: "manual" },
+      ],
+    };
+
+    const { result } = renderSelection();
+    expect(result.current.available).toBe(true);
+    expect(result.current.currentCode).toBe("");
+  });
+
+  test("a pick issues one services.stt.language PATCH", async () => {
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    providerCatalogData = {
+      providers: [
+        { id: "vellum", displayName: "Vellum", languageSelection: "manual" },
+      ],
+    };
+
+    const { result } = renderSelection();
+    act(() => result.current.selectLanguage("multi"));
+
+    expect(result.current.currentCode).toBe("multi");
+    await waitFor(() => expect(result.current.selecting).toBe(false));
+    expect(configPatchCalls).toHaveLength(1);
+    expect(configPatchCalls[0]!.path).toEqual({ assistant_id: ASSISTANT_ID });
+    expect(configPatchCalls[0]!.body).toEqual({
+      services: { stt: { language: "multi" } },
+    });
+  });
+
+  test("two rapid picks serialize in call order", async () => {
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    providerCatalogData = {
+      providers: [
+        { id: "vellum", displayName: "Vellum", languageSelection: "manual" },
+      ],
+    };
+    deferPatches = true;
+
+    const { result } = renderSelection();
+    act(() => result.current.selectLanguage("multi"));
+    act(() => result.current.selectLanguage("es"));
+
+    // The second write waits for the first to settle.
+    await waitFor(() => expect(configPatchCalls).toHaveLength(1));
+    expect(configPatchCalls).toHaveLength(1);
+    expect(result.current.currentCode).toBe("es");
+
+    act(() => patchResolvers[0]!({ response: { ok: true, status: 200 } }));
+    await waitFor(() => expect(configPatchCalls).toHaveLength(2));
+    expect(configPatchCalls[0]!.body).toEqual({
+      services: { stt: { language: "multi" } },
+    });
+    expect(configPatchCalls[1]!.body).toEqual({
+      services: { stt: { language: "es" } },
+    });
+    expect(result.current.selecting).toBe(true);
+
+    act(() => patchResolvers[1]!({ response: { ok: true, status: 200 } }));
+    await waitFor(() => expect(result.current.selecting).toBe(false));
+  });
+
+  test("the default pick writes explicit en, and en reads as the default code", async () => {
+    daemonConfigData = {
+      services: { stt: { provider: "vellum", language: "multi" } },
+    };
+    providerCatalogData = {
+      providers: [
+        { id: "vellum", displayName: "Vellum", languageSelection: "manual" },
+      ],
+    };
+
+    const { result } = renderSelection();
+    expect(result.current.currentCode).toBe("multi");
+
+    // config_patch cannot delete the key (a null leaf breaks schema
+    // validation on the next load), so the default pick writes "en".
+    daemonConfigData = {
+      services: { stt: { provider: "vellum", language: "en" } },
+    };
+    act(() => result.current.selectLanguage(""));
+
+    await waitFor(() => expect(result.current.selecting).toBe(false));
+    expect(configPatchCalls).toHaveLength(1);
+    expect(configPatchCalls[0]!.body).toEqual({
+      services: { stt: { language: "en" } },
+    });
+    // The refetched config holds "en"; the hook reads it as the default code.
+    await waitFor(() => expect(result.current.currentCode).toBe(""));
+  });
+});

--- a/clients/web/src/components/speech/use-stt-language-selection.test.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.test.ts
@@ -110,8 +110,16 @@ describe("useSttLanguageSelection", () => {
     daemonConfigData = { services: { stt: { provider: "google-gemini" } } };
     providerCatalogData = {
       providers: [
-        { id: "google-gemini", displayName: "Gemini", languageSelection: "auto" },
-        { id: "deepgram", displayName: "Deepgram", languageSelection: "manual" },
+        {
+          id: "google-gemini",
+          displayName: "Gemini",
+          languageSelection: "auto",
+        },
+        {
+          id: "deepgram",
+          displayName: "Deepgram",
+          languageSelection: "manual",
+        },
       ],
     };
 
@@ -130,6 +138,30 @@ describe("useSttLanguageSelection", () => {
     const { result } = renderSelection();
     expect(result.current.available).toBe(true);
     expect(result.current.currentCode).toBe("");
+  });
+
+  test("isLanguageSelectable reflects the probe per daemon provider id", () => {
+    // A form gates its picker on the DRAFT provider through this, so it must
+    // answer for ids other than the configured one.
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    providerCatalogData = {
+      providers: [
+        { id: "vellum", displayName: "Vellum", languageSelection: "manual" },
+        {
+          id: "openai-whisper",
+          displayName: "Whisper",
+          languageSelection: "auto",
+        },
+        { id: "deepgram", displayName: "Deepgram" },
+      ],
+    };
+
+    const { result } = renderSelection();
+    expect(result.current.isLanguageSelectable("vellum")).toBe(true);
+    expect(result.current.isLanguageSelectable("openai-whisper")).toBe(false);
+    // Absent capability field (old daemon) and unknown ids read as false.
+    expect(result.current.isLanguageSelectable("deepgram")).toBe(false);
+    expect(result.current.isLanguageSelectable("xai")).toBe(false);
   });
 
   test("a pick issues one services.stt.language PATCH", async () => {

--- a/clients/web/src/components/speech/use-stt-language-selection.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.ts
@@ -18,20 +18,16 @@
  * pretending to save a language the daemon would ignore.
  */
 
-import { useCallback, useMemo, useRef, useState } from "react";
-
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-
-import { toast } from "@vellumai/design-library/components/toast";
+import { useQuery } from "@tanstack/react-query";
 
 import {
   configGetOptions,
-  configGetQueryKey,
   sttProvidersGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
-import { configPatch } from "@/generated/daemon/sdk.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { STT_LANGUAGE_DEFAULT_CODE } from "@/lib/stt/language-catalog";
+
+import { useSerializedConfigSelection } from "@/components/speech/use-serialized-config-selection";
 
 /**
  * The code written when the user picks the default option. The daemon cannot
@@ -42,6 +38,17 @@ import { STT_LANGUAGE_DEFAULT_CODE } from "@/lib/stt/language-catalog";
  * reads treat unset and `"en"` as the same default code.
  */
 const DEFAULT_WRITE_CODE = "en";
+
+// Module-level so `select` identity only tracks real state (see
+// `useSerializedConfigSelection`). The default pick writes the explicit
+// English fallback described on `DEFAULT_WRITE_CODE`.
+const buildLanguagePatchBody = (code: string) => ({
+  services: {
+    stt: {
+      language: code === STT_LANGUAGE_DEFAULT_CODE ? DEFAULT_WRITE_CODE : code,
+    },
+  },
+});
 
 export interface UseSttLanguageSelection {
   /**
@@ -71,7 +78,6 @@ export function useSttLanguageSelection(
 ): UseSttLanguageSelection {
   const isOrgReady = useIsOrgReady();
   const enabled = isOrgReady && !!assistantId;
-  const queryClient = useQueryClient();
 
   const { data: providerCatalog } = useQuery({
     ...sttProvidersGetOptions({ path: { assistant_id: assistantId ?? "" } }),
@@ -106,72 +112,24 @@ export function useSttLanguageSelection(
   // provider is a guess, and the control must not flash in and out.
   const available = enabled && !!daemonConfig && providerAcceptsLanguage;
 
-  const [selecting, setSelecting] = useState(false);
-  // The code a pick is heading for, held until its write has landed in
-  // config. A check mark that waits out a round trip reads as a dropped
-  // click.
-  const [pendingCode, setPendingCode] = useState<string | null>(null);
+  // Unset and the explicit English fallback both read as the default code
+  // (display equivalence, see `DEFAULT_WRITE_CODE`).
+  const configured = daemonStt?.language;
+  const configuredCode =
+    !configured || configured === DEFAULT_WRITE_CODE
+      ? STT_LANGUAGE_DEFAULT_CODE
+      : configured;
 
-  const currentCode = useMemo(() => {
-    const configured = daemonStt?.language;
-    const normalized =
-      !configured || configured === DEFAULT_WRITE_CODE
-        ? STT_LANGUAGE_DEFAULT_CODE
-        : configured;
-    return pendingCode ?? normalized;
-  }, [pendingCode, daemonStt]);
-
-  // Writes run one at a time in click order, and only the newest one settles
-  // the UI. Concurrent PATCHes of the same config field can arrive out of
-  // order: config would then keep whichever landed last rather than what was
-  // clicked last, and the first response back would clear `selecting` while
-  // a later write was still in flight.
-  const writeChain = useRef<Promise<void>>(Promise.resolve());
-  const latestWrite = useRef(0);
-
-  const selectLanguage = useCallback(
-    (code: string) => {
-      if (!assistantId || code === currentCode) {
-        return;
-      }
-      const seq = ++latestWrite.current;
-      setPendingCode(code);
-      setSelecting(true);
-      writeChain.current = writeChain.current.then(async () => {
-        try {
-          const writeCode =
-            code === STT_LANGUAGE_DEFAULT_CODE ? DEFAULT_WRITE_CODE : code;
-          const { response } = await configPatch({
-            path: { assistant_id: assistantId },
-            body: { services: { stt: { language: writeCode } } },
-            throwOnError: false,
-          });
-          if (!response?.ok) {
-            toast.error("Couldn't change the language just now. Try again.");
-            return;
-          }
-          // Refetch config so `currentCode` reflects the write. The running
-          // session picks the new language up from config on its next turn.
-          await queryClient.invalidateQueries({
-            queryKey: configGetQueryKey({
-              path: { assistant_id: assistantId },
-            }),
-          });
-        } catch {
-          toast.error("Couldn't change the language just now. Try again.");
-        } finally {
-          // Superseded writes leave the state alone: the pick they'd revert
-          // to is not the one the user is waiting on. Dropping the pending
-          // code here also reverts a failed write to whatever config holds.
-          if (seq === latestWrite.current) {
-            setPendingCode(null);
-            setSelecting(false);
-          }
-        }
-      });
-    },
-    [assistantId, currentCode, queryClient],
-  );
+  const {
+    currentValue: currentCode,
+    selecting,
+    select: selectLanguage,
+  } = useSerializedConfigSelection({
+    assistantId,
+    configuredValue: configuredCode,
+    buildPatchBody: buildLanguagePatchBody,
+    failureMessage: "Couldn't change the language just now. Try again.",
+  });
 
   return { available, currentCode, selectLanguage, selecting };
 }

--- a/clients/web/src/components/speech/use-stt-language-selection.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.ts
@@ -1,0 +1,177 @@
+/**
+ * Spoken-language selection for the speech-to-text surfaces (the settings
+ * form, the voice first-run card, and the voice-room gear popover, hence
+ * `components/speech/` rather than any one domain). Reads the current
+ * language from daemon config and writes the chosen one back; the source of
+ * truth is `services.stt.language`, never a client store (server data has
+ * one owner).
+ *
+ * **Hot-apply:** the daemon resolves its STT language from config fresh on
+ * every spoken turn, and `config_patch` invalidates the config cache. So a
+ * pick here takes effect from the user's next utterance in the same session,
+ * with no session runtime message and independent of the form's Save button.
+ *
+ * Only offered when the daemon reports the configured provider as manually
+ * language-selectable (`languageSelection: "manual"` on the provider probe).
+ * Providers that auto-detect (Gemini, Whisper) and old daemons that omit the
+ * field read as unavailable, so the surfaces render no control rather than
+ * pretending to save a language the daemon would ignore.
+ */
+
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@vellumai/design-library/components/toast";
+
+import {
+  configGetOptions,
+  configGetQueryKey,
+  sttProvidersGetOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { configPatch } from "@/generated/daemon/sdk.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { STT_LANGUAGE_DEFAULT_CODE } from "@/lib/stt/language-catalog";
+
+/**
+ * The code written when the user picks the default option. The daemon cannot
+ * delete `services.stt.language`: `config_patch` deep-merges, and a `null`
+ * leaf lands as a literal null in raw config.json, which then fails the
+ * `z.string().min(1)` schema on every subsequent load. So the default pick
+ * writes explicit English (the provider default is English anyway), and
+ * reads treat unset and `"en"` as the same default code.
+ */
+const DEFAULT_WRITE_CODE = "en";
+
+export interface UseSttLanguageSelection {
+  /**
+   * True only when the daemon reports the configured STT provider as
+   * manually language-selectable. False for auto-detecting providers and
+   * for old daemons that omit the capability field.
+   */
+  available: boolean;
+  /**
+   * The currently-selected catalog code: the pick a write is still carrying,
+   * else the config value. Unset and `"en"` both read as
+   * `STT_LANGUAGE_DEFAULT_CODE` (display equivalence, see
+   * `DEFAULT_WRITE_CODE`).
+   */
+  currentCode: string;
+  /**
+   * Persist a language; hot-applies from the next spoken turn. Safe to call
+   * again before the last one lands, writes are serialized in call order.
+   */
+  selectLanguage: (code: string) => void;
+  /** A write is in flight. Stays true until the newest one settles. */
+  selecting: boolean;
+}
+
+export function useSttLanguageSelection(
+  assistantId: string | null,
+): UseSttLanguageSelection {
+  const isOrgReady = useIsOrgReady();
+  const enabled = isOrgReady && !!assistantId;
+  const queryClient = useQueryClient();
+
+  const { data: providerCatalog } = useQuery({
+    ...sttProvidersGetOptions({ path: { assistant_id: assistantId ?? "" } }),
+    enabled,
+    staleTime: Infinity,
+    retry: false,
+  });
+  const { data: daemonConfig } = useQuery({
+    ...configGetOptions({ path: { assistant_id: assistantId ?? "" } }),
+    enabled,
+    staleTime: 30_000,
+  });
+
+  // `services.stt` falls under the ConfigGetResponse index signature
+  // (`unknown`), so narrow it explicitly. Mirrors `SttProviderForm`.
+  const daemonStt = daemonConfig?.services?.stt as
+    | { provider?: string; mode?: string; language?: string }
+    | undefined;
+  // A legacy managed-mode config routes to Vellum while `provider` holds the
+  // BYOK restore value; an unset provider falls back to the daemon schema
+  // default (deepgram).
+  const configuredProvider =
+    daemonStt?.mode === "managed"
+      ? "vellum"
+      : (daemonStt?.provider ?? "deepgram");
+
+  const providerAcceptsLanguage =
+    providerCatalog?.providers?.find((p) => p.id === configuredProvider)
+      ?.languageSelection === "manual";
+
+  // Gated on config having actually arrived: before then the configured
+  // provider is a guess, and the control must not flash in and out.
+  const available = enabled && !!daemonConfig && providerAcceptsLanguage;
+
+  const [selecting, setSelecting] = useState(false);
+  // The code a pick is heading for, held until its write has landed in
+  // config. A check mark that waits out a round trip reads as a dropped
+  // click.
+  const [pendingCode, setPendingCode] = useState<string | null>(null);
+
+  const currentCode = useMemo(() => {
+    const configured = daemonStt?.language;
+    const normalized =
+      !configured || configured === DEFAULT_WRITE_CODE
+        ? STT_LANGUAGE_DEFAULT_CODE
+        : configured;
+    return pendingCode ?? normalized;
+  }, [pendingCode, daemonStt]);
+
+  // Writes run one at a time in click order, and only the newest one settles
+  // the UI. Concurrent PATCHes of the same config field can arrive out of
+  // order: config would then keep whichever landed last rather than what was
+  // clicked last, and the first response back would clear `selecting` while
+  // a later write was still in flight.
+  const writeChain = useRef<Promise<void>>(Promise.resolve());
+  const latestWrite = useRef(0);
+
+  const selectLanguage = useCallback(
+    (code: string) => {
+      if (!assistantId || code === currentCode) {
+        return;
+      }
+      const seq = ++latestWrite.current;
+      setPendingCode(code);
+      setSelecting(true);
+      writeChain.current = writeChain.current.then(async () => {
+        try {
+          const writeCode =
+            code === STT_LANGUAGE_DEFAULT_CODE ? DEFAULT_WRITE_CODE : code;
+          const { response } = await configPatch({
+            path: { assistant_id: assistantId },
+            body: { services: { stt: { language: writeCode } } },
+            throwOnError: false,
+          });
+          if (!response?.ok) {
+            toast.error("Couldn't change the language just now. Try again.");
+            return;
+          }
+          // Refetch config so `currentCode` reflects the write. The running
+          // session picks the new language up from config on its next turn.
+          await queryClient.invalidateQueries({
+            queryKey: configGetQueryKey({
+              path: { assistant_id: assistantId },
+            }),
+          });
+        } catch {
+          toast.error("Couldn't change the language just now. Try again.");
+        } finally {
+          // Superseded writes leave the state alone: the pick they'd revert
+          // to is not the one the user is waiting on. Dropping the pending
+          // code here also reverts a failed write to whatever config holds.
+          if (seq === latestWrite.current) {
+            setPendingCode(null);
+            setSelecting(false);
+          }
+        }
+      });
+    },
+    [assistantId, currentCode, queryClient],
+  );
+
+  return { available, currentCode, selectLanguage, selecting };
+}

--- a/clients/web/src/components/speech/use-stt-language-selection.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.ts
@@ -18,6 +18,8 @@
  * pretending to save a language the daemon would ignore.
  */
 
+import { useCallback } from "react";
+
 import { useQuery } from "@tanstack/react-query";
 
 import {
@@ -65,6 +67,15 @@ export interface UseSttLanguageSelection {
    */
   currentCode: string;
   /**
+   * Whether the daemon probe reports the given daemon provider id as
+   * manually language-selectable. `available` describes the CONFIGURED
+   * provider; a form whose dropdown holds an unsaved DRAFT choice gates its
+   * picker on the draft's daemon id through this instead, so switching to an
+   * auto-detecting provider hides the control before Save. Unknown ids and
+   * old daemons that omit the capability field read as false.
+   */
+  isLanguageSelectable: (daemonProviderId: string) => boolean;
+  /**
    * Persist a language; hot-applies from the next spoken turn. Safe to call
    * again before the last one lands, writes are serialized in call order.
    */
@@ -104,9 +115,15 @@ export function useSttLanguageSelection(
       ? "vellum"
       : (daemonStt?.provider ?? "deepgram");
 
-  const providerAcceptsLanguage =
-    providerCatalog?.providers?.find((p) => p.id === configuredProvider)
-      ?.languageSelection === "manual";
+  const catalogProviders = providerCatalog?.providers;
+  const isLanguageSelectable = useCallback(
+    (daemonProviderId: string) =>
+      catalogProviders?.find((p) => p.id === daemonProviderId)
+        ?.languageSelection === "manual",
+    [catalogProviders],
+  );
+
+  const providerAcceptsLanguage = isLanguageSelectable(configuredProvider);
 
   // Gated on config having actually arrived: before then the configured
   // provider is a guess, and the control must not flash in and out.
@@ -131,5 +148,11 @@ export function useSttLanguageSelection(
     failureMessage: "Couldn't change the language just now. Try again.",
   });
 
-  return { available, currentCode, selectLanguage, selecting };
+  return {
+    available,
+    currentCode,
+    isLanguageSelectable,
+    selectLanguage,
+    selecting,
+  };
 }

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -459,6 +459,67 @@ describe("SpeechToTextCard — Spoken language dropdown", () => {
     expect(languageTrigger()).toBeNull();
   });
 
+  test("hides when the draft switches to an auto-detecting provider", async () => {
+    // Saved provider vellum (manual), dropdown switched to OpenAI without
+    // saving: Whisper auto-detects, so a picker here would offer a language
+    // the drafted provider ignores.
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    providerCatalogData = {
+      providers: [
+        { id: "vellum", displayName: "Vellum", languageSelection: "manual" },
+        {
+          id: "openai-whisper",
+          displayName: "Whisper",
+          languageSelection: "auto",
+        },
+      ],
+    };
+    renderCard();
+
+    await waitFor(() => expect(languageTrigger()).not.toBeNull());
+
+    openProviderDropdown();
+    selectOption("OpenAI");
+
+    expect(languageTrigger()).toBeNull();
+  });
+
+  test("renders for an xai daemon without the Multilingual option", async () => {
+    // xai is configurable via the CLI but unrepresentable in the dropdown
+    // (which falls back to a placeholder); the picker still steers the xai
+    // daemon config, whose adapter drops "multi", so the Multilingual entry
+    // must not be offered.
+    daemonConfigData = { services: { stt: { provider: "xai" } } };
+    providerCatalogData = {
+      providers: [
+        { id: "xai", displayName: "xAI", languageSelection: "manual" },
+      ],
+    };
+    renderCard();
+
+    await waitFor(() => expect(languageTrigger()).not.toBeNull());
+    fireEvent.click(languageTrigger()!);
+    const options = visibleOptions();
+    expect(options).not.toContain("Multilingual");
+    expect(options).toContain("Spanish (Español)");
+  });
+
+  test("a persisted multi under an xai daemon renders via the custom fallback", async () => {
+    daemonConfigData = {
+      services: { stt: { provider: "xai", language: "multi" } },
+    };
+    providerCatalogData = {
+      providers: [
+        { id: "xai", displayName: "xAI", languageSelection: "manual" },
+      ],
+    };
+    renderCard();
+
+    // The trigger shows the persisted truth even though xai ignores it.
+    await waitFor(() => expect(languageTrigger()).not.toBeNull());
+    expect(languageTrigger()!.textContent).toContain("multi (custom)");
+  });
+
   test("shows an out-of-catalog configured language on the trigger", async () => {
     // Any non-empty string is a valid `services.stt.language` (CLI/chat can
     // write "en-US"); the trigger must show it rather than render blank.

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -246,7 +246,8 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     // The provider is unchanged and the daemon already has one, so no config
     // PATCH must fire (which would re-assert / risk clobbering the provider).
     const sttBody = configPatchCalls[0]?.body as
-      { services?: { stt?: Record<string, unknown> } } | undefined;
+      | { services?: { stt?: Record<string, unknown> } }
+      | undefined;
     expect(sttBody?.services?.stt ?? {}).not.toHaveProperty("provider");
   });
 
@@ -431,6 +432,52 @@ describe("SpeechToTextCard — Spoken language dropdown", () => {
     renderCard();
 
     expect(languageTrigger()).toBeNull();
+  });
+
+  test("hides while the form shows the client-only native provider", async () => {
+    // The daemon reports its own (language-selectable) provider, but the
+    // native recognizer never reads `services.stt.language` — a picker here
+    // would PATCH a value nothing consumes.
+    nativeDictationSupported = true;
+    daemonConfigData = { services: { stt: { provider: "deepgram" } } };
+    providerCatalogData = {
+      providers: [
+        {
+          id: "deepgram",
+          displayName: "Deepgram",
+          languageSelection: "manual",
+        },
+      ],
+    };
+    renderCard();
+
+    await waitFor(() => expect(languageTrigger()).not.toBeNull());
+
+    openProviderDropdown();
+    selectOption("macOS Native Dictation");
+
+    expect(languageTrigger()).toBeNull();
+  });
+
+  test("shows an out-of-catalog configured language on the trigger", async () => {
+    // Any non-empty string is a valid `services.stt.language` (CLI/chat can
+    // write "en-US"); the trigger must show it rather than render blank.
+    daemonConfigData = {
+      services: { stt: { provider: "deepgram", language: "en-US" } },
+    };
+    providerCatalogData = {
+      providers: [
+        {
+          id: "deepgram",
+          displayName: "Deepgram",
+          languageSelection: "manual",
+        },
+      ],
+    };
+    renderCard();
+
+    await waitFor(() => expect(languageTrigger()).not.toBeNull());
+    expect(languageTrigger()!.textContent).toContain("en-US");
   });
 
   test("does not render when the daemon omits the capability field (old daemon)", () => {

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -376,7 +376,7 @@ describe("SpeechToTextCard — Vellum provider", () => {
   });
 });
 
-describe("SpeechToTextCard — Spoken language dropdown", () => {
+describe("SpeechToTextCard: Spoken language dropdown", () => {
   beforeEach(() => {
     localStorage.clear();
     nativeDictationSupported = false;
@@ -436,7 +436,7 @@ describe("SpeechToTextCard — Spoken language dropdown", () => {
 
   test("hides while the form shows the client-only native provider", async () => {
     // The daemon reports its own (language-selectable) provider, but the
-    // native recognizer never reads `services.stt.language` — a picker here
+    // native recognizer never reads `services.stt.language`: a picker here
     // would PATCH a value nothing consumes.
     nativeDictationSupported = true;
     daemonConfigData = { services: { stt: { provider: "deepgram" } } };
@@ -480,6 +480,32 @@ describe("SpeechToTextCard — Spoken language dropdown", () => {
 
     openProviderDropdown();
     selectOption("OpenAI");
+
+    expect(languageTrigger()).toBeNull();
+  });
+
+  test("hides when the draft switches between manual providers", async () => {
+    // Saved provider deepgram (manual), dropdown switched to Vellum without
+    // saving: both are manual, but a pick would hot-apply to the still
+    // active deepgram config while the row advertises the draft's options,
+    // so any pending provider draft hides the picker.
+    daemonConfigData = { services: { stt: { provider: "deepgram" } } };
+    providerCatalogData = {
+      providers: [
+        {
+          id: "deepgram",
+          displayName: "Deepgram",
+          languageSelection: "manual",
+        },
+        { id: "vellum", displayName: "Vellum", languageSelection: "manual" },
+      ],
+    };
+    renderCard();
+
+    await waitFor(() => expect(languageTrigger()).not.toBeNull());
+
+    openProviderDropdown();
+    selectOption("Vellum");
 
     expect(languageTrigger()).toBeNull();
   });

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -8,6 +8,10 @@
  *   3. A persisted native choice on a build without the capability falls
  *      back to the default provider instead of an empty dropdown.
  *
+ * Plus the "Spoken language" dropdown: shown only when the daemon reports
+ * the configured provider as manually language-selectable, hidden for
+ * auto-detecting providers and old daemons that omit the capability field.
+ *
  * The native-dictation runtime module is mocked (its real implementation
  * imports a Vite `?worker&url` asset and probes `window.vellum`); the
  * design-library Dropdown is real, driven via its combobox trigger like
@@ -39,8 +43,11 @@ mock.module("@vellumai/design-library/components/toast", () => ({
   Toaster: () => null,
   ToastContent: () => null,
 }));
+// Mutable so the Spoken-language tests can enable the org-gated queries the
+// language hook depends on; the provider tests keep the gate closed.
+let orgReady = false;
 mock.module("@/hooks/use-is-org-ready", () => ({
-  useIsOrgReady: () => false,
+  useIsOrgReady: () => orgReady,
 }));
 
 // Controllable daemon config the config-get query resolves to. `initialData`
@@ -48,6 +55,15 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 // mirroring how the real query would already be cached. Default `{ services: {} }`
 // leaves the daemon with no stt provider, so the happy-path tests still PATCH it.
 let daemonConfigData: { services: Record<string, unknown> } = { services: {} };
+// Provider capability probe backing the Spoken-language dropdown. Default
+// empty: the language control stays hidden in the provider-focused tests.
+let providerCatalogData: {
+  providers: {
+    id: string;
+    displayName: string;
+    languageSelection?: "manual" | "auto";
+  }[];
+} = { providers: [] };
 mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
   configGetOptions: () => ({
     queryKey: ["config-get-test"],
@@ -55,6 +71,11 @@ mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
     initialData: daemonConfigData,
   }),
   configGetQueryKey: () => ["config-get-test"],
+  sttProvidersGetOptions: () => ({
+    queryKey: ["stt-providers-test"],
+    queryFn: () => Promise.resolve(providerCatalogData),
+    initialData: providerCatalogData,
+  }),
 }));
 
 // Capture the daemon writes Save now performs (CES key + services.stt config).
@@ -126,6 +147,8 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     credentialsSetCalls.length = 0;
     configPatchCalls.length = 0;
     daemonConfigData = { services: {} };
+    providerCatalogData = { providers: [] };
+    orgReady = false;
   });
 
   afterEach(() => {
@@ -250,6 +273,8 @@ describe("SpeechToTextCard — Vellum provider", () => {
     credentialsSetCalls.length = 0;
     configPatchCalls.length = 0;
     daemonConfigData = { services: {} };
+    providerCatalogData = { providers: [] };
+    orgReady = false;
   });
 
   afterEach(() => {
@@ -347,5 +372,74 @@ describe("SpeechToTextCard — Vellum provider", () => {
     });
     // The client keeps routing dictation locally.
     expect(localStorage.getItem(LS_STT_PROVIDER)).toBe("macos-native");
+  });
+});
+
+describe("SpeechToTextCard — Spoken language dropdown", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    nativeDictationSupported = false;
+    credentialsSetCalls.length = 0;
+    configPatchCalls.length = 0;
+    daemonConfigData = { services: {} };
+    providerCatalogData = { providers: [] };
+    // The language hook's queries are org-gated; open the gate so the
+    // capability probe and config read resolve.
+    orgReady = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  function languageTrigger(): HTMLButtonElement | null {
+    return document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Spoken language"]',
+    );
+  }
+
+  test("renders for a manually language-selectable provider and lists Multilingual", async () => {
+    daemonConfigData = { services: { stt: { provider: "deepgram" } } };
+    providerCatalogData = {
+      providers: [
+        {
+          id: "deepgram",
+          displayName: "Deepgram",
+          languageSelection: "manual",
+        },
+      ],
+    };
+    renderCard();
+
+    await waitFor(() => expect(languageTrigger()).not.toBeNull());
+    fireEvent.click(languageTrigger()!);
+    expect(visibleOptions()).toContain("Multilingual");
+  });
+
+  test("does not render for an auto-detecting provider", () => {
+    daemonConfigData = { services: { stt: { provider: "google-gemini" } } };
+    providerCatalogData = {
+      providers: [
+        {
+          id: "google-gemini",
+          displayName: "Gemini",
+          languageSelection: "auto",
+        },
+      ],
+    };
+    renderCard();
+
+    expect(languageTrigger()).toBeNull();
+  });
+
+  test("does not render when the daemon omits the capability field (old daemon)", () => {
+    daemonConfigData = { services: { stt: { provider: "deepgram" } } };
+    providerCatalogData = {
+      providers: [{ id: "deepgram", displayName: "Deepgram" }],
+    };
+    renderCard();
+
+    expect(languageTrigger()).toBeNull();
   });
 });

--- a/clients/web/src/lib/stt/language-catalog.test.ts
+++ b/clients/web/src/lib/stt/language-catalog.test.ts
@@ -33,17 +33,49 @@ describe("STT_LANGUAGES", () => {
 
 describe("sttLanguageOptionsFor", () => {
   test("returns the catalog unchanged for a catalog code", () => {
-    expect(sttLanguageOptionsFor("es")).toBe(STT_LANGUAGES);
+    expect(sttLanguageOptionsFor("es", "deepgram")).toBe(STT_LANGUAGES);
   });
 
   test("returns the catalog unchanged for the default code", () => {
-    expect(sttLanguageOptionsFor("")).toBe(STT_LANGUAGES);
+    expect(sttLanguageOptionsFor("", "deepgram")).toBe(STT_LANGUAGES);
+  });
+
+  test("includes Multilingual for deepgram and vellum", () => {
+    // Both run Deepgram nova-3 (vellum relays with the model pinned
+    // server-side), the only place "multi" code-switching works.
+    for (const providerId of ["deepgram", "vellum"]) {
+      const codes = sttLanguageOptionsFor("", providerId).map((o) => o.code);
+      expect(codes).toContain(STT_MULTI_CODE);
+    }
+  });
+
+  test("omits Multilingual for xai", () => {
+    // The resolver drops "multi" before it reaches the xAI adapter, so
+    // offering it would be a silent no-op.
+    const codes = sttLanguageOptionsFor("", "xai").map((o) => o.code);
+    expect(codes).not.toContain(STT_MULTI_CODE);
+    expect(sttLanguageOptionsFor("", "xai")).toHaveLength(
+      STT_LANGUAGES.length - 1,
+    );
+  });
+
+  test("a persisted multi under xai still renders via the custom fallback", () => {
+    // The picker shows the persisted truth even when the provider ignores
+    // it; a trigger that renders blank invites an accidental overwrite.
+    const options = sttLanguageOptionsFor(STT_MULTI_CODE, "xai");
+    expect(options[options.length - 1]).toEqual({
+      code: STT_MULTI_CODE,
+      label: "multi (custom)",
+    });
+    // The catalog's own Multilingual entry stays out; only the fallback
+    // carries the code.
+    expect(options.filter((o) => o.code === STT_MULTI_CODE)).toHaveLength(1);
   });
 
   test("appends a custom entry for an out-of-catalog code", () => {
     // `services.stt.language` accepts any non-empty string; a CLI-written
     // "en-US" must stay visible in the picker instead of a blank trigger.
-    const options = sttLanguageOptionsFor("en-US");
+    const options = sttLanguageOptionsFor("en-US", "deepgram");
     expect(options).toHaveLength(STT_LANGUAGES.length + 1);
     expect(options[options.length - 1]).toEqual({
       code: "en-US",

--- a/clients/web/src/lib/stt/language-catalog.test.ts
+++ b/clients/web/src/lib/stt/language-catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   STT_LANGUAGES,
   STT_MULTI_CODE,
+  sttLanguageOptionsFor,
   suggestedLanguageForLocale,
 } from "./language-catalog";
 
@@ -27,6 +28,27 @@ describe("STT_LANGUAGES", () => {
     expect(description).toContain("Japanese");
     expect(description).toContain("Italian");
     expect(description).toContain("Dutch");
+  });
+});
+
+describe("sttLanguageOptionsFor", () => {
+  test("returns the catalog unchanged for a catalog code", () => {
+    expect(sttLanguageOptionsFor("es")).toBe(STT_LANGUAGES);
+  });
+
+  test("returns the catalog unchanged for the default code", () => {
+    expect(sttLanguageOptionsFor("")).toBe(STT_LANGUAGES);
+  });
+
+  test("appends a custom entry for an out-of-catalog code", () => {
+    // `services.stt.language` accepts any non-empty string; a CLI-written
+    // "en-US" must stay visible in the picker instead of a blank trigger.
+    const options = sttLanguageOptionsFor("en-US");
+    expect(options).toHaveLength(STT_LANGUAGES.length + 1);
+    expect(options[options.length - 1]).toEqual({
+      code: "en-US",
+      label: "en-US (custom)",
+    });
   });
 });
 

--- a/clients/web/src/lib/stt/language-catalog.ts
+++ b/clients/web/src/lib/stt/language-catalog.ts
@@ -42,6 +42,28 @@ export const STT_LANGUAGES: readonly SttLanguageOption[] = [
 ];
 
 /**
+ * Dropdown options for a picker whose current selection is `currentCode`:
+ * the catalog, plus a synthetic "(custom)" entry when the code sits outside
+ * it. `services.stt.language` accepts any non-empty string (the CLI and chat
+ * config edits write codes like "en-US"), and a trigger that renders blank
+ * for such a value invites an accidental overwrite; the synthetic entry
+ * keeps the persisted value visible while picking a catalog option still
+ * overwrites it normally.
+ */
+export function sttLanguageOptionsFor(
+  currentCode: string,
+): readonly SttLanguageOption[] {
+  const inCatalog = STT_LANGUAGES.some((option) => option.code === currentCode);
+  if (inCatalog) {
+    return STT_LANGUAGES;
+  }
+  return [
+    ...STT_LANGUAGES,
+    { code: currentCode, label: `${currentCode} (custom)` },
+  ];
+}
+
+/**
  * Suggested STT language for a browser locale (`navigator.language`), or
  * `null` when no suggestion applies (English, empty, or outside the catalog).
  *

--- a/clients/web/src/lib/stt/language-catalog.ts
+++ b/clients/web/src/lib/stt/language-catalog.ts
@@ -42,25 +42,43 @@ export const STT_LANGUAGES: readonly SttLanguageOption[] = [
 ];
 
 /**
- * Dropdown options for a picker whose current selection is `currentCode`:
- * the catalog, plus a synthetic "(custom)" entry when the code sits outside
- * it. `services.stt.language` accepts any non-empty string (the CLI and chat
- * config edits write codes like "en-US"), and a trigger that renders blank
- * for such a value invites an accidental overwrite; the synthetic entry
- * keeps the persisted value visible while picking a catalog option still
- * overwrites it normally.
+ * Daemon provider ids whose language option accepts `"multi"`: Deepgram
+ * code-switching is a nova-3 mode, so it only works where nova-3 runs.
+ * `deepgram` streams to nova-3 directly and `vellum` relays to Deepgram
+ * with the model pinned to nova-3 server-side. Mirrors the resolver's guard
+ * in `assistant/src/providers/speech-to-text/resolve.ts`, which drops
+ * `"multi"` before it reaches any other adapter (xAI expects BCP-47 codes),
+ * so offering it elsewhere would be a silent no-op.
+ */
+const MULTI_CAPABLE_DAEMON_PROVIDERS: ReadonlySet<string> = new Set([
+  "deepgram",
+  "vellum",
+]);
+
+/**
+ * Dropdown options for a picker whose current selection is `currentCode`,
+ * steering the daemon provider `daemonProviderId`: the catalog, minus the
+ * Multilingual entry for providers whose adapter drops `"multi"` (see
+ * `MULTI_CAPABLE_DAEMON_PROVIDERS`), plus a synthetic "(custom)" entry when
+ * the code sits outside the offered set. `services.stt.language` accepts any
+ * non-empty string (the CLI and chat config edits write codes like "en-US",
+ * and can persist `"multi"` for a provider that ignores it), and a trigger
+ * that renders blank for such a value invites an accidental overwrite; the
+ * synthetic entry keeps the persisted value visible while picking a catalog
+ * option still overwrites it normally.
  */
 export function sttLanguageOptionsFor(
   currentCode: string,
+  daemonProviderId: string,
 ): readonly SttLanguageOption[] {
-  const inCatalog = STT_LANGUAGES.some((option) => option.code === currentCode);
+  const catalog = MULTI_CAPABLE_DAEMON_PROVIDERS.has(daemonProviderId)
+    ? STT_LANGUAGES
+    : STT_LANGUAGES.filter((option) => option.code !== STT_MULTI_CODE);
+  const inCatalog = catalog.some((option) => option.code === currentCode);
   if (inCatalog) {
-    return STT_LANGUAGES;
+    return catalog;
   }
-  return [
-    ...STT_LANGUAGES,
-    { code: currentCode, label: `${currentCode} (custom)` },
-  ];
+  return [...catalog, { code: currentCode, label: `${currentCode} (custom)` }];
 }
 
 /**


### PR DESCRIPTION
## Summary
- New useSttLanguageSelection hook: capability-probes /v1/stt/providers (languageSelection manual/auto), reads/writes services.stt.language via configPatch with optimistic + serialized writes
- Spoken language dropdown on the STT settings form, visible only for providers that accept an explicit language; hot-applies on the next spoken turn
- First production consumer of the PR 3 language catalog

Part of plan: stt-language-selection.md (PR 4 of 7)