### PR TITLE
fix(approvals): persist in-app guardian decisions so cards rehydrate decided (LUM-2919)

### DIFF
--- a/assistant/src/__tests__/guardian-card-rehydration.test.ts
+++ b/assistant/src/__tests__/guardian-card-rehydration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Rehydration coverage for in-app guardian decision cards (LUM-2919).
+ *
+ * Selecting Trust / Leave unverified / Block on a message-reaction card resolves
+ * the request server-side and the acting client completes its own card
+ * optimistically. That optimistic completion is in-memory only, so the terminal
+ * state must also reach the conversation's persisted `ui_surface` block, or
+ * re-entering the conversation rebuilds history from a card that still looks
+ * undecided and re-renders the raw button group.
+ *
+ * This exercises the real withdrawal → `markSurfaceCompleted` → history-render
+ * chain, asserting on what a returning client actually reads back.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantEvent } from "../api/index.js";
+
+const broadcasts: AssistantEvent[] = [];
+const realEventHub = await import("../runtime/assistant-event-hub.js");
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  ...realEventHub,
+  broadcastMessage: (msg: AssistantEvent) => {
+    broadcasts.push(msg);
+  },
+}));
+
+// Stand in for the messages table: `markSurfaceCompleted` scans it for the
+// block carrying the surface id and writes the patched content back.
+let rows: Array<{
+  id: string;
+  conversationId: string;
+  role: string;
+  content: unknown;
+  createdAt: number;
+  metadata: string | null;
+}> = [];
+
+const realCrud = await import("../persistence/conversation-crud.js");
+mock.module("../persistence/conversation-crud.js", () => ({
+  ...realCrud,
+  getMessages: (conversationId: string) =>
+    rows.filter((r) => r.conversationId === conversationId),
+  updateMessageContent: (id: string, content: string) => {
+    const row = rows.find((r) => r.id === id);
+    if (row) {
+      row.content = JSON.parse(content);
+    }
+  },
+}));
+
+import {
+  bridgeState,
+  gatewayGuardianRequestsStoreBridge,
+} from "./helpers/gateway-guardian-requests-store-bridge.js";
+
+mock.module(
+  "../channels/gateway-guardian-requests.js",
+  () => gatewayGuardianRequestsStoreBridge,
+);
+
+const { withdrawGuardianRequestCards } =
+  await import("../approvals/guardian-card-withdrawal.js");
+const { renderHistoryContent } = await import("../daemon/handlers/shared.js");
+
+import type { SimGuardianRequest } from "./guardian-gateway-sim.js";
+
+const CONVERSATION_ID = "conv-rehydration-1";
+
+/** The three-button trust decision card as it is first persisted. */
+function seedUndecidedCard(requestId: string): void {
+  rows = [
+    {
+      id: "msg-card",
+      conversationId: CONVERSATION_ID,
+      role: "assistant",
+      content: [
+        {
+          type: "ui_surface",
+          surfaceId: `access-request-${requestId}`,
+          surfaceType: "card",
+          title: "Access Request",
+          data: {
+            title: "Alice",
+            subtitle: "Requesting access to the assistant",
+            body: "",
+          },
+          actions: [
+            { id: `apr:${requestId}:trust`, label: "Trust", style: "primary" },
+            {
+              id: `apr:${requestId}:leave_unverified`,
+              label: "Leave unverified",
+            },
+            {
+              id: `apr:${requestId}:block`,
+              label: "Block",
+              style: "destructive",
+            },
+          ],
+        },
+      ],
+      createdAt: 0,
+      metadata: null,
+    },
+  ];
+}
+
+/** The surface a returning client reads off the rehydrated history row. */
+function rehydratedSurface() {
+  const row = rows.find((r) => r.id === "msg-card")!;
+  return renderHistoryContent(row.content).surfaces[0];
+}
+
+/** A pending access request whose in-app card sits in the conversation. */
+function seedPendingRequest(): SimGuardianRequest {
+  const request = bridgeState.seedRequest({
+    kind: "access_request",
+    sourceType: "channel",
+    sourceChannel: "slack",
+    guardianPrincipalId: "rehydration-test-principal",
+  });
+  bridgeState.seedDelivery({
+    requestId: request.id,
+    destinationChannel: "vellum",
+    destinationConversationId: CONVERSATION_ID,
+  });
+  seedUndecidedCard(request.id);
+  return request;
+}
+
+describe("in-app trust decision rehydration", () => {
+  beforeEach(() => {
+    bridgeState.reset();
+    broadcasts.length = 0;
+  });
+
+  test("an undecided card still carries its action buttons", () => {
+    seedPendingRequest();
+
+    const surface = rehydratedSurface();
+    expect(surface?.completed).toBeUndefined();
+    expect(surface?.actions).toHaveLength(3);
+  });
+
+  test("a decision made in-app rehydrates as completed, not as the button group", async () => {
+    const request = seedPendingRequest();
+
+    await withdrawGuardianRequestCards({
+      request,
+      status: "denied",
+      originChannel: "vellum",
+      decidedAction: "leave_unverified",
+    });
+
+    const surface = rehydratedSurface();
+    expect(surface?.completed).toBe(true);
+    // The neutral park label, not "Denied": the client infers the completion
+    // tone from this string.
+    expect(surface?.completionSummary).toBe("Left unverified");
+    // The card keeps its content for the audit trail; only the live
+    // affordances stop rendering, which the client drives off `completed`.
+    expect(surface?.data).toMatchObject({ title: "Alice" });
+  });
+
+  test("a trust decision made in-app rehydrates as approved", async () => {
+    const request = seedPendingRequest();
+
+    await withdrawGuardianRequestCards({
+      request,
+      status: "approved",
+      originChannel: "vellum",
+      decidedAction: "trust",
+    });
+
+    const surface = rehydratedSurface();
+    expect(surface?.completed).toBe(true);
+    expect(surface?.completionSummary).toBe("Approved");
+  });
+
+  test("an in-app decision does not re-broadcast over the acting client's own summary", async () => {
+    const request = seedPendingRequest();
+
+    await withdrawGuardianRequestCards({
+      request,
+      status: "approved",
+      originChannel: "vellum",
+      decidedAction: "trust",
+    });
+
+    expect(
+      broadcasts.filter((m) => m.type === "ui_surface_complete"),
+    ).toHaveLength(0);
+  });
+
+  test("a decision made on another surface both persists and broadcasts", async () => {
+    const request = seedPendingRequest();
+
+    await withdrawGuardianRequestCards({
+      request,
+      status: "denied",
+      originChannel: "slack",
+      decidedAction: "block",
+    });
+
+    expect(rehydratedSurface()?.completionSummary).toBe("Denied");
+    expect(
+      broadcasts.filter((m) => m.type === "ui_surface_complete"),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/__tests__/guardian-card-withdrawal.test.ts
+++ b/assistant/src/__tests__/guardian-card-withdrawal.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const completeSurfaceAndNotify = mock(() => {});
+const markSurfaceCompleted = mock(() => {});
 mock.module("../daemon/conversation-surfaces.js", () => ({
   completeSurfaceAndNotify,
+  markSurfaceCompleted,
 }));
 
 const withdrawSlackApprovalCard = mock(
@@ -56,6 +58,7 @@ describe("withdrawGuardianRequestCards", () => {
   beforeEach(() => {
     bridgeState.reset();
     completeSurfaceAndNotify.mockClear();
+    markSurfaceCompleted.mockClear();
     withdrawSlackApprovalCard.mockClear();
   });
 
@@ -81,7 +84,7 @@ describe("withdrawGuardianRequestCards", () => {
     );
   });
 
-  test("skips the in-app card when the decision originated in-app", async () => {
+  test("persists the in-app card's completion without broadcasting when the decision originated in-app", async () => {
     const req = makeRequest();
     bridgeState.seedDelivery({
       requestId: req.id,
@@ -95,8 +98,40 @@ describe("withdrawGuardianRequestCards", () => {
       originChannel: "vellum",
     });
 
-    // The acting in-app client already completed its own card optimistically.
+    // The acting client's optimistic completion is in-memory only, so the
+    // terminal state still has to reach history or a re-entry re-renders the
+    // undecided button group (LUM-2919).
+    expect(markSurfaceCompleted).toHaveBeenCalledTimes(1);
+    expect(markSurfaceCompleted).toHaveBeenCalledWith(
+      { conversationId: "conv-1" },
+      `access-request-${req.id}`,
+      "Approved",
+    );
+    // No broadcast: it would replace the resolver's reply text already on
+    // screen with the canonical status label.
     expect(completeSurfaceAndNotify).not.toHaveBeenCalled();
+  });
+
+  test("persists a park decided in-app under its neutral label", async () => {
+    const req = makeRequest();
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+
+    await withdrawGuardianRequestCards({
+      request: req,
+      status: "denied",
+      originChannel: "vellum",
+      decidedAction: "leave_unverified",
+    });
+
+    expect(markSurfaceCompleted).toHaveBeenCalledWith(
+      { conversationId: "conv-1" },
+      `access-request-${req.id}`,
+      "Left unverified",
+    );
   });
 
   test("withdraws the Slack card with decider and decision time", async () => {

--- a/assistant/src/approvals/guardian-card-withdrawal.ts
+++ b/assistant/src/approvals/guardian-card-withdrawal.ts
@@ -27,7 +27,10 @@ import {
   type GuardianRequestStatus,
   listGuardianRequestDeliveries,
 } from "../channels/gateway-guardian-requests.js";
-import { completeSurfaceAndNotify } from "../daemon/conversation-surfaces.js";
+import {
+  completeSurfaceAndNotify,
+  markSurfaceCompleted,
+} from "../daemon/conversation-surfaces.js";
 import { withdrawSlackApprovalCard } from "../messaging/providers/slack/withdraw.js";
 import { approvalCardSurfaceId } from "../notifications/approval-card-data.js";
 import {
@@ -78,10 +81,11 @@ export interface WithdrawGuardianCardsParams {
   /**
    * Channel the decision originated on, when applicable.
    *
-   * The acting in-app client completes its own card optimistically, so the
-   * in-app card is skipped when the decision originated in-app; it is withdrawn
-   * here only when the decision came from another surface. Omit (e.g. the expiry
-   * sweep) to withdraw every surface.
+   * Only the in-app card's `ui_surface_complete` broadcast is origin-sensitive:
+   * an in-app decision is already on screen with the resolver's own reply text,
+   * so re-broadcasting the canonical status label would overwrite it mid-session.
+   * The persisted completion is written regardless of origin. Omit (e.g. the
+   * expiry sweep) to broadcast on every surface.
    */
   originChannel?: string;
   /**
@@ -145,8 +149,17 @@ export async function withdrawGuardianRequestCards(
 
 /**
  * Withdraw the in-app approval card so it stops offering live actions while
- * keeping its content. Skipped when the decision originated in-app — the acting
- * client already completed the card itself.
+ * keeping its content.
+ *
+ * The completion is always persisted onto the card's `ui_surface` block. The
+ * acting client's optimistic completion is in-memory only, so without this write
+ * the conversation's history still carries an undecided card and re-entering the
+ * conversation re-renders the raw button group (LUM-2919).
+ *
+ * The `ui_surface_complete` broadcast is the only origin-sensitive half: when the
+ * decision came from in-app, the acting client is already showing the resolver's
+ * guardian-facing reply, and broadcasting the canonical status label back would
+ * replace that richer summary mid-session.
  */
 function withdrawVellumCard(
   request: WithdrawableGuardianRequest,
@@ -155,9 +168,6 @@ function withdrawVellumCard(
   originChannel: string | undefined,
   decidedAction: ApprovalAction | undefined,
 ): void {
-  if (originChannel === "vellum") {
-    return;
-  }
   if (!delivery.destinationConversationId) {
     return;
   }
@@ -165,10 +175,19 @@ function withdrawVellumCard(
   if (!surfaceId) {
     return;
   }
+  const summary = resolveStatusLabel(status, decidedAction);
+  if (originChannel === "vellum") {
+    markSurfaceCompleted(
+      { conversationId: delivery.destinationConversationId },
+      surfaceId,
+      summary,
+    );
+    return;
+  }
   completeSurfaceAndNotify(
     delivery.destinationConversationId,
     surfaceId,
-    resolveStatusLabel(status, decidedAction),
+    summary,
   );
 }
 

--- a/clients/web/src/domains/chat/components/surfaces/card-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/card-surface.test.tsx
@@ -278,3 +278,111 @@ describe("CardSurface", () => {
     expect(rendered).toContain("OK");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Guardian trust-decision cards
+// ---------------------------------------------------------------------------
+
+/**
+ * The Trust / Leave unverified / Block card as it comes back off conversation
+ * history. A decided card carries `completed` + `completionSummary` on its
+ * persisted `ui_surface` block, and those two fields alone must drive the
+ * rendered state: re-entering the conversation renders from history, with none
+ * of the acting session's in-memory optimistic state (LUM-2919).
+ */
+function trustDecisionCard(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "access-request-req-123",
+    surfaceType: "card",
+    title: "Access Request",
+    data: {
+      title: "Alice",
+      subtitle: "Requesting access to the assistant",
+      body: '> "Hey, can you help me set up my project environment?"',
+    },
+    actions: [
+      { id: "apr:req-123:trust", label: "Trust", style: "primary" },
+      { id: "apr:req-123:leave_unverified", label: "Leave unverified" },
+      { id: "apr:req-123:block", label: "Block", style: "destructive" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("CardSurface trust-decision rehydration", () => {
+  test("an undecided card renders the three decision buttons", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface surface={trustDecisionCard()} onAction={() => undefined} />,
+    );
+
+    expect(rendered).toContain(">Trust</button>");
+    expect(rendered).toContain(">Leave unverified</button>");
+    expect(rendered).toContain(">Block</button>");
+  });
+
+  test("a card rehydrated with a persisted decision renders that decision, not the buttons", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={trustDecisionCard({
+          completed: true,
+          completionSummary: "Left unverified",
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).toContain("Left unverified");
+    // The decision replaces the button group; the card body stays for the
+    // audit trail.
+    expect(rendered).not.toContain(">Trust</button>");
+    expect(rendered).not.toContain(">Leave unverified</button>");
+    expect(rendered).not.toContain(">Block</button>");
+    expect(rendered).toContain("Alice");
+  });
+
+  test("a rehydrated park reads neutral, not as an affirmative success", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={trustDecisionCard({
+          completed: true,
+          completionSummary: "Left unverified",
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    // History carries only the summary string, so the tone is inferred from it.
+    expect(rendered).toContain("lucide-circle-slash");
+    expect(rendered).not.toContain("lucide-circle-check");
+  });
+
+  test("a rehydrated block reads as a rejection", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={trustDecisionCard({
+          completed: true,
+          completionSummary: "Denied",
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).toContain("Denied");
+    expect(rendered).toContain("lucide-circle-x");
+  });
+
+  test("a rehydrated trust reads as a success", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={trustDecisionCard({
+          completed: true,
+          completionSummary: "Approved",
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).toContain("Approved");
+    expect(rendered).toContain("lucide-circle-check");
+  });
+});


### PR DESCRIPTION
## TL;DR

Deciding **Trust** / **Leave unverified** / **Block** on a message reaction card worked inline, but leaving the conversation and coming back re-rendered the undecided button group. The decision was persisted; the *card's* terminal state was not. This writes the card's completion to history regardless of which surface decided.

Fixes LUM-2919.

## What was actually wrong

The bug reads like a client-side rehydration gap, but the read path was already correct. The daemon never wrote the state for it to read.

`withdrawGuardianRequestCards` projects a resolved request's terminal status back onto every surface it was delivered to. For the in-app card it did this:

```ts
function withdrawVellumCard(...) {
  if (originChannel === "vellum") {
    return;   // "the acting client already completed the card itself"
  }
  ...
  completeSurfaceAndNotify(conversationId, surfaceId, label);
}
```

The premise behind that early return is wrong. The acting client's completion is a client-side transcript patch (`completeSubmittedSurface` in `surface-actions.ts`) and nothing more. `completeSurfaceAndNotify` does two things: it **persists** `completed` / `completionSummary` onto the conversation's `ui_surface` block, and it **broadcasts** `ui_surface_complete`. Skipping the whole call to avoid the broadcast also skipped the persist, so the stored block kept `completed` unset. `GET /v1/conversations/:id/messages` reads message rows straight from the DB, so re-entering the conversation rebuilt the card from an undecided block.

Decisions made on any *other* surface (Slack, the expiry sweep) never had this problem, which is why it only showed up for the in-app path.

## The fix

Split persist from broadcast. The completion is written unconditionally; only the broadcast stays origin-gated:

```ts
const summary = resolveStatusLabel(status, decidedAction);
if (originChannel === "vellum") {
  markSurfaceCompleted({ conversationId }, surfaceId, summary);
  return;
}
completeSurfaceAndNotify(conversationId, surfaceId, summary);
```

The broadcast gate is kept deliberately. The acting client is already showing the resolver's guardian-facing reply (e.g. "Alice will stay unverified."); re-broadcasting the canonical status label would replace that richer text mid-session. After a reload the card reads the canonical label, which is what every other surface shows.

**No client change was needed.** `wireSurfaceToDisplay` already maps `completed` / `completionSummary` off the wire, and `SurfaceContainer` already renders the completion row with a tone inferred from the summary (`inferCompletionTone`). That path just had no test pinning it, so this adds one.

## Before / after

| | Before | After |
| --- | --- | --- |
| Click Trust, stay in the conversation | Card shows the decision | Unchanged |
| Leave and come back after Trust | Three buttons again, as if nothing happened | "Approved" with a green check |
| Leave and come back after Leave unverified | Three buttons again | "Left unverified" with a neutral glyph |
| Leave and come back after Block | Three buttons again | "Denied" with a red glyph |
| Decision made in Slack, then open the app | Already correct | Unchanged |
| Clicking again on a stale card | Possible, and returned `already_resolved` | Not possible, no buttons to click |

The last row is a real side benefit: a stale duplicate click on a decided request is now unreachable rather than merely rejected.

## Why this is safe

- The write is the same `markSurfaceCompleted` every other surface-completion path already uses, on the same block, with the same label table (`resolveStatusLabel`). Nothing new is introduced.
- It is idempotent (patch-and-write on a block matched by `surfaceId`) and best-effort by contract: `withdrawGuardianRequestCards` is called after the decision's CAS has already committed, and each surface is attempted in its own try/catch, so a failed write can never surface as a failed decision.
- The inline flow is untouched: no broadcast is added for in-app decisions, so the acting client's optimistic completion and tone are exactly as before.
- Historical cards decided before this lands stay undecided in storage. There is no backfill; the gateway rows and the conversation blocks are separate stores and reconciling them retroactively would mean a migration that scans every conversation to re-derive labels. Not worth it for a card that is a stale audit artifact either way, and clicking one already returns `already_resolved` rather than re-deciding.

## Tests

- `assistant/src/__tests__/guardian-card-rehydration.test.ts` (new) drives the real withdrawal → `markSurfaceCompleted` → `renderHistoryContent` chain and asserts on what a returning client reads back: an undecided card keeps its three actions; a decision made in-app comes back `completed` with the right label per outcome (`Approved` / `Left unverified` / `Denied`); the in-app path does not broadcast; a Slack-origin decision both persists and broadcasts.
- `assistant/src/__tests__/guardian-card-withdrawal.test.ts` replaces the "skips the in-app card" expectation with persist-without-broadcast, plus a park-label case.
- `clients/web/.../card-surface.test.tsx` covers the render side: an undecided card renders the three buttons; a card rehydrated with a persisted decision renders that decision and none of the buttons; the tone glyph is neutral for a park, danger for a block, success for a trust.

Nothing was deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->