### PR TITLE
feat(platform): add platform_invoices_list and platform_invoices_get daemon routes

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22753,6 +22753,145 @@ paths:
                   - disconnected
                   - previousBaseUrl
                 additionalProperties: false
+  /v1/platform/invoices:
+    get:
+      operationId: platform_invoices_get
+      summary: List one page of the organization's Stripe invoices
+      description:
+        Fetches one page of the org's Stripe invoice history (newest first) from the platform billing invoices
+        endpoint. Amounts are in the currency's minor units. When has_more is true, pass the last invoice's id as
+        starting_after to fetch the next page.
+      tags:
+        - platform
+      parameters:
+        - name: starting_after
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Cursor: return invoices older than the invoice with this id (from the previous page's last entry)."
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invoices:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        number:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        status:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        currency:
+                          type: string
+                        amount_due:
+                          type: number
+                        amount_paid:
+                          type: number
+                        amount_remaining:
+                          type: number
+                        created:
+                          type: number
+                        hosted_invoice_url:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        invoice_pdf:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                      required:
+                        - id
+                        - number
+                        - status
+                        - currency
+                        - amount_due
+                        - amount_paid
+                        - amount_remaining
+                        - created
+                        - hosted_invoice_url
+                        - invoice_pdf
+                      additionalProperties: false
+                  has_more:
+                    type: boolean
+                required:
+                  - invoices
+                  - has_more
+                additionalProperties: false
+  /v1/platform/invoices/{id}:
+    get:
+      operationId: platform_invoices_by_id_get
+      summary: Get a single Stripe invoice by ID
+      description:
+        Pages through the org's invoice list from the platform and returns the invoice matching the given Stripe
+        invoice ID (e.g. in_xxx). 404 if no such invoice.
+      tags:
+        - platform
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  number:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  status:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  currency:
+                    type: string
+                  amount_due:
+                    type: number
+                  amount_paid:
+                    type: number
+                  amount_remaining:
+                    type: number
+                  created:
+                    type: number
+                  hosted_invoice_url:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  invoice_pdf:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - id
+                  - number
+                  - status
+                  - currency
+                  - amount_due
+                  - amount_paid
+                  - amount_remaining
+                  - created
+                  - hosted_invoice_url
+                  - invoice_pdf
+                additionalProperties: false
   /v1/platform/plans:
     get:
       operationId: platform_plans_get

--- a/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
@@ -42,6 +42,7 @@ const getHandler = ROUTES.find(
 
 const INVOICES_URL = "https://platform.test/v1/organizations/billing/invoices/";
 const MAX_INVOICE_PAGES = 25;
+const INVOICE_WALK_DEADLINE_MS = 30_000;
 
 function invoice(id: string) {
   return {
@@ -247,6 +248,29 @@ describe("platform_invoices_get", () => {
     );
     expect(err).toBeInstanceOf(InternalError);
     expect(err.message).toMatch(/aborted/);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("rejects with InternalError when the walk exceeds the aggregate deadline", async () => {
+    const realDateNow = Date.now;
+    let now = 0;
+    Date.now = () => now;
+    stubFetch(() => {
+      // Push the clock past the deadline once the first page has been
+      // served; the handler must not fetch a second page.
+      now = INVOICE_WALK_DEADLINE_MS + 1;
+      return jsonResponse({ invoices: [invoice("in_a")], has_more: true });
+    });
+
+    try {
+      const err = await expectRejection(() =>
+        getHandler({ pathParams: { id: "in_never" } }),
+      );
+      expect(err).toBeInstanceOf(InternalError);
+      expect(err.message).toMatch(/timed out after 30 seconds/);
+    } finally {
+      Date.now = realDateNow;
+    }
     expect(fetchCalls).toHaveLength(1);
   });
 

--- a/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
@@ -154,6 +154,19 @@ describe("platform_invoices_list", () => {
     expect(err).toBeInstanceOf(InternalError);
     expect(err.message).toMatch(/HTTP 500/);
   });
+
+  test("rejects with BadRequestError carrying the detail on an upstream 400", async () => {
+    stubFetch(
+      () => new Response("Invalid starting_after cursor", { status: 400 }),
+    );
+
+    const err = await expectRejection(() =>
+      listHandler({ queryParams: { starting_after: "in_bogus" } }),
+    );
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err.message).toMatch(/Invalid starting_after cursor/);
+    expect(err.message).toMatch(/starting_after/);
+  });
 });
 
 describe("platform_invoices_get", () => {
@@ -215,6 +228,45 @@ describe("platform_invoices_get", () => {
       getHandler({ pathParams: { id: "in_never" } }),
     ).rejects.toBeInstanceOf(InternalError);
     expect(fetchCalls).toHaveLength(MAX_INVOICE_PAGES);
+  });
+
+  test("stops the cursor walk when the request abort signal fires", async () => {
+    const controller = new AbortController();
+    stubFetch(() => {
+      // Abort after the first page has been served; the handler must not
+      // fetch a second page.
+      controller.abort();
+      return jsonResponse({ invoices: [invoice("in_a")], has_more: true });
+    });
+
+    const err = await expectRejection(() =>
+      getHandler({
+        pathParams: { id: "in_never" },
+        abortSignal: controller.signal,
+      }),
+    );
+    expect(err).toBeInstanceOf(InternalError);
+    expect(err.message).toMatch(/aborted/);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("threads the request abort signal into the page fetch", async () => {
+    const controller = new AbortController();
+    stubFetch(() =>
+      jsonResponse({ invoices: [invoice("in_target")], has_more: false }),
+    );
+
+    await getHandler({
+      pathParams: { id: "in_target" },
+      abortSignal: controller.signal,
+    });
+
+    // The fetch signal must be derived from the caller's signal: aborting
+    // the request aborts the in-flight platform fetch.
+    const fetchSignal = fetchCalls[0]!.init?.signal as AbortSignal;
+    expect(fetchSignal.aborted).toBe(false);
+    controller.abort();
+    expect(fetchSignal.aborted).toBe(true);
   });
 
   test("rejects with BadRequestError when the id path param is missing", async () => {

--- a/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
@@ -274,6 +274,44 @@ describe("platform_invoices_get", () => {
     expect(fetchCalls).toHaveLength(1);
   });
 
+  test("caps the per-page fetch timeout to the remaining walk deadline", async () => {
+    const realDateNow = Date.now;
+    let now = 0;
+    Date.now = () => now;
+    stubFetch((_url, callIndex) => {
+      if (callIndex === 0) {
+        // Leave only 50ms of aggregate budget for the next page.
+        now = INVOICE_WALK_DEADLINE_MS - 50;
+        return jsonResponse({ invoices: [invoice("in_a")], has_more: true });
+      }
+      // Hang until the fetch's combined signal aborts. With the timeout
+      // capped to the remaining 50ms this resolves almost immediately; an
+      // uncapped 10s timeout would blow the assertion on real elapsed time.
+      const signal = fetchCalls[callIndex]!.init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          now = INVOICE_WALK_DEADLINE_MS + 1;
+          reject(signal.reason as Error);
+        });
+      });
+    });
+
+    const startedRealMs = realDateNow();
+    try {
+      const err = await expectRejection(() =>
+        getHandler({ pathParams: { id: "in_never" } }),
+      );
+      expect(err).toBeInstanceOf(InternalError);
+      expect(err.message).toMatch(/timed out after 30 seconds/);
+    } finally {
+      Date.now = realDateNow;
+    }
+    expect(fetchCalls).toHaveLength(2);
+    // The second fetch was cancelled by the capped ~50ms timeout, not the
+    // flat 10s per-request timeout.
+    expect(realDateNow() - startedRealMs).toBeLessThan(5_000);
+  });
+
   test("threads the request abort signal into the page fetch", async () => {
     const controller = new AbortController();
     stubFetch(() =>

--- a/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for the platform_invoices_list and platform_invoices_get route
+ * handlers: cursor forwarding, page walking, the page cap, and error paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  BadRequestError,
+  InternalError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from "../errors.js";
+
+let platformBaseUrl = "https://platform.test";
+let authHeader: string | null = "Api-Key test";
+
+// Spread the real module: replacing it wholesale breaks unrelated importers
+// pulled in by the module under test.
+const actualRegistration =
+  await import("../../../inbound/platform-callback-registration.js");
+mock.module("../../../inbound/platform-callback-registration.js", () => ({
+  ...actualRegistration,
+  resolvePlatformCallbackRegistrationContext: async () => ({
+    isPlatform: false,
+    platformBaseUrl,
+    assistantId: "assistant-123",
+    hasAssistantApiKey: !!authHeader,
+    authHeader,
+    enabled: !!(platformBaseUrl && authHeader),
+  }),
+}));
+
+const { ROUTES } = await import("../platform-routes.js");
+
+const listHandler = ROUTES.find(
+  (r) => r.operationId === "platform_invoices_list",
+)!.handler;
+const getHandler = ROUTES.find(
+  (r) => r.operationId === "platform_invoices_get",
+)!.handler;
+
+const INVOICES_URL = "https://platform.test/v1/organizations/billing/invoices/";
+const MAX_INVOICE_PAGES = 25;
+
+function invoice(id: string) {
+  return {
+    id,
+    number: `INV-${id}`,
+    status: "paid",
+    currency: "usd",
+    amount_due: 1234,
+    amount_paid: 1234,
+    amount_remaining: 0,
+    created: 1750000000,
+    hosted_invoice_url: `https://stripe.test/${id}`,
+    invoice_pdf: null,
+  };
+}
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+const realFetch = globalThis.fetch;
+let fetchCalls: FetchCall[] = [];
+
+/** Stub globalThis.fetch, recording calls and answering via `respond`. */
+function stubFetch(
+  respond: (url: string, callIndex: number) => Response | Promise<Response>,
+): void {
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    fetchCalls.push({ url, init });
+    return respond(url, fetchCalls.length - 1);
+  }) as typeof fetch;
+}
+
+/** Await a handler call that must reject, returning the thrown error. */
+async function expectRejection(run: () => unknown): Promise<Error> {
+  try {
+    await run();
+  } catch (err) {
+    return err as Error;
+  }
+  throw new Error("expected rejection");
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  platformBaseUrl = "https://platform.test";
+  authHeader = "Api-Key test";
+  fetchCalls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("platform_invoices_list", () => {
+  test("returns the platform page and calls the bare invoices URL", async () => {
+    const page = { invoices: [invoice("in_1")], has_more: false };
+    stubFetch(() => jsonResponse(page));
+
+    expect(await listHandler({})).toEqual(page);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.url).toBe(INVOICES_URL);
+    expect(
+      (fetchCalls[0]!.init?.headers as Record<string, string>).Authorization,
+    ).toBe("Api-Key test");
+  });
+
+  test("forwards starting_after as a cursor and passes has_more through", async () => {
+    const page = { invoices: [invoice("in_2")], has_more: true };
+    stubFetch(() => jsonResponse(page));
+
+    const result = await listHandler({
+      queryParams: { starting_after: "in_a" },
+    });
+
+    expect(fetchCalls[0]!.url).toBe(`${INVOICES_URL}?starting_after=in_a`);
+    expect((result as { has_more: boolean }).has_more).toBe(true);
+  });
+
+  test("rejects with UnprocessableEntityError when credentials are missing", async () => {
+    platformBaseUrl = "";
+    stubFetch(() => jsonResponse({ invoices: [], has_more: false }));
+
+    await expect(listHandler({})).rejects.toBeInstanceOf(
+      UnprocessableEntityError,
+    );
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("rejects with InternalError naming the status on a non-OK response", async () => {
+    stubFetch(() => jsonResponse({ detail: "boom" }, 500));
+
+    const err = await expectRejection(() => listHandler({}));
+    expect(err).toBeInstanceOf(InternalError);
+    expect(err.message).toMatch(/HTTP 500/);
+  });
+});
+
+describe("platform_invoices_get", () => {
+  test("resolves an invoice found on the first page with one fetch", async () => {
+    const target = invoice("in_target");
+    stubFetch(() =>
+      jsonResponse({ invoices: [invoice("in_1"), target], has_more: false }),
+    );
+
+    expect(await getHandler({ pathParams: { id: "in_target" } })).toEqual(
+      target,
+    );
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("follows the cursor to a later page using the last invoice's id", async () => {
+    const target = invoice("in_target");
+    stubFetch((_url, callIndex) =>
+      callIndex === 0
+        ? jsonResponse({
+            invoices: [invoice("in_a"), invoice("in_b")],
+            has_more: true,
+          })
+        : jsonResponse({ invoices: [target], has_more: false }),
+    );
+
+    expect(await getHandler({ pathParams: { id: "in_target" } })).toEqual(
+      target,
+    );
+    expect(fetchCalls).toHaveLength(2);
+    expect(fetchCalls[1]!.url).toBe(`${INVOICES_URL}?starting_after=in_b`);
+  });
+
+  test("rejects with an actionable NotFoundError when the id is absent", async () => {
+    stubFetch(() =>
+      jsonResponse({ invoices: [invoice("in_other")], has_more: false }),
+    );
+
+    const err = await expectRejection(() =>
+      getHandler({ pathParams: { id: "in_missing" } }),
+    );
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.message).toMatch(
+      /Invoice "in_missing" not found.*assistant platform invoices list/,
+    );
+    // No paging beyond the final (has_more: false) page.
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("stops after MAX_INVOICE_PAGES pages when every page has more", async () => {
+    stubFetch((_url, callIndex) =>
+      jsonResponse({
+        invoices: [invoice(`in_${callIndex}`)],
+        has_more: true,
+      }),
+    );
+
+    await expect(
+      getHandler({ pathParams: { id: "in_never" } }),
+    ).rejects.toBeInstanceOf(InternalError);
+    expect(fetchCalls).toHaveLength(MAX_INVOICE_PAGES);
+  });
+
+  test("rejects with BadRequestError when the id path param is missing", async () => {
+    stubFetch(() => jsonResponse({ invoices: [], has_more: false }));
+
+    await expect(getHandler({})).rejects.toBeInstanceOf(BadRequestError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -574,6 +574,14 @@ async function handlePlatformInvoicesList(
  */
 const MAX_INVOICE_PAGES = 25;
 
+/**
+ * Aggregate wall-clock deadline for the invoices_get cursor walk, matching
+ * the gateway IPC client's 30s request timeout. Guards against the walk
+ * running long after the caller has given up, since a gateway IPC timeout
+ * does not abort the request signal.
+ */
+const INVOICE_WALK_DEADLINE_MS = 30_000;
+
 async function handlePlatformInvoiceGet(
   args: RouteHandlerArgs,
 ): Promise<PlatformInvoice> {
@@ -584,6 +592,7 @@ async function handlePlatformInvoiceGet(
 
   // There is no per-invoice platform endpoint, so walk the paginated list
   // until the invoice turns up or the cursor is exhausted.
+  const walkStartedAt = Date.now();
   let cursor: string | undefined;
   for (let pages = 0; pages < MAX_INVOICE_PAGES; pages++) {
     // Stop walking pages once the caller has gone away (gateway IPC timeout,
@@ -592,6 +601,12 @@ async function handlePlatformInvoiceGet(
     if (args.abortSignal?.aborted) {
       throw new InternalError(
         `Invoice lookup for "${id}" aborted: caller disconnected`,
+      );
+    }
+    if (Date.now() - walkStartedAt > INVOICE_WALK_DEADLINE_MS) {
+      throw new InternalError(
+        `Invoice lookup for "${id}" timed out after ` +
+          `${INVOICE_WALK_DEADLINE_MS / 1000} seconds while paging invoice history`,
       );
     }
     const page = await fetchPlatformInvoicesPage(cursor, args.abortSignal);

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -410,12 +410,21 @@ async function handlePlatformCredits(
   };
 }
 
+/** Default per-request timeout for platform fetches. */
+const PLATFORM_FETCH_TIMEOUT_MS = 10_000;
+
 interface FetchPlatformJsonOptions {
   /**
-   * Abort signal from the caller's request. Combined with the 10s
-   * per-request timeout so whichever fires first cancels the fetch.
+   * Abort signal from the caller's request. Combined with the per-request
+   * timeout so whichever fires first cancels the fetch.
    */
   signal?: AbortSignal;
+  /**
+   * Per-request timeout override in milliseconds. Defaults to
+   * PLATFORM_FETCH_TIMEOUT_MS; callers with an aggregate deadline (the
+   * invoices_get cursor walk) pass the remaining budget instead.
+   */
+  timeoutMs?: number;
   /**
    * When set, an upstream HTTP 400 is surfaced via this factory (typically a
    * BadRequestError built from the response detail) instead of the generic
@@ -445,7 +454,9 @@ async function fetchPlatformJson(
   }
 
   const url = `${context.platformBaseUrl}${path}`;
-  const timeout = AbortSignal.timeout(10_000);
+  const timeout = AbortSignal.timeout(
+    options?.timeoutMs ?? PLATFORM_FETCH_TIMEOUT_MS,
+  );
   let response: Response;
   try {
     response = await fetch(url, {
@@ -542,6 +553,7 @@ async function handlePlatformPlans(
 async function fetchPlatformInvoicesPage(
   startingAfter?: string,
   signal?: AbortSignal,
+  timeoutMs?: number,
 ): Promise<PlatformInvoicesListResponse> {
   let path = "/v1/organizations/billing/invoices/";
   if (startingAfter) {
@@ -549,6 +561,7 @@ async function fetchPlatformInvoicesPage(
   }
   return (await fetchPlatformJson(path, "invoices", {
     signal,
+    timeoutMs,
     // The platform returns 400 for an invalid or expired starting_after
     // cursor; keep that a client error instead of masking it as a 500.
     onBadRequest: (detail) =>
@@ -582,6 +595,13 @@ const MAX_INVOICE_PAGES = 25;
  */
 const INVOICE_WALK_DEADLINE_MS = 30_000;
 
+function invoiceWalkTimeoutError(id: string): InternalError {
+  return new InternalError(
+    `Invoice lookup for "${id}" timed out after ` +
+      `${INVOICE_WALK_DEADLINE_MS / 1000} seconds while paging invoice history`,
+  );
+}
+
 async function handlePlatformInvoiceGet(
   args: RouteHandlerArgs,
 ): Promise<PlatformInvoice> {
@@ -603,13 +623,30 @@ async function handlePlatformInvoiceGet(
         `Invoice lookup for "${id}" aborted: caller disconnected`,
       );
     }
-    if (Date.now() - walkStartedAt > INVOICE_WALK_DEADLINE_MS) {
-      throw new InternalError(
-        `Invoice lookup for "${id}" timed out after ` +
-          `${INVOICE_WALK_DEADLINE_MS / 1000} seconds while paging invoice history`,
-      );
+    const remainingMs = walkStartedAt + INVOICE_WALK_DEADLINE_MS - Date.now();
+    if (remainingMs <= 0) {
+      throw invoiceWalkTimeoutError(id);
     }
-    const page = await fetchPlatformInvoicesPage(cursor, args.abortSignal);
+    // Bound the page fetch by the remaining aggregate budget so a fetch
+    // started just under the deadline cannot run the walk past it.
+    let page: PlatformInvoicesListResponse;
+    try {
+      page = await fetchPlatformInvoicesPage(
+        cursor,
+        args.abortSignal,
+        Math.min(PLATFORM_FETCH_TIMEOUT_MS, remainingMs),
+      );
+    } catch (err) {
+      // A fetch cancelled by the deadline remainder should read as the
+      // walk's aggregate timeout, not a generic network failure.
+      if (
+        !args.abortSignal?.aborted &&
+        Date.now() - walkStartedAt >= INVOICE_WALK_DEADLINE_MS
+      ) {
+        throw invoiceWalkTimeoutError(id);
+      }
+      throw err;
+    }
     const match = page.invoices.find((invoice) => invoice.id === id);
     if (match) {
       return match;

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Platform route handlers for the shared HTTP/IPC route table.
  *
- * Serves eight operations:
+ * Serves ten operations:
  *   - platform_status (GET platform/status): aggregates platform context,
  *     credentials, assistant ID, and webhook secret. (Velay tunnel status
  *     lives on the gateway — see gateway_status.)
@@ -18,6 +18,10 @@
  *   - platform_subscription (GET platform/subscription): fetches the org's
  *     current plan, subscription status, and entitlements.
  *   - platform_plans (GET platform/plans): fetches the plan catalog with pricing.
+ *   - platform_invoices_list (GET platform/invoices): fetches one
+ *     cursor-paginated page of the org's Stripe invoice history.
+ *   - platform_invoices_get (GET platform/invoices/:id): pages through the
+ *     invoice list and returns a single invoice by Stripe invoice ID.
  */
 
 import { z } from "zod";
@@ -38,6 +42,7 @@ import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import {
   BadRequestError,
   InternalError,
+  NotFoundError,
   UnprocessableEntityError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -125,6 +130,28 @@ const PlatformCreditsResponseSchema = z.object({
   as_of: z.string(),
 });
 type PlatformCreditsResponse = z.infer<typeof PlatformCreditsResponseSchema>;
+
+const PlatformInvoiceSchema = z.object({
+  id: z.string(),
+  number: z.string().nullable(),
+  status: z.string().nullable(),
+  currency: z.string(),
+  amount_due: z.number(),
+  amount_paid: z.number(),
+  amount_remaining: z.number(),
+  created: z.number(),
+  hosted_invoice_url: z.string().nullable(),
+  invoice_pdf: z.string().nullable(),
+});
+type PlatformInvoice = z.infer<typeof PlatformInvoiceSchema>;
+
+const PlatformInvoicesListResponseSchema = z.object({
+  invoices: z.array(PlatformInvoiceSchema),
+  has_more: z.boolean(),
+});
+type PlatformInvoicesListResponse = z.infer<
+  typeof PlatformInvoicesListResponseSchema
+>;
 
 const SubscriptionPackageSchema = z.object({
   key: z.string(),
@@ -485,6 +512,66 @@ async function handlePlatformPlans(
   return { plans: data.plans ?? [] };
 }
 
+/**
+ * Fetch one cursor-paginated page of the org's Stripe invoice history from
+ * the platform. Pass the previous page's last invoice id as `startingAfter`
+ * to fetch the next (older) page.
+ */
+async function fetchPlatformInvoicesPage(
+  startingAfter?: string,
+): Promise<PlatformInvoicesListResponse> {
+  let path = "/v1/organizations/billing/invoices/";
+  if (startingAfter) {
+    path += `?${new URLSearchParams({ starting_after: startingAfter })}`;
+  }
+  return (await fetchPlatformJson(
+    path,
+    "invoices",
+  )) as PlatformInvoicesListResponse;
+}
+
+async function handlePlatformInvoicesList(
+  args: RouteHandlerArgs,
+): Promise<PlatformInvoicesListResponse> {
+  return await fetchPlatformInvoicesPage(args.queryParams?.starting_after);
+}
+
+/**
+ * Runaway guard for the invoices_get cursor walk — 25 pages is 2,500
+ * invoices at the platform's 100-per-page size.
+ */
+const MAX_INVOICE_PAGES = 25;
+
+async function handlePlatformInvoiceGet(
+  args: RouteHandlerArgs,
+): Promise<PlatformInvoice> {
+  const id = args.pathParams?.id;
+  if (!id) {
+    throw new BadRequestError("invoice id is required");
+  }
+
+  // There is no per-invoice platform endpoint, so walk the paginated list
+  // until the invoice turns up or the cursor is exhausted.
+  let cursor: string | undefined;
+  for (let pages = 0; pages < MAX_INVOICE_PAGES; pages++) {
+    const page = await fetchPlatformInvoicesPage(cursor);
+    const match = page.invoices.find((invoice) => invoice.id === id);
+    if (match) {
+      return match;
+    }
+    if (!page.has_more || page.invoices.length === 0) {
+      throw new NotFoundError(
+        `Invoice "${id}" not found. Run 'assistant platform invoices list' to see available invoices.`,
+      );
+    }
+    cursor = page.invoices.at(-1)!.id;
+  }
+
+  throw new InternalError(
+    `Invoice "${id}" not found in the first ${MAX_INVOICE_PAGES} pages of invoice history`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -610,5 +697,44 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["platform"],
     handler: handlePlatformPlans,
     responseBody: PlatformPlansResponseSchema,
+  },
+  {
+    operationId: "platform_invoices_list",
+    endpoint: "platform/invoices",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List one page of the organization's Stripe invoices",
+    description:
+      "Fetches one page of the org's Stripe invoice history (newest first) from the platform billing invoices endpoint. Amounts are in the currency's minor units. When has_more is true, pass the last invoice's id as starting_after to fetch the next page.",
+    tags: ["platform"],
+    queryParams: [
+      {
+        name: "starting_after",
+        type: "string",
+        required: false,
+        description:
+          "Cursor: return invoices older than the invoice with this id (from the previous page's last entry).",
+      },
+    ],
+    handler: handlePlatformInvoicesList,
+    responseBody: PlatformInvoicesListResponseSchema,
+  },
+  {
+    operationId: "platform_invoices_get",
+    endpoint: "platform/invoices/:id",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get a single Stripe invoice by ID",
+    description:
+      "Pages through the org's invoice list from the platform and returns the invoice matching the given Stripe invoice ID (e.g. in_xxx). 404 if no such invoice.",
+    tags: ["platform"],
+    handler: handlePlatformInvoiceGet,
+    responseBody: PlatformInvoiceSchema,
   },
 ];

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -410,15 +410,31 @@ async function handlePlatformCredits(
   };
 }
 
+interface FetchPlatformJsonOptions {
+  /**
+   * Abort signal from the caller's request. Combined with the 10s
+   * per-request timeout so whichever fires first cancels the fetch.
+   */
+  signal?: AbortSignal;
+  /**
+   * When set, an upstream HTTP 400 is surfaced via this factory (typically a
+   * BadRequestError built from the response detail) instead of the generic
+   * InternalError, so user-correctable input errors (e.g. an invalid
+   * pagination cursor) keep their 400 status. Other statuses are unaffected.
+   */
+  onBadRequest?: (detail: string) => Error;
+}
+
 /**
  * GET a JSON resource from the platform using the assistant's stored platform
  * credentials. Throws UnprocessableEntityError when credentials are missing and
  * InternalError on transport / non-2xx failures; `label` names the resource in
- * those error messages.
+ * those error messages. See FetchPlatformJsonOptions for per-call overrides.
  */
 async function fetchPlatformJson(
   path: string,
   label: string,
+  options?: FetchPlatformJsonOptions,
 ): Promise<unknown> {
   const context = await resolvePlatformCallbackRegistrationContext();
 
@@ -429,6 +445,7 @@ async function fetchPlatformJson(
   }
 
   const url = `${context.platformBaseUrl}${path}`;
+  const timeout = AbortSignal.timeout(10_000);
   let response: Response;
   try {
     response = await fetch(url, {
@@ -437,7 +454,9 @@ async function fetchPlatformJson(
         Authorization: context.authHeader,
         Accept: "application/json",
       },
-      signal: AbortSignal.timeout(10_000),
+      signal: options?.signal
+        ? AbortSignal.any([options.signal, timeout])
+        : timeout,
     });
   } catch (err) {
     throw new InternalError(
@@ -447,6 +466,9 @@ async function fetchPlatformJson(
 
   if (!response.ok) {
     const detail = await response.text().catch(() => "");
+    if (response.status === 400 && options?.onBadRequest) {
+      throw options.onBadRequest(detail);
+    }
     throw new InternalError(
       `Failed to fetch ${label} (HTTP ${response.status}): ${detail}`,
     );
@@ -519,25 +541,35 @@ async function handlePlatformPlans(
  */
 async function fetchPlatformInvoicesPage(
   startingAfter?: string,
+  signal?: AbortSignal,
 ): Promise<PlatformInvoicesListResponse> {
   let path = "/v1/organizations/billing/invoices/";
   if (startingAfter) {
     path += `?${new URLSearchParams({ starting_after: startingAfter })}`;
   }
-  return (await fetchPlatformJson(
-    path,
-    "invoices",
-  )) as PlatformInvoicesListResponse;
+  return (await fetchPlatformJson(path, "invoices", {
+    signal,
+    // The platform returns 400 for an invalid or expired starting_after
+    // cursor; keep that a client error instead of masking it as a 500.
+    onBadRequest: (detail) =>
+      new BadRequestError(
+        `Platform rejected the invoices request${detail ? `: ${detail}` : ""}. ` +
+          "If you passed starting_after, use the id of the last invoice from the previous page.",
+      ),
+  })) as PlatformInvoicesListResponse;
 }
 
 async function handlePlatformInvoicesList(
   args: RouteHandlerArgs,
 ): Promise<PlatformInvoicesListResponse> {
-  return await fetchPlatformInvoicesPage(args.queryParams?.starting_after);
+  return await fetchPlatformInvoicesPage(
+    args.queryParams?.starting_after,
+    args.abortSignal,
+  );
 }
 
 /**
- * Runaway guard for the invoices_get cursor walk — 25 pages is 2,500
+ * Runaway guard for the invoices_get cursor walk: 25 pages is 2,500
  * invoices at the platform's 100-per-page size.
  */
 const MAX_INVOICE_PAGES = 25;
@@ -554,7 +586,15 @@ async function handlePlatformInvoiceGet(
   // until the invoice turns up or the cursor is exhausted.
   let cursor: string | undefined;
   for (let pages = 0; pages < MAX_INVOICE_PAGES; pages++) {
-    const page = await fetchPlatformInvoicesPage(cursor);
+    // Stop walking pages once the caller has gone away (gateway IPC timeout,
+    // disconnected HTTP client). In-flight fetches are cancelled via the
+    // signal passed to fetchPlatformInvoicesPage.
+    if (args.abortSignal?.aborted) {
+      throw new InternalError(
+        `Invoice lookup for "${id}" aborted: caller disconnected`,
+      );
+    }
+    const page = await fetchPlatformInvoicesPage(cursor, args.abortSignal);
     const match = page.invoices.find((invoice) => invoice.id === id);
     if (match) {
       return match;


### PR DESCRIPTION
## Summary
- Adds platform_invoices_list (GET platform/invoices) proxying one cursor-paginated page of the org's Stripe invoices with starting_after/has_more support
- Adds platform_invoices_get (GET platform/invoices/:id) that pages through the platform list to find a single invoice by Stripe ID
- Covers both handlers with a new bun:test suite (cursor forwarding, page walking, page cap, error paths)

Part of plan: platform-invoices-cli.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->