### PR TITLE
feat(web): subscribe to native iOS keyboard height from keyboardWillShow

### DIFF
--- a/clients/web/src/runtime/native-keyboard-events.test.ts
+++ b/clients/web/src/runtime/native-keyboard-events.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for `subscribeNativeKeyboardHeight`.
+ *
+ * These pin the platform gate, the shape of the native payload, and the
+ * defensive height read that keeps a malformed `detail` from reaching layout.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockIsNativeIOS = true;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => mockIsNativeIOS,
+}));
+
+const { subscribeNativeKeyboardHeight } = await import(
+  "@/runtime/native-keyboard-events"
+);
+
+function dispatchWillShow(detail: unknown) {
+  window.dispatchEvent(new CustomEvent("keyboardWillShow", { detail }));
+}
+
+beforeEach(() => {
+  mockIsNativeIOS = true;
+});
+
+describe("subscribeNativeKeyboardHeight", () => {
+  test("reports the height carried by keyboardWillShow", () => {
+    const onHeightChange = mock((_height: number) => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
+
+    dispatchWillShow({ keyboardHeight: 336 });
+
+    expect(onHeightChange).toHaveBeenCalledTimes(1);
+    expect(onHeightChange).toHaveBeenCalledWith(336);
+    unsubscribe();
+  });
+
+  test("reports 0 on keyboardWillHide", () => {
+    const onHeightChange = mock((_height: number) => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
+
+    window.dispatchEvent(new Event("keyboardWillHide"));
+
+    expect(onHeightChange).toHaveBeenCalledTimes(1);
+    expect(onHeightChange).toHaveBeenCalledWith(0);
+    unsubscribe();
+  });
+
+  test("falls back to 0 for a malformed payload", () => {
+    const onHeightChange = mock((_height: number) => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
+
+    dispatchWillShow(undefined);
+    dispatchWillShow({});
+    dispatchWillShow({ keyboardHeight: "tall" });
+    dispatchWillShow({ keyboardHeight: -12 });
+
+    expect(onHeightChange).toHaveBeenCalledTimes(4);
+    for (const call of onHeightChange.mock.calls) {
+      expect(call).toEqual([0]);
+    }
+    unsubscribe();
+  });
+
+  test("attaches nothing outside the native iOS shell", () => {
+    mockIsNativeIOS = false;
+    const onHeightChange = mock((_height: number) => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
+
+    dispatchWillShow({ keyboardHeight: 336 });
+    window.dispatchEvent(new Event("keyboardWillHide"));
+
+    expect(onHeightChange).not.toHaveBeenCalled();
+    expect(() => {
+      unsubscribe();
+    }).not.toThrow();
+  });
+
+  test("unsubscribe detaches both listeners", () => {
+    const onHeightChange = mock((_height: number) => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
+
+    unsubscribe();
+    dispatchWillShow({ keyboardHeight: 336 });
+    window.dispatchEvent(new Event("keyboardWillHide"));
+
+    expect(onHeightChange).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/native-keyboard-events.ts
+++ b/clients/web/src/runtime/native-keyboard-events.ts
@@ -1,0 +1,61 @@
+import { isNativeIOS } from "@/runtime/platform-detection";
+
+/**
+ * Read `detail.keyboardHeight` off a native `keyboardWillShow` event.
+ *
+ * The plugin formats the payload as an object-literal string that the bridge
+ * evaluates, so an absent or malformed `detail` is possible; anything that is
+ * not a finite, non-negative number falls back to `0`. iPad's QuickType bar
+ * needs no special case here: the plugin already reports it as height `0`
+ * (`shouldIgnoreResizeForHeight` in `Keyboard.m`).
+ */
+function readKeyboardHeight(event: Event): number {
+  const { detail } = event as CustomEvent<unknown>;
+  if (typeof detail !== "object" || detail === null) {
+    return 0;
+  }
+  const height = Number((detail as { keyboardHeight?: unknown }).keyboardHeight);
+  if (!Number.isFinite(height) || height < 0) {
+    return 0;
+  }
+  return height;
+}
+
+/**
+ * Subscribe to the iOS keyboard height as the keyboard animation starts.
+ *
+ * `@capacitor/keyboard` dispatches `keyboardWillShow` and `keyboardWillHide` on
+ * `window` from its native keyboard observers
+ * (`triggerWindowJSEventWithEventName`). `keyboardWillShow` fires synchronously
+ * inside `onKeyboardWillShow`, before the plugin's own webview resize, which it
+ * defers by the keyboard animation duration plus 0.2s. Reading the height here
+ * is what lets layout follow the keyboard as it animates rather than a beat
+ * after it lands. `keyboardWillHide` carries no payload and means height `0`.
+ *
+ * These are plain window events, so the module needs no `@capacitor/keyboard`
+ * import and stays synchronous. Off the native iOS shell the events never fire;
+ * gating on {@link isNativeIOS} states that intent and guarantees no listener is
+ * attached in mobile Safari.
+ */
+export function subscribeNativeKeyboardHeight(
+  onHeightChange: (keyboardHeight: number) => void,
+): () => void {
+  if (!isNativeIOS()) {
+    return () => {};
+  }
+
+  const handleWillShow = (event: Event) => {
+    onHeightChange(readKeyboardHeight(event));
+  };
+  const handleWillHide = () => {
+    onHeightChange(0);
+  };
+
+  window.addEventListener("keyboardWillShow", handleWillShow);
+  window.addEventListener("keyboardWillHide", handleWillHide);
+
+  return () => {
+    window.removeEventListener("keyboardWillShow", handleWillShow);
+    window.removeEventListener("keyboardWillHide", handleWillHide);
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `subscribeNativeKeyboardHeight()`, an iOS-shell-only subscription to the Capacitor keyboard plugin's `keyboardWillShow`/`keyboardWillHide` window events.
- Reads the height from the CustomEvent detail defensively; no `@capacitor/keyboard` import, so the module stays synchronous.
- Consumed by PR 2 to remove the composer reposition lag.

Part of plan: ios-keyboard-lag-and-floating-sidebar.md (PR 1 of 5)