### PR TITLE
fix(config): clamp code-defined default profile maxTokens to the resolved model's output cap

### DIFF
--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   CODE_DEFAULT_PROFILE_ENTRIES,
   getEffectiveProfile,
   getEffectiveProfiles,
+  PROFILE_IMPLS,
   resolveDefaultProfileForProvider,
 } from "../default-profile-catalog.js";
 import {
@@ -19,7 +20,6 @@ import {
   resolveDefaultProfileKey,
 } from "../llm-resolver.js";
 import {
-  DEFAULT_PROVIDER_CHOICES,
   type DefaultProviderConfig,
   type LLMCallSite,
   LLMSchema,
@@ -341,22 +341,33 @@ describe("resolveDefaultProfileForProvider", () => {
     expect(entry?.source).toBe("managed");
   });
 
-  test("every default provider choice materializes every default profile key", () => {
-    for (const provider of DEFAULT_PROVIDER_CHOICES) {
-      for (const key of DEFAULT_PROFILE_KEYS) {
-        const entry = resolveDefaultProfileForProvider(
-          undefined,
-          key,
-          dp(provider),
-        );
-        expect(entry).toBeDefined();
-        expect(typeof entry?.model).toBe("string");
-        expect(entry?.source).toBe("managed");
-        if (entry?.provider !== "vellum") {
-          expect(entry?.provider_connection).toBe(`${provider}-personal`);
-        }
-      }
-    }
+  test("maxTokens clamps to the resolved model's catalog output cap", () => {
+    // atlascloud has no intent table: every intent resolves to its catalog
+    // defaultModel, which caps output at 8192, below the balanced template's
+    // 16000.
+    const balanced = resolveDefaultProfileForProvider(
+      undefined,
+      "balanced",
+      dp("atlascloud"),
+    );
+    expect(balanced?.maxTokens).toBe(8192);
+    // minimax's defaultModel caps output at 16384, below the quality
+    // template's 32000.
+    const quality = resolveDefaultProfileForProvider(
+      undefined,
+      "quality-optimized",
+      dp("minimax"),
+    );
+    expect(quality?.maxTokens).toBe(16384);
+  });
+
+  test("maxTokens stays at the template value when the model's cap allows it", () => {
+    const entry = resolveDefaultProfileForProvider(
+      undefined,
+      "balanced",
+      dp("anthropic"),
+    );
+    expect(entry?.maxTokens).toBe(PROFILE_IMPLS.balanced.anthropic.maxTokens);
   });
 
   test("BYOK columns resolve the intent to a provider-specific model and personal connection", () => {

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -1,5 +1,8 @@
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
-import { isModelInCatalog } from "../providers/model-catalog.js";
+import {
+  catalogMaxOutputTokens,
+  isModelInCatalog,
+} from "../providers/model-catalog.js";
 import { resolveModelIntent } from "../providers/model-intents.js";
 import type { ModelIntent } from "../providers/types.js";
 import { getManagedUpstream } from "../providers/vellum-model-routing.js";
@@ -524,14 +527,35 @@ function defaultProfileBodyForProvider(
   const impl = isDefaultProfileProvider(provider)
     ? PROFILE_IMPLS[name][provider]
     : { ...BYOK_PROFILE_IMPLS[name], provider };
-  return {
+  return clampMaxTokensToModelCap({
     ...materializeProfile(
       impl,
       impl.provider,
       resolveDefaultConnectionName(defaultProvider),
     ),
     source: "managed",
-  };
+  });
+}
+
+/**
+ * Clamp a code-owned default body's `maxTokens` to the resolved model's
+ * catalog `maxOutputTokens`. The shared BYOK templates request one token
+ * budget per intent, but the model a provider resolves can allow less
+ * (e.g. atlascloud caps output at 8192 while the balanced template asks for
+ * 16000), and an over-cap request is rejected upstream. The `vellum` column
+ * is exempt by construction: "vellum" is not a catalog provider, so the
+ * lookup misses and the hand-validated managed pins pass through untouched.
+ * User-authored profiles never reach this path.
+ */
+function clampMaxTokensToModelCap(body: ProfileEntry): ProfileEntry {
+  if (body.provider == null || body.model == null || body.maxTokens == null) {
+    return body;
+  }
+  const cap = catalogMaxOutputTokens(body.provider, body.model);
+  if (cap == null || body.maxTokens <= cap) {
+    return body;
+  }
+  return { ...body, maxTokens: cap };
 }
 
 /**

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -55,7 +55,7 @@ export const OS_BETA_PROFILE_KEY = "os-beta";
  * platform-managed column (routed through the single `vellum` connection to
  * an underlying provider per profile); the rest are BYOK columns whose
  * models resolve per provider via `resolveModelIntent`. The full set of
- * providers that can back `llm.defaultProvider` is wider — see
+ * providers that can back `llm.defaultProvider` is wider, see
  * `DEFAULT_PROVIDER_CHOICES` in `schemas/llm.ts`.
  *
  * Lives in this import-free module rather than `default-profile-catalog.ts`

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -2171,6 +2171,16 @@ export function isModelInCatalog(provider: string, modelId: string): boolean {
   return entry?.models.some((m) => m.id === modelId) ?? false;
 }
 
+/** The `maxOutputTokens` declared for a (provider, model) catalog entry, if any. */
+export function catalogMaxOutputTokens(
+  provider: string,
+  modelId: string,
+): number | undefined {
+  return PROVIDER_CATALOG.find((p) => p.id === provider)?.models.find(
+    (m) => m.id === modelId,
+  )?.maxOutputTokens;
+}
+
 /**
  * Model IDs (across all catalog providers) flagged
  * `supportsPromptCacheBreakpoints`. Consumed by the OpenAI Responses


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for byok-code-defined-defaults.md.

**Gap:** BYOK default templates request 16k/32k output tokens; widened providers whose models cap lower (atlascloud 8192, minimax 16384) got the value forwarded unclamped, so the hatch-active Balanced profile could be rejected upstream on every request.
**Fix:** default-profile materialization clamps template maxTokens to the catalog model's maxOutputTokens for concrete providers (vellum column passes through untouched; the conversion pass's historical-body comparisons are unaffected). Also folds in an em-dash comment-rule cleanup and drops a sweep test that duplicated the module-load catalog validation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->