### PR TITLE
feat(docs): production Dockerfile and image publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,10 @@
 !bun.lock
 !patches/
 !patches/**
-!clients/docs/package.json
+# Docs site image: the builder copies the full clients/docs sources (this also
+# covers the clients/docs/package.json manifest the other images install from).
+!clients/docs/
+!clients/docs/**
 !clients/macos/package.json
 !clients/web/package.json
 !cli/package.json
@@ -15,6 +18,7 @@
 # beneath that directory. This manifests as an extremely long build context load time.
 # Adding an explicit exclusion rule seems to help with this.
 clients/.build
+clients/docs/.next
 clients/ios
 clients/chrome-extension
 clients/macos/apple-containers-runtime
@@ -54,6 +58,8 @@ assistant/.env
 assistant/.env.*
 # Authoring-reference example plugins are not shipped with the production image.
 assistant/examples/
+clients/docs/.env
+clients/docs/.env.*
 credential-executor/.env
 credential-executor/.env.*
 gateway/.env

--- a/.github/workflows/publish-docs-image.yaml
+++ b/.github/workflows/publish-docs-image.yaml
@@ -29,10 +29,13 @@ on:
           - staging
           - production
 
-# Serialize publishes per environment so an older build cannot finish last
-# and overwrite the mutable `latest` tag from a newer commit.
+# Cancel superseded publishes per environment: concurrency groups run in
+# arbitrary order, so cancelling older runs is what guarantees the newest
+# commit's build is the one that tags `latest`. A cancelled run skips its
+# SHA tag; only the newest image matters in this registry.
 concurrency:
   group: publish-docs-image-${{ inputs.environment || 'dev' }}
+  cancel-in-progress: true
 
 env:
   DOCS_IMAGE_NAME: sandbox-images/docs-site

--- a/.github/workflows/publish-docs-image.yaml
+++ b/.github/workflows/publish-docs-image.yaml
@@ -1,0 +1,79 @@
+name: Publish Docs Image
+
+# Builds and publishes the docs-site image to the environment's Artifact
+# Registry. Pushes to main publish to `dev`; `workflow_dispatch` keeps the
+# staging/production registries manually reachable until the Phase 2/3
+# environment wiring lands.
+#
+# The image lives under the existing `sandbox-images` AR repo to avoid a
+# Phase 1 Terraform change; a dedicated repo can move to the Phase 2
+# Terraform PR if preferred.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'clients/docs/**'
+      - 'packages/design-library/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'patches/**'
+      - '.github/workflows/publish-docs-image.yaml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target GitHub environment to publish to.
+        type: choice
+        required: true
+        default: dev
+        options:
+          - dev
+          - staging
+          - production
+
+env:
+  DOCS_IMAGE_NAME: sandbox-images/docs-site
+
+jobs:
+  push-docs-image:
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    environment: ${{ inputs.environment || 'dev' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker ${{ vars.GCP_REGISTRY_HOST }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Compute image name
+        id: image
+        run: |
+          echo "gcp=${{ vars.GCP_REGISTRY_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ env.DOCS_IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
+
+      # Single-arch: GKE nodes are amd64, so no multi-arch digest/manifest
+      # dance is needed.
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: clients/docs/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.image.outputs.gcp }}:${{ github.sha }}
+            ${{ steps.image.outputs.gcp }}:latest
+          cache-from: type=gha,scope=docs-site
+          cache-to: type=gha,mode=max,ignore-error=true,scope=docs-site

--- a/.github/workflows/publish-docs-image.yaml
+++ b/.github/workflows/publish-docs-image.yaml
@@ -1,13 +1,10 @@
 name: Publish Docs Image
 
-# Builds and publishes the docs-site image to the environment's Artifact
-# Registry. Pushes to main publish to `dev`; `workflow_dispatch` keeps the
-# staging/production registries manually reachable until the Phase 2/3
-# environment wiring lands.
-#
-# The image lives under the existing `sandbox-images` AR repo to avoid a
-# Phase 1 Terraform change; a dedicated repo can move to the Phase 2
-# Terraform PR if preferred.
+# Builds and publishes the docs-site image to the target environment's
+# Artifact Registry. Pushes to main publish to `dev`; `workflow_dispatch`
+# can target the staging or production environments, which publish once
+# their registry vars are configured. The image lives under the existing
+# `sandbox-images` AR repo.
 
 on:
   push:

--- a/.github/workflows/publish-docs-image.yaml
+++ b/.github/workflows/publish-docs-image.yaml
@@ -18,6 +18,7 @@ on:
       - 'package.json'
       - 'bun.lock'
       - 'patches/**'
+      - '.dockerignore'
       - '.github/workflows/publish-docs-image.yaml'
   workflow_dispatch:
     inputs:
@@ -30,6 +31,11 @@ on:
           - dev
           - staging
           - production
+
+# Serialize publishes per environment so an older build cannot finish last
+# and overwrite the mutable `latest` tag from a newer commit.
+concurrency:
+  group: publish-docs-image-${{ inputs.environment || 'dev' }}
 
 env:
   DOCS_IMAGE_NAME: sandbox-images/docs-site

--- a/clients/docs/Dockerfile
+++ b/clients/docs/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1.20@sha256:26147acbda4f14c5add9946e2fd2ed543fc402884fd75146bd342a7f6271dc1d
+# Build stage
+FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7 AS builder
+
+WORKDIR /app
+
+# We must include every workspace member's manifest to validate and install the
+# workspace lockfile via --frozen-lockfile.
+# Note that we don't need source code to resolve cross-workspace dependencies.
+COPY package.json bun.lock ./
+COPY patches ./patches
+COPY clients/docs/package.json ./clients/docs/
+COPY clients/macos/package.json ./clients/macos/
+COPY clients/web/package.json ./clients/web/
+COPY cli/package.json ./cli/
+COPY gateway/package.json ./gateway/
+COPY credential-executor/package.json ./credential-executor/
+COPY assistant/package.json ./assistant/
+COPY assistant/src/api/package.json ./assistant/src/api/
+COPY --parents packages/*/package.json ./
+
+RUN bun install --frozen-lockfile --ignore-scripts --filter='./clients/docs'
+
+# Copy source after installing dependencies for better layer caching.
+COPY packages/design-library ./packages/design-library
+COPY clients/docs ./clients/docs
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN cd clients/docs && bun run build
+
+# Next standalone output omits public/ and the request-time markdown mirrors
+# (generated/md, served by the _md route). Ensure both exist so the runner
+# COPY works before the prebuild scripts that populate them land.
+RUN mkdir -p clients/docs/public clients/docs/generated/md
+
+# Runtime stage
+FROM node:22.22.2-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
+
+RUN groupadd --system --gid 1001 docs && \
+    useradd --system --uid 1001 --gid docs docs
+
+# The standalone tree mirrors the monorepo layout (server.js lives under
+# clients/docs/ with hoisted node_modules at the root).
+COPY --from=builder --chown=docs:docs /app/clients/docs/.next/standalone ./
+COPY --from=builder --chown=docs:docs /app/clients/docs/.next/static ./clients/docs/.next/static
+COPY --from=builder --chown=docs:docs /app/clients/docs/public ./clients/docs/public
+COPY --from=builder --chown=docs:docs /app/clients/docs/generated/md ./clients/docs/generated/md
+
+USER docs
+
+WORKDIR /app/clients/docs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/clients/docs/Dockerfile
+++ b/clients/docs/Dockerfile
@@ -19,7 +19,7 @@ COPY assistant/package.json ./assistant/
 COPY assistant/src/api/package.json ./assistant/src/api/
 COPY --parents packages/*/package.json ./
 
-RUN bun install --frozen-lockfile --ignore-scripts --filter='./clients/docs'
+RUN bun install --frozen-lockfile --ignore-scripts --filter=@vellumai/docs
 
 # Copy source after installing dependencies for better layer caching.
 COPY packages/design-library ./packages/design-library


### PR DESCRIPTION
## Summary
- Multi-stage clients/docs Dockerfile (bun builder → node standalone runner, public/ + generated/md included)
- publish-docs-image.yaml publishing sandbox-images/docs-site to the dev registry on main pushes

Reusing the existing sandbox-images AR repo avoids a Phase 1 Terraform change; a dedicated repo can move to the Phase 2 Terraform PR if preferred.

## Local verification
- `docker build -f clients/docs/Dockerfile .` succeeds against today's tree (placeholder page, no prebuild scripts yet)
- `docker run` as non-root serves `/docs` (200, placeholder page), `/api/health` (200 `{\"status\":\"ok\"}`), and `/_next/static` assets (200)
- `generated/md` + `public/` are baked as empty dirs today so the runner COPYs keep working when PRs 9/10 populate them
- actionlint clean on the new workflow

## Pending later PRs (not testable here)
- Search index + markdown-mirror routes (PRs 9/10) — the `bun run build` prebuild hook picks them up with no Dockerfile change
- page_view beacon (PR 12)
- Dev-registry publish happens post-merge to main (workflow path-filtered; `workflow_dispatch` reaches staging/production once Phase 2/3 vars land)

Part of plan: docs-app-phase-1.md (PR 14 of 15)