### PR TITLE
fix(web): onboarding relies on code-defined defaults instead of authoring custom-balanced

### DIFF
--- a/clients/web/src/domains/onboarding/provider-catalog.ts
+++ b/clients/web/src/domains/onboarding/provider-catalog.ts
@@ -22,7 +22,12 @@ export interface OnboardingProvider {
   readonly docsUrl: string | null;
   /** Whether an API key is required before the user can continue. */
   readonly requiresKey: boolean;
-  /** Balanced model used for the initial local assistant profile. */
+  /**
+   * Fallback model for the client-authored profile onboarding creates for
+   * providers the daemon's code-defined default profiles cannot serve (e.g.
+   * Ollama). Informational for the other providers — their models resolve
+   * through the daemon's intent × provider matrix.
+   */
   readonly defaultModel?: string;
   readonly models?: readonly OnboardingModel[];
 }
@@ -96,32 +101,6 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
     docsUrl: "https://openrouter.ai/keys",
     requiresKey: true,
     defaultModel: "anthropic/claude-sonnet-4.6",
-    models: [
-      {
-        id: "anthropic/claude-sonnet-4.6",
-        displayName: "Claude Sonnet 4.6",
-        contextWindowTokens: 200_000,
-        maxOutputTokens: 64_000,
-      },
-      {
-        id: "anthropic/claude-opus-4.8",
-        displayName: "Claude Opus 4.8",
-        contextWindowTokens: 200_000,
-        maxOutputTokens: 128_000,
-      },
-      {
-        id: "x-ai/grok-4.20",
-        displayName: "Grok 4.20",
-        contextWindowTokens: 200_000,
-        maxOutputTokens: 16_000,
-      },
-      {
-        id: "deepseek/deepseek-r1-0528",
-        displayName: "DeepSeek R1",
-        contextWindowTokens: 163_840,
-        maxOutputTokens: 32_000,
-      },
-    ],
   },
   {
     id: "vercel-ai-gateway",
@@ -131,34 +110,6 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
       "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway%2Fapi-keys&title=AI+Gateway+API+Keys",
     requiresKey: true,
     defaultModel: "anthropic/claude-sonnet-4.6",
-    // Context windows are capped at 200k (like the OpenRouter entry) so
-    // onboarding never opts new users into Anthropic long-context pricing.
-    models: [
-      {
-        id: "anthropic/claude-sonnet-4.6",
-        displayName: "Claude Sonnet 4.6",
-        contextWindowTokens: 200_000,
-        maxOutputTokens: 64_000,
-      },
-      {
-        id: "anthropic/claude-opus-4.8",
-        displayName: "Claude Opus 4.8",
-        contextWindowTokens: 200_000,
-        maxOutputTokens: 128_000,
-      },
-      {
-        id: "xai/grok-4.3",
-        displayName: "Grok 4.3",
-        contextWindowTokens: 200_000,
-        maxOutputTokens: 16_000,
-      },
-      {
-        id: "deepseek/deepseek-v4-flash",
-        displayName: "DeepSeek V4 Flash",
-        contextWindowTokens: 200_000,
-        maxOutputTokens: 384_000,
-      },
-    ],
   },
   {
     id: "openai-compatible",

--- a/clients/web/src/domains/onboarding/provider-key.test.ts
+++ b/clients/web/src/domains/onboarding/provider-key.test.ts
@@ -12,12 +12,16 @@ const configLlmProfilesByNamePutMock = mock(async () => ({
 const configPatchMock = mock(async () => ({
   response: { ok: true, status: 200 },
 }));
+const configLlmDefaultproviderPutMock = mock(async () => ({
+  response: { ok: true, status: 200 },
+}));
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   secretsPost: secretsPostMock,
   inferenceProviderconnectionsPost: inferenceProviderconnectionsPostMock,
   configLlmProfilesByNamePut: configLlmProfilesByNamePutMock,
   configPatch: configPatchMock,
+  configLlmDefaultproviderPut: configLlmDefaultproviderPutMock,
 }));
 
 const {
@@ -33,6 +37,7 @@ beforeEach(() => {
   inferenceProviderconnectionsPostMock.mockClear();
   configLlmProfilesByNamePutMock.mockClear();
   configPatchMock.mockClear();
+  configLlmDefaultproviderPutMock.mockClear();
 });
 
 describe("pending provider key", () => {
@@ -72,12 +77,85 @@ describe("pending provider key", () => {
     });
   });
 
-  test("applies an Ollama provider connection and activates the selected model profile", async () => {
+  test("API-key providers rely on the code-defined defaults: key, personal connection, default provider — no profile writes", async () => {
+    // GIVEN an OpenAI provider key
+    setPendingProviderKey({ provider: "openai", key: "sk-proj-test" });
+
+    // WHEN the pending key is applied
+    await applyPendingProviderKey("local-2");
+
+    // THEN the API key is stored
+    expect(secretsPostMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-2" },
+      body: { type: "api_key", name: "openai", value: "sk-proj-test" },
+      throwOnError: false,
+    });
+    // AND the `<provider>-personal` connection the default profiles dispatch
+    // through is created
+    expect(inferenceProviderconnectionsPostMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-2" },
+      body: {
+        name: "openai-personal",
+        provider: "openai",
+        auth: {
+          type: "api_key",
+          credential: "credential/openai/api_key",
+        },
+        label: "OpenAI (Personal)",
+      },
+      throwOnError: false,
+    });
+    // AND the default provider reflects the pick
+    expect(configLlmDefaultproviderPutMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-2" },
+      body: { provider: "openai" },
+      throwOnError: false,
+    });
+    // AND no profile is authored or activated — the hatch-activated
+    // `balanced` default stays in charge
+    expect(configLlmProfilesByNamePutMock).not.toHaveBeenCalled();
+    expect(configPatchMock).not.toHaveBeenCalled();
+    expect(peekPendingProviderKey()).toBeNull();
+  });
+
+  test("a selected model on an API-key provider is ignored — defaults resolve models via the daemon matrix", async () => {
+    setPendingProviderKey({
+      provider: "vercel-ai-gateway",
+      key: "vck_test",
+      model: "anthropic/claude-sonnet-4.6",
+    });
+
+    await applyPendingProviderKey("local-3");
+
+    expect(inferenceProviderconnectionsPostMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-3" },
+      body: {
+        name: "vercel-ai-gateway-personal",
+        provider: "vercel-ai-gateway",
+        auth: {
+          type: "api_key",
+          credential: "credential/vercel-ai-gateway/api_key",
+        },
+        label: "Vercel AI Gateway (Personal)",
+      },
+      throwOnError: false,
+    });
+    expect(configLlmDefaultproviderPutMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-3" },
+      body: { provider: "vercel-ai-gateway" },
+      throwOnError: false,
+    });
+    expect(configLlmProfilesByNamePutMock).not.toHaveBeenCalled();
+    expect(configPatchMock).not.toHaveBeenCalled();
+  });
+
+  test("Ollama authors a provider-named profile and activates it (no matrix column for keyless providers)", async () => {
     setPendingProviderKey({ provider: "ollama", key: "", model: "mistral" });
 
     await applyPendingProviderKey("local-1");
 
     expect(secretsPostMock).not.toHaveBeenCalled();
+    expect(configLlmDefaultproviderPutMock).not.toHaveBeenCalled();
     expect(inferenceProviderconnectionsPostMock).toHaveBeenCalledWith({
       path: { assistant_id: "local-1" },
       body: {
@@ -88,14 +166,13 @@ describe("pending provider key", () => {
       throwOnError: false,
     });
     expect(configLlmProfilesByNamePutMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-1", name: "custom-balanced" },
+      path: { assistant_id: "local-1", name: "ollama" },
       body: {
         provider: "ollama",
         model: "mistral",
         provider_connection: "ollama",
         source: "user",
-        label: "Balanced",
-        description: "Good balance of quality, cost, and speed",
+        label: "Ollama",
         maxTokens: 4096,
         contextWindow: { maxInputTokens: 32768 },
         effort: "none",
@@ -105,128 +182,65 @@ describe("pending provider key", () => {
     });
     expect(configPatchMock).toHaveBeenCalledWith({
       path: { assistant_id: "local-1" },
-      body: { llm: { activeProfile: "custom-balanced" } },
+      body: { llm: { activeProfile: "ollama" } },
       throwOnError: false,
     });
     expect(peekPendingProviderKey()).toBeNull();
   });
 
-  test("applies an OpenRouter API key, connection, and profile with model metadata", async () => {
-    // GIVEN an OpenRouter provider key with a selected model
+  test("openai-compatible authors a provider-named profile from the custom base URL + models", async () => {
     setPendingProviderKey({
-      provider: "openrouter",
-      key: "sk-or-v1-test",
-      model: "anthropic/claude-sonnet-4.6",
+      provider: "openai-compatible",
+      key: "sk-custom",
+      baseUrl: "https://llm.example.com/v1",
+      customModels: "model-a, model-b",
     });
 
-    // WHEN the pending key is applied
-    await applyPendingProviderKey("local-2");
+    await applyPendingProviderKey("local-4");
 
-    // THEN the API key is stored
     expect(secretsPostMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-2" },
+      path: { assistant_id: "local-4" },
       body: {
         type: "api_key",
-        name: "openrouter",
-        value: "sk-or-v1-test",
+        name: "openai-compatible",
+        value: "sk-custom",
       },
       throwOnError: false,
     });
-    // AND the provider connection is created with API-key auth
+    expect(configLlmDefaultproviderPutMock).not.toHaveBeenCalled();
     expect(inferenceProviderconnectionsPostMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-2" },
+      path: { assistant_id: "local-4" },
       body: {
-        name: "openrouter",
-        provider: "openrouter",
+        name: "openai-compatible",
+        provider: "openai-compatible",
         auth: {
           type: "api_key",
-          credential: "credential/openrouter/api_key",
+          credential: "credential/openai-compatible/api_key",
         },
+        base_url: "https://llm.example.com/v1",
+        models: [{ id: "model-a" }, { id: "model-b" }],
       },
       throwOnError: false,
     });
-    // AND the profile uses model metadata from the onboarding catalog
     expect(configLlmProfilesByNamePutMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-2", name: "custom-balanced" },
+      path: { assistant_id: "local-4", name: "openai-compatible" },
       body: {
-        provider: "openrouter",
-        model: "anthropic/claude-sonnet-4.6",
-        provider_connection: "openrouter",
+        provider: "openai-compatible",
+        model: "model-a",
+        provider_connection: "openai-compatible",
         source: "user",
-        label: "Balanced",
-        description: "Good balance of quality, cost, and speed",
-        maxTokens: 64_000,
+        label: "OpenAI-compatible",
+        maxTokens: 16_000,
         contextWindow: { maxInputTokens: 200_000 },
         effort: "high",
         thinking: { enabled: true, streamThinking: true },
       },
       throwOnError: false,
     });
-    // AND the profile is activated
     expect(configPatchMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-2" },
-      body: { llm: { activeProfile: "custom-balanced" } },
+      path: { assistant_id: "local-4" },
+      body: { llm: { activeProfile: "openai-compatible" } },
       throwOnError: false,
     });
-    expect(peekPendingProviderKey()).toBeNull();
-  });
-
-  test("applies a Vercel AI Gateway API key, connection, and profile with model metadata", async () => {
-    // GIVEN a Vercel AI Gateway provider key with no selected model
-    setPendingProviderKey({
-      provider: "vercel-ai-gateway",
-      key: "vck_test",
-    });
-
-    // WHEN the pending key is applied
-    await applyPendingProviderKey("local-3");
-
-    // THEN the API key is stored
-    expect(secretsPostMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-3" },
-      body: {
-        type: "api_key",
-        name: "vercel-ai-gateway",
-        value: "vck_test",
-      },
-      throwOnError: false,
-    });
-    // AND the provider connection is created with API-key auth
-    expect(inferenceProviderconnectionsPostMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-3" },
-      body: {
-        name: "vercel-ai-gateway",
-        provider: "vercel-ai-gateway",
-        auth: {
-          type: "api_key",
-          credential: "credential/vercel-ai-gateway/api_key",
-        },
-      },
-      throwOnError: false,
-    });
-    // AND the profile falls back to the catalog default model with its metadata
-    expect(configLlmProfilesByNamePutMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-3", name: "custom-balanced" },
-      body: {
-        provider: "vercel-ai-gateway",
-        model: "anthropic/claude-sonnet-4.6",
-        provider_connection: "vercel-ai-gateway",
-        source: "user",
-        label: "Balanced",
-        description: "Good balance of quality, cost, and speed",
-        maxTokens: 64_000,
-        contextWindow: { maxInputTokens: 200_000 },
-        effort: "high",
-        thinking: { enabled: true, streamThinking: true },
-      },
-      throwOnError: false,
-    });
-    // AND the profile is activated
-    expect(configPatchMock).toHaveBeenCalledWith({
-      path: { assistant_id: "local-3" },
-      body: { llm: { activeProfile: "custom-balanced" } },
-      throwOnError: false,
-    });
-    expect(peekPendingProviderKey()).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/provider-key.ts
+++ b/clients/web/src/domains/onboarding/provider-key.ts
@@ -1,4 +1,5 @@
 import {
+  configLlmDefaultproviderPut,
   configLlmProfilesByNamePut,
   configPatch,
   inferenceProviderconnectionsPost,
@@ -9,7 +10,10 @@ import {
   onboardingProvider,
   type OnboardingProviderId,
 } from "@/domains/onboarding/provider-catalog";
-import type { ProfileEntry } from "@/generated/daemon/types.gen";
+import type {
+  ConfigLlmDefaultproviderPutData,
+  ProfileEntry,
+} from "@/generated/daemon/types.gen";
 
 // Model-provider API key collected during onboarding. Held in sessionStorage
 // (consume-once) between the API-key step and the post-hatch application, then
@@ -17,8 +21,19 @@ import type { ProfileEntry } from "@/generated/daemon/types.gen";
 // holds the key in-memory and POSTs it to the daemon once the assistant is up.
 
 const PENDING_KEY_STORAGE = "onboarding.providerKey";
-const ONBOARDING_ACTIVE_PROFILE = "custom-balanced";
 const DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS = 200_000;
+
+/**
+ * Providers the daemon's code-defined default profiles cannot serve: Ollama is
+ * keyless/local and openai-compatible needs a user-supplied base URL + model
+ * list, so neither has a column in the intent × provider matrix. Onboarding
+ * authors and activates a user profile for these; every other catalog provider
+ * relies on the read-only defaults resolved through `llm.defaultProvider`.
+ */
+const PROFILE_AUTHORING_PROVIDERS = new Set<OnboardingProviderId>([
+  "ollama",
+  "openai-compatible",
+]);
 
 export interface PendingProviderKey {
   provider: OnboardingProviderId;
@@ -84,6 +99,15 @@ export function consumePendingProviderKey(): PendingProviderKey | null {
 // Daemon wrappers via the generated SDK. Duplicated minimally here because
 // cross-domain imports are ESLint-gated in clients/web.
 
+function ensureOk(
+  response: { ok: boolean; status: number } | undefined,
+  message: string,
+): void {
+  if (!response?.ok) {
+    throw Object.assign(new Error(message), { status: response?.status });
+  }
+}
+
 async function writeApiKeySecret(
   assistantId: string,
   provider: OnboardingProviderId,
@@ -94,14 +118,56 @@ async function writeApiKeySecret(
     body: { type: "api_key", name: provider, value },
     throwOnError: false,
   });
-  if (!response?.ok) {
-    throw Object.assign(new Error("Failed to write provider secret"), {
-      status: response?.status,
-    });
+  ensureOk(response, "Failed to write provider secret");
+}
+
+/**
+ * Create the `<provider>-personal` connection the BYOK columns of the intent ×
+ * provider matrix stamp onto the default profiles — the same connection a
+ * CLI hatch's seeding creates when the hatch overlay carries the provider.
+ */
+async function createPersonalConnection(
+  assistantId: string,
+  provider: OnboardingProviderId,
+): Promise<void> {
+  const displayName = onboardingProvider(provider)?.displayName ?? provider;
+  const { response } = await inferenceProviderconnectionsPost({
+    path: { assistant_id: assistantId },
+    body: {
+      name: `${provider}-personal`,
+      provider,
+      auth: {
+        type: "api_key",
+        credential: `credential/${provider}/api_key`,
+      },
+      label: `${displayName} (Personal)`,
+    },
+    throwOnError: false,
+  });
+  if (response?.status !== 409) {
+    ensureOk(response, "Failed to create provider connection");
   }
 }
 
-async function createProviderConnection(
+async function setDefaultProvider(
+  assistantId: string,
+  provider: OnboardingProviderId,
+): Promise<void> {
+  const { response } = await configLlmDefaultproviderPut({
+    path: { assistant_id: assistantId },
+    body: {
+      // The generated enum tracks the daemon's default-profile matrix, which
+      // can lag the onboarding catalog within a release; the daemon strict-
+      // validates, so an unsupported provider fails loudly rather than
+      // silently.
+      provider: provider as ConfigLlmDefaultproviderPutData["body"]["provider"],
+    },
+    throwOnError: false,
+  });
+  ensureOk(response, "Failed to set default provider");
+}
+
+async function createCustomProviderConnection(
   assistantId: string,
   provider: OnboardingProviderId,
   hasKey: boolean,
@@ -134,14 +200,12 @@ async function createProviderConnection(
     },
     throwOnError: false,
   });
-  if (!response?.ok && response?.status !== 409) {
-    throw Object.assign(new Error("Failed to create provider connection"), {
-      status: response?.status,
-    });
+  if (response?.status !== 409) {
+    ensureOk(response, "Failed to create provider connection");
   }
 }
 
-function buildOnboardingProfile(
+function buildCustomProviderProfile(
   provider: OnboardingProviderId,
   model: string,
 ): ProfileEntry {
@@ -152,8 +216,7 @@ function buildOnboardingProfile(
     model,
     provider_connection: provider,
     source: "user",
-    label: "Balanced",
-    description: "Good balance of quality, cost, and speed",
+    label: providerEntry?.displayName ?? provider,
     maxTokens: modelEntry?.maxOutputTokens ?? 16_000,
     contextWindow: {
       maxInputTokens:
@@ -173,40 +236,41 @@ function buildOnboardingProfile(
   return profile;
 }
 
-async function replaceOnboardingProfile(
+/**
+ * Author and activate a user profile for a provider the code-defined defaults
+ * cannot serve. Named after the provider — never `custom-balanced` or another
+ * default-sounding name, so it can't shadow the read-only default rail.
+ */
+async function applyCustomProviderProfile(
   assistantId: string,
   provider: OnboardingProviderId,
   model: string,
 ): Promise<void> {
-  const { response } = await configLlmProfilesByNamePut({
-    path: { assistant_id: assistantId, name: ONBOARDING_ACTIVE_PROFILE },
-    body: buildOnboardingProfile(provider, model),
+  const { response: putResponse } = await configLlmProfilesByNamePut({
+    path: { assistant_id: assistantId, name: provider },
+    body: buildCustomProviderProfile(provider, model),
     throwOnError: false,
   });
-  if (!response?.ok) {
-    throw Object.assign(new Error("Failed to set provider profile"), {
-      status: response?.status,
-    });
-  }
-}
-
-async function activateOnboardingProfile(assistantId: string): Promise<void> {
-  const { response } = await configPatch({
+  ensureOk(putResponse, "Failed to set provider profile");
+  const { response: patchResponse } = await configPatch({
     path: { assistant_id: assistantId },
-    body: { llm: { activeProfile: ONBOARDING_ACTIVE_PROFILE } },
+    body: { llm: { activeProfile: provider } },
     throwOnError: false,
   });
-  if (!response?.ok) {
-    throw Object.assign(new Error("Failed to activate provider profile"), {
-      status: response?.status,
-    });
-  }
+  ensureOk(patchResponse, "Failed to activate provider profile");
 }
 
 /**
  * Apply the model-provider selection collected during onboarding to the
  * freshly hatched local assistant. Consumes the pending key; no-op when nothing
  * was collected (e.g. Vellum Cloud, which skips the API-key step).
+ *
+ * API-key providers rely on the daemon's code-defined default profiles: store
+ * the key, create the `<provider>-personal` connection the defaults dispatch
+ * through, and point `llm.defaultProvider` at the picked provider. The hatch
+ * already activated `balanced`, so no profile is written. Only providers the
+ * matrix cannot serve (Ollama, openai-compatible) get a client-authored
+ * profile.
  */
 export async function applyPendingProviderKey(
   assistantId: string,
@@ -216,12 +280,20 @@ export async function applyPendingProviderKey(
     return;
   }
   const trimmed = pending.key.trim();
+
+  if (!PROFILE_AUTHORING_PROVIDERS.has(pending.provider)) {
+    await writeApiKeySecret(assistantId, pending.provider, trimmed);
+    await createPersonalConnection(assistantId, pending.provider);
+    await setDefaultProvider(assistantId, pending.provider);
+    return;
+  }
+
   const hasKey = trimmed.length > 0;
   const isOpenAICompatible = pending.provider === "openai-compatible";
   if (hasKey || isOpenAICompatible) {
     await writeApiKeySecret(assistantId, pending.provider, trimmed);
   }
-  await createProviderConnection(assistantId, pending.provider, hasKey, {
+  await createCustomProviderConnection(assistantId, pending.provider, hasKey, {
     baseUrl: pending.baseUrl,
     customModels: pending.customModels,
   });
@@ -235,7 +307,6 @@ export async function applyPendingProviderKey(
     firstCustomModel ||
     defaultModelForOnboardingProvider(pending.provider);
   if (model) {
-    await replaceOnboardingProfile(assistantId, pending.provider, model);
-    await activateOnboardingProfile(assistantId);
+    await applyCustomProviderProfile(assistantId, pending.provider, model);
   }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for byok-code-defined-defaults.md.

**Gap:** web onboarding still PUT+activated a client-authored custom-balanced and never passed the picked provider to the hatch, recreating the retired rail (with defaultProvider stuck on anthropic) on every web-onboarded BYOK install.
**Fix:** the flow now hands the picked provider to the daemon's hatch seeding and relies on the code-defined read-only defaults; the custom-balanced authoring rail is removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->