### PR TITLE
feat(web): suggest a spoken language on the voice first-run card for non-English locales

### DIFF
--- a/clients/web/src/components/speech/use-stt-language-selection.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.ts
@@ -67,6 +67,14 @@ export interface UseSttLanguageSelection {
    */
   currentCode: string;
   /**
+   * The daemon provider id a language pick steers: the configured STT
+   * provider, with the legacy managed-mode config reading as `"vellum"` and
+   * an unset provider as the daemon schema default (`"deepgram"`). Surfaces
+   * that build their option list with `sttLanguageOptionsFor` pass this so
+   * the config narrowing lives here once.
+   */
+  configuredProviderId: string;
+  /**
    * Whether the daemon probe reports the given daemon provider id as
    * manually language-selectable. `available` describes the CONFIGURED
    * provider; a form whose dropdown holds an unsaved DRAFT choice gates its
@@ -151,6 +159,7 @@ export function useSttLanguageSelection(
   return {
     available,
     currentCode,
+    configuredProviderId: configuredProvider,
     isLanguageSelectable,
     selectLanguage,
     selecting,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -14,7 +14,10 @@
  *     `markFirstRunSeen` (as the composer does) consumes the first run so a
  *     second entry would skip the card,
  *   - the voice-settings detour is a VIEW of this one modal, not a modal
- *     stacked on it, and returns to the intro.
+ *     stacked on it, and returns to the intro,
+ *   - the listening-language row renders only on locale evidence plus daemon
+ *     capability, never writes without an explicit pick, and holds Start
+ *     while a pick's write is in flight.
  */
 import { type ReactNode } from "react";
 
@@ -55,6 +58,23 @@ mock.module("@/components/speech/use-managed-voice-selection", () => ({
   }),
 }));
 
+// The listening-language row reads availability and the current code off the
+// daemon config graph through this hook; a mutable stub keeps the card free
+// of React Query and lets each test shape daemon capability independently of
+// the locale evidence it stubs on `navigator.language`.
+const STT_LANGUAGE_SELECTION_DEFAULTS = {
+  available: false,
+  currentCode: "",
+  configuredProviderId: "vellum",
+  isLanguageSelectable: () => false,
+  selectLanguage: (_code: string) => {},
+  selecting: false,
+};
+let sttLanguageSelection = { ...STT_LANGUAGE_SELECTION_DEFAULTS };
+mock.module("@/components/speech/use-stt-language-selection", () => ({
+  useSttLanguageSelection: () => sttLanguageSelection,
+}));
+
 // The settings view links to Models & Services; give it a plain anchor so the
 // card renders without a Router.
 mock.module("react-router", () => ({
@@ -80,7 +100,37 @@ function dialogTitle(): string {
   return document.querySelector('[data-slot="modal-title"]')?.textContent ?? "";
 }
 
-afterEach(cleanup);
+/**
+ * Stub the browser locale the card reads for its language suggestion. The
+ * original descriptor (own or absent, with the prototype getter beneath) is
+ * restored after every test so locale evidence never leaks between them.
+ */
+const originalLanguageDescriptor = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "language",
+);
+function stubLocale(language: string): void {
+  Object.defineProperty(window.navigator, "language", {
+    value: language,
+    configurable: true,
+  });
+}
+function restoreLocale(): void {
+  if (originalLanguageDescriptor) {
+    Object.defineProperty(
+      window.navigator,
+      "language",
+      originalLanguageDescriptor,
+    );
+  } else {
+    delete (window.navigator as { language?: string }).language;
+  }
+}
+
+afterEach(() => {
+  cleanup();
+  restoreLocale();
+});
 beforeEach(() => {
   // Fresh first run, both transcripts off — the real first-entry state.
   useVoicePrefsStore.setState({
@@ -88,6 +138,7 @@ beforeEach(() => {
     showAssistantTranscript: false,
     firstRunSeen: false,
   });
+  sttLanguageSelection = { ...STT_LANGUAGE_SELECTION_DEFAULTS };
 });
 
 describe("VoiceFirstRunCard", () => {
@@ -214,6 +265,90 @@ describe("VoiceFirstRunCard", () => {
       expect(dialogTitle()).toBe("Voices");
       fireEvent.click(getByLabelText("Back"));
       expect(getByText("Start talking")).toBeTruthy();
+    });
+  });
+
+  describe("listening language row", () => {
+    const ROW_LABEL = "Listening language";
+
+    /** The language dropdown's option rows, in render order. */
+    function languageOptions(getByLabelText: (label: string) => HTMLElement) {
+      fireEvent.click(getByLabelText(ROW_LABEL));
+      return Array.from(
+        document.querySelectorAll<HTMLElement>('[role="option"]'),
+      );
+    }
+
+    test("an English locale sees no row even when the provider is selectable", () => {
+      stubLocale("en-US");
+      sttLanguageSelection = { ...sttLanguageSelection, available: true };
+      const { queryByLabelText } = render(
+        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+      );
+      // No locale evidence means no row: the card stays exactly the card.
+      expect(queryByLabelText(ROW_LABEL)).toBeNull();
+    });
+
+    test("locale evidence without daemon support sees no row", () => {
+      stubLocale("hi-IN");
+      // `available` stays false: an auto-detecting provider or an old daemon.
+      const { queryByLabelText } = render(
+        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+      );
+      expect(queryByLabelText(ROW_LABEL)).toBeNull();
+    });
+
+    test("locale evidence plus a selectable provider shows the row with Multilingual suggested", () => {
+      stubLocale("hi-IN");
+      sttLanguageSelection = { ...sttLanguageSelection, available: true };
+      const { getByLabelText } = render(
+        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+      );
+
+      const options = languageOptions(getByLabelText);
+      // The suggestion sits directly after the current (default) value and
+      // carries the annotation; the rest of the catalog is unshuffled.
+      expect(options[0]?.textContent).toContain("English (default)");
+      expect(options[1]?.textContent).toContain("Multilingual");
+      expect(options[1]?.textContent).toContain("Suggested");
+    });
+
+    test("a pick writes the language; merely rendering writes nothing", () => {
+      stubLocale("hi-IN");
+      const selectLanguage = mock((_code: string) => {});
+      sttLanguageSelection = {
+        ...sttLanguageSelection,
+        available: true,
+        selectLanguage,
+      };
+      const { getByLabelText } = render(
+        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+      );
+      // Showing the smart default never auto-writes.
+      expect(selectLanguage).not.toHaveBeenCalled();
+
+      const multilingual = languageOptions(getByLabelText).find((o) =>
+        o.textContent?.includes("Multilingual"),
+      );
+      expect(multilingual).toBeTruthy();
+      fireEvent.click(multilingual!);
+
+      expect(selectLanguage).toHaveBeenCalledTimes(1);
+      expect(selectLanguage).toHaveBeenCalledWith("multi");
+    });
+
+    test("Start waits out an in-flight language write", () => {
+      stubLocale("hi-IN");
+      sttLanguageSelection = {
+        ...sttLanguageSelection,
+        available: true,
+        selecting: true,
+      };
+      const { getByText } = render(
+        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+      );
+      const start = getByText("Start talking").closest("button");
+      expect(start?.disabled).toBe(true);
     });
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -350,5 +350,22 @@ describe("VoiceFirstRunCard", () => {
       const start = getByText("Start talking").closest("button");
       expect(start?.disabled).toBe(true);
     });
+
+    test("the settings view's Start also waits out the language write", () => {
+      // A language pick on the intro followed by opening Voice settings must
+      // not offer a Start that races the config patch.
+      stubLocale("hi-IN");
+      sttLanguageSelection = {
+        ...sttLanguageSelection,
+        available: true,
+        selecting: true,
+      };
+      const { getByText } = render(
+        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+      );
+      fireEvent.click(getByText("Voice settings"));
+      const start = getByText("Start talking").closest("button");
+      expect(start?.disabled).toBe(true);
+    });
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -4,17 +4,27 @@ import {
   ArrowLeft,
   AudioLines,
   Captions,
+  Languages,
   MicOff,
   Settings,
 } from "lucide-react";
 
 import { Button } from "@vellumai/design-library/components/button";
+import {
+  Dropdown,
+  type DropdownOption,
+} from "@vellumai/design-library/components/dropdown";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
+import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 import { VoiceList } from "@/components/speech/voice-list";
 import { VoiceProvidersNote } from "@/components/speech/voice-providers-note";
+import {
+  sttLanguageOptionsFor,
+  suggestedLanguageForLocale,
+} from "@/lib/stt/language-catalog";
 import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -37,6 +47,16 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
  * quiet link points there. The label names a destination rather than an action:
  * the defaults work untouched, and a link reading like a task would imply setup
  * is owed. Quiet by design so it never competes with "Start talking".
+ *
+ * The second sanctioned exception is the listening-language row: a wrong STT
+ * language is broken rather than suboptimal (the assistant would mishear every
+ * turn), so it is the one default worth surfacing before the first session.
+ * The row appears only on locale evidence (the browser locale suggests a
+ * non-English spoken language) and only when the daemon reports the configured
+ * STT provider as language-selectable; English-locale users see the card
+ * unchanged. It is a surfaced smart default, not a question: nothing is
+ * written unless the user explicitly picks, and a pick hot-applies from the
+ * next spoken turn (no Save, matching the voice picker's semantics).
  *
  * Those settings are a **view within this one modal**, not a modal stacked on
  * it: entering swaps the card's header and body, and a back arrow returns to the
@@ -64,6 +84,51 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /** Mini idle avatar diameter — a quiet, in-context echo of the room avatar. */
 const AVATAR_SIZE = 44;
+
+/**
+ * Options for the listening-language dropdown: the shared catalog for the
+ * configured provider, with the locale-suggested code annotated "Suggested"
+ * and moved directly after the current value, so the smart default is the
+ * next thing the eye lands on without reshuffling the rest of the catalog.
+ * The annotation uses the option `suffix` affordance rather than the label,
+ * so the trigger keeps reading as a plain value once picked.
+ */
+function listeningLanguageOptions(
+  currentCode: string,
+  configuredProviderId: string,
+  suggestedCode: string,
+): DropdownOption<string>[] {
+  const options: DropdownOption<string>[] = sttLanguageOptionsFor(
+    currentCode,
+    configuredProviderId,
+  ).map((l) => ({
+    value: l.code,
+    label: l.nativeLabel ? `${l.label} (${l.nativeLabel})` : l.label,
+    tooltip: l.description,
+  }));
+  // The suggestion can be absent (a language-selectable provider whose
+  // adapter drops "multi"); the row still offers the catalog, just with
+  // nothing to headline.
+  const suggestedIndex = options.findIndex((o) => o.value === suggestedCode);
+  if (suggestedIndex === -1 || suggestedCode === currentCode) {
+    return options;
+  }
+  const [suggested] = options.splice(suggestedIndex, 1);
+  const annotated: DropdownOption<string> = {
+    ...suggested!,
+    suffix: (
+      <span className="text-label-small-default text-[var(--content-tertiary)]">
+        Suggested
+      </span>
+    ),
+  };
+  // `sttLanguageOptionsFor` guarantees the current code is represented (a
+  // synthetic "(custom)" entry covers out-of-catalog values), so this index
+  // always resolves.
+  const currentIndex = options.findIndex((o) => o.value === currentCode);
+  options.splice(currentIndex + 1, 0, annotated);
+  return options;
+}
 
 /**
  * Which view the card is showing: the welcome content, or the optional voice
@@ -100,6 +165,23 @@ export function VoiceFirstRunCard({
 
   const [view, setView] = useState<FirstRunView>("intro");
   const backToIntro = () => setView("intro");
+
+  // Locale evidence for the listening-language row: null for English locales
+  // and locales outside the catalog. Guarded for environments without a
+  // `navigator` (the pattern voice-input-button uses).
+  const suggestedCode = suggestedLanguageForLocale(
+    typeof navigator !== "undefined" ? navigator.language : undefined,
+  );
+  // A null assistant id keeps the hook's queries disabled, so without locale
+  // evidence the intro renders byte-identical to before, with no daemon
+  // fetches pulled into the first-run render.
+  const {
+    available: languageAvailable,
+    currentCode: languageCode,
+    configuredProviderId,
+    selectLanguage,
+    selecting: languageSelecting,
+  } = useSttLanguageSelection(suggestedCode !== null ? assistantId : null);
 
   return (
     <Modal.Root
@@ -196,6 +278,36 @@ export function VoiceFirstRunCard({
                   </span>
                 </li>
               </ul>
+              {/* A surfaced smart default, not a question: rendered only on
+                  locale evidence for a language-selectable provider (see the
+                  module docstring), and it writes nothing unless the user
+                  picks. A pick hot-applies from the next spoken turn, so it
+                  holds even if the card is then dismissed. */}
+              {suggestedCode !== null && languageAvailable && (
+                <div className="mt-5 flex items-center justify-between gap-3">
+                  <span className="flex items-center gap-2.5">
+                    <Languages
+                      aria-hidden
+                      className="size-4 shrink-0 text-[var(--content-secondary)]"
+                    />
+                    <span className="text-body-medium-default">
+                      Listening language
+                    </span>
+                  </span>
+                  <Dropdown
+                    size="compact"
+                    value={languageCode}
+                    onChange={selectLanguage}
+                    options={listeningLanguageOptions(
+                      languageCode,
+                      configuredProviderId,
+                      suggestedCode,
+                    )}
+                    aria-label="Listening language"
+                    className="min-w-44"
+                  />
+                </div>
+              )}
             </Modal.Body>
             <Modal.Footer className="items-center justify-between">
               {/* A destination, not a task: the defaults work, so this names
@@ -212,7 +324,14 @@ export function VoiceFirstRunCard({
                 <Settings aria-hidden className="size-3.5 shrink-0" />
                 <span className="hover:underline">Voice settings</span>
               </button>
-              <Button variant="primary" onClick={onStart}>
+              {/* Start waits out an in-flight language write (mirroring the
+                  Voices view's voice-write gate) so the session cannot open
+                  before the picked language lands. */}
+              <Button
+                variant="primary"
+                onClick={onStart}
+                disabled={languageSelecting}
+              >
                 Start talking
               </Button>
             </Modal.Footer>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -343,6 +343,7 @@ export function VoiceFirstRunCard({
             assistantId={assistantId}
             onStart={onStart}
             onBack={backToIntro}
+            startBlocked={languageSelecting}
           />
         )}
       </Modal.Content>
@@ -360,10 +361,17 @@ function VoiceSettingsView({
   assistantId,
   onStart,
   onBack,
+  startBlocked = false,
 }: {
   assistantId: string | null;
   onStart: () => void;
   onBack: () => void;
+  /**
+   * An in-flight write elsewhere on the card (the intro's language pick)
+   * that Start must also wait out, so the session cannot open on the
+   * previous STT language regardless of which view launches it.
+   */
+  startBlocked?: boolean;
 }) {
   // Own the selection here (rather than let the list self-commit) so the write's
   // in-flight state can gate Start: the picker reports a pick via `onChange`, and
@@ -402,14 +410,15 @@ function VoiceSettingsView({
       </Modal.Body>
       {/* Mirrors the intro footer (fine print left, primary right) and is always
           present, so the picker flows straight into the session without a size
-          change when a voice is chosen. Start waits out an in-flight voice write
-          so the session can't open on the previous voice. */}
+          change when a voice is chosen. Start waits out an in-flight voice or
+          language write so the session can't open on the previous voice or
+          the previous STT language. */}
       <Modal.Footer className="items-center justify-between gap-3">
         <VoiceProvidersNote />
         <Button
           variant="primary"
           onClick={onStart}
-          disabled={selecting}
+          disabled={selecting || startBlocked}
           className="shrink-0"
         >
           Start talking


### PR DESCRIPTION
## Summary
- The voice first-run card shows a Listening-language row only when the browser locale is a supported non-English language AND the daemon reports the configured STT provider as language-selectable
- The locale-matched option (Multilingual) is surfaced as Suggested; nothing is written without an explicit pick, which hot-applies via the shared language hook
- English-locale users see an unchanged card

Part of plan: stt-language-selection.md (PR 5 of 7)