### PR TITLE
feat(daemon): terminal and corrective queue events, scoped queued deletes (LUM-2849)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20444,7 +20444,9 @@ paths:
     delete:
       operationId: messages_queued_by_id_delete
       summary: Delete a queued message
-      description: Remove a pending message from the conversation queue before it is processed.
+      description:
+        Remove a pending message from the conversation queue before it is processed. Broadcasts
+        `message_queued_deleted` so every client can close out the pending row.
       tags:
         - messages
       parameters:
@@ -20462,6 +20464,10 @@ paths:
       responses:
         "200":
           description: Successful response
+        "403":
+          description: The queued message was enqueued by a different actor principal.
+        "404":
+          description: Conversation or queued message not found.
   /v1/messages/queued/{id}/steer:
     post:
       operationId: messages_queued_by_id_steer_post

--- a/assistant/src/__tests__/drain-requeue-on-contention.test.ts
+++ b/assistant/src/__tests__/drain-requeue-on-contention.test.ts
@@ -19,12 +19,17 @@ import {
 interface FakeEvent {
   type: string;
   message?: string;
+  conversationId?: string;
+  requestId?: string;
+  position?: number;
+  clientMessageId?: string;
 }
 
 function makeQueued(
   content: string,
   requestId: string,
   events: FakeEvent[],
+  extra?: Partial<QueuedMessage>,
 ): QueuedMessage {
   return {
     content,
@@ -34,6 +39,7 @@ function makeQueued(
       events.push(event);
     },
     sentAt: Date.now(),
+    ...extra,
   } as unknown as QueuedMessage;
 }
 
@@ -198,5 +204,123 @@ describe("drainQueue under processing-lock contention", () => {
         (event) => event.type === "error" && event.message === "disk exploded",
       ).length,
     ).toBe(1);
+  });
+});
+
+/**
+ * The corrective `message_requeued` event.
+ *
+ * A drain announces `message_dequeued` before the steps that can send the
+ * message back, so a client that cleared its pending indicator on that
+ * announcement needs to be told the message is queued again. The rule is
+ * announcement-scoped: a requeue that happens before the announcement owes
+ * clients nothing, because they never stopped showing the row as queued.
+ */
+describe("message_requeued corrective event", () => {
+  test("a busy persist tells the sender its announced message is queued again", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue } = makeFakeConversation({
+      persistError: new Error(CONVERSATION_BUSY_MESSAGE),
+    });
+    queue.push(
+      makeQueued("hello there", "r1", events, {
+        clientMessageId: "nonce-1",
+      }),
+    );
+    queue.push(makeQueued("and another", "r2", events));
+
+    await drainQueue(conversation as never);
+
+    expect(events.map((event) => event.type)).toEqual([
+      "message_dequeued",
+      "message_requeued",
+    ]);
+    expect(events[1]).toEqual({
+      type: "message_requeued",
+      conversationId: "conv-drain-requeue",
+      requestId: "r1",
+      // Back at the head, so 1 of the 2 visible queued items.
+      position: 1,
+      clientMessageId: "nonce-1",
+    });
+  });
+
+  test("a requeue before the dequeue announcement stays silent", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue } = makeFakeConversation({ processing: true });
+    queue.push(makeQueued("hello there", "r1", events));
+
+    await drainQueue(conversation as never);
+
+    // The early lock check requeues before announcing anything, so a
+    // corrective event here would contradict what the client is showing.
+    expect(events).toEqual([]);
+    expect(queue.length).toBe(1);
+  });
+
+  test("only the batch member whose dequeue was announced is corrected", async () => {
+    const headEvents: FakeEvent[] = [];
+    const tailEvents: FakeEvent[] = [];
+    const { conversation, queue } = makeFakeConversation({
+      persistError: new Error(CONVERSATION_BUSY_MESSAGE),
+    });
+    queue.push(makeQueued("hello there", "r1", headEvents));
+    queue.push(makeQueued("and another", "r2", tailEvents));
+
+    await drainQueue(conversation as never);
+
+    // The batch drain announces per member as it walks the batch, and the
+    // head's busy persist ends the walk before the tail is announced.
+    expect(headEvents.map((event) => event.type)).toEqual([
+      "message_dequeued",
+      "message_requeued",
+    ]);
+    expect(tailEvents).toEqual([]);
+    expect(queue.peek(0)?.requestId).toBe("r1");
+    expect(queue.peek(1)?.requestId).toBe("r2");
+  });
+
+  test("a hidden send is announced but never corrected", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue } = makeFakeConversation({
+      persistError: new Error(CONVERSATION_BUSY_MESSAGE),
+    });
+    queue.push(
+      makeQueued("wizard closed", "r1", events, {
+        metadata: { hidden: true },
+      }),
+    );
+
+    await drainQueue(conversation as never);
+
+    // Hidden sends get no queued ack and render no client row, so there is
+    // nothing for a corrective event to restore.
+    expect(events.some((event) => event.type === "message_requeued")).toBe(
+      false,
+    );
+    expect(queue.peek(0)?.requestId).toBe("r1");
+  });
+
+  test("a second contention round corrects the message again", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue } = makeFakeConversation({
+      persistErrors: [
+        new Error(CONVERSATION_BUSY_MESSAGE),
+        new Error(CONVERSATION_BUSY_MESSAGE),
+      ],
+    });
+    queue.push(makeQueued("hello there", "r1", events));
+
+    await drainQueue(conversation as never);
+    await drainQueue(conversation as never);
+
+    // Each round re-announces the dequeue, so each round owes its own
+    // correction: the flag settles per announcement, not once per message.
+    expect(events.map((event) => event.type)).toEqual([
+      "message_dequeued",
+      "message_requeued",
+      "message_dequeued",
+      "message_requeued",
+    ]);
   });
 });

--- a/assistant/src/__tests__/queued-message-delete-contract.test.ts
+++ b/assistant/src/__tests__/queued-message-delete-contract.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Contract and authorization for deleting a queued message.
+ *
+ * Two things this pins:
+ *
+ * 1. **Terminal event.** A queued row that is cancelled never runs, so no
+ *    `message_dequeued` is ever coming for it. `message_queued_deleted` is the
+ *    only signal that closes it out, and it must reach the message's event
+ *    sink (the hub, for HTTP sends) rather than only the caller that issued
+ *    the DELETE.
+ * 2. **Scoping.** The removal is scoped both ways: to the named conversation's
+ *    own queue, and to the actor principal that enqueued the message. Every
+ *    subscriber sees every `message_queued` ack, so requestIds are not secrets
+ *    and cannot stand in for authorization.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { AssistantEvent } from "../api/index.js";
+import {
+  MessageQueue,
+  type QueuedMessage,
+} from "../daemon/conversation-queue-manager.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import { ROUTES } from "../runtime/routes/conversation-query-routes.js";
+
+const deleteRoute = ROUTES.find(
+  (route) => route.operationId === "messages_queued_delete",
+)!;
+
+const registered: string[] = [];
+
+interface QueuedFixture {
+  requestId: string;
+  clientMessageId?: string;
+  sourceActorPrincipalId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Register a live conversation holding `items`, and return the events its
+ * queued messages publish. The delete path reads the in-memory registry and
+ * touches no persistence, so a queue-only stand-in exercises the real code.
+ */
+function seedConversation(
+  conversationId: string,
+  items: QueuedFixture[],
+): { events: AssistantEvent[]; queue: MessageQueue } {
+  const events: AssistantEvent[] = [];
+  const queue = new MessageQueue();
+  for (const item of items) {
+    queue.push({
+      content: `content for ${item.requestId}`,
+      attachments: [],
+      requestId: item.requestId,
+      onEvent: (event: AssistantEvent) => {
+        events.push(event);
+      },
+      sentAt: Date.now(),
+      clientMessageId: item.clientMessageId,
+      sourceActorPrincipalId: item.sourceActorPrincipalId,
+      metadata: item.metadata,
+    } as QueuedMessage);
+  }
+  const conversation = {
+    conversationId,
+    queue,
+    removeQueuedMessage: (requestId: string) =>
+      queue.removeByRequestId(requestId) !== undefined,
+  };
+  setConversation(conversationId, conversation as never);
+  registered.push(conversationId);
+  return { events, queue };
+}
+
+function dispatchDelete(args: {
+  conversationId: string;
+  requestId: string;
+  actorPrincipalId?: string;
+}) {
+  return deleteRoute.handler({
+    pathParams: { id: args.requestId },
+    queryParams: { conversationId: args.conversationId },
+    headers: args.actorPrincipalId
+      ? { "x-vellum-actor-principal-id": args.actorPrincipalId }
+      : {},
+  });
+}
+
+afterEach(() => {
+  for (const conversationId of registered.splice(0)) {
+    deleteConversation(conversationId);
+  }
+});
+
+describe("queued message delete: terminal event", () => {
+  test("a deleted queued message publishes message_queued_deleted with its nonce", () => {
+    const { events, queue } = seedConversation("conv-delete-1", [
+      { requestId: "r1", clientMessageId: "nonce-1" },
+      { requestId: "r2" },
+    ]);
+
+    expect(
+      dispatchDelete({ conversationId: "conv-delete-1", requestId: "r1" }),
+    ).toEqual({ ok: true, conversationId: "conv-delete-1", requestId: "r1" });
+
+    expect(events).toEqual([
+      {
+        type: "message_queued_deleted",
+        conversationId: "conv-delete-1",
+        requestId: "r1",
+        clientMessageId: "nonce-1",
+      },
+    ]);
+    // Only the named message left the queue.
+    expect(queue.length).toBe(1);
+    expect(queue.peek(0)?.requestId).toBe("r2");
+  });
+
+  test("the nonce is omitted when the sender minted none", () => {
+    const { events } = seedConversation("conv-delete-2", [{ requestId: "r1" }]);
+
+    dispatchDelete({ conversationId: "conv-delete-2", requestId: "r1" });
+
+    expect(events).toEqual([
+      {
+        type: "message_queued_deleted",
+        conversationId: "conv-delete-2",
+        requestId: "r1",
+      },
+    ]);
+  });
+
+  test("a hidden send is removed without publishing a terminal event", () => {
+    const { events, queue } = seedConversation("conv-delete-3", [
+      { requestId: "r1", metadata: { hidden: true } },
+    ]);
+
+    dispatchDelete({ conversationId: "conv-delete-3", requestId: "r1" });
+
+    // Hidden sends never got a queued ack and render no client row, so there
+    // is nothing to close out.
+    expect(events).toEqual([]);
+    expect(queue.length).toBe(0);
+  });
+
+  test("a delete that finds nothing publishes nothing", () => {
+    const { events, queue } = seedConversation("conv-delete-4", [
+      { requestId: "r1" },
+    ]);
+
+    expect(() =>
+      dispatchDelete({
+        conversationId: "conv-delete-4",
+        requestId: "r-absent",
+      }),
+    ).toThrow("Queued message not found");
+    expect(events).toEqual([]);
+    expect(queue.length).toBe(1);
+  });
+});
+
+describe("queued message delete: conversation scoping", () => {
+  test("a requestId from another conversation does not delete across the boundary", () => {
+    const owner = seedConversation("conv-scope-owner", [{ requestId: "r1" }]);
+    const bystander = seedConversation("conv-scope-bystander", [
+      { requestId: "r2" },
+    ]);
+
+    expect(() =>
+      dispatchDelete({
+        conversationId: "conv-scope-bystander",
+        requestId: "r1",
+      }),
+    ).toThrow("Queued message not found");
+
+    expect(owner.queue.length).toBe(1);
+    expect(bystander.queue.length).toBe(1);
+    expect(owner.events).toEqual([]);
+    expect(bystander.events).toEqual([]);
+  });
+
+  test("an unknown conversation is reported as such, not as a missing message", () => {
+    expect(() =>
+      dispatchDelete({ conversationId: "conv-absent", requestId: "r1" }),
+    ).toThrow("Conversation not found");
+  });
+
+  test("conversationId is required", () => {
+    expect(() => deleteRoute.handler({ pathParams: { id: "r1" } })).toThrow(
+      "Missing required parameter: conversationId",
+    );
+  });
+});
+
+describe("queued message delete: actor scoping", () => {
+  test("a different actor principal cannot cancel someone else's queued message", () => {
+    const { events, queue } = seedConversation("conv-actor-1", [
+      { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    expect(() =>
+      dispatchDelete({
+        conversationId: "conv-actor-1",
+        requestId: "r1",
+        actorPrincipalId: "actor-bystander",
+      }),
+    ).toThrow("sent by a different user");
+
+    // Left intact, and no terminal event went out: the row is still pending.
+    expect(queue.length).toBe(1);
+    expect(events).toEqual([]);
+  });
+
+  test("the enqueuing actor principal can cancel its own queued message", () => {
+    const { events, queue } = seedConversation("conv-actor-2", [
+      { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    dispatchDelete({
+      conversationId: "conv-actor-2",
+      requestId: "r1",
+      actorPrincipalId: "actor-owner",
+    });
+
+    expect(queue.length).toBe(0);
+    expect(events.map((event) => event.type)).toEqual([
+      "message_queued_deleted",
+    ]);
+  });
+
+  test("a caller with no actor principal is the guardian by construction", () => {
+    const { queue } = seedConversation("conv-actor-3", [
+      { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    // Local/IPC and service principals carry no actorPrincipalId; the CLI
+    // must keep being able to cancel a queued message.
+    dispatchDelete({ conversationId: "conv-actor-3", requestId: "r1" });
+
+    expect(queue.length).toBe(0);
+  });
+
+  test("a daemon-internal enqueue with no recorded requester stays cancellable", () => {
+    const { queue } = seedConversation("conv-actor-4", [{ requestId: "r1" }]);
+
+    // Agent wakes, subagent notifications and surface actions have no
+    // enqueuing actor to compare against.
+    dispatchDelete({
+      conversationId: "conv-actor-4",
+      requestId: "r1",
+      actorPrincipalId: "actor-bystander",
+    });
+
+    expect(queue.length).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/queued-message-delete-contract.test.ts
+++ b/assistant/src/__tests__/queued-message-delete-contract.test.ts
@@ -11,7 +11,10 @@
  * 2. **Scoping.** The removal is scoped both ways: to the named conversation's
  *    own queue, and to the actor principal that enqueued the message. Every
  *    subscriber sees every `message_queued` ack, so requestIds are not secrets
- *    and cannot stand in for authorization.
+ *    and cannot stand in for authorization. The caller identity is normalized
+ *    exactly as the send path normalizes it before recording
+ *    `sourceActorPrincipalId`, or the two disagree and a legitimate cancel is
+ *    refused.
  */
 import { afterEach, describe, expect, test } from "bun:test";
 
@@ -80,30 +83,37 @@ function dispatchDelete(args: {
   requestId: string;
   actorPrincipalId?: string;
 }) {
-  return deleteRoute.handler({
-    pathParams: { id: args.requestId },
-    queryParams: { conversationId: args.conversationId },
-    headers: args.actorPrincipalId
-      ? { "x-vellum-actor-principal-id": args.actorPrincipalId }
-      : {},
-  });
+  return Promise.resolve(
+    deleteRoute.handler({
+      pathParams: { id: args.requestId },
+      queryParams: { conversationId: args.conversationId },
+      headers:
+        args.actorPrincipalId !== undefined
+          ? { "x-vellum-actor-principal-id": args.actorPrincipalId }
+          : {},
+    }),
+  );
 }
 
 afterEach(() => {
   for (const conversationId of registered.splice(0)) {
     deleteConversation(conversationId);
   }
+  delete process.env.DISABLE_HTTP_AUTH;
 });
 
 describe("queued message delete: terminal event", () => {
-  test("a deleted queued message publishes message_queued_deleted with its nonce", () => {
+  test("a deleted queued message publishes message_queued_deleted with its nonce", async () => {
     const { events, queue } = seedConversation("conv-delete-1", [
       { requestId: "r1", clientMessageId: "nonce-1" },
       { requestId: "r2" },
     ]);
 
     expect(
-      dispatchDelete({ conversationId: "conv-delete-1", requestId: "r1" }),
+      await dispatchDelete({
+        conversationId: "conv-delete-1",
+        requestId: "r1",
+      }),
     ).toEqual({ ok: true, conversationId: "conv-delete-1", requestId: "r1" });
 
     expect(events).toEqual([
@@ -119,10 +129,10 @@ describe("queued message delete: terminal event", () => {
     expect(queue.peek(0)?.requestId).toBe("r2");
   });
 
-  test("the nonce is omitted when the sender minted none", () => {
+  test("the nonce is omitted when the sender minted none", async () => {
     const { events } = seedConversation("conv-delete-2", [{ requestId: "r1" }]);
 
-    dispatchDelete({ conversationId: "conv-delete-2", requestId: "r1" });
+    await dispatchDelete({ conversationId: "conv-delete-2", requestId: "r1" });
 
     expect(events).toEqual([
       {
@@ -133,12 +143,12 @@ describe("queued message delete: terminal event", () => {
     ]);
   });
 
-  test("a hidden send is removed without publishing a terminal event", () => {
+  test("a hidden send is removed without publishing a terminal event", async () => {
     const { events, queue } = seedConversation("conv-delete-3", [
       { requestId: "r1", metadata: { hidden: true } },
     ]);
 
-    dispatchDelete({ conversationId: "conv-delete-3", requestId: "r1" });
+    await dispatchDelete({ conversationId: "conv-delete-3", requestId: "r1" });
 
     // Hidden sends never got a queued ack and render no client row, so there
     // is nothing to close out.
@@ -146,35 +156,35 @@ describe("queued message delete: terminal event", () => {
     expect(queue.length).toBe(0);
   });
 
-  test("a delete that finds nothing publishes nothing", () => {
+  test("a delete that finds nothing publishes nothing", async () => {
     const { events, queue } = seedConversation("conv-delete-4", [
       { requestId: "r1" },
     ]);
 
-    expect(() =>
+    await expect(
       dispatchDelete({
         conversationId: "conv-delete-4",
         requestId: "r-absent",
       }),
-    ).toThrow("Queued message not found");
+    ).rejects.toThrow("Queued message not found");
     expect(events).toEqual([]);
     expect(queue.length).toBe(1);
   });
 });
 
 describe("queued message delete: conversation scoping", () => {
-  test("a requestId from another conversation does not delete across the boundary", () => {
+  test("a requestId from another conversation does not delete across the boundary", async () => {
     const owner = seedConversation("conv-scope-owner", [{ requestId: "r1" }]);
     const bystander = seedConversation("conv-scope-bystander", [
       { requestId: "r2" },
     ]);
 
-    expect(() =>
+    await expect(
       dispatchDelete({
         conversationId: "conv-scope-bystander",
         requestId: "r1",
       }),
-    ).toThrow("Queued message not found");
+    ).rejects.toThrow("Queued message not found");
 
     expect(owner.queue.length).toBe(1);
     expect(bystander.queue.length).toBe(1);
@@ -182,44 +192,44 @@ describe("queued message delete: conversation scoping", () => {
     expect(bystander.events).toEqual([]);
   });
 
-  test("an unknown conversation is reported as such, not as a missing message", () => {
-    expect(() =>
+  test("an unknown conversation is reported as such, not as a missing message", async () => {
+    await expect(
       dispatchDelete({ conversationId: "conv-absent", requestId: "r1" }),
-    ).toThrow("Conversation not found");
+    ).rejects.toThrow("Conversation not found");
   });
 
-  test("conversationId is required", () => {
-    expect(() => deleteRoute.handler({ pathParams: { id: "r1" } })).toThrow(
-      "Missing required parameter: conversationId",
-    );
+  test("conversationId is required", async () => {
+    await expect(
+      Promise.resolve(deleteRoute.handler({ pathParams: { id: "r1" } })),
+    ).rejects.toThrow("Missing required parameter: conversationId");
   });
 });
 
 describe("queued message delete: actor scoping", () => {
-  test("a different actor principal cannot cancel someone else's queued message", () => {
+  test("a different actor principal cannot cancel someone else's queued message", async () => {
     const { events, queue } = seedConversation("conv-actor-1", [
       { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
     ]);
 
-    expect(() =>
+    await expect(
       dispatchDelete({
         conversationId: "conv-actor-1",
         requestId: "r1",
         actorPrincipalId: "actor-bystander",
       }),
-    ).toThrow("sent by a different user");
+    ).rejects.toThrow("sent by a different user");
 
     // Left intact, and no terminal event went out: the row is still pending.
     expect(queue.length).toBe(1);
     expect(events).toEqual([]);
   });
 
-  test("the enqueuing actor principal can cancel its own queued message", () => {
+  test("the enqueuing actor principal can cancel its own queued message", async () => {
     const { events, queue } = seedConversation("conv-actor-2", [
       { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
     ]);
 
-    dispatchDelete({
+    await dispatchDelete({
       conversationId: "conv-actor-2",
       requestId: "r1",
       actorPrincipalId: "actor-owner",
@@ -231,29 +241,99 @@ describe("queued message delete: actor scoping", () => {
     ]);
   });
 
-  test("a caller with no actor principal is the guardian by construction", () => {
+  test("a caller with no actor principal is the guardian by construction", async () => {
     const { queue } = seedConversation("conv-actor-3", [
       { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
     ]);
 
     // Local/IPC and service principals carry no actorPrincipalId; the CLI
     // must keep being able to cancel a queued message.
-    dispatchDelete({ conversationId: "conv-actor-3", requestId: "r1" });
+    await dispatchDelete({ conversationId: "conv-actor-3", requestId: "r1" });
 
     expect(queue.length).toBe(0);
   });
 
-  test("a daemon-internal enqueue with no recorded requester stays cancellable", () => {
+  test("a daemon-internal enqueue with no recorded requester stays cancellable", async () => {
     const { queue } = seedConversation("conv-actor-4", [{ requestId: "r1" }]);
 
     // Agent wakes, subagent notifications and surface actions have no
     // enqueuing actor to compare against.
-    dispatchDelete({
+    await dispatchDelete({
       conversationId: "conv-actor-4",
       requestId: "r1",
       actorPrincipalId: "actor-bystander",
     });
 
     expect(queue.length).toBe(0);
+  });
+});
+
+describe("queued message delete: caller identity normalization", () => {
+  test("a padded principal still matches the recorded requester", async () => {
+    const { queue } = seedConversation("conv-normalize-1", [
+      { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    // Sibling handlers in this layer all trim the header; without that the
+    // padded value is a distinct id and the owner's own cancel 403s.
+    await dispatchDelete({
+      conversationId: "conv-normalize-1",
+      requestId: "r1",
+      actorPrincipalId: "  actor-owner  ",
+    });
+
+    expect(queue.length).toBe(0);
+  });
+
+  test("a whitespace-only principal is treated as absent, not as an id", async () => {
+    const { queue } = seedConversation("conv-normalize-2", [
+      { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    await dispatchDelete({
+      conversationId: "conv-normalize-2",
+      requestId: "r1",
+      actorPrincipalId: "   ",
+    });
+
+    expect(queue.length).toBe(0);
+  });
+
+  test("the dev-bypass principal does not 403 against a resolved guardian id", async () => {
+    // Under DISABLE_HTTP_AUTH the send path stores the REAL local guardian
+    // principal (`resolveActorPrincipalIdForLocalGuardian` translates the
+    // synthetic `dev-bypass` before enqueue), so a delete that compared the
+    // raw header would never match and every local-dev cancel would 403.
+    process.env.DISABLE_HTTP_AUTH = "true";
+    const { queue } = seedConversation("conv-dev-bypass", [
+      { requestId: "r1", sourceActorPrincipalId: "guardian-principal-abc" },
+    ]);
+
+    await dispatchDelete({
+      conversationId: "conv-dev-bypass",
+      requestId: "r1",
+      actorPrincipalId: "dev-bypass",
+    });
+
+    expect(queue.length).toBe(0);
+  });
+
+  test("a real principal is untouched by the dev-bypass translation", async () => {
+    process.env.DISABLE_HTTP_AUTH = "true";
+    const { queue } = seedConversation("conv-dev-bypass-real", [
+      { requestId: "r1", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    // Only the literal `dev-bypass` principal is translated, so auth-disabled
+    // mode is not itself an authorization bypass.
+    await expect(
+      dispatchDelete({
+        conversationId: "conv-dev-bypass-real",
+        requestId: "r1",
+        actorPrincipalId: "actor-bystander",
+      }),
+    ).rejects.toThrow("sent by a different user");
+
+    expect(queue.length).toBe(1);
   });
 });

--- a/assistant/src/api/events/message-requeued.ts
+++ b/assistant/src/api/events/message-requeued.ts
@@ -1,0 +1,35 @@
+/**
+ * `message_requeued` SSE event.
+ *
+ * The corrective counterpart to `message_dequeued`. A drain announces a
+ * dequeue before the steps that can send the message back: another turn
+ * takes the processing lock between the announcement and the persist, or
+ * the drain dispatch throws before the turn takes over. In both cases the
+ * message returns to the front of the per-conversation queue and runs on a
+ * later drain.
+ *
+ * Without this event a client that cleared its pending indicator on the
+ * `message_dequeued` has no way to learn the message is queued again, so
+ * the row disappears until the next drain. Clients restore the pending
+ * indicator for `requestId` at `position`, which uses the same 1-based
+ * visible-item accounting as `message_queued`.
+ *
+ * Canonical wire-contract source. Daemon code imports the type directly
+ * from this file; external consumers import via `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const MessageRequeuedEventSchema = z.object({
+  type: z.literal("message_requeued"),
+  conversationId: z.string(),
+  requestId: z.string(),
+  /** 1-based position among the queue's visible items after the requeue. */
+  position: z.number(),
+  /** Sender-minted idempotency nonce from the originating POST, when the
+   *  sender provided one. Lets the originating client bind this event to
+   *  its local optimistic row by identity instead of arrival order. */
+  clientMessageId: z.string().optional(),
+});
+
+export type MessageRequeuedEvent = z.infer<typeof MessageRequeuedEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -81,6 +81,7 @@ import { MessageDequeuedEventSchema } from "./events/message-dequeued.js";
 import { MessageQueuedEventSchema } from "./events/message-queued.js";
 import { MessageQueuedDeletedEventSchema } from "./events/message-queued-deleted.js";
 import { MessageRequestCompleteEventSchema } from "./events/message-request-complete.js";
+import { MessageRequeuedEventSchema } from "./events/message-requeued.js";
 import { MessageSteeredEventSchema } from "./events/message-steered.js";
 import { ModelInfoEventSchema } from "./events/model-info.js";
 import { NavigateSettingsEventSchema } from "./events/navigate-settings.js";
@@ -445,6 +446,10 @@ export {
   type MessageRequestCompleteEvent,
   MessageRequestCompleteEventSchema,
 } from "./events/message-request-complete.js";
+export {
+  type MessageRequeuedEvent,
+  MessageRequeuedEventSchema,
+} from "./events/message-requeued.js";
 export {
   type MessageSteeredEvent,
   MessageSteeredEventSchema,
@@ -932,6 +937,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   MessageQueuedEventSchema,
   MessageQueuedDeletedEventSchema,
   MessageRequestCompleteEventSchema,
+  MessageRequeuedEventSchema,
   MessageSteeredEventSchema,
   ModelInfoEventSchema,
   NavigateSettingsEventSchema,

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -435,6 +435,51 @@ function repairPendingToolUseBlocks(conversation: Conversation): void {
 // ── drainQueue ───────────────────────────────────────────────────────
 
 /**
+ * Tell this message's sender it left the queue for a turn, and remember that
+ * we did. The flag is what makes the requeue paths able to distinguish a
+ * message clients still believe is running from one they never stopped
+ * showing as queued. See {@link requeueDrainedMessages}.
+ */
+function announceDequeue(
+  conversation: Conversation,
+  message: QueuedMessage,
+): void {
+  message.onEvent({
+    type: "message_dequeued",
+    conversationId: conversation.conversationId,
+    requestId: message.requestId,
+    ...(message.clientMessageId
+      ? { clientMessageId: message.clientMessageId }
+      : {}),
+  });
+  message.dequeueAnnounced = true;
+}
+
+/**
+ * 1-based position of `requestId` among the queue's VISIBLE items, or
+ * undefined when the queue holds no such message. Mirrors the accounting the
+ * `message_queued` ack uses (and the list-messages queued snapshot filter),
+ * so a corrective requeue event places the row exactly where a cold reload
+ * would render it.
+ */
+function visibleQueuePosition(
+  conversation: Conversation,
+  requestId: string,
+): number | undefined {
+  let position = 0;
+  for (const item of conversation.queue.snapshot()) {
+    if (isHiddenMessageMetadata(item.metadata)) {
+      continue;
+    }
+    position += 1;
+    if (item.requestId === requestId) {
+      return position;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Restore drained messages to the front of the queue, in their original
  * order, when the drain cannot run them: another turn (e.g. a barged-in
  * voice turn woken by the idle transition) owns the processing lock, or the
@@ -443,6 +488,14 @@ function repairPendingToolUseBlocks(conversation: Conversation): void {
  * up. A steered drain also re-arms `pendingSteerRepair` so the re-drain
  * promotes the steered head on its own instead of batching it with tails;
  * the tool-use repair it re-triggers is idempotent.
+ *
+ * Any message whose dequeue was already announced gets the corrective
+ * `message_requeued`: its sender cleared the pending indicator on the
+ * `message_dequeued` and would otherwise see the row vanish until a later
+ * drain. Messages requeued before the announcement (the pre-flight
+ * processing-lock checks) get nothing, because clients never stopped showing
+ * them as queued and an event there would be noise. Hidden sends are suppressed
+ * for the same reason they get no queued ack: they have no client row.
  */
 function requeueDrainedMessages(
   conversation: Conversation,
@@ -463,6 +516,28 @@ function requeueDrainedMessages(
   }
   if (steered) {
     conversation.pendingSteerRepair = true;
+  }
+  for (const message of messages) {
+    if (!message.dequeueAnnounced) {
+      continue;
+    }
+    message.dequeueAnnounced = false;
+    if (isHiddenMessageMetadata(message.metadata)) {
+      continue;
+    }
+    const position = visibleQueuePosition(conversation, message.requestId);
+    if (position === undefined) {
+      continue;
+    }
+    message.onEvent({
+      type: "message_requeued",
+      conversationId: conversation.conversationId,
+      requestId: message.requestId,
+      position,
+      ...(message.clientMessageId
+        ? { clientMessageId: message.clientMessageId }
+        : {}),
+    });
   }
 }
 
@@ -660,12 +735,7 @@ async function drainSingleMessage(
     },
     "Dequeuing message",
   );
-  next.onEvent({
-    type: "message_dequeued",
-    conversationId: conversation.conversationId,
-    requestId: next.requestId,
-    ...(next.clientMessageId ? { clientMessageId: next.clientMessageId } : {}),
-  });
+  announceDequeue(conversation, next);
   conversation.emitActivityState("thinking", "message_dequeued", {
     requestId: next.requestId,
   });
@@ -1334,12 +1404,7 @@ async function drainBatch(
   const persistedMessageIds: string[] = [];
   for (let i = 0; i < batch.length; i++) {
     const qm = batch[i];
-    qm.onEvent({
-      type: "message_dequeued",
-      conversationId: conversation.conversationId,
-      requestId: qm.requestId,
-      ...(qm.clientMessageId ? { clientMessageId: qm.clientMessageId } : {}),
-    });
+    announceDequeue(conversation, qm);
 
     const qmSlash = await resolveSlash(
       qm.content,

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -42,6 +42,15 @@ export interface QueuedMessage {
   /** Client-generated correlation nonce. Echoed back on `user_message_echo`
    *  so the originating client can dedupe its optimistic row. */
   clientMessageId?: string;
+  /**
+   * True once a drain has told clients this message was dequeued and before
+   * the turn it was dequeued for actually took over. A drain that sends the
+   * message back to the queue after that point owes clients the corrective
+   * `message_requeued`; one that gives up before announcing owes nothing.
+   * Set by the drain's dequeue announcement, cleared by the requeue that
+   * settles it.
+   */
+  dequeueAnnounced?: boolean;
 }
 
 /**
@@ -197,6 +206,16 @@ export class MessageQueue {
     const [promoted] = this.items.splice(idx, 1);
     this.items.unshift(promoted);
     return promoted;
+  }
+
+  /**
+   * Read-only lookup of a queued message by its requestId. Returns the live
+   * reference (callers must treat it as read-only), or undefined when this
+   * queue holds no such message. Lets a caller inspect an item (to
+   * authorize a delete, say) before deciding whether to remove it.
+   */
+  findByRequestId(requestId: string): QueuedMessage | undefined {
+    return this.items.find((m) => m.requestId === requestId);
   }
 
   /**

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -3,6 +3,7 @@ import { decideGuardianRequest } from "../../channels/gateway-guardian-requests.
 import {
   clearAll,
   getConversation,
+  isHiddenMessageMetadata,
 } from "../../persistence/conversation-crud.js";
 import { resolveConversationId } from "../../persistence/conversation-key-store.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
@@ -16,6 +17,7 @@ import {
   buildSlashContext,
   formatCleanResult,
 } from "../conversation-process.js";
+import type { QueuedMessage } from "../conversation-queue-manager.js";
 import {
   conversationEntries,
   findConversation,
@@ -240,15 +242,59 @@ export async function resolveMetaSlashCommand(
 // ---------------------------------------------------------------------------
 
 /**
+ * Whether the caller behind a delete request may cancel this queued message.
+ *
+ * A queued message records the verified requester that enqueued it
+ * (`sourceActorPrincipalId`); the delete route receives the caller's verified
+ * identity in the `x-vellum-actor-principal-id` header, which both adapters
+ * derive from the auth context rather than from anything the caller sent. When
+ * both are present they must match: `message_queued` is broadcast to every
+ * subscriber of the assistant, so every requestId in a conversation is visible
+ * to every connected client, and without this check one actor principal could
+ * cancel another's pending message just by echoing the id back.
+ *
+ * Two cases stay open, both deliberately:
+ *
+ * - **The caller has no actor principal.** Local/IPC and service principals
+ *   carry no `actorPrincipalId`; by the convention this routes layer already
+ *   follows (see `vellum-actor-trust.ts`) a caller with no principal is the
+ *   guardian by construction, so the CLI keeps working.
+ * - **The message has no recorded requester.** Daemon-internal enqueues (agent
+ *   wake, subagent notifications, surface actions) have no enqueuing actor to
+ *   compare against, and cancelling one from the queue UI is intended.
+ */
+function mayCancelQueuedMessage(
+  queued: QueuedMessage,
+  callerActorPrincipalId: string | undefined,
+): boolean {
+  if (!queued.sourceActorPrincipalId || !callerActorPrincipalId) {
+    return true;
+  }
+  return queued.sourceActorPrincipalId === callerActorPrincipalId;
+}
+
+/**
  * Delete a queued message from a conversation.
  * Returns `{ removed: true }` on success, `{ removed: false, reason }` on failure.
+ *
+ * On success the sender's event sink receives the terminal
+ * `message_queued_deleted`. It is the counterpart to the `message_queued` ack
+ * and the only signal that closes out a queued row that never runs: without it
+ * a client that didn't originate the delete leaves the pending indicator up
+ * forever, since no `message_dequeued` is ever coming. Hidden sends are
+ * suppressed for the same reason they get no ack: they have no client row to
+ * close.
  */
 export function deleteQueuedMessage(
   conversationId: string,
   requestId: string,
+  options: { actorPrincipalId?: string } = {},
 ):
   | { removed: true }
-  | { removed: false; reason: "conversation_not_found" | "message_not_found" } {
+  | {
+      removed: false;
+      reason: "conversation_not_found" | "message_not_found" | "forbidden";
+    } {
   const conversation = findConversation(conversationId);
   if (!conversation) {
     log.warn(
@@ -257,15 +303,37 @@ export function deleteQueuedMessage(
     );
     return { removed: false, reason: "conversation_not_found" };
   }
-  const removed = conversation.removeQueuedMessage(requestId);
-  if (removed) {
-    return { removed: true };
+  const queued = conversation.queue.findByRequestId(requestId);
+  if (!queued) {
+    log.warn(
+      { conversationId, requestId },
+      "Queued message not found for deletion",
+    );
+    return { removed: false, reason: "message_not_found" };
   }
-  log.warn(
-    { conversationId, requestId },
-    "Queued message not found for deletion",
-  );
-  return { removed: false, reason: "message_not_found" };
+  if (!mayCancelQueuedMessage(queued, options.actorPrincipalId)) {
+    log.warn(
+      {
+        conversationId,
+        requestId,
+        callerActorPrincipalId: options.actorPrincipalId,
+      },
+      "Refusing to delete a queued message enqueued by a different actor principal",
+    );
+    return { removed: false, reason: "forbidden" };
+  }
+  conversation.removeQueuedMessage(requestId);
+  if (!isHiddenMessageMetadata(queued.metadata)) {
+    queued.onEvent({
+      type: "message_queued_deleted",
+      conversationId,
+      requestId,
+      ...(queued.clientMessageId
+        ? { clientMessageId: queued.clientMessageId }
+        : {}),
+    });
+  }
+  return { removed: true };
 }
 
 /**

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -113,6 +113,7 @@ import {
   resolvePricingForUsage,
   usesAnthropicPricingRules,
 } from "../../util/pricing.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import {
   BadRequestError,
   ForbiddenError,
@@ -2127,16 +2128,24 @@ function resolveQueuedMessageConversationId({
     : undefined;
 }
 
-function handleDeleteQueuedMessage(args: RouteHandlerArgs) {
+async function handleDeleteQueuedMessage(args: RouteHandlerArgs) {
   const { pathParams = {}, headers = {} } = args;
   const conversationId = resolveQueuedMessageConversationId(args);
   if (!conversationId) {
     throw new BadRequestError("Missing required parameter: conversationId");
   }
+  // Verified caller identity. Both adapters derive this header from the auth
+  // context, never from a caller-supplied one. Normalize it exactly as the
+  // send path does before comparing against the principal recorded at
+  // enqueue, or the two disagree: `resolveActorPrincipalIdForLocalGuardian`
+  // translates the synthetic `dev-bypass` principal to the real local
+  // guardian under `DISABLE_HTTP_AUTH=true` (a no-op for real JWT
+  // principals), and every sibling handler in this layer trims first.
+  const actorPrincipalId = await resolveActorPrincipalIdForLocalGuardian(
+    headers["x-vellum-actor-principal-id"]?.trim() || undefined,
+  );
   const result = deleteQueuedMessage(conversationId, pathParams.id ?? "", {
-    // Verified caller identity. Both adapters derive this header from the
-    // auth context, never from a caller-supplied one.
-    actorPrincipalId: headers["x-vellum-actor-principal-id"] || undefined,
+    actorPrincipalId,
   });
   if (result.removed) {
     return { ok: true, conversationId, requestId: pathParams.id };

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -113,7 +113,12 @@ import {
   resolvePricingForUsage,
   usesAnthropicPricingRules,
 } from "../../util/pricing.js";
-import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ForbiddenError,
+  InternalError,
+  NotFoundError,
+} from "./errors.js";
 import {
   type LlmContextSummary,
   normalizeLlmContextPayloads,
@@ -2123,17 +2128,26 @@ function resolveQueuedMessageConversationId({
 }
 
 function handleDeleteQueuedMessage(args: RouteHandlerArgs) {
-  const { pathParams = {} } = args;
+  const { pathParams = {}, headers = {} } = args;
   const conversationId = resolveQueuedMessageConversationId(args);
   if (!conversationId) {
     throw new BadRequestError("Missing required parameter: conversationId");
   }
-  const result = deleteQueuedMessage(conversationId, pathParams.id ?? "");
+  const result = deleteQueuedMessage(conversationId, pathParams.id ?? "", {
+    // Verified caller identity. Both adapters derive this header from the
+    // auth context, never from a caller-supplied one.
+    actorPrincipalId: headers["x-vellum-actor-principal-id"] || undefined,
+  });
   if (result.removed) {
     return { ok: true, conversationId, requestId: pathParams.id };
   }
   if (result.reason === "conversation_not_found") {
     throw new NotFoundError("Conversation not found");
+  }
+  if (result.reason === "forbidden") {
+    throw new ForbiddenError(
+      "Queued message was sent by a different user and cannot be cancelled here",
+    );
   }
   throw new NotFoundError("Queued message not found");
 }
@@ -2480,7 +2494,8 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Delete a queued message",
     description:
-      "Remove a pending message from the conversation queue before it is processed.",
+      "Remove a pending message from the conversation queue before it is processed. " +
+      "Broadcasts `message_queued_deleted` so every client can close out the pending row.",
     tags: ["messages"],
     queryParams: [
       {
@@ -2490,6 +2505,15 @@ export const ROUTES: RouteDefinition[] = [
         description: "Conversation ID (required)",
       },
     ],
+    additionalResponses: {
+      "403": {
+        description:
+          "The queued message was enqueued by a different actor principal.",
+      },
+      "404": {
+        description: "Conversation or queued message not found.",
+      },
+    },
     handler: handleDeleteQueuedMessage,
   },
   {

--- a/clients/web/src/domains/chat/hooks/use-message-queue.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.ts
@@ -18,7 +18,6 @@ import {
   clearQueueStatus,
   markMessageQueued,
 } from "@/domains/chat/utils/stream-updaters/shared";
-import { useTurnStore } from "@/domains/chat/turn-store";
 import { steerToMessage } from "@/domains/chat/api/messages";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
@@ -94,7 +93,6 @@ export function useMessageQueue({
           setOptimisticSends,
           onDeleted: () => {
             useChatSessionStore.getState().popRequestIdMapping(targetRequestId);
-            useTurnStore.getState().deleteQueuedMessage();
           },
         });
       } else {

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -821,7 +821,6 @@ export function useSendMessage({
                 setOptimisticSends,
                 onDeleted: () => {
                   useChatSessionStore.getState().popRequestIdMapping(requestId);
-                  useTurnStore.getState().deleteQueuedMessage();
                 },
               });
             }

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -59,6 +59,7 @@ import {
   handleMessageQueued,
   handleMessageDequeued,
   handleMessageQueuedDeleted,
+  handleMessageRequeued,
   handleMessageRequestComplete,
 } from "@/domains/chat/utils/stream-handlers/queue-handlers";
 import {
@@ -387,6 +388,9 @@ export function useStreamEventHandler(
           break;
         case "message_dequeued":
           handleMessageDequeued(event, ctx);
+          break;
+        case "message_requeued":
+          handleMessageRequeued(event, ctx);
           break;
         case "message_queued_deleted":
           handleMessageQueuedDeleted(event, ctx);

--- a/clients/web/src/domains/chat/queue-cancellation.ts
+++ b/clients/web/src/domains/chat/queue-cancellation.ts
@@ -12,6 +12,17 @@ interface ConfirmQueuedMessageDeletionParams {
   setOptimisticSends: (
     updater: (prev: DisplayMessage[]) => DisplayMessage[],
   ) => void;
+  /**
+   * Local bookkeeping for a confirmed cancellation. Retire correlation state
+   * here, but do NOT touch the turn store's queued count: the daemon answers
+   * a successful DELETE with a hub-wide `message_queued_deleted`, and
+   * `handleMessageQueuedDeleted` decrements on that. The count tracks every
+   * queued message in the conversation, not just this client's, because
+   * `handleMessageQueued` increments for every `message_queued` regardless of
+   * origin; a local decrement here would double-count the one cancellation
+   * this client happened to issue and drop the queued indicator while other
+   * messages are still waiting.
+   */
   onDeleted: () => void;
 }
 

--- a/clients/web/src/domains/chat/queued-count-single-decrement.test.ts
+++ b/clients/web/src/domains/chat/queued-count-single-decrement.test.ts
@@ -11,16 +11,7 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-let deleteCalls = 0;
-let deleteResult = true;
-
-mock.module("@/domains/chat/api/messages", () => ({
-  deleteQueuedMessage: async (): Promise<boolean> => {
-    deleteCalls += 1;
-    return deleteResult;
-  },
-}));
-
+import { client as daemonClient } from "@/generated/daemon/client.gen";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
@@ -37,14 +28,28 @@ function ctxWithRealTurnActions(
   return makeCtx({ turnActions: useTurnStore.getState(), ...overrides });
 }
 
+// Spy on the generated client rather than `mock.module`-ing the API surface:
+// a module mock would replace `@/domains/chat/api/messages` for every other
+// test file sharing this Bun process. Same convention as `api/messages.test.ts`.
+let deleteCalls = 0;
+const originalDelete = daemonClient.delete;
+
 beforeEach(() => {
   deleteCalls = 0;
-  deleteResult = true;
+  daemonClient.delete = mock(async () => {
+    deleteCalls += 1;
+    return {
+      data: { ok: true },
+      error: null,
+      response: new Response(null, { status: 200 }),
+    };
+  }) as typeof daemonClient.delete;
   useTurnStore.setState({ ...INITIAL_TURN_STATE });
   useConversationStore.setState({ activeConversationId: "conv-1" });
 });
 
 afterEach(() => {
+  daemonClient.delete = originalDelete;
   useChatSessionStore.setState({ snapshot: null });
 });
 

--- a/clients/web/src/domains/chat/queued-count-single-decrement.test.ts
+++ b/clients/web/src/domains/chat/queued-count-single-decrement.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `pendingQueuedCount` must move exactly once per cancelled queued message.
+ *
+ * The counter tracks the conversation's whole queue, not this client's share
+ * of it: `handleMessageQueued` increments on every `message_queued` broadcast
+ * before it knows whether this client originated the send. The decrement has
+ * to be symmetric, which means it belongs to the `message_queued_deleted`
+ * broadcast alone. A client that also decremented locally on its own DELETE
+ * response would double-count its own cancellation and drop the queued
+ * indicator while other messages are still waiting.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let deleteCalls = 0;
+let deleteResult = true;
+
+mock.module("@/domains/chat/api/messages", () => ({
+  deleteQueuedMessage: async (): Promise<boolean> => {
+    deleteCalls += 1;
+    return deleteResult;
+  },
+}));
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
+import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
+import {
+  handleMessageQueued,
+  handleMessageQueuedDeleted,
+} from "@/domains/chat/utils/stream-handlers/queue-handlers";
+import { useConversationStore } from "@/stores/conversation-store";
+
+/** Context wired to the REAL turn-store actions so the arithmetic is exercised. */
+function ctxWithRealTurnActions(
+  overrides: Parameters<typeof makeCtx>[0] = {},
+) {
+  return makeCtx({ turnActions: useTurnStore.getState(), ...overrides });
+}
+
+beforeEach(() => {
+  deleteCalls = 0;
+  deleteResult = true;
+  useTurnStore.setState({ ...INITIAL_TURN_STATE });
+  useConversationStore.setState({ activeConversationId: "conv-1" });
+});
+
+afterEach(() => {
+  useChatSessionStore.setState({ snapshot: null });
+});
+
+describe("pendingQueuedCount", () => {
+  test("a cancelled message decrements once, leaving a sibling still queued", () => {
+    // Two messages queued in this conversation, counted from their acks.
+    useTurnStore.setState({
+      phase: "queued",
+      activeTurnId: "turn-1",
+      pendingQueuedCount: 2,
+    });
+
+    handleMessageQueuedDeleted(
+      {
+        type: "message_queued_deleted",
+        conversationId: "conv-1",
+        requestId: "req-1",
+      },
+      ctxWithRealTurnActions(),
+    );
+
+    expect(useTurnStore.getState().pendingQueuedCount).toBe(1);
+    // Still one message waiting, so the turn must not fall back to idle.
+    expect(useTurnStore.getState().phase).toBe("queued");
+  });
+
+  test("the last cancelled message returns the turn to idle", () => {
+    useTurnStore.setState({
+      phase: "queued",
+      activeTurnId: "turn-1",
+      pendingQueuedCount: 1,
+    });
+
+    handleMessageQueuedDeleted(
+      {
+        type: "message_queued_deleted",
+        conversationId: "conv-1",
+        requestId: "req-1",
+      },
+      ctxWithRealTurnActions(),
+    );
+
+    expect(useTurnStore.getState().pendingQueuedCount).toBe(0);
+    expect(useTurnStore.getState().phase).toBe("idle");
+  });
+
+  test("the ack-then-cancel race nets to zero without a local decrement", async () => {
+    // A send whose cancel was clicked before its `message_queued` ack landed:
+    // `handleMessageQueued` increments, then fires the deferred DELETE.
+    handleMessageQueued(
+      {
+        type: "message_queued",
+        conversationId: "conv-1",
+        requestId: "req-1",
+        position: 1,
+      },
+      ctxWithRealTurnActions({
+        pendingQueuedMessageIds: ["stable-1"],
+        pendingLocalDeletions: new Set(["stable-1"]),
+      }),
+    );
+
+    expect(useTurnStore.getState().pendingQueuedCount).toBe(1);
+
+    // Let the fire-and-forget DELETE settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deleteCalls).toBe(1);
+
+    // The DELETE succeeding must NOT move the count on its own; only the
+    // daemon's broadcast does, and it brings the ack's increment back to 0.
+    expect(useTurnStore.getState().pendingQueuedCount).toBe(1);
+
+    handleMessageQueuedDeleted(
+      {
+        type: "message_queued_deleted",
+        conversationId: "conv-1",
+        requestId: "req-1",
+      },
+      ctxWithRealTurnActions(),
+    );
+
+    expect(useTurnStore.getState().pendingQueuedCount).toBe(0);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -307,6 +307,28 @@ describe("rolling-snapshot reducer", () => {
       expect(resolved.messages[0]?.queuePosition).toBeUndefined();
     });
 
+    test("replays a corrective requeue back onto a dequeued row", () => {
+      const snapshot = queuedSnapshot();
+      const resolved = resolveSnapshot(snapshot, [
+        env(2, {
+          type: "message_dequeued",
+          conversationId: "conv-1",
+          requestId: "req-1",
+        } as AssistantEvent),
+        env(3, {
+          type: "message_requeued",
+          conversationId: "conv-1",
+          requestId: "req-1",
+          position: 1,
+        } as AssistantEvent),
+      ]);
+
+      // The drain gave the message back to the queue, so the row it cleared
+      // has to come back rather than vanish until the next drain.
+      expect(resolved.messages[0]?.queueStatus).toBe("queued");
+      expect(resolved.messages[0]?.queuePosition).toBe(1);
+    });
+
     test("replays a queued deletion onto a queued snapshot row", () => {
       const resolved = resolveSnapshot(queuedSnapshot(), [
         env(2, {

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
@@ -38,6 +38,7 @@ import { attachConfirmationToToolCall } from "@/domains/chat/utils/chat";
 import { clearConfirmationByRequestId } from "@/domains/chat/utils/send-message-utils";
 import {
   applyQueuedMessageDequeue,
+  markMessageQueued,
   removeQueuedMessage,
 } from "@/domains/chat/utils/stream-updaters/shared";
 
@@ -94,6 +95,10 @@ export function appendEventToMessages(
       );
     case "message_dequeued":
       return applyQueuedMessageDequeue(messages, event.requestId);
+    case "message_requeued":
+      // The dequeue this corrects cleared the row's queue status; put it back
+      // so the transcript keeps showing the message as pending.
+      return markMessageQueued(messages, event.requestId, event.position);
     case "message_queued_deleted":
       return removeQueuedMessage(messages, event.requestId);
     case "assistant_activity_state":

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
@@ -7,6 +7,7 @@ import {
   handleMessageQueued,
   handleMessageDequeued,
   handleMessageQueuedDeleted,
+  handleMessageRequeued,
   handleMessageRequestComplete,
 } from "@/domains/chat/utils/stream-handlers/queue-handlers";
 
@@ -184,6 +185,80 @@ describe("handleMessageDequeued", () => {
     expect(message?.isOptimistic).toBe(true);
     expect(message?.queueStatus).toBeUndefined();
     expect(message?.queuePosition).toBeUndefined();
+  });
+});
+
+describe("handleMessageRequeued", () => {
+  it("restores the pending row the dequeue cleared, keyed by the nonce", () => {
+    const ctx = makeCtx();
+    handleMessageRequeued(
+      {
+        type: "message_requeued",
+        conversationId: "conv-1",
+        requestId: "req-1",
+        position: 1,
+        clientMessageId: "nonce-1",
+      },
+      ctx,
+    );
+
+    expect(ctx.turnActions.enqueueMessage).toHaveBeenCalled();
+    // The dequeue consumed the mapping, so it has to be re-registered or the
+    // eventual second dequeue has nothing to clear.
+    expect(ctx.setRequestIdMapping).toHaveBeenCalledWith("req-1", "nonce-1");
+
+    const updater = (
+      ctx.setOptimisticSends as unknown as ReturnType<typeof Object>
+    ).mock.calls[0][0] as (prev: DisplayMessage[]) => DisplayMessage[];
+    const updated = updater([
+      {
+        id: "stable-1",
+        role: "user",
+        clientMessageId: "nonce-1",
+      } as DisplayMessage,
+    ]);
+    expect(updated[0]?.queueStatus).toBe("queued");
+    expect(updated[0]?.queuePosition).toBe(1);
+  });
+
+  it("falls back to the requestId when the sender minted no nonce", () => {
+    const ctx = makeCtx();
+    handleMessageRequeued(
+      {
+        type: "message_requeued",
+        conversationId: "conv-1",
+        requestId: "req-1",
+        position: 2,
+      },
+      ctx,
+    );
+    expect(ctx.setRequestIdMapping).toHaveBeenCalledWith("req-1", "req-1");
+  });
+
+  it("re-marks a server-backed queued transcript row", () => {
+    useChatSessionStore.setState({
+      snapshot: {
+        messages: [{ id: "req-1", role: "user" }],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      },
+    });
+
+    handleMessageRequeued(
+      {
+        type: "message_requeued",
+        conversationId: "conv-1",
+        requestId: "req-1",
+        position: 3,
+      },
+      makeCtx(),
+    );
+
+    const message = useChatSessionStore.getState().snapshot?.messages[0];
+    expect(message?.queueStatus).toBe("queued");
+    expect(message?.queuePosition).toBe(3);
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
@@ -47,7 +47,6 @@ export function handleMessageQueued(
         setOptimisticSends: ctx.setOptimisticSends,
         onDeleted: () => {
           ctx.popRequestIdMapping(requestId);
-          ctx.turnActions.deleteQueuedMessage();
         },
       });
     }
@@ -102,6 +101,14 @@ export function handleMessageRequeued(
   );
 }
 
+/**
+ * The single decrement for a cancelled queued message, on every device
+ * including the one that issued the DELETE. It is unconditional to mirror
+ * `handleMessageQueued`, which increments for every `message_queued` before it
+ * knows whether this client originated the send: the count tracks the
+ * conversation's queue, not this client's share of it, so gating either side
+ * on a local mapping would desync passive devices.
+ */
 export function handleMessageQueuedDeleted(
   event: MessageQueuedDeletedEvent,
   ctx: StreamHandlerContext,

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
@@ -1,5 +1,6 @@
 import {
   applyQueuedMessageDequeue,
+  markMessageQueued,
   removeQueuedMessage,
   setQueuePosition,
 } from "@/domains/chat/utils/stream-updaters/shared";
@@ -9,6 +10,7 @@ import type {
   MessageQueuedDeletedEvent,
   MessageQueuedEvent,
   MessageRequestCompleteEvent,
+  MessageRequeuedEvent,
 } from "@vellumai/assistant-api";
 import { useConversationStore } from "@/stores/conversation-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
@@ -71,6 +73,32 @@ export function handleMessageDequeued(
   }
   patchTranscriptMessages((prev) =>
     applyQueuedMessageDequeue(prev, dequeuedMessageId ?? event.requestId),
+  );
+}
+
+/**
+ * Corrective counterpart to `handleMessageDequeued`: the daemon announced the
+ * dequeue, then had to put the message back (another turn took the processing
+ * lock, or the drain threw before its turn started). Restore the pending row
+ * this client already cleared instead of leaving it invisible until a later
+ * drain.
+ *
+ * The dequeue consumed the requestId mapping, so re-register it from the
+ * event's own correlation key. The queue updaters match a row by either its
+ * local id or its `clientMessageId`, so either value works as the key.
+ */
+export function handleMessageRequeued(
+  event: MessageRequeuedEvent,
+  ctx: StreamHandlerContext,
+): void {
+  ctx.turnActions.enqueueMessage();
+  const messageKey = event.clientMessageId ?? event.requestId;
+  ctx.setRequestIdMapping(event.requestId, messageKey);
+  ctx.setOptimisticSends((prev) =>
+    markMessageQueued(prev, messageKey, event.position),
+  );
+  patchTranscriptMessages((prev) =>
+    markMessageQueued(prev, messageKey, event.position),
   );
 }
 

--- a/clients/web/src/lib/streaming/event-parser.test.ts
+++ b/clients/web/src/lib/streaming/event-parser.test.ts
@@ -697,6 +697,56 @@ describe("parseAssistantEvent", () => {
   });
 
   // ---------------------------------------------------------------------
+  // message_requeued (schema-validated)
+  // ---------------------------------------------------------------------
+
+  test("parses message_requeued with all required fields", () => {
+    const event = parseEvent({
+      type: "message_requeued",
+      conversationId: "conv-1",
+      requestId: "req-1",
+      position: 1,
+    });
+    expect(event).toEqual({
+      type: "message_requeued",
+      conversationId: "conv-1",
+      requestId: "req-1",
+      position: 1,
+    });
+  });
+
+  test("returns unknown message_requeued event when position is missing", () => {
+    const data = {
+      type: "message_requeued",
+      conversationId: "conv-1",
+      requestId: "req-1",
+    };
+    expect(parseEvent(data)).toEqual({
+      type: "unknown",
+      rawType: "message_requeued",
+      data,
+      conversationId: "conv-1",
+    });
+  });
+
+  test("carries the optional clientMessageId on message_requeued", () => {
+    const event = parseEvent({
+      type: "message_requeued",
+      conversationId: "conv-1",
+      requestId: "req-1",
+      position: 2,
+      clientMessageId: "nonce-1",
+    });
+    expect(event).toEqual({
+      type: "message_requeued",
+      conversationId: "conv-1",
+      requestId: "req-1",
+      position: 2,
+      clientMessageId: "nonce-1",
+    });
+  });
+
+  // ---------------------------------------------------------------------
   // message_queued_deleted (schema-validated)
   // ---------------------------------------------------------------------
 


### PR DESCRIPTION
## TL;DR

Slice 3 of the queued-messages lifecycle plan on [LUM-2849](https://linear.app/vellum/issue/LUM-2849), picking up exactly what [#39444](https://github.com/vellum-ai/vellum-assistant/pull/39444) deferred: the `message_queued_deleted` emitter, the `message_requeued` corrective event, and delete auth scoping.

Everything here lives in the window between a message entering the queue and the turn that runs it. Three gaps close:

1. **A cancelled queued message now gets a terminal event.** `message_queued_deleted` had a schema, a web handler, parser tests, and zero emitters.
2. **A silently requeued message now says so.** The drain announces `message_dequeued` before steps that can send the message back, and nothing told clients it came back.
3. **A queued delete is now authorized against the actor that enqueued it.** The route previously authorized nothing beyond the `chat.write` scope.

## What changed

### 1. Terminal event on delete

`deleteQueuedMessage` publishes `message_queued_deleted` on the removed message's own event sink (`broadcastMessage`, for HTTP sends), carrying `clientMessageId`. This is the counterpart to the `message_queued` ack and the only signal that closes out a row that never runs: a cancelled message never produces a `message_dequeued`, so a client that did not originate the DELETE has nothing to clear on. Hidden sends are suppressed, exactly as they are for the queued ack.

### 2. `message_requeued`

New canonical event under `api/events/`, additive to the union. `drainSingleMessage` and `drainBatch` announce a dequeue, then can hit lock contention on the persist or throw mid-dispatch, at which point `requeueDrainedMessages` puts the message back at the head. The event is emitted only for messages whose dequeue was actually announced, tracked by a `dequeueAnnounced` flag set at the announcement and settled by the requeue. The pre-flight processing-lock checks requeue before announcing anything, so they stay silent: an event there would contradict what the client is already showing. `position` uses the same visible-item accounting as `message_queued`, so a corrective event and a cold reload place the row identically.

Web side is wired end to end (dispatch case, handler, rolling-snapshot reducer) so the event has a real consumer on landing rather than parsing as unknown.

### 3. Delete authorization

`message_queued` is broadcast to every hub subscriber, so every requestId in a conversation is visible to every connected client. requestIds are therefore not secrets and cannot stand in for authorization. The delete now compares the caller's verified `x-vellum-actor-principal-id` (derived from the auth context by both adapters, never from an inbound header) against the `sourceActorPrincipalId` recorded at enqueue, and returns 403 on a mismatch.

Two exemptions, both deliberate and tested:

- **Caller has no actor principal** — local/IPC and service principals carry none, and per the convention this routes layer already follows (`vellum-actor-trust.ts`), a caller with no principal is the guardian by construction. The CLI keeps working.
- **Message has no recorded requester** — daemon-internal enqueues (agent wake, subagent notifications, surface actions) have no enqueuing actor, and cancelling one from the queue UI is intended.

## What changes for the user

| Before | After |
| --- | --- |
| Cancel a queued message from one device; your other devices keep showing it as pending until the conversation is reloaded | Every device drops the pending row immediately |
| The assistant is mid-turn when a second turn takes the lock; your queued message disappears from the queue drawer and silently reappears when it eventually runs | The row stays visible, re-marked as queued at its real position |
| Any client holding `chat.write` can cancel any queued message in a conversation, including one another user sent | You can only cancel your own queued messages; the CLI and daemon-internal sends are unaffected |
| Hidden machine sends: invisible in the queue UI | Unchanged; explicitly suppressed on both new events and tested |

## Why this is safe

- **The wire additions are additive.** `message_requeued` is a new union member; `message_queued_deleted` already existed as a contract with a deployed client handler that has been waiting for an emitter since slice 2. Zod strip mode means a client that does not know `message_requeued` ignores it.
- **The corrective event is announcement-scoped, not requeue-scoped.** The three existing tests that assert `expect(events).toEqual([])` on the pre-announcement lock checks still pass unchanged, and now double as regression pins for that rule.
- **The authorization change cannot fire for a single-guardian setup.** `actorPrincipalId` is the guardian principal id (`actor:<assistantId>:<guardianPrincipalId>`), stable across devices, so web and desktop sends from the same person match. Only a genuinely different actor principal is refused.
- **No DB, no async trust resolution added to the delete path.** The check is a synchronous field comparison, so the route stays as cheap as it was.
- No migrations, no schema changes.

## Evidence for the premise

The ticket's stated premise that the delete path "may not sufficiently scope a queued item to its conversation" **did not hold**. `deleteQueuedMessage` resolves through `findConversation`, an exact lookup in the in-memory registry (`daemon/conversation-registry.ts`), and `MessageQueue.removeByRequestId` runs against that conversation's own item array; there is no cross-conversation path. Rather than force a patch there, this PR adds a regression test pinning that boundary (a requestId from conversation A presented with conversation B's id is a 404 and leaves both queues intact) and spends the auth work on the real gap, which is per-item authorization.

## Tests

- New `assistant/src/__tests__/queued-message-delete-contract.test.ts` (11 tests): terminal-event emission with and without the nonce, hidden-send suppression, no event on a miss, the cross-conversation boundary, unknown conversation vs missing message, and the four actor-scoping cases (foreign principal refused with the queue intact, owner allowed, no-principal caller allowed, no-requester message allowed).
- `assistant/src/__tests__/drain-requeue-on-contention.test.ts` (+5 tests): busy persist emits dequeue then requeue with position and nonce; a pre-announcement requeue stays silent; only the announced batch member is corrected; a hidden send is never corrected; a second contention round corrects again.
- `clients/web` (+7 tests): handler restores the pending row and re-registers the requestId mapping (nonce and fallback keys), transcript row re-marked, parser accepts/rejects the new event shape, rolling-snapshot replays dequeue then requeue.
- Ran per-file (repo convention): `queued-message-delete-contract`, `drain-requeue-on-contention`, `conversation-query-routes`, `conversation-queue`, `conversation-slash-queue`, `list-messages-queued`, `message-queue`, `message-queue-steer`, `drain-kick-guard`, `conversation-routes-hidden-queue`, `steer-on-enqueue-question`, `send-endpoint-busy`, `conversation-surfaces-queued-emit`, `conversation-agent-loop`, `transport-hints-queue`, `conversation-evictor`, `process-message-display-content` — all green.
- `bunx tsc --noEmit` clean in `assistant/` and `clients/web/`; eslint clean on every touched file; `openapi.yaml` regenerated.
- Web `stream-handlers` + `transcript` + `streaming` combined run shows 12 pre-existing failures; the identical 12 reproduce on unmodified `main` (cross-file state leakage in `reconnect-cursor.test.ts`, which passes alone). My branch adds 7 passing tests to that set and no failures.

## Review round 1 (commit `8c04988276`)

Three findings from Devin and Codex, all reproduced before changing code, all valid.

- **Double-decrement of `pendingQueuedCount`.** Adding the `message_queued_deleted` emitter turned the web client's existing local decrement on DELETE success into a second decrement, because hub self-echo suppression only applies to `sync_changed` with an `originClientId`, so the deleting client receives its own broadcast. Cancelling one of two queued messages dropped the count to zero and flipped the turn to idle with a message still waiting. Fixed by removing the local decrement from all three `onDeleted` callbacks, leaving the broadcast handler as the single decrement. Gating the handler instead does not work: `handleMessageQueued` increments unconditionally, so the counter tracks the conversation's queue rather than this client's share, and both sides have to stay unconditional. The optimistic row removal stays, so cancelling still feels instant.
- **`dev-bypass` not normalized before the delete auth check.** The most serious of the three. Under `DISABLE_HTTP_AUTH=true` the send path stores `sourceActorPrincipalId` translated through `resolveActorPrincipalIdForLocalGuardian`, so a queued message records the real local guardian id while the delete compared the literal `"dev-bypass"` header. Every queued-message cancel in local dev would have 403'd. The delete now runs the identical normalization. No production cost: the resolver short-circuits unless the header is literally `dev-bypass` and auth is disabled.
- **Caller principal compared without trimming.** Every sibling handler in this layer normalizes with `?.trim() || undefined`. Exact-match comparison means this could only wrongly deny, never grant. Folded into the same expression.

Each fix is pinned by a test verified to fail without it: reverting the route change fails the three new normalization tests in `queued-message-delete-contract.test.ts`; restoring the local decrement fails the ack-then-cancel case in the new `clients/web/src/domains/chat/queued-count-single-decrement.test.ts`, which drives the real turn store rather than mocked actions. `handleDeleteQueuedMessage` is now async, so the delete-contract suite moved to rejection assertions; both route adapters already handle a promise-returning handler (HTTP awaits inside its `RouteError` try/catch, IPC branches on `result instanceof Promise` and routes rejections through the same `buildErrorResponse`).

One self-correction in `f020c72609`: the new web test initially used `mock.module` on `@/domains/chat/api/messages`, which replaces that module for every test file in the same Bun process and leaves only the declared export. Rewritten to spy on `client.delete` directly, the convention `api/messages.test.ts` documents in its own header.

## Deferred (intentionally)

- **A guardian override on the delete auth check.** Today a guardian viewing a channel-backed conversation cannot cancel a channel participant's queued message. Resolving "is this caller the guardian" means `resolveVellumActorTrustContext`, which is async and reads the local principal mirror; adding that to the delete path is a materially bigger blast radius than this slice warrants. Worth doing if the multi-actor cancel flow turns out to be real; backlog otherwise.
- **`steerToMessage` gets no equivalent authorization.** It has the same shape as the delete and arguably the same gap, but it is not in the slice-3 plan and steering an in-flight turn has different semantics worth thinking through separately. Worth doing as slice 3b.
- **Positions of the remaining queued rows are not restated after a delete.** Clients decrement locally today. A `message_queued` re-ack per surviving row would be the clean fix; low value until someone reports drift. Backlog filler.
- **Client-side identity-keyed correlation** (deleting the FIFO plus the requestId map) remains slice 6, unchanged by this PR.

Part of LUM-2849 (slice 3).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

