### PR TITLE
feat(web): change the listening language from the voice room settings menu

### DIFF
--- a/clients/web/src/components/speech/stt-provider-form.tsx
+++ b/clients/web/src/components/speech/stt-provider-form.tsx
@@ -32,7 +32,10 @@ import {
   MACOS_NATIVE_STT_PROVIDER_ID,
   STT_PROVIDERS,
 } from "@/lib/provider-catalogs";
-import { sttLanguageOptionsFor } from "@/lib/stt/language-catalog";
+import {
+  sttLanguageLabel,
+  sttLanguageOptionsFor,
+} from "@/lib/stt/language-catalog";
 import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 
 /**
@@ -393,7 +396,7 @@ export function SttProviderForm({
               languageDaemonProviderId ?? "",
             ).map((l) => ({
               value: l.code,
-              label: l.nativeLabel ? `${l.label} (${l.nativeLabel})` : l.label,
+              label: sttLanguageLabel(l),
               tooltip: l.description,
             }))}
             aria-label="Spoken language"

--- a/clients/web/src/components/speech/use-stt-language-selection.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.ts
@@ -67,6 +67,14 @@ export interface UseSttLanguageSelection {
    */
   currentCode: string;
   /**
+   * Daemon id of the provider a pick would steer: the CONFIGURED one, with
+   * the legacy managed-mode and schema-default fallbacks applied. Meaningful
+   * only alongside `available` (before config arrives it holds the schema
+   * default); surfaces without a draft of their own pass this to
+   * `sttLanguageOptionsFor`.
+   */
+  configuredProviderId: string;
+  /**
    * Whether the daemon probe reports the given daemon provider id as
    * manually language-selectable. `available` describes the CONFIGURED
    * provider; a form whose dropdown holds an unsaved DRAFT choice gates its
@@ -151,6 +159,7 @@ export function useSttLanguageSelection(
   return {
     available,
     currentCode,
+    configuredProviderId: configuredProvider,
     isLanguageSelectable,
     selectLanguage,
     selecting,

--- a/clients/web/src/domains/chat/voice/voice-room/listening-language-picker-content.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/listening-language-picker-content.tsx
@@ -1,0 +1,156 @@
+/**
+ * The body of the listening-language picker modal: the short static catalog
+ * as a selectable list. Split from {@link ListeningLanguagePickerModal} so
+ * the modal file stays a thin wrapper and this listbox owns the interaction
+ * details.
+ *
+ * Selection state arrives as props from `useSttLanguageSelection`, which the
+ * voice-room settings menu calls once at a mount point that outlives this
+ * content (the modal unmounts it on close). Keeping the hook out of here
+ * preserves its serialized write chain across close/reopen: a pick made
+ * while an earlier slow PATCH is still in flight queues behind that write
+ * instead of racing it, so no reopen-and-repick can land an older request
+ * last. For the same reason a pick during an in-flight write is allowed, not
+ * blocked; the list only dims (`aria-busy`) while a write is pending.
+ *
+ * The options are real buttons carrying the listbox pattern (`role="option"`
+ * inside `role="listbox"`), so Enter/Space select natively;
+ * ArrowUp/ArrowDown/Home/End move focus between options via the container's
+ * keydown handler. Tabindex roves anchored on the selection: the selected
+ * option is the list's one tab stop and receives focus when the list mounts
+ * (the modal wrapper redirects Radix's open autofocus to it), so a keyboard
+ * user starts on their current language rather than on the first option,
+ * where Enter would overwrite the setting.
+ */
+
+import { type KeyboardEvent, useRef } from "react";
+
+import { Check } from "lucide-react";
+
+import { cn } from "@vellumai/design-library";
+import { Modal } from "@vellumai/design-library/components/modal";
+
+import {
+  sttLanguageLabel,
+  sttLanguageOptionsFor,
+} from "@/lib/stt/language-catalog";
+
+export interface ListeningLanguagePickerContentProps {
+  /** The currently-selected catalog code, a pending pick included. */
+  currentCode: string;
+  /** Daemon id of the configured STT provider, scoping the option catalog. */
+  configuredProviderId: string;
+  /** Persist a pick; the owning hook serializes writes in call order. */
+  selectLanguage: (code: string) => void;
+  /** A write is in flight; the list dims but stays interactive. */
+  selecting: boolean;
+  /** Close the picker (a pick hot-applies, so it also closes). */
+  onDone: () => void;
+}
+
+export function ListeningLanguagePickerContent({
+  currentCode,
+  configuredProviderId,
+  selectLanguage,
+  selecting,
+  onDone,
+}: ListeningLanguagePickerContentProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Roving focus between the option buttons. Enter/Space need no handling:
+  // the options are buttons, so activation comes for free.
+  const moveFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+      return;
+    }
+    const options = Array.from(
+      listRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]') ??
+        [],
+    );
+    if (options.length === 0) {
+      return;
+    }
+    // Keep the arrows from scrolling the list body underneath the focus move.
+    event.preventDefault();
+    const index = options.indexOf(document.activeElement as HTMLButtonElement);
+    const next =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? options.length - 1
+          : event.key === "ArrowDown"
+            ? Math.min(index + 1, options.length - 1)
+            : Math.max(index - 1, 0);
+    options[next]?.focus();
+  };
+
+  return (
+    <>
+      <Modal.Header>
+        <Modal.Title>Listening language</Modal.Title>
+        <Modal.Description>
+          Applies from your next spoken turn.
+        </Modal.Description>
+      </Modal.Header>
+      <Modal.Body>
+        <div
+          ref={listRef}
+          role="listbox"
+          aria-label="Listening language"
+          aria-busy={selecting}
+          onKeyDown={moveFocus}
+          className={cn(
+            "flex max-h-[60vh] flex-col overflow-y-auto",
+            // The dim signals the in-flight write without blocking a
+            // follow-up pick, which the hook queues behind it.
+            selecting && "opacity-70",
+          )}
+        >
+          {sttLanguageOptionsFor(currentCode, configuredProviderId).map(
+            (option) => {
+              const isSelected = option.code === currentCode;
+              return (
+                <button
+                  key={option.code}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  // Roving tabindex anchored on the selection: the selected
+                  // option is the one tab stop into the list.
+                  tabIndex={isSelected ? 0 : -1}
+                  onClick={() => {
+                    selectLanguage(option.code);
+                    onDone();
+                  }}
+                  className={cn(
+                    "flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2.5 text-left transition-colors",
+                    // Selected reads as a soft persistent fill + a trailing
+                    // check, like the voice list, not a form-field border.
+                    isSelected
+                      ? "bg-[var(--surface-active)]"
+                      : "hover:bg-[var(--surface-hover)]",
+                  )}
+                >
+                  <span className="min-w-0 flex-1 truncate text-body-medium-default text-[var(--content-default)]">
+                    {sttLanguageLabel(option)}
+                    {option.description && (
+                      <span className="block truncate text-label-small-default text-[var(--content-tertiary)]">
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
+                  {isSelected && (
+                    <Check
+                      aria-hidden
+                      className="size-4 shrink-0 text-[var(--system-positive-strong)]"
+                    />
+                  )}
+                </button>
+              );
+            },
+          )}
+        </div>
+      </Modal.Body>
+    </>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/listening-language-picker-modal.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/listening-language-picker-modal.tsx
@@ -1,0 +1,160 @@
+/**
+ * The listening-language picker: the short static catalog as a selectable
+ * list in a small modal, hosted outside the settings popover (a sibling of
+ * {@link VoicePickerModal}) so closing the popover can't unmount it and no
+ * transformed ancestor interferes with its positioning. A pick hot-applies
+ * from the next spoken turn (there is nothing to save), so it also closes
+ * the picker.
+ *
+ * The options are real buttons carrying the listbox pattern (`role="option"`
+ * inside `role="listbox"`), so Tab reaches the list and Enter/Space select
+ * natively; ArrowUp/ArrowDown/Home/End move focus between options via the
+ * container's keydown handler.
+ */
+
+import { type KeyboardEvent, useRef } from "react";
+
+import { Check } from "lucide-react";
+
+import { cn } from "@vellumai/design-library";
+import { Modal } from "@vellumai/design-library/components/modal";
+
+import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
+import {
+  sttLanguageLabel,
+  sttLanguageOptionsFor,
+} from "@/lib/stt/language-catalog";
+
+export interface ListeningLanguagePickerModalProps {
+  assistantId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ListeningLanguagePickerModal({
+  assistantId,
+  open,
+  onOpenChange,
+}: ListeningLanguagePickerModalProps) {
+  return (
+    <Modal.Root open={open} onOpenChange={onOpenChange}>
+      <Modal.Content size="sm">
+        {/* Own component so its daemon queries run only while the modal is
+            open — the host keeps this mounted across a whole session. */}
+        <ListeningLanguagePickerContent
+          assistantId={assistantId}
+          onDone={() => onOpenChange(false)}
+        />
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+function ListeningLanguagePickerContent({
+  assistantId,
+  onDone,
+}: {
+  assistantId: string | null;
+  onDone: () => void;
+}) {
+  const { currentCode, configuredProviderId, selectLanguage, selecting } =
+    useSttLanguageSelection(assistantId);
+
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Roving focus between the option buttons. Enter/Space need no handling:
+  // the options are buttons, so activation comes for free.
+  const moveFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+      return;
+    }
+    const options = Array.from(
+      listRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]') ??
+        [],
+    );
+    if (options.length === 0) {
+      return;
+    }
+    // Keep the arrows from scrolling the list body underneath the focus move.
+    event.preventDefault();
+    const index = options.indexOf(document.activeElement as HTMLButtonElement);
+    const next =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? options.length - 1
+          : event.key === "ArrowDown"
+            ? Math.min(index + 1, options.length - 1)
+            : Math.max(index - 1, 0);
+    options[next]?.focus();
+  };
+
+  return (
+    <>
+      <Modal.Header>
+        <Modal.Title>Listening language</Modal.Title>
+        <Modal.Description>
+          Applies from your next spoken turn.
+        </Modal.Description>
+      </Modal.Header>
+      <Modal.Body>
+        <div
+          ref={listRef}
+          role="listbox"
+          aria-label="Listening language"
+          onKeyDown={moveFocus}
+          className={cn(
+            "flex max-h-[60vh] flex-col overflow-y-auto",
+            selecting && "pointer-events-none opacity-70",
+          )}
+        >
+          {sttLanguageOptionsFor(currentCode, configuredProviderId).map(
+            (option) => {
+              const isSelected = option.code === currentCode;
+              return (
+                <button
+                  key={option.code}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => {
+                    // Mirrors the pointer-events guard above for the keyboard
+                    // path: no picks land while a write is in flight.
+                    if (selecting) {
+                      return;
+                    }
+                    selectLanguage(option.code);
+                    onDone();
+                  }}
+                  className={cn(
+                    "flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2.5 text-left transition-colors",
+                    // Selected reads as a soft persistent fill + a trailing
+                    // check, like the voice list — not a form-field border.
+                    isSelected
+                      ? "bg-[var(--surface-active)]"
+                      : "hover:bg-[var(--surface-hover)]",
+                  )}
+                >
+                  <span className="min-w-0 flex-1 truncate text-body-medium-default text-[var(--content-default)]">
+                    {sttLanguageLabel(option)}
+                    {option.description && (
+                      <span className="block truncate text-label-small-default text-[var(--content-tertiary)]">
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
+                  {isSelected && (
+                    <Check
+                      aria-hidden
+                      className="size-4 shrink-0 text-[var(--system-positive-strong)]"
+                    />
+                  )}
+                </button>
+              );
+            },
+          )}
+        </div>
+      </Modal.Body>
+    </>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/listening-language-picker-modal.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/listening-language-picker-modal.tsx
@@ -1,160 +1,68 @@
 /**
- * The listening-language picker: the short static catalog as a selectable
- * list in a small modal, hosted outside the settings popover (a sibling of
- * {@link VoicePickerModal}) so closing the popover can't unmount it and no
- * transformed ancestor interferes with its positioning. A pick hot-applies
- * from the next spoken turn (there is nothing to save), so it also closes
- * the picker.
+ * The listening-language picker: a small modal hosting
+ * {@link ListeningLanguagePickerContent}, kept outside the settings popover
+ * (a sibling of {@link VoicePickerModal}) so closing the popover can't
+ * unmount it and no transformed ancestor interferes with its positioning. A
+ * pick hot-applies from the next spoken turn (there is nothing to save), so
+ * it also closes the picker.
  *
- * The options are real buttons carrying the listbox pattern (`role="option"`
- * inside `role="listbox"`), so Tab reaches the list and Enter/Space select
- * natively; ArrowUp/ArrowDown/Home/End move focus between options via the
- * container's keydown handler.
+ * Selection state is threaded through from the settings menu, which owns the
+ * single `useSttLanguageSelection` call (see the content component for why
+ * the hook must outlive this modal's content).
  */
 
-import { type KeyboardEvent, useRef } from "react";
-
-import { Check } from "lucide-react";
-
-import { cn } from "@vellumai/design-library";
 import { Modal } from "@vellumai/design-library/components/modal";
 
-import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
-import {
-  sttLanguageLabel,
-  sttLanguageOptionsFor,
-} from "@/lib/stt/language-catalog";
+import { ListeningLanguagePickerContent } from "@/domains/chat/voice/voice-room/listening-language-picker-content";
 
 export interface ListeningLanguagePickerModalProps {
-  assistantId: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** See {@link ListeningLanguagePickerContentProps}. */
+  currentCode: string;
+  configuredProviderId: string;
+  selectLanguage: (code: string) => void;
+  selecting: boolean;
 }
 
 export function ListeningLanguagePickerModal({
-  assistantId,
   open,
   onOpenChange,
+  currentCode,
+  configuredProviderId,
+  selectLanguage,
+  selecting,
 }: ListeningLanguagePickerModalProps) {
   return (
     <Modal.Root open={open} onOpenChange={onOpenChange}>
-      <Modal.Content size="sm">
-        {/* Own component so its daemon queries run only while the modal is
-            open — the host keeps this mounted across a whole session. */}
+      <Modal.Content
+        size="sm"
+        // Radix autofocuses the first tabbable element on open, which would
+        // land a keyboard user on the first option, where Enter overwrites
+        // the setting; redirect the open autofocus to the selected option.
+        // This must happen in the autofocus hook rather than a mount effect
+        // in the content: the hook fires after the dialog's focus trap is
+        // already listening, so the trap records the option as the focus to
+        // restore when the closing settings popover pulls focus back to its
+        // trigger a tick later.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          const container = event.target as HTMLElement | null;
+          const target =
+            container?.querySelector<HTMLButtonElement>(
+              '[role="option"][aria-selected="true"]',
+            ) ?? container?.querySelector<HTMLButtonElement>('[role="option"]');
+          target?.focus();
+        }}
+      >
         <ListeningLanguagePickerContent
-          assistantId={assistantId}
+          currentCode={currentCode}
+          configuredProviderId={configuredProviderId}
+          selectLanguage={selectLanguage}
+          selecting={selecting}
           onDone={() => onOpenChange(false)}
         />
       </Modal.Content>
     </Modal.Root>
-  );
-}
-
-function ListeningLanguagePickerContent({
-  assistantId,
-  onDone,
-}: {
-  assistantId: string | null;
-  onDone: () => void;
-}) {
-  const { currentCode, configuredProviderId, selectLanguage, selecting } =
-    useSttLanguageSelection(assistantId);
-
-  const listRef = useRef<HTMLDivElement>(null);
-
-  // Roving focus between the option buttons. Enter/Space need no handling:
-  // the options are buttons, so activation comes for free.
-  const moveFocus = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
-      return;
-    }
-    const options = Array.from(
-      listRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]') ??
-        [],
-    );
-    if (options.length === 0) {
-      return;
-    }
-    // Keep the arrows from scrolling the list body underneath the focus move.
-    event.preventDefault();
-    const index = options.indexOf(document.activeElement as HTMLButtonElement);
-    const next =
-      event.key === "Home"
-        ? 0
-        : event.key === "End"
-          ? options.length - 1
-          : event.key === "ArrowDown"
-            ? Math.min(index + 1, options.length - 1)
-            : Math.max(index - 1, 0);
-    options[next]?.focus();
-  };
-
-  return (
-    <>
-      <Modal.Header>
-        <Modal.Title>Listening language</Modal.Title>
-        <Modal.Description>
-          Applies from your next spoken turn.
-        </Modal.Description>
-      </Modal.Header>
-      <Modal.Body>
-        <div
-          ref={listRef}
-          role="listbox"
-          aria-label="Listening language"
-          onKeyDown={moveFocus}
-          className={cn(
-            "flex max-h-[60vh] flex-col overflow-y-auto",
-            selecting && "pointer-events-none opacity-70",
-          )}
-        >
-          {sttLanguageOptionsFor(currentCode, configuredProviderId).map(
-            (option) => {
-              const isSelected = option.code === currentCode;
-              return (
-                <button
-                  key={option.code}
-                  type="button"
-                  role="option"
-                  aria-selected={isSelected}
-                  onClick={() => {
-                    // Mirrors the pointer-events guard above for the keyboard
-                    // path: no picks land while a write is in flight.
-                    if (selecting) {
-                      return;
-                    }
-                    selectLanguage(option.code);
-                    onDone();
-                  }}
-                  className={cn(
-                    "flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2.5 text-left transition-colors",
-                    // Selected reads as a soft persistent fill + a trailing
-                    // check, like the voice list — not a form-field border.
-                    isSelected
-                      ? "bg-[var(--surface-active)]"
-                      : "hover:bg-[var(--surface-hover)]",
-                  )}
-                >
-                  <span className="min-w-0 flex-1 truncate text-body-medium-default text-[var(--content-default)]">
-                    {sttLanguageLabel(option)}
-                    {option.description && (
-                      <span className="block truncate text-label-small-default text-[var(--content-tertiary)]">
-                        {option.description}
-                      </span>
-                    )}
-                  </span>
-                  {isSelected && (
-                    <Check
-                      aria-hidden
-                      className="size-4 shrink-0 text-[var(--system-positive-strong)]"
-                    />
-                  )}
-                </button>
-              );
-            },
-          )}
-        </div>
-      </Modal.Body>
-    </>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/listening-language-row.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/listening-language-row.tsx
@@ -1,0 +1,71 @@
+/**
+ * The "Listening language" row shown in the voice-room settings popover: the
+ * current language with a chevron, leading to the
+ * {@link ListeningLanguagePickerModal} the parent hosts. Renders nothing when
+ * the daemon doesn't offer manual language selection for the configured STT
+ * provider (auto-detecting providers, old daemons), so the popover never shows
+ * a control the daemon would ignore.
+ *
+ * The picker is a modal rather than an inline dropdown on purpose: the radix
+ * popover positions its content through a transformed wrapper, which becomes
+ * the containing block for fixed-position descendants, so the Dropdown menu's
+ * viewport coordinates land relative to the already-offset popover and the
+ * options render far from the trigger. Like the Voice row, this row only
+ * reports the click via `onOpen`; the parent closes the popover and opens the
+ * modal it owns outside it.
+ */
+
+import { ChevronRight } from "lucide-react";
+
+import { cn } from "@vellumai/design-library";
+
+import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
+import {
+  sttLanguageLabel,
+  sttLanguageOptionsFor,
+} from "@/lib/stt/language-catalog";
+
+export interface ListeningLanguageRowProps {
+  assistantId: string | null;
+  /** Open the language picker modal (owned by the parent). */
+  onOpen: () => void;
+  className?: string;
+}
+
+export function ListeningLanguageRow({
+  assistantId,
+  onOpen,
+  className,
+}: ListeningLanguageRowProps) {
+  const { available, currentCode, configuredProviderId } =
+    useSttLanguageSelection(assistantId);
+
+  if (!available) {
+    return null;
+  }
+
+  const current = sttLanguageOptionsFor(currentCode, configuredProviderId).find(
+    (option) => option.code === currentCode,
+  );
+
+  return (
+    <div className={cn("flex flex-col", className)}>
+      {/* Same straight full-width divider the Voice row draws (a border on a
+          rounded child would render with rounded ends). */}
+      <div className="border-t border-[var(--border-subtle)]" />
+      <button
+        type="button"
+        onClick={onOpen}
+        className="mt-1 flex w-full items-baseline gap-2 rounded-md px-1 py-2 text-left transition-colors hover:bg-[var(--surface-hover)]"
+      >
+        <span className="shrink-0 text-body-medium-default text-[var(--content-default)]">
+          Listening language
+        </span>
+        <span className="min-w-0 flex-1 truncate text-right text-label-small-default text-[var(--content-tertiary)]">
+          {current ? sttLanguageLabel(current) : currentCode}
+        </span>
+        <ChevronRight className="size-4 shrink-0 self-center text-[var(--content-tertiary)]" />
+      </button>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/listening-language-row.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/listening-language-row.tsx
@@ -6,6 +6,11 @@
  * provider (auto-detecting providers, old daemons), so the popover never shows
  * a control the daemon would ignore.
  *
+ * Selection state arrives as props: the settings menu owns the single
+ * `useSttLanguageSelection` call and shares it between this row and the
+ * picker, so the row and the picker always agree and the hook's serialized
+ * write chain outlives both (see the picker content component).
+ *
  * The picker is a modal rather than an inline dropdown on purpose: the radix
  * popover positions its content through a transformed wrapper, which becomes
  * the containing block for fixed-position descendants, so the Dropdown menu's
@@ -19,27 +24,33 @@ import { ChevronRight } from "lucide-react";
 
 import { cn } from "@vellumai/design-library";
 
-import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 import {
   sttLanguageLabel,
   sttLanguageOptionsFor,
 } from "@/lib/stt/language-catalog";
 
 export interface ListeningLanguageRowProps {
-  assistantId: string | null;
+  /**
+   * Whether the daemon offers manual language selection for the configured
+   * provider; false collapses the row entirely.
+   */
+  available: boolean;
+  /** The currently-selected catalog code, a pending pick included. */
+  currentCode: string;
+  /** Daemon id of the configured STT provider, scoping the option catalog. */
+  configuredProviderId: string;
   /** Open the language picker modal (owned by the parent). */
   onOpen: () => void;
   className?: string;
 }
 
 export function ListeningLanguageRow({
-  assistantId,
+  available,
+  currentCode,
+  configuredProviderId,
   onOpen,
   className,
 }: ListeningLanguageRowProps) {
-  const { available, currentCode, configuredProviderId } =
-    useSttLanguageSelection(assistantId);
-
   if (!available) {
     return null;
   }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
@@ -123,7 +123,6 @@ describe("VoiceRoomSettingsMenu", () => {
     // must show no language control rather than one the daemon ignores.
     openMenu();
     expect(screen.queryByText("Listening language")).toBeNull();
-    expect(screen.queryByLabelText("Listening language")).toBeNull();
   });
 
   test("shows the Listening language row with the current pick", () => {
@@ -133,24 +132,41 @@ describe("VoiceRoomSettingsMenu", () => {
       currentCode: "es",
     };
     openMenu();
-    expect(screen.getByText("Listening language")).toBeTruthy();
-    const trigger = screen.getByRole("combobox", {
-      name: "Listening language",
-    });
-    expect(trigger.textContent).toContain("Spanish (Español)");
+    const row = screen.getByText("Listening language").closest("button");
+    expect(row?.textContent).toContain("Spanish (Español)");
+  });
+
+  test("clicking the language row swaps the popover for the picker modal", () => {
+    languageSelection = { ...languageSelection, available: true };
+    openMenu();
+    fireEvent.click(screen.getByText("Listening language"));
+    // The popover closes (its Captions toggle unmounts) so the picker isn't
+    // stacked inside the popover's transformed wrapper...
+    expect(screen.queryByLabelText("Show captions")).toBeNull();
+    // ...and the modal opens outside it, caption and options included.
+    expect(
+      screen.getByRole("listbox", { name: "Listening language" }),
+    ).toBeTruthy();
     expect(
       screen.getByText("Applies from your next spoken turn."),
     ).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: /English \(default\)/ }),
+    ).toBeTruthy();
   });
 
-  test("picking a language passes its code to selectLanguage", () => {
+  test("picking a language passes its code to selectLanguage and closes the picker", () => {
     languageSelection = { ...languageSelection, available: true };
     openMenu();
+    fireEvent.click(screen.getByText("Listening language"));
     fireEvent.click(
-      screen.getByRole("combobox", { name: "Listening language" }),
+      screen.getByRole("option", { name: /French \(Français\)/ }),
     );
-    fireEvent.click(screen.getByRole("option", { name: "French (Français)" }));
     expect(languagePicks).toEqual(["fr"]);
+    // A pick hot-applies (nothing to save), so it also dismisses the picker.
+    expect(
+      screen.queryByRole("listbox", { name: "Listening language" }),
+    ).toBeNull();
   });
 
   test("language row leaves the Captions toggle and Voice row intact", () => {
@@ -162,10 +178,8 @@ describe("VoiceRoomSettingsMenu", () => {
     expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
     expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(true);
     // The Voice row (BYO variant here) still renders alongside the language
-    // dropdown.
+    // row.
     expect(screen.getByText("Your API key")).toBeTruthy();
-    expect(
-      screen.getByRole("combobox", { name: "Listening language" }),
-    ).toBeTruthy();
+    expect(screen.getByText("Listening language")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
@@ -167,6 +168,39 @@ describe("VoiceRoomSettingsMenu", () => {
     expect(
       screen.queryByRole("listbox", { name: "Listening language" }),
     ).toBeNull();
+  });
+
+  test("arrow keys walk the language options and Enter picks the focused one", async () => {
+    languageSelection = { ...languageSelection, available: true };
+    const user = userEvent.setup();
+    openMenu();
+    fireEvent.click(screen.getByText("Listening language"));
+    // The options are buttons, so Tab reaches them; arrows then rove focus.
+    const options = screen.getAllByRole("option");
+    options[0].focus();
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(options[1]);
+    // Enter activates the focused option like a click: the pick lands and the
+    // picker closes. Option 1 is Multilingual ("multi") for the vellum
+    // provider with no language set.
+    await user.keyboard("{Enter}");
+    expect(languagePicks).toEqual(["multi"]);
+    expect(
+      screen.queryByRole("listbox", { name: "Listening language" }),
+    ).toBeNull();
+  });
+
+  test("Home and End jump focus to the first and last language option", async () => {
+    languageSelection = { ...languageSelection, available: true };
+    const user = userEvent.setup();
+    openMenu();
+    fireEvent.click(screen.getByText("Listening language"));
+    const options = screen.getAllByRole("option");
+    options[0].focus();
+    await user.keyboard("{End}");
+    expect(document.activeElement).toBe(options[options.length - 1]);
+    await user.keyboard("{Home}");
+    expect(document.activeElement).toBe(options[0]);
   });
 
   test("language row leaves the Captions toggle and Voice row intact", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
@@ -21,6 +21,22 @@ mock.module("@/components/speech/use-managed-voice-selection", () => ({
   useManagedVoiceSelection: () => voiceSelection,
 }));
 
+// Same shape for the listening-language row: unavailable by default so the
+// menu renders without the daemon query graph. Mutable so tests can offer
+// languages and observe picks; `sttLanguageOptionsFor` itself is real.
+let languagePicks: string[] = [];
+let languageSelection = {
+  available: false,
+  currentCode: "",
+  configuredProviderId: "vellum",
+  isLanguageSelectable: () => false,
+  selectLanguage: (code: string) => languagePicks.push(code),
+  selecting: false,
+};
+mock.module("@/components/speech/use-stt-language-selection", () => ({
+  useSttLanguageSelection: () => languageSelection,
+}));
+
 // The BYO row links to Models & Services; a plain anchor renders it without a
 // Router.
 mock.module("react-router", () => ({
@@ -33,6 +49,12 @@ const { VoiceRoomSettingsMenu } = await import("./voice-room-settings-menu");
 
 beforeEach(() => {
   voiceSelection = { ...voiceSelection, available: false, isByok: false };
+  languagePicks = [];
+  languageSelection = {
+    ...languageSelection,
+    available: false,
+    currentCode: "",
+  };
   useVoicePrefsStore.setState({
     showUserTranscript: false,
     showAssistantTranscript: false,
@@ -94,5 +116,56 @@ describe("VoiceRoomSettingsMenu", () => {
     openMenu();
     expect(screen.queryByText("Voice")).toBeNull();
     expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  test("hides the Listening language row when selection is unavailable", () => {
+    // Auto-detecting providers and old daemons report unavailable; the menu
+    // must show no language control rather than one the daemon ignores.
+    openMenu();
+    expect(screen.queryByText("Listening language")).toBeNull();
+    expect(screen.queryByLabelText("Listening language")).toBeNull();
+  });
+
+  test("shows the Listening language row with the current pick", () => {
+    languageSelection = {
+      ...languageSelection,
+      available: true,
+      currentCode: "es",
+    };
+    openMenu();
+    expect(screen.getByText("Listening language")).toBeTruthy();
+    const trigger = screen.getByRole("combobox", {
+      name: "Listening language",
+    });
+    expect(trigger.textContent).toContain("Spanish (Español)");
+    expect(
+      screen.getByText("Applies from your next spoken turn."),
+    ).toBeTruthy();
+  });
+
+  test("picking a language passes its code to selectLanguage", () => {
+    languageSelection = { ...languageSelection, available: true };
+    openMenu();
+    fireEvent.click(
+      screen.getByRole("combobox", { name: "Listening language" }),
+    );
+    fireEvent.click(screen.getByRole("option", { name: "French (Français)" }));
+    expect(languagePicks).toEqual(["fr"]);
+  });
+
+  test("language row leaves the Captions toggle and Voice row intact", () => {
+    languageSelection = { ...languageSelection, available: true };
+    voiceSelection = { ...voiceSelection, available: false, isByok: true };
+    openMenu();
+    // Captions still flips both prefs together.
+    fireEvent.click(screen.getByLabelText("Show captions"));
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(true);
+    // The Voice row (BYO variant here) still renders alongside the language
+    // dropdown.
+    expect(screen.getByText("Your API key")).toBeTruthy();
+    expect(
+      screen.getByRole("combobox", { name: "Listening language" }),
+    ).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
@@ -1,9 +1,19 @@
 import { type ReactNode } from "react";
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+// Loaded (real) before the sdk.gen mock below replaces the registry entry, so
+// the mock can spread the full export surface and only override `configPatch`.
+import * as realDaemonSdk from "@/generated/daemon/sdk.gen";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 // The voice picker has its own tests; here it stays collapsed (unavailable) so
@@ -22,9 +32,39 @@ mock.module("@/components/speech/use-managed-voice-selection", () => ({
   useManagedVoiceSelection: () => voiceSelection,
 }));
 
-// Same shape for the listening-language row: unavailable by default so the
-// menu renders without the daemon query graph. Mutable so tests can offer
-// languages and observe picks; `sttLanguageOptionsFor` itself is real.
+// The daemon config PATCH the serialization tests observe. Each call records
+// the language it carries; `deferPatches` holds every call open until a test
+// releases it through `patchResolvers`, simulating a slow write.
+let patchCalls: Array<{ language: string }> = [];
+let patchResolvers: Array<() => void> = [];
+let deferPatches = false;
+async function recordConfigPatch(options: unknown) {
+  const body = (
+    options as { body: { services: { stt: { language: string } } } }
+  ).body;
+  patchCalls.push({ language: body.services.stt.language });
+  if (deferPatches) {
+    await new Promise<void>((resolve) => patchResolvers.push(resolve));
+  }
+  return { response: { ok: true } };
+}
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...realDaemonSdk,
+  configPatch: recordConfigPatch,
+}));
+
+// Imported after the sdk.gen mock so its `configPatch` binding links to the
+// recording mock above (bun in CI does not re-link already-loaded modules).
+const { useSerializedConfigSelection } =
+  await import("@/components/speech/use-serialized-config-selection");
+
+// The listening-language selection mock: unavailable by default so the menu
+// renders without the daemon query graph. Mutable so tests can offer
+// languages and observe picks; `sttLanguageOptionsFor` itself is real. The
+// serialization tests flip `serializedSelection` to swap in the REAL
+// `useSerializedConfigSelection` write chain (with `configPatch` mocked
+// above), so close/reopen write ordering exercises the shipped engine.
+let serializedSelection = false;
 let languagePicks: string[] = [];
 let languageSelection = {
   available: false,
@@ -34,8 +74,34 @@ let languageSelection = {
   selectLanguage: (code: string) => languagePicks.push(code),
   selecting: false,
 };
+
+const buildTestPatchBody = (code: string) => ({
+  services: { stt: { language: code } },
+});
+
+/** The mock hook: the static fixture, or the real serialized write chain. */
+function useMockSttLanguageSelection() {
+  // Called unconditionally so hook order is stable across modes.
+  const serialized = useSerializedConfigSelection({
+    assistantId: "asst_test",
+    configuredValue: "",
+    buildPatchBody: buildTestPatchBody,
+    failureMessage: "test failure",
+  });
+  if (!serializedSelection) {
+    return languageSelection;
+  }
+  return {
+    available: true,
+    currentCode: serialized.currentValue,
+    configuredProviderId: "vellum",
+    isLanguageSelectable: () => true,
+    selectLanguage: serialized.select,
+    selecting: serialized.selecting,
+  };
+}
 mock.module("@/components/speech/use-stt-language-selection", () => ({
-  useSttLanguageSelection: () => languageSelection,
+  useSttLanguageSelection: useMockSttLanguageSelection,
 }));
 
 // The BYO row links to Models & Services; a plain anchor renders it without a
@@ -50,12 +116,16 @@ const { VoiceRoomSettingsMenu } = await import("./voice-room-settings-menu");
 
 beforeEach(() => {
   voiceSelection = { ...voiceSelection, available: false, isByok: false };
+  serializedSelection = false;
   languagePicks = [];
   languageSelection = {
     ...languageSelection,
     available: false,
     currentCode: "",
   };
+  patchCalls = [];
+  patchResolvers = [];
+  deferPatches = false;
   useVoicePrefsStore.setState({
     showUserTranscript: false,
     showAssistantTranscript: false,
@@ -64,10 +134,15 @@ beforeEach(() => {
 
 afterEach(() => cleanup());
 
-/** Render the menu and open the gear popover. */
+/**
+ * Render the menu and open the gear popover. The QueryClientProvider serves
+ * the real `useSerializedConfigSelection` the mock hook always calls.
+ */
 function openMenu() {
   render(
-    <VoiceRoomSettingsMenu triggerClassName="ctrl" assistantId="asst_test" />,
+    <QueryClientProvider client={new QueryClient()}>
+      <VoiceRoomSettingsMenu triggerClassName="ctrl" assistantId="asst_test" />
+    </QueryClientProvider>,
   );
   fireEvent.click(screen.getByRole("button", { name: "Voice settings" }));
 }
@@ -201,6 +276,75 @@ describe("VoiceRoomSettingsMenu", () => {
     expect(document.activeElement).toBe(options[options.length - 1]);
     await user.keyboard("{Home}");
     expect(document.activeElement).toBe(options[0]);
+  });
+
+  test("opening the picker focuses the selected option, the list's one tab stop", () => {
+    languageSelection = {
+      ...languageSelection,
+      available: true,
+      currentCode: "es",
+    };
+    openMenu();
+    fireEvent.click(screen.getByText("Listening language"));
+    // Focus starts on the configured language, not the first option: from
+    // here Enter re-picks Spanish instead of overwriting it with English.
+    const spanish = screen.getByRole("option", {
+      name: /Spanish \(Español\)/,
+    });
+    expect(document.activeElement).toBe(spanish);
+    // Roving tabindex anchored on the selection: only the selected option is
+    // tabbable, the rest are reached with the arrow keys.
+    expect(spanish.tabIndex).toBe(0);
+    for (const option of screen.getAllByRole("option")) {
+      if (option !== spanish) {
+        expect(option.tabIndex).toBe(-1);
+      }
+    }
+  });
+
+  test("a slow write keeps picks serialized across picker close and reopen", async () => {
+    // Real write chain (mocked transport), with every PATCH held open until
+    // the test releases it.
+    serializedSelection = true;
+    deferPatches = true;
+    const user = userEvent.setup();
+    openMenu();
+    fireEvent.click(screen.getByText("Listening language"));
+
+    // First pick: its PATCH issues and stays in flight; the picker closes.
+    await user.click(
+      screen.getByRole("option", { name: /Spanish \(Español\)/ }),
+    );
+    expect(patchCalls).toEqual([{ language: "es" }]);
+    expect(
+      screen.queryByRole("listbox", { name: "Listening language" }),
+    ).toBeNull();
+
+    // Reopen and pick again while the first write is still unresolved. The
+    // hook state survived the picker unmount: the reopened list shows the
+    // pending Spanish pick as selected.
+    fireEvent.click(screen.getByRole("button", { name: "Voice settings" }));
+    fireEvent.click(screen.getByText("Listening language"));
+    expect(
+      screen
+        .getByRole("option", { name: /Spanish \(Español\)/ })
+        .getAttribute("aria-selected"),
+    ).toBe("true");
+    await user.click(
+      screen.getByRole("option", { name: /French \(Français\)/ }),
+    );
+
+    // The strongest observable of the shared chain: the second PATCH has not
+    // issued while the first is unresolved. Two independent chains (the
+    // pre-fix bug) would have fired it immediately.
+    expect(patchCalls).toEqual([{ language: "es" }]);
+
+    // Releasing the first write lets the queued one issue, in pick order.
+    await act(async () => {
+      patchResolvers.shift()?.();
+    });
+    await act(async () => {});
+    expect(patchCalls).toEqual([{ language: "es" }, { language: "fr" }]);
   });
 
   test("language row leaves the Captions toggle and Voice row intact", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
@@ -13,10 +13,17 @@
  *   which hot-applies on the assistant's next reply. Managed assistants only;
  *   a bring-your-own provider gets the disabled row and its Settings link (see
  *   {@link VoiceSettingRow}).
+ * - **Listening language**: the spoken language STT recognizes, as an inline
+ *   dropdown (the catalog is short and static, so it fits the popover; no
+ *   modal indirection like the query-backed voice list needs). Writes
+ *   `services.stt.language` through {@link useSttLanguageSelection}, which
+ *   hot-applies from the user's next spoken turn. Only rendered when the
+ *   daemon reports the configured STT provider as manually
+ *   language-selectable; auto-detecting providers and old daemons get no row.
  *
  * Captions are bound to the same `voice-prefs` store the Settings page uses;
- * voice is bound to daemon config, the source of truth the Settings → Voice
- * card also writes.
+ * voice and listening language are bound to daemon config, the source of
+ * truth the Settings page's speech cards also write.
  */
 
 import { useState } from "react";
@@ -24,11 +31,14 @@ import { useState } from "react";
 import { Captions, Settings } from "lucide-react";
 
 import { cn } from "@vellumai/design-library";
+import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Popover } from "@vellumai/design-library/components/popover";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
+import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 import { VoicePickerModal } from "@/components/speech/voice-picker-modal";
 import { VoiceSettingRow } from "@/domains/chat/voice/voice-room/voice-setting-row";
+import { sttLanguageOptionsFor } from "@/lib/stt/language-catalog";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 interface VoiceRoomSettingsMenuProps {
@@ -115,6 +125,11 @@ export function VoiceRoomSettingsMenu({
               }}
               className="mt-2"
             />
+
+            {/* Listening language → inline dropdown. Only when the daemon
+                reports the configured STT provider as language-selectable;
+                collapses to nothing otherwise, like the Voice row. */}
+            <ListeningLanguageRow assistantId={assistantId} className="mt-2" />
           </div>
         </Popover.Content>
       </Popover.Root>
@@ -124,5 +139,60 @@ export function VoiceRoomSettingsMenu({
         onOpenChange={setVoiceModalOpen}
       />
     </>
+  );
+}
+
+/**
+ * The "Listening language" section: a divider, a label, the language dropdown,
+ * and a caption stating when a pick lands. Renders nothing when the daemon
+ * doesn't offer manual language selection for the configured STT provider
+ * (auto-detecting providers, old daemons), so the popover never shows a
+ * control the daemon would ignore.
+ *
+ * The dropdown stays inline: the catalog is short and static, and with no
+ * `PortalContainerProvider` on the chat route its menu renders inside the
+ * popover content, so option clicks don't trip the popover's outside-click
+ * dismissal.
+ */
+function ListeningLanguageRow({
+  assistantId,
+  className,
+}: {
+  assistantId: string | null;
+  className?: string;
+}) {
+  const { available, currentCode, configuredProviderId, selectLanguage } =
+    useSttLanguageSelection(assistantId);
+
+  if (!available) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-col", className)}>
+      {/* Same straight full-width divider the Voice row draws (a border on a
+          rounded child would render with rounded ends). */}
+      <div className="border-t border-[var(--border-subtle)]" />
+      <span className="mt-2 px-1 text-body-medium-default text-[var(--content-default)]">
+        Listening language
+      </span>
+      <Dropdown
+        size="compact"
+        value={currentCode}
+        onChange={selectLanguage}
+        options={sttLanguageOptionsFor(currentCode, configuredProviderId).map(
+          (l) => ({
+            value: l.code,
+            label: l.nativeLabel ? `${l.label} (${l.nativeLabel})` : l.label,
+            tooltip: l.description,
+          }),
+        )}
+        aria-label="Listening language"
+        className="mt-1.5"
+      />
+      <p className="mt-1.5 px-1 text-label-small-default text-[var(--content-tertiary)]">
+        Applies from your next spoken turn.
+      </p>
+    </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
@@ -18,10 +18,11 @@
  *   wrapper is transformed, which makes it the containing block for the
  *   Dropdown menu's fixed-position coordinates, so an inline menu here lands
  *   far from its trigger). Writes `services.stt.language` through
- *   {@link useSttLanguageSelection}, which hot-applies from the user's next
+ *   `useSttLanguageSelection`, which hot-applies from the user's next
  *   spoken turn. Only rendered when the daemon reports the configured STT
  *   provider as manually language-selectable; auto-detecting providers and
- *   old daemons get no row.
+ *   old daemons get no row. See {@link ListeningLanguageRow} and
+ *   {@link ListeningLanguagePickerModal}.
  *
  * Captions are bound to the same `voice-prefs` store the Settings page uses;
  * voice and listening language are bound to daemon config, the source of
@@ -30,20 +31,16 @@
 
 import { useState } from "react";
 
-import { Captions, Check, ChevronRight, Settings } from "lucide-react";
+import { Captions, Settings } from "lucide-react";
 
 import { cn } from "@vellumai/design-library";
-import { Modal } from "@vellumai/design-library/components/modal";
 import { Popover } from "@vellumai/design-library/components/popover";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
-import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 import { VoicePickerModal } from "@/components/speech/voice-picker-modal";
+import { ListeningLanguagePickerModal } from "@/domains/chat/voice/voice-room/listening-language-picker-modal";
+import { ListeningLanguageRow } from "@/domains/chat/voice/voice-room/listening-language-row";
 import { VoiceSettingRow } from "@/domains/chat/voice/voice-room/voice-setting-row";
-import {
-  sttLanguageOptionsFor,
-  type SttLanguageOption,
-} from "@/lib/stt/language-catalog";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 interface VoiceRoomSettingsMenuProps {
@@ -157,174 +154,6 @@ export function VoiceRoomSettingsMenu({
         open={languageModalOpen}
         onOpenChange={setLanguageModalOpen}
       />
-    </>
-  );
-}
-
-/** One display string per option, shared by the row's value and the picker. */
-function languageLabel(option: SttLanguageOption): string {
-  return option.nativeLabel
-    ? `${option.label} (${option.nativeLabel})`
-    : option.label;
-}
-
-/**
- * The "Listening language" row: the current language with a chevron, leading
- * to {@link ListeningLanguagePickerModal}. Renders nothing when the daemon
- * doesn't offer manual language selection for the configured STT provider
- * (auto-detecting providers, old daemons), so the popover never shows a
- * control the daemon would ignore.
- *
- * The picker is a modal rather than an inline dropdown on purpose: the radix
- * popover positions its content through a transformed wrapper, which becomes
- * the containing block for fixed-position descendants, so the Dropdown menu's
- * viewport coordinates land relative to the already-offset popover and the
- * options render far from the trigger. Like the Voice row, this row only
- * reports the click via `onOpen`; the parent closes the popover and opens the
- * modal it owns outside it.
- */
-function ListeningLanguageRow({
-  assistantId,
-  onOpen,
-  className,
-}: {
-  assistantId: string | null;
-  /** Open the language picker modal (owned by the parent). */
-  onOpen: () => void;
-  className?: string;
-}) {
-  const { available, currentCode, configuredProviderId } =
-    useSttLanguageSelection(assistantId);
-
-  if (!available) {
-    return null;
-  }
-
-  const current = sttLanguageOptionsFor(currentCode, configuredProviderId).find(
-    (option) => option.code === currentCode,
-  );
-
-  return (
-    <div className={cn("flex flex-col", className)}>
-      {/* Same straight full-width divider the Voice row draws (a border on a
-          rounded child would render with rounded ends). */}
-      <div className="border-t border-[var(--border-subtle)]" />
-      <button
-        type="button"
-        onClick={onOpen}
-        className="mt-1 flex w-full items-baseline gap-2 rounded-md px-1 py-2 text-left transition-colors hover:bg-[var(--surface-hover)]"
-      >
-        <span className="shrink-0 text-body-medium-default text-[var(--content-default)]">
-          Listening language
-        </span>
-        <span className="min-w-0 flex-1 truncate text-right text-label-small-default text-[var(--content-tertiary)]">
-          {current ? languageLabel(current) : currentCode}
-        </span>
-        <ChevronRight className="size-4 shrink-0 self-center text-[var(--content-tertiary)]" />
-      </button>
-    </div>
-  );
-}
-
-/**
- * The listening-language picker: the short static catalog as a selectable
- * list in a small modal, hosted outside the settings popover (a sibling of
- * {@link VoicePickerModal}) so closing the popover can't unmount it and no
- * transformed ancestor interferes with its positioning. A pick hot-applies
- * from the next spoken turn (there is nothing to save), so it also closes
- * the picker.
- */
-function ListeningLanguagePickerModal({
-  assistantId,
-  open,
-  onOpenChange,
-}: {
-  assistantId: string | null;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  return (
-    <Modal.Root open={open} onOpenChange={onOpenChange}>
-      <Modal.Content size="sm">
-        {/* Own component so its daemon queries run only while the modal is
-            open — the host keeps this mounted across a whole session. */}
-        <ListeningLanguagePickerContent
-          assistantId={assistantId}
-          onDone={() => onOpenChange(false)}
-        />
-      </Modal.Content>
-    </Modal.Root>
-  );
-}
-
-function ListeningLanguagePickerContent({
-  assistantId,
-  onDone,
-}: {
-  assistantId: string | null;
-  onDone: () => void;
-}) {
-  const { currentCode, configuredProviderId, selectLanguage, selecting } =
-    useSttLanguageSelection(assistantId);
-
-  return (
-    <>
-      <Modal.Header>
-        <Modal.Title>Listening language</Modal.Title>
-        <Modal.Description>
-          Applies from your next spoken turn.
-        </Modal.Description>
-      </Modal.Header>
-      <Modal.Body>
-        <div
-          role="listbox"
-          aria-label="Listening language"
-          className={cn(
-            "flex max-h-[60vh] flex-col overflow-y-auto",
-            selecting && "pointer-events-none opacity-70",
-          )}
-        >
-          {sttLanguageOptionsFor(currentCode, configuredProviderId).map(
-            (option) => {
-              const isSelected = option.code === currentCode;
-              return (
-                <div
-                  key={option.code}
-                  role="option"
-                  aria-selected={isSelected}
-                  onClick={() => {
-                    selectLanguage(option.code);
-                    onDone();
-                  }}
-                  className={cn(
-                    "flex cursor-pointer items-center gap-2 rounded-md px-3 py-2.5 transition-colors",
-                    // Selected reads as a soft persistent fill + a trailing
-                    // check, like the voice list — not a form-field border.
-                    isSelected
-                      ? "bg-[var(--surface-active)]"
-                      : "hover:bg-[var(--surface-hover)]",
-                  )}
-                >
-                  <span className="min-w-0 flex-1 truncate text-body-medium-default text-[var(--content-default)]">
-                    {languageLabel(option)}
-                    {option.description && (
-                      <span className="block truncate text-label-small-default text-[var(--content-tertiary)]">
-                        {option.description}
-                      </span>
-                    )}
-                  </span>
-                  {isSelected && (
-                    <Check
-                      aria-hidden
-                      className="size-4 shrink-0 text-[var(--system-positive-strong)]"
-                    />
-                  )}
-                </div>
-              );
-            },
-          )}
-        </div>
-      </Modal.Body>
     </>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
@@ -19,7 +19,12 @@
  *   Dropdown menu's fixed-position coordinates, so an inline menu here lands
  *   far from its trigger). Writes `services.stt.language` through
  *   `useSttLanguageSelection`, which hot-applies from the user's next
- *   spoken turn. Only rendered when the daemon reports the configured STT
+ *   spoken turn. The hook is called once here, in a component that stays
+ *   mounted for the whole voice-room session, and its state is passed down
+ *   to the row and the picker: the hook's serialized write chain lives in
+ *   refs, so hosting it in the picker content (which unmounts on close)
+ *   would let a slow PATCH from a previous pick race a newer one across a
+ *   close/reopen. Only rendered when the daemon reports the configured STT
  *   provider as manually language-selectable; auto-detecting providers and
  *   old daemons get no row. See {@link ListeningLanguageRow} and
  *   {@link ListeningLanguagePickerModal}.
@@ -37,6 +42,7 @@ import { cn } from "@vellumai/design-library";
 import { Popover } from "@vellumai/design-library/components/popover";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
+import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 import { VoicePickerModal } from "@/components/speech/voice-picker-modal";
 import { ListeningLanguagePickerModal } from "@/domains/chat/voice/voice-room/listening-language-picker-modal";
 import { ListeningLanguageRow } from "@/domains/chat/voice/voice-room/listening-language-row";
@@ -71,6 +77,21 @@ export function VoiceRoomSettingsMenu({
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [voiceModalOpen, setVoiceModalOpen] = useState(false);
   const [languageModalOpen, setLanguageModalOpen] = useState(false);
+
+  // Listening-language selection lives here, above both the row and the
+  // picker, because this menu stays mounted for the whole voice-room session
+  // while the picker content unmounts on close: hoisting keeps the hook's
+  // serialized write chain alive across close/reopen, so a repick queues
+  // behind a still-in-flight PATCH instead of racing it. The queries behind
+  // the hook are cheap (an Infinity-staleTime capability probe plus the
+  // shared config query the row needs anyway).
+  const {
+    available: languageAvailable,
+    currentCode,
+    configuredProviderId,
+    selectLanguage,
+    selecting,
+  } = useSttLanguageSelection(assistantId);
 
   return (
     <>
@@ -134,7 +155,9 @@ export function VoiceRoomSettingsMenu({
                 STT provider as language-selectable; collapses to nothing
                 otherwise, like the Voice row. */}
             <ListeningLanguageRow
-              assistantId={assistantId}
+              available={languageAvailable}
+              currentCode={currentCode}
+              configuredProviderId={configuredProviderId}
               onOpen={() => {
                 setPopoverOpen(false);
                 setLanguageModalOpen(true);
@@ -150,9 +173,12 @@ export function VoiceRoomSettingsMenu({
         onOpenChange={setVoiceModalOpen}
       />
       <ListeningLanguagePickerModal
-        assistantId={assistantId}
         open={languageModalOpen}
         onOpenChange={setLanguageModalOpen}
+        currentCode={currentCode}
+        configuredProviderId={configuredProviderId}
+        selectLanguage={selectLanguage}
+        selecting={selecting}
       />
     </>
   );

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
@@ -13,13 +13,15 @@
  *   which hot-applies on the assistant's next reply. Managed assistants only;
  *   a bring-your-own provider gets the disabled row and its Settings link (see
  *   {@link VoiceSettingRow}).
- * - **Listening language**: the spoken language STT recognizes, as an inline
- *   dropdown (the catalog is short and static, so it fits the popover; no
- *   modal indirection like the query-backed voice list needs). Writes
- *   `services.stt.language` through {@link useSttLanguageSelection}, which
- *   hot-applies from the user's next spoken turn. Only rendered when the
- *   daemon reports the configured STT provider as manually
- *   language-selectable; auto-detecting providers and old daemons get no row.
+ * - **Listening language**: the spoken language STT recognizes, as a row that
+ *   opens a small picker modal (mirroring the Voice row: the popover's radix
+ *   wrapper is transformed, which makes it the containing block for the
+ *   Dropdown menu's fixed-position coordinates, so an inline menu here lands
+ *   far from its trigger). Writes `services.stt.language` through
+ *   {@link useSttLanguageSelection}, which hot-applies from the user's next
+ *   spoken turn. Only rendered when the daemon reports the configured STT
+ *   provider as manually language-selectable; auto-detecting providers and
+ *   old daemons get no row.
  *
  * Captions are bound to the same `voice-prefs` store the Settings page uses;
  * voice and listening language are bound to daemon config, the source of
@@ -28,17 +30,20 @@
 
 import { useState } from "react";
 
-import { Captions, Settings } from "lucide-react";
+import { Captions, Check, ChevronRight, Settings } from "lucide-react";
 
 import { cn } from "@vellumai/design-library";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Modal } from "@vellumai/design-library/components/modal";
 import { Popover } from "@vellumai/design-library/components/popover";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 import { VoicePickerModal } from "@/components/speech/voice-picker-modal";
 import { VoiceSettingRow } from "@/domains/chat/voice/voice-room/voice-setting-row";
-import { sttLanguageOptionsFor } from "@/lib/stt/language-catalog";
+import {
+  sttLanguageOptionsFor,
+  type SttLanguageOption,
+} from "@/lib/stt/language-catalog";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 interface VoiceRoomSettingsMenuProps {
@@ -68,6 +73,7 @@ export function VoiceRoomSettingsMenu({
   // unmount it.
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [voiceModalOpen, setVoiceModalOpen] = useState(false);
+  const [languageModalOpen, setLanguageModalOpen] = useState(false);
 
   return (
     <>
@@ -126,10 +132,18 @@ export function VoiceRoomSettingsMenu({
               className="mt-2"
             />
 
-            {/* Listening language → inline dropdown. Only when the daemon
-                reports the configured STT provider as language-selectable;
-                collapses to nothing otherwise, like the Voice row. */}
-            <ListeningLanguageRow assistantId={assistantId} className="mt-2" />
+            {/* Listening language → dedicated picker modal, same indirection
+                as the Voice row. Only when the daemon reports the configured
+                STT provider as language-selectable; collapses to nothing
+                otherwise, like the Voice row. */}
+            <ListeningLanguageRow
+              assistantId={assistantId}
+              onOpen={() => {
+                setPopoverOpen(false);
+                setLanguageModalOpen(true);
+              }}
+              className="mt-2"
+            />
           </div>
         </Popover.Content>
       </Popover.Root>
@@ -138,61 +152,179 @@ export function VoiceRoomSettingsMenu({
         open={voiceModalOpen}
         onOpenChange={setVoiceModalOpen}
       />
+      <ListeningLanguagePickerModal
+        assistantId={assistantId}
+        open={languageModalOpen}
+        onOpenChange={setLanguageModalOpen}
+      />
     </>
   );
 }
 
+/** One display string per option, shared by the row's value and the picker. */
+function languageLabel(option: SttLanguageOption): string {
+  return option.nativeLabel
+    ? `${option.label} (${option.nativeLabel})`
+    : option.label;
+}
+
 /**
- * The "Listening language" section: a divider, a label, the language dropdown,
- * and a caption stating when a pick lands. Renders nothing when the daemon
+ * The "Listening language" row: the current language with a chevron, leading
+ * to {@link ListeningLanguagePickerModal}. Renders nothing when the daemon
  * doesn't offer manual language selection for the configured STT provider
  * (auto-detecting providers, old daemons), so the popover never shows a
  * control the daemon would ignore.
  *
- * The dropdown stays inline: the catalog is short and static, and with no
- * `PortalContainerProvider` on the chat route its menu renders inside the
- * popover content, so option clicks don't trip the popover's outside-click
- * dismissal.
+ * The picker is a modal rather than an inline dropdown on purpose: the radix
+ * popover positions its content through a transformed wrapper, which becomes
+ * the containing block for fixed-position descendants, so the Dropdown menu's
+ * viewport coordinates land relative to the already-offset popover and the
+ * options render far from the trigger. Like the Voice row, this row only
+ * reports the click via `onOpen`; the parent closes the popover and opens the
+ * modal it owns outside it.
  */
 function ListeningLanguageRow({
   assistantId,
+  onOpen,
   className,
 }: {
   assistantId: string | null;
+  /** Open the language picker modal (owned by the parent). */
+  onOpen: () => void;
   className?: string;
 }) {
-  const { available, currentCode, configuredProviderId, selectLanguage } =
+  const { available, currentCode, configuredProviderId } =
     useSttLanguageSelection(assistantId);
 
   if (!available) {
     return null;
   }
 
+  const current = sttLanguageOptionsFor(currentCode, configuredProviderId).find(
+    (option) => option.code === currentCode,
+  );
+
   return (
     <div className={cn("flex flex-col", className)}>
       {/* Same straight full-width divider the Voice row draws (a border on a
           rounded child would render with rounded ends). */}
       <div className="border-t border-[var(--border-subtle)]" />
-      <span className="mt-2 px-1 text-body-medium-default text-[var(--content-default)]">
-        Listening language
-      </span>
-      <Dropdown
-        size="compact"
-        value={currentCode}
-        onChange={selectLanguage}
-        options={sttLanguageOptionsFor(currentCode, configuredProviderId).map(
-          (l) => ({
-            value: l.code,
-            label: l.nativeLabel ? `${l.label} (${l.nativeLabel})` : l.label,
-            tooltip: l.description,
-          }),
-        )}
-        aria-label="Listening language"
-        className="mt-1.5"
-      />
-      <p className="mt-1.5 px-1 text-label-small-default text-[var(--content-tertiary)]">
-        Applies from your next spoken turn.
-      </p>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="mt-1 flex w-full items-baseline gap-2 rounded-md px-1 py-2 text-left transition-colors hover:bg-[var(--surface-hover)]"
+      >
+        <span className="shrink-0 text-body-medium-default text-[var(--content-default)]">
+          Listening language
+        </span>
+        <span className="min-w-0 flex-1 truncate text-right text-label-small-default text-[var(--content-tertiary)]">
+          {current ? languageLabel(current) : currentCode}
+        </span>
+        <ChevronRight className="size-4 shrink-0 self-center text-[var(--content-tertiary)]" />
+      </button>
     </div>
+  );
+}
+
+/**
+ * The listening-language picker: the short static catalog as a selectable
+ * list in a small modal, hosted outside the settings popover (a sibling of
+ * {@link VoicePickerModal}) so closing the popover can't unmount it and no
+ * transformed ancestor interferes with its positioning. A pick hot-applies
+ * from the next spoken turn (there is nothing to save), so it also closes
+ * the picker.
+ */
+function ListeningLanguagePickerModal({
+  assistantId,
+  open,
+  onOpenChange,
+}: {
+  assistantId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Modal.Root open={open} onOpenChange={onOpenChange}>
+      <Modal.Content size="sm">
+        {/* Own component so its daemon queries run only while the modal is
+            open — the host keeps this mounted across a whole session. */}
+        <ListeningLanguagePickerContent
+          assistantId={assistantId}
+          onDone={() => onOpenChange(false)}
+        />
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+function ListeningLanguagePickerContent({
+  assistantId,
+  onDone,
+}: {
+  assistantId: string | null;
+  onDone: () => void;
+}) {
+  const { currentCode, configuredProviderId, selectLanguage, selecting } =
+    useSttLanguageSelection(assistantId);
+
+  return (
+    <>
+      <Modal.Header>
+        <Modal.Title>Listening language</Modal.Title>
+        <Modal.Description>
+          Applies from your next spoken turn.
+        </Modal.Description>
+      </Modal.Header>
+      <Modal.Body>
+        <div
+          role="listbox"
+          aria-label="Listening language"
+          className={cn(
+            "flex max-h-[60vh] flex-col overflow-y-auto",
+            selecting && "pointer-events-none opacity-70",
+          )}
+        >
+          {sttLanguageOptionsFor(currentCode, configuredProviderId).map(
+            (option) => {
+              const isSelected = option.code === currentCode;
+              return (
+                <div
+                  key={option.code}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => {
+                    selectLanguage(option.code);
+                    onDone();
+                  }}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 rounded-md px-3 py-2.5 transition-colors",
+                    // Selected reads as a soft persistent fill + a trailing
+                    // check, like the voice list — not a form-field border.
+                    isSelected
+                      ? "bg-[var(--surface-active)]"
+                      : "hover:bg-[var(--surface-hover)]",
+                  )}
+                >
+                  <span className="min-w-0 flex-1 truncate text-body-medium-default text-[var(--content-default)]">
+                    {languageLabel(option)}
+                    {option.description && (
+                      <span className="block truncate text-label-small-default text-[var(--content-tertiary)]">
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
+                  {isSelected && (
+                    <Check
+                      aria-hidden
+                      className="size-4 shrink-0 text-[var(--system-positive-strong)]"
+                    />
+                  )}
+                </div>
+              );
+            },
+          )}
+        </div>
+      </Modal.Body>
+    </>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -154,6 +154,21 @@ mock.module("@/domains/chat/surface-actions", () => ({
   handleSurfaceAction: handleSurfaceActionSpy,
 }));
 
+// The settings gear calls this hook at mount (hoisted above its picker so
+// the serialized write chain survives close/reopen), which would pull the
+// daemon React Query graph into every room render. Stubbed as unavailable;
+// its behavior is covered in voice-room-settings-menu.test.tsx.
+mock.module("@/components/speech/use-stt-language-selection", () => ({
+  useSttLanguageSelection: () => ({
+    available: false,
+    currentCode: "",
+    configuredProviderId: "vellum",
+    isLanguageSelectable: () => false,
+    selectLanguage: () => {},
+    selecting: false,
+  }),
+}));
+
 // Imported after the mocks so the room picks up the mocked modules.
 const { VoiceRoom } =
   await import("@/domains/chat/voice/voice-room/voice-room");

--- a/clients/web/src/lib/stt/language-catalog.ts
+++ b/clients/web/src/lib/stt/language-catalog.ts
@@ -16,6 +16,17 @@ export interface SttLanguageOption {
 /** Sentinel meaning "unset / provider default": recognition defaults to English. */
 export const STT_LANGUAGE_DEFAULT_CODE = "";
 
+/**
+ * One display string per option, e.g. "French (Français)", shared by every
+ * surface that renders the catalog: the Speech-to-Text form's dropdown and
+ * the voice-room row and picker.
+ */
+export function sttLanguageLabel(option: SttLanguageOption): string {
+  return option.nativeLabel
+    ? `${option.label} (${option.nativeLabel})`
+    : option.label;
+}
+
 export const STT_MULTI_CODE = "multi";
 
 export const STT_LANGUAGES: readonly SttLanguageOption[] = [


### PR DESCRIPTION
## Summary
- Adds a Listening language row to the voice room gear popover, visible only when the daemon reports the configured STT provider as language-selectable
- Inline dropdown (static short list, no stacked modal); picks hot-apply and take effect from the next spoken turn via the daemon's persistent-stream re-dial

Part of plan: stt-language-selection.md (PR 7 of 7)