### PR TITLE
fix: scope invoices load-more error to pagination fetches

### DIFF
--- a/clients/web/src/domains/settings/components/invoices-table.test.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.test.tsx
@@ -15,6 +15,8 @@ let listResult: InvoiceListResponse;
 let nextPages: Record<string, InvoiceListResponse>;
 // When set, ?starting_after= requests fail with this HTTP status.
 let nextPageErrorStatus: number | null;
+// When set, cursor-less (first page) requests fail with this HTTP status.
+let firstPageErrorStatus: number | null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -27,6 +29,12 @@ mock.module("@/generated/api/sdk.gen", () => ({
       return Promise.resolve({
         data: undefined,
         response: { ok: false, status: nextPageErrorStatus },
+      });
+    }
+    if (!cursor && firstPageErrorStatus !== null) {
+      return Promise.resolve({
+        data: undefined,
+        response: { ok: false, status: firstPageErrorStatus },
       });
     }
     return Promise.resolve({
@@ -65,20 +73,21 @@ function seedTwoPages(): void {
   };
 }
 
-function renderTable(): ReturnType<typeof render> {
+function renderTable(): ReturnType<typeof render> & { client: QueryClient } {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
+  const view = render(
     <QueryClientProvider client={client}>
       <InvoicesTable />
     </QueryClientProvider>,
   );
+  return { ...view, client };
 }
 
 async function openTable(options?: {
   showAll?: boolean;
-}): Promise<ReturnType<typeof render>> {
+}): Promise<ReturnType<typeof renderTable>> {
   const view = renderTable();
   fireEvent.click(view.getByTestId("invoices-toggle"));
   await waitFor(() =>
@@ -98,6 +107,7 @@ beforeEach(() => {
   };
   nextPages = {};
   nextPageErrorStatus = null;
+  firstPageErrorStatus = null;
 });
 
 afterEach(() => {
@@ -244,6 +254,23 @@ describe("InvoicesTable pagination", () => {
     );
     expect(queryByTestId("invoices-load-more")).toBeNull();
     expect(getByTestId("invoices-load-more-retry")).not.toBeNull();
+  });
+
+  test("a failed background refetch stays silent and keeps Load more", async () => {
+    seedTwoPages();
+    const { client, queryByTestId, getAllByTestId } = await openTable({
+      showAll: true,
+    });
+
+    expect(queryByTestId("invoices-load-more")).not.toBeNull();
+
+    firstPageErrorStatus = 500;
+    await client.refetchQueries();
+
+    await waitFor(() => expect(listRetrieveCalls.length).toBe(2));
+    expect(getAllByTestId("invoice-row").length).toBe(5);
+    expect(queryByTestId("invoices-load-more-error")).toBeNull();
+    expect(queryByTestId("invoices-load-more")).not.toBeNull();
   });
 
   test("a short first page with has_more still offers Load more", async () => {

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -76,6 +76,11 @@ export function InvoicesTable() {
   const [expanded, setExpanded] = useState(false);
   const [showAll, setShowAll] = useState(false);
   const [isDownloadingAll, setIsDownloadingAll] = useState(false);
+  // Sticky error flag scoped to pagination-initiated fetches (Load more and
+  // Retry). Unlike isRefetchError it ignores failed background refetches
+  // (window focus, reconnect), which should stay silent: the table still
+  // shows cached data and the user never asked for more.
+  const [pageLoadFailed, setPageLoadFailed] = useState(false);
 
   const invoicesQuery = useInfiniteQuery({
     // The table hides behind the Show invoices toggle, so don't fetch
@@ -110,11 +115,11 @@ export function InvoicesTable() {
     ? invoices
     : invoices.slice(0, INITIAL_VISIBLE);
   const hasHiddenRows = invoices.length > INITIAL_VISIBLE;
-  // Both flags stay true through the whole retry: a plain refetch clears the
-  // fetchMore meta (isFetchNextPageError drops), at which point the still-set
-  // error with data present reads as isRefetchError.
+  // pageLoadFailed keeps the error up through the whole retry: a plain
+  // refetch clears the fetchMore meta, so isFetchNextPageError alone would
+  // drop mid-retry.
   const showLoadMoreError =
-    invoicesQuery.isFetchNextPageError || invoicesQuery.isRefetchError;
+    invoicesQuery.isFetchNextPageError || pageLoadFailed;
   // "Load more" renders whenever every locally loaded row is already visible
   // but the server still has more, so remaining invoices are always reachable.
   // Retry supersedes it while the inline error is up.
@@ -123,15 +128,25 @@ export function InvoicesTable() {
     invoicesQuery.hasNextPage &&
     !showLoadMoreError;
 
+  function loadMore(): void {
+    // fetchNextPage() resolves with the query result rather than rejecting,
+    // so read isError from it to keep pageLoadFailed in sync.
+    void invoicesQuery
+      .fetchNextPage()
+      .then((result) => setPageLoadFailed(result.isError));
+  }
+
   function retryLoadMore(): void {
     // refetch() recomputes every cached page's cursor, healing a stale
     // starting_after, then fetchNextPage() fetches the page the user asked
     // for (a no-op if the refreshed pages already exhaust the list).
-    void invoicesQuery
-      .refetch()
-      .then((result) =>
-        result.isError ? undefined : invoicesQuery.fetchNextPage(),
-      );
+    void invoicesQuery.refetch().then((result) => {
+      if (result.isError) {
+        setPageLoadFailed(true);
+        return;
+      }
+      loadMore();
+    });
   }
 
   async function downloadAllInvoices(): Promise<void> {
@@ -335,7 +350,7 @@ export function InvoicesTable() {
                 {showLoadMore && (
                   <button
                     type="button"
-                    onClick={() => void invoicesQuery.fetchNextPage()}
+                    onClick={loadMore}
                     disabled={invoicesQuery.isFetchingNextPage}
                     className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
                     data-testid="invoices-load-more"


### PR DESCRIPTION
## Summary
Round-3 review fix for invoice-pagination-frontend.md (Codex P2 + Devin on #39518).

- Replaces the isRefetchError gate with sticky pagination-scoped error state, so failed background refetches (window focus, reconnect) no longer masquerade as load-more failures, hide Load more, or make Retry fetch an unrequested page.
- Pagination failures still surface and survive the retry flow; adds a regression test for the background-refetch case.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->