### PR TITLE
refactor(web): share the bare icon button class between the sidebar and chat header

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, type ReactNode } from "react";
 
+import { NATIVE_IOS_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-ios-button-constants";
 import { isElectron } from "@/runtime/is-electron";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 import { useTitleBarStore } from "@/stores/title-bar-store";
@@ -22,11 +23,6 @@ import { useTitleBarStore } from "@/stores/title-bar-store";
 // (≈ button left edge at 96px, leaving a ~25px gap past the green control).
 // Off Electron the inset is 0.
 const ELECTRON_TRAFFIC_LIGHT_CLEARANCE = 80;
-
-// iOS shell only: strip the touch-mobile pill fill so the glyph floats
-// bare while keeping the 40x40 tap target and focus ring.
-const NATIVE_IOS_BARE_ICON_BUTTON =
-  "native-ios:bg-transparent native-ios:hover:bg-transparent native-ios:active:bg-transparent";
 
 export interface ChatLayoutHeaderProps {
   isMobile: boolean;

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -31,6 +31,7 @@ import { PinnedAppNavItem } from "@/domains/chat/components/pinned-app-nav-item"
 import { useDragReorder } from "@/domains/chat/hooks/use-drag-reorder";
 import { SIDEBAR_CONVERSATION_LIMIT, useSidebarState, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state";
 import { copyIdToClipboard } from "@/domains/chat/utils/copy-id-to-clipboard";
+import { NATIVE_IOS_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-ios-button-constants";
 import { channelSectionKey } from "@/domains/chat/utils/sidebar-group-collapse-storage";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { Conversation } from "@/types/conversation-types";
@@ -40,11 +41,6 @@ import {
 } from "@/domains/chat/utils/group-icon-registry";
 import { getChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
 import { Button, SideMenu } from "@vellumai/design-library";
-
-// iOS shell only: strip the touch-mobile pill fill so the glyph floats
-// bare while keeping the 40x40 tap target and focus ring.
-const NATIVE_IOS_BARE_ICON_BUTTON =
-  "native-ios:bg-transparent native-ios:hover:bg-transparent native-ios:active:bg-transparent";
 
 /** @deprecated Use {@link SIDEBAR_CONVERSATION_LIMIT} from `use-sidebar-state.ts` */
 export const ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT =

--- a/clients/web/src/domains/chat/utils/native-ios-button-constants.ts
+++ b/clients/web/src/domains/chat/utils/native-ios-button-constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Strips the design library's touch-mobile pill fill from an icon-only ghost
+ * Button inside the Capacitor iOS shell, so the glyph floats bare.
+ *
+ * Both utilities sit outside any media query, so they apply on every iOS
+ * device: `bg-transparent` outranks `touch-mobile:bg-[var(--surface-lift)]`
+ * and `active:bg-transparent` outranks
+ * `touch-mobile:active:bg-[var(--surface-active)]`. There is no `hover:`
+ * member because Tailwind wraps that variant in `@media (hover: hover)`,
+ * which a touch iPhone never matches.
+ *
+ * The `native-ios:` prefix differs from `touch-mobile:`, so tailwind-merge
+ * keeps the design library's `touch-mobile:h-10 touch-mobile:w-10` and the
+ * 40x40 tap target survives.
+ */
+export const NATIVE_IOS_BARE_ICON_BUTTON =
+  "native-ios:bg-transparent native-ios:active:bg-transparent";


### PR DESCRIPTION
## Summary

- Extract the duplicated `NATIVE_IOS_BARE_ICON_BUTTON` constant (previously declared verbatim in both `assistant-side-menu.tsx` and `chat-layout-header.tsx`) into `domains/chat/utils/native-ios-button-constants.ts`. Both call sites live in `domains/chat`, so `eslint-rules/no-cross-domain-imports.mjs` (which only fires on `@/domains/<other>/` imports) never sees the import, and `utils/empty-state-constants.ts` is the existing constants-module precedent in that directory.
- Drop the dead `native-ios:hover:bg-transparent` member. Verified against `tailwindcss@4.1.8`: the `hover` variant registers as `&:hover { @media (hover: hover) { ... } }`, so a real compile of the class emits it inside `@media (hover: hover)`, which a touch iPhone (`hover: none`) never matches. The design-library rule it was countering, `touch-mobile:hover:bg-[var(--surface-active)]` (`button.tsx:207`), is doubly unreachable: same hover gate, nested inside `(pointer: coarse)`.
- The two live members stay. `native-ios:bg-transparent` beats `touch-mobile:bg-[var(--surface-lift)]` and `native-ios:active:bg-transparent` beats `touch-mobile:active:bg-[var(--surface-active)]`; Tailwind emits both with no media gate, and the `:is(:root[data-native-platform="ios"] *)` selector supplies the specificity.
- No call sites change: the same four Buttons (sidebar close X, sidebar search, header mobile hamburger, header mobile search) receive the constant. The 40x40 tap target is untouched, since `touch-mobile:h-10 touch-mobile:w-10` uses a different variant prefix that tailwind-merge preserves.

Addresses self-review findings on plan ios-capacitor-ui-polish.md