### PR TITLE
fix: memory ingest CLI self-review gaps

### DIFF
--- a/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
@@ -11,6 +11,9 @@
  *   - --dry-run and --overwrite pass through to the request body.
  *   - Invalid page results set exit code 1.
  *   - Malformed manifests are rejected client-side without any IPC call.
+ *   - Mid-run daemon failures keep the --json contract (error envelope with
+ *     the partial aggregate from committed batches), print partial counts in
+ *     text mode, and map the IPC status to the standard exit codes.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -83,7 +86,32 @@ mock.module("../../../../ipc/cli-client.js", () => ({
   exitFromIpcResult: (r: { statusCode?: number }) => {
     process.exitCode = r.statusCode === undefined ? 10 : 1;
   },
+  // Mirrors the real exit-code matrix (cli-client.ts): no statusCode = 10
+  // (transport), 5xx = 3, 4xx = 2, otherwise 1.
+  exitCodeFromIpcResult: (r: { statusCode?: number }) => {
+    if (r.statusCode === undefined) {
+      return 10;
+    }
+    if (r.statusCode >= 500) {
+      return 3;
+    }
+    if (r.statusCode >= 400) {
+      return 2;
+    }
+    return 1;
+  },
 }));
+
+// The CLI lazily imports the batch cap from the plugin's route module; mock
+// it so the test never loads daemon route internals (config loader, route
+// policy, ...). Only the constant is consumed at runtime - the
+// MemoryIngestResult import is type-only and erased.
+mock.module(
+  "../../../../plugins/defaults/memory/src/memory-ingest-routes.js",
+  () => ({
+    MAX_INGEST_PAGES_PER_CALL: 200,
+  }),
+);
 
 const capture = (...args: unknown[]) => {
   logOutput.push(args.map(String).join(" "));
@@ -268,6 +296,100 @@ describe("batching", () => {
       expect(summary.skipped).toBe(0);
       expect(summary.invalid).toBe(0);
       expect(summary.results).toHaveLength(250);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mid-run daemon failures: partial results + exit code
+// ---------------------------------------------------------------------------
+
+describe("mid-run daemon failure", () => {
+  /** Fail the second batch with a 409 after batch 1 committed 200 pages. */
+  function failSecondBatch(): void {
+    let call = 0;
+    ipcHandler = (method, params) => {
+      call += 1;
+      if (call >= 2) {
+        return {
+          ok: false,
+          error: "Ingest is locked: consolidation in progress",
+          statusCode: 409,
+        };
+      }
+      return defaultIpcHandler(method, params);
+    };
+  }
+
+  test("--json emits an error envelope with the partial aggregate from committed batches", async () => {
+    failSecondBatch();
+
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 250);
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        manifest,
+        "--json",
+      ]);
+
+      // 409 maps to exit code 2 (daemon 4xx).
+      expect(exitCode).toBe(2);
+      expect(ipcCalls).toHaveLength(2);
+
+      const envelope = JSON.parse(logOutput.at(-1)!);
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error).toContain("Ingest is locked");
+      expect(envelope.partial.written).toBe(200);
+      expect(envelope.partial.skipped).toBe(0);
+      expect(envelope.partial.invalid).toBe(0);
+      expect(envelope.partial.results).toHaveLength(200);
+    });
+  });
+
+  test("text mode prints the error and the partial written/skipped/invalid counts", async () => {
+    failSecondBatch();
+
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 250);
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        manifest,
+      ]);
+
+      expect(exitCode).toBe(2);
+      const output = logOutput.join("\n");
+      expect(output).toContain("Ingest is locked");
+      expect(output).toContain("wrote 200 page(s)");
+      expect(output).toContain("skipped 0 existing");
+      expect(output).toContain("0 invalid");
+    });
+  });
+
+  test("a transport failure with no statusCode exits 10", async () => {
+    ipcHandler = () => ({ ok: false, error: "Daemon is not running" });
+
+    await withTempDir(async (dir) => {
+      const manifest = writeManifest(dir, 1);
+
+      const { exitCode } = await runCommand([
+        "memory",
+        "ingest",
+        "--file",
+        manifest,
+        "--json",
+      ]);
+
+      expect(exitCode).toBe(10);
+      const envelope = JSON.parse(logOutput.at(-1)!);
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error).toContain("Daemon is not running");
+      expect(envelope.partial.written).toBe(0);
     });
   });
 });

--- a/assistant/src/cli/commands/memory/memory-ingest.ts
+++ b/assistant/src/cli/commands/memory/memory-ingest.ts
@@ -12,7 +12,7 @@ import { join, relative, sep } from "node:path";
 
 import type { Command } from "commander";
 
-import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { cliIpcCall, exitCodeFromIpcResult } from "../../../ipc/cli-client.js";
 import type { MemoryIngestResult } from "../../../plugins/defaults/memory/src/memory-ingest-routes.js";
 import { readStdinSync } from "../../../util/read-stdin.js";
 import { subcommand } from "../../lib/cli-command-help.js";
@@ -26,9 +26,6 @@ import { log } from "../../logger.js";
  * "Request timed out" while the assistant keeps working.
  */
 const INGEST_IPC_TIMEOUT_MS = 5 * 60 * 1000;
-
-/** Pages per `memory_ingest` call (the route caps a request at 200 pages). */
-const MAX_PAGES_PER_CALL = 200;
 
 interface IngestPage {
   slug: string;
@@ -169,6 +166,13 @@ export function registerMemoryIngestCommand(memory: Command): void {
       overwrite?: boolean;
       json?: boolean;
     }) => {
+      // Batch cap shared with the daemon route: the route rejects requests
+      // above this many pages, so the CLI chunks its input to match. Loaded
+      // lazily so the CLI module keeps daemon internals out of its static
+      // import graph (see src/cli/AGENTS.md).
+      const { MAX_INGEST_PAGES_PER_CALL } =
+        await import("../../../plugins/defaults/memory/src/memory-ingest-routes.js");
+
       let pages: IngestPage[];
       try {
         pages = assertUniqueSlugs(loadPages(opts));
@@ -199,7 +203,7 @@ export function registerMemoryIngestCommand(memory: Command): void {
         }
         return;
       }
-      for (const batch of chunk(pages, MAX_PAGES_PER_CALL)) {
+      for (const batch of chunk(pages, MAX_INGEST_PAGES_PER_CALL)) {
         const r = await cliIpcCall<MemoryIngestResult>(
           "memory_ingest",
           {
@@ -212,7 +216,24 @@ export function registerMemoryIngestCommand(memory: Command): void {
           { timeoutMs: INGEST_IPC_TIMEOUT_MS },
         );
         if (!r.ok) {
-          return exitFromIpcResult(r);
+          // A batch failed mid-run (e.g. 409 lock conflict, daemon down).
+          // Earlier batches have already committed, so report the partial
+          // aggregate instead of discarding it: a scripted migration needs
+          // to know exactly what landed before the failure.
+          const message = r.error ?? "Unknown error";
+          if (opts.json === true) {
+            log.info(
+              JSON.stringify({ ok: false, error: message, partial: aggregate }),
+            );
+          } else {
+            log.error(`Error: ${message}`);
+            log.error(
+              `Partial results before the failure: wrote ${aggregate.written} page(s); ` +
+                `skipped ${aggregate.skipped} existing; ${aggregate.invalid} invalid.`,
+            );
+          }
+          process.exitCode = exitCodeFromIpcResult(r);
+          return;
         }
         const payload = r.result!;
         aggregate.results.push(...payload.results);

--- a/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
@@ -33,6 +33,11 @@ import {
   MAX_INGEST_PAGES_PER_CALL,
 } from "../substrate/ingest.js";
 
+// Re-exported so IPC clients (the `assistant memory ingest` CLI) can chunk
+// their input to the same cap the route enforces, without reaching past this
+// route module into the substrate.
+export { MAX_INGEST_PAGES_PER_CALL };
+
 const MemoryIngestParamsSchema = z.object({
   /** Pages to ingest; `content` is the full page markdown (frontmatter + body). */
   pages: z

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -963,6 +963,14 @@ describe("assistant subcommand classification", () => {
     expect(result.riskLevel).toBe("low");
   });
 
+  test("assistant memory ingest → medium", async () => {
+    const result = await classifier.classify({
+      command: "assistant memory ingest --dir staging/",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
   test("assistant conversations clear → medium", async () => {
     const result = await classifier.classify({
       command: "assistant conversations clear --confirm",


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for memory-ingestion.md: the CLI now sources MAX_INGEST_PAGES_PER_CALL from the plugin (lazy import), emits a JSON envelope with partial aggregates on daemon-side failures, and the gateway classifier test pins assistant memory ingest at medium.