### PR TITLE
fix(ci): fail the iOS release when altool fails

### DIFF
--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -336,15 +336,75 @@ jobs:
             exit 1
           fi
 
+          # `altool` exits 0 even when it fails. It prints "VERIFY FAILED" or
+          # "UPLOAD FAILED", reports the reason, and returns success anyway, so
+          # `bash -e` never trips and the step goes green having shipped
+          # nothing. Every dev release between the VoiceActivity appex landing
+          # (#39306) and #39556 was green while uploading nothing at all: the
+          # appex was missing CFBundleDisplayName and App Store Connect
+          # rejected all of them.
+          #
+          # So the exit code is not the signal. `--output-format json` makes
+          # altool emit a `product-errors` array, which is, and it is a
+          # documented contract rather than a message string that can be
+          # reworded. The raw JSON is echoed so the log keeps the detail that
+          # the human-readable output used to carry.
+          #
+          # The text scan afterwards is a backstop for the case this exists to
+          # prevent: a failure altool reports in some shape that is neither a
+          # non-zero exit nor a `product-errors` entry. Between the three, a
+          # release that does not reach TestFlight cannot report success.
+          run_altool() {
+            local label="$1"
+            shift
+
+            local output status
+            set +e
+            output=$(xcrun altool "$@" --output-format json)
+            status=$?
+            set -e
+
+            printf '%s\n' "$output"
+
+            if [ "$status" -ne 0 ]; then
+              echo "::error::$label failed (altool exited $status)"
+              exit 1
+            fi
+
+            # Unparseable output is not proof of failure, and failing on it
+            # would block releases on a formatting change, so that case falls
+            # through to the text scan below instead. Both probes are one-line
+            # programs on purpose: a `run: |` block scalar ends at the first
+            # line indented less than the block, so an indentation-sensitive
+            # heredoc cannot live here.
+            if printf '%s' "$output" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
+              local errors
+              errors=$(printf '%s' "$output" | python3 -c 'import json,sys; print("\n".join(str(e.get("message","unknown error")) for e in (json.load(sys.stdin).get("product-errors") or [])))')
+              if [ -n "$errors" ]; then
+                while IFS= read -r message; do
+                  echo "::error::$label: $message"
+                done <<< "$errors"
+                exit 1
+              fi
+            else
+              echo "::warning::altool output was not valid JSON; relying on the text scan"
+            fi
+
+            if printf '%s' "$output" | grep -qE 'VERIFY FAILED|UPLOAD FAILED|Failed to (validate|upload)'; then
+              echo "::error::$label reported a failure in its output"
+              exit 1
+            fi
+          }
+
           echo "Validating $IPA_FILE..."
-          xcrun altool --validate-app \
+          run_altool "Validation" --validate-app \
             -f "$IPA_FILE" \
             --type ios \
             --apiKey "$ASC_KEY_ID" \
             --apiIssuer "$ASC_ISSUER_ID"
 
           echo "Uploading $IPA_FILE to TestFlight..."
-          xcrun altool --upload-package "$IPA_FILE" \
+          run_altool "Upload" --upload-package "$IPA_FILE" \
             --type ios \
             --apple-id "$APPLE_APP_ID" \
             --bundle-id "$BUNDLE_ID" \


### PR DESCRIPTION
## What

Routes both `xcrun altool` calls in `release-ios.yaml` through a helper that fails the step when altool fails.

## Why

`altool` exits 0 even when it fails. It prints `VERIFY FAILED` / `UPLOAD FAILED`, reports the reason, and returns success anyway, so Actions' default `bash -e` never trips and the step goes green having shipped nothing.

Every dev release between the VoiceActivity appex landing (#39306) and #39556 was green while uploading nothing. Run [30539430151](https://github.com/vellum-ai/vellum-assistant/actions/runs/30539430151) reports **success** with this in its own log:

```
VERIFY FAILED with 1 error
... Missing Info.plist value ... CFBundleDisplayName ...
Failed to validate package.
UPLOAD FAILED with 1 error
Failed to upload package.
```

That run was cited as evidence uploads were working, which is how the Live Activity looked broken on device for a day while the code was fine.

## How

The exit code becomes one signal among three. Any of these fails the step:

1. non-zero exit
2. a `product-errors` entry in altool's JSON output (its documented failure channel, rather than a message string that can be reworded)
3. a `VERIFY FAILED` / `UPLOAD FAILED` / `Failed to (validate|upload)` marker in the text

Apple's message is re-emitted as a `::error::` annotation, so the reason lands in the run summary instead of a log scroll:

```
::error::Upload: Missing Info.plist value. A value for the key 'CFBundleDisplayName' in bundle App Dev.app/PlugIns/VoiceActivity Dev.appex is required.
```

Unparseable JSON warns and falls through to the text scan rather than failing, so a formatting change on Apple's side cannot block a release by itself.

## Verification

Tested against a stub reproducing altool's exit-0-on-failure behavior, with the guard extracted verbatim from the workflow so the test cannot drift from what ships:

| Case | Expected | Result |
| --- | --- | --- |
| success payload | pass | PASS |
| `product-errors` (the real CFBundleDisplayName payload) | fail | PASS |
| `VERIFY FAILED` text | fail | PASS |
| non-zero exit | fail | PASS |
| non-JSON output | pass, with warning | PASS |

Workflow YAML re-parsed after the change. Worth knowing for reviewers: an earlier revision of this used a multi-line `python3 -c '...'` heredoc, which silently terminated the `run: |` block scalar because its body sat at column 0. Both probes are one-liners for that reason, and there is a comment saying so.

## Note

This cannot be verified by CI on this PR; `release-ios.yaml` only runs on a release. The real check is the next dev release, which should now either reach TestFlight or go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)