### PR TITLE
docs(skills): surface copy_from in skill-management's rendered tool docs

### DIFF
--- a/assistant/src/config/bundled-skills/skill-management/SKILL.md
+++ b/assistant/src/config/bundled-skills/skill-management/SKILL.md
@@ -114,7 +114,7 @@ Past 500 lines the model loses things in the middle. Warnings get buried, branch
 Companion files ship through `scaffold_managed_skill`'s `files` input and live inside the skill folder:
 
 - **`references/*.md`** for failure modes, gotchas, and cached values the body should point to.
-- **`scripts/*`** for reusable code the procedure runs. Store the exact version that already ran successfully, and have the new skill's body invoke it through the baseDir placeholder — the word baseDir in curly braces, which resolves to that skill's folder when it loads. The terminal does not run from the skill folder, so a bare `scripts/...` path would fail. (The placeholder is spelled out here rather than written literally because this very body undergoes the same substitution.)
+- **`scripts/*`** for reusable code the procedure runs. Store the exact version that already ran successfully — pass `copy_from` with the tested file's absolute path instead of pasting its contents into `content`, so the bytes that shipped are the bytes that ran. Have the new skill's body invoke it through the baseDir placeholder — the word baseDir in curly braces, which resolves to that skill's folder when it loads. The terminal does not run from the skill folder, so a bare `scripts/...` path would fail. (The placeholder is spelled out here rather than written literally because this very body undergoes the same substitution.)
 
 ## Step 6 - Test the skill before calling it done
 

--- a/assistant/src/config/bundled-skills/skill-management/SKILL.md
+++ b/assistant/src/config/bundled-skills/skill-management/SKILL.md
@@ -114,7 +114,7 @@ Past 500 lines the model loses things in the middle. Warnings get buried, branch
 Companion files ship through `scaffold_managed_skill`'s `files` input and live inside the skill folder:
 
 - **`references/*.md`** for failure modes, gotchas, and cached values the body should point to.
-- **`scripts/*`** for reusable code the procedure runs. Store the exact version that already ran successfully — pass `copy_from` with the tested file's absolute path instead of pasting its contents into `content`, so the bytes that shipped are the bytes that ran. Have the new skill's body invoke it through the baseDir placeholder — the word baseDir in curly braces, which resolves to that skill's folder when it loads. The terminal does not run from the skill folder, so a bare `scripts/...` path would fail. (The placeholder is spelled out here rather than written literally because this very body undergoes the same substitution.)
+- **`scripts/*`** for reusable code the procedure runs. Store the exact version that already ran successfully: pass `copy_from` with the tested file's absolute path instead of pasting its contents into `content`, so the bytes that shipped are the bytes that ran. Have the new skill's body invoke it through the baseDir placeholder (the word baseDir in curly braces), which resolves to that skill's folder when it loads. The terminal does not run from the skill folder, so a bare `scripts/...` path would fail. (The placeholder is spelled out here rather than written literally because this very body undergoes the same substitution.)
 
 ## Step 6 - Test the skill before calling it done
 

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -72,7 +72,7 @@
               },
               "required": ["path"]
             },
-            "description": "Optional companion files written under the skill directory, referenced from SKILL.md: references/*.md for gotchas and cached values, scripts/* for reusable code that already ran successfully. Have the body invoke scripts via the {baseDir} placeholder (e.g. `python3 {baseDir}/scripts/export-report.py`) — it resolves to the skill folder on load. Paths must resolve inside the skill folder."
+            "description": "Optional companion files written under the skill directory, referenced from SKILL.md: references/*.md for gotchas and cached values, scripts/* for reusable code that already ran successfully. Each entry is {path, content} or {path, copy_from} — exactly one of content or copy_from. Prefer copy_from (the absolute path of an existing on-disk file, under the workspace or system temp dir, at most 1 MiB) over re-emitting file bytes inline. Have the body invoke scripts via the {baseDir} placeholder (e.g. `python3 {baseDir}/scripts/export-report.py`) — it resolves to the skill folder on load. Paths must resolve inside the skill folder."
           },
           "add_to_index": {
             "type": "boolean",

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -72,7 +72,7 @@
               },
               "required": ["path"]
             },
-            "description": "Optional companion files written under the skill directory, referenced from SKILL.md: references/*.md for gotchas and cached values, scripts/* for reusable code that already ran successfully. Each entry is {path, content} or {path, copy_from} — exactly one of content or copy_from. Prefer copy_from (the absolute path of an existing on-disk file, under the workspace or system temp dir, at most 1 MiB) over re-emitting file bytes inline. Have the body invoke scripts via the {baseDir} placeholder (e.g. `python3 {baseDir}/scripts/export-report.py`) — it resolves to the skill folder on load. Paths must resolve inside the skill folder."
+            "description": "Optional companion files written under the skill directory, referenced from SKILL.md: references/*.md for gotchas and cached values, scripts/* for reusable code that already ran successfully. Each entry is {path, content} or {path, copy_from}: exactly one of content or copy_from. Prefer copy_from (the absolute path of an existing on-disk file, under the workspace or system temp dir, at most 1 MiB) over re-emitting file bytes inline. Have the body invoke scripts via the {baseDir} placeholder (e.g. `python3 {baseDir}/scripts/export-report.py`); it resolves to the skill folder on load. Paths must resolve inside the skill folder."
           },
           "add_to_index": {
             "type": "boolean",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -51,7 +51,7 @@
     },
     "skill-management": {
       "docsSlug": "skill-management",
-      "sha256": "23ee1a0fb1d53f7cab88348883987f9a5a833520cfe420fc44055f0d27b5563a"
+      "sha256": "3bd118eeeb6ee097ddccf82dd2f475ac09ec6ea97b69acac678c1fbb779d7db1"
     },
     "subagent": {
       "docsSlug": "subagent",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -51,7 +51,7 @@
     },
     "skill-management": {
       "docsSlug": "skill-management",
-      "sha256": "3bd118eeeb6ee097ddccf82dd2f475ac09ec6ea97b69acac678c1fbb779d7db1"
+      "sha256": "cc095fdb54af9ab614227aca110449b7ae6d4466e80ee4b36f0b9ce04e7aa92d"
     },
     "subagent": {
       "docsSlug": "subagent",


### PR DESCRIPTION
## Summary
- Extend the top-level `files` parameter description in skill-management's TOOLS.json to state the entry shape — `{path, content}` or `{path, copy_from}`, exactly one — and to prefer `copy_from` (absolute path of an existing on-disk file under the workspace or system temp dir, ≤1 MiB) over re-emitting file bytes inline. The skill-load renderer (`assistant/src/tools/skills/load.ts`) only shows top-level parameter descriptions, so the nested item schema where `copy_from` was documented is invisible to the model at runtime.
- Update SKILL.md Step 5 (companion files) to say the way to store the exact script version that already ran is `copy_from` with the tested file's absolute path, not pasting contents into `content`.
- Re-record the skill-docs-sync fingerprint for skill-management (the public docs page does not cover companion files, so no platform docs change is needed).

## Original prompt
A production transcript from today (glm-5p2) showed the assistant loading skill-management, confidently asserting that `files` only takes `{path, content}` and that no copy-from feature exists, then burning six more LLM calls grepping daemon source after the user corrected it with "doesn't copy_from exist?". Root cause: `copy_from` was documented only in the nested item schema, which the rendered tool docs drop. The user asked to make `copy_from` explicit in the two places the model actually reads: the top-level `files` description and SKILL.md Step 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)