### PR TITLE
perf(voice): repoint the latency-optimized pin to GPT-5.6 Luna (JARVIS-1371)

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -836,8 +836,10 @@ describe("loadConfig startup behavior", () => {
     );
     expect(raw.llm.profiles["custom-quality-optimized"].model).toBe("gpt-5.4");
     expect(raw.llm.profiles["custom-cost-optimized"].provider).toBe("openai");
+    // BYOK `cost-optimized` carries `intent: "latency-optimized"`, so it
+    // resolves to the same model as the latency class.
     expect(raw.llm.profiles["custom-cost-optimized"].model).toBe(
-      "gpt-5.4-nano",
+      "gpt-5.6-luna",
     );
 
     // The managed defaults exist only as thin disabled stubs on a BYOK hatch.

--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -26,7 +26,7 @@ describe("model intents", () => {
       "claude-opus-4-6",
     );
     expect(resolveModelIntent("openai", "latency-optimized")).toBe(
-      "gpt-5.4-nano",
+      "gpt-5.6-luna",
     );
     expect(resolveModelIntent("gemini", "latency-optimized")).toBe(
       "gemini-3.1-flash-lite",

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -112,23 +112,17 @@ const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
     },
   },
   "latency-optimized": {
-    // The managed latency class. Its leading tokens ARE the live-voice
-    // turn-taking verdict, so TTFT — and specifically the tail, not the
-    // median — is what this profile optimizes: a verdict later than
+    // The managed latency class. Its leading tokens are the live-voice
+    // turn-taking verdict, so what this profile optimizes is the tail of
+    // time-to-first-token rather than the median: a verdict slower than
     // `liveVoice.frontModel.endpointDecisionTimeoutMs` trips the speculative
     // fail-open commit in live-voice-session.ts, which is audible dead air.
     //
-    // Benched against the real front-door shape (full system prompt, no tool
-    // schemas — the front-door leg runs toolless): p50 ~525ms / p95 ~625-715ms,
-    // versus ~960ms / ~1100-1620ms for `claude-haiku-4-5-20251001`, which rode
-    // the budget line and breached it in up to 24% of turns.
-    //
-    // Two constraints on replacing this: the model's managed credentials must
-    // be provisioned in EVERY environment (`gemini-3.5-flash-lite` benches
-    // faster still but has no key in prod or staging), and the upstream is
-    // derived from this model id alone — `provider: "vellum"` is the
-    // provider-agnostic managed sentinel, so `getManagedUpstream` resolves the
-    // real upstream via the model's catalog owner.
+    // Two constraints bind the model id. Its managed credentials must be
+    // provisioned in every environment, and it alone selects the upstream:
+    // `provider` below is the provider-agnostic managed sentinel, so
+    // `getManagedUpstream` resolves the real upstream from the model's catalog
+    // owner.
     model: "gpt-5.6-luna",
     provider: "vellum",
     source: "managed",

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -112,12 +112,24 @@ const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
     },
   },
   "latency-optimized": {
-    // The managed latency class. `cost-optimized`'s upstream showed
-    // multi-second cross-session TTFT tails on live voice drives, which the
-    // front model's leading tokens cannot absorb — they ARE the turn-taking
-    // verdict. Replace only with a model whose managed credentials are
-    // provisioned in every environment.
-    model: "claude-haiku-4-5-20251001",
+    // The managed latency class. Its leading tokens ARE the live-voice
+    // turn-taking verdict, so TTFT — and specifically the tail, not the
+    // median — is what this profile optimizes: a verdict later than
+    // `liveVoice.frontModel.endpointDecisionTimeoutMs` trips the speculative
+    // fail-open commit in live-voice-session.ts, which is audible dead air.
+    //
+    // Benched against the real front-door shape (full system prompt, no tool
+    // schemas — the front-door leg runs toolless): p50 ~525ms / p95 ~625-715ms,
+    // versus ~960ms / ~1100-1620ms for `claude-haiku-4-5-20251001`, which rode
+    // the budget line and breached it in up to 24% of turns.
+    //
+    // Two constraints on replacing this: the model's managed credentials must
+    // be provisioned in EVERY environment (`gemini-3.5-flash-lite` benches
+    // faster still but has no key in prod or staging), and the upstream is
+    // derived from this model id alone — `provider: "vellum"` is the
+    // provider-agnostic managed sentinel, so `getManagedUpstream` resolves the
+    // real upstream via the model's catalog owner.
+    model: "gpt-5.6-luna",
     provider: "vellum",
     source: "managed",
     label: "Latency",

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -271,15 +271,16 @@ describe("RetryProvider — callSite resolution", () => {
   });
 
   test("live-voice front-door call sites reach OpenAI with reasoning off", async () => {
-    // The `latency-optimized` pin's whole value is TTFT, and on an OpenAI
-    // upstream that depends entirely on disabled thinking being encoded as
-    // `effort: "none"` — OpenAI-compatible APIs reason by default when the
-    // field is absent, which pushes first-token past the verdict deadline the
-    // profile exists to beat. The profile declares `provider: "vellum"` (the
-    // provider-agnostic managed sentinel) and the real upstream is derived
-    // from the model id, so the stub is named for that resolved upstream
-    // rather than the sentinel — matching what `createAdapterFromConnection`
-    // builds for a managed route.
+    // The `latency-optimized` pin's whole value is time-to-first-token, and on
+    // an OpenAI upstream that depends entirely on disabled thinking being
+    // encoded as `effort: "none"`. OpenAI-compatible APIs reason by default
+    // when the field is absent, which pushes first-token past the verdict
+    // deadline the profile exists to beat.
+    //
+    // The profile declares `provider: "vellum"` (the provider-agnostic managed
+    // sentinel) and the real upstream comes from the model id, so the stub is
+    // named for that resolved upstream rather than the sentinel, matching what
+    // `createAdapterFromConnection` builds for a managed route.
     setLlmConfig({});
 
     const expected = CODE_DEFAULT_PROFILE_ENTRIES["latency-optimized"];

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -270,6 +270,35 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.max_tokens).toBe(expected.maxTokens as number);
   });
 
+  test("live-voice front-door call sites reach OpenAI with reasoning off", async () => {
+    // The `latency-optimized` pin's whole value is TTFT, and on an OpenAI
+    // upstream that depends entirely on disabled thinking being encoded as
+    // `effort: "none"` — OpenAI-compatible APIs reason by default when the
+    // field is absent, which pushes first-token past the verdict deadline the
+    // profile exists to beat. The profile declares `provider: "vellum"` (the
+    // provider-agnostic managed sentinel) and the real upstream is derived
+    // from the model id, so the stub is named for that resolved upstream
+    // rather than the sentinel — matching what `createAdapterFromConnection`
+    // builds for a managed route.
+    setLlmConfig({});
+
+    const expected = CODE_DEFAULT_PROFILE_ENTRIES["latency-optimized"];
+    for (const callSite of ["voiceFrontDoor", "voiceFrontDecision"] as const) {
+      let seen: SendMessageOptions | undefined;
+      const wrapped = new RetryProvider(
+        makeProvider("openai", (options) => {
+          seen = options;
+        }),
+      );
+
+      await wrapped.sendMessage(DUMMY_MESSAGES, { config: { callSite } });
+
+      const config = seen?.config as Record<string, unknown>;
+      expect(config.model).toBe(expected.model as string);
+      expect(config.effort).toBe("none");
+    }
+  });
+
   test("propagates resolved effort/speed/temperature; omits server-side fields", async () => {
     setLlmConfig({
       callSites: {

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -18,7 +18,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   },
   openai: {
     balanced: "gpt-5.4-mini",
-    "latency-optimized": "gpt-5.4-nano",
+    "latency-optimized": "gpt-5.6-luna",
     "quality-optimized": "gpt-5.4",
     "vision-optimized": "gpt-5.4",
   },


### PR DESCRIPTION
## Why

The live-voice front door's leading tokens **are** the turn-taking verdict, so the `latency-optimized` profile is judged on TTFT — and on the **tail**, not the median. A verdict later than `liveVoice.frontModel.endpointDecisionTimeoutMs` (1200ms) trips the speculative fail-open commit in `live-voice-session.ts`, which is audible dead air.

The incumbent `claude-haiku-4-5-20251001` was the slowest of the three candidates benched and rode the budget line.

## Bench

Measured in the **real front-door shape** — full `buildSystemPrompt()`, **no tool schemas**, since the front-door leg runs toolless via the `toolsDisabledDepth` bracket in `voice-session-bridge.ts`. Tool defs are ~60% of the prefill, and including them inverts the ranking. n=25 × 2 runs, reasoning disabled to match the profile:

| | ttft p50 | ttft p95 | over 1200ms budget |
|---|---|---|---|
| gemini-3.5-flash-lite | 368–373ms | 465–481ms | 0/25, 0/25 |
| **gpt-5.6-luna** | **521–532ms** | **625–715ms** | **0/25, 0/25** |
| claude-haiku-4-5 (current) | 942–979ms | 1101–1623ms | 6/25, then 0/25 |

Haiku's 6/25 (24%) breach independently reproduces the JARVIS-1302 QA finding of "25% timeout at 1200ms".

Flash-Lite is fastest but fails the profile's own "provisioned in every environment" bar: the proxy resolves gemini → a secret named `GEMINI_API_KEY`, which exists in **no** project (nonprod has `GOOGLE_API_KEY`; prod and staging have no Google API key). Luna needs no provisioning — `OPENAI_API_KEY` is already wired in all three envs.

## Changes

- `config/default-profile-catalog.ts` — managed `latency-optimized` model → `gpt-5.6-luna`. The profile keeps `provider: "vellum"` (the provider-agnostic managed sentinel); `getManagedUpstream` derives `openai` from the model's catalog owner, and `default-profile-catalog.ts` already guards that this resolves.
- `providers/model-intents.ts` — BYOK openai `latency-optimized` → `gpt-5.6-luna`, replacing the stale `gpt-5.4-nano`.
- New test in `retry-callsite.test.ts` guarding the invariant the win rests on: disabled thinking must reach OpenAI as `effort: "none"`, since OpenAI-compatible APIs reason by default when the field is absent. Without that translation the pin loses its latency advantage silently.

## Scope note

This profile is the shared latency class and also fronts non-voice call sites (`conversationStarters`, `replySuggestion`, memory consolidation/retriever). Repointing the profile is the designed seam — the alternative, a bare per-call-site model pin, is what `call-site-defaults.ts` deliberately moved away from so BYOK installs resolve through the intent table instead of a model id they may hold no credential for. Workspace migrations and `prune-seeded-callsite-defaults.ts` hardcode the old ids as historical fingerprints and are intentionally untouched.

## Testing

- `bun test src/config src/providers` — 955 pass / 158 fail, **identical to the same command on the base commit**; those failures are pre-existing on main, not introduced here.
- Targeted suites all green: `default-profile-catalog`, `retry-callsite`, `call-site-routing-provider`, `profile-materialization` (91 pass).
- `bunx tsc --noEmit` clean; eslint clean.
- Verified resolution directly: `getManagedUpstream("gpt-5.6-luna")` → `openai`; both `voiceFrontDoor` and `voiceFrontDecision` resolve to `gpt-5.6-luna` at `effort: low` → `none` on the wire; BYOK anthropic unchanged.

## Follow-ups (not this PR)

- Provision a Google key and reconcile the `GEMINI_API_KEY` name, then re-evaluate Flash-Lite — it is the actual latency winner.
- `ackGenerationTimeoutMs: 600` is breached ~100% of the time by both Haiku and Luna (only Flash-Lite meets it), so `llmAckText` cannot work until that budget is raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)