### PR TITLE
feat(web): create a group by right-clicking the conversation list

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -492,11 +492,17 @@ export function ChatLayout({
   // The move-to-group menu's "New group…" item and the group actions menu's
   // "Rename" open the shared NameInputDialog through the request store; the
   // GroupNameDialogFromStore connector (mounted below) performs the
-  // create-then-move / rename on submit. "New group…" is the only
-  // group-creation entry point — there is no standalone create button.
+  // create-then-move / rename on submit. Two entry points reach it: a
+  // conversation's "New group…" (creates the group, then files that
+  // conversation into it) and the sidebar's own right-click "New group…"
+  // (creates an empty one).
   const handleRequestCreateGroup = useCallback(
     (conversation: Conversation) =>
       useGroupNameRequestStore.getState().requestCreateGroup(conversation),
+    [],
+  );
+  const handleRequestCreateEmptyGroup = useCallback(
+    () => useGroupNameRequestStore.getState().requestCreateGroup(),
     [],
   );
   const handleRequestRenameGroup = useCallback(
@@ -798,6 +804,7 @@ export function ChatLayout({
       onUnarchiveConversation={handleUnarchiveConversation}
       onMarkConversationUnread={handleMarkConversationUnread}
       onMarkConversationRead={handleMarkConversationRead}
+      onCreateGroup={handleRequestCreateEmptyGroup}
       onRenameGroup={handleRequestRenameGroup}
       onDeleteGroup={handleDeleteGroup}
       onMarkAllReadInGroup={handleMarkAllReadInGroup}

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -64,6 +64,9 @@ export const ConversationSections: Story = {
     activeConversationId: "r1",
     onSelectConversation: () => {},
     onStartNewConversation: () => {},
+    // Wires the list's right-click "New group…" — omitting it drops the
+    // affordance entirely, so the story has to pass it to show the menu.
+    onCreateGroup: () => {},
     // Wiring the bulk handlers is what puts the header menu on every
     // section — Pinned and Chats included.
     onMarkAllReadInGroup: () => {},

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -64,7 +64,7 @@ export const ConversationSections: Story = {
     activeConversationId: "r1",
     onSelectConversation: () => {},
     onStartNewConversation: () => {},
-    // Wires the list's right-click "New group…" — omitting it drops the
+    // Wires the list's right-click "New group…" - omitting it drops the
     // affordance entirely, so the story has to pass it to show the menu.
     onCreateGroup: () => {},
     // Wiring the bulk handlers is what puts the header menu on every

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -82,7 +82,7 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onMarkConversationUnread?: (conversation: Conversation) => void;
   onMarkConversationRead?: (conversation: Conversation) => void;
   /**
-   * Create a new, empty custom group — the sidebar's own "New group…", as
+   * Create a new, empty custom group - the sidebar's own "New group…", as
    * opposed to {@link AssistantSideMenuProps.onCreateGroupInto}, which creates
    * a group around an existing conversation. Omit to drop the affordance.
    */

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -21,6 +21,7 @@ import {
   type ConversationListContextValue,
 } from "@/domains/chat/components/conversation-list-context";
 import { ConversationNavSection } from "@/domains/chat/components/conversation-nav-section";
+import { SidebarListContextMenu } from "@/domains/chat/components/sidebar-list-context-menu";
 import { CollapsedGroupFlyout } from "@/domains/chat/components/conversation-rail-flyout";
 import {
   GroupActionsMenu,
@@ -80,6 +81,12 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onUnarchiveConversation?: (conversation: Conversation) => void;
   onMarkConversationUnread?: (conversation: Conversation) => void;
   onMarkConversationRead?: (conversation: Conversation) => void;
+  /**
+   * Create a new, empty custom group — the sidebar's own "New group…", as
+   * opposed to {@link AssistantSideMenuProps.onCreateGroupInto}, which creates
+   * a group around an existing conversation. Omit to drop the affordance.
+   */
+  onCreateGroup?: () => void;
   onRenameGroup?: (groupId: string) => void;
   onDeleteGroup?: (groupId: string) => void;
   onMarkAllReadInGroup?: (conversations: Conversation[]) => void;
@@ -172,6 +179,7 @@ export function AssistantSideMenu({
   onMarkConversationUnread,
   onMarkConversationRead,
   conversationGroups,
+  onCreateGroup,
   onRenameGroup,
   onDeleteGroup,
   onMarkAllReadInGroup,
@@ -528,7 +536,7 @@ export function AssistantSideMenu({
               ))}
             </div>
           ) : (
-            <>
+            <SidebarListContextMenu onCreateGroup={onCreateGroup}>
               {/* Pinned, Chats, and the channel sections share one accordion
                   root, so its gap governs every section boundary uniformly.
                   Their open state lives in two storage buckets (Pinned/Chats
@@ -627,7 +635,7 @@ export function AssistantSideMenu({
                   </CollapsibleNavSection.Root>
                 </>
               ) : null}
-            </>
+            </SidebarListContextMenu>
           )}
         </SideMenu.Body>
 

--- a/clients/web/src/domains/chat/components/sidebar-list-context-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-list-context-menu.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Tests for {@link SidebarListContextMenu} — the sidebar's own right-click
+ * menu, and the standalone group-creation entry point.
+ *
+ * The interesting property is that it layers over rows and section headers
+ * that already own context menus, so most of what's asserted here is about
+ * *not* firing when something more specific should.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+
+mock.module("@/utils/pointer", () => ({
+  isPointerCoarse: () => false,
+}));
+
+import { ContextMenu } from "@vellumai/design-library";
+
+import { SidebarListContextMenu } from "@/domains/chat/components/sidebar-list-context-menu";
+
+function rightClick(el: Element) {
+  act(() => {
+    el.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, button: 2 }),
+    );
+  });
+}
+
+describe("SidebarListContextMenu", () => {
+  test("right-clicking the list offers New group…", async () => {
+    const { container } = render(
+      createElement(SidebarListContextMenu, {
+        onCreateGroup: () => {},
+        children: createElement("div", { "data-testid": "sections" }, "sections"),
+      }),
+    );
+    try {
+      rightClick(container.querySelector('[data-testid="sections"]')!);
+
+      await waitFor(() => {
+        expect(document.querySelector('[role="menu"]')?.textContent).toContain(
+          "New group",
+        );
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("selecting New group… requests a group with no conversation", async () => {
+    let created = 0;
+    const { container } = render(
+      createElement(SidebarListContextMenu, {
+        onCreateGroup: () => (created += 1),
+        children: createElement("div", { "data-testid": "sections" }, "sections"),
+      }),
+    );
+    try {
+      rightClick(container.querySelector('[data-testid="sections"]')!);
+
+      await waitFor(() => {
+        expect(document.querySelector('[role="menuitem"]')).not.toBeNull();
+      });
+      act(() => {
+        document.querySelector<HTMLElement>('[role="menuitem"]')!.click();
+      });
+
+      await waitFor(() => expect(created).toBe(1));
+    } finally {
+      cleanup();
+    }
+  });
+
+  // The whole reason `ContextMenu.Trigger` stops propagation: a row inside the
+  // list has its own menu, and a right-click there must open that one only —
+  // not both.
+  test("a nested row menu wins; the list menu stays closed", async () => {
+    const { container } = render(
+      createElement(SidebarListContextMenu, {
+        onCreateGroup: () => {},
+        children: createElement(
+          ContextMenu.Root,
+          null,
+          createElement(
+            ContextMenu.Trigger,
+            null,
+            createElement("div", { "data-testid": "row" }, "a row"),
+          ),
+          createElement(
+            ContextMenu.Content,
+            null,
+            createElement(ContextMenu.Item, null, "Row action"),
+          ),
+        ),
+      }),
+    );
+    try {
+      rightClick(container.querySelector('[data-testid="row"]')!);
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('[role="menu"]')).toHaveLength(1);
+      });
+      expect(document.querySelector('[role="menu"]')?.textContent).toContain(
+        "Row action",
+      );
+      expect(
+        document.querySelector('[role="menu"]')?.textContent,
+      ).not.toContain("New group");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("renders children unwrapped when group creation isn't available", () => {
+    const { container } = render(
+      createElement(SidebarListContextMenu, {
+        children: createElement("div", { "data-testid": "sections" }, "sections"),
+      }),
+    );
+    try {
+      expect(
+        container.querySelector('[data-slot="sidebar-list-context-target"]'),
+      ).toBeNull();
+      expect(container.querySelector('[data-testid="sections"]')).not.toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/clients/web/src/domains/chat/components/sidebar-list-context-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-list-context-menu.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for {@link SidebarListContextMenu} — the sidebar's own right-click
+ * Tests for {@link SidebarListContextMenu} - the sidebar's own right-click
  * menu, and the standalone group-creation entry point.
  *
  * The interesting property is that it layers over rows and section headers
@@ -73,7 +73,7 @@ describe("SidebarListContextMenu", () => {
   });
 
   // The whole reason `ContextMenu.Trigger` stops propagation: a row inside the
-  // list has its own menu, and a right-click there must open that one only —
+  // list has its own menu, and a right-click there must open that one only -
   // not both.
   test("a nested row menu wins; the list menu stays closed", async () => {
     const { container } = render(

--- a/clients/web/src/domains/chat/components/sidebar-list-context-menu.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-list-context-menu.tsx
@@ -1,0 +1,69 @@
+/**
+ * Right-click menu for the sidebar's conversation list as a whole.
+ *
+ * Until now a group could only be created from a conversation's "New group…",
+ * which meant you had to already have something to file before you could make
+ * somewhere to file it. This is the standalone entry point: right-click
+ * anywhere in the list — including the empty space below the last section —
+ * and create an empty group.
+ *
+ * Two details make it safe to layer over a list whose rows and section headers
+ * already have their own context menus:
+ *
+ * - `ContextMenu.Trigger` stops `contextmenu` from propagating, so the
+ *   innermost trigger wins and a right-click on a row opens the row's menu
+ *   only. This wrapper is what that behavior exists for.
+ * - The wrapper stretches (`flex-1`) to fill the scrollport, so the empty area
+ *   under the sections is part of the target rather than dead space.
+ *
+ * Desktop-only for now: on touch, Radix arms this on long-press, the same
+ * gesture the conversation rows and section headers already use for their
+ * bottom sheets. Giving the list a competing long-press target needs its own
+ * gesture pass.
+ */
+
+import { FolderPlus } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { ContextMenu } from "@vellumai/design-library";
+
+import { isPointerCoarse } from "@/utils/pointer";
+
+export interface SidebarListContextMenuProps {
+  /** Open the "New group" dialog. Omit to render children unwrapped. */
+  onCreateGroup?: () => void;
+  children: ReactNode;
+}
+
+export function SidebarListContextMenu({
+  onCreateGroup,
+  children,
+}: SidebarListContextMenuProps) {
+  if (!onCreateGroup || isPointerCoarse()) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>
+        {/* `gap-4` restates the Body's own gap: wrapping the sections in one
+            element makes them a single flex item, so the spacing they relied
+            on has to be reproduced here. */}
+        <div
+          data-slot="sidebar-list-context-target"
+          className="flex flex-1 flex-col gap-4"
+        >
+          {children}
+        </div>
+      </ContextMenu.Trigger>
+      <ContextMenu.Content>
+        <ContextMenu.Item
+          leftIcon={<FolderPlus size={14} />}
+          onSelect={onCreateGroup}
+        >
+          New group…
+        </ContextMenu.Item>
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  );
+}

--- a/clients/web/src/domains/chat/components/sidebar-list-context-menu.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-list-context-menu.tsx
@@ -1,11 +1,10 @@
 /**
  * Right-click menu for the sidebar's conversation list as a whole.
  *
- * Until now a group could only be created from a conversation's "New group…",
- * which meant you had to already have something to file before you could make
- * somewhere to file it. This is the standalone entry point: right-click
- * anywhere in the list — including the empty space below the last section —
- * and create an empty group.
+ * The standalone way to create a group: right-click anywhere in the list,
+ * including the empty space below the last section, and make an empty one.
+ * The other entry point, a conversation's own "New group…", requires
+ * something to file first.
  *
  * Two details make it safe to layer over a list whose rows and section headers
  * already have their own context menus:

--- a/clients/web/src/domains/chat/group-name-dialog-from-store.test.tsx
+++ b/clients/web/src/domains/chat/group-name-dialog-from-store.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for {@link GroupNameDialogFromStore}.
+ *
+ * One dialog serves three requests — create-and-file, create-empty, and
+ * rename — so what matters is that each submit runs exactly the right
+ * mutations. Creating an empty group in particular must not move anything.
+ */
+
+import { describe, expect, mock, test, afterEach } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+
+mock.module("@/lib/backwards-compat/use-supports-group-icons", () => ({
+  useSupportsGroupIcons: () => false,
+}));
+
+import { GroupNameDialogFromStore } from "@/domains/chat/group-name-dialog-from-store";
+import { useGroupNameRequestStore } from "@/domains/chat/group-name-request-store";
+import type { Conversation } from "@/types/conversation-types";
+
+const GROUP = { id: "grp-new", name: "Reviews" };
+
+interface Harness {
+  created: string[];
+  moved: { conversationId: string; groupId: string }[];
+  renamed: { groupId: string; name: string }[];
+}
+
+function renderDialog(harness: Harness) {
+  return render(
+    createElement(GroupNameDialogFromStore, {
+      createGroup: async (name: string) => {
+        harness.created.push(name);
+        return GROUP as never;
+      },
+      moveToGroup: (conversation: Conversation, groupId: string) => {
+        harness.moved.push({
+          conversationId: conversation.conversationId,
+          groupId,
+        });
+      },
+      renameGroup: (groupId: string, name: string) => {
+        harness.renamed.push({ groupId, name });
+      },
+    }),
+  );
+}
+
+function makeHarness(): Harness {
+  return { created: [], moved: [], renamed: [] };
+}
+
+async function submit(name: string) {
+  const input = await waitFor(() => {
+    const el = document.querySelector<HTMLInputElement>("input");
+    if (!el) {
+      throw new Error("no input");
+    }
+    return el;
+  });
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, name);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  const submitButton = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => /create|save/i.test(b.textContent ?? ""));
+  act(() => submitButton?.click());
+}
+
+afterEach(() => {
+  cleanup();
+  useGroupNameRequestStore.getState().clearGroupNameRequest();
+});
+
+describe("GroupNameDialogFromStore", () => {
+  test("creating from the sidebar makes an empty group and moves nothing", async () => {
+    const harness = makeHarness();
+    renderDialog(harness);
+
+    act(() => {
+      // No conversation — the sidebar's own "New group…".
+      useGroupNameRequestStore.getState().requestCreateGroup();
+    });
+    await submit("Reviews");
+
+    await waitFor(() => expect(harness.created).toEqual(["Reviews"]));
+    expect(harness.moved).toEqual([]);
+    expect(harness.renamed).toEqual([]);
+  });
+
+  test("creating from a conversation still files that conversation in", async () => {
+    const harness = makeHarness();
+    renderDialog(harness);
+
+    act(() => {
+      useGroupNameRequestStore
+        .getState()
+        .requestCreateGroup({ conversationId: "c1" } as Conversation);
+    });
+    await submit("Reviews");
+
+    await waitFor(() => expect(harness.created).toEqual(["Reviews"]));
+    expect(harness.moved).toEqual([
+      { conversationId: "c1", groupId: "grp-new" },
+    ]);
+  });
+
+  test("renaming touches neither create nor move", async () => {
+    const harness = makeHarness();
+    renderDialog(harness);
+
+    act(() => {
+      useGroupNameRequestStore
+        .getState()
+        .requestRenameGroup("grp-a", "Old", null);
+    });
+    await submit("New name");
+
+    await waitFor(() =>
+      expect(harness.renamed).toEqual([
+        { groupId: "grp-a", name: "New name" },
+      ]),
+    );
+    expect(harness.created).toEqual([]);
+    expect(harness.moved).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/chat/group-name-dialog-from-store.test.tsx
+++ b/clients/web/src/domains/chat/group-name-dialog-from-store.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Tests for {@link GroupNameDialogFromStore}.
  *
- * One dialog serves three requests — create-and-file, create-empty, and
- * rename — so what matters is that each submit runs exactly the right
+ * One dialog serves three requests - create-and-file, create-empty, and
+ * rename - so what matters is that each submit runs exactly the right
  * mutations. Creating an empty group in particular must not move anything.
  */
 
@@ -83,7 +83,7 @@ describe("GroupNameDialogFromStore", () => {
     renderDialog(harness);
 
     act(() => {
-      // No conversation — the sidebar's own "New group…".
+      // No conversation - the sidebar's own "New group…".
       useGroupNameRequestStore.getState().requestCreateGroup();
     });
     await submit("Reviews");

--- a/clients/web/src/domains/chat/group-name-dialog-from-store.tsx
+++ b/clients/web/src/domains/chat/group-name-dialog-from-store.tsx
@@ -11,10 +11,11 @@ import type {
 /**
  * Store-driven group-name dialog. Reads the pending create/rename request from
  * {@link useGroupNameRequestStore} and drives one {@link NameInputDialog} for
- * both. On a "create" submit it creates the group and moves the requesting
- * conversation into it; on "rename" it renames. Extracted so the
- * create-then-move / rename wiring lives with the dialog rather than being
- * threaded through the parent orchestrator's dependency tree.
+ * both. On a "create" submit it creates the group, then moves the requesting
+ * conversation into it when the request carried one; on "rename" it renames.
+ * Extracted so the create-then-move / rename wiring lives with the dialog
+ * rather than being threaded through the parent orchestrator's dependency
+ * tree.
  *
  * The icon picker renders only when the active assistant persists group
  * icons ({@link useSupportsGroupIcons}); against an older assistant the
@@ -46,7 +47,9 @@ export function GroupNameDialogFromStore({
       clear();
       if (request.mode === "create") {
         const group = await createGroup(name, icon);
-        if (group) {
+        // No conversation means this came from the sidebar's own "New group…",
+        // which creates an empty group rather than filing something into it.
+        if (group && request.conversation) {
           moveToGroup(request.conversation, group.id);
         }
       } else {

--- a/clients/web/src/domains/chat/group-name-request-store.ts
+++ b/clients/web/src/domains/chat/group-name-request-store.ts
@@ -16,14 +16,21 @@ import { createSelectors } from "@/utils/create-selectors";
 import type { Conversation } from "@/types/conversation-types";
 
 /**
- * A pending group-name dialog. `create` carries the conversation that will be
- * moved into the newly created group; `rename` carries the target group id and
- * a snapshot of its current name and icon, captured at request time so a
- * background groups refetch can't reset the inputs mid-edit (mirrors
- * `rename-request-store`).
+ * A pending group-name dialog.
+ *
+ * `create` optionally carries a conversation to move into the new group. Two
+ * entry points share it: "New group…" on a conversation's menu (creates, then
+ * moves that conversation in) and "New group…" on the sidebar's own context
+ * menu (creates an empty group and leaves it for the user to fill). The
+ * conversation is what distinguishes them, so the dialog itself needs no mode
+ * beyond create/rename.
+ *
+ * `rename` carries the target group id and a snapshot of its current name and
+ * icon, captured at request time so a background groups refetch can't reset
+ * the inputs mid-edit (mirrors `rename-request-store`).
  */
 export type GroupNameRequest =
-  | { mode: "create"; conversation: Conversation }
+  | { mode: "create"; conversation?: Conversation }
   | {
       mode: "rename";
       groupId: string;
@@ -36,7 +43,8 @@ interface GroupNameRequestState {
 }
 
 interface GroupNameRequestActions {
-  requestCreateGroup: (conversation: Conversation) => void;
+  /** Omit `conversation` to create an empty group. */
+  requestCreateGroup: (conversation?: Conversation) => void;
   requestRenameGroup: (
     groupId: string,
     currentName: string,

--- a/packages/design-library/src/components/context-menu.tsx
+++ b/packages/design-library/src/components/context-menu.tsx
@@ -42,7 +42,7 @@ type TriggerProps = ComponentProps<typeof ContextMenuPrimitive.Trigger>;
  * Radix's own handler calls `preventDefault()` but not `stopPropagation()`, so
  * a trigger inside another trigger's subtree lets the event keep bubbling and
  * **both** menus open at once. Stopping it here makes nesting safe for every
- * consumer rather than leaving each call site to remember — a region menu (a
+ * consumer rather than leaving each call site to remember - a region menu (a
  * list, a canvas) can wrap rows that have menus of their own.
  *
  * `composeEventHandlers` runs same-element listeners regardless, so Radix

--- a/packages/design-library/src/components/context-menu.tsx
+++ b/packages/design-library/src/components/context-menu.tsx
@@ -35,11 +35,28 @@ const Root = ContextMenuPrimitive.Root;
 
 type TriggerProps = ComponentProps<typeof ContextMenuPrimitive.Trigger>;
 
-function Trigger({ asChild = true, ...props }: TriggerProps) {
+/**
+ * Nested triggers resolve innermost-first, matching what a right-click means
+ * everywhere else: the most specific thing under the pointer wins.
+ *
+ * Radix's own handler calls `preventDefault()` but not `stopPropagation()`, so
+ * a trigger inside another trigger's subtree lets the event keep bubbling and
+ * **both** menus open at once. Stopping it here makes nesting safe for every
+ * consumer rather than leaving each call site to remember — a region menu (a
+ * list, a canvas) can wrap rows that have menus of their own.
+ *
+ * `composeEventHandlers` runs same-element listeners regardless, so Radix
+ * still opens this trigger's own menu.
+ */
+function Trigger({ asChild = true, onContextMenu, ...props }: TriggerProps) {
   return (
     <ContextMenuPrimitive.Trigger
       data-slot="context-menu-trigger"
       asChild={asChild}
+      onContextMenu={(event) => {
+        onContextMenu?.(event);
+        event.stopPropagation();
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
## TL;DR

Right-click anywhere in the sidebar's conversation list - including the empty space below the last section - to create a group.

Ships ahead of [#39559](https://github.com/vellum-ai/vellum-assistant/pull/39559) (LUM-2909), which makes every section an independently orderable peer; being able to *create* a section is the missing half of that.

## What changes for you

| | Before | After |
|---|---|---|
| Creating a group | Only from a conversation's "New group…" - you needed something to file first | Right-click the conversation list and create an empty one |
| Right-click a conversation row | Row menu | Unchanged - the row's menu, alone |
| Right-click a section header | Section menu | Unchanged - the section's menu, alone |
| Touch | - | Unchanged; this is desktop-only for now (see below) |

## Design

**The dialog already existed.** `GroupNameDialogFromStore` drives one `NameInputDialog` for create and rename alike. The only change is that a create request's `conversation` becomes optional: with one, it creates then files that conversation in (today's behavior); without one, it just creates. No second dialog, no new mode.

**One design-library fix makes the layering safe.** `ContextMenu.Trigger` now stops `contextmenu` from propagating. Radix's own handler calls `preventDefault()` but not `stopPropagation()`, so a trigger nested inside another trigger's subtree opens **both** menus. Innermost-wins is what right-click means everywhere else, and fixing it in the primitive means every future region menu gets it rather than each call site remembering. There is no nesting in the app today, so this is a no-op for current usage - the new sidebar menu is its first consumer.

**The target stretches.** The wrapper is `flex-1`, so the empty area under the last section is part of the right-click target rather than dead space. That's where you'd naturally aim when the point is "make a new one".

## Why this is safe

- **No server change.** `createGroup` already exists and is unchanged; this only adds a caller that omits the move.
- **The one shared-primitive change is inert today.** No nested `ContextMenu` triggers exist in the app, so nothing currently propagates past an inner trigger.
- **Verified in Chromium, not just asserted in tests**: right-click on empty space opens `["New group…"]` alone; on a conversation row, exactly one menu with no "New group"; on a section header, exactly one menu with its bulk actions.
- 7 new tests (4 for the menu including the nesting guard, 3 for the dialog covering create-empty / create-and-file / rename), plus the existing sidebar and conversation-menu suites still passing.

## Deferred

- **Touch.** Radix arms a context menu on long-press, the same gesture conversation rows and section headers already use for their bottom sheets. Giving the list a competing long-press target needs its own gesture pass, so the affordance is gated to fine pointers.
- **Anything else in the menu.** One item today. "New chat" and friends are a separate conversation about what a list-level menu should carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
