### PR TITLE
feat(self-knowledge): trigger on privacy, data, and access questions

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1134,11 +1134,10 @@
           "display-name": "Vellum Self-Knowledge",
           "activation-hints": [
             "what model the assistant is running on",
-            "how Vellum works or its architecture",
-            "its current configuration or settings",
-            "what it can do, or what skills/tools are available",
-            "how to self-host a Vellum assistant",
-            "how to configure your own model API key"
+            "how it works, its architecture or config",
+            "what it can do or which skills/tools are available",
+            "how to self-host or bring your own API key",
+            "whether your data is private, who can access it, or used for training"
           ],
           "avoid-when": [
             "changing configuration (use in-chat config instead)"
@@ -1146,7 +1145,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-28T20:26:37.000Z"
+      "updatedAt": "2026-07-30T15:27:10.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -9,11 +9,10 @@ metadata:
     display-name: "Vellum Self-Knowledge"
     activation-hints:
       - "what model the assistant is running on"
-      - "how Vellum works or its architecture"
-      - "its current configuration or settings"
-      - "what it can do, or what skills/tools are available"
-      - "how to self-host a Vellum assistant"
-      - "how to configure your own model API key"
+      - "how it works, its architecture or config"
+      - "what it can do or which skills/tools are available"
+      - "how to self-host or bring your own API key"
+      - "whether your data is private, who can access it, or used for training"
     avoid-when:
       - "changing configuration (use in-chat config instead)"
 ---


### PR DESCRIPTION
## Prompt / plan

Continuation of the self-knowledge FAQ-coverage work (#39365). That PR widened the `vellum-self-knowledge` activation-hints to cover install and self-hosting questions but deliberately left the billing/pricing FAQ section for a forthcoming `assistant platform billing` CLI (which still doesn't exist — only `platform credits`, which the prior review explicitly declined to route to).

The next-largest **uncovered** section of the docs FAQ (`/help/faq`) is **Privacy & Data** — six questions with zero matching activation-hint:

- "Is my data safe?"
- "Does Vellum train on my data?"
- "Does Vellum collect telemetry?"
- "Can my employer see what I do with Vellum?"
- "Can other people access my assistant?"

Because no hint matched, the skill often never fired for these, even though it already has the sources of truth to answer them (docs `/trust-security/*`, `/help/faq`, and CLI `assistant trust list`).

**Approach:** add a privacy/data/access activation-hint. The rendered capability card (`buildSkillContent` in `assistant/src/plugins/defaults/memory/graph/capability-seed.ts`) is **hard-clipped at 500 chars**, and the card was already at 494/500. To make room without clipping, fold the two architecture/config hints into one and the two hosting hints into one — both keep their keywords (`config`, `self-host`, `API key`), so routing precision holds. New card measures **496 chars**. Description left lean, following the precedent set at the end of #39365 (hints prioritized over description keywords under the same budget).

Regenerated `skills/catalog.json` to match.

## Test plan

- Computed the rendered `buildSkillContent` card length against the exact code formula: **496 chars** (≤ 500, no clipping).
- `node scripts/skills/check-catalog.mjs` → `skills/catalog.json is up to date.`
- `node scripts/skills/lint-skill-spec.mjs` → `Validated 72 skill(s) - all SKILL.md files conform to the spec.`

## CLI verb checklist

No new routes under `assistant/src/runtime/routes/`; N/A.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WE7j4VV8Wenqs6zmAiznk)_