### PR TITLE
fix(web): stop the iOS new-chat bootstrap from racing deep links

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -13,6 +13,7 @@ import {
 import {
   createDraftConversationId,
   resolveBootstrappedConversationId,
+  shouldMintNewChatDraft,
 } from "@/domains/chat/utils/conversation-selection";
 import {
   loadLastViewedConversationId,
@@ -291,7 +292,6 @@ export function useConversationLoader({
   // recent* fetch failed (we still have last-known-good data to land on).
   // -------------------------------------------------------------------------
   const lastAppliedUrlConversationIdRef = useRef<string | null>(null);
-  const newChatDraftConversationIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (assistantStateKind !== "active") {
       return;
@@ -301,14 +301,20 @@ export function useConversationLoader({
     }
 
     const explicitConversationId = urlConversationId;
+    const currentConversationId =
+      useConversationStore.getState().activeConversationId;
 
     // The Capacitor iOS shell cold-launches into a fresh draft instead of
-    // resuming a conversation. Held in a ref so effect re-runs reuse the key.
-    let newChatDraftConversationId: string | null = null;
-    if (isNativeIOS()) {
-      newChatDraftConversationIdRef.current ??= createDraftConversationId();
-      newChatDraftConversationId = newChatDraftConversationIdRef.current;
-    }
+    // resuming a conversation. Minted per pass rather than retained: the pass
+    // that mints the key also writes it to the store, and a retained key would
+    // later resolve to a conversation the user has already sent in.
+    const newChatDraftConversationId = shouldMintNewChatDraft({
+      platformStartsInNewChat: isNativeIOS(),
+      urlConversationId: explicitConversationId,
+      currentConversationId,
+    })
+      ? createDraftConversationId()
+      : null;
 
     // Only the "resume last-viewed" / "land on latest foreground" fallbacks
     // read the fetched list. An explicit URL key, an onboarding draft, the
@@ -319,7 +325,7 @@ export function useConversationLoader({
       explicitConversationId != null ||
       searchParams.get("onboarding") === "1" ||
       (assistantIdRef.current === assistantId &&
-        useConversationStore.getState().activeConversationId != null) ||
+        currentConversationId != null) ||
       newChatDraftConversationId != null
     );
     if (needsConversationList && conversationListIsPending) {
@@ -358,8 +364,7 @@ export function useConversationLoader({
       queryParamKey: explicitConversationId,
       onboardingDraftConversationId,
       newChatDraftConversationId,
-      currentConversationId:
-        useConversationStore.getState().activeConversationId,
+      currentConversationId,
       currentAssistantId: assistantIdRef.current,
       nextAssistantId: assistantId,
       storedConversationId: loadLastViewedConversationId(assistantId),

--- a/clients/web/src/domains/chat/utils/conversation-selection.test.ts
+++ b/clients/web/src/domains/chat/utils/conversation-selection.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveBootstrappedConversationId } from "@/domains/chat/utils/conversation-selection";
+import {
+  resolveBootstrappedConversationId,
+  shouldMintNewChatDraft,
+} from "@/domains/chat/utils/conversation-selection";
 
 const conversations = [
   { conversationId: "old-visible" },
@@ -230,5 +233,67 @@ describe("resolveBootstrappedConversationId", () => {
         }),
       ).toBe("old-visible");
     });
+
+    test("resolves the same key with or without the conversation list", () => {
+      const args = {
+        queryParamKey: null,
+        newChatDraftConversationId: "new-chat-draft",
+        currentConversationId: null,
+        currentAssistantId: null,
+        nextAssistantId: "asst-1",
+        storedConversationId: "old-visible",
+        defaultConversationId: "new-latest",
+      };
+      // The draft short-circuits both list-backed fallbacks, so the loader can
+      // land on it before the conversation-list fetch settles.
+      expect(
+        resolveBootstrappedConversationId({ ...args, conversations: [] }),
+      ).toBe("new-chat-draft");
+      expect(resolveBootstrappedConversationId({ ...args, conversations })).toBe(
+        "new-chat-draft",
+      );
+    });
+  });
+});
+
+describe("shouldMintNewChatDraft", () => {
+  test("mints while nothing is selected in the URL or the store", () => {
+    expect(
+      shouldMintNewChatDraft({
+        platformStartsInNewChat: true,
+        urlConversationId: null,
+        currentConversationId: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("withholds the draft when the URL already names a conversation", () => {
+    expect(
+      shouldMintNewChatDraft({
+        platformStartsInNewChat: true,
+        urlConversationId: "from-deep-link",
+        currentConversationId: null,
+      }),
+    ).toBe(false);
+  });
+
+  test("withholds the draft when a conversation is already selected", () => {
+    expect(
+      shouldMintNewChatDraft({
+        platformStartsInNewChat: true,
+        urlConversationId: null,
+        currentConversationId: "already-sent-draft",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not mint when the platform does not start in a new chat", () => {
+    expect(
+      shouldMintNewChatDraft({
+        platformStartsInNewChat: false,
+        urlConversationId: null,
+        currentConversationId: null,
+      }),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/utils/conversation-selection.ts
+++ b/clients/web/src/domains/chat/utils/conversation-selection.ts
@@ -5,7 +5,8 @@ interface ResolveBootstrappedConversationIdArgs {
   onboardingDraftConversationId?: string | null;
   /**
    * Client-minted draft key for platforms that cold-launch into a new chat
-   * (the Capacitor iOS shell). Absent everywhere else.
+   * (the Capacitor iOS shell), supplied only while nothing is selected yet
+   * (see `shouldMintNewChatDraft`). Absent everywhere else.
    */
   newChatDraftConversationId?: string | null;
   currentConversationId: string | null;
@@ -26,6 +27,34 @@ export function createDraftConversationId(): string {
       // cases (older Safari / non-secure context) so draft creation does not
       // hard-crash.
       `draft-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+interface ShouldMintNewChatDraftArgs {
+  /** True on platforms that cold-launch into a new chat (the iOS shell). */
+  platformStartsInNewChat: boolean;
+  urlConversationId: string | null;
+  currentConversationId: string | null;
+}
+
+/**
+ * Whether the bootstrap should mint a fresh draft key for a platform that
+ * cold-launches into a new chat.
+ *
+ * True only while nothing is selected in the URL or the conversation store,
+ * which is the cold-launch pass. Once a key is selected (including one a deep
+ * link just navigated to) the draft is withheld, so the bootstrap resolves the
+ * existing selection instead of replacing the route with an empty composer.
+ */
+export function shouldMintNewChatDraft({
+  platformStartsInNewChat,
+  urlConversationId,
+  currentConversationId,
+}: ShouldMintNewChatDraftArgs): boolean {
+  return (
+    platformStartsInNewChat &&
+    urlConversationId == null &&
+    currentConversationId == null
+  );
 }
 
 function isStoredConversationSelectable(


### PR DESCRIPTION
## Summary

- Mint the iOS new-chat draft only when nothing is selected in the URL or the conversation store, instead of on every bootstrap effect run. `isNativeIOS()` is constant-true in the shell, so the old unconditional mint left `needsConversationList` permanently false and the conversation-list wait never fired for the whole session.
- Drop `newChatDraftConversationIdRef`. The gated pass writes the minted key to the store in the same effect body, so nothing needs to retain it. A retained key could only be re-served once the user had already sent in that conversation, which would present a real thread as a fresh chat.
- Extract the gate as `shouldMintNewChatDraft` in `conversation-selection.ts` so the decision rule is unit-testable at the pure layer, and add coverage there.
- Precedence order in `resolveBootstrappedConversationId` is unchanged.

## Notes for review

Keeping the draft as a `needsConversationList` disjunct is deliberate: on the cold-launch pass the draft short-circuits both list-backed fallbacks, so waiting for the list cannot change the resolved key. The new test `resolves the same key with or without the conversation list` pins that.

Addresses self-review findings on plan ios-capacitor-ui-polish.md