### PR TITLE
feat(cli): `assistant memory ingest` - batch-ingest staged concept pages

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -73,6 +73,7 @@ const BASELINE: Record<string, readonly string[]> = {
   ],
   "image-recovery": ["src/daemon/conversation-error.ts"],
   memory: [
+    "src/cli/commands/memory/memory-ingest.ts",
     "src/cli/commands/memory/memory-retrospective.ts",
     "src/cli/commands/memory/memory-v2-compare-render.ts",
     "src/cli/commands/memory/memory-v2.ts",

--- a/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
@@ -20,6 +20,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
+import { assertNotLiveDb } from "../../../../__tests__/assert-not-live-db.js";
 import { applyCommandHelp } from "../../../lib/cli-command-help.js";
 import { memoryHelp } from "../index.help.js";
 
@@ -142,6 +143,7 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   try {
     await fn(dir);
   } finally {
+    assertNotLiveDb(dir);
     rmSync(dir, { recursive: true, force: true });
   }
 }

--- a/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Tests for the `assistant memory ingest` CLI subcommand.
+ *
+ * Validates:
+ *   - Registration under `memory` and the `memory_ingest` operation id with a
+ *     long per-batch IPC timeout.
+ *   - --dir walking: nested .md files derive slugs from relative paths with
+ *     forward slashes (people/alice.md becomes people/alice).
+ *   - Chunking: manifests above 200 pages fan out into multiple IPC calls and
+ *     the summary aggregates across batches.
+ *   - --dry-run and --overwrite pass through to the request body.
+ *   - Invalid page results set exit code 1.
+ *   - Malformed manifests are rejected client-side without any IPC call.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import { applyCommandHelp } from "../../../lib/cli-command-help.js";
+import { memoryHelp } from "../index.help.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+interface CapturedIpcCall {
+  method: string;
+
+  params?: any;
+  options?: { timeoutMs?: number; signal?: AbortSignal };
+}
+
+/** Every `cliIpcCall` invocation, in order. */
+let ipcCalls: CapturedIpcCall[] = [];
+
+/** Computes the mock IPC result for each call; overridable per test. */
+let ipcHandler: (method: string, params?: any) => any = defaultIpcHandler;
+
+/** Captured log output for assertion. */
+let logOutput: string[] = [];
+
+/** Success result echoing one `written` entry per requested page. */
+function defaultIpcHandler(_method: string, params?: any) {
+  const pages = (params?.body?.pages ?? []) as {
+    slug: string;
+    content: string;
+  }[];
+  return {
+    ok: true,
+    result: {
+      results: pages.map((p) => ({
+        slug: p.slug,
+        action: "written",
+        warnings: [],
+      })),
+      written: pages.length,
+      skipped: 0,
+      invalid: 0,
+      dryRun: params?.body?.dryRun === true,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (
+    method: string,
+
+    params?: any,
+    options?: { timeoutMs?: number; signal?: AbortSignal },
+  ) => {
+    ipcCalls.push({ method, params, options });
+    return ipcHandler(method, params);
+  },
+  exitFromIpcResult: (r: { statusCode?: number }) => {
+    process.exitCode = r.statusCode === undefined ? 10 : 1;
+  },
+}));
+
+const capture = (...args: unknown[]) => {
+  logOutput.push(args.map(String).join(" "));
+};
+const fakeLogger = {
+  info: capture,
+  warn: capture,
+  error: capture,
+  debug: () => {},
+};
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => fakeLogger,
+  getCliLogger: () => fakeLogger,
+}));
+
+// ---------------------------------------------------------------------------
+// Import modules under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerMemoryIngestCommand } = await import("../memory-ingest.js");
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeErr: () => {},
+    writeOut: () => {},
+  });
+  const memory = program.command("memory");
+  applyCommandHelp(memory, memoryHelp);
+  registerMemoryIngestCommand(memory);
+  return program;
+}
+
+async function runCommand(args: string[]): Promise<{ exitCode: number }> {
+  process.exitCode = 0;
+  try {
+    const program = buildProgram();
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) {
+      process.exitCode = 1;
+    }
+  }
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+  return { exitCode };
+}
+
+/** Create a temp dir, run the callback, and always clean it up. */
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "memory-ingest-test-"));
+  try {
+    await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Write a JSON manifest of `count` synthetic pages and return its path. */
+function writeManifest(dir: string, count: number): string {
+  const pages = Array.from({ length: count }, (_, i) => ({
+    slug: `topics/page-${String(i).padStart(3, "0")}`,
+    content: `---\ntitle: Page ${i}\n---\nBody ${i}\n`,
+  }));
+  const path = join(dir, "manifest.json");
+  writeFileSync(path, JSON.stringify(pages));
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ipcCalls = [];
+  ipcHandler = defaultIpcHandler;
+  logOutput = [];
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Registration + operation id
+// ---------------------------------------------------------------------------
+
+describe("registration", () => {
+  test("registers ingest under memory", () => {
+    const program = buildProgram();
+    const memory = program.commands.find((c) => c.name() === "memory");
+    expect(memory).toBeDefined();
+    const ingest = memory!.commands.find((c) => c.name() === "ingest");
+    expect(ingest).toBeDefined();
+  });
+
+  test("sends memory_ingest with a 5-minute per-batch IPC timeout", async () => {
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 2);
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        manifest,
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(ipcCalls).toHaveLength(1);
+      expect(ipcCalls[0].method).toBe("memory_ingest");
+      expect(ipcCalls[0].options!.timeoutMs).toBe(5 * 60 * 1000);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --dir walking + slug derivation
+// ---------------------------------------------------------------------------
+
+describe("--dir input", () => {
+  test("derives slugs from relative paths with forward slashes", async () => {
+    await withTempDir(async (dir) => {
+      mkdirSync(join(dir, "people"), { recursive: true });
+      writeFileSync(join(dir, "people", "alice.md"), "# Alice\n");
+      writeFileSync(join(dir, "top.md"), "# Top\n");
+      writeFileSync(join(dir, "notes.txt"), "not a page");
+
+      const { exitCode } = await runCommand(["memory", "ingest", "--dir", dir]);
+
+      expect(exitCode).toBe(0);
+      expect(ipcCalls).toHaveLength(1);
+      const pages = ipcCalls[0].params!.body.pages as {
+        slug: string;
+        content: string;
+      }[];
+      expect(pages.map((p) => p.slug)).toEqual(["people/alice", "top"]);
+      expect(pages[0].content).toBe("# Alice\n");
+      expect(pages[1].content).toBe("# Top\n");
+    });
+  });
+
+  test("fails with an actionable error when the directory does not exist", async () => {
+    const { exitCode } = await runCommand([
+      "memory",
+      "ingest",
+      "--dir",
+      "/nonexistent/staging-dir",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(ipcCalls).toHaveLength(0);
+    expect(logOutput.join("\n")).toContain("Directory not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chunking + aggregation
+// ---------------------------------------------------------------------------
+
+describe("batching", () => {
+  test("chunks above 200 pages into multiple IPC calls and aggregates the summary", async () => {
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 250);
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        manifest,
+        "--json",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(ipcCalls).toHaveLength(2);
+      expect(ipcCalls[0].params!.body.pages).toHaveLength(200);
+      expect(ipcCalls[1].params!.body.pages).toHaveLength(50);
+
+      const summary = JSON.parse(logOutput.at(-1)!);
+      expect(summary.written).toBe(250);
+      expect(summary.skipped).toBe(0);
+      expect(summary.invalid).toBe(0);
+      expect(summary.results).toHaveLength(250);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flag pass-through
+// ---------------------------------------------------------------------------
+
+describe("flag pass-through", () => {
+  test("--dry-run and --overwrite are forwarded in the request body", async () => {
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 1);
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        manifest,
+        "--dry-run",
+        "--overwrite",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(ipcCalls).toHaveLength(1);
+      expect(ipcCalls[0].params!.body.dryRun).toBe(true);
+      expect(ipcCalls[0].params!.body.overwrite).toBe(true);
+    });
+  });
+
+  test("omits dryRun and overwrite from the body when the flags are absent", async () => {
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 1);
+
+      await runCommand(["memory", "ingest", "--file", manifest]);
+
+      expect(ipcCalls).toHaveLength(1);
+      expect(ipcCalls[0].params!.body).not.toContainKey("dryRun");
+      expect(ipcCalls[0].params!.body).not.toContainKey("overwrite");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid results
+// ---------------------------------------------------------------------------
+
+describe("invalid page results", () => {
+  test("sets exit code 1 and reports each invalid slug", async () => {
+    ipcHandler = () => ({
+      ok: true,
+      result: {
+        results: [
+          { slug: "good/page", action: "written", warnings: [] },
+          {
+            slug: "bad/page",
+            action: "invalid",
+            warnings: [],
+            error: "missing frontmatter",
+          },
+        ],
+        written: 1,
+        skipped: 0,
+        invalid: 1,
+        dryRun: false,
+      },
+    });
+
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 2);
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        manifest,
+      ]);
+
+      expect(exitCode).toBe(1);
+      const output = logOutput.join("\n");
+      expect(output).toContain("bad/page");
+      expect(output).toContain("missing frontmatter");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client-side validation
+// ---------------------------------------------------------------------------
+
+describe("manifest validation", () => {
+  test("rejects a non-array manifest without any IPC call", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, "manifest.json");
+      writeFileSync(path, JSON.stringify({ not: "an array" }));
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        path,
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(ipcCalls).toHaveLength(0);
+      expect(logOutput.join("\n")).toContain("must be a JSON array");
+    });
+  });
+
+  test("rejects a page missing content with a per-index error and no IPC call", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, "manifest.json");
+      writeFileSync(
+        path,
+        JSON.stringify([
+          { slug: "ok/page", content: "body" },
+          { slug: "broken/page" },
+        ]),
+      );
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        path,
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(ipcCalls).toHaveLength(0);
+      expect(logOutput.join("\n")).toContain("[1].content");
+    });
+  });
+
+  test("rejects unparseable JSON without any IPC call", async () => {
+    await withTempDir(async (dir) => {
+      const path = join(dir, "manifest.json");
+      writeFileSync(path, "{ not json");
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        path,
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(ipcCalls).toHaveLength(0);
+      expect(logOutput.join("\n")).toContain("Invalid JSON manifest");
+    });
+  });
+
+  test("rejects passing both --dir and --file", async () => {
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 1);
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--dir",
+        dir,
+        "--file",
+        manifest,
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(ipcCalls).toHaveLength(0);
+      expect(logOutput.join("\n")).toContain("not both");
+    });
+  });
+});

--- a/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
@@ -356,6 +356,32 @@ describe("invalid page results", () => {
 // ---------------------------------------------------------------------------
 
 describe("manifest validation", () => {
+  test("rejects duplicate slugs that would land in different chunks, with no IPC call", async () => {
+    await withTempDir(async (dir) => {
+      // 201 entries: entry 0 and entry 200 share a slug, so they would be
+      // split across two 200-page batches and evade the route's per-request
+      // duplicate check.
+      const manifest = Array.from({ length: 201 }, (_, i) => ({
+        slug: i === 200 ? "page-0" : `page-${String(i)}`,
+        content: "body",
+      }));
+      const path = join(dir, "manifest.json");
+      writeFileSync(path, JSON.stringify(manifest));
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        path,
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(ipcCalls).toHaveLength(0);
+      expect(logOutput.join("\n")).toContain("Duplicate slugs in input");
+      expect(logOutput.join("\n")).toContain("page-0");
+    });
+  });
+
   test("rejects a non-array manifest without any IPC call", async () => {
     await withTempDir(async (dir) => {
       const path = join(dir, "manifest.json");

--- a/assistant/src/cli/commands/memory/index.help.ts
+++ b/assistant/src/cli/commands/memory/index.help.ts
@@ -35,7 +35,8 @@ Examples:
   $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --statement "Prefers tea"
   $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123
   $ assistant memory v2 validate
-  $ assistant memory v3 rebuild-index`,
+  $ assistant memory v3 rebuild-index
+  $ assistant memory ingest --dir .mv3/staging --dry-run`,
   subcommands: [
     {
       name: "nodes",
@@ -760,6 +761,59 @@ Example:
   $ assistant memory v3 eval-tally --verdicts .mv3/eval/verdicts.json --key .mv3/eval/key.json`,
         },
       ],
+    },
+    {
+      name: "ingest",
+      description:
+        "Batch-ingest staged concept pages directly into memory (bypasses the consolidation buffer)",
+      options: [
+        {
+          flags: "--dir <path>",
+          description:
+            "Directory of staged .md pages; slug = relative path minus .md, with forward slashes",
+        },
+        {
+          flags: "--file <path>",
+          description:
+            "JSON manifest file: an array of { slug, content } objects",
+        },
+        {
+          flags: "--dry-run",
+          description: "Validate and report without writing any pages",
+        },
+        {
+          flags: "--overwrite",
+          description:
+            "Rewrite pages whose slug already exists (default: skip them)",
+        },
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON summary output",
+        },
+      ],
+      helpText: `
+Input sources (pick exactly one):
+  --dir   Walks the directory recursively for .md files. Each file's slug is
+          its relative path minus the .md extension, with forward slashes
+          (people/alice.md becomes people/alice).
+  --file  Reads a JSON manifest: an array of { slug, content } objects where
+          content is the full page markdown (frontmatter + body).
+  stdin   With neither flag, the same JSON manifest is read from stdin when
+          it is piped (not a TTY).
+
+Behavior:
+  Writes fully-formed concept pages straight into memory/concepts/, bypassing
+  the consolidation buffer. Pages whose slug already exists are skipped unless
+  --overwrite is passed. Every page is validated and reported individually;
+  invalid pages set a non-zero exit code without blocking valid ones. Requests
+  are sent in batches of 200 pages. When the consolidation lock is held the
+  command fails and names the holder; retry after the current writer finishes.
+  Requires concept-page memory (memory.v3.live or memory.v2.enabled).
+
+Examples:
+  $ assistant memory ingest --dir .mv3/staging --dry-run
+  $ assistant memory ingest --dir .mv3/staging --overwrite
+  $ cat pages.json | assistant memory ingest --json`,
     },
     {
       name: "retrospective",

--- a/assistant/src/cli/commands/memory/index.ts
+++ b/assistant/src/cli/commands/memory/index.ts
@@ -4,6 +4,7 @@ import { applyCommandHelp } from "../../lib/cli-command-help.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { memoryHelp } from "./index.help.js";
 import { registerMemoryItemsCommand } from "./items.js";
+import { registerMemoryIngestCommand } from "./memory-ingest.js";
 import { registerMemoryRetrospectiveCommand } from "./memory-retrospective.js";
 import { registerMemoryV2Command } from "./memory-v2.js";
 import { registerMemoryV3Command } from "./memory-v3.js";
@@ -22,6 +23,7 @@ export function registerMemoryCommand(program: Command): void {
       registerMemoryItemsCommand(memory);
       registerMemoryV2Command(memory);
       registerMemoryV3Command(memory);
+      registerMemoryIngestCommand(memory);
       registerMemoryRetrospectiveCommand(memory);
       registerMemoryWorkerCommand(memory);
     },

--- a/assistant/src/cli/commands/memory/memory-ingest.ts
+++ b/assistant/src/cli/commands/memory/memory-ingest.ts
@@ -1,0 +1,221 @@
+/**
+ * `assistant memory ingest` subcommand.
+ *
+ * Batch-ingests fully-formed concept pages (frontmatter + body markdown)
+ * straight into memory/concepts/ via the daemon's `memory_ingest` route,
+ * bypassing the consolidation buffer. Input comes from a staging directory
+ * of .md files (--dir), a JSON manifest file (--file), or piped stdin.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import type { MemoryIngestResult } from "../../../plugins/defaults/memory/src/memory-ingest-routes.js";
+import { readStdinSync } from "../../../util/read-stdin.js";
+import { subcommand } from "../../lib/cli-command-help.js";
+import { log } from "../../logger.js";
+
+/**
+ * IPC timeout for `ingest`. A batch validates and writes up to 200 pages
+ * under the consolidation lock and enqueues reindex follow-up jobs, which
+ * can outlast `cliIpcCall`'s default 60s on large batches, so allow a
+ * generous 5-minute ceiling per batch rather than report a spurious
+ * "Request timed out" while the assistant keeps working.
+ */
+const INGEST_IPC_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Pages per `memory_ingest` call (the route caps a request at 200 pages). */
+const MAX_PAGES_PER_CALL = 200;
+
+interface IngestPage {
+  slug: string;
+  content: string;
+}
+
+/** Recursively collect .md files under `dir`; slug = relative path minus `.md`. */
+function walkMarkdownFiles(root: string, dir: string, out: IngestPage[]): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkMarkdownFiles(root, full, out);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      const rel = relative(root, full);
+      const slug = rel.slice(0, -".md".length).split(sep).join("/");
+      out.push({ slug, content: readFileSync(full, "utf-8") });
+    }
+  }
+}
+
+/** Validate a parsed JSON manifest into pages, with per-index error messages. */
+function validateManifest(raw: unknown): IngestPage[] {
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      "Manifest must be a JSON array of { slug, content } objects.",
+    );
+  }
+  return raw.map((item, i) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error(
+        `Manifest item [${i}] must be an object with string 'slug' and 'content' fields.`,
+      );
+    }
+    const { slug, content } = item as Record<string, unknown>;
+    if (typeof slug !== "string" || slug.length === 0) {
+      throw new Error(
+        `Manifest item [${i}].slug is required and must be a non-empty string.`,
+      );
+    }
+    if (typeof content !== "string") {
+      throw new Error(
+        `Manifest item [${i}].content is required and must be a string (the full page markdown).`,
+      );
+    }
+    return { slug, content };
+  });
+}
+
+/** Assemble the page list from --dir, --file, or piped stdin. */
+function loadPages(opts: { dir?: string; file?: string }): IngestPage[] {
+  if (opts.dir !== undefined && opts.file !== undefined) {
+    throw new Error(
+      "Pass either --dir or --file, not both. Drop one of the two input flags.",
+    );
+  }
+  if (opts.dir !== undefined) {
+    let stats;
+    try {
+      stats = statSync(opts.dir);
+    } catch {
+      throw new Error(`Directory not found: ${opts.dir}`);
+    }
+    if (!stats.isDirectory()) {
+      throw new Error(`Not a directory: ${opts.dir}`);
+    }
+    const pages: IngestPage[] = [];
+    walkMarkdownFiles(opts.dir, opts.dir, pages);
+    pages.sort((a, b) => a.slug.localeCompare(b.slug));
+    return pages;
+  }
+  let raw: string;
+  if (opts.file !== undefined) {
+    if (!existsSync(opts.file)) {
+      throw new Error(`File not found: ${opts.file}`);
+    }
+    raw = readFileSync(opts.file, "utf-8");
+  } else {
+    if (process.stdin.isTTY) {
+      throw new Error(
+        "No input provided. Pipe JSON into stdin or use --file <path> or --dir <path>.",
+      );
+    }
+    raw = readStdinSync();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid JSON manifest: ${msg}`);
+  }
+  return validateManifest(parsed);
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+}
+
+export function registerMemoryIngestCommand(memory: Command): void {
+  subcommand(memory, "ingest").action(
+    async (opts: {
+      dir?: string;
+      file?: string;
+      dryRun?: boolean;
+      overwrite?: boolean;
+      json?: boolean;
+    }) => {
+      let pages: IngestPage[];
+      try {
+        pages = loadPages(opts);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.json === true) {
+          log.info(JSON.stringify({ ok: false, error: msg }));
+        } else {
+          log.error(`Error: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const aggregate: MemoryIngestResult = {
+        results: [],
+        written: 0,
+        skipped: 0,
+        invalid: 0,
+        dryRun: opts.dryRun === true,
+      };
+
+      if (pages.length === 0) {
+        if (opts.json === true) {
+          log.info(JSON.stringify(aggregate));
+        } else {
+          log.info("No pages to ingest.");
+        }
+        return;
+      }
+      for (const batch of chunk(pages, MAX_PAGES_PER_CALL)) {
+        const r = await cliIpcCall<MemoryIngestResult>(
+          "memory_ingest",
+          {
+            body: {
+              pages: batch,
+              ...(opts.dryRun === true ? { dryRun: true } : {}),
+              ...(opts.overwrite === true ? { overwrite: true } : {}),
+            },
+          },
+          { timeoutMs: INGEST_IPC_TIMEOUT_MS },
+        );
+        if (!r.ok) {
+          return exitFromIpcResult(r);
+        }
+        const payload = r.result!;
+        aggregate.results.push(...payload.results);
+        aggregate.written += payload.written;
+        aggregate.skipped += payload.skipped;
+        aggregate.invalid += payload.invalid;
+      }
+
+      if (opts.json === true) {
+        log.info(JSON.stringify(aggregate));
+      } else {
+        const verb = aggregate.dryRun ? "Would write" : "Wrote";
+        log.info(
+          `${verb} ${aggregate.written} page(s); skipped ${aggregate.skipped} existing; ${aggregate.invalid} invalid.`,
+        );
+        for (const res of aggregate.results) {
+          for (const warning of res.warnings) {
+            log.warn(`  ${res.slug}: ${warning}`);
+          }
+          if (res.action === "invalid") {
+            log.error(`  invalid ${res.slug}: ${res.error ?? "unknown error"}`);
+          }
+        }
+        if (aggregate.skipped > 0 && opts.overwrite !== true) {
+          log.info(
+            "Re-run with --overwrite to rewrite pages whose slug already exists.",
+          );
+        }
+      }
+      if (aggregate.invalid > 0) {
+        process.exitCode = 1;
+      }
+    },
+  );
+}

--- a/assistant/src/cli/commands/memory/memory-ingest.ts
+++ b/assistant/src/cli/commands/memory/memory-ingest.ts
@@ -123,6 +123,35 @@ function loadPages(opts: { dir?: string; file?: string }): IngestPage[] {
   return validateManifest(parsed);
 }
 
+/**
+ * Reject duplicate slugs across the whole input before chunking. The route's
+ * duplicate check is per request, so duplicates that land in different
+ * 200-page batches would bypass it: without --overwrite the later copy is
+ * misreported as an existing-page skip, and with --overwrite it silently
+ * replaces the earlier one.
+ */
+function assertUniqueSlugs(pages: IngestPage[]): IngestPage[] {
+  const firstIndexBySlug = new Map<string, number>();
+  const duplicates: string[] = [];
+  for (const [index, page] of pages.entries()) {
+    const first = firstIndexBySlug.get(page.slug);
+    if (first === undefined) {
+      firstIndexBySlug.set(page.slug, index);
+    } else {
+      duplicates.push(
+        `"${page.slug}" (entries ${String(first)} and ${String(index)})`,
+      );
+    }
+  }
+  if (duplicates.length > 0) {
+    throw new Error(
+      `Duplicate slugs in input: ${duplicates.join(", ")}. ` +
+        "Each slug may appear once per ingest.",
+    );
+  }
+  return pages;
+}
+
 function chunk<T>(items: T[], size: number): T[][] {
   const batches: T[][] = [];
   for (let i = 0; i < items.length; i += size) {
@@ -142,7 +171,7 @@ export function registerMemoryIngestCommand(memory: Command): void {
     }) => {
       let pages: IngestPage[];
       try {
-        pages = loadPages(opts);
+        pages = assertUniqueSlugs(loadPages(opts));
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (opts.json === true) {

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -610,6 +610,7 @@ describe("command-registry", () => {
       expect(getAssistantPath("memory items create").baseRisk).toBe("medium");
       expect(getAssistantPath("memory items update").baseRisk).toBe("medium");
       expect(getAssistantPath("memory items delete").baseRisk).toBe("medium");
+      expect(getAssistantPath("memory ingest").baseRisk).toBe("medium");
       expect(getAssistantPath("plugins list").baseRisk).toBe("low");
       expect(getAssistantPath("plugins inspect").baseRisk).toBe("low");
       expect(getAssistantPath("plugins diff").baseRisk).toBe("low");

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -173,6 +173,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "mcp auth",
   "mcp remove",
   "memory",
+  "memory ingest",
   "memory nodes",
   "memory nodes stats",
   "memory nodes list",
@@ -615,6 +616,12 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "mcp add", risk: "high" },
   { path: "mcp auth", risk: "medium" },
   { path: "mcp remove", risk: "low" },
+  {
+    path: "memory ingest",
+    risk: "medium",
+    reason:
+      "Writes concept pages directly into assistant memory, bypassing the consolidation buffer, and enqueues reindex jobs",
+  },
   {
     path: "memory nodes delete",
     risk: "medium",


### PR DESCRIPTION
## Summary
- New memory ingest subcommand: --dir/--file/stdin input, client-side validation, 200-page batching, dry-run/overwrite, aggregated human and --json output
- Declarative help entry, gateway risk-registry coverage, CLI tests

Part of plan: memory-ingestion.md (PR 7 of 11)