### PR TITLE
fix(ios): add CFBundleDisplayName to VoiceActivity widget extension

### DIFF
--- a/clients/ios/App/App/Config/Extension-Base.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Base.xcconfig
@@ -15,8 +15,19 @@
 // higher than its host app's fails to install on the OS versions the
 // app still claims to support.
 //
-// BUNDLE_URL_SCHEME is the one app-target variable each per-environment
-// extension xcconfig does restate. The Live Activity's widgetURL has to
+// BUNDLE_URL_SCHEME and BUNDLE_DISPLAY_NAME are the app-target variables
+// each per-environment extension xcconfig does restate. Both are copied
+// verbatim from the matching App*.xcconfig.
+//
+// BUNDLE_DISPLAY_NAME reaches the appex's Info.plist as CFBundleDisplayName.
+// It is not optional: App Store validation rejects an embedded bundle that
+// omits the key (ITMS-90360), and because these values are per-target, an
+// appex that references $(BUNDLE_DISPLAY_NAME) without defining it here gets
+// an empty string rather than the containing app's name, which is the same
+// rejection. The name is also user-visible, since this bundle ships the
+// StartVoiceControl Control Center control.
+//
+// The Live Activity's widgetURL has to
 // deep-link into its *own* containing app, so the value must be copied
 // verbatim from the matching App*.xcconfig — a mismatch sends a Dev
 // build's island tap into the production app. It reaches Swift as the

--- a/clients/ios/App/App/Config/Extension-Dev.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Dev.xcconfig
@@ -5,6 +5,7 @@
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_DISPLAY_NAME = Vellum Dev
 BUNDLE_URL_SCHEME = vellum-assistant-dev
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity
 

--- a/clients/ios/App/App/Config/Extension-Staging.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Staging.xcconfig
@@ -5,6 +5,7 @@
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_DISPLAY_NAME = Vellum Staging
 BUNDLE_URL_SCHEME = vellum-assistant-staging
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity
 

--- a/clients/ios/App/App/Config/Extension.xcconfig
+++ b/clients/ios/App/App/Config/Extension.xcconfig
@@ -4,6 +4,7 @@
 
 #include "Extension-Base.xcconfig"
 
+BUNDLE_DISPLAY_NAME = Vellum
 BUNDLE_URL_SCHEME = vellum-assistant
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.VoiceActivity
 

--- a/clients/ios/App/VoiceActivity/Info.plist
+++ b/clients/ios/App/VoiceActivity/Info.plist
@@ -10,6 +10,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(BUNDLE_DISPLAY_NAME)</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
## TL;DR

Apple sent an **ITMS-90360** enforcement notice for Vellum Dev 0.11.0 build 202607300053: the embedded `VoiceActivity` widget extension (`App Dev.app/PlugIns/VoiceActivity Dev.appex`) ships an `Info.plist` with no `CFBundleDisplayName`. This adds the key, and defines the `BUNDLE_DISPLAY_NAME` it expands from in the three extension xcconfigs.

Linear: [LUM-2918](https://linear.app/vellum/issue/LUM-2918)

## Why this is two changes, not one

The obvious fix is to copy the two lines from `App/Info.plist` into `VoiceActivity/Info.plist`. That alone would not have cleared the notice.

Xcode build settings are **per-target**. `BUNDLE_DISPLAY_NAME` is defined in `App.xcconfig` / `App-Staging.xcconfig` / `App-Dev.xcconfig`, which only the three app targets use. The `VoiceActivity*` targets use `Extension*.xcconfig`, and `Extension-Base.xcconfig` deliberately does **not** `#include Base.xcconfig` (it documents why: the app-only settings there are wrong or harmful on an appex). So `$(BUNDLE_DISPLAY_NAME)` referenced from the appex plist resolves against a variable nothing defines, and expands to an empty string.

An empty `CFBundleDisplayName` is the same App Store rejection as a missing one, so the plist-only fix would have shipped another rejected build. `clients/ios/docs/NATIVE_VOICE.md` already documents this exact expand-to-empty failure mode for the app target.

Each value is copied verbatim from the matching `App*.xcconfig`, following the rule already established in this file for `BUNDLE_URL_SCHEME` (the other app-target variable the extension configs restate).

## What changes for the user

The appex display name is user-visible: this bundle ships the `StartVoiceControl` Control Center control.

| | Before | After |
|---|---|---|
| `VoiceActivity.appex` display name | *(key absent)* | `Vellum` |
| `VoiceActivity Staging.appex` | *(key absent)* | `Vellum Staging` |
| `VoiceActivity Dev.appex` | *(key absent)* | `Vellum Dev` |
| App Store Connect upload | ITMS-90360 notice | passes validation |

No change to the app targets, bundle IDs, signing, versions, or any runtime behavior.

## Why it is safe

- Adds one Info.plist key and one xcconfig variable per environment. No code, no build-graph change.
- `project.yml` is untouched, so no Xcode project regeneration is needed and the `project.yml`-freshness pre-build guard is unaffected.
- The values match the containing app's display name exactly, so nothing new appears in any user-facing surface.

## Verification

`xcodegen` is not installed on this machine, so I could not run `xcodebuild -showBuildSettings` end-to-end. Instead I resolved the `#include` chain statically and checked **every** variable the appex plist references against each of the three extension configs:

```
VoiceActivity/Info.plist references: BUNDLE_DISPLAY_NAME, BUNDLE_URL_SCHEME,
  CURRENT_PROJECT_VERSION, EXECUTABLE_NAME, MARKETING_VERSION,
  PRODUCT_BUNDLE_IDENTIFIER, PRODUCT_BUNDLE_PACKAGE_TYPE, PRODUCT_NAME

--- VoiceActivity Dev  (Extension-Dev.xcconfig) ---
  BUNDLE_DISPLAY_NAME          = 'Vellum Dev'
  BUNDLE_URL_SCHEME            = 'vellum-assistant-dev'
  PRODUCT_BUNDLE_IDENTIFIER    = 'ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity'
  EXECUTABLE_NAME / PRODUCT_NAME / PRODUCT_BUNDLE_PACKAGE_TYPE = <Xcode builtin>

RESULT: all plist variables resolve
```

All three extension targets resolve cleanly (full output in the commit discussion). Run against the plist-only version of this fix, the same check reports `BUNDLE_DISPLAY_NAME = UNDEFINED -> expands to ''`, which is what caught the gap. Both plists pass `plutil -lint`.

Final confirmation is the next TestFlight upload passing validation without an ITMS-90360 notice.

## Deferred

- **The appex plist is not covered by CI.** Nothing verifies that a `$(VAR)` in an Info.plist is actually defined for the target that consumes it, which is why this reached an Apple enforcement notice rather than a red build. A check like the one above would be cheap to add to `release-ios.yaml`. Left out to keep this PR to the fix, and because it wants its own discussion about where iOS-config linting belongs. Worth doing (this is the second per-target-variable footgun documented in `Extension-Base.xcconfig`), not just backlog filler.
- Did not touch the stale `Extension-Base.xcconfig` header claiming the per-environment configs override "the one key that differs: the bundle ID"; it was already inaccurate before this change (`BUNDLE_URL_SCHEME`) and is unrelated cleanup.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->