### PR TITLE
feat(live-voice): re-dial the persistent STT stream when the configured language changes

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, mock, test } from "bun:test";
 
 import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
+import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -740,6 +741,124 @@ describe("LiveVoiceSession STT", () => {
 
     await session.close("websocket_close");
     expect(transcriber.stopCalls).toBe(1);
+  });
+
+  test("re-dials a fresh transcriber when services.stt.language changes between utterances", async () => {
+    const originalRaw = loadRawConfig();
+    const transcribers: FinalizingMockStreamingTranscriber[] = [];
+    const resolver = mock(async () => {
+      const transcriber = new FinalizingMockStreamingTranscriber();
+      transcribers.push(transcriber);
+      return transcriber;
+    });
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+    });
+
+    try {
+      await session.start();
+      await session.handleBinaryAudio(loudPcmChunk());
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(
+        () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+      );
+
+      // The voice-room gear patches services.stt.language while the session
+      // idles between turns; no session protocol message is involved.
+      const rawServices = (originalRaw.services ?? {}) as Record<
+        string,
+        unknown
+      >;
+      saveRawConfig({
+        ...originalRaw,
+        services: {
+          ...rawServices,
+          stt: {
+            ...((rawServices.stt ?? {}) as Record<string, unknown>),
+            language: "hi",
+          },
+        },
+      });
+
+      await session.handleBinaryAudio(loudPcmChunk());
+      await waitFor(() => transcribers.length === 2);
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(
+        () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+      );
+
+      // The old-language stream is stopped and a fresh one dialed; both
+      // turns read "utterance 1" because each transcriber's finalize
+      // counter starts at one, which is itself proof the second stream is
+      // a fresh instance rather than the reused first.
+      expect(resolver).toHaveBeenCalledTimes(2);
+      expect(transcribers[0]?.stopCalls).toBe(1);
+      expect(transcribers[1]?.startCalls).toBe(1);
+      expect(transcribers[1]?.stopCalls).toBe(0);
+      expect(startVoiceTurn.mock.calls.map((call) => call[0].content)).toEqual([
+        "utterance 1",
+        "utterance 1",
+      ]);
+      expect(
+        frames.flatMap((frame) =>
+          frame.type === "stt_final" ? [frame.text] : [],
+        ),
+      ).toEqual(["utterance 1", "utterance 1"]);
+    } finally {
+      await session.close("websocket_close");
+      saveRawConfig(originalRaw);
+    }
+  });
+
+  test("keeps the zero-round-trip re-arm when the configured language is unchanged", async () => {
+    const originalRaw = loadRawConfig();
+    const rawServices = (originalRaw.services ?? {}) as Record<string, unknown>;
+    saveRawConfig({
+      ...originalRaw,
+      services: {
+        ...rawServices,
+        stt: {
+          ...((rawServices.stt ?? {}) as Record<string, unknown>),
+          language: "en-US",
+        },
+      },
+    });
+    const transcriber = new FinalizingMockStreamingTranscriber();
+    const resolver = mock(async () => transcriber);
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+    });
+
+    try {
+      await session.start();
+      await session.handleBinaryAudio(loudPcmChunk());
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(
+        () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+      );
+
+      await session.handleBinaryAudio(loudPcmChunk());
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(
+        () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+      );
+
+      // A set-and-unchanged language matches at every re-arm, so the
+      // session keeps the single shared stream.
+      expect(resolver).toHaveBeenCalledTimes(1);
+      expect(transcriber.startCalls).toBe(1);
+      expect(transcriber.stopCalls).toBe(0);
+      expect(transcriber.finalizeCalls).toBe(2);
+    } finally {
+      await session.close("websocket_close");
+      saveRawConfig(originalRaw);
+    }
   });
 
   test("grace timeout starts the turn with collected segments when the finalize flush never arrives", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -163,6 +163,10 @@ function loudPcmChunk(amplitude = 8_000, sampleCount = 240): Uint8Array {
   return new Uint8Array(buffer);
 }
 
+function silentPcmChunk(sampleCount = 240): Uint8Array {
+  return new Uint8Array(Buffer.alloc(sampleCount * 2));
+}
+
 function createSessionWithTranscriber(
   transcriber = new MockStreamingTranscriber(),
 ) {
@@ -820,6 +824,83 @@ describe("LiveVoiceSession STT", () => {
         () => frames.filter((frame) => frame.type === "tts_done").length === 3,
       );
       expect(resolver).toHaveBeenCalledTimes(2);
+      expect(transcribers[1]?.stopCalls).toBe(0);
+    } finally {
+      await session.close("websocket_close");
+      saveRawConfig(originalRaw);
+    }
+  });
+
+  test("re-dials for a language change when the eager cycle holds only pre-roll silence", async () => {
+    const originalRaw = loadRawConfig();
+    const transcribers: FinalizingMockStreamingTranscriber[] = [];
+    const resolver = mock(async () => {
+      const transcriber = new FinalizingMockStreamingTranscriber();
+      transcribers.push(transcriber);
+      return transcriber;
+    });
+    // Deferred turn completion: silence sent while the turn is in flight
+    // parks in the VAD pre-roll ring, so the finalize-time eager re-arm
+    // flushes it into the next cycle (assigning a turnId without speech).
+    const pendingCompletions: Array<() => void> = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      pendingCompletions.push(() => {
+        options.callbacks?.message_complete?.({
+          type: "message_complete",
+          conversationId: options.conversationId,
+          messageId: "assistant-message-123",
+        });
+      });
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+    });
+
+    try {
+      await session.start();
+      await session.handleBinaryAudio(loudPcmChunk());
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => pendingCompletions.length === 1);
+      // Idle mic while the assistant responds: silence lands in the
+      // pre-roll ring ahead of the eager re-arm.
+      await session.handleBinaryAudio(silentPcmChunk());
+      await session.handleBinaryAudio(silentPcmChunk());
+      pendingCompletions.shift()?.();
+      await waitFor(
+        () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+      );
+
+      const rawServices = (originalRaw.services ?? {}) as Record<
+        string,
+        unknown
+      >;
+      saveRawConfig({
+        ...originalRaw,
+        services: {
+          ...rawServices,
+          stt: {
+            ...((rawServices.stt ?? {}) as Record<string, unknown>),
+            language: "hi",
+          },
+        },
+      });
+
+      // First speech after the change: the silence-only eager cycle retires
+      // with the old-language stream and a fresh one dials.
+      await session.handleBinaryAudio(loudPcmChunk());
+      await waitFor(() => transcribers.length === 2);
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => pendingCompletions.length === 1);
+      pendingCompletions.shift()?.();
+      await waitFor(
+        () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+      );
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+      expect(transcribers[0]?.stopCalls).toBe(1);
       expect(transcribers[1]?.stopCalls).toBe(0);
     } finally {
       await session.close("websocket_close");

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -807,6 +807,20 @@ describe("LiveVoiceSession STT", () => {
           frame.type === "stt_final" ? [frame.text] : [],
         ),
       ).toEqual(["utterance 1", "utterance 1"]);
+
+      // A retired stream's stop() emits closed asynchronously, possibly
+      // after the replacement stream is installed. The stale close must
+      // leave the replacement's shared-stream state intact: the next
+      // utterance re-arms the replacement instead of dialing a third
+      // stream.
+      transcribers[0]?.emit({ type: "closed" });
+      await session.handleBinaryAudio(loudPcmChunk());
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(
+        () => frames.filter((frame) => frame.type === "tts_done").length === 3,
+      );
+      expect(resolver).toHaveBeenCalledTimes(2);
+      expect(transcribers[1]?.stopCalls).toBe(0);
     } finally {
       await session.close("websocket_close");
       saveRawConfig(originalRaw);

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -330,6 +330,13 @@ interface UtteranceCycle {
   // server_vad has the turn detector for the same question, and never sets
   // this — its ingress is handleServerVadAudio.
   manualAudioCaptured: boolean;
+  // server_vad capture routed speech (not just pre-roll silence) into this
+  // cycle. Distinguishes an eagerly re-armed cycle holding only leading
+  // silence from one already carrying the user's utterance: the
+  // stale-language interception in handleServerVadAudio may retire the
+  // former, never the latter. turnId cannot answer this, because a
+  // silence-only pre-roll flush assigns it too.
+  speechRouted: boolean;
   pendingAudioChunks: Buffer[];
   pendingAudioBytes: number;
   finalTranscriptSegments: string[];
@@ -768,6 +775,7 @@ function createUtteranceCycle(): UtteranceCycle {
     finalizeRequested: false,
     transcriber: null,
     manualAudioCaptured: false,
+    speechRouted: false,
     pendingAudioChunks: [],
     pendingAudioBytes: 0,
     finalTranscriptSegments: [],
@@ -1520,17 +1528,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Language change made while the session idles: the post-turn re-arm
     // binds the next cycle to the shared stream eagerly, before the picker
     // patches services.stt.language, so the stale binding surfaces when
-    // speech first reaches the armed cycle. An empty cycle (turnId is
-    // assigned with the first routed chunk) retires together with the
-    // old-language stream and falls through to the lazy arm below, which
-    // dials a fresh stream with the configured language.
+    // speech first reaches the armed cycle. A cycle that has routed no
+    // speech (pre-roll silence flushed at arm time does not count, see
+    // speechRouted) retires together with the old-language stream and
+    // falls through to the lazy arm below, which dials a fresh stream
+    // with the configured language.
     const sharedForLanguage = this.sharedTranscriber;
     if (
       sharedForLanguage &&
       utterance.transcriber === sharedForLanguage &&
       !utterance.released &&
       !utterance.completed &&
-      utterance.turnId === null &&
+      !utterance.speechRouted &&
       this.sharedStreamLanguageIsStale()
     ) {
       this.retireSharedTranscriberForRedial(sharedForLanguage);
@@ -1559,6 +1568,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
     }
 
+    // Speech is now reaching the cycle, either in this chunk or parked in
+    // the pre-roll about to flush; read the flag before takeVadPreRoll
+    // resets it.
+    if (hasSpeech || this.vadPreRollHasSpeech) {
+      utterance.speechRouted = true;
+    }
     for (const preRollChunk of this.takeVadPreRoll()) {
       await this.routeVadAudio(utterance, preRollChunk);
     }
@@ -1615,9 +1630,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Arm-time flush: parked release-window audio joins the new cycle's
   // pending buffer so a completed parked utterance needs no further speech.
   private flushVadPreRollIntoPending(utterance: UtteranceCycle): void {
+    // Read before takeVadPreRoll resets it: a ring holding parked speech
+    // makes this cycle speech-bearing, a silence-only ring does not.
+    const preRollHadSpeech = this.vadPreRollHasSpeech;
     for (const chunk of this.takeVadPreRoll()) {
       this.collectUserAudio(utterance, chunk);
       this.bufferPendingUtteranceAudio(utterance, chunk);
+    }
+    if (preRollHadSpeech) {
+      utterance.speechRouted = true;
     }
   }
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1007,6 +1007,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // providers without finalizeUtterance, and after an unexpected stream
   // close (the next arm resolves a fresh transcriber).
   private sharedTranscriber: StreamingTranscriber | null = null;
+  // The `services.stt.language` value the shared stream was dialed with.
+  // Providers pin the language per connection, so the persistent re-arm
+  // compares this against the current config and re-dials on a change
+  // instead of reusing a stream locked to the old language. Cleared
+  // whenever sharedTranscriber is cleared.
+  private sharedTranscriberLanguage: string | undefined;
   /**
    * FIFO of released cycles awaiting finalize settlement on the shared
    * stream, oldest first. Flush finals and `finalized` signals carry no
@@ -1248,13 +1254,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     const shared = this.sharedTranscriber;
     if (shared) {
-      // Persistent re-arm: the shared stream is already open, so the cycle
-      // goes straight to streaming with no resolve/start round-trip.
-      utterance.transcriber = shared;
-      return await this.activateUtterance(utterance, replayTurnEnd);
+      if (!this.sharedStreamLanguageIsStale()) {
+        // Persistent re-arm: the shared stream is already open, so the cycle
+        // goes straight to streaming with no resolve/start round-trip.
+        utterance.transcriber = shared;
+        return await this.activateUtterance(utterance, replayTurnEnd);
+      }
+      // The shared stream is pinned to the old language, so retire it and
+      // fall through to the fresh resolve, which reads the language from
+      // config at resolve time.
+      this.retireSharedTranscriberForRedial(shared);
     }
 
     try {
+      // Snapshot the language the resolver reads so the shared stream's
+      // dialed language is recorded for the re-arm comparison (the session
+      // passes no explicit language option).
+      const sttLanguage = getConfig().services.stt.language;
       const transcriber = await this.resolveTranscriber({
         sampleRate: this.context.startFrame.audio.sampleRate,
       });
@@ -1280,6 +1296,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // its events route by cycle ownership instead of binding to this
         // one cycle.
         this.sharedTranscriber = transcriber;
+        this.sharedTranscriberLanguage = sttLanguage;
         await transcriber.start((event) => {
           void this.handleSharedTranscriberEvent(transcriber, event);
         });
@@ -1341,7 +1358,39 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   ): void {
     if (transcriber && this.sharedTranscriber === transcriber) {
       this.sharedTranscriber = null;
+      this.sharedTranscriberLanguage = undefined;
     }
+  }
+
+  // Config-driven language change detection: the web client's language
+  // picker patches services.stt.language and the daemon's config cache
+  // invalidation surfaces the new value on the next getConfig() read, with
+  // no session protocol message involved.
+  private sharedStreamLanguageIsStale(): boolean {
+    return this.sharedTranscriberLanguage !== getConfig().services.stt.language;
+  }
+
+  // Retires the shared stream so the next arm dials a fresh one (used when
+  // the configured language changes between utterances). Any cycle still in
+  // the finalize queue here has already dispatched its assistant turn:
+  // arming a new cycle requires assistantTurnStarted or completed, and only
+  // an arm reaches this path. Draining the queue is therefore bookkeeping
+  // that matches the unexpected-close drain: the drained cycles' late flush
+  // tails die with the old stream, and their sealed transcripts stand.
+  private retireSharedTranscriberForRedial(shared: StreamingTranscriber): void {
+    this.releaseSharedTranscriber(shared);
+    this.clearFinalizeGraceTimer();
+    const drained = this.finalizeQueue;
+    this.finalizeQueue = [];
+    for (const finalizing of drained) {
+      if (finalizing.transcriber === shared) {
+        finalizing.transcriber = null;
+      }
+      if (finalizing.phase === "released") {
+        finalizing.phase = "transcriber_closed";
+      }
+    }
+    stopTranscriberBestEffort(shared);
   }
 
   private isUtteranceStale(utterance: UtteranceCycle): boolean {
@@ -1465,6 +1514,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     let utterance = this.currentUtterance;
     if (!utterance) {
       return;
+    }
+    // Language change made while the session idles: the post-turn re-arm
+    // binds the next cycle to the shared stream eagerly, before the picker
+    // patches services.stt.language, so the stale binding surfaces when
+    // speech first reaches the armed cycle. An empty cycle (turnId is
+    // assigned with the first routed chunk) retires together with the
+    // old-language stream and falls through to the lazy arm below, which
+    // dials a fresh stream with the configured language.
+    const sharedForLanguage = this.sharedTranscriber;
+    if (
+      sharedForLanguage &&
+      utterance.transcriber === sharedForLanguage &&
+      !utterance.released &&
+      !utterance.completed &&
+      utterance.turnId === null &&
+      this.sharedStreamLanguageIsStale()
+    ) {
+      this.retireSharedTranscriberForRedial(sharedForLanguage);
+      utterance.transcriber = null;
+      utterance.phase = "transcriber_closed";
+      await this.finalizePendingUtterance(utterance, "stt_language_changed");
     }
     if (utterance.released || utterance.completed) {
       // Parked speech makes silent chunks arm-worthy too: the parked
@@ -2920,6 +2990,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // The shared stream closed under the session: fall back to the
         // per-cycle path — the next arm resolves a fresh transcriber.
         this.sharedTranscriber = null;
+        this.sharedTranscriberLanguage = undefined;
         this.clearFinalizeGraceTimer();
         const drained = this.finalizeQueue;
         this.finalizeQueue = [];
@@ -3060,6 +3131,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.finalizeQueue = [];
     const shared = this.sharedTranscriber;
     this.sharedTranscriber = null;
+    this.sharedTranscriberLanguage = undefined;
     const utterance = this.currentUtterance;
     const transcriber = utterance?.transcriber ?? null;
     if (utterance) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1267,12 +1267,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     try {
-      // Snapshot the language the resolver reads so the shared stream's
-      // dialed language is recorded for the re-arm comparison (the session
-      // passes no explicit language option).
+      // One language snapshot serves both the dial and the re-arm
+      // comparison: passing it to the resolver keeps the stream's actual
+      // language and the recorded sharedTranscriberLanguage identical even
+      // when config changes while the resolver awaits credentials.
       const sttLanguage = getConfig().services.stt.language;
       const transcriber = await this.resolveTranscriber({
         sampleRate: this.context.startFrame.audio.sampleRate,
+        ...(sttLanguage ? { language: sttLanguage } : {}),
       });
 
       if (this.isUtteranceStale(utterance)) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2989,6 +2989,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         await this.sendTranscriberErrorFrame(event);
         return;
       case "closed": {
+        if (this.sharedTranscriber !== transcriber) {
+          // A retired stream's stop() emits closed asynchronously, possibly
+          // after a replacement stream is installed. The retire path already
+          // drained the finalize queue and nulled the stream refs, so this
+          // close is stale bookkeeping; mutating here would clear the
+          // replacement's state and seal its in-flight utterance early.
+          return;
+        }
         // The shared stream closed under the session: fall back to the
         // per-cycle path — the next arm resolves a fresh transcriber.
         this.sharedTranscriber = null;


### PR DESCRIPTION
## Summary
- Persistent (server-VAD) live-voice sessions record the language their shared STT stream was dialed with and compare it against services.stt.language at each re-arm
- On mismatch the shared stream is released and torn down via the existing teardown path and the next utterance resolves a fresh transcriber with the new language; unchanged language keeps the zero-round-trip re-arm
- Per-cycle mode needs no change: every utterance re-resolves and reads the config

Part of plan: stt-language-selection.md (PR 6 of 7)