### PR TITLE
fix: invoices pagination retry recovery and infinite query key

### DIFF
--- a/clients/web/openapi-ts.config.ts
+++ b/clients/web/openapi-ts.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@hey-api/openapi-ts";
+import { defaultPaginationKeywords, defineConfig } from "@hey-api/openapi-ts";
 
 const reactQueryPlugin = {
   name: "@tanstack/react-query",
@@ -11,6 +11,14 @@ export default defineConfig([
   {
     input: "./openapi-schemas/platform.yaml",
     output: "src/generated/api",
+    parser: {
+      // HeyAPI only detects pagination params by exact keyword match, so the
+      // invoices endpoint's starting_after cursor needs an explicit entry to
+      // get the generated infinite query key/options.
+      pagination: {
+        keywords: [...defaultPaginationKeywords, "starting_after"],
+      },
+    },
     plugins: ["@hey-api/client-fetch", reactQueryPlugin],
   },
   {

--- a/clients/web/src/domains/settings/components/invoices-table.test.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.test.tsx
@@ -1,9 +1,6 @@
 /**
- * Tests for the collapsed-by-default Invoices section.
- *
- * The section renders just its header plus a "Show invoices" toggle in the
- * top-right corner; the table (and its backing fetch) only materializes once
- * the toggle is clicked, and collapses again on a second click.
+ * Tests for the Invoices section: the collapsed-by-default toggle plus the
+ * cursor-paginated table behind it (Load more, inline error, and retry).
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -56,6 +53,18 @@ function makeInvoice(id: string): Invoice {
   };
 }
 
+/** Five invoices on page 1 with more behind cursor "5": invoices 6 and 7. */
+function seedTwoPages(): void {
+  listResult = {
+    invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
+    has_more: true,
+  };
+  nextPages["5"] = {
+    invoices: [makeInvoice("6"), makeInvoice("7")],
+    has_more: false,
+  };
+}
+
 function renderTable(): ReturnType<typeof render> {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -67,9 +76,26 @@ function renderTable(): ReturnType<typeof render> {
   );
 }
 
+async function openTable(options?: {
+  showAll?: boolean;
+}): Promise<ReturnType<typeof render>> {
+  const view = renderTable();
+  fireEvent.click(view.getByTestId("invoices-toggle"));
+  await waitFor(() =>
+    expect(view.queryByTestId("invoices-table")).not.toBeNull(),
+  );
+  if (options?.showAll) {
+    fireEvent.click(view.getByTestId("invoices-show-more"));
+  }
+  return view;
+}
+
 beforeEach(() => {
   listRetrieveCalls = [];
-  listResult = { invoices: [makeInvoice("1"), makeInvoice("2")], has_more: false };
+  listResult = {
+    invoices: [makeInvoice("1"), makeInvoice("2")],
+    has_more: false,
+  };
   nextPages = {};
   nextPageErrorStatus = null;
 });
@@ -93,11 +119,8 @@ describe("InvoicesTable collapse", () => {
   });
 
   test("expanding fetches and shows the table; collapsing hides it again", async () => {
-    const { getByTestId, queryByTestId, getAllByTestId } = renderTable();
+    const { getByTestId, queryByTestId, getAllByTestId } = await openTable();
 
-    fireEvent.click(getByTestId("invoices-toggle"));
-
-    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
     expect(listRetrieveCalls.length).toBe(1);
     expect(getAllByTestId("invoice-row").length).toBe(2);
     expect(getByTestId("invoices-toggle").textContent).toContain(
@@ -122,27 +145,15 @@ describe("InvoicesTable collapse", () => {
     fireEvent.click(getByTestId("invoices-toggle"));
 
     await waitFor(() => expect(queryByTestId("invoices-empty")).not.toBeNull());
-    // No invoices — the Download all button stays hidden even when expanded.
     expect(queryByTestId("invoices-download-all")).toBeNull();
   });
 });
 
 describe("InvoicesTable pagination", () => {
   test("Load more requests the next page with starting_after and renders both pages", async () => {
-    listResult = {
-      invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
-      has_more: true,
-    };
-    nextPages["5"] = {
-      invoices: [makeInvoice("6"), makeInvoice("7")],
-      has_more: false,
-    };
-    const { getByTestId, queryByTestId, getAllByTestId } = renderTable();
+    seedTwoPages();
+    const { getByTestId, queryByTestId, getAllByTestId } = await openTable();
 
-    fireEvent.click(getByTestId("invoices-toggle"));
-    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
-
-    // Collapsed to the first 4 rows; Load more only appears once expanded.
     expect(getAllByTestId("invoice-row").length).toBe(4);
     expect(queryByTestId("invoices-load-more")).toBeNull();
 
@@ -155,7 +166,6 @@ describe("InvoicesTable pagination", () => {
     expect(listRetrieveCalls.length).toBe(2);
     expect(listRetrieveCalls[1]).toEqual({ starting_after: "5" });
 
-    // Final page loaded, so Load more disappears and Show less remains.
     expect(queryByTestId("invoices-load-more")).toBeNull();
     expect(getByTestId("invoices-show-more").textContent).toContain(
       "Show less",
@@ -167,12 +177,7 @@ describe("InvoicesTable pagination", () => {
       invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
       has_more: false,
     };
-    const { getByTestId, queryByTestId } = renderTable();
-
-    fireEvent.click(getByTestId("invoices-toggle"));
-    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
-
-    fireEvent.click(getByTestId("invoices-show-more"));
+    const { getByTestId, queryByTestId } = await openTable({ showAll: true });
 
     expect(queryByTestId("invoices-load-more")).toBeNull();
     expect(getByTestId("invoices-show-more").textContent).toContain(
@@ -186,15 +191,10 @@ describe("InvoicesTable pagination", () => {
       invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
       has_more: true,
     };
-    const { getByTestId, queryByTestId, getAllByTestId } = renderTable();
+    const { getByTestId, queryByTestId, getAllByTestId } = await openTable({
+      showAll: true,
+    });
 
-    fireEvent.click(getByTestId("invoices-toggle"));
-    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
-
-    fireEvent.click(getByTestId("invoices-show-more"));
-
-    // Expanded with more pages on the server: Show less and Load more
-    // render together instead of Load more replacing the toggle.
     expect(getByTestId("invoices-show-more").textContent).toContain(
       "Show less",
     );
@@ -210,34 +210,40 @@ describe("InvoicesTable pagination", () => {
   });
 
   test("a failed Load more keeps loaded rows and shows an inline retry", async () => {
-    listResult = {
-      invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
-      has_more: true,
-    };
+    seedTwoPages();
     nextPageErrorStatus = 400;
     const { getByTestId, queryByTestId, queryByText, getAllByTestId } =
-      renderTable();
-
-    fireEvent.click(getByTestId("invoices-toggle"));
-    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
-    fireEvent.click(getByTestId("invoices-show-more"));
+      await openTable({ showAll: true });
 
     fireEvent.click(getByTestId("invoices-load-more"));
 
     await waitFor(() =>
       expect(queryByTestId("invoices-load-more-error")).not.toBeNull(),
     );
-    // Page 1 rows survive the page 2 failure; no full-panel error.
     expect(getAllByTestId("invoice-row").length).toBe(5);
     expect(queryByText("Failed to load invoices.")).toBeNull();
 
-    // Retry refetches loaded pages and clears the inline error.
     nextPageErrorStatus = null;
     fireEvent.click(getByTestId("invoices-load-more-retry"));
+
+    // Retry refetches cached pages, then fetches the page that failed.
+    await waitFor(() => expect(getAllByTestId("invoice-row").length).toBe(7));
+    expect(queryByTestId("invoices-load-more-error")).toBeNull();
+    expect(listRetrieveCalls.at(-1)).toEqual({ starting_after: "5" });
+  });
+
+  test("Load more is hidden while the inline error is shown", async () => {
+    seedTwoPages();
+    nextPageErrorStatus = 400;
+    const { getByTestId, queryByTestId } = await openTable({ showAll: true });
+
+    fireEvent.click(getByTestId("invoices-load-more"));
+
     await waitFor(() =>
-      expect(queryByTestId("invoices-load-more-error")).toBeNull(),
+      expect(queryByTestId("invoices-load-more-error")).not.toBeNull(),
     );
-    expect(getAllByTestId("invoice-row").length).toBe(5);
+    expect(queryByTestId("invoices-load-more")).toBeNull();
+    expect(getByTestId("invoices-load-more-retry")).not.toBeNull();
   });
 
   test("a short first page with has_more still offers Load more", async () => {
@@ -249,10 +255,7 @@ describe("InvoicesTable pagination", () => {
       invoices: ["3", "4", "5"].map(makeInvoice),
       has_more: false,
     };
-    const { getByTestId, queryByTestId, getAllByTestId } = renderTable();
-
-    fireEvent.click(getByTestId("invoices-toggle"));
-    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
+    const { getByTestId, queryByTestId, getAllByTestId } = await openTable();
 
     // Two rows, nothing hidden locally, but the server has more:
     // Load more must render so the rest is reachable.
@@ -260,8 +263,6 @@ describe("InvoicesTable pagination", () => {
     fireEvent.click(getByTestId("invoices-load-more"));
 
     await waitFor(() => expect(getAllByTestId("invoice-row").length).toBe(4));
-    // Once appended rows exceed the collapsed window, the normal
-    // Show more toggle takes over.
     expect(getByTestId("invoices-show-more").textContent).toContain(
       "Show more (1 more)",
     );

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -9,18 +9,14 @@ import { useState } from "react";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
 
-import { organizationsBillingInvoicesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import { organizationsBillingInvoicesRetrieveInfiniteQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import {
   organizationsBillingInvoicesDownloadRetrieve,
   organizationsBillingInvoicesRetrieve,
 } from "@/generated/api/sdk.gen";
 import type { InvoiceListResponse } from "@/generated/api/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
-import {
-  ApiError,
-  assertHasResponse,
-  extractErrorMessage,
-} from "@/utils/api-errors";
+import { assertHasResponse, toApiError } from "@/utils/api-errors";
 import { formatFriendlyDate } from "@/utils/format-date";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
@@ -85,7 +81,7 @@ export function InvoicesTable() {
     // The table hides behind the Show invoices toggle, so don't fetch
     // billing history for a section the user may never open.
     enabled: expanded,
-    queryKey: organizationsBillingInvoicesRetrieveQueryKey(),
+    queryKey: organizationsBillingInvoicesRetrieveInfiniteQueryKey(),
     queryFn: async ({ signal, pageParam }) => {
       const { data, error, response } =
         await organizationsBillingInvoicesRetrieve({
@@ -98,12 +94,9 @@ export function InvoicesTable() {
       }
       assertHasResponse(response, error, "Failed to load invoices.");
       if (!response.ok || !data) {
-        // ApiError carries the HTTP status so the global retry predicate can
-        // skip retrying 4xx, notably the stale starting_after cursor 400.
-        throw new ApiError(
-          response.status,
-          extractErrorMessage(error, response, "Failed to load invoices."),
-        );
+        // The stale starting_after cursor 400 is a 4xx, so the global retry
+        // predicate won't retry it.
+        throw toApiError(error, response);
       }
       return data;
     },
@@ -117,11 +110,29 @@ export function InvoicesTable() {
     ? invoices
     : invoices.slice(0, INITIAL_VISIBLE);
   const hasHiddenRows = invoices.length > INITIAL_VISIBLE;
-  const showVisibilityToggle = showAll || hasHiddenRows;
+  // Both flags stay true through the whole retry: a plain refetch clears the
+  // fetchMore meta (isFetchNextPageError drops), at which point the still-set
+  // error with data present reads as isRefetchError.
+  const showLoadMoreError =
+    invoicesQuery.isFetchNextPageError || invoicesQuery.isRefetchError;
   // "Load more" renders whenever every locally loaded row is already visible
   // but the server still has more, so remaining invoices are always reachable.
+  // Retry supersedes it while the inline error is up.
   const showLoadMore =
-    (showAll || !hasHiddenRows) && invoicesQuery.hasNextPage;
+    (showAll || !hasHiddenRows) &&
+    invoicesQuery.hasNextPage &&
+    !showLoadMoreError;
+
+  function retryLoadMore(): void {
+    // refetch() recomputes every cached page's cursor, healing a stale
+    // starting_after, then fetchNextPage() fetches the page the user asked
+    // for (a no-op if the refreshed pages already exhaust the list).
+    void invoicesQuery
+      .refetch()
+      .then((result) =>
+        result.isError ? undefined : invoicesQuery.fetchNextPage(),
+      );
+  }
 
   async function downloadAllInvoices(): Promise<void> {
     setIsDownloadingAll(true);
@@ -208,7 +219,7 @@ export function InvoicesTable() {
               Loading invoices...
             </Typography>
           </div>
-        ) : invoicesQuery.isError && !invoicesQuery.data ? (
+        ) : invoicesQuery.isLoadingError ? (
           <Notice tone="error">Failed to load invoices.</Notice>
         ) : invoices.length === 0 ? (
           <Typography
@@ -307,9 +318,9 @@ export function InvoicesTable() {
                 </tbody>
               </table>
             </div>
-            {(showVisibilityToggle || showLoadMore) && (
+            {(hasHiddenRows || showLoadMore || showLoadMoreError) && (
               <div className="flex flex-wrap items-center gap-4 self-start">
-                {showVisibilityToggle && (
+                {hasHiddenRows && (
                   <button
                     type="button"
                     onClick={() => setShowAll((v) => !v)}
@@ -335,7 +346,7 @@ export function InvoicesTable() {
                     Load more
                   </button>
                 )}
-                {invoicesQuery.isFetchNextPageError && (
+                {showLoadMoreError && (
                   <div
                     className="flex items-center gap-2"
                     data-testid="invoices-load-more-error"
@@ -349,12 +360,14 @@ export function InvoicesTable() {
                     </Typography>
                     <button
                       type="button"
-                      // refetch() recomputes cursors from fresh pages, so it
-                      // also recovers from a stale starting_after cursor.
-                      onClick={() => void invoicesQuery.refetch()}
-                      className="text-body-small-default text-[var(--content-tertiary)] underline transition-colors hover:text-[var(--content-secondary)]"
+                      onClick={retryLoadMore}
+                      disabled={invoicesQuery.isRefetching}
+                      className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)] underline transition-colors hover:text-[var(--content-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
                       data-testid="invoices-load-more-retry"
                     >
+                      {invoicesQuery.isRefetching && (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      )}
                       Retry
                     </button>
                   </div>


### PR DESCRIPTION
## Summary
Round-2 review fixes for invoice-pagination-frontend.md (Codex P2 on #39512 + internal integration review).

- Retry now refreshes cursors AND fetches the requested page, shows progress, surfaces refetch failures (isRefetchError), and supersedes Load more while the error is visible.
- starting_after added to the codegen pagination keywords so the generated infinite query key/options are used, matching the system-events precedent (or documented fallback).
- Cleanups: reuse toApiError, isLoadingError gate, footer logic simplification, test scaffolding dedup and comment pruning.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->