### PR TITLE
feat(contacts): defaultValue pre-fill for contact prompts + visible disabled Save button

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6126,6 +6126,9 @@ paths:
                 placeholder:
                   description: Placeholder text for the address input field.
                   type: string
+                defaultValue:
+                  description: Suggested address to pre-fill the input with (e.g. a known email). The user can edit it before submitting.
+                  type: string
                 label:
                   description: Display label shown in the prompt UI.
                   type: string

--- a/assistant/src/api/events/contact-request.ts
+++ b/assistant/src/api/events/contact-request.ts
@@ -25,6 +25,7 @@ export const ContactRequestEventSchema = z.object({
   requestId: z.string(),
   channel: z.string().optional(),
   placeholder: z.string().optional(),
+  defaultValue: z.string().optional(),
   label: z.string().optional(),
   description: z.string().optional(),
   role: z.string().optional(),

--- a/assistant/src/cli/commands/contacts.help.ts
+++ b/assistant/src/cli/commands/contacts.help.ts
@@ -97,6 +97,11 @@ Examples:
           description: "Placeholder text for the address input field",
         },
         {
+          flags: "--default-value <address>",
+          description:
+            "Suggested address to pre-fill the input with (user can edit before submitting)",
+        },
+        {
           flags: "--role <role>",
           description:
             "Intended role: guardian, trusted-contact, or unknown (default: unknown)",

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -257,6 +257,7 @@ export function registerContactsCommand(program: Command): void {
           opts: {
             channel?: string;
             placeholder?: string;
+            defaultValue?: string;
             role?: string;
             label?: string;
             description?: string;
@@ -271,6 +272,7 @@ export function registerContactsCommand(program: Command): void {
               body: {
                 channel: opts.channel,
                 placeholder: opts.placeholder,
+                defaultValue: opts.defaultValue,
                 role: opts.role ?? "unknown",
                 label: opts.label,
                 description: opts.description,

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -104,6 +104,12 @@ const ContactPromptParams = z.object({
     .string()
     .optional()
     .describe("Placeholder text for the address input field."),
+  defaultValue: z
+    .string()
+    .optional()
+    .describe(
+      "Suggested address to pre-fill the input with (e.g. a known email). The user can edit it before submitting.",
+    ),
   label: z
     .string()
     .optional()
@@ -125,7 +131,7 @@ const ContactPromptParams = z.object({
 async function handleContactPrompt({
   body = {},
 }: RouteHandlerArgs): Promise<ContactPromptResult> {
-  const { channel, placeholder, label, description, role } =
+  const { channel, placeholder, defaultValue, label, description, role } =
     ContactPromptParams.parse(body);
 
   const requestId = uuid();
@@ -144,6 +150,7 @@ async function handleContactPrompt({
       requestId,
       channel,
       placeholder,
+      defaultValue,
       label,
       description,
       role,

--- a/clients/web/src/domains/chat/components/contact-prompt-card.test.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { ContactPromptCard } from "@/domains/chat/components/contact-prompt-card";
 
-// No jest-dom matchers registered in test-setup.ts — assert against raw DOM
+// No jest-dom matchers registered in test-setup.ts, so assert against raw DOM
 // properties instead of toHaveValue()/toBeDisabled().
 
 function noop() {}

--- a/clients/web/src/domains/chat/components/contact-prompt-card.test.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.test.tsx
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { ContactPromptCard } from "@/domains/chat/components/contact-prompt-card";
+
+// No jest-dom matchers registered in test-setup.ts — assert against raw DOM
+// properties instead of toHaveValue()/toBeDisabled().
+
+function noop() {}
+
+const baseProps = {
+  isSubmitting: false,
+  accepted: false,
+  onSubmit: noop,
+  onCancel: noop,
+};
+
+function addressInput(): HTMLInputElement {
+  return screen.getByRole("textbox") as HTMLInputElement;
+}
+
+function saveButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+}
+
+describe("ContactPromptCard defaultValue", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("pre-fills the input with defaultValue and enables Save", () => {
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        contactRequest={{
+          requestId: "req-1",
+          channel: "email",
+          defaultValue: "user@example.com",
+          placeholder: "Enter email address",
+        }}
+      />,
+    );
+
+    expect(addressInput().value).toBe("user@example.com");
+    expect(saveButton().disabled).toBe(false);
+  });
+
+  test("leaves the input empty and Save disabled when only a placeholder is provided", () => {
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        contactRequest={{
+          requestId: "req-2",
+          channel: "email",
+          placeholder: "Enter email address",
+        }}
+      />,
+    );
+
+    expect(addressInput().value).toBe("");
+    expect(addressInput().placeholder).toBe("Enter email address");
+    expect(saveButton().disabled).toBe(true);
+  });
+
+  test("submits the pre-filled defaultValue as-is", () => {
+    const onSubmit = mock(() => {});
+
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        onSubmit={onSubmit}
+        contactRequest={{
+          requestId: "req-3",
+          channel: "sms",
+          defaultValue: "555-0100",
+        }}
+      />,
+    );
+
+    fireEvent.click(saveButton());
+
+    expect(onSubmit).toHaveBeenCalledWith("555-0100", "sms");
+  });
+
+  test("submits the edited address, not the original defaultValue", () => {
+    const onSubmit = mock(() => {});
+
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        onSubmit={onSubmit}
+        contactRequest={{
+          requestId: "req-4",
+          channel: "email",
+          defaultValue: "user@example.com",
+        }}
+      />,
+    );
+
+    fireEvent.change(addressInput(), {
+      target: { value: "edited@example.com" },
+    });
+    fireEvent.click(saveButton());
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("edited@example.com", "email");
+  });
+
+  test("keying by requestId resets the address when a new request arrives", () => {
+    // Mirrors PendingContactRequestRow, which keys the card by requestId so a
+    // replacement contact_request remounts it instead of keeping stale state.
+    const { rerender } = render(
+      <ContactPromptCard
+        key="req-5"
+        {...baseProps}
+        contactRequest={{
+          requestId: "req-5",
+          channel: "email",
+          defaultValue: "first@example.com",
+        }}
+      />,
+    );
+
+    fireEvent.change(addressInput(), {
+      target: { value: "typed@example.com" },
+    });
+
+    rerender(
+      <ContactPromptCard
+        key="req-6"
+        {...baseProps}
+        contactRequest={{
+          requestId: "req-6",
+          channel: "email",
+          defaultValue: "second@example.com",
+        }}
+      />,
+    );
+
+    expect(addressInput().value).toBe("second@example.com");
+  });
+});

--- a/clients/web/src/domains/chat/components/contact-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.tsx
@@ -1,13 +1,14 @@
 import { CheckCircle, Loader2, X } from "lucide-react";
 import { type FormEvent, useState } from "react";
 
-import { Card, Input, Typography } from "@vellumai/design-library";
+import { Button, Card, Input, Typography } from "@vellumai/design-library";
 
 export interface ContactPromptCardProps {
   contactRequest: {
     requestId: string;
     channel?: string;
     placeholder?: string;
+    defaultValue?: string;
     label?: string;
     description?: string;
     role?: string;
@@ -25,7 +26,9 @@ export function ContactPromptCard({
   onSubmit,
   onCancel,
 }: ContactPromptCardProps) {
-  const [address, setAddress] = useState("");
+  // Render sites must key this card by `requestId` so a new contact_request
+  // remounts it and re-runs this initializer instead of keeping stale state.
+  const [address, setAddress] = useState(contactRequest.defaultValue ?? "");
   const canSubmit = address.trim().length > 0 && !isSubmitting && !accepted;
 
   // Derive a sensible channelType from the hint (free text → normalised key).
@@ -91,32 +94,24 @@ export function ContactPromptCard({
             autoFocus
           />
           <div className="flex justify-end gap-2">
-            <button
+            <Button
               type="button"
+              variant="ghost"
               onClick={onCancel}
               disabled={isSubmitting}
-              // typography: off-scale — inline form button, not prose
-
-              className="rounded px-3 py-1.5 text-sm text-[var(--content-secondary)] hover:bg-[var(--surface-secondary)]"
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               type="submit"
+              variant="primary"
               disabled={!canSubmit}
-              // typography: off-scale — inline form button, not prose
-
-              className="flex items-center gap-1.5 rounded bg-[var(--color-accent)] px-3 py-1.5 text-sm text-white disabled:opacity-50"
+              leftIcon={
+                isSubmitting ? <Loader2 className="animate-spin" /> : undefined
+              }
             >
-              {isSubmitting ? (
-                <>
-                  <Loader2 size={14} className="animate-spin" />
-                  Saving…
-                </>
-              ) : (
-                "Save"
-              )}
-            </button>
+              {isSubmitting ? "Saving…" : "Save"}
+            </Button>
           </div>
         </form>
       )}

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -101,6 +101,7 @@ export function useTranscriptData({
               requestId: pendingContactRequest.requestId,
               channel: pendingContactRequest.channel,
               placeholder: pendingContactRequest.placeholder,
+              defaultValue: pendingContactRequest.defaultValue,
               label: pendingContactRequest.label,
               description: pendingContactRequest.description,
               role: pendingContactRequest.role,

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -21,6 +21,7 @@ export interface BuildTranscriptItemsInput {
     requestId: string;
     channel?: string;
     placeholder?: string;
+    defaultValue?: string;
     label?: string;
     description?: string;
     role?: string;
@@ -170,6 +171,7 @@ export function buildTranscriptItems(
       requestId: pendingContactRequest.requestId,
       channel: pendingContactRequest.channel,
       placeholder: pendingContactRequest.placeholder,
+      defaultValue: pendingContactRequest.defaultValue,
       label: pendingContactRequest.label,
       description: pendingContactRequest.description,
       role: pendingContactRequest.role,

--- a/clients/web/src/domains/chat/transcript/pending-contact-request-row.tsx
+++ b/clients/web/src/domains/chat/transcript/pending-contact-request-row.tsx
@@ -21,6 +21,8 @@ export function PendingContactRequestRow() {
 
   return (
     <ContactPromptCard
+      // Remount per request so a replacement prompt starts with fresh state.
+      key={pendingContactRequest.requestId}
       contactRequest={pendingContactRequest}
       isSubmitting={isSubmitting}
       accepted={accepted}

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -62,6 +62,7 @@ export interface PendingContactRequestItem extends TranscriptItemBase {
   /** Channel type hint from the daemon (e.g. "phone", "email"). */
   channel?: string;
   placeholder?: string;
+  defaultValue?: string;
   label?: string;
   description?: string;
   role?: string;

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
@@ -119,6 +119,7 @@ export function handleContactRequest(
     requestId: event.requestId,
     channel: event.channel,
     placeholder: event.placeholder,
+    defaultValue: event.defaultValue,
     label: event.label,
     description: event.description,
     role: event.role,

--- a/clients/web/src/types/interaction-ui-types.ts
+++ b/clients/web/src/types/interaction-ui-types.ts
@@ -58,6 +58,7 @@ export interface PendingContactRequestState {
   requestId: string;
   channel?: string;
   placeholder?: string;
+  defaultValue?: string;
   label?: string;
   description?: string;
   role?: string;


### PR DESCRIPTION
## Summary
- Adds an optional `defaultValue` field through the full contact-prompt chain — CLI `--default-value` flag → `contacts/prompt` route → `contact_request` event → web types → `ContactPromptCard` — so callers can suggest an address that pre-fills the input (user-editable before submit). `placeholder` stays hint-text only, and `assistant/openapi.yaml` is regenerated for the new request-body property.
- Replaces `ContactPromptCard`'s raw `<button>`s with design-library `Button` (matching `SecretPromptCard`) so the disabled Save state is visibly distinct on mobile instead of `disabled:opacity-50` on an accent background.
- Keys the card by `requestId` at its render site so a replacement `contact_request` remounts it with fresh state (no stale address under a new request id), and adds component tests covering pre-fill, placeholder-only, edited submit, and remount-reset.

## Notes
- Backwards compat: the web only *reads* the new optional wire field with a natural fallback (empty input, today's behavior), so no version gate is needed per `clients/web/docs/BACKWARDS_COMPAT.md` read-fallback rules.
- Replaces #39544, which reused `placeholder` as a submit value (P2), left `defaultValue` unbound in the route handler (P1), and skipped the OpenAPI regen (P2). This implements the same goal from scratch with those addressed.

## Original prompt
The user asked to close PR #39544 (a bot-authored fix for the contact prompt card where the suggested address only showed as placeholder text and the disabled Save button was nearly invisible on mobile) and implement its original goal from scratch. The goal: pre-fill the contact prompt input with a suggested address via a proper `defaultValue` field rather than misusing `placeholder`, and make the Save button's disabled state clearly visible by using the design-library `Button` component.