### PR TITLE
feat(ios-voice): show the assistant's avatar in the Live Activity (JARVIS-1373)

### DIFF
--- a/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
+++ b/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
@@ -103,4 +103,26 @@ struct VoiceSessionAttributes: ActivityAttributes {
     }
 
     var assistantName: String
+
+    /// The assistant's avatar as encoded image data (PNG, or JPEG for
+    /// photographic uploads), or `nil` when there is none to show.
+    ///
+    /// An attribute rather than `ContentState` because it is fixed for the
+    /// activity's lifetime: it travels once, at `request`, and never through
+    /// an update. `ContentState` is re-sent on every phase change, and
+    /// ActivityKit rate-limits updates, so image bytes on that path would
+    /// exhaust the budget `use-live-activity-mirror.ts` protects.
+    ///
+    /// **The bytes travel because the extension cannot fetch them.** A Live
+    /// Activity renders from a snapshot with no async image loading, so a URL
+    /// would only ever draw a placeholder. That is also why this is not an App
+    /// Group: a shared container solves file *sharing*, and nothing here needs
+    /// a file.
+    ///
+    /// Kept small by `encodeAvatarForIsland`, which scales and re-encodes
+    /// until it fits a budget well under ActivityKit's documented 4KB ceiling
+    /// for attributes plus content state. Oversize does not degrade the
+    /// avatar, it throws `attributesTooLarge` and there is no island at all,
+    /// so the web side sends nothing rather than sending too much.
+    var avatarImageData: Data?
 }

--- a/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
+++ b/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
@@ -119,10 +119,11 @@ struct VoiceSessionAttributes: ActivityAttributes {
     /// Group: a shared container solves file *sharing*, and nothing here needs
     /// a file.
     ///
-    /// Kept small by `encodeAvatarForIsland`, which scales and re-encodes
-    /// until it fits a budget well under ActivityKit's documented 4KB ceiling
-    /// for attributes plus content state. Oversize does not degrade the
-    /// avatar, it throws `attributesTooLarge` and there is no island at all,
-    /// so the web side sends nothing rather than sending too much.
+    /// Kept small by `encodeAvatarForIsland`, which scales and re-encodes until
+    /// it fits a measured budget. The real ceiling is far below the 4KB Apple
+    /// documents for attributes plus content state: 3366 bytes threw
+    /// `attributesTooLarge` on an iPhone 17 Pro simulator while 1997 rendered.
+    /// Oversize does not degrade the avatar, it kills the whole activity, so
+    /// the web side sends nothing rather than sending too much.
     var avatarImageData: Data?
 }

--- a/clients/ios/App/App/VoiceLiveActivityPlugin.swift
+++ b/clients/ios/App/App/VoiceLiveActivityPlugin.swift
@@ -154,7 +154,10 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             }
             do {
                 self.activity = try Activity.request(
-                    attributes: VoiceSessionAttributes(assistantName: assistantName),
+                    attributes: VoiceSessionAttributes(
+                        assistantName: assistantName,
+                        avatarImageData: Self.avatarImageData(from: call)
+                    ),
                     content: Self.content(state)
                 )
                 call.resolve(["started": true])
@@ -251,6 +254,25 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     // MARK: - Payload
+
+    /// Decode the optional `avatarBase64` attribute off a bridge call.
+    ///
+    /// Best-effort in both directions: a bundle too old to send the field and
+    /// a payload that is not valid base64 both resolve to `nil`, which the
+    /// island renders as its accent glyph. Nothing about an avatar is worth
+    /// failing a session over, and rejecting here would cost the user the
+    /// whole Live Activity rather than just its picture.
+    ///
+    /// Size is deliberately not checked. `encodeAvatarForIsland` keeps the
+    /// payload under budget on the web side, and the only authority on what
+    /// actually fits is `Activity.request`, which throws
+    /// `attributesTooLarge` and is already handled by the caller's `catch`.
+    private static func avatarImageData(from call: CAPPluginCall) -> Data? {
+        guard let base64 = call.getString("avatarBase64"), !base64.isEmpty else {
+            return nil
+        }
+        return Data(base64Encoded: base64)
+    }
 
     /// Read the four `ContentState` fields off a bridge call. `phase` is
     /// required and must decode; the rest degrade to harmless defaults rather

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -68,17 +68,25 @@ struct VoiceAccentGlyph: View {
     }
 }
 
-/// The assistant's avatar, circular, at a given diameter.
+/// The assistant's avatar at a given size.
 ///
 /// Takes an already-decoded image so each slot decides its own fallback: the
 /// roomy layouts substitute an accent-filled badge, the tight ones a bare
 /// glyph. Decoding is the only image work done here, because the bytes arrive
-/// already sized and encoded from the web side — a Live Activity cannot fetch
-/// or resize anything at render time.
+/// already sized and encoded from the web side, and a Live Activity cannot
+/// fetch or resize anything at render time.
 ///
-/// The hairline border matches ``VoiceAccentBadge``: an avatar can be any
-/// color, including one that vanishes into a light or dark Lock Screen, so its
-/// edge is drawn rather than assumed.
+/// **Deliberately neither cropped to a circle nor bordered.** A character
+/// avatar is a shaped creature on a transparent background whose silhouette
+/// runs out to the edges of its square, so a circular mask cuts the edges off
+/// and a ring drawn around it frames empty space. `scaledToFit` keeps the whole
+/// silhouette, and the alpha the PNG rungs preserve is what lets it sit
+/// directly on the island.
+///
+/// The cost is a custom *uploaded* avatar, which is square and would look
+/// tidier masked. Distinguishing them would mean sending the avatar kind across
+/// the bridge; the shaped creature is the default and the common case, so it
+/// wins the single treatment until that is worth the plumbing.
 struct VoiceAvatarImage: View {
     let image: UIImage
     var diameter: CGFloat
@@ -86,10 +94,8 @@ struct VoiceAvatarImage: View {
     var body: some View {
         Image(uiImage: image)
             .resizable()
-            .scaledToFill()
+            .scaledToFit()
             .frame(width: diameter, height: diameter)
-            .clipShape(Circle())
-            .overlay(Circle().strokeBorder(Color.primary.opacity(0.2), lineWidth: 1))
             .accessibilityHidden(true)
     }
 }

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // Shared building blocks for the live-voice Live Activity.
 //
@@ -67,20 +68,80 @@ struct VoiceAccentGlyph: View {
     }
 }
 
-/// The accent glyph as a filled badge, for the roomier Lock Screen and
-/// expanded layouts.
+/// The assistant's avatar, circular, at a given diameter.
 ///
-/// The glyph is black or white by the accent's own luminance so it is legible
-/// on any avatar color, and the hairline border is `.primary` so the badge's
-/// edge reads against a light *and* a dark Lock Screen.
-struct VoiceAccentBadge: View {
-    let accent: Color
+/// Takes an already-decoded image so each slot decides its own fallback: the
+/// roomy layouts substitute an accent-filled badge, the tight ones a bare
+/// glyph. Decoding is the only image work done here, because the bytes arrive
+/// already sized and encoded from the web side — a Live Activity cannot fetch
+/// or resize anything at render time.
+///
+/// The hairline border matches ``VoiceAccentBadge``: an avatar can be any
+/// color, including one that vanishes into a light or dark Lock Screen, so its
+/// edge is drawn rather than assumed.
+struct VoiceAvatarImage: View {
+    let image: UIImage
+    var diameter: CGFloat
 
     var body: some View {
-        VoiceAccentGlyph(accent: accent.contrastingForeground)
-            .frame(width: 34, height: 34)
-            .background(accent, in: Circle())
+        Image(uiImage: image)
+            .resizable()
+            .scaledToFill()
+            .frame(width: diameter, height: diameter)
+            .clipShape(Circle())
             .overlay(Circle().strokeBorder(Color.primary.opacity(0.2), lineWidth: 1))
+            .accessibilityHidden(true)
+    }
+}
+
+/// Decode the avatar attribute, or `nil` when there is none and when the bytes
+/// do not form an image. A payload that fails to decode is treated exactly
+/// like an absent one: the slot falls back to its accent treatment rather than
+/// rendering a gap.
+func voiceAvatarImage(_ data: Data?) -> UIImage? {
+    guard let data else { return nil }
+    return UIImage(data: data)
+}
+
+/// The assistant's avatar for the roomier Lock Screen and expanded layouts,
+/// falling back to the accent glyph as a filled badge.
+///
+/// In the fallback the glyph is black or white by the accent's own luminance
+/// so it is legible on any avatar color, and the hairline border is `.primary`
+/// so the badge's edge reads against a light *and* a dark Lock Screen.
+struct VoiceAccentBadge: View {
+    let accent: Color
+    var avatarImageData: Data?
+
+    var body: some View {
+        if let image = voiceAvatarImage(avatarImageData) {
+            VoiceAvatarImage(image: image, diameter: 34)
+        } else {
+            VoiceAccentGlyph(accent: accent.contrastingForeground)
+                .frame(width: 34, height: 34)
+                .background(accent, in: Circle())
+                .overlay(Circle().strokeBorder(Color.primary.opacity(0.2), lineWidth: 1))
+        }
+    }
+}
+
+/// The identity mark for the two tightest slots, the compact leading and the
+/// minimal presentation: the avatar if there is one, the accent waveform if
+/// not.
+///
+/// Sized rather than left to the slot because these are the only presentations
+/// iOS renders inline with the status bar, where an unconstrained image would
+/// be laid out against the whole island rather than its own corner.
+struct VoiceCompactIdentity: View {
+    let accent: Color
+    var avatarImageData: Data?
+
+    var body: some View {
+        if let image = voiceAvatarImage(avatarImageData) {
+            VoiceAvatarImage(image: image, diameter: 20)
+        } else {
+            VoiceAccentGlyph(accent: accent, scale: .small)
+        }
     }
 }
 
@@ -131,10 +192,11 @@ struct VoiceSessionLockScreenView: View {
     /// Whether ActivityKit considers this content out of date; drops the phase
     /// label. See `ContentState.displayLabel(isStale:)`.
     let isStale: Bool
+    var avatarImageData: Data?
 
     var body: some View {
         HStack(spacing: 12) {
-            VoiceAccentBadge(accent: state.accentColor)
+            VoiceAccentBadge(accent: state.accentColor, avatarImageData: avatarImageData)
             VStack(alignment: .leading, spacing: 2) {
                 VoiceSessionText(text: assistantName, font: .headline)
                 VoiceSessionText(text: state.displayLabel(isStale: isStale), color: .secondary)

--- a/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
@@ -30,15 +30,17 @@ struct VoiceSessionLiveActivity: Widget {
             VoiceSessionLockScreenView(
                 assistantName: context.attributes.assistantName,
                 state: context.state,
-                isStale: context.isStale
+                isStale: context.isStale,
+                avatarImageData: context.attributes.avatarImageData
             )
             .widgetURL(VoiceModeDeepLink.resume.url())
         } dynamicIsland: { context in
             let state = context.state
             let label = state.displayLabel(isStale: context.isStale)
+            let avatar = context.attributes.avatarImageData
             return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    VoiceAccentBadge(accent: state.accentColor)
+                    VoiceAccentBadge(accent: state.accentColor, avatarImageData: avatar)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     // Nothing to say when unmuted: an always-present mic glyph
@@ -57,14 +59,14 @@ struct VoiceSessionLiveActivity: Widget {
                     )
                 }
             } compactLeading: {
-                VoiceAccentGlyph(accent: state.accentColor, scale: .small)
+                VoiceCompactIdentity(accent: state.accentColor, avatarImageData: avatar)
             } compactTrailing: {
                 // The tightest slot there is. It still shows the passed label,
                 // truncated — substituting a shorter native string here is
                 // precisely the fossilization this design avoids.
                 VoiceSessionText(text: label, font: .caption2, color: .secondary)
             } minimal: {
-                VoiceAccentGlyph(accent: state.accentColor, scale: .small)
+                VoiceCompactIdentity(accent: state.accentColor, avatarImageData: avatar)
             }
             .widgetURL(VoiceModeDeepLink.resume.url())
             .keylineTint(state.accentColor)

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -43,6 +43,31 @@ const updateVoiceLiveActivity = mock(
 );
 const endVoiceLiveActivity = mock(async (): Promise<void> => undefined);
 
+// Holds the avatar encode open so a phase change can land between `start`
+// being requested and the bridge actually being called. Stubbed rather than
+// delegating to the real encoder: the real one needs a canvas, and importing
+// the module here in order to wrap it deadlocks module init.
+let encodeGate: Promise<void> | null = null;
+
+mock.module("@/utils/avatar-island-encode", () => ({
+  ISLAND_AVATAR_MAX_BYTES: 2000,
+  encodeAvatarForIsland: async () => {
+    if (encodeGate) {
+      await encodeGate;
+    }
+    return null;
+  },
+}));
+
+mock.module("@/hooks/use-island-avatar-source", () => ({
+  useIslandAvatarSource: () => undefined,
+  getIslandAvatarSource: () => ({
+    kind: "character",
+    svg: "<svg/>",
+    dataUri: "d",
+  }),
+}));
+
 mock.module("@/runtime/native-live-activity", () => ({
   startVoiceLiveActivity,
   updateVoiceLiveActivity,
@@ -167,6 +192,59 @@ describe("starting the activity", () => {
       assistantName: "Ada",
     });
     expect(updateVoiceLiveActivity).not.toHaveBeenCalled();
+  });
+
+  // The encode is a canvas draw, so `start` is not synchronous with the store
+  // transition that requested it. A phase landing inside that window pushes an
+  // `update` the native side drops for want of an activity to update, so the
+  // island would open on the stale phase and stay there until something else
+  // changed.
+  test("opens on the newest phase when one lands during the avatar encode", async () => {
+    let openGate = () => undefined as void;
+    encodeGate = new Promise<void>((resolve) => {
+      openGate = () => {
+        resolve();
+      };
+    });
+
+    renderMirror();
+    await setPhase("connecting");
+    expect(startVoiceLiveActivity).not.toHaveBeenCalled();
+
+    // Moves on while the encode is still pending.
+    await setPhase("listening");
+
+    await act(async () => {
+      openGate();
+      await Promise.resolve();
+    });
+
+    expect(startVoiceLiveActivity).toHaveBeenCalledTimes(1);
+    expect(lastStartPayload()).toMatchObject({ phase: "listening" });
+    encodeGate = null;
+  });
+
+  // The same window, but the session ends inside it. A late `start` would
+  // strand an island that only the next launch could clear.
+  test("does not start at all when the session ends during the encode", async () => {
+    let openGate = () => undefined as void;
+    encodeGate = new Promise<void>((resolve) => {
+      openGate = () => {
+        resolve();
+      };
+    });
+
+    renderMirror();
+    await setPhase("connecting");
+    await setPhase("idle");
+
+    await act(async () => {
+      openGate();
+      await Promise.resolve();
+    });
+
+    expect(startVoiceLiveActivity).not.toHaveBeenCalled();
+    encodeGate = null;
   });
 
   test("a session already running at mount is picked up (controller remount)", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -17,6 +17,11 @@
  * Every store write here is `await`ed because the mirror observes *settled*
  * state — it coalesces each synchronous burst of `set()` calls into one
  * microtask — so a push lands a microtask after the write.
+ *
+ * `start` is additionally asynchronous in its own right: it resolves the
+ * avatar before requesting the activity. No avatar source is published here
+ * (`RootLayout` owns that publisher), so these tests exercise the
+ * no-avatar path and only need the settle they already do.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -168,6 +173,9 @@ describe("starting the activity", () => {
     await settled(() => useLiveVoiceStore.getState().setState("listening"));
 
     renderMirror();
+    // `start` resolves the avatar before it fires, so the mount-time pickup
+    // lands a microtask later than the render.
+    await settled();
 
     expect(startVoiceLiveActivity).toHaveBeenCalledTimes(1);
     expect(lastStartPayload()).toMatchObject({

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -114,24 +114,35 @@ async function islandAvatarBase64(): Promise<string | undefined> {
 }
 
 /**
- * Start the activity once the avatar is encoded, unless the session ended
- * while that was happening.
+ * Start the activity once the avatar is encoded.
  *
  * The encode is a canvas draw, so `start` is no longer synchronous with the
- * store transition that triggered it. A session that ends inside that window
- * would otherwise have its `end` overtaken by this `start` and strand an
- * island nothing is driving, which is the one failure the plugin's
- * single-activity handle cannot clean up until the next launch.
+ * store transition that triggered it, and the session can move underneath it.
+ * `currentStart` is therefore resolved *after* the await rather than captured
+ * before it, and answers both questions the delay creates:
+ *
+ * - **The session ended.** It returns `null`, so `end` is not overtaken by a
+ *   late `start` that would strand an island nothing is driving. That is the
+ *   one failure the plugin's single-activity handle cannot clean up until the
+ *   next launch.
+ * - **The phase moved on.** It returns the *latest* content, not the phase that
+ *   opened the window. Any `update` pushed while this was pending was dropped
+ *   natively, because there was no activity to update yet, so starting from the
+ *   captured payload would leave the island showing "Connecting…" until the
+ *   next phase change happened to repaint it.
  */
 async function startWithAvatar(
-  start: VoiceLiveActivityStart,
-  stillWanted: () => boolean,
+  currentStart: () => VoiceLiveActivityStart | null,
 ): Promise<void> {
   const avatarBase64 = await islandAvatarBase64();
-  if (!stillWanted()) {
+  const start = currentStart();
+  if (start === null) {
     return;
   }
-  await startVoiceLiveActivity({ ...start, ...(avatarBase64 ? { avatarBase64 } : {}) });
+  await startVoiceLiveActivity({
+    ...start,
+    ...(avatarBase64 ? { avatarBase64 } : {}),
+  });
 }
 
 /** Whether two payloads would render the same island. */
@@ -180,18 +191,23 @@ export function useLiveActivityMirror(): void {
         pushed = content;
         generation += 1;
         const started = generation;
-        void startWithAvatar(
-          {
-            ...content,
-            // An `ActivityAttributes` field, not `ContentState`: fixed for the
-            // activity's lifetime, so it is read once here and never pushed
-            // again. The avatar is added by `startWithAvatar` for the same
-            // reason.
-            assistantName: assistantDisplayName(
-              useAssistantIdentityStore.getState().name,
-            ),
-          },
-          () => generation === started && pushed !== null,
+        void startWithAvatar(() =>
+          // Read at start time, not capture time. `pushed` tracks the newest
+          // content, so a phase that landed during the avatar encode is what
+          // the island opens on; its own `update` was dropped natively for
+          // want of an activity to update.
+          generation === started && pushed !== null
+            ? {
+                ...pushed,
+                // An `ActivityAttributes` field, not `ContentState`: fixed for
+                // the activity's lifetime, so it is read once here and never
+                // pushed again. The avatar is added by `startWithAvatar` for
+                // the same reason.
+                assistantName: assistantDisplayName(
+                  useAssistantIdentityStore.getState().name,
+                ),
+              }
+            : null,
         );
         return;
       }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -41,12 +41,16 @@ import {
   type LiveVoiceState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { getRenderedAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
+import { getIslandAvatarSource } from "@/hooks/use-island-avatar-source";
 import {
   endVoiceLiveActivity,
   startVoiceLiveActivity,
   updateVoiceLiveActivity,
   type VoiceLiveActivityContent,
+  type VoiceLiveActivityStart,
 } from "@/runtime/native-live-activity";
+import { encodeAvatarForIsland } from "@/utils/avatar-island-encode";
+import type { AvatarRender } from "@/utils/avatar-render";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { assistantDisplayName } from "@/utils/assistant-display-name";
 
@@ -86,6 +90,50 @@ function toActivityContent(
   };
 }
 
+/**
+ * The last avatar encoded for the island, keyed by the source it came from.
+ *
+ * Module scope, so a user who starts several sessions pays the canvas draw
+ * once. The key is the resolved {@link AvatarRender}, which is a stable object
+ * per avatar (republished only when the avatar itself changes), so identity
+ * comparison is enough and there is nothing to invalidate.
+ */
+let encodedAvatar: { source: AvatarRender | null; base64: string | null } | null =
+  null;
+
+/** The island avatar for the current assistant, encoding it on first use. */
+async function islandAvatarBase64(): Promise<string | undefined> {
+  const source = getIslandAvatarSource();
+  if (source === null) {
+    return undefined;
+  }
+  if (encodedAvatar?.source !== source) {
+    encodedAvatar = { source, base64: await encodeAvatarForIsland(source) };
+  }
+  return encodedAvatar.base64 ?? undefined;
+}
+
+/**
+ * Start the activity once the avatar is encoded, unless the session ended
+ * while that was happening.
+ *
+ * The encode is a canvas draw, so `start` is no longer synchronous with the
+ * store transition that triggered it. A session that ends inside that window
+ * would otherwise have its `end` overtaken by this `start` and strand an
+ * island nothing is driving, which is the one failure the plugin's
+ * single-activity handle cannot clean up until the next launch.
+ */
+async function startWithAvatar(
+  start: VoiceLiveActivityStart,
+  stillWanted: () => boolean,
+): Promise<void> {
+  const avatarBase64 = await islandAvatarBase64();
+  if (!stillWanted()) {
+    return;
+  }
+  await startVoiceLiveActivity({ ...start, ...(avatarBase64 ? { avatarBase64 } : {}) });
+}
+
 /** Whether two payloads would render the same island. */
 function sameContent(
   a: VoiceLiveActivityContent,
@@ -109,6 +157,11 @@ export function useLiveActivityMirror(): void {
      * no gain — `update`/`end` are native no-ops when nothing is running.
      */
     let pushed: VoiceLiveActivityContent | null = null;
+    /**
+     * Bumped on every start and every end, so an in-flight `startWithAvatar`
+     * can tell whether the session it was starting is still the current one.
+     */
+    let generation = 0;
 
     const sync = (session: LiveVoiceState): void => {
       const content = toActivityContent(session);
@@ -118,21 +171,28 @@ export function useLiveActivityMirror(): void {
           return;
         }
         pushed = null;
+        generation += 1;
         void endVoiceLiveActivity();
         return;
       }
 
       if (pushed === null) {
         pushed = content;
-        void startVoiceLiveActivity({
-          ...content,
-          // An `ActivityAttributes` field, not `ContentState`: fixed for the
-          // activity's lifetime, so it is read once here and never pushed
-          // again.
-          assistantName: assistantDisplayName(
-            useAssistantIdentityStore.getState().name,
-          ),
-        });
+        generation += 1;
+        const started = generation;
+        void startWithAvatar(
+          {
+            ...content,
+            // An `ActivityAttributes` field, not `ContentState`: fixed for the
+            // activity's lifetime, so it is read once here and never pushed
+            // again. The avatar is added by `startWithAvatar` for the same
+            // reason.
+            assistantName: assistantDisplayName(
+              useAssistantIdentityStore.getState().name,
+            ),
+          },
+          () => generation === started && pushed !== null,
+        );
         return;
       }
 

--- a/clients/web/src/hooks/use-electron-icon-sync.ts
+++ b/clients/web/src/hooks/use-electron-icon-sync.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { isElectron } from "@/runtime/is-electron";
 import { setAssistantIcon } from "@/runtime/icon";
+import { rasterizeAvatar } from "@/utils/avatar-raster";
 import { resolveAvatarRender } from "@/utils/avatar-render";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 
@@ -11,89 +12,6 @@ import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
  * Tray. Matches the native app's avatar rendering size.
  */
 const ICON_SIZE = 512;
-
-/**
- * The largest centered square of a `srcW`×`srcH` source — the source rect for
- * an `object-cover` draw, matching the in-app `ChatAvatar` so non-square
- * uploads render identically on the icon surfaces instead of being stretched.
- * Returns null for a degenerate (zero-dimension) source so the caller draws
- * nothing rather than throwing.
- */
-export function coverCropSquare(
-  srcW: number,
-  srcH: number,
-): { sx: number; sy: number; side: number } | null {
-  if (srcW <= 0 || srcH <= 0) {
-    return null;
-  }
-  const side = Math.min(srcW, srcH);
-  return { sx: (srcW - side) / 2, sy: (srcH - side) / 2, side };
-}
-
-/**
- * Draw `src` (an SVG data URI or a renderer-owned blob URL) onto an offscreen
- * canvas at `size`×`size` and return the PNG bytes. Returns null if the image
- * can't be drawn so the caller can fall back to the bundled mark.
- *
- * Non-square sources are center-cropped to a square before scaling (see
- * `coverCropSquare`) so a portrait or logo renders identically on the
- * Dock/menu-bar icons instead of being stretched to fill the square canvas.
- */
-async function rasterizeAvatar(
-  src: string,
-  size: number,
-): Promise<Uint8Array | null> {
-  const image = new Image();
-  image.decoding = "async";
-  const loaded = new Promise<void>((resolve, reject) => {
-    image.onload = () => {
-      resolve();
-    };
-    image.onerror = () => {
-      reject(new Error("avatar image failed to load"));
-    };
-  });
-  image.src = src;
-  await loaded;
-
-  const canvas = document.createElement("canvas");
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) {
-    return null;
-  }
-  ctx.clearRect(0, 0, size, size);
-
-  // `naturalWidth/Height` is the decoded pixel size (SVG sources fall back to
-  // `width/height`, which equal `size` here). Scale the centered square crop
-  // to fill the canvas, preserving aspect ratio.
-  const crop = coverCropSquare(
-    image.naturalWidth || image.width,
-    image.naturalHeight || image.height,
-  );
-  if (crop) {
-    ctx.drawImage(
-      image,
-      crop.sx,
-      crop.sy,
-      crop.side,
-      crop.side,
-      0,
-      0,
-      size,
-      size,
-    );
-  }
-
-  const blob = await new Promise<Blob | null>((resolve) => {
-    canvas.toBlob(resolve, "image/png");
-  });
-  if (!blob) {
-    return null;
-  }
-  return new Uint8Array(await blob.arrayBuffer());
-}
 
 /**
  * Publish the assistant's avatar to the Electron host so the main process can

--- a/clients/web/src/hooks/use-island-avatar-source.ts
+++ b/clients/web/src/hooks/use-island-avatar-source.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+
+import { resolveAvatarRender, type AvatarRender } from "@/utils/avatar-render";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+
+/**
+ * Size the character avatar is composited at before rasterizing. The SVG is
+ * resolution-independent, so this only sets the ceiling the encoder's ladder
+ * scales down from; it is not the size the island renders.
+ */
+const SOURCE_SIZE = 128;
+
+/**
+ * The avatar `useLiveActivityMirror` should send to iOS, or null when there is
+ * none. Published rather than subscribed for the same reason as the rendered
+ * accent hex in `use-avatar-accent-var.ts`: the mirror runs entirely inside an
+ * effect, deliberately holding no reactive subscription, so it reads this
+ * imperatively at the moment a session starts.
+ */
+let islandAvatarSource: AvatarRender | null = null;
+
+/** The current avatar source for non-React readers. See {@link useIslandAvatarSource}. */
+export function getIslandAvatarSource(): AvatarRender | null {
+  return islandAvatarSource;
+}
+
+/**
+ * Publish the assistant's avatar for the iOS Live Activity.
+ *
+ * Mounted in `RootLayout` alongside the favicon, Electron icon and accent-var
+ * syncs, all of which consume the same avatar query and resolve their source
+ * through `resolveAvatarRender` so no surface can drift onto a different
+ * avatar than the one the user is looking at.
+ *
+ * This publishes the *unrasterized* render. Turning it into bytes costs a
+ * canvas draw, and the overwhelmingly common case is a user who never starts a
+ * voice session at all, so the encode is deferred to the mirror and happens at
+ * most once per session rather than on every avatar change.
+ *
+ * Publish-only with no cleanup, matching `useAvatarAccentVar`: clearing on
+ * unmount would make a second mount order-dependent, and a stale avatar is a
+ * better failure than none.
+ */
+export function useIslandAvatarSource(
+  customImageUrl: string | null,
+  components: CharacterComponents | null,
+  traits: CharacterTraits | null,
+): void {
+  useEffect(() => {
+    islandAvatarSource = resolveAvatarRender(
+      customImageUrl,
+      components,
+      traits,
+      SOURCE_SIZE,
+    );
+  }, [customImageUrl, components, traits]);
+}

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -50,6 +50,7 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useAvatarAccentVar } from "@/hooks/use-avatar-accent-var";
 import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
+import { useIslandAvatarSource } from "@/hooks/use-island-avatar-source";
 import { useElectronIdentitySync } from "@/hooks/use-electron-identity-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
@@ -153,6 +154,9 @@ export function RootLayout() {
   // Publish the avatar accent as `--avatar-accent` so chat loading shimmers
   // (and any future accent-tinted UI) can read it from plain CSS.
   useAvatarAccentVar(avatar.components, avatar.traits, avatar.customImageUrl);
+  // Publish the same avatar for the iOS Live Activity, which cannot fetch an
+  // image at render time and needs the bytes to travel with the activity.
+  useIslandAvatarSource(avatar.customImageUrl, avatar.components, avatar.traits);
 
   // Feed the same avatar to the Electron Dock + menu-bar icons, and publish
   // the live connection status to the menu-bar dot. Both no-op off Electron.

--- a/clients/web/src/runtime/native-live-activity.ts
+++ b/clients/web/src/runtime/native-live-activity.ts
@@ -63,6 +63,17 @@ export interface VoiceLiveActivityContent {
 /** {@link VoiceLiveActivityContent} plus the fields fixed for the activity's lifetime. */
 export interface VoiceLiveActivityStart extends VoiceLiveActivityContent {
   assistantName: string;
+  /**
+   * The assistant's avatar as base64 PNG or JPEG, sized to fit ActivityKit's
+   * payload ceiling by `encodeAvatarForIsland`. Omitted when there is no
+   * avatar or none small enough, which the island renders as its accent glyph.
+   *
+   * An attribute rather than content: it is fixed for the activity's lifetime,
+   * so it is sent once at `start` and never re-sent. Pushing image bytes
+   * through `update` would burn the ActivityKit update budget this module's
+   * caller works to stay inside.
+   */
+  avatarBase64?: string;
 }
 
 interface VoiceLiveActivityPlugin {

--- a/clients/web/src/utils/avatar-island-encode.test.ts
+++ b/clients/web/src/utils/avatar-island-encode.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for `encodeAvatarForIsland` — fitting the assistant avatar inside
+ * ActivityKit's payload ceiling.
+ *
+ * `rasterizeAvatar` is stubbed at the module boundary: it needs a canvas, and
+ * what matters here is the ladder's decision-making, not the pixels. The stub
+ * reports a byte size per (size, type) so each test can describe an avatar
+ * that compresses well or badly and assert which rung it lands on.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/** Recorded rasterize attempts, in order, so the ladder's walk is assertable. */
+let attempts: Array<{ size: number; type: string; quality?: number }> = [];
+/** Bytes the stub returns per attempt, keyed by `<size>:<type>`. */
+let byteSizes: Record<string, number> = {};
+/** When set, the stub throws instead of returning, as an undrawable source does. */
+let throwOnDraw = false;
+
+mock.module("@/utils/avatar-raster", () => ({
+  rasterizeAvatar: async (
+    _src: string,
+    size: number,
+    type: string,
+    quality?: number,
+  ) => {
+    attempts.push({ size, type, quality });
+    if (throwOnDraw) {
+      throw new Error("source failed to load");
+    }
+    const bytes = byteSizes[`${size}:${type}`];
+    return bytes === undefined ? null : new Uint8Array(bytes);
+  },
+}));
+
+const { encodeAvatarForIsland, ISLAND_AVATAR_MAX_BYTES } = await import(
+  "@/utils/avatar-island-encode"
+);
+
+const CHARACTER = {
+  kind: "character" as const,
+  svg: "<svg/>",
+  dataUri: "data:image/svg+xml,%3Csvg/%3E",
+};
+const IMAGE = { kind: "image" as const, url: "blob:avatar" };
+
+beforeEach(() => {
+  attempts = [];
+  byteSizes = {};
+  throwOnDraw = false;
+});
+
+describe("encodeAvatarForIsland", () => {
+  test("returns null for an assistant with no avatar, without rasterizing", async () => {
+    expect(await encodeAvatarForIsland({ kind: "none" })).toBeNull();
+    expect(attempts).toHaveLength(0);
+  });
+
+  // The character case: flat colors compress well, so it should keep the
+  // sharpest rung rather than being scaled down defensively.
+  test("takes the largest PNG when it already fits", async () => {
+    byteSizes["128:image/png"] = 900;
+
+    expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
+    expect(attempts).toEqual([{ size: 128, type: "image/png", quality: undefined }]);
+  });
+
+  test("steps down until a rung fits", async () => {
+    byteSizes["128:image/png"] = 9000;
+    byteSizes["96:image/png"] = 4000;
+    byteSizes["64:image/png"] = 1200;
+
+    expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
+    expect(attempts.map((a) => a.size)).toEqual([128, 96, 64]);
+  });
+
+  // The photographic case: PNG never fits, so it has to reach the JPEG rungs.
+  test("falls through to JPEG for a source PNG cannot fit", async () => {
+    byteSizes["128:image/png"] = 40000;
+    byteSizes["96:image/png"] = 22000;
+    byteSizes["64:image/png"] = 9000;
+    byteSizes["96:image/jpeg"] = 1400;
+
+    expect(await encodeAvatarForIsland(IMAGE)).not.toBeNull();
+    expect(attempts.at(-1)).toEqual({
+      size: 96,
+      type: "image/jpeg",
+      quality: 0.75,
+    });
+  });
+
+  // Going over the ceiling is not a worse avatar, it is no Live Activity at
+  // all, so nothing is better than something too big.
+  test("returns null when no rung fits rather than sending an oversize payload", async () => {
+    byteSizes = {
+      "128:image/png": 99000,
+      "96:image/png": 99000,
+      "64:image/png": 99000,
+      "96:image/jpeg": 99000,
+      "64:image/jpeg": 99000,
+      "48:image/jpeg": 99000,
+    };
+
+    expect(await encodeAvatarForIsland(IMAGE)).toBeNull();
+    expect(attempts).toHaveLength(6);
+  });
+
+  test("accepts a payload exactly on the ceiling", async () => {
+    byteSizes["128:image/png"] = ISLAND_AVATAR_MAX_BYTES;
+
+    expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
+  });
+
+  // An undrawable source fails identically at every size, so retrying the
+  // whole ladder would just be five more failures.
+  test("gives up immediately when the source will not draw", async () => {
+    throwOnDraw = true;
+
+    expect(await encodeAvatarForIsland(IMAGE)).toBeNull();
+    expect(attempts).toHaveLength(1);
+  });
+
+  test("stays under ActivityKit's documented 4KB attribute ceiling", () => {
+    expect(ISLAND_AVATAR_MAX_BYTES).toBeLessThan(4096);
+  });
+});

--- a/clients/web/src/utils/avatar-island-encode.test.ts
+++ b/clients/web/src/utils/avatar-island-encode.test.ts
@@ -1,10 +1,10 @@
 /**
- * Tests for `encodeAvatarForIsland` — fitting the assistant avatar inside
+ * Tests for `encodeAvatarForIsland`, fitting the assistant avatar inside
  * ActivityKit's payload ceiling.
  *
  * The rasterizer is injected rather than stubbed with `mock.module`: it needs a
  * canvas, and what matters here is the ladder's decision-making, not the
- * pixels. Injection also keeps the stub local — mocking the module would
+ * pixels. Injection also keeps the stub local, because mocking the module would
  * replace the whole of `avatar-raster` for every test file sharing the process,
  * stripping `coverCropSquare` out from under `avatar-raster.test.ts`.
  *

--- a/clients/web/src/utils/avatar-island-encode.test.ts
+++ b/clients/web/src/utils/avatar-island-encode.test.ts
@@ -2,13 +2,22 @@
  * Tests for `encodeAvatarForIsland` — fitting the assistant avatar inside
  * ActivityKit's payload ceiling.
  *
- * `rasterizeAvatar` is stubbed at the module boundary: it needs a canvas, and
- * what matters here is the ladder's decision-making, not the pixels. The stub
- * reports a byte size per (size, type) so each test can describe an avatar
- * that compresses well or badly and assert which rung it lands on.
+ * The rasterizer is injected rather than stubbed with `mock.module`: it needs a
+ * canvas, and what matters here is the ladder's decision-making, not the
+ * pixels. Injection also keeps the stub local — mocking the module would
+ * replace the whole of `avatar-raster` for every test file sharing the process,
+ * stripping `coverCropSquare` out from under `avatar-raster.test.ts`.
+ *
+ * The stub reports a byte size per (size, type) so each test can describe an
+ * avatar that compresses well or badly and assert which rung it lands on.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  encodeAvatarForIsland,
+  ISLAND_AVATAR_MAX_BYTES,
+} from "@/utils/avatar-island-encode";
 
 /** Recorded rasterize attempts, in order, so the ladder's walk is assertable. */
 let attempts: Array<{ size: number; type: string; quality?: number }> = [];
@@ -17,25 +26,24 @@ let byteSizes: Record<string, number> = {};
 /** When set, the stub throws instead of returning, as an undrawable source does. */
 let throwOnDraw = false;
 
-mock.module("@/utils/avatar-raster", () => ({
-  rasterizeAvatar: async (
-    _src: string,
-    size: number,
-    type: string,
-    quality?: number,
-  ) => {
-    attempts.push({ size, type, quality });
-    if (throwOnDraw) {
-      throw new Error("source failed to load");
-    }
-    const bytes = byteSizes[`${size}:${type}`];
-    return bytes === undefined ? null : new Uint8Array(bytes);
-  },
-}));
+/** Stands in for the canvas rasterizer, recording each attempt. */
+const rasterize = async (
+  _src: string,
+  size: number,
+  type: string,
+  quality?: number,
+): Promise<Uint8Array | null> => {
+  attempts.push({ size, type, quality });
+  if (throwOnDraw) {
+    throw new Error("source failed to load");
+  }
+  const bytes = byteSizes[`${size}:${type}`];
+  return bytes === undefined ? null : new Uint8Array(bytes);
+};
 
-const { encodeAvatarForIsland, ISLAND_AVATAR_MAX_BYTES } = await import(
-  "@/utils/avatar-island-encode"
-);
+/** `encodeAvatarForIsland` with the stub wired in at its default budget. */
+const encode = (render: Parameters<typeof encodeAvatarForIsland>[0]) =>
+  encodeAvatarForIsland(render, ISLAND_AVATAR_MAX_BYTES, rasterize as never);
 
 const CHARACTER = {
   kind: "character" as const,
@@ -52,7 +60,7 @@ beforeEach(() => {
 
 describe("encodeAvatarForIsland", () => {
   test("returns null for an assistant with no avatar, without rasterizing", async () => {
-    expect(await encodeAvatarForIsland({ kind: "none" })).toBeNull();
+    expect(await encode({ kind: "none" })).toBeNull();
     expect(attempts).toHaveLength(0);
   });
 
@@ -61,7 +69,7 @@ describe("encodeAvatarForIsland", () => {
   test("takes the largest PNG when it already fits", async () => {
     byteSizes["128:image/png"] = 900;
 
-    expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
+    expect(await encode(CHARACTER)).not.toBeNull();
     expect(attempts).toEqual([{ size: 128, type: "image/png", quality: undefined }]);
   });
 
@@ -74,7 +82,7 @@ describe("encodeAvatarForIsland", () => {
     byteSizes["48:image/png"] = 2419;
     byteSizes["40:image/png"] = 1997;
 
-    expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
+    expect(await encode(CHARACTER)).not.toBeNull();
     expect(attempts.map((a) => a.size)).toEqual([128, 96, 64, 48, 40]);
   });
 
@@ -86,7 +94,7 @@ describe("encodeAvatarForIsland", () => {
     }
     byteSizes["64:image/jpeg"] = 1400;
 
-    expect(await encodeAvatarForIsland(IMAGE)).not.toBeNull();
+    expect(await encode(IMAGE)).not.toBeNull();
     expect(attempts.at(-1)).toEqual({
       size: 64,
       type: "image/jpeg",
@@ -104,7 +112,7 @@ describe("encodeAvatarForIsland", () => {
     byteSizes["48:image/png"] = 1900;
     byteSizes["64:image/jpeg"] = 400;
 
-    expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
+    expect(await encode(CHARACTER)).not.toBeNull();
     expect(attempts.at(-1)).toEqual({
       size: 48,
       type: "image/png",
@@ -121,14 +129,14 @@ describe("encodeAvatarForIsland", () => {
     byteSizes["64:image/jpeg"] = 99000;
     byteSizes["48:image/jpeg"] = 99000;
 
-    expect(await encodeAvatarForIsland(IMAGE)).toBeNull();
+    expect(await encode(IMAGE)).toBeNull();
     expect(attempts).toHaveLength(8);
   });
 
   test("accepts a payload exactly on the ceiling", async () => {
     byteSizes["128:image/png"] = ISLAND_AVATAR_MAX_BYTES;
 
-    expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
+    expect(await encode(CHARACTER)).not.toBeNull();
   });
 
   // An undrawable source fails identically at every size, so retrying the
@@ -136,7 +144,7 @@ describe("encodeAvatarForIsland", () => {
   test("gives up immediately when the source will not draw", async () => {
     throwOnDraw = true;
 
-    expect(await encodeAvatarForIsland(IMAGE)).toBeNull();
+    expect(await encode(IMAGE)).toBeNull();
     expect(attempts).toHaveLength(1);
   });
 

--- a/clients/web/src/utils/avatar-island-encode.test.ts
+++ b/clients/web/src/utils/avatar-island-encode.test.ts
@@ -65,44 +65,64 @@ describe("encodeAvatarForIsland", () => {
     expect(attempts).toEqual([{ size: 128, type: "image/png", quality: undefined }]);
   });
 
+  // The measured shape for the default character avatar: 128px PNG is 6860
+  // bytes, 96px 5010, 64px 3366, 48px 2419, and only 40px fits at 1997.
   test("steps down until a rung fits", async () => {
-    byteSizes["128:image/png"] = 9000;
-    byteSizes["96:image/png"] = 4000;
-    byteSizes["64:image/png"] = 1200;
+    byteSizes["128:image/png"] = 6860;
+    byteSizes["96:image/png"] = 5010;
+    byteSizes["64:image/png"] = 3366;
+    byteSizes["48:image/png"] = 2419;
+    byteSizes["40:image/png"] = 1997;
 
     expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
-    expect(attempts.map((a) => a.size)).toEqual([128, 96, 64]);
+    expect(attempts.map((a) => a.size)).toEqual([128, 96, 64, 48, 40]);
   });
 
-  // The photographic case: PNG never fits, so it has to reach the JPEG rungs.
+  // The photographic case: PNG never fits at any size, so it has to reach the
+  // JPEG rungs even though those lose the avatar's transparency.
   test("falls through to JPEG for a source PNG cannot fit", async () => {
-    byteSizes["128:image/png"] = 40000;
-    byteSizes["96:image/png"] = 22000;
-    byteSizes["64:image/png"] = 9000;
-    byteSizes["96:image/jpeg"] = 1400;
+    for (const size of [128, 96, 64, 48, 40, 32]) {
+      byteSizes[`${size}:image/png`] = 40000;
+    }
+    byteSizes["64:image/jpeg"] = 1400;
 
     expect(await encodeAvatarForIsland(IMAGE)).not.toBeNull();
     expect(attempts.at(-1)).toEqual({
-      size: 96,
+      size: 64,
       type: "image/jpeg",
-      quality: 0.75,
+      quality: 0.7,
+    });
+  });
+
+  // JPEG is matted onto white, which reads as a white disc against the black
+  // Dynamic Island, so a PNG that fits must always win even when a JPEG rung
+  // would be smaller.
+  test("prefers a PNG that fits over a smaller JPEG", async () => {
+    byteSizes["128:image/png"] = 40000;
+    byteSizes["96:image/png"] = 40000;
+    byteSizes["64:image/png"] = 40000;
+    byteSizes["48:image/png"] = 1900;
+    byteSizes["64:image/jpeg"] = 400;
+
+    expect(await encodeAvatarForIsland(CHARACTER)).not.toBeNull();
+    expect(attempts.at(-1)).toEqual({
+      size: 48,
+      type: "image/png",
+      quality: undefined,
     });
   });
 
   // Going over the ceiling is not a worse avatar, it is no Live Activity at
   // all, so nothing is better than something too big.
   test("returns null when no rung fits rather than sending an oversize payload", async () => {
-    byteSizes = {
-      "128:image/png": 99000,
-      "96:image/png": 99000,
-      "64:image/png": 99000,
-      "96:image/jpeg": 99000,
-      "64:image/jpeg": 99000,
-      "48:image/jpeg": 99000,
-    };
+    for (const size of [128, 96, 64, 48, 40, 32]) {
+      byteSizes[`${size}:image/png`] = 99000;
+    }
+    byteSizes["64:image/jpeg"] = 99000;
+    byteSizes["48:image/jpeg"] = 99000;
 
     expect(await encodeAvatarForIsland(IMAGE)).toBeNull();
-    expect(attempts).toHaveLength(6);
+    expect(attempts).toHaveLength(8);
   });
 
   test("accepts a payload exactly on the ceiling", async () => {
@@ -120,7 +140,11 @@ describe("encodeAvatarForIsland", () => {
     expect(attempts).toHaveLength(1);
   });
 
-  test("stays under ActivityKit's documented 4KB attribute ceiling", () => {
-    expect(ISLAND_AVATAR_MAX_BYTES).toBeLessThan(4096);
+  // 3366 bytes threw `attributesTooLarge` on a simulator and produced no Live
+  // Activity at all; 1997 rendered. The ceiling is nowhere near the documented
+  // 4KB, so this pins the measured value rather than the documented one.
+  test("stays under the measured ActivityKit ceiling, not the documented one", () => {
+    expect(ISLAND_AVATAR_MAX_BYTES).toBeLessThan(3366);
+    expect(ISLAND_AVATAR_MAX_BYTES).toBeGreaterThanOrEqual(1997);
   });
 });

--- a/clients/web/src/utils/avatar-island-encode.ts
+++ b/clients/web/src/utils/avatar-island-encode.ts
@@ -1,0 +1,115 @@
+/**
+ * Encoding the assistant avatar small enough to travel inside an iOS Live
+ * Activity's `ActivityAttributes`.
+ *
+ * ## Why bytes, and why so few
+ *
+ * A Live Activity view renders from a snapshot in the widget extension's
+ * process. There is no async image loading there — `AsyncImage` only ever
+ * draws its placeholder — so an avatar cannot be handed over as a URL for the
+ * extension to fetch. It has to arrive already decoded, which means the bytes
+ * travel with the activity.
+ *
+ * ActivityKit caps how much can travel: `Activity.request` throws
+ * `ActivityAuthorizationError.attributesTooLarge`, and Apple documents the
+ * ceiling as 4KB for the attributes and content state *combined*.
+ * {@link ISLAND_AVATAR_MAX_BYTES} therefore claims well under half of that,
+ * leaving the assistant name, phase label, accent hex and mute flag room to
+ * grow without the avatar being what pushes the activity over.
+ *
+ * Going over is not a degraded avatar, it is **no Live Activity at all** — the
+ * request throws and the island never appears. That asymmetry is why
+ * {@link encodeAvatarForIsland} returns null rather than its smallest attempt
+ * when nothing fits: an island with a waveform glyph is fine, and an island
+ * that failed to start is not.
+ *
+ * ## Why a ladder rather than one size
+ *
+ * The two avatar kinds compress nothing alike. A character avatar is a handful
+ * of flat colors and shrinks to almost nothing as PNG, so it can afford real
+ * resolution. A photographic upload does not, and needs JPEG and a smaller
+ * square to fit at all. Rather than pick a lowest common denominator that
+ * makes character avatars needlessly soft, try candidates from best to worst
+ * and take the first that fits.
+ */
+
+import { rasterizeAvatar } from "@/utils/avatar-raster";
+import type { AvatarRender } from "@/utils/avatar-render";
+
+/**
+ * Byte ceiling for the encoded avatar.
+ *
+ * Apple documents ActivityKit's limit as 4KB across attributes plus content
+ * state. This claims 1.5KB of that, which leaves well over half for everything
+ * else and absorbs the overhead of however ActivityKit archives the payload —
+ * a detail that is not contractual, so the headroom is deliberate rather than
+ * calculated.
+ */
+export const ISLAND_AVATAR_MAX_BYTES = 1536;
+
+/**
+ * Encoding attempts, best first. Character avatars are expected to land on the
+ * first or second; photographic uploads fall through to the JPEG rungs.
+ */
+const CANDIDATES: ReadonlyArray<{
+  size: number;
+  type: "image/png" | "image/jpeg";
+  quality?: number;
+}> = [
+  { size: 128, type: "image/png" },
+  { size: 96, type: "image/png" },
+  { size: 64, type: "image/png" },
+  { size: 96, type: "image/jpeg", quality: 0.75 },
+  { size: 64, type: "image/jpeg", quality: 0.7 },
+  { size: 48, type: "image/jpeg", quality: 0.6 },
+];
+
+/** Base64 for bytes, without a data-URI prefix — the bridge carries the payload raw. */
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Rasterize `render` as small as it needs to be to fit `maxBytes`, returning
+ * base64 or null.
+ *
+ * Null means "show the accent glyph instead", and is the right answer for a
+ * `none` avatar, a source that fails to draw, and an avatar that will not fit
+ * at any rung. Every caller must treat it as ordinary rather than as an error:
+ * the Live Activity is a flourish, and none of these cases should cost the
+ * user their island.
+ */
+export async function encodeAvatarForIsland(
+  render: AvatarRender,
+  maxBytes: number = ISLAND_AVATAR_MAX_BYTES,
+): Promise<string | null> {
+  if (render.kind === "none") {
+    return null;
+  }
+  const src = render.kind === "character" ? render.dataUri : render.url;
+
+  for (const candidate of CANDIDATES) {
+    let bytes: Uint8Array | null;
+    try {
+      bytes = await rasterizeAvatar(
+        src,
+        candidate.size,
+        candidate.type,
+        candidate.quality,
+      );
+    } catch {
+      // The source itself will not draw (a revoked blob URL, a cross-origin
+      // upload). No later rung can fix that, so stop rather than retry it
+      // five more times.
+      return null;
+    }
+    if (bytes && bytes.byteLength <= maxBytes) {
+      return toBase64(bytes);
+    }
+  }
+  return null;
+}

--- a/clients/web/src/utils/avatar-island-encode.ts
+++ b/clients/web/src/utils/avatar-island-encode.ts
@@ -5,8 +5,8 @@
  * ## Why bytes, and why so few
  *
  * A Live Activity view renders from a snapshot in the widget extension's
- * process. There is no async image loading there — `AsyncImage` only ever
- * draws its placeholder — so an avatar cannot be handed over as a URL for the
+ * process. There is no async image loading there (`AsyncImage` only ever
+ * draws its placeholder), so an avatar cannot be handed over as a URL for the
  * extension to fetch. It has to arrive already decoded, which means the bytes
  * travel with the activity.
  *
@@ -17,7 +17,7 @@
  * assistant name, phase label, accent hex and mute flag room to grow without
  * the avatar being what pushes the activity over.
  *
- * Going over is not a degraded avatar, it is **no Live Activity at all** — the
+ * Going over is not a degraded avatar, it is **no Live Activity at all**: the
  * request throws and the island never appears. That asymmetry is why
  * {@link encodeAvatarForIsland} returns null rather than its smallest attempt
  * when nothing fits: an island with a waveform glyph is fine, and an island
@@ -81,7 +81,7 @@ const CANDIDATES: ReadonlyArray<{
   { size: 48, type: "image/jpeg", quality: 0.6 },
 ];
 
-/** Base64 for bytes, without a data-URI prefix — the bridge carries the payload raw. */
+/** Base64 for bytes, without a data-URI prefix: the bridge carries the payload raw. */
 function toBase64(bytes: Uint8Array): string {
   let binary = "";
   for (const byte of bytes) {

--- a/clients/web/src/utils/avatar-island-encode.ts
+++ b/clients/web/src/utils/avatar-island-encode.ts
@@ -11,11 +11,11 @@
  * travel with the activity.
  *
  * ActivityKit caps how much can travel: `Activity.request` throws
- * `ActivityAuthorizationError.attributesTooLarge`, and Apple documents the
- * ceiling as 4KB for the attributes and content state *combined*.
- * {@link ISLAND_AVATAR_MAX_BYTES} therefore claims well under half of that,
- * leaving the assistant name, phase label, accent hex and mute flag room to
- * grow without the avatar being what pushes the activity over.
+ * `ActivityAuthorizationError.attributesTooLarge` past a ceiling that is much
+ * lower in practice than the 4KB Apple documents. See
+ * {@link ISLAND_AVATAR_MAX_BYTES} for what was actually measured, and leave the
+ * assistant name, phase label, accent hex and mute flag room to grow without
+ * the avatar being what pushes the activity over.
  *
  * Going over is not a degraded avatar, it is **no Live Activity at all** — the
  * request throws and the island never appears. That asymmetry is why
@@ -25,12 +25,10 @@
  *
  * ## Why a ladder rather than one size
  *
- * The two avatar kinds compress nothing alike. A character avatar is a handful
- * of flat colors and shrinks to almost nothing as PNG, so it can afford real
- * resolution. A photographic upload does not, and needs JPEG and a smaller
- * square to fit at all. Rather than pick a lowest common denominator that
- * makes character avatars needlessly soft, try candidates from best to worst
- * and take the first that fits.
+ * The two avatar kinds compress nothing alike, and neither compresses as well
+ * as it looks like it should. Rather than pick a lowest common denominator,
+ * try candidates from best to worst and take the first that fits. See
+ * {@link CANDIDATES} for the measured sizes the ladder is built around.
  */
 
 import { rasterizeAvatar } from "@/utils/avatar-raster";
@@ -39,17 +37,34 @@ import type { AvatarRender } from "@/utils/avatar-render";
 /**
  * Byte ceiling for the encoded avatar.
  *
- * Apple documents ActivityKit's limit as 4KB across attributes plus content
- * state. This claims 1.5KB of that, which leaves well over half for everything
- * else and absorbs the overhead of however ActivityKit archives the payload —
- * a detail that is not contractual, so the headroom is deliberate rather than
- * calculated.
+ * **Measured, not derived.** Apple documents ActivityKit's limit as 4KB across
+ * attributes plus content state, but that is not the number that works: on an
+ * iPhone 17 Pro simulator (iOS 26.5), a 3366-byte avatar threw
+ * `attributesTooLarge` and produced no Live Activity at all, while 1997 bytes
+ * rendered. The effective ceiling is therefore somewhere between the two, well
+ * under what the documentation implies, presumably because ActivityKit's own
+ * archiving counts against the same budget.
+ *
+ * 2000 is the value that was verified end to end. Re-measure before raising
+ * it, on a device or simulator, by watching whether the island appears at all:
+ * there is no error to observe, because the whole activity is what fails.
  */
-export const ISLAND_AVATAR_MAX_BYTES = 1536;
+export const ISLAND_AVATAR_MAX_BYTES = 2000;
 
 /**
- * Encoding attempts, best first. Character avatars are expected to land on the
- * first or second; photographic uploads fall through to the JPEG rungs.
+ * Encoding attempts, best first.
+ *
+ * Sizes step down further than seems necessary because the avatar compresses
+ * far worse than a flat-color character suggests: measured for the default
+ * character avatar, 128px PNG is 6860 bytes, 96px is 5010, 64px is 3366, 48px
+ * is 2419, and only 40px lands under budget at 1997. The anti-aliased edges of
+ * the composited shapes, not the number of colors, are what cost.
+ *
+ * PNG rungs come first and go all the way down because they keep the avatar's
+ * transparency. JPEG is smaller per pixel but has no alpha, so
+ * {@link rasterizeAvatar} mattes it onto white, which reads as a white disc
+ * against the black Dynamic Island. It is a real fallback for photographic
+ * uploads, which PNG cannot fit at any useful size, but never a first choice.
  */
 const CANDIDATES: ReadonlyArray<{
   size: number;
@@ -59,7 +74,9 @@ const CANDIDATES: ReadonlyArray<{
   { size: 128, type: "image/png" },
   { size: 96, type: "image/png" },
   { size: 64, type: "image/png" },
-  { size: 96, type: "image/jpeg", quality: 0.75 },
+  { size: 48, type: "image/png" },
+  { size: 40, type: "image/png" },
+  { size: 32, type: "image/png" },
   { size: 64, type: "image/jpeg", quality: 0.7 },
   { size: 48, type: "image/jpeg", quality: 0.6 },
 ];

--- a/clients/web/src/utils/avatar-island-encode.ts
+++ b/clients/web/src/utils/avatar-island-encode.ts
@@ -103,6 +103,10 @@ function toBase64(bytes: Uint8Array): string {
 export async function encodeAvatarForIsland(
   render: AvatarRender,
   maxBytes: number = ISLAND_AVATAR_MAX_BYTES,
+  // Injected rather than mocked at the module boundary: `mock.module` replaces
+  // the whole of `avatar-raster`, which silently strips `coverCropSquare` from
+  // every test file that shares the process.
+  rasterize: typeof rasterizeAvatar = rasterizeAvatar,
 ): Promise<string | null> {
   if (render.kind === "none") {
     return null;
@@ -112,7 +116,7 @@ export async function encodeAvatarForIsland(
   for (const candidate of CANDIDATES) {
     let bytes: Uint8Array | null;
     try {
-      bytes = await rasterizeAvatar(
+      bytes = await rasterize(
         src,
         candidate.size,
         candidate.type,

--- a/clients/web/src/utils/avatar-raster.test.ts
+++ b/clients/web/src/utils/avatar-raster.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { coverCropSquare } from "@/hooks/use-electron-icon-sync";
+import { coverCropSquare } from "@/utils/avatar-raster";
 
-// Locks `object-cover` parity for the Dock/menu-bar icons: a non-square avatar
+// Locks `object-cover` parity for every rasterized avatar surface
+// (Dock/menu-bar icons, the iOS Live Activity): a non-square avatar
 // must be center-cropped to a square (not stretched), matching the in-app
 // `ChatAvatar`. Regressed when the rasterizer used a 4-arg `drawImage` that
 // stretched the source to fill the square canvas.

--- a/clients/web/src/utils/avatar-raster.ts
+++ b/clients/web/src/utils/avatar-raster.ts
@@ -14,7 +14,7 @@
  */
 
 /**
- * The largest centered square of a `srcW`×`srcH` source — the source rect for
+ * The largest centered square of a `srcW`×`srcH` source, the source rect for
  * an `object-cover` draw, matching the in-app `ChatAvatar` so non-square
  * uploads render identically on the icon surfaces instead of being stretched.
  * Returns null for a degenerate (zero-dimension) source so the caller draws

--- a/clients/web/src/utils/avatar-raster.ts
+++ b/clients/web/src/utils/avatar-raster.ts
@@ -1,0 +1,112 @@
+/**
+ * Rasterizing the assistant avatar to pixels, for the surfaces that cannot
+ * consume the trait-composited SVG directly.
+ *
+ * Two consumers, for different reasons. The Electron Dock/Tray icons need PNG
+ * because `nativeImage` decodes only PNG/JPEG. The iOS Live Activity needs
+ * bytes because a widget renders from a snapshot: there is no async image
+ * loading in a Live Activity view, so an avatar has to arrive already decoded
+ * rather than as a URL the extension could fetch.
+ *
+ * Source precedence (character SVG, then custom image, then none) is not
+ * decided here. It comes from `resolveAvatarRender`, so every avatar surface
+ * agrees on which avatar it is drawing.
+ */
+
+/**
+ * The largest centered square of a `srcW`×`srcH` source — the source rect for
+ * an `object-cover` draw, matching the in-app `ChatAvatar` so non-square
+ * uploads render identically on the icon surfaces instead of being stretched.
+ * Returns null for a degenerate (zero-dimension) source so the caller draws
+ * nothing rather than throwing.
+ */
+export function coverCropSquare(
+  srcW: number,
+  srcH: number,
+): { sx: number; sy: number; side: number } | null {
+  if (srcW <= 0 || srcH <= 0) {
+    return null;
+  }
+  const side = Math.min(srcW, srcH);
+  return { sx: (srcW - side) / 2, sy: (srcH - side) / 2, side };
+}
+
+/**
+ * Draw `src` (an SVG data URI or a renderer-owned blob URL) onto an offscreen
+ * canvas at `size`×`size` and return the encoded bytes. Returns null if the
+ * image can't be drawn so the caller can fall back.
+ *
+ * Non-square sources are center-cropped to a square before scaling (see
+ * {@link coverCropSquare}) so a portrait or logo renders identically instead
+ * of being stretched to fill the square canvas.
+ *
+ * `type`/`quality` are passed through to `canvas.toBlob`. PNG keeps the
+ * transparency a character avatar is composited with; JPEG is smaller for
+ * photographic uploads but flattens alpha, so it is only worth reaching for
+ * under a byte budget.
+ */
+export async function rasterizeAvatar(
+  src: string,
+  size: number,
+  type: "image/png" | "image/jpeg" = "image/png",
+  quality?: number,
+): Promise<Uint8Array | null> {
+  const image = new Image();
+  image.decoding = "async";
+  const loaded = new Promise<void>((resolve, reject) => {
+    image.onload = () => {
+      resolve();
+    };
+    image.onerror = () => {
+      reject(new Error("avatar image failed to load"));
+    };
+  });
+  image.src = src;
+  await loaded;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return null;
+  }
+  ctx.clearRect(0, 0, size, size);
+
+  // JPEG has no alpha, so an un-backed transparent avatar would flatten to
+  // black. White matches the light-surface treatment the avatar is designed
+  // against, and only applies on the JPEG fallback path.
+  if (type === "image/jpeg") {
+    ctx.fillStyle = "#FFFFFF";
+    ctx.fillRect(0, 0, size, size);
+  }
+
+  // `naturalWidth/Height` is the decoded pixel size (SVG sources fall back to
+  // `width/height`, which equal `size` here). Scale the centered square crop
+  // to fill the canvas, preserving aspect ratio.
+  const crop = coverCropSquare(
+    image.naturalWidth || image.width,
+    image.naturalHeight || image.height,
+  );
+  if (crop) {
+    ctx.drawImage(
+      image,
+      crop.sx,
+      crop.sy,
+      crop.side,
+      crop.side,
+      0,
+      0,
+      size,
+      size,
+    );
+  }
+
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob(resolve, type, quality);
+  });
+  if (!blob) {
+    return null;
+  }
+  return new Uint8Array(await blob.arrayBuffer());
+}


### PR DESCRIPTION
Closes JARVIS-1373.

Renders the assistant's avatar in the Dynamic Island and on the Lock Screen instead of an accent-tinted waveform glyph. Verified on an iPhone 17 Pro simulator (iOS 26.5) on both surfaces.

## No App Group needed

`NATIVE_VOICE.md` framed this as requiring a shared container: an App Group capability on all six App IDs, six regenerated provisioning profiles, entitlements files, and an avatar-caching path. That is only true for sharing a *file*.

`ActivityAttributes` is `Codable`, so the avatar travels as `Data` and renders through `Image(uiImage:)`. No entitlement, no portal work. What is genuinely impossible is fetching a URL at render time, since a Live Activity renders from a snapshot and `AsyncImage` only ever draws its placeholder.

It rides in `ActivityAttributes`, not `ContentState`: attributes are fixed at request time and sent once, while content is re-sent on every phase change against a rate-limited update budget that `use-live-activity-mirror.ts` already works to stay inside.

## The budget is measured, not documented

The first attempt rendered nothing, and both reasons were estimates that turned out wrong.

**The ceiling.** Apple documents 4KB across attributes plus content state, so the budget was set to 1536 as a conservative fraction. The real ceiling is far lower:

| Payload | Result |
| --- | --- |
| 3366 bytes | `attributesTooLarge`, **no Live Activity at all** |
| 1997 bytes | renders |

Presumably ActivityKit's own archiving counts against the same budget. `ISLAND_AVATAR_MAX_BYTES` is now 2000, the value verified end to end, and the comment says to re-measure rather than re-derive. Note the failure mode: oversize does not degrade the avatar, it kills the whole activity, and there is no error to observe.

**The sizes.** A flat-color character avatar was assumed to compress to almost nothing. Measured, for the default avatar:

| Rung | Bytes |
| --- | --- |
| 128 PNG | 6860 |
| 96 PNG | 5010 |
| 64 PNG | 3366 |
| 48 PNG | 2419 |
| 40 PNG | **1997** |

Anti-aliased edges, not color count, are what cost. Every original rung was over budget, so the encoder returned null and the island fell back to its glyph.

## Rendering

PNG rungs come first and step down to 32px before reaching for JPEG, because JPEG has no alpha and is matted onto white, which reads as a white disc against the black island. A PNG that fits wins even when a JPEG rung is smaller; pinned in a test.

The avatar is drawn with `scaledToFit` and **no** circular mask or border. A character avatar is a shaped creature whose silhouette runs to the edges of its square, so a circle cut the edges off and a ring framed empty space. The tradeoff is a custom uploaded avatar, which is square and would look tidier masked; telling them apart needs the avatar kind sent across the bridge, and the shaped creature is the common case.

## Shared, not duplicated

The rasterizer the Electron Dock/Tray icons already used moves to `utils/avatar-raster.ts` so both surfaces share one implementation, and source precedence still comes from `resolveAvatarRender` so no avatar surface can drift onto a different avatar than the one on screen.

## Verification

52 tests pass, including the four files run together. `encodeAvatarForIsland` takes the rasterizer as a parameter rather than being stubbed with `mock.module`, which replaced the whole of `avatar-raster` for every file sharing the process and stripped `coverCropSquare` out from under `avatar-raster.test.ts` — each file passed alone, the four together did not.

Swift builds clean. Rebased onto main after #39568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)