### PR TITLE
feat(docs): styling foundation from design-library tokens + docs theme

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -120,11 +120,15 @@
     "clients/docs": {
       "name": "@vellumai/docs",
       "dependencies": {
+        "@vellumai/design-library": "workspace:*",
+        "clsx": "2.1.1",
         "next": "16.2.6",
         "react": "19.2.6",
         "react-dom": "19.2.6",
+        "tailwind-merge": "3.6.0",
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "4.1.8",
         "@types/bun": "1.3.14",
         "@types/node": "26.1.2",
         "@types/react": "19.2.14",
@@ -132,6 +136,7 @@
         "eslint": "10.2.0",
         "eslint-config-next": "16.2.6",
         "eslint-plugin-react-hooks": "7.1.1",
+        "tailwindcss": "4.1.8",
         "typescript": "5.9.3",
         "typescript-eslint": "8.58.1",
       },
@@ -540,6 +545,8 @@
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.25.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-wU1VgXNtMvdVotX49txc3WJUDV+/QbLpsgjMvFhlRmp37osdLbI7L7y+iwAlQATwfjLxcv1r1p3ZxZBcXlGhcQ=="],
 
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
+
+    "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
@@ -1408,6 +1415,8 @@
     "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ=="],
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA=="],
+
+    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.8", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.8", "@tailwindcss/oxide": "4.1.8", "postcss": "^8.4.41", "tailwindcss": "4.1.8" } }, "sha512-vB/vlf7rIky+w94aWMw34bWW1ka6g6C3xIOdICKX2GC0VcLtL6fhlLiafF0DVIwa9V6EHz8kbWMkS2s2QvvNlw=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
 
@@ -4021,6 +4030,12 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tailwindcss/postcss/@tailwindcss/node": ["@tailwindcss/node@4.1.8", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "enhanced-resolve": "^5.18.1", "jiti": "^2.4.2", "lightningcss": "1.30.1", "magic-string": "^0.30.17", "source-map-js": "^1.2.1", "tailwindcss": "4.1.8" } }, "sha512-OWwBsbC9BFAJelmnNcrKuf+bka2ZxCE2A4Ft53Tkg4uoiE67r/PMEYwCsourC26E+kmxfwE0hVzMdxqeW+xu7Q=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.8", "", { "dependencies": { "detect-libc": "^2.0.4", "tar": "^7.4.3" }, "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.8", "@tailwindcss/oxide-darwin-arm64": "4.1.8", "@tailwindcss/oxide-darwin-x64": "4.1.8", "@tailwindcss/oxide-freebsd-x64": "4.1.8", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.8", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.8", "@tailwindcss/oxide-linux-arm64-musl": "4.1.8", "@tailwindcss/oxide-linux-x64-gnu": "4.1.8", "@tailwindcss/oxide-linux-x64-musl": "4.1.8", "@tailwindcss/oxide-wasm32-wasi": "4.1.8", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.8", "@tailwindcss/oxide-win32-x64-msvc": "4.1.8" } }, "sha512-d7qvv9PsM5N3VNKhwVUhpK6r4h9wtLkJ6lz9ZY9aeZgrUWk1Z8VPyqyDT9MZlem7GTGseRQHkeB1j3tC7W1P+A=="],
+
+    "@tailwindcss/postcss/tailwindcss": ["tailwindcss@4.1.8", "", {}, "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
@@ -4092,6 +4107,8 @@
     "@vellumai/docs/eslint": ["eslint@10.2.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.4", "@eslint/config-helpers": "^0.5.4", "@eslint/core": "^1.2.0", "@eslint/plugin-kit": "^0.7.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA=="],
 
     "@vellumai/docs/react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
+    "@vellumai/docs/tailwindcss": ["tailwindcss@4.1.8", "", {}, "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og=="],
 
     "@vellumai/docs/typescript-eslint": ["typescript-eslint@8.58.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.1", "@typescript-eslint/parser": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg=="],
 
@@ -4573,6 +4590,32 @@
 
     "@sentry/electron/@sentry/browser/@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.50.0", "", { "dependencies": { "@sentry-internal/replay": "10.50.0", "@sentry/core": "10.50.0" } }, "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw=="],
 
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.1.8", "", { "os": "android", "cpu": "arm64" }, "sha512-Fbz7qni62uKYceWYvUjRqhGfZKwhZDQhlrJKGtnZfuNtHFqa8wmr+Wn74CTWERiW2hn3mN5gTpOoxWKk0jRxjg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.1.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RdRvedGsT0vwVVDztvyXhKpsU2ark/BjgG0huo4+2BluxdXo8NDgzl77qh0T1nUxmM11eXwR8jA39ibvSTbi7A=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.1.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-t6PgxjEMLp5Ovf7uMb2OFmb3kqzVTPPakWpBIFzppk4JE4ix0yEtbtSjPbU8+PZETpaYMtXvss2Sdkx8Vs4XRw=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.1.8", "", { "os": "freebsd", "cpu": "x64" }, "sha512-g8C8eGEyhHTqwPStSwZNSrOlyx0bhK/V/+zX0Y+n7DoRUzyS8eMbVshVOLJTDDC+Qn9IJnilYbIKzpB9n4aBsg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.1.8", "", { "os": "linux", "cpu": "arm" }, "sha512-Jmzr3FA4S2tHhaC6yCjac3rGf7hG9R6Gf2z9i9JFcuyy0u79HfQsh/thifbYTF2ic82KJovKKkIB6Z9TdNhCXQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.1.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-qq7jXtO1+UEtCmCeBBIRDrPFIVI4ilEQ97qgBGdwXAARrUqSn/L9fUrkb1XP/mvVtoVeR2bt/0L77xx53bPZ/Q=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.1.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-O6b8QesPbJCRshsNApsOIpzKt3ztG35gfX9tEf4arD7mwNinsoCKxkj8TgEE0YRjmjtO3r9FlJnT/ENd9EVefQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.1.8", "", { "os": "linux", "cpu": "x64" }, "sha512-32iEXX/pXwikshNOGnERAFwFSfiltmijMIAbUhnNyjFr3tmWmMJWQKU2vNcFX0DACSXJ3ZWcSkzNbaKTdngH6g=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.1.8", "", { "os": "linux", "cpu": "x64" }, "sha512-s+VSSD+TfZeMEsCaFaHTaY5YNj3Dri8rST09gMvYQKwPphacRG7wbuQ5ZJMIJXN/puxPcg/nU+ucvWguPpvBDg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.1.8", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@emnapi/wasi-threads": "^1.0.2", "@napi-rs/wasm-runtime": "^0.2.10", "@tybys/wasm-util": "^0.9.0", "tslib": "^2.8.0" }, "cpu": "none" }, "sha512-CXBPVFkpDjM67sS1psWohZ6g/2/cd+cq56vPxK4JeawelxwK4YECgl9Y9TjkE2qfF+9/s1tHHJqrC4SS6cVvSg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.1.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-7GmYk1n28teDHUjPlIx4Z6Z4hHEgvP5ZW2QS9ygnDAdI/myh3HTHjDqtSqgu1BpRoI4OiLx+fThAyA1JePoENA=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.8", "", { "os": "win32", "cpu": "x64" }, "sha512-fou+U20j+Jl0EHwK92spoWISON2OBnCazIc038Xj2TdweYV33ZRkS9nwqiUi2d/Wba5xg5UoHfvynnb/UB49cQ=="],
+
     "@types/cacheable-request/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "@types/connect/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
@@ -5025,6 +5068,38 @@
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
 
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.30.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.30.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.30.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.30.1", "", { "os": "linux", "cpu": "arm" }, "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.30.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.30.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.30.1", "", { "os": "linux", "cpu": "x64" }, "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.30.1", "", { "os": "linux", "cpu": "x64" }, "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.30.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" }, "bundled": true }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.9.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@vellumai/ces-client/@types/bun/bun-types/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@vellumai/ces-client/@types/bun/bun-types/@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
@@ -5396,6 +5471,8 @@
     "iconv-corefoundation/cli-truncate/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "temp/rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@vellumai/ces-client/@types/bun/bun-types/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/clients/docs/package.json
+++ b/clients/docs/package.json
@@ -11,11 +11,15 @@
     "test": "bun test src"
   },
   "dependencies": {
+    "@vellumai/design-library": "workspace:*",
+    "clsx": "2.1.1",
     "next": "16.2.6",
     "react": "19.2.6",
-    "react-dom": "19.2.6"
+    "react-dom": "19.2.6",
+    "tailwind-merge": "3.6.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "4.1.8",
     "@types/bun": "1.3.14",
     "@types/node": "26.1.2",
     "@types/react": "19.2.14",
@@ -23,6 +27,7 @@
     "eslint": "10.2.0",
     "eslint-config-next": "16.2.6",
     "eslint-plugin-react-hooks": "7.1.1",
+    "tailwindcss": "4.1.8",
     "typescript": "5.9.3",
     "typescript-eslint": "8.58.1"
   }

--- a/clients/docs/postcss.config.mjs
+++ b/clients/docs/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/clients/docs/src/app/docs/docs-theme.css
+++ b/clients/docs/src/app/docs/docs-theme.css
@@ -1,0 +1,1218 @@
+/* Prevent macOS elastic overscroll from revealing the body background
+   behind the docs shell (the header and content have different colors).
+   overflow-x: hidden clips any content that bleeds past the viewport. */
+html:has(.docs-shell) {
+  overscroll-behavior: none;
+  overflow-x: hidden;
+}
+
+.docs-shell {
+  --docs-bg: #ffffff;
+  --docs-sidebar-bg: #ffffff;
+  --docs-surface: var(--color-stone-50, #F6F5F4);
+  --docs-surface-strong: #ffffff;
+  --docs-border: var(--color-stone-200, #E9E6E2);
+  --docs-border-strong: var(--color-moss-200, #CFCCC9);
+  --docs-text: var(--color-stone-900, #17191C);
+  --docs-text-muted: var(--color-stone-700, #5A6672);
+  --docs-text-subtle: var(--color-stone-600, #71808E);
+  --docs-accent: #059669;
+  --docs-accent-strong: #047857;
+  --docs-accent-soft: #ECFDF5;
+  --docs-overlay: rgba(23, 25, 28, 0.32);
+  background: var(--docs-bg);
+  color: var(--docs-text);
+}
+
+.dark .docs-shell {
+  --docs-bg: var(--color-moss-950, #111214);
+  --docs-sidebar-bg: var(--color-moss-900, #17191C);
+  --docs-surface: var(--color-moss-700, #24292E);
+  --docs-surface-strong: var(--color-moss-700, #24292E);
+  --docs-border: var(--color-moss-600, #2D3339);
+  --docs-border-strong: var(--color-moss-500, #444D56);
+  --docs-text: var(--color-moss-50, #F6F5F4);
+  --docs-text-muted: var(--color-moss-100, #E5E7EB);
+  --docs-text-subtle: var(--color-moss-300, #B0B6BD);
+  --docs-accent: #34D399;
+  --docs-accent-strong: #6EE7B7;
+  --docs-accent-soft: rgba(16, 185, 129, 0.15);
+  --docs-overlay: rgba(0, 0, 0, 0.52);
+}
+
+.docs-shell .docs-layout {
+  width: 100%;
+}
+
+.docs-shell .docs-header {
+  border-color: var(--docs-border);
+  background: var(--docs-surface-strong);
+}
+
+.docs-shell .docs-brand-area {
+  border-color: var(--docs-border);
+}
+
+.docs-shell .docs-brand-area img {
+  filter: brightness(0) saturate(100%) invert(38%) sepia(15%) saturate(900%) hue-rotate(73deg) brightness(95%) contrast(88%);
+}
+
+.dark .docs-shell .docs-brand-area img {
+  filter: brightness(0) saturate(100%) invert(73%) sepia(8%) saturate(400%) hue-rotate(73deg) brightness(95%) contrast(88%);
+}
+
+.docs-shell .docs-header-link {
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .docs-header-link:hover {
+  color: var(--docs-text);
+}
+
+.docs-shell .docs-header-link-active {
+  color: var(--docs-accent) !important;
+}
+
+/* Tavily-style tabs row: thin border-top divider, accent underline beneath
+   the active tab. Sits below the brand+search+CTA row in the header. */
+.docs-shell .docs-header-tabs {
+  background: var(--docs-surface-strong);
+  border-color: var(--docs-border);
+}
+
+.docs-shell .docs-header-tabs .docs-header-link {
+  position: relative;
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+}
+
+.docs-shell .docs-header-tabs .docs-header-link-active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--docs-accent);
+}
+
+/* Header search input — shrinks to fit a comfortable max width in the middle
+   of the top row. */
+.docs-shell .docs-header-search .docs-search-trigger {
+  width: 100%;
+}
+
+.docs-shell .docs-main {
+  max-width: 900px;
+}
+
+.docs-shell .docs-breadcrumb {
+  color: var(--docs-text-subtle);
+}
+
+.docs-shell .docs-eyebrow {
+  color: var(--docs-accent);
+}
+
+.docs-shell .docs-title {
+  color: var(--docs-text);
+  font-family: "DM Sans", sans-serif;
+}
+
+/* H2/H3 inside docs match H1: DM Sans + bold + tight tracking.
+   Defined outside @layer to beat .marketing-root h2/h3 in marketing.css
+   which sets font-weight 600. Specificity (0,2,1) beats (0,1,1) so this
+   wins without !important. */
+.docs-shell .docs-prose h2,
+.docs-shell .docs-prose h3 {
+  font-family: "DM Sans", sans-serif;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+}
+
+.docs-shell .docs-subtitle {
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .docs-prose {
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .docs-prose p {
+  font-size: 1.06rem;
+  line-height: 1.85;
+}
+
+/* Default typography for bare h2/h3/ul/ol/li/p inside docs-prose.
+   Wrapped in :where() AND nested in @layer base so per-element Tailwind
+   utilities (e.g. SectionHeading's mb-4 mt-0 text-3xl, or a page's
+   own text-base) reliably win. Without the layer wrap, these rules
+   were unlayered and Tailwind utilities (which live in @layer utilities)
+   could not override them regardless of :where() specificity. */
+@layer base {
+  :where(.docs-shell .docs-prose p) {
+    margin-bottom: 1rem;
+  }
+
+  :where(.docs-shell .docs-prose h2) {
+    margin-top: 2.75rem;
+    margin-bottom: 1rem;
+    font-family: "DM Sans", sans-serif;
+    font-size: 1.875rem;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    line-height: 1.25;
+    color: var(--docs-text);
+  }
+
+  :where(.docs-shell .docs-prose h3) {
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    font-family: "DM Sans", sans-serif;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.35;
+    color: var(--docs-text);
+  }
+
+  :where(.docs-shell .docs-prose h2:first-child),
+  :where(.docs-shell .docs-prose h3:first-child) {
+    margin-top: 0;
+  }
+
+  :where(.docs-shell .docs-prose ul) {
+    list-style-type: disc;
+    padding-left: 1.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.25rem;
+  }
+
+  :where(.docs-shell .docs-prose ol) {
+    list-style-type: decimal;
+    padding-left: 1.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.25rem;
+  }
+
+  :where(.docs-shell .docs-prose li) {
+    font-size: 1.06rem;
+    line-height: 1.7;
+    margin-bottom: 0.4rem;
+  }
+
+  :where(.docs-shell .docs-prose li > p) {
+    margin-bottom: 0.4rem;
+  }
+
+  :where(.docs-shell .docs-prose li::marker) {
+    color: var(--docs-text-muted);
+  }
+}
+
+.docs-shell .docs-main strong {
+  color: var(--docs-text) !important;
+  font-weight: 600;
+}
+
+.docs-shell .docs-main a {
+  color: var(--docs-accent) !important;
+  text-decoration-color: rgba(39, 126, 65, 0.42) !important;
+  text-underline-offset: 3px;
+}
+
+.docs-shell .docs-main a:hover {
+  color: var(--docs-accent-strong) !important;
+  text-decoration-color: rgba(27, 94, 48, 0.62) !important;
+}
+
+.docs-shell .docs-main code {
+  border: 1px solid var(--docs-border);
+  background: var(--docs-sidebar-bg);
+  color: var(--docs-text);
+}
+
+.docs-shell .docs-main pre {
+  border: 1px solid var(--docs-border) !important;
+  background: var(--docs-surface) !important;
+}
+
+/* Suppress double border when pre is inside an already-bordered container */
+.docs-shell .docs-main div[class*="border"] > pre {
+  border: 0 !important;
+  background: transparent !important;
+}
+
+.docs-shell .docs-main pre code {
+  border: 0;
+  background: transparent;
+  color: var(--docs-text);
+}
+
+.docs-shell .docs-main table {
+  border-color: var(--docs-border);
+}
+
+.docs-shell .docs-main table thead tr,
+.docs-shell .docs-main table tbody tr {
+  background: transparent !important;
+}
+
+.docs-shell .docs-main table th {
+  border-bottom: 1px solid var(--docs-border-strong);
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .docs-main table td {
+  border-bottom: 1px solid var(--docs-border);
+}
+
+.docs-shell .docs-main :is(dl > div, section > div.rounded-xl, article) {
+  border-color: var(--docs-border);
+  background: var(--docs-surface);
+}
+
+.docs-shell .docs-home-principle {
+  border: 1px solid var(--docs-border);
+  border-radius: 12px;
+  background: var(--docs-surface);
+  padding: 1rem 1.1rem;
+}
+
+/* The CollapsibleSection's h3 sits inside a flex button row with a chevron.
+   The :where(.docs-prose h3) defaults below would otherwise add 2rem of
+   margin-top, breaking the centered chevron+title alignment. Override with
+   real specificity so the row stays compact and centered. */
+.docs-shell .docs-home-principle h3 {
+  margin: 0;
+  padding: 0;
+}
+
+.docs-shell .docs-home-principle p {
+  font-size: 0.98rem;
+  line-height: 1.75;
+}
+
+.docs-nav-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.docs-nav-card {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.15rem 1.25rem;
+  background: var(--docs-surface);
+  border: 1px solid var(--docs-border);
+  border-radius: 12px;
+  text-decoration: none !important;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.docs-nav-card:hover {
+  border-color: var(--docs-border-strong);
+  box-shadow: 0 4px 16px rgba(34, 34, 30, 0.06);
+}
+
+.docs-nav-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.docs-nav-card-title {
+  font-weight: 600;
+  font-size: 1.02rem;
+  color: var(--docs-text) !important;
+}
+
+.docs-nav-card-desc {
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--docs-text-muted) !important;
+}
+
+.docs-nav-card-arrow {
+  flex-shrink: 0;
+  font-size: 1.1rem;
+  color: var(--docs-accent) !important;
+  transition: transform 0.18s ease;
+}
+
+.docs-nav-card:hover .docs-nav-card-arrow {
+  transform: translateX(3px);
+}
+
+.docs-shell .docs-nav-panel {
+  border-color: var(--docs-border);
+  background: var(--docs-sidebar-bg);
+}
+
+/* Tavily-style section dividers in the sidebar. Each NavSection sits in its
+   own group; the first one in the list has no top spacing, every following
+   one gets a soft top divider plus breathing room. */
+.docs-shell .docs-nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.docs-shell .docs-nav-section + .docs-nav-section,
+.docs-shell .docs-nav-list > li + .docs-nav-section {
+  margin-top: 1.25rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--docs-border);
+}
+
+.docs-shell .docs-nav-section-label {
+  color: var(--docs-text);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.docs-shell .docs-nav-section-label:hover {
+  color: var(--docs-text);
+}
+
+.docs-shell .docs-nav-section-label-active {
+  color: var(--docs-accent);
+}
+
+.docs-shell .docs-nav-link-active {
+  background: var(--docs-accent-soft);
+  color: var(--docs-accent);
+}
+
+.docs-shell .docs-nav-link-active .docs-nav-link-icon,
+.docs-shell .docs-nav-link-active .docs-nav-link-icon svg {
+  color: var(--docs-accent);
+}
+
+.docs-shell .docs-nav-link-inactive {
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .docs-nav-link-inactive .docs-nav-link-icon,
+.docs-shell .docs-nav-link-inactive .docs-nav-link-icon svg {
+  color: var(--docs-text-subtle);
+}
+
+.docs-shell .docs-nav-link-inactive:hover {
+  color: var(--docs-text);
+  background: var(--docs-surface-strong);
+}
+
+.docs-shell .docs-nav-link-inactive:hover .docs-nav-link-icon,
+.docs-shell .docs-nav-link-inactive:hover .docs-nav-link-icon svg {
+  color: var(--docs-text);
+}
+
+.docs-shell .docs-nav-link-active:focus-visible,
+.docs-shell .docs-nav-link-inactive:focus-visible {
+  outline: 2px solid var(--docs-accent);
+  outline-offset: -2px;
+}
+
+.docs-shell .docs-nav-mobile-trigger {
+  border-color: var(--docs-border);
+  background: var(--docs-surface-strong);
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .docs-nav-overlay {
+  background: var(--docs-overlay);
+}
+
+.docs-shell .docs-nav-close {
+  color: var(--docs-text-subtle);
+}
+
+.docs-shell .docs-nav-close:hover {
+  color: var(--docs-text);
+  background: var(--docs-surface-strong);
+}
+
+.docs-shell .docs-search {
+  position: relative;
+}
+
+.docs-shell .docs-search-trigger {
+  width: 100%;
+  border: 1px solid var(--docs-border);
+  background: var(--docs-surface-strong);
+  color: var(--docs-text);
+  border-radius: 10px;
+  padding: 9px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.14s ease, box-shadow 0.14s ease, background-color 0.14s ease;
+}
+
+.docs-shell .docs-search-trigger:hover {
+  border-color: var(--docs-border-strong);
+  box-shadow: 0 6px 18px rgba(34, 34, 30, 0.07);
+}
+
+.docs-shell .docs-search-trigger:focus-visible {
+  outline: 0;
+  border-color: var(--docs-accent);
+  box-shadow: 0 0 0 3px rgba(39, 126, 65, 0.2);
+}
+
+.docs-shell .docs-search-icon {
+  color: var(--docs-text-subtle);
+  flex: 0 0 auto;
+}
+
+.docs-shell .docs-search-trigger-text {
+  color: var(--docs-text-muted);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  flex: 1;
+}
+
+.docs-shell .docs-search-shortcut {
+  margin-left: auto;
+  border: 1px solid var(--docs-border);
+  color: var(--docs-text-subtle);
+  background: var(--docs-surface);
+  border-radius: 6px;
+  font-size: 0.68rem;
+  line-height: 1;
+  padding: 4px 6px;
+  letter-spacing: 0.04em;
+}
+
+.docs-shell .docs-search-spotlight-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 220;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  background: rgba(28, 31, 38, 0.36);
+  backdrop-filter: blur(5px) saturate(110%);
+  -webkit-backdrop-filter: blur(5px) saturate(110%);
+  padding: 1rem;
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.docs-shell .docs-search-spotlight {
+  width: min(760px, calc(100vw - 2rem));
+  margin-top: clamp(6vh, 10vh, 12vh);
+  border: 1px solid var(--docs-border-strong);
+  background: var(--docs-surface-strong);
+  border-radius: 18px;
+  box-shadow:
+    0 28px 68px rgba(25, 25, 25, 0.25),
+    0 4px 14px rgba(25, 25, 25, 0.09);
+  overflow: hidden;
+  transform: translateY(16px) scale(0.97);
+  opacity: 0;
+  transition:
+    transform 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 200ms ease;
+}
+
+.docs-shell .docs-search-spotlight-overlay.is-open {
+  opacity: 1;
+}
+
+.docs-shell .docs-search-spotlight.is-open {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+.docs-shell .docs-search-spotlight-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--docs-border);
+  padding: 17px 18px 16px;
+  background: linear-gradient(180deg, var(--docs-surface) 0%, var(--docs-surface-strong) 100%);
+}
+
+.docs-shell .docs-search-spotlight-icon {
+  color: var(--docs-text-subtle);
+  flex: 0 0 auto;
+}
+
+.docs-shell .docs-search-spotlight-input {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--docs-text);
+  font-size: clamp(1.05rem, 1.55vw, 1.45rem);
+  line-height: 1.2;
+  font-weight: 540;
+}
+
+.docs-shell .docs-search-spotlight-input::placeholder {
+  color: var(--docs-text-subtle);
+}
+
+.docs-shell .docs-search-spotlight-input:focus {
+  outline: none;
+}
+
+.docs-shell .docs-search-esc {
+  flex: 0 0 auto;
+  border: 1px solid var(--docs-border-strong);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 0.72rem;
+  line-height: 1;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--docs-text-subtle);
+  background: var(--docs-surface);
+  cursor: pointer;
+  transition: all 140ms ease;
+}
+
+.docs-shell .docs-search-esc:hover {
+  border-color: var(--docs-border);
+  color: var(--docs-text);
+}
+
+.docs-shell .docs-search-spotlight-results {
+  max-height: min(66vh, 590px);
+  overflow-y: auto;
+  padding: 6px 7px 7px;
+}
+
+.docs-shell .docs-search-status {
+  padding: 12px 13px;
+  color: var(--docs-text-muted);
+  font-size: 0.86rem;
+  font-weight: 510;
+}
+
+.docs-shell .docs-search-suggestions {
+  padding: 4px 0;
+}
+
+.docs-shell .docs-search-suggestions-label {
+  color: var(--docs-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 6px 13px;
+}
+
+.docs-shell .docs-search-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.docs-shell .docs-search-item-wrapper {
+  margin: 0;
+  padding: 0;
+}
+
+.docs-shell .docs-search-item {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  border-radius: 11px;
+  padding: 11px 12px;
+  cursor: pointer;
+  transition: background-color 150ms ease, transform 150ms ease;
+}
+
+.docs-shell .docs-search-suggestion-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.docs-shell .docs-search-suggestion-icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--docs-accent-strong);
+  background: var(--docs-accent-soft);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.docs-shell .docs-search-item.is-active,
+.docs-shell .docs-search-item:hover {
+  background: var(--docs-accent-soft);
+  transform: translateY(-1px);
+}
+
+.docs-shell .docs-search-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.docs-shell .docs-search-title {
+  color: var(--docs-text);
+  font-size: 0.95rem;
+  font-weight: 680;
+}
+
+.docs-shell .docs-search-page {
+  color: var(--docs-text-muted);
+  font-size: 0.76rem;
+  white-space: nowrap;
+}
+
+.docs-shell .docs-search-snippet {
+  color: var(--docs-text-muted);
+  font-size: 0.82rem;
+  margin-top: 4px;
+  line-height: 1.45;
+}
+
+.docs-shell .docs-search-snippet mark,
+.docs-shell .docs-search-title mark {
+  background: rgba(233, 242, 236, 0.95);
+  color: var(--docs-accent-strong);
+  border-radius: 3px;
+  padding: 0 1px;
+}
+
+@media (max-width: 768px) {
+  .docs-shell .docs-search-spotlight {
+    width: calc(100vw - 1rem);
+    margin-top: 3vh;
+    border-radius: 12px;
+  }
+
+  .docs-shell .docs-search-spotlight-input-wrap {
+    padding: 12px;
+  }
+
+  .docs-shell .docs-search-spotlight-input {
+    font-size: 1rem;
+  }
+
+  .docs-shell .docs-search-page {
+    white-space: normal;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-shell .docs-search-spotlight-overlay,
+  .docs-shell .docs-search-spotlight,
+  .docs-shell .docs-search-item {
+    transition: none;
+  }
+}
+
+/* Tailwind utility overrides scoped to docs pages */
+.docs-shell .text-zinc-900 {
+  color: var(--docs-text);
+}
+
+.docs-shell .text-zinc-800 {
+  color: var(--docs-text);
+}
+
+.docs-shell .text-zinc-700 {
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .text-zinc-600,
+.docs-shell .text-zinc-500 {
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .text-zinc-400 {
+  color: var(--docs-text-subtle);
+}
+
+.docs-shell .text-zinc-100 {
+  color: var(--docs-bg);
+}
+
+.docs-shell .border-zinc-300 {
+  border-color: var(--docs-border-strong);
+}
+
+.docs-shell .border-zinc-200 {
+  border-color: var(--docs-border);
+}
+
+.docs-shell .bg-zinc-50 {
+  background: var(--docs-surface);
+}
+
+.docs-shell table .bg-zinc-50,
+.docs-shell table [class*="bg-zinc"] {
+  background: transparent !important;
+}
+
+.docs-shell .bg-zinc-950 {
+  background: var(--docs-accent-strong);
+}
+
+.docs-shell .bg-zinc-950\/30 {
+  background: var(--docs-overlay);
+}
+
+.docs-shell .bg-white,
+.docs-shell .bg-white\/95 {
+  background: var(--docs-surface-strong);
+}
+
+.docs-shell .hover\:bg-zinc-100:hover {
+  background: var(--docs-surface-strong);
+}
+
+.docs-shell .hover\:text-zinc-900:hover {
+  color: var(--docs-text);
+}
+
+.docs-shell .bg-emerald-100 {
+  background: var(--docs-accent-soft);
+}
+
+.docs-shell .text-emerald-700,
+.docs-shell .text-emerald-600,
+.docs-shell .text-emerald-500 {
+  color: var(--docs-accent);
+}
+
+.docs-shell .border-emerald-500 {
+  border-color: var(--docs-accent);
+}
+
+/* Keep code text readable when legacy light-text utility classes are present. */
+.docs-shell .docs-main pre.text-zinc-100,
+.docs-shell .docs-main pre.text-stone-100,
+.docs-shell .docs-main pre .text-zinc-100,
+.docs-shell .docs-main pre .text-stone-100,
+.docs-shell .docs-main code.text-zinc-100,
+.docs-shell .docs-main code.text-stone-100 {
+  color: var(--docs-text) !important;
+}
+
+/* ── Theme picker ────────────────────────────────────────────────────── */
+
+.docs-theme-picker {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--docs-border);
+  border-radius: 10px;
+  background: var(--docs-sidebar-bg);
+  padding: 3px;
+  gap: 1px;
+  transition: opacity 0.2s ease;
+}
+
+.docs-theme-picker:hover {
+  border-color: var(--docs-border-strong);
+}
+
+.docs-theme-picker-indicator {
+  position: absolute;
+  left: 3px;
+  top: 3px;
+  width: calc((100% - 6px - 2px) / 3);
+  height: calc(100% - 6px);
+  border-radius: 7px;
+  background: var(--docs-surface-strong);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.06),
+    0 0 0 0.5px rgba(0, 0, 0, 0.04);
+  transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 0;
+}
+
+.dark .docs-theme-picker-indicator {
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.2),
+    0 0 0 0.5px rgba(255, 255, 255, 0.04);
+}
+
+.docs-theme-picker-option {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 24px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--docs-text-subtle);
+  cursor: pointer;
+  transition: color 0.18s ease;
+}
+
+.docs-theme-picker-option:hover {
+  color: var(--docs-text-muted);
+}
+
+.docs-theme-picker-option.is-active {
+  color: var(--docs-accent);
+}
+
+.docs-theme-picker-option:focus-visible {
+  outline: 2px solid var(--docs-accent);
+  outline-offset: -1px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-theme-picker-indicator {
+    transition: none;
+  }
+}
+
+/* ── Nav CTA button ──────────────────────────────────────────────────── */
+
+.docs-nav-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  background: var(--docs-accent);
+  color: #fff !important;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  border: 0;
+  transition: opacity 0.15s ease;
+}
+
+.docs-nav-cta:hover {
+  opacity: 0.88;
+}
+
+/* ── GitHub wordmark link in docs header ─────────────────────────────── */
+
+.docs-github-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  width: 32px;
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+}
+
+.docs-github-logo {
+  height: 22px;
+  width: 22px;
+  display: block;
+}
+
+/* The wordmark is black-on-transparent. Invert in dark mode. */
+.dark .docs-github-logo {
+  filter: invert(1);
+}
+
+.docs-github-link:hover {
+  opacity: 0.7;
+}
+
+.docs-shell ~ footer.de-offgrid-footer {
+  display: none;
+}
+
+/* ── Privacy & Data — Security tier cards ────────────────────────────── */
+
+.docs-shell {
+  --privacy-secure: var(--color-forest-700, #516748);
+  --privacy-secure-soft: var(--color-forest-100, #edf2eb);
+  --privacy-secure-border: rgba(81, 103, 72, 0.22);
+  --privacy-context: var(--color-amber-700, #c97c10);
+  --privacy-context-soft: rgba(201, 124, 16, 0.08);
+  --privacy-context-border: rgba(201, 124, 16, 0.18);
+  --privacy-danger: var(--color-danger-600, #e86b40);
+}
+
+.dark .docs-shell {
+  --privacy-secure: var(--color-forest-400, #98a88f);
+  --privacy-secure-soft: rgba(152, 168, 143, 0.08);
+  --privacy-secure-border: rgba(152, 168, 143, 0.18);
+  --privacy-context: var(--color-amber-500, #fac426);
+  --privacy-context-soft: rgba(250, 196, 38, 0.06);
+  --privacy-context-border: rgba(250, 196, 38, 0.14);
+  --privacy-danger: var(--color-danger-400, #f9c0a2);
+}
+
+/* Tier legend pills */
+
+.docs-shell .privacy-tier-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+  font-weight: 650;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  padding: 5px 13px;
+  border-radius: 100px;
+}
+
+.docs-shell .privacy-tier-pill--secure {
+  background: var(--privacy-secure-soft);
+  color: var(--privacy-secure);
+  border: 1px solid var(--privacy-secure-border);
+}
+
+.docs-shell .privacy-tier-pill--context {
+  background: var(--privacy-context-soft);
+  color: var(--privacy-context);
+  border: 1px solid var(--privacy-context-border);
+}
+
+/* Tier sub-heading */
+
+.docs-shell .privacy-tier-heading {
+  font-size: 0.7rem;
+  font-weight: 660;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--docs-text-subtle);
+  margin-bottom: 0.75rem;
+}
+
+/* Card grid */
+
+.docs-shell .privacy-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+@media (min-width: 640px) {
+  .docs-shell .privacy-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Individual card */
+
+.docs-shell .privacy-card {
+  position: relative;
+  border: 1px solid var(--docs-border);
+  border-radius: 14px;
+  padding: 1.1rem 1.25rem;
+  background: var(--docs-surface);
+  overflow: hidden;
+  transition:
+    border-color 0.22s ease,
+    transform 0.22s ease,
+    box-shadow 0.22s ease;
+  animation: privacyCardReveal 0.5s cubic-bezier(0.22, 0.68, 0.32, 1) both;
+}
+
+.docs-shell .privacy-card::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  border-radius: 3px 0 0 3px;
+}
+
+.docs-shell .privacy-card--secure::before {
+  background: var(--privacy-secure);
+}
+
+.docs-shell .privacy-card--context::before {
+  background: var(--privacy-context);
+}
+
+.docs-shell .privacy-card:hover {
+  border-color: var(--docs-border-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+}
+
+.dark .docs-shell .privacy-card:hover {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.22);
+}
+
+/* Staggered entrance */
+
+.docs-shell .privacy-card:nth-child(1) { animation-delay: 0s; }
+.docs-shell .privacy-card:nth-child(2) { animation-delay: 0.06s; }
+.docs-shell .privacy-card:nth-child(3) { animation-delay: 0.12s; }
+.docs-shell .privacy-card:nth-child(4) { animation-delay: 0.18s; }
+
+@keyframes privacyCardReveal {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Card internals */
+
+.docs-shell .privacy-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.docs-shell .privacy-card-icon {
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+
+.docs-shell .privacy-card-icon--secure {
+  color: var(--privacy-secure);
+}
+
+.docs-shell .privacy-card-icon--context {
+  color: var(--privacy-context);
+}
+
+.docs-shell .privacy-card-title {
+  font-weight: 640;
+  font-size: 0.95rem;
+  color: var(--docs-text);
+  line-height: 1.35;
+}
+
+.docs-shell .privacy-card-desc {
+  font-size: 0.82rem;
+  color: var(--docs-text-muted);
+  margin-top: 2px;
+  line-height: 1.45;
+}
+
+.docs-shell .privacy-card-path {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--docs-sidebar-bg);
+  border: 1px solid var(--docs-border);
+  color: var(--docs-text-muted);
+  font-family: var(--font-mono, "DM Mono", monospace);
+}
+
+.docs-shell .privacy-card-detail {
+  font-size: 0.78rem;
+  color: var(--docs-text-subtle);
+  margin-top: 8px;
+  font-style: italic;
+  line-height: 1.5;
+}
+
+/* Callout box (replaces blockquote) */
+
+.docs-shell .privacy-callout {
+  position: relative;
+  border: none;
+  border-radius: 0;
+  padding: 1.15rem 1.25rem 1.15rem 3rem;
+  background: transparent;
+  margin: 1.5rem 0;
+}
+
+.docs-shell .privacy-callout::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  border-radius: 2px;
+  background: var(--privacy-context);
+}
+
+.docs-shell .privacy-callout-icon {
+  position: absolute;
+  left: 0.9rem;
+  top: 1.25rem;
+  color: var(--privacy-context);
+}
+
+.docs-shell .privacy-callout p {
+  margin: 0 !important;
+  font-size: 0.92rem !important;
+  line-height: 1.75 !important;
+}
+
+/* Risk-level dots for permission section */
+
+.docs-shell .privacy-risk-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 5px;
+  position: relative;
+  top: -1px;
+}
+
+.docs-shell .privacy-risk-dot--low {
+  background: var(--privacy-secure);
+}
+
+.docs-shell .privacy-risk-dot--medium {
+  background: var(--privacy-context);
+}
+
+.docs-shell .privacy-risk-dot--high {
+  background: var(--privacy-danger);
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-shell .privacy-card {
+    animation: none;
+  }
+}
+
+/* Dark mode: brighten all dim Tailwind body text inside docs.
+   Inline classes like `text-zinc-600` / `text-stone-600` would otherwise
+   stay dark on the dark background. Force them to the docs-text-muted
+   variable so they inherit the dark-mode brightness. */
+.dark .docs-shell .docs-main .text-zinc-500,
+.dark .docs-shell .docs-main .text-zinc-600,
+.dark .docs-shell .docs-main .text-zinc-700,
+.dark .docs-shell .docs-main .text-zinc-800,
+.dark .docs-shell .docs-main .text-stone-500,
+.dark .docs-shell .docs-main .text-stone-600,
+.dark .docs-shell .docs-main .text-stone-700,
+.dark .docs-shell .docs-main .text-stone-800 {
+  color: var(--docs-text-muted) !important;
+}
+
+/* Also brighten the smaller-print labels (table headers, captions) so
+   they stay legible without becoming as bright as body text. */
+.dark .docs-shell .docs-main .text-zinc-400,
+.dark .docs-shell .docs-main .text-stone-400 {
+  color: var(--docs-text-subtle) !important;
+}

--- a/clients/docs/src/app/docs/docs-theme.css
+++ b/clients/docs/src/app/docs/docs-theme.css
@@ -97,7 +97,7 @@ html:has(.docs-shell) {
   background: var(--docs-accent);
 }
 
-/* Header search input — shrinks to fit a comfortable max width in the middle
+/* Header search input: shrinks to fit a comfortable max width in the middle
    of the top row. */
 .docs-shell .docs-header-search .docs-search-trigger {
   width: 100%;
@@ -937,7 +937,7 @@ html:has(.docs-shell) {
   display: none;
 }
 
-/* ── Privacy & Data — Security tier cards ────────────────────────────── */
+/* ── Privacy & Data: Security tier cards ────────────────────────────── */
 
 .docs-shell {
   --privacy-secure: var(--color-forest-700, #516748);

--- a/clients/docs/src/app/globals.css
+++ b/clients/docs/src/app/globals.css
@@ -1,0 +1,7 @@
+@import "tailwindcss";
+@import "@vellumai/design-library/tokens.css";
+
+/* tokens.css already declares `@custom-variant dark` keyed on [data-theme=dark].
+ * docs-theme.css (ported from the platform repo) keys off the `.dark` class
+ * instead, so expose a class-keyed variant under a separate name. */
+@custom-variant dark-class (&:where(.dark, .dark *));

--- a/clients/docs/src/app/globals.css
+++ b/clients/docs/src/app/globals.css
@@ -1,7 +1,2 @@
 @import "tailwindcss";
 @import "@vellumai/design-library/tokens.css";
-
-/* tokens.css already declares `@custom-variant dark` keyed on [data-theme=dark].
- * docs-theme.css (ported from the platform repo) keys off the `.dark` class
- * instead, so expose a class-keyed variant under a separate name. */
-@custom-variant dark-class (&:where(.dark, .dark *));

--- a/clients/docs/src/app/layout.tsx
+++ b/clients/docs/src/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from "react";
 
 import "./globals.css";
-// TODO(docs-app-phase-1 PR 5): move this import into the docs layout once it
-// exists; imported here temporarily so the placeholder page exercises it.
 import "./docs/docs-theme.css";
 
 /* Pre-hydration theme bootstrap. Mirrors the key precedence of the assistant

--- a/clients/docs/src/app/layout.tsx
+++ b/clients/docs/src/app/layout.tsx
@@ -1,9 +1,32 @@
 import type { ReactNode } from "react";
 
+import "./globals.css";
+// TODO(docs-app-phase-1 PR 5): move this import into the docs layout once it
+// exists; imported here temporarily so the placeholder page exercises it.
+import "./docs/docs-theme.css";
+
+/* Pre-hydration port of the platform themeInitScript contract: reads the
+ * shared `vellum_theme` key (platform-only "velvet" counts as dark) and stamps
+ * BOTH `.dark` (docs-theme.css) and `data-theme` (design-library tokens) to
+ * avoid a light-mode flash for dark users. */
+const themeInitScript = `
+(function() {
+  try {
+    var theme = localStorage.getItem('vellum_theme') || 'system';
+    var isDark = theme === 'velvet' || theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', isDark);
+    document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+  } catch (e) {}
+})();
+`;
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="en" suppressHydrationWarning>
+      <body className="font-sans">
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        {children}
+      </body>
     </html>
   );
 }

--- a/clients/docs/src/app/layout.tsx
+++ b/clients/docs/src/app/layout.tsx
@@ -5,15 +5,17 @@ import "./globals.css";
 // exists; imported here temporarily so the placeholder page exercises it.
 import "./docs/docs-theme.css";
 
-/* Pre-hydration port of the platform themeInitScript contract: reads the
- * shared `vellum_theme` key (platform-only "velvet" counts as dark) and stamps
+/* Pre-hydration theme bootstrap. Mirrors the key precedence of the assistant
+ * SPA's clients/web/public/theme-init.js (`device:theme` first, then the
+ * shared `vellum_theme` key, then system preference; platform-only "velvet"
+ * counts as dark) since both apps share the www.vellum.ai origin. Stamps
  * BOTH `.dark` (docs-theme.css) and `data-theme` (design-library tokens) to
  * avoid a light-mode flash for dark users. */
 const themeInitScript = `
 (function() {
   try {
-    var theme = localStorage.getItem('vellum_theme') || 'system';
-    var isDark = theme === 'velvet' || theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    var theme = localStorage.getItem('device:theme') || localStorage.getItem('vellum_theme') || 'system';
+    var isDark = theme === 'velvet' || theme === 'dark' || (theme === 'system' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
     document.documentElement.classList.toggle('dark', isDark);
     document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
   } catch (e) {}


### PR DESCRIPTION
## Summary
- Wire Tailwind 4 + @vellumai/design-library tokens.css into clients/docs
- Port docs-theme.css verbatim from the platform docs tree
- Add dual .dark + data-theme theme bootstrap script (localStorage vellum_theme contract preserved)

Part of plan: docs-app-phase-1.md (PR 2 of 15)