### PR TITLE
fix: hide the language picker when the settled card diverges from the steered provider

### DIFF
--- a/clients/web/src/components/speech/stt-provider-form.tsx
+++ b/clients/web/src/components/speech/stt-provider-form.tsx
@@ -176,15 +176,20 @@ export function SttProviderForm({
   // unsaved draft of a different one: offering the draft's languages would
   // write a value the still-active provider may ignore (e.g. Multilingual
   // drafted for Vellum while xAI runs, whose resolver drops "multi"). A
-  // settled selection with no daemon mapping (the client-only native choice,
-  // whose recognizer never reads `services.stt.language`) also hides the
-  // picker, unless the daemon itself runs a provider the dropdown can't
-  // represent (e.g. xai via CLI renders as a placeholder), which is exactly
-  // what the picker steers.
+  // settled selection with a daemon mapping shows the picker only when that
+  // mapping IS the provider the pick steers (the hook's
+  // `configuredProviderId`): with no `services.stt` config, a stale
+  // cross-assistant localStorage choice can settle the card on a provider
+  // (e.g. auto-detecting Whisper) that diverges from the daemon-default
+  // provider the pick would write for. A settled selection with no daemon
+  // mapping (the client-only native choice, whose recognizer never reads
+  // `services.stt.language`) also hides the picker, unless the daemon itself
+  // runs a provider the dropdown can't represent (e.g. xai via CLI renders
+  // as a placeholder), which is exactly what the picker steers.
   const languagePickerVisible =
     languageAvailable &&
     draftProvider === serverProvider &&
-    (!!STT_DAEMON_PROVIDER[draftProvider] ||
+    (STT_DAEMON_PROVIDER[draftProvider]?.provider === languageProviderId ||
       (!!daemonSttProvider && !CARD_ID_BY_DAEMON_PROVIDER[daemonSttProvider]));
   const [apiKeyText, setApiKeyText] = useState("");
   const [providerHasKey, setProviderHasKey] = useState(false);

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -567,6 +567,39 @@ describe("SpeechToTextCard: Spoken language dropdown", () => {
     expect(languageTrigger()!.textContent).toContain("en-US");
   });
 
+  test("hides when a stale localStorage provider settles the card off the steered daemon default", async () => {
+    // No `services.stt` config, so the pick steers the daemon schema default
+    // (deepgram, manual), but the cross-assistant localStorage choice settles
+    // the card on auto-detecting Whisper with no pending draft. The mapped
+    // branch of the gate requires the card's daemon mapping to equal the
+    // steered provider, so no picker renders under the auto card.
+    localStorage.setItem(LS_STT_PROVIDER, "openai");
+    daemonConfigData = { services: {} };
+    providerCatalogData = {
+      providers: [
+        {
+          id: "deepgram",
+          displayName: "Deepgram",
+          languageSelection: "manual",
+        },
+        {
+          id: "openai-whisper",
+          displayName: "Whisper",
+          languageSelection: "auto",
+        },
+      ],
+    };
+    renderCard();
+
+    // The card settles on the localStorage provider (no draft pending).
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="STT provider"]',
+    );
+    await waitFor(() => expect(trigger?.textContent).toContain("OpenAI"));
+
+    expect(languageTrigger()).toBeNull();
+  });
+
   test("does not render when the daemon omits the capability field (old daemon)", () => {
     daemonConfigData = { services: { stt: { provider: "deepgram" } } };
     providerCatalogData = {


### PR DESCRIPTION
## Summary
Fixes a round-2 review gap for stt-language-selection.md.

**Gap:** with no daemon services.stt config and a stale cross-assistant localStorage provider, the picker rendered under an auto-detecting card while steering the daemon default.
**Fix:** the mapped-card branch of the visibility gate now requires the card's daemon mapping to equal the hook's configuredProviderId, with a regression test for the sparse-config corner.