### PR TITLE
fix(web): render voice stories from shipped sources, write down the story rule

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -1395,8 +1395,36 @@ renders correctly given the data it actually receives in production.
   helpers that transform a different input format into the prop shape —
   that adds a layer of indirection that hides what the component
   actually receives.
+- **Render the real components; never a story-local lookalike.** A story
+  that draws its own children with its own padding, type token, or hover
+  state documents a layout the app doesn't ship, and it can't catch a
+  regression in the thing it claims to document. If a story needs a
+  layout the shipped primitives can't express, that's the signal a
+  primitive is missing, not a licence to hand-roll one in the story.
+- **Wrappers go in decorators, styling goes in the component.** A story
+  may frame its subject (a width, a backdrop, a provider); it may not
+  restyle it. When a story and a call site need the same treatment,
+  extract it and import it from both, the way
+  `NATIVE_IOS_BARE_ICON_BUTTON` and `VOICE_ASSISTANT_CAPTION_CLASS` are.
+- **No raw hex or off-scale sizes in story _styling_.** The token rules
+  apply to story files exactly as they do to product code. A `#17191C`
+  backdrop or a `text-[15px]` caption is the same defect in a story as in
+  the app, and harder to spot. Hex in sample _data_ is fine (an avatar
+  color the component receives as a prop) — the line is whether the value
+  styles the story or is the fixture.
+- **Pin a viewport when the component is responsive.** Components with
+  `max-md:` variants key off the *viewport*, so at a narrow window a
+  story silently renders the mobile treatment while still passing a
+  desktop variant. Set `globals: { viewport: { value: ... } }` on the
+  meta (viewport is built into Storybook core, no addon needed). Note
+  this holds the **Canvas** only: every story on a docs page shares one
+  iframe, so no per-story viewport applies in **Docs**, and that iframe
+  runs roughly 300px narrower than the browser window.
 
-Reference: [Storybook — Writing stories](https://storybook.js.org/docs/writing-stories)
+References:
+- [Storybook — Writing stories](https://storybook.js.org/docs/writing-stories)
+- [Storybook — Decorators](https://storybook.js.org/docs/writing-stories/decorators)
+- [Storybook — Viewport](https://storybook.js.org/docs/essentials/viewport)
 
 ---
 

--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -1410,7 +1410,7 @@ renders correctly given the data it actually receives in production.
   apply to story files exactly as they do to product code. A `#17191C`
   backdrop or a `text-[15px]` caption is the same defect in a story as in
   the app, and harder to spot. Hex in sample _data_ is fine (an avatar
-  color the component receives as a prop) — the line is whether the value
+  color the component receives as a prop): the line is whether the value
   styles the story or is the fixture.
 - **Pin a viewport when the component is responsive.** Components with
   `max-md:` variants key off the *viewport*, so at a narrow window a
@@ -1422,9 +1422,9 @@ renders correctly given the data it actually receives in production.
   runs roughly 300px narrower than the browser window.
 
 References:
-- [Storybook — Writing stories](https://storybook.js.org/docs/writing-stories)
-- [Storybook — Decorators](https://storybook.js.org/docs/writing-stories/decorators)
-- [Storybook — Viewport](https://storybook.js.org/docs/essentials/viewport)
+- [Storybook - Writing stories](https://storybook.js.org/docs/writing-stories)
+- [Storybook - Decorators](https://storybook.js.org/docs/writing-stories/decorators)
+- [Storybook - Viewport](https://storybook.js.org/docs/essentials/viewport)
 
 ---
 

--- a/clients/web/src/components/collapsible-nav-section.stories.tsx
+++ b/clients/web/src/components/collapsible-nav-section.stories.tsx
@@ -32,16 +32,31 @@ interface NavSectionStoryArgs {
 
 const meta: Meta<NavSectionStoryArgs> = {
   title: "Components/CollapsibleNavSection",
+  globals: {
+    viewport: { value: "sbDesktop", isRotated: false },
+  },
   parameters: {
     layout: "padded",
-    /* NOTE: section headers and rows carry `max-md:` variants for the mobile
-       drawer - 16px type, 46px rows instead of 14px/30px. Those key off the
-       *viewport*, and the Docs canvas iframe runs ~300px narrower than the
-       browser window, so on a window under roughly 1070px these stories render
-       the mobile drawer's metrics while still showing the `rail` variant - a
-       combination the app never ships. Pinning a viewport needs
-       `@storybook/addon-viewport`, which isn't installed; tracked in LUM-2921.
-       Until then, read these at a wide window. */
+    viewport: {
+      options: {
+        sbDesktop: {
+          name: "Desktop",
+          styles: { width: "1280px", height: "760px" },
+          type: "desktop",
+        },
+      },
+    },
+    /* Section headers and rows carry `max-md:` variants for the mobile drawer
+       (16px type, 46px rows instead of 14px/30px). Those key off the
+       *viewport*, so at a narrow browser window these stories would render the
+       mobile drawer's metrics while still showing the `rail` variant, a
+       combination the app never ships. The pinned viewport above holds the
+       Canvas at desktop width regardless of window size.
+
+       It does not reach the Docs canvas: every story on a docs page shares one
+       iframe, so no per-story viewport applies there, and that iframe runs
+       roughly 300px narrower than the window. Read these in Canvas, or widen
+       the window past ~1070px for Docs. Tracked in LUM-2921. */
   },
   argTypes: {
     label: { control: "text" },

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -70,6 +70,7 @@ import {
 } from "./voice-room-layout";
 import {
   splitTranscriptWords,
+  VOICE_ASSISTANT_CAPTION_CLASS,
   VoiceTranscriptText,
 } from "./voice-transcript-text";
 
@@ -168,7 +169,7 @@ export function VoiceAmbientTranscript() {
           <div
             data-testid="voice-ambient-assistant"
             aria-live="polite"
-            className="break-words text-[clamp(17px,2.5vmin,26px)] leading-relaxed"
+            className={VOICE_ASSISTANT_CAPTION_CLASS}
           >
             <VoiceTranscriptText
               text={assistantTranscript}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -176,9 +176,11 @@ function RoomScene({
     <div
       ref={ref}
       data-theme="dark"
+      /* No backdrop of its own: `VoiceRoomAmbientBackground` paints the room's
+         void gradient across `inset-0`, so anything set here would only ever
+         be a guess at one of its stops. */
       className="relative flex items-center justify-center overflow-hidden rounded-lg"
       style={{
-        background: "#05060b",
         minHeight,
         ["--avatar-accent" as string]: SAMPLE_ACCENT,
       }}
@@ -453,7 +455,7 @@ export const States: Story = {
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {VISUALS.map((visual) => (
         <div key={visual} className="flex flex-col gap-2">
-          <span className="text-[13px] font-medium text-white/60">
+          <span className="text-body-small-default text-[var(--content-tertiary)]">
             {visual}
           </span>
           <ColorLookScene
@@ -477,7 +479,7 @@ export const Colors: Story = {
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {COLOR_IDS.map((colorId) => (
         <div key={colorId} className="flex flex-col gap-2">
-          <span className="text-[13px] font-medium text-white/60">
+          <span className="text-body-small-default text-[var(--content-tertiary)]">
             {colorId}
           </span>
           <ColorLookScene {...args} colorId={colorId} minHeight={300} />
@@ -502,7 +504,7 @@ export const RespondingSketches: Story = {
       {(["rings", "halo", "waveform", "pulse"] as const).map(
         (respondingStyle) => (
           <div key={respondingStyle} className="flex flex-col gap-2">
-            <span className="text-[13px] font-medium text-white/60">
+            <span className="text-body-small-default text-[var(--content-tertiary)]">
               {respondingStyle}
             </span>
             <ColorLookScene
@@ -574,7 +576,7 @@ export const VoidLookStates: VoidStory = {
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {VISUALS.map((visual) => (
         <div key={visual} className="flex flex-col gap-2">
-          <span className="text-[13px] font-medium text-white/60">
+          <span className="text-body-small-default text-[var(--content-tertiary)]">
             {visual}
           </span>
           {/* Tall enough that the lower zone's caption clears the avatar in a

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -31,6 +31,20 @@ import { Fragment, useMemo } from "react";
 import { motion, useReducedMotion } from "motion/react";
 
 /**
+ * Type treatment for the assistant half of the room's caption: the fluid size
+ * ramp and the line height its word reveal is tuned against. Lives here rather
+ * than at the call site so the room and its stories render the caption at one
+ * scale, and a story cannot document a size the app never shows. Mirrors the
+ * `NATIVE_IOS_BARE_ICON_BUTTON` pattern in `domains/chat/utils/`.
+ *
+ * Pair it with `VOICE_ROOM_TEXT_MEASURE` and left alignment: the reveal adds a
+ * word at a time, and centered text re-centers its last line on every arrival,
+ * so the words already on screen would shift sideways as speech streams in.
+ */
+export const VOICE_ASSISTANT_CAPTION_CLASS =
+  "break-words text-[clamp(17px,2.5vmin,26px)] leading-relaxed";
+
+/**
  * The exact word segmentation the component renders (whitespace runs collapse,
  * empty tokens drop). Exported so the spoken-word cursor maps audio progress
  * onto the same words the render uses.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
@@ -13,7 +13,11 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { toneForBg } from "@/utils/avatar-tone";
 
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
-import { VoiceTranscriptText } from "./voice-transcript-text";
+import { VOICE_ROOM_TEXT_MEASURE } from "./voice-room-layout";
+import {
+  VOICE_ASSISTANT_CAPTION_CLASS,
+  VoiceTranscriptText,
+} from "./voice-transcript-text";
 
 /**
  * Iteration harness for the voice room's live captions — the room's two text
@@ -243,17 +247,29 @@ export const SpokenWordHighlight: Story = {
   ),
 };
 
-/** Neutral dark surface for the isolated caption scenes (no room plumbing). */
+/**
+ * The room's assistant caption, minus the room plumbing (no avatar tone, no
+ * zone positioning, no motion) so a scene can isolate the reveal itself.
+ *
+ * Everything that governs how the caption *looks* still comes from the shipped
+ * source: `VOICE_ASSISTANT_CAPTION_CLASS` for the type ramp,
+ * `VOICE_ROOM_TEXT_MEASURE` for the column, `--surface-base` for the dark
+ * backdrop, and left alignment because the word reveal is tuned for it. With no
+ * `--room-fg` set, `VoiceTranscriptText` falls back to the theme content
+ * tokens, which is a real code path (an avatar with no tone).
+ */
 function CaptionSurface({ children }: { children: ReactNode }) {
   return (
     <div
       data-theme="dark"
-      className="flex min-h-[240px] items-center justify-center rounded-lg p-10"
-      style={{ backgroundColor: "#17191C" }}
+      className="flex min-h-[240px] items-center justify-center rounded-lg bg-[var(--surface-base)] p-10"
     >
-      <p className="max-w-[36rem] text-center text-[15px] leading-relaxed text-balance">
+      <div
+        className={`w-full ${VOICE_ASSISTANT_CAPTION_CLASS}`}
+        style={{ maxWidth: VOICE_ROOM_TEXT_MEASURE }}
+      >
         {children}
-      </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## TL;DR

First pass on [LUM-2921](https://linear.app/vellum/issue/LUM-2921/storybook-stories-must-render-real-components-not-story-local): three stories that drew their own version of the thing they document, plus the written rule that would have caught all of them.

## What was wrong

| Story | Drew its own | Now |
|---|---|---|
| `voice-transcript` | `#17191C` backdrop, 15px centered text | `--surface-base`, the room's ramp + measure, left-aligned |
| `voice-avatar` | `#05060b` frame, `text-[13px] text-white/60` labels | No backdrop (the real component paints it), labels on the type scale |
| `collapsible-nav-section` | Mobile metrics at a narrow window | Pinned desktop viewport |

**`voice-transcript`** is the clearest case. `CaptionSurface` sized the caption at 15px where the room ramps `clamp(17px, 2.5vmin, 26px)`, and centered it. Centering is not a cosmetic difference here: the reveal adds a word at a time, and centered text re-centers its last line on every arrival, so words already on screen shift sideways as speech streams in. The story was documenting a treatment the component is specifically built to avoid.

**`voice-avatar`** painted `#05060b` on the scene frame, underneath `VoiceRoomAmbientBackground`, which already covers `inset-0` with the void gradient. The hex was a guess at one of that gradient's stops (`rgb(5,6,11)` at 46%). Deleting it changes nothing visually and removes the duplicate.

## The missing primitive

The caption's type ramp lived only at the room's call site, so the story had no way to match it except by copying. It moves into `VOICE_ASSISTANT_CAPTION_CLASS`, next to the component it styles, and the room imports it. Same shape as the existing `NATIVE_IOS_BARE_ICON_BUTTON` extraction (#39520).

## Viewport

The `max-md:` variants on the sidebar key off the *viewport*, so at a narrow window a story rendered the mobile drawer's 16px/46px metrics while still passing `variant="rail"` - a pairing the app never ships. `globals: { viewport: ... }` pins the Canvas at desktop width.

Correcting something I wrote on the previous PR: I claimed this needed `@storybook/addon-viewport` and was inert without it. Both wrong. Viewport is built into Storybook core, and the pin works - my test drove a raw `iframe.html` URL, which bypasses the manager where the addon resizes the frame. Measured properly: at a 900px window, Canvas reports `innerWidth: 1280` and 14px headers.

It does **not** reach Docs: every story on a docs page shares one iframe, so no per-story viewport applies there. That limitation is documented on the story and stays on the ticket.

## Why this is safe

- **One production file changes**, `voice-ambient-transcript.tsx`, and only to import the class string it previously spelled inline. Byte-identical output.
- Everything else is story files and a doc.
- 87 tests across the voice-room and nav-section suites pass; typecheck and lint clean.
- Both stories re-rendered and compared: the caption backdrop resolves to the same `#17191C` the hex hardcoded, and the avatar void gradient is unchanged.

## Not in this PR

- **`collapsible.stories.tsx`**, which the ticket listed. On inspection it is not a defect: `Collapsible` ships headless by design ("structural layout and slide animation; trigger styling is the consumer's responsibility"), and it lives in `packages/design-library`, which cannot import the app's `CollapsibleNavSection`. Its dressing is already fully tokenized - no raw hex, no off-scale sizes. Ticket updated with the reasoning.
- **The lint guard.** Scoping it revealed that blunt syntax bans misfire: hex in *sample data* (an avatar color passed as a prop) and `text-[13px]` on *story furniture* are both legitimate. The honest version is a custom rule matching the real signal - a story-local component declaration whose JSX carries row chrome - in the shape of the existing `eslint-rules/no-cross-domain-imports.mjs`. Left on the ticket rather than shipping a rule that needs suppressions on day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->