### PR TITLE
feat(docs): port lexical docs search library

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -120,6 +120,7 @@
     "clients/docs": {
       "name": "@vellumai/docs",
       "dependencies": {
+        "minisearch": "7.2.0",
         "next": "16.2.6",
         "react": "19.2.6",
         "react-dom": "19.2.6",
@@ -129,6 +130,7 @@
         "@types/node": "26.1.2",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
+        "cheerio": "1.2.0",
         "eslint": "10.2.0",
         "eslint-config-next": "16.2.6",
         "eslint-plugin-react-hooks": "7.1.1",
@@ -1877,6 +1879,8 @@
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "bplist-parser": ["bplist-parser@0.3.2", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ=="],
@@ -1940,6 +1944,10 @@
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -2022,6 +2030,10 @@
     "cross-dirname": ["cross-dirname@0.1.0", "", {}, "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
@@ -2117,6 +2129,14 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "dot-prop": ["dot-prop@10.1.0", "", { "dependencies": { "type-fest": "^5.0.0" } }, "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q=="],
 
     "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
@@ -2162,6 +2182,8 @@
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -2464,6 +2486,8 @@
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -2869,6 +2893,8 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
+
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
@@ -2924,6 +2950,8 @@
     "nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
 
     "normalize-url": ["normalize-url@6.1.0", "", {}, "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -2986,6 +3014,10 @@
     "parse-ms": ["parse-ms@2.1.0", "", {}, "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -3627,7 +3659,9 @@
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -4165,6 +4199,8 @@
 
     "c12/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
+    "cheerio/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -4191,6 +4227,8 @@
 
     "dmg-license/plist": ["plist@3.1.1", "", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
 
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "electron/@electron/get": ["@electron/get@5.0.0", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^3.0.0", "graceful-fs": "^4.2.11", "progress": "^2.0.3", "semver": "^7.6.3", "sumchecker": "^3.0.1" }, "optionalDependencies": { "undici": "^7.24.4" } }, "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA=="],
@@ -4212,6 +4250,8 @@
     "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "elementtree/sax": ["sax@1.1.4", "", {}, "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg=="],
+
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
@@ -4266,6 +4306,8 @@
     "global-agent/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "happy-dom/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "iconv-corefoundation/cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
 
@@ -4406,6 +4448,8 @@
     "vitest/@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
 
     "vitest/@vitest/spy": ["@vitest/spy@4.1.6", "", {}, "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 

--- a/clients/docs/package.json
+++ b/clients/docs/package.json
@@ -11,12 +11,14 @@
     "test": "bun test src"
   },
   "dependencies": {
+    "minisearch": "7.2.0",
     "next": "16.2.6",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
+    "cheerio": "1.2.0",
     "@types/node": "26.1.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/clients/docs/src/lib/docs/search/extract.test.ts
+++ b/clients/docs/src/lib/docs/search/extract.test.ts
@@ -135,6 +135,53 @@ describe("extractDocsPageFromHtml", () => {
     expect(pageChunk?.body).not.toContain("AlphaBeta");
   });
 
+  test("reads section headings whose id lives only on the section wrapper", () => {
+    const html = `
+      <div class="docs-main">
+        <div class="docs-breadcrumb">Docs / Intro</div>
+        <h1>Overview</h1>
+        <div class="docs-prose">
+          <section id="intro">
+            <h2>Introduction</h2>
+            <p>Welcome to the product.</p>
+          </section>
+        </div>
+      </div>
+    `;
+
+    const extracted = extractDocsPageFromHtml("/docs/overview", html);
+
+    const sectionChunk = extracted.chunks.find((chunk) => chunk.sectionId === "intro");
+    expect(sectionChunk?.heading).toBe("Introduction");
+    expect(sectionChunk?.body).toContain("Welcome to the product");
+  });
+
+  test("keeps child h3 content inside a standalone h2 block", () => {
+    const html = `
+      <div class="docs-main">
+        <div class="docs-breadcrumb">Docs / Guides</div>
+        <h1>Guides</h1>
+        <div class="docs-prose">
+          <h2 id="parent">Parent Topic</h2>
+          <h3 id="child">Child Detail</h3>
+          <p>Child body content here.</p>
+          <h2 id="sibling">Sibling Topic</h2>
+          <p>Sibling body content.</p>
+        </div>
+      </div>
+    `;
+
+    const extracted = extractDocsPageFromHtml("/docs/guides", html);
+
+    const parentChunk = extracted.chunks.find((chunk) => chunk.sectionId === "parent");
+    expect(parentChunk).toBeDefined();
+    expect(parentChunk?.body).toContain("Child body content");
+    expect(parentChunk?.body).not.toContain("Sibling body content");
+
+    const childChunk = extracted.chunks.find((chunk) => chunk.sectionId === "child");
+    expect(childChunk?.body).toContain("Child body content");
+  });
+
   test("creates fallback page chunk when headings are missing", () => {
     const html = `
       <div class="docs-main">

--- a/clients/docs/src/lib/docs/search/extract.test.ts
+++ b/clients/docs/src/lib/docs/search/extract.test.ts
@@ -85,6 +85,56 @@ describe("extractDocsPageFromHtml", () => {
     expect(setupChunks.length).toBe(1);
   });
 
+  test("scopes standalone heading chunks to their own heading block", () => {
+    const html = `
+      <div class="docs-main">
+        <div class="docs-breadcrumb">Docs / Guides</div>
+        <h1>Guides</h1>
+        <div class="docs-prose">
+          <h2 id="install">Install</h2>
+          <p>Download the installer bundle.</p>
+          <h2 id="uninstall">Uninstall</h2>
+          <p>Remove the zamboni directory.</p>
+        </div>
+      </div>
+    `;
+
+    const extracted = extractDocsPageFromHtml("/docs/guides", html);
+
+    const installChunk = extracted.chunks.find((chunk) => chunk.sectionId === "install");
+    const uninstallChunk = extracted.chunks.find((chunk) => chunk.sectionId === "uninstall");
+
+    expect(installChunk?.body).toContain("installer bundle");
+    expect(installChunk?.body).not.toContain("zamboni");
+    expect(uninstallChunk?.body).toContain("zamboni");
+    expect(uninstallChunk?.body).not.toContain("installer bundle");
+  });
+
+  test("preserves spaces between adjacent elements", () => {
+    const html = `
+      <div class="docs-main">
+        <div class="docs-breadcrumb">Docs / Features</div>
+        <h1>Features</h1>
+        <div class="docs-prose">
+          <section id="list">
+            <h2 id="list">List</h2>
+            <ul><li>Alpha</li><li>Beta</li></ul>
+          </section>
+        </div>
+      </div>
+    `;
+
+    const extracted = extractDocsPageFromHtml("/docs/features", html);
+
+    const sectionChunk = extracted.chunks.find((chunk) => chunk.sectionId === "list");
+    expect(sectionChunk?.body).toContain("Alpha Beta");
+    expect(sectionChunk?.body).not.toContain("AlphaBeta");
+
+    const pageChunk = extracted.chunks.find((chunk) => chunk.sectionId === null);
+    expect(pageChunk?.body).toContain("Alpha Beta");
+    expect(pageChunk?.body).not.toContain("AlphaBeta");
+  });
+
   test("creates fallback page chunk when headings are missing", () => {
     const html = `
       <div class="docs-main">

--- a/clients/docs/src/lib/docs/search/extract.test.ts
+++ b/clients/docs/src/lib/docs/search/extract.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractDocsPageFromHtml } from "@/lib/docs/search/extract";
+
+describe("extractDocsPageFromHtml", () => {
+  test("extracts route metadata and section chunks", () => {
+    const html = `
+      <div class="docs-main">
+        <div class="docs-breadcrumb">Docs / Getting Started</div>
+        <h1>Getting Started</h1>
+        <div class="docs-prose">
+          <section id="install">
+            <h2 id="install">Installation</h2>
+            <p>Run the installer and open the app.</p>
+          </section>
+        </div>
+      </div>
+    `;
+
+    const extracted = extractDocsPageFromHtml("/docs/getting-started", html);
+
+    expect(extracted.pageTitle).toBe("Getting Started");
+    expect(extracted.breadcrumb).toBe("Docs / Getting Started");
+    expect(extracted.chunks.length).toBeGreaterThanOrEqual(2);
+
+    const sectionChunk = extracted.chunks.find((chunk) => chunk.sectionId === "install");
+    expect(sectionChunk?.url).toBe("/docs/getting-started#install");
+    expect(sectionChunk?.heading).toBe("Installation");
+    expect(sectionChunk?.body).toContain("Run the installer");
+  });
+
+  test("extracts multiple heading levels from sections", () => {
+    const html = `
+      <div class="docs-main">
+        <div class="docs-breadcrumb">Docs / Help</div>
+        <h1>FAQ</h1>
+        <div class="docs-prose">
+          <section id="top">
+            <h2 id="top">Top Questions</h2>
+            <p>Top answers.</p>
+          </section>
+          <section id="billing">
+            <h3 id="billing">Billing</h3>
+            <p>Billing answers.</p>
+          </section>
+        </div>
+      </div>
+    `;
+
+    const extracted = extractDocsPageFromHtml("/docs/help/faq", html);
+
+    const h2Chunk = extracted.chunks.find((chunk) => chunk.sectionId === "top");
+    const h3Chunk = extracted.chunks.find((chunk) => chunk.sectionId === "billing");
+
+    expect(h2Chunk?.headingLevel).toBe(2);
+    expect(h3Chunk?.headingLevel).toBe(3);
+  });
+
+  test("creates fallback page chunk when headings are missing", () => {
+    const html = `
+      <div class="docs-main">
+        <div class="docs-breadcrumb">Docs / Intro</div>
+        <h1>Welcome</h1>
+        <div class="docs-prose">
+          <p>Hello docs world.</p>
+          <p>This page has no section headings.</p>
+        </div>
+      </div>
+    `;
+
+    const extracted = extractDocsPageFromHtml("/docs", html);
+
+    expect(extracted.chunks.length).toBeGreaterThan(0);
+    const pageChunk = extracted.chunks.find((chunk) => chunk.sectionId === null);
+    expect(pageChunk).toBeDefined();
+    expect(pageChunk?.url).toBe("/docs");
+    expect(pageChunk?.body).toContain("Hello docs world");
+  });
+});

--- a/clients/docs/src/lib/docs/search/extract.test.ts
+++ b/clients/docs/src/lib/docs/search/extract.test.ts
@@ -56,6 +56,35 @@ describe("extractDocsPageFromHtml", () => {
     expect(h3Chunk?.headingLevel).toBe(3);
   });
 
+  test("chunks standalone headings even when sections exist", () => {
+    const html = `
+      <div class="docs-main">
+        <div class="docs-breadcrumb">Docs / Guides</div>
+        <h1>Guides</h1>
+        <div class="docs-prose">
+          <section id="setup">
+            <h2 id="setup">Setup</h2>
+            <p>Setup instructions here.</p>
+          </section>
+          <h2 id="troubleshooting">Troubleshooting</h2>
+          <p>Troubleshooting tips here.</p>
+        </div>
+      </div>
+    `;
+
+    const extracted = extractDocsPageFromHtml("/docs/guides", html);
+
+    const sectionChunk = extracted.chunks.find((chunk) => chunk.sectionId === "setup");
+    const standaloneChunk = extracted.chunks.find((chunk) => chunk.sectionId === "troubleshooting");
+
+    expect(sectionChunk?.url).toBe("/docs/guides#setup");
+    expect(standaloneChunk?.url).toBe("/docs/guides#troubleshooting");
+    expect(standaloneChunk?.heading).toBe("Troubleshooting");
+
+    const setupChunks = extracted.chunks.filter((chunk) => chunk.sectionId === "setup");
+    expect(setupChunks.length).toBe(1);
+  });
+
   test("creates fallback page chunk when headings are missing", () => {
     const html = `
       <div class="docs-main">

--- a/clients/docs/src/lib/docs/search/extract.ts
+++ b/clients/docs/src/lib/docs/search/extract.ts
@@ -1,4 +1,4 @@
-import { load } from "cheerio";
+import { load, type Cheerio, type CheerioAPI } from "cheerio";
 
 import type { DocsSearchChunk } from "@/lib/docs/search/types";
 import { normalizeText, uniqueTokens } from "@/lib/docs/search/text";
@@ -7,6 +7,26 @@ export interface ExtractedDocsPage {
   pageTitle: string;
   breadcrumb: string;
   chunks: DocsSearchChunk[];
+}
+
+// Cheerio<AnyNode> derived without importing domhandler, which is not a direct dependency.
+type NodeSelection = ReturnType<Cheerio<never>["contents"]>;
+
+// Cheerio's .text() concatenates adjacent elements without separators, fusing tokens
+// like <li>Alpha</li><li>Beta</li> into "AlphaBeta". Insert element boundaries as spaces
+// on a detached clone so extracted text keeps one token per word.
+function elementText($: CheerioAPI, selection: NodeSelection): string {
+  const parts: string[] = [];
+
+  selection.each((_, node) => {
+    const clone = $(node).clone();
+    clone.find("*").each((_, descendant) => {
+      $(descendant).before(" ").after(" ");
+    });
+    parts.push(clone.text());
+  });
+
+  return normalizeText(parts.join(" "));
 }
 
 function cleanSectionBody(sectionText: string, headingText: string): string {
@@ -73,8 +93,8 @@ export function extractDocsPageFromHtml(route: string, html: string): ExtractedD
   const $ = load(html);
   const main = $(".docs-main").first();
 
-  const pageTitle = normalizeText(main.find("h1").first().text()) || "Docs";
-  const breadcrumb = normalizeText(main.find(".docs-breadcrumb").first().text()) || "Docs";
+  const pageTitle = elementText($, main.find("h1").first()) || "Docs";
+  const breadcrumb = elementText($, main.find(".docs-breadcrumb").first()) || "Docs";
 
   const proseRoot = main.find(".docs-prose").first();
   const chunks: DocsSearchChunk[] = [];
@@ -89,10 +109,10 @@ export function extractDocsPageFromHtml(route: string, html: string): ExtractedD
     }
 
     const headingEl = section.find("h2[id], h3[id]").first();
-    const headingText = normalizeText(headingEl.text()) || sectionId;
+    const headingText = elementText($, headingEl) || sectionId;
     const tagName = headingEl.get(0)?.tagName?.toLowerCase();
     const headingLevel: 1 | 2 | 3 = tagName === "h3" ? 3 : 2;
-    const body = cleanSectionBody(section.text(), headingText);
+    const body = cleanSectionBody(elementText($, section), headingText);
 
     if (!body) {
       return;
@@ -120,11 +140,15 @@ export function extractDocsPageFromHtml(route: string, html: string): ExtractedD
       return;
     }
 
-    const headingText = normalizeText(heading.text()) || sectionId;
+    const headingText = elementText($, heading) || sectionId;
     const headingLevel: 1 | 2 | 3 = heading.get(0)?.tagName?.toLowerCase() === "h3" ? 3 : 2;
 
-    const block = heading.closest("section").length > 0 ? heading.closest("section") : heading.parent();
-    const body = cleanSectionBody(block.text(), headingText);
+    const parentSection = heading.closest("section");
+    const block =
+      parentSection.length > 0
+        ? parentSection
+        : heading.add(heading.nextUntil("h1, h2, h3, h4, section"));
+    const body = cleanSectionBody(elementText($, block), headingText);
 
     if (!body) {
       return;
@@ -145,7 +169,7 @@ export function extractDocsPageFromHtml(route: string, html: string): ExtractedD
     seenIds.add(sectionId);
   });
 
-  const pageBody = normalizeText(proseRoot.text());
+  const pageBody = elementText($, proseRoot);
   if (pageBody) {
     chunks.unshift(
       makeChunk({

--- a/clients/docs/src/lib/docs/search/extract.ts
+++ b/clients/docs/src/lib/docs/search/extract.ts
@@ -108,7 +108,7 @@ export function extractDocsPageFromHtml(route: string, html: string): ExtractedD
       return;
     }
 
-    const headingEl = section.find("h2[id], h3[id]").first();
+    const headingEl = section.find("h2, h3").first();
     const headingText = elementText($, headingEl) || sectionId;
     const tagName = headingEl.get(0)?.tagName?.toLowerCase();
     const headingLevel: 1 | 2 | 3 = tagName === "h3" ? 3 : 2;
@@ -144,10 +144,13 @@ export function extractDocsPageFromHtml(route: string, html: string): ExtractedD
     const headingLevel: 1 | 2 | 3 = heading.get(0)?.tagName?.toLowerCase() === "h3" ? 3 : 2;
 
     const parentSection = heading.closest("section");
+    // Stop only at same-or-higher-level headings so an h2 block keeps its
+    // child h3 content instead of ending at the first subsection heading.
+    const stopSelector = headingLevel === 3 ? "h1, h2, h3, section" : "h1, h2, section";
     const block =
       parentSection.length > 0
         ? parentSection
-        : heading.add(heading.nextUntil("h1, h2, h3, h4, section"));
+        : heading.add(heading.nextUntil(stopSelector));
     const body = cleanSectionBody(elementText($, block), headingText);
 
     if (!body) {

--- a/clients/docs/src/lib/docs/search/extract.ts
+++ b/clients/docs/src/lib/docs/search/extract.ts
@@ -113,39 +113,37 @@ export function extractDocsPageFromHtml(route: string, html: string): ExtractedD
     seenIds.add(sectionId);
   });
 
-  if (chunks.length === 0) {
-    proseRoot.find("h2[id], h3[id]").each((_, element) => {
-      const heading = $(element);
-      const sectionId = normalizeText(heading.attr("id") ?? "") || null;
-      if (!sectionId || seenIds.has(sectionId)) {
-        return;
-      }
+  proseRoot.find("h2[id], h3[id]").each((_, element) => {
+    const heading = $(element);
+    const sectionId = normalizeText(heading.attr("id") ?? "") || null;
+    if (!sectionId || seenIds.has(sectionId)) {
+      return;
+    }
 
-      const headingText = normalizeText(heading.text()) || sectionId;
-      const headingLevel: 1 | 2 | 3 = heading.get(0)?.tagName?.toLowerCase() === "h3" ? 3 : 2;
+    const headingText = normalizeText(heading.text()) || sectionId;
+    const headingLevel: 1 | 2 | 3 = heading.get(0)?.tagName?.toLowerCase() === "h3" ? 3 : 2;
 
-      const block = heading.closest("section").length > 0 ? heading.closest("section") : heading.parent();
-      const body = cleanSectionBody(block.text(), headingText);
+    const block = heading.closest("section").length > 0 ? heading.closest("section") : heading.parent();
+    const body = cleanSectionBody(block.text(), headingText);
 
-      if (!body) {
-        return;
-      }
+    if (!body) {
+      return;
+    }
 
-      chunks.push(
-        makeChunk({
-          route,
-          pageTitle,
-          breadcrumb,
-          heading: headingText,
-          headingLevel,
-          sectionId,
-          body,
-        })
-      );
+    chunks.push(
+      makeChunk({
+        route,
+        pageTitle,
+        breadcrumb,
+        heading: headingText,
+        headingLevel,
+        sectionId,
+        body,
+      })
+    );
 
-      seenIds.add(sectionId);
-    });
-  }
+    seenIds.add(sectionId);
+  });
 
   const pageBody = normalizeText(proseRoot.text());
   if (pageBody) {

--- a/clients/docs/src/lib/docs/search/extract.ts
+++ b/clients/docs/src/lib/docs/search/extract.ts
@@ -1,0 +1,166 @@
+import { load } from "cheerio";
+
+import type { DocsSearchChunk } from "@/lib/docs/search/types";
+import { normalizeText, uniqueTokens } from "@/lib/docs/search/text";
+
+export interface ExtractedDocsPage {
+  pageTitle: string;
+  breadcrumb: string;
+  chunks: DocsSearchChunk[];
+}
+
+function cleanSectionBody(sectionText: string, headingText: string): string {
+  const normalizedSection = normalizeText(sectionText);
+  if (!headingText) {
+    return normalizedSection;
+  }
+
+  if (normalizedSection.toLowerCase().startsWith(headingText.toLowerCase())) {
+    return normalizeText(normalizedSection.slice(headingText.length));
+  }
+
+  return normalizedSection;
+}
+
+function buildKeywords(route: string, breadcrumb: string, pageTitle: string, heading: string, sectionId: string | null): string[] {
+  const routeTokens = route
+    .replace(/^\/docs\/?/, "")
+    .split("/")
+    .flatMap((segment) => segment.split("-"));
+
+  return uniqueTokens([
+    ...routeTokens,
+    breadcrumb,
+    pageTitle,
+    heading,
+    sectionId ?? "",
+  ]);
+}
+
+function makeChunk(params: {
+  route: string;
+  pageTitle: string;
+  breadcrumb: string;
+  heading: string;
+  headingLevel: 1 | 2 | 3;
+  sectionId: string | null;
+  body: string;
+}): DocsSearchChunk {
+  const url = params.sectionId ? `${params.route}#${params.sectionId}` : params.route;
+  const id = params.sectionId ? `${params.route}#${params.sectionId}` : `${params.route}#__page`;
+
+  return {
+    id,
+    route: params.route,
+    url,
+    pageTitle: params.pageTitle,
+    breadcrumb: params.breadcrumb,
+    heading: params.heading,
+    headingLevel: params.headingLevel,
+    sectionId: params.sectionId,
+    body: params.body,
+    keywords: buildKeywords(
+      params.route,
+      params.breadcrumb,
+      params.pageTitle,
+      params.heading,
+      params.sectionId
+    ),
+  };
+}
+
+export function extractDocsPageFromHtml(route: string, html: string): ExtractedDocsPage {
+  const $ = load(html);
+  const main = $(".docs-main").first();
+
+  const pageTitle = normalizeText(main.find("h1").first().text()) || "Docs";
+  const breadcrumb = normalizeText(main.find(".docs-breadcrumb").first().text()) || "Docs";
+
+  const proseRoot = main.find(".docs-prose").first();
+  const chunks: DocsSearchChunk[] = [];
+
+  const seenIds = new Set<string>();
+
+  proseRoot.find("section[id]").each((_, element) => {
+    const section = $(element);
+    const sectionId = normalizeText(section.attr("id") ?? "") || null;
+    if (!sectionId || seenIds.has(sectionId)) {
+      return;
+    }
+
+    const headingEl = section.find("h2[id], h3[id]").first();
+    const headingText = normalizeText(headingEl.text()) || sectionId;
+    const tagName = headingEl.get(0)?.tagName?.toLowerCase();
+    const headingLevel: 1 | 2 | 3 = tagName === "h3" ? 3 : 2;
+    const body = cleanSectionBody(section.text(), headingText);
+
+    if (!body) {
+      return;
+    }
+
+    chunks.push(
+      makeChunk({
+        route,
+        pageTitle,
+        breadcrumb,
+        heading: headingText,
+        headingLevel,
+        sectionId,
+        body,
+      })
+    );
+
+    seenIds.add(sectionId);
+  });
+
+  if (chunks.length === 0) {
+    proseRoot.find("h2[id], h3[id]").each((_, element) => {
+      const heading = $(element);
+      const sectionId = normalizeText(heading.attr("id") ?? "") || null;
+      if (!sectionId || seenIds.has(sectionId)) {
+        return;
+      }
+
+      const headingText = normalizeText(heading.text()) || sectionId;
+      const headingLevel: 1 | 2 | 3 = heading.get(0)?.tagName?.toLowerCase() === "h3" ? 3 : 2;
+
+      const block = heading.closest("section").length > 0 ? heading.closest("section") : heading.parent();
+      const body = cleanSectionBody(block.text(), headingText);
+
+      if (!body) {
+        return;
+      }
+
+      chunks.push(
+        makeChunk({
+          route,
+          pageTitle,
+          breadcrumb,
+          heading: headingText,
+          headingLevel,
+          sectionId,
+          body,
+        })
+      );
+
+      seenIds.add(sectionId);
+    });
+  }
+
+  const pageBody = normalizeText(proseRoot.text());
+  if (pageBody) {
+    chunks.unshift(
+      makeChunk({
+        route,
+        pageTitle,
+        breadcrumb,
+        heading: pageTitle,
+        headingLevel: 1,
+        sectionId: null,
+        body: pageBody,
+      })
+    );
+  }
+
+  return { pageTitle, breadcrumb, chunks };
+}

--- a/clients/docs/src/lib/docs/search/index-loader.ts
+++ b/clients/docs/src/lib/docs/search/index-loader.ts
@@ -1,0 +1,42 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { DocsSearchIndexFile } from "@/lib/docs/search/types";
+
+const EMPTY_INDEX: DocsSearchIndexFile = {
+  version: 1,
+  generatedAt: new Date(0).toISOString(),
+  chunks: [],
+};
+
+let cachedIndex: DocsSearchIndexFile | null = null;
+
+function getIndexPath(): string {
+  return process.env.DOCS_SEARCH_INDEX_PATH ?? join(process.cwd(), "public", "docs", "search-index.json");
+}
+
+export async function loadDocsSearchIndex(): Promise<DocsSearchIndexFile> {
+  if (cachedIndex) {
+    return cachedIndex;
+  }
+
+  try {
+    const raw = await readFile(getIndexPath(), "utf8");
+    const parsed = JSON.parse(raw) as DocsSearchIndexFile;
+
+    if (!Array.isArray(parsed.chunks)) {
+      cachedIndex = EMPTY_INDEX;
+      return cachedIndex;
+    }
+
+    cachedIndex = parsed;
+    return cachedIndex;
+  } catch {
+    cachedIndex = EMPTY_INDEX;
+    return cachedIndex;
+  }
+}
+
+export function resetDocsSearchIndexCache(): void {
+  cachedIndex = null;
+}

--- a/clients/docs/src/lib/docs/search/ranker.test.ts
+++ b/clients/docs/src/lib/docs/search/ranker.test.ts
@@ -54,6 +54,26 @@ describe("searchDocsIndex", () => {
     expect(fuzzy.results[0]?.route).toBe("/docs/help/common-issues");
   });
 
+  test("builds fuzzy-match snippets from the matched term, not the raw query token", () => {
+    const index: DocsSearchIndexFile = {
+      ...BASE_INDEX,
+      chunks: [
+        {
+          ...BASE_INDEX.chunks[1]!,
+          body: `${"Filler text that pads the beginning of the body well past the snippet window so a start-of-body fallback would miss the match. ".repeat(3)}Reconnect your Google Calendar integration to fix sync.`,
+        },
+      ],
+    };
+
+    const fuzzy = searchDocsIndex({
+      query: "calender",
+      index,
+      limit: 5,
+    });
+
+    expect(fuzzy.results[0]?.snippet.toLowerCase()).toContain("calendar");
+  });
+
   test("boosts title/heading matches over body-only matches", () => {
     const index: DocsSearchIndexFile = {
       ...BASE_INDEX,

--- a/clients/docs/src/lib/docs/search/ranker.test.ts
+++ b/clients/docs/src/lib/docs/search/ranker.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { searchDocsIndex } from "@/lib/docs/search/ranker";
+import type { DocsSearchIndexFile } from "@/lib/docs/search/types";
+
+const BASE_INDEX: DocsSearchIndexFile = {
+  version: 1,
+  generatedAt: new Date().toISOString(),
+  chunks: [
+    {
+      id: "/docs/getting-started#__page",
+      route: "/docs/getting-started",
+      url: "/docs/getting-started",
+      pageTitle: "Getting Started",
+      breadcrumb: "Docs / Getting Started",
+      heading: "Getting Started",
+      headingLevel: 1,
+      sectionId: null,
+      body: "Install Vellum quickly and run your first workflow.",
+      keywords: ["installation", "quickstart"],
+    },
+    {
+      id: "/docs/help/common-issues#oauth",
+      route: "/docs/help/common-issues",
+      url: "/docs/help/common-issues#oauth",
+      pageTitle: "Common Issues",
+      breadcrumb: "Docs / Help / Common Issues",
+      heading: "OAuth connection failed",
+      headingLevel: 2,
+      sectionId: "oauth",
+      body: "Fix OAuth and reconnect your Google Calendar integration.",
+      keywords: ["oauth", "google", "calendar"],
+    },
+  ],
+};
+
+describe("searchDocsIndex", () => {
+  test("supports prefix and fuzzy lexical matching", () => {
+    const prefix = searchDocsIndex({
+      query: "instal",
+      index: BASE_INDEX,
+      limit: 5,
+    });
+
+    expect(prefix.mode).toBe("lexical");
+    expect(prefix.results[0]?.route).toBe("/docs/getting-started");
+
+    const fuzzy = searchDocsIndex({
+      query: "calender",
+      index: BASE_INDEX,
+      limit: 5,
+    });
+
+    expect(fuzzy.results[0]?.route).toBe("/docs/help/common-issues");
+  });
+
+  test("boosts title/heading matches over body-only matches", () => {
+    const index: DocsSearchIndexFile = {
+      ...BASE_INDEX,
+      chunks: [
+        {
+          ...BASE_INDEX.chunks[0]!,
+          id: "/docs/title-match#__page",
+          route: "/docs/title-match",
+          url: "/docs/title-match",
+          pageTitle: "Permissions Guide",
+          heading: "Permissions Guide",
+          body: "General introduction.",
+          keywords: ["permissions"],
+        },
+        {
+          ...BASE_INDEX.chunks[1]!,
+          id: "/docs/body-match#__page",
+          route: "/docs/body-match",
+          url: "/docs/body-match",
+          pageTitle: "Help",
+          heading: "Help",
+          body: "This paragraph mentions permissions once.",
+          keywords: [],
+        },
+      ],
+    };
+
+    const result = searchDocsIndex({
+      query: "permissions",
+      index,
+      limit: 5,
+    });
+
+    expect(result.results[0]?.route).toBe("/docs/title-match");
+  });
+});

--- a/clients/docs/src/lib/docs/search/ranker.ts
+++ b/clients/docs/src/lib/docs/search/ranker.ts
@@ -1,0 +1,171 @@
+import MiniSearch from "minisearch";
+
+import { extractSnippet, normalizeText } from "@/lib/docs/search/text";
+import type {
+  DocsSearchChunk,
+  DocsSearchIndexFile,
+  DocsSearchResult,
+} from "@/lib/docs/search/types";
+
+interface SearchableChunk extends DocsSearchChunk {
+  keywordsText: string;
+}
+
+interface RankedChunk {
+  chunk: DocsSearchChunk;
+  lexicalScore: number;
+  score: number;
+}
+
+const SEARCH_BOOSTS = {
+  pageTitle: 4,
+  heading: 3,
+  keywordsText: 2,
+  breadcrumb: 1.5,
+  body: 1,
+} as const;
+
+const miniSearchCache = new WeakMap<DocsSearchChunk[], MiniSearch<SearchableChunk>>();
+const chunkMapCache = new WeakMap<DocsSearchChunk[], Map<string, DocsSearchChunk>>();
+
+function toSearchableChunk(chunk: DocsSearchChunk): SearchableChunk {
+  return {
+    ...chunk,
+    keywordsText: chunk.keywords.join(" "),
+  };
+}
+
+function getChunkMap(chunks: DocsSearchChunk[]): Map<string, DocsSearchChunk> {
+  const cached = chunkMapCache.get(chunks);
+  if (cached) {
+    return cached;
+  }
+
+  const map = new Map<string, DocsSearchChunk>();
+  for (const chunk of chunks) {
+    map.set(chunk.id, chunk);
+  }
+
+  chunkMapCache.set(chunks, map);
+  return map;
+}
+
+function getMiniSearch(chunks: DocsSearchChunk[]): MiniSearch<SearchableChunk> {
+  const cached = miniSearchCache.get(chunks);
+  if (cached) {
+    return cached;
+  }
+
+  const mini = new MiniSearch<SearchableChunk>({
+    idField: "id",
+    fields: ["pageTitle", "heading", "breadcrumb", "keywordsText", "body"],
+    storeFields: ["id"],
+    tokenize: (text) =>
+      normalizeText(text)
+        .toLowerCase()
+        .split(/\W+/)
+        .filter((token) => token.length > 1),
+    processTerm: (term) => term.toLowerCase(),
+  });
+
+  mini.addAll(chunks.map(toSearchableChunk));
+  miniSearchCache.set(chunks, mini);
+
+  return mini;
+}
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return 10;
+  }
+  return Math.min(Math.max(Math.floor(limit), 1), 20);
+}
+
+function normalizeLexicalScores(candidates: RankedChunk[]): RankedChunk[] {
+  const maxLexical = Math.max(...candidates.map((candidate) => candidate.lexicalScore), 1);
+
+  return candidates.map((candidate) => ({
+    ...candidate,
+    score: candidate.lexicalScore / maxLexical,
+  }));
+}
+
+function lexicalSearch(params: {
+  query: string;
+  chunks: DocsSearchChunk[];
+  topK: number;
+}): RankedChunk[] {
+  const mini = getMiniSearch(params.chunks);
+  const chunkMap = getChunkMap(params.chunks);
+
+  const raw = mini.search(params.query, {
+    combineWith: "OR",
+    prefix: true,
+    fuzzy: (term) => (term.length >= 5 ? 0.2 : false),
+    boost: SEARCH_BOOSTS,
+  });
+
+  const ranked = raw
+    .slice(0, params.topK)
+    .map((result) => {
+      const chunk = chunkMap.get(String(result.id));
+      if (!chunk) {
+        return null;
+      }
+
+      return {
+        chunk,
+        lexicalScore: result.score,
+        score: result.score,
+      } satisfies RankedChunk;
+    })
+    .filter((candidate): candidate is RankedChunk => candidate !== null);
+
+  if (ranked.length === 0) {
+    return [];
+  }
+
+  return normalizeLexicalScores(ranked).sort((a, b) => b.score - a.score);
+}
+
+function toResult(query: string, candidate: RankedChunk): DocsSearchResult {
+  return {
+    id: candidate.chunk.id,
+    url: candidate.chunk.url,
+    route: candidate.chunk.route,
+    pageTitle: candidate.chunk.pageTitle,
+    heading: candidate.chunk.heading,
+    sectionId: candidate.chunk.sectionId,
+    snippet: extractSnippet(candidate.chunk.body, query),
+    score: candidate.score,
+    lexicalScore: candidate.lexicalScore,
+  };
+}
+
+export function searchDocsIndex(params: {
+  query: string;
+  limit?: number;
+  index: DocsSearchIndexFile;
+}): { mode: "lexical"; results: DocsSearchResult[] } {
+  const query = normalizeText(params.query);
+  const limit = clampLimit(params.limit ?? 10);
+
+  if (query.length < 2 || params.index.chunks.length === 0) {
+    return {
+      mode: "lexical",
+      results: [],
+    };
+  }
+
+  const lexicalTopK = Math.max(40, limit * 4);
+  const candidates = lexicalSearch({
+    query,
+    chunks: params.index.chunks,
+    topK: lexicalTopK,
+  });
+
+  return {
+    mode: "lexical",
+    results: candidates.slice(0, limit).map((candidate) => toResult(query, candidate)),
+  };
+}

--- a/clients/docs/src/lib/docs/search/ranker.ts
+++ b/clients/docs/src/lib/docs/search/ranker.ts
@@ -13,6 +13,7 @@ interface SearchableChunk extends DocsSearchChunk {
 
 interface RankedChunk {
   chunk: DocsSearchChunk;
+  matchedTerms: string[];
   lexicalScore: number;
   score: number;
 }
@@ -115,6 +116,7 @@ function lexicalSearch(params: {
 
       return {
         chunk,
+        matchedTerms: result.terms,
         lexicalScore: result.score,
         score: result.score,
       } satisfies RankedChunk;
@@ -129,6 +131,8 @@ function lexicalSearch(params: {
 }
 
 function toResult(query: string, candidate: RankedChunk): DocsSearchResult {
+  const snippetQuery = [...candidate.matchedTerms, query].join(" ").trim() || query;
+
   return {
     id: candidate.chunk.id,
     url: candidate.chunk.url,
@@ -136,7 +140,7 @@ function toResult(query: string, candidate: RankedChunk): DocsSearchResult {
     pageTitle: candidate.chunk.pageTitle,
     heading: candidate.chunk.heading,
     sectionId: candidate.chunk.sectionId,
-    snippet: extractSnippet(candidate.chunk.body, query),
+    snippet: extractSnippet(candidate.chunk.body, snippetQuery),
     score: candidate.score,
     lexicalScore: candidate.lexicalScore,
   };

--- a/clients/docs/src/lib/docs/search/rate-limit.ts
+++ b/clients/docs/src/lib/docs/search/rate-limit.ts
@@ -1,0 +1,53 @@
+/**
+ * Simple in-memory sliding-window rate limiter keyed by IP address,
+ * used by the docs search endpoint to prevent abuse.
+ */
+
+interface WindowEntry {
+  count: number;
+  resetAt: number;
+}
+
+const windows = new Map<string, WindowEntry>();
+
+const WINDOW_MS = 60_000; // 1 minute
+const MAX_REQUESTS = 30; // per window per IP
+
+// Periodically prune expired entries to avoid unbounded memory growth.
+const PRUNE_INTERVAL_MS = 5 * 60_000;
+let lastPrune = Date.now();
+
+function pruneExpired(): void {
+  const now = Date.now();
+  if (now - lastPrune < PRUNE_INTERVAL_MS) {
+    return;
+  }
+
+  lastPrune = now;
+  for (const [key, entry] of windows) {
+    if (now >= entry.resetAt) {
+      windows.delete(key);
+    }
+  }
+}
+
+// GCP ALB appends: ..., <real-client-ip>, <lb-ip>. Use second-to-last to get the real IP.
+export function resolveClientIp(forwardedFor: string | null): string {
+  const parts = forwardedFor?.split(",").map((part) => part.trim()) ?? [];
+  return parts.at(-2) || parts[0] || "unknown";
+}
+
+export function isRateLimited(ip: string): boolean {
+  pruneExpired();
+
+  const now = Date.now();
+  const entry = windows.get(ip);
+
+  if (!entry || now >= entry.resetAt) {
+    windows.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return false;
+  }
+
+  entry.count += 1;
+  return entry.count > MAX_REQUESTS;
+}

--- a/clients/docs/src/lib/docs/search/text.ts
+++ b/clients/docs/src/lib/docs/search/text.ts
@@ -1,0 +1,89 @@
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "to",
+  "with",
+]);
+
+export function normalizeText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+export function tokenize(value: string): string[] {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9\s-]/g, " ");
+  return normalized
+    .split(/[\s-]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2 && !STOP_WORDS.has(token));
+}
+
+export function uniqueTokens(values: string[]): string[] {
+  return Array.from(new Set(values.flatMap(tokenize)));
+}
+
+export function extractSnippet(body: string, query: string, maxLen = 180): string {
+  const source = normalizeText(body);
+  if (!source) {
+    return "";
+  }
+
+  const tokens = uniqueTokens([query]);
+  if (tokens.length === 0) {
+    return source.length <= maxLen ? source : `${source.slice(0, maxLen - 1)}...`;
+  }
+
+  const lower = source.toLowerCase();
+  let matchIndex = -1;
+
+  for (const token of tokens) {
+    const idx = lower.indexOf(token.toLowerCase());
+    if (idx !== -1 && (matchIndex === -1 || idx < matchIndex)) {
+      matchIndex = idx;
+    }
+  }
+
+  if (matchIndex === -1) {
+    return source.length <= maxLen ? source : `${source.slice(0, maxLen - 1)}...`;
+  }
+
+  const contextBefore = Math.floor(maxLen * 0.4);
+  const start = Math.max(0, matchIndex - contextBefore);
+  const end = Math.min(source.length, start + maxLen);
+  const snippet = source.slice(start, end);
+
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < source.length ? "..." : "";
+
+  return `${prefix}${snippet}${suffix}`;
+}
+
+export function highlightSnippet(snippet: string, query: string): string {
+  const tokens = uniqueTokens([query]).sort((a, b) => b.length - a.length);
+  if (tokens.length === 0 || !snippet) {
+    return snippet;
+  }
+
+  let output = snippet;
+  for (const token of tokens) {
+    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    output = output.replace(new RegExp(`(${escaped})`, "ig"), "<mark>$1</mark>");
+  }
+
+  return output;
+}

--- a/clients/docs/src/lib/docs/search/types.ts
+++ b/clients/docs/src/lib/docs/search/types.ts
@@ -1,0 +1,37 @@
+export interface DocsSearchChunk {
+  id: string;
+  route: string;
+  url: string;
+  pageTitle: string;
+  breadcrumb: string;
+  heading: string;
+  headingLevel: 1 | 2 | 3;
+  sectionId: string | null;
+  body: string;
+  keywords: string[];
+}
+
+export interface DocsSearchIndexFile {
+  version: number;
+  generatedAt: string;
+  chunks: DocsSearchChunk[];
+}
+
+export interface DocsSearchResult {
+  id: string;
+  url: string;
+  route: string;
+  pageTitle: string;
+  heading: string;
+  sectionId: string | null;
+  snippet: string;
+  score: number;
+  lexicalScore: number;
+}
+
+export interface DocsSearchResponse {
+  query: string;
+  mode: "lexical";
+  tookMs: number;
+  results: DocsSearchResult[];
+}


### PR DESCRIPTION
## Summary
- Port the docs search lib (tokenize, extract, BM25 ranker, IP rate limiter, index loader) from the platform repo
- Drop unreachable embeddings/semantic mode - lexical-only
- Index default path moves to public/docs/search-index.json

Part of plan: docs-app-phase-1.md (PR 4 of 15)