### PR TITLE
fix(web): correct command palette close focus, exit interactivity, and mount latch

### DIFF
--- a/clients/web/src/components/command-palette/command-palette.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette.test.tsx
@@ -109,7 +109,58 @@ describe("CommandPalette", () => {
 
     // The load-bearing behavior: AnimatePresence holds the sheet in the DOM
     // while the exit plays, so the chat underneath stays covered.
-    expect(screen.getByRole("dialog", { name: "Search" })).toBeTruthy();
+    expect(screen.getByRole("dialog", { hidden: true })).toBeTruthy();
+  });
+
+  test("stops taking taps and announcing itself while the exit plays", () => {
+    isMobileRef.value = true;
+    nativeIOSRef.value = true;
+
+    const { rerender } = renderPalette(true);
+    const sheet = screen.getByRole("dialog", { name: "Search" });
+    expect(sheet.getAttribute("aria-modal")).toBe("true");
+    expect(sheet.style.pointerEvents).toBe("");
+
+    rerender(paletteElement(false));
+
+    // The sheet still covers the viewport for the length of the exit, so the
+    // chat and drawer underneath have to stay reachable.
+    expect(sheet.style.pointerEvents).toBe("none");
+    expect(sheet.getAttribute("aria-hidden")).toBe("true");
+    expect(sheet.hasAttribute("aria-modal")).toBe(false);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  test("releases focus held inside the sheet when the exit starts", () => {
+    isMobileRef.value = true;
+    nativeIOSRef.value = true;
+
+    const { rerender } = renderPalette(true);
+    const input = screen.getByRole("textbox", { name: "Search" });
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    rerender(paletteElement(false));
+
+    // Blurring here starts the iOS keyboard dismissal alongside the slide-out.
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  test("leaves focus outside the sheet alone when the exit starts", () => {
+    isMobileRef.value = true;
+    nativeIOSRef.value = true;
+
+    const composer = document.createElement("textarea");
+    document.body.appendChild(composer);
+    const { rerender } = renderPalette(true);
+
+    composer.focus();
+    rerender(paletteElement(false));
+
+    // Selecting "New Conversation" focuses the composer before the palette
+    // closes, so the close must not take that focus back.
+    expect(document.activeElement).toBe(composer);
+    composer.remove();
   });
 
   test("renders the mobile sheet affordances in the iOS shell", () => {

--- a/clients/web/src/components/command-palette/command-palette.tsx
+++ b/clients/web/src/components/command-palette/command-palette.tsx
@@ -1,9 +1,15 @@
 import type { LucideIcon } from "lucide-react";
 import { Loader2, Search, X } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  motion,
+  useIsPresent,
+  useReducedMotion,
+} from "motion/react";
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   type CSSProperties,
   type FC,
@@ -31,6 +37,13 @@ const MOBILE_SHEET_SAFE_AREA_STYLE: CSSProperties = {
     "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
   paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
   paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+};
+
+// The exiting sheet still covers the viewport, so taps aimed at the chat and
+// the drawer underneath have to pass through it.
+const MOBILE_SHEET_EXITING_STYLE: CSSProperties = {
+  ...MOBILE_SHEET_SAFE_AREA_STYLE,
+  pointerEvents: "none",
 };
 
 // ---------------------------------------------------------------------------
@@ -74,6 +87,64 @@ export interface CommandPaletteProps {
   surface?: "overlay" | "window";
 }
 
+interface MobileSheetProps {
+  /** Key-down handler from useCommandPalette for keyboard navigation. */
+  onKeyDown: (e: KeyboardEvent) => void;
+  children: ReactNode;
+}
+
+/**
+ * Full-screen sheet used by the iOS shell, sliding up on open and out on
+ * close. It outlives `isOpen` for the length of the exit, and AnimatePresence
+ * renders the exiting element with the props it was frozen at, so everything
+ * that has to change the moment the exit starts reads `useIsPresent()`
+ * instead: the sheet stops taking taps, drops out of the accessibility tree,
+ * and releases focus.
+ */
+const MobileSheet: FC<MobileSheetProps> = ({ onKeyDown, children }) => {
+  const isPresent = useIsPresent();
+  const reduceMotion = useReducedMotion();
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  // Blurring the search input starts the iOS keyboard dismissal in parallel
+  // with the slide-out. Scoped to the sheet so focus that a close handler
+  // moved elsewhere (the composer, after "New Conversation") survives.
+  useLayoutEffect(() => {
+    if (isPresent) {
+      return;
+    }
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && sheetRef.current?.contains(active)) {
+      active.blur();
+    }
+  }, [isPresent]);
+
+  return (
+    <motion.div
+      ref={sheetRef}
+      className={MOBILE_SHEET_CLASSES}
+      style={
+        isPresent ? MOBILE_SHEET_SAFE_AREA_STYLE : MOBILE_SHEET_EXITING_STYLE
+      }
+      role="dialog"
+      aria-modal={isPresent ? true : undefined}
+      aria-hidden={isPresent ? undefined : true}
+      aria-label="Search"
+      onKeyDown={onKeyDown}
+      initial={{ y: "100%", opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      exit={{ y: "100%", opacity: 0 }}
+      transition={
+        reduceMotion
+          ? { duration: 0 }
+          : { duration: 0.28, ease: [0.16, 1, 0.3, 1] }
+      }
+    >
+      {children}
+    </motion.div>
+  );
+};
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -101,7 +172,6 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
 }) => {
   const isMobile = useIsMobile();
   const isNativeIOSShell = useIsNativeIOS();
-  const reduceMotion = useReducedMotion();
   const overlayRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -292,26 +362,10 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
     return (
       <AnimatePresence>
         {isOpen ? (
-          <motion.div
-            key="command-palette-sheet"
-            className={MOBILE_SHEET_CLASSES}
-            style={MOBILE_SHEET_SAFE_AREA_STYLE}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Search"
-            onKeyDown={onKeyDown}
-            initial={{ y: "100%", opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: "100%", opacity: 0 }}
-            transition={
-              reduceMotion
-                ? { duration: 0 }
-                : { duration: 0.28, ease: [0.16, 1, 0.3, 1] }
-            }
-          >
+          <MobileSheet key="command-palette-sheet" onKeyDown={onKeyDown}>
             {searchInputRow}
             {resultsList}
-          </motion.div>
+          </MobileSheet>
         ) : null}
       </AnimatePresence>
     );

--- a/clients/web/src/components/command-palette/use-command-palette.test.ts
+++ b/clients/web/src/components/command-palette/use-command-palette.test.ts
@@ -8,17 +8,17 @@ import { useCommandPaletteStore } from "@/stores/command-palette-store";
 afterEach(() => {
   cleanup();
   useCommandPaletteStore.getState().close();
-  for (const input of document.querySelectorAll("input")) {
+  for (const input of document.querySelectorAll("input, textarea")) {
     input.remove();
   }
 });
 
 describe("useCommandPalette", () => {
-  test("blurs the focused element when closing", () => {
-    const input = document.createElement("input");
-    document.body.appendChild(input);
-    input.focus();
-    expect(document.activeElement).toBe(input);
+  test("leaves focus an action moved outside the palette alone", () => {
+    // Mirrors item selection: `handleIndexSelect` runs the action and then
+    // closes, and "New Conversation" focuses the composer on the way through.
+    const composer = document.createElement("textarea");
+    document.body.appendChild(composer);
 
     const { result } = renderHook(() => useCommandPalette({ itemCount: 0 }));
 
@@ -28,10 +28,11 @@ describe("useCommandPalette", () => {
     expect(result.current.isOpen).toBe(true);
 
     act(() => {
+      composer.focus();
       result.current.close();
     });
 
-    expect(document.activeElement).not.toBe(input);
+    expect(document.activeElement).toBe(composer);
     expect(result.current.isOpen).toBe(false);
     expect(result.current.query).toBe("");
   });

--- a/clients/web/src/components/command-palette/use-command-palette.ts
+++ b/clients/web/src/components/command-palette/use-command-palette.ts
@@ -91,12 +91,10 @@ export function useCommandPalette({
   }, [storeOpen]);
 
   const close = useCallback(() => {
-    // Blur first so iOS starts dismissing the keyboard before the palette
-    // leaves the screen; the viewport reflow then overlaps the close
-    // instead of following it.
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
-    }
+    // Focus stays where it is: item selection runs its action before closing,
+    // and actions such as "New Conversation" focus the composer. Releasing
+    // focus held inside the palette itself is the palette component's job
+    // (see `command-palette.tsx`).
     storeClose();
     setQuery("");
     setSelectedIndex(0);

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -67,7 +67,6 @@ import {
 import { openCommandPaletteWindow } from "@/runtime/command-palette-window";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { useIsNativeIOS } from "@/runtime/platform-detection";
 import { isPopoutWindow, openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -574,16 +573,17 @@ export function ChatLayout({
       switchConversation: handleSelectConversation,
     });
 
-  const isNativeIOSShell = useIsNativeIOS();
-  // iOS shell: keep the palette subtree mounted after first open so the
-  // AnimatePresence exit inside CommandPalette can run.
+  // Mount the palette on its first open and keep it mounted so the
+  // AnimatePresence exit inside CommandPalette has a host; CommandPalette
+  // renders nothing while closed on surfaces that have no exit. Items that
+  // navigate outside this layout (Settings) unmount the subtree in the same
+  // commit as the close, so those selections skip the exit.
   const [paletteEverOpened, setPaletteEverOpened] = useState(false);
   useEffect(() => {
     if (commandPalette.isOpen && !paletteEverOpened) {
       setPaletteEverOpened(true);
     }
   }, [commandPalette.isOpen, paletteEverOpened]);
-  const keepPaletteMounted = isNativeIOSShell && paletteEverOpened;
 
   // Electron host commands (File menu / global hotkeys). The hook is a
   // no-op on the web host. Handlers close over the latest state via an
@@ -1023,7 +1023,7 @@ export function ChatLayout({
         renameGroup={renameGroup}
         moveToGroup={handleMoveToGroup}
       />
-      {commandPalette.isOpen || keepPaletteMounted ? (
+      {commandPalette.isOpen || paletteEverOpened ? (
         <LazyBoundary>
           <CommandPalette
             isOpen={commandPalette.isOpen}


### PR DESCRIPTION
## Summary

- Stop `useCommandPalette.close()` blurring `document.activeElement`. Item selection runs its action and then closes, so the blur was undoing the composer focus that "New Conversation" had just requested (`startNewConversation` -> `navigateToNewConversation` -> `requestComposerFocus`), on desktop web, Electron, mobile web and iOS alike. `consumePendingComposerFocus()` had already cleared the pending flag, so nothing refocused.
- Move the keyboard-dismissal blur into the palette itself, scoped to the sheet: the iOS sheet releases focus only when the focus sits inside it, so focus a close handler moved elsewhere survives. This also covers the header/sidebar search buttons, which toggle the store directly and never reached `close()`.
- Make the exiting iOS sheet non-interactive and unannounced. It stays mounted for the full 280ms exit over `fixed inset-0 z-50`, so it now carries `pointer-events: none` and `aria-hidden` (and drops `aria-modal`) the moment the exit starts. AnimatePresence renders the exiting element with frozen props, so the sheet reads `useIsPresent()` rather than the parent's `isOpen`.
- Simplify the mount latch in `chat-layout.tsx`: drop `useIsNativeIOS` and keep the palette mounted after its first open on every platform. The old `isNativeIOS() && everOpened` gate pinned the component mounted on iPad, where `useIsMobile()` is false and no exit ever plays. Whether a close animates is now decided only inside `CommandPalette`.
- Record the one close path that cannot animate: `action-settings` navigates to `/assistant/settings`, which sits under an `ActiveAssistantGate` sibling of `ChatLayoutRoute`, so `ChatLayout` and the palette subtree unmount in the same commit as the close. Deferring the navigation or hoisting the palette above the route boundary are both larger changes than this fix PR should carry, so the limitation is documented instead of silently claimed away.

## Tests

- `use-command-palette.test.ts` now asserts that focus moved outside the palette survives the close. Verified failing against the previous `close()` (reverted the fix, ran the file, saw the assertion fail).
- `command-palette.test.tsx` adds three cases: the exiting sheet is `pointer-events: none` / `aria-hidden` / no `aria-modal`, focus inside the sheet is released on exit, and focus outside it is not. All three verified failing against the pre-fix component.

Addresses self-review findings on plan ios-capacitor-ui-polish.md