### PR TITLE
fix: skills self-review gaps

### DIFF
--- a/skills/assistant-migration/scripts/lib/memory-items.ts
+++ b/skills/assistant-migration/scripts/lib/memory-items.ts
@@ -20,18 +20,28 @@ export interface MemoryImportItem {
   context?: string;
 }
 
-/** Print items as a JSON array on stdout (the stable parser output contract). */
+/**
+ * Print items as a JSON array on stdout (the stable parser output contract).
+ * Thin convenience wrapper over `createItemsJsonStreamWriter`, which is the
+ * single definition of the output format.
+ */
 export function printItemsJson(items: MemoryImportItem[]): void {
-  process.stdout.write(JSON.stringify(items, null, 2) + "\n");
+  const writer = createItemsJsonStreamWriter((chunk) =>
+    process.stdout.write(chunk),
+  );
+  for (const item of items) {
+    writer.writeItem(item);
+  }
+  writer.end();
 }
 
 /**
- * Incremental writer for the same JSON array contract as `printItemsJson`,
- * for parsers whose candidate sets are too large to hold in memory. Items
- * are serialized one at a time (constant-size buffer per item), so neither
- * the full array nor a full serialized string ever exists. The emitted
- * bytes match `printItemsJson` exactly: a 2-space-indented JSON array plus
- * a trailing newline, parseable as `MemoryImportItem[]`.
+ * Incremental writer defining the parser stdout contract: a 2-space-indented
+ * JSON array plus a trailing newline, byte-identical to
+ * `JSON.stringify(items, null, 2) + "\n"` and parseable as
+ * `MemoryImportItem[]`. Items are serialized one at a time (constant-size
+ * buffer per item), so parsers whose candidate sets are too large to hold in
+ * memory can stream; `printItemsJson` delegates here for the in-memory case.
  *
  * Call `writeItem` per candidate, then `end` exactly once to close the
  * array.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-30T00:00:37.000Z"
+      "updatedAt": "2026-07-30T01:01:07.000Z"
     },
     {
       "id": "chat-complex-documents",
@@ -623,7 +623,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T23:59:49.000Z"
+      "updatedAt": "2026-07-30T01:01:07.000Z"
     },
     {
       "id": "notifications",

--- a/skills/memory-corpus-ingest/SKILL.md
+++ b/skills/memory-corpus-ingest/SKILL.md
@@ -62,11 +62,9 @@ Census the corpus and produce a machine-readable slice plan:
 
 ```bash
 mkdir -p "$VELLUM_WORKSPACE_DIR/imports/<source>/.staging"
-bun run scripts/inventory.ts "$VELLUM_WORKSPACE_DIR/imports/<source>" \
+bun run {baseDir}/scripts/inventory.ts "$VELLUM_WORKSPACE_DIR/imports/<source>" \
   > "$VELLUM_WORKSPACE_DIR/imports/<source>/.staging/plan.json"
 ```
-
-(`scripts/inventory.ts` is relative to this skill's directory.)
 
 The script prints a human census to stderr (file count, total size, extension mix, date range) and a JSON plan to stdout: `{ files, totalBytes, byExtension, dateRange, suggestedSlices }`. Each suggested slice is a date-windowed group of files sized for one skim pass. Review the plan before skimming:
 

--- a/skills/memory-corpus-ingest/references/fathom.md
+++ b/skills/memory-corpus-ingest/references/fathom.md
@@ -17,7 +17,7 @@ Discovery moves:
 
 ```bash
 # shape of the tree and the extension mix
-bun run scripts/inventory.ts "$VELLUM_WORKSPACE_DIR/imports/fathom"
+bun run {baseDir}/scripts/inventory.ts "$VELLUM_WORKSPACE_DIR/imports/fathom"
 
 # spot-check one of each file type before trusting any assumption
 find "$VELLUM_WORKSPACE_DIR/imports/fathom" -name '*.vtt' | head -3


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for memory-ingestion.md: memory-items now has one JSON serializer (printItemsJson delegates to the stream writer), and memory-corpus-ingest anchors its inventory script with {baseDir}.

🤖 Generated with [Claude Code](https://claude.com/claude-code)