### PR TITLE
fix: resolve BYOK default profiles for any usable API-key hatch provider

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4743,6 +4743,12 @@ paths:
                     - fireworks
                     - openrouter
                     - vellum
+                    - together
+                    - vercel-ai-gateway
+                    - minimax
+                    - atlascloud
+                    - baseten
+                    - poolside
                 connectionName:
                   type: string
                   minLength: 1
@@ -33548,6 +33554,12 @@ components:
                     - fireworks
                     - openrouter
                     - vellum
+                    - together
+                    - vercel-ai-gateway
+                    - minimax
+                    - atlascloud
+                    - baseten
+                    - poolside
                 connectionName:
                   type: string
                   minLength: 1
@@ -33919,6 +33931,12 @@ components:
                 - fireworks
                 - openrouter
                 - vellum
+                - together
+                - vercel-ai-gateway
+                - minimax
+                - atlascloud
+                - baseten
+                - poolside
             - type: "null"
         connectionName:
           type: string

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -71,6 +71,7 @@ import { migrateProviderConnectionStatusLabel } from "../persistence/migrations/
 import { migrateProviderConnectionBaseUrlAndModels } from "../persistence/migrations/250-provider-connection-base-url-and-models.js";
 import * as schema from "../persistence/schema/index.js";
 import { getConnection } from "../providers/inference/connections.js";
+import { getProviderDefaultModel } from "../providers/model-intents.js";
 import { getConfigQuarantineNoticePath } from "../util/platform.js";
 import { setStorePathForTesting } from "./encrypted-store-test-helpers.js";
 
@@ -864,6 +865,48 @@ describe("loadConfig startup behavior", () => {
     expect(effective["quality-optimized"]?.model).toBe("gpt-5.4");
     expect(effective["cost-optimized"]?.provider).toBe("openai");
     expect(effective["cost-optimized"]?.model).toBe("gpt-5.4-nano");
+  });
+
+  test("off-platform hatch with a provider outside the named matrix columns resolves through the shared BYOK templates", () => {
+    // `together` has no column in PROFILE_IMPLS and no intent table: the
+    // defaults must still anchor on it (not fall back to anthropic), backed
+    // by the `together-personal` connection and its catalog defaultModel.
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify({ llm: { default: { provider: "together" } } }, null, 2) +
+        "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+    const db = createProviderConnectionsDb();
+
+    mergeDefaultConfigAndSeedInferenceProfiles(db);
+    const config = loadConfig();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.defaultProvider).toEqual({ provider: "together" });
+    // The parsed schema keeps the value — `.catch(undefined)` must not drop it.
+    expect(config.llm.defaultProvider).toEqual({ provider: "together" });
+    for (const name of LEGACY_HATCH_PROFILE_NAMES) {
+      expect(raw.llm.profiles[name]).toBeUndefined();
+    }
+    expect(getConnection(db, "together-personal")).not.toBeNull();
+
+    const effective = getEffectiveProfilesForProvider(
+      raw.llm.profiles,
+      raw.llm.defaultProvider,
+    );
+    for (const name of [
+      "balanced",
+      "quality-optimized",
+      "cost-optimized",
+    ] as const) {
+      expect(effective[name]?.provider).toBe("together");
+      expect(effective[name]?.provider_connection).toBe("together-personal");
+      expect(effective[name]?.model).toBe(getProviderDefaultModel("together"));
+      expect(effective[name]?.source).toBe("managed");
+    }
   });
 
   test("off-platform boot leaves an existing managed entry byte-identical", () => {

--- a/assistant/src/__tests__/default-provider-ensure.test.ts
+++ b/assistant/src/__tests__/default-provider-ensure.test.ts
@@ -159,9 +159,18 @@ describe("ensureDefaultProvider", () => {
     expect(llm().defaultProvider).toEqual({ provider: "anthropic" });
   });
 
-  test("an invalid/non-catalog signal falls through to the matrix", async () => {
+  test("a legacy signal naming a non-matrix API-key provider is honored", async () => {
     proxyState.prereqs = false;
     writeConfig({ llm: { default: { provider: "minimax" } } });
+
+    await ensureDefaultProvider(workspaceDir);
+
+    expect(llm().defaultProvider).toEqual({ provider: "minimax" });
+  });
+
+  test("a signal naming a provider that cannot back the defaults falls through", async () => {
+    proxyState.prereqs = false;
+    writeConfig({ llm: { default: { provider: "litellm" } } });
 
     await ensureDefaultProvider(workspaceDir);
 

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -19,6 +19,8 @@ import {
   resolveDefaultProfileKey,
 } from "../llm-resolver.js";
 import {
+  DEFAULT_PROVIDER_CHOICES,
+  type DefaultProviderConfig,
   type LLMCallSite,
   LLMSchema,
   type ProfileEntry,
@@ -281,11 +283,25 @@ describe("schema validation", () => {
       LLMSchema.parse({ callSites: { mainAgent: { profile: "no-such" } } }),
     ).toThrow();
   });
+
+  test("defaultProvider accepts any default-capable API-key provider and drops the rest", () => {
+    expect(
+      LLMSchema.parse({ defaultProvider: { provider: "together" } })
+        .defaultProvider,
+    ).toEqual({ provider: "together" });
+    // Endpoint-supplied and keyless providers have no code-resolvable
+    // default profile implementation; the catch drops them atomically.
+    for (const provider of ["litellm", "openai-compatible", "ollama"]) {
+      expect(
+        LLMSchema.parse({ defaultProvider: { provider } }).defaultProvider,
+      ).toBeUndefined();
+    }
+  });
 });
 
 describe("resolveDefaultProfileForProvider", () => {
   const dp = (
-    provider: (typeof DEFAULT_PROFILE_PROVIDERS)[number],
+    provider: DefaultProviderConfig["provider"],
     connectionName?: string,
   ) => ({ provider, ...(connectionName ? { connectionName } : {}) });
 
@@ -307,6 +323,38 @@ describe("resolveDefaultProfileForProvider", () => {
           expect(entry?.provider_connection).toBeDefined();
         }
         expect(entry?.source).toBe("managed");
+      }
+    }
+  });
+
+  test("a provider without a named matrix column materializes from the shared BYOK templates", () => {
+    const entry = resolveDefaultProfileForProvider(
+      undefined,
+      "balanced",
+      dp("together"),
+    );
+    expect(entry?.provider).toBe("together");
+    expect(entry?.provider_connection).toBe("together-personal");
+    // No intent table for `together`: the intent falls back to the
+    // provider's catalog defaultModel.
+    expect(entry?.model).toBe(resolveModelIntent("together", "balanced"));
+    expect(entry?.source).toBe("managed");
+  });
+
+  test("every default provider choice materializes every default profile key", () => {
+    for (const provider of DEFAULT_PROVIDER_CHOICES) {
+      for (const key of DEFAULT_PROFILE_KEYS) {
+        const entry = resolveDefaultProfileForProvider(
+          undefined,
+          key,
+          dp(provider),
+        );
+        expect(entry).toBeDefined();
+        expect(typeof entry?.model).toBe("string");
+        expect(entry?.source).toBe("managed");
+        if (entry?.provider !== "vellum") {
+          expect(entry?.provider_connection).toBe(`${provider}-personal`);
+        }
       }
     }
   });

--- a/assistant/src/config/__tests__/seed-default-provider.test.ts
+++ b/assistant/src/config/__tests__/seed-default-provider.test.ts
@@ -108,6 +108,22 @@ describe("seedInferenceProfiles / llm.defaultProvider", () => {
     expect(llm.defaultProvider).toEqual({ provider: "openai" });
   });
 
+  test("BYOK hatch with a non-matrix API-key provider writes that provider", () => {
+    const llm = seed(
+      { llm: { default: { provider: "together" } } },
+      { isHatch: true },
+    );
+    expect(llm.defaultProvider).toEqual({ provider: "together" });
+  });
+
+  test("BYOK hatch with an endpoint-supplied provider falls back to anthropic", () => {
+    const llm = seed(
+      { llm: { default: { provider: "litellm" } } },
+      { isHatch: true },
+    );
+    expect(llm.defaultProvider).toEqual({ provider: "anthropic" });
+  });
+
   test("BYOK hatch with provider ollama falls back to anthropic", () => {
     const llm = seed(
       { llm: { default: { provider: "ollama" } } },

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -10,6 +10,7 @@ import {
   type DefaultProfileProvider,
   INTERNAL_PROFILE_KEYS,
   type InternalProfileKey,
+  isDefaultProfileProvider,
   OS_BETA_PROFILE_KEY,
   PROFILE_MATRIX_KEYS,
   type ProfileMatrixKey,
@@ -17,6 +18,7 @@ import {
 import { resolveDefaultConnectionName } from "./default-provider-resolution.js";
 import {
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+  DEFAULT_PROVIDER_CHOICES,
   type DefaultProviderConfig,
   type ProfileEntry,
 } from "./schemas/llm.js";
@@ -132,9 +134,11 @@ const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
 
 /**
  * The BYOK implementation of each default profile intent, shared by every
- * non-vellum provider column. The concrete model resolves per provider from
- * the `intent` via `resolveModelIntent` at materialization time. `provider`
- * is stamped per column.
+ * non-vellum provider. The concrete model resolves per provider from the
+ * `intent` via `resolveModelIntent` at materialization time (falling back to
+ * the provider's catalog `defaultModel` when it has no intent table).
+ * `provider` is stamped per column for the named matrix columns, and
+ * per-request for any other default-capable provider.
  */
 const BYOK_PROFILE_IMPLS: Record<
   ProfileMatrixKey,
@@ -336,6 +340,27 @@ for (const key of PROFILE_MATRIX_KEYS) {
   }
 }
 
+// Provider choices without a named column materialize from the shared BYOK
+// templates; verify each one's resolved model lands in the catalog.
+for (const provider of DEFAULT_PROVIDER_CHOICES) {
+  if (isDefaultProfileProvider(provider)) {
+    continue;
+  }
+  for (const key of PROFILE_MATRIX_KEYS) {
+    const { model } = materializeProfile(
+      { ...BYOK_PROFILE_IMPLS[key], provider },
+      provider,
+    );
+    if (model == null || !isModelInCatalog(provider, model)) {
+      throw new Error(
+        `Default provider choice "${provider}" cannot materialize "${key}": ` +
+          `resolved model "${model ?? ""}" is not in PROVIDER_CATALOG. ` +
+          `Update model-catalog.ts or model-intents.ts.`,
+      );
+    }
+  }
+}
+
 function buildDefaultProfileEntries(): Record<string, ProfileEntry> {
   const entries: Record<string, ProfileEntry> = {};
   for (const key of PROFILE_MATRIX_KEYS) {
@@ -360,10 +385,9 @@ export const CODE_DEFAULT_PROFILE_ENTRIES: Readonly<
 
 /**
  * The per-default-profile fields that remain workspace-owned state: the
- * exact whitelist `seedInferenceProfiles` preserves across reseeds (BYOK
- * label suffix, hatch-time/user disable, pre-existing topP overrides).
- * Carried by key-presence rather than truthiness so an explicit `null`
- * (cleared field) survives too.
+ * exact whitelist `seedInferenceProfiles` preserves across reseeds (user
+ * renames, user disables, topP overrides). Carried by key-presence rather
+ * than truthiness so an explicit `null` (cleared field) survives too.
  */
 const WORKSPACE_OWNED_DEFAULT_FIELDS = ["label", "status", "topP"] as const;
 
@@ -440,18 +464,22 @@ function resolveAgainstBody(
 
 /**
  * Like `getEffectiveProfile`, but a default profile key's code-owned body
- * comes from the default provider's column of the intent × provider matrix
- * instead of always the `vellum` column. A `null` defaultProvider and every
- * non-matrix name fall back to `getEffectiveProfile`'s behavior.
+ * comes from the default provider's implementation of the intent × provider
+ * matrix instead of always the `vellum` column. A `null` defaultProvider and
+ * every non-matrix name fall back to `getEffectiveProfile`'s behavior.
  *
  * Non-obvious rules:
  *
  * - The `vellum` column stamps `provider: "vellum"` with no connection —
  *   dispatch derives the upstream from the model per-request.
- * - The resolved body carries `source: "managed"` regardless of column:
+ * - A default provider without a named matrix column materializes from the
+ *   shared `BYOK_PROFILE_IMPLS` templates, with `resolveModelIntent`
+ *   falling back to the provider's catalog `defaultModel`.
+ * - The resolved body carries `source: "managed"` regardless of provider:
  *   default profile content is code-owned whichever provider implements it.
- *   The BYOK templates' `source: "user"` is hatch-time state for
- *   materialized `custom-*` copies, not an ownership claim on the body.
+ *   The BYOK templates' `source: "user"` exists for the conversion pass's
+ *   frozen `custom-*` reference bodies (`USER_PROFILE_TEMPLATES`), not as
+ *   an ownership claim on the body.
  */
 export function resolveDefaultProfileForProvider(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,
@@ -492,7 +520,10 @@ function defaultProfileBodyForProvider(
   if (defaultProvider == null || !isMatrixProfileKey(name)) {
     return CODE_DEFAULT_PROFILE_ENTRIES[name];
   }
-  const impl = PROFILE_IMPLS[name][defaultProvider.provider];
+  const { provider } = defaultProvider;
+  const impl = isDefaultProfileProvider(provider)
+    ? PROFILE_IMPLS[name][provider]
+    : { ...BYOK_PROFILE_IMPLS[name], provider };
   return {
     ...materializeProfile(
       impl,

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -51,10 +51,12 @@ export type ProfileMatrixKey = DefaultProfileKey | InternalProfileKey;
 export const OS_BETA_PROFILE_KEY = "os-beta";
 
 /**
- * Providers that can serve the default profiles. `vellum` is the
+ * The named columns of the intent × provider matrix. `vellum` is the
  * platform-managed column (routed through the single `vellum` connection to
  * an underlying provider per profile); the rest are BYOK columns whose
- * models resolve per provider via `resolveModelIntent`.
+ * models resolve per provider via `resolveModelIntent`. The full set of
+ * providers that can back `llm.defaultProvider` is wider — see
+ * `DEFAULT_PROVIDER_CHOICES` in `schemas/llm.ts`.
  *
  * Lives in this import-free module rather than `default-profile-catalog.ts`
  * so `schemas/llm.ts` can import it without a circular dependency (the
@@ -69,3 +71,15 @@ export const DEFAULT_PROFILE_PROVIDERS = [
   "vellum",
 ] as const;
 export type DefaultProfileProvider = (typeof DEFAULT_PROFILE_PROVIDERS)[number];
+
+/**
+ * Whether a provider has its own named column in the matrix. Providers
+ * outside this set can still back the default profiles: they materialize
+ * from the shared BYOK templates with the intent falling back to the
+ * provider's catalog `defaultModel` (see `defaultProfileBodyForProvider`).
+ */
+export function isDefaultProfileProvider(
+  value: string,
+): value is DefaultProfileProvider {
+  return (DEFAULT_PROFILE_PROVIDERS as readonly string[]).includes(value);
+}

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "../../providers/inference/auth.js";
+import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { isCodexSubscriptionModel } from "../../providers/openai/codex-models.js";
 import {
   getManagedUpstream,
@@ -50,9 +52,40 @@ export const LLMProvider = z
   .meta({ id: "LLMProvider" });
 type LLMProvider = z.infer<typeof LLMProvider>;
 
-// Deliberately narrower than `LLMProvider`: only providers that can serve
-// the code-defined default profile catalog.
-const DefaultProviderEnum = z.enum(DEFAULT_PROFILE_PROVIDERS);
+/**
+ * Providers that can back `llm.defaultProvider`: the named columns of the
+ * default-profile matrix plus every API-key catalog provider whose personal
+ * connection can serve the shared BYOK templates (fixed base URL, and a
+ * non-empty catalog `defaultModel` for the intent fallback in
+ * `resolveModelIntent`). Deliberately narrower than `LLMProvider`: keyless
+ * (ollama) and endpoint-supplied (openai-compatible, litellm) providers have
+ * no code-resolvable default profile implementation.
+ */
+export const DEFAULT_PROVIDER_CHOICES: readonly LLMProvider[] = [
+  ...new Set<LLMProvider>([
+    ...DEFAULT_PROFILE_PROVIDERS,
+    ...PROVIDER_CATALOG.filter(
+      (entry) =>
+        entry.setupMode === "api-key" &&
+        !PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(entry.id) &&
+        entry.defaultModel !== "",
+    )
+      .map((entry) => entry.id)
+      // A catalog provider absent from `LLMProvider` cannot be referenced by
+      // any profile, so it cannot back the defaults either.
+      .filter((id): id is LLMProvider =>
+        (LLMProvider.options as readonly string[]).includes(id),
+      ),
+  ]),
+];
+
+export function isDefaultProviderChoice(value: string): boolean {
+  return (DEFAULT_PROVIDER_CHOICES as readonly string[]).includes(value);
+}
+
+const DefaultProviderEnum = z.enum(
+  DEFAULT_PROVIDER_CHOICES as [LLMProvider, ...LLMProvider[]],
+);
 
 /**
  * Validation for routing-identity (provider, model) pairs in stored config.

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -6,7 +6,6 @@ import {
   MANAGED_CONNECTION_NAMES,
 } from "../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
-import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -14,10 +13,9 @@ import {
   MANAGED_PROFILE_NAMES,
   MANAGED_PROFILE_TEMPLATES,
 } from "./default-profile-catalog.js";
-import { DEFAULT_PROFILE_PROVIDERS } from "./default-profile-names.js";
 import { loadRawConfig, saveRawConfig } from "./loader.js";
 import { isDispatchableProfile } from "./profile-dispatchability.js";
-import type { ProfileEntry } from "./schemas/llm.js";
+import { isDefaultProviderChoice, type ProfileEntry } from "./schemas/llm.js";
 
 const log = getLogger("seed-inference-profiles");
 
@@ -74,7 +72,7 @@ export function seedInferenceProfiles(
 
   // A hatch overlay that explicitly selected a managed connection routes the
   // default provider through vellum rather than the entered BYOK key.
-  const hatchSelectedManagedConnection = getHatchSelectedManagedConnection(
+  const hatchSelectedManagedConnection = didHatchSelectManagedConnection(
     llm,
     profiles,
     options,
@@ -121,7 +119,7 @@ export function seedInferenceProfiles(
     llm.defaultProvider = {
       provider: resolveHatchDefaultProvider(
         isPlatform,
-        hatchSelectedManagedConnection !== undefined,
+        hatchSelectedManagedConnection,
         usableHatchProvider,
       ),
     };
@@ -223,12 +221,13 @@ function resolveHatchDefaultProvider(
   if (isPlatform || selectedManagedConnection) {
     return "vellum";
   }
-  if (
-    hatchProvider !== undefined &&
-    (DEFAULT_PROFILE_PROVIDERS as readonly string[]).includes(hatchProvider)
-  ) {
+  if (hatchProvider !== undefined && isDefaultProviderChoice(hatchProvider)) {
     return hatchProvider;
   }
+  log.warn(
+    { provider: hatchProvider ?? null },
+    "Hatch provider cannot back the default profiles; falling back to anthropic",
+  );
   return "anthropic";
 }
 
@@ -334,18 +333,18 @@ function firstActiveManagedProfile(
   return undefined;
 }
 
-function getHatchSelectedManagedConnection(
+function didHatchSelectManagedConnection(
   llm: Record<string, unknown>,
   profiles: Record<string, Record<string, unknown>>,
   options: SeedInferenceProfilesOptions,
-): string | undefined {
+): boolean {
   if (!options.isHatch || options.preserveActiveProfile !== true) {
-    return undefined;
+    return false;
   }
 
   const activeProfile = readString(llm.activeProfile);
   if (!activeProfile) {
-    return undefined;
+    return false;
   }
 
   const activeProfileEntry = readObject(profiles[activeProfile]);
@@ -359,18 +358,16 @@ function getHatchSelectedManagedConnection(
     const explicitConnection = readString(
       activeProfileEntry.provider_connection,
     );
-    return explicitConnection &&
+    return (
+      explicitConnection !== undefined &&
       MANAGED_CONNECTION_NAMES.has(explicitConnection)
-      ? explicitConnection
-      : undefined;
+    );
   }
 
   // A default-profile name with no explicit connection selects the managed
   // route: the vellum column IS the managed column, and its profiles route
   // through the canonical vellum row.
-  return MANAGED_PROFILE_TEMPLATES[activeProfile]
-    ? VELLUM_MANAGED_CONNECTION_NAME
-    : undefined;
+  return MANAGED_PROFILE_TEMPLATES[activeProfile] !== undefined;
 }
 
 /**

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -15,14 +15,16 @@
  */
 import { z } from "zod";
 
-import { DEFAULT_PROFILE_PROVIDERS } from "../../config/default-profile-names.js";
 import { setDefaultProvider } from "../../config/default-provider.js";
 import {
   getDefaultProviderFromConfig,
   resolveDefaultConnectionName,
 } from "../../config/default-provider-resolution.js";
 import { getConfigReadOnly } from "../../config/loader.js";
-import { DefaultProviderSchema } from "../../config/schemas/llm.js";
+import {
+  DEFAULT_PROVIDER_CHOICES,
+  DefaultProviderSchema,
+} from "../../config/schemas/llm.js";
 import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
@@ -45,7 +47,9 @@ const availabilitySchema = z.object({
 
 const defaultProviderStatusSchema = z
   .object({
-    provider: z.enum(DEFAULT_PROFILE_PROVIDERS).nullable(),
+    provider: z
+      .enum(DEFAULT_PROVIDER_CHOICES as [string, ...string[]])
+      .nullable(),
     /** Explicit connection pin, when the persisted value carries one. */
     connectionName: z.string().optional(),
     /** The connection the default resolves to (explicit pin or convention). */
@@ -88,7 +92,7 @@ async function handlePutDefaultProvider({
   const result = DefaultProviderSchema.safeParse(body);
   if (!result.success) {
     throw new BadRequestError(
-      `Invalid default provider. "provider" must be one of: ${DEFAULT_PROFILE_PROVIDERS.join(
+      `Invalid default provider. "provider" must be one of: ${DEFAULT_PROVIDER_CHOICES.join(
         ", ",
       )}; "connectionName" is optional and must be a non-empty string.`,
     );

--- a/assistant/src/workspace/default-provider-ensure.ts
+++ b/assistant/src/workspace/default-provider-ensure.ts
@@ -1,10 +1,12 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { DEFAULT_PROFILE_PROVIDERS } from "../config/default-profile-names.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { invalidateConfigCache } from "../config/loader.js";
-import { DefaultProviderSchema } from "../config/schemas/llm.js";
+import {
+  DefaultProviderSchema,
+  isDefaultProviderChoice,
+} from "../config/schemas/llm.js";
 import { hasManagedProxyPrereqs } from "../providers/platform-proxy/context.js";
 import { getProviderKeyAsync } from "../security/secure-keys.js";
 
@@ -102,7 +104,7 @@ async function resolveProvider(llm: Record<string, unknown>): Promise<string> {
   const legacyProvider = readObject(llm.default)?.provider;
   if (
     typeof legacyProvider === "string" &&
-    isDefaultProfileProvider(legacyProvider)
+    isDefaultProviderChoice(legacyProvider)
   ) {
     // `llm.default.provider` defaults to "anthropic" in LLMConfigBase and the
     // first-launch seed persists that default, so a bare "anthropic" is
@@ -132,7 +134,7 @@ async function resolveProvider(llm: Record<string, unknown>): Promise<string> {
       if (typeof provider !== "string") {
         continue;
       }
-      return isDefaultProfileProvider(provider)
+      return isDefaultProviderChoice(provider)
         ? provider
         : await loginFallback();
     }
@@ -146,12 +148,6 @@ async function loginFallback(): Promise<string> {
     return "vellum";
   }
   return "anthropic";
-}
-
-function isDefaultProfileProvider(
-  value: string,
-): value is (typeof DEFAULT_PROFILE_PROVIDERS)[number] {
-  return (DEFAULT_PROFILE_PROVIDERS as readonly string[]).includes(value);
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for byok-code-defined-defaults.md.

**Gap:** hatching with a provider outside the default-profile matrix (groq, together, vercel-ai-gateway, ...) set defaultProvider to anthropic while only <provider>-personal existed, leaving the defaults pointing at a nonexistent anthropic-personal connection.
**Fix:** the BYOK column now resolves for any usable API-key catalog provider (intent fallback = provider defaultModel), and the hatch keeps the real provider as defaultProvider.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->