### PR TITLE
fix: xai batch language handling and deepgram option consolidation

### DIFF
--- a/assistant/docs/stt-provider-onboarding.md
+++ b/assistant/docs/stt-provider-onboarding.md
@@ -30,7 +30,7 @@ This ensures the exhaustive switch in `daemon-batch-transcriber.ts` produces a c
 
 The `services.stt.providers` map uses a sparse `z.record(z.string(), ...)` schema, so adding a new provider does **not** require a workspace migration to seed a `services.stt.providers.<id>` entry. Users only need to set `services.stt.provider` to the new ID and supply credentials.
 
-**Language handling.** `services.stt.language` is resolved centrally in `resolveStreamingTranscriber()` (and in `resolveBatchTranscriber()` for the daemon-batch boundary), so a new adapter inherits it for free: accept a `language` option in the adapter's constructor and forward it to the provider. If the provider auto-detects natively and has no language parameter (as Gemini and Whisper do), accept nothing and let the resolver's value be ignored; document that choice in the adapter, because "no language param" means auto-detect for some providers and _English_ for others (Deepgram), and that difference has already caused one bug.
+**Language handling.** `services.stt.language` is resolved centrally in `resolveStreamingTranscriber()` (and in `resolveBatchTranscriber()` for the daemon-batch boundary), so a new adapter inherits it for free: accept a `language` option in the adapter's constructor and forward it to the provider. If the provider auto-detects natively and has no language parameter (as Gemini and Whisper do), accept nothing and let the resolver's value be ignored; document that choice in the adapter, because "no language param" means auto-detect for some providers and _English_ for others (Deepgram), and that difference is an easy source of silent wrong-language transcription. A provider that supports both batch and streaming must forward the language on **both** paths, not just the streaming one.
 
 ## 4. Adapter wiring
 
@@ -54,13 +54,14 @@ If the new provider **shares** an existing credential name (e.g. reuses `"openai
 
 All client-facing metadata is part of the daemon's provider catalog entry (`src/providers/speech-to-text/provider-catalog.ts`). When adding a new provider, include these fields in the catalog entry:
 
-| Field              | Description                                                              |
-| ------------------ | ------------------------------------------------------------------------ |
-| `displayName`      | Human-readable name shown in client settings UI.                         |
-| `subtitle`         | Short description displayed below the provider selector.                 |
-| `setupMode`        | `"api-key"` (inline key field) or `"cli"` (instructions-only).           |
-| `setupHint`        | Brief guidance shown during setup.                                       |
-| `credentialsGuide` | Object with `description`, `url`, and `linkLabel` for the key mgmt page. |
+| Field               | Description                                                                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `displayName`       | Human-readable name shown in client settings UI.                                                                                                                        |
+| `subtitle`          | Short description displayed below the provider selector.                                                                                                                |
+| `setupMode`         | `"api-key"` (inline key field) or `"cli"` (instructions-only).                                                                                                          |
+| `setupHint`         | Brief guidance shown during setup.                                                                                                                                      |
+| `languageSelection` | `"manual"` (provider takes a language parameter, clients show a picker) or `"auto"` (native detection, picker hidden). See the "Language handling" paragraph in step 3. |
+| `credentialsGuide`  | Object with `description`, `url`, and `linkLabel` for the key mgmt page.                                                                                                |
 
 Native clients fetch this metadata at launch via `GET /v1/stt/providers`. No separate client-side file updates are needed.
 

--- a/assistant/src/providers/speech-to-text/__tests__/deepgram.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, test } from "bun:test";
 
-import { deepgramModelOverrideForLanguage } from "../deepgram.js";
+import { deepgramLanguageOptions } from "../deepgram.js";
 
-describe("deepgramModelOverrideForLanguage", () => {
-  test('"multi" pins nova-3 (the only model that accepts code-switching)', () => {
-    expect(deepgramModelOverrideForLanguage("multi")).toEqual({
+describe("deepgramLanguageOptions", () => {
+  test('"multi" pairs the language with nova-3 (the only model that accepts code-switching)', () => {
+    expect(deepgramLanguageOptions("multi")).toEqual({
       model: "nova-3",
+      language: "multi",
     });
   });
 
-  test("a specific language returns no override, keeping the caller's default model", () => {
-    expect(deepgramModelOverrideForLanguage("hi")).toEqual({});
+  test("a specific language returns only the language, keeping the caller's default model", () => {
+    expect(deepgramLanguageOptions("hi")).toEqual({ language: "hi" });
   });
 
-  test("an unset language returns no override", () => {
-    expect(deepgramModelOverrideForLanguage(undefined)).toEqual({});
+  test("an unset language returns no options at all", () => {
+    expect(deepgramLanguageOptions(undefined)).toEqual({});
+  });
+
+  test("an empty-string language returns no options at all", () => {
+    expect(deepgramLanguageOptions("")).toEqual({});
   });
 });

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -136,7 +136,7 @@ mock.module("../openai-whisper-stream.js", () => ({
 const deepgramBatchCtorCalls: Array<{ apiKey: string; options: unknown }> = [];
 
 // Real module captured before the mock replaces it, so pure exports
-// (deepgramModelOverrideForLanguage) stay real while the provider class
+// (deepgramLanguageOptions) stay real while the provider class
 // alone is stubbed.
 const actualDeepgram = await import("../deepgram.js");
 

--- a/assistant/src/providers/speech-to-text/deepgram.ts
+++ b/assistant/src/providers/speech-to-text/deepgram.ts
@@ -23,22 +23,34 @@ export interface DeepgramProviderOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Language-derived model override
+// Language-derived constructor options
 // ---------------------------------------------------------------------------
 
 /**
- * Deepgram model override implied by a language selection, for spreading
- * into adapter constructor options.
+ * Deepgram constructor options implied by a language selection, for
+ * spreading into adapter constructor options. Owning the model+language
+ * pairing here keeps the invariant in one place instead of at each call
+ * site (the batch adapter and the realtime resolver spread this the same
+ * way).
  *
- * Deepgram's `"multi"` code-switching language requires nova-3: the default
- * models of the batch and realtime adapters reject `language=multi`, so that
- * value pins `model: "nova-3"`. Every other value (including unset) returns
- * an empty override and keeps the caller's default model.
+ * - Unset returns `{}`: the adapter passes no `language` param, which
+ *   Deepgram decodes as English (NOT auto-detection).
+ * - A normal code returns `{ language }` and keeps the caller's default
+ *   model.
+ * - `"multi"` (code-switching) requires nova-3: the default models of the
+ *   batch and realtime adapters reject `language=multi`, so that value
+ *   also pins `model: "nova-3"`.
  */
-export function deepgramModelOverrideForLanguage(
-  language: string | undefined,
-): { model: string } | Record<string, never> {
-  return language === "multi" ? { model: "nova-3" } : {};
+export function deepgramLanguageOptions(language: string | undefined): {
+  model?: string;
+  language?: string;
+} {
+  if (!language) {
+    return {};
+  }
+  return language === "multi"
+    ? { model: "nova-3", language: "multi" }
+    : { language };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -7,7 +7,7 @@ import type {
   SttProviderId,
 } from "../../stt/types.js";
 import { getLogger } from "../../util/logger.js";
-import { deepgramModelOverrideForLanguage } from "./deepgram.js";
+import { deepgramLanguageOptions } from "./deepgram.js";
 import {
   getCredentialProvider,
   getProviderEntry,
@@ -64,9 +64,11 @@ export async function resolveBatchTranscriber(): Promise<BatchTranscriber | null
   }
 
   const apiKey = await getProviderKeyAsync(credentialProviderName);
-  return createDaemonBatchTranscriber(apiKey, provider as SttProviderId, {
-    ...(language ? { language } : {}),
-  });
+  return createDaemonBatchTranscriber(
+    apiKey,
+    provider as SttProviderId,
+    language,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -478,8 +480,7 @@ async function createStreamingTranscriber(
         await import("./deepgram-realtime.js");
       return new DeepgramRealtimeTranscriber(apiKey, {
         sampleRate: options.sampleRate,
-        ...deepgramModelOverrideForLanguage(options.language),
-        ...(options.language ? { language: options.language } : {}),
+        ...deepgramLanguageOptions(options.language),
         ...(options.diarize ? { diarize: true } : {}),
         ...(options.utteranceBoundaryFinals
           ? {
@@ -549,7 +550,9 @@ async function createStreamingTranscriber(
         sampleRate: options.sampleRate,
         // `language` IS in the relay's param allowlist, and the relay pins
         // the STT model to nova-3 server-side, so "multi" code-switching
-        // needs nothing from the platform, only this forward.
+        // needs nothing from the platform, only this forward. Source:
+        // vellum-assistant-platform: velay/internal/velay/deepgram.go
+        // (deepgramSTTParams allowlist; deepgramSTTModel pin).
         ...(options.language ? { language: options.language } : {}),
         ...(options.utteranceBoundaryFinals
           ? { utteranceBoundaryFinals: true }

--- a/assistant/src/providers/speech-to-text/xai.test.ts
+++ b/assistant/src/providers/speech-to-text/xai.test.ts
@@ -98,6 +98,49 @@ describe("XAIProvider", () => {
     expect((file as Blob).type).toBe("audio/mpeg");
   });
 
+  test("forwards a configured language as a form field, appended before the file", async () => {
+    let capturedBody: FormData | undefined;
+
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedBody = init?.body as FormData;
+      return new Response(JSON.stringify({ text: "hola" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new XAIProvider(TEST_API_KEY, { language: "es" });
+    await provider.transcribe(Buffer.from("fake-audio"), "audio/wav");
+
+    expect(capturedBody!.get("language")).toBe("es");
+    // xAI requires `file` to be the LAST field in the multipart body.
+    expect([...capturedBody!.keys()]).toEqual(["language", "file"]);
+  });
+
+  test("omits the language field entirely when no language is configured", async () => {
+    let capturedBody: FormData | undefined;
+
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedBody = init?.body as FormData;
+      return new Response(JSON.stringify({ text: "hello" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new XAIProvider(TEST_API_KEY);
+    await provider.transcribe(Buffer.from("fake-audio"), "audio/wav");
+
+    expect(capturedBody!.get("language")).toBeNull();
+    expect([...capturedBody!.keys()]).toEqual(["file"]);
+  });
+
   test("returns empty text when API returns empty text field", async () => {
     globalThis.fetch = (async () => {
       return new Response(JSON.stringify({ text: "" }), {

--- a/assistant/src/providers/speech-to-text/xai.ts
+++ b/assistant/src/providers/speech-to-text/xai.ts
@@ -27,14 +27,22 @@ function extensionFromMime(mimeType: string): string {
 /**
  * Build a FormData payload for the xAI `/v1/stt` endpoint.
  *
- * xAI does not require a `model` field. The xAI docs explicitly require the
- * `file` field to be appended LAST in the multipart body, so we only append
- * the file here (no other fields in v1).
+ * xAI does not require a `model` field. The optional `language` field is a
+ * plain language code (e.g. "en", "fr"). The xAI docs explicitly require the
+ * `file` field to be appended LAST in the multipart body, so every option
+ * field goes in before it.
  */
-function buildXaiFormData(audio: Buffer, mimeType: string): FormData {
+function buildXaiFormData(
+  audio: Buffer,
+  mimeType: string,
+  language?: string,
+): FormData {
   const ext = extensionFromMime(mimeType);
 
   const formData = new FormData();
+  if (language) {
+    formData.append("language", language);
+  }
   // xAI requires the `file` field to be LAST in the multipart body.
   formData.append(
     "file",
@@ -55,9 +63,10 @@ async function xaiTranscribe(
   apiKey: string,
   audio: Buffer,
   mimeType: string,
+  language?: string,
   signal?: AbortSignal,
 ): Promise<string> {
-  const formData = buildXaiFormData(audio, mimeType);
+  const formData = buildXaiFormData(audio, mimeType, language);
 
   const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
 
@@ -79,11 +88,22 @@ async function xaiTranscribe(
   return result.text?.trim() ?? "";
 }
 
+export interface XAIProviderOptions {
+  /**
+   * Language code (e.g. "en", "fr") forwarded as the `language` form field.
+   * Omitted by default; xAI auto-detects the spoken language natively when
+   * no hint is given.
+   */
+  language?: string;
+}
+
 export class XAIProvider {
   private readonly apiKey: string;
+  private readonly language: string | undefined;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, options: XAIProviderOptions = {}) {
     this.apiKey = apiKey;
+    this.language = options.language;
   }
 
   async transcribe(
@@ -91,7 +111,13 @@ export class XAIProvider {
     mimeType: string,
     signal?: AbortSignal,
   ): Promise<SttTranscribeResult> {
-    const text = await xaiTranscribe(this.apiKey, audio, mimeType, signal);
+    const text = await xaiTranscribe(
+      this.apiKey,
+      audio,
+      mimeType,
+      this.language,
+      signal,
+    );
     return { text };
   }
 }

--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -32,7 +32,7 @@ const deepgramProviderCtorCalls: Array<{ apiKey: string; options: unknown }> =
   [];
 
 // Real module captured before the mock replaces it, so pure exports
-// (deepgramModelOverrideForLanguage) stay real while the provider class
+// (deepgramLanguageOptions) stay real while the provider class
 // alone is stubbed.
 const actualDeepgram =
   await import("../../providers/speech-to-text/deepgram.js");
@@ -70,9 +70,17 @@ mock.module("../../providers/speech-to-text/google-gemini.js", () => ({
 let mockXAITranscribeResult: { text: string } = { text: "" };
 let mockXAITranscribeError: Error | null = null;
 
+/**
+ * Captured XAIProvider constructor calls so tests can assert which options
+ * (language) the batch adapter forwards.
+ */
+const xaiProviderCtorCalls: Array<{ apiKey: string; options: unknown }> = [];
+
 mock.module("../../providers/speech-to-text/xai.js", () => ({
   XAIProvider: class MockXAIProvider {
-    constructor(_apiKey: string) {}
+    constructor(apiKey: string, options?: unknown) {
+      xaiProviderCtorCalls.push({ apiKey, options });
+    }
     async transcribe(_audio: Buffer, _mimeType: string, _signal?: AbortSignal) {
       if (mockXAITranscribeError) {
         throw mockXAITranscribeError;
@@ -101,6 +109,7 @@ describe("createDaemonBatchTranscriber", () => {
     mockGeminiTranscribeError = null;
     mockXAITranscribeResult = { text: "" };
     mockXAITranscribeError = null;
+    xaiProviderCtorCalls.length = 0;
   });
 
   // -------------------------------------------------------------------------
@@ -270,9 +279,7 @@ describe("createDaemonBatchTranscriber", () => {
     const transcriber = createDaemonBatchTranscriber(
       "dg-test-key",
       "deepgram",
-      {
-        language: "hi",
-      },
+      "hi",
     );
     await transcriber!.transcribe({
       audio: Buffer.from("fake-audio"),
@@ -293,9 +300,7 @@ describe("createDaemonBatchTranscriber", () => {
     const transcriber = createDaemonBatchTranscriber(
       "dg-test-key",
       "deepgram",
-      {
-        language: "multi",
-      },
+      "multi",
     );
     await transcriber!.transcribe({
       audio: Buffer.from("fake-audio"),
@@ -457,6 +462,51 @@ describe("createDaemonBatchTranscriber", () => {
     } catch (err) {
       expect(err).toBe(original);
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // Language forwarding — xAI
+  // -------------------------------------------------------------------------
+
+  test("forwards the configured language to the xAI provider", async () => {
+    const transcriber = createDaemonBatchTranscriber(
+      "xai-test-key",
+      "xai",
+      "hi",
+    );
+    await transcriber!.transcribe({
+      audio: Buffer.from("fake-audio"),
+      mimeType: "audio/ogg",
+    });
+
+    expect(xaiProviderCtorCalls).toHaveLength(1);
+    expect(xaiProviderCtorCalls[0]?.options).toMatchObject({ language: "hi" });
+  });
+
+  test("never passes 'multi' to the xAI provider (a Deepgram-specific value, not a language code)", async () => {
+    const transcriber = createDaemonBatchTranscriber(
+      "xai-test-key",
+      "xai",
+      "multi",
+    );
+    await transcriber!.transcribe({
+      audio: Buffer.from("fake-audio"),
+      mimeType: "audio/ogg",
+    });
+
+    expect(xaiProviderCtorCalls).toHaveLength(1);
+    expect(xaiProviderCtorCalls[0]?.options).not.toHaveProperty("language");
+  });
+
+  test("passes no language to the xAI provider when none is configured", async () => {
+    const transcriber = createDaemonBatchTranscriber("xai-test-key", "xai");
+    await transcriber!.transcribe({
+      audio: Buffer.from("fake-audio"),
+      mimeType: "audio/ogg",
+    });
+
+    expect(xaiProviderCtorCalls).toHaveLength(1);
+    expect(xaiProviderCtorCalls[0]?.options).not.toHaveProperty("language");
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -83,12 +83,12 @@ class DeepgramBatchTranscriber implements BatchTranscriber {
   async transcribe(
     request: SttTranscribeRequest,
   ): Promise<SttTranscribeResult> {
-    const { DeepgramProvider, deepgramModelOverrideForLanguage } =
+    const { DeepgramProvider, deepgramLanguageOptions } =
       await import("../providers/speech-to-text/deepgram.js");
-    const provider = new DeepgramProvider(this.apiKey, {
-      ...deepgramModelOverrideForLanguage(this.language),
-      ...(this.language ? { language: this.language } : {}),
-    });
+    const provider = new DeepgramProvider(
+      this.apiKey,
+      deepgramLanguageOptions(this.language),
+    );
 
     return provider.transcribe(request.audio, request.mimeType, request.signal);
   }
@@ -142,16 +142,25 @@ class XAIBatchTranscriber implements BatchTranscriber {
   readonly boundaryId = "daemon-batch" as const;
 
   private readonly apiKey: string;
+  private readonly language: string | undefined;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, language?: string) {
     this.apiKey = apiKey;
+    this.language = language;
   }
 
   async transcribe(
     request: SttTranscribeRequest,
   ): Promise<SttTranscribeResult> {
     const { XAIProvider } = await import("../providers/speech-to-text/xai.js");
-    const provider = new XAIProvider(this.apiKey);
+    const provider = new XAIProvider(this.apiKey, {
+      // "multi" is Deepgram's code-switching mode, not a language code, so
+      // it never reaches xAI (which auto-detects multilingual audio natively
+      // when no hint is given). Mirrors the streaming resolver's xai case.
+      ...(this.language && this.language !== "multi"
+        ? { language: this.language }
+        : {}),
+    });
     return provider.transcribe(request.audio, request.mimeType, request.signal);
   }
 }
@@ -200,16 +209,6 @@ export function normalizeSttError(err: unknown): SttError {
 // Public resolver / factory
 // ---------------------------------------------------------------------------
 
-/**
- * Create a `BatchTranscriber` for the daemon-batch boundary.
- *
- * Callers provide the API key and provider ID (obtained via the authorized
- * secure-keys importer in `providers/speech-to-text/resolve.ts`) so that
- * this module doesn't need to import secure-keys directly.
- *
- * Returns `null` when `apiKey` is falsy, signalling to the caller that
- * batch transcription is unavailable.
- */
 // ---------------------------------------------------------------------------
 // Vellum managed adapter — implements BatchTranscriber on top of the
 // platform's managed speech endpoint. No API key: the platform connection
@@ -234,23 +233,26 @@ class VellumManagedBatchTranscriber implements BatchTranscriber {
 }
 
 /**
- * Options for {@link createDaemonBatchTranscriber}.
+ * Create a `BatchTranscriber` for the daemon-batch boundary.
+ *
+ * Callers provide the API key and provider ID (obtained via the authorized
+ * secure-keys importer in `providers/speech-to-text/resolve.ts`) so that
+ * this module doesn't need to import secure-keys directly. Returns `null`
+ * when `apiKey` is falsy, signalling to the caller that batch transcription
+ * is unavailable.
+ *
+ * `language` is the spoken language, forwarded to providers whose batch API
+ * accepts one: Deepgram (where `"multi"` also pins nova-3) and xAI (where
+ * `"multi"` is dropped because it is a Deepgram-specific value, not a
+ * language code). Whisper and Gemini auto-detect natively and take no
+ * language parameter, so it is silently ignored for them, as is the vellum
+ * managed path (the platform speech proxy accepts no language parameter;
+ * see the deferral note in `resolveBatchTranscriber`).
  */
-export interface DaemonBatchTranscriberOptions {
-  /**
-   * Spoken language forwarded to providers whose batch API accepts one
-   * (Deepgram). Whisper, Gemini, and xAI auto-detect natively and take no
-   * language parameter, so it is silently ignored for them, as is the
-   * vellum managed path (the platform speech proxy accepts no language
-   * parameter; see the deferral note in `resolveBatchTranscriber`).
-   */
-  language?: string;
-}
-
 export function createDaemonBatchTranscriber(
   apiKey: string | null | undefined,
   providerId: SttProviderId,
-  options: DaemonBatchTranscriberOptions = {},
+  language?: string,
 ): BatchTranscriber | null {
   // vellum authenticates via the platform connection, not an API key.
   if (providerId === "vellum") {
@@ -264,11 +266,11 @@ export function createDaemonBatchTranscriber(
     case "openai-whisper":
       return new WhisperBatchTranscriber(apiKey);
     case "deepgram":
-      return new DeepgramBatchTranscriber(apiKey, options.language);
+      return new DeepgramBatchTranscriber(apiKey, language);
     case "google-gemini":
       return new GoogleGeminiBatchTranscriber(apiKey);
     case "xai":
-      return new XAIBatchTranscriber(apiKey);
+      return new XAIBatchTranscriber(apiKey, language);
     default: {
       // Exhaustive check — compile error if a new SttProviderId is added
       // without a corresponding case here.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for stt-language-selection.md.

**Gap:** xAI batch (all xAI telephony) silently ignored the configured language while cataloged manual; the deepgram model+language pairing was duplicated; the velay-allowlist assertion lacked its platform-side citation; onboarding-doc table and phrasing fixes.