### PR TITLE
feat(web): slide the mobile command palette out on close in the iOS shell

### DIFF
--- a/clients/web/src/components/command-palette/command-palette-window-page.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette-window-page.test.tsx
@@ -61,6 +61,7 @@ const localSelectedRef = {
   value: null as { assistantId: string; name?: string } | null,
 };
 mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => false,
   getSelectedAssistant: () => localSelectedRef.value,
   getActiveAssistant: () =>
     resolvedRef.activeAssistantId

--- a/clients/web/src/components/command-palette/command-palette.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette.test.tsx
@@ -107,8 +107,8 @@ describe("CommandPalette", () => {
 
     rerender(paletteElement(false));
 
-    // The load-bearing behavior: close is no longer a synchronous unmount, so
-    // AnimatePresence still holds the sheet while the exit plays.
+    // The load-bearing behavior: AnimatePresence holds the sheet in the DOM
+    // while the exit plays, so the chat underneath stays covered.
     expect(screen.getByRole("dialog", { name: "Search" })).toBeTruthy();
   });
 

--- a/clients/web/src/components/command-palette/command-palette.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette.test.tsx
@@ -2,10 +2,15 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
 
 const isMobileRef = { value: false };
+const nativeIOSRef = { value: false };
 
 mock.module("@/hooks/use-is-mobile", () => ({
   useIsMobile: () => isMobileRef.value,
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeIOS: () => nativeIOSRef.value,
 }));
 
 const { CommandPalette } =
@@ -14,7 +19,34 @@ const { CommandPalette } =
 afterEach(() => {
   cleanup();
   isMobileRef.value = false;
+  nativeIOSRef.value = false;
 });
+
+const SECTIONS = [
+  {
+    id: "actions",
+    label: "Actions",
+    items: [{ id: "new", title: "New Conversation" }],
+  },
+];
+
+function paletteElement(isOpen: boolean) {
+  return (
+    <CommandPalette
+      isOpen={isOpen}
+      onClose={() => undefined}
+      query=""
+      onQueryChange={() => undefined}
+      selectedIndex={0}
+      sections={SECTIONS}
+      onKeyDown={() => undefined}
+    />
+  );
+}
+
+function renderPalette(isOpen: boolean) {
+  return render(paletteElement(isOpen));
+}
 
 describe("CommandPalette", () => {
   test("uses compact desktop styling inside the floating window even at mobile widths", () => {
@@ -28,13 +60,7 @@ describe("CommandPalette", () => {
         query=""
         onQueryChange={() => undefined}
         selectedIndex={0}
-        sections={[
-          {
-            id: "actions",
-            label: "Actions",
-            items: [{ id: "new", title: "New Conversation" }],
-          },
-        ]}
+        sections={SECTIONS}
         onKeyDown={() => undefined}
       />,
     );
@@ -49,5 +75,50 @@ describe("CommandPalette", () => {
     const selected = screen.getByRole("option", { selected: true });
     expect(selected.className).toContain("h-10");
     expect(selected.className).toContain("text-sm");
+  });
+
+  test("renders nothing while closed outside the iOS shell", () => {
+    isMobileRef.value = true;
+    nativeIOSRef.value = false;
+
+    renderPalette(false);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  test("unmounts the sheet synchronously on close outside the iOS shell", () => {
+    isMobileRef.value = true;
+    nativeIOSRef.value = false;
+
+    const { rerender } = renderPalette(true);
+    expect(screen.getByRole("dialog", { name: "Search" })).toBeTruthy();
+
+    rerender(paletteElement(false));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  test("keeps the sheet in the DOM after close in the iOS shell", () => {
+    isMobileRef.value = true;
+    nativeIOSRef.value = true;
+
+    const { rerender } = renderPalette(true);
+    expect(screen.getByRole("dialog", { name: "Search" })).toBeTruthy();
+
+    rerender(paletteElement(false));
+
+    // The load-bearing behavior: close is no longer a synchronous unmount, so
+    // AnimatePresence still holds the sheet while the exit plays.
+    expect(screen.getByRole("dialog", { name: "Search" })).toBeTruthy();
+  });
+
+  test("renders the mobile sheet affordances in the iOS shell", () => {
+    isMobileRef.value = true;
+    nativeIOSRef.value = true;
+
+    renderPalette(true);
+
+    expect(screen.getByRole("dialog", { name: "Search" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Close search" })).toBeTruthy();
   });
 });

--- a/clients/web/src/components/command-palette/command-palette.tsx
+++ b/clients/web/src/components/command-palette/command-palette.tsx
@@ -1,9 +1,11 @@
 import type { LucideIcon } from "lucide-react";
 import { Loader2, Search, X } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   useCallback,
   useEffect,
   useRef,
+  type CSSProperties,
   type FC,
   type KeyboardEvent,
   type MouseEvent,
@@ -12,9 +14,24 @@ import {
 import { createPortal } from "react-dom";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useIsNativeIOS } from "@/runtime/platform-detection";
 import { Button, Typography } from "@vellumai/design-library";
 
 import { CommandPaletteItem } from "@/components/command-palette/command-palette-item";
+
+// z-50 keeps the full-screen palette above the navigation drawer (fixed z-40
+// in chat-layout), which stays mounted underneath so dismissing search returns
+// to the menu.
+const MOBILE_SHEET_CLASSES =
+  "fixed inset-0 z-50 flex flex-col bg-[var(--surface-lift)]";
+
+const MOBILE_SHEET_SAFE_AREA_STYLE: CSSProperties = {
+  paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+  paddingBottom:
+    "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+  paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+  paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -83,6 +100,8 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
   surface = "overlay",
 }) => {
   const isMobile = useIsMobile();
+  const isNativeIOSShell = useIsNativeIOS();
+  const reduceMotion = useReducedMotion();
   const overlayRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -118,14 +137,18 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
     [onClose],
   );
 
-  if (!isOpen) {
+  const isWindowSurface = surface === "window";
+  const useMobileLayout = isMobile && !isWindowSurface;
+  // iOS shell only: the sheet stays mounted while closed so AnimatePresence
+  // can play the slide-out exit.
+  const animateMobileSheet = isNativeIOSShell && useMobileLayout;
+
+  if (!isOpen && !animateMobileSheet) {
     return null;
   }
 
   // Flatten all items to compute the global index for each item.
   let flatIndex = 0;
-  const isWindowSurface = surface === "window";
-  const useMobileLayout = isMobile && !isWindowSurface;
 
   const searchInputRow = (
     <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-base)] px-4 py-3">
@@ -265,27 +288,44 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
     </div>
   );
 
+  if (animateMobileSheet) {
+    return (
+      <AnimatePresence>
+        {isOpen ? (
+          <motion.div
+            key="command-palette-sheet"
+            className={MOBILE_SHEET_CLASSES}
+            style={MOBILE_SHEET_SAFE_AREA_STYLE}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Search"
+            onKeyDown={onKeyDown}
+            initial={{ y: "100%", opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: "100%", opacity: 0 }}
+            transition={
+              reduceMotion
+                ? { duration: 0 }
+                : { duration: 0.28, ease: [0.16, 1, 0.3, 1] }
+            }
+          >
+            {searchInputRow}
+            {resultsList}
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    );
+  }
+
   if (useMobileLayout) {
     return (
       <div
-        // z-50 keeps the full-screen palette above the navigation drawer
-        // (fixed z-40 in chat-layout), which stays mounted underneath so
-        // dismissing search returns to the menu.
-        className="fixed inset-0 z-50 flex flex-col bg-[var(--surface-lift)]"
+        className={MOBILE_SHEET_CLASSES}
         role="dialog"
         aria-modal="true"
         aria-label="Search"
         onKeyDown={onKeyDown}
-        style={{
-          paddingTop:
-            "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
-          paddingBottom:
-            "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
-          paddingLeft:
-            "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
-          paddingRight:
-            "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
-        }}
+        style={MOBILE_SHEET_SAFE_AREA_STYLE}
       >
         {searchInputRow}
         {resultsList}

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -67,6 +67,7 @@ import {
 import { openCommandPaletteWindow } from "@/runtime/command-palette-window";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { useIsNativeIOS } from "@/runtime/platform-detection";
 import { isPopoutWindow, openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -573,6 +574,17 @@ export function ChatLayout({
       switchConversation: handleSelectConversation,
     });
 
+  const isNativeIOSShell = useIsNativeIOS();
+  // iOS shell: keep the palette subtree mounted after first open so the
+  // AnimatePresence exit inside CommandPalette can run.
+  const [paletteEverOpened, setPaletteEverOpened] = useState(false);
+  useEffect(() => {
+    if (commandPalette.isOpen && !paletteEverOpened) {
+      setPaletteEverOpened(true);
+    }
+  }, [commandPalette.isOpen, paletteEverOpened]);
+  const keepPaletteMounted = isNativeIOSShell && paletteEverOpened;
+
   // Electron host commands (File menu / global hotkeys). The hook is a
   // no-op on the web host. Handlers close over the latest state via an
   // internal ref, so we don't need to memoize them. Composer focus is
@@ -1011,7 +1023,7 @@ export function ChatLayout({
         renameGroup={renameGroup}
         moveToGroup={handleMoveToGroup}
       />
-      {commandPalette.isOpen ? (
+      {commandPalette.isOpen || keepPaletteMounted ? (
         <LazyBoundary>
           <CommandPalette
             isOpen={commandPalette.isOpen}


### PR DESCRIPTION
## Summary

- On the Capacitor iOS shell only, the full-screen search sheet now slides out (280ms, fade + translate) instead of unmounting in a single commit. Closing today reveals the chat at the same instant the focused input unmounts, so the keyboard dismissal, the WKWebView frame resize, and the transcript re-pin all land on the frame the chat becomes visible; keeping the opaque sheet on screen lets that reflow finish behind it. Pairs with PR 7's blur, which starts the keyboard dismissal at close-start.
- Required restructuring a double conditional: `chat-layout.tsx` gated the mount on `commandPalette.isOpen` and `command-palette.tsx` early-returned null, either of which would silently skip an `AnimatePresence` exit. The outer mount now latches open on iOS (`keepPaletteMounted`), which also keeps the `LazyBoundary` and lazy chunk mounted; the inner bail only returns null when the animated branch is inactive.
- Every close path animates because they all flip the same store flag: X button, Escape, Cmd+K, item select, and the Electron host toggles. Desktop (>=768px), the Electron `surface="window"` branch, and mobile browsers are unchanged: `animateMobileSheet` and `keepPaletteMounted` are both false there, so the inner bail reduces to today's `if (!isOpen) return null`.

Part of plan: ios-capacitor-ui-polish.md (PR 8 of 9)