### PR TITLE
feat(plugin-api): expose read-only contact lookup

### DIFF
--- a/assistant/src/plugin-api/__tests__/contacts.test.ts
+++ b/assistant/src/plugin-api/__tests__/contacts.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the plugin-facing contact lookup.
+ *
+ * The store and the gateway reader are mocked at module level so these stay
+ * about the contract a gating caller depends on: what `null` means, and what an
+ * unreachable gateway looks like.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type ChannelState = { status: string; verifiedAt: number | null } | undefined;
+
+let storeResult: unknown = null;
+let gatewayResult: ChannelState;
+let lastStoreQuery: unknown = null;
+
+mock.module("../../contacts/contact-store.js", () => ({
+  findContactChannel: mock((params: unknown) => {
+    lastStoreQuery = params;
+    return storeResult;
+  }),
+}));
+
+mock.module("../../contacts/gateway-channel-read.js", () => ({
+  gatewayContactChannelState: mock(async () => gatewayResult),
+}));
+
+const { findContactByChannelAddress } = await import("../contacts.js");
+
+function match(overrides: Record<string, unknown> = {}) {
+  return {
+    contact: { id: "contact_1", displayName: "Dana" },
+    channel: {
+      contactId: "contact_1",
+      type: "phone",
+      address: "+15551234567",
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  storeResult = null;
+  gatewayResult = undefined;
+  lastStoreQuery = null;
+});
+
+describe("findContactByChannelAddress", () => {
+  test("returns null when no contact holds the address", async () => {
+    // The load-bearing case for a gate: null is "not a known contact", never
+    // "unknown, allow".
+    expect(
+      await findContactByChannelAddress("phone", "+15559990000"),
+    ).toBeNull();
+  });
+
+  test("passes the channel type and address through to the store", async () => {
+    await findContactByChannelAddress("phone", "+15551234567");
+    expect(lastStoreQuery).toEqual({
+      channelType: "phone",
+      address: "+15551234567",
+    });
+  });
+
+  test("returns the contact with its gateway status", async () => {
+    storeResult = match();
+    gatewayResult = { status: "active", verifiedAt: 1_700_000_000_000 };
+
+    const result = await findContactByChannelAddress("phone", "+15551234567");
+
+    expect(result).toEqual({
+      contactId: "contact_1",
+      displayName: "Dana",
+      channelType: "phone",
+      address: "+15551234567",
+      status: "active",
+      verifiedAt: 1_700_000_000_000,
+    });
+  });
+
+  test("reports the stored address, which may be canonicalized", async () => {
+    // The store canonicalizes on lookup, so a caller that keys on the address
+    // should key on what came back rather than what it asked for.
+    storeResult = match();
+
+    const result = await findContactByChannelAddress("phone", "5551234567");
+
+    expect(result?.address).toBe("+15551234567");
+  });
+
+  test("an unreachable gateway leaves status undefined rather than defaulting", async () => {
+    // The reader this wraps fails open for display callers. Defaulting to
+    // "active" here would silently turn every gate built on it into a hole.
+    storeResult = match();
+    gatewayResult = undefined;
+
+    const result = await findContactByChannelAddress("phone", "+15551234567");
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBeUndefined();
+    expect(result?.verifiedAt).toBeUndefined();
+  });
+
+  test("surfaces a non-active status verbatim", async () => {
+    storeResult = match();
+    gatewayResult = { status: "blocked", verifiedAt: null };
+
+    const result = await findContactByChannelAddress("phone", "+15551234567");
+
+    expect(result?.status).toBe("blocked");
+  });
+});

--- a/assistant/src/plugin-api/contacts.ts
+++ b/assistant/src/plugin-api/contacts.ts
@@ -1,0 +1,86 @@
+/**
+ * Plugin-facing contact lookup.
+ *
+ * A plugin that owns an inbound channel needs to answer one question before it
+ * lets a message reach the agent loop: **is this sender someone the user
+ * knows?** {@link findContactByChannelAddress} answers exactly that and nothing
+ * more. It is deliberately read-only — plugins do not create, modify, or delete
+ * contacts, because a channel that could mint its own contacts could admit its
+ * own senders.
+ *
+ * ## This is a lookup, not an admission decision
+ *
+ * The canonical admission path is the gateway's: trust classification against
+ * `actorExternalId`, then the per-channel admission floor. A plugin that
+ * forwards inbound through the host's channel pipeline gets that for free and
+ * should not re-derive it here.
+ *
+ * This exists for the narrower case of a plugin that must gate a sender itself.
+ * Two things follow, and getting either wrong turns the gate into a hole:
+ *
+ * - **A `null` result means "not a known contact", not "unknown, allow".**
+ * - **An absent `status` means the gateway could not be reached.** The ACL is
+ *   gateway-owned, so an unreachable read is unknown standing, not good
+ *   standing. A gate must treat `undefined` the same as `blocked`. The
+ *   host-internal reader this wraps fails *open* for its own callers, which are
+ *   display paths where a missing badge is better than an error; a gate has the
+ *   opposite requirement, and the difference is why the field is optional here
+ *   rather than defaulted.
+ */
+
+import { findContactChannel } from "../contacts/contact-store.js";
+import { gatewayContactChannelState } from "../contacts/gateway-channel-read.js";
+
+/** A contact channel matching an inbound address. */
+export interface PluginContactMatch {
+  contactId: string;
+  displayName: string;
+  /** Channel type the match was found under. */
+  channelType: string;
+  /** Address as stored, which may be canonicalized from the query. */
+  address: string;
+  /**
+   * Gateway-owned channel status — `active`, `pending`, `unverified`,
+   * `revoked`, or `blocked`.
+   *
+   * `undefined` when the gateway could not be reached or holds no row for this
+   * channel. Callers gating admission must treat that as untrusted; see the
+   * module docs.
+   */
+  status: string | undefined;
+  /** Epoch ms the channel was verified, when the gateway reports one. */
+  verifiedAt: number | null | undefined;
+}
+
+/**
+ * Find the contact reachable at `address` on `channelType`.
+ *
+ * `channelType` is the contact-channel vocabulary (`phone`, `email`, `slack`,
+ * …), which is not the same set as the gateway's `ChannelId`. A channel whose
+ * identity is a phone number can look up under `phone` and match a contact the
+ * user already has, without minting a channel type of its own.
+ *
+ * Returns `null` when no contact holds that address.
+ */
+export async function findContactByChannelAddress(
+  channelType: string,
+  address: string,
+): Promise<PluginContactMatch | null> {
+  const match = findContactChannel({ channelType, address });
+  if (!match) return null;
+
+  const state = await gatewayContactChannelState({
+    contactId: match.channel.contactId,
+    type: match.channel.type,
+    address: match.channel.address,
+  });
+
+  return {
+    contactId: match.contact.id,
+    displayName: match.contact.displayName,
+    channelType: match.channel.type,
+    address: match.channel.address,
+    status: state?.status,
+    verifiedAt: state?.verifiedAt,
+  };
+}

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -173,6 +173,14 @@ export {
   CredentialResolutionError,
   resolveCredential,
 } from "./resolve-credential.js";
+// Read-only contact lookup, for a plugin that owns an inbound channel and must
+// decide whether a sender is someone the user knows before letting the message
+// reach the agent loop. Deliberately read-only: a channel that could mint its
+// own contacts could admit its own senders. A `null` result means "not a known
+// contact", and an absent `status` means the gateway was unreachable — a gate
+// must treat both as untrusted rather than as permission. See the module docs.
+export type { PluginContactMatch } from "./contacts.js";
+export { findContactByChannelAddress } from "./contacts.js";
 // Resolve a provider for a call site (optionally overriding the profile) so a
 // plugin can run inference through the workspace's configured profiles and
 // credentials — managed-proxy or BYOK — without supplying its own API key.


### PR DESCRIPTION
## Prompt / plan

The iMessage plugin needs to decide whether an inbound text may reach the agent loop. The right answer is the user's existing contact graph, not a second allowlist the plugin maintains — one place to add and remove people, no drift. Plugins had no way to ask, so this exposes the read side of the contact graph through `@vellumai/plugin-api`.

Consumed by `vellum-ai/imessage#7`, where it gates inbound admission.

## What this adds

`findContactByChannelAddress(channelType, address)` → `PluginContactMatch | null`, in `assistant/src/plugin-api/contacts.ts`. Read-only: it resolves a channel address to the owning contact and that channel's ACL status. No mutation, no enumeration, no way to list the contact graph.

Two properties of the return value are load-bearing for any caller using this as a gate, and both are documented on the function:

- **`null` means "not a known contact"** — not "lookup failed".
- **An absent `status` means the gateway was unreachable.** The underlying reader deliberately fails *open* for display callers (a contact card should still render when the ACL read times out), which is the opposite of what a gate needs. `status: undefined` is surfaced rather than defaulted so a caller gating on it can treat unknown standing as not-good standing. The iMessage plugin refuses on it.

## Test plan

`assistant/src/plugin-api/__tests__/contacts.test.ts` — 6 tests, passing. Covers: no match returns null, a match returns the contact and channel fields, status passes through, an unreachable gateway surfaces `undefined` rather than a default, and the channel type/address round-trip.

Mocks `../../contacts/contact-store.js` and `../../contacts/gateway-channel-read.js` at the module level.

---
_Generated by [Claude Code](https://claude.ai/code/session_015nCPQbJHQq5J2Vbu4k4W9C)_