### PR TITLE
fix(ios): give the VoiceActivity appex a CFBundleDisplayName

### DIFF
--- a/clients/ios/App/App/Config/Extension-Base.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Base.xcconfig
@@ -15,13 +15,20 @@
 // higher than its host app's fails to install on the OS versions the
 // app still claims to support.
 //
-// BUNDLE_URL_SCHEME is the one app-target variable each per-environment
-// extension xcconfig does restate. The Live Activity's widgetURL has to
-// deep-link into its *own* containing app, so the value must be copied
-// verbatim from the matching App*.xcconfig — a mismatch sends a Dev
-// build's island tap into the production app. It reaches Swift as the
-// VellumURLScheme Info.plist key, never as CFBundleURLTypes: an appex
-// must not register a URL type.
+// BUNDLE_URL_SCHEME and BUNDLE_DISPLAY_NAME are the two app-target
+// variables each per-environment extension xcconfig does restate, and
+// both must be copied verbatim from the matching App*.xcconfig.
+//
+// BUNDLE_URL_SCHEME: the Live Activity's widgetURL has to deep-link into
+// its *own* containing app — a mismatch sends a Dev build's island tap
+// into the production app. It reaches Swift as the VellumURLScheme
+// Info.plist key, never as CFBundleURLTypes: an appex must not register
+// a URL type.
+//
+// BUNDLE_DISPLAY_NAME: App Store Connect requires CFBundleDisplayName on
+// a widget extension and rejects the entire upload without it. Nothing
+// catches that locally — the archive builds and signs clean, and the
+// failure surfaces at the altool step in release-ios.yaml.
 //
 // The extension ships no entitlements file at all: no App Group
 // (ContentState carries only primitives across the ActivityKit

--- a/clients/ios/App/App/Config/Extension-Dev.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Dev.xcconfig
@@ -5,6 +5,7 @@
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_DISPLAY_NAME = Vellum Dev
 BUNDLE_URL_SCHEME = vellum-assistant-dev
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity
 

--- a/clients/ios/App/App/Config/Extension-Staging.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Staging.xcconfig
@@ -5,6 +5,7 @@
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_DISPLAY_NAME = Vellum Staging
 BUNDLE_URL_SCHEME = vellum-assistant-staging
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity
 

--- a/clients/ios/App/App/Config/Extension.xcconfig
+++ b/clients/ios/App/App/Config/Extension.xcconfig
@@ -4,6 +4,7 @@
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_DISPLAY_NAME = Vellum
 BUNDLE_URL_SCHEME = vellum-assistant
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.VoiceActivity
 

--- a/clients/ios/App/VoiceActivity/Info.plist
+++ b/clients/ios/App/VoiceActivity/Info.plist
@@ -4,6 +4,16 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<!-- Required on an appex: App Store Connect rejects the whole upload
+	     ("Missing Info.plist value … CFBundleDisplayName") when a widget
+	     extension omits it, and the failure lands at the altool step long
+	     after the archive has built and signed. Distinct from CFBundleName
+	     below, which XcodeGen derives from the target name and so reads
+	     "VoiceActivity Dev" — a build-system identifier, not something to
+	     show a user. This is the name that appears in the widget gallery,
+	     so it tracks the containing app's display name per environment. -->
+	<key>CFBundleDisplayName</key>
+	<string>$(BUNDLE_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## What

Adds `CFBundleDisplayName` to the VoiceActivity widget extension's `Info.plist`, sourced from a `BUNDLE_DISPLAY_NAME` restated in each per-environment `Extension-*.xcconfig`.

## Why

Every iOS release upload has failed App Store Connect validation since the Live Activity extension landed:

```
Validation failed (409) Missing Info.plist value. A value for the key
'CFBundleDisplayName' in bundle App Dev.app/PlugIns/VoiceActivity Dev.appex
is required. (ID: b0972588-6e25-478d-bb75-27a38dc78e08)
```

The archive builds and signs clean, so this only surfaces at the `altool` step — the release job looks like it worked right up until the upload. **No build containing the Dynamic Island or Lock Screen Live Activity has ever reached TestFlight**, which is why neither surface appeared on device while the code itself was fine. This blocks dev, staging and production alike; all three embed the same appex.

`CFBundleName` was already set, but XcodeGen derives it from the target name (`VoiceActivity Dev`) — a build-system identifier, not a name to show a user. `CFBundleDisplayName` is what the widget gallery renders, so it tracks the containing app's display name per environment, exactly as `BUNDLE_URL_SCHEME` already does.

## Verification

Built all three schemes and read the embedded appex `Info.plist`:

| appex | `CFBundleDisplayName` |
| --- | --- |
| `VoiceActivity Dev.appex` | `Vellum Dev` |
| `VoiceActivity Staging.appex` | `Vellum Staging` |
| `VoiceActivity.appex` | `Vellum` |

Separately confirmed on the iOS 26.5 Simulator (iPhone 17 Pro) that the Live Activity itself works — the island renders correctly once a build actually carries the extension.

## Notes

Not covered by CI: nothing local rejects an appex missing this key, and the iOS PR workflow builds without archiving. The real check is the next dev release reaching TestFlight.

One follow-up this unblocks rather than fixes: once a build with `VoiceAudioSessionPlugin` is actually installed, the interruption handler at `clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts:136` ends the session on any `AVAudioSession` interruption — including, potentially, the one a background transition produces. That path has never run on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)