### PR TITLE
fix(ios-voice): stop activating our own AVAudioSession

### DIFF
--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -150,25 +150,25 @@ This is a rule, not a caveat. The iOS app is a `server.url` shell: it bundles no
 
 Three things follow from the rule:
 
-- **Pick a fallback the caller can proceed with.** `activateVoiceAudioSession()` resolves `false`, `endVoiceLiveActivity()` resolves `undefined`. There is no error branch to write, and no call site may treat a `false` as a reason not to start a session.
+- **Pick a fallback the caller can proceed with.** `startVoiceLiveActivity()` resolves `false`, `endVoiceLiveActivity()` resolves `undefined`. There is no error branch to write, and no call site may treat a `false` as a reason not to start a session.
 - **Fire and forget at the call site.** A bare `void` is enough: because every export in these modules goes through `callNativeVoice`, none of them can reject, so there is no rejection for a call site to handle. A hung or failed bridge call must never delay a voice session.
 - **Destructure the plugin inline inside `invoke`.** The lazy-import rule at the top of this document applies verbatim: only the *result* may cross the `async` boundary, never the plugin Proxy.
 
-**No capability probes.** Neither voice plugin exposes an `isAvailable`, and neither web module wants one: `startVoiceLiveActivity()` resolving `false` and `activateVoiceAudioSession()` resolving `false` already cover every reason there is no native side — off-iOS, an older shell, and (for Live Activities) the user having switched them off in Settings. A probe that can itself be absent just moves the problem, and it is the only answer a caller could act on anyway.
+**No capability probes.** Neither voice plugin exposes an `isAvailable`, and neither web module wants one: `startVoiceLiveActivity()` resolving `false` already covers every reason there is no native side: off-iOS, an older shell, and the user having switched Live Activities off in Settings. A probe that can itself be absent just moves the problem, and it is the only answer a caller could act on anyway.
 
 ### The background-audio contract
 
-**Read § "Full-duplex TTS must render through a MediaStream track" before you touch any of this.** That section warns against reconfiguring the shared `AVAudioSession` around microphone capture, and `VoiceAudioSession` is the one plugin in the tree that does it. What keeps the two compatible is that activation happens exactly once, at a session's leading edge, and is never re-asserted mid-session — the re-assert under a live capture unit was the prime suspect when this pattern shipped as #39331 and produced **no capture at all** on device, reverted in #39345.
+**Read § "Full-duplex TTS must render through a MediaStream track" before you touch any of this.** That section warns against reconfiguring the shared `AVAudioSession` around microphone capture. `VoiceAudioSession` is the one plugin in the tree that can do it, and **nothing calls it any more**: `activateVoiceAudioSession()` has no production caller, by the decision recorded below. The bridge function and the native plugin both remain, so reintroducing activation is one line away and must not be taken casually.
 
-That history is the reason this is device-only territory. A change here that looks obviously correct and passes in the Simulator is precisely the failure mode that already shipped once.
+That history is the reason this is device-only territory. A change here that looks obviously correct and passes in the Simulator is precisely the failure mode that has now shipped twice.
 
 **Echo cancellation does not depend on this.** It used to be the argument for `.voiceChat`; since #39347 it comes from WebKit's own voice-processing unit, reached by routing TTS through a `MediaStreamAudioDestinationNode`. So if this plugin ever has to go, AEC does not go with it.
 
-**Settled, the hard way: the web layer no longer activates an audio session at all.** The pattern broke live voice on a handset twice. First as #39331 (no capture at all, reverted in #39345), then again when it returned in #39306, where a session died roughly 60ms after its WebSocket opened while the Simulator sustained one normally against the same backend. The second failure went unattributed for a day because every #39306 upload was rejected by App Store Connect until #39556, so the plugin had never actually run on a device. `useNativeAudioSessionLifecycle` now only subscribes to interruptions; it never calls `activate`. Do not reintroduce the activation without a device test, and note that a green Simulator run is not one.
+**The rule: the web layer does not activate an audio session.** Settled the hard way, because the pattern broke live voice on a handset twice. First as #39331 (no capture at all, reverted in #39345), then again when it returned in #39306, where a session died roughly 60ms after its WebSocket opened while the Simulator sustained one normally against the same backend. The second failure went unattributed for a day because every #39306 upload was rejected by App Store Connect until #39556, so the plugin had never actually run on a device. `useNativeAudioSessionLifecycle` now only subscribes to interruptions; it never calls `activate`. Do not reintroduce the activation without a device test, and note that a green Simulator run is not one.
 
 The `VoiceAudioSession` plugin stays in the shell: its interruption reporting listens to `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri taking the input from WebKit's session, which is unrelated to owning a session ourselves.
 
-What is genuinely still open is **background audio**. `UIBackgroundModes: audio` in `clients/ios/App/App/Info.plist`, plus an active `.playAndRecord` / `.voiceChat` session, buys:
+What is genuinely still open is **background audio**, and note that the list below describes what an active session *would* buy. None of it is in effect today, because nothing activates one. `UIBackgroundModes: audio` in `clients/ios/App/App/Info.plist`, plus an active `.playAndRecord` / `.voiceChat` session, would buy:
 
 - audio keeps playing while the app is backgrounded or the screen is locked;
 - the mic route survives backgrounding;

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -164,6 +164,10 @@ That history is the reason this is device-only territory. A change here that loo
 
 **Echo cancellation does not depend on this.** It used to be the argument for `.voiceChat`; since #39347 it comes from WebKit's own voice-processing unit, reached by routing TTS through a `MediaStreamAudioDestinationNode`. So if this plugin ever has to go, AEC does not go with it.
 
+**Settled, the hard way: the web layer no longer activates an audio session at all.** The pattern broke live voice on a handset twice. First as #39331 (no capture at all, reverted in #39345), then again when it returned in #39306, where a session died roughly 60ms after its WebSocket opened while the Simulator sustained one normally against the same backend. The second failure went unattributed for a day because every #39306 upload was rejected by App Store Connect until #39556, so the plugin had never actually run on a device. `useNativeAudioSessionLifecycle` now only subscribes to interruptions; it never calls `activate`. Do not reintroduce the activation without a device test, and note that a green Simulator run is not one.
+
+The `VoiceAudioSession` plugin stays in the shell: its interruption reporting listens to `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri taking the input from WebKit's session, which is unrelated to owning a session ourselves.
+
 What is genuinely still open is **background audio**. `UIBackgroundModes: audio` in `clients/ios/App/App/Info.plist`, plus an active `.playAndRecord` / `.voiceChat` session, buys:
 
 - audio keeps playing while the app is backgrounded or the screen is locked;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -334,71 +334,47 @@ describe("session lifetime", () => {
 // ---------------------------------------------------------------------------
 
 describe("native audio session", () => {
-  test("activates once per session, not once per phase change", async () => {
+  // The regression guard. Activating our own AVAudioSession alongside the one
+  // WebKit holds for getUserMedia has broken live voice on a handset twice:
+  // #39331 (no capture at all, reverted in #39345) and again in #39306, where
+  // a session died ~60ms after its socket opened. Nothing may reintroduce it
+  // without a device test, and the Simulator cannot provide one.
+  test("never activates an audio session of its own", async () => {
     const h = renderPersistentController();
-    expect(activateVoiceAudioSession).not.toHaveBeenCalled();
-
     await startListeningViaStarter(h);
-    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
 
-    // The churn a real turn produces. The audio session is already held; none
-    // of this may re-activate it.
-    act(() => {
-      useLiveVoiceStore.getState().setState("thinking");
-      useLiveVoiceStore.getState().setState("speaking");
-      useLiveVoiceStore.getState().setState("listening");
-    });
-    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
+    // The churn a real turn produces, none of which may reach the bridge.
+    for (const phase of ["transcribing", "thinking", "speaking", "listening"] as const) {
+      await act(async () => {
+        useLiveVoiceStore.getState().setState(phase);
+        await Promise.resolve();
+      });
+    }
+
+    expect(activateVoiceAudioSession).not.toHaveBeenCalled();
     expect(deactivateVoiceAudioSession).not.toHaveBeenCalled();
   });
 
-  test("deactivates when the session reaches idle", async () => {
-    const h = renderPersistentController();
-    await startListeningViaStarter(h);
-
-    await act(async () => {
-      useLiveVoiceStore.getState().controls?.stop();
-      await Promise.resolve();
-    });
-
-    expect(useLiveVoiceStore.getState().state).toBe("idle");
-    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
-  });
-
-  test("deactivates when the session fails", async () => {
+  test("never deactivates one either, through idle, failure or unmount", async () => {
     const h = renderPersistentController();
     await startListeningViaStarter(h);
 
     await act(async () => {
       useLiveVoiceStore.getState().fail("velay unreachable");
+      await Promise.resolve();
     });
-
-    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
-  });
-
-  // The reconnect path re-enters `connectSession`, which resets the store (to
-  // `idle`) and immediately sets `connecting` again. Acting on that phantom
-  // `idle` would run `setActive(false, .notifyOthersOnDeactivation)` →
-  // `setActive(true)` mid-session — possibly while backgrounded or locked,
-  // which is exactly the state the `audio` background mode exists to hold open.
-  test("a reconnect that passes through idle does not churn the audio session", async () => {
-    const h = renderPersistentController();
-    await startListeningViaStarter(h);
-    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
-
     await act(async () => {
-      const store = useLiveVoiceStore.getState();
-      store.reset();
-      store.setState("connecting");
-      store.setReconnecting(true);
-      store.setSessionContext("assistant-1", "conv-1");
+      useLiveVoiceStore.getState().setState("idle");
+      await Promise.resolve();
+    });
+    act(() => {
+      h.view.unmount();
     });
 
     expect(deactivateVoiceAudioSession).not.toHaveBeenCalled();
-    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
   });
 
-  test("deactivates on unmount and drops the interruption listener", async () => {
+  test("drops the interruption listener on unmount", async () => {
     const h = renderPersistentController();
     await startListeningViaStarter(h);
 
@@ -406,21 +382,7 @@ describe("native audio session", () => {
       h.view.unmount();
     });
 
-    // Exactly one release, whichever order the controller's own teardown and
-    // this cleanup happen to run in.
-    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
     expect(unsubscribeInterruptions).toHaveBeenCalledTimes(1);
-  });
-
-  test("unmounting without a session deactivates nothing", () => {
-    const h = renderPersistentController();
-
-    act(() => {
-      h.view.unmount();
-    });
-
-    expect(activateVoiceAudioSession).not.toHaveBeenCalled();
-    expect(deactivateVoiceAudioSession).not.toHaveBeenCalled();
   });
 
   test("an interruption ends the active session", async () => {
@@ -433,10 +395,10 @@ describe("native audio session", () => {
     });
 
     // A phone call took the mic; the session ends rather than listening into
-    // a dead input.
+    // a dead input. The interruption arrives on WebKit's session, which is why
+    // this still works without us owning one.
     expect(h.lastClient().ended).toBe(true);
     expect(useLiveVoiceStore.getState().state).toBe("idle");
-    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
   });
 
   test("an interruption ending does not resume or disturb the session", async () => {
@@ -450,7 +412,6 @@ describe("native audio session", () => {
 
     expect(useLiveVoiceStore.getState().state).toBe("listening");
     expect(h.lastClient().closed).toBe(false);
-    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
   });
 
   test("an interruption with no session running is a no-op", async () => {
@@ -466,13 +427,10 @@ describe("native audio session", () => {
   });
 
   // The skew case: an App Store shell older than the `VoiceAudioSession`
-  // plugin. Voice must behave exactly as it does today. The bridge resolves its
-  // fallback rather than rejecting — `callNativeVoice` swallows the "no web
-  // implementation" error, which `runtime/native-audio-session.test.ts` pins
-  // directly.
+  // plugin, where even the interruption listener never fires. Voice must behave
+  // exactly as it does with one. `runtime/native-audio-session.test.ts` pins the
+  // bridge's own off-native and missing-plugin behavior directly.
   test("a bridge with no plugin behind it neither blocks nor breaks a session", async () => {
-    activateVoiceAudioSession.mockImplementation(async () => false);
-
     const h = renderPersistentController();
     await startListeningViaStarter(h);
     expect(useLiveVoiceStore.getState().state).toBe("listening");

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -40,15 +40,11 @@ import {
 import {
   endLiveVoiceSession,
   isLiveVoiceSessionActive,
-  subscribeSettledLiveVoiceState,
   useLiveVoiceStore,
-  type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { drainPendingVoiceStartDeepLink } from "@/domains/chat/voice/live-voice/start-voice-deep-link";
 import { useLiveActivityMirror } from "@/domains/chat/voice/live-voice/use-live-activity-mirror";
 import {
-  activateVoiceAudioSession,
-  deactivateVoiceAudioSession,
   subscribeVoiceAudioInterruptions,
 } from "@/runtime/native-audio-session";
 
@@ -59,73 +55,47 @@ export type UseLiveVoiceSessionControllerOptions = Pick<
 >;
 
 /**
- * Hold the native iOS audio session open for exactly as long as a live-voice
- * session is running.
+ * Report native `AVAudioSession` interruptions into the live-voice session.
  *
- * Driven off store *phase transitions* rather than off the `starter`, so
- * sessions begun from any surface — the composer mic, a start-voice deep link,
- * a reconnect — are covered symmetrically, and so `failed` releases the audio
- * session just as `idle` does.
+ * **This deliberately no longer activates an audio session of its own.**
+ * WebKit owns the shared `AVAudioSession` backing `getUserMedia` in a
+ * `WKWebView`, and activating ours alongside it is what `docs/CAPACITOR.md`
+ * § "Full-duplex TTS must render through a MediaStream track" warns about. That
+ * pattern has now broken live voice on a handset twice: first as #39331, which
+ * produced no capture at all and was reverted in #39345, and again when it
+ * returned in #39306, where a session died roughly 60ms after its socket
+ * opened. The second failure took a while to attribute because #39306's uploads
+ * were all rejected by App Store Connect until #39556, so the plugin had never
+ * actually run on a device before.
  *
- * Everything runs through {@link subscribeSettledLiveVoiceState} inside an
- * effect, never a reactive selector in a render body: the controller sets
- * `observeAudioState: false` precisely so high-frequency amplitude/transcript
- * updates do not re-render the mounting layout, and reading `state` reactively
- * here would subscribe the layout to session churn all over again. Settled
- * rather than raw because a reconnect passes through `idle` on its way back to
- * `connecting` within one tick, and tearing the audio session down and back up
- * on every retry is exactly what the `audio` background mode exists to prevent.
+ * Nothing else depended on it. Echo cancellation moved to WebKit's own
+ * voice-processing unit in #39347 via a `MediaStreamAudioDestinationNode`, and
+ * background/lock-screen audio is claimed by `UIBackgroundModes: audio` in
+ * `Info.plist`, which is independent of this call. Whether the plist entry
+ * alone actually sustains a backgrounded session is still unmeasured (see the
+ * background-audio contract in `docs/CAPACITOR.md`), but a session that dies
+ * immediately in the foreground is strictly worse than one that may not survive
+ * backgrounding.
  *
- * Off the iOS shell every call is a no-op (see `runtime/native-audio-session`),
- * so this is inert in the browser and on Electron.
+ * The interruption subscription stays. It listens to
+ * `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri
+ * taking the input from WebKit's session, and ending on that is unrelated to
+ * owning a session ourselves.
  *
- * **This is the riskiest call in the iOS voice feature — do not change it
- * without a handset.** WebKit owns the shared `AVAudioSession` backing
- * `getUserMedia` in a `WKWebView`, so activating our own around a live capture
- * unit is what `docs/CAPACITOR.md` § "Full-duplex TTS must render through a
- * MediaStream track" warns about: the same pattern shipped as #39331, produced
- * no capture at all, and was reverted in #39345.
+ * Off the iOS shell this is a no-op (see `runtime/native-audio-session`), so it
+ * is inert in the browser and on Electron.
  *
- * Two things keep it in the tree anyway. Activation happens once, at the
- * session's leading edge, never re-asserted mid-session (the re-assert was the
- * prime suspect in #39331) — that is what `holdingAudioSession` guarantees. And
- * echo cancellation no longer rides on it at all: #39347 gets AEC from WebKit's
- * own voice-processing unit via a `MediaStreamAudioDestinationNode`, so the only
- * thing left on this call is background/lock-screen audio.
- *
- * **The Simulator cannot evaluate any of that** — its mock audio device has no
+ * **The Simulator cannot evaluate any of this.** Its mock audio device has no
  * acoustic path, so it passes whether or not a real handset would go silent.
- * Every Simulator run passed during #39331.
+ * Every Simulator run passed during #39331, and the Simulator sustained a
+ * session normally throughout the #39306 failure too.
  */
 function useNativeAudioSessionLifecycle(): void {
   useEffect(() => {
-    // Mirrors whether we currently hold the native audio session, so activate
-    // fires once per session — not once per `listening`/`thinking`/`speaking`
-    // transition — and deactivate never double-fires.
-    let holdingAudioSession = false;
-
-    const sync = (state: LiveVoiceSessionState): void => {
-      const active = isLiveVoiceSessionActive(state);
-      if (active === holdingAudioSession) {
-        return;
-      }
-      holdingAudioSession = active;
-      void (active
-        ? activateVoiceAudioSession()
-        : deactivateVoiceAudioSession());
-    };
-
-    // A session can already be running when this mounts (the controller
-    // remounts across layout-level route changes while the store persists).
-    sync(useLiveVoiceStore.getState().state);
-    const unsubscribeStore = subscribeSettledLiveVoiceState((s) =>
-      sync(s.state),
-    );
-
     const unsubscribeInterruptions = subscribeVoiceAudioInterruptions(
       (event) => {
         // A phone call or Siri has taken the mic. End the session rather than
-        // leave it "listening" into a dead input. No auto-resume on `ended` —
+        // leave it "listening" into a dead input. No auto-resume on `ended`:
         // the user restarts explicitly.
         if (event.type !== "began") {
           return;
@@ -137,18 +107,7 @@ function useNativeAudioSessionLifecycle(): void {
       },
     );
 
-    return () => {
-      unsubscribeStore();
-      unsubscribeInterruptions();
-      // A live audio session must never outlive its controller. Usually the
-      // sibling teardown in `useLiveVoice` has already reset the store to
-      // `idle` (which `sync` observed), leaving this a no-op; it covers the
-      // orders where it has not.
-      if (holdingAudioSession) {
-        holdingAudioSession = false;
-        void deactivateVoiceAudioSession();
-      }
-    };
+    return unsubscribeInterruptions;
   }, []);
 }
 


### PR DESCRIPTION
## What

`useNativeAudioSessionLifecycle` no longer calls `activateVoiceAudioSession()`. It keeps only the interruption subscription.

**Web-side only, so it deploys without an App Store cycle.**

## Why

Live voice dies on a handset roughly 60 ms after its WebSocket opens, with no error shown.

```
14:32:03.846  Live voice WebSocket opened
14:32:03.905  Live voice WebSocket closed   code: 4001
```

Compare healthy sessions earlier the same day:

| Session | Duration | Close code | Deepgram |
| --- | --- | --- | --- |
| 01:59, 02:01, 13:36 | 7s to 2m11s | 1000 | opened, closed normally |
| **14:32** | **59 ms** | **4001** | **never started** |

4001 is velay's bridge remapping a 1001 "going away" (`toSafeWebSocketCloseCode`, `gateway/src/velay/bridge-utils.ts:238`). The session never got as far as creating an STT session.

The cause is the audio session. WebKit owns the shared `AVAudioSession` backing `getUserMedia` in a `WKWebView`, and activating ours alongside it is what `CAPACITOR.md` has warned about since #39331, which produced no capture at all and was reverted in #39345. It returned unflagged in #39306. Activation fires at `connecting` (`isLiveVoiceSessionActive` is true there), putting it exactly inside the window where the session dies.

**Why this took a day to attribute:** every #39306 upload was rejected by App Store Connect until #39556 landed, so the plugin had never actually run on a device. The first build to carry it broke voice immediately.

## Isolation

The Simulator, against the same dev backend with an equivalent build, sustains a session for 30+ seconds and does not reproduce. That is expected and is the point: the Simulator's mock audio device has no acoustic path, and `CAPACITOR.md` already records that every Simulator run passed while the device was dead in #39331.

## What is not lost

- **AEC**: moved to WebKit's own voice-processing unit in #39347 via a `MediaStreamAudioDestinationNode`.
- **Background audio**: claimed by `UIBackgroundModes: audio` in `Info.plist`, independent of this call.
- **Phone-call/Siri handling**: the interruption subscription listens to `AVAudioSession.sharedInstance()`, so it still fires for WebKit's session.

The `VoiceAudioSession` plugin stays in the shell for that interruption reporting.

## Honest caveat

Whether the plist entry alone sustains a *backgrounded* session is still unmeasured. This may mean voice again stops when the app is backgrounded, which is the problem that started this thread. That trade is deliberate: a session that dies in the foreground is strictly worse than one that may not survive backgrounding, and background audio can be measured once voice works at all.

## Verification

18 controller tests pass. The tests that pinned activation are rewritten as a regression guard that it never happens, since the Simulator cannot be trusted to catch a reintroduction. Recorded in `CAPACITOR.md`'s background-audio contract.

Not verifiable here: the fix itself. It needs the handset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)