### PR TITLE
fix(web): square collapsed-rail tiles, calm banner action type, drop rail divider

### DIFF
--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -726,7 +726,8 @@ describe("StatusBanner", () => {
       expect(html).toContain('data-tone="neutral"');
       expect(html).toContain("bg-[var(--surface-active)]");
       expect(html).toContain("items-center");
-      expect(html).toContain("[&amp;_[data-slot=button]]:uppercase");
+      expect(html).toContain("[&amp;_[data-slot=button]]:text-body-small-default");
+      expect(html).not.toContain("[&amp;_[data-slot=button]]:uppercase");
       expect(html).not.toContain(
         "[&amp;_[data-slot=button]]:hover:bg-[color-mix(in_srgb,var(--status-banner-action-color)_12%,transparent)]",
       );

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -205,7 +205,7 @@ export function StatusBannerNotice({
               : "gap-1.5 pl-2 leading-[18px]",
             "[&_[data-slot=button]]:h-auto [&_[data-slot=button]]:border-0 [&_[data-slot=button]]:bg-transparent",
             "[&_[data-slot=button]]:-mx-1 [&_[data-slot=button]]:rounded-sm [&_[data-slot=button]]:px-1 [&_[data-slot=button]]:py-0",
-            "[&_[data-slot=button]]:text-label-medium-default [&_[data-slot=button]]:uppercase",
+            "[&_[data-slot=button]]:text-body-small-default",
             "[&_[data-slot=button]]:leading-[inherit] [&_[data-slot=button]]:shadow-none",
             "[&_[data-slot=button]]:[--vbtn-fg:var(--status-banner-action-color)]",
             "[&_[data-slot=button]]:hover:!bg-transparent [&_[data-slot=button]]:hover:!opacity-100",

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -232,7 +232,8 @@ export function AssistantNavItem({
       title="New Chat"
       data-tour-id="new-chat"
       className={cn(
-        "group relative flex w-full cursor-pointer items-center overflow-hidden rounded-[8px] select-none",
+        "group relative flex w-full cursor-pointer items-center overflow-hidden select-none",
+        collapsed ? "rounded-[6px]" : "rounded-[8px]",
         "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
         "transition-colors duration-150 active:scale-[0.98]",
         hex && !navTourActive
@@ -242,7 +243,11 @@ export function AssistantNavItem({
       )}
       style={
         {
-          height: isMobile ? MOBILE_ROW_HEIGHT : NEW_CHAT_ROW_HEIGHT,
+          height: collapsed
+            ? COLLAPSED_ASSISTANT_ROW_HEIGHT
+            : isMobile
+              ? MOBILE_ROW_HEIGHT
+              : NEW_CHAT_ROW_HEIGHT,
           gap: SIDEBAR_CHIP_GAP,
           paddingLeft: collapsed ? 0 : ROW_PADDING_X,
           paddingRight: collapsed ? 0 : ROW_PADDING_X,
@@ -291,7 +296,7 @@ export function AssistantNavItem({
           aria-current={active ? "page" : undefined}
           className={cn(
             "group relative flex w-full cursor-pointer items-center overflow-hidden select-none",
-            collapsed ? "rounded-[8px]" : "rounded-[6px]",
+            "rounded-[6px]",
             "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
             "transition-colors duration-150 active:scale-[0.98]",
             active
@@ -376,7 +381,7 @@ export function AssistantNavItem({
       aria-current={active ? "page" : undefined}
       className={cn(
         "group relative flex w-full cursor-pointer items-center overflow-hidden select-none",
-        collapsed ? "rounded-[8px]" : "rounded-[6px]",
+        "rounded-[6px]",
         "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
         "transition-[filter,transform,background-color,color] duration-300 active:scale-[0.98]",
         navTourActive

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -396,7 +396,7 @@ export function AssistantSideMenu({
         variant={variant}
         width={width}
         onWidthChange={onWidthChange}
-        className="relative h-full"
+        className="relative h-full border-0"
       >
         <SideMenu.Header>
           {variant === "overlay" ? (


### PR DESCRIPTION
## Summary

Three small UI polish tweaks to the desktop chat layout, from red-annotated design feedback on the collapsed sidebar rail and version-update banner:

- **Square the two top rail tiles.** On the collapsed rail the "New Chat" (+) tile and the assistant-avatar tile used `rounded-[8px]` (the design system's `--radius-md`), reading rounder than the crisp `rounded-[6px]` group-icon tiles below them — and the (+) tile was a 32×38 portrait rectangle rather than a square. Both collapsed tiles are now `rounded-[6px]`, and the (+) tile is a 32×32 square (matching the avatar), so the whole rail speaks one icon-tile language. Expanded-sidebar rows are untouched (the change is gated on `collapsed`).
- **Calm the banner action typography.** `StatusBannerNotice` forced its action buttons to 11px `text-label-medium-default` **uppercase** — the "out of place" treatment on the update banner's `Update / Later` links. They now render as normal sentence-case `text-body-small-default`, in the banner's own type scale. Shared component, so every status banner's actions improve consistently. The `Update | Later` divider is unchanged.
- **Drop the leftmost vertical divider.** The thin line between the rail and the app was the rail card's own 1px border. Removed via a scoped `border-0` on the app's `<SideMenu>` (tailwind-merge lets the consumer class win over the internal border-width), so the rail blends into the page while still reading as a distinct panel via its `--surface-overlay` background. Scoped to this app's rail — the shared design-library default is unchanged.

The exact corner radius / tile sizing in the first change is easy to tune in review.

## Original prompt

Working from a screenshot of the desktop app with three red-annotated UI nits, the ask was to make all three improvements in one PR: (1) the two top sidebar rail buttons should read as squares, (2) the update banner's "UPDATE | LATER" typography feels out of place, and (3) the leftmost vertical divider next to the rail isn't needed. Implemented against the web client's Tailwind v4 + `@vellumai/design-library` conventions, keeping each change minimal and scoped.