### PR TITLE
fix: web stt-language consolidation (shared labels, single provider derivation)

### DIFF
--- a/clients/web/src/components/speech/stt-provider-form.tsx
+++ b/clients/web/src/components/speech/stt-provider-form.tsx
@@ -167,34 +167,25 @@ export function SttProviderForm({
   const {
     available: languageAvailable,
     currentCode: languageCode,
-    isLanguageSelectable,
+    configuredProviderId: languageProviderId,
     selectLanguage,
   } = useSttLanguageSelection(assistantId);
-  // A language pick hot-applies to the daemon's CONFIGURED provider, so the
-  // picker binds to that provider and hides while the dropdown holds an
+  // A language pick hot-applies to the daemon's CONFIGURED provider (the
+  // hook's `configuredProviderId`, which its `available` already vets), so
+  // the picker binds to that provider and hides while the dropdown holds an
   // unsaved draft of a different one: offering the draft's languages would
   // write a value the still-active provider may ignore (e.g. Multilingual
-  // drafted for Vellum while xAI runs, whose resolver drops "multi"). With
-  // no pending draft, the steered id is the daemon's own provider when the
-  // dropdown can't represent it (e.g. xai via CLI renders as a placeholder),
-  // otherwise the selection's mapping. The client-only native choice has no
-  // daemon mapping (its recognizer never reads `services.stt.language`), so
-  // it resolves to undefined and the capability check below hides the
-  // picker.
-  const languageDaemonProviderId = useMemo(() => {
-    if (draftProvider !== serverProvider) {
-      return undefined;
-    }
-    if (daemonSttProvider && !CARD_ID_BY_DAEMON_PROVIDER[daemonSttProvider]) {
-      return daemonSttProvider;
-    }
-    return STT_DAEMON_PROVIDER[draftProvider]?.provider;
-  }, [daemonSttProvider, draftProvider, serverProvider]);
-  // Unknown and absent probe entries read as false, hiding the control
-  // rather than offering a language its provider ignores.
-  const draftLanguageSelectable =
-    !!languageDaemonProviderId &&
-    isLanguageSelectable(languageDaemonProviderId);
+  // drafted for Vellum while xAI runs, whose resolver drops "multi"). A
+  // settled selection with no daemon mapping (the client-only native choice,
+  // whose recognizer never reads `services.stt.language`) also hides the
+  // picker, unless the daemon itself runs a provider the dropdown can't
+  // represent (e.g. xai via CLI renders as a placeholder), which is exactly
+  // what the picker steers.
+  const languagePickerVisible =
+    languageAvailable &&
+    draftProvider === serverProvider &&
+    (!!STT_DAEMON_PROVIDER[draftProvider] ||
+      (!!daemonSttProvider && !CARD_ID_BY_DAEMON_PROVIDER[daemonSttProvider]));
   const [apiKeyText, setApiKeyText] = useState("");
   const [providerHasKey, setProviderHasKey] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -383,7 +374,7 @@ export function SttProviderForm({
         />
       </div>
 
-      {languageAvailable && draftLanguageSelectable && (
+      {languagePickerVisible && (
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Spoken language
@@ -393,10 +384,12 @@ export function SttProviderForm({
             onChange={selectLanguage}
             options={sttLanguageOptionsFor(
               languageCode,
-              languageDaemonProviderId ?? "",
+              languageProviderId,
             ).map((l) => ({
               value: l.code,
               label: sttLanguageLabel(l),
+              // The design-library Dropdown has no visible per-option
+              // description line, so the copy rides the hover tooltip.
               tooltip: l.description,
             }))}
             aria-label="Spoken language"

--- a/clients/web/src/components/speech/use-stt-language-selection.test.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.test.ts
@@ -140,28 +140,38 @@ describe("useSttLanguageSelection", () => {
     expect(result.current.currentCode).toBe("");
   });
 
-  test("isLanguageSelectable reflects the probe per daemon provider id", () => {
-    // A form gates its picker on the DRAFT provider through this, so it must
-    // answer for ids other than the configured one.
-    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+  test("exposes the configured provider id, mapping legacy managed mode", () => {
+    // Surfaces build their option list from this, so the config narrowing
+    // (managed-mode aliasing, the schema-default fallback) lives here once.
+    daemonConfigData = {
+      services: { stt: { mode: "managed", provider: "deepgram" } },
+    };
     providerCatalogData = {
       providers: [
         { id: "vellum", displayName: "Vellum", languageSelection: "manual" },
-        {
-          id: "openai-whisper",
-          displayName: "Whisper",
-          languageSelection: "auto",
-        },
-        { id: "deepgram", displayName: "Deepgram" },
       ],
     };
 
     const { result } = renderSelection();
-    expect(result.current.isLanguageSelectable("vellum")).toBe(true);
-    expect(result.current.isLanguageSelectable("openai-whisper")).toBe(false);
-    // Absent capability field (old daemon) and unknown ids read as false.
-    expect(result.current.isLanguageSelectable("deepgram")).toBe(false);
-    expect(result.current.isLanguageSelectable("xai")).toBe(false);
+    expect(result.current.configuredProviderId).toBe("vellum");
+    expect(result.current.available).toBe(true);
+  });
+
+  test("an unset provider reads as the daemon schema default", () => {
+    daemonConfigData = { services: {} };
+    providerCatalogData = {
+      providers: [
+        {
+          id: "deepgram",
+          displayName: "Deepgram",
+          languageSelection: "manual",
+        },
+      ],
+    };
+
+    const { result } = renderSelection();
+    expect(result.current.configuredProviderId).toBe("deepgram");
+    expect(result.current.available).toBe(true);
   });
 
   test("a pick issues one services.stt.language PATCH", async () => {

--- a/clients/web/src/components/speech/use-stt-language-selection.ts
+++ b/clients/web/src/components/speech/use-stt-language-selection.ts
@@ -18,8 +18,6 @@
  * pretending to save a language the daemon would ignore.
  */
 
-import { useCallback } from "react";
-
 import { useQuery } from "@tanstack/react-query";
 
 import {
@@ -75,15 +73,6 @@ export interface UseSttLanguageSelection {
    */
   configuredProviderId: string;
   /**
-   * Whether the daemon probe reports the given daemon provider id as
-   * manually language-selectable. `available` describes the CONFIGURED
-   * provider; a form whose dropdown holds an unsaved DRAFT choice gates its
-   * picker on the draft's daemon id through this instead, so switching to an
-   * auto-detecting provider hides the control before Save. Unknown ids and
-   * old daemons that omit the capability field read as false.
-   */
-  isLanguageSelectable: (daemonProviderId: string) => boolean;
-  /**
    * Persist a language; hot-applies from the next spoken turn. Safe to call
    * again before the last one lands, writes are serialized in call order.
    */
@@ -123,15 +112,12 @@ export function useSttLanguageSelection(
       ? "vellum"
       : (daemonStt?.provider ?? "deepgram");
 
-  const catalogProviders = providerCatalog?.providers;
-  const isLanguageSelectable = useCallback(
-    (daemonProviderId: string) =>
-      catalogProviders?.find((p) => p.id === daemonProviderId)
-        ?.languageSelection === "manual",
-    [catalogProviders],
-  );
-
-  const providerAcceptsLanguage = isLanguageSelectable(configuredProvider);
+  // Unknown ids and old daemons that omit the capability field read as
+  // false, so the surfaces render no control rather than pretending to save
+  // a language the daemon would ignore.
+  const providerAcceptsLanguage =
+    providerCatalog?.providers?.find((p) => p.id === configuredProvider)
+      ?.languageSelection === "manual";
 
   // Gated on config having actually arrived: before then the configured
   // provider is a guess, and the control must not flash in and out.
@@ -160,7 +146,6 @@ export function useSttLanguageSelection(
     available,
     currentCode,
     configuredProviderId: configuredProvider,
-    isLanguageSelectable,
     selectLanguage,
     selecting,
   };

--- a/clients/web/src/domains/chat/voice/voice-room/listening-language-row.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/listening-language-row.tsx
@@ -24,10 +24,7 @@ import { ChevronRight } from "lucide-react";
 
 import { cn } from "@vellumai/design-library";
 
-import {
-  sttLanguageLabel,
-  sttLanguageOptionsFor,
-} from "@/lib/stt/language-catalog";
+import { sttLanguageLabelForCode } from "@/lib/stt/language-catalog";
 
 export interface ListeningLanguageRowProps {
   /**
@@ -55,10 +52,6 @@ export function ListeningLanguageRow({
     return null;
   }
 
-  const current = sttLanguageOptionsFor(currentCode, configuredProviderId).find(
-    (option) => option.code === currentCode,
-  );
-
   return (
     <div className={cn("flex flex-col", className)}>
       {/* Same straight full-width divider the Voice row draws (a border on a
@@ -73,7 +66,7 @@ export function ListeningLanguageRow({
           Listening language
         </span>
         <span className="min-w-0 flex-1 truncate text-right text-label-small-default text-[var(--content-tertiary)]">
-          {current ? sttLanguageLabel(current) : currentCode}
+          {sttLanguageLabelForCode(currentCode, configuredProviderId)}
         </span>
         <ChevronRight className="size-4 shrink-0 self-center text-[var(--content-tertiary)]" />
       </button>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -66,7 +66,6 @@ const STT_LANGUAGE_SELECTION_DEFAULTS = {
   available: false,
   currentCode: "",
   configuredProviderId: "vellum",
-  isLanguageSelectable: () => false,
   selectLanguage: (_code: string) => {},
   selecting: false,
 };

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -22,6 +22,7 @@ import { useSttLanguageSelection } from "@/components/speech/use-stt-language-se
 import { VoiceList } from "@/components/speech/voice-list";
 import { VoiceProvidersNote } from "@/components/speech/voice-providers-note";
 import {
+  sttLanguageLabel,
   sttLanguageOptionsFor,
   suggestedLanguageForLocale,
 } from "@/lib/stt/language-catalog";
@@ -103,7 +104,9 @@ function listeningLanguageOptions(
     configuredProviderId,
   ).map((l) => ({
     value: l.code,
-    label: l.nativeLabel ? `${l.label} (${l.nativeLabel})` : l.label,
+    label: sttLanguageLabel(l),
+    // The design-library Dropdown has no visible per-option description
+    // line, so the copy rides the hover tooltip.
     tooltip: l.description,
   }));
   // The suggestion can be absent (a language-selectable provider whose

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
@@ -70,7 +70,6 @@ let languageSelection = {
   available: false,
   currentCode: "",
   configuredProviderId: "vellum",
-  isLanguageSelectable: () => false,
   selectLanguage: (code: string) => languagePicks.push(code),
   selecting: false,
 };
@@ -95,7 +94,6 @@ function useMockSttLanguageSelection() {
     available: true,
     currentCode: serialized.currentValue,
     configuredProviderId: "vellum",
-    isLanguageSelectable: () => true,
     selectLanguage: serialized.select,
     selecting: serialized.selecting,
   };

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -163,7 +163,6 @@ mock.module("@/components/speech/use-stt-language-selection", () => ({
     available: false,
     currentCode: "",
     configuredProviderId: "vellum",
-    isLanguageSelectable: () => false,
     selectLanguage: () => {},
     selecting: false,
   }),

--- a/clients/web/src/lib/stt/language-catalog.test.ts
+++ b/clients/web/src/lib/stt/language-catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   STT_LANGUAGES,
   STT_MULTI_CODE,
+  sttLanguageLabelForCode,
   sttLanguageOptionsFor,
   suggestedLanguageForLocale,
 } from "./language-catalog";
@@ -81,6 +82,33 @@ describe("sttLanguageOptionsFor", () => {
       code: "en-US",
       label: "en-US (custom)",
     });
+  });
+});
+
+describe("sttLanguageLabelForCode", () => {
+  test("labels a catalog code with its native name", () => {
+    expect(sttLanguageLabelForCode("fr", "deepgram")).toBe("French (Français)");
+  });
+
+  test("labels the default code", () => {
+    expect(sttLanguageLabelForCode("", "deepgram")).toBe("English (default)");
+  });
+
+  test("labels multi under a multi-capable provider", () => {
+    expect(sttLanguageLabelForCode(STT_MULTI_CODE, "vellum")).toBe(
+      "Multilingual",
+    );
+  });
+
+  test("labels multi under xai via the custom fallback", () => {
+    // The xai catalog omits Multilingual, so the synthetic entry carries it.
+    expect(sttLanguageLabelForCode(STT_MULTI_CODE, "xai")).toBe(
+      "multi (custom)",
+    );
+  });
+
+  test("labels an out-of-catalog code via the custom fallback", () => {
+    expect(sttLanguageLabelForCode("en-US", "deepgram")).toBe("en-US (custom)");
   });
 });
 

--- a/clients/web/src/lib/stt/language-catalog.ts
+++ b/clients/web/src/lib/stt/language-catalog.ts
@@ -93,6 +93,23 @@ export function sttLanguageOptionsFor(
 }
 
 /**
+ * Display label for the code as the provider-scoped option list renders it:
+ * the catalog label when the code is in the catalog (Multilingual under a
+ * multi-capable provider), else the synthetic "(custom)" label. Falls back
+ * to the raw code defensively, though `sttLanguageOptionsFor` always
+ * represents the current code.
+ */
+export function sttLanguageLabelForCode(
+  code: string,
+  daemonProviderId: string,
+): string {
+  const option = sttLanguageOptionsFor(code, daemonProviderId).find(
+    (candidate) => candidate.code === code,
+  );
+  return option ? sttLanguageLabel(option) : code;
+}
+
+/**
  * Suggested STT language for a browser locale (`navigator.language`), or
  * `null` when no suggestion applies (English, empty, or outside the catalog).
  *


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for stt-language-selection.md.

**Gap:** the first-run card re-implemented the shared label helper; three parallel derivations of the steered provider id; single-consumer hook member; dead fallback; multi description hover-gated where a visible line may be supported.