### PR TITLE
feat(skills): memory-corpus-ingest - skim large datasets into map pages + a drill-in retrieval skill

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T19:33:00.000Z"
+      "updatedAt": "2026-07-29T19:34:08.000Z"
     },
     {
       "id": "chat-complex-documents",
@@ -599,6 +599,31 @@
       },
       "compatibility": "Requires curl and python3. Works on macOS and Linux.",
       "updatedAt": "2026-06-03T03:10:07.000Z"
+    },
+    {
+      "id": "memory-corpus-ingest",
+      "name": "memory-corpus-ingest",
+      "description": "Ingest a large dataset into memory as a skimmed map. Cold-store the raw files under a workspace imports directory, census them into a slice plan, skim each slice into compact map pages that point back at the raw files, ingest the map with the memory ingest CLI, and author a drill-in retrieval skill so the corpus stays searchable on demand. For recording archives, transcript collections, document dumps, and any corpus too large to hold in memory directly.",
+      "metadata": {
+        "emoji": "🗺️",
+        "vellum": {
+          "category": "system",
+          "display-name": "Corpus Ingest",
+          "user-invocable": "true",
+          "activation-hints": [
+            "User wants to import a large dataset, recordings archive, or document dump into memory",
+            "User asks the assistant to learn a big folder of files or a document collection",
+            "User mentions a Fathom recordings export or an archive of meeting transcripts",
+            "User wants the assistant to know what is in a corpus without pasting it all into chat"
+          ],
+          "avoid-when": [
+            "The input is a small set of distilled memories or an export from another assistant (use assistant-migration)",
+            "The input is ChatGPT conversation history (use chatgpt-import)"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants",
+      "updatedAt": "2026-07-29T23:39:06.000Z"
     },
     {
       "id": "notifications",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -623,7 +623,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T23:48:16.000Z"
+      "updatedAt": "2026-07-29T23:58:42.000Z"
     },
     {
       "id": "notifications",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -623,7 +623,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T23:39:06.000Z"
+      "updatedAt": "2026-07-29T23:48:16.000Z"
     },
     {
       "id": "notifications",

--- a/skills/memory-corpus-ingest/SKILL.md
+++ b/skills/memory-corpus-ingest/SKILL.md
@@ -115,9 +115,10 @@ The map tells the model a slice exists; the drill-in skill is how it follows the
 # search.sh <pattern> [YYYY-MM]  scoped search over the <source> cold store
 DIR="$VELLUM_WORKSPACE_DIR/imports/<source>"
 if [ -n "$2" ]; then
-  # Two globs: one for the date in a filename, one for the date in a
-  # directory segment (rg's "-g foo" does not match foo/bar).
-  rg -i -C 3 "$1" "$DIR" --glob "*$2*" --glob "*$2*/**"
+  # Two globs: a slash-free pattern matches the date in any basename, and
+  # the "**/" prefixed pattern matches the date in a directory segment at
+  # any depth (a leading "*" cannot cross path separators).
+  rg -i -C 3 "$1" "$DIR" --glob "*$2*" --glob "**/*$2*/**"
 else
   rg -i -C 3 "$1" "$DIR"
 fi

--- a/skills/memory-corpus-ingest/SKILL.md
+++ b/skills/memory-corpus-ingest/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: memory-corpus-ingest
+description: Ingest a large dataset into memory as a skimmed map. Cold-store the raw files under a workspace imports directory, census them into a slice plan, skim each slice into compact map pages that point back at the raw files, ingest the map with the memory ingest CLI, and author a drill-in retrieval skill so the corpus stays searchable on demand. For recording archives, transcript collections, document dumps, and any corpus too large to hold in memory directly.
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🗺️"
+  vellum:
+    category: "system"
+    display-name: "Corpus Ingest"
+    user-invocable: true
+    activation-hints:
+      - "User wants to import a large dataset, recordings archive, or document dump into memory"
+      - "User asks the assistant to learn a big folder of files or a document collection"
+      - "User mentions a Fathom recordings export or an archive of meeting transcripts"
+      - "User wants the assistant to know what is in a corpus without pasting it all into chat"
+    avoid-when:
+      - "The input is a small set of distilled memories or an export from another assistant (use assistant-migration)"
+      - "The input is ChatGPT conversation history (use chatgpt-import)"
+---
+
+# Corpus Ingest
+
+Bring a large dataset into the assistant's working knowledge without stuffing it into memory. The model is a library: the workspace holds the stacks (the raw files, cold and complete), memory holds the card catalog (a small set of map pages that say what exists, when it is from, and where to look), and a purpose-built retrieval skill is the librarian that walks to the right shelf on demand.
+
+Two invariants drive everything below:
+
+1. **Raw data never enters the memory corpus.** Nothing from the dataset is written into `memory/concepts/` except the map pages, and nothing is ever appended to `memory/buffer.md` (bulk buffer appends trip the consolidation burst guard and per-run caps; the map bypasses the buffer entirely via `assistant memory ingest`).
+2. **The map stays small.** Roughly 10 to 50 pages regardless of corpus size. If the corpus doubles, the pages get denser or the slices get coarser; the page count does not double.
+
+## Procedure
+
+### Step 1: Scope and confirm
+
+Identify the source and its size before committing:
+
+```bash
+du -sh /path/to/raw-corpus
+find /path/to/raw-corpus -type f | wc -l
+```
+
+Tell the user what will happen: the raw files move into the workspace, a bounded number of summarization passes read them once to build the map, the map is ingested into memory, and a lookup skill is authored for drill-in. Skimming a large corpus is real LLM work that costs time and money; confirm before starting. For Fathom recording exports, read `references/fathom.md` first for format discovery and slicing guidance.
+
+### Step 2: Cold-store the raw corpus
+
+Land the raw files under an imports directory in the workspace, one directory per source:
+
+```bash
+cd "$VELLUM_WORKSPACE_DIR"
+mkdir -p imports/<source>
+cp -R /path/to/raw-corpus/. imports/<source>/
+```
+
+Rules:
+
+- **Never place raw corpus files under `memory/`.** The cold store is `imports/<source>/`; the map is the only thing that enters memory.
+- Treat the cold store as read-only once landed. The map pages and the drill-in skill both point at these paths; moving files later breaks every pointer.
+- If the corpus is huge, check free disk space first and copy in batches. Prefer copy over move until the user confirms the original can be released.
+
+### Step 3: Inventory and slice plan
+
+Census the corpus and produce a machine-readable slice plan:
+
+```bash
+mkdir -p "$VELLUM_WORKSPACE_DIR/imports/<source>/.staging"
+bun run scripts/inventory.ts "$VELLUM_WORKSPACE_DIR/imports/<source>" \
+  > "$VELLUM_WORKSPACE_DIR/imports/<source>/.staging/plan.json"
+```
+
+(`scripts/inventory.ts` is relative to this skill's directory.)
+
+The script prints a human census to stderr (file count, total size, extension mix, date range) and a JSON plan to stdout: `{ files, totalBytes, byExtension, dateRange, suggestedSlices }`. Each suggested slice is a date-windowed group of files sized for one skim pass. Review the plan before skimming:
+
+- If the slice count is outside roughly 10 to 50, adjust: merge sparse adjacent slices or split dense ones. The plan is a suggestion, not a contract.
+- Files with no recognizable date cluster on file mtime; if mtimes are all import-day (a fresh copy), pick slices by directory or topic instead and say so in the map.
+
+### Step 4: Skim each slice into a staged map page
+
+For each slice in the plan, run one summarization pass that reads the slice's files and writes one staged map page:
+
+- Output goes to the staging directory as `<slug>.md` (for example `imports/fathom/.staging/fathom-recordings-2025-q1.md`). The slug is the filename minus `.md`.
+- Every page follows `references/map-page-template.md` exactly: lead that stands alone as the retrieval card, a `Raw data:` pointer line in the lead, `## ` sections per topic or time slice, and `source:` / `origin_date:` / `ref_files:` / `links:` frontmatter.
+- Also write one corpus index page (`kind: index`) whose `links:` enumerate all slice pages.
+
+**Bound the fan-out.** The number of skim passes equals the number of slices in the plan, full stop. Run them a few at a time (parallelism of 3 or 4 is plenty). Never spawn one pass per file, never let a pass recursively spawn more passes, and never re-skim slices that already have a staged page unless their content changed. An unbounded fan-out over a large corpus is the expensive failure mode of this skill.
+
+A skim pass extracts what a future search needs to route: decisions, recurring topics, named people and projects, date spans, open threads. It does not transcribe. Verbatim content stays cold; the map records that it exists and where.
+
+### Step 5: Ingest the map
+
+Dry-run first, review, then ingest for real:
+
+```bash
+cd "$VELLUM_WORKSPACE_DIR"
+assistant memory ingest --dir imports/<source>/.staging --dry-run
+```
+
+The dry run validates every page and reports per-page results without writing. Fix anything reported `invalid` (bad frontmatter, bad slug), then run without `--dry-run`. Notes:
+
+- Requires concept-page memory (`memory.v3.live` or `memory.v2.enabled`).
+- Existing slugs are skipped unless `--overwrite` is passed; use `--overwrite` when re-running after edits.
+- Pages go up in batches of 200 (a map should never get near that).
+- If the command fails because the consolidation lock is held, it names the holder; wait for that run to finish and retry.
+
+After ingest, the maintain job picks up the new pages and embeds their sections; the map becomes retrievable shortly after, with each page's card dated by its `origin_date` rather than the import day.
+
+### Step 6: Author the drill-in retrieval skill
+
+The map tells the model a slice exists; the drill-in skill is how it follows the pointer. Author a workspace skill for this corpus under `$VELLUM_WORKSPACE_DIR/skills/<source>-lookup/`:
+
+- `SKILL.md` with frontmatter per the Agent Skills spec (`name` matching the directory, keyword-rich `description`) and activation hints drawn from the intents you actually observed while scoping (for example "when the user asks what was said in a meeting", "when a question needs the <source> archive").
+- `scripts/` with actually runnable search commands over the cold store, not prose descriptions of searching. A minimal helper is a ripgrep wrapper scoped to the imports directory with date filtering:
+
+```bash
+#!/usr/bin/env bash
+# search.sh <pattern> [YYYY-MM]  scoped search over the <source> cold store
+DIR="$VELLUM_WORKSPACE_DIR/imports/<source>"
+if [ -n "$2" ]; then
+  rg -i -C 3 "$1" "$DIR" --glob "*$2*"
+else
+  rg -i -C 3 "$1" "$DIR"
+fi
+```
+
+- The skill body should name the cold-store root, the slice layout, and the map pages' slugs so the model can go from a card to a file in one step.
+
+Confirm the new skill appears in `assistant skills list` (workspace skills are picked up from the workspace `skills/` directory).
+
+### Step 7: Verify
+
+Run 3 to 5 representative queries a real user would ask of this corpus (mix a routing question, a specific-fact question, and a date-scoped question). For each, check:
+
+1. A map card is selected for the turn (the slice page or the corpus index surfaces).
+2. The assistant follows the card's `Raw data:` pointer or invokes the drill-in skill to reach the actual files.
+3. The answer cites content that exists in the cold store.
+
+If a query routes to nothing, the relevant lead is not doing its card job; rewrite it and re-ingest that page with `--overwrite`. For large ingests, `assistant memory v3 eval` is an optional gate: it proves the corpus retrieves at least as well after the ingest as before it.
+
+## Hard rules
+
+- Raw corpus content never enters `memory/concepts/` or `memory/buffer.md`. Map pages only, via `assistant memory ingest`.
+- The cold store lives under `imports/<source>/` and is read-only after landing.
+- Map size is 10 to 50 pages regardless of corpus size.
+- Drill-in pointers (the `Raw data:` line) live in the page lead, because the card renderer injects the lead plus a section list; a pointer buried in a section is invisible at routing time.
+- `origin_date:` is the content's own date, never the import date.
+- Skim fan-out is bounded by the slice plan; one pass per slice, a few in flight at a time.
+- Always dry-run the ingest before the real run.
+
+## References
+
+- `references/map-page-template.md`: the exact article shape for map pages, with a full example. Read before writing any staged page.
+- `references/fathom.md`: Fathom recording archives specifically; export discovery, speaker and date extraction, slicing, and what belongs in the map versus the cold store.

--- a/skills/memory-corpus-ingest/SKILL.md
+++ b/skills/memory-corpus-ingest/SKILL.md
@@ -115,7 +115,9 @@ The map tells the model a slice exists; the drill-in skill is how it follows the
 # search.sh <pattern> [YYYY-MM]  scoped search over the <source> cold store
 DIR="$VELLUM_WORKSPACE_DIR/imports/<source>"
 if [ -n "$2" ]; then
-  rg -i -C 3 "$1" "$DIR" --glob "*$2*"
+  # Two globs: one for the date in a filename, one for the date in a
+  # directory segment (rg's "-g foo" does not match foo/bar).
+  rg -i -C 3 "$1" "$DIR" --glob "*$2*" --glob "*$2*/**"
 else
   rg -i -C 3 "$1" "$DIR"
 fi
@@ -133,7 +135,7 @@ Run 3 to 5 representative queries a real user would ask of this corpus (mix a ro
 2. The assistant follows the card's `Raw data:` pointer or invokes the drill-in skill to reach the actual files.
 3. The answer cites content that exists in the cold store.
 
-If a query routes to nothing, the relevant lead is not doing its card job; rewrite it and re-ingest that page with `--overwrite`. For large ingests, `assistant memory v3 eval` is an optional gate: it proves the corpus retrieves at least as well after the ingest as before it.
+If a query routes to nothing, the relevant lead is not doing its card job; rewrite it and re-ingest that page with `--overwrite`. For large ingests, `assistant memory v3 eval` can additionally gate the change, but it is a two-corpus comparison requiring `--snapshot`, `--staging`, and `--out`; use it only when you captured a pre-ingest snapshot of `memory/concepts/` to compare against. Otherwise the query checks above are the verification.
 
 ## Hard rules
 

--- a/skills/memory-corpus-ingest/references/fathom.md
+++ b/skills/memory-corpus-ingest/references/fathom.md
@@ -1,0 +1,75 @@
+# Fathom Recording Archives
+
+Fathom is a meeting recorder: it joins calls, records them, transcribes them, and generates AI summaries. A user's Fathom archive is a natural corpus for this skill because it is large, append-only, strongly dated, and queried by date and topic ("what did we decide in the March planning call").
+
+Fathom's export shapes change between plans and product versions, so this reference describes tolerant discovery rather than exact field names. Inventory first, spot-check a few files, and adapt.
+
+## What an export typically contains
+
+Expect some mix of, per meeting:
+
+- **A transcript**, commonly WebVTT (`.vtt`) or plain text. VTT files interleave cue timing lines with the spoken text.
+- **An AI summary**, commonly markdown or plain text: bullets, action items, sometimes chapter headings.
+- **The recording itself** (video or audio), or only a link back to Fathom's site. Media files can dominate the byte count.
+- Sometimes a per-meeting metadata blob (title, date, attendees) as JSON or as a header block inside the summary file.
+
+Discovery moves:
+
+```bash
+# shape of the tree and the extension mix
+bun run scripts/inventory.ts "$VELLUM_WORKSPACE_DIR/imports/fathom"
+
+# spot-check one of each file type before trusting any assumption
+find "$VELLUM_WORKSPACE_DIR/imports/fathom" -name '*.vtt' | head -3
+```
+
+If the export contains large media files, keep them cold and skim from transcripts and summaries only; the map never needs the audio. If only recordings exist with no transcripts, stop and tell the user: transcription is a separate (and costly) step to decide on explicitly, not something to slip into a skim pass.
+
+## Extracting meeting dates
+
+Try in this order, falling back down the list:
+
+1. **Filenames and directory names.** Exports commonly encode the date in the meeting file or folder name (`2025-03-12 Acme sync.vtt` or similar). The inventory script already recognizes common date patterns in filenames.
+2. **Metadata or summary headers.** A date line near the top of the summary or a metadata JSON field.
+3. **File mtimes.** Only trustworthy if the export preserved them; a fresh download often stamps everything with the download day. If every mtime is the same day, do not trust mtimes for chronology.
+
+The per-meeting date feeds two things: which slice a meeting belongs to, and the slice page's `origin_date` (the latest meeting date in the slice).
+
+## Extracting speaker names
+
+- **VTT voice tags**: cues like `<v Alice Chen>...</v>` name the speaker inline. Strip the tags for reading; harvest the names for the map.
+- **Speaker-prefixed lines**: plain-text transcripts often use `Alice Chen: ...` line prefixes.
+- **Summary attendee lists**: AI summaries frequently open with attendees; cheaper to harvest than the transcript.
+
+Speaker names matter to the map at the level of who owns what and who recurs, not per-utterance attribution.
+
+## Recommended slicing
+
+- **Monthly slices** for a dense archive (several meetings a week).
+- **Quarterly slices** for a sparser one, or when monthly slicing would push the map past roughly 50 pages.
+- One map page per slice, plus the single corpus index page.
+- If one month is disproportionately dense (an offsite week, a launch), the inventory script splits oversize buckets into parts; keep those as separate pages rather than writing one giant page.
+
+Per-meeting map pages are almost always wrong: a year of weekly calls would mint hundreds of pages and blow the map budget. The meeting grain lives in the cold store and is reachable through the drill-in skill.
+
+## What belongs in the map page versus the cold store
+
+In the map page (per slice):
+
+- Decisions, with dates and who made them.
+- Recurring topics and their arc across the slice (raised, debated, resolved or still open).
+- Named people, customers, and projects that recur, and what they own.
+- Open threads at the end of the slice.
+- Meeting count and the kinds of meetings, so density is visible from the card.
+
+Stays cold (reachable via drill-in, never copied into memory):
+
+- Verbatim transcript text and quotes, except a short quote that is itself the decision.
+- Cue timestamps, filler, small talk.
+- AI summary text wholesale; the skim distills across meetings, it does not concatenate summaries.
+
+## Drill-in skill notes for Fathom
+
+- Scope searches to the imports directory and offer date filtering by path segment (month directories make `--glob "*2025-03*"` style filters work).
+- Search with surrounding context (`rg -C 3`) because VTT timing lines break up sentences; a match without context is often unreadable.
+- When a search hits a `.vtt` file, the companion summary file for the same meeting is usually the faster read; teach the skill to name that pairing.

--- a/skills/memory-corpus-ingest/references/map-page-template.md
+++ b/skills/memory-corpus-ingest/references/map-page-template.md
@@ -20,7 +20,7 @@ Retrieval is section-grain: the model sees a compact card per article, which is 
 | `source`      | `import:<provider>` (for example `import:fathom`); marks the page as ingested, not consolidated                                                                                                                                                                                                  |
 | `origin_date` | ISO 8601 date of the slice's own content, such as the last meeting date in the slice. Never the import date. It drives the fresh lane's effective recency and the dated stamp on the card, so an archive slice from 2023 sorts as 2023 material instead of flooding the fresh lane on import day |
 
-Note on `links:` entries: the format is `"<target-slug> — <one line on why>"` and the separator is literally space, em dash, space. That token is how the edge lane splits the target slug from the annotation, so reproduce it exactly (it is parser syntax, not punctuation style).
+Note on `links:` entries: the format is `"<target-slug> — <one line on why>"` and the separator is literally space, em dash, space. That token is how the edge lane splits the target slug from the annotation, so reproduce it exactly. This is a deliberate, scoped exception to the repository's no-em-dash rule: the separator is frozen parser syntax consumed by the memory plugin's edge and card renderers, not prose punctuation, and changing it would break every existing page's authored links.
 
 ## Full example: a slice page
 

--- a/skills/memory-corpus-ingest/references/map-page-template.md
+++ b/skills/memory-corpus-ingest/references/map-page-template.md
@@ -1,0 +1,118 @@
+# Map Page Template
+
+A map page is a memory-v3 article whose only job is routing: it tells the model what a slice of the cold store contains, when it is from, and where the raw files live. It follows the standard v3 article shape (a lead that is the retrieval card, plus named `## ` sections), with corpus-specific frontmatter on top.
+
+Retrieval is section-grain: the model sees a compact card per article, which is the page's lead (everything before the first `## `) plus a list of its section names. Two consequences:
+
+1. **The `Raw data:` pointer must live in the lead.** A pointer in a section body is invisible at routing time; the model would select the card and still not know where the files are.
+2. **Section names are navigation.** Name each section so the model can tell from the name alone whether the answer lives there.
+
+## Frontmatter fields
+
+| Field         | Value for a map page                                                                                                                                                                                                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `title`       | Human title naming the corpus and the slice window                                                                                                                                                                                                                                               |
+| `slug`        | Flat kebab-case, matching the staged filename minus `.md` (for example `fathom-recordings-2025-q1`)                                                                                                                                                                                              |
+| `tags`        | Corpus name plus topic labels                                                                                                                                                                                                                                                                    |
+| `main`        | The corpus index page's slug                                                                                                                                                                                                                                                                     |
+| `links`       | Sibling slice pages plus the corpus index page, annotated                                                                                                                                                                                                                                        |
+| `ref_files`   | The cold-store paths (files or directories) this slice covers, relative to the workspace root                                                                                                                                                                                                    |
+| `source`      | `import:<provider>` (for example `import:fathom`); marks the page as ingested, not consolidated                                                                                                                                                                                                  |
+| `origin_date` | ISO 8601 date of the slice's own content, such as the last meeting date in the slice. Never the import date. It drives the fresh lane's effective recency and the dated stamp on the card, so an archive slice from 2023 sorts as 2023 material instead of flooding the fresh lane on import day |
+
+Note on `links:` entries: the format is `"<target-slug> — <one line on why>"` and the separator is literally space, em dash, space. That token is how the edge lane splits the target slug from the annotation, so reproduce it exactly (it is parser syntax, not punctuation style).
+
+## Full example: a slice page
+
+```markdown
+---
+title: Fathom Recordings 2025 Q1
+slug: fathom-recordings-2025-q1
+tags: [fathom, meetings, imports]
+main: fathom-recordings-map
+links:
+  - "fathom-recordings-map — the corpus index for the whole Fathom archive"
+  - "fathom-recordings-2025-q2 — the next quarter of the same archive"
+ref_files:
+  - imports/fathom/2025-01
+  - imports/fathom/2025-02
+  - imports/fathom/2025-03
+source: import:fathom
+origin_date: "2025-03-27"
+---
+
+# Fathom Recordings 2025 Q1
+
+Map of the Fathom meeting archive for January through March 2025: 41 recorded
+meetings, mostly the weekly product sync, six customer calls (Acme, Northwind,
+and four prospects), and the three-session Q1 planning series that produced the
+pricing revamp decision. Raw data: imports/fathom/2025-01 through
+imports/fathom/2025-03 in the workspace (per-meeting transcripts and AI
+summaries); drill in with the fathom-lookup skill.
+
+## q1 planning series and decisions
+
+Three sessions (Jan 14, Jan 21, Feb 4). Decided: ship the pricing revamp in Q2,
+defer the enterprise tier, hire one more platform engineer. The Feb 4 session
+holds the final pricing numbers and the dissent from finance.
+
+## customer calls
+
+Acme (Jan 9, Mar 12): renewal risk raised in January, resolved by March after
+the SSO fix. Northwind (Feb 20): expansion interest, waiting on SOC 2. Four
+prospect calls in March, all mid-market, common objection was onboarding time.
+
+## recurring topics in the weekly sync
+
+Release cadence complaints (every January sync), flaky CI (Jan through Feb,
+resolved Feb 18), the analytics rewrite (ongoing all quarter, owner Dana).
+
+## open threads at quarter end
+
+Northwind expansion blocked on SOC 2. Analytics rewrite unscheduled for Q2.
+Pricing revamp comms plan not yet drafted.
+```
+
+What makes this lead work as a card: it states scope (which archive, which window), density (41 meetings, what kinds), the one headline outcome, and the pointer. A model deciding where to look for "what did we tell Acme in March" can route from the card alone.
+
+## The corpus index page
+
+Write exactly one index page per corpus, marked `kind: index`. It is a routing layer: its lead describes the whole archive and names the cold-store root, and its `links:` enumerate every slice page. No body content beyond the summary-level through-line; detail lives on the slices.
+
+```markdown
+---
+title: Fathom Recordings Map
+slug: fathom-recordings-map
+tags: [fathom, meetings, imports]
+main: fathom-recordings-map
+kind: index
+links:
+  - "fathom-recordings-2025-q1 — Jan to Mar 2025, planning series and Acme renewal"
+  - "fathom-recordings-2025-q2 — Apr to Jun 2025, pricing revamp shipped"
+ref_files:
+  - imports/fathom
+source: import:fathom
+origin_date: "2025-06-30"
+---
+
+# Fathom Recordings Map
+
+Index of the imported Fathom meeting archive: 83 recorded meetings from January
+through June 2025, mapped as one page per quarter. Raw data: imports/fathom in
+the workspace; drill in with the fathom-lookup skill. Slices are listed in
+links with one-line summaries.
+
+## how this archive is organized
+
+One directory per month under imports/fathom, one map page per quarter, one
+transcript plus one AI summary per meeting.
+```
+
+## Rules of thumb
+
+- **Lead length**: one to three short paragraphs. The lead orients and points; sections carry the detail. A bloated lead starves other pages' cards.
+- **What goes in sections**: decisions with dates, recurring topics with their arc, named people and what they own, open threads. Facts a future search would need to route or answer.
+- **What stays cold**: verbatim transcript text, per-utterance timestamps, filler. The map records that content exists and where, not the content itself.
+- **Slug discipline**: flat, kebab-case, specific, and stable across re-ingests (re-running with `--overwrite` updates the same page instead of creating a twin).
+- **`ref_files` versus the `Raw data:` line**: both list the same cold-store paths. `ref_files` is the structured form for tooling; the lead line is the copy the model actually sees on the card. Keep them in sync.
+- **`origin_date` per page**: each slice page carries its own slice's date, so the archive spreads across the timeline instead of stacking on one day. The index page carries the corpus's most recent content date.

--- a/skills/memory-corpus-ingest/scripts/inventory.test.ts
+++ b/skills/memory-corpus-ingest/scripts/inventory.test.ts
@@ -62,6 +62,12 @@ describe("dateFromFilename", () => {
     expect(dateFromFilename("release-1.2.3.txt")).toBeNull();
     expect(dateFromFilename("undated-notes.txt")).toBeNull();
   });
+
+  test("rejects syntactically shaped but impossible calendar dates", () => {
+    expect(dateFromFilename("2025-02-29 standup.vtt")).toBeNull();
+    expect(dateFromFilename("2025-04-31 retro.vtt")).toBeNull();
+    expect(dateFromFilename("2024-02-29 leap-day.vtt")).toBe("2024-02-29");
+  });
 });
 
 describe("walkFiles", () => {

--- a/skills/memory-corpus-ingest/scripts/inventory.test.ts
+++ b/skills/memory-corpus-ingest/scripts/inventory.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildInventory,
+  dateFromFilename,
+  suggestSlices,
+  walkFiles,
+  type FileInfo,
+} from "./inventory.ts";
+
+let root: string;
+
+function writeFixture(relPath: string, content: string, mtime?: Date): void {
+  const full = join(root, relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content);
+  if (mtime) {
+    utimesSync(full, mtime, mtime);
+  }
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "corpus-inventory-"));
+  // Dated filenames across two quarters
+  writeFixture("2025-01/2025-01-09 acme sync.vtt", "WEBVTT\n\nhello");
+  writeFixture("2025-01/2025-01-09 acme sync.md", "# summary");
+  writeFixture("2025-02/2025_02_20 northwind.vtt", "WEBVTT\n\nworld");
+  writeFixture("2025-04/20250402-planning.txt", "notes");
+  // Undated file: date should come from mtime
+  writeFixture(
+    "misc/undated-notes.txt",
+    "no date here",
+    new Date("2025-03-15T12:00:00Z"),
+  );
+  // Hidden entries must be skipped
+  writeFixture(".staging/should-not-count.md", "staged page");
+  writeFixture("2025-01/.hidden-file.md", "hidden");
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("dateFromFilename", () => {
+  test("recognizes dashed, underscored, and compact dates", () => {
+    expect(dateFromFilename("2025-01-09 acme sync.vtt")).toBe("2025-01-09");
+    expect(dateFromFilename("2025_02_20 northwind.vtt")).toBe("2025-02-20");
+    expect(dateFromFilename("20250402-planning.txt")).toBe("2025-04-02");
+  });
+
+  test("rejects implausible dates and plain numbers", () => {
+    expect(dateFromFilename("2025-13-40 broken.txt")).toBeNull();
+    expect(dateFromFilename("release-1.2.3.txt")).toBeNull();
+    expect(dateFromFilename("undated-notes.txt")).toBeNull();
+  });
+});
+
+describe("walkFiles", () => {
+  test("censuses files, skips dot-entries, and sorts by date", () => {
+    const files = walkFiles(root);
+    expect(files.length).toBe(5);
+    expect(files.some((f) => f.path.includes(".staging"))).toBe(false);
+    expect(files.some((f) => f.path.includes(".hidden-file"))).toBe(false);
+    const dates = files.map((f) => f.date);
+    expect(dates).toEqual([...dates].sort());
+  });
+
+  test("prefers filename dates and falls back to mtime", () => {
+    const files = walkFiles(root);
+    const dated = files.find((f) => f.path.endsWith("acme sync.vtt"));
+    expect(dated?.date).toBe("2025-01-09");
+    expect(dated?.dateFromName).toBe(true);
+    const undated = files.find((f) => f.path.endsWith("undated-notes.txt"));
+    expect(undated?.date).toBe("2025-03-15");
+    expect(undated?.dateFromName).toBe(false);
+  });
+});
+
+describe("buildInventory", () => {
+  test("reports counts, sizes, extensions, and date range", () => {
+    const inventory = buildInventory(root);
+    expect(inventory.files).toBe(5);
+    expect(inventory.totalBytes).toBeGreaterThan(0);
+    expect(inventory.byExtension[".vtt"]).toBe(2);
+    expect(inventory.byExtension[".md"]).toBe(1);
+    expect(inventory.byExtension[".txt"]).toBe(2);
+    expect(inventory.dateRange).toEqual({
+      earliest: "2025-01-09",
+      latest: "2025-04-02",
+    });
+  });
+
+  test("suggests monthly slices when they fit the budget", () => {
+    const inventory = buildInventory(root);
+    const labels = inventory.suggestedSlices.map((s) => s.label);
+    expect(labels).toEqual(["2025-01", "2025-02", "2025-03", "2025-04"]);
+    const january = inventory.suggestedSlices[0];
+    expect(january.fileCount).toBe(2);
+    expect(january.paths.every((p) => p.startsWith("2025-01/"))).toBe(true);
+  });
+
+  test("returns an empty plan for an empty directory", () => {
+    const empty = mkdtempSync(join(tmpdir(), "corpus-empty-"));
+    try {
+      const inventory = buildInventory(empty);
+      expect(inventory.files).toBe(0);
+      expect(inventory.dateRange).toBeNull();
+      expect(inventory.suggestedSlices).toEqual([]);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("suggestSlices", () => {
+  const fileOn = (date: string, name: string): FileInfo => ({
+    path: name,
+    bytes: 10,
+    date,
+    dateFromName: true,
+  });
+
+  test("coarsens month groups to quarters when over the slice budget", () => {
+    const files = [
+      fileOn("2025-01-05", "a.txt"),
+      fileOn("2025-02-05", "b.txt"),
+      fileOn("2025-03-05", "c.txt"),
+      fileOn("2025-04-05", "d.txt"),
+    ];
+    const slices = suggestSlices(files, { maxSlices: 2 });
+    expect(slices.map((s) => s.label)).toEqual(["2025-Q1", "2025-Q2"]);
+    expect(slices[0].fileCount).toBe(3);
+    expect(slices[0].earliest).toBe("2025-01-05");
+    expect(slices[0].latest).toBe("2025-03-05");
+  });
+
+  test("coarsens to years when quarters still exceed the budget", () => {
+    const files = [
+      fileOn("2024-01-05", "a.txt"),
+      fileOn("2024-07-05", "b.txt"),
+      fileOn("2025-02-05", "c.txt"),
+      fileOn("2025-11-05", "d.txt"),
+    ];
+    const slices = suggestSlices(files, { maxSlices: 2 });
+    expect(slices.map((s) => s.label)).toEqual(["2024", "2025"]);
+  });
+
+  test("splits oversize buckets into parts", () => {
+    const files = [
+      fileOn("2025-01-01", "a.txt"),
+      fileOn("2025-01-02", "b.txt"),
+      fileOn("2025-01-03", "c.txt"),
+      fileOn("2025-01-04", "d.txt"),
+      fileOn("2025-01-05", "e.txt"),
+    ];
+    const slices = suggestSlices(files, { maxFilesPerSlice: 2 });
+    expect(slices.map((s) => s.label)).toEqual([
+      "2025-01 (part 1)",
+      "2025-01 (part 2)",
+      "2025-01 (part 3)",
+    ]);
+    expect(slices.reduce((sum, s) => sum + s.fileCount, 0)).toBe(5);
+    expect(slices[0].paths).toEqual(["a.txt", "b.txt"]);
+  });
+});

--- a/skills/memory-corpus-ingest/scripts/inventory.ts
+++ b/skills/memory-corpus-ingest/scripts/inventory.ts
@@ -78,13 +78,21 @@ const FILENAME_DATE_PATTERNS = [
 export function dateFromFilename(path: string): string | null {
   for (const pattern of FILENAME_DATE_PATTERNS) {
     const match = path.match(pattern);
-    if (!match) continue;
+    if (!match) {
+      continue;
+    }
     const year = Number(match[1]);
     const month = Number(match[2]);
     const day = Number(match[3]);
-    if (year < 1980 || year > 2100) continue;
-    if (month < 1 || month > 12) continue;
-    if (day < 1 || day > 31) continue;
+    if (year < 1980 || year > 2100) {
+      continue;
+    }
+    if (month < 1 || month > 12) {
+      continue;
+    }
+    if (day < 1 || day > 31) {
+      continue;
+    }
     return `${match[1]}-${match[2]}-${match[3]}`;
   }
   return null;
@@ -100,7 +108,9 @@ export function walkFiles(root: string): FileInfo[] {
   const results: FileInfo[] = [];
   const walk = (dir: string, rel: string): void => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name.startsWith(".")) continue;
+      if (entry.name.startsWith(".")) {
+        continue;
+      }
       const full = join(dir, entry.name);
       const relPath = rel === "" ? entry.name : `${rel}/${entry.name}`;
       if (entry.isDirectory()) {
@@ -199,7 +209,9 @@ export function suggestSlices(
   const maxSlices = options.maxSlices ?? DEFAULT_MAX_SLICES;
   const maxFilesPerSlice =
     options.maxFilesPerSlice ?? DEFAULT_MAX_FILES_PER_SLICE;
-  if (files.length === 0) return [];
+  if (files.length === 0) {
+    return [];
+  }
 
   const grains: Array<(date: string) => string> = [
     (date) => date.slice(0, 7), // month: 2025-03
@@ -250,10 +262,15 @@ export function buildInventory(
 // -- CLI --
 
 function formatBytes(bytes: number): string {
-  if (bytes >= 1024 * 1024 * 1024)
+  if (bytes >= 1024 * 1024 * 1024) {
     return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
   return `${bytes} B`;
 }
 

--- a/skills/memory-corpus-ingest/scripts/inventory.ts
+++ b/skills/memory-corpus-ingest/scripts/inventory.ts
@@ -1,0 +1,298 @@
+#!/usr/bin/env bun
+
+/**
+ * Census a corpus directory and propose a slice plan for skim passes.
+ *
+ * Walks the directory recursively (skipping dot-files and dot-directories,
+ * so a `.staging/` tree inside the corpus is not counted), records size and
+ * date per file, and groups files into date-windowed slices sized for one
+ * summarization pass each.
+ *
+ * Per-file dates prefer a date embedded in the filename (2025-03-12,
+ * 2025_03_12, or 20250312) and fall back to the file mtime. Slices group by
+ * month, coarsening to quarter and then year when the month count exceeds
+ * the slice budget; buckets with too many files are split into parts.
+ *
+ * Usage:
+ *   bun run scripts/inventory.ts <corpus-dir>
+ *
+ * Stdout: JSON { files, totalBytes, byExtension, dateRange, suggestedSlices }
+ * Stderr: human-readable census.
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { extname, join } from "node:path";
+
+// -- Types --
+
+export interface FileInfo {
+  /** Path relative to the corpus root, with forward slashes. */
+  path: string;
+  bytes: number;
+  /** ISO date (YYYY-MM-DD): filename date when present, else mtime date. */
+  date: string;
+  /** True when `date` came from the filename rather than the mtime. */
+  dateFromName: boolean;
+}
+
+export interface Slice {
+  label: string;
+  earliest: string;
+  latest: string;
+  fileCount: number;
+  bytes: number;
+  paths: string[];
+}
+
+export interface Inventory {
+  files: number;
+  totalBytes: number;
+  byExtension: Record<string, number>;
+  dateRange: { earliest: string; latest: string } | null;
+  suggestedSlices: Slice[];
+}
+
+export interface SliceOptions {
+  /** Upper bound on slice count before coarsening the date grain. */
+  maxSlices?: number;
+  /** Buckets with more files than this are split into parts. */
+  maxFilesPerSlice?: number;
+}
+
+const DEFAULT_MAX_SLICES = 40;
+const DEFAULT_MAX_FILES_PER_SLICE = 200;
+
+// -- Filename date extraction --
+
+const FILENAME_DATE_PATTERNS = [
+  /(\d{4})-(\d{2})-(\d{2})/, // 2025-03-12
+  /(\d{4})_(\d{2})_(\d{2})/, // 2025_03_12
+  /(?<![0-9])(\d{4})(\d{2})(\d{2})(?![0-9])/, // 20250312
+];
+
+/**
+ * Extract an ISO date (YYYY-MM-DD) from a date-like pattern in a file path,
+ * or null when no plausible date is present. Month and day ranges are
+ * validated so version strings like 1.2.20250199 do not match.
+ */
+export function dateFromFilename(path: string): string | null {
+  for (const pattern of FILENAME_DATE_PATTERNS) {
+    const match = path.match(pattern);
+    if (!match) continue;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    if (year < 1980 || year > 2100) continue;
+    if (month < 1 || month > 12) continue;
+    if (day < 1 || day > 31) continue;
+    return `${match[1]}-${match[2]}-${match[3]}`;
+  }
+  return null;
+}
+
+// -- Directory walk --
+
+/**
+ * Recursively list files under `root`. Dot-files and dot-directories are
+ * skipped so staging trees (`.staging/`) and OS litter are not censused.
+ */
+export function walkFiles(root: string): FileInfo[] {
+  const results: FileInfo[] = [];
+  const walk = (dir: string, rel: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+      const full = join(dir, entry.name);
+      const relPath = rel === "" ? entry.name : `${rel}/${entry.name}`;
+      if (entry.isDirectory()) {
+        walk(full, relPath);
+      } else if (entry.isFile()) {
+        const stat = statSync(full);
+        const nameDate = dateFromFilename(relPath);
+        results.push({
+          path: relPath,
+          bytes: stat.size,
+          date: nameDate ?? isoDate(stat.mtimeMs),
+          dateFromName: nameDate !== null,
+        });
+      }
+    }
+  };
+  walk(root, "");
+  results.sort((a, b) =>
+    a.date === b.date
+      ? a.path.localeCompare(b.path)
+      : a.date.localeCompare(b.date),
+  );
+  return results;
+}
+
+function isoDate(epochMs: number): string {
+  return new Date(epochMs).toISOString().slice(0, 10);
+}
+
+// -- Slice planning --
+
+function quarterKey(date: string): string {
+  const month = Number(date.slice(5, 7));
+  const quarter = Math.ceil(month / 3);
+  return `${date.slice(0, 4)}-Q${quarter}`;
+}
+
+function groupBy(
+  files: FileInfo[],
+  keyOf: (date: string) => string,
+): Map<string, FileInfo[]> {
+  const groups = new Map<string, FileInfo[]>();
+  for (const file of files) {
+    const key = keyOf(file.date);
+    const bucket = groups.get(key);
+    if (bucket) {
+      bucket.push(file);
+    } else {
+      groups.set(key, [file]);
+    }
+  }
+  return groups;
+}
+
+function toSlice(label: string, bucket: FileInfo[]): Slice {
+  return {
+    label,
+    earliest: bucket[0].date,
+    latest: bucket[bucket.length - 1].date,
+    fileCount: bucket.length,
+    bytes: bucket.reduce((sum, f) => sum + f.bytes, 0),
+    paths: bucket.map((f) => f.path),
+  };
+}
+
+/** Split any bucket larger than `maxFilesPerSlice` into sequential parts. */
+function splitOversize(
+  label: string,
+  bucket: FileInfo[],
+  maxFilesPerSlice: number,
+): Slice[] {
+  if (bucket.length <= maxFilesPerSlice) {
+    return [toSlice(label, bucket)];
+  }
+  const parts = Math.ceil(bucket.length / maxFilesPerSlice);
+  const perPart = Math.ceil(bucket.length / parts);
+  const slices: Slice[] = [];
+  for (let i = 0; i < parts; i++) {
+    const chunk = bucket.slice(i * perPart, (i + 1) * perPart);
+    if (chunk.length > 0) {
+      slices.push(toSlice(`${label} (part ${i + 1})`, chunk));
+    }
+  }
+  return slices;
+}
+
+/**
+ * Group files (already sorted by date) into date-windowed slices: monthly,
+ * coarsening to quarterly and then yearly when the group count exceeds
+ * `maxSlices`, with oversize buckets split into parts.
+ */
+export function suggestSlices(
+  files: FileInfo[],
+  options: SliceOptions = {},
+): Slice[] {
+  const maxSlices = options.maxSlices ?? DEFAULT_MAX_SLICES;
+  const maxFilesPerSlice =
+    options.maxFilesPerSlice ?? DEFAULT_MAX_FILES_PER_SLICE;
+  if (files.length === 0) return [];
+
+  const grains: Array<(date: string) => string> = [
+    (date) => date.slice(0, 7), // month: 2025-03
+    quarterKey, // quarter: 2025-Q1
+    (date) => date.slice(0, 4), // year: 2025
+  ];
+
+  // Try month, then quarter, then year; if even years exceed the budget
+  // (a decades-spanning corpus), the yearly grouping is used as-is.
+  let groups = groupBy(files, grains[0]);
+  for (let i = 1; i < grains.length && groups.size > maxSlices; i++) {
+    groups = groupBy(files, grains[i]);
+  }
+
+  const slices: Slice[] = [];
+  for (const label of [...groups.keys()].sort()) {
+    slices.push(...splitOversize(label, groups.get(label)!, maxFilesPerSlice));
+  }
+  return slices;
+}
+
+// -- Inventory assembly --
+
+export function buildInventory(
+  root: string,
+  options: SliceOptions = {},
+): Inventory {
+  const files = walkFiles(root);
+  const byExtension: Record<string, number> = {};
+  let totalBytes = 0;
+  for (const file of files) {
+    const ext = extname(file.path).toLowerCase() || "(none)";
+    byExtension[ext] = (byExtension[ext] ?? 0) + 1;
+    totalBytes += file.bytes;
+  }
+  return {
+    files: files.length,
+    totalBytes,
+    byExtension,
+    dateRange:
+      files.length === 0
+        ? null
+        : { earliest: files[0].date, latest: files[files.length - 1].date },
+    suggestedSlices: suggestSlices(files, options),
+  };
+}
+
+// -- CLI --
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+function main(): void {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error("Usage: bun run scripts/inventory.ts <corpus-dir>");
+    process.exit(1);
+  }
+  if (!statSync(dir, { throwIfNoEntry: false })?.isDirectory()) {
+    console.error(`Not a directory: ${dir}`);
+    process.exit(1);
+  }
+
+  const inventory = buildInventory(dir);
+
+  console.error(`Corpus census for ${dir}`);
+  console.error(`  files: ${inventory.files}`);
+  console.error(`  total size: ${formatBytes(inventory.totalBytes)}`);
+  const extensions = Object.entries(inventory.byExtension)
+    .sort((a, b) => b[1] - a[1])
+    .map(([ext, count]) => `${ext} x${count}`)
+    .join(", ");
+  console.error(`  extensions: ${extensions || "(none)"}`);
+  if (inventory.dateRange) {
+    console.error(
+      `  date range: ${inventory.dateRange.earliest} to ${inventory.dateRange.latest}`,
+    );
+  }
+  console.error(`  suggested slices: ${inventory.suggestedSlices.length}`);
+  for (const slice of inventory.suggestedSlices) {
+    console.error(
+      `    ${slice.label}: ${slice.fileCount} files, ${formatBytes(slice.bytes)} (${slice.earliest} to ${slice.latest})`,
+    );
+  }
+
+  console.log(JSON.stringify(inventory, null, 2));
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/skills/memory-corpus-ingest/scripts/inventory.ts
+++ b/skills/memory-corpus-ingest/scripts/inventory.ts
@@ -72,8 +72,10 @@ const FILENAME_DATE_PATTERNS = [
 
 /**
  * Extract an ISO date (YYYY-MM-DD) from a date-like pattern in a file path,
- * or null when no plausible date is present. Month and day ranges are
- * validated so version strings like 1.2.20250199 do not match.
+ * or null when no plausible date is present. Candidates are validated
+ * against the actual calendar (a UTC round-trip), so version strings like
+ * 1.2.20250199 and impossible dates like 2025-02-29 in a non-leap year or
+ * 2025-04-31 do not match; callers then fall back to the file mtime.
  */
 export function dateFromFilename(path: string): string | null {
   for (const pattern of FILENAME_DATE_PATTERNS) {
@@ -87,10 +89,15 @@ export function dateFromFilename(path: string): string | null {
     if (year < 1980 || year > 2100) {
       continue;
     }
-    if (month < 1 || month > 12) {
-      continue;
-    }
-    if (day < 1 || day > 31) {
+    // Round-trip through Date.UTC: JavaScript normalizes overflow (month 13
+    // becomes January, April 31 becomes May 1), so a candidate is a real
+    // calendar date only when every component survives unchanged.
+    const roundTrip = new Date(Date.UTC(year, month - 1, day));
+    if (
+      roundTrip.getUTCFullYear() !== year ||
+      roundTrip.getUTCMonth() !== month - 1 ||
+      roundTrip.getUTCDate() !== day
+    ) {
       continue;
     }
     return `${match[1]}-${match[2]}-${match[3]}`;


### PR DESCRIPTION
## Summary
- New catalog skill: cold-store raw corpus, inventory + chunk plan, bounded subagent skim into map pages, ingest via the CLI, author a drill-in retrieval skill, verify
- Map-page template with lead-resident pointers; Fathom reference; inventory script + test

Part of plan: memory-ingestion.md (PR 10 of 11)