### PR TITLE
fix(ci): paginate the dev-release jobs lookup so changelogs and the idle gate work (LUM-2920)

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -62,17 +62,27 @@ jobs:
           # register-release job succeeded; that run's head SHA is the last
           # released commit. (See notify-dev-release for why we key off the job
           # conclusion rather than the overall run conclusion.)
+          #
+          # The jobs listing MUST be paginated: this workflow has >30 jobs and
+          # the API defaults to 30 per page, so register-release lands on page 2
+          # and an unpaginated call silently yields an empty conclusion.
+          #
+          # The runs listing is deliberately NOT --paginate'd — it is a bounded
+          # lookback window, not an exhaustive scan. It must stay comfortably
+          # longer than the longest expected quiet stretch, because every idle
+          # hour adds one cancelled run to it; at 100 the hourly schedule gives
+          # ~4 days of runway, which covers weekends and long holidays.
           PREV_SHA=""
           while read -r rid rsha; do
             [ -z "$rid" ] && continue
-            CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" \
+            CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" --paginate \
               --jq '[.jobs[] | select(.name == "register-release") | .conclusion] | .[0] // empty')
             if [ "$CONCL" = "success" ]; then
               PREV_SHA="$rsha"
               break
             fi
           done < <(gh api \
-            "repos/${REPO}/actions/workflows/dev-release.yaml/runs?branch=main&status=completed&per_page=30&exclude_pull_requests=true" \
+            "repos/${REPO}/actions/workflows/dev-release.yaml/runs?branch=main&status=completed&per_page=100&exclude_pull_requests=true" \
             --jq ".workflow_runs[] | select(.id != ${RUN_ID}) | \"\(.id) \(.head_sha)\"")
 
           echo "Last successful dev release SHA: ${PREV_SHA:-<none>}"
@@ -1345,17 +1355,23 @@ jobs:
           # an older SHA and re-announce already-released commits. Walk recent
           # completed runs newest-first and pick the first whose register-release
           # job succeeded.
+          #
+          # The jobs listing MUST be paginated: this workflow has >30 jobs and
+          # the API defaults to 30 per page, so register-release lands on page 2
+          # and an unpaginated call silently yields an empty conclusion — which
+          # degrades to the single-commit fallback below. See check-for-new-commits
+          # for why the runs listing is bounded rather than fully paginated.
           PREV_SHA=""
           while read -r rid rsha; do
             [ -z "$rid" ] && continue
-            CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" \
+            CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" --paginate \
               --jq '[.jobs[] | select(.name == "register-release") | .conclusion] | .[0] // empty')
             if [ "$CONCL" = "success" ]; then
               PREV_SHA="$rsha"
               break
             fi
           done < <(gh api \
-            "repos/${REPO}/actions/workflows/dev-release.yaml/runs?branch=main&status=completed&per_page=30&exclude_pull_requests=true" \
+            "repos/${REPO}/actions/workflows/dev-release.yaml/runs?branch=main&status=completed&per_page=100&exclude_pull_requests=true" \
             --jq ".workflow_runs[] | select(.id != ${RUN_ID}) | \"\(.id) \(.head_sha)\"")
 
           echo "Previous dev release SHA: ${PREV_SHA:-<none>}"

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -67,16 +67,25 @@ jobs:
           # the API defaults to 30 per page, so register-release lands on page 2
           # and an unpaginated call silently yields an empty conclusion.
           #
-          # The runs listing is deliberately NOT --paginate'd — it is a bounded
+          # The runs listing is deliberately NOT --paginate'd: it is a bounded
           # lookback window, not an exhaustive scan. It must stay comfortably
           # longer than the longest expected quiet stretch, because every idle
           # hour adds one cancelled run to it; at 100 the hourly schedule gives
-          # ~4 days of runway, which covers weekends and long holidays.
+          # ~4 days of runway, which covers weekends and long holidays. That
+          # bounds the walk below at 100 requests (~1 each, since 42 jobs fit in
+          # one per_page=100 page), well inside this job's 5-minute timeout.
           PREV_SHA=""
           while read -r rid rsha; do
             [ -z "$rid" ] && continue
-            CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" --paginate \
-              --jq '[.jobs[] | select(.name == "register-release") | .conclusion] | .[0] // empty')
+            # Best-effort, for the same reason as the cancel call below: a
+            # per-run API failure (purged run, transient 5xx, rate limit) must
+            # not fail this gate job and turn an idle no-op into a workflow
+            # failure. Skip that run and keep walking.
+            if ! CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" --paginate \
+              --jq '[.jobs[] | select(.name == "register-release") | .conclusion] | .[0] // empty'); then
+              echo "::warning::Could not read jobs for run ${rid}; skipping it in the dev-release walk-back."
+              continue
+            fi
             if [ "$CONCL" = "success" ]; then
               PREV_SHA="$rsha"
               break
@@ -1358,14 +1367,20 @@ jobs:
           #
           # The jobs listing MUST be paginated: this workflow has >30 jobs and
           # the API defaults to 30 per page, so register-release lands on page 2
-          # and an unpaginated call silently yields an empty conclusion — which
+          # and an unpaginated call silently yields an empty conclusion, which
           # degrades to the single-commit fallback below. See check-for-new-commits
           # for why the runs listing is bounded rather than fully paginated.
           PREV_SHA=""
           while read -r rid rsha; do
             [ -z "$rid" ] && continue
-            CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" --paginate \
-              --jq '[.jobs[] | select(.name == "register-release") | .conclusion] | .[0] // empty')
+            # Best-effort: a per-run API failure must not abort the notification
+            # step, which would drop the Slack message for a real release
+            # entirely. Skip that run and keep walking.
+            if ! CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" --paginate \
+              --jq '[.jobs[] | select(.name == "register-release") | .conclusion] | .[0] // empty'); then
+              echo "::warning::Could not read jobs for run ${rid}; skipping it in the dev-release walk-back."
+              continue
+            fi
             if [ "$CONCL" = "success" ]; then
               PREV_SHA="$rsha"
               break


### PR DESCRIPTION
## TL;DR

Every `#dev-releases` Slack message has been reporting **1 commit**, and the hourly schedule has been building even when nothing landed. Both come from one bug: two `gh api .../jobs` calls lacked pagination, so the job they look for was never in the response. This adds `?per_page=100 --paginate` to both.

## Root cause

`dev-release.yaml` expands to **42 jobs** (30 declared, 6 with matrices). Two loops walk recent runs to find the last released commit by checking the `register-release` job's conclusion:

```
CONCL=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" --jq '...select(.name == "register-release")...')
```

The Actions jobs API returns **30 jobs per page** by default, and `register-release` is **job 35**. It was never in page 1, so the filter fell through to `// empty` and `PREV_SHA` stayed unset in both callers.

Verified directly against the API. Every recent run:

| run | jobs | unpaginated | paginated |
|---|---|---|---|
| 30547812147 | 42 | *(empty)* | `success` |
| 30539430151 | 42 | *(empty)* | `success` |
| 30535970820 | 42 | *(empty)* | `success` |
| ...10 more | 40-42 | *(empty)* | `success` / `skipped` |

And in the production run logs:

```
check-for-new-commits: Last successful dev release SHA: <none>
check-for-new-commits: No previous successful dev release found, proceeding.
notify-dev-release:    Previous dev release SHA: <none>
notify-dev-release:    Commits listed: 1 (total_commits=1)
```

## What changes for the user

| | Before | After |
|---|---|---|
| Slack changelog | Always the HEAD commit only, "1 commit" | Every commit since the last actual release |
| Commits announced (last 12 releases) | 12 | 29, so **17 were silently dropped** |
| Idle hourly run | Builds all 42 jobs, publishes byte-identical images, posts a redundant Slack message | Cancelled by the existing gate. No build, no message |
| Lookback window | 30 runs (~30h) | 100 runs (~4 days) |
| Transient API failure mid walk-back | Kills the step: gate job fails an idle run, notify job drops the Slack message | Warns, skips that run, keeps walking |

## Why the lookback window also changed

The 30 to 100 bump on the *runs* query isn't drive-by. It becomes load-bearing only once this fix lands. With the idle gate working, every quiet hour leaves a **cancelled** run in that window. At 30 entries an hourly schedule exhausts it after ~30 quiet hours, an ordinary Friday-evening-to-Monday-morning gap, which would empty `PREV_SHA` again and reintroduce the exact single-commit message this PR fixes. 100 gives ~4 days of runway.

That query is deliberately **not** `--paginate`'d: it's a bounded lookback, and paginating it would walk every run ever recorded.

## Cost of the walk-back

Measured with `GH_DEBUG=api`: **1 HTTP request per run**, ~1.3s. 42 jobs fit in a single `per_page=100` page, so `--paginate` finds no `next` link and stops. It's there so this doesn't silently re-break past 100 jobs, which is the exact failure mode being fixed.

Worst case is ~100 requests / ~130s, and only when no run in the window has a successful `register-release` (a >4-day outage). That sits inside the job's 5-minute timeout with roughly 2x margin. Steady state is 1-2 requests. A quiet weekend is ~60, and only the gate job pays it, since `notify-dev-release` doesn't run on cancelled runs.

## Why this is safe

- Query-string and flag changes plus error handling and comments. No logic, ordering, or job-graph changes.
- `--paginate` with `--jq` filters per page and `// empty` suppresses non-matching pages, so exactly one line is emitted. Confirmed live: `CONCL=[success] lines=1`.
- Simulated the fixed algorithm against live data: it resolves `PREV_SHA=272b6e7` and would list 3 commits, versus the 1 the current code reports.
- Error tolerance reproduced with a stubbed `gh` that fails on one run mid-walk. Old form exits **1** and the step dies; new form warns, skips, resolves the correct `PREV_SHA`, exits **0**.
- `--paginate` is already the established pattern in this file (the compare API call in `notify-dev-release`).

## Verification

- Audited `.github/` for other `actions/runs/.../jobs` calls. Only these two exist, and both are fixed.
- YAML parses. All 30 jobs intact.
- Both modified `run:` blocks are `shellcheck` clean.
- Zero em dashes on added lines. File count went 30 to 28, so only the two new lines changed; the 28 pre-existing ones are untouched per the "not swept retroactively" clause in `AGENTS.md`.

## Note on the original report

The filed evidence said "94 PRs merged to main since Jul 29". The actual figure is **33 commits** on `main` since Jul 29 00:00Z. More precisely, `272b6e7` landed at 00:07Z and the next commit didn't land until 13:45Z, so today's 10 identical-SHA runs were *genuinely* idle. For those runs the correct behaviour is **no Slack message at all** (symptom 2), not a longer changelog. The truncated-changelog symptom is real and independently confirmed by the 12-release table above.

## Not done here

- No automated guard against this regressing (for example, a check asserting `register-release` resolves). The comments at both call sites are the mitigation. A real guard needs a workflow-test harness this repo doesn't have. Happy to file a follow-up.
- The first commit message in this branch contains an em dash. Fixing it needs a history rewrite, which isn't worth a force-push on a branch under review. The squash-merge title and body are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)