### PR TITLE
fix(web): take the voice-room eyes off React state, name the rest of the commit traffic (LUM-2927)

### DIFF
--- a/clients/web/src/domains/chat/components/composer-peek.tsx
+++ b/clients/web/src/domains/chat/components/composer-peek.tsx
@@ -25,6 +25,7 @@ import { createPortal } from "react-dom";
 import { motion, useReducedMotion } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { recordUpdate } from "@/lib/commit-pressure";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { avatarPeekMetrics } from "@/utils/avatar-peek-metrics";
@@ -159,26 +160,29 @@ export function ComposerPeek({
     // The composer moves and resizes under the peeks without firing any
     // event we could subscribe to — the centered empty-state group reflows
     // as the greeting streams in, the textarea autogrows, slots settle.
-    // Track its rect every frame; the updater bails (same state object)
-    // when nothing changed, so idle frames don't re-render.
+    // Track its rect every frame, scheduling an update only on a frame where
+    // the rect actually moved. An unconditional per-frame `setRect` still
+    // enters the commit stream whenever the fiber already has pending lanes
+    // (React's eager bailout only applies to an idle fiber), which is exactly
+    // the traffic that trips the nested-update limit. See
+    // docs/CONVENTIONS.md, "Keep decorative animation out of the commit
+    // stream".
     let raf = 0;
+    let last: TargetRect | null = null;
     const track = () => {
-      setRect((prev) => {
-        const next = measure();
-        if (!next) {
-          return prev;
-        }
-        if (
-          prev &&
-          next.left === prev.left &&
-          next.top === prev.top &&
-          next.width === prev.width &&
-          next.height === prev.height
-        ) {
-          return prev;
-        }
-        return next;
-      });
+      const next = measure();
+      if (
+        next &&
+        (last === null ||
+          next.left !== last.left ||
+          next.top !== last.top ||
+          next.width !== last.width ||
+          next.height !== last.height)
+      ) {
+        last = next;
+        recordUpdate("composer-peek");
+        setRect(next);
+      }
       raf = requestAnimationFrame(track);
     };
     raf = requestAnimationFrame(track);

--- a/clients/web/src/domains/chat/voice/use-audio-amplitude.ts
+++ b/clients/web/src/domains/chat/voice/use-audio-amplitude.ts
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 
+import { recordUpdate } from "@/lib/commit-pressure";
 import { getVoiceInputMediaStream } from "@/utils/voice-input-device";
 
 /**
  * Real-time microphone amplitude via Web Audio API.
  *
  * When `active` is true, pipes audio through an `AnalyserNode` and reads RMS
- * amplitude at ~33 Hz (every `requestAnimationFrame`). The raw RMS is
+ * amplitude on every `requestAnimationFrame`, so at the display refresh rate
+ * (60Hz, or 120Hz on a high-refresh display). The raw RMS is
  * exponentially smoothed (0.5/0.5 EMA) and scaled to 0-1 via
  * `min(smoothed * 14.0, 1.0)`, matching the macOS
  * `AudioEngineController` algorithm.
@@ -78,6 +80,7 @@ export function useAudioAmplitude({
         const scaled = Math.min(smoothed * 14.0, 1.0);
         if (scaled !== lastSetRef.current) {
           lastSetRef.current = scaled;
+          recordUpdate("audio-amplitude");
           setAmplitude(scaled);
         }
 

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -61,6 +61,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { recordUpdate } from "@/lib/commit-pressure";
 
 /**
  * Ceiling on cursor advancement, in words per second of played audio.
@@ -186,6 +187,7 @@ export function useSpokenWordCursor(wordCount: number): number | null {
       }
       if (next !== cursorRef.current) {
         cursorRef.current = next;
+        recordUpdate("spoken-word-cursor");
         setIndex(next);
       }
       raf = requestAnimationFrame(tick);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.test.tsx
@@ -8,9 +8,9 @@
  * rendered transforms without producing a React render, and every blink
  * reopens.
  *
- * Regression coverage for the error-185 family (LUM-2927): a per-frame or
- * per-pointer-event updater here is what walked React's nested-update counter
- * to its limit, and the throw that followed stranded the lids shut.
+ * Both assertions carry more weight than render cost. A `setState` on either
+ * path counts toward React's nested-update limit, and a throw from the blink
+ * timer would strand the lids shut for the life of the room. See LUM-2927.
  */
 
 import { useEffect } from "react";
@@ -51,7 +51,7 @@ afterEach(() => {
   cleanup();
 });
 
-describe("VoiceRoomEyes — parallax stays out of the commit stream", () => {
+describe("VoiceRoomEyes: parallax stays out of the commit stream", () => {
   test("pointer movement moves the eyes without a React render", () => {
     let renders = 0;
     const { parallax } = renderEyes(() => {
@@ -90,7 +90,7 @@ describe("VoiceRoomEyes — parallax stays out of the commit stream", () => {
   });
 });
 
-describe("VoiceRoomEyes — blink stays out of the commit stream", () => {
+describe("VoiceRoomEyes: blink stays out of the commit stream", () => {
   test("a click blinks the lids shut and reopens them, with no React render", async () => {
     let renders = 0;
     const { lids, parallax } = renderEyes(() => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for `VoiceRoomEyes`.
+ *
+ * The blink and the cursor parallax are decorative, so they drive the DOM
+ * through refs instead of React state (see `docs/CONVENTIONS.md`, "Keep
+ * decorative animation out of the commit stream"). These tests pin that
+ * property down from the outside: pointer movement and blink ticks change the
+ * rendered transforms without producing a React render, and every blink
+ * reopens.
+ *
+ * Regression coverage for the error-185 family (LUM-2927): a per-frame or
+ * per-pointer-event updater here is what walked React's nested-update counter
+ * to its limit, and the throw that followed stranded the lids shut.
+ */
+
+import { useEffect } from "react";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+
+import {
+  VoiceRoomEyes,
+  type VoiceRoomEyeArt,
+} from "@/domains/chat/voice/voice-room/voice-room-eyes";
+
+const ART: VoiceRoomEyeArt = {
+  paths: [{ svgPath: "M0 0 H10 V10 H0 Z", color: "#000000" }],
+  bbox: { x: 0, y: 0, w: 10, h: 10 },
+};
+
+const VIEWPORT = { w: 1000, h: 800 };
+
+function renderEyes(onRender?: () => void) {
+  function Probe() {
+    useEffect(() => {
+      onRender?.();
+    });
+    return <VoiceRoomEyes art={ART} viewport={VIEWPORT} />;
+  }
+  const utils = render(<Probe />);
+  const root = utils.getByTestId("voice-room-eyes");
+  // The lid group carries the blink transform; the parallax layer carries the
+  // cursor offset.
+  const lids = root.querySelector("g") as SVGGElement;
+  const parallax = root.querySelector("svg")?.parentElement as HTMLElement;
+  return { ...utils, lids, parallax };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("VoiceRoomEyes — parallax stays out of the commit stream", () => {
+  test("pointer movement moves the eyes without a React render", () => {
+    let renders = 0;
+    const { parallax } = renderEyes(() => {
+      renders += 1;
+    });
+    const before = renders;
+
+    act(() => {
+      fireEvent.mouseMove(window, { clientX: 1000, clientY: 800 });
+    });
+
+    expect(parallax.style.transform).not.toBe("translate(0px, 0px)");
+    expect(renders).toBe(before);
+  });
+
+  test("the offset tracks the pointer's position in the window", () => {
+    const { parallax } = renderEyes();
+
+    // Dead center maps to a zero offset.
+    act(() => {
+      fireEvent.mouseMove(window, {
+        clientX: window.innerWidth / 2,
+        clientY: window.innerHeight / 2,
+      });
+    });
+    expect(parallax.style.transform).toBe("translate(0px, 0px)");
+
+    // The far corner maps to the full excursion (CURSOR_MAX_X/Y).
+    act(() => {
+      fireEvent.mouseMove(window, {
+        clientX: window.innerWidth,
+        clientY: window.innerHeight,
+      });
+    });
+    expect(parallax.style.transform).toBe("translate(4px, 3px)");
+  });
+});
+
+describe("VoiceRoomEyes — blink stays out of the commit stream", () => {
+  test("a click blinks the lids shut and reopens them, with no React render", async () => {
+    let renders = 0;
+    const { lids, parallax } = renderEyes(() => {
+      renders += 1;
+    });
+    const before = renders;
+
+    act(() => {
+      fireEvent.click(parallax);
+    });
+    expect(lids.style.transform).toBe("scaleY(0.1)");
+    expect(renders).toBe(before);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    expect(lids.style.transform).toBe("scaleY(1)");
+    expect(renders).toBe(before);
+  });
+
+  test("rapid clicks still reopen the lids", async () => {
+    const { lids, parallax } = renderEyes();
+
+    // Each click supersedes the pending reopen, so the last one has to win:
+    // dropping a reopen is what leaves the eyes squinting for the session.
+    act(() => {
+      fireEvent.click(parallax);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60));
+    });
+    act(() => {
+      fireEvent.click(parallax);
+    });
+    expect(lids.style.transform).toBe("scaleY(0.1)");
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    expect(lids.style.transform).toBe("scaleY(1)");
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -833,16 +833,25 @@ export function VoiceRoomEyes({
   const { w, h } = viewport;
   const playEntrance = !reduce;
 
-  const [pointer, setPointer] = useState({ x: 0, y: 0 });
+  // The parallax offset and the blink are decorative, so both drive the DOM
+  // through a ref rather than React state: a pointer-rate or frame-rate
+  // updater in the commit stream is what walks React's nested-update counter
+  // to its limit. See docs/CONVENTIONS.md, "Keep decorative animation out of
+  // the commit stream". The rendered values below stay constant so a re-render
+  // never clobbers the imperative write.
+  const parallaxRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (reduce) {
       return;
     }
     const onMove = (e: MouseEvent) => {
-      setPointer({
-        x: (e.clientX / window.innerWidth - 0.5) * 2,
-        y: (e.clientY / window.innerHeight - 0.5) * 2,
-      });
+      const node = parallaxRef.current;
+      if (!node) {
+        return;
+      }
+      const x = (e.clientX / window.innerWidth - 0.5) * 2;
+      const y = (e.clientY / window.innerHeight - 0.5) * 2;
+      node.style.transform = `translate(${x * CURSOR_MAX_X}px, ${y * CURSOR_MAX_Y}px)`;
     };
     window.addEventListener("mousemove", onMove);
     return () => window.removeEventListener("mousemove", onMove);
@@ -850,7 +859,14 @@ export function VoiceRoomEyes({
 
   // Two settle blinks once the entrance lands, then a slow random idle blink —
   // onboarding's entrance blink choreography.
-  const [blinking, setBlinking] = useState(false);
+  const eyelidsRef = useRef<SVGGElement | null>(null);
+  const setBlink = useCallback((closed: boolean) => {
+    const node = eyelidsRef.current;
+    if (node) {
+      node.style.transform = closed ? "scaleY(0.1)" : "scaleY(1)";
+    }
+  }, []);
+
   const [entranceDone, setEntranceDone] = useState(!playEntrance);
   useEffect(() => {
     if (reduce || !entranceDone) {
@@ -862,12 +878,12 @@ export function VoiceRoomEyes({
       if (cancelled) {
         return;
       }
-      setBlinking(true);
+      setBlink(true);
       t = setTimeout(() => {
         if (cancelled) {
           return;
         }
-        setBlinking(false);
+        setBlink(false);
         t = setTimeout(next, 140);
       }, 140);
     };
@@ -875,18 +891,21 @@ export function VoiceRoomEyes({
       t = setTimeout(() => blink(idle), 2500 + Math.random() * 4000);
     };
     blink(() => blink(idle));
+    // Leaving the lids open on teardown keeps a torn-down or re-armed loop
+    // from stranding the eyes mid-blink.
     return () => {
       cancelled = true;
       clearTimeout(t);
+      setBlink(false);
     };
-  }, [reduce, entranceDone]);
+  }, [reduce, entranceDone, setBlink]);
 
   // Poke-the-eyes delight: clicking the eyes fires a single blink and a quick
-  // springy wobble that settles back. The blink drives the same `blinking`
-  // state the idle loop uses (its own timeout is tracked so rapid clicks don't
-  // leak), and the wobble rides a dedicated controls-driven layer so it can't
-  // fight the entrance keyframes or the per-state scale tween. Reduced motion
-  // keeps the discrete blink and skips the wobble.
+  // springy wobble that settles back. The blink goes through the same
+  // `setBlink` the idle loop uses (its own timeout is tracked so rapid clicks
+  // don't leak), and the wobble rides a dedicated controls-driven layer so it
+  // can't fight the entrance keyframes or the per-state scale tween. Reduced
+  // motion keeps the discrete blink and skips the wobble.
   const wobble = useAnimationControls();
   const manualBlinkTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(
@@ -898,11 +917,11 @@ export function VoiceRoomEyes({
     [],
   );
   const reactToClick = useCallback(() => {
-    setBlinking(true);
+    setBlink(true);
     if (manualBlinkTimeout.current) {
       clearTimeout(manualBlinkTimeout.current);
     }
-    manualBlinkTimeout.current = setTimeout(() => setBlinking(false), 140);
+    manualBlinkTimeout.current = setTimeout(() => setBlink(false), 140);
     if (reduce) {
       return;
     }
@@ -912,7 +931,7 @@ export function VoiceRoomEyes({
       rotate: [0, -2.5, 1.5, 0],
       transition: { duration: 0.5, ease: "easeOut" },
     });
-  }, [reduce, wobble]);
+  }, [reduce, wobble, setBlink]);
 
   const originX = entranceOrigin?.x ?? w / 2;
   const originY = entranceOrigin?.y ?? (ENTER_FROM_CENTER_VH / 100) * h;
@@ -1029,8 +1048,9 @@ export function VoiceRoomEyes({
                 cursor — a few px only, so they stay visually centered on the
                 room's spine (see CURSOR_MAX_X / CURSOR_MAX_Y). */}
             <div
+              ref={parallaxRef}
               style={{
-                transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
+                transform: "translate(0px, 0px)",
                 transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
               }}
             >
@@ -1041,8 +1061,9 @@ export function VoiceRoomEyes({
                 style={{ overflow: "visible", display: "block" }}
               >
                 <g
+                  ref={eyelidsRef}
                   style={{
-                    transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
+                    transform: "scaleY(1)",
                     transformOrigin: `${cx}px ${cy}px`,
                     transition: "transform 0.14s ease-in-out",
                   }}

--- a/clients/web/src/lib/commit-pressure.ts
+++ b/clients/web/src/lib/commit-pressure.ts
@@ -48,8 +48,10 @@ const MAX_SOURCES = 24;
  * instrumented, and `query:*` keys are minted from live query ids.
  */
 export type UpdateSource =
-  | "avatar-morph"
+  | "audio-amplitude"
+  | "composer-peek"
   | "smooth-stream"
+  | "spoken-word-cursor"
   | "transcript-scroll"
   | "viewport-min-height"
   | (string & {});


### PR DESCRIPTION
## TL;DR

`Maximum update depth exceeded` (React error 185) has been filed 24 separate times in `vellum-assistant-web` over the last 55 days, each blaming a different frame. It is not a render loop. It is sustained frame-rate update traffic walking React's nested-update counter to its limit, and the reported frame is whichever `setState` ran next.

This PR removes the voice room's contribution to that traffic and closes the instrumentation gap that stopped the existing probe from naming the cause.

Part of LUM-2927. Investigated from LUM-2922 / [VELLUM-ASSISTANT-WEB-7F](https://vellum.sentry.io/issues/7642307317/).

## The evidence

`lib/commit-pressure.ts` captured usable data for the first time. Two events, same session, same `trace_id`, 26 seconds apart, blaming different frames:

| | 7F (LUM-2922) | 7E |
| --- | --- | --- |
| blamed frame | `voice-room-eyes` blink timer | `use-spoken-word-cursor` rAF |
| commits / window | 85 / 1568ms (54/s) | 57 / 1311ms (43/s) |
| maxBackToBackCommits | 16 | **1** |
| updates | 0 | 0 |
| sources | {} | {} |

`maxBackToBackCommits: 1` means no two commits were within 8ms of each other, so there is no synchronous loop. React increments its counter on every commit that finishes with an ordinary update already queued, and about one second of uninterrupted per-frame traffic reaches 51 and throws.

`updates: 0` with 57 to 85 chat-route commits is the other half of the finding: none of the traffic was coming from an instrumented source, so the enrichment built specifically to make these actionable could not name anything.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Moving the mouse over the voice room | Re-renders the eyes on every pointer event | Eyes drift, no re-render |
| Eyes blinking | Two React state updates per blink | No React state updates |
| Eyes after an error-185 throw lands on the blink timer | Stay squashed shut (`scaleY(0.1)`) until the room is reopened | Cannot happen: no state to strand |
| Composer peek tracking the composer | Schedules a React update every frame while armed | Schedules only on a frame where the rect moved |
| The next error-185 Sentry event | `sources: {}` | Names the updaters that were actually running |

No visual change. The parallax and blink look and time exactly as before.

## Why it is safe

- The blink and parallax were already pure visual output. Nothing read `blinking` or `pointer` other than the two `transform` strings they produced, so moving them to a ref cannot change behavior anywhere else.
- The rendered `transform` values are now constants, which is the condition the convention calls out: React only patches attributes whose props changed, so a re-render cannot clobber the imperative write. `transformOrigin` still comes from props and still updates normally.
- The idle blink loop reopens the lids on teardown, so a re-armed loop cannot leave them shut.
- `composer-peek` keeps the same comparison it always did, just hoisted out of the state updater. The previous version relied on React's eager bailout, which only applies to a fiber with no pending lanes, so it stopped bailing under exactly the load that matters.
- New test file covers all of it: pointer movement and blinks produce no React render, the offset maths is unchanged, and rapid clicks still reopen.

Typecheck clean, lint clean (0 errors), 119 tests pass across the affected files.

## Deliberately deferred

Tracked on LUM-2927, not done here to keep this reviewable:

- **`useAudioAmplitude` is the biggest remaining violator** and is worth doing next. It calls `setAmplitude` every rAF frame, and `global-push-to-talk-bridge` and `chat-composer` then mirror that value into a Zustand store from an effect, so it is two commits per frame while recording. Its consumers want a value to draw with, not to render with, so the `getAmplitude` getter pattern already used by `voice-listening-waves` and `voice-avatar` is the target shape. Left alone here because the store mirror feeds the Electron dictation overlay and needs its own transport decision. Instrumented in this PR so the next event proves or clears it.
- **`use-spoken-word-cursor`** stays on React state. Its updates are word-rate rather than frame-rate and the index genuinely drives rendered output, so it is not obviously misplaced. Instrumented rather than changed.
- **Sentry fingerprinting.** These 24 issues should be grouped, otherwise every new bystander frame keeps minting a new Linear ticket.

## Note

`avatar-morph` is dropped from the `UpdateSource` union. It has had no call site since LUM-2859 moved that animation to imperative writes; the union is documentation of what is instrumented, and it was naming something that is not.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->