### PR TITLE
refactor(assistant): validate the host bash/file/CU result bodies via parseBody (LUM-2923)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -13719,13 +13719,17 @@ paths:
               properties:
                 requestId:
                   type: string
+                  minLength: 1
                   description: Pending bash request ID
                 stdout:
                   type: string
                 stderr:
                   type: string
                 exitCode:
-                  type: number
+                  anyOf:
+                    - type: number
+                    - type: "null"
+                  description: Process exit status, or null when terminated by a signal
                 timedOut:
                   type: boolean
               required:
@@ -13888,6 +13892,7 @@ paths:
               properties:
                 requestId:
                   type: string
+                  minLength: 1
                   description: Pending CU request ID
                 axTree:
                   type: string
@@ -13955,6 +13960,7 @@ paths:
               properties:
                 requestId:
                   type: string
+                  minLength: 1
                   description: Pending request ID to resolve
                 content:
                   type: string

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -448,3 +448,69 @@ describe("handleHostBashResult", () => {
     );
   });
 });
+
+// ── Request body validation ──────────────────────────────────────────
+
+describe("handleHostBashResult: request body validation", () => {
+  beforeEach(() => {
+    pendingStore.clear();
+    resolvedIds.length = 0;
+    resolveSpy.length = 0;
+    clientActorPrincipals.clear();
+  });
+
+  test("rejects a body that is not an object", () => {
+    expect(() => handleHostBashResult({ body: undefined })).toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("rejects an empty-string requestId", () => {
+    expect(() => handleHostBashResult({ body: bashBody("") })).toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("rejects a wrongly typed field before the interaction is consumed", () => {
+    const requestId = "req-bash-bad-exit-code";
+    registerPending(requestId);
+
+    expect(() =>
+      handleHostBashResult({
+        body: { ...bashBody(requestId), exitCode: "0" },
+      }),
+    ).toThrow(BadRequestError);
+
+    expect(resolveSpy).toHaveLength(0);
+    expect(pendingStore.has(requestId)).toBe(true);
+  });
+
+  test("accepts a null exitCode (process terminated by a signal)", async () => {
+    const requestId = "req-bash-signal-kill";
+    registerPending(requestId);
+
+    const result = await handleHostBashResult({
+      body: { ...bashBody(requestId), exitCode: null, timedOut: true },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(resolveSpy[0].result.exitCode).toBeNull();
+  });
+
+  test("tolerates unknown keys", async () => {
+    const requestId = "req-bash-unknown-keys";
+    registerPending(requestId);
+
+    const result = await handleHostBashResult({
+      body: { ...bashBody(requestId), somethingNew: "ignored" },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(resolveSpy[0].result).toEqual({
+      stdout: "hello\n",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    });
+  });
+});

--- a/assistant/src/__tests__/host-cu-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-cu-routes-targeted.test.ts
@@ -419,3 +419,90 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
     });
   });
 });
+
+// ── Request body validation ──────────────────────────────────────────────────
+
+describe("handleHostCuResult: request body validation", () => {
+  beforeEach(() => {
+    pendingStore.clear();
+    conversationStore.clear();
+    actorPrincipalByClient.clear();
+    resolvedIds.length = 0;
+    cuResolveSpy.length = 0;
+    registerConversation("conv-cu-1");
+  });
+
+  test("rejects a body that is not an object", () => {
+    expect(() => handleHostCuResult({ body: undefined })).toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("rejects an empty-string requestId", () => {
+    expect(() => handleHostCuResult({ body: cuBody("") })).toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("rejects a wrongly typed field before the interaction is consumed", () => {
+    const requestId = "req-cu-bad-screenshot-width";
+    registerPending(requestId);
+
+    expect(() =>
+      handleHostCuResult({
+        body: { ...cuBody(requestId), screenshotWidthPx: "800" },
+      }),
+    ).toThrow(BadRequestError);
+
+    expect(cuResolveSpy).toHaveLength(0);
+    expect(pendingStore.has(requestId)).toBe(true);
+  });
+
+  test("forwards a full observation payload unchanged", async () => {
+    const requestId = "req-cu-full-observation";
+    registerPending(requestId);
+
+    const result = await handleHostCuResult({
+      body: {
+        requestId,
+        axTree: "Button [1]",
+        axDiff: "+Button [1]",
+        screenshot: "base64png",
+        screenshotWidthPx: 1600,
+        screenshotHeightPx: 1000,
+        screenWidthPt: 800,
+        screenHeightPt: 500,
+        executionResult: "Clicked",
+        executionError: undefined,
+        secondaryWindows: "none",
+        userGuidance: "look here",
+      },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(cuResolveSpy[0].payload).toMatchObject({
+      axTree: "Button [1]",
+      axDiff: "+Button [1]",
+      screenshot: "base64png",
+      screenshotWidthPx: 1600,
+      screenshotHeightPx: 1000,
+      screenWidthPt: 800,
+      screenHeightPt: 500,
+      executionResult: "Clicked",
+      secondaryWindows: "none",
+      userGuidance: "look here",
+    });
+  });
+
+  test("tolerates unknown keys", async () => {
+    const requestId = "req-cu-unknown-keys";
+    registerPending(requestId);
+
+    const result = await handleHostCuResult({
+      body: { ...cuBody(requestId), somethingNew: "ignored" },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(cuResolveSpy[0].payload).not.toHaveProperty("somethingNew");
+  });
+});

--- a/assistant/src/__tests__/host-file-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-routes-targeted.test.ts
@@ -407,3 +407,63 @@ describe("handleHostFileResult — targetClientId guard", () => {
     });
   });
 });
+
+// ── Request body validation ─────────────────────────────────────────────────
+
+describe("handleHostFileResult: request body validation", () => {
+  beforeEach(() => {
+    pendingStore.clear();
+    resolvedIds.length = 0;
+    resolveSpy.length = 0;
+    clientActors.clear();
+  });
+
+  test("rejects a body that is not an object", () => {
+    expect(() => handleHostFileResult({ body: undefined })).toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("rejects an empty-string requestId", () => {
+    expect(() => handleHostFileResult({ body: fileBody("") })).toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("rejects a wrongly typed field before the interaction is consumed", () => {
+    const requestId = "req-file-bad-is-error";
+    registerPending(requestId);
+
+    expect(() =>
+      handleHostFileResult({
+        body: { ...fileBody(requestId), isError: "yes" },
+      }),
+    ).toThrow(BadRequestError);
+
+    expect(resolveSpy).toHaveLength(0);
+    expect(pendingStore.has(requestId)).toBe(true);
+  });
+
+  test("accepts a body carrying only requestId", async () => {
+    const requestId = "req-file-minimal";
+    registerPending(requestId);
+
+    const result = await handleHostFileResult({ body: { requestId } });
+
+    expect(result).toEqual({ accepted: true });
+    expect(resolveSpy[0].result.content).toBe("");
+    expect(resolveSpy[0].result.isError).toBe(false);
+  });
+
+  test("tolerates unknown keys", async () => {
+    const requestId = "req-file-unknown-keys";
+    registerPending(requestId);
+
+    const result = await handleHostFileResult({
+      body: { ...fileBody(requestId), somethingNew: "ignored" },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(resolveSpy[0].result).not.toHaveProperty("somethingNew");
+  });
+});

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -20,28 +20,43 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+/**
+ * Body of `POST /v1/host-bash-result`, declared as the route's `requestBody`
+ * and parsed by the handler, so the OpenAPI contract and the runtime check are
+ * one schema rather than two hand-kept copies.
+ *
+ * `exitCode` is nullable because a process terminated by a signal has no exit
+ * status: the desktop executor forwards Node's `close` argument verbatim, which
+ * is `null` on signal termination (including its own timeout kill). The proxy
+ * result type carries that `null` through to the tool output.
+ *
+ * Unknown keys are stripped rather than rejected, so a desktop client that
+ * reports a newer result field still resolves its pending request.
+ */
+const HostBashResultBodySchema = z.object({
+  requestId: z.string().min(1).describe("Pending bash request ID"),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  exitCode: z
+    .number()
+    .nullable()
+    .describe("Process exit status, or null when terminated by a signal")
+    .optional(),
+  timedOut: z.boolean().optional(),
+});
 
 // ---------------------------------------------------------------------------
 // POST /v1/host-bash-result
 // ---------------------------------------------------------------------------
 
 async function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
-  if (!body || typeof body !== "object") {
-    throw new BadRequestError("Request body is required");
-  }
-
-  const { requestId, stdout, stderr, exitCode, timedOut } = body as {
-    requestId?: string;
-    stdout?: string;
-    stderr?: string;
-    exitCode?: number | null;
-    timedOut?: boolean;
-  };
-
-  if (!requestId || typeof requestId !== "string") {
-    throw new BadRequestError("requestId is required");
-  }
+  const { requestId, stdout, stderr, exitCode, timedOut } = parseBody(
+    HostBashResultBodySchema,
+    body,
+  );
 
   const submittingClientId =
     headers?.["x-vellum-client-id"]?.trim() || undefined;
@@ -114,13 +129,7 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Submit host bash result",
     description: "Resolve a pending host bash request by requestId.",
     tags: ["host"],
-    requestBody: z.object({
-      requestId: z.string().describe("Pending bash request ID"),
-      stdout: z.string().optional(),
-      stderr: z.string().optional(),
-      exitCode: z.number().optional(),
-      timedOut: z.boolean().optional(),
-    }),
+    requestBody: HostBashResultBodySchema,
     responseBody: z.object({
       accepted: z.boolean(),
     }),

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -20,17 +20,37 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+/**
+ * Body of `POST /v1/host-cu-result`, declared as the route's `requestBody` and
+ * parsed by the handler, so the OpenAPI contract and the runtime check are one
+ * schema rather than two hand-kept copies.
+ *
+ * Unknown keys are stripped rather than rejected, so a desktop client that
+ * reports a newer observation field still resolves its pending request.
+ */
+const HostCuResultBodySchema = z.object({
+  requestId: z.string().min(1).describe("Pending CU request ID"),
+  axTree: z.string().describe("Accessibility tree").optional(),
+  axDiff: z.string().describe("Accessibility tree diff").optional(),
+  screenshot: z.string().describe("Base64 screenshot").optional(),
+  screenshotWidthPx: z.number().optional(),
+  screenshotHeightPx: z.number().optional(),
+  screenWidthPt: z.number().optional(),
+  screenHeightPt: z.number().optional(),
+  executionResult: z.string().optional(),
+  executionError: z.string().optional(),
+  secondaryWindows: z.string().optional(),
+  userGuidance: z.string().optional(),
+});
 
 // ---------------------------------------------------------------------------
 // POST /v1/host-cu-result
 // ---------------------------------------------------------------------------
 
 async function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
-  if (!body || typeof body !== "object") {
-    throw new BadRequestError("Request body is required");
-  }
-
   const {
     requestId,
     axTree,
@@ -44,24 +64,7 @@ async function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     executionError,
     secondaryWindows,
     userGuidance,
-  } = body as {
-    requestId?: string;
-    axTree?: string;
-    axDiff?: string;
-    screenshot?: string;
-    screenshotWidthPx?: number;
-    screenshotHeightPx?: number;
-    screenWidthPt?: number;
-    screenHeightPt?: number;
-    executionResult?: string;
-    executionError?: string;
-    secondaryWindows?: string;
-    userGuidance?: string;
-  };
-
-  if (!requestId || typeof requestId !== "string") {
-    throw new BadRequestError("requestId is required");
-  }
+  } = parseBody(HostCuResultBodySchema, body);
 
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {
@@ -152,20 +155,7 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Submit host CU result",
     description: "Resolve a pending host computer-use request by requestId.",
     tags: ["host"],
-    requestBody: z.object({
-      requestId: z.string().describe("Pending CU request ID"),
-      axTree: z.string().describe("Accessibility tree").optional(),
-      axDiff: z.string().describe("Accessibility tree diff").optional(),
-      screenshot: z.string().describe("Base64 screenshot").optional(),
-      screenshotWidthPx: z.number().optional(),
-      screenshotHeightPx: z.number().optional(),
-      screenWidthPt: z.number().optional(),
-      screenHeightPt: z.number().optional(),
-      executionResult: z.string().optional(),
-      executionError: z.string().optional(),
-      secondaryWindows: z.string().optional(),
-      userGuidance: z.string().optional(),
-    }),
+    requestBody: HostCuResultBodySchema,
     responseBody: z.object({
       accepted: z.boolean(),
     }),

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -20,30 +20,42 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+/**
+ * Body of `POST /v1/host-file-result`, declared as the route's `requestBody`
+ * and parsed by the handler, so the OpenAPI contract and the runtime check are
+ * one schema rather than two hand-kept copies.
+ *
+ * Unknown keys are stripped rather than rejected, so a desktop client that
+ * reports a newer result field still resolves its pending request.
+ */
+const HostFileResultBodySchema = z.object({
+  requestId: z.string().min(1).describe("Pending request ID to resolve"),
+  content: z.string().describe("File content result").optional(),
+  isError: z.boolean().describe("Whether the result is an error").optional(),
+  imageData: z
+    .string()
+    .describe("Optional base64-encoded image bytes for successful image reads")
+    .optional(),
+  audioData: z
+    .string()
+    .describe("Optional base64-encoded audio bytes for successful audio reads")
+    .optional(),
+  audioMimeType: z
+    .string()
+    .describe("MIME type for audioData (e.g. audio/mpeg)")
+    .optional(),
+});
 
 // ---------------------------------------------------------------------------
 // POST /v1/host-file-result
 // ---------------------------------------------------------------------------
 
 async function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
-  if (!body || typeof body !== "object") {
-    throw new BadRequestError("Request body is required");
-  }
-
   const { requestId, content, isError, imageData, audioData, audioMimeType } =
-    body as {
-      requestId?: string;
-      content?: string;
-      isError?: boolean;
-      imageData?: string;
-      audioData?: string;
-      audioMimeType?: string;
-    };
-
-  if (!requestId || typeof requestId !== "string") {
-    throw new BadRequestError("requestId is required");
-  }
+    parseBody(HostFileResultBodySchema, body);
 
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {
@@ -117,30 +129,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Resolve a pending host file proxy request by requestId when the desktop client returns execution results.",
     tags: ["host-file"],
-    requestBody: z.object({
-      requestId: z.string().describe("Pending request ID to resolve"),
-      content: z.string().describe("File content result").optional(),
-      isError: z
-        .boolean()
-        .describe("Whether the result is an error")
-        .optional(),
-      imageData: z
-        .string()
-        .describe(
-          "Optional base64-encoded image bytes for successful image reads",
-        )
-        .optional(),
-      audioData: z
-        .string()
-        .describe(
-          "Optional base64-encoded audio bytes for successful audio reads",
-        )
-        .optional(),
-      audioMimeType: z
-        .string()
-        .describe("MIME type for audioData (e.g. audio/mpeg)")
-        .optional(),
-    }),
+    requestBody: HostFileResultBodySchema,
     responseBody: z.object({
       accepted: z.boolean(),
     }),


### PR DESCRIPTION
## TL;DR

Three host-proxy result routes (`/v1/host-bash-result`, `/v1/host-file-result`, `/v1/host-cu-result`) declared a Zod `requestBody` for OpenAPI but validated it at runtime with a `body as {...}` cast plus a hand-rolled `!requestId` check. Everything except `requestId` reached the awaiting proxy unvalidated. This parses each body against its own declared schema via the shared `parseBody` helper, so the wire contract and the runtime check are one schema instead of two hand-kept copies.

Part of LUM-2923. Continues the per-route rollout from LUM-2796 (#39051) and LUM-2793 (#39393), which established `parseBody` and converted `/v1/host-app-control-result`.

## Why this slice

The three routes converted here are exact structural siblings of `host-app-control-routes.ts`, already converted under LUM-2793: same handler skeleton, same `pending-interactions` tracker, same `400/403/404/409` contract, same client sender (`HostProxyPoster` in `clients/macos`), one AGENTS.md section. A reviewer checks the pattern once and confirms it three times.

`host-browser-result` is the fourth sibling and is **deliberately excluded**. Its body checks live in an exported resolver (`resolveHostBrowserResultByRequestId`) with its own `{ ok, code, status }` return contract, it is unit-tested directly against untyped frames, and the file carries two more routes that validate inline. Converting it means redesigning that resolver boundary, which is a different change with a different blast radius. Follow-up, not scope creep here.

## Why this is safe

- Every schema is the route's **own already-declared** `requestBody`, moved into a named const and reused. No new shapes were invented.
- Schemas stay **non-strict** (unknown keys stripped, not rejected), matching the LUM-2793 precedent, so a desktop client reporting a newer result field still resolves its pending request.
- Malformed input is rejected **before** the pending interaction is looked up or consumed, so a bad body can no longer half-resolve a request. Covered by test.
- Errors flow through `BadRequestError`, which both the HTTP and IPC adapters already map to `400`. No new error path.
- No typecasts to runtime-boundary shapes were introduced; three were removed.

### One declared-contract correction

`host-bash-result` declared `exitCode: z.number()`, but that was wrong and parsing it as written would have broken a routine case. A process terminated by a signal has no exit status: the macOS executor forwards Node's [`close`](https://nodejs.org/api/child_process.html#event-close) argument verbatim, which is `null` on signal termination, **including its own timeout kill**. Three independent sources agree `null` is legal and meaningful:

- `clients/macos/src/main/host-proxy-poster.ts:26` typed `exitCode?: number | null`
- `assistant/src/daemon/host-bash-proxy.ts:27` typed `exitCode: number | null`
- the handler already normalized via `exitCode ?? null`

So the schema is `.nullable()` and the spec now documents the shape clients already send. Enforcing the declared schema literally would have started returning 400 for exactly the timeout-and-kill path.

## What changes for the user

| Request | Before | After |
| --- | --- | --- |
| Well-formed result body | Accepted | Accepted, unchanged |
| Result body with extra unknown fields | Accepted, extras ignored | Accepted, extras ignored |
| `exitCode: null` from a signal-killed command | Accepted (spec said otherwise) | Accepted, and the spec now says so |
| `isError: "yes"` instead of a boolean | Passed a string into `HostFileProxy` through a boolean-typed field | `400 Invalid request body: isError: ...` |
| `screenshotWidthPx: "800"` instead of a number | Passed a string into the CU observation | `400` |
| `exitCode: "0"` instead of a number | Passed a string into the bash result | `400` |
| `requestId: ""` | `400` | `400`, unchanged (now `minLength: 1` in the spec) |
| Missing or non-object body | `400` | `400`, unchanged |

Only the daemon side changes. No client change is required, and no currently-sent payload becomes invalid.

## OpenAPI delta

Regenerated with `bun run generate:openapi`. Two kinds of change, both documenting existing behavior:

- `minLength: 1` on the three `requestId` fields, documenting the empty-string rejection the old `!requestId` guards already performed.
- `exitCode` becomes `number | null` with a description, per above.

## Tests

Added a `request body validation` block to each of the three existing route test files (extending them rather than adding new files):

- non-object body rejected
- empty-string `requestId` rejected
- wrongly typed field rejected **and** the pending interaction left unconsumed
- unknown keys tolerated
- `exitCode: null` accepted and forwarded as `null` (the regression guard for the correction above)
- minimal body (`requestId` only) still defaults correctly (file)
- full observation payload forwarded unchanged (CU)

```
host-bash-routes            26 pass  0 fail
host-file-routes-targeted   22 pass  0 fail
host-cu-routes-targeted     21 pass  0 fail
```

Also run green: `host-bash-proxy`, `host-cu-proxy`, `host-file-proxy`, `host-file-proxy-targeted`, `host-proxy-interface`, `host-proxy-base`, `background-shell-host-bash`, `route-tags-guard`, `gateway-only-guard`. Plus `bunx tsc --noEmit` and `eslint` clean.

## Deferred, and why

1. **`host-browser-result` conversion.** Different boundary (exported resolver with its own status-code contract, plus two sibling routes in the file). Worth doing; belongs in its own PR. Recommend doing this next.
2. **The duplicated same-actor guard.** `host-bash` / `host-file` / `host-cu` / `host-app-control` / `host-browser` each repeat roughly 35 lines of identical behavior: pending lookup, kind check, `targetClientId` match, `resolveActorPrincipalIdForLocalGuardian`, `enforceSameActorOrThrow`. By the repo's own "extract on the second occurrence" rule this is the higher-leverage fix in this area, and it is a bigger deal than the body casts. It is deliberately not bundled here because it is security-relevant code across five files and mixing it with body validation would blur two risk profiles in one review. **Recommend prioritizing this over converting more routes.**
3. **The remaining body-cast route families** (`secret-routes`, `credential-routes`, `guardian-action-routes`, `channel-verification-routes`, and the wider scan). Separate cohesive slices, one family per PR. Note that `credential-routes` and `channel-verification-routes` mix body casts with unrelated `result as {...}` casts, so those need scoping care rather than a blanket sweep.

I did **not** convert every cast found by the original scan. Several are not route-body casts at all, and `approval-routes.ts` (on an older list) no longer contains the pattern.

## Unrelated finding, not fixed here

While scoping, I found that `assistant/src/runtime/AGENTS.md` (and its duplicate `src/runtime/CLAUDE.md`) documents a `ChromeExtensionRegistry` singleton at `runtime/chrome-extension-registry.ts` and `/v1/browser-relay` WebSocket handlers in `http-server.ts`. Neither exists in the tree: no file matches that name, there are zero `ChromeExtensionRegistry` references in `assistant/src`, and `http-server.ts` has no `browser-relay` branch (only a test fixture that connects to it). The docs describe machinery that is gone. Flagging rather than fixing, since doc correction is outside this PR's scope. Happy to file a ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->