### PR TITLE
fix(gateway): don't leak an orphaned Slack Socket Mode client at boot

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2174,6 +2174,12 @@ async function main() {
 
   // ── Slack Socket Mode lifecycle ──
   let slackSocketClient: SlackSocketModeClient | null = null;
+  // Guards concurrent startSlackSocket calls: at boot both the credential
+  // watcher's and the config-file watcher's initial polls fire it, and the
+  // second call can pass the stop() guard while the first is still awaiting
+  // credentials — leaving the first client running (open WebSocket, reconnect
+  // loop, cleanup timer) with no reference to stop it.
+  let slackStartGeneration = 0;
 
   /** Fire-and-forget: notify the platform of inbound Slack activity so the
    *  idle-sleep timer is reset for this assistant.
@@ -2225,6 +2231,7 @@ async function main() {
   }
 
   async function startSlackSocket(): Promise<void> {
+    const generation = ++slackStartGeneration;
     if (slackSocketClient) {
       slackSocketClient.stop();
       slackSocketClient = null;
@@ -2236,6 +2243,9 @@ async function main() {
     const appToken = await credentialCache.get(
       credentialKey("slack_channel", "app_token"),
     );
+    // A newer call started while we awaited credentials — let it own the
+    // client. Everything below is synchronous, so one check suffices.
+    if (generation !== slackStartGeneration) return;
     if (!botToken || !appToken) return;
 
     const threadModeRaw = configFileCache.getString("slack", "threadMode");

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2177,7 +2177,7 @@ async function main() {
   // Guards concurrent startSlackSocket calls: at boot both the credential
   // watcher's and the config-file watcher's initial polls fire it, and the
   // second call can pass the stop() guard while the first is still awaiting
-  // credentials — leaving the first client running (open WebSocket, reconnect
+  // credentials, leaving the first client running (open WebSocket, reconnect
   // loop, cleanup timer) with no reference to stop it.
   let slackStartGeneration = 0;
 
@@ -2243,9 +2243,11 @@ async function main() {
     const appToken = await credentialCache.get(
       credentialKey("slack_channel", "app_token"),
     );
-    // A newer call started while we awaited credentials — let it own the
+    // A newer call started while we awaited credentials, so let it own the
     // client. Everything below is synchronous, so one check suffices.
-    if (generation !== slackStartGeneration) return;
+    if (generation !== slackStartGeneration) {
+      return;
+    }
     if (!botToken || !appToken) return;
 
     const threadModeRaw = configFileCache.getString("slack", "threadMode");


### PR DESCRIPTION
## Summary
- Every gateway boot fired `startSlackSocket()` twice — the credential watcher's and config-file watcher's initial polls both diff against an empty baseline, so `slack_channel` credentials and the `slack` config key always read as changed. A user-facing symptom: the gateway visibly connects to Slack twice on every startup.
- The two calls race: each awaits two `credentialCache.get` reads before assigning `slackSocketClient`, so the second call can pass the `stop()` guard while the first is still awaiting — whichever client is assigned last orphans the other (live WebSocket, reconnect loop, and hourly dedup cleanup timer with no reference left to stop them).
- Adds a generation counter (same idiom as `credential-cache.ts`): each call captures `++slackStartGeneration` and bails after its awaits if a newer call has started, so the newest call is the sole client owner and boot collapses to a single Slack connection.

## Original prompt
While investigating a user report (relayed from a doctor session) that their gateway was being OOM-killed and "connects to Slack twice on every startup", we traced the double connection to the two watcher initial polls both triggering `startSlackSocket()` at boot, plus an await race that can orphan a client permanently. The user asked to ship the fix: serialize the calls with a generation counter so the newest call wins and no client is ever orphaned. The Discord path shares the shape but has only one boot trigger and was explicitly left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqbjZ8GgoAXwCQKnFKtxzs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->