### PR TITLE
fix: invoices retry in-flight coverage and error reset on collapse

### DIFF
--- a/clients/web/src/domains/settings/components/invoices-table.test.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.test.tsx
@@ -256,6 +256,29 @@ describe("InvoicesTable pagination", () => {
     expect(getByTestId("invoices-load-more-retry")).not.toBeNull();
   });
 
+  test("collapsing and re-expanding clears the inline error", async () => {
+    seedTwoPages();
+    nextPageErrorStatus = 400;
+    const { getByTestId, queryByTestId, getAllByTestId } = await openTable({
+      showAll: true,
+    });
+
+    fireEvent.click(getByTestId("invoices-load-more"));
+    await waitFor(() =>
+      expect(queryByTestId("invoices-load-more-error")).not.toBeNull(),
+    );
+
+    nextPageErrorStatus = null;
+    fireEvent.click(getByTestId("invoices-toggle"));
+    expect(queryByTestId("invoices-table")).toBeNull();
+    fireEvent.click(getByTestId("invoices-toggle"));
+
+    await waitFor(() => expect(queryByTestId("invoices-table")).not.toBeNull());
+    expect(getAllByTestId("invoice-row").length).toBeGreaterThan(0);
+    expect(queryByTestId("invoices-load-more-error")).toBeNull();
+    expect(queryByTestId("invoices-load-more")).not.toBeNull();
+  });
+
   test("a failed background refetch stays silent and keeps Load more", async () => {
     seedTwoPages();
     const { client, queryByTestId, getAllByTestId } = await openTable({

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -127,6 +127,10 @@ export function InvoicesTable() {
     (showAll || !hasHiddenRows) &&
     invoicesQuery.hasNextPage &&
     !showLoadMoreError;
+  // A retry runs as a refetch followed by a next-page fetch; cover both
+  // phases so a mid-retry click can't cancel the in-flight page fetch.
+  const retryInFlight =
+    invoicesQuery.isRefetching || invoicesQuery.isFetchingNextPage;
 
   function loadMore(): void {
     // fetchNextPage() resolves with the query result rather than rejecting,
@@ -219,7 +223,12 @@ export function InvoicesTable() {
                   <ChevronDown className="h-4 w-4" />
                 )
               }
-              onClick={() => setExpanded((v) => !v)}
+              onClick={() => {
+                // Collapsing abandons a failed page load; re-expanding
+                // refetches, so a stale banner would sit over fresh data.
+                setPageLoadFailed(false);
+                setExpanded((v) => !v);
+              }}
               data-testid="invoices-toggle"
             >
               {expanded ? "Hide invoices" : "Show invoices"}
@@ -376,11 +385,11 @@ export function InvoicesTable() {
                     <button
                       type="button"
                       onClick={retryLoadMore}
-                      disabled={invoicesQuery.isRefetching}
+                      disabled={retryInFlight}
                       className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)] underline transition-colors hover:text-[var(--content-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
                       data-testid="invoices-load-more-retry"
                     >
-                      {invoicesQuery.isRefetching && (
+                      {retryInFlight && (
                         <Loader2 className="h-4 w-4 animate-spin" />
                       )}
                       Retry


### PR DESCRIPTION
## Summary
Round-4 review fixes for invoice-pagination-frontend.md (internal verification + Devin on #39528).

- Retry stays disabled with a spinner through both retry phases (refetch, then next-page fetch), so a mid-retry click can no longer cancel the in-flight page fetch and transiently drop the error banner.
- Collapsing the invoices section clears the sticky page-load error, so re-expanding no longer shows a stale failure banner over freshly refetched data; adds a regression test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->