### PR TITLE
Redesign the assistant chooser and hosting screens; remove platform assistants from the lockfile while logged out

### DIFF
--- a/clients/web/src/domains/onboarding/components/radio-card-nav.ts
+++ b/clients/web/src/domains/onboarding/components/radio-card-nav.ts
@@ -1,0 +1,41 @@
+import type { KeyboardEvent } from "react";
+
+const NEXT_KEYS = new Set(["ArrowDown", "ArrowRight"]);
+const PREV_KEYS = new Set(["ArrowUp", "ArrowLeft"]);
+
+/**
+ * Arrow-key navigation for a `role="radiogroup"` container of rich card
+ * radios, reproducing native radio-group semantics: arrows move focus and
+ * selection to the adjacent enabled radio, wrapping at the ends. Pairs with
+ * a roving tab stop on the cards (`tabIndex` 0 on the checked card, -1
+ * elsewhere). The design-library `RadioGroup`/`Radio` primitives own these
+ * semantics for standard dot-and-label radios, but their fixed layout cannot
+ * wrap these card surfaces, so the chooser cards reproduce them instead.
+ *
+ * Selection is applied by clicking the target card, so each card's own
+ * select handler stays the single source of truth.
+ */
+export function handleRadioCardArrowNav(e: KeyboardEvent<HTMLElement>): void {
+  if (!NEXT_KEYS.has(e.key) && !PREV_KEYS.has(e.key)) {
+    return;
+  }
+  const radios = Array.from(
+    e.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]'),
+  );
+  if (radios.length === 0) {
+    return;
+  }
+  const forward = NEXT_KEYS.has(e.key);
+  const focused = radios.indexOf(document.activeElement as HTMLElement);
+  const current =
+    focused >= 0
+      ? focused
+      : radios.findIndex((r) => r.getAttribute("aria-checked") === "true");
+  const next =
+    current < 0
+      ? radios[forward ? 0 : radios.length - 1]
+      : radios[(current + (forward ? 1 : -1) + radios.length) % radios.length];
+  e.preventDefault();
+  next.focus();
+  next.click();
+}

--- a/clients/web/src/domains/onboarding/components/radio-card-nav.ts
+++ b/clients/web/src/domains/onboarding/components/radio-card-nav.ts
@@ -12,6 +12,9 @@ const PREV_KEYS = new Set(["ArrowUp", "ArrowLeft"]);
  * semantics for standard dot-and-label radios, but their fixed layout cannot
  * wrap these card surfaces, so the chooser cards reproduce them instead.
  *
+ * Only events originating on one of the group's radios are handled; arrows
+ * pressed on other controls inside the group (a create row, a card's inline
+ * buttons) keep their default behavior and never move the selection.
  * Selection is applied by clicking the target card, so each card's own
  * select handler stays the single source of truth.
  */
@@ -19,22 +22,21 @@ export function handleRadioCardArrowNav(e: KeyboardEvent<HTMLElement>): void {
   if (!NEXT_KEYS.has(e.key) && !PREV_KEYS.has(e.key)) {
     return;
   }
+  const origin = (e.target as HTMLElement).closest<HTMLElement>(
+    '[role="radio"]',
+  );
+  if (!origin) {
+    return;
+  }
   const radios = Array.from(
     e.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]'),
   );
-  if (radios.length === 0) {
+  const current = radios.indexOf(origin);
+  if (current < 0) {
     return;
   }
-  const forward = NEXT_KEYS.has(e.key);
-  const focused = radios.indexOf(document.activeElement as HTMLElement);
-  const current =
-    focused >= 0
-      ? focused
-      : radios.findIndex((r) => r.getAttribute("aria-checked") === "true");
-  const next =
-    current < 0
-      ? radios[forward ? 0 : radios.length - 1]
-      : radios[(current + (forward ? 1 : -1) + radios.length) % radios.length];
+  const delta = NEXT_KEYS.has(e.key) ? 1 : -1;
+  const next = radios[(current + delta + radios.length) % radios.length];
   e.preventDefault();
   next.focus();
   next.click();

--- a/clients/web/src/domains/onboarding/components/session-corner-action.tsx
+++ b/clients/web/src/domains/onboarding/components/session-corner-action.tsx
@@ -1,8 +1,9 @@
 import { LogIn, LogOut } from "lucide-react";
+import { useNavigate } from "react-router";
 
-import { hardNavigate } from "@/lib/auth/hard-navigate";
+import { handleLogout } from "@/lib/auth/handle-logout";
 import { isElectron } from "@/runtime/is-electron";
-import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import { useHasPlatformSession } from "@/stores/auth-store";
 import { Button } from "@vellumai/design-library/components/button";
 
 /**
@@ -11,14 +12,15 @@ import { Button } from "@vellumai/design-library/components/button";
  * Escapes the layout's scroll container by positioning against the
  * OnboardingLayout root, clearing the iOS status bar via the safe-area inset.
  *
- * Hidden on electron — the compact Swift-parity onboarding windows keep
+ * Hidden on electron: the compact Swift-parity onboarding windows keep
  * their own login affordances.
  *
  * Login rides the screen's own `useOnboardingLogin` instance (passed in) so
  * the corner control and any in-flow login affordance share pending state.
- * Logout ends the platform session and reloads the page in place, so the
- * screen re-resolves in its logged-out state — or the route middleware
- * redirects if this runtime requires a session.
+ * Logout delegates to the local-mode-aware `handleLogout`: with an active
+ * local assistant it drops only the platform session (this screen then
+ * re-renders logged out in place); otherwise it runs the full logout and
+ * owns the resulting navigation.
  */
 export function SessionCornerAction({
   loginLoading,
@@ -29,17 +31,12 @@ export function SessionCornerAction({
   onLogin: () => void;
   onCancelLogin: () => void;
 }) {
+  const navigate = useNavigate();
   const hasPlatformSession = useHasPlatformSession();
-  const logout = useAuthStore.use.logout();
 
   if (isElectron()) {
     return null;
   }
-
-  const handleLogout = async () => {
-    await logout();
-    hardNavigate(window.location.pathname + window.location.search);
-  };
 
   return (
     <div
@@ -53,7 +50,7 @@ export function SessionCornerAction({
         leftIcon={hasPlatformSession ? <LogOut /> : <LogIn />}
         onClick={
           hasPlatformSession
-            ? () => void handleLogout()
+            ? () => void handleLogout(navigate)
             : loginLoading
               ? onCancelLogin
               : onLogin

--- a/clients/web/src/domains/onboarding/components/session-corner-action.tsx
+++ b/clients/web/src/domains/onboarding/components/session-corner-action.tsx
@@ -1,0 +1,66 @@
+import { LogIn, LogOut } from "lucide-react";
+
+import { hardNavigate } from "@/lib/auth/hard-navigate";
+import { isElectron } from "@/runtime/is-electron";
+import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import { Button } from "@vellumai/design-library/components/button";
+
+/**
+ * Quiet session control pinned to the top-right corner of the pre-chat
+ * chooser screens: "Log in" without a platform session, "Log out" with one.
+ * Escapes the layout's scroll container by positioning against the
+ * OnboardingLayout root, clearing the iOS status bar via the safe-area inset.
+ *
+ * Hidden on electron — the compact Swift-parity onboarding windows keep
+ * their own login affordances.
+ *
+ * Login rides the screen's own `useOnboardingLogin` instance (passed in) so
+ * the corner control and any in-flow login affordance share pending state.
+ * Logout ends the platform session and reloads the page in place, so the
+ * screen re-resolves in its logged-out state — or the route middleware
+ * redirects if this runtime requires a session.
+ */
+export function SessionCornerAction({
+  loginLoading,
+  onLogin,
+  onCancelLogin,
+}: {
+  loginLoading: boolean;
+  onLogin: () => void;
+  onCancelLogin: () => void;
+}) {
+  const hasPlatformSession = useHasPlatformSession();
+  const logout = useAuthStore.use.logout();
+
+  if (isElectron()) {
+    return null;
+  }
+
+  const handleLogout = async () => {
+    await logout();
+    hardNavigate(window.location.pathname + window.location.search);
+  };
+
+  return (
+    <div
+      className="absolute right-6 top-[max(1.5rem,env(safe-area-inset-top))] z-10"
+      style={{ animation: "fadeInUp 0.5s ease-out 0.2s both" }}
+    >
+      <Button
+        variant="ghost"
+        size="compact"
+        className="text-[var(--content-tertiary)]"
+        leftIcon={hasPlatformSession ? <LogOut /> : <LogIn />}
+        onClick={
+          hasPlatformSession
+            ? () => void handleLogout()
+            : loginLoading
+              ? onCancelLogin
+              : onLogin
+        }
+      >
+        {hasPlatformSession ? "Log out" : loginLoading ? "Cancel" : "Log in"}
+      </Button>
+    </div>
+  );
+}

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { handleRadioCardArrowNav } from "@/domains/onboarding/components/radio-card-nav";
 import { SessionCornerAction } from "@/domains/onboarding/components/session-corner-action";
 import { setPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
@@ -90,14 +91,14 @@ export function HostingScreen() {
   } = useOnboardingLogin(`${routes.onboarding.hosting}?from=select-assistant`);
 
   // Electron mirrors the Swift client's Hosting step, which has no login
-  // affordance — its login lives on the wake-up step instead.
+  // affordance; its login lives on the wake-up step instead.
   const showLogin = fromSelectAssistant && !hasPlatformSession && !electron;
 
   const onContinue = () => {
     if (selected === "vellum-cloud") {
       clearGatewayToken();
       setSelfHostedConnection(null);
-      // Cloud is managed — drop any provider key staged from a prior
+      // Cloud is managed: drop any provider key staged from a prior
       // Local/Docker visit so it can't leak into a later local hatch.
       setPendingProviderKey(null);
       void navigate(routes.onboarding.privacy);
@@ -161,6 +162,7 @@ export function HostingScreen() {
         <div
           role="radiogroup"
           aria-label="Hosting options"
+          onKeyDown={handleRadioCardArrowNav}
           className={`grid w-full ${electron ? "mt-8 gap-2" : "auto-rows-fr mt-10 gap-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
         >
@@ -169,6 +171,7 @@ export function HostingScreen() {
               key={opt.mode}
               option={opt}
               selected={selected === opt.mode}
+              tabStop={selected === opt.mode}
               onSelect={() => {
                 if (!opt.disabled) {
                   setSelected(opt.mode);
@@ -225,12 +228,15 @@ export function HostingScreen() {
 function HostingCard({
   option,
   selected,
+  tabStop,
   onSelect,
   loginLabel,
   onLogin,
 }: {
   option: HostingOption;
   selected: boolean;
+  /** The radiogroup's single roving tab stop lands on this card. */
+  tabStop: boolean;
   onSelect: () => void;
   loginLabel: string;
   /** Present on the locked cloud card when logging in can unlock it. */
@@ -249,7 +255,7 @@ function HostingCard({
     <div
       role={locked ? undefined : "radio"}
       aria-checked={locked ? undefined : selected}
-      tabIndex={locked ? undefined : 0}
+      tabIndex={locked ? undefined : tabStop ? 0 : -1}
       onClick={locked ? undefined : onSelect}
       onKeyDown={
         locked

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -141,17 +141,16 @@ export function HostingScreen() {
           className={`text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          Where do you want your assistant to live?
+          Choose where you want your assistant to live.{" "}
+          <a
+            href={docsUrl(routes.docs.hostingOptions)}
+            target="_blank"
+            rel="noreferrer"
+            className="underline transition-colors hover:text-[var(--content-default)]"
+          >
+            Need help deciding?
+          </a>
         </p>
-        <a
-          href={docsUrl(routes.docs.hostingOptions)}
-          target="_blank"
-          rel="noreferrer"
-          className="mt-2 text-body-small-default text-[var(--content-tertiary)] underline transition-colors hover:text-[var(--content-default)]"
-          style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
-        >
-          Need help choosing?
-        </a>
 
         {loginError && (
           <p className="mt-4 text-body-small-default text-[var(--system-negative-strong)]">

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -1,4 +1,4 @@
-import { Cloud, Laptop } from "lucide-react";
+import { ArrowLeft, Check, Cloud, Laptop } from "lucide-react";
 import { useEffect, useState, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
@@ -25,7 +25,7 @@ interface HostingOption {
   badge?: string;
 }
 
-const ICON_CLASS = "h-5 w-5 shrink-0 text-[var(--content-secondary)]";
+const ICON_CLASS = "h-5 w-5 shrink-0";
 
 function useHostingOptions(): HostingOption[] {
   const hasPlatformSession = useHasPlatformSession();
@@ -88,8 +88,8 @@ export function HostingScreen() {
     cancel: cancelLogin,
   } = useOnboardingLogin(`${routes.onboarding.hosting}?from=select-assistant`);
 
-  // Electron mirrors the Swift client's Hosting step, which has no Log In
-  // button — its login affordance lives on the wake-up step instead.
+  // Electron mirrors the Swift client's Hosting step, which has no login
+  // affordance — its login lives on the wake-up step instead.
   const showLogin = fromSelectAssistant && !hasPlatformSession && !electron;
 
   const onContinue = () => {
@@ -114,8 +114,13 @@ export function HostingScreen() {
   return (
     <OnboardingLayout>
       <div
-        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-16"} text-[var(--content-default)]`}
+        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6"} text-[var(--content-default)]`}
       >
+        {/* The main block floats in the space above the creature footer;
+            electron keeps its compact top-aligned flow. */}
+        <div
+          className={`flex w-full flex-col items-center ${electron ? "" : "flex-1 justify-center"}`}
+        >
         <h1
           className={
             electron
@@ -140,6 +145,8 @@ export function HostingScreen() {
         )}
 
         <div
+          role="radiogroup"
+          aria-label="Hosting options"
           className={`grid w-full ${electron ? "mt-8 gap-2" : "auto-rows-fr mt-10 gap-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
         >
@@ -153,12 +160,20 @@ export function HostingScreen() {
                   setSelected(opt.mode);
                 }
               }}
+              loginLabel={loginLoading ? "Cancel" : "Log in to use"}
+              onLogin={
+                opt.disabled && opt.mode === "vellum-cloud" && showLogin
+                  ? loginLoading
+                    ? cancelLogin
+                    : () => void login()
+                  : undefined
+              }
             />
           ))}
         </div>
 
         <div
-          className={`mt-8 flex w-full flex-col ${electron ? "gap-2.5" : "gap-2"}`}
+          className="mt-8 w-full"
           style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
         >
           <Button
@@ -170,22 +185,16 @@ export function HostingScreen() {
           >
             Continue
           </Button>
-          {showLogin && (
-            <Button
-              variant="outlined"
-              size="regular"
-              fullWidth
-              className="h-11 text-base"
-              onClick={loginLoading ? cancelLogin : () => void login()}
-            >
-              {loginLoading ? "Cancel" : "Log In"}
-            </Button>
-          )}
+        </div>
+        <div
+          className="mt-3"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+        >
           <Button
-            variant="outlined"
-            size="regular"
-            fullWidth
-            className={electron ? undefined : "h-11 text-base"}
+            variant="ghost"
+            size="compact"
+            className="text-[var(--content-tertiary)]"
+            leftIcon={<ArrowLeft />}
             onClick={onBack}
             disabled={loginLoading}
           >
@@ -197,11 +206,12 @@ export function HostingScreen() {
           href={docsUrl(routes.docs.hostingOptions)}
           target="_blank"
           rel="noreferrer"
-          className="prechat-md-regular mt-6 text-body-medium-default text-[var(--content-default)] underline"
+          className="prechat-md-regular mt-5 text-body-medium-default text-[var(--content-default)] underline"
           style={{ animation: "fadeInUp 0.5s ease-out 0.6s both" }}
         >
           Need help choosing?
         </a>
+        </div>
       </div>
     </OnboardingLayout>
   );
@@ -211,44 +221,78 @@ function HostingCard({
   option,
   selected,
   onSelect,
+  loginLabel,
+  onLogin,
 }: {
   option: HostingOption;
   selected: boolean;
   onSelect: () => void;
+  loginLabel: string;
+  /** Present on the locked cloud card when logging in can unlock it. */
+  onLogin?: () => void;
 }) {
   // Electron compacts the card to the Swift client's hosting-card metrics
   // (APIKeyStepView.swift): 72px fixed height, 12px padding, 12px radius,
-  // 12px icon→text gap, 11px description, 1.5px radio ring with a
-  // primary-filled/white-dot selected state.
+  // 12px icon→text gap, 11px description.
   const electron = isElectron();
+  const locked = !!option.disabled;
+  // The badge explains a lock nothing on this card can lift (e.g. Limit
+  // Reached); when logging in unlocks the card, the login button replaces it.
+  const badge = onLogin ? undefined : option.badge;
+
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      disabled={option.disabled}
-      className={`flex w-full items-center border text-left transition-colors ${
+    <div
+      role={locked ? undefined : "radio"}
+      aria-checked={locked ? undefined : selected}
+      tabIndex={locked ? undefined : 0}
+      onClick={locked ? undefined : onSelect}
+      onKeyDown={
+        locked
+          ? undefined
+          : (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelect();
+              }
+            }
+      }
+      className={[
+        "group flex w-full items-center border text-left",
         electron
           ? "h-[72px] gap-3 rounded-lg p-3"
-          : "gap-4 rounded-xl px-4 py-4"
-      } ${
-        option.disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"
-      } ${
-        selected && !option.disabled
-          ? `${electron ? "border-[var(--primary-base)]/50" : "border-[var(--primary-base)]"} bg-[var(--primary-base)]/5`
-          : `${electron ? "border-[var(--border-disabled)]" : "border-[var(--border-element)]"} bg-transparent`
-      }`}
+          : "gap-4 rounded-2xl px-5 py-4",
+        "transition-all duration-200 ease-out",
+        locked
+          ? "border-[var(--border-base)] bg-[var(--surface-overlay)]"
+          : "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary-base)]",
+        locked
+          ? ""
+          : selected
+            ? "border-[var(--primary-base)] bg-[var(--surface-lift)]"
+            : "border-[var(--border-base)] bg-[var(--surface-lift)]/60 hover:border-[var(--border-element)] hover:bg-[var(--surface-lift)]",
+      ].join(" ")}
     >
-      {option.icon}
+      <div
+        className={[
+          "flex shrink-0 items-center justify-center transition-colors duration-200",
+          electron ? "h-8 w-8 rounded-lg" : "h-10 w-10 rounded-xl",
+          selected && !locked
+            ? "bg-[var(--primary-base)] text-[var(--surface-base)]"
+            : "bg-[var(--surface-active)]/40 text-[var(--content-secondary)]",
+        ].join(" ")}
+      >
+        {option.icon}
+      </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="text-body-medium-default text-[var(--content-default)]">
             {option.label}
           </span>
-          {option.badge && (
+          {badge && (
             <span
-              className={`rounded-full bg-[var(--surface-tertiary)] px-2 py-0.5 text-[var(--content-tertiary)] ${electron ? "text-label-medium-default" : "text-body-small-default"}`}
+              className={`rounded-full bg-[var(--surface-active)]/40 px-2 py-0.5 text-[var(--content-tertiary)] ${electron ? "text-label-medium-default" : "text-body-small-default"}`}
             >
-              {option.badge}
+              {badge}
             </span>
           )}
         </div>
@@ -258,25 +302,33 @@ function HostingCard({
           {option.subtitle}
         </span>
       </div>
-      {!option.disabled && (
+      {onLogin && (
+        <Button
+          variant="primary"
+          size="regular"
+          className="shrink-0"
+          onClick={onLogin}
+        >
+          {loginLabel}
+        </Button>
+      )}
+      {!locked && (
         <div
-          className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full ${
-            electron ? "border-[1.5px]" : "border-2"
-          } ${
+          className={[
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200",
             selected
-              ? electron
-                ? "border-[var(--primary-base)] bg-[var(--primary-base)]"
-                : "border-[var(--primary-base)]"
-              : "border-[var(--border-element)]"
-          }`}
+              ? "border-[var(--primary-base)] bg-[var(--primary-base)]"
+              : "border-[var(--border-element)] group-hover:border-[var(--content-tertiary)]",
+          ].join(" ")}
         >
           {selected && (
-            <div
-              className={`h-1.5 w-1.5 rounded-full ${electron ? "bg-[var(--aux-white)]" : "bg-[var(--primary-base)]"}`}
+            <Check
+              className="h-3 w-3 text-[var(--surface-base)]"
+              strokeWidth={3}
             />
           )}
         </div>
       )}
-    </button>
+    </div>
   );
 }

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { SessionCornerAction } from "@/domains/onboarding/components/session-corner-action";
 import { setPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
@@ -113,6 +114,11 @@ export function HostingScreen() {
 
   return (
     <OnboardingLayout>
+      <SessionCornerAction
+        loginLoading={loginLoading}
+        onLogin={() => void login()}
+        onCancelLogin={cancelLogin}
+      />
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6"} text-[var(--content-default)]`}
       >
@@ -137,6 +143,15 @@ export function HostingScreen() {
         >
           Where do you want your assistant to live?
         </p>
+        <a
+          href={docsUrl(routes.docs.hostingOptions)}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-2 text-body-small-default text-[var(--content-tertiary)] underline transition-colors hover:text-[var(--content-default)]"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
+        >
+          Need help choosing?
+        </a>
 
         {loginError && (
           <p className="mt-4 text-body-small-default text-[var(--system-negative-strong)]">
@@ -202,15 +217,6 @@ export function HostingScreen() {
           </Button>
         </div>
 
-        <a
-          href={docsUrl(routes.docs.hostingOptions)}
-          target="_blank"
-          rel="noreferrer"
-          className="prechat-md-regular mt-5 text-body-medium-default text-[var(--content-default)] underline"
-          style={{ animation: "fadeInUp 0.5s ease-out 0.6s both" }}
-        >
-          Need help choosing?
-        </a>
         </div>
       </div>
     </OnboardingLayout>

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -433,8 +433,8 @@ export function SelectAssistantScreen() {
         message={
           <>
             This won&rsquo;t delete{" "}
-            {removeTarget ? assistantLabel(removeTarget) : "the assistant"} —
-            it only removes it from this device. Logging in will make it
+            {removeTarget ? assistantLabel(removeTarget) : "the assistant"}.
+            It only removes it from this device. Logging in will make it
             available again.
             {removeError && (
               <span className="mt-2 block text-[var(--system-negative-strong)]">

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -295,29 +295,19 @@ export function SelectAssistantScreen() {
   return (
     <OnboardingLayout>
       <div
-        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-16"} text-[var(--content-default)]`}
+        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6"} text-[var(--content-default)]`}
       >
+        {/* The main block floats in the space above the creature footer;
+            electron keeps its compact top-aligned flow. */}
         <div
-          className="w-full"
-          style={{ animation: "fadeInUp 0.5s ease-out both" }}
+          className={`flex w-full flex-col items-center ${electron ? "" : "flex-1 justify-center"}`}
         >
-          <Button
-            variant="ghost"
-            size="compact"
-            className="-ml-2 text-[var(--content-tertiary)]"
-            leftIcon={<ArrowLeft />}
-            onClick={onBack}
-            disabled={connecting || loginLoading}
-          >
-            Back
-          </Button>
-        </div>
         <h1
-          className={`${
+          className={`text-center ${
             electron
               ? "text-title-large"
               : "text-3xl font-semibold tracking-tight"
-          } ${electron ? "mt-4" : "mt-6"}`}
+          }`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
           Choose an Assistant
@@ -374,23 +364,19 @@ export function SelectAssistantScreen() {
             }
             disabled={connecting || loginLoading}
             className={[
-              "group flex w-full items-center border border-dashed border-[var(--border-element)] text-left",
-              electron ? "gap-3 rounded-lg p-3" : "gap-4 rounded-2xl px-5 py-4",
+              "group flex w-full items-center justify-center gap-2 border border-dashed border-[var(--border-element)]/50 text-[var(--content-tertiary)]",
+              electron ? "rounded-lg px-3 py-2.5" : "rounded-xl px-5 py-3",
               "cursor-pointer transition-all duration-200 ease-out",
-              "text-[var(--content-tertiary)] hover:bg-[var(--surface-secondary)] hover:text-[var(--content-default)]",
+              "hover:border-[var(--border-element)] hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]",
               "disabled:cursor-not-allowed disabled:opacity-50",
             ].join(" ")}
           >
-            <div
-              className={[
-                "flex shrink-0 items-center justify-center",
-                electron ? "h-8 w-8 rounded-lg" : "h-10 w-10 rounded-xl",
-                "bg-[var(--surface-tertiary)] text-[var(--content-secondary)]",
-              ].join(" ")}
+            <Plus className="h-4 w-4" />
+            <span
+              className={
+                electron ? "text-body-small-default" : "text-body-medium-default"
+              }
             >
-              <Plus className="h-5 w-5" />
-            </div>
-            <span className="text-body-medium-default">
               Create a new assistant
             </span>
           </button>
@@ -413,6 +399,22 @@ export function SelectAssistantScreen() {
             </Button>
           </div>
         )}
+        <div
+          className={accessibleAssistants.length > 0 ? "mt-3" : "mt-8"}
+          style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+        >
+          <Button
+            variant="ghost"
+            size="compact"
+            className="text-[var(--content-tertiary)]"
+            leftIcon={<ArrowLeft />}
+            onClick={onBack}
+            disabled={connecting || loginLoading}
+          >
+            Back
+          </Button>
+        </div>
+        </div>
       </div>
       <ConnectRecoveryDialog
         open={recoveryAssistant != null}
@@ -500,11 +502,13 @@ function AssistantCard({
         electron ? "gap-3 rounded-lg p-3" : "gap-4 rounded-2xl px-5 py-4",
         "transition-all duration-200 ease-out",
         locked
+          ? "border-[var(--border-base)] bg-[var(--surface-overlay)]"
+          : "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary-base)]",
+        locked
           ? ""
-          : "cursor-pointer hover:bg-[var(--surface-secondary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary-base)]",
-        selected && !locked
-          ? "border-[var(--primary-base)] bg-[var(--primary-base)]/[0.08] shadow-[inset_0_0_0_1px_var(--primary-base)]"
-          : "border-[var(--border-element)] bg-transparent",
+          : selected
+            ? "border-[var(--primary-base)] bg-[var(--surface-lift)]"
+            : "border-[var(--border-base)] bg-[var(--surface-lift)]/60 hover:border-[var(--border-element)] hover:bg-[var(--surface-lift)]",
       ].join(" ")}
     >
       <div
@@ -512,8 +516,8 @@ function AssistantCard({
           "flex shrink-0 items-center justify-center transition-colors duration-200",
           electron ? "h-8 w-8 rounded-lg" : "h-10 w-10 rounded-xl",
           selected && !locked
-            ? "bg-[var(--primary-base)]/15 text-[var(--primary-base)]"
-            : "bg-[var(--surface-tertiary)] text-[var(--content-secondary)]",
+            ? "bg-[var(--primary-base)] text-[var(--surface-base)]"
+            : "bg-[var(--surface-active)]/40 text-[var(--content-secondary)]",
         ].join(" ")}
       >
         {assistant.isLocal ? (
@@ -524,9 +528,7 @@ function AssistantCard({
       </div>
 
       <div className="min-w-0 flex-1">
-        <span
-          className={`block text-body-medium-default ${locked ? "text-[var(--content-secondary)]" : "text-[var(--content-default)]"}`}
-        >
+        <span className="block text-body-medium-default text-[var(--content-default)]">
           {assistantLabel(assistant)}
         </span>
         <span

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/local-mode";
 import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-recovery-dialog";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { handleRadioCardArrowNav } from "@/domains/onboarding/components/radio-card-nav";
 import { SessionCornerAction } from "@/domains/onboarding/components/session-corner-action";
 import { formatRelativeDate } from "@/utils/format-date";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
@@ -100,7 +101,7 @@ export function SelectAssistantScreen() {
   );
   const [removePending, setRemovePending] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
-  // After a manual removal the user is mid-management on this screen — a
+  // After a manual removal the user is mid-management on this screen: a
   // sudden auto-connect to the sole remaining assistant would be jarring, so
   // the auto-skip stands down for the rest of the visit.
   const removedThisVisitRef = useRef(false);
@@ -131,10 +132,10 @@ export function SelectAssistantScreen() {
       // Offer recovery only where wake can actually run: the assistant is local
       // and CLI-wakeable AND this runtime has a local-mode host (mirrors the
       // wake affordance gate in status-banner), and the failure is one a
-      // guardian re-provision can fix — the token is gone/unrefreshable on disk,
+      // guardian re-provision can fix (the token is gone/unrefreshable on disk,
       // the gateway rejected it at the /auth/token mint (a 401 from a signing-key
-      // mismatch), or the local gateway is unresolved (no recorded port).
-      // Otherwise keep the generic message — repair can't help.
+      // mismatch), or the local gateway is unresolved with no recorded port).
+      // Otherwise keep the generic message; repair can't help.
       if (
         assistant.isLocal &&
         isLocalModeHostAvailable() &&
@@ -156,7 +157,7 @@ export function SelectAssistantScreen() {
     setRecoveryPending(false);
     setRecoveryError(null);
     // If recovery interrupted an auto-skip, dismissing it must land on the
-    // chooser — leaving autoSkipping set would re-render the indefinite
+    // chooser; leaving autoSkipping set would re-render the indefinite
     // "Connecting…" screen with no way out.
     setAutoSkipping(false);
   };
@@ -180,7 +181,7 @@ export function SelectAssistantScreen() {
         // Re-provisioning the guardian token revokes the gateway session
         // token derived from the old one. The cached token is still valid by
         // its local expiry, so `ensureGatewayToken` on reconnect would reuse
-        // it and every gateway call would 401 — drop it so the reconnect mints
+        // it and every gateway call would 401, so drop it and the reconnect mints
         // a fresh one against the new guardian principal.
         clearGatewayToken();
         clearRecoveryState();
@@ -247,7 +248,7 @@ export function SelectAssistantScreen() {
 
   // Auto-skip when there's exactly one assistant and it's accessible.
   // Don't skip when the user just logged in or navigated here deliberately
-  // (e.g. from settings or the Developer menu) — let them see the chooser.
+  // (e.g. from settings or the Developer menu): let them see the chooser.
   // Reactive to assistants so it fires when the store populates after mount.
   useEffect(() => {
     if (fromLogin || noAutoSkip || removedThisVisitRef.current) {
@@ -328,6 +329,7 @@ export function SelectAssistantScreen() {
         <div
           role="radiogroup"
           aria-label="Assistants"
+          onKeyDown={handleRadioCardArrowNav}
           className={`flex w-full flex-col ${electron ? "mt-8 gap-2" : "mt-10 gap-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
@@ -339,6 +341,11 @@ export function SelectAssistantScreen() {
                 assistant={assistant}
                 selected={selected === assistant.id}
                 locked={!accessible}
+                tabStop={
+                  selected == null
+                    ? accessibleAssistants[0]?.id === assistant.id
+                    : selected === assistant.id
+                }
                 onSelect={() => {
                   if (accessible) {
                     setSelected(assistant.id);
@@ -463,6 +470,7 @@ function AssistantCard({
   assistant,
   selected,
   locked,
+  tabStop,
   onSelect,
   loginLabel,
   loginDisabled,
@@ -473,6 +481,8 @@ function AssistantCard({
   selected: boolean;
   /** Not selectable in this session (platform-hosted without a login). */
   locked: boolean;
+  /** The radiogroup's single roving tab stop lands on this card. */
+  tabStop: boolean;
   onSelect: () => void;
   loginLabel: string;
   loginDisabled: boolean;
@@ -491,7 +501,7 @@ function AssistantCard({
     <div
       role={locked ? undefined : "radio"}
       aria-checked={locked ? undefined : selected}
-      tabIndex={locked ? undefined : 0}
+      tabIndex={locked ? undefined : tabStop ? 0 : -1}
       onClick={locked ? undefined : onSelect}
       onKeyDown={
         locked

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -107,9 +107,20 @@ export function SelectAssistantScreen() {
   const removedThisVisitRef = useRef(false);
 
   // Default selection: the app's known selected assistant when accessible,
-  // else the first accessible assistant.
+  // else the first accessible assistant. Also reconciles an existing
+  // selection that stops being accessible (an in-place logout locks the
+  // platform cards), so Continue can never target a locked assistant.
   useEffect(() => {
-    if (selected != null || accessibleAssistants.length === 0) {
+    if (accessibleAssistants.length === 0) {
+      if (selected != null) {
+        setSelected(null);
+      }
+      return;
+    }
+    if (
+      selected != null &&
+      accessibleAssistants.some((a) => a.id === selected)
+    ) {
       return;
     }
     const resolved = resolveSelectedAssistantId(currentOrganizationId);

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/local-mode";
 import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-recovery-dialog";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { SessionCornerAction } from "@/domains/onboarding/components/session-corner-action";
 import { formatRelativeDate } from "@/utils/format-date";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { isElectron } from "@/runtime/is-electron";
@@ -294,6 +295,11 @@ export function SelectAssistantScreen() {
 
   return (
     <OnboardingLayout>
+      <SessionCornerAction
+        loginLoading={loginLoading}
+        onLogin={() => void login()}
+        onCancelLogin={cancelLogin}
+      />
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6"} text-[var(--content-default)]`}
       >

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -539,11 +539,11 @@ function AssistantCard({
       </div>
 
       {locked ? (
-        <div className="flex shrink-0 items-center gap-1">
+        <div className="flex shrink-0 items-center gap-2">
           {onLogin && (
             <Button
-              variant="outlined"
-              size="compact"
+              variant="primary"
+              size="regular"
               onClick={onLogin}
               disabled={loginDisabled}
             >
@@ -555,7 +555,8 @@ function AssistantCard({
               <Menu.Trigger asChild>
                 <Button
                   variant="ghost"
-                  size="compact"
+                  size="regular"
+                  className="text-[var(--content-tertiary)]"
                   iconOnly={<EllipsisVertical />}
                   aria-label={`Actions for ${assistantLabel(assistant)}`}
                 />

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -1,5 +1,12 @@
-import { Check, Cloud, Laptop } from "lucide-react";
-import { useEffect, useState } from "react";
+import {
+  ArrowLeft,
+  Check,
+  Cloud,
+  EllipsisVertical,
+  Laptop,
+  Plus,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { resolveSelectedAssistantId } from "@/assistant/selection";
@@ -10,6 +17,7 @@ import {
 } from "@/lib/auth/gateway-session";
 import {
   isCliWakeableAssistant,
+  removePlatformAssistantFromLockfile,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
 import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-recovery-dialog";
@@ -30,6 +38,8 @@ import {
 } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { Menu } from "@vellumai/design-library/components/menu";
 
 function assistantLabel(a: ResolvedAssistant): string {
   if (a.name) {
@@ -38,11 +48,12 @@ function assistantLabel(a: ResolvedAssistant): string {
   return a.isLocal ? "Local Assistant" : "Cloud Assistant";
 }
 
-function assistantSubtitle(a: ResolvedAssistant): string | undefined {
+function assistantSubtitle(a: ResolvedAssistant): string {
+  const hosting = a.isLocal ? "On this computer" : "Cloud-hosted";
   if (!a.hatchedAt) {
-    return undefined;
+    return hosting;
   }
-  return `Created ${formatRelativeDate(a.hatchedAt)}`;
+  return `${hosting} · Created ${formatRelativeDate(a.hatchedAt)}`;
 }
 
 export function SelectAssistantScreen() {
@@ -67,8 +78,10 @@ export function SelectAssistantScreen() {
 
   const accessibleAssistants = assistants.filter(isAccessible);
 
-  const hasPlatformAssistants = assistants.some((a) => a.isPlatformHosted);
-  const showLogin = hasPlatformAssistants && !hasPlatformSession;
+  // A locked platform entry can be forgotten on this device (dropped from the
+  // lockfile) only where a local-mode host can rewrite the lockfile.
+  const canRemoveLockedAssistants =
+    !hasPlatformSession && isLocalModeHostAvailable();
 
   const [selected, setSelected] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
@@ -80,6 +93,16 @@ export function SelectAssistantScreen() {
     useState<ResolvedAssistant | null>(null);
   const [recoveryPending, setRecoveryPending] = useState(false);
   const [recoveryError, setRecoveryError] = useState<string | null>(null);
+  // Target of the "Remove from this device" confirmation dialog.
+  const [removeTarget, setRemoveTarget] = useState<ResolvedAssistant | null>(
+    null,
+  );
+  const [removePending, setRemovePending] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  // After a manual removal the user is mid-management on this screen — a
+  // sudden auto-connect to the sole remaining assistant would be jarring, so
+  // the auto-skip stands down for the rest of the visit.
+  const removedThisVisitRef = useRef(false);
 
   // Default selection: the app's known selected assistant when accessible,
   // else the first accessible assistant.
@@ -192,12 +215,41 @@ export function SelectAssistantScreen() {
     setRecoveryPending(false);
   };
 
+  const closeRemoveDialog = () => {
+    if (removePending) {
+      return;
+    }
+    setRemoveTarget(null);
+    setRemoveError(null);
+  };
+
+  const handleRemoveConfirm = async () => {
+    if (!removeTarget || removePending) {
+      return;
+    }
+    setRemovePending(true);
+    setRemoveError(null);
+    try {
+      const result = await removePlatformAssistantFromLockfile(removeTarget.id);
+      if (result.ok) {
+        removedThisVisitRef.current = true;
+        setRemoveTarget(null);
+      } else {
+        setRemoveError(result.error ?? "Failed to remove. Please try again.");
+      }
+    } catch (err) {
+      console.error("selectAssistant.removeFromDevice failed", err);
+      setRemoveError("Failed to remove. Please try again.");
+    }
+    setRemovePending(false);
+  };
+
   // Auto-skip when there's exactly one assistant and it's accessible.
   // Don't skip when the user just logged in or navigated here deliberately
   // (e.g. from settings or the Developer menu) — let them see the chooser.
   // Reactive to assistants so it fires when the store populates after mount.
   useEffect(() => {
-    if (fromLogin || noAutoSkip) {
+    if (fromLogin || noAutoSkip || removedThisVisitRef.current) {
       return;
     }
     if (connecting || autoSkipping) {
@@ -245,22 +297,31 @@ export function SelectAssistantScreen() {
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-16"} text-[var(--content-default)]`}
       >
+        <div
+          className="w-full"
+          style={{ animation: "fadeInUp 0.5s ease-out both" }}
+        >
+          <Button
+            variant="ghost"
+            size="compact"
+            className="-ml-2 text-[var(--content-tertiary)]"
+            leftIcon={<ArrowLeft />}
+            onClick={onBack}
+            disabled={connecting || loginLoading}
+          >
+            Back
+          </Button>
+        </div>
         <h1
-          className={
+          className={`${
             electron
               ? "text-title-large"
               : "text-3xl font-semibold tracking-tight"
-          }
+          } ${electron ? "mt-4" : "mt-6"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
           Choose an Assistant
         </h1>
-        <p
-          className={`text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-3"}`}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
-        >
-          Select which assistant you&rsquo;d like to use.
-        </p>
 
         {displayError && (
           <p className="mt-4 text-body-small-default text-[var(--system-negative-strong)]">
@@ -269,8 +330,10 @@ export function SelectAssistantScreen() {
         )}
 
         <div
+          role="radiogroup"
+          aria-label="Assistants"
           className={`flex w-full flex-col ${electron ? "mt-8 gap-2" : "mt-10 gap-3"}`}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
+          style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
           {assistants.map((assistant) => {
             const accessible = isAccessible(assistant);
@@ -279,27 +342,65 @@ export function SelectAssistantScreen() {
                 key={assistant.id}
                 assistant={assistant}
                 selected={selected === assistant.id}
-                disabled={!accessible}
-                badge={
-                  !accessible && assistant.isPlatformHosted
-                    ? "Requires Account"
-                    : undefined
-                }
+                locked={!accessible}
                 onSelect={() => {
                   if (accessible) {
                     setSelected(assistant.id);
                   }
                 }}
+                loginLabel={loginLoading ? "Cancel" : "Log in to use"}
+                loginDisabled={connecting}
+                onLogin={
+                  !accessible && assistant.isPlatformHosted
+                    ? loginLoading
+                      ? cancelLogin
+                      : () => void login()
+                    : undefined
+                }
+                onRemove={
+                  assistant.isPlatformHosted && canRemoveLockedAssistants
+                    ? () => setRemoveTarget(assistant)
+                    : undefined
+                }
               />
             );
           })}
+          <button
+            type="button"
+            onClick={() =>
+              void navigate(
+                `${routes.onboarding.hosting}?from=select-assistant`,
+              )
+            }
+            disabled={connecting || loginLoading}
+            className={[
+              "group flex w-full items-center border border-dashed border-[var(--border-element)] text-left",
+              electron ? "gap-3 rounded-lg p-3" : "gap-4 rounded-2xl px-5 py-4",
+              "cursor-pointer transition-all duration-200 ease-out",
+              "text-[var(--content-tertiary)] hover:bg-[var(--surface-secondary)] hover:text-[var(--content-default)]",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+            ].join(" ")}
+          >
+            <div
+              className={[
+                "flex shrink-0 items-center justify-center",
+                electron ? "h-8 w-8 rounded-lg" : "h-10 w-10 rounded-xl",
+                "bg-[var(--surface-tertiary)] text-[var(--content-secondary)]",
+              ].join(" ")}
+            >
+              <Plus className="h-5 w-5" />
+            </div>
+            <span className="text-body-medium-default">
+              Create a new assistant
+            </span>
+          </button>
         </div>
 
-        <div
-          className={`mt-8 flex w-full flex-col ${electron ? "gap-2.5" : "gap-2"}`}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
-        >
-          {accessibleAssistants.length > 0 && (
+        {accessibleAssistants.length > 0 && (
+          <div
+            className="mt-8 w-full"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
+          >
             <Button
               variant="primary"
               size="regular"
@@ -310,44 +411,8 @@ export function SelectAssistantScreen() {
             >
               {connecting ? "Connecting…" : "Continue"}
             </Button>
-          )}
-          <Button
-            variant="outlined"
-            size="regular"
-            fullWidth
-            className={electron ? undefined : "h-11 text-base"}
-            onClick={() =>
-              void navigate(
-                `${routes.onboarding.hosting}?from=select-assistant`,
-              )
-            }
-            disabled={connecting || loginLoading}
-          >
-            Create New Assistant
-          </Button>
-          {showLogin && (
-            <Button
-              variant="outlined"
-              size="regular"
-              fullWidth
-              className={electron ? undefined : "h-11 text-base"}
-              onClick={loginLoading ? cancelLogin : () => void login()}
-              disabled={connecting}
-            >
-              {loginLoading ? "Cancel" : "Log In"}
-            </Button>
-          )}
-          <Button
-            variant="outlined"
-            size="regular"
-            fullWidth
-            className={electron ? undefined : "h-11 text-base"}
-            onClick={onBack}
-            disabled={connecting || loginLoading}
-          >
-            Back
-          </Button>
-        </div>
+          </div>
+        )}
       </div>
       <ConnectRecoveryDialog
         open={recoveryAssistant != null}
@@ -360,6 +425,28 @@ export function SelectAssistantScreen() {
         onRepair={() => void handleRecoveryRepair()}
         onRetire={() => void handleRecoveryRetire()}
       />
+      <ConfirmDialog
+        open={removeTarget != null}
+        title="Remove from this device?"
+        message={
+          <>
+            This won&rsquo;t delete{" "}
+            {removeTarget ? assistantLabel(removeTarget) : "the assistant"} —
+            it only removes it from this device. Logging in will make it
+            available again.
+            {removeError && (
+              <span className="mt-2 block text-[var(--system-negative-strong)]">
+                {removeError}
+              </span>
+            )}
+          </>
+        }
+        confirmLabel="Remove"
+        destructive
+        isPending={removePending}
+        onConfirm={() => void handleRemoveConfirm()}
+        onCancel={closeRemoveDialog}
+      />
     </OnboardingLayout>
   );
 }
@@ -367,15 +454,24 @@ export function SelectAssistantScreen() {
 function AssistantCard({
   assistant,
   selected,
-  disabled,
-  badge,
+  locked,
   onSelect,
+  loginLabel,
+  loginDisabled,
+  onLogin,
+  onRemove,
 }: {
   assistant: ResolvedAssistant;
   selected: boolean;
-  disabled: boolean;
-  badge?: string;
+  /** Not selectable in this session (platform-hosted without a login). */
+  locked: boolean;
   onSelect: () => void;
+  loginLabel: string;
+  loginDisabled: boolean;
+  /** Present only on locked platform cards: log in to unlock this assistant. */
+  onLogin?: () => void;
+  /** Present when the entry can be forgotten on this device: opens the confirm. */
+  onRemove?: () => void;
 }) {
   const subtitle = assistantSubtitle(assistant);
   // Electron compacts the card to the Swift client's onboarding-card metrics
@@ -384,18 +480,29 @@ function AssistantCard({
   const electron = isElectron();
 
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      disabled={disabled}
+    <div
+      role={locked ? undefined : "radio"}
+      aria-checked={locked ? undefined : selected}
+      tabIndex={locked ? undefined : 0}
+      onClick={locked ? undefined : onSelect}
+      onKeyDown={
+        locked
+          ? undefined
+          : (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelect();
+              }
+            }
+      }
       className={[
         "group flex w-full items-center border text-left",
         electron ? "gap-3 rounded-lg p-3" : "gap-4 rounded-2xl px-5 py-4",
         "transition-all duration-200 ease-out",
-        disabled
-          ? "cursor-not-allowed opacity-50"
-          : "cursor-pointer hover:bg-[var(--surface-secondary)]",
-        selected && !disabled
+        locked
+          ? ""
+          : "cursor-pointer hover:bg-[var(--surface-secondary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary-base)]",
+        selected && !locked
           ? "border-[var(--primary-base)] bg-[var(--primary-base)]/[0.08] shadow-[inset_0_0_0_1px_var(--primary-base)]"
           : "border-[var(--border-element)] bg-transparent",
       ].join(" ")}
@@ -404,7 +511,7 @@ function AssistantCard({
         className={[
           "flex shrink-0 items-center justify-center transition-colors duration-200",
           electron ? "h-8 w-8 rounded-lg" : "h-10 w-10 rounded-xl",
-          selected && !disabled
+          selected && !locked
             ? "bg-[var(--primary-base)]/15 text-[var(--primary-base)]"
             : "bg-[var(--surface-tertiary)] text-[var(--content-secondary)]",
         ].join(" ")}
@@ -417,28 +524,52 @@ function AssistantCard({
       </div>
 
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="text-body-medium-default text-[var(--content-default)]">
-            {assistantLabel(assistant)}
-          </span>
-          {badge && (
-            <span
-              className={`rounded-full bg-[var(--surface-tertiary)] px-2 py-0.5 text-[var(--content-tertiary)] ${electron ? "text-label-medium-default" : "text-body-small-default"}`}
-            >
-              {badge}
-            </span>
-          )}
-        </div>
-        {subtitle && (
-          <span
-            className={`mt-0.5 block text-[var(--content-tertiary)] ${electron ? "text-label-medium-default" : "text-body-small-default"}`}
-          >
-            {subtitle}
-          </span>
-        )}
+        <span
+          className={`block text-body-medium-default ${locked ? "text-[var(--content-secondary)]" : "text-[var(--content-default)]"}`}
+        >
+          {assistantLabel(assistant)}
+        </span>
+        <span
+          className={`mt-0.5 block text-[var(--content-tertiary)] ${electron ? "text-label-medium-default" : "text-body-small-default"}`}
+        >
+          {subtitle}
+        </span>
       </div>
 
-      {!disabled && (
+      {locked ? (
+        <div className="flex shrink-0 items-center gap-1">
+          {onLogin && (
+            <Button
+              variant="outlined"
+              size="compact"
+              onClick={onLogin}
+              disabled={loginDisabled}
+            >
+              {loginLabel}
+            </Button>
+          )}
+          {onRemove && (
+            <Menu.Root>
+              <Menu.Trigger asChild>
+                <Button
+                  variant="ghost"
+                  size="compact"
+                  iconOnly={<EllipsisVertical />}
+                  aria-label={`Actions for ${assistantLabel(assistant)}`}
+                />
+              </Menu.Trigger>
+              <Menu.Content align="end" sideOffset={4}>
+                <Menu.Item
+                  onSelect={onRemove}
+                  className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
+                >
+                  Remove from this device…
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Root>
+          )}
+        </div>
+      ) : (
         <div
           className={[
             "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200",
@@ -455,6 +586,6 @@ function AssistantCard({
           )}
         </div>
       )}
-    </button>
+    </div>
   );
 }

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -189,9 +189,21 @@ describe("removePlatformAssistantFromLockfile", () => {
     organizationId: "org-1",
   } as LockfileAssistant;
 
+  const platformOtherOrg: LockfileAssistant = {
+    assistantId: "platform-c",
+    cloud: "vellum",
+    organizationId: "org-2",
+  } as LockfileAssistant;
+
   test("rewrites the remaining platform entries scoped to the entry's org and commits", async () => {
-    setLockfile({ assistants: [localA, platformA, platformB], activeAssistant: "local-a" });
-    const resulting = { assistants: [localA, platformB], activeAssistant: "local-a" };
+    setLockfile({
+      assistants: [localA, platformA, platformB, platformOtherOrg],
+      activeAssistant: "local-a",
+    });
+    const resulting = {
+      assistants: [localA, platformB, platformOtherOrg],
+      activeAssistant: "local-a",
+    };
     replacePlatformAssistantsHost.mockResolvedValueOnce({
       ok: true as const,
       lockfile: resulting,
@@ -203,6 +215,9 @@ describe("removePlatformAssistantFromLockfile", () => {
     expect(replacePlatformAssistantsHost).toHaveBeenCalledTimes(1);
     const [entries, org] = replacePlatformAssistantsHost.mock.calls[0]!;
     expect(org).toBe("org-1");
+    // Other orgs' entries stay out of the payload so the host preserves
+    // their on-disk records raw instead of replacing them with the
+    // renderer's parsed copies.
     expect(entries).toEqual([expect.objectContaining({ assistantId: "platform-b" })]);
     expect(useLockfileStore.getState().lockfile).toEqual(resulting);
     expect(useLockfileStore.getState().committed).toBe(true);

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -8,7 +8,7 @@ const replacePlatformAssistantsHost = mock(
   async (
     _entries: Array<Record<string, unknown>>,
     _organizationId?: string,
-  ) => ({
+  ): Promise<localModeHost.LockfileWriteResult> => ({
     ok: true as const,
     lockfile: { assistants: [], activeAssistant: null },
   }),
@@ -48,6 +48,7 @@ import {
   loadLockfile,
   primeLocalGatewayConnection,
   reconcileSelectedAssistant,
+  removePlatformAssistantFromLockfile,
   saveManagedLockfileAssistant,
   syncPlatformAssistantsToLockfile,
   UnresolvedLocalGatewayError,
@@ -172,6 +173,99 @@ describe("syncPlatformAssistantsToLockfile", () => {
     expect(replacePlatformAssistantsHost).toHaveBeenCalledTimes(1);
     expect(useLockfileStore.getState().lockfile).toBeNull();
     expect(localStorage.getItem(LOCKFILE_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("removePlatformAssistantFromLockfile", () => {
+  const platformA: LockfileAssistant = {
+    assistantId: "platform-a",
+    cloud: "vellum",
+    organizationId: "org-1",
+  } as LockfileAssistant;
+
+  const platformB: LockfileAssistant = {
+    assistantId: "platform-b",
+    cloud: "vellum",
+    organizationId: "org-1",
+  } as LockfileAssistant;
+
+  test("rewrites the remaining platform entries scoped to the entry's org and commits", async () => {
+    setLockfile({ assistants: [localA, platformA, platformB], activeAssistant: "local-a" });
+    const resulting = { assistants: [localA, platformB], activeAssistant: "local-a" };
+    replacePlatformAssistantsHost.mockResolvedValueOnce({
+      ok: true as const,
+      lockfile: resulting,
+    });
+
+    const result = await removePlatformAssistantFromLockfile("platform-a");
+
+    expect(result.ok).toBe(true);
+    expect(replacePlatformAssistantsHost).toHaveBeenCalledTimes(1);
+    const [entries, org] = replacePlatformAssistantsHost.mock.calls[0]!;
+    expect(org).toBe("org-1");
+    expect(entries).toEqual([expect.objectContaining({ assistantId: "platform-b" })]);
+    expect(useLockfileStore.getState().lockfile).toEqual(resulting);
+    expect(useLockfileStore.getState().committed).toBe(true);
+  });
+
+  test("a legacy org-less entry removes via the unscoped replace", async () => {
+    setLockfile({ assistants: [platform, platformB], activeAssistant: null });
+    replacePlatformAssistantsHost.mockResolvedValueOnce({
+      ok: true as const,
+      lockfile: { assistants: [platformB], activeAssistant: null },
+    });
+
+    const result = await removePlatformAssistantFromLockfile("platform-a");
+
+    expect(result.ok).toBe(true);
+    const [entries, org] = replacePlatformAssistantsHost.mock.calls[0]!;
+    expect(org).toBeUndefined();
+    expect(entries).toEqual([expect.objectContaining({ assistantId: "platform-b" })]);
+  });
+
+  test("refuses a local assistant without touching the host", async () => {
+    setLockfile({ assistants: [localA, platformA], activeAssistant: "local-a" });
+
+    const result = await removePlatformAssistantFromLockfile("local-a");
+
+    expect(result.ok).toBe(false);
+    expect(replacePlatformAssistantsHost).not.toHaveBeenCalled();
+  });
+
+  test("refuses an unknown id without touching the host", async () => {
+    setLockfile({ assistants: [platformA], activeAssistant: null });
+
+    const result = await removePlatformAssistantFromLockfile("nope");
+
+    expect(result.ok).toBe(false);
+    expect(replacePlatformAssistantsHost).not.toHaveBeenCalled();
+  });
+
+  test("surfaces a host failure without committing", async () => {
+    setLockfile({ assistants: [platformA, platformB], activeAssistant: null });
+    replacePlatformAssistantsHost.mockResolvedValueOnce({
+      ok: false,
+      error: "disk unavailable",
+    });
+
+    const result = await removePlatformAssistantFromLockfile("platform-a");
+
+    expect(result).toEqual({ ok: false, error: "disk unavailable" });
+    expect(useLockfileStore.getState().committed).toBe(false);
+    expect(localStorage.getItem(LOCKFILE_STORAGE_KEY)).toBeNull();
+  });
+
+  test("clears a selection that pointed at the removed entry", async () => {
+    setLockfile({ assistants: [localA, platformA], activeAssistant: "local-a" });
+    setSelected("platform-a");
+    replacePlatformAssistantsHost.mockResolvedValueOnce({
+      ok: true as const,
+      lockfile: { assistants: [localA], activeAssistant: "local-a" },
+    });
+
+    await removePlatformAssistantFromLockfile("platform-a");
+
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBeNull();
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -347,8 +347,18 @@ export async function removePlatformAssistantFromLockfile(
   if (!entry || !isPlatformAssistant(entry)) {
     return { ok: false, error: "This assistant isn't in the local list." };
   }
+  // Only the target org's entries ride the replace payload: the host treats
+  // every supplied id as replaced-by-payload, and the renderer's parsed copies
+  // drop host-only fields, so other orgs' on-disk records must stay out of the
+  // payload to survive raw. A legacy org-less entry can't be scoped; its
+  // unscoped replace resends every platform entry (minus the target).
   const remaining = getPlatformAssistants()
     .filter((a) => a.assistantId !== assistantId)
+    .filter(
+      (a) =>
+        entry.organizationId == null ||
+        a.organizationId === entry.organizationId,
+    )
     .map((a) => ({ ...a }));
   const result = await replacePlatformAssistantsHost(
     remaining,

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -333,7 +333,7 @@ export async function syncPlatformAssistantsToLockfile(
 }
 
 /**
- * Remove a platform-hosted assistant's lockfile entry — a device-local
+ * Remove a platform-hosted assistant's lockfile entry: a device-local
  * "forget" that never touches the assistant itself. Rides the platform-replace
  * host channel scoped to the entry's org: the remaining platform entries are
  * written back minus the target, so local entries and other orgs' platform

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -332,6 +332,35 @@ export async function syncPlatformAssistantsToLockfile(
   }
 }
 
+/**
+ * Remove a platform-hosted assistant's lockfile entry — a device-local
+ * "forget" that never touches the assistant itself. Rides the platform-replace
+ * host channel scoped to the entry's org: the remaining platform entries are
+ * written back minus the target, so local entries and other orgs' platform
+ * entries are untouched. A platform sync while logged in re-adds the
+ * assistant, so this only affects what the device lists while logged out.
+ */
+export async function removePlatformAssistantFromLockfile(
+  assistantId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const entry = getLockfileAssistant(assistantId);
+  if (!entry || !isPlatformAssistant(entry)) {
+    return { ok: false, error: "This assistant isn't in the local list." };
+  }
+  const remaining = getPlatformAssistants()
+    .filter((a) => a.assistantId !== assistantId)
+    .map((a) => ({ ...a }));
+  const result = await replacePlatformAssistantsHost(
+    remaining,
+    entry.organizationId,
+  );
+  if (!result.ok) {
+    return { ok: false, error: result.error || "Failed to remove assistant." };
+  }
+  commitLockfile(result.lockfile);
+  return { ok: true };
+}
+
 // ---------------------------------------------------------------------------
 // Retire
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Redesigns the two pre-chat chooser screens (select-assistant and hosting) and adds the ability to remove a platform-hosted assistant from this device while logged out.

### Remove from this device (new capability)

- Locked platform cards (platform-hosted, no session) get a kebab menu with **"Remove from this device…"**, confirmed via `ConfirmDialog`.
- New `removePlatformAssistantFromLockfile()` in `lib/local-mode.ts` rides the **existing** org-scoped `replacePlatformAssistantsHost` channel — no new host/IPC surface, so it works on already-shipped desktop hosts with no version-skew risk. It rewrites the lockfile minus the target; local entries and other orgs' platform entries are untouched.
- Deliberate semantics: this is a device-local "forget", not a retire. A later login re-syncs platform assistants and the entry returns — the dialog copy says so.
- After a manual removal the single-assistant auto-skip stands down for the rest of the visit so the chooser doesn't yank the user into a connection mid-management.

### Chooser consolidation (select-assistant)

Previously: four equal-weight full-width buttons (Continue / Create New Assistant / Log In / Back) and a `disabled` locked card that was a dead end. Now every per-assistant affordance lives on its card:

- Locked platform cards are alive: full-legibility text plus an inline **"Log in to use"** primary button (replaces the global Log In button and the "Requires Account" badge).
- "Create a new assistant" is a compact dashed row at the end of the list.
- Back is a quiet ghost link below Continue; Continue is the sole primary button.
- Cards are proper radios in a radiogroup with keyboard support (they were plain buttons with no grouping semantics).

### Visual redesign (both screens)

- The main block vertically centers in the space above the creature footer (matching `welcome-screen`); electron keeps its compact Swift-parity top-aligned flow.
- Cards become filled `--surface-lift` surfaces with a single crisp `--primary-base` ring and an inverted icon chip when selected; locked cards sit on the quieter `--surface-overlay`.
- **Bug fix**: both screens referenced `--surface-secondary` / `--surface-tertiary`, which are defined nowhere in `tokens.css` — the hover state was a no-op. All references now use real tokens.
- New shared `SessionCornerAction`: a subtle log in / log out control pinned top-right on both screens (browser only; hidden on electron). Logout reloads in place so the screen re-resolves logged out.
- Hosting subtitle now reads "Choose where you want your assistant to live. Need help deciding?" with the question as the inline docs link; the "Limit Reached" badge remains (login can't lift that lock).

## Testing

- 6 new unit tests for `removePlatformAssistantFromLockfile` (org-scoped rewrite, legacy org-less entries, refusing local/unknown ids, host failure without commit, selection cleanup); all 53 tests in `local-mode.test.ts` pass.
- Visually verified in the browser in both the logged-out state (locked card, log-in CTA, kebab → confirm dialog) and the logged-in state (selectable card, Continue).
- `tsc` and lint clean for all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)