### PR TITLE
fix(agent): resume a turn when the model call dies mid-generation

### DIFF
--- a/assistant/src/__tests__/agent-loop-resume-interrupted.test.ts
+++ b/assistant/src/__tests__/agent-loop-resume-interrupted.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Cover for the loop's interrupted-call recovery.
+ *
+ * The reported failure: the model runs several tools, the next call streams for
+ * a while and then dies (the upstream killed a generation that blew its decode
+ * deadline), and the loop surfaces the error and ends the turn — leaving the
+ * task half-done until the user types "continue". These tests assert the loop
+ * now carries on by itself, and that it still stops when carrying on would be
+ * pointless.
+ *
+ * The recovery is built into {@link AgentLoop}, not contributed by a plugin, so
+ * these run it as the loop's own behavior. The default plugin stack is
+ * registered because the loop fires hook chains during a turn regardless.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { AgentEvent } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../providers/types.js";
+import { ProviderError } from "../util/errors.js";
+
+const tools: ToolDefinition[] = [
+  {
+    name: "read_file",
+    description: "Read a file",
+    input_schema: { type: "object", properties: { path: { type: "string" } } },
+  },
+];
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "finish the course page" }],
+};
+
+/** The rejection from the reported turn, thrown from inside a live stream. */
+function midStreamRejection(): ProviderError {
+  return new ProviderError(
+    "OpenAI-compatible API error (unknown status): litellm.MidStreamFallbackError: " +
+      "litellm.APIConnectionError: OpenAIException - Decode wall clock timeout after 600s",
+    "openai-compatible",
+  );
+}
+
+/** A scripted turn: return a response, or stream `thinking` and then throw. */
+type Turn =
+  | { kind: "reply"; response: ProviderResponse }
+  | { kind: "interrupt"; thinking: string }
+  | { kind: "refuse" };
+
+function scriptedProvider(turns: Turn[]): {
+  provider: Provider;
+  callCount: () => number;
+} {
+  let index = 0;
+  const provider: Provider = {
+    name: "openai-compatible",
+    async sendMessage(
+      _messages: Message[],
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      const turn = turns[Math.min(index, turns.length - 1)]!;
+      index++;
+      if (turn.kind === "refuse") {
+        // Rejected before generating: nothing ever streams.
+        throw midStreamRejection();
+      }
+      if (turn.kind === "interrupt") {
+        options?.onEvent?.({ type: "thinking_delta", thinking: turn.thinking });
+        throw midStreamRejection();
+      }
+      for (const block of turn.response.content) {
+        if (block.type === "text") {
+          options?.onEvent?.({ type: "text_delta", text: block.text });
+        }
+      }
+      return turn.response;
+    },
+  };
+  return { provider, callCount: () => index };
+}
+
+function reply(text: string): Turn {
+  return {
+    kind: "reply",
+    response: {
+      content: [{ type: "text", text }],
+      model: "glm-5.2",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "end_turn",
+    },
+  };
+}
+
+function callsTool(id: string): Turn {
+  return {
+    kind: "reply",
+    response: {
+      content: [
+        { type: "tool_use", id, name: "read_file", input: { path: "app.js" } },
+      ],
+      model: "glm-5.2",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "tool_use",
+    },
+  };
+}
+
+function runLoop(provider: Provider, callSite: LLMCallSite = "mainAgent") {
+  const events: AgentEvent[] = [];
+  const loop = new AgentLoop({
+    provider,
+    systemPrompt: "system",
+    conversationId: "conv-resume-e2e",
+    tools,
+    toolExecutor: async () => ({ content: "file data", isError: false }),
+  });
+  return loop
+    .run({
+      requestId: "req-resume-e2e",
+      messages: [userMessage],
+      callSite,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    })
+    .then((result) => ({ ...result, events }));
+}
+
+function assistantTextOf(history: Message[]): string {
+  return history
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.content)
+    .map((block) => (block.type === "text" ? block.text : ""))
+    .join("");
+}
+
+describe("AgentLoop — a call interrupted mid-generation", () => {
+  beforeEach(() => {
+    resetPluginRegistryAndRegisterDefaults();
+  });
+
+  test("carries on instead of ending the turn", async () => {
+    const { provider, callCount } = scriptedProvider([
+      callsTool("call-1"),
+      { kind: "interrupt", thinking: "Now I need to understand the layout" },
+      reply("Done — the page is wired up."),
+    ]);
+
+    const { history, events } = await runLoop(provider);
+
+    // The turn finished on its own: tool call, interrupted call, resumed call.
+    expect(callCount()).toBe(3);
+    expect(assistantTextOf(history)).toContain("Done — the page is wired up.");
+    expect(events.filter((event) => event.type === "error")).toHaveLength(0);
+  });
+
+  test("keeps the tool work the interrupted turn had already done", async () => {
+    const { provider } = scriptedProvider([
+      callsTool("call-1"),
+      { kind: "interrupt", thinking: "reading the file" },
+      reply("Summary of the file."),
+    ]);
+
+    const { history } = await runLoop(provider);
+
+    // The resumed call re-sends the same history, so the completed tool call
+    // and its result are still there rather than being replayed or dropped.
+    const toolUses = history
+      .flatMap((message) => message.content)
+      .filter((block) => block.type === "tool_use");
+    const toolResults = history
+      .flatMap((message) => message.content)
+      .filter((block) => block.type === "tool_result");
+    expect(toolUses).toHaveLength(1);
+    expect(toolResults).toHaveLength(1);
+  });
+
+  test("surfaces the error when the resumed call is interrupted too", async () => {
+    const { provider, callCount } = scriptedProvider([
+      { kind: "interrupt", thinking: "starting" },
+    ]);
+
+    const { events } = await runLoop(provider);
+
+    // One resume, then the error stands rather than looping.
+    expect(callCount()).toBe(2);
+    expect(events.filter((event) => event.type === "error")).toHaveLength(1);
+  });
+
+  test("does not resume a background call site", async () => {
+    // A compaction, subagent, or other background call answers to a caller
+    // that owns its own failure handling; nobody is sitting there to type
+    // "continue" at it.
+    const { provider, callCount } = scriptedProvider([
+      { kind: "interrupt", thinking: "summarizing" },
+    ]);
+
+    await runLoop(provider, "compactionAgent");
+
+    expect(callCount()).toBe(1);
+  });
+
+  test("does not resume a request the provider refused outright", async () => {
+    // Nothing streamed, so re-sending the identical request would fail the same
+    // way; the error surfaces on the first rejection.
+    const { provider, callCount } = scriptedProvider([{ kind: "refuse" }]);
+
+    const { events } = await runLoop(provider);
+
+    expect(callCount()).toBe(1);
+    expect(events.filter((event) => event.type === "error")).toHaveLength(1);
+  });
+});

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2978,12 +2978,20 @@ describe("session-agent-loop", () => {
       }));
 
       // GIVEN a real loop whose provider streams a delta — landing a debounced
-      // partial flush on the reserved row — then rejects, so the loop emits
-      // `provider_error` and `error` and exits with no `message_complete`.
+      // partial flush on the reserved row — then rejects. The loop resumes a
+      // call that died after it had started streaming, so the second attempt
+      // is scripted to fail before streaming anything: that keeps exactly one
+      // row carrying partial content, and the turn then exits via
+      // `provider_error` with no `message_complete`.
+      let attempt = 0;
       const ctx = makeCtx({
         loopProvider: {
           name: "mock-provider",
           async sendMessage(_messages, options) {
+            attempt++;
+            if (attempt > 1) {
+              throw new Error("upstream 500");
+            }
             options?.onEvent?.({ type: "text_delta", text: "hello world" });
             await new Promise((resolve) => setTimeout(resolve, 1100));
             throw new Error("upstream 500");
@@ -3007,11 +3015,12 @@ describe("session-agent-loop", () => {
         .split("\n");
       expect(orphanLines).toHaveLength(1);
       expect(updateMessageContentMock).toHaveBeenCalledTimes(0);
-      expect(deleteMessageByIdMock).toHaveBeenCalledTimes(1);
-      const deleteCall = deleteMessageByIdMock.mock.calls[0] as unknown as [
-        string,
-      ];
-      expect(deleteCall[0]).toBe("msg-orphan-with-partial");
+      // Scoped to the row under test: the resumed attempt reserves a row of
+      // its own, which its own cleanup deletes.
+      const deletedIds = deleteMessageByIdMock.mock.calls.map(
+        (call) => (call as unknown as [string])[0],
+      );
+      expect(deletedIds).toContain("msg-orphan-with-partial");
     });
   });
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1028,6 +1028,10 @@ export class AgentLoop {
     // rejection means the repair could not recover, so the error surfaces
     // instead of looping. Turn-scoped, so each turn recovers afresh.
     let orderingRepairAttempted = false;
+    // One resume per turn after a call dies mid-generation: a second
+    // interruption means re-issuing is not getting through, so the error
+    // surfaces instead of looping.
+    let interruptedCallResumed = false;
     let lastLlmCallTime = 0;
     let exitReason: ExitReason | null = null;
     // Armed at the end of a tool-use iteration so the budget gate runs at the
@@ -1176,6 +1180,12 @@ export class AgentLoop {
       // elsewhere in the turn body (tool execution, the success-path stop
       // chain, post-model-call hooks) must not re-enter the stop chain.
       let providerCallError: unknown;
+      // Set once the model streams its first token on this iteration's call.
+      // Two readers: latency instrumentation stamps time-to-first-token off
+      // its rising edge, and the outer catch reads it to tell a refused
+      // request from a generation that died mid-flight. Declared here so that
+      // catch can reach it.
+      let streamedTokens = false;
 
       try {
         // ── Pre-call budget gate ─────────────────────────────────────
@@ -1527,11 +1537,6 @@ export class AgentLoop {
         // the client would otherwise see nothing.
         let streamedVisibleText = false;
 
-        // Latency instrumentation: stamp the first streamed token (thinking or
-        // text) of THIS call exactly once, so each per-call segment carries its
-        // own time-to-first-token. Reset per provider call.
-        let firstTokenMarked = false;
-
         // The `onEvent` wrapping below applies sensitive-output placeholder
         // substitution to streamed text while forwarding every other event
         // type through unchanged.
@@ -1541,10 +1546,10 @@ export class AgentLoop {
           config: providerConfig,
           onEvent: (event) => {
             if (
-              !firstTokenMarked &&
+              !streamedTokens &&
               (event.type === "thinking_delta" || event.type === "text_delta")
             ) {
-              firstTokenMarked = true;
+              streamedTokens = true;
               latencyTracker?.markFirstToken(
                 event.type === "thinking_delta" ? "thinking" : "text",
               );
@@ -2496,6 +2501,30 @@ export class AgentLoop {
             // onto the new array; the repaired history is the base the retry's
             // output appends after.
             newMessagesStart = history.length;
+            continue;
+          }
+
+          // Last: the call died mid-generation. `streamedTokens` means the
+          // provider accepted the request and started producing before it
+          // failed, so the request is fine and re-issuing it as-is is the
+          // recovery — nothing to repair, which is why no branch above claims
+          // it. A rejection that streamed nothing is the opposite case (the
+          // provider refused the request), and an identical resend would be
+          // refused identically, so those surface. Main-agent turns only:
+          // background call sites answer to callers that handle their own
+          // failures.
+          if (
+            streamedTokens &&
+            !interruptedCallResumed &&
+            callSite === "mainAgent" &&
+            postModelCallContinues < MAX_POST_MODEL_CALL_CONTINUES
+          ) {
+            interruptedCallResumed = true;
+            postModelCallContinues++;
+            rlog.warn(
+              { turn: toolUseTurns, messageCount: history.length, err },
+              "Model call died mid-generation, resuming the turn",
+            );
             continue;
           }
         }


### PR DESCRIPTION
## Prompt / plan

From user feedback (diagnostics bundle attached to the report): their model started producing garbage mid-task and the turn just ended, leaving them to type "continue" to get it moving again.

The garbage is a provider/model problem we can't fix from here. **The interruption is ours**, and it's the whole of this PR.

### What the diagnostics show

The reported turn, `019fa894-f74f-7147-9a11-ed8130fb07aa` (conversation `dc0bf36d`, turn 12), ten tool calls into the task:

```
15:00:00.647  agent-loop  LLM call start
15:10:19.718  agent-loop  Agent loop error during turn processing
  err: litellm.MidStreamFallbackError … Decode wall clock timeout after 600s
  apiErrorCode: "500"   reason: "unknown"
```

One `LLM call start`, no `LLM call complete`, and **zero retries** — no `[retry] Retrying after transient error` line anywhere in the window covering this turn or the second dead turn in the same bundle (14:42–15:11). The error arrived from inside an already-200 stream, so the SDK saw no HTTP status, `deriveReason` returned `unknown`, and `RetryProvider` doesn't retry `unknown`. One attempt, ten minutes, dead turn, all the completed tool work stranded behind an error message.

### Why nothing recovered

The loop's provider-rejection block already recovers from rejections it can **repair first**: it deep-repairs history on a `tool_use`/`tool_result` ordering rejection, and it honors a `post-model-call` hook that re-normalized the history (image-recovery downscaling an oversized image). Both fix something, then re-issue.

Nothing owned the case where there is nothing to fix: the provider accepted the request, started generating, and the call died in flight. So the turn ended.

### The fix

One more branch on the end of that same block — the loop's own behavior, not a plugin, since a turn not dying isn't opt-in.

It keys off whether the model **streamed any token** before the call failed. That single bit separates the two failure classes:

- **Nothing streamed** — the provider refused the request itself (credentials, an oversized image, malformed history). An identical resend is refused identically, so this is left to the repair-first branches above, or it surfaces.
- **Something streamed** — the request was fine and generation was underway when the call died. Re-issue it as-is; the history is untouched because there is nothing to repair.

Because the gate asks *was it interrupted* rather than *what was it producing*, it needs no opinion about the model's output and covers every interruption class — the reported decode-deadline kill, a connection dropped after the provider layer's retries are spent, anything else that cuts a live generation.

Bounded to one resume per turn (matching the single "continue" a user types before deciding for themselves), sharing the block's existing `MAX_POST_MODEL_CALL_CONTINUES` backstop, and confined to the user-facing turn — background, subagent, and compaction call sites answer to callers that own their own failure handling.

The streamed-token flag is the one the loop already kept for time-to-first-token, hoisted to iteration scope so the catch can read it, rather than a second flag that could drift.

### Scope notes

Two things were in earlier revisions of this PR and are deliberately out:

- **A streaming detector for token noise** (`<unk>` runs, cross-script splicing) that aborted the call early. Large and opinionated about one failure signature; the resume covers the reported turn without it.
- **A `deriveReason` fix** classifying mid-stream numeric body codes as retryable. That gap is real and worth its own PR: with it, the provider layer would retry these before the turn layer ever sees them, saving the wall clock the failed call burns. Without it, the resume still recovers, but only after paying that cost once.

## Test plan

`src/__tests__/agent-loop-resume-interrupted.test.ts` drives the **real `AgentLoop`** with a provider that streams and then throws the verbatim rejection from the report:

- A turn that calls a tool, gets interrupted mid-stream, and finishes on its own — 3 provider calls, no `error` event.
- The completed tool call and its result survive the resume intact (re-sent, not replayed or dropped).
- A second interruption surfaces the error instead of looping.
- A background call site (`compactionAgent`) is not resumed.
- A rejection that streamed nothing is not resumed — the error surfaces on the first failure.

Existing suites green: `agent-loop`, `empty-response-hook`, `max-tokens-continue-hook`, `image-recovery-hook`, `vision-recovery`, `default-plugin-names-guard` (135 tests). `bun run typecheck:fast`, `bun run lint`, Prettier clean.

Production diff: `agent/loop.ts`, +57/−7, most of it comment. No new files, no config surface, no plugin, no API surface, no provider-layer change.

Not verified against a live endpoint — I can't reproduce the upstream's decode-deadline kill on demand. The test reproduces the loop-level failure shape the logs show: stream, then throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5JpiA2UG729UaAFwnnScW