### PR TITLE
feat(memory): deterministic batch concept-page ingest service in the substrate

### DIFF
--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/ingest.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/ingest.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for `substrate/ingest.ts`.
+ *
+ * Coverage matrix:
+ *   - Happy path: N valid pages written, both reindex job types enqueued once.
+ *   - Dry-run: nothing on disk, no lock file, no enqueues, per-page results
+ *     still reported.
+ *   - Collision: existing slug skipped without `overwrite`, rewritten with it.
+ *   - Malformed page (bad frontmatter YAML, schema failure, unterminated
+ *     fence): `invalid` with an error string while valid batch-mates write.
+ *   - Lock held by a live PID: IngestLockedError, zero writes, zero enqueues.
+ *   - Batch over the cap: RangeError.
+ *   - In-batch duplicate slug: later occurrence `invalid`.
+ *   - Provenance warnings: missing `source`, unparseable `origin_date`.
+ *
+ * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`. Sample
+ * content uses generic placeholders (Alice).
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── jobs-store mock ─────────────────────────────────────────────────
+//
+// The ingest service enqueues reindex follow-ups through the shared memory
+// job queue; an in-memory recorder stands in for the DB so the tests can
+// assert the fan-out without initializing sqlite.
+const enqueuedJobs: Array<{
+  type: string;
+  payload: Record<string, unknown>;
+}> = [];
+let nextJobIdCounter = 0;
+// Job types the service should see as already pending; drives the
+// enqueue-coalescing branch (`hasPendingJobOfType`).
+let pendingJobTypes = new Set<string>();
+
+mock.module("../../../../../persistence/jobs-store.js", () => ({
+  enqueueMemoryJob: (
+    type: string,
+    payload: Record<string, unknown>,
+  ): string => {
+    enqueuedJobs.push({ type, payload });
+    nextJobIdCounter += 1;
+    return `job-${nextJobIdCounter}`;
+  },
+  hasPendingJobOfType: (type: string): boolean => pendingJobTypes.has(type),
+  isMemoryEnabled: () => true,
+}));
+
+const { IngestLockedError, ingestPages, MAX_INGEST_PAGES_PER_CALL } =
+  await import("../ingest.js");
+const { getConsolidationLockPath } = await import("../consolidation-lock.js");
+const { listPages, readPage } = await import("../page-store.js");
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), "memory-ingest-test-"));
+  enqueuedJobs.length = 0;
+  pendingJobTypes = new Set();
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+/** A well-formed page carrying provenance so it yields zero warnings. */
+function validPage(body: string): string {
+  return `---\nsource: import:chatgpt\norigin_date: 2025-03-14\n---\n${body}\n`;
+}
+
+function lockPath(): string {
+  return getConsolidationLockPath(join(workspace, "memory"));
+}
+
+describe("ingestPages", () => {
+  test("happy path writes every page and enqueues both reindex jobs once", async () => {
+    const summary = await ingestPages(workspace, [
+      { slug: "people/alice", content: validPage("Alice likes hiking.") },
+      { slug: "projects/garden", content: validPage("Garden redesign notes.") },
+      { slug: "recipes", content: validPage("Favorite recipes.") },
+    ]);
+
+    expect(summary.written).toBe(3);
+    expect(summary.skipped).toBe(0);
+    expect(summary.invalid).toBe(0);
+    expect(summary.dryRun).toBe(false);
+    expect(summary.results.map((r) => r.action)).toEqual([
+      "written",
+      "written",
+      "written",
+    ]);
+    expect(summary.results.every((r) => r.warnings.length === 0)).toBe(true);
+
+    const alice = await readPage(workspace, "people/alice");
+    expect(alice?.body.trim()).toBe("Alice likes hiking.");
+    expect(alice?.frontmatter.source).toBe("import:chatgpt");
+    expect(await listPages(workspace)).toEqual([
+      "people/alice",
+      "projects/garden",
+      "recipes",
+    ]);
+
+    expect(enqueuedJobs.map((j) => j.type).sort()).toEqual([
+      "memory_v2_reembed",
+      "memory_v3_maintain",
+    ]);
+    // The lock is released after the batch.
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("dry-run reports per-page results without disk writes, lock, or enqueues", async () => {
+    const summary = await ingestPages(
+      workspace,
+      [
+        { slug: "people/alice", content: validPage("Alice likes hiking.") },
+        { slug: "bad slug", content: validPage("whitespace slug") },
+      ],
+      { dryRun: true },
+    );
+
+    expect(summary.dryRun).toBe(true);
+    expect(summary.written).toBe(1);
+    expect(summary.invalid).toBe(1);
+    expect(summary.results[0]).toMatchObject({
+      slug: "people/alice",
+      action: "written",
+    });
+    expect(summary.results[1].action).toBe("invalid");
+    expect(summary.results[1].error).toContain("whitespace");
+
+    expect(await listPages(workspace)).toEqual([]);
+    expect(existsSync(lockPath())).toBe(false);
+    expect(enqueuedJobs).toEqual([]);
+  });
+
+  test("existing slug is skipped without overwrite and rewritten with it", async () => {
+    await ingestPages(workspace, [
+      { slug: "people/alice", content: validPage("Original body.") },
+    ]);
+    enqueuedJobs.length = 0;
+
+    const skipped = await ingestPages(workspace, [
+      { slug: "people/alice", content: validPage("Replacement body.") },
+    ]);
+    expect(skipped.results[0].action).toBe("skipped_exists");
+    expect(skipped.written).toBe(0);
+    expect(skipped.skipped).toBe(1);
+    const unchanged = await readPage(workspace, "people/alice");
+    expect(unchanged?.body.trim()).toBe("Original body.");
+    // Nothing written, so no reindex fan-out.
+    expect(enqueuedJobs).toEqual([]);
+
+    const overwritten = await ingestPages(
+      workspace,
+      [{ slug: "people/alice", content: validPage("Replacement body.") }],
+      { overwrite: true },
+    );
+    expect(overwritten.results[0].action).toBe("written");
+    const replaced = await readPage(workspace, "people/alice");
+    expect(replaced?.body.trim()).toBe("Replacement body.");
+  });
+
+  test("malformed pages are invalid with an error string while valid batch-mates write", async () => {
+    const summary = await ingestPages(workspace, [
+      // Broken YAML inside the fence.
+      { slug: "broken-yaml", content: "---\nedges: [unclosed\n---\nbody\n" },
+      // Well-formed YAML that fails the frontmatter schema (edges must be an array).
+      { slug: "schema-fail", content: "---\nedges: not-an-array\n---\nbody\n" },
+      // Fence that opens but never closes (degraded parse).
+      { slug: "unterminated", content: "---\nsource: import:chatgpt\nbody\n" },
+      { slug: "good", content: validPage("Survives the batch.") },
+    ]);
+
+    expect(summary.invalid).toBe(3);
+    expect(summary.written).toBe(1);
+    for (const result of summary.results.slice(0, 3)) {
+      expect(result.action).toBe("invalid");
+      expect(typeof result.error).toBe("string");
+      expect(result.error!.length).toBeGreaterThan(0);
+    }
+    expect(summary.results[2].error).toContain("closing --- fence is missing");
+
+    expect(await listPages(workspace)).toEqual(["good"]);
+    expect(enqueuedJobs.map((j) => j.type).sort()).toEqual([
+      "memory_v2_reembed",
+      "memory_v3_maintain",
+    ]);
+  });
+
+  test("held lock throws IngestLockedError with the holder and writes nothing", async () => {
+    const path = lockPath();
+    mkdirSync(dirname(path), { recursive: true });
+    const holderPayload = `${process.pid} ${Date.now()} consolidation`;
+    writeFileSync(path, `${holderPayload}\n`);
+
+    let thrown: unknown;
+    try {
+      await ingestPages(workspace, [
+        { slug: "people/alice", content: validPage("Alice likes hiking.") },
+      ]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(IngestLockedError);
+    expect((thrown as InstanceType<typeof IngestLockedError>).holder).toBe(
+      holderPayload,
+    );
+
+    expect(await listPages(workspace)).toEqual([]);
+    expect(enqueuedJobs).toEqual([]);
+    // The pre-existing lock is left in place for its holder.
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test("batch over the cap throws RangeError before any validation", async () => {
+    const pages = Array.from(
+      { length: MAX_INGEST_PAGES_PER_CALL + 1 },
+      (_, i) => ({ slug: `page-${i}`, content: validPage(`Body ${i}.`) }),
+    );
+    await expect(ingestPages(workspace, pages)).rejects.toBeInstanceOf(
+      RangeError,
+    );
+    expect(await listPages(workspace)).toEqual([]);
+  });
+
+  test("in-batch duplicate slug is invalid; the first occurrence wins", async () => {
+    const summary = await ingestPages(workspace, [
+      { slug: "people/alice", content: validPage("First occurrence.") },
+      { slug: "people/alice", content: validPage("Second occurrence.") },
+    ]);
+
+    expect(summary.written).toBe(1);
+    expect(summary.invalid).toBe(1);
+    expect(summary.results[1].action).toBe("invalid");
+    expect(summary.results[1].error).toContain("duplicate slug");
+    const page = await readPage(workspace, "people/alice");
+    expect(page?.body.trim()).toBe("First occurrence.");
+  });
+
+  test("missing source and unparseable origin_date produce warnings, not failures", async () => {
+    const summary = await ingestPages(workspace, [
+      { slug: "no-source", content: "---\nedges: []\n---\nNo provenance.\n" },
+      {
+        slug: "bad-date",
+        content:
+          "---\nsource: import:chatgpt\norigin_date: sometime last spring\n---\nBody.\n",
+      },
+    ]);
+
+    expect(summary.written).toBe(2);
+    expect(summary.invalid).toBe(0);
+    expect(summary.results[0].warnings.join(" ")).toContain("source");
+    expect(summary.results[1].warnings.join(" ")).toContain("origin_date");
+  });
+
+  test("a pending reindex job of the same type suppresses its duplicate enqueue", async () => {
+    pendingJobTypes = new Set(["memory_v2_reembed"]);
+    await ingestPages(workspace, [
+      { slug: "people/alice", content: validPage("Alice likes hiking.") },
+    ]);
+    expect(enqueuedJobs.map((j) => j.type)).toEqual(["memory_v3_maintain"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/ingest.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/ingest.test.ts
@@ -12,6 +12,10 @@
  *   - Batch over the cap: RangeError.
  *   - In-batch duplicate slug: later occurrence `invalid`.
  *   - Provenance warnings: missing `source`, unparseable `origin_date`.
+ *   - Under-lock collision snapshot: a page committed between validation and
+ *     the write phase is skipped, and `listPages` runs after `tryAcquireLock`.
+ *   - Partial write failure: the reindex fan-out still runs for committed
+ *     pages while the write error propagates.
  *
  * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`. Sample
  * content uses generic placeholders (Alice).
@@ -54,6 +58,57 @@ mock.module("../../../../../persistence/jobs-store.js", () => ({
   isMemoryEnabled: () => true,
 }));
 
+// ── page-store / consolidation-lock delegating mocks ────────────────
+//
+// Thin wrappers around the real modules that record the ordering of lock
+// acquisition vs the collision snapshot and expose two race hooks: a
+// callback fired right after the lock is acquired (simulating a concurrent
+// writer that committed just before the snapshot) and a set of slugs whose
+// `writePage` rejects (simulating a mid-batch write failure).
+//
+// `mock.module` mutates the already-imported namespace objects in place, so
+// the wrapped functions are snapshotted into standalone consts first; calling
+// through the namespace after mocking would recurse into the wrapper.
+const realPageStore = await import("../page-store.js");
+const realLock = await import("../consolidation-lock.js");
+const realListPages = realPageStore.listPages;
+const realWritePage = realPageStore.writePage;
+const realTryAcquireLock = realLock.tryAcquireLock;
+
+const callTrace: string[] = [];
+let onLockAcquired: (() => void) | undefined;
+let failWriteSlugs = new Set<string>();
+
+mock.module("../page-store.js", () => ({
+  ...realPageStore,
+  listPages: (workspaceDir: string): Promise<string[]> => {
+    callTrace.push("listPages");
+    return realListPages(workspaceDir);
+  },
+  writePage: (...args: Parameters<typeof realWritePage>): Promise<void> => {
+    if (failWriteSlugs.has(args[1].slug)) {
+      return Promise.reject(
+        new Error(`simulated write failure: ${args[1].slug}`),
+      );
+    }
+    return realWritePage(...args);
+  },
+}));
+
+mock.module("../consolidation-lock.js", () => ({
+  ...realLock,
+  tryAcquireLock: (
+    ...args: Parameters<typeof realTryAcquireLock>
+  ): string | null => {
+    const holder = realTryAcquireLock(...args);
+    if (holder === null) {
+      callTrace.push("tryAcquireLock");
+      onLockAcquired?.();
+    }
+    return holder;
+  },
+}));
+
 const { IngestLockedError, ingestPages, MAX_INGEST_PAGES_PER_CALL } =
   await import("../ingest.js");
 const { getConsolidationLockPath } = await import("../consolidation-lock.js");
@@ -65,6 +120,9 @@ beforeEach(() => {
   workspace = mkdtempSync(join(tmpdir(), "memory-ingest-test-"));
   enqueuedJobs.length = 0;
   pendingJobTypes = new Set();
+  callTrace.length = 0;
+  onLockAcquired = undefined;
+  failWriteSlugs = new Set();
 });
 
 afterEach(() => {
@@ -267,5 +325,72 @@ describe("ingestPages", () => {
       { slug: "people/alice", content: validPage("Alice likes hiking.") },
     ]);
     expect(enqueuedJobs.map((j) => j.type)).toEqual(["memory_v3_maintain"]);
+  });
+
+  test("a page committed during lock acquisition is skipped, not overwritten", async () => {
+    // Simulated concurrent writer: the colliding page lands on disk after
+    // validation ran and right after the lock is acquired, so only an
+    // under-lock snapshot can see it.
+    onLockAcquired = () => {
+      const path = join(workspace, "memory", "concepts", "people", "alice.md");
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, validPage("Concurrent writer body."));
+    };
+
+    const summary = await ingestPages(workspace, [
+      { slug: "people/alice", content: validPage("Ingest body.") },
+    ]);
+
+    // The collision snapshot ran after lock acquisition.
+    expect(callTrace).toEqual(["tryAcquireLock", "listPages"]);
+    expect(summary.results[0].action).toBe("skipped_exists");
+    expect(summary.written).toBe(0);
+    expect(summary.skipped).toBe(1);
+    const preserved = await readPage(workspace, "people/alice");
+    expect(preserved?.body.trim()).toBe("Concurrent writer body.");
+    // Nothing written, so no reindex fan-out; the lock is released.
+    expect(enqueuedJobs).toEqual([]);
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("dry-run takes its advisory snapshot without touching the lock", async () => {
+    await ingestPages(
+      workspace,
+      [{ slug: "people/alice", content: validPage("Alice likes hiking.") }],
+      { dryRun: true },
+    );
+    expect(callTrace).toEqual(["listPages"]);
+  });
+
+  test("a mid-batch write failure still enqueues reindex follow-ups for committed pages", async () => {
+    failWriteSlugs = new Set(["projects/garden"]);
+
+    let thrown: unknown;
+    try {
+      await ingestPages(workspace, [
+        { slug: "people/alice", content: validPage("Alice likes hiking.") },
+        {
+          slug: "projects/garden",
+          content: validPage("Garden redesign notes."),
+        },
+      ]);
+    } catch (err) {
+      thrown = err;
+    }
+
+    // The write error propagates to the caller.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain(
+      "simulated write failure: projects/garden",
+    );
+    // The first page committed before the failure and still gets its
+    // reindex fan-out, once per job type.
+    expect(await listPages(workspace)).toEqual(["people/alice"]);
+    expect(enqueuedJobs.map((j) => j.type).sort()).toEqual([
+      "memory_v2_reembed",
+      "memory_v3_maintain",
+    ]);
+    // The lock is released despite the failure.
+    expect(existsSync(lockPath())).toBe(false);
   });
 });

--- a/assistant/src/plugins/defaults/memory/substrate/ingest.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/ingest.ts
@@ -1,0 +1,259 @@
+// SUBSTRATE (v2+v3).
+/**
+ * Memory substrate: deterministic batch concept-page ingest.
+ *
+ * Validates and writes a batch of caller-supplied concept pages (full page
+ * markdown, frontmatter + body) into `memory/concepts/`. Purely mechanical:
+ * no LLM calls, no network I/O. Every page is validated individually and
+ * reported individually, so one malformed page never sinks the batch.
+ *
+ * Writes hold the consolidation lock so an ingest cannot interleave with a
+ * consolidation pass rewriting the same corpus; after the lock is released,
+ * reindex follow-up jobs are enqueued so the freshly written pages become
+ * retrievable.
+ */
+
+import { join } from "node:path";
+
+import {
+  enqueueMemoryJob,
+  hasPendingJobOfType,
+  type MemoryJobType,
+} from "../../../../persistence/jobs-store.js";
+import { getLogger } from "../logging.js";
+import {
+  getConsolidationLockPath,
+  releaseLock,
+  tryAcquireLock,
+} from "./consolidation-lock.js";
+import {
+  listPages,
+  parsePageContent,
+  validateSlug,
+  writePage,
+} from "./page-store.js";
+import type { ConceptPage } from "./types.js";
+
+const log = getLogger("memory-ingest");
+
+/** One page to ingest. `content` is the full page markdown (frontmatter + body). */
+export interface IngestPageInput {
+  slug: string;
+  content: string;
+}
+
+export interface IngestOptions {
+  /** Validate and report without touching disk or the lock. */
+  dryRun?: boolean;
+  /** Rewrite pages whose slug already exists on disk (default: skip them). */
+  overwrite?: boolean;
+}
+
+export interface IngestPageResult {
+  slug: string;
+  action: "written" | "skipped_exists" | "invalid";
+  warnings: string[];
+  error?: string;
+}
+
+export interface IngestSummary {
+  results: IngestPageResult[];
+  written: number;
+  skipped: number;
+  invalid: number;
+  dryRun: boolean;
+}
+
+/** Hard cap on batch size; larger batches should be split by the caller. */
+export const MAX_INGEST_PAGES_PER_CALL = 200;
+
+/** Thrown when the consolidation lock is held by another writer. */
+export class IngestLockedError extends Error {
+  /** The lock file's holder payload (typically `<pid> <timestamp> <tag>`). */
+  readonly holder: string;
+
+  constructor(holder: string) {
+    super(`memory ingest skipped: consolidation lock held by ${holder}`);
+    this.name = "IngestLockedError";
+    this.holder = holder;
+  }
+}
+
+/**
+ * Reindex fan-out after a batch that wrote at least one page, mirroring the
+ * post-consolidation follow-ups: a conservative full reembed (the embedder's
+ * content-hash cache makes unchanged pages effectively free) plus v3 index
+ * maintenance (a no-op job on installs where v3 is not live).
+ */
+const REINDEX_JOB_TYPES: readonly MemoryJobType[] = [
+  "memory_v2_reembed",
+  "memory_v3_maintain",
+];
+
+/**
+ * Validate and write a batch of concept pages under `workspaceDir`.
+ *
+ * Per page, in order:
+ *   1. Slug shape (`validateSlug`) and in-batch uniqueness (a later duplicate
+ *      of an earlier slug is `invalid`).
+ *   2. Content parse via `parsePageContent`. A schema failure or a degraded
+ *      parse (unterminated frontmatter fence) yields `invalid` with the parse
+ *      error string: validation is per-page and loud, never a silent drop
+ *      (see the `.strict()` incident documented on
+ *      `ConceptPageFrontmatterSchema` for what silent dropping cost).
+ *   3. Provenance warnings (non-blocking): missing `source` frontmatter, and
+ *      an `origin_date` that `Date.parse` cannot read.
+ *   4. Collision against on-disk slugs: `skipped_exists` unless
+ *      `opts.overwrite`.
+ *
+ * With `dryRun` the summary is returned without touching disk or the lock.
+ * Otherwise the consolidation lock is held across the writes; a held lock
+ * throws {@link IngestLockedError} before anything is written. After release,
+ * reindex follow-ups are enqueued when at least one page was written.
+ *
+ * Throws `RangeError` when the batch exceeds {@link MAX_INGEST_PAGES_PER_CALL}.
+ */
+export async function ingestPages(
+  workspaceDir: string,
+  pages: IngestPageInput[],
+  opts?: IngestOptions,
+): Promise<IngestSummary> {
+  if (pages.length > MAX_INGEST_PAGES_PER_CALL) {
+    throw new RangeError(
+      `ingest batch of ${pages.length} pages exceeds the per-call cap of ` +
+        `${MAX_INGEST_PAGES_PER_CALL}; split it into smaller batches`,
+    );
+  }
+
+  const dryRun = opts?.dryRun === true;
+  const overwrite = opts?.overwrite === true;
+
+  const existingSlugs = new Set(await listPages(workspaceDir));
+  const seenSlugs = new Set<string>();
+  const results: IngestPageResult[] = [];
+  const toWrite: ConceptPage[] = [];
+
+  for (const input of pages) {
+    const warnings: string[] = [];
+    const invalid = (error: string): IngestPageResult => ({
+      slug: input.slug,
+      action: "invalid",
+      warnings,
+      error,
+    });
+
+    try {
+      validateSlug(input.slug);
+    } catch (err) {
+      results.push(invalid(err instanceof Error ? err.message : String(err)));
+      continue;
+    }
+
+    if (seenSlugs.has(input.slug)) {
+      results.push(invalid(`duplicate slug within batch: ${input.slug}`));
+      continue;
+    }
+    seenSlugs.add(input.slug);
+
+    let page: ConceptPage;
+    try {
+      page = parsePageContent(input.slug, input.content);
+    } catch (err) {
+      results.push(invalid(err instanceof Error ? err.message : String(err)));
+      continue;
+    }
+    if (page.parseWarning !== undefined) {
+      results.push(invalid(page.parseWarning));
+      continue;
+    }
+
+    if (page.frontmatter.source === undefined) {
+      warnings.push(
+        "missing `source` frontmatter; imported pages should carry a " +
+          "provenance tag (convention `import:<provider>`)",
+      );
+    }
+    if (
+      page.frontmatter.origin_date !== undefined &&
+      Number.isNaN(Date.parse(page.frontmatter.origin_date))
+    ) {
+      warnings.push(
+        `unparseable \`origin_date\`: ${page.frontmatter.origin_date}`,
+      );
+    }
+
+    if (existingSlugs.has(input.slug) && !overwrite) {
+      results.push({ slug: input.slug, action: "skipped_exists", warnings });
+      continue;
+    }
+
+    results.push({ slug: input.slug, action: "written", warnings });
+    toWrite.push(page);
+  }
+
+  const summary: IngestSummary = {
+    results,
+    written: results.filter((r) => r.action === "written").length,
+    skipped: results.filter((r) => r.action === "skipped_exists").length,
+    invalid: results.filter((r) => r.action === "invalid").length,
+    dryRun,
+  };
+
+  if (dryRun) {
+    return summary;
+  }
+
+  const lockPath = getConsolidationLockPath(join(workspaceDir, "memory"));
+  const holder = tryAcquireLock(lockPath, "ingest");
+  if (holder !== null) {
+    throw new IngestLockedError(holder);
+  }
+  try {
+    for (const page of toWrite) {
+      await writePage(workspaceDir, page);
+    }
+  } finally {
+    releaseLock(lockPath);
+  }
+
+  if (summary.written > 0) {
+    enqueueReindexFollowUps();
+    log.info(
+      {
+        written: summary.written,
+        skipped: summary.skipped,
+        invalid: summary.invalid,
+      },
+      "ingest batch written",
+    );
+  }
+
+  return summary;
+}
+
+/**
+ * Best-effort reindex fan-out. Each enqueue coalesces with an already-pending
+ * job of the same type: follow-ups carry no payload and read all state at
+ * execution time, so one pending row covers any number of completed batches.
+ * A failed enqueue does not undo the writes; the next consolidation pass
+ * performs the same fan-out.
+ */
+function enqueueReindexFollowUps(): void {
+  for (const jobType of REINDEX_JOB_TYPES) {
+    try {
+      if (hasPendingJobOfType(jobType)) {
+        log.debug(
+          { jobType },
+          "ingest: reindex follow-up already pending; skipping duplicate enqueue",
+        );
+        continue;
+      }
+      enqueueMemoryJob(jobType, {});
+    } catch (err) {
+      log.warn(
+        { err, jobType },
+        "ingest: failed to enqueue reindex follow-up; continuing",
+      );
+    }
+  }
+}

--- a/assistant/src/plugins/defaults/memory/substrate/ingest.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/ingest.ts
@@ -8,9 +8,11 @@
  * reported individually, so one malformed page never sinks the batch.
  *
  * Writes hold the consolidation lock so an ingest cannot interleave with a
- * consolidation pass rewriting the same corpus; after the lock is released,
- * reindex follow-up jobs are enqueued so the freshly written pages become
- * retrievable.
+ * consolidation pass rewriting the same corpus, and the collision snapshot
+ * is taken under that lock so a concurrent writer's page is never silently
+ * overwritten. After the lock is released, reindex follow-up jobs are
+ * enqueued whenever at least one page was written (even when a later write
+ * in the batch failed), so the freshly written pages become retrievable.
  */
 
 import { join } from "node:path";
@@ -104,12 +106,18 @@ const REINDEX_JOB_TYPES: readonly MemoryJobType[] = [
  *   3. Provenance warnings (non-blocking): missing `source` frontmatter, and
  *      an `origin_date` that `Date.parse` cannot read.
  *   4. Collision against on-disk slugs: `skipped_exists` unless
- *      `opts.overwrite`.
+ *      `opts.overwrite`. The snapshot backing this check is taken under the
+ *      consolidation lock, so a page committed by another writer between
+ *      validation and the write phase is still skipped rather than
+ *      overwritten.
  *
- * With `dryRun` the summary is returned without touching disk or the lock.
- * Otherwise the consolidation lock is held across the writes; a held lock
- * throws {@link IngestLockedError} before anything is written. After release,
- * reindex follow-ups are enqueued when at least one page was written.
+ * With `dryRun` the summary is returned without touching disk or the lock;
+ * the dry-run collision snapshot is lock-free and therefore advisory.
+ * Otherwise the consolidation lock is held across the snapshot and the
+ * writes; a held lock throws {@link IngestLockedError} before anything is
+ * written. After release, reindex follow-ups are enqueued when at least one
+ * page was written, including when a later write in the batch threw after
+ * earlier pages committed (the error still propagates).
  *
  * Throws `RangeError` when the batch exceeds {@link MAX_INGEST_PAGES_PER_CALL}.
  */
@@ -128,10 +136,12 @@ export async function ingestPages(
   const dryRun = opts?.dryRun === true;
   const overwrite = opts?.overwrite === true;
 
-  const existingSlugs = new Set(await listPages(workspaceDir));
   const seenSlugs = new Set<string>();
   const results: IngestPageResult[] = [];
-  const toWrite: ConceptPage[] = [];
+  // Pages that passed validation. Collision classification is deferred so
+  // the on-disk snapshot can be taken under the consolidation lock; each
+  // entry keeps a reference to its (provisional) result in `results`.
+  const pending: PendingPage[] = [];
 
   for (const input of pages) {
     const warnings: string[] = [];
@@ -182,25 +192,24 @@ export async function ingestPages(
       );
     }
 
-    if (existingSlugs.has(input.slug) && !overwrite) {
-      results.push({ slug: input.slug, action: "skipped_exists", warnings });
-      continue;
-    }
-
-    results.push({ slug: input.slug, action: "written", warnings });
-    toWrite.push(page);
+    // Provisional action: `classifyCollisions` downgrades it to
+    // `skipped_exists` when the slug already exists on disk and overwrite
+    // is off.
+    const result: IngestPageResult = {
+      slug: input.slug,
+      action: "written",
+      warnings,
+    };
+    results.push(result);
+    pending.push({ page, result });
   }
 
-  const summary: IngestSummary = {
-    results,
-    written: results.filter((r) => r.action === "written").length,
-    skipped: results.filter((r) => r.action === "skipped_exists").length,
-    invalid: results.filter((r) => r.action === "invalid").length,
-    dryRun,
-  };
-
   if (dryRun) {
-    return summary;
+    // Dry-run is advisory: the snapshot is taken without the lock, so a
+    // concurrent writer can change what a later real run would do.
+    const existingSlugs = new Set(await listPages(workspaceDir));
+    classifyCollisions(pending, existingSlugs, overwrite);
+    return summarize(results, dryRun);
   }
 
   const lockPath = getConsolidationLockPath(join(workspaceDir, "memory"));
@@ -208,27 +217,78 @@ export async function ingestPages(
   if (holder !== null) {
     throw new IngestLockedError(holder);
   }
+  let successfulWrites = 0;
   try {
+    // The snapshot is taken under the lock so a page committed by another
+    // writer after validation still classifies as a collision.
+    const existingSlugs = new Set(await listPages(workspaceDir));
+    const toWrite = classifyCollisions(pending, existingSlugs, overwrite);
+    const summary = summarize(results, dryRun);
+
     for (const page of toWrite) {
       await writePage(workspaceDir, page);
+      successfulWrites += 1;
     }
+
+    if (summary.written > 0) {
+      log.info(
+        {
+          written: summary.written,
+          skipped: summary.skipped,
+          invalid: summary.invalid,
+        },
+        "ingest batch written",
+      );
+    }
+    return summary;
   } finally {
     releaseLock(lockPath);
+    // Every committed page needs reindexing, including when a later write
+    // in the batch threw; the follow-ups are enqueued before that error
+    // propagates to the caller.
+    if (successfulWrites > 0) {
+      enqueueReindexFollowUps();
+    }
   }
+}
 
-  if (summary.written > 0) {
-    enqueueReindexFollowUps();
-    log.info(
-      {
-        written: summary.written,
-        skipped: summary.skipped,
-        invalid: summary.invalid,
-      },
-      "ingest batch written",
-    );
+/** A validated page awaiting collision classification against the on-disk set. */
+interface PendingPage {
+  page: ConceptPage;
+  result: IngestPageResult;
+}
+
+/**
+ * Downgrade pending results whose slug is already on disk to `skipped_exists`
+ * (unless overwriting) and return the pages left to write, in batch order.
+ */
+function classifyCollisions(
+  pending: readonly PendingPage[],
+  existingSlugs: ReadonlySet<string>,
+  overwrite: boolean,
+): ConceptPage[] {
+  const toWrite: ConceptPage[] = [];
+  for (const { page, result } of pending) {
+    if (existingSlugs.has(result.slug) && !overwrite) {
+      result.action = "skipped_exists";
+      continue;
+    }
+    toWrite.push(page);
   }
+  return toWrite;
+}
 
-  return summary;
+function summarize(
+  results: IngestPageResult[],
+  dryRun: boolean,
+): IngestSummary {
+  return {
+    results,
+    written: results.filter((r) => r.action === "written").length,
+    skipped: results.filter((r) => r.action === "skipped_exists").length,
+    invalid: results.filter((r) => r.action === "invalid").length,
+    dryRun,
+  };
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/substrate/page-store.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/page-store.ts
@@ -202,39 +202,41 @@ const UNTERMINATED_FENCE_WARNING =
   "whole file is treated as body and its frontmatter fields are ignored";
 
 /**
- * Split raw file contents into (frontmatter, body). If no frontmatter block
- * is present the entire input is treated as body and an empty frontmatter
- * block is returned (validated by `ConceptPageFrontmatterSchema` so a bad
- * type on a declared field surfaces as a parse error to the caller, not
- * silently dropped data). The schema is `.passthrough()`, so unknown keys are
- * kept rather than rejected — migrated corpora carry leaked source-page fields.
+ * Parse full page content (frontmatter + body) into a `ConceptPage`. If no
+ * frontmatter block is present the entire input is treated as body and an
+ * empty frontmatter block is returned (validated by
+ * `ConceptPageFrontmatterSchema` so a bad type on a declared field surfaces
+ * as a parse error to the caller, not silently dropped data). The schema is
+ * `.passthrough()`, so unknown keys are kept rather than rejected: migrated
+ * corpora carry leaked source-page fields.
  *
- * A file that OPENS a frontmatter fence without ever closing it also parses
+ * Content that OPENS a frontmatter fence without ever closing it also parses
  * as body-only (a partially-visible page beats an invisible one), but carries
- * a `parseWarning` so index-level consumers can surface it for repair.
+ * a `parseWarning` so consumers can surface it for repair.
  *
  * The schema's defaults guarantee `edges` and `ref_files` are always arrays
  * even on freshly created pages with empty frontmatter.
+ *
+ * Shared by `readPage` (which supplies raw file contents) and callers holding
+ * page content that has not touched disk yet (e.g. batch ingest validation).
  */
-function parsePageContent(raw: string): {
-  frontmatter: ConceptPage["frontmatter"];
-  body: string;
-  parseWarning?: string;
-} {
-  const match = raw.match(FRONTMATTER_REGEX);
+export function parsePageContent(slug: string, content: string): ConceptPage {
+  const match = content.match(FRONTMATTER_REGEX);
   if (!match) {
     return {
+      slug,
       frontmatter: ConceptPageFrontmatterSchema.parse({}),
-      body: raw,
-      ...(FRONTMATTER_OPENER_REGEX.test(raw)
+      body: content,
+      ...(FRONTMATTER_OPENER_REGEX.test(content)
         ? { parseWarning: UNTERMINATED_FENCE_WARNING }
         : {}),
     };
   }
   const yamlBlock = match[1];
-  const body = raw.slice(match[0].length);
+  const body = content.slice(match[0].length);
   const parsed = parseYaml(yamlBlock) ?? {};
   return {
+    slug,
     frontmatter: ConceptPageFrontmatterSchema.parse(parsed),
     body,
   };
@@ -277,13 +279,7 @@ export async function readPage(
     }
     throw err;
   }
-  const { frontmatter, body, parseWarning } = parsePageContent(raw);
-  return {
-    slug,
-    frontmatter,
-    body,
-    ...(parseWarning !== undefined ? { parseWarning } : {}),
-  };
+  return parsePageContent(slug, raw);
 }
 
 /**


### PR DESCRIPTION
## Summary
- substrate/ingest.ts: validated, lock-holding batch writer for concept pages (dry-run, overwrite policy, per-page results)
- page-store parsePageContent extraction; reindex via enqueued memory_v2_reembed + memory_v3_maintain

Part of plan: memory-ingestion.md (PR 5 of 11)