### PR TITLE
feat(docs): port metadata/domains/routes support libs

### DIFF
--- a/clients/docs/src/lib/agent-markdown-paths.ts
+++ b/clients/docs/src/lib/agent-markdown-paths.ts
@@ -1,0 +1,16 @@
+/**
+ * Public markdown alternate URL for a docs page. Lives under /docs/* (e.g.
+ * /docs/pricing -> /docs/pricing.md) because ingress only routes /docs/* to
+ * this app; the platform's legacy /md/* URLs would hit the old app.
+ */
+export function agentMarkdownPathForPage(path: string): string | undefined {
+  if (path === "/docs") {
+    return "/docs/index.md";
+  }
+
+  if (path.startsWith("/docs/")) {
+    return `${path}.md`;
+  }
+
+  return undefined;
+}

--- a/clients/docs/src/lib/domains.ts
+++ b/clients/docs/src/lib/domains.ts
@@ -1,0 +1,2 @@
+/** Canonical marketing site domain. Canonical URLs stay on www even though this app serves only /docs. */
+export const WWW_DOMAIN = "www.vellum.ai";

--- a/clients/docs/src/lib/metadata.test.ts
+++ b/clients/docs/src/lib/metadata.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { agentMarkdownPathForPage } from "@/lib/agent-markdown-paths";
+import { createMetadata } from "@/lib/metadata";
+
+describe("createMetadata", () => {
+  test("builds the canonical URL from SITE_URL and path", () => {
+    const metadata = createMetadata({
+      title: "Pricing",
+      description: "Vellum pricing",
+      path: "/docs/pricing",
+    });
+
+    expect(metadata.alternates?.canonical).toBe(
+      "https://www.vellum.ai/docs/pricing",
+    );
+  });
+
+  test("adds a .md markdown alternate for a docs page", () => {
+    const metadata = createMetadata({
+      title: "Pricing",
+      description: "Vellum pricing",
+      path: "/docs/pricing",
+    });
+
+    expect(metadata.alternates?.types).toEqual({
+      "text/markdown": "https://www.vellum.ai/docs/pricing.md",
+    });
+  });
+
+  test("adds a markdown alternate for a nested docs path", () => {
+    const metadata = createMetadata({
+      title: "Privacy and Data",
+      description: "Trust and security",
+      path: "/docs/trust-security/privacy-and-data",
+    });
+
+    expect(metadata.alternates?.types).toEqual({
+      "text/markdown":
+        "https://www.vellum.ai/docs/trust-security/privacy-and-data.md",
+    });
+  });
+
+  test("maps the docs index to /docs/index.md", () => {
+    const metadata = createMetadata({
+      title: "Docs",
+      description: "Vellum docs",
+      path: "/docs",
+    });
+
+    expect(metadata.alternates?.canonical).toBe("https://www.vellum.ai/docs");
+    expect(metadata.alternates?.types).toEqual({
+      "text/markdown": "https://www.vellum.ai/docs/index.md",
+    });
+  });
+});
+
+describe("agentMarkdownPathForPage", () => {
+  test("returns undefined for non-docs paths", () => {
+    expect(agentMarkdownPathForPage("/blog/some-post")).toBeUndefined();
+    expect(agentMarkdownPathForPage("/")).toBeUndefined();
+  });
+});

--- a/clients/docs/src/lib/metadata.ts
+++ b/clients/docs/src/lib/metadata.ts
@@ -1,0 +1,99 @@
+import type { Metadata } from "next";
+
+import { agentMarkdownPathForPage } from "@/lib/agent-markdown-paths";
+import { WWW_DOMAIN } from "@/lib/domains";
+
+export const SITE_URL = `https://${WWW_DOMAIN}`;
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/og-cover-v2.jpg`;
+export const TWITTER_HANDLE = "@vellum_ai";
+
+// The default dynamic OG endpoint at /api/og renders a 1200x630 PNG.
+// Declaring dimensions on the meta tags helps unfurlers (especially
+// LinkedIn) render previews on first share without re-probing.
+const DEFAULT_OG_IMAGE_WIDTH = 1200;
+const DEFAULT_OG_IMAGE_HEIGHT = 630;
+
+interface CreateMetadataOptions {
+  title: string;
+  description: string;
+  path: string;
+  image?: string;
+  imageAlt?: string;
+  imageWidth?: number;
+  imageHeight?: number;
+  type?: "website" | "article";
+  publishedTime?: string;
+  authors?: string[];
+  twitterCreator?: string;
+}
+
+export function createMetadata({
+  title,
+  description,
+  path,
+  image,
+  imageAlt,
+  imageWidth,
+  imageHeight,
+  type = "website",
+  publishedTime,
+  authors,
+  twitterCreator,
+}: CreateMetadataOptions): Metadata {
+  const url = `${SITE_URL}${path}`;
+  const usingDefaultOgImage = !image;
+  const ogImage =
+    image ?? `${SITE_URL}/api/og?title=${encodeURIComponent(title)}`;
+  const ogImageAlt = imageAlt ?? title;
+  // Only assume dimensions for the default endpoint. Custom images may be
+  // arbitrary sizes (showcase avatars, blog hero art, etc.).
+  const width =
+    imageWidth ?? (usingDefaultOgImage ? DEFAULT_OG_IMAGE_WIDTH : undefined);
+  const height =
+    imageHeight ?? (usingDefaultOgImage ? DEFAULT_OG_IMAGE_HEIGHT : undefined);
+
+  const markdownPath = agentMarkdownPathForPage(path);
+  const markdownAlternate = markdownPath
+    ? { "text/markdown": `${SITE_URL}${markdownPath}` }
+    : undefined;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+      ...(markdownAlternate && { types: markdownAlternate }),
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "Vellum",
+      type,
+      locale: "en_US",
+      images: [
+        {
+          url: ogImage,
+          ...(width !== undefined && { width }),
+          ...(height !== undefined && { height }),
+          alt: ogImageAlt,
+        },
+      ],
+      ...(publishedTime && { publishedTime }),
+      ...(authors && { authors }),
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: TWITTER_HANDLE,
+      creator: twitterCreator ?? TWITTER_HANDLE,
+      title,
+      description,
+      images: [
+        {
+          url: ogImage,
+          alt: ogImageAlt,
+        },
+      ],
+    },
+  };
+}

--- a/clients/docs/src/lib/routes.ts
+++ b/clients/docs/src/lib/routes.ts
@@ -1,5 +1,5 @@
 /**
- * URL registry for the docs app — only what docs pages consume.
+ * URL registry for the docs app: only what docs pages consume.
  * Internal paths are cast `as Route` (the legal pages land in later PRs of
  * this migration); app destinations are cross-app absolute URLs.
  */

--- a/clients/docs/src/lib/routes.ts
+++ b/clients/docs/src/lib/routes.ts
@@ -1,7 +1,7 @@
 /**
  * URL registry for the docs app: only what docs pages consume.
- * Internal paths are cast `as Route` (the legal pages land in later PRs of
- * this migration); app destinations are cross-app absolute URLs.
+ * Internal paths are cast `as Route` because they point at pages outside the
+ * generated typedRoutes union; app destinations are cross-app absolute URLs.
  */
 
 import type { Route } from "next";

--- a/clients/docs/src/lib/routes.ts
+++ b/clients/docs/src/lib/routes.ts
@@ -1,0 +1,25 @@
+/**
+ * URL registry for the docs app — only what docs pages consume.
+ * Internal paths are cast `as Route` (the legal pages land in later PRs of
+ * this migration); app destinations are cross-app absolute URLs.
+ */
+
+import type { Route } from "next";
+
+import { WWW_DOMAIN } from "@/lib/domains";
+
+export const routes = {
+  docs: {
+    legal: {
+      privacyPolicy: "/docs/privacy-policy" as Route,
+      termsOfUse: "/docs/vellum-terms-of-use" as Route,
+      prohibitedUse: "/docs/prohibited-use" as Route,
+      privacyAndData: "/docs/trust-security/privacy-and-data" as Route,
+    },
+  },
+
+  // Cross-app destinations served by other Vellum apps.
+  signup: `https://${WWW_DOMAIN}/account/signup`,
+  login: `https://${WWW_DOMAIN}/account/login`,
+  assistant: `https://${WWW_DOMAIN}/assistant`,
+} as const;


### PR DESCRIPTION
## Summary
- Port domains.ts and metadata.ts (createMetadata, canonical URLs unchanged)
- Port agent-markdown-paths.ts with /docs-prefixed .md alternates (/docs/pricing.md scheme)
- Minimal routes.ts with cross-app absolute URLs

Part of plan: docs-app-phase-1.md (PR 3 of 15)