### PR TITLE
feat(cli): add `assistant platform invoices list` and `assistant platform invoices get`

### DIFF
--- a/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
@@ -133,11 +133,11 @@ describe("assistant platform invoices list", () => {
 
     expect(text).toContain("INV-0001");
     expect(text).toContain("Status:  paid");
-    expect(text).toContain("Amount:  $12.34 USD");
+    expect(text).toContain("Amount:  USD 12.34");
     expect(text).toContain("https://pay.example.com/in_a");
     // Invoice with a null number falls back to its id.
     expect(text).toContain("in_b");
-    expect(text).toContain("Amount:  $56.00 USD");
+    expect(text).toContain("Amount:  USD 56.00");
     // Not JSON output.
     expect(() => JSON.parse(text.trim())).toThrow();
   });
@@ -194,8 +194,41 @@ describe("assistant platform invoices get", () => {
 
     expect(text).toContain("INV-0001");
     expect(text).toContain("Status:  paid");
-    expect(text).toContain("Amount:  $12.34 USD");
+    expect(text).toContain("Amount:  USD 12.34");
     expect(text).toContain("PDF:     https://pay.example.com/in_a.pdf");
+  });
+
+  test("plain text mode scales zero-decimal currencies without dividing by 100", async () => {
+    mockResponse = {
+      ok: true,
+      result: { ...invoiceA, currency: "jpy", amount_due: 1200 },
+    };
+
+    const out = await runInvoices(["get", "in_a"]);
+
+    expect(out.join("")).toContain("Amount:  JPY 1,200");
+  });
+
+  test("plain text mode uses three decimals for three-decimal currencies", async () => {
+    mockResponse = {
+      ok: true,
+      result: { ...invoiceA, currency: "bhd", amount_due: 12345 },
+    };
+
+    const out = await runInvoices(["get", "in_a"]);
+
+    expect(out.join("")).toContain("Amount:  BHD 12.345");
+  });
+
+  test("plain text mode falls back to raw minor units for invalid currency codes", async () => {
+    mockResponse = {
+      ok: true,
+      result: { ...invoiceA, currency: "zz", amount_due: 1234 },
+    };
+
+    const out = await runInvoices(["get", "in_a"]);
+
+    expect(out.join("")).toContain("Amount:  1234 ZZ (minor units)");
   });
 });
 

--- a/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
@@ -220,6 +220,17 @@ describe("assistant platform invoices get", () => {
     expect(out.join("")).toContain("Amount:  BHD 12.345");
   });
 
+  test("plain text mode keeps Stripe's two-decimal scaling for ISK despite ISO zero-decimal metadata", async () => {
+    mockResponse = {
+      ok: true,
+      result: { ...invoiceA, currency: "isk", amount_due: 500 },
+    };
+
+    const out = await runInvoices(["get", "in_a"]);
+
+    expect(out.join("")).toContain("Amount:  ISK 5.00");
+  });
+
   test("plain text mode falls back to raw minor units for invalid currency codes", async () => {
     mockResponse = {
       ok: true,

--- a/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const invoiceA = {
+  id: "in_a",
+  number: "INV-0001",
+  status: "paid",
+  currency: "usd",
+  amount_due: 1234,
+  amount_paid: 1234,
+  amount_remaining: 0,
+  created: 1750000000,
+  hosted_invoice_url: "https://pay.example.com/in_a",
+  invoice_pdf: "https://pay.example.com/in_a.pdf",
+};
+
+const invoiceB = {
+  id: "in_b",
+  number: null,
+  status: "open",
+  currency: "usd",
+  amount_due: 5600,
+  amount_paid: 0,
+  amount_remaining: 5600,
+  created: 1747000000,
+  hosted_invoice_url: null,
+  invoice_pdf: null,
+};
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockCalls: Array<[string, Record<string, unknown>]> = [];
+let mockResponse: unknown = {
+  ok: true,
+  result: { invoices: [invoiceA, invoiceB], has_more: false },
+};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
+    mockCalls.push([method, params]);
+    return mockResponse;
+  },
+  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
+    throw new Error("exitFromIpcResult called");
+  },
+}));
+
+const { registerPlatformCommand } = await import("../index.js");
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerPlatformCommand(program);
+  return program;
+}
+
+function captureStdout(fn: () => Promise<void>): Promise<string[]> {
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown) => {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  return fn()
+    .then(() => chunks)
+    .finally(() => {
+      process.stdout.write = origWrite;
+    });
+}
+
+async function runInvoices(args: string[]): Promise<string[]> {
+  return captureStdout(async () => {
+    const program = buildProgram();
+    await program.parseAsync([
+      "node",
+      "assistant",
+      "platform",
+      "invoices",
+      ...args,
+    ]);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant platform invoices list", () => {
+  beforeEach(() => {
+    mockCalls = [];
+    mockResponse = {
+      ok: true,
+      result: { invoices: [invoiceA, invoiceB], has_more: false },
+    };
+    process.exitCode = 0;
+  });
+
+  test("calls platform_invoices_list and emits the page as JSON with --json", async () => {
+    const out = await runInvoices(["list", "--json"]);
+
+    expect(mockCalls[0][0]).toBe("platform_invoices_list");
+    expect(mockCalls[0][1]).toEqual({});
+
+    const parsed = JSON.parse(out.join(""));
+    expect(parsed.invoices).toHaveLength(2);
+    expect(parsed.invoices[0].id).toBe("in_a");
+    expect(parsed.has_more).toBe(false);
+  });
+
+  test("forwards --starting-after as the starting_after query param", async () => {
+    await runInvoices(["list", "--starting-after", "in_a", "--json"]);
+
+    expect(mockCalls[0][0]).toBe("platform_invoices_list");
+    expect(mockCalls[0][1]).toEqual({
+      queryParams: { starting_after: "in_a" },
+    });
+  });
+
+  test("plain text mode renders number, status, and amount lines", async () => {
+    const out = await runInvoices(["list"]);
+    const text = out.join("");
+
+    expect(text).toContain("INV-0001");
+    expect(text).toContain("Status:  paid");
+    expect(text).toContain("Amount:  $12.34 USD");
+    expect(text).toContain("https://pay.example.com/in_a");
+    // Invoice with a null number falls back to its id.
+    expect(text).toContain("in_b");
+    expect(text).toContain("Amount:  $56.00 USD");
+    // Not JSON output.
+    expect(() => JSON.parse(text.trim())).toThrow();
+  });
+
+  test("plain text mode reports an empty page", async () => {
+    mockResponse = { ok: true, result: { invoices: [], has_more: false } };
+
+    const out = await runInvoices(["list"]);
+
+    expect(out.join("").trim()).toBe("No invoices found.");
+  });
+
+  test("plain text mode ends with a paging hint when has_more is true", async () => {
+    mockResponse = {
+      ok: true,
+      result: { invoices: [invoiceA, invoiceB], has_more: true },
+    };
+
+    const out = await runInvoices(["list"]);
+
+    expect(out.join("").trim()).toEndWith(
+      "More invoices available. Run 'assistant platform invoices list --starting-after in_b' for the next page.",
+    );
+  });
+
+  test("plain text mode omits the paging hint when has_more is false", async () => {
+    const out = await runInvoices(["list"]);
+
+    expect(out.join("")).not.toContain("More invoices available");
+  });
+});
+
+describe("assistant platform invoices get", () => {
+  beforeEach(() => {
+    mockCalls = [];
+    mockResponse = { ok: true, result: invoiceA };
+    process.exitCode = 0;
+  });
+
+  test("calls platform_invoices_get with the id path param and emits JSON with --json", async () => {
+    const out = await runInvoices(["get", "in_123", "--json"]);
+
+    expect(mockCalls[0][0]).toBe("platform_invoices_get");
+    expect(mockCalls[0][1]).toEqual({ pathParams: { id: "in_123" } });
+
+    const parsed = JSON.parse(out.join(""));
+    expect(parsed.id).toBe("in_a");
+    expect(parsed.amount_due).toBe(1234);
+  });
+
+  test("plain text mode renders the invoice block including the PDF link", async () => {
+    const out = await runInvoices(["get", "in_a"]);
+    const text = out.join("");
+
+    expect(text).toContain("INV-0001");
+    expect(text).toContain("Status:  paid");
+    expect(text).toContain("Amount:  $12.34 USD");
+    expect(text).toContain("PDF:     https://pay.example.com/in_a.pdf");
+  });
+});
+
+describe("assistant platform invoices error handling", () => {
+  beforeEach(() => {
+    mockCalls = [];
+    mockResponse = {
+      ok: false,
+      error: "Platform credentials not available",
+      statusCode: 422,
+    };
+    process.exitCode = 0;
+  });
+
+  test("list exits via exitFromIpcResult on IPC failure without writing output", async () => {
+    let thrown: unknown;
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      try {
+        await program.parseAsync([
+          "node",
+          "assistant",
+          "platform",
+          "invoices",
+          "list",
+        ]);
+      } catch (err) {
+        thrown = err;
+      }
+    });
+
+    expect((thrown as Error).message).toBe("exitFromIpcResult called");
+    expect(out.join("")).toBe("");
+  });
+
+  test("get exits via exitFromIpcResult on IPC failure without writing output", async () => {
+    let thrown: unknown;
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      try {
+        await program.parseAsync([
+          "node",
+          "assistant",
+          "platform",
+          "invoices",
+          "get",
+          "in_missing",
+        ]);
+      } catch (err) {
+        thrown = err;
+      }
+    });
+
+    expect((thrown as Error).message).toBe("exitFromIpcResult called");
+    expect(out.join("")).toBe("");
+  });
+});
+
+describe("assistant platform invoices --help", () => {
+  test("group help renders both subcommands", async () => {
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      try {
+        await program.parseAsync([
+          "node",
+          "assistant",
+          "platform",
+          "invoices",
+          "--help",
+        ]);
+      } catch {
+        // exitOverride throws on --help; ignore
+      }
+    });
+    const text = out.join("");
+
+    expect(text).toContain("list");
+    expect(text).toContain("get");
+    expect(text).toContain("Stripe invoice history");
+  });
+
+  test("list help renders the --starting-after option", async () => {
+    const out = await captureStdout(async () => {
+      const program = buildProgram();
+      try {
+        await program.parseAsync([
+          "node",
+          "assistant",
+          "platform",
+          "invoices",
+          "list",
+          "--help",
+        ]);
+      } catch {
+        // exitOverride throws on --help; ignore
+      }
+    });
+
+    expect(out.join("")).toContain("--starting-after <invoice-id>");
+  });
+});

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -23,6 +23,7 @@ Examples:
   $ assistant platform credits --json
   $ assistant platform subscription --json
   $ assistant platform plans --json
+  $ assistant platform invoices list --json
   $ assistant platform connect
   $ assistant platform disconnect
   $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json`,
@@ -144,6 +145,93 @@ ensure VELLUM_PLATFORM_URL is set and credentials are stored).
 Examples:
   $ assistant platform plans
   $ assistant platform plans --json`,
+    },
+    {
+      name: "invoices",
+      description: "Read the organization's Stripe invoice history",
+      helpText: `
+Invoices are read from the platform's billing invoices endpoint using this
+assistant's platform API key. Amounts are in the currency's minor units
+(e.g. cents); 'created' is a Unix timestamp in seconds.
+
+The platform returns one page of invoices at a time (newest first). When
+the response's 'has_more' is true, pass the last invoice's id via
+--starting-after to fetch the next (older) page.
+
+Requires platform credentials (run 'assistant platform connect' first or
+ensure VELLUM_PLATFORM_URL is set and credentials are stored).
+
+Examples:
+  $ assistant platform invoices list --json
+  $ assistant platform invoices list --starting-after in_1AbCdEfGh
+  $ assistant platform invoices get in_1AbCdEfGh --json`,
+      subcommands: [
+        {
+          name: "list",
+          description:
+            "List one page of the organization's Stripe invoices, newest first",
+          options: [
+            {
+              flags: "--starting-after <invoice-id>",
+              description:
+                "Cursor: return invoices older than this invoice id (use the last id from the previous page)",
+            },
+          ],
+          helpText: `
+Fetches one page of the org's Stripe invoice history from the platform,
+newest first.
+
+Fields:
+  invoices            One page of invoices, each with the fields below
+  id                  Stripe invoice ID; pass it to 'assistant platform
+                      invoices get' or to --starting-after
+  number              Human-readable invoice number, or null
+  status              Stripe status (draft, open, paid, uncollectible,
+                      void), or null
+  currency            Lowercase ISO currency code (e.g. usd)
+  amount_due          Amount due in the currency's minor units (e.g. cents)
+  amount_paid         Amount paid, in minor units
+  amount_remaining    Amount still owed, in minor units
+  created             Creation time as a Unix timestamp in seconds
+  hosted_invoice_url  Link to the hosted Stripe invoice page, or null
+  invoice_pdf         Link to the invoice PDF, or null
+  has_more            True when older invoices exist beyond this page;
+                      fetch them with --starting-after
+
+Requires platform credentials (run 'assistant platform connect' first or
+ensure VELLUM_PLATFORM_URL is set and credentials are stored).
+
+Examples:
+  $ assistant platform invoices list --json
+  $ assistant platform invoices list --starting-after in_1AbCdEfGh --json`,
+        },
+        {
+          name: "get",
+          description: "Show a single Stripe invoice by ID",
+          arguments: [
+            {
+              name: "<invoice-id>",
+              description:
+                "Stripe invoice ID (e.g. in_1AbCdEfGh); run 'assistant platform invoices list' to find it",
+            },
+          ],
+          helpText: `
+Arguments:
+  <invoice-id>  Stripe invoice ID (e.g. in_1AbCdEfGh); run 'assistant
+                platform invoices list' to find it
+
+The platform has no per-invoice endpoint, so the assistant pages through
+the org's invoice list (newest first) until the ID matches. Unknown IDs
+return a not-found error.
+
+Requires platform credentials (run 'assistant platform connect' first or
+ensure VELLUM_PLATFORM_URL is set and credentials are stored).
+
+Examples:
+  $ assistant platform invoices get in_1AbCdEfGh
+  $ assistant platform invoices get in_1AbCdEfGh --json`,
+        },
+      ],
     },
     {
       name: "disconnect",

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -151,8 +151,11 @@ Examples:
       description: "Read the organization's Stripe invoice history",
       helpText: `
 Invoices are read from the platform's billing invoices endpoint using this
-assistant's platform API key. Amounts are in the currency's minor units
-(e.g. cents); 'created' is a Unix timestamp in seconds.
+assistant's platform API key. Amounts are Stripe-scaled integers: divide
+by 100 for most currencies, by 1 for Stripe zero-decimal currencies
+(e.g. JPY, KRW), and by 1000 for three-decimal ones (e.g. BHD). ISK, HUF,
+TWD, and UGX stay two-decimal in Stripe's API for backward compatibility.
+'created' is a Unix timestamp in seconds.
 
 The platform returns one page of invoices at a time (newest first). When
 the response's 'has_more' is true, pass the last invoice's id via
@@ -189,9 +192,13 @@ Fields:
   status              Stripe status (draft, open, paid, uncollectible,
                       void), or null
   currency            Lowercase ISO currency code (e.g. usd)
-  amount_due          Amount due in the currency's minor units (e.g. cents)
-  amount_paid         Amount paid, in minor units
-  amount_remaining    Amount still owed, in minor units
+  amount_due          Amount due as a Stripe-scaled integer: divide by
+                      100 for most currencies, by 1 for Stripe
+                      zero-decimal currencies (e.g. JPY, KRW), and by
+                      1000 for three-decimal ones (e.g. BHD); ISK, HUF,
+                      TWD, and UGX stay two-decimal in Stripe's API
+  amount_paid         Amount paid, same Stripe scaling as amount_due
+  amount_remaining    Amount still owed, same Stripe scaling as amount_due
   created             Creation time as a Unix timestamp in seconds
   hosted_invoice_url  Link to the hosted Stripe invoice page, or null
   invoice_pdf         Link to the invoice PDF, or null
@@ -221,8 +228,9 @@ Arguments:
                 platform invoices list' to find it
 
 The platform has no per-invoice endpoint, so the assistant pages through
-the org's invoice list (newest first) until the ID matches. Unknown IDs
-return a not-found error.
+the org's invoice list (newest first) until the ID matches. The lookup
+searches the most recent 2,500 invoices (25 pages) and errors if the ID
+is not found within that range.
 
 Requires platform credentials (run 'assistant platform connect' first or
 ensure VELLUM_PLATFORM_URL is set and credentials are stored).

--- a/assistant/src/cli/commands/platform/index.ts
+++ b/assistant/src/cli/commands/platform/index.ts
@@ -14,6 +14,7 @@ import { shouldOutputJson, writeOutput } from "../../output.js";
 import { registerPlatformConnectCommand } from "./connect.js";
 import { registerPlatformDisconnectCommand } from "./disconnect.js";
 import { platformHelp } from "./index.help.js";
+import { registerPlatformInvoicesCommands } from "./invoices.js";
 
 interface PlatformStatusResult {
   isPlatform: boolean;
@@ -235,6 +236,12 @@ export function registerPlatformCommand(program: Command): void {
           }
         },
       );
+
+      // -----------------------------------------------------------------------
+      // invoices
+      // -----------------------------------------------------------------------
+
+      registerPlatformInvoicesCommands(platform);
 
       // -----------------------------------------------------------------------
       // disconnect

--- a/assistant/src/cli/commands/platform/invoices.ts
+++ b/assistant/src/cli/commands/platform/invoices.ts
@@ -24,28 +24,76 @@ interface PlatformInvoicesListResult {
 }
 
 /**
- * Amounts are in the currency's minor units; render as major units using the
- * currency's own minor-unit scale (2 for USD, 0 for JPY, 3 for BHD), e.g.
- * "USD 12.34". Unknown currency codes fall back to the raw minor-unit amount.
+ * These lists follow Stripe's amount scaling rules
+ * (https://docs.stripe.com/currencies), not ISO 4217 metadata. Notably,
+ * Stripe keeps two-decimal scaling for ISK, HUF, TWD, and UGX for backward
+ * compatibility even though ISO treats them as zero-decimal, so those codes
+ * are deliberately absent from the zero-decimal list.
+ */
+const STRIPE_ZERO_DECIMAL_CURRENCIES = new Set([
+  "BIF",
+  "CLP",
+  "DJF",
+  "GNF",
+  "JPY",
+  "KMF",
+  "KRW",
+  "MGA",
+  "PYG",
+  "RWF",
+  "VND",
+  "VUV",
+  "XAF",
+  "XOF",
+  "XPF",
+]);
+
+const STRIPE_THREE_DECIMAL_CURRENCIES = new Set([
+  "BHD",
+  "JOD",
+  "KWD",
+  "OMR",
+  "TND",
+]);
+
+function stripeScaleDigits(currencyCode: string): number {
+  if (STRIPE_ZERO_DECIMAL_CURRENCIES.has(currencyCode)) {
+    return 0;
+  }
+  if (STRIPE_THREE_DECIMAL_CURRENCIES.has(currencyCode)) {
+    return 3;
+  }
+  return 2;
+}
+
+/**
+ * Amounts are in Stripe's minor units; render as major units using Stripe's
+ * amount scaling rules (2 for USD, 0 for JPY, 3 for BHD), e.g. "USD 12.34".
+ * The display fraction digits are forced to match the same scale so Intl's
+ * ISO metadata cannot round Stripe's two-decimal special cases (ISK, HUF,
+ * TWD, UGX). Unknown currency codes fall back to the raw minor-unit amount.
  */
 function formatInvoiceAmount(
   amountMinorUnits: number,
   currency: string,
 ): string {
+  const code = currency.toUpperCase();
+  const digits = stripeScaleDigits(code);
   try {
     const formatter = new Intl.NumberFormat("en-US", {
       style: "currency",
-      currency: currency.toUpperCase(),
+      currency: code,
       currencyDisplay: "code",
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
     });
-    const digits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
     // Intl separates the code and number with U+00A0; use a plain space.
     return formatter
       .format(amountMinorUnits / 10 ** digits)
       .replace(/\u00a0/g, " ");
   } catch {
     // Intl.NumberFormat throws a RangeError on invalid currency codes.
-    return `${amountMinorUnits} ${currency.toUpperCase()} (minor units)`;
+    return `${amountMinorUnits} ${code} (minor units)`;
   }
 }
 

--- a/assistant/src/cli/commands/platform/invoices.ts
+++ b/assistant/src/cli/commands/platform/invoices.ts
@@ -23,12 +23,37 @@ interface PlatformInvoicesListResult {
   has_more: boolean;
 }
 
-/** Amounts are in the currency's minor units (cents); render as major units. */
+/**
+ * Amounts are in the currency's minor units; render as major units using the
+ * currency's own minor-unit scale (2 for USD, 0 for JPY, 3 for BHD), e.g.
+ * "USD 12.34". Unknown currency codes fall back to the raw minor-unit amount.
+ */
+function formatInvoiceAmount(
+  amountMinorUnits: number,
+  currency: string,
+): string {
+  try {
+    const formatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: currency.toUpperCase(),
+      currencyDisplay: "code",
+    });
+    const digits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
+    // Intl separates the code and number with U+00A0; use a plain space.
+    return formatter
+      .format(amountMinorUnits / 10 ** digits)
+      .replace(/\u00a0/g, " ");
+  } catch {
+    // Intl.NumberFormat throws a RangeError on invalid currency codes.
+    return `${amountMinorUnits} ${currency.toUpperCase()} (minor units)`;
+  }
+}
+
 function logInvoice(invoice: PlatformInvoice, includePdf: boolean): void {
   log.info(invoice.number ?? invoice.id);
   log.info(`  Status:  ${invoice.status ?? "unknown"}`);
   log.info(
-    `  Amount:  $${(invoice.amount_due / 100).toFixed(2)} ${invoice.currency.toUpperCase()}`,
+    `  Amount:  ${formatInvoiceAmount(invoice.amount_due, invoice.currency)}`,
   );
   log.info(
     `  Created: ${new Date(invoice.created * 1000).toISOString().slice(0, 10)}`,

--- a/assistant/src/cli/commands/platform/invoices.ts
+++ b/assistant/src/cli/commands/platform/invoices.ts
@@ -1,0 +1,104 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
+import { log } from "../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
+
+interface PlatformInvoice {
+  id: string;
+  number: string | null;
+  status: string | null;
+  currency: string;
+  amount_due: number;
+  amount_paid: number;
+  amount_remaining: number;
+  created: number;
+  hosted_invoice_url: string | null;
+  invoice_pdf: string | null;
+}
+
+interface PlatformInvoicesListResult {
+  invoices: PlatformInvoice[];
+  has_more: boolean;
+}
+
+/** Amounts are in the currency's minor units (cents); render as major units. */
+function logInvoice(invoice: PlatformInvoice, includePdf: boolean): void {
+  log.info(invoice.number ?? invoice.id);
+  log.info(`  Status:  ${invoice.status ?? "unknown"}`);
+  log.info(
+    `  Amount:  $${(invoice.amount_due / 100).toFixed(2)} ${invoice.currency.toUpperCase()}`,
+  );
+  log.info(
+    `  Created: ${new Date(invoice.created * 1000).toISOString().slice(0, 10)}`,
+  );
+  if (invoice.hosted_invoice_url) {
+    log.info(`  URL:     ${invoice.hosted_invoice_url}`);
+  }
+  if (includePdf && invoice.invoice_pdf) {
+    log.info(`  PDF:     ${invoice.invoice_pdf}`);
+  }
+}
+
+export function registerPlatformInvoicesCommands(platform: Command): void {
+  const invoices = subcommand(platform, "invoices");
+
+  subcommand(invoices, "list").action(
+    async (opts: { startingAfter?: string }, cmd: Command) => {
+      const r = await cliIpcCall<PlatformInvoicesListResult>(
+        "platform_invoices_list",
+        opts.startingAfter
+          ? { queryParams: { starting_after: opts.startingAfter } }
+          : {},
+      );
+      if (!r.ok) {
+        return exitFromIpcResult(
+          { ok: false, error: r.error, statusCode: r.statusCode },
+          cmd,
+        );
+      }
+
+      const result = r.result!;
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, result);
+      } else {
+        if (result.invoices.length === 0) {
+          log.info("No invoices found.");
+        } else {
+          for (const invoice of result.invoices) {
+            logInvoice(invoice, false);
+            log.info("");
+          }
+        }
+        const lastId = result.invoices.at(-1)?.id;
+        if (result.has_more && lastId) {
+          log.info(
+            `More invoices available. Run 'assistant platform invoices list --starting-after ${lastId}' for the next page.`,
+          );
+        }
+      }
+    },
+  );
+
+  subcommand(invoices, "get").action(
+    async (invoiceId: string, _opts: Record<string, unknown>, cmd: Command) => {
+      const r = await cliIpcCall<PlatformInvoice>("platform_invoices_get", {
+        pathParams: { id: invoiceId },
+      });
+      if (!r.ok) {
+        return exitFromIpcResult(
+          { ok: false, error: r.error, statusCode: r.statusCode },
+          cmd,
+        );
+      }
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, r.result!);
+      } else {
+        logInvoice(r.result!, true);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds an 'assistant platform invoices' CLI namespace with 'list' (one cursor-paginated page, --starting-after option, has_more paging hint) and 'get <invoice-id>' verbs
- Thin IPC forwarding to the platform_invoices_list/get daemon routes, mirroring the platform credits pattern
- Help-module entries and a bun:test suite covering JSON/human output, cursor forwarding, and error exits

Part of plan: platform-invoices-cli.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->