### PR TITLE
fix(web): pin the iOS keyboard plugin config and correct platform-detection docs

### DIFF
--- a/clients/web/capacitor.config.ts
+++ b/clients/web/capacitor.config.ts
@@ -1,4 +1,5 @@
 import type { CapacitorConfig } from "@capacitor/cli";
+import { KeyboardResize, KeyboardStyle } from "@capacitor/keyboard";
 
 // `server.url` is baked into `../ios/App/App/capacitor.config.json` (gitignored)
 // by `cap sync`, so whatever URL resolves here at sync time is what the
@@ -89,6 +90,27 @@ const config: CapacitorConfig = {
     // `env(safe-area-inset-*)`, which is what PRs #4821 and #4832 assume.
     contentInset: "never",
     scheme: SCHEME_NAMES[env] ?? "App",
+  },
+  // The plugin owns keyboard avoidance on iOS: its `load()` removes the web
+  // view's own keyboard notification observers and resizes the frame itself.
+  // Pin both iOS knobs to the behavior the app already depends on so an
+  // upstream default change cannot move them silently.
+  plugins: {
+    Keyboard: {
+      // `native` resizes the whole WKWebView frame above the keyboard, which
+      // is what `src/hooks/use-visible-viewport.ts` measures against
+      // (`innerHeight` and `visualViewport.height` shrink together). `body`,
+      // `ionic`, and `none` leave the frame at full height and break that
+      // keyboard-height derivation.
+      resize: KeyboardResize.Native,
+      // `DEFAULT` follows the device appearance. The plugin swizzles
+      // `keyboardAppearance` on `WKContentView` and `UITextInputTraits`
+      // process-wide to whatever is set here, so the soft keyboard tracks the
+      // iOS Settings appearance and never the in-app light/dark/velvet theme.
+      // No `style` value expresses "follow the in-app theme"; that needs a
+      // runtime `Keyboard.setStyle()` call.
+      style: KeyboardStyle.Default,
+    },
   },
 };
 

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -572,11 +572,14 @@ body {
  * ::-webkit-scrollbar above replaces WKWebView's auto-hiding overlay
  * indicator with an always-visible bar, which reads as broken on iOS.
  * Scrolling and momentum are unaffected. The
- * :root[data-native-platform="ios"] prefix covers both the document
- * scrollbar and every inner scroller, and outranks the :root * and
- * [data-theme] scrollbar rules above on specificity. */
+ * :root[data-native-platform="ios"] prefix covers the document scrollbar,
+ * every inner scroller, and the ::before / ::after pseudo-elements, mirroring
+ * the :root * selector list above, and outranks both it and the [data-theme]
+ * scrollbar rules on specificity. */
 :root[data-native-platform="ios"],
-:root[data-native-platform="ios"] * {
+:root[data-native-platform="ios"] *,
+:root[data-native-platform="ios"] *::before,
+:root[data-native-platform="ios"] *::after {
   scrollbar-width: none;
 }
 

--- a/clients/web/src/runtime/platform-detection.ts
+++ b/clients/web/src/runtime/platform-detection.ts
@@ -308,9 +308,18 @@ export function useIsMacOSWeb(): boolean {
 }
 
 /**
- * Hydration-safe hook form of `isNativeIOS()`: false on the server and on
- * the first client render, settles after mount. Use this in JSX instead of
- * the bare function (docs/CAPACITOR.md) to avoid first-paint flicker.
+ * Hook form of `isNativeIOS()`, safe to call from a render body.
+ *
+ * The value is correct on the very first render and constant thereafter:
+ * Capacitor injects `native-bridge.js` as a `WKUserScript` at
+ * `.atDocumentStart`, so `window.Capacitor` exists before this bundle
+ * executes. `subscribe` is a noop because nothing can change the value, and
+ * the `getServerSnapshot` argument is unreachable because `clients/web`
+ * renders client-only through `createRoot` (no SSR, no hydration).
+ *
+ * Prefer it over the bare function in JSX (docs/CAPACITOR.md): it keeps the
+ * shape consistent with `useIsIOSWeb` / `useIsMacOSWeb` and stays correct if a
+ * prerender step is ever added. There is no first-paint flicker to avoid.
  */
 export function useIsNativeIOS(): boolean {
   return useSyncExternalStore(noop, isNativeIOS, () => false);


### PR DESCRIPTION
## Summary

- Pin `plugins.Keyboard` in `capacitor.config.ts` instead of inheriting unpinned upstream defaults. `resize: KeyboardResize.Native` keeps the whole-WKWebView-frame resize that `src/hooks/use-visible-viewport.ts` derives keyboard height from; `style: KeyboardStyle.Default` keeps the device-appearance keyboard. Both serialize to exactly today's implicit defaults (`native` / `DEFAULT`), so this is behavior-preserving, and the comment documents the plugin's process-wide `keyboardAppearance` swizzle.
- Reword the `useIsNativeIOS` docstring. It claimed the value is false on first render and settles after mount; there is no SSR in `clients/web` (`createRoot`, no `hydrateRoot`) and Capacitor injects `native-bridge.js` at `.atDocumentStart`, so the value is already final on render #1 and `subscribe` is a noop. The hook stays for render-safety and sibling consistency.
- Extend the iOS `scrollbar-width: none` rule to `*::before` / `*::after` so it exactly mirrors the `:root *` block it shadows.

Addresses self-review findings on plan ios-capacitor-ui-polish.md