### PR TITLE
feat(memory): rank the v3 fresh lane and card date stamps on origin-aware `freshAt`, not raw mtime

### DIFF
--- a/assistant/src/plugins/defaults/memory/graph-topology/__tests__/build-memory-graph.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/__tests__/build-memory-graph.test.ts
@@ -15,6 +15,7 @@ function entry(
     edges: [],
     leaves: [],
     modifiedAt: 1,
+    freshAt: 1,
     ...over,
   };
 }

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
@@ -76,6 +76,7 @@ function makePage(
     summary?: string;
     body?: string;
     leaves?: string[];
+    originDate?: string;
   } = {},
 ): ConceptPage {
   return {
@@ -86,6 +87,9 @@ function makePage(
       ref_urls: [],
       ...(opts.summary !== undefined ? { summary: opts.summary } : {}),
       ...(opts.leaves !== undefined ? { leaves: opts.leaves } : {}),
+      ...(opts.originDate !== undefined
+        ? { origin_date: opts.originDate }
+        : {}),
     },
     body: opts.body ?? "",
   };
@@ -374,6 +378,48 @@ describe("getPageIndex", () => {
     expect(idx.bySlug.get("skills/browser")?.summary).toBe(
       "Seeded skill content.",
     );
+  });
+
+  test("freshAt is the parsed origin_date; modifiedAt stays raw mtime", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("imported", { summary: "I", originDate: "2019-03-05" }),
+    );
+
+    const idx = await getPageIndex(workspaceDir);
+    const entry = idx.bySlug.get("imported")!;
+    expect(entry.freshAt).toBe(Date.parse("2019-03-05"));
+    // The file was written just now, so its raw mtime is far past the
+    // backdated origin: modifiedAt must not follow origin_date.
+    expect(entry.modifiedAt).toBeGreaterThan(entry.freshAt);
+  });
+
+  test("freshAt falls back to file mtime when origin_date is absent", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "A" }));
+
+    const idx = await getPageIndex(workspaceDir);
+    const entry = idx.bySlug.get("alice")!;
+    expect(entry.freshAt).toBeGreaterThan(0);
+    expect(entry.freshAt).toBe(entry.modifiedAt);
+  });
+
+  test("freshAt falls back to file mtime when origin_date is unparseable", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("garbled", { summary: "G", originDate: "not-a-date" }),
+    );
+
+    const idx = await getPageIndex(workspaceDir);
+    const entry = idx.bySlug.get("garbled")!;
+    expect(entry.freshAt).toBeGreaterThan(0);
+    expect(entry.freshAt).toBe(entry.modifiedAt);
+  });
+
+  test("synthetic skill entries carry freshAt 0", async () => {
+    skillState.entries = [{ id: "browser", content: "Drive a browser." }];
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("skills/browser")?.freshAt).toBe(0);
   });
 
   test("collision dedupe leaves non-colliding pages and skills intact", async () => {

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
@@ -409,6 +409,22 @@ describe("getPageIndex", () => {
     expect(entry.freshAt).not.toBe(entry.modifiedAt);
   });
 
+  test("freshAt reads an offset-less ISO datetime as UTC", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("meeting", {
+        summary: "M",
+        originDate: "2019-06-10T14:23:00",
+      }),
+    );
+
+    const idx = await getPageIndex(workspaceDir);
+    const entry = idx.bySlug.get("meeting")!;
+    // Deterministic across host timezones: the offset-less datetime is
+    // normalized to UTC before parsing.
+    expect(entry.freshAt).toBe(Date.parse("2019-06-10T14:23:00Z"));
+  });
+
   test("freshAt falls back to file mtime when origin_date is absent", async () => {
     await writePage(workspaceDir, makePage("alice", { summary: "A" }));
 

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
@@ -391,7 +391,22 @@ describe("getPageIndex", () => {
     expect(entry.freshAt).toBe(Date.parse("2019-03-05"));
     // The file was written just now, so its raw mtime is far past the
     // backdated origin: modifiedAt must not follow origin_date.
-    expect(entry.modifiedAt).toBeGreaterThan(entry.freshAt);
+    expect(entry.modifiedAt).toBeGreaterThan(Date.parse("2019-03-05"));
+  });
+
+  test("freshAt keeps a pre-epoch origin_date as its negative parsed epoch", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("archival", { summary: "A", originDate: "1969-07-20" }),
+    );
+
+    const idx = await getPageIndex(workspaceDir);
+    const entry = idx.bySlug.get("archival")!;
+    // 1969-07-20 parses to a negative epoch-ms value; the declared
+    // chronology wins over the current file mtime.
+    expect(entry.freshAt).toBe(Date.parse("1969-07-20"));
+    expect(entry.freshAt).toBeLessThan(0);
+    expect(entry.freshAt).not.toBe(entry.modifiedAt);
   });
 
   test("freshAt falls back to file mtime when origin_date is absent", async () => {
@@ -415,11 +430,11 @@ describe("getPageIndex", () => {
     expect(entry.freshAt).toBe(entry.modifiedAt);
   });
 
-  test("synthetic skill entries carry freshAt 0", async () => {
+  test("synthetic skill entries carry freshAt null", async () => {
     skillState.entries = [{ id: "browser", content: "Drive a browser." }];
 
     const idx = await getPageIndex(workspaceDir);
-    expect(idx.bySlug.get("skills/browser")?.freshAt).toBe(0);
+    expect(idx.bySlug.get("skills/browser")?.freshAt).toBeNull();
   });
 
   test("collision dedupe leaves non-colliding pages and skills intact", async () => {

--- a/assistant/src/plugins/defaults/memory/substrate/page-index.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/page-index.ts
@@ -306,10 +306,13 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
 /**
  * Effective recency for a real concept page: the parsed `origin_date`
  * frontmatter (ISO 8601 date or datetime) when present and parseable, else
- * the file mtime. Any finite parse result is accepted — dates at or before
+ * the file mtime. Any finite parse result is accepted; dates at or before
  * 1970-01-01 yield zero or negative epoch ms and are valid chronology. An
- * unparseable value degrades to mtime rather than dropping the page from
- * recency ranking.
+ * offset-less ISO datetime (e.g. `2026-06-10T14:23:00`) is read as UTC so
+ * identical pages rank at the same instant on hosts in different timezones
+ * (bare `Date.parse` would apply the host's local offset). An unparseable
+ * value degrades to mtime rather than dropping the page from recency
+ * ranking.
  */
 function resolveFreshAt(
   originDate: string | undefined,
@@ -318,8 +321,25 @@ function resolveFreshAt(
   if (originDate === undefined) {
     return mtimeMs;
   }
-  const parsed = Date.parse(originDate);
+  const parsed = Date.parse(normalizeOffsetlessIsoToUtc(originDate));
   return Number.isFinite(parsed) ? parsed : mtimeMs;
+}
+
+/**
+ * Matches an ISO 8601 datetime with no timezone designator (no trailing `Z`
+ * or numeric offset). Date-only strings are excluded: the spec already
+ * assigns them UTC and `Date.parse` honors that.
+ */
+const OFFSETLESS_ISO_DATETIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/;
+
+/**
+ * Append `Z` to an offset-less ISO datetime so `Date.parse` reads it as UTC.
+ * Strings with an explicit offset, date-only strings, and non-ISO shapes
+ * pass through unchanged for `Date.parse` to accept or reject as before.
+ */
+function normalizeOffsetlessIsoToUtc(value: string): string {
+  return OFFSETLESS_ISO_DATETIME.test(value) ? `${value}Z` : value;
 }
 
 /** First line of an error's message — parse errors (YAML) are multi-line with

--- a/assistant/src/plugins/defaults/memory/substrate/page-index.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/page-index.ts
@@ -73,14 +73,15 @@ export interface PageIndexEntry {
   modifiedAt: number;
   /**
    * Effective recency in epoch ms: `Date.parse(frontmatter.origin_date)` when
-   * that field is present and parseable, else the file mtime; 0 for synthetic
-   * entries. Imported or backfilled pages carry the date their content is
-   * about, so recency-ranked consumers (the v3 fresh lane, card date stamps)
-   * read this instead of `modifiedAt`. `splitTier1` deliberately keeps sorting
-   * on `modifiedAt`: consolidation-facing tier ranking reflects actual edit
-   * recency.
+   * that field is present and parseable (pre-epoch dates yield zero or
+   * negative values and are kept), else the file mtime; `null` for synthetic
+   * entries (skills, CLI commands), which have no recency signal. Imported or
+   * backfilled pages carry the date their content is about, so recency-ranked
+   * consumers (the v3 fresh lane, card date stamps) read this instead of
+   * `modifiedAt`. `splitTier1` deliberately keeps sorting on `modifiedAt`:
+   * consolidation-facing tier ranking reflects actual edit recency.
    */
-  freshAt: number;
+  freshAt: number | null;
 }
 
 /**
@@ -157,7 +158,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     outgoingSlugs: string[];
     leaves: string[];
     modifiedAt: number;
-    freshAt: number;
+    freshAt: number | null;
   }
 
   const [
@@ -240,7 +241,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       outgoingSlugs: [],
       leaves: [],
       modifiedAt: 0,
-      freshAt: 0,
+      freshAt: null,
     });
   }
 
@@ -251,7 +252,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       outgoingSlugs: [],
       leaves: [],
       modifiedAt: 0,
-      freshAt: 0,
+      freshAt: null,
     });
   }
 
@@ -304,9 +305,11 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
 
 /**
  * Effective recency for a real concept page: the parsed `origin_date`
- * frontmatter (ISO 8601 date or datetime) when present and parseable to a
- * positive epoch-ms value, else the file mtime. An unparseable value degrades
- * to mtime rather than dropping the page from recency ranking.
+ * frontmatter (ISO 8601 date or datetime) when present and parseable, else
+ * the file mtime. Any finite parse result is accepted — dates at or before
+ * 1970-01-01 yield zero or negative epoch ms and are valid chronology. An
+ * unparseable value degrades to mtime rather than dropping the page from
+ * recency ranking.
  */
 function resolveFreshAt(
   originDate: string | undefined,
@@ -316,7 +319,7 @@ function resolveFreshAt(
     return mtimeMs;
   }
   const parsed = Date.parse(originDate);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : mtimeMs;
+  return Number.isFinite(parsed) ? parsed : mtimeMs;
 }
 
 /** First line of an error's message — parse errors (YAML) are multi-line with

--- a/assistant/src/plugins/defaults/memory/substrate/page-index.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/page-index.ts
@@ -66,9 +66,21 @@ export interface PageIndexEntry {
   /**
    * File mtime in epoch ms; 0 for synthetic entries (skills, CLI commands)
    * that have no on-disk source file. Used by `splitTier1` to rank pages
-   * by recency.
+   * by recency. This stays raw mtime because the maintain job's re-embed
+   * delta (`computeChangedPages` in v3/maintain-job.ts) diffs on it; the
+   * origin-aware recency signal lives in {@link PageIndexEntry.freshAt}.
    */
   modifiedAt: number;
+  /**
+   * Effective recency in epoch ms: `Date.parse(frontmatter.origin_date)` when
+   * that field is present and parseable, else the file mtime; 0 for synthetic
+   * entries. Imported or backfilled pages carry the date their content is
+   * about, so recency-ranked consumers (the v3 fresh lane, card date stamps)
+   * read this instead of `modifiedAt`. `splitTier1` deliberately keeps sorting
+   * on `modifiedAt`: consolidation-facing tier ranking reflects actual edit
+   * recency.
+   */
+  freshAt: number;
 }
 
 /**
@@ -145,6 +157,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     outgoingSlugs: string[];
     leaves: string[];
     modifiedAt: number;
+    freshAt: number;
   }
 
   const [
@@ -216,6 +229,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       outgoingSlugs: page.frontmatter.edges,
       leaves: page.frontmatter.leaves ?? [],
       modifiedAt: mtimeMs,
+      freshAt: resolveFreshAt(page.frontmatter.origin_date, mtimeMs),
     });
   }
 
@@ -226,6 +240,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       outgoingSlugs: [],
       leaves: [],
       modifiedAt: 0,
+      freshAt: 0,
     });
   }
 
@@ -236,6 +251,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       outgoingSlugs: [],
       leaves: [],
       modifiedAt: 0,
+      freshAt: 0,
     });
   }
 
@@ -252,6 +268,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       edges: [],
       leaves: draft.leaves,
       modifiedAt: draft.modifiedAt,
+      freshAt: draft.freshAt,
     };
     bySlug.set(entry.slug, entry);
     byId.set(entry.id, entry);
@@ -283,6 +300,23 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
   const index: PageIndex = { entries, bySlug, byId, rendered, parseFailures };
   cache = { workspaceDir, index };
   return index;
+}
+
+/**
+ * Effective recency for a real concept page: the parsed `origin_date`
+ * frontmatter (ISO 8601 date or datetime) when present and parseable to a
+ * positive epoch-ms value, else the file mtime. An unparseable value degrades
+ * to mtime rather than dropping the page from recency ranking.
+ */
+function resolveFreshAt(
+  originDate: string | undefined,
+  mtimeMs: number,
+): number {
+  if (originDate === undefined) {
+    return mtimeMs;
+  }
+  const parsed = Date.parse(originDate);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : mtimeMs;
 }
 
 /** First line of an error's message — parse errors (YAML) are multi-line with
@@ -391,6 +425,7 @@ function buildLocalPageIndex(
       edges: [],
       leaves: src.leaves,
       modifiedAt: src.modifiedAt,
+      freshAt: src.freshAt,
     };
     localBySlug.set(local.slug, local);
     localById.set(local.id, local);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/card.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/card.test.ts
@@ -24,11 +24,11 @@ describe("renderCard — annotation line", () => {
     const card = renderCard(
       "page-a",
       PAGE,
-      "[lane: fresh · updated 2026-06-10 14:23 UTC]",
+      "[lane: fresh · dated 2026-06-10 14:23 UTC]",
     );
     expect(
       card.startsWith(
-        "# memory/concepts/page-a.md\n[lane: fresh · updated 2026-06-10 14:23 UTC]\nLead paragraph for page a.",
+        "# memory/concepts/page-a.md\n[lane: fresh · dated 2026-06-10 14:23 UTC]\nLead paragraph for page a.",
       ),
     ).toBe(true);
     expect(card).toContain("[sections: §Alpha]");

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -442,6 +442,7 @@ async function buildFixtureLanes(): Promise<FixtureLanes> {
     edges: [],
     leaves: [],
     modifiedAt: 0,
+    freshAt: 0,
   }));
   const edgeGraph = await buildEdgeGraph(entries, async (slug) => RAW[slug]!);
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -442,7 +442,7 @@ async function buildFixtureLanes(): Promise<FixtureLanes> {
     edges: [],
     leaves: [],
     modifiedAt: 0,
-    freshAt: 0,
+    freshAt: null,
   }));
   const edgeGraph = await buildEdgeGraph(entries, async (slug) => RAW[slug]!);
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/edge.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/edge.test.ts
@@ -13,7 +13,7 @@ function entry(id: number, slug: Slug, edges: number[] = []): PageIndexEntry {
     edges,
     leaves: [],
     modifiedAt: 0,
-    freshAt: 0,
+    freshAt: null,
   };
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/edge.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/edge.test.ts
@@ -6,7 +6,15 @@ import type { Slug } from "../types.js";
 
 /** Minimal page-index entry factory — only the fields the edge lane reads. */
 function entry(id: number, slug: Slug, edges: number[] = []): PageIndexEntry {
-  return { id, slug, summary: "", edges, leaves: [], modifiedAt: 0 };
+  return {
+    id,
+    slug,
+    summary: "",
+    edges,
+    leaves: [],
+    modifiedAt: 0,
+    freshAt: 0,
+  };
 }
 
 /** Build a raw-page reader from a fixture map; missing slugs read as "". */

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/fresh-set.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/fresh-set.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { computeFreshSet } from "../fresh-set.js";
 
-const entry = (slug: string, freshAt: number) => ({ slug, freshAt });
+const entry = (slug: string, freshAt: number | null) => ({ slug, freshAt });
 
 describe("computeFreshSet", () => {
   test("ranks by effective recency, newest first", () => {
@@ -39,12 +39,29 @@ describe("computeFreshSet", () => {
     expect(slugs).toEqual(["b", "c"]);
   });
 
-  test("skips synthetic entries (freshAt 0)", () => {
+  test("skips synthetic entries (freshAt null)", () => {
     const slugs = computeFreshSet(
-      [entry("skills/oura", 0), entry("real-page", 500)],
+      [entry("skills/oura", null), entry("real-page", 500)],
       { k: 5, excludeSlugs: new Set() },
     );
     expect(slugs).toEqual(["real-page"]);
+  });
+
+  test("a pre-epoch page is included and ranks below newer pages", () => {
+    // 1969-07-20 parses to a negative epoch-ms value. The page must stay in
+    // the lane with its declared chronology instead of being dropped or
+    // ranked by mtime.
+    const preEpoch = Date.parse("1969-07-20");
+    expect(preEpoch).toBeLessThan(0);
+    const slugs = computeFreshSet(
+      [
+        entry("apollo-archive", preEpoch),
+        entry("written-today", Date.parse("2026-07-29")),
+        entry("epoch-day", 0),
+      ],
+      { k: 3, excludeSlugs: new Set() },
+    );
+    expect(slugs).toEqual(["written-today", "epoch-day", "apollo-archive"]);
   });
 
   test("k = 0 disables the lane", () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/fresh-set.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/fresh-set.test.ts
@@ -2,15 +2,32 @@ import { describe, expect, test } from "bun:test";
 
 import { computeFreshSet } from "../fresh-set.js";
 
-const entry = (slug: string, modifiedAt: number) => ({ slug, modifiedAt });
+const entry = (slug: string, freshAt: number) => ({ slug, freshAt });
 
 describe("computeFreshSet", () => {
-  test("ranks by modification time, newest first", () => {
+  test("ranks by effective recency, newest first", () => {
     const slugs = computeFreshSet(
       [entry("old", 1000), entry("newest", 3000), entry("mid", 2000)],
       { k: 3, excludeSlugs: new Set() },
     );
     expect(slugs).toEqual(["newest", "mid", "old"]);
+  });
+
+  test("an origin-dated import ranks below a recently written page", () => {
+    // The imported page's file was written moments ago (its raw mtime is the
+    // newest on disk), but its declared origin date is years old, so its
+    // freshAt is ancient. The lane ranks on freshAt alone: the recently
+    // written page wins.
+    const importedFreshAt = Date.parse("2019-03-05");
+    const writtenFreshAt = Date.parse("2026-07-29");
+    const slugs = computeFreshSet(
+      [
+        entry("imported-archive", importedFreshAt),
+        entry("written-today", writtenFreshAt),
+      ],
+      { k: 1, excludeSlugs: new Set() },
+    );
+    expect(slugs).toEqual(["written-today"]);
   });
 
   test("cuts to k after exclusions", () => {
@@ -22,7 +39,7 @@ describe("computeFreshSet", () => {
     expect(slugs).toEqual(["b", "c"]);
   });
 
-  test("skips synthetic entries (modifiedAt 0)", () => {
+  test("skips synthetic entries (freshAt 0)", () => {
     const slugs = computeFreshSet(
       [entry("skills/oura", 0), entry("real-page", 500)],
       { k: 5, excludeSlugs: new Set() },
@@ -36,7 +53,7 @@ describe("computeFreshSet", () => {
     ).toEqual([]);
   });
 
-  test("breaks modification-time ties by slug, ascending", () => {
+  test("breaks effective-recency ties by slug, ascending", () => {
     const slugs = computeFreshSet(
       [entry("zebra", 1000), entry("apple", 1000), entry("mango", 1000)],
       { k: 3, excludeSlugs: new Set() },

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -142,6 +142,7 @@ function makeEntries(): PageIndexEntry[] {
     edges: [],
     leaves: [],
     modifiedAt: 0,
+    freshAt: 0,
   }));
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -142,7 +142,7 @@ function makeEntries(): PageIndexEntry[] {
     edges: [],
     leaves: [],
     modifiedAt: 0,
-    freshAt: 0,
+    freshAt: null,
   }));
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -178,6 +178,7 @@ function makeEntries(): PageIndexEntry[] {
     edges: [],
     leaves: [],
     modifiedAt: 0,
+    freshAt: 0,
   }));
 }
 
@@ -872,6 +873,7 @@ describe("orchestrate — edge-only injection", () => {
       edges: [],
       leaves: [],
       modifiedAt: 0,
+      freshAt: 0,
     }));
     const sectionIndex = await buildSectionIndex(slugs, async (s) => pages[s]!);
     const needle = buildSectionNeedle(sectionIndex);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -178,7 +178,7 @@ function makeEntries(): PageIndexEntry[] {
     edges: [],
     leaves: [],
     modifiedAt: 0,
-    freshAt: 0,
+    freshAt: null,
   }));
 }
 
@@ -873,7 +873,7 @@ describe("orchestrate — edge-only injection", () => {
       edges: [],
       leaves: [],
       modifiedAt: 0,
-      freshAt: 0,
+      freshAt: null,
     }));
     const sectionIndex = await buildSectionIndex(slugs, async (s) => pages[s]!);
     const needle = buildSectionNeedle(sectionIndex);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -173,6 +173,7 @@ function makeEntries(): PageIndexEntry[] {
     edges: [],
     leaves: [],
     modifiedAt: 0,
+    freshAt: 0,
   }));
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -173,7 +173,7 @@ function makeEntries(): PageIndexEntry[] {
     edges: [],
     leaves: [],
     modifiedAt: 0,
-    freshAt: 0,
+    freshAt: null,
   }));
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -298,6 +298,7 @@ mock.module("../../substrate/page-index.js", () => ({
         edges: [],
         leaves: [],
         modifiedAt: 0,
+        freshAt: 0,
       },
       {
         slug: "page-2",
@@ -306,6 +307,7 @@ mock.module("../../substrate/page-index.js", () => ({
         edges: [],
         leaves: [],
         modifiedAt: 0,
+        freshAt: 0,
       },
       // A synthetic capability row — same shape the v2 page index appends for
       // skills/CLI commands. `initLanes` must route it through the capability
@@ -317,6 +319,7 @@ mock.module("../../substrate/page-index.js", () => ({
         edges: [],
         leaves: [],
         modifiedAt: 0,
+        freshAt: 0,
       },
       // Extra real concept rows (modifiedAt > 0) a test can request to cross the
       // v3 full-profile page threshold; default 0 keeps the corpus sparse (lean).
@@ -327,6 +330,7 @@ mock.module("../../substrate/page-index.js", () => ({
         edges: [],
         leaves: [],
         modifiedAt: 1,
+        freshAt: 1,
       })),
     ],
     bySlug: new Map(),

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -298,7 +298,7 @@ mock.module("../../substrate/page-index.js", () => ({
         edges: [],
         leaves: [],
         modifiedAt: 0,
-        freshAt: 0,
+        freshAt: null,
       },
       {
         slug: "page-2",
@@ -307,7 +307,7 @@ mock.module("../../substrate/page-index.js", () => ({
         edges: [],
         leaves: [],
         modifiedAt: 0,
-        freshAt: 0,
+        freshAt: null,
       },
       // A synthetic capability row — same shape the v2 page index appends for
       // skills/CLI commands. `initLanes` must route it through the capability
@@ -319,7 +319,7 @@ mock.module("../../substrate/page-index.js", () => ({
         edges: [],
         leaves: [],
         modifiedAt: 0,
-        freshAt: 0,
+        freshAt: null,
       },
       // Extra real concept rows (modifiedAt > 0) a test can request to cross the
       // v3 full-profile page threshold; default 0 keeps the corpus sparse (lean).

--- a/assistant/src/plugins/defaults/memory/v3/card.ts
+++ b/assistant/src/plugins/defaults/memory/v3/card.ts
@@ -108,7 +108,7 @@ function renderCurrentLine(fields: Record<string, unknown>): string | null {
  *
  * ```
  * # memory/concepts/<slug>.md
- * [lane: fresh · updated 2026-06-10 14:23]
+ * [lane: fresh · dated 2026-06-10 14:23]
  * <head section verbatim>
  *
  * [sections: §… · §…]

--- a/assistant/src/plugins/defaults/memory/v3/fresh-set.ts
+++ b/assistant/src/plugins/defaults/memory/v3/fresh-set.ts
@@ -1,13 +1,16 @@
 /**
  * Recency fresh-set lane.
  *
- * Returns the top-K page slugs by most-recent on-disk modification
- * (`PageIndexEntry.modifiedAt`). The fresh set keeps *just-written* pages in
- * the candidate pool during the window before the other lanes can reach them:
- * a page consolidated minutes ago has no selection history (so frecency can't
- * rank it into the hot set) and a "what happened today?"-shaped message gives
- * the finder lanes nothing lexical to match it on. Recency is exactly the
- * signal those lanes are missing, so it gets its own lane.
+ * Returns the top-K page slugs by effective recency
+ * (`PageIndexEntry.freshAt`: the parsed `origin_date` frontmatter when
+ * present, else the file mtime), so origin-dated imports sort by their
+ * original chronology instead of their import time. The fresh set keeps
+ * *just-written* pages in the candidate pool during the window before the
+ * other lanes can reach them: a page consolidated minutes ago has no
+ * selection history (so frecency can't rank it into the hot set) and a
+ * "what happened today?"-shaped message gives the finder lanes nothing
+ * lexical to match it on. Recency is exactly the signal those lanes are
+ * missing, so it gets its own lane.
  *
  * Like core and hot, the fresh set is a stable-prefix lane: it is computed at
  * lane init and recomputed only on lane invalidation (the consolidation
@@ -19,7 +22,7 @@
  * Slugs in `excludeSlugs` (core + hot members) are dropped before the K cut —
  * those pages already sit in the stable prefix, so re-listing them would only
  * spend fresh slots on duplicates. Synthetic capability entries carry
- * `modifiedAt: 0` and are skipped: they have no on-disk write to be fresh by.
+ * `freshAt: 0` and are skipped: they have no on-disk write to be fresh by.
  */
 
 import type { Slug } from "./types.js";
@@ -27,8 +30,9 @@ import type { Slug } from "./types.js";
 /** The slice of a page-index entry the fresh lane ranks on. */
 export interface FreshSetEntry {
   slug: Slug;
-  /** File mtime in epoch ms; `0` for synthetic entries (skills, CLI commands). */
-  modifiedAt: number;
+  /** Effective recency in epoch ms (origin date when declared, else file
+   *  mtime); `0` for synthetic entries (skills, CLI commands). */
+  freshAt: number;
 }
 
 export interface FreshSetOptions {
@@ -40,9 +44,9 @@ export interface FreshSetOptions {
 }
 
 /**
- * Compute the top-`k` fresh slugs by file modification time, newest first.
+ * Compute the top-`k` fresh slugs by effective recency, newest first.
  *
- * Deterministic for fixed inputs: ties break `modifiedAt` desc, then slug asc.
+ * Deterministic for fixed inputs: ties break `freshAt` desc, then slug asc.
  */
 export function computeFreshSet(
   entries: readonly FreshSetEntry[],
@@ -54,8 +58,8 @@ export function computeFreshSet(
   }
 
   return entries
-    .filter((entry) => entry.modifiedAt > 0 && !excludeSlugs.has(entry.slug))
-    .sort((a, b) => b.modifiedAt - a.modifiedAt || (a.slug < b.slug ? -1 : 1))
+    .filter((entry) => entry.freshAt > 0 && !excludeSlugs.has(entry.slug))
+    .sort((a, b) => b.freshAt - a.freshAt || (a.slug < b.slug ? -1 : 1))
     .slice(0, k)
     .map((entry) => entry.slug);
 }

--- a/assistant/src/plugins/defaults/memory/v3/fresh-set.ts
+++ b/assistant/src/plugins/defaults/memory/v3/fresh-set.ts
@@ -22,7 +22,7 @@
  * Slugs in `excludeSlugs` (core + hot members) are dropped before the K cut —
  * those pages already sit in the stable prefix, so re-listing them would only
  * spend fresh slots on duplicates. Synthetic capability entries carry
- * `freshAt: 0` and are skipped: they have no on-disk write to be fresh by.
+ * `freshAt: null` and are skipped: they have no on-disk write to be fresh by.
  */
 
 import type { Slug } from "./types.js";
@@ -31,8 +31,9 @@ import type { Slug } from "./types.js";
 export interface FreshSetEntry {
   slug: Slug;
   /** Effective recency in epoch ms (origin date when declared, else file
-   *  mtime); `0` for synthetic entries (skills, CLI commands). */
-  freshAt: number;
+   *  mtime); pre-epoch origin dates are valid zero or negative values.
+   *  `null` for synthetic entries (skills, CLI commands). */
+  freshAt: number | null;
 }
 
 export interface FreshSetOptions {
@@ -58,7 +59,12 @@ export function computeFreshSet(
   }
 
   return entries
-    .filter((entry) => entry.freshAt > 0 && !excludeSlugs.has(entry.slug))
+    .filter(
+      (entry): entry is FreshSetEntry & { freshAt: number } =>
+        entry.freshAt !== null &&
+        Number.isFinite(entry.freshAt) &&
+        !excludeSlugs.has(entry.slug),
+    )
     .sort((a, b) => b.freshAt - a.freshAt || (a.slug < b.slug ? -1 : 1))
     .slice(0, k)
     .map((entry) => entry.slug);

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -284,10 +284,12 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     .map((entry) => entry.slug)
     .filter((slug) => sectionIndex.byArticle.has(slug));
 
-  // Fresh is the modification-recency top-K over the page index with core and
-  // hot excluded (fresh never duplicates the rest of the prefix). Page mtimes
-  // move at consolidation — the same event that invalidates the lanes — so the
-  // set is recomputed exactly when it can have changed.
+  // Fresh is the effective-recency top-K over the page index (`freshAt`:
+  // origin date when declared, else mtime, so backdated imports rank by their
+  // original chronology) with core and hot excluded (fresh never duplicates
+  // the rest of the prefix). Page mtimes move at consolidation, the same
+  // event that invalidates the lanes, so the set is recomputed exactly when
+  // it can have changed.
   const freshSlugs = computeFreshSet(pageIndex.entries, {
     k: tuning.freshSetK,
     excludeSlugs: new Set([...coreSlugs, ...hotSlugs]),
@@ -314,11 +316,12 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   // body into the byte-stable prefix. Disk pages render raw (frontmatter +
   // body) through `renderCard` so `kind: index` pages surface their `links:`
   // map in the card TOC. Each disk card carries its lane annotation; fresh
-  // cards additionally carry the page's last-modified time (an absolute
-  // stamp — it only changes when the page does, so the card stays byte-stable
-  // between lane recomputes).
-  const modifiedAtBySlug = new Map(
-    pageIndex.entries.map((entry) => [entry.slug, entry.modifiedAt]),
+  // cards additionally carry the page's effective-recency time (`freshAt`, so
+  // imported pages display their original date; an absolute stamp that only
+  // changes when the page does, so the card stays byte-stable between lane
+  // recomputes).
+  const freshAtBySlug = new Map(
+    pageIndex.entries.map((entry) => [entry.slug, entry.freshAt]),
   );
   const laneAnnotation = (
     slug: Slug,
@@ -327,15 +330,11 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     if (lane !== "fresh") {
       return `[lane: ${lane}]`;
     }
-    const modifiedAt = modifiedAtBySlug.get(slug);
-    if (
-      modifiedAt === undefined ||
-      !Number.isFinite(modifiedAt) ||
-      modifiedAt <= 0
-    ) {
+    const freshAt = freshAtBySlug.get(slug);
+    if (freshAt === undefined || !Number.isFinite(freshAt) || freshAt <= 0) {
       return "[lane: fresh]";
     }
-    const stamp = new Date(modifiedAt)
+    const stamp = new Date(freshAt)
       .toISOString()
       .slice(0, 16)
       .replace("T", " ");

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -342,7 +342,10 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
       .toISOString()
       .slice(0, 16)
       .replace("T", " ");
-    return `[lane: fresh · updated ${stamp} UTC]`;
+    // "dated", not "updated": for origin-dated imports the stamp is the
+    // content's original chronology, not a last-modified time, and claiming
+    // an update would feed the selector false temporal metadata.
+    return `[lane: fresh · dated ${stamp} UTC]`;
   };
   const prefixCards = new Map<Slug, string>();
   for (const [lane, slugs] of [

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -331,7 +331,11 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
       return `[lane: ${lane}]`;
     }
     const freshAt = freshAtBySlug.get(slug);
-    if (freshAt === undefined || !Number.isFinite(freshAt) || freshAt <= 0) {
+    if (
+      freshAt === undefined ||
+      freshAt === null ||
+      !Number.isFinite(freshAt)
+    ) {
       return "[lane: fresh]";
     }
     const stamp = new Date(freshAt)


### PR DESCRIPTION
## Summary
- PageIndexEntry gains freshAt (origin_date when parseable, else mtime; 0 for synthetic)
- Fresh lane and card date stamps consume freshAt; maintain-job re-embed delta stays on raw mtime

Part of plan: memory-ingestion.md (PR 2 of 11)