### PR TITLE
fix(workspace): delete label-only hatch stubs and keep carried disables

### DIFF
--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -434,7 +434,7 @@ describe("ensureByokDefaultProfiles", () => {
     expectSecondRunNoop();
   });
 
-  test("a copy renamed to the visible managed label converts and the carried stub survives", () => {
+  test("a copy renamed exactly to the hatch-stub label converts with the label dropped", () => {
     const config = uneditedByokConfig();
     const profileMap = (config.llm as Record<string, unknown>)
       .profiles as Record<string, Record<string, unknown>>;
@@ -447,12 +447,11 @@ describe("ensureByokDefaultProfiles", () => {
     ensureByokDefaultProfiles(workspaceDir);
 
     expect(profiles()["custom-balanced"]).toBeUndefined();
-    expect(profiles().balanced).toEqual({
-      source: "managed",
-      label: "Balanced (Managed)",
-    });
+    // Carrying the label would reproduce the hatch-stub shape, so it is
+    // dropped; with no other overlay state no stub is written.
+    expect(profiles().balanced).toBeUndefined();
+    expect(llm().activeProfile).toBe("balanced");
     expectSecondRunNoop();
-    // Third run: the carried stub is never mistaken for a hatch stub.
     expectSecondRunNoop();
   });
 
@@ -482,7 +481,6 @@ describe("ensureByokDefaultProfiles", () => {
       llm: {
         defaultProvider: { provider: "anthropic" },
         profiles: {
-          balanced: { source: "managed", label: "Balanced (Managed)" },
           "quality-optimized": {
             source: "managed",
             status: "active",
@@ -496,6 +494,47 @@ describe("ensureByokDefaultProfiles", () => {
     ensureByokDefaultProfiles(workspaceDir);
 
     expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("a label-only hatch stub with no status key is deleted", () => {
+    // Installs that predate #30367's status seeding got only the label
+    // rewrite, and migration 126 thinned them to { source, label }.
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        profiles: {
+          balanced: { source: "managed", label: "Balanced (Managed)" },
+          "cost-optimized": { source: "managed", label: "Speed (Managed)" },
+        },
+      },
+    });
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles().balanced).toBeUndefined();
+    expect(profiles()["cost-optimized"]).toBeUndefined();
+    expectSecondRunNoop();
+  });
+
+  test("a user disable on the retired copy lands on the bare key past a label-only stub", () => {
+    const config = uneditedByokConfig();
+    const profileMap = (config.llm as Record<string, unknown>)
+      .profiles as Record<string, Record<string, unknown>>;
+    profileMap.balanced = { source: "managed", label: "Balanced (Managed)" };
+    profileMap["custom-balanced"] = {
+      ...profileMap["custom-balanced"],
+      status: "disabled",
+    };
+    writeConfig(config);
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-balanced"]).toBeUndefined();
+    expect(profiles().balanced).toEqual({
+      source: "managed",
+      status: "disabled",
+    });
+    expectSecondRunNoop();
   });
 
   test("a disabled copy converts and carries the status onto a thin stub", () => {

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -40,10 +40,11 @@ const log = getLogger("byok-default-profile-ensure");
 // profile each boot, the model is accepted from the current intent resolution
 // or a git-verified historical era (`HISTORICAL_INTENT_MODELS`), and `label`/
 // `status` are user overlay state: a rename or disable survives conversion
-// as a thin managed stub on the bare key. `llm.advisorProfile` and
-// `llm.activeProfile` are re-validated in the same write because
-// `seedInferenceProfiles` runs earlier in boot and judged the pre-conversion
-// state.
+// as a thin managed stub on the bare key (except a rename colliding with
+// the frozen hatch-stub label, which is dropped at the carry arm).
+// `llm.advisorProfile` and `llm.activeProfile` are re-validated in the same
+// write because `seedInferenceProfiles` runs earlier in boot and judged the
+// pre-conversion state.
 //
 // This is a boot ensure pass rather than a workspace migration because
 // "unedited" is judged against the live catalog: the comparison template is
@@ -58,14 +59,19 @@ const log = getLogger("byok-default-profile-ensure");
 // stub or copy was removed.
 
 /**
- * The exact stub shape BYOK hatches wrote on each default key: thin (only
- * the workspace-owned overlay fields), `source: "managed"`,
- * `status: "disabled"`, and the frozen per-key label. Deletion requires the
- * full shape — a thin managed entry differing in any of these fields (a
- * re-enabled stub, a guard-side edit on the bare key, or label/status
- * carried off a retired copy by this pass) is indistinguishable from user
- * overlay state and stays. A managed-source entry with any other key (a
- * platform overlay body) is not a stub and is likewise left alone.
+ * The exact stub shapes BYOK hatching left on each default key: thin (only
+ * the workspace-owned overlay fields), `source: "managed"`, the frozen
+ * per-key label, and either `status: "disabled"` (seeded at hatch, #30367)
+ * or no `status` key at all (installs that already existed when #30367
+ * landed got only the label rewrite; migration 126 thinned those bodies to
+ * `{ source, label }`). Deletion requires the full shape: a thin managed
+ * entry differing in any other way (a re-enabled stub with
+ * `status: "active"`, a guard-side edit on the bare key, or a non-frozen
+ * label or status carried off a retired copy by this pass) is user overlay
+ * state and stays. The carry arm below never writes a stub matching this
+ * shape, so a match is always hatch-written. A managed-source entry with
+ * any other key (a platform overlay body) is not a stub and is likewise
+ * left alone.
  */
 const STUB_ONLY_KEYS = new Set(["source", "status", "label"]);
 const HATCH_STUB_LABELS: Record<DefaultProfileKey, string> = {
@@ -81,7 +87,7 @@ function isHatchStub(
   return (
     entry.source === "managed" &&
     Object.keys(entry).every((k) => STUB_ONLY_KEYS.has(k)) &&
-    entry.status === "disabled" &&
+    (!("status" in entry) || entry.status === "disabled") &&
     entry.label === HATCH_STUB_LABELS[key]
   );
 }
@@ -198,8 +204,9 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 
   // Deleting a hatch stub makes the default key resolve active from the
   // default provider's catalog column (and drops the stub's suffixed label).
-  // Only the exact frozen hatch shape is provably hatch-written; anything
-  // else (including a stub the user re-enabled through the guard) stays.
+  // Only the exact frozen hatch shapes are classified hatch-written;
+  // anything else (including a stub the user re-enabled through the guard)
+  // stays.
   for (const key of DEFAULT_PROFILE_KEYS) {
     const entry = readObject(profiles[key]);
     if (entry === null || !isHatchStub(key, entry)) {
@@ -231,13 +238,17 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
     delete profiles[name];
     if (overlay !== null && readObject(profiles[key]) === null) {
       const stub: Record<string, unknown> = { source: "managed", ...overlay };
-      // A carried label that reproduces the exact hatch-stub shape would be
-      // deleted by the stub arm on the next boot; the disable is the half
-      // worth keeping, so only the colliding label is dropped.
+      // A carried label that reproduces the hatch-stub shape is
+      // indistinguishable from a genuine hatch stub and would be deleted by
+      // the stub arm on the next boot, so the colliding label is never
+      // carried. A carried disable survives as a label-less stub; a
+      // rename-only collision leaves no overlay worth writing.
       if (isHatchStub(key, stub)) {
         delete stub.label;
       }
-      profiles[key] = stub;
+      if (Object.keys(stub).length > 1) {
+        profiles[key] = stub;
+      }
     }
     retired.set(name, key);
     changed = true;


### PR DESCRIPTION
## Summary
Fixes round-3 review finding for byok-code-defined-defaults.md.

**Gap:** installs that predate 2026-05-12 carry label-only hatch stubs ({source, label "<Key> (Managed)"} with no status key, per #30367's label rewrite plus migration 126 thinning); the exact-shape predicate required status disabled, so those stubs survived with a frozen stale label and a user disable on the retired copy was dropped.
**Fix:** the predicate accepts absent status as hatch-written (explicit re-enables still survive via their active status), and the carry site drops suffix-colliding rename labels so idempotency holds. Also fixes an em-dash comment-rule violation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->