### PR TITLE
feat(docs): port page_view attribution proxy (vid cookie, UTM capture)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -120,6 +120,7 @@
     "clients/docs": {
       "name": "@vellumai/docs",
       "dependencies": {
+        "isbot": "5.1.40",
         "next": "16.2.6",
         "react": "19.2.6",
         "react-dom": "19.2.6",
@@ -2600,6 +2601,8 @@
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isbinaryfile": ["isbinaryfile@5.0.7", "", {}, "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ=="],
+
+    "isbot": ["isbot@5.1.40", "", {}, "sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ=="],
 
     "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 

--- a/clients/docs/next.config.ts
+++ b/clients/docs/next.config.ts
@@ -3,6 +3,12 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   typedRoutes: true,
+  // Without this, Next's middleware adapter strips the router prefetch
+  // headers (Next-Router-Prefetch, Next-Router-Segment-Prefetch, RSC) before
+  // src/proxy.ts runs, so isPrefetch() could never suppress segment-cache
+  // prefetches and every landing would emit a burst of phantom page_view
+  // rows (see FLIGHT_HEADERS in next/dist/server/web/adapter.js).
+  skipMiddlewareUrlNormalize: true,
 };
 
 export default nextConfig;

--- a/clients/docs/package.json
+++ b/clients/docs/package.json
@@ -11,6 +11,7 @@
     "test": "bun test src"
   },
   "dependencies": {
+    "isbot": "5.1.40",
     "next": "16.2.6",
     "react": "19.2.6",
     "react-dom": "19.2.6"

--- a/clients/docs/src/proxy.test.ts
+++ b/clients/docs/src/proxy.test.ts
@@ -40,7 +40,7 @@ function request(
   const req = new NextRequest(url, {
     headers: { "user-agent": userAgent, ...headers },
   });
-  // host, cookie, and referer are Fetch-spec forbidden request headers —
+  // host, cookie, and referer are Fetch-spec forbidden request headers;
   // Request() may strip them during construction. Set them after via
   // Headers.set(). Cookies must also be set on NextRequest's internal cookie
   // jar via req.cookies.set() since it doesn't re-read the raw header.
@@ -218,6 +218,15 @@ describe("docs proxy UTM/click-ID capture", () => {
     });
   });
 
+  test("an empty click ID param does not infer paid attribution", () => {
+    proxy(request("https://www.vellum.ai/docs?gclid="));
+
+    const [entry] = pageViewLogs();
+    expect(entry?.utm_resolution).toBeUndefined();
+    expect(entry?.utm_source).toBeUndefined();
+    expect(entry?.gclid).toBeUndefined();
+  });
+
   test("overlong click ID values are truncated to 512 chars", () => {
     proxy(request(`https://www.vellum.ai/docs?gclid=${"x".repeat(600)}`));
 
@@ -238,6 +247,24 @@ describe("docs proxy UTM/click-ID capture", () => {
       utm_resolution: "referrer",
     });
   });
+
+  test.each([
+    ["https://www.google.com/", "google", "organic"],
+    ["https://www.google.co.uk/", "google", "organic"],
+    ["https://notgoogle.com/", "notgoogle.com", "referral"],
+    ["https://x.com.example.org/", "x.com.example.org", "referral"],
+  ])(
+    "referrer %s classifies as source=%s medium=%s",
+    (referrer, source, medium) => {
+      proxy(request("https://www.vellum.ai/docs", { referrer }));
+
+      expect(pageViewLogs()[0]).toMatchObject({
+        utm_source: source,
+        utm_medium: medium,
+        utm_resolution: "referrer",
+      });
+    },
+  );
 
   test("utm_source=chatgpt without utm_medium gets geo backfilled", () => {
     proxy(request("https://www.vellum.ai/docs?utm_source=chatgpt"));
@@ -263,7 +290,7 @@ describe("docs proxy UTM/click-ID capture", () => {
 
 describe("docs proxy JSON log contract", () => {
   // Key order copied from a platform page_view log line (the platform's
-  // emitPageViewLog in vellum-assistant-platform web/src/proxy.ts) — the
+  // emitPageViewLog in vellum-assistant-platform web/src/proxy.ts); the
   // BigQuery sink + dbt stg_marketing_events__page_views parse this shape.
   const PLATFORM_FIXTURE = {
     source: "marketing",

--- a/clients/docs/src/proxy.test.ts
+++ b/clients/docs/src/proxy.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { NextRequest } from "next/server";
+
+import { config, proxy } from "@/proxy";
+
+const VID_COOKIE_NAME = "vellum_vid";
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36";
+
+const consoleInfoMock = mock(() => {});
+const originalConsoleInfo = console.info;
+
+beforeEach(() => {
+  consoleInfoMock.mockClear();
+  console.info = consoleInfoMock;
+});
+
+afterEach(() => {
+  console.info = originalConsoleInfo;
+});
+
+function request(
+  url: string,
+  {
+    host = "www.vellum.ai",
+    cookie,
+    referrer,
+    userAgent = BROWSER_UA,
+    headers = {},
+  }: {
+    host?: string;
+    cookie?: string;
+    referrer?: string;
+    userAgent?: string;
+    headers?: Record<string, string>;
+  } = {},
+): NextRequest {
+  const req = new NextRequest(url, {
+    headers: { "user-agent": userAgent, ...headers },
+  });
+  // host, cookie, and referer are Fetch-spec forbidden request headers —
+  // Request() may strip them during construction. Set them after via
+  // Headers.set(). Cookies must also be set on NextRequest's internal cookie
+  // jar via req.cookies.set() since it doesn't re-read the raw header.
+  req.headers.set("host", host);
+  if (cookie) {
+    req.headers.set("cookie", cookie);
+    for (const pair of cookie.split(";")) {
+      const [name, ...rest] = pair.trim().split("=");
+      if (name) {
+        req.cookies.set(name, rest.join("="));
+      }
+    }
+  }
+  if (referrer) {
+    req.headers.set("referer", referrer);
+  }
+  return req;
+}
+
+function vidSetCookie(response: Response): string | undefined {
+  const headers = response.headers as Headers & { getSetCookie(): string[] };
+  return headers
+    .getSetCookie()
+    .find((cookie) => cookie.startsWith(`${VID_COOKIE_NAME}=`));
+}
+
+function pageViewLogs(): Array<Record<string, string>> {
+  return (consoleInfoMock.mock.calls as unknown as string[][])
+    .map(([line]) => JSON.parse(line ?? "{}") as Record<string, string>)
+    .filter((entry) => entry.event === "page_view");
+}
+
+describe("docs proxy page_view logging", () => {
+  test("hitting /docs emits exactly one page_view line with a vid", () => {
+    proxy(request("https://www.vellum.ai/docs"));
+
+    const logs = pageViewLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.vid).toMatch(/^[0-9a-f-]{36}$/);
+    expect(logs[0]?.path).toBe("/docs");
+  });
+
+  test("nested docs pages are logged", () => {
+    proxy(request("https://www.vellum.ai/docs/quickstart"));
+
+    expect(pageViewLogs()[0]?.path).toBe("/docs/quickstart");
+  });
+
+  test.each([
+    ["/docs/api/health", "API route"],
+    ["/docs/api/search", "API route"],
+    ["/docs/_md/quickstart", "agent-markdown mirror"],
+    ["/docs/quickstart.md", "markdown variant"],
+    ["/docs/sitemap.xml", "sitemap"],
+    ["/docs/llms.txt", "llms.txt"],
+    ["/docs/images/hero.webp", "static asset"],
+    ["/pricing", "non-docs path"],
+  ])("%s (%s) is not logged as a page view", (path) => {
+    proxy(request(`https://www.vellum.ai${path}`));
+
+    expect(pageViewLogs()).toHaveLength(0);
+  });
+
+  test("bot user agents are not logged", () => {
+    proxy(
+      request("https://www.vellum.ai/docs", {
+        userAgent:
+          "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+      }),
+    );
+
+    expect(pageViewLogs()).toHaveLength(0);
+  });
+});
+
+describe("docs proxy prefetch filtering", () => {
+  test.each([
+    ["Next-Router-Segment-Prefetch", "/_tree"],
+    ["Next-Router-Prefetch", "1"],
+    ["Sec-Purpose", "prefetch"],
+    ["Sec-Purpose", "prefetch;prerender"],
+    ["Purpose", "prefetch"],
+  ])("%s: %s requests are not logged as page views", (header, value) => {
+    proxy(
+      request("https://www.vellum.ai/docs", { headers: { [header]: value } }),
+    );
+
+    expect(pageViewLogs()).toHaveLength(0);
+  });
+
+  test("prefetch requests still mint the vid cookie", () => {
+    const response = proxy(
+      request("https://www.vellum.ai/docs", {
+        headers: { "Next-Router-Segment-Prefetch": "/_tree" },
+      }),
+    );
+
+    expect(vidSetCookie(response)).toBeDefined();
+  });
+});
+
+describe("docs proxy visitor cookie", () => {
+  test("mints a vid cookie when absent and logs the same vid", () => {
+    const response = proxy(request("https://www.vellum.ai/docs"));
+
+    const cookie = vidSetCookie(response);
+    expect(cookie).toBeDefined();
+    if (!cookie) {
+      throw new Error("Expected vellum_vid cookie");
+    }
+    expect(cookie).toContain("Max-Age=7776000"); // 90 days
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).toContain("Secure");
+
+    const mintedVid = cookie.split(";")[0]?.split("=")[1];
+    expect(pageViewLogs()[0]?.vid).toBe(mintedVid ?? "");
+  });
+
+  test("reuses an existing vid cookie without re-setting it", () => {
+    const existingVid = "11111111-2222-3333-4444-555555555555";
+    const response = proxy(
+      request("https://www.vellum.ai/docs", {
+        cookie: `${VID_COOKIE_NAME}=${existingVid}`,
+      }),
+    );
+
+    expect(vidSetCookie(response)).toBeUndefined();
+    expect(pageViewLogs()[0]?.vid).toBe(existingVid);
+  });
+
+  test("cookie is Domain=.vellum.ai when Host is www.vellum.ai", () => {
+    const response = proxy(request("https://www.vellum.ai/docs"));
+
+    expect(vidSetCookie(response)).toContain("Domain=.vellum.ai");
+  });
+
+  test("cookie is host-only (no Domain) on localhost dev", () => {
+    const response = proxy(
+      request("http://localhost:3005/docs", { host: "localhost" }),
+    );
+
+    const cookie = vidSetCookie(response);
+    expect(cookie).toBeDefined();
+    expect(cookie).not.toContain("Domain=");
+    expect(cookie).not.toContain("Secure");
+  });
+});
+
+describe("docs proxy UTM/click-ID capture", () => {
+  test("explicit UTM params are logged with explicit resolution", () => {
+    proxy(
+      request(
+        "https://www.vellum.ai/docs?utm_source=linkedin&utm_medium=social&utm_campaign=launch",
+      ),
+    );
+
+    expect(pageViewLogs()[0]).toMatchObject({
+      path: "/docs",
+      utm_source: "linkedin",
+      utm_medium: "social",
+      utm_campaign: "launch",
+      utm_resolution: "explicit",
+    });
+  });
+
+  test("click IDs are logged raw alongside inferred paid attribution", () => {
+    proxy(request("https://www.vellum.ai/docs?gclid=abc123"));
+
+    expect(pageViewLogs()[0]).toMatchObject({
+      utm_source: "google",
+      utm_medium: "cpc",
+      utm_resolution: "click_id",
+      gclid: "abc123",
+    });
+  });
+
+  test("overlong click ID values are truncated to 512 chars", () => {
+    proxy(request(`https://www.vellum.ai/docs?gclid=${"x".repeat(600)}`));
+
+    expect(pageViewLogs()[0]?.gclid).toBe("x".repeat(512));
+  });
+
+  test("referrer-inferred attribution is logged with referrer resolution", () => {
+    proxy(
+      request("https://www.vellum.ai/docs/quickstart", {
+        referrer: "https://chatgpt.com/c/abc123",
+      }),
+    );
+
+    expect(pageViewLogs()[0]).toMatchObject({
+      referrer: "https://chatgpt.com/c/abc123",
+      utm_source: "chatgpt",
+      utm_medium: "geo",
+      utm_resolution: "referrer",
+    });
+  });
+
+  test("utm_source=chatgpt without utm_medium gets geo backfilled", () => {
+    proxy(request("https://www.vellum.ai/docs?utm_source=chatgpt"));
+
+    expect(pageViewLogs()[0]).toMatchObject({
+      utm_source: "chatgpt",
+      utm_medium: "geo",
+    });
+  });
+
+  test("same-site referrer produces no attribution fields", () => {
+    proxy(
+      request("https://www.vellum.ai/docs", {
+        referrer: "https://www.vellum.ai/",
+      }),
+    );
+
+    const [entry] = pageViewLogs();
+    expect(entry?.utm_source).toBeUndefined();
+    expect(entry?.utm_resolution).toBeUndefined();
+  });
+});
+
+describe("docs proxy JSON log contract", () => {
+  // Key order copied from a platform page_view log line (the platform's
+  // emitPageViewLog in vellum-assistant-platform web/src/proxy.ts) — the
+  // BigQuery sink + dbt stg_marketing_events__page_views parse this shape.
+  const PLATFORM_FIXTURE = {
+    source: "marketing",
+    event: "page_view",
+    vid: "0d4f5be2-9c11-4e08-9f4e-3a9d1a3f6b7e",
+    path: "/plugins/cognee",
+    referrer: "https://t.co/Xc0y1brRmQ",
+    timestamp: "2026-07-21T18:04:11.132Z",
+    utm_source: "x",
+    utm_medium: "social",
+    utm_resolution: "referrer",
+  };
+
+  test("attributed page_view lines match the platform key set and order", () => {
+    proxy(
+      request("https://www.vellum.ai/docs", {
+        referrer: "https://t.co/Xc0y1brRmQ",
+      }),
+    );
+
+    const [entry] = pageViewLogs();
+    expect(Object.keys(entry ?? {})).toEqual(Object.keys(PLATFORM_FIXTURE));
+    expect(entry).toMatchObject({
+      source: "marketing",
+      event: "page_view",
+      referrer: "https://t.co/Xc0y1brRmQ",
+      utm_source: "x",
+      utm_medium: "social",
+      utm_resolution: "referrer",
+    });
+    expect(entry?.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  test("direct-traffic lines carry only the six base keys", () => {
+    proxy(request("https://www.vellum.ai/docs"));
+
+    const [entry] = pageViewLogs();
+    expect(Object.keys(entry ?? {})).toEqual([
+      "source",
+      "event",
+      "vid",
+      "path",
+      "referrer",
+      "timestamp",
+    ]);
+  });
+});
+
+describe("docs proxy matcher", () => {
+  test("is scoped to /docs", () => {
+    expect(config.matcher).toEqual(["/docs/:path*"]);
+  });
+});

--- a/clients/docs/src/proxy.test.ts
+++ b/clients/docs/src/proxy.test.ts
@@ -253,6 +253,7 @@ describe("docs proxy UTM/click-ID capture", () => {
     ["https://www.google.co.uk/", "google", "organic"],
     ["https://notgoogle.com/", "notgoogle.com", "referral"],
     ["https://x.com.example.org/", "x.com.example.org", "referral"],
+    ["https://www.google.cat/", "google", "organic"],
     ["https://google.example.org/", "google.example.org", "referral"],
     ["https://mail.google.example.org/", "mail.google.example.org", "referral"],
     ["https://copilot.bing.com/", "copilot", "geo"],

--- a/clients/docs/src/proxy.test.ts
+++ b/clients/docs/src/proxy.test.ts
@@ -253,6 +253,10 @@ describe("docs proxy UTM/click-ID capture", () => {
     ["https://www.google.co.uk/", "google", "organic"],
     ["https://notgoogle.com/", "notgoogle.com", "referral"],
     ["https://x.com.example.org/", "x.com.example.org", "referral"],
+    ["https://google.example.org/", "google.example.org", "referral"],
+    ["https://mail.google.example.org/", "mail.google.example.org", "referral"],
+    ["https://copilot.bing.com/", "copilot", "geo"],
+    ["https://copilot.microsoft.com/", "copilot", "geo"],
   ])(
     "referrer %s classifies as source=%s medium=%s",
     (referrer, source, medium) => {

--- a/clients/docs/src/proxy.ts
+++ b/clients/docs/src/proxy.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
  * (vellum-assistant-platform `web/src/proxy.ts`): page_view logging, the
  * `vellum_vid` visitor cookie, and UTM/click-ID capture. The page_view JSON
  * contract is parsed downstream (BigQuery log sink + dbt
- * `stg_marketing_events__page_views`) — field names must not change.
+ * `stg_marketing_events__page_views`); field names must not change.
  *
  * NEXT.JS MIDDLEWARE WORKAROUND: `request.nextUrl.hostname` returns the server
  * bind address (0.0.0.0) behind a reverse proxy (GKE L7 load balancer), not the
@@ -75,7 +75,7 @@ function buildUTMPayload(request: NextRequest): Record<string, string> | null {
 
 /**
  * Paid click IDs appended by ad platforms when auto-tagging is enabled.
- * A URL with one of these — even without explicit utm_* params — is paid traffic.
+ * A URL with one of these, even without explicit utm_* params, is paid traffic.
  */
 const PAID_CLICK_IDS: ReadonlyArray<{
   params: readonly string[];
@@ -121,7 +121,9 @@ function inferUTMFromClickIds(
   const searchParams = request.nextUrl.searchParams;
   for (const rule of PAID_CLICK_IDS) {
     for (const param of rule.params) {
-      if (searchParams.has(param)) {
+      // Nonempty only, matching pickClickIds: a bare `?gclid=` must not
+      // produce a paid row with no supporting click ID in the payload.
+      if (searchParams.get(param)) {
         return {
           utm_source: rule.source,
           utm_medium: rule.medium,
@@ -138,6 +140,16 @@ function hostMatches(host: string, domain: string): boolean {
   return host === domain || host.endsWith(`.${domain}`);
 }
 
+function hostMatchesAny(host: string, domains: readonly string[]): boolean {
+  return domains.some((domain) => hostMatches(host, domain));
+}
+
+// Google search spans ccTLDs (google.com, google.co.uk, google.de, ...), so a
+// suffix match against a fixed domain can't cover it. Match the "google" label
+// at a dot boundary followed by at most two trailing labels, which rejects
+// lookalikes (notgoogle.com) and embedded brands (google.com.evil.org).
+const GOOGLE_SEARCH_HOST = /(^|\.)google\.[a-z]{2,}(\.[a-z]{2,})?$/;
+
 function inferUTMFromReferrer(
   request: NextRequest,
 ): Record<string, string> | null {
@@ -148,7 +160,9 @@ function inferUTMFromReferrer(
 
   let host = "";
   try {
-    host = new URL(referrer).host.toLowerCase();
+    // hostname, not host: an explicit port would defeat the exact/suffix
+    // matches below.
+    host = new URL(referrer).hostname.toLowerCase();
   } catch {
     return null;
   }
@@ -165,19 +179,25 @@ function inferUTMFromReferrer(
   let medium: string | undefined;
 
   // Search engines
-  if (host.includes("google.") && !host.includes("gemini.google.com")) {
+  if (
+    GOOGLE_SEARCH_HOST.test(host) &&
+    !hostMatches(host, "gemini.google.com")
+  ) {
     source = "google";
     medium = "organic";
-  } else if (host.includes("bing.com") && !host.includes("copilot.")) {
+  } else if (
+    hostMatches(host, "bing.com") &&
+    !hostMatches(host, "copilot.bing.com")
+  ) {
     source = "bing";
     medium = "organic";
-  } else if (host.includes("duckduckgo.com")) {
+  } else if (hostMatches(host, "duckduckgo.com")) {
     source = "duckduckgo";
     medium = "organic";
-  } else if (host.includes("search.yahoo.com")) {
+  } else if (hostMatches(host, "search.yahoo.com")) {
     source = "yahoo";
     medium = "organic";
-  } else if (host.includes("baidu.com")) {
+  } else if (hostMatches(host, "baidu.com")) {
     source = "baidu";
     medium = "organic";
   } else if (hostMatches(host, "search.brave.com")) {
@@ -195,43 +215,34 @@ function inferUTMFromReferrer(
   }
   // AI engines (GEO = generative engine optimization)
   else if (
-    host.includes("chat.openai.com") ||
-    host.includes("chatgpt.com") ||
-    host.includes("r.openai.com")
+    hostMatchesAny(host, ["chat.openai.com", "chatgpt.com", "r.openai.com"])
   ) {
     source = "chatgpt";
     medium = "geo";
-  } else if (host.includes("claude.ai") || host.includes("anthropic.com")) {
+  } else if (hostMatchesAny(host, ["claude.ai", "anthropic.com"])) {
     source = "claude";
     medium = "geo";
-  } else if (host.includes("perplexity.ai")) {
+  } else if (hostMatches(host, "perplexity.ai")) {
     source = "perplexity";
     medium = "geo";
-  } else if (host.includes("gemini.google.com")) {
+  } else if (hostMatches(host, "gemini.google.com")) {
     source = "gemini";
     medium = "geo";
-  } else if (host.includes("copilot.microsoft.com")) {
+  } else if (hostMatches(host, "copilot.microsoft.com")) {
     source = "copilot";
     medium = "geo";
-  } else if (host.includes("grok.com")) {
+  } else if (hostMatches(host, "grok.com")) {
     source = "grok";
     medium = "geo";
-  } else if (
-    host.includes("chat.deepseek.com") ||
-    host.includes("deepseek.com")
-  ) {
+  } else if (hostMatches(host, "deepseek.com")) {
     source = "deepseek";
     medium = "geo";
-  } else if (host.includes("meta.ai")) {
+  } else if (hostMatches(host, "meta.ai")) {
     source = "meta-ai";
     medium = "geo";
   }
   // Social
-  else if (
-    host.includes("x.com") ||
-    host.includes("twitter.com") ||
-    host === "t.co"
-  ) {
+  else if (hostMatchesAny(host, ["x.com", "twitter.com", "t.co"])) {
     source = "x";
     medium = "social";
   } else if (
@@ -242,31 +253,31 @@ function inferUTMFromReferrer(
   ) {
     source = "linkedin";
     medium = "social";
-  } else if (host.includes("facebook.com") || host.includes("instagram.com")) {
+  } else if (hostMatchesAny(host, ["facebook.com", "instagram.com"])) {
     source = "facebook";
     medium = "social";
-  } else if (host.includes("youtube.com")) {
+  } else if (hostMatches(host, "youtube.com")) {
     source = "youtube";
     medium = "social";
-  } else if (host.includes("reddit.com")) {
+  } else if (hostMatches(host, "reddit.com")) {
     source = "reddit";
     medium = "social";
-  } else if (host.includes("tiktok.com")) {
+  } else if (hostMatches(host, "tiktok.com")) {
     source = "tiktok";
     medium = "social";
-  } else if (host.includes("threads.net")) {
+  } else if (hostMatches(host, "threads.net")) {
     source = "threads";
     medium = "social";
-  } else if (host.includes("bsky.app")) {
+  } else if (hostMatches(host, "bsky.app")) {
     source = "bluesky";
     medium = "social";
-  } else if (host.includes("news.ycombinator.com")) {
+  } else if (hostMatches(host, "news.ycombinator.com")) {
     source = "hackernews";
     medium = "social";
-  } else if (host.includes("producthunt.com")) {
+  } else if (hostMatches(host, "producthunt.com")) {
     source = "producthunt";
     medium = "social";
-  } else if (host.includes("github.com")) {
+  } else if (hostMatches(host, "github.com")) {
     source = "github";
     medium = "referral";
   } else if (
@@ -395,7 +406,7 @@ function resolveEntryAttribution(
   const explicit = buildUTMPayload(request);
   // Click IDs ride along on the payload regardless of how source/medium
   // resolve, so the warehouse can attribute paid entries. They can only be
-  // present in the first two branches — any click ID in the URL makes
+  // present in the first two branches; any nonempty click ID in the URL makes
   // inferUTMFromClickIds match.
   const clickIds = pickClickIds(request);
 
@@ -420,7 +431,7 @@ function resolveEntryAttribution(
 
   const inferred = inferUTMFromReferrer(request);
 
-  // Explicit UTM params without source (e.g. just ?utm_campaign=...) — use
+  // Explicit UTM params without source (e.g. just ?utm_campaign=...): use
   // referrer inference to fill in source/medium when available
   if (explicit) {
     return {

--- a/clients/docs/src/proxy.ts
+++ b/clients/docs/src/proxy.ts
@@ -1,0 +1,461 @@
+import { isbot } from "isbot";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Attribution-only port of the platform marketing proxy
+ * (vellum-assistant-platform `web/src/proxy.ts`): page_view logging, the
+ * `vellum_vid` visitor cookie, and UTM/click-ID capture. The page_view JSON
+ * contract is parsed downstream (BigQuery log sink + dbt
+ * `stg_marketing_events__page_views`) — field names must not change.
+ *
+ * NEXT.JS MIDDLEWARE WORKAROUND: `request.nextUrl.hostname` returns the server
+ * bind address (0.0.0.0) behind a reverse proxy (GKE L7 load balancer), not the
+ * public hostname, so all host-based checks in this file read the Host header
+ * directly. See https://github.com/vercel/next.js/issues/37536.
+ */
+
+const APEX_DOMAIN = "vellum.ai";
+const VELLUM_COOKIE_DOMAIN = ".vellum.ai";
+
+function isVellumDomain(host: string): boolean {
+  return host === APEX_DOMAIN || host.endsWith(`.${APEX_DOMAIN}`);
+}
+
+const VID_COOKIE_NAME = "vellum_vid";
+const VID_MAX_AGE = 90 * 24 * 60 * 60; // 90 days, same as the platform proxy
+
+const UTM_PARAMS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
+function buildUTMPayload(request: NextRequest): Record<string, string> | null {
+  const params = request.nextUrl.searchParams;
+  const utmValues: Record<string, string> = {};
+  for (const key of UTM_PARAMS) {
+    const value = params.get(key);
+    if (value) {
+      utmValues[key] = value;
+    }
+  }
+
+  if (Object.keys(utmValues).length === 0) {
+    return null;
+  }
+
+  // Backfill utm_medium for known AI sources when only utm_source is present
+  if (utmValues.utm_source && !utmValues.utm_medium) {
+    const src = utmValues.utm_source.toLowerCase();
+    if (
+      src.includes("chatgpt") ||
+      src.includes("openai") ||
+      src.includes("claude") ||
+      src.includes("anthropic") ||
+      src.includes("perplexity") ||
+      src.includes("gemini") ||
+      src.includes("copilot") ||
+      src.includes("grok") ||
+      src.includes("deepseek") ||
+      src.includes("meta-ai") ||
+      src.includes("meta ai")
+    ) {
+      utmValues.utm_medium = "geo";
+    }
+  }
+
+  return {
+    ...utmValues,
+    landing_page: request.nextUrl.pathname,
+    referrer: request.headers.get("referer") || "",
+  };
+}
+
+/**
+ * Paid click IDs appended by ad platforms when auto-tagging is enabled.
+ * A URL with one of these — even without explicit utm_* params — is paid traffic.
+ */
+const PAID_CLICK_IDS: ReadonlyArray<{
+  params: readonly string[];
+  source: string;
+  medium: string;
+}> = [
+  { params: ["gclid", "gbraid", "wbraid"], source: "google", medium: "cpc" },
+  { params: ["msclkid"], source: "bing", medium: "cpc" },
+  { params: ["fbclid"], source: "facebook", medium: "paid_social" },
+  { params: ["li_fat_id"], source: "linkedin", medium: "paid_social" },
+  { params: ["twclid"], source: "x", medium: "paid_social" },
+  { params: ["ttclid"], source: "tiktok", medium: "paid_social" },
+];
+
+const CLICK_ID_PARAMS: readonly string[] = PAID_CLICK_IDS.flatMap(
+  (rule) => rule.params,
+);
+
+// Mirrors the platform's cap (_CLICK_ID_FIELD_MAX_LENGTHS in Django's
+// marketing_attribution middleware).
+const CLICK_ID_MAX_LENGTH = 512;
+
+const LOGGED_ATTRIBUTION_KEYS: readonly string[] = [
+  ...UTM_PARAMS,
+  ...CLICK_ID_PARAMS,
+];
+
+/** Raw click ID params present in the URL, for log persistence. */
+function pickClickIds(request: NextRequest): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const param of CLICK_ID_PARAMS) {
+    const value = request.nextUrl.searchParams.get(param);
+    if (value) {
+      out[param] = value.slice(0, CLICK_ID_MAX_LENGTH);
+    }
+  }
+  return out;
+}
+
+function inferUTMFromClickIds(
+  request: NextRequest,
+): Record<string, string> | null {
+  const searchParams = request.nextUrl.searchParams;
+  for (const rule of PAID_CLICK_IDS) {
+    for (const param of rule.params) {
+      if (searchParams.has(param)) {
+        return {
+          utm_source: rule.source,
+          utm_medium: rule.medium,
+          landing_page: request.nextUrl.pathname,
+          referrer: request.headers.get("referer") || "",
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function hostMatches(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+function inferUTMFromReferrer(
+  request: NextRequest,
+): Record<string, string> | null {
+  const referrer = request.headers.get("referer") || "";
+  if (!referrer) {
+    return null;
+  }
+
+  let host = "";
+  try {
+    host = new URL(referrer).host.toLowerCase();
+  } catch {
+    return null;
+  }
+
+  // Don't infer for same-site navigation
+  const currentHost =
+    request.headers.get("host")?.split(":")[0]?.replace(/^www\./, "") ?? "";
+  const refHost = host.replace(/^www\./, "");
+  if (refHost === currentHost) {
+    return null;
+  }
+
+  let source: string | undefined;
+  let medium: string | undefined;
+
+  // Search engines
+  if (host.includes("google.") && !host.includes("gemini.google.com")) {
+    source = "google";
+    medium = "organic";
+  } else if (host.includes("bing.com") && !host.includes("copilot.")) {
+    source = "bing";
+    medium = "organic";
+  } else if (host.includes("duckduckgo.com")) {
+    source = "duckduckgo";
+    medium = "organic";
+  } else if (host.includes("search.yahoo.com")) {
+    source = "yahoo";
+    medium = "organic";
+  } else if (host.includes("baidu.com")) {
+    source = "baidu";
+    medium = "organic";
+  } else if (hostMatches(host, "search.brave.com")) {
+    source = "brave";
+    medium = "organic";
+  } else if (hostMatches(host, "kagi.com")) {
+    source = "kagi";
+    medium = "organic";
+  } else if (hostMatches(host, "ecosia.org")) {
+    source = "ecosia";
+    medium = "organic";
+  } else if (hostMatches(host, "yandex.ru") || hostMatches(host, "yandex.com")) {
+    source = "yandex";
+    medium = "organic";
+  }
+  // AI engines (GEO = generative engine optimization)
+  else if (
+    host.includes("chat.openai.com") ||
+    host.includes("chatgpt.com") ||
+    host.includes("r.openai.com")
+  ) {
+    source = "chatgpt";
+    medium = "geo";
+  } else if (host.includes("claude.ai") || host.includes("anthropic.com")) {
+    source = "claude";
+    medium = "geo";
+  } else if (host.includes("perplexity.ai")) {
+    source = "perplexity";
+    medium = "geo";
+  } else if (host.includes("gemini.google.com")) {
+    source = "gemini";
+    medium = "geo";
+  } else if (host.includes("copilot.microsoft.com")) {
+    source = "copilot";
+    medium = "geo";
+  } else if (host.includes("grok.com")) {
+    source = "grok";
+    medium = "geo";
+  } else if (
+    host.includes("chat.deepseek.com") ||
+    host.includes("deepseek.com")
+  ) {
+    source = "deepseek";
+    medium = "geo";
+  } else if (host.includes("meta.ai")) {
+    source = "meta-ai";
+    medium = "geo";
+  }
+  // Social
+  else if (
+    host.includes("x.com") ||
+    host.includes("twitter.com") ||
+    host === "t.co"
+  ) {
+    source = "x";
+    medium = "social";
+  } else if (
+    hostMatches(host, "linkedin.com") ||
+    // LinkedIn's link shortener and Android app referrer
+    host === "lnkd.in" ||
+    host === "com.linkedin.android"
+  ) {
+    source = "linkedin";
+    medium = "social";
+  } else if (host.includes("facebook.com") || host.includes("instagram.com")) {
+    source = "facebook";
+    medium = "social";
+  } else if (host.includes("youtube.com")) {
+    source = "youtube";
+    medium = "social";
+  } else if (host.includes("reddit.com")) {
+    source = "reddit";
+    medium = "social";
+  } else if (host.includes("tiktok.com")) {
+    source = "tiktok";
+    medium = "social";
+  } else if (host.includes("threads.net")) {
+    source = "threads";
+    medium = "social";
+  } else if (host.includes("bsky.app")) {
+    source = "bluesky";
+    medium = "social";
+  } else if (host.includes("news.ycombinator.com")) {
+    source = "hackernews";
+    medium = "social";
+  } else if (host.includes("producthunt.com")) {
+    source = "producthunt";
+    medium = "social";
+  } else if (host.includes("github.com")) {
+    source = "github";
+    medium = "referral";
+  } else if (
+    hostMatches(host, "teams.microsoft.com") ||
+    hostMatches(host, "teams.cdn.office.net")
+  ) {
+    source = "teams";
+    medium = "referral";
+  }
+  // Generic referral
+  else {
+    source = refHost;
+    medium = "referral";
+  }
+
+  if (!source) {
+    return null;
+  }
+
+  return {
+    utm_source: source,
+    utm_medium: medium!,
+    landing_page: request.nextUrl.pathname,
+    referrer,
+  };
+}
+
+function generateVisitorId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Docs page paths only: exclude API routes, the agent-markdown mirror, and
+ * file-like paths (static assets, `.md` variants, sitemap.xml, llms.txt).
+ */
+function isPagePath(pathname: string): boolean {
+  if (pathname !== "/docs" && !pathname.startsWith("/docs/")) {
+    return false;
+  }
+  if (pathname === "/docs/api" || pathname.startsWith("/docs/api/")) {
+    return false;
+  }
+  if (pathname === "/docs/_md" || pathname.startsWith("/docs/_md/")) {
+    return false;
+  }
+  const lastSegment = pathname.split("/").at(-1) ?? "";
+  return !lastSegment.includes(".");
+}
+
+function isPrefetch(request: NextRequest): boolean {
+  if (request.headers.has("Next-Router-Prefetch")) {
+    return true;
+  }
+  // Next 16's segment cache prefetches with one request per route segment,
+  // carrying this header instead of Next-Router-Prefetch.
+  if (request.headers.has("Next-Router-Segment-Prefetch")) {
+    return true;
+  }
+  const secPurpose = request.headers.get("Sec-Purpose") ?? "";
+  const purpose = request.headers.get("Purpose") ?? "";
+  return secPurpose.includes("prefetch") || purpose.includes("prefetch");
+}
+
+function emitPageViewLog(
+  request: NextRequest,
+  vid: string,
+  pathname: string,
+  attribution: EntryAttribution | null,
+): void {
+  const entry: Record<string, string> = {
+    source: "marketing",
+    event: "page_view",
+    vid,
+    path: pathname,
+    referrer: request.headers.get("referer") || "",
+    timestamp: new Date().toISOString(),
+  };
+  if (attribution) {
+    for (const key of LOGGED_ATTRIBUTION_KEYS) {
+      if (attribution.payload[key]) {
+        entry[key] = attribution.payload[key];
+      }
+    }
+    entry.utm_resolution = attribution.resolution;
+  }
+  console.info(JSON.stringify(entry));
+}
+
+function resolveVisitorId(request: NextRequest): string {
+  return request.cookies.get(VID_COOKIE_NAME)?.value ?? generateVisitorId();
+}
+
+function setVisitorIdCookie(
+  request: NextRequest,
+  host: string,
+  response: Response,
+  vid: string,
+): void {
+  if (request.cookies.get(VID_COOKIE_NAME)?.value) {
+    return;
+  }
+
+  const secure = request.nextUrl.protocol === "https:";
+  const domain = isVellumDomain(host) ? `; Domain=${VELLUM_COOKIE_DOMAIN}` : "";
+  response.headers.append(
+    "Set-Cookie",
+    `${VID_COOKIE_NAME}=${vid}; Path=/; Max-Age=${VID_MAX_AGE}; SameSite=Lax; HttpOnly${secure ? "; Secure" : ""}${domain}`,
+  );
+}
+
+type EntryAttribution = {
+  payload: Record<string, string>;
+  /** How utm_source/utm_medium were determined for this entry. */
+  resolution: "explicit" | "click_id" | "referrer";
+};
+
+/**
+ * Resolve the attribution for this request: explicit UTM params win, then
+ * paid click IDs (gclid, fbclid, etc.), then referrer inference. Merged
+ * payloads keep explicit params (e.g. utm_campaign) on top of inferred
+ * source/medium.
+ */
+function resolveEntryAttribution(
+  request: NextRequest,
+): EntryAttribution | null {
+  const explicit = buildUTMPayload(request);
+  // Click IDs ride along on the payload regardless of how source/medium
+  // resolve, so the warehouse can attribute paid entries. They can only be
+  // present in the first two branches — any click ID in the URL makes
+  // inferUTMFromClickIds match.
+  const clickIds = pickClickIds(request);
+
+  if (explicit?.utm_source) {
+    // Explicit source always wins (last-touch for paid campaigns)
+    return {
+      payload: { ...explicit, ...clickIds },
+      resolution: "explicit",
+    };
+  }
+
+  const clickIdPayload = inferUTMFromClickIds(request);
+  if (clickIdPayload) {
+    return {
+      payload: {
+        ...(explicit ? { ...clickIdPayload, ...explicit } : clickIdPayload),
+        ...clickIds,
+      },
+      resolution: "click_id",
+    };
+  }
+
+  const inferred = inferUTMFromReferrer(request);
+
+  // Explicit UTM params without source (e.g. just ?utm_campaign=...) — use
+  // referrer inference to fill in source/medium when available
+  if (explicit) {
+    return {
+      payload: inferred ? { ...inferred, ...explicit } : explicit,
+      resolution: inferred ? "referrer" : "explicit",
+    };
+  }
+
+  if (!inferred) {
+    return null;
+  }
+  return { payload: inferred, resolution: "referrer" };
+}
+
+export function proxy(request: NextRequest) {
+  const host = request.headers.get("host")?.split(":")[0] ?? "";
+  const { pathname } = request.nextUrl;
+
+  const response = NextResponse.next();
+  const vid = resolveVisitorId(request);
+  setVisitorIdCookie(request, host, response, vid);
+
+  const userAgent = request.headers.get("user-agent") || "";
+  if (isPagePath(pathname) && !isbot(userAgent) && !isPrefetch(request)) {
+    let decodedPath: string;
+    try {
+      decodedPath = decodeURIComponent(pathname);
+    } catch {
+      decodedPath = pathname;
+    }
+    emitPageViewLog(request, vid, decodedPath, resolveEntryAttribution(request));
+  }
+  return response;
+}
+
+export const config = {
+  matcher: ["/docs/:path*"],
+};

--- a/clients/docs/src/proxy.ts
+++ b/clients/docs/src/proxy.ts
@@ -145,10 +145,13 @@ function hostMatchesAny(host: string, domains: readonly string[]): boolean {
 }
 
 // Google search spans ccTLDs (google.com, google.co.uk, google.de, ...), so a
-// suffix match against a fixed domain can't cover it. Match the "google" label
-// at a dot boundary followed by at most two trailing labels, which rejects
-// lookalikes (notgoogle.com) and embedded brands (google.com.evil.org).
-const GOOGLE_SEARCH_HOST = /(^|\.)google\.[a-z]{2,}(\.[a-z]{2,})?$/;
+// suffix match against a fixed domain can't cover it. Require "google" to be
+// the registrable label: the suffix must be a bare TLD (com, de, fr, ...) or a
+// known second-level country form (co.uk, com.au, ...). This rejects
+// lookalikes (notgoogle.com), embedded brands (google.com.evil.org), and
+// third-party registrable domains carrying a google label (google.example.org).
+const GOOGLE_SEARCH_HOST =
+  /(^|\.)google\.(com|[a-z]{2}|(co|com)\.[a-z]{2})$/;
 
 function inferUTMFromReferrer(
   request: NextRequest,
@@ -228,7 +231,9 @@ function inferUTMFromReferrer(
   } else if (hostMatches(host, "gemini.google.com")) {
     source = "gemini";
     medium = "geo";
-  } else if (hostMatches(host, "copilot.microsoft.com")) {
+  } else if (
+    hostMatchesAny(host, ["copilot.microsoft.com", "copilot.bing.com"])
+  ) {
     source = "copilot";
     medium = "geo";
   } else if (hostMatches(host, "grok.com")) {

--- a/clients/docs/src/proxy.ts
+++ b/clients/docs/src/proxy.ts
@@ -151,7 +151,7 @@ function hostMatchesAny(host: string, domains: readonly string[]): boolean {
 // lookalikes (notgoogle.com), embedded brands (google.com.evil.org), and
 // third-party registrable domains carrying a google label (google.example.org).
 const GOOGLE_SEARCH_HOST =
-  /(^|\.)google\.(com|[a-z]{2}|(co|com)\.[a-z]{2})$/;
+  /(^|\.)google\.(com|cat|[a-z]{2}|(co|com)\.[a-z]{2})$/;
 
 function inferUTMFromReferrer(
   request: NextRequest,


### PR DESCRIPTION
## Summary
- Port the attribution middleware surface: page_view JSON log emitter (byte-compatible with the platform contract), vellum_vid cookie mint/reuse, UTM/click-ID capture
- Bot + prefetch gating incl. Next-Router-Segment-Prefetch check

Note: log lines only reach BigQuery after the Phase 2 platform Terraform change extends the pageview sink filter (currently container_name="nextjs") to this app's container name (docs).

### skipMiddlewareUrlNormalize (next.config.ts, beyond the planned file list)
Next 16.2.6's middleware adapter strips the FLIGHT_HEADERS (RSC, Next-Router-Prefetch, Next-Router-Segment-Prefetch, ...) before the proxy runs — verified empirically in both dev and next start, and in next/dist/server/web/adapter.js — unless skipMiddlewareUrlNormalize is set. Without it, isPrefetch() can never see the segment-prefetch header and every landing emits phantom page_view bursts. With the flag, a Next-Router-Segment-Prefetch request emits nothing (verified in dev and prod-mode servers).

Heads-up for the platform repo: the same stripping applies there (same Next version, flag not set), so the platform's own Next-Router-Segment-Prefetch check from platform#9370 appears inert in prod — its unbounded dbt burst-scrubber in stg_marketing_events__page_views is what actually removes phantom rows. Worth a platform follow-up.

Part of plan: docs-app-phase-1.md (PR 12 of 15)