### PR TITLE
fix: round-2 self-review notes (fathom skill-dir anchor, CLI partial semantics, comment conventions)

### DIFF
--- a/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-ingest.test.ts
@@ -105,11 +105,15 @@ mock.module("../../../../ipc/cli-client.js", () => ({
 // The CLI lazily imports the batch cap from the plugin's route module; mock
 // it so the test never loads daemon route internals (config loader, route
 // policy, ...). Only the constant is consumed at runtime - the
-// MemoryIngestResult import is type-only and erased.
+// MemoryIngestResult import is type-only and erased. The value comes from
+// the substrate module (the constant's true owner, cheap to import) so the
+// chunking tests track the real cap instead of a hardcoded copy.
+import { MAX_INGEST_PAGES_PER_CALL } from "../../../../plugins/defaults/memory/substrate/ingest.js";
+
 mock.module(
   "../../../../plugins/defaults/memory/src/memory-ingest-routes.js",
   () => ({
-    MAX_INGEST_PAGES_PER_CALL: 200,
+    MAX_INGEST_PAGES_PER_CALL,
   }),
 );
 

--- a/assistant/src/cli/commands/memory/memory-ingest.ts
+++ b/assistant/src/cli/commands/memory/memory-ingest.ts
@@ -217,10 +217,11 @@ export function registerMemoryIngestCommand(memory: Command): void {
         );
         if (!r.ok) {
           // A batch failed mid-run (e.g. 409 lock conflict, daemon down).
-          // Earlier batches have already committed, so report the partial
-          // aggregate instead of discarding it: a scripted migration needs
-          // to know exactly what landed before the failure.
+          // `partial` covers fully completed batches only and is therefore a
+          // lower bound: the daemon commits pages one by one, so the failing
+          // batch itself may have written pages this aggregate cannot see.
           const message = r.error ?? "Unknown error";
+          const verb = aggregate.dryRun ? "would write" : "wrote";
           if (opts.json === true) {
             log.info(
               JSON.stringify({ ok: false, error: message, partial: aggregate }),
@@ -228,7 +229,8 @@ export function registerMemoryIngestCommand(memory: Command): void {
           } else {
             log.error(`Error: ${message}`);
             log.error(
-              `Partial results before the failure: wrote ${aggregate.written} page(s); ` +
+              `Partial results from completed batches (the failing batch is ` +
+                `indeterminate): ${verb} ${aggregate.written} page(s); ` +
                 `skipped ${aggregate.skipped} existing; ${aggregate.invalid} invalid.`,
             );
           }

--- a/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-ingest-routes.ts
@@ -97,9 +97,9 @@ export async function handleMemoryIngest(
         `Memory ingest rejected: consolidation lock held by ${err.holder}. Retry after the current writer finishes.`,
       );
     }
-    // No RangeError mapping: the schema's `.max(MAX_INGEST_PAGES_PER_CALL)`
-    // rejects oversized batches in `parseBody` before `ingestPages` runs, so
-    // its internal cap guard is unreachable on this path.
+    // The schema's `.max(MAX_INGEST_PAGES_PER_CALL)` rejects oversized
+    // batches in `parseBody` before `ingestPages` runs; anything else that
+    // escapes `ingestPages` is an internal error for the adapter to surface.
     throw err;
   }
 }

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
@@ -479,7 +479,7 @@ describe("getPageIndex", () => {
 });
 
 // ---------------------------------------------------------------------------
-// parseOriginDate — the shared origin_date parser
+// parseOriginDate: the shared origin_date parser
 // ---------------------------------------------------------------------------
 
 describe("parseOriginDate", () => {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-30T01:01:07.000Z"
+      "updatedAt": "2026-07-30T01:03:23.000Z"
     },
     {
       "id": "chat-complex-documents",
@@ -623,7 +623,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-30T01:01:07.000Z"
+      "updatedAt": "2026-07-30T01:22:19.000Z"
     },
     {
       "id": "notifications",

--- a/skills/memory-corpus-ingest/references/fathom.md
+++ b/skills/memory-corpus-ingest/references/fathom.md
@@ -17,11 +17,16 @@ Discovery moves:
 
 ```bash
 # shape of the tree and the extension mix
-bun run {baseDir}/scripts/inventory.ts "$VELLUM_WORKSPACE_DIR/imports/fathom"
+bun run <skill-dir>/scripts/inventory.ts "$VELLUM_WORKSPACE_DIR/imports/fathom"
 
 # spot-check one of each file type before trusting any assumption
 find "$VELLUM_WORKSPACE_DIR/imports/fathom" -name '*.vtt' | head -3
 ```
+
+(`<skill-dir>` is the installed skill directory. The runnable form lives in
+SKILL.md Step 3, whose `{baseDir}` placeholder the skill loader substitutes at
+load time; substitution does not apply to reference files, so resolve the path
+yourself when running from here.)
 
 If the export contains large media files, keep them cold and skim from transcripts and summaries only; the map never needs the audio. If only recordings exist with no transcripts, stop and tell the user: transcription is a separate (and costly) step to decide on explicitly, not something to slip into a skim pass.
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for memory-ingestion.md (round 2).

**Gaps:** references/fathom.md used the {baseDir} placeholder, which is only substituted in SKILL.md bodies; the CLI failure branch overclaimed partial certainty and said wrote during dry runs; a route comment narrated the diff; one em dash in a new test header; the CLI test mock hardcoded the batch cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)