### PR TITLE
fix(schedule): prove owner authorship before a deferred wake recovers trust (LUM-2929)

### DIFF
--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1374,7 +1374,7 @@ describe("wake mode in schedule routes", () => {
     clearTables();
   });
 
-  test("PATCH accepts 'wake' as a valid mode", async () => {
+  test("PATCH accepts 'wake' as a valid mode for an owner", async () => {
     const schedule = await createSchedule({
       name: "Wake test",
       cronExpression: "* * * * *",
@@ -1383,9 +1383,11 @@ describe("wake mode in schedule routes", () => {
     });
 
     const route = findRoute("schedules/:id", "PATCH");
+    // Wake mutations are owner-gated; a local IPC caller is the owner.
     const result = (await route.handler({
       pathParams: { id: schedule.id },
       body: { mode: "wake", wakeConversationId: "conv-xyz" },
+      headers: { "x-vellum-principal-type": "local" },
     })) as {
       schedules: Array<{
         id: string;

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -18,10 +18,16 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
+  hasOwnerDeferProvenance,
+  LEGACY_DEFER_CREATED_BY,
+  OWNER_DEFER_CREATED_BY,
+} from "../schedule/defer-provenance.js";
+import {
   cancelSchedule,
   claimDueSchedules,
   completeOneShot,
   completeScheduleRun,
+  createOwnerDeferredWake,
   createSchedule,
   createScheduleRun,
   deleteSchedule,
@@ -231,15 +237,8 @@ describe("createSchedule (cron)", () => {
     expect(getSchedule(job.id)!.createdFromConversationId).toBe("conv-source");
     expect(listSchedules()[0].createdFromConversationId).toBe("conv-source");
 
-    const updated = await updateSchedule(job.id, {
-      createdFromConversationId: "conv-updated",
-    });
-    expect(updated!.createdFromConversationId).toBe("conv-updated");
-
-    const cleared = await updateSchedule(job.id, {
-      createdFromConversationId: null,
-    });
-    expect(cleared!.createdFromConversationId).toBeNull();
+    // Create-only: `updateSchedule` does not accept it, so a wake's
+    // source-conversation binding cannot drift from what creation recorded.
   });
 
   test("stores schedule_syntax in the DB row", async () => {
@@ -1400,5 +1399,104 @@ describe("describeCronExpression", () => {
 
   test("returns description for valid cron expression", () => {
     expect(describeCronExpression("0 9 * * *")).toBe("Every day at 9:00 AM");
+  });
+});
+
+// ── Owner-defer provenance is durable ────────────────────────────────────
+
+describe("owner-defer provenance", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM cron_runs");
+    getDb().run("DELETE FROM cron_jobs");
+  });
+
+  async function trustedDefer() {
+    return createOwnerDeferredWake({
+      conversationId: "conv-target",
+      hint: "check the build",
+      fireAt: Date.now() + 60_000,
+    });
+  }
+
+  test("the narrow constructor sets marker, target, and source binding together", async () => {
+    const job = await trustedDefer();
+
+    expect(job.mode).toBe("wake");
+    expect(job.wakeConversationId).toBe("conv-target");
+    expect(job.createdFromConversationId).toBe("conv-target");
+    expect(hasOwnerDeferProvenance(job.createdBy)).toBe(true);
+    expect(job.quiet).toBe(true);
+  });
+
+  test("generic createSchedule cannot mint the marker", async () => {
+    await expect(
+      createSchedule({
+        name: "forged",
+        message: "hello",
+        mode: "wake",
+        wakeConversationId: "conv-target",
+        // Only reachable by casting; the parameter type excludes the reserved
+        // value, so ordinary code cannot even express this call.
+        createdBy: OWNER_DEFER_CREATED_BY as "agent",
+        nextRunAt: Date.now() + 60_000,
+      }),
+    ).rejects.toThrow(/only by createOwnerDeferredWake/);
+  });
+
+  test("a trusted row refuses a trigger-text rewrite", async () => {
+    const job = await trustedDefer();
+    await expect(
+      updateSchedule(job.id, { message: "do something else" }),
+    ).rejects.toThrow(/fixed at creation/);
+    expect(getSchedule(job.id)!.message).toBe("check the build");
+  });
+
+  test("a trusted row refuses a target rewrite", async () => {
+    const job = await trustedDefer();
+    await expect(
+      updateSchedule(job.id, { wakeConversationId: "conv-elsewhere" }),
+    ).rejects.toThrow(/fixed at creation/);
+    expect(getSchedule(job.id)!.wakeConversationId).toBe("conv-target");
+  });
+
+  test("a trusted row refuses a mode change", async () => {
+    const job = await trustedDefer();
+    await expect(updateSchedule(job.id, { mode: "execute" })).rejects.toThrow(
+      /fixed at creation/,
+    );
+    expect(getSchedule(job.id)!.mode).toBe("wake");
+  });
+
+  test("a trusted row still accepts unrelated edits and same-value writes", async () => {
+    const job = await trustedDefer();
+
+    const updated = await updateSchedule(job.id, {
+      enabled: false,
+      message: "check the build",
+      mode: "wake",
+      wakeConversationId: "conv-target",
+    });
+
+    expect(updated!.enabled).toBe(false);
+  });
+
+  test("a legacy defer stays fully editable", async () => {
+    const legacy = await createSchedule({
+      name: "Deferred wake",
+      message: "check the build",
+      mode: "wake",
+      wakeConversationId: "conv-target",
+      createdBy: LEGACY_DEFER_CREATED_BY,
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    const updated = await updateSchedule(legacy.id, {
+      message: "something else",
+      wakeConversationId: "conv-elsewhere",
+    });
+
+    expect(updated!.message).toBe("something else");
+    expect(updated!.wakeConversationId).toBe("conv-elsewhere");
+    expect(hasOwnerDeferProvenance(updated!.createdBy)).toBe(false);
   });
 });

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -16,6 +16,11 @@ mock.module("../daemon/process-message.js", () => ({
   processMessage: mockProcessMessage,
 }));
 
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
+import {
+  createConversation,
+  setConversationOriginChannelIfUnset,
+} from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
@@ -51,7 +56,8 @@ describe("scheduler wake mode", () => {
   });
 
   test("wake schedule calls wakeAgentForOpportunity with correct args", async () => {
-    // GIVEN a one-shot wake schedule with a conversation ID
+    // GIVEN a one-shot wake schedule targeting a local conversation
+    createConversation({ id: "conv-xyz" });
     const schedule = await createSchedule({
       name: "Wake Test",
       message: "Check back on this",
@@ -64,17 +70,49 @@ describe("scheduler wake mode", () => {
     // WHEN the scheduler fires
     await runDueSchedulesOnce();
 
-    // THEN wakeAgentForOpportunity is called with the correct arguments
+    // THEN wakeAgentForOpportunity is called with the correct arguments,
+    // including the conversation's guardian resting trust. Without it the
+    // resumed turn resolves the fail-closed `unknown` class and every
+    // sensitive tool it deferred mid-task is denied (LUM-2929).
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledWith({
       conversationId: "conv-xyz",
       hint: "Check back on this",
       source: "defer",
       persistTriggerAsEvent: true,
+      trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
     });
 
     // AND processMessage is never called (wake mode doesn't use it)
     expect(mockProcessMessage).not.toHaveBeenCalled();
+  });
+
+  test("a wake on a remote-channel conversation carries no elevated trust", async () => {
+    // GIVEN a wake schedule whose target conversation originated on a remote
+    // channel, so no resting trust can be reconstructed for it
+    createConversation({ id: "conv-telegram" });
+    setConversationOriginChannelIfUnset("conv-telegram", "telegram");
+    const schedule = await createSchedule({
+      name: "Remote Wake",
+      message: "Follow up",
+      mode: "wake",
+      wakeConversationId: "conv-telegram",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    // WHEN the scheduler fires
+    await runDueSchedulesOnce();
+
+    // THEN the wake runs with no trust context at all, so the turn resolves the
+    // fail-closed `unknown` class and sensitive tools stay denied
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledWith({
+      conversationId: "conv-telegram",
+      hint: "Follow up",
+      source: "defer",
+      persistTriggerAsEvent: true,
+    });
   });
 
   test("missing wakeConversationId logs warning and completes (not fails)", async () => {

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -23,7 +23,10 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { createSchedule } from "../schedule/schedule-store.js";
+import {
+  createOwnerDeferredWake,
+  createSchedule,
+} from "../schedule/schedule-store.js";
 import { runDueSchedulesOnce } from "../schedule/scheduler.js";
 
 await initializeDb();
@@ -58,12 +61,11 @@ describe("scheduler wake mode", () => {
   test("wake schedule calls wakeAgentForOpportunity with correct args", async () => {
     // GIVEN a one-shot wake schedule targeting a local conversation
     createConversation({ id: "conv-xyz" });
-    const schedule = await createSchedule({
+    const schedule = await createOwnerDeferredWake({
+      conversationId: "conv-xyz",
+      hint: "Check back on this",
+      fireAt: Date.now() - 1000,
       name: "Wake Test",
-      message: "Check back on this",
-      mode: "wake",
-      wakeConversationId: "conv-xyz",
-      nextRunAt: Date.now() - 1000,
     });
     forceScheduleDue(schedule.id);
 

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -73,9 +73,8 @@ describe("scheduler wake mode", () => {
     await runDueSchedulesOnce();
 
     // THEN wakeAgentForOpportunity is called with the correct arguments,
-    // including the conversation's guardian resting trust. Without it the
-    // resumed turn resolves the fail-closed `unknown` class and every
-    // sensitive tool it deferred mid-task is denied (LUM-2929).
+    // including the target conversation's guardian resting trust, which the
+    // resumed turn runs under.
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledWith({
       conversationId: "conv-xyz",

--- a/assistant/src/__tests__/wake-schedule-escalation.test.ts
+++ b/assistant/src/__tests__/wake-schedule-escalation.test.ts
@@ -1,0 +1,436 @@
+/**
+ * End-to-end escalation regression for deferred wakes, driven through the real
+ * route handlers and the real scheduler tick.
+ *
+ * The attack: a caller who is authenticated but is NOT the assistant's current
+ * owner tries to make a wake fire against the guardian's own conversation. The
+ * schedule routes require only `settings.write` and a principal type in
+ * `ACTOR_PRINCIPALS`, and an `actor` token authenticates a device rather than
+ * proving current guardian binding (`auth/require-bound-guardian.ts` exists for
+ * exactly that reason), so route reachability is not authority.
+ *
+ * The autonomous due-tick carries no actor at all, so it cannot re-derive who
+ * chose a row's target. Everything therefore has to hold on the write side and
+ * in the row's own durable provenance.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const mockWakeAgentForOpportunity = mock(
+  (
+    _opts: Record<string, unknown>,
+  ): Promise<{
+    invoked: boolean;
+    producedToolCalls: boolean;
+    reason?: string;
+  }> => Promise.resolve({ invoked: true, producedToolCalls: false }),
+);
+mock.module("../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: mockWakeAgentForOpportunity,
+}));
+
+// The owner check reads the live vellum guardian binding. Drive it directly so
+// "current guardian", "rebound guardian", and "gateway unreachable" are all
+// expressible.
+let boundGuardianPrincipalId: string | null = "guardian-principal";
+mock.module("../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => guardianRows(),
+  getGuardianDeliveryFresh: async () => guardianRows(),
+  guardianForChannel: (
+    list: Array<{ channelType: string; status: string }>,
+    channelType: string,
+  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+}));
+function guardianRows() {
+  if (boundGuardianPrincipalId === null) {
+    return null;
+  }
+  return [
+    {
+      channelType: "vellum",
+      contactId: "guardian-contact",
+      principalId: boundGuardianPrincipalId,
+      address: boundGuardianPrincipalId,
+      status: "active",
+    },
+  ];
+}
+
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
+import { createConversation } from "../persistence/conversation-crud.js";
+import { getDb, getSqliteFrom } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { ROUTES as SCHEDULE_ROUTES } from "../runtime/routes/schedule-routes.js";
+import type { RouteHandlerArgs } from "../runtime/routes/types.js";
+import { LEGACY_DEFER_CREATED_BY } from "../schedule/defer-provenance.js";
+import {
+  createOwnerDeferredWake,
+  createSchedule,
+  getSchedule,
+} from "../schedule/schedule-store.js";
+import { runDueSchedulesOnce } from "../schedule/scheduler.js";
+
+await initializeDb();
+
+const TARGET = "conv-guardian-owned";
+
+/** A device token that is not the currently bound guardian. */
+const STALE_ACTOR = {
+  "x-vellum-principal-type": "actor",
+  "x-vellum-actor-principal-id": "revoked-or-rebound-principal",
+};
+/** The guardian's own web/desktop client. */
+const CURRENT_GUARDIAN = {
+  "x-vellum-principal-type": "actor",
+  "x-vellum-actor-principal-id": "guardian-principal",
+};
+/** The guardian's CLI, over the local IPC socket. */
+const LOCAL_CALLER = { "x-vellum-principal-type": "local" };
+
+function routeFor(operationId: string) {
+  const route = SCHEDULE_ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`route not registered: ${operationId}`);
+  }
+  return route;
+}
+
+function callRoute(
+  operationId: string,
+  args: RouteHandlerArgs,
+): Promise<unknown> {
+  return Promise.resolve(routeFor(operationId).handler(args));
+}
+
+function forceScheduleDue(scheduleId: string): void {
+  getSqliteFrom(getDb()).run(
+    "UPDATE cron_jobs SET next_run_at = ? WHERE id = ?",
+    [Date.now() - 1000, scheduleId],
+  );
+}
+
+/** Corrupt a persisted wake target directly, bypassing every route guard. */
+function forceWakeTarget(scheduleId: string, conversationId: string): void {
+  getSqliteFrom(getDb()).run(
+    "UPDATE cron_jobs SET wake_conversation_id = ? WHERE id = ?",
+    [conversationId, scheduleId],
+  );
+}
+
+function trustOfLastWake(): unknown {
+  const call = mockWakeAgentForOpportunity.mock.calls.at(-1);
+  return (call?.[0] as Record<string, unknown> | undefined)?.trustContext;
+}
+
+function resetAll(): void {
+  const db = getDb();
+  db.run("DELETE FROM cron_runs");
+  db.run("DELETE FROM cron_jobs");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+  mockWakeAgentForOpportunity.mockClear();
+  boundGuardianPrincipalId = "guardian-principal";
+  createConversation({ id: TARGET });
+}
+
+/** A real owner-created deferral on the guardian's own conversation. */
+function seedOwnerDefer() {
+  return createOwnerDeferredWake({
+    conversationId: TARGET,
+    hint: "check the build",
+    fireAt: Date.now() + 60_000,
+  });
+}
+
+describe("a non-owner cannot retarget a schedule onto a guardian conversation", () => {
+  beforeEach(resetAll);
+
+  test("POST /v1/schedules refuses to create a wake schedule outright", async () => {
+    await expect(
+      callRoute("createSchedule", {
+        body: {
+          name: "pwn",
+          expression: "* * * * *",
+          message: "run something as the guardian",
+          mode: "wake",
+          wakeConversationId: TARGET,
+        },
+        headers: STALE_ACTOR,
+      }),
+    ).rejects.toThrow(/Only 'execute', 'script', and 'workflow' modes/);
+  });
+
+  test("PATCH cannot flip an owned schedule to wake mode", async () => {
+    const schedule = await createSchedule({
+      name: "innocuous",
+      message: "hello",
+      mode: "execute",
+      expression: "* * * * *",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    await expect(
+      callRoute("updateSchedule", {
+        pathParams: { id: schedule.id },
+        body: {
+          mode: "wake",
+          wakeConversationId: TARGET,
+          message: "exfiltrate the workspace",
+        },
+        headers: STALE_ACTOR,
+      }),
+    ).rejects.toThrow(/only be changed by the assistant's owner/);
+
+    const after = getSchedule(schedule.id);
+    expect(after?.mode).toBe("execute");
+    expect(after?.wakeConversationId).toBeNull();
+  });
+
+  test("PATCH cannot retarget or rewrite an existing defer", async () => {
+    const defer = await seedOwnerDefer();
+
+    for (const body of [
+      { wakeConversationId: "conv-elsewhere" },
+      { message: "exfiltrate the workspace" },
+    ]) {
+      await expect(
+        callRoute("updateSchedule", {
+          pathParams: { id: defer.id },
+          body,
+          headers: STALE_ACTOR,
+        }),
+      ).rejects.toThrow(/only be changed by the assistant's owner/);
+    }
+
+    const after = getSchedule(defer.id);
+    expect(after?.wakeConversationId).toBe(TARGET);
+    expect(after?.message).toBe("check the build");
+  });
+
+  test("the due tick cannot be made to fire a retargeted wake", async () => {
+    const schedule = await createSchedule({
+      name: "innocuous",
+      message: "hello",
+      mode: "execute",
+      expression: "* * * * *",
+      nextRunAt: Date.now() + 60_000,
+    });
+    await callRoute("updateSchedule", {
+      pathParams: { id: schedule.id },
+      body: { mode: "wake", wakeConversationId: TARGET },
+      headers: STALE_ACTOR,
+    }).catch(() => undefined);
+
+    forceScheduleDue(schedule.id);
+    await runDueSchedulesOnce();
+
+    expect(
+      mockWakeAgentForOpportunity.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>).conversationId === TARGET,
+      ),
+    ).toHaveLength(0);
+  });
+});
+
+describe("toggle-enable cannot be used as a firing trigger", () => {
+  beforeEach(resetAll);
+
+  test("a non-owner cannot enable a disabled wake schedule", async () => {
+    const defer = await seedOwnerDefer();
+    await callRoute("toggleSchedule", {
+      pathParams: { id: defer.id },
+      body: { enabled: false },
+      headers: LOCAL_CALLER,
+    });
+
+    await expect(
+      callRoute("toggleSchedule", {
+        pathParams: { id: defer.id },
+        body: { enabled: true },
+        headers: STALE_ACTOR,
+      }),
+    ).rejects.toThrow(/only be changed by the assistant's owner/);
+
+    // Still disabled, so the due tick fires nothing even once it is past due.
+    forceScheduleDue(defer.id);
+    await runDueSchedulesOnce();
+    expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
+  });
+
+  test("cancel and delete are owner-gated too", async () => {
+    const defer = await seedOwnerDefer();
+
+    await expect(
+      callRoute("cancelSchedule", {
+        pathParams: { id: defer.id },
+        headers: STALE_ACTOR,
+      }),
+    ).rejects.toThrow(/only be changed by the assistant's owner/);
+    await expect(
+      callRoute("deleteSchedule", {
+        pathParams: { id: defer.id },
+        headers: STALE_ACTOR,
+      }),
+    ).rejects.toThrow(/only be changed by the assistant's owner/);
+
+    expect(getSchedule(defer.id)).not.toBeNull();
+  });
+
+  test("ordinary schedules are unaffected by the wake bar", async () => {
+    const schedule = await createSchedule({
+      name: "ordinary",
+      message: "hello",
+      mode: "execute",
+      expression: "* * * * *",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    await callRoute("toggleSchedule", {
+      pathParams: { id: schedule.id },
+      body: { enabled: false },
+      headers: STALE_ACTOR,
+    });
+
+    expect(getSchedule(schedule.id)?.enabled).toBe(false);
+  });
+});
+
+describe("run-now is refused outright for a non-owner", () => {
+  beforeEach(resetAll);
+
+  test("an unauthorized run-now makes zero wake calls", async () => {
+    const defer = await seedOwnerDefer();
+
+    await expect(
+      callRoute("runScheduleNow", {
+        pathParams: { id: defer.id },
+        headers: STALE_ACTOR,
+      }),
+    ).rejects.toThrow(/only be changed by the assistant's owner/);
+
+    // Not merely trust-less: no turn runs at all. Firing early would pollute
+    // the guardian's transcript and spend inference, and refusing suppresses
+    // nothing, since the autonomous tick still fires the deferral on time.
+    expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
+  });
+
+  test("a caller with no identity headers is refused", async () => {
+    const defer = await seedOwnerDefer();
+
+    await expect(
+      callRoute("runScheduleNow", {
+        pathParams: { id: defer.id },
+        headers: {},
+      }),
+    ).rejects.toThrow(/only be changed by the assistant's owner/);
+    expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
+  });
+
+  test("a rebound guardian's old token stops qualifying", async () => {
+    const defer = await seedOwnerDefer();
+    boundGuardianPrincipalId = "a-different-principal";
+
+    await expect(
+      callRoute("runScheduleNow", {
+        pathParams: { id: defer.id },
+        headers: CURRENT_GUARDIAN,
+      }),
+    ).rejects.toThrow(/only be changed by the assistant's owner/);
+    expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
+  });
+
+  test("an unreadable guardian binding fails closed", async () => {
+    const defer = await seedOwnerDefer();
+    boundGuardianPrincipalId = null;
+
+    await expect(
+      callRoute("runScheduleNow", {
+        pathParams: { id: defer.id },
+        headers: CURRENT_GUARDIAN,
+      }),
+    ).rejects.toThrow(/only be changed by the assistant's owner/);
+    expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
+  });
+
+  test("the current bound guardian may run it now, with trust recovered", async () => {
+    const defer = await seedOwnerDefer();
+
+    await callRoute("runScheduleNow", {
+      pathParams: { id: defer.id },
+      headers: CURRENT_GUARDIAN,
+    });
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    expect(trustOfLastWake()).toEqual(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+  });
+
+  test("a local caller may run it now, with trust recovered", async () => {
+    const defer = await seedOwnerDefer();
+
+    await callRoute("runScheduleNow", {
+      pathParams: { id: defer.id },
+      headers: LOCAL_CALLER,
+    });
+
+    expect(trustOfLastWake()).toEqual(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+  });
+});
+
+describe("the due tick honors durable row provenance", () => {
+  beforeEach(resetAll);
+
+  test("an owner-created defer fires with the target's guardian trust", async () => {
+    const defer = await seedOwnerDefer();
+    forceScheduleDue(defer.id);
+
+    await runDueSchedulesOnce();
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    expect(trustOfLastWake()).toEqual(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+  });
+
+  test("a pre-upgrade defer row fires without trust", async () => {
+    // The row an upgrade inherits: it may already have been retargeted or
+    // rewritten while the update surface still allowed it, and nothing tells
+    // it apart from an untouched one. It keeps working as a schedule and
+    // never recovers trust.
+    const legacy = await createSchedule({
+      name: "Deferred wake",
+      message: "check the build",
+      mode: "wake",
+      wakeConversationId: TARGET,
+      createdFromConversationId: TARGET,
+      createdBy: LEGACY_DEFER_CREATED_BY,
+      nextRunAt: Date.now() + 60_000,
+    });
+    forceScheduleDue(legacy.id);
+
+    await runDueSchedulesOnce();
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    expect(trustOfLastWake()).toBeUndefined();
+  });
+
+  test("a marked row whose target was corrupted in the DB fires without trust", async () => {
+    // Belt to the route guard's braces: even with the marker intact and every
+    // route bypassed, moving the target breaks its equality with the write-once
+    // source binding, so the tick refuses to elevate.
+    createConversation({ id: "conv-other-guardian-owned" });
+    const defer = await seedOwnerDefer();
+    forceWakeTarget(defer.id, "conv-other-guardian-owned");
+    forceScheduleDue(defer.id);
+
+    await runDueSchedulesOnce();
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    expect(
+      (
+        mockWakeAgentForOpportunity.mock.calls.at(-1)?.[0] as Record<
+          string,
+          unknown
+        >
+      ).conversationId,
+    ).toBe("conv-other-guardian-owned");
+    expect(trustOfLastWake()).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/wake-schedule-trust.test.ts
+++ b/assistant/src/__tests__/wake-schedule-trust.test.ts
@@ -1,0 +1,132 @@
+/**
+ * A deferred wake resumes a conversation with nobody on the other end, so it
+ * has no inbound actor to derive trust from. It runs under the target
+ * conversation's reconstructed resting trust instead: guardian for the
+ * guardian's own local conversation, nothing at all for one whose origin is a
+ * remote channel.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { recoverRestingTrustContext } from "../daemon/conversation-resting-trust.js";
+import {
+  FALLBACK_TURN_TRUST,
+  INTERNAL_GUARDIAN_TRUST_CONTEXT,
+  resolveTrustClass,
+} from "../daemon/trust-context.js";
+import {
+  createConversation,
+  setConversationOriginChannelIfUnset,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
+import { buildWakeScheduleOptions } from "../schedule/wake-schedule-options.js";
+import { resolveSensitiveToolDecision } from "../tools/tool-approval-handler.js";
+
+await initializeDb();
+
+const WAKE_JOB = { message: "Check back on this", inferenceProfile: null };
+
+/**
+ * The decision the sensitive-tool gate reaches for an invocation with the given
+ * resting trust, with no channel approval cell to lift the floor. `null` trust
+ * is what a wake with no `trustContext` resolves at tool-setup time
+ * (`currentTurnTrustContext ?? trustContext ?? FALLBACK_TURN_TRUST`).
+ */
+function gateDecision(
+  trustContext: ReturnType<typeof recoverRestingTrustContext>,
+  reach: "sandbox" | "host",
+): string {
+  const { sensitiveToolApproval } = resolveCapabilities(
+    resolveTrustClass(trustContext ?? FALLBACK_TURN_TRUST),
+  );
+  return resolveSensitiveToolDecision({
+    reach,
+    cellThreshold: undefined,
+    sensitiveToolApproval,
+  });
+}
+
+describe("deferred wake resting trust", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM messages");
+    getDb().run("DELETE FROM conversations");
+  });
+
+  test("a local conversation wakes under guardian trust", () => {
+    createConversation({ id: "conv-local" });
+
+    expect(buildWakeScheduleOptions(WAKE_JOB, "conv-local")).toEqual({
+      conversationId: "conv-local",
+      hint: "Check back on this",
+      source: "defer",
+      persistTriggerAsEvent: true,
+      trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
+    });
+  });
+
+  test("the internal vellum channel is a guardian-owned local conversation", () => {
+    createConversation({ id: "conv-vellum" });
+    setConversationOriginChannelIfUnset("conv-vellum", "vellum");
+
+    expect(buildWakeScheduleOptions(WAKE_JOB, "conv-vellum")).toHaveProperty(
+      "trustContext",
+      INTERNAL_GUARDIAN_TRUST_CONTEXT,
+    );
+  });
+
+  test("a remote-channel conversation wakes with no reconstructed trust", () => {
+    createConversation({ id: "conv-remote" });
+    setConversationOriginChannelIfUnset("conv-remote", "telegram");
+
+    const options = buildWakeScheduleOptions(WAKE_JOB, "conv-remote");
+
+    // Absent, not `undefined`: a fabricated context here would either hand a
+    // remote-origin conversation the guardian's capabilities or bury the reply
+    // under `unknown` provenance.
+    expect(options).not.toHaveProperty("trustContext");
+    expect(options).toEqual({
+      conversationId: "conv-remote",
+      hint: "Check back on this",
+      source: "defer",
+      persistTriggerAsEvent: true,
+    });
+  });
+
+  test("the schedule's inference profile still rides along", () => {
+    createConversation({ id: "conv-local" });
+
+    expect(
+      buildWakeScheduleOptions(
+        { ...WAKE_JOB, inferenceProfile: "fast" },
+        "conv-local",
+      ),
+    ).toHaveProperty("forceOverrideProfile", "fast");
+  });
+
+  test("guardian resting trust clears the sensitive-tool gate", () => {
+    createConversation({ id: "conv-local" });
+    const trust = recoverRestingTrustContext("conv-local");
+
+    expect(trust).toEqual(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+    // Both reaches: `bash` in the workspace sandbox and a host-reaching
+    // invocation. The guardian self-approves either, which is what makes a
+    // resumed deferred wake able to keep using the tools it deferred mid-task.
+    expect(gateDecision(trust, "sandbox")).toBe("proceed");
+    expect(gateDecision(trust, "host")).toBe("proceed");
+  });
+
+  test("a remote-origin wake stays fail-closed on sensitive tools", () => {
+    createConversation({ id: "conv-remote" });
+    setConversationOriginChannelIfUnset("conv-remote", "telegram");
+    const trust = recoverRestingTrustContext("conv-remote");
+
+    expect(trust).toBeNull();
+    // `deny`, not `escalate-and-wait`: this is the branch that produces the
+    // "requires guardian approval from a verified channel identity" message,
+    // and it must keep producing it for a wake whose trust cannot be recovered.
+    expect(gateDecision(trust, "sandbox")).toBe("deny");
+    expect(gateDecision(trust, "host")).toBe("deny");
+  });
+});

--- a/assistant/src/__tests__/wake-schedule-trust.test.ts
+++ b/assistant/src/__tests__/wake-schedule-trust.test.ts
@@ -50,7 +50,7 @@ const OWNER_WAKE_JOB = {
   createdFromConversationId: TARGET,
 };
 
-/** A defer written before owner provenance existed. */
+/** A defer carrying legacy provenance, which records no author. */
 const LEGACY_WAKE_JOB = {
   ...OWNER_WAKE_JOB,
   createdBy: LEGACY_DEFER_CREATED_BY,
@@ -115,8 +115,8 @@ describe("an owner-authored defer on a guardian-owned conversation", () => {
     const options = buildWakeScheduleOptions(OWNER_WAKE_JOB, TARGET);
 
     // `bash` in the workspace sandbox and a host-reaching invocation alike.
-    // This is what lets a resumed deferral keep using the tools it deferred
-    // mid-task, which is the bug LUM-2929 reported.
+    // This is what lets a resumed deferral keep using the tools it was using
+    // when it deferred.
     expect(gateDecision(options.trustContext, "sandbox")).toBe("proceed");
     expect(gateDecision(options.trustContext, "host")).toBe("proceed");
   });
@@ -151,10 +151,9 @@ describe("a row without owner provenance recovers nothing", () => {
   });
 
   test("a legacy defer fails closed even on a guardian-owned target", () => {
-    // Pre-upgrade rows are the whole reason the marker is versioned. While the
-    // update surface still accepted `wakeConversationId`, an actor could have
-    // retargeted an existing defer, and nothing distinguishes such a row from
-    // an untouched one. They keep firing; they never recover trust.
+    // A legacy row records no author for its target or text, so a retargeted
+    // one is indistinguishable from an untouched one. Such rows keep firing;
+    // they never recover trust.
     const options = buildWakeScheduleOptions(LEGACY_WAKE_JOB, TARGET);
 
     expect(options).not.toHaveProperty("trustContext");

--- a/assistant/src/__tests__/wake-schedule-trust.test.ts
+++ b/assistant/src/__tests__/wake-schedule-trust.test.ts
@@ -1,9 +1,14 @@
 /**
- * A deferred wake resumes a conversation with nobody on the other end, so it
- * has no inbound actor to derive trust from. It runs under the target
- * conversation's reconstructed resting trust instead: guardian for the
- * guardian's own local conversation, nothing at all for one whose origin is a
- * remote channel.
+ * What a deferred wake's row must prove before its turn can recover the target
+ * conversation's resting trust.
+ *
+ * The scheduler's due-tick has no caller: it cannot re-derive who chose the
+ * wake's target or its trigger text, so the row itself has to carry that proof
+ * in fields no update path can rewrite. Two independent conditions must hold,
+ * and this file covers both plus every way each one fails.
+ *
+ * Authorization of the firing ITSELF (who may edit, enable, or trigger a wake
+ * schedule) is a route concern and lives in `wake-schedule-escalation.test.ts`.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
@@ -14,28 +19,64 @@ import {
   INTERNAL_GUARDIAN_TRUST_CONTEXT,
   resolveTrustClass,
 } from "../daemon/trust-context.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 import {
   createConversation,
   setConversationOriginChannelIfUnset,
 } from "../persistence/conversation-crud.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getDb, getSqliteFrom } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import type { WakeOptions } from "../runtime/agent-wake.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
+import {
+  LEGACY_DEFER_CREATED_BY,
+  OWNER_DEFER_CREATED_BY,
+} from "../schedule/defer-provenance.js";
 import { buildWakeScheduleOptions } from "../schedule/wake-schedule-options.js";
 import { resolveSensitiveToolDecision } from "../tools/tool-approval-handler.js";
 
 await initializeDb();
 
-const WAKE_JOB = { message: "Check back on this", inferenceProfile: null };
+const TARGET = "conv-guardian-owned";
+
+/**
+ * A row as `createOwnerDeferredWake` writes it: owner provenance, and a
+ * source-conversation binding equal to the wake target.
+ */
+const OWNER_WAKE_JOB = {
+  message: "Check back on this",
+  inferenceProfile: null,
+  createdBy: OWNER_DEFER_CREATED_BY,
+  createdFromConversationId: TARGET,
+};
+
+/** A defer written before owner provenance existed. */
+const LEGACY_WAKE_JOB = {
+  ...OWNER_WAKE_JOB,
+  createdBy: LEGACY_DEFER_CREATED_BY,
+};
+
+/**
+ * Write a raw `origin_channel` the canonical channel set does not contain, the
+ * way a row from a newer build, a renamed channel id, or corrupted data would
+ * look. `setConversationOriginChannelIfUnset` only accepts a `ChannelId`, so
+ * this has to go in under the type system.
+ */
+function writeRawOriginChannel(conversationId: string, raw: string): void {
+  getSqliteFrom(getDb()).run(
+    "UPDATE conversations SET origin_channel = ? WHERE id = ?",
+    [raw, conversationId],
+  );
+}
 
 /**
  * The decision the sensitive-tool gate reaches for an invocation with the given
- * resting trust, with no channel approval cell to lift the floor. `null` trust
+ * resting trust, with no channel approval cell to lift the floor. Absent trust
  * is what a wake with no `trustContext` resolves at tool-setup time
  * (`currentTurnTrustContext ?? trustContext ?? FALLBACK_TURN_TRUST`).
  */
 function gateDecision(
-  trustContext: ReturnType<typeof recoverRestingTrustContext>,
+  trustContext: TrustContext | null | undefined,
   reach: "sandbox" | "host",
 ): string {
   const { sensitiveToolApproval } = resolveCapabilities(
@@ -48,17 +89,21 @@ function gateDecision(
   });
 }
 
-describe("deferred wake resting trust", () => {
+/** The gate decision a wake built with these options would reach for `bash`. */
+function wakeGateDecision(options: WakeOptions): string {
+  return gateDecision(options.trustContext, "sandbox");
+}
+
+describe("an owner-authored defer on a guardian-owned conversation", () => {
   beforeEach(() => {
     getDb().run("DELETE FROM messages");
     getDb().run("DELETE FROM conversations");
+    createConversation({ id: TARGET });
   });
 
-  test("a local conversation wakes under guardian trust", () => {
-    createConversation({ id: "conv-local" });
-
-    expect(buildWakeScheduleOptions(WAKE_JOB, "conv-local")).toEqual({
-      conversationId: "conv-local",
+  test("recovers the target's guardian resting trust", () => {
+    expect(buildWakeScheduleOptions(OWNER_WAKE_JOB, TARGET)).toEqual({
+      conversationId: TARGET,
       hint: "Check back on this",
       source: "defer",
       persistTriggerAsEvent: true,
@@ -66,67 +111,146 @@ describe("deferred wake resting trust", () => {
     });
   });
 
-  test("the internal vellum channel is a guardian-owned local conversation", () => {
+  test("clears the sensitive-tool gate at both reaches", () => {
+    const options = buildWakeScheduleOptions(OWNER_WAKE_JOB, TARGET);
+
+    // `bash` in the workspace sandbox and a host-reaching invocation alike.
+    // This is what lets a resumed deferral keep using the tools it deferred
+    // mid-task, which is the bug LUM-2929 reported.
+    expect(gateDecision(options.trustContext, "sandbox")).toBe("proceed");
+    expect(gateDecision(options.trustContext, "host")).toBe("proceed");
+  });
+
+  test("the internal vellum channel counts as guardian-owned", () => {
     createConversation({ id: "conv-vellum" });
     setConversationOriginChannelIfUnset("conv-vellum", "vellum");
 
-    expect(buildWakeScheduleOptions(WAKE_JOB, "conv-vellum")).toHaveProperty(
-      "trustContext",
-      INTERNAL_GUARDIAN_TRUST_CONTEXT,
-    );
-  });
-
-  test("a remote-channel conversation wakes with no reconstructed trust", () => {
-    createConversation({ id: "conv-remote" });
-    setConversationOriginChannelIfUnset("conv-remote", "telegram");
-
-    const options = buildWakeScheduleOptions(WAKE_JOB, "conv-remote");
-
-    // Absent, not `undefined`: a fabricated context here would either hand a
-    // remote-origin conversation the guardian's capabilities or bury the reply
-    // under `unknown` provenance.
-    expect(options).not.toHaveProperty("trustContext");
-    expect(options).toEqual({
-      conversationId: "conv-remote",
-      hint: "Check back on this",
-      source: "defer",
-      persistTriggerAsEvent: true,
-    });
+    expect(
+      buildWakeScheduleOptions(
+        { ...OWNER_WAKE_JOB, createdFromConversationId: "conv-vellum" },
+        "conv-vellum",
+      ),
+    ).toHaveProperty("trustContext", INTERNAL_GUARDIAN_TRUST_CONTEXT);
   });
 
   test("the schedule's inference profile still rides along", () => {
-    createConversation({ id: "conv-local" });
-
     expect(
       buildWakeScheduleOptions(
-        { ...WAKE_JOB, inferenceProfile: "fast" },
-        "conv-local",
+        { ...OWNER_WAKE_JOB, inferenceProfile: "fast" },
+        TARGET,
       ),
     ).toHaveProperty("forceOverrideProfile", "fast");
   });
+});
 
-  test("guardian resting trust clears the sensitive-tool gate", () => {
-    createConversation({ id: "conv-local" });
-    const trust = recoverRestingTrustContext("conv-local");
-
-    expect(trust).toEqual(INTERNAL_GUARDIAN_TRUST_CONTEXT);
-    // Both reaches: `bash` in the workspace sandbox and a host-reaching
-    // invocation. The guardian self-approves either, which is what makes a
-    // resumed deferred wake able to keep using the tools it deferred mid-task.
-    expect(gateDecision(trust, "sandbox")).toBe("proceed");
-    expect(gateDecision(trust, "host")).toBe("proceed");
+describe("a row without owner provenance recovers nothing", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM messages");
+    getDb().run("DELETE FROM conversations");
+    createConversation({ id: TARGET });
   });
 
-  test("a remote-origin wake stays fail-closed on sensitive tools", () => {
+  test("a legacy defer fails closed even on a guardian-owned target", () => {
+    // Pre-upgrade rows are the whole reason the marker is versioned. While the
+    // update surface still accepted `wakeConversationId`, an actor could have
+    // retargeted an existing defer, and nothing distinguishes such a row from
+    // an untouched one. They keep firing; they never recover trust.
+    const options = buildWakeScheduleOptions(LEGACY_WAKE_JOB, TARGET);
+
+    expect(options).not.toHaveProperty("trustContext");
+    expect(wakeGateDecision(options)).toBe("deny");
+  });
+
+  test("an unmarked schedule fails closed", () => {
+    const options = buildWakeScheduleOptions(
+      { ...OWNER_WAKE_JOB, createdBy: "agent" },
+      TARGET,
+    );
+
+    expect(options).not.toHaveProperty("trustContext");
+    expect(wakeGateDecision(options)).toBe("deny");
+  });
+
+  test("a marked row whose source binding was never set fails closed", () => {
+    const options = buildWakeScheduleOptions(
+      { ...OWNER_WAKE_JOB, createdFromConversationId: null },
+      TARGET,
+    );
+
+    expect(options).not.toHaveProperty("trustContext");
+    expect(wakeGateDecision(options)).toBe("deny");
+  });
+
+  test("a marked row retargeted away from its source binding fails closed", () => {
+    // The second half of the proof, standing on its own: even if the marker
+    // survived and the route guard were bypassed or regressed, moving
+    // `wakeConversationId` breaks the equality with the write-once source
+    // binding, so the retargeted row cannot elevate.
+    const options = buildWakeScheduleOptions(
+      { ...OWNER_WAKE_JOB, createdFromConversationId: "conv-somewhere-else" },
+      TARGET,
+    );
+
+    expect(options).not.toHaveProperty("trustContext");
+    expect(wakeGateDecision(options)).toBe("deny");
+  });
+});
+
+describe("target provenance still bounds an owner-authored defer", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM messages");
+    getDb().run("DELETE FROM conversations");
+  });
+
+  /** An owner-marked row correctly bound to `conversationId`. */
+  function ownerJobFor(conversationId: string) {
+    return { ...OWNER_WAKE_JOB, createdFromConversationId: conversationId };
+  }
+
+  test("a remote-channel target recovers nothing", () => {
     createConversation({ id: "conv-remote" });
     setConversationOriginChannelIfUnset("conv-remote", "telegram");
-    const trust = recoverRestingTrustContext("conv-remote");
 
-    expect(trust).toBeNull();
-    // `deny`, not `escalate-and-wait`: this is the branch that produces the
-    // "requires guardian approval from a verified channel identity" message,
-    // and it must keep producing it for a wake whose trust cannot be recovered.
-    expect(gateDecision(trust, "sandbox")).toBe("deny");
-    expect(gateDecision(trust, "host")).toBe("deny");
+    const options = buildWakeScheduleOptions(
+      ownerJobFor("conv-remote"),
+      "conv-remote",
+    );
+
+    // Absent, not `undefined`: a fabricated context would either hand a
+    // remote-origin conversation the guardian's capabilities or bury the reply
+    // under `unknown` provenance.
+    expect(options).not.toHaveProperty("trustContext");
+    expect(wakeGateDecision(options)).toBe("deny");
+  });
+
+  test("an unrecognized stored origin recovers nothing", () => {
+    // `getConversationOriginChannel` would collapse an unparseable value into
+    // the same `null` an unset column yields, which would read as local. A row
+    // from a newer build, a renamed channel id, or corrupted data must land
+    // where a remote channel lands.
+    createConversation({ id: "conv-future" });
+    writeRawOriginChannel("conv-future", "channel-from-a-newer-build");
+
+    expect(recoverRestingTrustContext("conv-future")).toBeNull();
+    expect(
+      buildWakeScheduleOptions(ownerJobFor("conv-future"), "conv-future"),
+    ).not.toHaveProperty("trustContext");
+  });
+
+  test("an empty-string origin recovers nothing", () => {
+    createConversation({ id: "conv-blank" });
+    writeRawOriginChannel("conv-blank", "");
+
+    expect(recoverRestingTrustContext("conv-blank")).toBeNull();
+  });
+
+  test("a conversation that does not exist recovers nothing", () => {
+    // Inert in practice (the wake rejects it as `not_found` before a turn
+    // runs), but trust is granted on a positively recognized local origin, so
+    // an absent row must never be one.
+    expect(recoverRestingTrustContext("conv-missing")).toBeNull();
+    expect(
+      buildWakeScheduleOptions(ownerJobFor("conv-missing"), "conv-missing"),
+    ).not.toHaveProperty("trustContext");
   });
 });

--- a/assistant/src/daemon/conversation-resting-trust.ts
+++ b/assistant/src/daemon/conversation-resting-trust.ts
@@ -1,0 +1,45 @@
+/**
+ * Resting trust for a conversation resumed without an inbound actor.
+ *
+ * Wakes and startup resumes re-enter a conversation that already exists, with
+ * no inbound message to derive trust from. They cannot invent an actor, so they
+ * reconstruct the trust the conversation sits at when nobody is talking to it.
+ */
+
+import { getConversationOriginChannel } from "../persistence/conversation-crud.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "./trust-context.js";
+import type { TrustContext } from "./trust-context-types.js";
+
+/**
+ * Rebuild the trust context a conversation resumes under when no inbound actor
+ * is present, or `null` when it cannot be recovered.
+ *
+ * Only the guardian's own local conversations are recoverable at rest: a
+ * remote-channel turn's trust class is stamped per inbound message from the
+ * gateway verdict and never persisted, so it cannot be reconstructed here.
+ * Local conversations (`originChannel` unset, meaning a desktop/web/CLI turn
+ * that never carried a channel message, or the internal `vellum` channel)
+ * belong to the guardian owner, so they resume under
+ * {@link INTERNAL_GUARDIAN_TRUST_CONTEXT}: the trust class `loadFromDb` needs
+ * to rehydrate their guardian-provenance history instead of filtering it to
+ * empty, and the class the tool-approval gate reads to let the guardian's own
+ * sensitive tools run. Any other origin returns `null` so the caller runs the
+ * turn under no reconstructed context rather than a fabricated one, which would
+ * either grant a low-trust conversation guardian capability or bury the reply
+ * under `unknown` provenance.
+ *
+ * A conversation id with no row also reads as local, since the origin lookup
+ * cannot tell a missing row from a null column. That is inert: every caller
+ * resolves the conversation before the trust is applied to anything, and a
+ * missing conversation is rejected there (`wakeAgentForOpportunity` returns
+ * `not_found`) before a turn runs.
+ */
+export function recoverRestingTrustContext(
+  conversationId: string,
+): TrustContext | null {
+  const originChannel = getConversationOriginChannel(conversationId);
+  if (originChannel === null || originChannel === "vellum") {
+    return INTERNAL_GUARDIAN_TRUST_CONTEXT;
+  }
+  return null;
+}

--- a/assistant/src/daemon/conversation-resting-trust.ts
+++ b/assistant/src/daemon/conversation-resting-trust.ts
@@ -6,9 +6,15 @@
  * reconstruct the trust the conversation sits at when nobody is talking to it.
  */
 
-import { getConversationOriginChannel } from "../persistence/conversation-crud.js";
+import { getConversation } from "../persistence/conversation-crud.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "./trust-context.js";
 import type { TrustContext } from "./trust-context-types.js";
+
+/**
+ * The internal control-plane channel. A conversation stamped with it is the
+ * assistant's own, not a remote correspondent's.
+ */
+const INTERNAL_ORIGIN_CHANNEL = "vellum";
 
 /**
  * Rebuild the trust context a conversation resumes under when no inbound actor
@@ -17,28 +23,41 @@ import type { TrustContext } from "./trust-context-types.js";
  * Only the guardian's own local conversations are recoverable at rest: a
  * remote-channel turn's trust class is stamped per inbound message from the
  * gateway verdict and never persisted, so it cannot be reconstructed here.
- * Local conversations (`originChannel` unset, meaning a desktop/web/CLI turn
- * that never carried a channel message, or the internal `vellum` channel)
- * belong to the guardian owner, so they resume under
+ * A local conversation is one whose stored `origin_channel` is either SQL NULL
+ * (a desktop/web/CLI turn that never carried a channel message) or the internal
+ * `vellum` channel. Those belong to the guardian owner, so they resume under
  * {@link INTERNAL_GUARDIAN_TRUST_CONTEXT}: the trust class `loadFromDb` needs
  * to rehydrate their guardian-provenance history instead of filtering it to
  * empty, and the class the tool-approval gate reads to let the guardian's own
- * sensitive tools run. Any other origin returns `null` so the caller runs the
- * turn under no reconstructed context rather than a fabricated one, which would
- * either grant a low-trust conversation guardian capability or bury the reply
- * under `unknown` provenance.
+ * sensitive tools run.
  *
- * A conversation id with no row also reads as local, since the origin lookup
- * cannot tell a missing row from a null column. That is inert: every caller
- * resolves the conversation before the trust is applied to anything, and a
- * missing conversation is rejected there (`wakeAgentForOpportunity` returns
- * `not_found`) before a turn runs.
+ * Everything else returns `null`, and the caller runs the turn under no
+ * reconstructed context rather than a fabricated one, which would either grant
+ * a low-trust conversation guardian capability or bury the reply under
+ * `unknown` provenance. "Everything else" is deliberately the whole remainder,
+ * not just the recognized remote channels:
+ *
+ * - A **missing conversation row** recovers nothing. Callers reject it on their
+ *   own path anyway (`wakeAgentForOpportunity` returns `not_found`), so this is
+ *   belt and braces rather than the only guard.
+ * - An **unrecognized stored value** recovers nothing. This is why the raw
+ *   column is read here instead of `getConversationOriginChannel()`: that
+ *   accessor runs the value through `parseChannelId`, which maps any string
+ *   outside the canonical channel set to the same `null` a genuinely unset
+ *   column produces. Reading through it would let a row written by a newer
+ *   build, a renamed channel id, or corrupted data pass as local and resume at
+ *   guardian trust. Trust is granted only on an origin positively recognized as
+ *   local, never on the absence of a recognizable one.
  */
 export function recoverRestingTrustContext(
   conversationId: string,
 ): TrustContext | null {
-  const originChannel = getConversationOriginChannel(conversationId);
-  if (originChannel === null || originChannel === "vellum") {
+  const conversation = getConversation(conversationId);
+  if (!conversation) {
+    return null;
+  }
+  const { originChannel } = conversation;
+  if (originChannel === null || originChannel === INTERNAL_ORIGIN_CHANNEL) {
     return INTERNAL_GUARDIAN_TRUST_CONTEXT;
   }
   return null;

--- a/assistant/src/daemon/interrupted-turn-reconciler.ts
+++ b/assistant/src/daemon/interrupted-turn-reconciler.ts
@@ -69,8 +69,9 @@ export interface InterruptedTurnReconciliation {
   capped: string[];
   /**
    * Conversation ids left un-resumed because their resting trust could not be
-   * reconstructed from persisted state (a remote-channel turn whose per-actor
-   * gateway verdict is not stored). Their stale flag is still cleared.
+   * reconstructed from persisted state: a remote-channel turn whose per-actor
+   * gateway verdict is not stored, or an origin the build does not recognize.
+   * Their stale flag is still cleared.
    */
   trustUnrecoverable: string[];
 }

--- a/assistant/src/daemon/interrupted-turn-reconciler.ts
+++ b/assistant/src/daemon/interrupted-turn-reconciler.ts
@@ -16,17 +16,17 @@
  * still-set flags here at boot; the monitor clears them a few seconds later.
  *
  * Each resume runs under the conversation's reconstructed resting trust (see
- * {@link recoverRestingTrustContext}); conversations whose trust can't be
- * rebuilt from persisted state are cleared but left un-resumed.
+ * `recoverRestingTrustContext` in `conversation-resting-trust.ts`);
+ * conversations whose trust can't be rebuilt from persisted state are cleared
+ * but left un-resumed.
  */
 
 import {
-  getConversationOriginChannel,
   incrementProcessingResumeAttempts,
   listInterruptedConversations,
 } from "../persistence/conversation-crud.js";
 import { getLogger } from "../util/logger.js";
-import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "./trust-context.js";
+import { recoverRestingTrustContext } from "./conversation-resting-trust.js";
 import type { TrustContext } from "./trust-context-types.js";
 
 const log = getLogger("interrupted-turns");
@@ -73,33 +73,6 @@ export interface InterruptedTurnReconciliation {
    * gateway verdict is not stored). Their stale flag is still cleared.
    */
   trustUnrecoverable: string[];
-}
-
-/**
- * Rebuild the trust context an interrupted conversation must resume under, or
- * `null` when it can't be recovered.
- *
- * Only the guardian's own local conversations are recoverable at rest: a
- * remote-channel turn's trust class is stamped per inbound message from the
- * gateway verdict and never persisted, so it cannot be reconstructed here.
- * Local conversations — `originChannel` unset (a desktop/web/CLI turn that
- * never carried a channel message) or the internal `vellum` channel — belong
- * to the guardian owner, so they resume under
- * {@link INTERNAL_GUARDIAN_TRUST_CONTEXT}: the trust class `loadFromDb` needs
- * to rehydrate their guardian-provenance history instead of filtering it to
- * empty. Any other origin returns `null` so the caller skips the resume rather
- * than run the turn under a fabricated context — which would either grant a
- * low-trust turn guardian capability or bury the reply under `unknown`
- * provenance.
- */
-function recoverRestingTrustContext(
-  conversationId: string,
-): TrustContext | null {
-  const originChannel = getConversationOriginChannel(conversationId);
-  if (originChannel === null || originChannel === "vellum") {
-    return INTERNAL_GUARDIAN_TRUST_CONTEXT;
-  }
-  return null;
 }
 
 /**

--- a/assistant/src/runtime/auth/owner-caller.ts
+++ b/assistant/src/runtime/auth/owner-caller.ts
@@ -1,0 +1,95 @@
+/**
+ * Transport-neutral "is this caller the assistant's owner" check.
+ *
+ * `requireBoundGuardian` answers the same question from an `AuthContext`, but
+ * it is wired into the HTTP adapter through the `requireGuardian` route flag,
+ * and the IPC adapter drops every route carrying that flag
+ * (`ipc/routes/route-adapter.ts`). A route that must stay reachable from the
+ * CLI therefore cannot use the flag, and instead asks this helper from inside
+ * the handler, where both transports have already resolved caller identity into
+ * headers.
+ */
+
+import { isHttpAuthDisabled } from "../../config/env.js";
+import {
+  getGuardianDelivery,
+  getGuardianDeliveryFresh,
+  guardianForChannel,
+} from "../../contacts/guardian-delivery-reader.js";
+
+/**
+ * Whether `actorPrincipalId` is the principal currently bound as the vellum
+ * guardian. Fails closed when the binding cannot be read (the gateway is
+ * unreachable, so the list comes back null) and when the matching row is not
+ * active, which is what makes a revoked or rebound principal stop matching.
+ *
+ * `fresh` selects the read. The binding is written gateway side and those
+ * writes do not invalidate the daemon's cache, so a cached list can describe a
+ * binding that was revoked or rebound up to the cache TTL ago. Callers whose
+ * threat model is the stale credential itself must pass `fresh: true` and pay
+ * one single-flight IPC round trip. It is NOT the default: the established
+ * `requireGuardian` routes are host-proxy result callbacks that run once per
+ * round trip of an active session, and forcing an uncached read on each would
+ * be a hot-path regression for no change in what those routes protect.
+ */
+export async function matchesBoundGuardian(
+  actorPrincipalId: string | undefined,
+  options?: { fresh?: boolean },
+): Promise<boolean> {
+  if (!actorPrincipalId) {
+    return false;
+  }
+  const read = options?.fresh ? getGuardianDeliveryFresh : getGuardianDelivery;
+  const guardians = await read({ channelTypes: ["vellum"] });
+  if (!guardians) {
+    return false;
+  }
+  const guardian = guardianForChannel(guardians, "vellum");
+  return guardian?.principalId === actorPrincipalId;
+}
+
+/**
+ * Whether the caller holds owner authority over this assistant right now.
+ *
+ * Two callers qualify:
+ *
+ * - A **local IPC caller** (the CLI, or another host-resident process). The IPC
+ *   socket is host-local and the host is inside the trust boundary.
+ * - The **current bound vellum guardian**, identified by matching the verified
+ *   `x-vellum-actor-principal-id` against the live binding. This is what keeps
+ *   the guardian's own web and desktop clients working, since they arrive as
+ *   `actor` over HTTP rather than as `local`.
+ *
+ * Principal TYPE alone is deliberately not enough. Production actor tokens are
+ * minted only for the guardian principal, but a token is a bearer credential
+ * that outlives the binding it was minted against: it stays signature-valid
+ * until it expires, while the binding behind it can be revoked or rebound to a
+ * different principal. Re-reading the binding per call is what makes a stale or
+ * rebound token stop qualifying. It also excludes the service principals
+ * (`svc_gateway`, `svc_daemon`) that share the same route policy but carry no
+ * actor identity of their own, and it keeps the check correct if the set of
+ * mint paths ever widens.
+ *
+ * Both transports derive the identity headers from verified auth and strip any
+ * inbound copy, so neither can be spoofed by the caller.
+ *
+ * The auth-disabled bypass mirrors `requireBoundGuardian` and `enforcePolicy`:
+ * when the daemon is not enforcing its own auth, it is sitting behind something
+ * that is, and every gate in the process defers to that uniformly.
+ */
+export async function isOwnerCaller(
+  headers?: Record<string, string>,
+): Promise<boolean> {
+  if (isHttpAuthDisabled()) {
+    return true;
+  }
+  if (headers?.["x-vellum-principal-type"] === "local") {
+    return true;
+  }
+  // Fresh: a deferred wake fires unattended and can recover guardian trust, so
+  // a binding revoked or rebound minutes ago must stop qualifying immediately
+  // rather than at the next cache expiry.
+  return matchesBoundGuardian(headers?.["x-vellum-actor-principal-id"], {
+    fresh: true,
+  });
+}

--- a/assistant/src/runtime/auth/require-bound-guardian.ts
+++ b/assistant/src/runtime/auth/require-bound-guardian.ts
@@ -1,9 +1,6 @@
 import { isHttpAuthDisabled } from "../../config/env.js";
-import {
-  getGuardianDelivery,
-  guardianForChannel,
-} from "../../contacts/guardian-delivery-reader.js";
 import { httpError } from "../http-errors.js";
+import { matchesBoundGuardian } from "./owner-caller.js";
 import type { AuthContext } from "./types.js";
 
 /**
@@ -20,24 +17,12 @@ export async function requireBoundGuardian(
   if (isHttpAuthDisabled()) {
     return null;
   }
-  if (!authContext.actorPrincipalId) {
-    return httpError(
-      "FORBIDDEN",
-      "Actor is not the bound guardian for this channel",
-      403,
-    );
-  }
-  const guardians = await getGuardianDelivery({ channelTypes: ["vellum"] });
-  if (!guardians) {
-    // Gateway unreachable — fail closed.
-    return httpError(
-      "FORBIDDEN",
-      "Actor is not the bound guardian for this channel",
-      403,
-    );
-  }
-  const guardian = guardianForChannel(guardians, "vellum");
-  if (guardian && guardian.principalId === authContext.actorPrincipalId) {
+  // Missing actor id, an unreadable binding (gateway unreachable), a
+  // non-matching principal, and a non-active row all fail closed inside
+  // `matchesBoundGuardian`. Cached read: these routes are host-proxy result
+  // callbacks on an active session, and this preserves their established
+  // semantics. The wake surface asks for a fresh binding explicitly.
+  if (await matchesBoundGuardian(authContext.actorPrincipalId)) {
     return null;
   }
   return httpError(

--- a/assistant/src/runtime/routes/defer-routes.ts
+++ b/assistant/src/runtime/routes/defer-routes.ts
@@ -9,8 +9,12 @@ import { z } from "zod";
 
 import { getConversation } from "../../persistence/conversation-crud.js";
 import {
+  DEFER_CREATED_BY_VALUES,
+  isDeferSchedule,
+} from "../../schedule/defer-provenance.js";
+import {
   cancelSchedule,
-  createSchedule,
+  createOwnerDeferredWake,
   getSchedule,
   listSchedules,
 } from "../../schedule/schedule-store.js";
@@ -30,7 +34,7 @@ const MAX_DEFER_HORIZON_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 function countActiveDefers(conversationId?: string): number {
   const jobs = listSchedules({
     mode: "wake",
-    createdBy: "defer",
+    createdBy: DEFER_CREATED_BY_VALUES,
     conversationId,
   });
   return jobs.filter((j) => j.status === "active" || j.status === "firing")
@@ -97,14 +101,11 @@ async function handleDeferCreate({ body = {} }: RouteHandlerArgs) {
     );
   }
 
-  const job = await createSchedule({
-    name: name ?? "Deferred wake",
-    message: hint,
-    mode: "wake",
-    wakeConversationId: conversationId,
-    nextRunAt: resolvedFireAt,
-    quiet: true,
-    createdBy: "defer",
+  const job = await createOwnerDeferredWake({
+    conversationId,
+    hint,
+    fireAt: resolvedFireAt,
+    ...(name !== undefined ? { name } : {}),
   });
 
   return {
@@ -120,7 +121,7 @@ async function handleDeferList({ body = {} }: RouteHandlerArgs) {
 
   const jobs = listSchedules({
     mode: "wake",
-    createdBy: "defer",
+    createdBy: DEFER_CREATED_BY_VALUES,
     conversationId,
   });
 
@@ -145,7 +146,7 @@ async function handleDeferCancel({ body = {} }: RouteHandlerArgs) {
 
   if (id) {
     const job = getSchedule(id);
-    if (!job || job.mode !== "wake" || job.createdBy !== "defer") {
+    if (!job || job.mode !== "wake" || !isDeferSchedule(job.createdBy)) {
       return { cancelled: 0, error: "Not a deferred wake" };
     }
     const ok = await cancelSchedule(id);
@@ -155,7 +156,7 @@ async function handleDeferCancel({ body = {} }: RouteHandlerArgs) {
   if (all) {
     const jobs = listSchedules({
       mode: "wake",
-      createdBy: "defer",
+      createdBy: DEFER_CREATED_BY_VALUES,
       conversationId,
     });
 

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -15,6 +15,7 @@ import {
   getUsageCostForRun,
   listRunConversationIds,
 } from "../../persistence/llm-usage-store.js";
+import { isDeferSchedule } from "../../schedule/defer-provenance.js";
 import { validateScheduleInferenceProfile } from "../../schedule/inference-profile.js";
 import {
   describeRRuleExpression,
@@ -46,9 +47,15 @@ import { initializeTools } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
 import { normalizeCapabilityManifest } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import { isOwnerCaller } from "../auth/owner-caller.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { parseEpochMillisRange } from "./epoch-millis-range.js";
-import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ForbiddenError,
+  InternalError,
+  NotFoundError,
+} from "./errors.js";
 import {
   paginateRuns,
   parseRunsBeforeCursor,
@@ -59,6 +66,39 @@ import {
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("schedule-routes");
+
+/**
+ * Refuse a state change that touches a deferred-wake schedule unless the caller
+ * holds owner authority right now ({@link isOwnerCaller}: a local IPC caller,
+ * or the current bound vellum guardian).
+ *
+ * A wake row is guardian-owned deferral state. Its target and trigger text
+ * decide what an unattended, potentially guardian-trust turn will do, and even
+ * the transitions that cannot elevate (enabling, cancelling, deleting) decide
+ * whether and when that turn runs at all. The generic schedule editor is shared
+ * with ordinary schedules and is reachable by any `settings.write` caller, so
+ * it applies this narrower bar for wake rows only. Non-wake schedules are
+ * unaffected.
+ *
+ * Applied to a schedule's CURRENT mode and to its RESULTING mode, so a caller
+ * can neither edit an existing wake row nor turn another schedule into one.
+ */
+async function assertWakeMutationAllowed(
+  existing: ScheduleJob | null,
+  resultingMode: string | undefined,
+  headers: Record<string, string> | undefined,
+): Promise<void> {
+  const touchesWake = existing?.mode === "wake" || resultingMode === "wake";
+  if (!touchesWake) {
+    return;
+  }
+  if (await isOwnerCaller(headers)) {
+    return;
+  }
+  throw new ForbiddenError(
+    "Deferred wake schedules can only be changed by the assistant's owner",
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Response schemas (shared by all schedule routes)
@@ -239,7 +279,7 @@ function handleListSchedules(queryParams: Record<string, string>) {
   const jobs = listSchedules();
   const filtered = includeAll
     ? jobs
-    : jobs.filter((j) => j.createdBy !== "defer");
+    : jobs.filter((j) => !isDeferSchedule(j.createdBy));
   const sourceConversationCache = new Map<
     string,
     CreatedFromConversationState
@@ -412,11 +452,20 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
   }
 }
 
-async function handleToggleSchedule(id: string, body: Record<string, unknown>) {
+async function handleToggleSchedule(
+  id: string,
+  body: Record<string, unknown>,
+  headers?: Record<string, string>,
+) {
   const enabled = body.enabled;
   if (typeof enabled !== "boolean") {
     throw new BadRequestError("enabled is required");
   }
+
+  // Enabling is a firing trigger in its own right: a disabled wake row whose
+  // `nextRunAt` has already passed fires on the next tick the moment it is
+  // enabled, with no further caller involvement.
+  await assertWakeMutationAllowed(getSchedule(id), undefined, headers);
 
   const updated = await updateSchedule(id, { enabled });
   if (!updated) {
@@ -426,7 +475,11 @@ async function handleToggleSchedule(id: string, body: Record<string, unknown>) {
   return handleListSchedules({});
 }
 
-async function handleDeleteSchedule(id: string) {
+async function handleDeleteSchedule(
+  id: string,
+  headers?: Record<string, string>,
+) {
+  await assertWakeMutationAllowed(getSchedule(id), undefined, headers);
   const removed = await deleteSchedule(id);
   if (!removed) {
     throw new NotFoundError("Schedule not found");
@@ -435,7 +488,11 @@ async function handleDeleteSchedule(id: string) {
   return handleListSchedules({});
 }
 
-async function handleCancelSchedule(id: string) {
+async function handleCancelSchedule(
+  id: string,
+  headers?: Record<string, string>,
+) {
+  await assertWakeMutationAllowed(getSchedule(id), undefined, headers);
   const cancelled = await cancelSchedule(id);
   if (!cancelled) {
     throw new NotFoundError("Schedule not found or not cancellable");
@@ -457,7 +514,11 @@ const VALID_ROUTING_INTENTS = [
   "all_channels",
 ] as const;
 
-async function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
+async function handleUpdateSchedule(
+  id: string,
+  body: Record<string, unknown>,
+  headers?: Record<string, string>,
+) {
   if (
     "mode" in body &&
     !VALID_MODES.includes(body.mode as (typeof VALID_MODES)[number])
@@ -490,6 +551,7 @@ async function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
   if (existing) {
     const resultingMode =
       "mode" in body ? (body.mode as string) : existing.mode;
+    await assertWakeMutationAllowed(existing, resultingMode, headers);
     if (resultingMode === "workflow") {
       const resultingWorkflowName =
         "workflowName" in body
@@ -859,8 +921,8 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       schedules: z.array(scheduleSchema).describe("Updated schedule list"),
     }),
-    handler: ({ pathParams, body }: RouteHandlerArgs) =>
-      handleToggleSchedule(pathParams!.id, body ?? {}),
+    handler: ({ pathParams, body, headers }: RouteHandlerArgs) =>
+      handleToggleSchedule(pathParams!.id, body ?? {}, headers),
   },
   {
     operationId: "deleteSchedule",
@@ -876,8 +938,8 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       schedules: z.array(scheduleSchema).describe("Updated schedule list"),
     }),
-    handler: ({ pathParams }: RouteHandlerArgs) =>
-      handleDeleteSchedule(pathParams!.id),
+    handler: ({ pathParams, headers }: RouteHandlerArgs) =>
+      handleDeleteSchedule(pathParams!.id, headers),
   },
   {
     operationId: "updateSchedule",
@@ -941,8 +1003,8 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       schedules: z.array(scheduleSchema).describe("Updated schedule list"),
     }),
-    handler: ({ pathParams, body }: RouteHandlerArgs) =>
-      handleUpdateSchedule(pathParams!.id, body ?? {}),
+    handler: ({ pathParams, body, headers }: RouteHandlerArgs) =>
+      handleUpdateSchedule(pathParams!.id, body ?? {}, headers),
   },
   {
     operationId: "cancelSchedule",
@@ -958,8 +1020,8 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       schedules: z.array(scheduleSchema).describe("Updated schedule list"),
     }),
-    handler: ({ pathParams }: RouteHandlerArgs) =>
-      handleCancelSchedule(pathParams!.id),
+    handler: ({ pathParams, headers }: RouteHandlerArgs) =>
+      handleCancelSchedule(pathParams!.id, headers),
   },
   {
     operationId: "runScheduleNow",
@@ -975,12 +1037,15 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       schedules: z.array(scheduleSchema).describe("Updated schedule list"),
     }),
-    handler: ({ pathParams }: RouteHandlerArgs) =>
-      handleRunScheduleNow(pathParams!.id),
+    handler: ({ pathParams, headers }: RouteHandlerArgs) =>
+      handleRunScheduleNow(pathParams!.id, headers),
   },
 ];
 
-async function handleRunScheduleNow(id: string) {
+async function handleRunScheduleNow(
+  id: string,
+  headers?: Record<string, string>,
+) {
   const schedule = getSchedule(id);
   if (!schedule) {
     throw new NotFoundError("Schedule not found");
@@ -1100,6 +1165,12 @@ async function handleRunScheduleNow(id: string) {
 
   // ── Wake mode (resume an existing conversation, no new message) ────
   if (schedule.mode === "wake") {
+    // Refuse before invoking anything. Firing early is not a lesser act than
+    // editing: it runs a turn in the target conversation on demand, which
+    // pollutes the transcript and spends inference even when no trust is
+    // recovered. Denying it also suppresses nothing, since the autonomous tick
+    // still fires the deferral at its scheduled time.
+    await assertWakeMutationAllowed(schedule, undefined, headers);
     if (!schedule.wakeConversationId) {
       throw new BadRequestError("Wake schedule has no target conversation");
     }

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -41,6 +41,7 @@ import {
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
+import { buildWakeScheduleOptions } from "../../schedule/wake-schedule-options.js";
 import { initializeTools } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
 import { normalizeCapabilityManifest } from "../../workflows/capabilities.js";
@@ -1104,15 +1105,9 @@ async function handleRunScheduleNow(id: string) {
     }
     const { wakeAgentForOpportunity } = await import("../agent-wake.js");
     try {
-      await wakeAgentForOpportunity({
-        conversationId: schedule.wakeConversationId,
-        hint: schedule.message,
-        source: "defer",
-        persistTriggerAsEvent: true,
-        ...(schedule.inferenceProfile
-          ? { forceOverrideProfile: schedule.inferenceProfile }
-          : {}),
-      });
+      await wakeAgentForOpportunity(
+        buildWakeScheduleOptions(schedule, schedule.wakeConversationId),
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err, jobId: schedule.id }, "Manual wake execution failed");

--- a/assistant/src/schedule/defer-provenance.ts
+++ b/assistant/src/schedule/defer-provenance.ts
@@ -1,0 +1,51 @@
+/**
+ * Provenance of a deferred-wake schedule row, recorded in `createdBy`.
+ *
+ * A wake firing resumes an existing conversation unattended and can recover
+ * that conversation's resting trust, so it needs durable proof that the row's
+ * target and trigger text were chosen by the assistant's owner. `createdBy` is
+ * the field that can carry that proof: it is set once at creation and appears
+ * in no update path (`updateSchedule` does not accept it, so no route, tool, or
+ * CLI command can rewrite it).
+ *
+ * The value is versioned rather than reused because rows written before the
+ * proof existed cannot be told apart from rows that were retargeted while the
+ * update surface still allowed it. Legacy rows keep working as schedules and
+ * keep their place in the defer UI; they simply never recover trust.
+ */
+
+/**
+ * Defers written before owner provenance was recorded. Functional, but carries
+ * no proof of who chose its target, so it never recovers resting trust.
+ */
+export const LEGACY_DEFER_CREATED_BY = "defer";
+
+/**
+ * Defers created through the defer surface by a verified owner (a local IPC
+ * caller, or the current bound guardian). Only this value can recover trust.
+ */
+export const OWNER_DEFER_CREATED_BY = "defer:owner";
+
+/** Every value that marks a row as a deferred wake, for listing and filtering. */
+export const DEFER_CREATED_BY_VALUES: readonly string[] = [
+  LEGACY_DEFER_CREATED_BY,
+  OWNER_DEFER_CREATED_BY,
+];
+
+/**
+ * Whether the row is a deferred wake at all. Use for presentation concerns
+ * (hiding defers from the schedule list, naming, defer list/cancel scoping),
+ * never to decide trust.
+ */
+export function isDeferSchedule(createdBy: string): boolean {
+  return DEFER_CREATED_BY_VALUES.includes(createdBy);
+}
+
+/**
+ * Whether the row carries durable proof that an owner chose its wake target and
+ * trigger text. This is the only defer-provenance question that may feed a
+ * trust decision.
+ */
+export function hasOwnerDeferProvenance(createdBy: string): boolean {
+  return createdBy === OWNER_DEFER_CREATED_BY;
+}

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -1,5 +1,5 @@
 import { Cron } from "croner";
-import { and, asc, desc, eq, isNull, lt, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, lt, lte, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../persistence/db-connection.js";
@@ -10,6 +10,12 @@ import { scheduleJobs, scheduleRuns } from "../persistence/schema/index.js";
 import { publishSchedulesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import { withSqliteRetry } from "../util/sqlite-retry.js";
+import {
+  hasOwnerDeferProvenance,
+  isDeferSchedule,
+  LEGACY_DEFER_CREATED_BY,
+  OWNER_DEFER_CREATED_BY,
+} from "./defer-provenance.js";
 import {
   computeNextRunAt as computeNextRunAtEngine,
   isValidScheduleExpression,
@@ -114,7 +120,15 @@ export function isValidCronExpression(expr: string): boolean {
   }
 }
 
-export async function createSchedule(params: {
+/**
+ * Insert a schedule row. Unexported on purpose: it is the only writer of
+ * `createdBy` and `createdFromConversationId`, the two fields a deferred wake's
+ * firing reads as proof of who authored its target and trigger text. Callers
+ * reach it through {@link createSchedule} (which cannot mint owner-defer
+ * provenance) or {@link createOwnerDeferredWake} (which is the only thing that
+ * can).
+ */
+interface InsertScheduleParams {
   name: string;
   description?: string;
   cronExpression?: string | null;
@@ -141,7 +155,30 @@ export async function createSchedule(params: {
   inferenceProfile?: string | null;
   groupId?: string | null;
   createdFromConversationId?: string | null;
-}): Promise<ScheduleJob> {
+}
+
+/**
+ * Values ordinary schedule creation may record in `createdBy`.
+ *
+ * Deliberately a closed union rather than `string`: it excludes the owner-defer
+ * marker at the type level, so {@link createSchedule} cannot express the
+ * provenance that lets a wake firing recover trust. The legacy defer value
+ * stays available because rows written before the marker existed still need to
+ * be representable.
+ */
+export type OrdinaryScheduleCreator =
+  | "agent"
+  | "user"
+  | typeof LEGACY_DEFER_CREATED_BY;
+
+/** Parameters for ordinary schedule creation. */
+export type CreateScheduleParams = Omit<InsertScheduleParams, "createdBy"> & {
+  createdBy?: OrdinaryScheduleCreator;
+};
+
+async function insertSchedule(
+  params: InsertScheduleParams,
+): Promise<ScheduleJob> {
   const expression = params.expression ?? params.cronExpression ?? null;
   const isOneShot = expression == null;
   const syntax = params.syntax ?? "cron";
@@ -189,7 +226,7 @@ export async function createSchedule(params: {
   const createdFromConversationId = params.createdFromConversationId ?? null;
   const description = normalizeDescription(
     params.description,
-    params.createdBy === "defer" ? "" : params.name,
+    isDeferSchedule(params.createdBy ?? "") ? "" : params.name,
   );
 
   let nextRunAt: number;
@@ -249,6 +286,63 @@ export async function createSchedule(params: {
 }
 
 /**
+ * Create an ordinary schedule.
+ *
+ * Cannot mint owner-defer provenance: that marker is what lets an unattended
+ * wake firing recover its target conversation's resting trust, so it is issued
+ * only by {@link createOwnerDeferredWake}, which sets it together with the
+ * target and source binding that give it meaning. Passing the reserved value
+ * here throws rather than silently downgrading, so a caller reaching for it
+ * fails loudly instead of producing a row that looks trusted.
+ */
+export async function createSchedule(
+  params: CreateScheduleParams,
+): Promise<ScheduleJob> {
+  if (params.createdBy && hasOwnerDeferProvenance(params.createdBy)) {
+    throw new Error(
+      "Owner-defer provenance is issued only by createOwnerDeferredWake()",
+    );
+  }
+  return insertSchedule(params);
+}
+
+/**
+ * Create a deferred wake on `conversationId`, carrying durable proof that the
+ * assistant's owner chose both its target and its trigger text.
+ *
+ * The proof is the combination this function sets atomically and nothing else
+ * can assemble: owner provenance in `createdBy`, the wake target, and the
+ * source-conversation binding that must equal it. All three are write-once
+ * (absent from `updateSchedule`'s parameters), and `updateSchedule` refuses to
+ * rewrite the trigger text or target of a row carrying the marker, so a row's
+ * target and text are exactly what this call recorded.
+ *
+ * Callers must have established owner authority first; `defer/create` is the
+ * only production caller and is gated accordingly.
+ */
+export async function createOwnerDeferredWake(params: {
+  conversationId: string;
+  hint: string;
+  fireAt: number;
+  name?: string;
+  inferenceProfile?: string | null;
+}): Promise<ScheduleJob> {
+  return insertSchedule({
+    name: params.name ?? "Deferred wake",
+    message: params.hint,
+    mode: "wake",
+    wakeConversationId: params.conversationId,
+    createdFromConversationId: params.conversationId,
+    createdBy: OWNER_DEFER_CREATED_BY,
+    nextRunAt: params.fireAt,
+    quiet: true,
+    ...(params.inferenceProfile !== undefined
+      ? { inferenceProfile: params.inferenceProfile }
+      : {}),
+  });
+}
+
+/**
  * Sidebar group for conversations created by a schedule's runs. The job's
  * `groupId` wins only while the group still exists: a schedule may outlive
  * its custom group, and creating a conversation with a dangling group id
@@ -293,7 +387,7 @@ export function listSchedules(options?: {
   oneShotOnly?: boolean;
   recurringOnly?: boolean;
   mode?: ScheduleMode;
-  createdBy?: string;
+  createdBy?: string | readonly string[];
   conversationId?: string;
 }): ScheduleJob[] {
   const db = getDb();
@@ -311,7 +405,12 @@ export function listSchedules(options?: {
     conditions.push(eq(scheduleJobs.mode, options.mode));
   }
   if (options?.createdBy) {
-    conditions.push(eq(scheduleJobs.createdBy, options.createdBy));
+    const createdBy = options.createdBy;
+    conditions.push(
+      typeof createdBy === "string"
+        ? eq(scheduleJobs.createdBy, createdBy)
+        : inArray(scheduleJobs.createdBy, [...createdBy]),
+    );
   }
   if (options?.conversationId) {
     conditions.push(
@@ -354,7 +453,18 @@ export async function updateSchedule(
     timeoutMs?: number | null;
     inferenceProfile?: string | null;
     groupId?: string | null;
-    createdFromConversationId?: string | null;
+    // `createdBy` and `createdFromConversationId` are deliberately absent: a
+    // deferred wake's firing reads both to decide whether the woken turn may
+    // recover its target conversation's resting trust (see
+    // `wake-schedule-options.ts`), and proof that can be rewritten is not
+    // proof. Keeping them out of this type makes that structural rather than a
+    // caller convention, so reaching for them is a compile error instead of a
+    // silent trust bypass.
+    //
+    // `message`, `wakeConversationId`, and `mode` stay in this type because
+    // ordinary schedules and legacy defers edit them freely. On a row carrying
+    // owner-defer provenance they are immutable, enforced at the top of the
+    // function body rather than in the type, since the distinction is per-row.
   },
 ): Promise<ScheduleJob | null> {
   const db = getDb();
@@ -365,6 +475,29 @@ export async function updateSchedule(
     .get();
   if (!existing) {
     return null;
+  }
+
+  // Owner-defer provenance certifies that the assistant's owner chose both the
+  // conversation this wake resumes and the text it carries. Rewriting either
+  // would leave the marker standing over content it no longer describes, so on
+  // these rows the authority-bearing trio is fixed at creation. Same-value
+  // writes pass, so an idempotent update that echoes current state is not an
+  // error. Changing a trusted defer is cancel-and-recreate through
+  // `createOwnerDeferredWake`, which is exactly what the defer surface exposes.
+  // Legacy defers stay editable and never recover trust either way.
+  if (hasOwnerDeferProvenance(existing.createdBy)) {
+    const rewritesTrigger =
+      updates.message !== undefined && updates.message !== existing.message;
+    const rewritesTarget =
+      updates.wakeConversationId !== undefined &&
+      updates.wakeConversationId !== existing.wakeConversationId;
+    const rewritesMode =
+      updates.mode !== undefined && updates.mode !== existing.mode;
+    if (rewritesTrigger || rewritesTarget || rewritesMode) {
+      throw new Error(
+        "A trusted deferred wake's target, trigger text, and mode are fixed at creation; cancel and re-create it",
+      );
+    }
   }
 
   // Resolve the effective syntax and expression after this update
@@ -478,9 +611,6 @@ export async function updateSchedule(
   }
   if (updates.groupId !== undefined) {
     set.groupId = updates.groupId;
-  }
-  if (updates.createdFromConversationId !== undefined) {
-    set.createdFromConversationId = updates.createdFromConversationId;
   }
 
   // Recompute nextRunAt if schedule timing may have changed (only for recurring)

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -479,7 +479,7 @@ export async function updateSchedule(
 
   // Owner-defer provenance certifies that the assistant's owner chose both the
   // conversation this wake resumes and the text it carries. Rewriting either
-  // would leave the marker standing over content it no longer describes, so on
+  // would leave the marker standing over content it does not describe, so on
   // these rows the authority-bearing trio is fixed at creation. Same-value
   // writes pass, so an idempotent update that echoes current state is not an
   // error. Changing a trusted defer is cancel-and-recreate through

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -45,6 +45,7 @@ import {
   scheduleRetry,
   setScheduleRunConversationId,
 } from "./schedule-store.js";
+import { buildWakeScheduleOptions } from "./wake-schedule-options.js";
 import {
   isScheduleWorkerAdministrativelyStopped,
   probeScheduleWorker,
@@ -649,15 +650,9 @@ export async function runDueSchedulesOnce(
           { jobId: job.id, name: job.name, wakeConversationId, isOneShot },
           "Executing wake schedule",
         );
-        const result = await wakeAgentForOpportunity({
-          conversationId: wakeConversationId,
-          hint: job.message,
-          source: "defer",
-          persistTriggerAsEvent: true,
-          ...(job.inferenceProfile
-            ? { forceOverrideProfile: job.inferenceProfile }
-            : {}),
-        });
+        const result = await wakeAgentForOpportunity(
+          buildWakeScheduleOptions(job, wakeConversationId),
+        );
 
         if (result.reason === "timeout" && isOneShot) {
           // The conversation is busy processing a tool call. Retry on

--- a/assistant/src/schedule/wake-schedule-options.ts
+++ b/assistant/src/schedule/wake-schedule-options.ts
@@ -32,13 +32,12 @@ type WakeScheduleFields = Pick<
  *   creation, so retargeting `wakeConversationId` breaks the equality even if
  *   the update surface's own guard were bypassed or regressed.
  *
- * Rows written before this proof existed carry neither, so they fail closed.
- * That is deliberate and cannot be relaxed: while the update surface still
- * accepted `wakeConversationId`, an actor could have retargeted an existing
- * defer, and nothing distinguishes such a row from an untouched one. A legacy
- * defer keeps firing and keeps its place in the defer list; its woken turn
- * simply runs at the fail-closed `unknown` class, exactly as every wake did
- * before this proof was introduced. Re-creating the defer earns the elevation.
+ * A row carrying legacy defer provenance carries neither field and therefore
+ * fails closed. That is deliberate and cannot be relaxed: such a row's target
+ * and text have no recorded author, so a retargeted one is indistinguishable
+ * from an untouched one. It keeps firing and keeps its place in the defer list;
+ * its woken turn runs at the fail-closed `unknown` class. Re-creating the defer
+ * earns the elevation.
  */
 function hasOwnerAuthoredWakeTarget(
   job: WakeScheduleFields,

--- a/assistant/src/schedule/wake-schedule-options.ts
+++ b/assistant/src/schedule/wake-schedule-options.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared construction of the wake invocation a `mode: "wake"` schedule fires.
+ *
+ * The scheduler's due-tick and the manual "run now" route both resume the
+ * schedule's target conversation, so they build the same invocation here rather
+ * than each assembling their own.
+ */
+
+import { recoverRestingTrustContext } from "../daemon/conversation-resting-trust.js";
+import type { WakeOptions } from "../runtime/agent-wake.js";
+import type { ScheduleJob } from "./schedule-store.js";
+
+/** The schedule fields a wake firing reads. */
+type WakeScheduleFields = Pick<ScheduleJob, "message" | "inferenceProfile">;
+
+/**
+ * Build the {@link WakeOptions} for firing a wake schedule against
+ * `wakeConversationId`.
+ *
+ * A wake schedule carries no actor: it is a deferral the assistant set on a
+ * conversation that already exists, and nobody is on the other end when it
+ * fires. So the woken turn runs under the target conversation's own resting
+ * trust ({@link recoverRestingTrustContext}), never more. For the guardian's
+ * own local conversation that is guardian, which is what lets the resumed turn
+ * keep using the sensitive tools it was using before it deferred. For a
+ * conversation whose origin is a remote channel there is no resting trust to
+ * recover, so `trustContext` is omitted and the turn resolves the fail-closed
+ * `unknown` class, denying sensitive tools exactly as it does today.
+ *
+ * Trust is derived from the target conversation rather than from whoever
+ * triggered the firing, so a manual "run now" cannot lift a wake above the
+ * conversation it lands in.
+ */
+export function buildWakeScheduleOptions(
+  job: WakeScheduleFields,
+  wakeConversationId: string,
+): WakeOptions {
+  const trustContext = recoverRestingTrustContext(wakeConversationId);
+  return {
+    conversationId: wakeConversationId,
+    hint: job.message,
+    source: "defer",
+    persistTriggerAsEvent: true,
+    ...(trustContext ? { trustContext } : {}),
+    ...(job.inferenceProfile
+      ? { forceOverrideProfile: job.inferenceProfile }
+      : {}),
+  };
+}

--- a/assistant/src/schedule/wake-schedule-options.ts
+++ b/assistant/src/schedule/wake-schedule-options.ts
@@ -8,34 +8,80 @@
 
 import { recoverRestingTrustContext } from "../daemon/conversation-resting-trust.js";
 import type { WakeOptions } from "../runtime/agent-wake.js";
+import { hasOwnerDeferProvenance } from "./defer-provenance.js";
 import type { ScheduleJob } from "./schedule-store.js";
 
 /** The schedule fields a wake firing reads. */
-type WakeScheduleFields = Pick<ScheduleJob, "message" | "inferenceProfile">;
+type WakeScheduleFields = Pick<
+  ScheduleJob,
+  "message" | "inferenceProfile" | "createdBy" | "createdFromConversationId"
+>;
+
+/**
+ * Whether this row carries durable proof that its wake target and trigger text
+ * were chosen by the assistant's owner.
+ *
+ * The due-tick has no caller: it cannot re-derive who selected the target, so
+ * the row itself has to carry the answer, in fields no update path can rewrite.
+ * Two independent ones must agree:
+ *
+ * - `createdBy` is {@link hasOwnerDeferProvenance}. Set only by `defer/create`,
+ *   which is owner-gated, and absent from `updateSchedule`'s signature, so no
+ *   route, tool, or CLI command can write it after creation.
+ * - `createdFromConversationId` equals the wake target. Also write-once at
+ *   creation, so retargeting `wakeConversationId` breaks the equality even if
+ *   the update surface's own guard were bypassed or regressed.
+ *
+ * Rows written before this proof existed carry neither, so they fail closed.
+ * That is deliberate and cannot be relaxed: while the update surface still
+ * accepted `wakeConversationId`, an actor could have retargeted an existing
+ * defer, and nothing distinguishes such a row from an untouched one. A legacy
+ * defer keeps firing and keeps its place in the defer list; its woken turn
+ * simply runs at the fail-closed `unknown` class, exactly as every wake did
+ * before this proof was introduced. Re-creating the defer earns the elevation.
+ */
+function hasOwnerAuthoredWakeTarget(
+  job: WakeScheduleFields,
+  wakeConversationId: string,
+): boolean {
+  return (
+    hasOwnerDeferProvenance(job.createdBy) &&
+    job.createdFromConversationId === wakeConversationId
+  );
+}
 
 /**
  * Build the {@link WakeOptions} for firing a wake schedule against
  * `wakeConversationId`.
  *
- * A wake schedule carries no actor: it is a deferral the assistant set on a
+ * A wake schedule carries no actor of its own: it is a deferral set on a
  * conversation that already exists, and nobody is on the other end when it
  * fires. So the woken turn runs under the target conversation's own resting
  * trust ({@link recoverRestingTrustContext}), never more. For the guardian's
  * own local conversation that is guardian, which is what lets the resumed turn
- * keep using the sensitive tools it was using before it deferred. For a
- * conversation whose origin is a remote channel there is no resting trust to
- * recover, so `trustContext` is omitted and the turn resolves the fail-closed
- * `unknown` class, denying sensitive tools exactly as it does today.
+ * keep using the sensitive tools it was using before it deferred.
  *
- * Trust is derived from the target conversation rather than from whoever
- * triggered the firing, so a manual "run now" cannot lift a wake above the
- * conversation it lands in.
+ * Elevation needs BOTH halves, and grants the lesser of them:
+ *
+ * - **The row must prove an owner chose its target and text**
+ *   ({@link hasOwnerAuthoredWakeTarget}). Naming a privileged conversation is
+ *   therefore not itself the grant.
+ * - **The target must be guardian-owned** ({@link recoverRestingTrustContext}).
+ *   Trust comes from the conversation the wake lands in, so a wake can never
+ *   rise above its target: a remote-channel conversation recovers nothing and
+ *   its turn resolves the fail-closed `unknown` class.
+ *
+ * Callers are separately responsible for authorizing the firing itself. The
+ * scheduler's due-tick has no caller to authorize; `schedules/:id/run` refuses
+ * a non-owner before reaching this function.
  */
 export function buildWakeScheduleOptions(
   job: WakeScheduleFields,
   wakeConversationId: string,
 ): WakeOptions {
-  const trustContext = recoverRestingTrustContext(wakeConversationId);
+  const trustContext = hasOwnerAuthoredWakeTarget(job, wakeConversationId)
+    ? recoverRestingTrustContext(wakeConversationId)
+    : null;
   return {
     conversationId: wakeConversationId,
     hint: job.message,


### PR DESCRIPTION
## TL;DR

A deferred wake (`mode: "wake"` schedule) fired with no trust context, so the resumed turn resolved the fail-closed `unknown` class and every sensitive tool was denied with `this action requires guardian approval from a verified channel identity`. A wake now recovers its target conversation's resting trust, but only against durable proof that the assistant's owner chose the wake's target and trigger text.

Closes LUM-2929

## Root cause

`runDueSchedulesOnce`'s wake branch called `wakeAgentForOpportunity` with no `trustContext`. Tool setup fell through `currentTurnTrustContext ?? trustContext ?? FALLBACK_TURN_TRUST` (`conversation-tool-setup.ts:349`) to the `unknown` class, whose `sensitiveToolApproval: "deny"` `resolveSensitiveToolDecision` returns verbatim and `sensitiveToolDeniedMessage` renders as the reported string.

That fallback is only reached when the conversation is not resident. A resident conversation still carried the last turn's trust, which is why sending an interactive guardian message made the identical tool call succeed a moment later.

## Why the obvious fix was not enough

Deriving trust from the target conversation alone is exploitable, and review caught it. The autonomous due-tick has **no caller**, so it cannot re-derive who chose the target. Meanwhile `PATCH /v1/schedules/:id` accepted `mode` and `wakeConversationId`, and `POST /v1/schedules/:id/toggle` could enable an already-due row. An authenticated non-owner could therefore point a schedule at the guardian's conversation and let the tick fire it at guardian trust.

Route reachability is not authority here. `settings.write` + `ACTOR_PRINCIPALS` is what those routes require, but an `actor` token authenticates a device, not the current guardian binding: `auth/require-bound-guardian.ts` exists precisely because the two differ. Production actor tokens are minted only for the guardian principal (`guardian-bootstrap.ts` says so explicitly), so the live cases are stale tokens after revocation or rebinding, compromised device credentials, service principals, and any future widening of the mint paths.

## The invariant

A wake recovers trust only when **both** hold, and it grants the lesser:

**1. The row proves owner authorship**, in fields no update path can rewrite:

| Field | Guarantee |
| --- | --- |
| `createdBy` carries owner defer provenance | Issued only by the new `createOwnerDeferredWake()`. Absent from `updateSchedule`'s parameters. Generic `createSchedule` excludes the reserved value at the **type** level and rejects it at runtime. |
| `createdFromConversationId` equals the wake target | Create-only, so retargeting `wakeConversationId` breaks the equality even if a route guard regressed. |

**2. The target is guardian-owned.** Trust comes from the conversation the wake lands in, so a wake can never rise above its target. A remote-channel, unparseable, or missing origin recovers nothing.

## Pre-upgrade rows fail closed

Rows written before this proof existed carry neither field. While the update surface still accepted `wakeConversationId`, an actor could have retargeted an existing defer, and nothing distinguishes such a row from an untouched one, so **legacy defers never recover trust**. They keep firing and keep their place in the defer list. Re-creating the defer earns the elevation. No migration: `createdBy` is versioned, and the legacy value stays a first-class citizen for listing, naming, and cancellation.

## Owner authority, transport-neutral

`isOwnerCaller()` admits a local IPC caller (CLI) or the actor whose verified principal id matches the **live** vellum guardian binding, so the guardian's web and desktop clients keep working. It reads **fresh**, because gateway-side binding writes do not invalidate the daemon cache and a stale snapshot is exactly the actor this check exists to deny. `requireBoundGuardian` keeps its **cached** read: those are host-proxy result callbacks on active sessions, and forcing an uncached IPC read per round trip would be a hot-path regression for no security gain.

Applied to every state transition that can make a wake fire or change what it does: update, toggle, cancel, delete, and run-now. Run-now **refuses before invoking anything**, since firing early runs a turn in the guardian's conversation and denying it suppresses nothing (the tick still fires on time). Ordinary schedules are untouched.

## In-agent tool path

Audited, no tool changes needed. `schedule_create` / `schedule_update` exclude `wake` from their `VALID_MODES`, so tools cannot mint or convert wake rows, and neither accepts `wakeConversationId` or `createdBy`. `schedule_update` can still edit an existing wake's generic fields given its id, but `canManageSchedules` restricts it to guardian trust and the store now refuses to rewrite an owner-marked row's target, trigger text, or mode. `schedule_delete` is side-effect gated and deletion is availability-only.

## Before / after

| Deferred wake fires on... | Before | After |
| --- | --- | --- |
| Your own conversation, assistant still resident | Sensitive tools work | Unchanged |
| Your own conversation, after a restart or eviction | Denied: "requires guardian approval from a verified channel identity" | Works, same as if you had just typed in the conversation |
| A defer created before this change | Denied | Still denied, by design. Re-create it to get the fix |
| A Slack/Telegram-originated conversation | Denied | Unchanged, still denied |
| A non-owner editing, enabling, or triggering a wake | Allowed | 403, and run-now invokes nothing |
| Guardian web/desktop managing a defer | Allowed | Unchanged |
| Any non-wake schedule | Unchanged | Unchanged |

## Tests

161 passing across the focused suite. Exploit-focused coverage drives the **real route handlers and the real scheduler tick**:

- Non-owner cannot create, flip to, retarget, or rewrite a wake row; the due tick then fires nothing at the guardian target.
- Toggle-enable denial, then force-due, proving no guardian-trust wake.
- Cancel and delete denial; ordinary schedules unaffected.
- Unauthorized run-now, absent identity, rebound guardian, and unreadable binding all reject with **zero** wake calls.
- Current bound guardian and local caller run-now both fire with guardian trust.
- Pre-upgrade legacy row aimed at the guardian target fires **without** trust.
- Owner-marked row whose target was corrupted by direct DB write fires **without** trust.
- Store: the trusted trio (target, text, mode) is immutable; legacy rows stay editable; generic create cannot mint the marker.

I verified the regressions actually catch the bug by reverting the write-side guard: the retarget and due-tick cases go red.

## Notes

No migrations. No feature flags. No changes to the capability matrix or the approval-decision composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)