### PR TITLE
fix: guard config_patch against provider-less services.stt blocks

### DIFF
--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -7,7 +7,6 @@ import type {
   SttProviderId,
 } from "../../stt/types.js";
 import { getLogger } from "../../util/logger.js";
-import { deepgramLanguageOptions } from "./deepgram.js";
 import {
   getCredentialProvider,
   getProviderEntry,
@@ -478,6 +477,10 @@ async function createStreamingTranscriber(
     case "deepgram": {
       const { DeepgramRealtimeTranscriber } =
         await import("./deepgram-realtime.js");
+      // Lazy like the xai case's xaiLanguageOptions import: pulling the
+      // batch adapter module in at top level would defeat the lazy module
+      // graph this factory documents.
+      const { deepgramLanguageOptions } = await import("./deepgram.js");
       return new DeepgramRealtimeTranscriber(apiKey, {
         sampleRate: options.sampleRate,
         ...deepgramLanguageOptions(options.language),

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -50,7 +50,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
   },
 }));
 
-import { loadRawConfig } from "../../../config/loader.js";
+import { getConfig, loadRawConfig } from "../../../config/loader.js";
 import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
 import {
@@ -1506,6 +1506,86 @@ describe("call-site override tuning backfill", () => {
       body: { llm: { callSites: { recall: null } } },
     });
     expect(savedCallSites().recall).toBeUndefined();
+  });
+});
+
+describe("sparse services.stt patch provider seeding", () => {
+  const configPatchRoute = ROUTES.find(
+    (r) => r.operationId === "config_patch",
+  )!;
+
+  const savedServices = () =>
+    (loadRawConfig().services ?? {}) as Record<
+      string,
+      Record<string, unknown> | undefined
+    >;
+
+  beforeEach(() => {
+    // No services.stt block: exactly the sparse state where the web
+    // language picker's hot-apply patch would otherwise persist a
+    // provider-less stt block. The tts block is the canary for the
+    // LUM-2758 failure family (a validation reset wipes it too).
+    rawConfigFixture = {
+      services: { tts: { provider: "elevenlabs" } },
+    };
+    seedRawConfig();
+  });
+
+  test("language-only patch onto a config with no stt block seeds the effective provider", async () => {
+    const effectiveProvider = getConfig().services.stt.provider;
+
+    await configPatchRoute.handler({
+      body: { services: { stt: { language: "hi" } } },
+    });
+
+    const stt = savedServices().stt!;
+    expect(stt.language).toBe("hi");
+    expect(stt.provider).toBe(effectiveProvider);
+    // The persisted block validates, so the language round-trips through
+    // the parsed config instead of tripping the salvage ladder.
+    const parsed = getConfig().services;
+    expect(parsed.stt.language).toBe("hi");
+    expect(parsed.stt.provider).toBe(effectiveProvider);
+    // Unrelated tts settings survive: no services-section reset happened.
+    expect(savedServices().tts).toEqual({ provider: "elevenlabs" });
+  });
+
+  test("language patch onto a config that has a provider is a pure merge", async () => {
+    rawConfigFixture = {
+      services: { stt: { provider: "xai" }, tts: { provider: "elevenlabs" } },
+    };
+    seedRawConfig();
+
+    await configPatchRoute.handler({
+      body: { services: { stt: { language: "hi" } } },
+    });
+
+    const stt = savedServices().stt!;
+    expect(stt.provider).toBe("xai");
+    expect(stt.language).toBe("hi");
+  });
+
+  test("non-language stt patch without a provider is seeded too", async () => {
+    // The schema requires a provider whenever the stt block exists, so the
+    // seed covers every sparse stt write, not just language.
+    const effectiveProvider = getConfig().services.stt.provider;
+
+    await configPatchRoute.handler({
+      body: { services: { stt: { providers: { deepgram: {} } } } },
+    });
+
+    const stt = savedServices().stt!;
+    expect(stt.provider).toBe(effectiveProvider);
+    expect(stt.providers).toEqual({ deepgram: {} });
+  });
+
+  test("a patch not touching stt invents no stt block", async () => {
+    await configPatchRoute.handler({
+      body: { heartbeat: { activeHoursStart: 9 } },
+    });
+
+    expect(savedServices().stt).toBeUndefined();
+    expect(savedServices().tts).toEqual({ provider: "elevenlabs" });
   });
 });
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1499,6 +1499,34 @@ function scrubRemovedServiceModes(raw: Record<string, unknown>): void {
   }
 }
 
+/**
+ * A persisted `services.stt` block must satisfy SttServiceSchema, whose
+ * `provider` is required. The services-level default fills the provider only
+ * when `services.stt` is wholly absent, so a sparse patch like
+ * `{ services: { stt: { language } } }` deep-merged into a config with no
+ * stt block persists a provider-less block that fails validation and trips
+ * the loader's salvage ladder: the patched value never applies and the whole
+ * `services` section can reset to defaults on the next load (the LUM-2758
+ * failure family). Seed the effective provider into any stt block that lacks
+ * a non-empty string one so every config_patch writer stays self-consistent.
+ * The seed applies to any stt key, not just language: the schema requires
+ * the provider whenever the block exists. A block carrying a non-empty
+ * string provider is left alone, even an invalid one, so an explicit
+ * provider write is never silently rewritten.
+ */
+function seedSttProviderForSparseBlock(raw: Record<string, unknown>): void {
+  const services = readPlainObject(raw.services);
+  const stt = readPlainObject(services?.stt);
+  if (!stt) {
+    return;
+  }
+  const provider = stt.provider;
+  if (typeof provider === "string" && provider.trim().length > 0) {
+    return;
+  }
+  stt.provider = getConfig().services.stt.provider;
+}
+
 async function handlePatchConfig({ body }: RouteHandlerArgs) {
   if (
     !body ||
@@ -1518,6 +1546,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
   backfillNewCallSiteEntries(raw, patch);
   deepMergeOverwrite(raw, patch);
   scrubRemovedServiceModes(raw);
+  seedSttProviderForSparseBlock(raw);
 
   await commitConfigWrite(raw, "patch");
 


### PR DESCRIPTION
## Summary
Fixes a round-3 verification gap for stt-language-selection.md.

**Gap:** the web pickers' hot-apply patch could persist a services.stt block without the schema-required provider on sparse configs, tripping the validation salvage ladder (language silently dropped; services section reset risk on restart). The settings-skill write was already guarded; config_patch was not.
**Fix:** handlePatchConfig seeds the effective provider into any patched services.stt block that lacks one, protecting every config_patch writer.