### PR TITLE
feat(voice): drive the room and minimized-bar animations off real audio (JARVIS-1376)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -3,7 +3,7 @@
  *
  * The bar is purely presentational, so tests drive it prop-by-prop: state
  * label mapping, control presence, callback wiring, and accessibility
- * attributes. The embedded `VoiceListeningWaves` is SVG + a rAF loop writing
+ * attributes. The embedded `VoiceReactiveWaves` is SVG + a rAF loop writing
  * a CSS var — inert under happy-dom, so no harness is needed here.
  */
 

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -37,10 +37,8 @@ import {
   isLiveVoiceMicLive,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import {
-  VOICE_WAVE_EDGE_FADE_CLASS,
-  VoiceListeningWaves,
-} from "@/domains/chat/voice/voice-room/voice-listening-waves";
+import { VOICE_WAVE_EDGE_FADE_CLASS } from "@/domains/chat/voice/voice-room/voice-listening-waves";
+import { VoiceReactiveWaves } from "@/domains/chat/voice/voice-room/voice-reactive-waves";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
 
 // While the mic is not live (muted, assistant speaking) the waves read a
@@ -137,7 +135,7 @@ export function VoiceComposerBar({
             : undefined
         }
       >
-        <VoiceListeningWaves
+        <VoiceReactiveWaves
           getAmplitude={
             isLiveVoiceMicLive(state) ? getAmplitude : SILENT_AMPLITUDE
           }

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -38,7 +38,10 @@ import {
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { VOICE_WAVE_EDGE_FADE_CLASS } from "@/domains/chat/voice/voice-room/voice-listening-waves";
-import { VoiceReactiveWaves } from "@/domains/chat/voice/voice-room/voice-reactive-waves";
+import {
+  MESH_INLINE_TUNING,
+  VoiceMeshWaves,
+} from "@/domains/chat/voice/voice-room/voice-mesh-waves";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
 
 // While the mic is not live (muted, assistant speaking) the waves read a
@@ -135,12 +138,13 @@ export function VoiceComposerBar({
             : undefined
         }
       >
-        <VoiceReactiveWaves
+        <VoiceMeshWaves
           getAmplitude={
             isLiveVoiceMicLive(state) ? getAmplitude : SILENT_AMPLITUDE
           }
           palette="accent"
           placement="inline"
+          tuning={MESH_INLINE_TUNING}
         />
       </div>
       <div className="flex shrink-0 items-center gap-1">

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -13,7 +13,7 @@
  * (`isLiveVoiceSessionOwnedBy`): for any active session exactly one of
  * {composer bar, title-bar pill} renders.
  *
- * The embedded `VoiceListeningWaves` is SVG + a rAF loop writing a CSS var —
+ * The embedded `VoiceReactiveWaves` is SVG + a rAF loop writing a CSS var —
  * inert under happy-dom, so no harness is needed.
  */
 

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -2,7 +2,7 @@
  * Tests for `VoiceSessionPill`.
  *
  * The pill is purely presentational, so tests drive it directly through
- * props. The embedded `VoiceListeningWaves` is SVG + a rAF loop writing a
+ * props. The embedded `VoiceReactiveWaves` is SVG + a rAF loop writing a
  * CSS var — inert under happy-dom, so no harness is needed here.
  *
  * `useIsMobile` is mocked because the pill has two genuinely different forms

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -66,10 +66,8 @@ import {
   isLiveVoiceMicLive,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import {
-  VOICE_WAVE_EDGE_FADE_CLASS,
-  VoiceListeningWaves,
-} from "@/domains/chat/voice/voice-room/voice-listening-waves";
+import { VOICE_WAVE_EDGE_FADE_CLASS } from "@/domains/chat/voice/voice-room/voice-listening-waves";
+import { VoiceReactiveWaves } from "@/domains/chat/voice/voice-room/voice-reactive-waves";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 
@@ -134,7 +132,7 @@ export function VoiceSessionPill({
   // to fill (the component is absolutely positioned) and overflow-hidden so
   // the drifting layers clip to it.
   const waves = (
-    <VoiceListeningWaves
+    <VoiceReactiveWaves
       getAmplitude={
         isLiveVoiceMicLive(state) && !muted ? getAmplitude : SILENT_AMPLITUDE
       }

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -95,8 +95,34 @@ const RAW_PCM_MIME_TYPE = "audio/pcm";
  * weight toward each new read (~60 Hz from the avatar's rAF); `DECAY` eases the
  * pulse back to rest between turns. These are the visual-feel knobs.
  */
-const OUTPUT_AMPLITUDE_GAIN = 4;
-const OUTPUT_AMPLITUDE_SMOOTHING = 0.3;
+/*
+ * What must match the capture path (`pcm-capture.ts`) is the *mapped* 0–1
+ * range, not the constants: the two meters measure different things. That one
+ * is a microphone in a room, this one is the output bus, and their raw RMS
+ * ranges are nowhere near each other — so identical gains would be the bug,
+ * not the fix. Both feed the same visuals (the room's wave band, the
+ * responding rings, the avatar), so what a surface tuned against one signal
+ * needs is for the other to arrive on the same scale.
+ *
+ * The original gain of 4 came from an assumed speech RMS of 0.05–0.2. Measured
+ * against the rendered band, this path actually sits an order of magnitude
+ * lower — around 0.02 — so the assistant's voice arrived at roughly a sixth of
+ * the user's for equivalent speech, and its band read as a faint smudge next
+ * to a mic band that looked right.
+ *
+ * The mapping is a saturating exponential rather than `min(1, rms * gain)`.
+ * A linear gain large enough to lift a 0.02 RMS into view hard-clips the
+ * moment speech gets louder, which trades a band that is too faint for one
+ * that is bright but stops responding — the exact pair of complaints this
+ * meter has already produced once. `1 - exp(-rms * GAIN)` approaches 1
+ * smoothly, so loud passages still separate from each other and the tuning is
+ * forgiving of the true RMS range being somewhat different again.
+ *
+ * Every consumer is decorative — no threshold, VAD, or barge-in decision reads
+ * this — so this is a display curve, not signal processing.
+ */
+const OUTPUT_AMPLITUDE_GAIN = 40;
+const OUTPUT_AMPLITUDE_SMOOTHING = 0.5;
 const OUTPUT_AMPLITUDE_DECAY = 0.85;
 
 /** Normalize a frame's `mimeType` (strip params, lowercase) for dispatch. */
@@ -626,7 +652,8 @@ export class LiveVoiceAudioPlayer {
       sumSquares += sample * sample;
     }
     const rms = Math.sqrt(sumSquares / samples.length);
-    const scaled = Math.min(1, rms * OUTPUT_AMPLITUDE_GAIN);
+    // Saturating rather than clipping — see the constant's note above.
+    const scaled = 1 - Math.exp(-rms * OUTPUT_AMPLITUDE_GAIN);
     this.smoothedOutputAmplitude =
       OUTPUT_AMPLITUDE_SMOOTHING * scaled +
       (1 - OUTPUT_AMPLITUDE_SMOOTHING) * this.smoothedOutputAmplitude;

--- a/clients/web/src/domains/chat/voice/voice-room/use-reactive-eyes.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-reactive-eyes.ts
@@ -1,0 +1,111 @@
+/**
+ * Audio-reactive motion for the voice room's eyes.
+ *
+ * The eyes already blink, drift toward the cursor, and resize per session
+ * state — but every one of those is driven by a timer, the pointer, or a
+ * discrete state change. None of them is driven by sound, so through a whole
+ * spoken turn the eyes hold exactly one pose. Against a band of waves that
+ * *does* move, they read as artwork pasted on top.
+ *
+ * This hook closes that gap without touching the eye artwork, which is
+ * arbitrary per-character SVG (`art.paths`) with no isolable pupil or lid to
+ * animate. What it can address is the group as a whole, and two whole-group
+ * gestures carry the two audio states:
+ *
+ * - `listening` — the eyes *open up* toward the speaker as the mic gets loud:
+ *   a widening dominated by `scaleY`, plus a small lift. Reads as attention.
+ * - `responding` — the eyes ride the assistant's own voice with a rounder
+ *   `scale` pulse and a slight bounce, the same "energy going out" language
+ *   the responding treatment uses behind them.
+ *
+ * Both are deliberately small (a few percent). The eyes are the room's
+ * fixed point — the reference everything else moves against — so the goal is
+ * for them to look *alive*, not to make them dance. Anything larger fights the
+ * per-state resize tween and reads as the "spastic" pass that JARVIS-1263
+ * already had to walk back.
+ *
+ * Written straight to a CSS custom property from a rAF loop, never React
+ * state: the eyes sit inside a Motion tree, and a per-frame re-render there
+ * would fight the entrance keyframes and the size tween.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { createAmplitudeSmoother } from "./voice-motion";
+
+/** Which gesture the eyes express — `null` silences the reaction entirely. */
+export type VoiceEyeReaction = "listening" | "responding" | null;
+
+/**
+ * Attack/release per gesture. Listening tracks the mic tightly so the eyes
+ * answer the speaker's onset; responding is softer at both ends so the eyes
+ * ride the shape of a phrase rather than every plosive in it.
+ */
+const BALLISTICS: Record<
+  NonNullable<VoiceEyeReaction>,
+  { attackMs: number; releaseMs: number }
+> = {
+  listening: { attackMs: 70, releaseMs: 300 },
+  responding: { attackMs: 110, releaseMs: 380 },
+};
+
+/**
+ * Drive `--eye-amp` (0–1) on the returned element from a live amplitude poll.
+ *
+ * The element also carries `data-eye-reaction`, which selects the gesture in
+ * CSS (see `.voice-room-eyes-reactive` in `index.css`). Returns a ref to spread
+ * onto the wrapper that should carry the motion.
+ */
+export function useReactiveEyes(
+  reaction: VoiceEyeReaction,
+  getAmplitude?: () => number,
+) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const getAmplitudeRef = useRef(getAmplitude);
+  useEffect(() => {
+    getAmplitudeRef.current = getAmplitude;
+  }, [getAmplitude]);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    // No gesture, no source, or the user asked for less motion: park the var
+    // at rest so the wrapper is a no-op transform rather than a stale pose.
+    if (
+      !reaction ||
+      !getAmplitudeRef.current ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      node.style.setProperty("--eye-amp", "0");
+      return;
+    }
+
+    const smoother = createAmplitudeSmoother(BALLISTICS[reaction]);
+    let raf = 0;
+    let lastTime = performance.now();
+    let lastWritten = "";
+    const tick = (now: number) => {
+      const dt = Math.min(100, now - lastTime);
+      lastTime = now;
+      const source = getAmplitudeRef.current;
+      const target = source ? Math.min(1, Math.max(0, source())) : 0;
+      const next = smoother.step(target, dt).toFixed(3);
+      if (next !== lastWritten) {
+        lastWritten = next;
+        node.style.setProperty("--eye-amp", next);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(raf);
+      // Release the pose on unmount/gesture change so the next state does not
+      // inherit a frozen mid-syllable value.
+      node.style.setProperty("--eye-amp", "0");
+    };
+  }, [reaction]);
+
+  return ref;
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-amplitude-history.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-amplitude-history.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the rolling amplitude history.
+ *
+ * This is the substrate that makes the reactive voice visuals reactive: the
+ * ring buffer whose contents *are* the rendered terrain. Its two contracts are
+ * that samples come back oldest-first (so the terrain scrolls the right way)
+ * and that the buffer advances on wall-clock time rather than per call (so the
+ * scroll rate does not change with the display's refresh rate).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { createAmplitudeHistory } from "./voice-amplitude-history";
+
+/** Read the whole buffer with no smoothing. */
+function snapshot(
+  history: ReturnType<typeof createAmplitudeHistory>,
+): number[] {
+  const out = new Float32Array(history.size);
+  history.read(out);
+  return Array.from(out);
+}
+
+describe("createAmplitudeHistory", () => {
+  test("starts silent", () => {
+    const history = createAmplitudeHistory({ size: 4, periodMs: 10 });
+    expect(snapshot(history)).toEqual([0, 0, 0, 0]);
+  });
+
+  test("appends one sample per elapsed period, oldest first", () => {
+    const history = createAmplitudeHistory({ size: 4, periodMs: 10 });
+    history.push(1, 10);
+    history.push(0.5, 10);
+    // Newest sample lands at the right edge, which is where new energy enters.
+    expect(snapshot(history)).toEqual([0, 0, 1, 0.5]);
+  });
+
+  test("does not advance until a full period has elapsed", () => {
+    const history = createAmplitudeHistory({ size: 4, periodMs: 10 });
+    history.push(1, 4);
+    expect(snapshot(history)).toEqual([0, 0, 0, 0]);
+    history.push(1, 4);
+    expect(snapshot(history)).toEqual([0, 0, 0, 0]);
+    // 4 + 4 + 4 = 12 ms crosses the 10 ms boundary; the remainder carries over.
+    history.push(1, 4);
+    expect(snapshot(history)).toEqual([0, 0, 0, 1]);
+  });
+
+  test("a long frame gap advances by the time actually elapsed", () => {
+    const history = createAmplitudeHistory({ size: 4, periodMs: 10 });
+    history.push(1, 10);
+    // A dropped frame worth 3 periods must not scroll only one step, or the
+    // terrain would lag behind the audio it is supposed to be a record of.
+    history.push(0.25, 30);
+    expect(snapshot(history)).toEqual([1, 0.25, 0.25, 0.25]);
+  });
+
+  test("caps catch-up at one full buffer", () => {
+    const history = createAmplitudeHistory({ size: 4, periodMs: 10 });
+    // A backgrounded tab resuming after a minute: the whole window is the same
+    // value either way, so this must stay O(size), not O(elapsed).
+    history.push(0.5, 60_000);
+    expect(snapshot(history)).toEqual([0.5, 0.5, 0.5, 0.5]);
+  });
+
+  test("overwrites oldest samples once full", () => {
+    const history = createAmplitudeHistory({ size: 3, periodMs: 10 });
+    for (const amp of [1, 2, 3, 4]) {
+      history.push(amp, 10);
+    }
+    expect(snapshot(history)).toEqual([2, 3, 4]);
+  });
+
+  test("ignores negative deltas", () => {
+    const history = createAmplitudeHistory({ size: 3, periodMs: 10 });
+    history.push(1, -50);
+    expect(snapshot(history)).toEqual([0, 0, 0]);
+  });
+
+  test("smoothing averages over a centred window, clamped at the edges", () => {
+    const history = createAmplitudeHistory({ size: 5, periodMs: 10 });
+    for (const amp of [0, 0, 1, 0, 0]) {
+      history.push(amp, 10);
+    }
+    const out = new Float32Array(5);
+    history.read(out, 3);
+    // The spike spreads into its neighbours; the ends average over what exists.
+    expect(Array.from(out).map((n) => Number(n.toFixed(4)))).toEqual([
+      0, 0.3333, 0.3333, 0.3333, 0,
+    ]);
+  });
+
+  test("smooth = 1 is a raw read", () => {
+    const history = createAmplitudeHistory({ size: 3, periodMs: 10 });
+    for (const amp of [0, 1, 0]) {
+      history.push(amp, 10);
+    }
+    const out = new Float32Array(3);
+    history.read(out, 1);
+    expect(Array.from(out)).toEqual([0, 1, 0]);
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-amplitude-history.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-amplitude-history.ts
@@ -1,0 +1,88 @@
+/**
+ * Rolling amplitude history — the shared substrate under every reactive voice
+ * visual.
+ *
+ * The point of the reactive surfaces is that their geometry is a *record* of
+ * what was said rather than a shape authored ahead of time, and that record is
+ * this: a fixed-size ring buffer of the amplitude, advanced on a wall-clock
+ * cadence so the terrain scrolls at the same rate regardless of display
+ * refresh. `voice-reactive-waves.tsx` keeps one per layer (differing cadences
+ * are what turn one signal into a layered band); `voice-mesh-waves.tsx` keeps a
+ * single one shared across all of its depth lines.
+ *
+ * Deliberately allocation-free after construction: `read` fills a caller-owned
+ * array, so a 60 Hz draw loop can run without producing garbage.
+ */
+
+/** A fixed-size, time-paced ring buffer of amplitude samples. */
+export interface AmplitudeHistory {
+  /** Number of samples retained — the horizontal resolution of the terrain. */
+  readonly size: number;
+  /**
+   * Advance by `dtMs`, appending `amp` once per elapsed sample period.
+   *
+   * A long frame gap (a backgrounded tab, a dropped frame) can span several
+   * periods; appending all of them keeps the scroll honest to wall-clock time.
+   * The catch-up is capped at one full buffer — past that the whole window is
+   * the same value anyway.
+   */
+  push(amp: number, dtMs: number): void;
+  /**
+   * Read oldest-first into `out`, applying a centred moving average of width
+   * `smooth` samples (1 = raw). `out` must be at least {@link size} long.
+   */
+  read(out: Float32Array, smooth?: number): void;
+}
+
+export function createAmplitudeHistory({
+  size,
+  periodMs,
+}: {
+  size: number;
+  /** Milliseconds per sample — sets both scroll speed and window length. */
+  periodMs: number;
+}): AmplitudeHistory {
+  const samples = new Float32Array(size);
+  // Index of the oldest sample, i.e. the left edge of the rendered terrain.
+  let head = 0;
+  let elapsed = 0;
+
+  return {
+    size,
+
+    push(amp: number, dtMs: number): void {
+      elapsed += Math.max(0, dtMs);
+      let pushes = Math.floor(elapsed / periodMs);
+      if (pushes <= 0) {
+        return;
+      }
+      elapsed -= pushes * periodMs;
+      pushes = Math.min(pushes, size);
+      for (let i = 0; i < pushes; i++) {
+        samples[head] = amp;
+        head = (head + 1) % size;
+      }
+    },
+
+    read(out: Float32Array, smooth = 1): void {
+      const half = Math.max(0, Math.floor(smooth / 2));
+      for (let i = 0; i < size; i++) {
+        if (half === 0) {
+          out[i] = samples[(head + i) % size];
+          continue;
+        }
+        let sum = 0;
+        let count = 0;
+        for (let k = -half; k <= half; k++) {
+          const j = i + k;
+          if (j < 0 || j >= size) {
+            continue;
+          }
+          sum += samples[(head + j) % size];
+          count++;
+        }
+        out[i] = count > 0 ? sum / count : 0;
+      }
+    },
+  };
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Tests for `VoiceMeshWaves`.
+ *
+ * The mesh draws to a canvas, so there is no DOM geometry to inspect the way
+ * the SVG band's `d` attribute can be. Instead the canvas context is replaced
+ * with a recorder and the assertions are made against the path the component
+ * actually walks — which is the same question either way: does the shape the
+ * user sees depend on the audio, or not?
+ *
+ * happy-dom has no real 2D context, so the recorder is required for these to
+ * run at all; it doubles as the instrument.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+
+import { VoiceMeshWaves } from "./voice-mesh-waves";
+
+/** Every y coordinate the component drew, per render pass. */
+interface Recorder {
+  ys: number[];
+  strokes: number;
+  strokeStyles: string[];
+  composite: string | null;
+}
+
+let recorder: Recorder;
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+let originalResizeObserver: typeof globalThis.ResizeObserver;
+let originalRect: typeof Element.prototype.getBoundingClientRect;
+
+/** A minimal recording stand-in for CanvasRenderingContext2D. */
+function createFakeContext(): unknown {
+  return {
+    setTransform: () => {},
+    clearRect: () => {
+      // Each frame starts fresh; keep only the latest so assertions read one
+      // frame rather than an ever-growing accumulation.
+      recorder.ys = [];
+      recorder.strokes = 0;
+      recorder.strokeStyles = [];
+    },
+    beginPath: () => {},
+    moveTo: (_x: number, y: number) => recorder.ys.push(y),
+    lineTo: (_x: number, y: number) => recorder.ys.push(y),
+    stroke: () => {
+      recorder.strokes += 1;
+    },
+    set globalCompositeOperation(value: string) {
+      recorder.composite = value;
+    },
+    get globalCompositeOperation() {
+      return recorder.composite ?? "";
+    },
+    set strokeStyle(value: string) {
+      recorder.strokeStyles.push(value);
+    },
+    get strokeStyle() {
+      return recorder.strokeStyles.at(-1) ?? "";
+    },
+    lineWidth: 1,
+    lineJoin: "round",
+  };
+}
+
+beforeEach(() => {
+  recorder = { ys: [], strokes: 0, strokeStyles: [], composite: null };
+
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function getContext() {
+    return createFakeContext();
+  } as typeof HTMLCanvasElement.prototype.getContext;
+
+  // happy-dom lays nothing out, so the component would size itself to a 1×1
+  // box and every displacement would collapse. Give it a real band to draw in.
+  originalRect = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function rect() {
+    return {
+      width: 600,
+      height: 200,
+      top: 0,
+      left: 0,
+      right: 600,
+      bottom: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+
+  originalResizeObserver = globalThis.ResizeObserver;
+  if (!originalResizeObserver) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+  Element.prototype.getBoundingClientRect = originalRect;
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+/**
+ * Long enough for the component's amplitude history to fill end to end
+ * (96 samples at ~34 ms), plus headroom for a slow CI box.
+ */
+const HISTORY_FILL_MS = 4_000;
+
+/** Peak-to-peak spread of the drawn sheet — how far it displaced. */
+function spread(ys: number[]): number {
+  return ys.length > 0 ? Math.max(...ys) - Math.min(...ys) : 0;
+}
+
+describe("VoiceMeshWaves", () => {
+  test("renders a canvas inside the placement-anchored band", () => {
+    const { container } = render(
+      <VoiceMeshWaves getAmplitude={() => 0} placement="center" />,
+    );
+    expect(container.querySelector("canvas[data-mesh-canvas]")).not.toBeNull();
+    // Positioning is inherited from the shared band CSS, so the placement
+    // class has to be on the host or the sheet lands in the wrong zone.
+    expect(
+      container.querySelector(".voice-listening-waves--center"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(".voice-listening-waves--mesh"),
+    ).not.toBeNull();
+  });
+
+  test("draws one stroked line per depth, additively", async () => {
+    render(<VoiceMeshWaves getAmplitude={() => 0.5} />);
+    await waitFor(() => {
+      expect(recorder.strokes).toBeGreaterThan(30);
+    });
+    // The glow is entirely emergent from overlapping strokes — if this ever
+    // reverts to source-over, the woven ridges go flat.
+    expect(recorder.composite).toBe("lighter");
+    // Each depth line gets its own alpha, so the sheet has a front and back.
+    expect(new Set(recorder.strokeStyles).size).toBeGreaterThan(1);
+  });
+
+  test(
+    "loud audio displaces the sheet further than silence",
+    async () => {
+      render(<VoiceMeshWaves getAmplitude={() => 1} />);
+      await waitFor(() => {
+        expect(recorder.strokes).toBeGreaterThan(30);
+      });
+      // The history spans 96 samples at ~34 ms, so it takes ~3.3 s of sustained
+      // audio before the whole width reflects the level. Measuring earlier
+      // reads a sheet that is mostly still at rest, and whether the loud region
+      // happens to land on a crest or a zero-crossing of the ripple makes the
+      // result depend on phase rather than on amplitude.
+      await new Promise((resolve) => setTimeout(resolve, HISTORY_FILL_MS));
+      const loud = spread(recorder.ys);
+      cleanup();
+
+      recorder = { ys: [], strokes: 0, strokeStyles: [], composite: null };
+      render(<VoiceMeshWaves getAmplitude={() => 0} />);
+      await waitFor(() => {
+        expect(recorder.strokes).toBeGreaterThan(30);
+      });
+      const quiet = spread(recorder.ys);
+
+      // The whole point of the engine: the surface answers the signal.
+      expect(loud).toBeGreaterThan(quiet * 1.8);
+      // ...but it never flat-lines, so silence still reads as alive, not off.
+      expect(quiet).toBeGreaterThan(0);
+    },
+    HISTORY_FILL_MS + 5_000,
+  );
+
+  test("publishes --voice-amp for the shared placement CSS", async () => {
+    const { container } = render(<VoiceMeshWaves getAmplitude={() => 0.8} />);
+    const host = container.querySelector<HTMLElement>(".voice-listening-waves")!;
+    await waitFor(() => {
+      expect(
+        Number(host.style.getPropertyValue("--voice-amp")),
+      ).toBeGreaterThan(0);
+    });
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.test.tsx
@@ -180,6 +180,59 @@ describe("VoiceMeshWaves", () => {
     HISTORY_FILL_MS + 5_000,
   );
 
+  test("dark ink composites normally, light ink additively", async () => {
+    // Not a style preference. `lighter` is additive, so a black stroke
+    // contributes zero and the whole sheet renders invisible — the room's
+    // assistant band is black. Getting this wrong does not look worse, it
+    // looks like nothing, which is why the mode follows luminance rather than
+    // being a caller's choice.
+    render(<VoiceMeshWaves getAmplitude={() => 0.5} color="#000000" />);
+    await waitFor(() => {
+      expect(recorder.strokes).toBeGreaterThan(30);
+    });
+    expect(recorder.composite).toBe("source-over");
+    cleanup();
+
+    recorder = { ys: [], strokes: 0, strokeStyles: [], composite: null };
+    render(<VoiceMeshWaves getAmplitude={() => 0.5} color="#FFFFFF" />);
+    await waitFor(() => {
+      expect(recorder.strokes).toBeGreaterThan(30);
+    });
+    expect(recorder.composite).toBe("lighter");
+  });
+
+  test("explicit ink overrides the palette, and is what gets stroked", async () => {
+    render(
+      <VoiceMeshWaves
+        getAmplitude={() => 0.5}
+        palette="aurora"
+        color="#000000"
+      />,
+    );
+    await waitFor(() => {
+      expect(recorder.strokeStyles.length).toBeGreaterThan(0);
+    });
+    // Aurora would be cyan; the explicit ink wins.
+    expect(recorder.strokeStyles.every((s) => s.startsWith("rgba(0,0,0,"))).toBe(
+      true,
+    );
+  });
+
+  test("fades out entirely as the voice stops", async () => {
+    // Opacity is a ceiling reached at full amplitude, scaled from zero — so
+    // silence leaves nothing on screen rather than an idling decoration.
+    const { container } = render(
+      <VoiceMeshWaves getAmplitude={() => 0} peakOpacity={0.4} />,
+    );
+    const host = container.querySelector<HTMLElement>(".voice-listening-waves")!;
+    expect(host.style.getPropertyValue("--band-peak-opacity")).toBe("0.4");
+    await waitFor(() => {
+      expect(recorder.strokes).toBeGreaterThan(30);
+    });
+    // The CSS multiplies the two, so a zero amplitude means a zero band.
+    expect(Number(host.style.getPropertyValue("--voice-amp") || "0")).toBe(0);
+  });
+
   test("publishes --voice-amp for the shared placement CSS", async () => {
     const { container } = render(<VoiceMeshWaves getAmplitude={() => 0.8} />);
     const host = container.querySelector<HTMLElement>(".voice-listening-waves")!;

--- a/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.test.tsx
@@ -15,7 +15,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { cleanup, render, waitFor } from "@testing-library/react";
 
-import { VoiceMeshWaves } from "./voice-mesh-waves";
+import {
+  DEFAULT_MESH_TUNING,
+  VoiceMeshWaves,
+  meshDisplacement,
+} from "./voice-mesh-waves";
 
 /** Every y coordinate the component drew, per render pass. */
 interface Recorder {
@@ -184,5 +188,106 @@ describe("VoiceMeshWaves", () => {
         Number(host.style.getPropertyValue("--voice-amp")),
       ).toBeGreaterThan(0);
     });
+  });
+});
+
+/**
+ * The weave's shape, tested through `meshDisplacement` rather than the canvas.
+ *
+ * The property at issue — that the pinches where depth lines converge into a
+ * "twist" travel across the band rather than sitting in fixed spots — only
+ * shows up when averaged over ten-odd seconds of motion, which a component
+ * test cannot wait for. Against the pure function it is a few milliseconds.
+ */
+describe("meshDisplacement", () => {
+  /**
+   * Spread of the sheet across depth at each x: the pinches are its minima.
+   * This is the same quantity the canvas draws, minus the pixel scaling.
+   */
+  function spreadProfile(timeSec: number, samples = 96, lines = 92): number[] {
+    const out: number[] = [];
+    for (let i = 0; i < samples; i++) {
+      const u = i / (samples - 1);
+      let lo = Infinity;
+      let hi = -Infinity;
+      for (let line = 0; line < lines; line++) {
+        const depth = line / (lines - 1);
+        // A flat envelope, so the only thing that can move the pinches is the
+        // wave math itself — not the amplitude history scrolling underneath.
+        const swirl = u * 0.4 * DEFAULT_MESH_TUNING.swirl;
+        const v = meshDisplacement(
+          u,
+          depth,
+          timeSec,
+          swirl,
+          DEFAULT_MESH_TUNING,
+        );
+        const y = (depth - 0.5) * DEFAULT_MESH_TUNING.spread -
+          DEFAULT_MESH_TUNING.displace * v;
+        if (y < lo) {lo = y;}
+        if (y > hi) {hi = y;}
+      }
+      out.push(hi - lo);
+    }
+    return out;
+  }
+
+  /**
+   * How much persistent structure survives averaging the profile over
+   * `seconds` of motion, as a coefficient of variation.
+   *
+   * Pinned pinches keep their dips through the average, so this stays high;
+   * travelling pinches smear the average flat, so it drops.
+   */
+  function persistentStructure(seconds: number): number {
+    const samples = 96;
+    const acc = new Array<number>(samples).fill(0);
+    let frames = 0;
+    for (let t = 0; t < seconds; t += 0.05) {
+      const profile = spreadProfile(t, samples);
+      for (let i = 0; i < samples; i++) {
+        acc[i] += profile[i];
+      }
+      frames++;
+    }
+    const avg = acc.map((v) => v / frames);
+    const mean = avg.reduce((a, b) => a + b, 0) / samples;
+    const variance =
+      avg.reduce((a, b) => a + (b - mean) ** 2, 0) / samples;
+    return Math.sqrt(variance) / mean;
+  }
+
+  test("the twists do not stay in the same place", () => {
+    // Measured over the window a viewer actually perceives. The original
+    // counter-propagating formula scored ~0.22 here — deep dips at fixed x,
+    // which is exactly the "why are the twists always in the same spot"
+    // report. Co-propagating the two ripples plus the slow wander takes it
+    // to ~0.06. The threshold sits well below the old value and well above
+    // the new one, so it fails if either mechanism is removed.
+    expect(persistentStructure(12)).toBeLessThan(0.12);
+  });
+
+  test("the sheet still has real structure at any instant", () => {
+    // The flatness above must come from the pattern *moving*, not from the
+    // sheet having been smoothed into a featureless tube.
+    const profile = spreadProfile(3.2);
+    const mean = profile.reduce((a, b) => a + b, 0) / profile.length;
+    const range = Math.max(...profile) - Math.min(...profile);
+    expect(range / mean).toBeGreaterThan(0.3);
+  });
+
+  test("stays within its normalized range", () => {
+    for (let t = 0; t < 6; t += 0.37) {
+      for (let i = 0; i <= 10; i++) {
+        const v = meshDisplacement(
+          i / 10,
+          0.5,
+          t,
+          1.2,
+          DEFAULT_MESH_TUNING,
+        );
+        expect(Math.abs(v)).toBeLessThanOrEqual(1.0001);
+      }
+    }
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.tsx
@@ -31,7 +31,7 @@
  * resolved from the same CSS custom properties in JS instead.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { createAmplitudeSmoother } from "./voice-motion";
 import { createAmplitudeHistory } from "./voice-amplitude-history";
@@ -41,40 +41,170 @@ import type {
 } from "./voice-listening-waves";
 
 /**
- * Depth lines in the sheet. The woven look needs enough of them that adjacent
- * curves read as a surface rather than as separate strokes; below ~30 it looks
- * like a stack of lines, and past ~60 the added density is invisible but the
- * per-frame cost is not.
+ * The knobs that decide what the sheet looks like.
+ *
+ * These are exposed rather than baked in because the woven look is genuinely
+ * sensitive to their ratios — `spread` vs `displace` in particular is the
+ * difference between a folded ribbon and a flat stack of parallel lines — and
+ * that is a judgement call best made by looking, not by reasoning. See the
+ * `MESH_PRESETS` in the stories for the ones worth comparing.
  */
-const LINES = 46;
-
-/** Horizontal samples per line. Straight segments at this density read smooth. */
-const SAMPLES = 96;
-
-/** Samples of amplitude history retained, and how fast the terrain scrolls. */
-const HISTORY_SIZE = 96;
-const HISTORY_PERIOD_MS = 34;
+export interface VoiceMeshTuning {
+  /**
+   * Depth lines in the sheet. Enough that adjacent curves read as a surface
+   * rather than as separate strokes; below ~30 it looks like a stack of lines,
+   * and past ~90 the added density is invisible but the per-frame cost is not.
+   */
+  lines: number;
+  /** Horizontal samples per line. Straight segments at this density read smooth. */
+  samples: number;
+  /**
+   * How far the sheet's near and far edges sit apart, as a fraction of the band
+   * height. Small values make the curves nearly coincide so they only separate
+   * where the phase shift pulls them apart — that is what reads as a bundle of
+   * filaments rather than as ruled lines.
+   */
+  spread: number;
+  /** Peak vertical displacement, as a fraction of the band height. */
+  displace: number;
+  /**
+   * Phase offset between the near and far edges of the sheet, in radians. The
+   * whole trick: around half a turn the far edge rides the opposite part of the
+   * wave from the near edge, so the sheet twists and the curves cross. At 0
+   * they move as one and the mesh collapses into a single fat line.
+   */
+  depthPhase: number;
+  /** Cycles across the band for the two ripples. Lower = broader lobes. */
+  cyclesA: number;
+  cyclesB: number;
+  /** How fast the weave travels, in radians per second. */
+  driftSpeed: number;
+  /**
+   * Speed of the second ripple as a fraction of the first. Both travel the
+   * *same* direction — that is deliberate. Counter-propagating waves form a
+   * standing pattern whose nodes oscillate around fixed centres, which is what
+   * made the twists appear pinned to the same few spots. Same direction at
+   * different speeds gives a beat that translates instead.
+   */
+  driftRatioB: number;
+  /**
+   * How strongly the amplitude history warps the weave's phase along x.
+   *
+   * Phase accumulates as a running total of the envelope, so where the voice
+   * was loud the phase advances faster and the weave bunches tighter. That
+   * makes the twists land where the speech was — and because the history
+   * scrolls left, they travel with it. Without this, the audio only scales the
+   * sheet's height and the *structure* is a fixed formula, which is what reads
+   * as static however much the sheet swells.
+   */
+  swirl: number;
+  /**
+   * Amplitude and rate of a slow phase wander applied to each ripple.
+   *
+   * Belt and braces for silence: with no audio there is no swirl, so this keeps
+   * the interference pattern sliding rather than settling into one pose. Two
+   * incommensurate rates, so it does not visibly loop.
+   */
+  wander: number;
+  wanderHzA: number;
+  wanderHzB: number;
+  /** Stroke alpha at the far and near edges — the sheet's depth cue. */
+  alphaFar: number;
+  alphaNear: number;
+  /** Displacement floor, so the sheet still breathes through silence. */
+  idleEnvelope: number;
+  /** Samples of amplitude history retained, and how fast the terrain scrolls. */
+  historySize: number;
+  historyPeriodMs: number;
+}
 
 /**
- * How far the sheet's near and far edges sit apart, as a fraction of the band
- * height. The sheet is thin relative to its displacement — that is what makes
- * it read as a ribbon seen nearly edge-on rather than as a landscape.
+ * The "dense" tuning: many lines at low alpha, with the sheet's edges close
+ * enough together that the curves nearly coincide. That combination is what
+ * makes the weave *resolve* — at the original 46 lines and 0.3 spread the
+ * curves read as ruled lines at different heights (a stack) before they read
+ * as one folded surface.
  */
-const SHEET_SPREAD = 0.3;
-
-/** Peak vertical displacement of the ribbon, as a fraction of the band height. */
-const DISPLACE = 0.34;
+export const DEFAULT_MESH_TUNING: VoiceMeshTuning = {
+  lines: 92,
+  samples: 96,
+  spread: 0.12,
+  displace: 0.4,
+  depthPhase: Math.PI * 1.7,
+  cyclesA: 1.6,
+  cyclesB: 2.7,
+  driftSpeed: 0.9,
+  driftRatioB: 0.55,
+  swirl: 5.5,
+  wander: 0.9,
+  wanderHzA: 0.037,
+  wanderHzB: 0.023,
+  alphaFar: 0.035,
+  alphaNear: 0.13,
+  idleEnvelope: 0.13,
+  historySize: 96,
+  historyPeriodMs: 34,
+};
 
 /**
- * Phase offset between the near and far edges of the sheet, in radians. This is
- * the whole trick: at ~half a turn the far edge is riding the opposite part of
- * the wave from the near edge, so the sheet twists and the curves cross. At 0
- * they would move as one and the mesh would collapse into a single fat line.
+ * Strip-height override for the inline surfaces (the composer's voice bar).
+ *
+ * The room gives the sheet hundreds of pixels; the composer strip gives it
+ * about 24. At the room's 92 lines that is a quarter-pixel of separation each,
+ * so the weave collapses into a solid smear and every line's individual alpha
+ * stacks into a flat block. Fewer lines with more separation and more alpha
+ * each keeps it legible as a woven ribbon at strip height — the same
+ * accommodation `WAVE_LAYERS_INLINE` makes for the filled band.
  */
-const DEPTH_PHASE = Math.PI * 1.7;
+export const MESH_INLINE_TUNING: Partial<VoiceMeshTuning> = {
+  lines: 26,
+  spread: 0.18,
+  displace: 0.62,
+  alphaFar: 0.1,
+  alphaNear: 0.34,
+};
 
-/** Idle displacement floor, so the sheet still breathes through silence. */
-const IDLE_ENVELOPE = 0.13;
+/**
+ * The sheet's normalized vertical displacement at one point, in roughly −1..1.
+ *
+ * Pure and exported so the weave's behaviour can be tested directly rather than
+ * by rendering seconds of canvas: the property that matters — that the pinches
+ * where depth lines converge *travel* rather than sit in fixed spots — is only
+ * visible when averaged over ten-odd seconds, which is not something a
+ * component test can afford to wait for.
+ *
+ * `swirl` is the phase already accumulated from the amplitude history up to
+ * this x (see {@link VoiceMeshTuning.swirl}); the caller computes it once per
+ * frame for the whole band rather than per line.
+ */
+export function meshDisplacement(
+  u: number,
+  depth: number,
+  timeSec: number,
+  swirl: number,
+  config: VoiceMeshTuning,
+): number {
+  const phase = timeSec * config.driftSpeed + depth * config.depthPhase;
+  const wanderA =
+    config.wander * Math.sin(timeSec * config.wanderHzA * Math.PI * 2);
+  const wanderB =
+    config.wander * Math.sin(timeSec * config.wanderHzB * Math.PI * 2 + 1.9);
+  // Both ripples travel the same direction at different speeds, so their beat
+  // — and every pinch in it — translates across the band. Counter-propagating
+  // them (the first cut) made a standing pattern whose nodes only oscillated
+  // around fixed centres, which is what read as static.
+  return (
+    0.6 *
+      Math.sin(u * Math.PI * 2 * config.cyclesA + phase + swirl + wanderA) +
+    0.4 *
+      Math.sin(
+        u * Math.PI * 2 * config.cyclesB +
+          phase * config.driftRatioB +
+          swirl * 1.6 +
+          wanderB,
+      )
+  );
+}
 
 /** Fixed cyan for the `aurora` palette — matches the filled band's accent. */
 const AURORA_HEX = "#22D3EE";
@@ -135,11 +265,14 @@ export function VoiceMeshWaves({
   getAmplitude,
   palette = "aurora",
   placement = "bottom",
+  tuning,
 }: {
   /** Amplitude source (0–1), polled in a rAF loop. */
   getAmplitude: () => number;
   palette?: VoiceWavePalette;
   placement?: VoiceWavePlacement;
+  /** Overrides on {@link DEFAULT_MESH_TUNING}. */
+  tuning?: Partial<VoiceMeshTuning>;
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -147,6 +280,14 @@ export function VoiceMeshWaves({
   useEffect(() => {
     getAmplitudeRef.current = getAmplitude;
   }, [getAmplitude]);
+
+  // Serialized, so a caller passing a fresh object literal every render does
+  // not tear down and restart the draw loop 60 times a second.
+  const tuningKey = JSON.stringify(tuning ?? {});
+  const config = useMemo(
+    () => ({ ...DEFAULT_MESH_TUNING, ...(JSON.parse(tuningKey) as Partial<VoiceMeshTuning>) }),
+    [tuningKey],
+  );
 
   useEffect(() => {
     const host = hostRef.current;
@@ -186,10 +327,13 @@ export function VoiceMeshWaves({
 
     const smoother = createAmplitudeSmoother({ attackMs: 80, releaseMs: 350 });
     const history = createAmplitudeHistory({
-      size: HISTORY_SIZE,
-      periodMs: HISTORY_PERIOD_MS,
+      size: config.historySize,
+      periodMs: config.historyPeriodMs,
     });
-    const envelope = new Float32Array(HISTORY_SIZE);
+    const envelope = new Float32Array(config.historySize);
+    // Phase warp accumulated along x from the envelope — see `swirl`. Held
+    // alongside the envelope so it is rebuilt once per frame, not per line.
+    const warp = new Float32Array(config.historySize);
 
     const draw = (timeSec: number) => {
       ctx.clearRect(0, 0, width, height);
@@ -202,32 +346,44 @@ export function VoiceMeshWaves({
       // The sheet hangs from the middle of the band; placement CSS decides
       // where the band itself sits on screen.
       const centerY = height / 2;
-      const spreadPx = height * SHEET_SPREAD;
-      const displacePx = height * DISPLACE;
+      const spreadPx = height * config.spread;
+      const displacePx = height * config.displace;
+      const alphaSpan = config.alphaNear - config.alphaFar;
+      const lastSample = config.historySize - 1;
+      // Running total of the envelope, normalized to its own length so `swirl`
+      // means the same thing whatever the history size: loud stretches advance
+      // the phase faster, so the weave bunches where the voice was.
+      let running = 0;
+      for (let i = 0; i < config.historySize; i++) {
+        running += envelope[i];
+        warp[i] = (running / config.historySize) * config.swirl;
+      }
       const [r, g, b] = stroke;
 
-      for (let line = 0; line < LINES; line++) {
+      for (let line = 0; line < config.lines; line++) {
         // 0 = far edge of the sheet, 1 = near edge.
-        const depth = line / (LINES - 1);
+        const depth = config.lines > 1 ? line / (config.lines - 1) : 0.5;
         const baseY = centerY + (depth - 0.5) * spreadPx;
-        const phase = timeSec * 0.9 + depth * DEPTH_PHASE;
         // Near lines read brighter, so the sheet has a front and a back
         // instead of looking like a flat stack.
-        ctx.strokeStyle = `rgba(${r},${g},${b},${(0.07 + depth * 0.16).toFixed(3)})`;
+        ctx.strokeStyle = `rgba(${r},${g},${b},${(config.alphaFar + depth * alphaSpan).toFixed(3)})`;
         ctx.beginPath();
 
-        for (let i = 0; i < SAMPLES; i++) {
-          const u = i / (SAMPLES - 1);
+        for (let i = 0; i < config.samples; i++) {
+          const u = i / (config.samples - 1);
           const x = u * width;
           // Envelope from the amplitude history: what was said, scrolling left.
-          const amp =
-            envelope[Math.min(HISTORY_SIZE - 1, Math.round(u * (HISTORY_SIZE - 1)))];
-          const gain = IDLE_ENVELOPE + amp * (1 - IDLE_ENVELOPE);
-          // Two ripples at different rates, counter-rotating through depth, so
-          // the sheet interferes with itself rather than rippling uniformly.
-          const wave =
-            0.6 * Math.sin(u * Math.PI * 2 * 1.6 + phase) +
-            0.4 * Math.sin(u * Math.PI * 2 * 2.7 - phase * 1.25);
+          const sample = Math.min(lastSample, Math.round(u * lastSample));
+          const amp = envelope[sample];
+          const gain = config.idleEnvelope + amp * (1 - config.idleEnvelope);
+          // Phase warp from what was said up to this point along the band.
+          const wave = meshDisplacement(
+            u,
+            depth,
+            timeSec,
+            warp[sample],
+            config,
+          );
           const y = baseY - gain * displacePx * wave;
           if (i === 0) {
             ctx.moveTo(x, y);
@@ -274,7 +430,7 @@ export function VoiceMeshWaves({
       cancelAnimationFrame(raf);
       observer.disconnect();
     };
-  }, [palette]);
+  }, [palette, config]);
 
   const className = [
     "voice-listening-waves",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.tsx
@@ -1,0 +1,295 @@
+/**
+ * Mesh waves — the "wireframe ribbon" alternative to the filled band.
+ *
+ * Where `voice-reactive-waves.tsx` draws three filled layers, this draws the
+ * *same* signal as a woven surface: several dozen hairline curves, each one the
+ * wave field sampled at a different depth. Neighbouring depths are phase-shifted
+ * relative to one another, so the sheet twists and folds through itself, and
+ * the crossings pile strokes on top of each other into bright ridges — the
+ * oscilloscope-mesh look, where all the luminance is emergent rather than
+ * painted.
+ *
+ * Canvas, not SVG. The filled band gets away with three `<path>` elements
+ * because three `d` rewrites a frame is cheap; this needs 40+ polylines, and
+ * rewriting that many path attributes every frame would thrash style and paint
+ * for a purely decorative layer. On a canvas the whole sheet is one draw pass
+ * with `globalCompositeOperation = "lighter"`, which is also what produces the
+ * additive glow where lines converge — there is no blur or shadow anywhere in
+ * here. `streaming-waveform.tsx` sets the same canvas precedent for the
+ * dictation waveform.
+ *
+ * Audio drives the *envelope*, not the wave: the shared amplitude history
+ * scales how far the sheet displaces at each x, so a loud syllable swells the
+ * ribbon into a lobe that then travels left and flattens, while the underlying
+ * ripple keeps its shape. That split is what keeps the look coherent — an
+ * amplitude-driven ribbon still reads as one continuous surface, where
+ * amplitude-driven *frequency* would read as noise.
+ *
+ * Positioning reuses the `voice-listening-waves--{placement}` rules, which are
+ * placement-only (inset, height, the `--voice-amp` rise); the palette and style
+ * rules target `path` and simply do not match a canvas, so the stroke color is
+ * resolved from the same CSS custom properties in JS instead.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { createAmplitudeSmoother } from "./voice-motion";
+import { createAmplitudeHistory } from "./voice-amplitude-history";
+import type {
+  VoiceWavePalette,
+  VoiceWavePlacement,
+} from "./voice-listening-waves";
+
+/**
+ * Depth lines in the sheet. The woven look needs enough of them that adjacent
+ * curves read as a surface rather than as separate strokes; below ~30 it looks
+ * like a stack of lines, and past ~60 the added density is invisible but the
+ * per-frame cost is not.
+ */
+const LINES = 46;
+
+/** Horizontal samples per line. Straight segments at this density read smooth. */
+const SAMPLES = 96;
+
+/** Samples of amplitude history retained, and how fast the terrain scrolls. */
+const HISTORY_SIZE = 96;
+const HISTORY_PERIOD_MS = 34;
+
+/**
+ * How far the sheet's near and far edges sit apart, as a fraction of the band
+ * height. The sheet is thin relative to its displacement — that is what makes
+ * it read as a ribbon seen nearly edge-on rather than as a landscape.
+ */
+const SHEET_SPREAD = 0.3;
+
+/** Peak vertical displacement of the ribbon, as a fraction of the band height. */
+const DISPLACE = 0.34;
+
+/**
+ * Phase offset between the near and far edges of the sheet, in radians. This is
+ * the whole trick: at ~half a turn the far edge is riding the opposite part of
+ * the wave from the near edge, so the sheet twists and the curves cross. At 0
+ * they would move as one and the mesh would collapse into a single fat line.
+ */
+const DEPTH_PHASE = Math.PI * 1.7;
+
+/** Idle displacement floor, so the sheet still breathes through silence. */
+const IDLE_ENVELOPE = 0.13;
+
+/** Fixed cyan for the `aurora` palette — matches the filled band's accent. */
+const AURORA_HEX = "#22D3EE";
+
+/**
+ * Resolve a CSS color to `r,g,b` for use in `rgba()` strokes.
+ *
+ * Only the forms the avatar/tone tokens actually take need handling: hex (the
+ * bundled avatar palette) and `rgb()` / `rgba()` (the tone tokens). Anything
+ * else falls back rather than throwing — a decorative layer must never take the
+ * room down.
+ */
+function toRgb(color: string, fallback: [number, number, number]): [number, number, number] {
+  const value = color.trim();
+  const hex = value.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hex) {
+    const h = hex[1];
+    const full =
+      h.length === 3
+        ? h
+            .split("")
+            .map((c) => c + c)
+            .join("")
+        : h;
+    return [
+      parseInt(full.slice(0, 2), 16),
+      parseInt(full.slice(2, 4), 16),
+      parseInt(full.slice(4, 6), 16),
+    ];
+  }
+  const rgb = value.match(/^rgba?\(([^)]+)\)$/i);
+  if (rgb) {
+    const parts = rgb[1].split(/[,\s/]+/).filter(Boolean).map(Number);
+    if (parts.length >= 3 && parts.slice(0, 3).every(Number.isFinite)) {
+      return [parts[0], parts[1], parts[2]];
+    }
+  }
+  return fallback;
+}
+
+/** Stroke color for the sheet, read from the same tokens the band's CSS uses. */
+function resolveStroke(
+  node: HTMLElement,
+  palette: VoiceWavePalette,
+): [number, number, number] {
+  const styles = getComputedStyle(node);
+  if (palette === "aurora") {
+    return toRgb(AURORA_HEX, [34, 211, 238]);
+  }
+  const token =
+    palette === "accent"
+      ? styles.getPropertyValue("--avatar-accent")
+      : styles.getPropertyValue("--room-fg");
+  return toRgb(token, palette === "accent" ? [99, 102, 241] : [255, 255, 255]);
+}
+
+export function VoiceMeshWaves({
+  getAmplitude,
+  palette = "aurora",
+  placement = "bottom",
+}: {
+  /** Amplitude source (0–1), polled in a rAF loop. */
+  getAmplitude: () => number;
+  palette?: VoiceWavePalette;
+  placement?: VoiceWavePlacement;
+}) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const getAmplitudeRef = useRef(getAmplitude);
+  useEffect(() => {
+    getAmplitudeRef.current = getAmplitude;
+  }, [getAmplitude]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    const canvas = canvasRef.current;
+    if (!host || !canvas) {
+      return;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return;
+    }
+
+    const reduce = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    let stroke = resolveStroke(host, palette);
+
+    // Backing store follows the element's CSS size × DPR; the context is scaled
+    // so all drawing below is in CSS pixels and `lineWidth = 1` stays hairline.
+    let width = 0;
+    let height = 0;
+    const resize = () => {
+      const rect = host.getBoundingClientRect();
+      const dpr = Math.min(2, window.devicePixelRatio || 1);
+      width = Math.max(1, rect.width);
+      height = Math.max(1, rect.height);
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      // The accent can change with the avatar; the observer is the cheapest
+      // point to notice without subscribing to anything.
+      stroke = resolveStroke(host, palette);
+    };
+    resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(host);
+
+    const smoother = createAmplitudeSmoother({ attackMs: 80, releaseMs: 350 });
+    const history = createAmplitudeHistory({
+      size: HISTORY_SIZE,
+      periodMs: HISTORY_PERIOD_MS,
+    });
+    const envelope = new Float32Array(HISTORY_SIZE);
+
+    const draw = (timeSec: number) => {
+      ctx.clearRect(0, 0, width, height);
+      // Additive: where the folded sheet stacks strokes, the pile brightens.
+      // This is the entire lighting model — no shadow, no blur.
+      ctx.globalCompositeOperation = "lighter";
+      ctx.lineWidth = 1;
+      ctx.lineJoin = "round";
+
+      // The sheet hangs from the middle of the band; placement CSS decides
+      // where the band itself sits on screen.
+      const centerY = height / 2;
+      const spreadPx = height * SHEET_SPREAD;
+      const displacePx = height * DISPLACE;
+      const [r, g, b] = stroke;
+
+      for (let line = 0; line < LINES; line++) {
+        // 0 = far edge of the sheet, 1 = near edge.
+        const depth = line / (LINES - 1);
+        const baseY = centerY + (depth - 0.5) * spreadPx;
+        const phase = timeSec * 0.9 + depth * DEPTH_PHASE;
+        // Near lines read brighter, so the sheet has a front and a back
+        // instead of looking like a flat stack.
+        ctx.strokeStyle = `rgba(${r},${g},${b},${(0.07 + depth * 0.16).toFixed(3)})`;
+        ctx.beginPath();
+
+        for (let i = 0; i < SAMPLES; i++) {
+          const u = i / (SAMPLES - 1);
+          const x = u * width;
+          // Envelope from the amplitude history: what was said, scrolling left.
+          const amp =
+            envelope[Math.min(HISTORY_SIZE - 1, Math.round(u * (HISTORY_SIZE - 1)))];
+          const gain = IDLE_ENVELOPE + amp * (1 - IDLE_ENVELOPE);
+          // Two ripples at different rates, counter-rotating through depth, so
+          // the sheet interferes with itself rather than rippling uniformly.
+          const wave =
+            0.6 * Math.sin(u * Math.PI * 2 * 1.6 + phase) +
+            0.4 * Math.sin(u * Math.PI * 2 * 2.7 - phase * 1.25);
+          const y = baseY - gain * displacePx * wave;
+          if (i === 0) {
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+        ctx.stroke();
+      }
+    };
+
+    // Reduced motion: draw the sheet once, at rest, and stop. The band's CSS
+    // holds a steady low state for the same reason.
+    if (reduce) {
+      history.read(envelope, 3);
+      draw(0);
+      return () => observer.disconnect();
+    }
+
+    let raf = 0;
+    let lastTime = performance.now();
+    let lastAmpWritten = "";
+    const tick = (now: number) => {
+      const dt = Math.min(100, now - lastTime);
+      lastTime = now;
+      const target = Math.min(1, Math.max(0, getAmplitudeRef.current()));
+      const amp = smoother.step(target, dt);
+
+      // Keep publishing `--voice-amp`: the placement CSS reads it for the
+      // band's rise and brightness, which composes over the canvas.
+      const ampText = amp.toFixed(3);
+      if (ampText !== lastAmpWritten) {
+        lastAmpWritten = ampText;
+        host.style.setProperty("--voice-amp", ampText);
+      }
+
+      history.push(amp, dt);
+      history.read(envelope, 3);
+      draw(now / 1000);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+    };
+  }, [palette]);
+
+  const className = [
+    "voice-listening-waves",
+    "voice-listening-waves--mesh",
+    `voice-listening-waves--${palette}`,
+    `voice-listening-waves--${placement}`,
+  ].join(" ");
+
+  return (
+    <div ref={hostRef} className={className} aria-hidden>
+      <canvas
+        ref={canvasRef}
+        data-mesh-canvas=""
+        className="absolute inset-0 h-full w-full"
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-mesh-waves.tsx
@@ -113,23 +113,41 @@ export interface VoiceMeshTuning {
   alphaNear: number;
   /** Displacement floor, so the sheet still breathes through silence. */
   idleEnvelope: number;
+  /**
+   * How fast the band reaches its opacity ceiling as amplitude rises.
+   *
+   * Opacity and displacement both used to scale linearly with amplitude, which
+   * multiplied out: at half volume the sheet was half as tall *and* half as
+   * visible, so presence fell off with the square of the signal and ordinary
+   * speech — which rarely holds near full amplitude — barely registered.
+   * Displacement is what should carry dynamics; opacity only has to say that a
+   * voice is present, so it saturates at `1 / opacityKnee` of full amplitude
+   * and stays there. Still reaches zero in silence.
+   */
+  opacityKnee: number;
   /** Samples of amplitude history retained, and how fast the terrain scrolls. */
   historySize: number;
   historyPeriodMs: number;
 }
 
 /**
- * The "dense" tuning: many lines at low alpha, with the sheet's edges close
- * enough together that the curves nearly coincide. That combination is what
- * makes the weave *resolve* — at the original 46 lines and 0.3 spread the
- * curves read as ruled lines at different heights (a stack) before they read
- * as one folded surface.
+ * The "filament" tuning: many lines at low alpha with the sheet's near and far
+ * edges almost coincident, so the curves separate only where the twist pulls
+ * them apart. That is what reads as a bundle of filaments rather than as ruled
+ * lines at different heights — the earlier 46-line/0.3-spread tuning looked
+ * like a stack before it looked like one folded surface.
+ *
+ * `idleEnvelope` is 0 on purpose: displacement is now proportional to
+ * amplitude with no floor under it, so the sheet flattens as the voice stops
+ * instead of holding a resting breath. The band's opacity fades out over the
+ * same signal (see `--band-peak-opacity` in `index.css`), so silence leaves
+ * nothing on screen rather than an idling decoration.
  */
 export const DEFAULT_MESH_TUNING: VoiceMeshTuning = {
   lines: 92,
   samples: 96,
-  spread: 0.12,
-  displace: 0.4,
+  spread: 0.06,
+  displace: 0.42,
   depthPhase: Math.PI * 1.7,
   cyclesA: 1.6,
   cyclesB: 2.7,
@@ -139,9 +157,10 @@ export const DEFAULT_MESH_TUNING: VoiceMeshTuning = {
   wander: 0.9,
   wanderHzA: 0.037,
   wanderHzB: 0.023,
-  alphaFar: 0.035,
-  alphaNear: 0.13,
-  idleEnvelope: 0.13,
+  alphaFar: 0.08,
+  alphaNear: 0.42,
+  idleEnvelope: 0,
+  opacityKnee: 3,
   historySize: 96,
   historyPeriodMs: 34,
 };
@@ -160,8 +179,8 @@ export const MESH_INLINE_TUNING: Partial<VoiceMeshTuning> = {
   lines: 26,
   spread: 0.18,
   displace: 0.62,
-  alphaFar: 0.1,
-  alphaNear: 0.34,
+  alphaFar: 0.16,
+  alphaNear: 0.6,
 };
 
 /**
@@ -249,7 +268,11 @@ function toRgb(color: string, fallback: [number, number, number]): [number, numb
 function resolveStroke(
   node: HTMLElement,
   palette: VoiceWavePalette,
+  color?: string,
 ): [number, number, number] {
+  if (color) {
+    return toRgb(color, [255, 255, 255]);
+  }
   const styles = getComputedStyle(node);
   if (palette === "aurora") {
     return toRgb(AURORA_HEX, [34, 211, 238]);
@@ -261,16 +284,51 @@ function resolveStroke(
   return toRgb(token, palette === "accent" ? [99, 102, 241] : [255, 255, 255]);
 }
 
+/**
+ * Which compositing mode the sheet's overlapping strokes accumulate under.
+ *
+ * This is not a style preference — it is forced by the ink. `lighter` is
+ * additive, so it can only ever brighten what is already on the canvas: a
+ * black stroke contributes zero and the entire sheet renders invisible. Dark
+ * ink therefore has to composite normally, where each stroke's alpha pulls the
+ * pixel further toward the stroke color. Overlaps still accumulate either way,
+ * which is what keeps the woven ridges emergent rather than painted — they
+ * just accumulate toward white in one mode and toward black in the other.
+ *
+ * Chosen from perceived luminance rather than exposed as a knob, because
+ * getting it wrong does not look worse, it looks like nothing at all.
+ */
+function compositeFor(stroke: [number, number, number]): GlobalCompositeOperation {
+  const [r, g, b] = stroke;
+  // Rec. 601 luma, which is close enough for a light/dark decision.
+  const luma = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luma >= 0.5 ? "lighter" : "source-over";
+}
+
 export function VoiceMeshWaves({
   getAmplitude,
   palette = "aurora",
   placement = "bottom",
+  color,
+  peakOpacity = 1,
   tuning,
 }: {
   /** Amplitude source (0–1), polled in a rAF loop. */
   getAmplitude: () => number;
   palette?: VoiceWavePalette;
   placement?: VoiceWavePlacement;
+  /**
+   * Explicit stroke color, overriding `palette`. The room uses this to tell
+   * the two voices apart by ink instead of by position — see `BAND_VOICE`.
+   * Compositing follows the color's luminance automatically.
+   */
+  color?: string;
+  /**
+   * Band opacity at full amplitude. Opacity scales linearly from 0, so the
+   * sheet fades out entirely as the voice stops rather than settling to a
+   * resting visibility.
+   */
+  peakOpacity?: number;
   /** Overrides on {@link DEFAULT_MESH_TUNING}. */
   tuning?: Partial<VoiceMeshTuning>;
 }) {
@@ -303,7 +361,8 @@ export function VoiceMeshWaves({
     const reduce = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
-    let stroke = resolveStroke(host, palette);
+    let stroke = resolveStroke(host, palette, color);
+    let composite = compositeFor(stroke);
 
     // Backing store follows the element's CSS size × DPR; the context is scaled
     // so all drawing below is in CSS pixels and `lineWidth = 1` stays hairline.
@@ -319,7 +378,8 @@ export function VoiceMeshWaves({
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       // The accent can change with the avatar; the observer is the cheapest
       // point to notice without subscribing to anything.
-      stroke = resolveStroke(host, palette);
+      stroke = resolveStroke(host, palette, color);
+      composite = compositeFor(stroke);
     };
     resize();
     const observer = new ResizeObserver(resize);
@@ -337,9 +397,10 @@ export function VoiceMeshWaves({
 
     const draw = (timeSec: number) => {
       ctx.clearRect(0, 0, width, height);
-      // Additive: where the folded sheet stacks strokes, the pile brightens.
-      // This is the entire lighting model — no shadow, no blur.
-      ctx.globalCompositeOperation = "lighter";
+      // Where the folded sheet stacks strokes, the pile accumulates — toward
+      // white under `lighter`, toward the ink under `source-over`. That is the
+      // entire lighting model; there is no shadow or blur anywhere in here.
+      ctx.globalCompositeOperation = composite;
       ctx.lineWidth = 1;
       ctx.lineJoin = "round";
 
@@ -412,12 +473,16 @@ export function VoiceMeshWaves({
       const target = Math.min(1, Math.max(0, getAmplitudeRef.current()));
       const amp = smoother.step(target, dt);
 
-      // Keep publishing `--voice-amp`: the placement CSS reads it for the
-      // band's rise and brightness, which composes over the canvas.
+      // `--voice-amp` stays for the shared placement CSS; `--band-presence` is
+      // the saturating curve the mesh's own opacity rides (see `opacityKnee`).
       const ampText = amp.toFixed(3);
       if (ampText !== lastAmpWritten) {
         lastAmpWritten = ampText;
         host.style.setProperty("--voice-amp", ampText);
+        host.style.setProperty(
+          "--band-presence",
+          Math.min(1, amp * config.opacityKnee).toFixed(3),
+        );
       }
 
       history.push(amp, dt);
@@ -430,7 +495,7 @@ export function VoiceMeshWaves({
       cancelAnimationFrame(raf);
       observer.disconnect();
     };
-  }, [palette, config]);
+  }, [palette, color, config]);
 
   const className = [
     "voice-listening-waves",
@@ -440,7 +505,12 @@ export function VoiceMeshWaves({
   ].join(" ");
 
   return (
-    <div ref={hostRef} className={className} aria-hidden>
+    <div
+      ref={hostRef}
+      className={className}
+      style={{ ["--band-peak-opacity" as string]: peakOpacity }}
+      aria-hidden
+    >
       <canvas
         ref={canvasRef}
         data-mesh-canvas=""

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
@@ -60,7 +60,7 @@ import { VoiceMeshWaves, type VoiceMeshTuning } from "./voice-mesh-waves";
 // ---------------------------------------------------------------------------
 
 /** How the harness sources the 0–1 amplitude every surface is driven by. */
-type Driver = "mic" | "speech" | "silence" | "manual";
+type Driver = "mic" | "speech" | "ramp" | "silence" | "manual";
 
 /**
  * Match the app's own mic scaling so the harness is honest about levels:
@@ -97,6 +97,25 @@ function useDriver(
     if (driver === "silence") {
       ampRef.current = 0;
     }
+  }, [driver]);
+
+  // Ramp: a slow triangle through the whole 0–1 range. Speech envelopes jump
+  // around too fast to tell "responds to amplitude" from "moves a lot", so this
+  // is the driver to judge responsiveness on — anything that answers amplitude
+  // should visibly swell and subside once per cycle.
+  useEffect(() => {
+    if (driver !== "ramp") {
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = () => {
+      const t = ((performance.now() - start) / 1000) % 6;
+      ampRef.current = t < 3 ? t / 3 : (6 - t) / 3;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
   }, [driver]);
 
   // Simulated speech: ~3.5 Hz syllabic tremor under a 0.4 Hz phrase swell,
@@ -247,6 +266,7 @@ interface SceneArgs {
   bodyShape: string;
   respondingStyle: VoiceRespondingStyle;
   captionEmphasis: VoiceCaptionEmphasis;
+  bandStrength: number;
 }
 
 /** The room's color look in a measured frame, driven by the selected source. */
@@ -307,9 +327,10 @@ function RoomFrame({
           waveEngine={args.engine}
           waveStyle={args.waveStyle}
           wavePalette={args.wavePalette}
-          // Listening arrives from the ceiling; the responding band answers
-          // from the floor (see `respondingStyle: "waves"`).
-          wavePlacement="top"
+          // Both voices sit on the floor and are told apart by ink instead
+          // (see `BAND_VOICE`); `wavePlacement` still moves the listening band
+          // to the ceiling if the split-by-position version is wanted back.
+          wavePlacement="bottom"
           respondingStyle={args.respondingStyle}
           captionEmphasis={args.captionEmphasis}
           eyePlacement="center"
@@ -366,16 +387,17 @@ const defaultArgs: SceneArgs = {
   eyeStyle: BUNDLED_COMPONENTS.eyeStyles[0]?.id ?? "grumpy",
   bodyShape: "blob",
   respondingStyle: "waves",
-  captionEmphasis: "muted",
+  captionEmphasis: "hidden",
+  bandStrength: 1,
 };
 
 const argTypes = {
   visual: { options: VISUALS, control: { type: "select" as const } },
   driver: {
-    options: ["speech", "mic", "silence", "manual"] satisfies Driver[],
+    options: ["speech", "mic", "ramp", "silence", "manual"] satisfies Driver[],
     control: { type: "inline-radio" as const },
     description:
-      "mic = your real microphone (prompts for permission); speech = simulated envelope; silence = hard zero; manual = the slider.",
+      "mic = your real microphone (prompts for permission); speech = simulated envelope; ramp = a slow 0→1→0 sweep, the one to judge amplitude-responsiveness on; silence = hard zero; manual = the slider.",
   },
   amplitude: {
     control: { type: "range" as const, min: 0, max: 1, step: 0.01 },
@@ -406,6 +428,11 @@ const argTypes = {
   bodyShape: {
     options: BUNDLED_COMPONENTS.bodyShapes.map((b) => b.id),
     control: { type: "select" as const },
+  },
+  bandStrength: {
+    control: { type: "range" as const, min: 0.25, max: 3, step: 0.05 },
+    description:
+      "Multiplier on the band's opacity ceiling (1 = the designer's 0.4 white / 0.2 black). Only affects the Band Strength story.",
   },
   captionEmphasis: {
     options: ["muted", "hidden", "full"] satisfies VoiceCaptionEmphasis[],
@@ -723,14 +750,14 @@ const MESH_PRESETS: {
   tuning: Partial<VoiceMeshTuning>;
 }[] = [
   {
-    name: "dense (current default)",
-    note: "92 lines at low alpha, edges close together — what the rooms and the composer bar now use",
+    name: "filament (current default)",
+    note: "edges almost coincident — the curves part only where the twist pulls them apart",
     tuning: {},
   },
   {
-    name: "filament",
-    note: "edges closer still, so the curves separate only where the twist pulls them apart",
-    tuning: { spread: 0.06, displace: 0.42, alphaNear: 0.18 },
+    name: "slack",
+    note: "slower drift and broader lobes; the other one the designer liked",
+    tuning: { driftSpeed: 0.42, cyclesA: 1.1, cyclesB: 1.9 },
   },
   {
     name: "broad lobes",
@@ -743,13 +770,13 @@ const MESH_PRESETS: {
     tuning: { depthPhase: Math.PI * 3.1 },
   },
   {
-    name: "slack",
-    note: "slower drift and a softer floor — calmer at rest, more of a swell on speech",
-    tuning: { driftSpeed: 0.42, idleEnvelope: 0.07, cyclesA: 1.1, cyclesB: 1.9 },
+    name: "dense (previous default)",
+    note: "edges further apart — starts to read as ruled lines rather than one bundle",
+    tuning: { spread: 0.12, displace: 0.4, alphaNear: 0.13 },
   },
   {
     name: "original (46 lines)",
-    note: "the first tuning, for reference — reads as ruled lines at different heights, not one surface",
+    note: "the first tuning, for reference — a stack of lines, not a folded surface",
     tuning: {
       lines: 46,
       spread: 0.3,
@@ -934,6 +961,225 @@ function CaptionEmphasisScene(args: SceneArgs) {
               className="rounded-xl"
               style={{ height: 460 }}
             />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Both voices on the floor, told apart by ink rather than by position.
+ *
+ * The earlier pass split them by edge — mic at the ceiling, reply at the
+ * bottom — which read well but rearranged the room's whole composition twice
+ * a turn. Here the layout holds still: the user's voice lifts a pale sheet off
+ * the floor (white, 0.4 ceiling), the assistant's answers in a darker one
+ * (black, 0.2), and the eyes never share the frame with a band overhead.
+ *
+ * Both fade from *nothing*, not from a resting visibility — displacement and
+ * opacity both scale from zero, so between turns the floor is empty and the
+ * band flattens away as the voice stops rather than cutting.
+ *
+ * Worth knowing: the dark band composites differently out of necessity, not
+ * taste. The mesh's ridges come from overlapping strokes accumulating under
+ * `lighter`, which is additive — black contributes zero and the sheet would
+ * render invisible. Dark ink composites normally instead, accumulating toward
+ * the ink rather than toward white. `compositeFor()` picks from luminance.
+ */
+export const InkSplit: Story = {
+  name: "Placement — Ink Split (both on the floor)",
+  args: { ...defaultArgs, driver: "speech" },
+  render: (args) => <InkSplitScene {...args} />,
+};
+
+function InkSplitScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div className="grid gap-4 lg:grid-cols-3">
+        {(
+          [
+            ["listening", "user speaking — white, 0.4"],
+            ["thinking", "between turns — the floor is empty"],
+            ["responding", "assistant speaking — black, 0.2"],
+          ] as const
+        ).map(([visual, label]) => (
+          <div key={visual} className="flex flex-col gap-2">
+            <span className="text-[13px] font-medium text-white/60">
+              {label}
+            </span>
+            <RoomFrame
+              args={{ ...args, visual }}
+              getAmplitude={getAmplitude}
+              className="rounded-xl"
+              style={{ height: 480 }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A strength ladder for both voices, so the opacity ceilings can be picked by
+ * eye rather than argued about in the abstract.
+ *
+ * The designer's numbers — white at 0.4, black at 0.2 — are the `1.0` column.
+ * They read fainter than intended at first because two mistakes compounded:
+ * the ceiling multiplied per-line alphas that had been calibrated against a
+ * fully-opaque container, and opacity scaled linearly with amplitude on top of
+ * a displacement that already did, so presence fell off with the *square* of
+ * the signal. Both are fixed (`opacityKnee`, and full-strength base alphas), so
+ * this ladder now moves the ceiling itself.
+ *
+ * Worth judging the two rows separately: the pale band accumulates additively
+ * and saturates toward white, while the dark one composites normally and
+ * accumulates toward the ink, so equal numbers do not read as equal presence.
+ */
+export const BandStrength: Story = {
+  name: "Band — Strength Ladder",
+  args: { ...defaultArgs, driver: "speech" },
+  render: (args) => <BandStrengthScene {...args} />,
+};
+
+const STRENGTHS = [0.5, 1, 1.75, 2.5];
+
+function BandStrengthScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      {(
+        [
+          ["listening", "user — white", 0.4],
+          ["responding", "assistant — black", 0.2],
+        ] as const
+      ).map(([visual, label, base]) => (
+        <div key={visual} className="mb-6">
+          <div className="mb-2 text-[13px] font-medium text-white/60">
+            {label}
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {STRENGTHS.map((strength) => (
+              <div key={strength} className="flex flex-col gap-1">
+                <span className="font-mono text-[11px] text-white/45">
+                  ×{strength} → {(base * strength).toFixed(2)}
+                  {strength === 1 ? "  (designer's)" : ""}
+                </span>
+                <BandStrengthCell
+                  args={args}
+                  visual={visual}
+                  strength={strength}
+                  getAmplitude={getAmplitude}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One cell of the ladder. The strength multiplier is applied by overriding
+ * `--band-peak-opacity` on a wrapper, which is the same variable the room's
+ * per-voice ceiling sets — so this scales the real thing rather than
+ * approximating it.
+ */
+function BandStrengthCell({
+  args,
+  visual,
+  strength,
+  getAmplitude,
+}: {
+  args: SceneArgs;
+  visual: VoiceAvatarVisual;
+  strength: number;
+  getAmplitude: () => number;
+}) {
+  return (
+    <div
+      style={
+        {
+          "--band-strength": strength,
+        } as React.CSSProperties
+      }
+      className="[&_.voice-listening-waves--mesh]:[opacity:calc(var(--band-presence,0)*var(--band-peak-opacity,1)*var(--band-strength,1))]"
+    >
+      <RoomFrame
+        args={{ ...args, visual }}
+        getAmplitude={getAmplitude}
+        className="rounded-lg"
+        style={{ height: 300 }}
+      />
+    </div>
+  );
+}
+
+/**
+ * The assistant band's amplitude response, on the ramp driver.
+ *
+ * `opacityKnee` sets how fast the band reaches its opacity ceiling: at 3 it is
+ * fully opaque by a third of full amplitude and everything above that looks
+ * identical. That is right for the *pale* band, whose silhouette reads clearly
+ * enough that displacement can carry the dynamics on its own — but wrong for
+ * the dark one, where the low-contrast silhouette means opacity is doing most
+ * of the visible work, and saturating it early made the assistant's voice look
+ * like it had stopped tracking amplitude at all.
+ *
+ * On the ramp driver each frame should visibly swell and subside once per
+ * cycle. The lower the knee, the more of the amplitude range you can actually
+ * see. 1.0 is perfectly linear; the room currently ships 1.3.
+ */
+export const RespondingResponse: Story = {
+  name: "Band — Assistant Response Curve",
+  args: { ...defaultArgs, driver: "ramp", visual: "responding" },
+  render: (args) => <RespondingResponseScene {...args} />,
+};
+
+const KNEES = [1, 1.3, 2, 3];
+
+function RespondingResponseScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {KNEES.map((knee) => (
+          <div key={knee} className="flex flex-col gap-1">
+            <span className="font-mono text-[11px] text-white/45">
+              knee {knee.toFixed(1)}
+              {knee === 1 ? "  (linear)" : ""}
+              {knee === 1.3 ? "  (shipping)" : ""}
+              {knee === 3 ? "  (was)" : ""}
+            </span>
+            <div
+              style={{ ["--band-knee" as string]: knee }}
+              className="[&_.voice-listening-waves--mesh]:[opacity:calc(min(1,var(--voice-amp,0)*var(--band-knee,1))*var(--band-peak-opacity,1))]"
+            >
+              <RoomFrame
+                args={{ ...args, visual: "responding" }}
+                getAmplitude={getAmplitude}
+                className="rounded-lg"
+                style={{ height: 320 }}
+              />
+            </div>
           </div>
         ))}
       </div>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
@@ -1,0 +1,625 @@
+/**
+ * Iteration harness for the *reactive* voice animations — the three surfaces a
+ * live session can occupy, all on one amplitude source:
+ *
+ * 1. **Room — Desktop** — the full-screen color look, eyes and wave band.
+ * 2. **Minimized — Composer Bar** — the inline strip that replaces the chat
+ *    input's action row while the room is minimized.
+ * 3. **Room — Mobile** — the same room in a phone frame.
+ *
+ * The point of the harness is the **Driver** knob. The old band's geometry was
+ * authored once at mount and only slid sideways, so it looked identical whether
+ * the mic was clipping or unplugged — the "it's just a PNG" read. Here the
+ * geometry is rebuilt every frame from a rolling history of the amplitude, so
+ * the surfaces should look obviously different per driver:
+ *
+ * - `mic` — **your actual microphone**, via `getUserMedia`. The honest test:
+ *   talk, and the crest you make should travel left and decay off the edge.
+ *   Storybook will prompt for permission the first time.
+ * - `speech` — a simulated-speech envelope (syllabic tremor under a phrase
+ *   swell), for iterating without talking to your laptop all afternoon.
+ * - `silence` — a hard zero. The band should settle to its resting breath
+ *   within about a second, *not* keep marching. If `silence` and `speech` look
+ *   the same, the animation is not reactive and this harness has failed.
+ * - `manual` — the Amplitude slider, for pinning a level and judging a pose.
+ *
+ * `Engine` A/Bs the new geometry against the original sine band on the same
+ * driver, which is the fastest way to see what changed.
+ *
+ * Nothing hits the network or the daemon: the avatar is resolved from bundled
+ * components and the amplitude comes from whichever driver is selected.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// The `.voice-listening-waves` / `.voice-room-eyes-reactive` rules are
+// hand-written in the app's global stylesheet, not Tailwind utilities —
+// Storybook's preview.css only pulls Tailwind + tokens.
+import "@/index.css";
+
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { toneForBg } from "@/utils/avatar-tone";
+
+import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+import {
+  VoiceRoomColorLook,
+  resolveVoiceRoomLook,
+  type VoiceWaveEngine,
+} from "./voice-room-eyes";
+import type { VoiceAvatarVisual } from "./voice-avatar-state";
+import type { VoiceWavePalette, VoiceWaveStyle } from "./voice-listening-waves";
+
+// ---------------------------------------------------------------------------
+// Amplitude drivers
+// ---------------------------------------------------------------------------
+
+/** How the harness sources the 0–1 amplitude every surface is driven by. */
+type Driver = "mic" | "speech" | "silence" | "manual";
+
+/**
+ * Match the app's own mic scaling so the harness is honest about levels:
+ * `pcm-capture.ts` and `use-audio-amplitude.ts` both take an RMS, smooth it
+ * with a 0.5 EMA, and scale by 14 before clamping to 1.
+ */
+const AMPLITUDE_SMOOTHING = 0.5;
+const AMPLITUDE_SCALE = 14.0;
+
+/**
+ * A stable `getAmplitude` poll function for the selected driver.
+ *
+ * Amplitude never flows through React state here, matching every real call
+ * site: the value lives in a ref that the surfaces' own rAF loops read. The
+ * returned function is referentially stable, so swapping drivers never
+ * restarts the consumers' loops.
+ */
+function useDriver(
+  driver: Driver,
+  manualAmplitude: number,
+): { getAmplitude: () => number; micError: string | null } {
+  const ampRef = useRef(0);
+  const [micError, setMicError] = useState<string | null>(null);
+
+  // Manual: mirror the slider into the ref.
+  useEffect(() => {
+    if (driver === "manual") {
+      ampRef.current = manualAmplitude;
+    }
+  }, [driver, manualAmplitude]);
+
+  // Silence: a hard zero, so the resting state can be judged honestly.
+  useEffect(() => {
+    if (driver === "silence") {
+      ampRef.current = 0;
+    }
+  }, [driver]);
+
+  // Simulated speech: ~3.5 Hz syllabic tremor under a 0.4 Hz phrase swell,
+  // plus jitter — the same envelope the existing voice stories use.
+  useEffect(() => {
+    if (driver !== "speech") {
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = () => {
+      const t = (performance.now() - start) / 1000;
+      const syllable = 0.5 + 0.5 * Math.sin(t * 2 * Math.PI * 3.5);
+      const phrase = 0.6 + 0.4 * Math.sin(t * 2 * Math.PI * 0.4);
+      ampRef.current = Math.min(
+        1,
+        Math.max(0, syllable * phrase * 0.9 + Math.random() * 0.12),
+      );
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [driver]);
+
+  // Real microphone. Held open only while `mic` is selected — the tracks are
+  // stopped and the context closed on switch away, so Storybook does not sit
+  // on the mic indicator all day.
+  useEffect(() => {
+    if (driver !== "mic") {
+      return;
+    }
+    let cancelled = false;
+    let raf = 0;
+    let stream: MediaStream | null = null;
+    let context: AudioContext | null = null;
+
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      } catch (error) {
+        if (!cancelled) {
+          setMicError(
+            error instanceof Error ? error.message : "Microphone unavailable",
+          );
+        }
+        return;
+      }
+      if (cancelled) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+      setMicError(null);
+      context = new AudioContext();
+      const analyser = context.createAnalyser();
+      analyser.fftSize = 256;
+      context.createMediaStreamSource(stream).connect(analyser);
+      const buffer = new Uint8Array(analyser.frequencyBinCount);
+      let smoothed = 0;
+      const tick = () => {
+        analyser.getByteTimeDomainData(buffer);
+        let sum = 0;
+        for (const sample of buffer) {
+          const centered = sample / 128 - 1;
+          sum += centered * centered;
+        }
+        const rms = Math.sqrt(sum / buffer.length);
+        smoothed =
+          AMPLITUDE_SMOOTHING * rms + (1 - AMPLITUDE_SMOOTHING) * smoothed;
+        ampRef.current = Math.min(smoothed * AMPLITUDE_SCALE, 1);
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    };
+    void start();
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      stream?.getTracks().forEach((track) => track.stop());
+      void context?.close();
+      ampRef.current = 0;
+    };
+  }, [driver]);
+
+  return { getAmplitude: useCallback(() => ampRef.current, []), micError };
+}
+
+/** Measure a box with a ResizeObserver — the room look sizes against it. */
+function useBoxSize() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    const measure = () => {
+      const r = el.getBoundingClientRect();
+      setSize({ w: r.width, h: r.height });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return { ref, size };
+}
+
+/**
+ * A live read-out of the amplitude the surfaces are being fed.
+ *
+ * This is the harness's control: if the number moves and the band does not,
+ * the band is not reactive. Sampled at ~12 Hz rather than per frame — it is a
+ * debug read-out, and it is the one place in this file allowed to re-render.
+ */
+function AmplitudeReadout({ getAmplitude }: { getAmplitude: () => number }) {
+  const [value, setValue] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setValue(getAmplitude()), 80);
+    return () => clearInterval(id);
+  }, [getAmplitude]);
+  return (
+    <div className="flex items-center gap-2 font-mono text-[11px] text-white/50">
+      <span className="w-20 tabular-nums">amp {value.toFixed(3)}</span>
+      <div className="h-1 w-32 overflow-hidden rounded-full bg-white/10">
+        <div
+          className="h-full rounded-full bg-white/70"
+          style={{ width: `${Math.round(value * 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenes
+// ---------------------------------------------------------------------------
+
+interface SceneArgs {
+  visual: VoiceAvatarVisual;
+  driver: Driver;
+  amplitude: number;
+  engine: VoiceWaveEngine;
+  waveStyle: VoiceWaveStyle;
+  wavePalette: VoiceWavePalette;
+  colorId: string;
+  eyeStyle: string;
+  bodyShape: string;
+}
+
+/** The room's color look in a measured frame, driven by the selected source. */
+function RoomFrame({
+  args,
+  getAmplitude,
+  className,
+  style,
+}: {
+  args: SceneArgs;
+  getAmplitude: () => number;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const { ref, size } = useBoxSize();
+  const look = resolveVoiceRoomLook(
+    BUNDLED_COMPONENTS,
+    {
+      bodyShape: args.bodyShape,
+      eyeStyle: args.eyeStyle,
+      color: args.colorId,
+    },
+    null,
+  );
+  const tone = look ? toneForBg(look.bgHex) : null;
+
+  // Only `listening` (mic) and `responding` (TTS) are audio-reactive in the
+  // real app; silence the driver elsewhere so `thinking` holds steady rather
+  // than bobbing to a signal it would never receive.
+  const gated = useCallback(
+    () =>
+      args.visual === "listening" || args.visual === "responding"
+        ? getAmplitude()
+        : 0,
+    [args.visual, getAmplitude],
+  );
+
+  return (
+    <div
+      ref={ref}
+      data-theme={tone?.isLight ? "light" : "dark"}
+      className={`relative overflow-hidden ${className ?? ""}`}
+      style={{
+        ...style,
+        ["--room-fg" as string]: tone?.fg ?? "#FFFFFF",
+        ["--room-fg-muted" as string]: tone?.fgMuted ?? "rgba(255,255,255,0.7)",
+        ["--room-wash" as string]: tone?.wash ?? "rgba(255,255,255,0.1)",
+      }}
+    >
+      {look && size.w > 0 ? (
+        <VoiceRoomColorLook
+          // Remount when the engine or traits change so the entrance replays
+          // and the two engines start from the same clean state.
+          key={`${args.engine}-${args.colorId}-${args.eyeStyle}-${args.bodyShape}`}
+          look={look}
+          visual={args.visual}
+          getAmplitude={gated}
+          waveEngine={args.engine}
+          waveStyle={args.waveStyle}
+          wavePalette={args.wavePalette}
+          wavePlacement="bottom"
+          eyePlacement="center"
+          viewport={size}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/** Driver controls + the amplitude read-out, shared by every story. */
+function DriverBar({
+  driver,
+  getAmplitude,
+  micError,
+}: {
+  driver: Driver;
+  getAmplitude: () => number;
+  micError: string | null;
+}) {
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-4">
+      <span className="text-[13px] font-medium text-white/60">
+        driver: {driver}
+      </span>
+      <AmplitudeReadout getAmplitude={getAmplitude} />
+      {micError ? (
+        <span className="text-[12px] text-red-400">mic: {micError}</span>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const VISUALS: VoiceAvatarVisual[] = [
+  "idle",
+  "listening",
+  "thinking",
+  "responding",
+  "reconnecting",
+];
+
+const defaultArgs: SceneArgs = {
+  visual: "listening",
+  driver: "speech",
+  amplitude: 0.5,
+  engine: "reactive",
+  waveStyle: "fill",
+  wavePalette: "tone",
+  colorId: "green",
+  eyeStyle: BUNDLED_COMPONENTS.eyeStyles[0]?.id ?? "grumpy",
+  bodyShape: "blob",
+};
+
+const argTypes = {
+  visual: { options: VISUALS, control: { type: "select" as const } },
+  driver: {
+    options: ["speech", "mic", "silence", "manual"] satisfies Driver[],
+    control: { type: "inline-radio" as const },
+    description:
+      "mic = your real microphone (prompts for permission); speech = simulated envelope; silence = hard zero; manual = the slider.",
+  },
+  amplitude: {
+    control: { type: "range" as const, min: 0, max: 1, step: 0.01 },
+    description: "Level for the `manual` driver. Ignored by the others.",
+  },
+  engine: {
+    options: ["reactive", "sine"] satisfies VoiceWaveEngine[],
+    control: { type: "inline-radio" as const },
+    description:
+      "reactive = geometry rebuilt per frame from the amplitude history; sine = the original fixed silhouette.",
+  },
+  waveStyle: {
+    options: ["fill", "line"] satisfies VoiceWaveStyle[],
+    control: { type: "inline-radio" as const },
+  },
+  wavePalette: {
+    options: ["tone", "accent", "aurora"] satisfies VoiceWavePalette[],
+    control: { type: "inline-radio" as const },
+  },
+  colorId: {
+    options: BUNDLED_COMPONENTS.colors.map((c) => c.id),
+    control: { type: "select" as const },
+  },
+  eyeStyle: {
+    options: BUNDLED_COMPONENTS.eyeStyles.map((e) => e.id),
+    control: { type: "select" as const },
+  },
+  bodyShape: {
+    options: BUNDLED_COMPONENTS.bodyShapes.map((b) => b.id),
+    control: { type: "select" as const },
+  },
+};
+
+const meta: Meta<SceneArgs> = {
+  title: "Chat/Voice/Reactive Animations",
+  parameters: { layout: "fullscreen" },
+  args: defaultArgs,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ padding: 24, background: "#0b0d10", minHeight: "100vh" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<SceneArgs>;
+
+// ---------------------------------------------------------------------------
+// Story scenes
+//
+// Each story renders one of these rather than calling hooks inside `render`:
+// a Storybook `render` callback is not a component, so hooks there break the
+// rules-of-hooks contract (and would not re-run cleanly on an args change).
+// ---------------------------------------------------------------------------
+
+/** Surface 1 — the full room at desktop proportions. */
+function RoomDesktopScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <RoomFrame
+        args={args}
+        getAmplitude={getAmplitude}
+        className="rounded-xl"
+        style={{ height: "min(72vh, 640px)" }}
+      />
+    </div>
+  );
+}
+
+/** Surface 2 — the minimized bar, inside a composer card. */
+function ComposerBarScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  // The bar takes a session state, not a visual; map the two audio-bearing
+  // visuals onto the states that keep the mic live.
+  const state: LiveVoiceSessionState =
+    args.visual === "responding" ? "speaking" : "listening";
+  const accent =
+    BUNDLED_COMPONENTS.colors.find((c) => c.id === args.colorId)?.hex ??
+    "#3E9E8A";
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      {/* Judged inside the surface it ships in, not on a bare background. */}
+      <div
+        className="mx-auto max-w-3xl rounded-xl border border-white/10 bg-[#1b1e22]"
+        style={{ ["--avatar-accent" as string]: accent }}
+      >
+        <VoiceComposerBar
+          state={state}
+          getAmplitude={getAmplitude}
+          muted={false}
+          onToggleMute={() => {}}
+          onEnd={() => {}}
+          onExpand={() => {}}
+          standalone
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Surface 3 — the same room in a phone frame. */
+function RoomMobileScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div className="flex justify-center">
+        <div className="rounded-[44px] border-[10px] border-black bg-black shadow-2xl">
+          <RoomFrame
+            args={args}
+            getAmplitude={getAmplitude}
+            className="rounded-[34px]"
+            style={{ width: 340, height: 700 }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Both engines on one shared amplitude source. */
+function EngineComparisonScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div className="grid gap-4 lg:grid-cols-2">
+        {(["reactive", "sine"] as const).map((engine) => (
+          <div key={engine} className="flex flex-col gap-2">
+            <span className="text-[13px] font-medium text-white/60">
+              {engine}
+              {engine === "sine" ? " (original)" : ""}
+            </span>
+            <RoomFrame
+              args={{ ...args, engine }}
+              getAmplitude={getAmplitude}
+              className="rounded-xl"
+              style={{ height: 460 }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Every session phase on one driver. */
+function StatesScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {VISUALS.map((visual) => (
+          <div key={visual} className="flex flex-col gap-2">
+            <span className="text-[13px] font-medium text-white/60">
+              {visual}
+            </span>
+            <RoomFrame
+              args={{ ...args, visual }}
+              getAmplitude={getAmplitude}
+              className="rounded-xl"
+              style={{ height: 320 }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/**
+ * Surface 1 — the full room on desktop. Switch **Driver** to `mic` and talk:
+ * each syllable should raise a crest that travels left and decays off the
+ * edge, and the eyes should widen with your voice. Set `responding` to see the
+ * same machinery driven by the assistant's output instead.
+ */
+export const RoomDesktop: Story = {
+  name: "Room — Desktop",
+  render: (args) => <RoomDesktopScene {...args} />,
+};
+
+/**
+ * Surface 2 — the minimized bar that replaces the chat input's action row.
+ * Same engine as the room, at strip height with steeper gains. On `silence` it
+ * should settle to a slow resting breath; on `mic` it should track speech
+ * tightly enough to read as a level meter.
+ */
+export const MinimizedComposerBar: Story = {
+  name: "Minimized — Composer Bar",
+  render: (args) => <ComposerBarScene {...args} />,
+};
+
+/**
+ * Surface 3 — the same room in a phone frame. The room is a full-app takeover
+ * on every platform, so this is the desktop look at phone proportions: the
+ * check is that the band still reads at a narrow width and the eyes still
+ * clear the chrome.
+ */
+export const RoomMobile: Story = {
+  name: "Room — Mobile",
+  render: (args) => <RoomMobileScene {...args} />,
+};
+
+/**
+ * The A/B that settles the question. Both frames share one amplitude source,
+ * so any difference is the engine alone.
+ *
+ * Watch the **silhouette**, not the motion: the `sine` band's crests are a
+ * fixed shape sliding at a constant rate — identical whether the driver is
+ * `speech` or `silence` — while the `reactive` band's crests are raised by the
+ * signal and flatten without it. Switching the driver to `silence` is the
+ * clearest demonstration: only one of the two frames notices.
+ */
+export const EngineComparison: Story = {
+  name: "Engine — Reactive vs Sine",
+  render: (args) => <EngineComparisonScene {...args} />,
+};
+
+/**
+ * Every session phase side by side on one driver, to check the hand-offs: the
+ * band and the eye reaction should both be live in `listening` and
+ * `responding`, and both still in `idle` / `thinking` / `reconnecting` — a
+ * reaction in a phase that carries no audio is animating noise.
+ */
+export const States: Story = {
+  render: (args) => <StatesScene {...args} />,
+};

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
@@ -47,11 +47,13 @@ import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live
 import {
   VoiceRoomColorLook,
   resolveVoiceRoomLook,
+  type VoiceCaptionEmphasis,
+  type VoiceRespondingStyle,
   type VoiceWaveEngine,
 } from "./voice-room-eyes";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 import type { VoiceWavePalette, VoiceWaveStyle } from "./voice-listening-waves";
-import { VoiceMeshWaves } from "./voice-mesh-waves";
+import { VoiceMeshWaves, type VoiceMeshTuning } from "./voice-mesh-waves";
 
 // ---------------------------------------------------------------------------
 // Amplitude drivers
@@ -243,6 +245,8 @@ interface SceneArgs {
   colorId: string;
   eyeStyle: string;
   bodyShape: string;
+  respondingStyle: VoiceRespondingStyle;
+  captionEmphasis: VoiceCaptionEmphasis;
 }
 
 /** The room's color look in a measured frame, driven by the selected source. */
@@ -303,7 +307,11 @@ function RoomFrame({
           waveEngine={args.engine}
           waveStyle={args.waveStyle}
           wavePalette={args.wavePalette}
-          wavePlacement="bottom"
+          // Listening arrives from the ceiling; the responding band answers
+          // from the floor (see `respondingStyle: "waves"`).
+          wavePlacement="top"
+          respondingStyle={args.respondingStyle}
+          captionEmphasis={args.captionEmphasis}
           eyePlacement="center"
           viewport={size}
         />
@@ -351,12 +359,14 @@ const defaultArgs: SceneArgs = {
   visual: "listening",
   driver: "speech",
   amplitude: 0.5,
-  engine: "reactive",
+  engine: "mesh",
   waveStyle: "fill",
   wavePalette: "tone",
   colorId: "green",
   eyeStyle: BUNDLED_COMPONENTS.eyeStyles[0]?.id ?? "grumpy",
   bodyShape: "blob",
+  respondingStyle: "waves",
+  captionEmphasis: "muted",
 };
 
 const argTypes = {
@@ -396,6 +406,24 @@ const argTypes = {
   bodyShape: {
     options: BUNDLED_COMPONENTS.bodyShapes.map((b) => b.id),
     control: { type: "select" as const },
+  },
+  captionEmphasis: {
+    options: ["muted", "hidden", "full"] satisfies VoiceCaptionEmphasis[],
+    control: { type: "inline-radio" as const },
+    description:
+      "How prominent the state caption is while audio flows. Only affects listening/responding — thinking always keeps its caption.",
+  },
+  respondingStyle: {
+    options: [
+      "waves",
+      "rings",
+      "halo",
+      "waveform",
+      "pulse",
+    ] satisfies VoiceRespondingStyle[],
+    control: { type: "inline-radio" as const },
+    description:
+      "waves = the band answering from the floor (the mirror of listening); the rest are the earlier radiate-from-the-eyes sketches.",
   },
 };
 
@@ -636,6 +664,12 @@ export const States: Story = {
  * voice; on `silence` it settles to a slow resting breath rather than
  * flat-lining, so the surface never looks switched off.
  *
+ * The band itself no longer travels: the shared placement CSS used to
+ * translate the whole container on `--voice-amp`, which stacked a second
+ * response on the same signal and read as the sheet bouncing behind its own
+ * breathing. The mesh opts out of that (`--mesh` in `index.css`), so all the
+ * vertical motion you see is the geometry answering the audio.
+ *
  * `wavePalette` retints it: `aurora` is the reference cyan, `accent` takes the
  * avatar's hue, `tone` follows the room foreground.
  */
@@ -670,6 +704,238 @@ function MeshShowcaseScene(args: SceneArgs) {
           palette={args.wavePalette}
           placement="center"
         />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mesh variants
+// ---------------------------------------------------------------------------
+
+/**
+ * Tuning sketches for the mesh, each pulling on a different reason the default
+ * can read as flat. The names describe the intent, not the numbers.
+ */
+const MESH_PRESETS: {
+  name: string;
+  note: string;
+  tuning: Partial<VoiceMeshTuning>;
+}[] = [
+  {
+    name: "dense (current default)",
+    note: "92 lines at low alpha, edges close together — what the rooms and the composer bar now use",
+    tuning: {},
+  },
+  {
+    name: "filament",
+    note: "edges closer still, so the curves separate only where the twist pulls them apart",
+    tuning: { spread: 0.06, displace: 0.42, alphaNear: 0.18 },
+  },
+  {
+    name: "broad lobes",
+    note: "fewer cycles, so the sheet makes big sweeping swells instead of busy ripple",
+    tuning: { cyclesA: 0.8, cyclesB: 1.5 },
+  },
+  {
+    name: "hard twist",
+    note: "a full turn across depth, so the sheet folds through itself more than once",
+    tuning: { depthPhase: Math.PI * 3.1 },
+  },
+  {
+    name: "slack",
+    note: "slower drift and a softer floor — calmer at rest, more of a swell on speech",
+    tuning: { driftSpeed: 0.42, idleEnvelope: 0.07, cyclesA: 1.1, cyclesB: 1.9 },
+  },
+  {
+    name: "original (46 lines)",
+    note: "the first tuning, for reference — reads as ruled lines at different heights, not one surface",
+    tuning: {
+      lines: 46,
+      spread: 0.3,
+      displace: 0.34,
+      alphaFar: 0.07,
+      alphaNear: 0.23,
+    },
+  },
+];
+
+/** One mesh preset on black, labelled. */
+function MeshPresetCell({
+  name,
+  note,
+  tuning,
+  palette,
+  getAmplitude,
+}: {
+  name: string;
+  note: string;
+  tuning: Partial<VoiceMeshTuning>;
+  palette: VoiceWavePalette;
+  getAmplitude: () => number;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[13px] font-medium text-white/70">{name}</span>
+      <span className="text-[11px] leading-snug text-white/40">{note}</span>
+      <div
+        className="relative mt-1 overflow-hidden rounded-lg bg-black"
+        style={{ height: 260 }}
+      >
+        <VoiceMeshWaves
+          getAmplitude={getAmplitude}
+          palette={palette}
+          placement="center"
+          tuning={tuning}
+        />
+      </div>
+    </div>
+  );
+}
+
+function MeshVariantsScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div className="grid gap-5 lg:grid-cols-2 xl:grid-cols-3">
+        {MESH_PRESETS.map((preset) => (
+          <MeshPresetCell
+            key={preset.name}
+            {...preset}
+            palette={args.wavePalette}
+            getAmplitude={getAmplitude}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Six tunings of the mesh on one shared amplitude source, so the differences
+ * are the tuning alone.
+ *
+ * The knob that matters most is `spread` versus `displace`. The default keeps
+ * the sheet's near and far edges 30% of the band apart, which is enough that
+ * the curves read as *ruled lines at different heights* — a stack — before
+ * they read as one folded surface. Pulling `spread` down toward ~0.08 makes
+ * the curves nearly coincide, so the only thing separating them is the phase
+ * twist, and the bundle starts behaving like the filaments in the reference.
+ * Everything else here is secondary: line count and alpha decide whether the
+ * weave resolves or reads as individual strokes, and the cycle counts decide
+ * whether it makes broad lobes or busy ripple.
+ */
+export const MeshVariants: Story = {
+  name: "Mesh — Variants",
+  args: { ...defaultArgs, wavePalette: "aurora" },
+  render: (args) => <MeshVariantsScene {...args} />,
+};
+
+/**
+ * The spatial split, in one frame per phase: the user's voice arrives from the
+ * **ceiling** while listening, the assistant's answers from the **floor** while
+ * responding, and the eyes sit on the axis between them.
+ *
+ * The argument for it is that the room then says *who is speaking* by where the
+ * energy is, using one visual language throughout — where the earlier `rings`
+ * treatment answered the listening band with a different metaphor entirely
+ * (concentric circles from behind the eyes), so a turn changing hands also
+ * changed the vocabulary. Flip `respondingStyle` to `rings` to compare.
+ */
+export const TopBottomSplit: Story = {
+  name: "Placement — Top / Bottom Split",
+  args: { ...defaultArgs, driver: "speech" },
+  render: (args) => <TopBottomSplitScene {...args} />,
+};
+
+function TopBottomSplitScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div className="grid gap-4 lg:grid-cols-2">
+        {(
+          [
+            ["listening", "user speaking — band at the ceiling"],
+            ["responding", "assistant speaking — band at the floor"],
+          ] as const
+        ).map(([visual, label]) => (
+          <div key={visual} className="flex flex-col gap-2">
+            <span className="text-[13px] font-medium text-white/60">
+              {label}
+            </span>
+            <RoomFrame
+              args={{ ...args, visual }}
+              getAmplitude={getAmplitude}
+              className="rounded-xl"
+              style={{ height: 520 }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The three answers to "how loud should the words be while the visuals are
+ * already talking", side by side in the listening state.
+ *
+ * The caption was written when the band was a fixed silhouette that could not
+ * indicate anything on its own. Now that it visibly answers the microphone,
+ * "Listening" is naming something the screen is already showing — and it sits
+ * in the same lower zone the live transcript wants.
+ *
+ * - **muted** (default) — kept as a small dim label. Still legible if you look
+ *   for it, no longer competing with the animation or the transcript.
+ * - **hidden** — gone entirely while audio flows; the animation carries the
+ *   state alone. The most honest to "nobody reads UI copy", and the one to
+ *   pick if the band reads unambiguously on its own.
+ * - **full** — the original weight, for comparison.
+ *
+ * `thinking` is deliberately exempt in every mode: it has no audio and no band,
+ * so dropping its caption would leave a still, silent room with nothing saying
+ * that work is happening. Scrub `visual` to `thinking` to confirm.
+ */
+export const CaptionEmphasis: Story = {
+  name: "Caption — Emphasis",
+  args: { ...defaultArgs, visual: "listening" },
+  render: (args) => <CaptionEmphasisScene {...args} />,
+};
+
+function CaptionEmphasisScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div className="grid gap-4 lg:grid-cols-3">
+        {(["muted", "hidden", "full"] as const).map((captionEmphasis) => (
+          <div key={captionEmphasis} className="flex flex-col gap-2">
+            <span className="text-[13px] font-medium text-white/60">
+              {captionEmphasis}
+              {captionEmphasis === "muted" ? " (default)" : ""}
+            </span>
+            <RoomFrame
+              args={{ ...args, captionEmphasis }}
+              getAmplitude={getAmplitude}
+              className="rounded-xl"
+              style={{ height: 460 }}
+            />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
@@ -51,6 +51,7 @@ import {
 } from "./voice-room-eyes";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 import type { VoiceWavePalette, VoiceWaveStyle } from "./voice-listening-waves";
+import { VoiceMeshWaves } from "./voice-mesh-waves";
 
 // ---------------------------------------------------------------------------
 // Amplitude drivers
@@ -371,10 +372,10 @@ const argTypes = {
     description: "Level for the `manual` driver. Ignored by the others.",
   },
   engine: {
-    options: ["reactive", "sine"] satisfies VoiceWaveEngine[],
+    options: ["reactive", "mesh", "sine"] satisfies VoiceWaveEngine[],
     control: { type: "inline-radio" as const },
     description:
-      "reactive = geometry rebuilt per frame from the amplitude history; sine = the original fixed silhouette.",
+      "reactive = filled band rebuilt per frame from the amplitude history; mesh = the same signal as a woven wireframe sheet; sine = the original fixed silhouette.",
   },
   waveStyle: {
     options: ["fill", "line"] satisfies VoiceWaveStyle[],
@@ -513,8 +514,8 @@ function EngineComparisonScene(args: SceneArgs) {
         getAmplitude={getAmplitude}
         micError={micError}
       />
-      <div className="grid gap-4 lg:grid-cols-2">
-        {(["reactive", "sine"] as const).map((engine) => (
+      <div className="grid gap-4 lg:grid-cols-3">
+        {(["reactive", "mesh", "sine"] as const).map((engine) => (
           <div key={engine} className="flex flex-col gap-2">
             <span className="text-[13px] font-medium text-white/60">
               {engine}
@@ -524,7 +525,7 @@ function EngineComparisonScene(args: SceneArgs) {
               args={{ ...args, engine }}
               getAmplitude={getAmplitude}
               className="rounded-xl"
-              style={{ height: 460 }}
+              style={{ height: 420 }}
             />
           </div>
         ))}
@@ -600,17 +601,17 @@ export const RoomMobile: Story = {
 };
 
 /**
- * The A/B that settles the question. Both frames share one amplitude source,
- * so any difference is the engine alone.
+ * The comparison that settles the question. All three frames share one
+ * amplitude source, so every difference is the engine alone.
  *
  * Watch the **silhouette**, not the motion: the `sine` band's crests are a
  * fixed shape sliding at a constant rate — identical whether the driver is
- * `speech` or `silence` — while the `reactive` band's crests are raised by the
- * signal and flatten without it. Switching the driver to `silence` is the
- * clearest demonstration: only one of the two frames notices.
+ * `speech` or `silence` — while `reactive` and `mesh` are raised by the signal
+ * and flatten without it. Switching the driver to `silence` is the clearest
+ * demonstration: only one of the three frames fails to notice.
  */
 export const EngineComparison: Story = {
-  name: "Engine — Reactive vs Sine",
+  name: "Engine — Reactive vs Mesh vs Sine",
   render: (args) => <EngineComparisonScene {...args} />,
 };
 
@@ -623,3 +624,53 @@ export const EngineComparison: Story = {
 export const States: Story = {
   render: (args) => <StatesScene {...args} />,
 };
+
+/**
+ * The mesh engine on its own, big and on black — the reference aesthetic:
+ * a woven wireframe sheet whose brightness is entirely emergent, piled up
+ * where the folded surface crosses itself.
+ *
+ * Audio drives the *envelope*, not the ripple: a loud syllable swells the
+ * sheet into a lobe that travels left and flattens, while the underlying weave
+ * keeps its character. Drive it from `mic` and watch the lobe follow your
+ * voice; on `silence` it settles to a slow resting breath rather than
+ * flat-lining, so the surface never looks switched off.
+ *
+ * `wavePalette` retints it: `aurora` is the reference cyan, `accent` takes the
+ * avatar's hue, `tone` follows the room foreground.
+ */
+export const MeshShowcase: Story = {
+  name: "Mesh — Showcase",
+  args: { ...defaultArgs, engine: "mesh", wavePalette: "aurora" },
+  render: (args) => <MeshShowcaseScene {...args} />,
+};
+
+/** The mesh alone on black, at the scale the reference is judged at. */
+function MeshShowcaseScene(args: SceneArgs) {
+  const { getAmplitude, micError } = useDriver(args.driver, args.amplitude);
+  return (
+    <div>
+      <DriverBar
+        driver={args.driver}
+        getAmplitude={getAmplitude}
+        micError={micError}
+      />
+      <div
+        className="relative overflow-hidden rounded-xl bg-black"
+        style={{
+          height: "min(70vh, 620px)",
+          ["--avatar-accent" as string]:
+            BUNDLED_COMPONENTS.colors.find((c) => c.id === args.colorId)?.hex ??
+            "#3E9E8A",
+          ["--room-fg" as string]: "#FFFFFF",
+        }}
+      >
+        <VoiceMeshWaves
+          getAmplitude={getAmplitude}
+          palette={args.wavePalette}
+          placement="center"
+        />
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Tests for `VoiceReactiveWaves`.
+ *
+ * These exist for one reason: to pin down the property the old sine band
+ * lacked. That band authored its silhouette once at mount and only slid it
+ * sideways, so it drew the same shape whether the mic was clipping or muted —
+ * the "it looks like a PNG" report this component was written to answer.
+ *
+ * So the assertions are about the *geometry* (`d`), not about the CSS var:
+ * writing `--voice-amp` is exactly what the old band already did. If a future
+ * change reverts to pre-authored paths, the silence-vs-speech comparison below
+ * is what should fail.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+
+import { VoiceReactiveWaves } from "./voice-reactive-waves";
+
+afterEach(() => {
+  cleanup();
+});
+
+/** The rendered path geometry, back-to-front. */
+function paths(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll<SVGPathElement>("path[data-reactive-wave]"),
+  ).map((p) => p.getAttribute("d") ?? "");
+}
+
+/** Wait until the rAF loop has drawn at least one frame into every layer. */
+async function waitForFirstFrame(container: HTMLElement): Promise<string[]> {
+  await waitFor(() => {
+    const drawn = paths(container);
+    expect(drawn.length).toBeGreaterThan(0);
+    expect(drawn.every((d) => d.length > 0)).toBe(true);
+  });
+  return paths(container);
+}
+
+/**
+ * The peak crest height of a filled path, in viewBox units above the floor.
+ *
+ * The path closes down to y=200, so the smallest y in the curve is the tallest
+ * crest. Parsing the numbers straight out of the `d` string keeps this honest
+ * about what actually got rendered.
+ */
+function crestHeight(d: string): number {
+  const ys = Array.from(d.matchAll(/[,\s](-?\d+\.?\d*)(?=[\sCLZ]|$)/g))
+    .map((m) => Number(m[1]))
+    .filter((n) => Number.isFinite(n));
+  return ys.length > 0 ? 200 - Math.min(...ys) : 0;
+}
+
+describe("VoiceReactiveWaves", () => {
+  test("renders one path per layer and fills them from the animation loop", async () => {
+    const { container } = render(<VoiceReactiveWaves getAmplitude={() => 0} />);
+
+    // Nothing is authored at mount — a placeholder shape would be a silhouette
+    // that is not the signal, which is the bug this component fixes.
+    expect(paths(container)).toEqual(["", "", ""]);
+
+    const drawn = await waitForFirstFrame(container);
+    expect(drawn).toHaveLength(3);
+  });
+
+  test("mirrored placements draw both halves", async () => {
+    const { container } = render(
+      <VoiceReactiveWaves getAmplitude={() => 0.5} placement="inline" />,
+    );
+    const drawn = await waitForFirstFrame(container);
+    // Three layers per half, both halves fed from the same histories.
+    expect(drawn).toHaveLength(6);
+  });
+
+  test("loud speech raises taller crests than silence", async () => {
+    const loud = render(<VoiceReactiveWaves getAmplitude={() => 1} />);
+    const quiet = render(<VoiceReactiveWaves getAmplitude={() => 0} />);
+
+    await waitForFirstFrame(loud.container);
+    await waitForFirstFrame(quiet.container);
+
+    // Let the history fill so the crest reflects the sustained level rather
+    // than the smoother's first few milliseconds of attack.
+    await waitFor(
+      () => {
+        const loudCrest = Math.max(...paths(loud.container).map(crestHeight));
+        expect(loudCrest).toBeGreaterThan(40);
+      },
+      { timeout: 3000 },
+    );
+
+    const loudCrest = Math.max(...paths(loud.container).map(crestHeight));
+    const quietCrest = Math.max(...paths(quiet.container).map(crestHeight));
+
+    // The whole point: the silhouette is a function of the signal. Silence
+    // keeps only the small resting sway, so the gap is large, not marginal.
+    expect(loudCrest).toBeGreaterThan(quietCrest * 3);
+  });
+
+  test("geometry keeps changing frame to frame while audio is flowing", async () => {
+    // A moving signal, so the history scrolls a genuinely different terrain.
+    let t = 0;
+    const { container } = render(
+      <VoiceReactiveWaves
+        getAmplitude={() => {
+          t += 1;
+          return 0.5 + 0.5 * Math.sin(t / 4);
+        }}
+      />,
+    );
+
+    const first = await waitForFirstFrame(container);
+    await waitFor(() => {
+      // Any layer redrawing differently proves the path is regenerated rather
+      // than translated by CSS.
+      expect(paths(container).some((d, i) => d !== first[i])).toBe(true);
+    });
+  });
+
+  test("still emits --voice-amp for the placement CSS", async () => {
+    const { container } = render(
+      <VoiceReactiveWaves getAmplitude={() => 0.8} />,
+    );
+    const band = container.querySelector<HTMLElement>(
+      ".voice-listening-waves",
+    )!;
+    await waitFor(() => {
+      expect(Number(band.style.getPropertyValue("--voice-amp"))).toBeGreaterThan(
+        0,
+      );
+    });
+  });
+
+  test("opts out of the drift keyframe the sine band relies on", async () => {
+    const { container } = render(
+      <VoiceReactiveWaves getAmplitude={() => 0.5} />,
+    );
+    // The reactive modifier is what switches `voice-wave-drift` off in CSS;
+    // leaving it on would slide the terrain a second time.
+    expect(
+      container.querySelector(".voice-listening-waves--reactive"),
+    ).not.toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.tsx
@@ -1,0 +1,371 @@
+/**
+ * Signal-driven listening waves — the reactive replacement for the fixed sine
+ * geometry in `voice-listening-waves.tsx`.
+ *
+ * The original band authors three sine paths *once at mount* from constant
+ * amplitudes and cycle counts, then slides them sideways with a CSS keyframe.
+ * Live amplitude only reaches `translateY` / `opacity` on the whole layer, so
+ * the silhouette itself is frozen: the band reads as a picture on a conveyor
+ * belt, not as a voice. That is the "looks like a PNG" complaint, precisely.
+ *
+ * Here the geometry *is* the signal. Each layer keeps a rolling history of the
+ * amplitude it has been fed and rebuilds its path every frame from that
+ * history, so the terrain is a scrolling record of what was actually said: a
+ * loud syllable raises a crest that then travels left and decays off the edge,
+ * and silence flattens the band within a second. Nothing is pre-authored, so
+ * nothing can look pre-rendered.
+ *
+ * Depth comes from the history itself rather than from parallax speeds: each
+ * layer samples at its own cadence (back slow and broad, front fast and
+ * crisp), so the same speech writes a wide swell behind and a tight ripple in
+ * front. Because the layers scroll by regenerating geometry, the CSS drift
+ * keyframe is switched off (`--reactive`); leaving it on would double the
+ * motion.
+ *
+ * Rendering discipline matches the rest of the voice surfaces: amplitude is
+ * polled inside a rAF loop and written straight to the DOM (`setAttribute` on
+ * the path, `--voice-amp` on the container) — never through React state, which
+ * would re-render the tree 60 times a second.
+ *
+ * The container reuses `voice-listening-waves`' class names, so every existing
+ * palette (`aurora` / `accent` / `tone`), style (`fill` / `line`), and
+ * placement (`top` / `bottom` / `center` / `inline`) applies unchanged. The two
+ * components are prop-compatible: swapping one for the other is an import
+ * change.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { createAmplitudeSmoother } from "./voice-motion";
+import type {
+  VoiceWavePalette,
+  VoiceWavePlacement,
+  VoiceWaveStyle,
+} from "./voice-listening-waves";
+
+// Same authored viewBox as the sine band, so the placement/palette CSS (which
+// assumes a fill closing to `VIEW_H`) applies without change. Unlike the sine
+// band the path spans exactly one viewBox width: there is no CSS drift to tile
+// against, because the history scroll supplies the horizontal motion.
+const VIEW_W = 1200;
+const VIEW_H = 200;
+
+/**
+ * Samples retained per layer. Each becomes one spline knot, so this is both
+ * the horizontal resolution of the terrain and (with the layer's cadence) how
+ * many seconds of speech stay on screen. 64 keeps the per-frame path string
+ * small enough that three layers cost well under a millisecond.
+ */
+const HISTORY = 64;
+
+/**
+ * Per-layer character. `periodMs` is how often the layer takes a sample, which
+ * sets both its scroll speed and its time window: the back layer samples
+ * slowly, so its history spans ~4s of speech as broad hills, while the front
+ * layer spans ~1.4s as a tight ripple. `gain` is the crest height as a
+ * fraction of the viewBox; `smooth` is a moving-average width in samples
+ * (wider = rounder hills); `sway` is the idle breathing amplitude that keeps
+ * the band alive through silence.
+ */
+interface ReactiveWaveLayer {
+  modifier: "back" | "mid" | "front";
+  periodMs: number;
+  gain: number;
+  smooth: number;
+  sway: number;
+  swayHz: number;
+  swayPhase: number;
+}
+
+const WAVE_LAYERS: ReactiveWaveLayer[] = [
+  {
+    modifier: "back",
+    periodMs: 62,
+    gain: 0.42,
+    smooth: 5,
+    sway: 0.05,
+    swayHz: 0.05,
+    swayPhase: 0,
+  },
+  {
+    modifier: "mid",
+    periodMs: 40,
+    gain: 0.54,
+    smooth: 3,
+    sway: 0.038,
+    swayHz: 0.08,
+    swayPhase: 1.1,
+  },
+  {
+    modifier: "front",
+    periodMs: 24,
+    gain: 0.36,
+    smooth: 2,
+    sway: 0.028,
+    swayHz: 0.13,
+    swayPhase: 2.3,
+  },
+];
+
+/**
+ * Inline strips (the composer bar, the title-bar pill) squeeze the 200-unit
+ * viewBox into ~24 px, which flattens the room's crests into hairlines. Same
+ * cadences and character — only the gains and sway are steepened so the
+ * ripple stays legible at strip height, mirroring what `WAVE_LAYERS_INLINE`
+ * does for the sine band.
+ */
+const WAVE_LAYERS_INLINE: ReactiveWaveLayer[] = WAVE_LAYERS.map((layer) => ({
+  ...layer,
+  gain: layer.gain * 1.6,
+  sway: layer.sway * 1.5,
+}));
+
+/**
+ * One layer's rolling amplitude history: a fixed-size ring buffer plus the
+ * time accumulator that paces pushes at the layer's cadence, decoupling the
+ * scroll speed from the display refresh rate.
+ */
+interface LayerHistory {
+  samples: Float32Array;
+  /** Index of the *oldest* sample — the left edge of the band. */
+  head: number;
+  /** Milliseconds accumulated toward the next push. */
+  elapsed: number;
+}
+
+function createHistory(): LayerHistory {
+  return { samples: new Float32Array(HISTORY), head: 0, elapsed: 0 };
+}
+
+/**
+ * Advance a layer by `dtMs`, pushing `amp` for each sample period elapsed.
+ *
+ * A long frame gap (a background tab, a dropped frame) can span several
+ * periods; pushing them all keeps the band's scroll rate honest to wall-clock
+ * time. The catch-up is capped at a full buffer — after a tab has been hidden
+ * for a minute there is no point rewriting the same value 2000 times.
+ */
+function pushHistory(history: LayerHistory, amp: number, dtMs: number, periodMs: number): void {
+  history.elapsed += dtMs;
+  let pushes = Math.floor(history.elapsed / periodMs);
+  if (pushes <= 0) {
+    return;
+  }
+  history.elapsed -= pushes * periodMs;
+  pushes = Math.min(pushes, HISTORY);
+  for (let i = 0; i < pushes; i++) {
+    history.samples[history.head] = amp;
+    history.head = (history.head + 1) % HISTORY;
+  }
+}
+
+/**
+ * Read the history oldest-first into `out`, applying the layer's moving
+ * average and idle sway, and convert to viewBox y-coordinates.
+ *
+ * The sway is added rather than blended so speech always stacks on top of the
+ * resting breath: at silence the band is a slow swell, and a loud syllable
+ * still reads as a crest above it. Its phase advances with `timeSec` and
+ * varies along x, so the resting state drifts instead of standing still.
+ */
+function readLayer(
+  history: LayerHistory,
+  layer: ReactiveWaveLayer,
+  timeSec: number,
+  out: Float32Array,
+): void {
+  const { samples, head } = history;
+  const half = Math.max(0, Math.floor(layer.smooth / 2));
+  for (let i = 0; i < HISTORY; i++) {
+    // Moving average centred on i, clamped at both ends of the window.
+    let sum = 0;
+    let count = 0;
+    for (let k = -half; k <= half; k++) {
+      const j = i + k;
+      if (j < 0 || j >= HISTORY) {
+        continue;
+      }
+      sum += samples[(head + j) % HISTORY];
+      count++;
+    }
+    const amp = count > 0 ? sum / count : 0;
+    const sway =
+      layer.sway *
+      (0.5 +
+        0.5 *
+          Math.sin(
+            timeSec * layer.swayHz * 2 * Math.PI +
+              layer.swayPhase +
+              (i / HISTORY) * Math.PI * 2,
+          ));
+    const height = (amp * layer.gain + sway) * VIEW_H;
+    out[i] = VIEW_H - height;
+  }
+}
+
+/**
+ * Build a smooth path through the sampled heights.
+ *
+ * The knots are joined with a Catmull-Rom spline converted to cubic Béziers,
+ * which turns the sampled staircase into rolling hills without the overshoot a
+ * naive smoothing would give on a sharp consonant. `fill` closes the curve
+ * down to the viewBox floor (the "water" look the palettes fill); `line`
+ * leaves it open to be stroked.
+ */
+function buildPath(ys: Float32Array, style: VoiceWaveStyle): string {
+  const step = VIEW_W / (HISTORY - 1);
+  const x = (i: number) => i * step;
+  const y = (i: number) => ys[Math.min(HISTORY - 1, Math.max(0, i))];
+
+  let d = `M0,${y(0).toFixed(1)}`;
+  for (let i = 0; i < HISTORY - 1; i++) {
+    const y0 = y(i - 1);
+    const y1 = y(i);
+    const y2 = y(i + 1);
+    const y3 = y(i + 2);
+    const c1x = x(i) + step / 3;
+    const c1y = y1 + (y2 - y0) / 6;
+    const c2x = x(i + 1) - step / 3;
+    const c2y = y2 - (y3 - y1) / 6;
+    d += `C${c1x.toFixed(1)},${c1y.toFixed(1)} ${c2x.toFixed(1)},${c2y.toFixed(1)} ${x(i + 1).toFixed(1)},${y2.toFixed(1)}`;
+  }
+  if (style === "fill") {
+    d += `L${VIEW_W},${VIEW_H}L0,${VIEW_H}Z`;
+  }
+  return d;
+}
+
+export function VoiceReactiveWaves({
+  getAmplitude,
+  waveStyle = "fill",
+  palette = "aurora",
+  placement = "bottom",
+}: {
+  /** Amplitude source (0–1), polled in a rAF loop — mic while listening, TTS output while responding. */
+  getAmplitude: () => number;
+  waveStyle?: VoiceWaveStyle;
+  palette?: VoiceWavePalette;
+  placement?: VoiceWavePlacement;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const getAmplitudeRef = useRef(getAmplitude);
+  useEffect(() => {
+    getAmplitudeRef.current = getAmplitude;
+  }, [getAmplitude]);
+
+  const inline = placement === "inline";
+  const layers = inline ? WAVE_LAYERS_INLINE : WAVE_LAYERS;
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    // Honour the OS setting the same way the sine band does: the CSS holds a
+    // steady low band under `prefers-reduced-motion`, so skip the loop
+    // entirely rather than animating geometry nobody asked to see.
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+
+    const paths = Array.from(
+      node.querySelectorAll<SVGPathElement>("path[data-reactive-wave]"),
+    );
+    if (paths.length === 0) {
+      return;
+    }
+
+    // Same VU ballistic as the sine band — fast attack so speech onset lands
+    // immediately, slower release so crests decay instead of snapping flat.
+    const smoother = createAmplitudeSmoother({ attackMs: 80, releaseMs: 350 });
+    const histories = layers.map(createHistory);
+    const scratch = new Float32Array(HISTORY);
+    let raf = 0;
+    let lastTime = performance.now();
+    let lastAmpWritten = "";
+
+    const tick = (now: number) => {
+      // Clamp the delta so a backgrounded tab resumes smoothly rather than
+      // flushing minutes of history in one frame.
+      const dt = Math.min(100, now - lastTime);
+      lastTime = now;
+      const target = Math.min(1, Math.max(0, getAmplitudeRef.current()));
+      const amp = smoother.step(target, dt);
+
+      // Keep publishing `--voice-amp`: the existing placement CSS reads it for
+      // the band's rise/recede and brightness, which still composes on top of
+      // the reactive geometry.
+      const ampText = amp.toFixed(3);
+      if (ampText !== lastAmpWritten) {
+        lastAmpWritten = ampText;
+        node.style.setProperty("--voice-amp", ampText);
+      }
+
+      const timeSec = now / 1000;
+      for (let i = 0; i < layers.length; i++) {
+        const layer = layers[i];
+        // Every layer is fed the same amplitude; the differing cadences are
+        // what turn one signal into a layered, parallaxed terrain.
+        pushHistory(histories[i], amp, dt, layer.periodMs);
+        readLayer(histories[i], layer, timeSec, scratch);
+        // Paths are ordered back→front per half, so a mirrored (center /
+        // inline) band walks the same layer list twice.
+        const d = buildPath(scratch, waveStyle);
+        for (let h = i; h < paths.length; h += layers.length) {
+          paths[h].setAttribute("d", d);
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+    // `placement` belongs here even though the loop never reads it: mirrored
+    // placements render each layer twice, so switching between a single band
+    // and a mirrored one changes the path count under a loop that captured the
+    // node list once. Without this, a live `wavePlacement` change (the
+    // Storybook knob does exactly that) leaves half the paths frozen.
+  }, [layers, waveStyle, placement]);
+
+  const className = [
+    "voice-listening-waves",
+    "voice-listening-waves--reactive",
+    `voice-listening-waves--${waveStyle}`,
+    `voice-listening-waves--${palette}`,
+    `voice-listening-waves--${placement}`,
+  ].join(" ");
+
+  // `d` is intentionally empty at mount: the first rAF frame fills it. An
+  // authored placeholder would flash a shape that is not the signal.
+  const svgLayers = (half: string) =>
+    layers.map((layer) => (
+      <svg
+        key={`${half}-${layer.modifier}`}
+        className={`voice-wave voice-wave--${layer.modifier}`}
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        preserveAspectRatio="none"
+      >
+        <path data-reactive-wave="" d="" />
+      </svg>
+    ));
+
+  // Center/inline mirror the band into two halves meeting at the midline, so
+  // the fill hugs the centre line from above and below (see the sine band).
+  if (placement === "center" || placement === "inline") {
+    return (
+      <div ref={ref} className={className} aria-hidden>
+        <div className="voice-listening-waves__half voice-listening-waves__half--top">
+          {svgLayers("top")}
+        </div>
+        <div className="voice-listening-waves__half voice-listening-waves__half--bottom">
+          {svgLayers("bottom")}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref} className={className} aria-hidden>
+      {svgLayers("single")}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.tsx
@@ -37,6 +37,7 @@
 import { useEffect, useRef } from "react";
 
 import { createAmplitudeSmoother } from "./voice-motion";
+import { createAmplitudeHistory } from "./voice-amplitude-history";
 import type {
   VoiceWavePalette,
   VoiceWavePlacement,
@@ -121,74 +122,20 @@ const WAVE_LAYERS_INLINE: ReactiveWaveLayer[] = WAVE_LAYERS.map((layer) => ({
 }));
 
 /**
- * One layer's rolling amplitude history: a fixed-size ring buffer plus the
- * time accumulator that paces pushes at the layer's cadence, decoupling the
- * scroll speed from the display refresh rate.
- */
-interface LayerHistory {
-  samples: Float32Array;
-  /** Index of the *oldest* sample — the left edge of the band. */
-  head: number;
-  /** Milliseconds accumulated toward the next push. */
-  elapsed: number;
-}
-
-function createHistory(): LayerHistory {
-  return { samples: new Float32Array(HISTORY), head: 0, elapsed: 0 };
-}
-
-/**
- * Advance a layer by `dtMs`, pushing `amp` for each sample period elapsed.
- *
- * A long frame gap (a background tab, a dropped frame) can span several
- * periods; pushing them all keeps the band's scroll rate honest to wall-clock
- * time. The catch-up is capped at a full buffer — after a tab has been hidden
- * for a minute there is no point rewriting the same value 2000 times.
- */
-function pushHistory(history: LayerHistory, amp: number, dtMs: number, periodMs: number): void {
-  history.elapsed += dtMs;
-  let pushes = Math.floor(history.elapsed / periodMs);
-  if (pushes <= 0) {
-    return;
-  }
-  history.elapsed -= pushes * periodMs;
-  pushes = Math.min(pushes, HISTORY);
-  for (let i = 0; i < pushes; i++) {
-    history.samples[history.head] = amp;
-    history.head = (history.head + 1) % HISTORY;
-  }
-}
-
-/**
- * Read the history oldest-first into `out`, applying the layer's moving
- * average and idle sway, and convert to viewBox y-coordinates.
+ * Turn a layer's smoothed history (already in `out`, oldest-first) into
+ * viewBox y-coordinates, adding the layer's idle sway.
  *
  * The sway is added rather than blended so speech always stacks on top of the
  * resting breath: at silence the band is a slow swell, and a loud syllable
  * still reads as a crest above it. Its phase advances with `timeSec` and
  * varies along x, so the resting state drifts instead of standing still.
  */
-function readLayer(
-  history: LayerHistory,
+function toViewBoxY(
   layer: ReactiveWaveLayer,
   timeSec: number,
   out: Float32Array,
 ): void {
-  const { samples, head } = history;
-  const half = Math.max(0, Math.floor(layer.smooth / 2));
   for (let i = 0; i < HISTORY; i++) {
-    // Moving average centred on i, clamped at both ends of the window.
-    let sum = 0;
-    let count = 0;
-    for (let k = -half; k <= half; k++) {
-      const j = i + k;
-      if (j < 0 || j >= HISTORY) {
-        continue;
-      }
-      sum += samples[(head + j) % HISTORY];
-      count++;
-    }
-    const amp = count > 0 ? sum / count : 0;
     const sway =
       layer.sway *
       (0.5 +
@@ -198,8 +145,7 @@ function readLayer(
               layer.swayPhase +
               (i / HISTORY) * Math.PI * 2,
           ));
-    const height = (amp * layer.gain + sway) * VIEW_H;
-    out[i] = VIEW_H - height;
+    out[i] = VIEW_H - (out[i] * layer.gain + sway) * VIEW_H;
   }
 }
 
@@ -278,7 +224,9 @@ export function VoiceReactiveWaves({
     // Same VU ballistic as the sine band — fast attack so speech onset lands
     // immediately, slower release so crests decay instead of snapping flat.
     const smoother = createAmplitudeSmoother({ attackMs: 80, releaseMs: 350 });
-    const histories = layers.map(createHistory);
+    const histories = layers.map((layer) =>
+      createAmplitudeHistory({ size: HISTORY, periodMs: layer.periodMs }),
+    );
     const scratch = new Float32Array(HISTORY);
     let raf = 0;
     let lastTime = performance.now();
@@ -306,8 +254,9 @@ export function VoiceReactiveWaves({
         const layer = layers[i];
         // Every layer is fed the same amplitude; the differing cadences are
         // what turn one signal into a layered, parallaxed terrain.
-        pushHistory(histories[i], amp, dt, layer.periodMs);
-        readLayer(histories[i], layer, timeSec, scratch);
+        histories[i].push(amp, dt);
+        histories[i].read(scratch, layer.smooth);
+        toViewBoxY(layer, timeSec, scratch);
         // Paths are ordered back→front per half, so a mirrored (center /
         // inline) band walks the same layer list twice.
         const d = buildPath(scratch, waveStyle);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.test.tsx
@@ -41,9 +41,13 @@ function renderEyes(onRender?: () => void) {
   const utils = render(<Probe />);
   const root = utils.getByTestId("voice-room-eyes");
   // The lid group carries the blink transform; the parallax layer carries the
-  // cursor offset.
+  // cursor offset. Addressed by test id rather than by tree position: the eyes
+  // stack several transform layers that compose rather than replace each other
+  // (parallax, the audio reaction, the per-state size tween), and `svg`'s
+  // parent silently became a different one of them when the reaction layer
+  // landed.
   const lids = root.querySelector("g") as SVGGElement;
-  const parallax = root.querySelector("svg")?.parentElement as HTMLElement;
+  const parallax = utils.getByTestId("voice-room-eyes-parallax");
   return { ...utils, lids, parallax };
 }
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -1265,6 +1265,7 @@ export function VoiceRoomEyes({
                 room's spine (see CURSOR_MAX_X / CURSOR_MAX_Y). */}
             <div
               ref={parallaxRef}
+              data-testid="voice-room-eyes-parallax"
               style={{
                 transform: "translate(0px, 0px)",
                 transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -63,6 +63,8 @@ import {
 } from "./voice-listening-waves";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 import { createAmplitudeSmoother } from "./voice-motion";
+import { useReactiveEyes, type VoiceEyeReaction } from "./use-reactive-eyes";
+import { VoiceReactiveWaves } from "./voice-reactive-waves";
 import {
   VOICE_ROOM_CAPTION_TEXT,
   VOICE_ROOM_LOWER_ZONE_BOTTOM,
@@ -106,6 +108,49 @@ const EYE_STATE_SCALE: Record<VoiceAvatarVisual, number> = {
 };
 /** How long the eyes take to resize between states. */
 const EYE_RESIZE_MS = 500;
+
+/**
+ * Which audio gesture the eyes express per session phase. Only the two states
+ * that actually carry audio react: `listening` follows the mic, `responding`
+ * follows the TTS output. `thinking` is deliberately still — there is no sound
+ * to answer, and a reaction there would be animating noise.
+ */
+const EYE_REACTION: Record<VoiceAvatarVisual, VoiceEyeReaction> = {
+  idle: null,
+  listening: "listening",
+  thinking: null,
+  responding: "responding",
+  reconnecting: null,
+};
+
+/**
+ * Which wave band the room draws.
+ *
+ * `reactive` rebuilds the wave geometry every frame from a rolling history of
+ * the live amplitude, so the terrain is a record of what was actually said.
+ * `sine` is the original fixed-geometry band, kept so the two can be compared
+ * side by side in Storybook — its silhouette is authored once at mount and
+ * only slid sideways, which is what made the room read as a static image.
+ */
+export type VoiceWaveEngine = "reactive" | "sine";
+
+/** Draw the listening band with whichever engine the caller selected. */
+function WaveBand({
+  engine,
+  ...props
+}: {
+  engine: VoiceWaveEngine;
+  getAmplitude: () => number;
+  waveStyle?: VoiceWaveStyle;
+  palette?: VoiceWavePalette;
+  placement?: VoiceWavePlacement;
+}) {
+  return engine === "reactive" ? (
+    <VoiceReactiveWaves {...props} />
+  ) : (
+    <VoiceListeningWaves {...props} />
+  );
+}
 /** State caption shown below the eyes, per visual (none for idle / connecting-
  *  side states, which the room's own connect label covers). */
 const EYE_STATE_CAPTION: Partial<Record<VoiceAvatarVisual, string>> = {
@@ -239,6 +284,7 @@ export function VoiceRoomColorLook({
   waveStyle = "fill",
   showStateCaption = true,
   entryOrigin = null,
+  waveEngine = "reactive",
   viewport,
 }: {
   look: VoiceRoomLook;
@@ -261,6 +307,8 @@ export function VoiceRoomColorLook({
   /** Viewport point the entrance grows from (the tapped control). Null → the
    *  fixed screen-center origin. */
   entryOrigin?: { x: number; y: number } | null;
+  /** Which wave band to draw. See {@link VoiceWaveEngine}. */
+  waveEngine?: VoiceWaveEngine;
   /** Override the room box (Storybook renders in a box, not the full window). */
   viewport?: { w: number; h: number };
 }) {
@@ -402,7 +450,8 @@ export function VoiceRoomColorLook({
             exit={{ opacity: 0 }}
             transition={{ duration: reduce ? 0 : 0.3 }}
           >
-            <VoiceListeningWaves
+            <WaveBand
+              engine={waveEngine}
               getAmplitude={getAmplitude}
               waveStyle={waveStyle}
               palette={wavePalette}
@@ -462,6 +511,16 @@ export function VoiceRoomColorLook({
         sizeScale={sizeScale}
         // Reconnecting: fade the eyes back — presence dimmed while away.
         dimmed={visual === "reconnecting"}
+        // Audio reaction on top of the size tween: the eyes widen with the
+        // user's mic while listening and pulse with the assistant's own voice
+        // while responding, so they stay alive through a turn instead of
+        // holding one pose for its whole duration.
+        eyeReaction={EYE_REACTION[visual]}
+        getAmplitude={
+          visual === "responding"
+            ? (getResponseAmplitude ?? getAmplitude)
+            : getAmplitude
+        }
       />
 
       {/* State caption in the room's lower zone (unless the live captions are
@@ -657,7 +716,7 @@ function VoiceRespondingTreatment({
   if (style === "waveform") {
     // The assistant's own voice — reuse the centered band, output-driven.
     return getAmplitude ? (
-      <VoiceListeningWaves
+      <VoiceReactiveWaves
         getAmplitude={getAmplitude}
         waveStyle={waveStyle}
         palette="tone"
@@ -816,6 +875,8 @@ export function VoiceRoomEyes({
   entranceOrigin,
   sizeScale = 1,
   dimmed = false,
+  eyeReaction = null,
+  getAmplitude,
 }: {
   art: VoiceRoomEyeArt;
   /** The room box the eyes are framed in (the caller's live viewport size). */
@@ -823,6 +884,14 @@ export function VoiceRoomEyes({
   placement?: VoiceEyePlacement;
   /** Viewport point the eyes grow from on entrance. Defaults to screen center. */
   entranceOrigin?: { x: number; y: number };
+  /**
+   * Audio gesture the eyes express — `listening` widens them with the mic,
+   * `responding` pulses them with the assistant's own voice, `null` holds them
+   * still. See `use-reactive-eyes.ts`.
+   */
+  eyeReaction?: VoiceEyeReaction;
+  /** Amplitude source (0–1) for {@link eyeReaction}, polled in a rAF loop. */
+  getAmplitude?: () => number;
   /** Per-state size, as a scale of the rest geometry — tweened on change so the
    *  eyes resize smoothly (they never move). See {@link EYE_STATE_SCALE}. */
   sizeScale?: number;
@@ -832,6 +901,7 @@ export function VoiceRoomEyes({
   const reduce = useReducedMotion();
   const { w, h } = viewport;
   const playEntrance = !reduce;
+  const reactiveRef = useReactiveEyes(eyeReaction, getAmplitude);
 
   // The parallax offset and the blink are decorative, so both drive the DOM
   // through a ref rather than React state: a pointer-rate or frame-rate
@@ -1054,25 +1124,37 @@ export function VoiceRoomEyes({
                 transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
               }}
             >
-              <svg
-                viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
-                width={geometry.eyesW}
-                height={geometry.eyesH}
-                style={{ overflow: "visible", display: "block" }}
+              {/* Audio reaction: its own layer so the per-frame amplitude
+                  transform composes with the blink squish below and the size
+                  tween above instead of overwriting either. */}
+              <div
+                ref={reactiveRef}
+                className="voice-room-eyes-reactive"
+                data-eye-reaction={eyeReaction ?? undefined}
               >
-                <g
-                  ref={eyelidsRef}
-                  style={{
-                    transform: "scaleY(1)",
-                    transformOrigin: `${cx}px ${cy}px`,
-                    transition: "transform 0.14s ease-in-out",
-                  }}
+                <svg
+                  viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
+                  width={geometry.eyesW}
+                  height={geometry.eyesH}
+                  style={{ overflow: "visible", display: "block" }}
                 >
-                  {art.paths.map((p, i) => (
-                    <path key={i} d={p.svgPath} fill={p.color} />
-                  ))}
-                </g>
-              </svg>
+                  {/* Eyelids are driven imperatively (LUM-2927) — the blink
+                      must not re-render this tree, and neither must the audio
+                      reaction on the wrapper above it. */}
+                  <g
+                    ref={eyelidsRef}
+                    style={{
+                      transform: "scaleY(1)",
+                      transformOrigin: `${cx}px ${cy}px`,
+                      transition: "transform 0.14s ease-in-out",
+                    }}
+                  >
+                    {art.paths.map((p, i) => (
+                      <path key={i} d={p.svgPath} fill={p.color} />
+                    ))}
+                  </g>
+                </svg>
+              </div>
             </div>
           </motion.div>
         </div>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -286,14 +286,15 @@ export function VoiceRoomColorLook({
   visual = "idle",
   getAmplitude,
   getResponseAmplitude,
-  respondingStyle = "rings",
+  respondingStyle = "waves",
   eyePlacement = "center",
   wavePlacement = "top",
   wavePalette = "tone",
   waveStyle = "fill",
   showStateCaption = true,
+  captionEmphasis = "hidden",
   entryOrigin = null,
-  waveEngine = "reactive",
+  waveEngine = "mesh",
   viewport,
 }: {
   look: VoiceRoomLook;
@@ -313,6 +314,8 @@ export function VoiceRoomColorLook({
   /** Show the state caption below the eyes. Off when the room's live captions
    *  are on — the transcript already names/fills that space. */
   showStateCaption?: boolean;
+  /** How prominent that caption is while audio flows. See {@link VoiceCaptionEmphasis}. */
+  captionEmphasis?: VoiceCaptionEmphasis;
   /** Viewport point the entrance grows from (the tapped control). Null → the
    *  fixed screen-center origin. */
   entryOrigin?: { x: number; y: number } | null;
@@ -480,6 +483,11 @@ export function VoiceRoomColorLook({
             exit={{ opacity: 0 }}
             transition={{ duration: reduce ? 0 : 0.3 }}
           >
+            <VoiceThinkingBand
+              engine={waveEngine}
+              palette={wavePalette}
+              waveStyle={waveStyle}
+            />
             <VoiceThinkingIndicator
               viewport={{ w, h }}
               eyesBottom={thinkingEyeBottom}
@@ -502,9 +510,11 @@ export function VoiceRoomColorLook({
           >
             <VoiceRespondingTreatment
               style={respondingStyle}
+              engine={waveEngine}
               getAmplitude={getResponseAmplitude ?? getAmplitude}
               waveStyle={waveStyle}
               wavePlacement={wavePlacement}
+              wavePalette={wavePalette}
               viewport={{ w, h }}
             />
           </motion.div>
@@ -534,7 +544,9 @@ export function VoiceRoomColorLook({
 
       {/* State caption in the room's lower zone (unless the live captions are
           on — the assistant transcript occupies that zone instead). */}
-      {showStateCaption ? <VoiceStateCaption visual={visual} /> : null}
+      {showStateCaption ? (
+        <VoiceStateCaption visual={visual} emphasis={captionEmphasis} />
+      ) : null}
     </>
   );
 }
@@ -558,23 +570,75 @@ export function VoiceRoomColorLook({
  * Both looks share this anchor, so the caption reads in the same place
  * regardless of avatar type.
  */
-export function VoiceStateCaption({ visual }: { visual: VoiceAvatarVisual }) {
+/**
+ * How loudly the room states the phase in words.
+ *
+ * The caption existed to name beats the visuals could not. Every phase now has
+ * a band of its own — the mic at the ceiling, the reply at the floor, and the
+ * hand-off sweeping between them — so the words were repeating what the screen
+ * already showed while competing with the transcript for the same lower zone.
+ * `hidden` (the default) drops the caption and lets the animation carry the
+ * state alone; `muted` keeps it as a small dim label; `full` is the original
+ * weight.
+ *
+ * Applies uniformly across phases. It did once exempt `thinking`, back when
+ * that state had nothing but a dot triad and dropping its caption would have
+ * left a still, silent room — {@link VoiceThinkingBand} is what removed the
+ * need for the exception.
+ */
+export type VoiceCaptionEmphasis = "full" | "muted" | "hidden";
+
+/** Scale + opacity applied to the caption per emphasis, while audio flows. */
+const CAPTION_EMPHASIS: Record<
+  VoiceCaptionEmphasis,
+  { scale: number; opacity: number } | null
+> = {
+  full: { scale: 1, opacity: 1 },
+  muted: { scale: 0.72, opacity: 0.55 },
+  hidden: null,
+};
+
+/**
+ * The thinking band's own envelope.
+ *
+ * No microphone and no TTS, so there is nothing to poll — but a flat zero would
+ * collapse the sheet to its idle floor and read as a dead band sliding down the
+ * screen. A slow swell gives the sweep something to carry. Module-level so its
+ * identity is stable and the mesh's draw loop never restarts.
+ */
+const THINKING_ENVELOPE = () =>
+  0.3 + 0.2 * Math.sin(performance.now() / 850);
+
+/** One full ceiling→floor pass of the thinking band, in seconds. */
+const THINKING_SWEEP_SEC = 3.4;
+
+export function VoiceStateCaption({
+  visual,
+  emphasis = "hidden",
+}: {
+  visual: VoiceAvatarVisual;
+  emphasis?: VoiceCaptionEmphasis;
+}) {
   const reduce = useReducedMotion();
   const label = EYE_STATE_CAPTION[visual];
+  const treatment = CAPTION_EMPHASIS[emphasis];
   return (
     <AnimatePresence mode="wait">
-      {label ? (
+      {label && treatment ? (
         <motion.div
           key={label}
           data-testid="voice-state-caption"
+          data-emphasis={emphasis}
           aria-hidden="true"
           className="pointer-events-none absolute left-1/2 z-[1] -translate-x-1/2 text-center font-medium tracking-wide text-[var(--room-fg-muted,rgba(255,255,255,0.7))]"
           style={{
             bottom: VOICE_ROOM_LOWER_ZONE_BOTTOM,
-            fontSize: VOICE_ROOM_CAPTION_TEXT,
+            // Scale the type rather than transform the box, so the caption
+            // stays on the lower zone's baseline instead of drifting off it.
+            fontSize: `calc(${VOICE_ROOM_CAPTION_TEXT} * ${treatment.scale})`,
           }}
           initial={reduce ? false : { opacity: 0, y: 6 }}
-          animate={{ opacity: 1, y: 0 }}
+          animate={{ opacity: treatment.opacity, y: 0 }}
           exit={reduce ? { opacity: 0 } : { opacity: 0, y: -6 }}
           transition={{ duration: reduce ? 0 : 0.28, ease: "easeOut" }}
         >
@@ -659,7 +723,22 @@ function VoiceThinkingIndicator({
  * - `pulse`    — the whole color field brightens gently on speech peaks.
  * All ride the TTS-output amplitude and tint from the room foreground tone.
  */
-export type VoiceRespondingStyle = "rings" | "halo" | "waveform" | "pulse";
+/**
+ * How the assistant's voice is drawn while it speaks.
+ *
+ * `waves` is the spatial counterpart to the listening band: the user's voice
+ * arrives from the ceiling, the assistant's answers from the floor, so the two
+ * halves of a turn own opposite edges of the room and the eyes sit on the axis
+ * between them. The rest are earlier sketches — `rings` and `halo` radiate from
+ * behind the eyes, `pulse` lightens the whole field, `waveform` reuses the
+ * listening band at whatever placement the room is already using.
+ */
+export type VoiceRespondingStyle =
+  | "waves"
+  | "rings"
+  | "halo"
+  | "waveform"
+  | "pulse";
 
 /**
  * Smoothed output-amplitude → `--resp-amp` on a ref, for the responding
@@ -703,17 +782,82 @@ function useRespondingAmp(getAmplitude?: () => number) {
   return ref;
 }
 
+/**
+ * The `thinking` band — the turn in transit.
+ *
+ * Listening owns the ceiling and responding owns the floor, which left the
+ * hand-off between them as the one beat with no band at all: shrunken eyes, a
+ * dot triad, and an otherwise empty room. Against two full-screen woven sheets
+ * that reads as the state having been forgotten.
+ *
+ * So thinking is drawn as the same sheet *travelling* from the user's edge to
+ * the assistant's, on a loop. That is not decoration chosen to fill the gap —
+ * it is what the state actually is. The user's turn has landed and the reply
+ * has not started, so the energy is between edges, and the room says so with
+ * the same vocabulary it uses either side of the beat. It also gives the phase
+ * a direction, so a long think reads as progress rather than as a hang.
+ *
+ * Dimmer than the audible bands on purpose: nothing is making sound here, and
+ * a sweep at full strength would claim more presence than either real voice.
+ */
+function VoiceThinkingBand({
+  engine,
+  palette,
+  waveStyle,
+}: {
+  engine: VoiceWaveEngine;
+  palette: VoiceWavePalette;
+  waveStyle: VoiceWaveStyle;
+}) {
+  const reduce = useReducedMotion();
+  return (
+    <motion.div
+      aria-hidden="true"
+      data-testid="voice-thinking-band"
+      className="pointer-events-none absolute inset-x-0"
+      style={{ height: "42%", opacity: 0.55 }}
+      initial={{ top: "-14%" }}
+      // Reduced motion parks it midway rather than sweeping: the state still
+      // reads as "between the two edges", just without the travel.
+      animate={reduce ? { top: "29%" } : { top: ["-14%", "72%"] }}
+      transition={
+        reduce
+          ? { duration: 0 }
+          : {
+              duration: THINKING_SWEEP_SEC,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }
+      }
+    >
+      {/* `inline` fills the travelling box rather than anchoring to a screen
+          edge — the box is what carries the position here. */}
+      <WaveBand
+        engine={engine}
+        getAmplitude={THINKING_ENVELOPE}
+        waveStyle={waveStyle}
+        palette={palette}
+        placement="inline"
+      />
+    </motion.div>
+  );
+}
+
 function VoiceRespondingTreatment({
   style,
+  engine,
   getAmplitude,
   waveStyle,
   wavePlacement,
+  wavePalette,
   viewport,
 }: {
   style: VoiceRespondingStyle;
+  engine: VoiceWaveEngine;
   getAmplitude?: () => number;
   waveStyle: VoiceWaveStyle;
   wavePlacement: VoiceWavePlacement;
+  wavePalette: VoiceWavePalette;
   viewport: { w: number; h: number };
 }) {
   const ampRef = useRespondingAmp(getAmplitude);
@@ -722,10 +866,28 @@ function VoiceRespondingTreatment({
   // and resolve against the window) so proportions match app and Storybook.
   const M = Math.min(viewport.w, viewport.h);
 
+  if (style === "waves") {
+    // The mirror of listening: the same band, the same engine, anchored to the
+    // floor instead of the ceiling and fed the TTS output rather than the mic.
+    // Nothing about it is a different visual language — that is the point. The
+    // room says who is speaking by *where* the energy is, not by switching
+    // metaphors mid-turn.
+    return getAmplitude ? (
+      <WaveBand
+        engine={engine}
+        getAmplitude={getAmplitude}
+        waveStyle={waveStyle}
+        palette={wavePalette}
+        placement="bottom"
+      />
+    ) : null;
+  }
+
   if (style === "waveform") {
     // The assistant's own voice — reuse the centered band, output-driven.
     return getAmplitude ? (
-      <VoiceReactiveWaves
+      <WaveBand
+        engine={engine}
         getAmplitude={getAmplitude}
         waveStyle={waveStyle}
         palette="tone"
@@ -837,9 +999,12 @@ export function VoiceRespondingRings({
     <VoiceRespondingTreatment
       style="rings"
       getAmplitude={getAmplitude}
-      // waveStyle/wavePlacement are only read by the `waveform` style; inert here.
+      // engine/waveStyle/wavePlacement/wavePalette are only read by the band
+      // styles (`waves`, `waveform`); inert for the rings.
+      engine="reactive"
       waveStyle="fill"
       wavePlacement="top"
+      wavePalette="tone"
       viewport={viewport ?? measured}
     />
   );

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -141,6 +141,9 @@ export type VoiceWaveEngine = "reactive" | "mesh" | "sine";
 function WaveBand({
   engine,
   waveStyle,
+  color,
+  peakOpacity,
+  opacityKnee,
   ...props
 }: {
   engine: VoiceWaveEngine;
@@ -148,11 +151,24 @@ function WaveBand({
   waveStyle?: VoiceWaveStyle;
   palette?: VoiceWavePalette;
   placement?: VoiceWavePlacement;
+  /** Mesh-only: explicit ink, its opacity ceiling, and how fast that ceiling
+   *  is reached. See {@link BAND_VOICE}. */
+  color?: string;
+  peakOpacity?: number;
+  opacityKnee?: number;
 }) {
   // The mesh is stroked hairlines by construction, so fill-vs-line does not
-  // apply to it — it takes no `waveStyle`.
+  // apply to it; the filled bands in turn take their color from the palette
+  // CSS and have nowhere to put an explicit ink.
   if (engine === "mesh") {
-    return <VoiceMeshWaves {...props} />;
+    return (
+      <VoiceMeshWaves
+        {...props}
+        color={color}
+        peakOpacity={peakOpacity}
+        tuning={opacityKnee === undefined ? undefined : { opacityKnee }}
+      />
+    );
   }
   return engine === "reactive" ? (
     <VoiceReactiveWaves waveStyle={waveStyle} {...props} />
@@ -288,7 +304,7 @@ export function VoiceRoomColorLook({
   getResponseAmplitude,
   respondingStyle = "waves",
   eyePlacement = "center",
-  wavePlacement = "top",
+  wavePlacement = "bottom",
   wavePalette = "tone",
   waveStyle = "fill",
   showStateCaption = true,
@@ -468,6 +484,9 @@ export function VoiceRoomColorLook({
               waveStyle={waveStyle}
               palette={wavePalette}
               placement={wavePlacement}
+              color={BAND_VOICE.listening.color}
+              peakOpacity={BAND_VOICE.listening.peakOpacity}
+              opacityKnee={BAND_VOICE.listening.opacityKnee}
             />
           </motion.div>
         ) : null}
@@ -483,11 +502,6 @@ export function VoiceRoomColorLook({
             exit={{ opacity: 0 }}
             transition={{ duration: reduce ? 0 : 0.3 }}
           >
-            <VoiceThinkingBand
-              engine={waveEngine}
-              palette={wavePalette}
-              waveStyle={waveStyle}
-            />
             <VoiceThinkingIndicator
               viewport={{ w, h }}
               eyesBottom={thinkingEyeBottom}
@@ -599,18 +613,34 @@ const CAPTION_EMPHASIS: Record<
 };
 
 /**
- * The thinking band's own envelope.
+ * How each voice's band is inked.
  *
- * No microphone and no TTS, so there is nothing to poll — but a flat zero would
- * collapse the sheet to its idle floor and read as a dead band sliding down the
- * screen. A slow swell gives the sweep something to carry. Module-level so its
- * identity is stable and the mesh's draw loop never restarts.
+ * Both sit on the floor. An earlier pass told them apart by *position* — the
+ * mic at the ceiling, the reply at the bottom — which read well but meant the
+ * room's whole composition rearranged itself twice a turn. Keeping both at the
+ * same edge and separating them by ink instead holds the layout still: the
+ * user's voice lifts a pale sheet off the floor, the assistant's answers in a
+ * darker one, and the eyes never have to share the frame with a band overhead.
+ *
+ * The two are deliberately not symmetric, because dark ink and pale ink do not
+ * behave the same way on a mid-tone background:
+ *
+ * - **Opacity ceiling.** Black at 0.2 is nowhere near "half as present" as
+ *   white at 0.4 — light-on-midtone is a far bigger luminance step than
+ *   dark-on-midtone at equal alpha, so the dark band needs a higher number to
+ *   land in the same perceptual place.
+ * - **`opacityKnee`.** The pale band's *silhouette* reads clearly, so opacity
+ *   can saturate early and let displacement carry the dynamics. The dark
+ *   band's silhouette is low-contrast, so opacity is doing most of the visible
+ *   work — saturating it early made the assistant's voice look like it had
+ *   stopped responding to amplitude at all. It stays closer to linear.
+ *
+ * Both still reach zero in silence, so the floor is empty between turns.
  */
-const THINKING_ENVELOPE = () =>
-  0.3 + 0.2 * Math.sin(performance.now() / 850);
-
-/** One full ceiling→floor pass of the thinking band, in seconds. */
-const THINKING_SWEEP_SEC = 3.4;
+const BAND_VOICE = {
+  listening: { color: "#FFFFFF", peakOpacity: 0.4, opacityKnee: 3 },
+  responding: { color: "#000000", peakOpacity: 0.45, opacityKnee: 1.3 },
+} as const;
 
 export function VoiceStateCaption({
   visual,
@@ -782,67 +812,6 @@ function useRespondingAmp(getAmplitude?: () => number) {
   return ref;
 }
 
-/**
- * The `thinking` band — the turn in transit.
- *
- * Listening owns the ceiling and responding owns the floor, which left the
- * hand-off between them as the one beat with no band at all: shrunken eyes, a
- * dot triad, and an otherwise empty room. Against two full-screen woven sheets
- * that reads as the state having been forgotten.
- *
- * So thinking is drawn as the same sheet *travelling* from the user's edge to
- * the assistant's, on a loop. That is not decoration chosen to fill the gap —
- * it is what the state actually is. The user's turn has landed and the reply
- * has not started, so the energy is between edges, and the room says so with
- * the same vocabulary it uses either side of the beat. It also gives the phase
- * a direction, so a long think reads as progress rather than as a hang.
- *
- * Dimmer than the audible bands on purpose: nothing is making sound here, and
- * a sweep at full strength would claim more presence than either real voice.
- */
-function VoiceThinkingBand({
-  engine,
-  palette,
-  waveStyle,
-}: {
-  engine: VoiceWaveEngine;
-  palette: VoiceWavePalette;
-  waveStyle: VoiceWaveStyle;
-}) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      aria-hidden="true"
-      data-testid="voice-thinking-band"
-      className="pointer-events-none absolute inset-x-0"
-      style={{ height: "42%", opacity: 0.55 }}
-      initial={{ top: "-14%" }}
-      // Reduced motion parks it midway rather than sweeping: the state still
-      // reads as "between the two edges", just without the travel.
-      animate={reduce ? { top: "29%" } : { top: ["-14%", "72%"] }}
-      transition={
-        reduce
-          ? { duration: 0 }
-          : {
-              duration: THINKING_SWEEP_SEC,
-              repeat: Infinity,
-              ease: "easeInOut",
-            }
-      }
-    >
-      {/* `inline` fills the travelling box rather than anchoring to a screen
-          edge — the box is what carries the position here. */}
-      <WaveBand
-        engine={engine}
-        getAmplitude={THINKING_ENVELOPE}
-        waveStyle={waveStyle}
-        palette={palette}
-        placement="inline"
-      />
-    </motion.div>
-  );
-}
-
 function VoiceRespondingTreatment({
   style,
   engine,
@@ -879,6 +848,9 @@ function VoiceRespondingTreatment({
         waveStyle={waveStyle}
         palette={wavePalette}
         placement="bottom"
+        color={BAND_VOICE.responding.color}
+        peakOpacity={BAND_VOICE.responding.peakOpacity}
+        opacityKnee={BAND_VOICE.responding.opacityKnee}
       />
     ) : null;
   }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -65,6 +65,7 @@ import type { VoiceAvatarVisual } from "./voice-avatar-state";
 import { createAmplitudeSmoother } from "./voice-motion";
 import { useReactiveEyes, type VoiceEyeReaction } from "./use-reactive-eyes";
 import { VoiceReactiveWaves } from "./voice-reactive-waves";
+import { VoiceMeshWaves } from "./voice-mesh-waves";
 import {
   VOICE_ROOM_CAPTION_TEXT,
   VOICE_ROOM_LOWER_ZONE_BOTTOM,
@@ -126,17 +127,20 @@ const EYE_REACTION: Record<VoiceAvatarVisual, VoiceEyeReaction> = {
 /**
  * Which wave band the room draws.
  *
- * `reactive` rebuilds the wave geometry every frame from a rolling history of
- * the live amplitude, so the terrain is a record of what was actually said.
- * `sine` is the original fixed-geometry band, kept so the two can be compared
- * side by side in Storybook — its silhouette is authored once at mount and
- * only slid sideways, which is what made the room read as a static image.
+ * `reactive` rebuilds the filled wave geometry every frame from a rolling
+ * history of the live amplitude, so the terrain is a record of what was
+ * actually said. `mesh` draws the same signal as a woven wireframe sheet —
+ * dozens of phase-shifted hairlines on a canvas, brightening where they cross.
+ * `sine` is the original fixed-geometry band, kept so the alternatives can be
+ * compared against it in Storybook — its silhouette is authored once at mount
+ * and only slid sideways, which is what made the room read as a static image.
  */
-export type VoiceWaveEngine = "reactive" | "sine";
+export type VoiceWaveEngine = "reactive" | "mesh" | "sine";
 
 /** Draw the listening band with whichever engine the caller selected. */
 function WaveBand({
   engine,
+  waveStyle,
   ...props
 }: {
   engine: VoiceWaveEngine;
@@ -145,10 +149,15 @@ function WaveBand({
   palette?: VoiceWavePalette;
   placement?: VoiceWavePlacement;
 }) {
+  // The mesh is stroked hairlines by construction, so fill-vs-line does not
+  // apply to it — it takes no `waveStyle`.
+  if (engine === "mesh") {
+    return <VoiceMeshWaves {...props} />;
+  }
   return engine === "reactive" ? (
-    <VoiceReactiveWaves {...props} />
+    <VoiceReactiveWaves waveStyle={waveStyle} {...props} />
   ) : (
-    <VoiceListeningWaves {...props} />
+    <VoiceListeningWaves waveStyle={waveStyle} {...props} />
   );
 }
 /** State caption shown below the eyes, per visual (none for idle / connecting-

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -85,11 +85,11 @@ mock.module("@/domains/chat/voice/voice-room/voice-avatar", () => ({
   ),
 }));
 
-// Stub the listening waves (rAF loop + SVG geometry) so the room-chrome tests
-// stay focused on wiring: we only assert the room mounts them in the right
-// phase, not how they animate.
-mock.module("@/domains/chat/voice/voice-room/voice-listening-waves", () => ({
-  VoiceListeningWaves: () => <div data-testid="listening-waves" />,
+// Stub the listening waves (rAF loop + per-frame SVG geometry) so the
+// room-chrome tests stay focused on wiring: we only assert the room mounts
+// them in the right phase, not how they animate.
+mock.module("@/domains/chat/voice/voice-room/voice-reactive-waves", () => ({
+  VoiceReactiveWaves: () => <div data-testid="listening-waves" />,
 }));
 
 // The room resolves its look (color-with-eyes vs the ambient void) and the

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -88,8 +88,20 @@ mock.module("@/domains/chat/voice/voice-room/voice-avatar", () => ({
 // Stub the listening waves (rAF loop + per-frame SVG geometry) so the
 // room-chrome tests stay focused on wiring: we only assert the room mounts
 // them in the right phase, not how they animate.
+const waveStub = ({ placement }: { placement?: string }) => (
+  <div data-testid="listening-waves" data-placement={placement} />
+);
+// Both engines are stubbed: the room draws the mesh, but which engine is the
+// default is a design decision that has already changed once, and these tests
+// are about *where* the band lands, not which one draws it. `placement` is
+// surfaced so they can assert the room's spatial language — the user's voice
+// arrives at the ceiling, the assistant's answers from the floor.
+mock.module("@/domains/chat/voice/voice-room/voice-mesh-waves", () => ({
+  VoiceMeshWaves: waveStub,
+  MESH_INLINE_TUNING: {},
+}));
 mock.module("@/domains/chat/voice/voice-room/voice-reactive-waves", () => ({
-  VoiceReactiveWaves: () => <div data-testid="listening-waves" />,
+  VoiceReactiveWaves: waveStub,
 }));
 
 // The room resolves its look (color-with-eyes vs the ambient void) and the
@@ -171,6 +183,10 @@ mock.module("@/components/speech/use-stt-language-selection", () => ({
 // Imported after the mocks so the room picks up the mocked modules.
 const { VoiceRoom } =
   await import("@/domains/chat/voice/voice-room/voice-room");
+// The caption is exercised directly as well as through the room: the room
+// hides it, so its emphasis contract is only observable component-side.
+const { VoiceStateCaption } =
+  await import("@/domains/chat/voice/voice-room/voice-room-eyes");
 const { useChatSessionStore } =
   await import("@/domains/chat/chat-session-store");
 const { attachSurface } =
@@ -638,7 +654,7 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
     expect(exitButton()).not.toBeNull();
   });
 
-  test("the color look shows no waveform outside listening", () => {
+  test("the color look answers from the floor while the assistant speaks", () => {
     mockAvatarData = {
       components: CHARACTER_COMPONENTS,
       traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
@@ -647,7 +663,41 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
     startOwnedSession("speaking");
     render(<VoiceRoom />);
     expect(eyes()).not.toBeNull();
-    expect(screen.queryByTestId("listening-waves")).toBeNull();
+    // Both halves of a turn use the same band; which edge it occupies is what
+    // says whose voice it is. Speaking answers from the bottom.
+    expect(screen.getByTestId("listening-waves").dataset.placement).toBe(
+      "bottom",
+    );
+  });
+
+  test("the color look gathers at the ceiling while the user speaks", () => {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
+      customImageUrl: null,
+    };
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(screen.getByTestId("listening-waves").dataset.placement).toBe("top");
+  });
+
+  test("the color look sweeps the band between edges while thinking", () => {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
+      customImageUrl: null,
+    };
+    startOwnedSession("thinking");
+    render(<VoiceRoom />);
+    // Thinking is the turn in transit: neither edge owns it, so the band
+    // travels between them rather than anchoring to the ceiling or the floor.
+    const band = screen.getByTestId("voice-thinking-band");
+    expect(band).toBeTruthy();
+    expect(
+      band.querySelector("[data-testid='listening-waves']")?.getAttribute(
+        "data-placement",
+      ),
+    ).toBe("inline");
   });
 
   test("a default character (no traits) gets first-component eyes", () => {
@@ -696,7 +746,7 @@ describe("VoiceRoom — state caption (shared across looks)", () => {
   }
 
   // The void look (custom-image / unresolved avatar) carries the centered
-  // avatar, not the eyes, but shares the same caption in the same beat.
+  // avatar, not the eyes, but shares the same caption beat.
   function renderVoidLook(state: LiveVoiceSessionState) {
     mockAvatarData = {
       components: CHARACTER_COMPONENTS,
@@ -707,37 +757,58 @@ describe("VoiceRoom — state caption (shared across looks)", () => {
     render(<VoiceRoom />);
   }
 
-  test("shows the state caption below the eyes by default (captions off)", () => {
+  // The room passes `captionEmphasis: "hidden"`, so nothing it can be told
+  // about transcripts will make a caption appear. The tests that used to
+  // exercise `showStateCaption` through the room have moved down to
+  // `VoiceStateCaption`, where the emphasis can be varied and the assertions
+  // still mean something — left here they would have passed unconditionally.
+  test("paints no caption by default — the bands carry the state", () => {
     renderCharacterLook("listening");
-    expect(caption()?.textContent).toBe("Listening");
-  });
-
-  test("stands the caption down when the assistant transcript is enabled", () => {
-    useVoicePrefsStore.setState({ showAssistantTranscript: true });
-    renderCharacterLook("speaking");
     expect(caption()).toBeNull();
   });
 
-  test("keeps the caption when only the user transcript is enabled", () => {
-    // The user transcript floats *above* the eyes, so it never fills the
-    // caption's lower space — enabling it alone must not blank the caption.
-    useVoicePrefsStore.setState({ showUserTranscript: true });
-    renderCharacterLook("listening");
-    expect(caption()?.textContent).toBe("Listening");
-  });
-
-  test("the void look shows the same caption below the custom avatar (parity)", () => {
+  test("paints no caption in the void look either", () => {
     renderVoidLook("speaking");
-    // Void look — the centered avatar, not the eyes — still names the beat.
     expect(screen.getByTestId("voice-avatar")).toBeTruthy();
     expect(screen.queryByTestId("voice-room-eyes")).toBeNull();
-    expect(caption()?.textContent).toBe("Speaking");
+    expect(caption()).toBeNull();
+  });
+});
+
+describe("VoiceStateCaption — emphasis", () => {
+  const caption = () => screen.queryByTestId("voice-state-caption");
+
+  test("hidden paints nothing", () => {
+    render(<VoiceStateCaption visual="listening" emphasis="hidden" />);
+    expect(caption()).toBeNull();
   });
 
-  test("the void look stands its caption down for the assistant transcript too", () => {
-    useVoicePrefsStore.setState({ showAssistantTranscript: true });
-    renderVoidLook("speaking");
+  test("muted keeps the label, quietly", () => {
+    render(<VoiceStateCaption visual="listening" emphasis="muted" />);
+    expect(caption()?.textContent).toBe("Listening");
+    expect(caption()?.dataset.emphasis).toBe("muted");
+  });
+
+  test("full keeps the original weight", () => {
+    render(<VoiceStateCaption visual="responding" emphasis="full" />);
+    expect(caption()?.textContent).toBe("Speaking");
+    expect(caption()?.dataset.emphasis).toBe("full");
+  });
+
+  test("emphasis applies uniformly across phases", () => {
+    // `thinking` was once exempt, back when it had nothing but a dot triad and
+    // dropping its caption left a still, silent room. The transit band is what
+    // removed the need for that exception.
+    render(<VoiceStateCaption visual="thinking" emphasis="hidden" />);
     expect(caption()).toBeNull();
+  });
+
+  test("names no beat for the states that have no label", () => {
+    for (const visual of ["idle", "reconnecting"] as const) {
+      cleanup();
+      render(<VoiceStateCaption visual={visual} emphasis="full" />);
+      expect(caption()).toBeNull();
+    }
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -88,14 +88,24 @@ mock.module("@/domains/chat/voice/voice-room/voice-avatar", () => ({
 // Stub the listening waves (rAF loop + per-frame SVG geometry) so the
 // room-chrome tests stay focused on wiring: we only assert the room mounts
 // them in the right phase, not how they animate.
-const waveStub = ({ placement }: { placement?: string }) => (
-  <div data-testid="listening-waves" data-placement={placement} />
+const waveStub = ({
+  placement,
+  color,
+}: {
+  placement?: string;
+  color?: string;
+}) => (
+  <div
+    data-testid="listening-waves"
+    data-placement={placement}
+    data-color={color}
+  />
 );
 // Both engines are stubbed: the room draws the mesh, but which engine is the
 // default is a design decision that has already changed once, and these tests
-// are about *where* the band lands, not which one draws it. `placement` is
-// surfaced so they can assert the room's spatial language — the user's voice
-// arrives at the ceiling, the assistant's answers from the floor.
+// are about which band the room raises, not which component draws it.
+// `placement` and `color` are surfaced because together they are the room's
+// whole vocabulary for whose voice is on screen.
 mock.module("@/domains/chat/voice/voice-room/voice-mesh-waves", () => ({
   VoiceMeshWaves: waveStub,
   MESH_INLINE_TUNING: {},
@@ -654,50 +664,42 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
     expect(exitButton()).not.toBeNull();
   });
 
-  test("the color look answers from the floor while the assistant speaks", () => {
+  function renderCharacterAt(state: LiveVoiceSessionState) {
     mockAvatarData = {
       components: CHARACTER_COMPONENTS,
       traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
       customImageUrl: null,
     };
-    startOwnedSession("speaking");
+    startOwnedSession(state);
     render(<VoiceRoom />);
-    expect(eyes()).not.toBeNull();
-    // Both halves of a turn use the same band; which edge it occupies is what
-    // says whose voice it is. Speaking answers from the bottom.
-    expect(screen.getByTestId("listening-waves").dataset.placement).toBe(
-      "bottom",
-    );
+    return screen.queryByTestId("listening-waves");
+  }
+
+  test("both voices raise their band from the floor", () => {
+    // An earlier pass split them by edge, which rearranged the room's whole
+    // composition twice a turn. Sharing the floor keeps the layout still.
+    expect(renderCharacterAt("listening")?.dataset.placement).toBe("bottom");
+    cleanup();
+    expect(renderCharacterAt("speaking")?.dataset.placement).toBe("bottom");
   });
 
-  test("the color look gathers at the ceiling while the user speaks", () => {
-    mockAvatarData = {
-      components: CHARACTER_COMPONENTS,
-      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
-      customImageUrl: null,
-    };
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    expect(screen.getByTestId("listening-waves").dataset.placement).toBe("top");
+  test("ink is what tells the two voices apart", () => {
+    // With position no longer carrying it, the color is the entire signal for
+    // whose voice is on screen — the pale sheet is the user, the dark one the
+    // assistant. If these ever match, the room stops distinguishing them.
+    const listening = renderCharacterAt("listening")?.dataset.color;
+    cleanup();
+    const speaking = renderCharacterAt("speaking")?.dataset.color;
+    expect(listening).toBe("#FFFFFF");
+    expect(speaking).toBe("#000000");
+    expect(listening).not.toBe(speaking);
   });
 
-  test("the color look sweeps the band between edges while thinking", () => {
-    mockAvatarData = {
-      components: CHARACTER_COMPONENTS,
-      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
-      customImageUrl: null,
-    };
-    startOwnedSession("thinking");
-    render(<VoiceRoom />);
-    // Thinking is the turn in transit: neither edge owns it, so the band
-    // travels between them rather than anchoring to the ceiling or the floor.
-    const band = screen.getByTestId("voice-thinking-band");
-    expect(band).toBeTruthy();
-    expect(
-      band.querySelector("[data-testid='listening-waves']")?.getAttribute(
-        "data-placement",
-      ),
-    ).toBe("inline");
+  test("the floor is empty between turns", () => {
+    // No band while thinking, and no transit sweep either: the listening band
+    // flattens and fades out as the voice stops, which is the hand-off.
+    expect(renderCharacterAt("thinking")).toBeNull();
+    expect(screen.queryByTestId("voice-thinking-band")).toBeNull();
   });
 
   test("a default character (no traits) gets first-component eyes", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -79,7 +79,7 @@ import { toVoiceAvatarVisual } from "./voice-avatar-state";
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceRoomSettingsMenu } from "./voice-room-settings-menu";
 import { VoiceAvatar } from "./voice-avatar";
-import { VoiceReactiveWaves } from "./voice-reactive-waves";
+import { VoiceMeshWaves } from "./voice-mesh-waves";
 import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import {
@@ -267,7 +267,7 @@ function VoiceRoomOverlay() {
         <>
           <VoiceRoomAmbientBackground />
           {visual === "listening" ? (
-            <VoiceReactiveWaves
+            <VoiceMeshWaves
               getAmplitude={getLiveVoiceInputAmplitude}
               palette="accent"
               // Same top edge as the color look, above the centered avatar —

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -79,7 +79,7 @@ import { toVoiceAvatarVisual } from "./voice-avatar-state";
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceRoomSettingsMenu } from "./voice-room-settings-menu";
 import { VoiceAvatar } from "./voice-avatar";
-import { VoiceListeningWaves } from "./voice-listening-waves";
+import { VoiceReactiveWaves } from "./voice-reactive-waves";
 import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import {
@@ -267,7 +267,7 @@ function VoiceRoomOverlay() {
         <>
           <VoiceRoomAmbientBackground />
           {visual === "listening" ? (
-            <VoiceListeningWaves
+            <VoiceReactiveWaves
               getAmplitude={getLiveVoiceInputAmplitude}
               palette="accent"
               // Same top edge as the color look, above the centered avatar —

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -983,6 +983,41 @@ body {
   }
 }
 
+/* Mesh band (voice-mesh-waves.tsx): the canvas already answers amplitude in its
+ * own geometry — the sheet expands and contracts as the envelope swells — so the
+ * container must NOT also translate or scale with `--voice-amp`. Two responses
+ * stacked on one signal read as the whole band bouncing up and down behind a
+ * sheet that is separately breathing, which is the tell that this is an effect
+ * rather than a picture of the voice. Keep the static anchoring (and the
+ * brightness, which composes fine); drop the movement. */
+.voice-listening-waves--mesh,
+.voice-listening-waves--mesh.voice-listening-waves--top,
+.voice-listening-waves--mesh.voice-listening-waves--inline {
+  transform: none;
+}
+/* The centered band still needs its own -50% or it drops half a band height;
+ * only the amplitude-driven scaleY comes off. */
+.voice-listening-waves--mesh.voice-listening-waves--center {
+  transform: translateY(-50%);
+}
+
+/* Push the two edge bands further out of frame than the filled band sits.
+ *
+ * The mesh centers its sheet inside whatever box it is given, so a band
+ * spanning 0–42% puts the weave's spine at 21% — close enough to the middle
+ * that it crowds the eyes and reads as two competing centerpieces. Hanging the
+ * box off the edge moves the spine to ~11% (and its mirror at ~89%), which
+ * both clears the eyes and lets the sheet run off the top and bottom of the
+ * screen rather than terminating inside it — the energy arrives from outside
+ * the room instead of starting at a visible boundary. The room's own
+ * `overflow-hidden` does the clipping. */
+.voice-listening-waves--mesh.voice-listening-waves--top {
+  top: -10%;
+}
+.voice-listening-waves--mesh.voice-listening-waves--bottom {
+  bottom: -10%;
+}
+
 /* Reactive band (voice-reactive-waves.tsx): the path geometry is rebuilt every
  * frame from a rolling history of the live amplitude, so the horizontal motion
  * *is* the signal scrolling by. The drift keyframe above would slide that

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -950,6 +950,48 @@ body {
   }
 }
 
+/* Audio-reactive eyes (use-reactive-eyes.ts). `--eye-amp` is written per frame
+ * from the live amplitude; the gesture is picked by `data-eye-reaction`.
+ * Deliberately small — the eyes are the room's fixed point, so this is meant to
+ * read as alive, not as dancing. Composes with (rather than replaces) the
+ * entrance keyframes and the per-state size tween, which live on ancestors. */
+.voice-room-eyes-reactive {
+  --eye-amp: 0;
+  transform-origin: center;
+  will-change: transform;
+}
+
+/* Listening: the eyes open up toward the speaker — mostly vertical, so it
+ * reads as widening rather than as zooming — and lift very slightly. */
+.voice-room-eyes-reactive[data-eye-reaction="listening"] {
+  transform: translateY(calc(var(--eye-amp) * -1.5%))
+    scaleX(calc(1 + var(--eye-amp) * 0.03))
+    scaleY(calc(1 + var(--eye-amp) * 0.1));
+}
+
+/* Responding: a rounder pulse on the assistant's own output amplitude, with a
+ * small bounce — the "energy going out" language of the responding treatment
+ * radiating behind them. */
+.voice-room-eyes-reactive[data-eye-reaction="responding"] {
+  transform: translateY(calc(var(--eye-amp) * -2.5%))
+    scale(calc(1 + var(--eye-amp) * 0.055));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-room-eyes-reactive {
+    transform: none;
+  }
+}
+
+/* Reactive band (voice-reactive-waves.tsx): the path geometry is rebuilt every
+ * frame from a rolling history of the live amplitude, so the horizontal motion
+ * *is* the signal scrolling by. The drift keyframe above would slide that
+ * terrain a second time, so it comes off — everything else (palette, style,
+ * placement, the `--voice-amp` rise/brightness) still applies. */
+.voice-listening-waves--reactive path {
+  animation: none;
+}
+
 /* Line style: stroke the open curve; no fill. */
 .voice-listening-waves--line path {
   fill: none;

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -994,6 +994,16 @@ body {
 .voice-listening-waves--mesh.voice-listening-waves--top,
 .voice-listening-waves--mesh.voice-listening-waves--inline {
   transform: none;
+  /* Fade all the way out with the voice, rather than to the shared band's 0.28
+   * floor. The sheet's displacement already drops to nothing as amplitude does
+   * (`idleEnvelope: 0`), so a floored opacity would leave a flat, permanently
+   * visible line across the room between turns. `--band-peak-opacity` is the
+   * per-voice ceiling the room sets (see `BAND_VOICE`); `--band-presence` is a
+   * saturating curve on the amplitude rather than the raw value, so the ceiling
+   * is reached at ordinary speaking level instead of only at a shout — see
+   * `opacityKnee`. Multiplying two linear ramps was what made the band read as
+   * barely there. */
+  opacity: calc(var(--band-presence, 0) * var(--band-peak-opacity, 1));
 }
 /* The centered band still needs its own -50% or it drops half a band height;
  * only the amplitude-driven scaleY comes off. */


### PR DESCRIPTION
Closes JARVIS-1376.

## The report

The voice visuals were reported as looking "like PNGs that don't actually respond to changes in voice, words, volume, etc." That read is accurate, and the cause is specific:

- `wavePoints()` in `voice-listening-waves.tsx` builds each wave path **once at mount** from constant amplitudes (26/34/22) and cycle counts (4/6/8).
- Live amplitude only ever reaches `translateY` and `opacity` on the whole layer; a CSS keyframe (`voice-wave-drift`) slides it sideways at a fixed rate.
- So the silhouette is frozen. The band draws the same shape whether the mic is clipping or muted — a picture on a conveyor belt.
- The eyes were no better: a blink timer, cursor parallax, and a discrete per-state scale tween, with **no** audio input at all. Through a whole spoken turn they hold exactly one pose.

## The change

**`VoiceReactiveWaves`** — the geometry *is* the signal. Each layer keeps a rolling history of the amplitude it has been fed and rebuilds its path every frame from that history, so the terrain is a record of what was actually said: a loud syllable raises a crest that travels left and decays off the edge, and silence flattens the band within about a second.

- Depth comes from per-layer sampling **cadence** rather than parallax speeds — one signal writes a broad swell behind (~4s window) and a tight ripple in front (~1.4s).
- Knots are joined with a Catmull-Rom spline so it reads as rolling hills, not an oscilloscope.
- A small idle sway keeps the band breathing through silence rather than going dead flat.
- The CSS drift keyframe comes off (`--reactive`); the history scroll now supplies the horizontal motion, and leaving it on would slide the terrain twice.

**`use-reactive-eyes.ts`** — the eyes get an audio gesture: they widen with the mic while `listening` and pulse with the assistant's own output while `responding`. The eye artwork is arbitrary per-character SVG with no isolable pupil, so this animates the group as a whole. Deliberately small (a few percent) — the eyes are the room's fixed point, and JARVIS-1263 already had to walk back a "spastic" pass. `thinking` stays still on purpose: no sound to answer.

Both are prop-compatible drop-ins, so all four surfaces move over: the color-look room, the ambient void look, the minimized composer bar, and the title-bar pill. Amplitude is still polled inside rAF and written straight to the DOM (`setAttribute` / CSS var), never through React state.

## Storybook

New `Chat/Voice/Reactive Animations` section covering the three surfaces from the report:

| Story | Surface |
|---|---|
| **Room — Desktop** | full-screen color look |
| **Minimized — Composer Bar** | the inline strip that replaces the chat input |
| **Room — Mobile** | the room in a phone frame |
| **Engine — Reactive vs Sine** | A/B on one shared amplitude source |
| **States** | every session phase, to check the hand-offs |

The **Driver** knob is the point: `mic` opens your **actual microphone** via `getUserMedia`, so this can be judged against a real voice rather than a simulated envelope. `silence` is the cheap proof — the old band marches on regardless, the new one settles.

## Verification

- `bun run typecheck` clean; `eslint` clean.
- New `voice-reactive-waves.test.tsx` (6 tests) pins the property the old band lacked: geometry is asserted, not the CSS var. Loud speech produces crests >3× silence, and paths change frame to frame. If a future change reverts to pre-authored geometry, that comparison fails.
- All 14 affected voice test files pass individually (297 tests): room, pill, pill host, composer bar, chat composer.
- Storybook dev server boots and all 5 stories register and transform.

## Note on scope

You asked for this in Storybook, and that's where it's built — but since the components are drop-in replacements, the production call sites move over too (that's the ticket). If you'd rather look first and land the swap separately, `waveEngine="sine"` on `VoiceRoomColorLook` reverts the room, and the composer bar / pill are one import each.

I have **not** seen this render — there's no browser automation in this environment, so correctness is covered by tests and the visual judgement is yours. `cd clients/web && bun run storybook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)