### PR TITLE
fix: imported-conversation source consumers

### DIFF
--- a/assistant/src/home/feed-source-enrichment.test.ts
+++ b/assistant/src/home/feed-source-enrichment.test.ts
@@ -34,6 +34,13 @@ describe("classifyConversationSource", () => {
     expect(classifyConversationSource("home-feed")).toBe("user");
   });
 
+  it("classifies imported conversations ('import:<provider>') as user", () => {
+    expect(classifyConversationSource("import:chatgpt")).toBe("user");
+    expect(classifyConversationSource("import:claude")).toBe("user");
+    // Bare "import" without the prefix separator is not an import source.
+    expect(classifyConversationSource("import")).toBe("other");
+  });
+
   it("falls through to 'other' for unknown / paired-delivery / empty sources", () => {
     expect(classifyConversationSource("notification")).toBe("other");
     expect(classifyConversationSource("something-else")).toBe("other");

--- a/assistant/src/home/feed-source-enrichment.ts
+++ b/assistant/src/home/feed-source-enrichment.ts
@@ -57,6 +57,11 @@ export interface FeedSourceEnrichmentDeps {
 export function classifyConversationSource(
   source: string | null | undefined,
 ): FeedItemSourceType {
+  // Imported history (`import:<provider>`) is a user conversation that
+  // happened elsewhere; present it like any other user conversation.
+  if (source?.startsWith("import:")) {
+    return "user";
+  }
   switch (source) {
     case "heartbeat":
       return "heartbeat";

--- a/assistant/src/plugins/defaults/memory/v3-eval/eval-packets.ts
+++ b/assistant/src/plugins/defaults/memory/v3-eval/eval-packets.ts
@@ -394,6 +394,9 @@ export function mineTurns(
     .innerJoin(conversations, eq(messages.conversationId, conversations.id))
     .where(
       and(
+        // Imported conversations (source LIKE 'import:%') are deliberately
+        // excluded: they predate this assistant's own retrieval behavior and
+        // would skew packets toward foreign conversation styles.
         sql`COALESCE(${conversations.source}, 'user') = 'user'`,
         sql`${conversations.scheduleJobId} IS NULL`,
         ...(exclude.length > 0
@@ -424,6 +427,9 @@ function minePinnedTurns(db: DrizzleDb, pinnedTurnIds: string[]): MinedTurn[] {
     .where(
       and(
         inArray(messages.conversationId, conversationIds),
+        // Imported conversations (source LIKE 'import:%') are deliberately
+        // excluded: they predate this assistant's own retrieval behavior and
+        // would skew packets toward foreign conversation styles.
         sql`COALESCE(${conversations.source}, 'user') = 'user'`,
         sql`${conversations.scheduleJobId} IS NULL`,
       ),


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for memory-ingestion.md: import:<provider> conversation sources now classify like user conversations in the home feed, and their exclusion from v3 eval-packet sampling is documented as deliberate.