### PR TITLE
feat(docs): port releases section with public API fetch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -127,6 +127,8 @@
         "next": "16.2.6",
         "react": "19.2.6",
         "react-dom": "19.2.6",
+        "react-markdown": "10.1.0",
+        "remark-gfm": "4.0.1",
         "tailwind-merge": "3.6.0",
       },
       "devDependencies": {

--- a/clients/docs/package.json
+++ b/clients/docs/package.json
@@ -18,6 +18,8 @@
     "next": "16.2.6",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "react-markdown": "10.1.0",
+    "remark-gfm": "4.0.1",
     "tailwind-merge": "3.6.0"
   },
   "devDependencies": {

--- a/clients/docs/src/app/docs/(releases)/layout.tsx
+++ b/clients/docs/src/app/docs/(releases)/layout.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { type ReactNode } from "react";
+
+import { ReleasesNav } from "@/app/docs/_components/releases-nav";
+import { WWW_DOMAIN } from "@/lib/domains";
+import { fetchReleases } from "@/lib/releases-server";
+
+import "@/app/docs/docs-theme.css";
+
+export const metadata: Metadata = {
+  description:
+    "Release notes for Vellum. See what's new, what changed, and what's coming.",
+};
+
+interface ReleasesLayoutProps {
+  children: ReactNode;
+}
+
+export default async function ReleasesLayout({
+  children,
+}: ReleasesLayoutProps) {
+  const releases = await fetchReleases();
+
+  return (
+    <div className="docs-shell min-h-screen">
+      <header className="docs-header sticky top-0 z-20 border-b backdrop-blur">
+        {/* Top row in centered band */}
+        <div className="mx-auto max-w-[1280px]">
+          <div className="flex h-14 items-center">
+            <div className="docs-brand-area flex h-full items-center gap-2 px-4 md:w-64 md:shrink-0 md:px-6">
+              <Link
+                href="/docs"
+                className="docs-nav-title flex items-center gap-2 font-['DM_Sans',sans-serif] text-lg font-bold no-underline"
+              >
+                Vellum
+              </Link>
+            </div>
+          </div>
+        </div>
+        {/* Section nav band: border-t spans full viewport, content centered */}
+        <div className="docs-header-tabs hidden border-t md:block">
+          <div className="mx-auto max-w-[1280px]">
+            <div className="flex h-11 items-center">
+              <div className="md:w-64 md:shrink-0" />
+              <div className="flex h-full flex-1 items-center gap-6 px-4 md:pl-8 md:pr-4">
+                <Link
+                  href="/docs"
+                  className="docs-header-link text-sm font-medium no-underline"
+                >
+                  Docs
+                </Link>
+                <Link
+                  href="/docs/releases"
+                  className="docs-header-link docs-header-link-active text-sm font-medium no-underline"
+                >
+                  Releases
+                </Link>
+                <a
+                  href={`https://${WWW_DOMAIN}/skills`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="docs-header-link text-sm font-medium no-underline"
+                >
+                  Skills
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+      <div className="docs-layout mx-auto flex max-w-[1280px] min-h-[calc(100vh-57px)] md:min-h-[calc(100vh-101px)]">
+        <ReleasesNav releases={releases} />
+        <div className="docs-content-area min-w-0 flex-1">
+          <div className="flex items-start gap-6 px-4 py-6 md:px-10 md:py-10">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/docs/src/app/docs/(releases)/releases/page.tsx
+++ b/clients/docs/src/app/docs/(releases)/releases/page.tsx
@@ -1,0 +1,17 @@
+import { ReleasesContent } from "@/app/docs/_components/releases-content";
+import { createMetadata } from "@/lib/metadata";
+import { fetchReleases } from "@/lib/releases-server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = createMetadata({
+  title: "Releases - Vellum Docs",
+  description:
+    "Vellum release notes, versioning, update channels, and how to stay up to date with the latest features and fixes.",
+  path: "/docs/releases",
+});
+
+export default async function ReleasesPage() {
+  const releases = await fetchReleases();
+  return <ReleasesContent releases={releases} />;
+}

--- a/clients/docs/src/app/docs/_components/release-markdown.tsx
+++ b/clients/docs/src/app/docs/_components/release-markdown.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 

--- a/clients/docs/src/app/docs/_components/release-markdown.tsx
+++ b/clients/docs/src/app/docs/_components/release-markdown.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface ReleaseMarkdownProps {
+  content: string;
+}
+
+export function ReleaseMarkdown({ content }: ReleaseMarkdownProps) {
+  return (
+    <div className="[&_h3]:mt-6 [&_h3]:mb-3 [&_h3]:text-xl [&_h3]:font-semibold [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:my-3 [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:my-3 [&_li]:mb-1.5 [&_li]:leading-relaxed [&_p]:mb-3 [&_code]:rounded [&_code]:bg-zinc-100 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-sm dark:[&_code]:bg-zinc-800">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  );
+}

--- a/clients/docs/src/app/docs/_components/releases-content.tsx
+++ b/clients/docs/src/app/docs/_components/releases-content.tsx
@@ -114,7 +114,7 @@ export function ReleasesContent({ releases }: ReleasesContentProps) {
                     className="rounded-xl border border-zinc-200 p-5 md:p-6 scroll-mt-24"
                   >
                     <div className="mb-4 flex items-center justify-between gap-3">
-                      <h3 className="text-base font-bold text-zinc-900">
+                      <h3 className="text-base font-bold">
                         <a
                           href={`#${releaseAnchor(release)}`}
                           className="no-underline text-inherit hover:underline"

--- a/clients/docs/src/app/docs/_components/releases-content.tsx
+++ b/clients/docs/src/app/docs/_components/releases-content.tsx
@@ -1,12 +1,8 @@
 import { ReleaseMarkdown } from "@/app/docs/_components/release-markdown";
 import { WWW_DOMAIN } from "@/lib/domains";
 import type { ApiRelease } from "@/lib/releases-server";
-import { groupApiReleasesByMonth } from "@/lib/releases-server";
+import { groupApiReleasesByMonth, releaseAnchor } from "@/lib/releases-server";
 import { routes } from "@/lib/routes";
-
-function releaseAnchor(release: ApiRelease) {
-  return `v${release.version}`;
-}
 
 function monthAnchor(releasedAt: string) {
   const d = new Date(releasedAt);

--- a/clients/docs/src/app/docs/_components/releases-content.tsx
+++ b/clients/docs/src/app/docs/_components/releases-content.tsx
@@ -1,0 +1,167 @@
+import { ReleaseMarkdown } from "@/app/docs/_components/release-markdown";
+import { WWW_DOMAIN } from "@/lib/domains";
+import type { ApiRelease } from "@/lib/releases-server";
+import { groupApiReleasesByMonth } from "@/lib/releases-server";
+import { routes } from "@/lib/routes";
+
+function releaseAnchor(release: ApiRelease) {
+  return `v${release.version}`;
+}
+
+function monthAnchor(releasedAt: string) {
+  const d = new Date(releasedAt);
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  return `release-${year}-${month}`;
+}
+
+function formatFullDate(releasedAt: string) {
+  const d = new Date(releasedAt);
+  return d.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function getMonthYear(releasedAt: string) {
+  const d = new Date(releasedAt);
+  return d.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+interface ReleasesContentProps {
+  releases: ApiRelease[];
+}
+
+export function ReleasesContent({ releases }: ReleasesContentProps) {
+  const groups = groupApiReleasesByMonth(releases);
+  const firstRelease = groups[0]?.releases[0];
+  const pageTitle = firstRelease
+    ? getMonthYear(firstRelease.released_at)
+    : "Releases";
+
+  return (
+    <div className="docs-main min-w-0 flex-1">
+      <div className="docs-breadcrumb mb-2 text-sm">Docs / Releases</div>
+      <div className="docs-title-row mt-2 mb-8 flex items-start justify-between gap-6">
+        <h1 className="docs-title font-['DM_Sans',sans-serif] text-4xl font-bold tracking-tight md:text-5xl">
+          {pageTitle}
+        </h1>
+        <a
+          href={routes.signup}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-900 no-underline transition-colors hover:border-zinc-300 hover:bg-zinc-50"
+          aria-label="Sign up for Vellum Cloud"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14" />
+            <polyline points="12 5 19 12 12 19" />
+          </svg>
+          Get started
+        </a>
+      </div>
+
+      <a
+        href={`https://${WWW_DOMAIN}/roadmap`}
+        className="group mb-10 flex items-center justify-between gap-4 rounded-xl border border-zinc-200 bg-white p-5 no-underline transition-colors hover:border-zinc-300 hover:bg-zinc-50"
+      >
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-semibold text-zinc-900">
+            Looking for what&apos;s coming next?
+          </span>
+          <span className="text-sm text-zinc-600">
+            See the roadmap. Shipping soon, up next, and what we&apos;re exploring.
+          </span>
+        </div>
+        <span
+          className="shrink-0 text-lg text-zinc-400 transition-transform group-hover:translate-x-0.5"
+          aria-hidden="true"
+        >
+          &rarr;
+        </span>
+      </a>
+
+      <div className="docs-prose space-y-12">
+        {groups.map((group) => {
+          const firstReleasedAt = group.releases[0]?.released_at;
+          if (!firstReleasedAt) {return null;}
+          return (
+            <div
+              key={group.month}
+              id={monthAnchor(firstReleasedAt)}
+              className="scroll-mt-24"
+            >
+              <div className="space-y-8">
+                {group.releases.map((release) => (
+                  <article
+                    key={release.version}
+                    id={releaseAnchor(release)}
+                    className="rounded-xl border border-zinc-200 p-5 md:p-6 scroll-mt-24"
+                  >
+                    <div className="mb-4 flex items-center justify-between gap-3">
+                      <h3 className="text-base font-bold text-zinc-900">
+                        <a
+                          href={`#${releaseAnchor(release)}`}
+                          className="no-underline text-inherit hover:underline"
+                        >
+                          v{release.version}
+                        </a>
+                      </h3>
+                      <div className="flex items-center gap-2.5 shrink-0">
+                        <time
+                          dateTime={release.released_at}
+                          className="text-xs text-zinc-400"
+                        >
+                          {formatFullDate(release.released_at)}
+                        </time>
+                        <a
+                          href={`https://github.com/vellum-ai/vellum-assistant/releases/tag/v${release.version}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`View v${release.version} on GitHub`}
+                          className="inline-flex items-center justify-center rounded-md p-1 text-zinc-400 no-underline transition-colors hover:text-zinc-600 hover:bg-zinc-100"
+                        >
+                          <svg
+                            width="15"
+                            height="15"
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            aria-hidden="true"
+                          >
+                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                          </svg>
+                        </a>
+                      </div>
+                    </div>
+                    {release.description ? (
+                      <ReleaseMarkdown content={release.description} />
+                    ) : (
+                      <p className="text-sm text-zinc-500">
+                        No release notes available.
+                      </p>
+                    )}
+                  </article>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/clients/docs/src/app/docs/_components/releases-nav.tsx
+++ b/clients/docs/src/app/docs/_components/releases-nav.tsx
@@ -4,11 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { ApiRelease } from "@/lib/releases-server";
-import { groupApiReleasesByMonth } from "@/lib/releases-server";
-
-function releaseAnchor(release: ApiRelease) {
-  return `v${release.version}`;
-}
+import { groupApiReleasesByMonth, releaseAnchor } from "@/lib/releases-server";
 
 function getCurrentMonth() {
   const now = new Date();

--- a/clients/docs/src/app/docs/_components/releases-nav.tsx
+++ b/clients/docs/src/app/docs/_components/releases-nav.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { ApiRelease } from "@/lib/releases-server";
+import { groupApiReleasesByMonth } from "@/lib/releases-server";
+
+function releaseAnchor(release: ApiRelease) {
+  return `v${release.version}`;
+}
+
+function getCurrentMonth() {
+  const now = new Date();
+  return now.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function ChevronRightIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={`shrink-0 transition-transform duration-200 ${
+        expanded ? "rotate-90" : ""
+      }`}
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+interface ReleasesNavProps {
+  releases: ApiRelease[];
+}
+
+/**
+ * Sticky sidebar listing releases grouped by month, with scroll-tracked
+ * highlighting via an IntersectionObserver. Desktop-only; small viewports
+ * navigate the releases list through in-page anchors.
+ */
+export function ReleasesNav({ releases }: ReleasesNavProps) {
+  const groups = groupApiReleasesByMonth(releases);
+  const [activeId, setActiveId] = useState<string>("");
+
+  const [expandedMonths, setExpandedMonths] = useState<Set<string>>(() => {
+    const currentMonth = getCurrentMonth();
+    const hasCurrentMonth = groups.some((g) => g.month === currentMonth);
+    const initial = hasCurrentMonth ? currentMonth : groups[0]?.month;
+    return initial ? new Set([initial]) : new Set();
+  });
+
+  const toggleMonth = useCallback((month: string) => {
+    setExpandedMonths((prev) => {
+      const next = new Set(prev);
+      if (next.has(month)) {
+        next.delete(month);
+      } else {
+        next.add(month);
+      }
+      return next;
+    });
+  }, []);
+
+  const releaseToMonth = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const group of groups) {
+      for (const release of group.releases) {
+        map.set(releaseAnchor(release), group.month);
+      }
+    }
+    return map;
+  }, [groups]);
+
+  useEffect(() => {
+    const ids = groups.flatMap((g) => g.releases.map(releaseAnchor));
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const id = entry.target.id;
+            setActiveId(id);
+            const month = releaseToMonth.get(id);
+            if (month) {
+              setExpandedMonths((prev) => {
+                if (prev.has(month)) {
+                  return prev;
+                }
+                const next = new Set(prev);
+                next.add(month);
+                return next;
+              });
+            }
+          }
+        }
+      },
+      { rootMargin: "-80px 0px -60% 0px", threshold: 0 },
+    );
+
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (el) {
+        observer.observe(el);
+      }
+    }
+
+    return () => observer.disconnect();
+  }, [groups, releaseToMonth]);
+
+  return (
+    <nav className="docs-nav-panel hidden border-r md:sticky md:top-[101px] md:block md:h-[calc(100vh-101px)] md:w-64 md:shrink-0 md:self-start md:overflow-y-auto md:pb-8">
+      <div className="px-4 pb-4 pt-4 md:pt-8">
+        <div className="mb-5">
+          <Link
+            href="/docs/releases"
+            className="docs-nav-title font-['DM_Sans',sans-serif] text-lg font-bold no-underline"
+          >
+            Releases
+          </Link>
+        </div>
+        <ul className="list-none space-y-1 p-0 m-0">
+          {groups.map((group) => {
+            const isExpanded = expandedMonths.has(group.month);
+            return (
+              <li key={group.month} className="m-0 p-0">
+                <button
+                  type="button"
+                  onClick={() => toggleMonth(group.month)}
+                  className="docs-nav-section-label flex w-full items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-bold tracking-normal normal-case text-left transition-colors hover:bg-[var(--docs-surface)] cursor-pointer"
+                >
+                  <ChevronRightIcon expanded={isExpanded} />
+                  {group.month}
+                </button>
+                <div
+                  className="grid transition-[grid-template-rows] duration-200 ease-out"
+                  style={{
+                    gridTemplateRows: isExpanded ? "1fr" : "0fr",
+                  }}
+                >
+                  <div className="overflow-hidden">
+                    <ul className="list-none space-y-0.5 p-0 m-0 pt-0.5">
+                      {group.releases.map((release) => {
+                        const anchor = releaseAnchor(release);
+                        const isActive = activeId === anchor;
+                        return (
+                          <li key={release.version} className="m-0 p-0">
+                            <a
+                              href={`#${anchor}`}
+                              className={`flex items-center justify-between rounded-lg py-2 pl-7 pr-3 text-sm no-underline transition-colors ${
+                                isActive
+                                  ? "docs-nav-link-active font-medium"
+                                  : "docs-nav-link-inactive"
+                              }`}
+                            >
+                              <span>v{release.version}</span>
+                            </a>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/clients/docs/src/lib/releases-server.test.ts
+++ b/clients/docs/src/lib/releases-server.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type ApiRelease,
+  groupApiReleasesByMonth,
+  hasRealNotes,
+} from "./releases-server";
+
+function makeRelease(overrides: Partial<ApiRelease> = {}): ApiRelease {
+  return {
+    version: "0.10.0",
+    released_at: "2026-07-01T12:00:00Z",
+    is_stable: true,
+    description: "Fixed a bug",
+    url: null,
+    ...overrides,
+  };
+}
+
+describe("hasRealNotes", () => {
+  test("returns false for a null description", () => {
+    expect(hasRealNotes(makeRelease({ description: null }))).toBe(false);
+  });
+
+  test("returns false for an empty description", () => {
+    expect(hasRealNotes(makeRelease({ description: "" }))).toBe(false);
+  });
+
+  test("returns false for whitespace-only descriptions", () => {
+    expect(hasRealNotes(makeRelease({ description: "  \n\n  " }))).toBe(false);
+  });
+
+  test("returns false when only build metadata lines are present", () => {
+    const description = [
+      "**Build:** `0.8.10`",
+      "**Commit:** `abc123`",
+      "**Built at:** 2026-07-01T12:00:00Z",
+    ].join("\n");
+    expect(hasRealNotes(makeRelease({ description }))).toBe(false);
+  });
+
+  test("strips metadata lines with markdown list prefixes", () => {
+    const description = [
+      "- **Build:** `0.8.10`",
+      "* **Commit:** `abc123`",
+      "> **Built at:** 2026-07-01",
+    ].join("\n");
+    expect(hasRealNotes(makeRelease({ description }))).toBe(false);
+  });
+
+  test("returns true when real notes accompany build metadata", () => {
+    const description = [
+      "### Highlights",
+      "- Fixed the thing",
+      "**Build:** `0.8.10`",
+      "**Commit:** `abc123`",
+    ].join("\n");
+    expect(hasRealNotes(makeRelease({ description }))).toBe(true);
+  });
+
+  test("returns true for plain human-written notes", () => {
+    expect(
+      hasRealNotes(makeRelease({ description: "Adds dark mode support." })),
+    ).toBe(true);
+  });
+});
+
+describe("groupApiReleasesByMonth", () => {
+  test("groups releases by UTC month preserving order", () => {
+    const releases = [
+      makeRelease({ version: "0.10.2", released_at: "2026-07-20T00:00:00Z" }),
+      makeRelease({ version: "0.10.1", released_at: "2026-07-05T00:00:00Z" }),
+      makeRelease({ version: "0.10.0", released_at: "2026-06-28T00:00:00Z" }),
+    ];
+    const groups = groupApiReleasesByMonth(releases);
+    expect(groups.map((g) => g.month)).toEqual(["July 2026", "June 2026"]);
+    expect(groups[0]?.releases.map((r) => r.version)).toEqual([
+      "0.10.2",
+      "0.10.1",
+    ]);
+    expect(groups[1]?.releases.map((r) => r.version)).toEqual(["0.10.0"]);
+  });
+
+  test("returns an empty list for no releases", () => {
+    expect(groupApiReleasesByMonth([])).toEqual([]);
+  });
+});

--- a/clients/docs/src/lib/releases-server.test.ts
+++ b/clients/docs/src/lib/releases-server.test.ts
@@ -63,6 +63,15 @@ describe("hasRealNotes", () => {
       hasRealNotes(makeRelease({ description: "Adds dark mode support." })),
     ).toBe(true);
   });
+
+  test("keeps notes that begin with a metadata word but lack the colon", () => {
+    expect(
+      hasRealNotes(makeRelease({ description: "Build performance improved." })),
+    ).toBe(true);
+    expect(
+      hasRealNotes(makeRelease({ description: "Commit signing is enforced." })),
+    ).toBe(true);
+  });
 });
 
 describe("groupApiReleasesByMonth", () => {

--- a/clients/docs/src/lib/releases-server.test.ts
+++ b/clients/docs/src/lib/releases-server.test.ts
@@ -72,6 +72,17 @@ describe("hasRealNotes", () => {
       hasRealNotes(makeRelease({ description: "Commit signing is enforced." })),
     ).toBe(true);
   });
+
+  test("keeps colon-prefixed human notes without backticked values", () => {
+    expect(
+      hasRealNotes(
+        makeRelease({ description: "**Build:** Improved startup performance" }),
+      ),
+    ).toBe(true);
+    expect(
+      hasRealNotes(makeRelease({ description: "Commit: enforce signing" })),
+    ).toBe(true);
+  });
 });
 
 describe("groupApiReleasesByMonth", () => {

--- a/clients/docs/src/lib/releases-server.ts
+++ b/clients/docs/src/lib/releases-server.ts
@@ -1,0 +1,87 @@
+import { cache } from "react";
+
+export interface ApiRelease {
+  version: string;
+  released_at: string;
+  is_stable: boolean;
+  description: string | null;
+  url: string | null;
+}
+
+/**
+ * Resolves where release data is fetched from. Defaults to the public API;
+ * RELEASES_API_URL overrides explicitly, and DJANGO_INTERNAL_URL supports
+ * in-cluster fetch against the backend service directly.
+ */
+function getReleasesBaseUrl(): string {
+  return (
+    process.env.RELEASES_API_URL ||
+    process.env.DJANGO_INTERNAL_URL ||
+    "https://www.vellum.ai"
+  );
+}
+
+// Some releases are published with auto-generated build metadata only
+// (e.g. "**Build:** `0.8.10` **Commit:** `abc123` **Built at:** ...").
+// Those have no human-written notes and should not appear on the page.
+export function hasRealNotes(release: ApiRelease): boolean {
+  if (!release.description) {return false;}
+  const stripped = release.description
+    .split("\n")
+    .filter(
+      (line) =>
+        !/^\s*[*_#>\-\s]*(\*\*)?\s*(build|commit|built at)\s*:?(\*\*)?/i.test(
+          line,
+        ),
+    )
+    .join("\n")
+    .trim();
+  return stripped.length > 0;
+}
+
+export const fetchReleases = cache(async (): Promise<ApiRelease[]> => {
+  const baseUrl = getReleasesBaseUrl();
+  const url = `${baseUrl}/v1/releases/?stable=true&limit=100`;
+  try {
+    const res = await fetch(url, {
+      // When targeting an internal service URL, the request bypasses the load
+      // balancer that terminates TLS and normally adds this header. Setting it
+      // manually keeps the backend from redirecting insecure requests.
+      headers: { "X-Forwarded-Proto": "https" },
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) {
+      console.error(
+        `[releases] fetch failed: ${res.status} ${res.statusText}`,
+        { url },
+      );
+      return [];
+    }
+    const releases: ApiRelease[] = await res.json();
+    return releases.filter(hasRealNotes);
+  } catch (err) {
+    console.error("[releases] fetch error", { url, error: String(err) });
+    return [];
+  }
+});
+
+export function groupApiReleasesByMonth(releases: ApiRelease[]) {
+  const groups: { month: string; releases: ApiRelease[] }[] = [];
+  const monthMap = new Map<string, ApiRelease[]>();
+
+  for (const release of releases) {
+    const d = new Date(release.released_at);
+    const label = d.toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+    if (!monthMap.has(label)) {
+      monthMap.set(label, []);
+      groups.push({ month: label, releases: monthMap.get(label)! });
+    }
+    monthMap.get(label)!.push(release);
+  }
+
+  return groups;
+}

--- a/clients/docs/src/lib/releases-server.ts
+++ b/clients/docs/src/lib/releases-server.ts
@@ -30,9 +30,7 @@ export function hasRealNotes(release: ApiRelease): boolean {
     .split("\n")
     .filter(
       (line) =>
-        !/^\s*[*_#>\-\s]*(\*\*)?\s*(build|commit|built at)\s*:?(\*\*)?/i.test(
-          line,
-        ),
+        !/^\s*[*_#>\-\s]*(\*\*)?\s*(build|commit|built at)\s*:/i.test(line),
     )
     .join("\n")
     .trim();

--- a/clients/docs/src/lib/releases-server.ts
+++ b/clients/docs/src/lib/releases-server.ts
@@ -21,16 +21,27 @@ function getReleasesBaseUrl(): string {
   );
 }
 
+// Shared by the releases sidebar and article list so link hrefs and element
+// ids never diverge.
+export function releaseAnchor(release: ApiRelease): string {
+  return `v${release.version}`;
+}
+
 // Some releases are published with auto-generated build metadata only
 // (e.g. "**Build:** `0.8.10` **Commit:** `abc123` **Built at:** ...").
-// Those have no human-written notes and should not appear on the page.
+// Metadata "Build:"/"Commit:" values are backtick-wrapped and "Built at:"
+// lines are always machine-stamped, so those are stripped; human notes that
+// merely start with the same word ("Build performance improved", "Commit:
+// enforce signing everywhere") are kept.
 export function hasRealNotes(release: ApiRelease): boolean {
   if (!release.description) {return false;}
   const stripped = release.description
     .split("\n")
     .filter(
       (line) =>
-        !/^\s*[*_#>\-\s]*(\*\*)?\s*(build|commit|built at)\s*:/i.test(line),
+        !/^\s*[*_#>\-\s]*(\*\*)?\s*(built at\s*:|(build|commit)\s*:(\*\*)?\s*(`|$))/i.test(
+          line,
+        ),
     )
     .join("\n")
     .trim();

--- a/clients/docs/src/lib/releases-server.ts
+++ b/clients/docs/src/lib/releases-server.ts
@@ -47,6 +47,10 @@ export const fetchReleases = cache(async (): Promise<ApiRelease[]> => {
       // manually keeps the backend from redirecting insecure requests.
       headers: { "X-Forwarded-Proto": "https" },
       next: { revalidate: 60 },
+      // Bound the request so a stalled upstream hits the empty-list fallback
+      // instead of holding the dynamic releases render for the runtime's
+      // default network timeout.
+      signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
       console.error(


### PR DESCRIPTION
## Summary
- Port releases-server (public API fetch by default, RELEASES_API_URL / DJANGO_INTERNAL_URL overrides, fail-soft empty list)
- Port the (releases) route group with force-dynamic rendering and revalidate-60 fetch
- Port releases components with react-markdown + remark-gfm

Part of plan: docs-app-phase-1.md (PR 8 of 15)