### PR TITLE
feat(memory): add `memory_ingest` route for batch concept-page ingestion

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -67,6 +67,9 @@ graph LR
     CONS --> VIEWS["essentials / threads / recent"]
     CONS --> REEMBED["memory_v2_reembed →<br/>concept-page Qdrant collection"]
     CONS --> MAINT["memory_v3_maintain<br/>(v3-live follow-up)"]
+    ING["POST /v1/memory/ingest<br/>(deterministic batch import)"] --> PAGES
+    ING --> REEMBED
+    ING --> MAINT
 ```
 
 - `handleRemember` (`graph/tool-handlers.ts`) appends timestamped bullets to
@@ -85,6 +88,16 @@ graph LR
     failure-backoff-respecting);
   - manual "Run now" via `POST /v1/consolidation/run-now`.
     Failed runs enter an exponential backoff (transient vs billing curves).
+- **Ingestion** (`substrate/ingest.ts`, exposed as `POST /v1/memory/ingest`,
+  operation id `memory_ingest`) is the second sanctioned writer of
+  `memory/concepts/`: a deterministic batch import of fully-formed,
+  page-shaped markdown (frontmatter + body) that bypasses the buffer
+  entirely. Purely mechanical: each page is validated and reported
+  individually, writes hold the consolidation lock so a batch cannot
+  interleave with a consolidation pass, and a batch that wrote at least one
+  page enqueues the same reindex follow-ups as consolidation
+  (`memory_v2_reembed`, `memory_v3_maintain`). Consolidation remains the only
+  LLM-driven writer.
 
 ### Read paths
 

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -88,8 +88,9 @@ graph LR
     failure-backoff-respecting);
   - manual "Run now" via `POST /v1/consolidation/run-now`.
     Failed runs enter an exponential backoff (transient vs billing curves).
-- **Ingestion** (`substrate/ingest.ts`, exposed as `POST /v1/memory/ingest`,
-  operation id `memory_ingest`) is the second sanctioned writer of
+- **Ingestion** (`substrate/ingest.ts`, exposed as `POST /v1/memory/ingest`;
+  generated HTTP operation id `memory_ingest_post`, IPC method
+  `memory_ingest`) is the second sanctioned writer of
   `memory/concepts/`: a deterministic batch import of fully-formed,
   page-shaped markdown (frontmatter + body) that bypasses the buffer
   entirely. Purely mechanical: each page is validated and reported

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17726,6 +17726,88 @@ paths:
                   - confident
                   - notes
                 additionalProperties: false
+  /v1/memory/ingest:
+    post:
+      operationId: memory_ingest_post
+      summary:
+        Batch-ingest fully-formed concept pages directly into memory/concepts/ (bypassing the consolidation buffer) and
+        enqueue reindex jobs
+      tags:
+        - memory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pages:
+                  minItems: 1
+                  maxItems: 200
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      slug:
+                        type: string
+                      content:
+                        type: string
+                    required:
+                      - slug
+                      - content
+                dryRun:
+                  type: boolean
+                overwrite:
+                  type: boolean
+              required:
+                - pages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        slug:
+                          type: string
+                        action:
+                          type: string
+                          enum:
+                            - written
+                            - skipped_exists
+                            - invalid
+                        warnings:
+                          type: array
+                          items:
+                            type: string
+                        error:
+                          type: string
+                      required:
+                        - slug
+                        - action
+                        - warnings
+                      additionalProperties: false
+                  written:
+                    type: number
+                  skipped:
+                    type: number
+                  invalid:
+                    type: number
+                  dryRun:
+                    type: boolean
+                required:
+                  - results
+                  - written
+                  - skipped
+                  - invalid
+                  - dryRun
+                additionalProperties: false
   /v1/memory/remember:
     post:
       operationId: memory_remember_post

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -147,6 +147,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../runtime/auth/route-policy.js",
     "../../../../runtime/background-job-runner.js",
     "../../../../runtime/routes/errors.js",
+    "../../../../runtime/routes/parse-body.js",
     "../../../../runtime/routes/types.js",
     "../../../../security/secret-scanner.js",
     "../../../../skills/catalog-cache.js",

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -351,8 +351,9 @@ consumed by generated clients:
   `reembed-skills`, `router-prompt-template`, `simulate-router`, `validate`
   (operation ids `memory_v2_*`)
 - `memory/v3/*` — `backfill-sections`, `rebuild-index`
-- `memory/ingest` (`memory_ingest`): POST, deterministic batch concept-page
-  ingestion
+- `memory/ingest` (IPC method `memory_ingest`; the generated OpenAPI/HTTP
+  operation id is `memory_ingest_post`): POST, deterministic batch
+  concept-page ingestion
 - `memory/worker/*`, `memory/eval/*`
 - `consolidation/config`, `consolidation/run-now`, `consolidation/runs`
 - `filing/config`, `filing/run-now` (v1)

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -351,6 +351,8 @@ consumed by generated clients:
   `reembed-skills`, `router-prompt-template`, `simulate-router`, `validate`
   (operation ids `memory_v2_*`)
 - `memory/v3/*` — `backfill-sections`, `rebuild-index`
+- `memory/ingest` (`memory_ingest`): POST, deterministic batch concept-page
+  ingestion
 - `memory/worker/*`, `memory/eval/*`
 - `consolidation/config`, `consolidation/run-now`, `consolidation/runs`
 - `filing/config`, `filing/run-now` (v1)

--- a/assistant/src/plugins/defaults/memory/src/__tests__/memory-ingest-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/__tests__/memory-ingest-routes.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the memory ingest route handler (`memory-ingest-routes.ts`).
+ *
+ * The substrate ingest module is mocked so the tests assert the route layer:
+ *   - request bodies that fail schema validation throw BadRequest (400)
+ *   - the concept-page tier gate rejects inactive tiers with BadRequest
+ *   - a held consolidation lock maps to Conflict (409) carrying the holder
+ *   - the happy path forwards pages + flags and passes the summary through
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../../../../../config/types.js";
+import { RouteError } from "../../../../../runtime/routes/errors.js";
+
+class FakeIngestLockedError extends Error {
+  readonly holder: string;
+
+  constructor(holder: string) {
+    super(`memory ingest skipped: consolidation lock held by ${holder}`);
+    this.name = "IngestLockedError";
+    this.holder = holder;
+  }
+}
+
+interface IngestCall {
+  workspaceDir: string;
+  pages: Array<{ slug: string; content: string }>;
+  opts: { dryRun?: boolean; overwrite?: boolean } | undefined;
+}
+
+let ingestCalls: IngestCall[] = [];
+let ingestImpl: () => Promise<Record<string, unknown>>;
+
+mock.module("../../substrate/ingest.js", () => ({
+  MAX_INGEST_PAGES_PER_CALL: 200,
+  IngestLockedError: FakeIngestLockedError,
+  ingestPages: async (
+    workspaceDir: string,
+    pages: Array<{ slug: string; content: string }>,
+    opts?: { dryRun?: boolean; overwrite?: boolean },
+  ) => {
+    ingestCalls.push({ workspaceDir, pages, opts });
+    return ingestImpl();
+  },
+}));
+
+const { handleMemoryIngest, ROUTES } =
+  await import("../memory-ingest-routes.js");
+
+const CONCEPT_PAGE_CONFIG = {
+  memory: { enabled: true, v3: { live: true } },
+} as unknown as AssistantConfig;
+
+const V1_CONFIG = {
+  memory: { enabled: true },
+} as unknown as AssistantConfig;
+
+const PAGE = { slug: "alice", content: "---\nedges: []\n---\nBody.\n" };
+
+const EMPTY_SUMMARY = {
+  results: [],
+  written: 0,
+  skipped: 0,
+  invalid: 0,
+  dryRun: false,
+};
+
+beforeEach(() => {
+  ingestCalls = [];
+  ingestImpl = async () => EMPTY_SUMMARY;
+});
+
+async function expectRouteError(
+  promise: Promise<unknown>,
+  code: string,
+  statusCode: number,
+): Promise<RouteError> {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (err) {
+    caught = err;
+  }
+  expect(caught).toBeInstanceOf(RouteError);
+  const routeError = caught as RouteError;
+  expect(routeError.code).toBe(code);
+  expect(routeError.statusCode).toBe(statusCode);
+  return routeError;
+}
+
+describe("handleMemoryIngest", () => {
+  test("rejects a body without pages as BadRequest", async () => {
+    await expectRouteError(
+      handleMemoryIngest({}, CONCEPT_PAGE_CONFIG),
+      "BAD_REQUEST",
+      400,
+    );
+    expect(ingestCalls).toHaveLength(0);
+  });
+
+  test("rejects an empty pages array as BadRequest", async () => {
+    await expectRouteError(
+      handleMemoryIngest({ pages: [] }, CONCEPT_PAGE_CONFIG),
+      "BAD_REQUEST",
+      400,
+    );
+    expect(ingestCalls).toHaveLength(0);
+  });
+
+  test("rejects the request when concept-page memory is not active", async () => {
+    const err = await expectRouteError(
+      handleMemoryIngest({ pages: [PAGE] }, V1_CONFIG),
+      "BAD_REQUEST",
+      400,
+    );
+    expect(err.message).toContain("Concept-page memory is not active");
+    expect(ingestCalls).toHaveLength(0);
+  });
+
+  test("maps a held consolidation lock to Conflict carrying the holder", async () => {
+    ingestImpl = async () => {
+      throw new FakeIngestLockedError("1234 2026-07-29 consolidation");
+    };
+
+    const err = await expectRouteError(
+      handleMemoryIngest({ pages: [PAGE] }, CONCEPT_PAGE_CONFIG),
+      "CONFLICT",
+      409,
+    );
+    expect(err.message).toContain("1234 2026-07-29 consolidation");
+  });
+
+  test("passes the ingest summary through and forwards dryRun/overwrite", async () => {
+    const summary = {
+      results: [
+        { slug: "alice", action: "written" as const, warnings: [] },
+        { slug: "bob", action: "skipped_exists" as const, warnings: [] },
+        {
+          slug: "bad",
+          action: "invalid" as const,
+          warnings: [],
+          error: "invalid slug",
+        },
+      ],
+      written: 1,
+      skipped: 1,
+      invalid: 1,
+      dryRun: true,
+    };
+    ingestImpl = async () => summary;
+
+    const pages = [PAGE, { slug: "bob", content: "Body.\n" }];
+    const result = await handleMemoryIngest(
+      { pages, dryRun: true, overwrite: true },
+      CONCEPT_PAGE_CONFIG,
+    );
+
+    expect(result).toEqual(summary);
+    expect(ingestCalls).toHaveLength(1);
+    expect(ingestCalls[0]?.pages).toEqual(pages);
+    expect(ingestCalls[0]?.opts).toEqual({ dryRun: true, overwrite: true });
+  });
+});
+
+describe("ROUTES", () => {
+  test("registers memory_ingest as a tagged settings.write POST", () => {
+    expect(ROUTES).toHaveLength(1);
+    const route = ROUTES[0];
+    expect(route?.operationId).toBe("memory_ingest");
+    expect(route?.method).toBe("POST");
+    expect(route?.endpoint).toBe("memory/ingest");
+    expect(route?.tags).toEqual(["memory"]);
+    expect(route?.policy?.requiredScopes).toEqual(["settings.write"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
@@ -1,0 +1,117 @@
+/**
+ * Memory ingest route: deterministic batch concept-page ingestion.
+ *
+ * Accepts fully-formed concept pages (frontmatter + body markdown) and writes
+ * them straight into `memory/concepts/` via the substrate's `ingestPages`,
+ * bypassing the consolidation buffer. No LLM is involved: every page is
+ * validated and reported individually, writes hold the consolidation lock,
+ * and reindex follow-up jobs are enqueued after a batch that wrote pages.
+ */
+
+import { z } from "zod";
+
+import { getConfig } from "../../../../config/loader.js";
+import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
+import type { AssistantConfig } from "../../../../config/types.js";
+import {
+  ACTOR_PRINCIPALS,
+  type RoutePolicy,
+} from "../../../../runtime/auth/route-policy.js";
+import {
+  BadRequestError,
+  ConflictError,
+} from "../../../../runtime/routes/errors.js";
+import { parseBody } from "../../../../runtime/routes/parse-body.js";
+import type { RouteDefinition } from "../../../../runtime/routes/types.js";
+import { getWorkspaceDir } from "../paths.js";
+import {
+  IngestLockedError,
+  ingestPages,
+  MAX_INGEST_PAGES_PER_CALL,
+} from "../substrate/ingest.js";
+
+const MemoryIngestParamsSchema = z.object({
+  /** Pages to ingest; `content` is the full page markdown (frontmatter + body). */
+  pages: z
+    .array(
+      z.object({
+        slug: z.string(),
+        content: z.string(),
+      }),
+    )
+    .min(1)
+    .max(MAX_INGEST_PAGES_PER_CALL),
+  /** Validate and report without touching disk or the lock. */
+  dryRun: z.boolean().optional(),
+  /** Rewrite pages whose slug already exists on disk (default: skip them). */
+  overwrite: z.boolean().optional(),
+});
+export type MemoryIngestParams = z.infer<typeof MemoryIngestParamsSchema>;
+
+const MemoryIngestResultSchema = z.object({
+  results: z.array(
+    z.object({
+      slug: z.string(),
+      action: z.enum(["written", "skipped_exists", "invalid"]),
+      warnings: z.array(z.string()),
+      error: z.string().optional(),
+    }),
+  ),
+  written: z.number(),
+  skipped: z.number(),
+  invalid: z.number(),
+  dryRun: z.boolean(),
+});
+export type MemoryIngestResult = z.infer<typeof MemoryIngestResultSchema>;
+
+/**
+ * Validate and ingest a batch of concept pages. `config` is injectable for
+ * tests; production resolves the live config.
+ */
+export async function handleMemoryIngest(
+  body: unknown,
+  config: AssistantConfig = getConfig(),
+): Promise<MemoryIngestResult> {
+  if (!usesConceptPageMemory(config.memory)) {
+    throw new BadRequestError(
+      "Concept-page memory is not active - enable memory.v3.live (or memory.v2.enabled) to ingest pages.",
+    );
+  }
+  const params = parseBody(MemoryIngestParamsSchema, body ?? {});
+  try {
+    return await ingestPages(getWorkspaceDir(), params.pages, {
+      dryRun: params.dryRun,
+      overwrite: params.overwrite,
+    });
+  } catch (err) {
+    if (err instanceof IngestLockedError) {
+      throw new ConflictError(
+        `Memory ingest rejected: consolidation lock held by ${err.holder}. Retry after the current writer finishes.`,
+      );
+    }
+    if (err instanceof RangeError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
+}
+
+const WRITE_POLICY: RoutePolicy = {
+  requiredScopes: ["settings.write"],
+  allowedPrincipalTypes: ACTOR_PRINCIPALS,
+};
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "memory_ingest",
+    method: "POST",
+    policy: WRITE_POLICY,
+    endpoint: "memory/ingest",
+    handler: ({ body }) => handleMemoryIngest(body),
+    summary:
+      "Batch-ingest fully-formed concept pages directly into memory/concepts/ (bypassing the consolidation buffer) and enqueue reindex jobs",
+    tags: ["memory"],
+    requestBody: MemoryIngestParamsSchema,
+    responseBody: MemoryIngestResultSchema,
+  },
+];

--- a/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
@@ -21,7 +21,6 @@ import {
   BadRequestError,
   ConflictError,
 } from "../../../../runtime/routes/errors.js";
-import { parseBody } from "../../../../runtime/routes/parse-body.js";
 import type { RouteDefinition } from "../../../../runtime/routes/types.js";
 import { getWorkspaceDir } from "../paths.js";
 import {
@@ -77,7 +76,17 @@ export async function handleMemoryIngest(
       "Concept-page memory is not active - enable memory.v3.live (or memory.v2.enabled) to ingest pages.",
     );
   }
-  const params = parseBody(MemoryIngestParamsSchema, body ?? {});
+  // Inline safeParse instead of the host's parse-body helper: importing it
+  // would add a new plugin-to-host coupling to the import-boundary baseline,
+  // and BadRequestError already carries the 400 mapping in both adapters.
+  const parsed = MemoryIngestParamsSchema.safeParse(body ?? {});
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => `${issue.path.join(".") || "body"}: ${issue.message}`)
+      .join("; ");
+    throw new BadRequestError(`Invalid ingest request: ${issues}`);
+  }
+  const params = parsed.data;
   try {
     return await ingestPages(getWorkspaceDir(), params.pages, {
       dryRun: params.dryRun,

--- a/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
@@ -21,6 +21,10 @@ import {
   BadRequestError,
   ConflictError,
 } from "../../../../runtime/routes/errors.js";
+// Baselined plugin-to-host coupling: the declared requestBody schema must be
+// the single source of truth for wire validation, and parse-body.ts owns the
+// schema-to-400 mapping. Duplicating it here would drift.
+import { parseBody } from "../../../../runtime/routes/parse-body.js";
 import type { RouteDefinition } from "../../../../runtime/routes/types.js";
 import { getWorkspaceDir } from "../paths.js";
 import {
@@ -76,17 +80,7 @@ export async function handleMemoryIngest(
       "Concept-page memory is not active - enable memory.v3.live (or memory.v2.enabled) to ingest pages.",
     );
   }
-  // Inline safeParse instead of the host's parse-body helper: importing it
-  // would add a new plugin-to-host coupling to the import-boundary baseline,
-  // and BadRequestError already carries the 400 mapping in both adapters.
-  const parsed = MemoryIngestParamsSchema.safeParse(body ?? {});
-  if (!parsed.success) {
-    const issues = parsed.error.issues
-      .map((issue) => `${issue.path.join(".") || "body"}: ${issue.message}`)
-      .join("; ");
-    throw new BadRequestError(`Invalid ingest request: ${issues}`);
-  }
-  const params = parsed.data;
+  const params = parseBody(MemoryIngestParamsSchema, body ?? {});
   try {
     return await ingestPages(getWorkspaceDir(), params.pages, {
       dryRun: params.dryRun,

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -10,6 +10,7 @@
 
 import { ROUTES as MEMORY_EVAL_ROUTES } from "../../plugins/defaults/memory/src/memory-eval-routes.js";
 import { ROUTES as MEMORY_GRAPH_ROUTES } from "../../plugins/defaults/memory/src/memory-graph-routes.js";
+import { ROUTES as MEMORY_INGEST_ROUTES } from "../../plugins/defaults/memory/src/memory-ingest-routes.js";
 import { ROUTES as MEMORY_ITEM_ROUTES } from "../../plugins/defaults/memory/src/memory-item-routes.js";
 import { ROUTES as MEMORY_V2_ROUTES } from "../../plugins/defaults/memory/src/memory-v2-routes.js";
 import { ROUTES as MEMORY_V3_ROUTES } from "../../plugins/defaults/memory/src/memory-v3-routes.js";
@@ -248,6 +249,7 @@ export const ROUTES: RouteDefinition[] = [
   ...LLM_CALL_SITES_ROUTES,
   ...MEMORY_EVAL_ROUTES,
   ...MEMORY_GRAPH_ROUTES,
+  ...MEMORY_INGEST_ROUTES,
   ...MEMORY_ITEM_ROUTES,
   ...MEMORY_V2_ROUTES,
   ...MEMORY_V3_ROUTES,


### PR DESCRIPTION
## Summary
- POST /v1/memory/ingest: settings.write actor route over substrate ingestPages (dry-run, overwrite, per-page results; Conflict on held lock)
- openapi regenerated; FROZEN NAMES + memory.md write-path docs updated

Part of plan: memory-ingestion.md (PR 6 of 11)