### PR TITLE
feat(web): open agent session details from a header Activity control (LUM-2848)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.stories.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.stories.tsx
@@ -2,9 +2,9 @@
  * Full-header visual matrix, built to protect the conversation header's right
  * cluster now that `ConversationActivityPill` sits in it beside Assets.
  *
- * The header is assembled here the way `ChatLayout` + `routes.tsx` assemble it —
+ * The header is assembled here the way `ChatLayout` + `routes.tsx` assemble it:
  * a long conversation title in the centre slot, and Assets / Activity /
- * Notifications in `topBarRightSlot` — because the thing worth protecting is the
+ * Notifications in `topBarRightSlot`. The thing worth protecting is the
  * *composition*: whether the title still shrinks, and whether the cluster stays
  * readable once Activity joins it.
  *
@@ -12,7 +12,7 @@
  * belongs to the home domain and `routes.tsx` injects it into the chat layout at
  * runtime, so importing it here trips the cross-domain import rule. The stand-in
  * is the same ghost icon-only `Button` with the same glyph, which is all this
- * story needs it to be — it exists to occupy the cluster, not to be exercised.
+ * story needs it to be. It exists to occupy the cluster, not to be exercised.
  *
  * Six states are covered. The per-status card matrix for subagents and ACP
  * runs belongs to their component tests, not to a header story.
@@ -48,7 +48,7 @@ const LONG_TITLE =
 // Fixtures
 // ---------------------------------------------------------------------------
 
-/** One running ACP run and one finished subagent — the mixed case. */
+/** One running ACP run and one finished subagent: the mixed case. */
 function seedMixedActivity() {
   useAcpRunStore.getState().spawnRun({
     acpSessionId: "acp-live",
@@ -91,7 +91,7 @@ function seedMixedActivity() {
   });
 }
 
-/** Finished work only — nothing running, everything still reopenable. */
+/** Finished work only. Nothing running, everything still reopenable. */
 function seedCompletedActivity() {
   for (const [i, label] of [
     "slack-thread-audit",
@@ -118,7 +118,7 @@ function seedCompletedActivity() {
 }
 
 /**
- * Several of each kind running and finished at once — the case that shows the
+ * Several of each kind running and finished at once: the case that shows the
  * stacks overlapping, the `+N` remainder, and (the point) ACP brand marks and
  * subagent avatars mixed inside the *same* stack. The groups are status groups,
  * never per-kind ones.
@@ -181,7 +181,7 @@ function resetActivity() {
 }
 
 /**
- * Placeholder for the injected `NotificationsBell` — same ghost icon-only
+ * Placeholder for the injected `NotificationsBell`: the same ghost icon-only
  * `Button` and glyph, so the cluster's spacing and shrink behavior match the
  * real header. See the file header for why the real component isn't imported.
  */
@@ -297,7 +297,7 @@ function setMatchMedia(impl: typeof window.matchMedia) {
  */
 function ForceMobile({ children }: { children: React.ReactNode }) {
   // Installed from a `useState` initializer, which runs exactly once and during
-  // this component's render — i.e. before any child samples the query. An
+  // this component's render, i.e. before any child samples the query. An
   // identity check against the saved original would not work here: `bind`
   // returns a new function object, so it never compares equal to the global.
   const [original] = useState(() => {
@@ -354,7 +354,7 @@ type Story = StoryObj<typeof Harness>;
 
 /**
  * The header with no agent activity at all: a long title, Assets, Notifications
- * — and no Activity control, because the conversation has nothing to reopen.
+ * and no Activity control, because the conversation has nothing to reopen.
  * This is the baseline the control must not disturb.
  */
 export const DesktopBaseline: Story = {
@@ -363,7 +363,7 @@ export const DesktopBaseline: Story = {
 
 /**
  * One running ACP run and one finished subagent. Closed, the trigger shows the
- * live treatment and counts only the running work — the finished session is
+ * live treatment and counts only the running work. The finished session is
  * reachable but doesn't inflate the count or make the header look busy.
  */
 export const DesktopMixedClosed: Story = {
@@ -382,7 +382,7 @@ export const DesktopMixedOpen: Story = {
 
 /**
  * Nothing running, three finished subagents. The trigger drops the pulsing dots
- * and the primary tint, keeping the green check and its stack — finished work
+ * and the primary tint, keeping the green check and its stack. Finished work
  * stays reachable without the header claiming anything is in progress.
  */
 export const DesktopCompletedClosed: Story = {
@@ -392,7 +392,7 @@ export const DesktopCompletedClosed: Story = {
 /**
  * Five running and four finished, both mixing ACP runs with subagents. Shows the
  * chips overlapping inside each stack, the `+N` remainder past three, and the
- * point that the two groups are *status* groups — a Claude brand mark and a
+ * point that the two groups are *status* groups: a Claude brand mark and a
  * subagent avatar sit in the same stack.
  */
 export const DesktopManyClosed: Story = {

--- a/clients/web/src/domains/chat/chat-layout-header.stories.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.stories.tsx
@@ -14,7 +14,7 @@
  * is the same ghost icon-only `Button` with the same glyph, which is all this
  * story needs it to be — it exists to occupy the cluster, not to be exercised.
  *
- * Only four states are covered. The per-status card matrix for subagents and ACP
+ * Six states are covered. The per-status card matrix for subagents and ACP
  * runs belongs to their component tests, not to a header story.
  */
 
@@ -91,6 +91,90 @@ function seedMixedActivity() {
   });
 }
 
+/** Finished work only — nothing running, everything still reopenable. */
+function seedCompletedActivity() {
+  for (const [i, label] of [
+    "slack-thread-audit",
+    "gateway-log-sweep",
+    "retry-policy-review",
+  ].entries()) {
+    const id = `sa-done-${i}`;
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: id,
+      label,
+      objective: label,
+      status: "completed",
+      conversationId: `${id}-child`,
+      parentConversationId: CONVERSATION_ID,
+      timestamp: T0 + i * 100,
+    });
+    useSubagentStore.getState().loadDetail({
+      subagentId: id,
+      events: [
+        { id: `${id}-e1`, type: "text", content: "Done", timestamp: T0 },
+      ],
+    });
+  }
+}
+
+/**
+ * Several of each kind running and finished at once — the case that shows the
+ * stacks overlapping, the `+N` remainder, and (the point) ACP brand marks and
+ * subagent avatars mixed inside the *same* stack. The groups are status groups,
+ * never per-kind ones.
+ */
+function seedManyMixedActivity() {
+  // Running: one ACP run alongside four subagents.
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId: "acp-live",
+    agent: "claude",
+    parentConversationId: CONVERSATION_ID,
+    startedAt: T0,
+  });
+  useAcpRunStore.getState().receiveEvent({
+    acpSessionId: "acp-live",
+    event: {
+      seq: 1,
+      updateType: "tool_call",
+      toolCallId: "tc-1",
+      toolTitle: "Reading gateway restart logs",
+      toolStatus: "in_progress",
+    },
+  });
+  for (let i = 0; i < 4; i++) {
+    const id = `sa-live-${i}`;
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: id,
+      label: `researcher-${i}`,
+      objective: "",
+      status: "running",
+      conversationId: `${id}-child`,
+      parentConversationId: CONVERSATION_ID,
+      timestamp: T0 + 10 + i * 10,
+    });
+    useSubagentStore.getState().loadDetail({
+      subagentId: id,
+      events: [
+        { id: `${id}-e1`, type: "text", content: "Working", timestamp: T0 },
+      ],
+    });
+  }
+
+  // Finished: a settled ACP run alongside the finished subagents.
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId: "acp-done",
+    agent: "claude",
+    parentConversationId: CONVERSATION_ID,
+    startedAt: T0 - 500,
+  });
+  useAcpRunStore.getState().setTerminal({
+    acpSessionId: "acp-done",
+    status: "completed",
+    completedAt: T0 - 100,
+  });
+  seedCompletedActivity();
+}
+
 function resetActivity() {
   useAcpRunStore.getState().reset();
   useSubagentStore.getState().reset();
@@ -123,10 +207,10 @@ function NotificationsStandIn() {
  * into whichever story renders next.
  */
 function Harness({
-  withActivity,
+  activity,
   isMobile,
 }: {
-  withActivity: boolean;
+  activity: "none" | "mixed" | "completed" | "many";
   isMobile: boolean;
 }) {
   const queryClient = useQueryClient();
@@ -157,8 +241,12 @@ function Harness({
       }),
       { documents: [] },
     );
-    if (withActivity) {
+    if (activity === "mixed") {
       seedMixedActivity();
+    } else if (activity === "completed") {
+      seedCompletedActivity();
+    } else if (activity === "many") {
+      seedManyMixedActivity();
     }
     return true;
   });
@@ -270,7 +358,7 @@ type Story = StoryObj<typeof Harness>;
  * This is the baseline the control must not disturb.
  */
 export const DesktopBaseline: Story = {
-  args: { withActivity: false, isMobile: false },
+  args: { activity: "none", isMobile: false },
 };
 
 /**
@@ -279,7 +367,7 @@ export const DesktopBaseline: Story = {
  * reachable but doesn't inflate the count or make the header look busy.
  */
 export const DesktopMixedClosed: Story = {
-  args: { withActivity: true, isMobile: false },
+  args: { activity: "mixed", isMobile: false },
 };
 
 /**
@@ -288,8 +376,27 @@ export const DesktopMixedClosed: Story = {
  * detail viewer.
  */
 export const DesktopMixedOpen: Story = {
-  args: { withActivity: true, isMobile: false },
+  args: { activity: "mixed", isMobile: false },
   play: openActivityPanel,
+};
+
+/**
+ * Nothing running, three finished subagents. The trigger drops the pulsing dots
+ * and the primary tint, keeping the green check and its stack — finished work
+ * stays reachable without the header claiming anything is in progress.
+ */
+export const DesktopCompletedClosed: Story = {
+  args: { activity: "completed", isMobile: false },
+};
+
+/**
+ * Five running and four finished, both mixing ACP runs with subagents. Shows the
+ * chips overlapping inside each stack, the `+N` remainder past three, and the
+ * point that the two groups are *status* groups — a Claude brand mark and a
+ * subagent avatar sit in the same stack.
+ */
+export const DesktopManyClosed: Story = {
+  args: { activity: "many", isMobile: false },
 };
 
 /**
@@ -297,7 +404,7 @@ export const DesktopMixedOpen: Story = {
  * Activity opens the bottom sheet rather than a popover.
  */
 export const MobileMixedOpen: Story = {
-  args: { withActivity: true, isMobile: true },
+  args: { activity: "mixed", isMobile: true },
   decorators: [
     (Story) => (
       <ForceMobile>

--- a/clients/web/src/domains/chat/chat-layout-header.stories.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.stories.tsx
@@ -1,0 +1,309 @@
+/**
+ * Full-header visual matrix, built to protect the conversation header's right
+ * cluster now that `ConversationActivityPill` sits in it beside Assets.
+ *
+ * The header is assembled here the way `ChatLayout` + `routes.tsx` assemble it —
+ * a long conversation title in the centre slot, and Assets / Activity /
+ * Notifications in `topBarRightSlot` — because the thing worth protecting is the
+ * *composition*: whether the title still shrinks, and whether the cluster stays
+ * readable once Activity joins it.
+ *
+ * Notifications is a stand-in, not the real `NotificationsBell`: that component
+ * belongs to the home domain and `routes.tsx` injects it into the chat layout at
+ * runtime, so importing it here trips the cross-domain import rule. The stand-in
+ * is the same ghost icon-only `Button` with the same glyph, which is all this
+ * story needs it to be — it exists to occupy the cluster, not to be exercised.
+ *
+ * Only four states are covered. The per-status card matrix for subagents and ACP
+ * runs belongs to their component tests, not to a header story.
+ */
+
+import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Bell } from "lucide-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "@vellumai/design-library";
+
+import {
+  appsGetQueryKey,
+  documentsGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { ChatLayoutHeader } from "@/domains/chat/chat-layout-header";
+import { ConversationActivityPill } from "@/domains/chat/components/conversation-activity-pill";
+import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { MOBILE_MEDIA_QUERY } from "@/hooks/use-is-mobile";
+
+const ASSISTANT_ID = "asst-story";
+const CONVERSATION_ID = "conv-story";
+const T0 = 1_700_000_000_000;
+
+const LONG_TITLE =
+  "Investigating why the nightly ingestion job silently drops Slack threads " +
+  "after a gateway restart";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** One running ACP run and one finished subagent — the mixed case. */
+function seedMixedActivity() {
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId: "acp-live",
+    agent: "claude",
+    parentConversationId: CONVERSATION_ID,
+    startedAt: T0,
+  });
+  useAcpRunStore.getState().receiveEvent({
+    acpSessionId: "acp-live",
+    event: {
+      seq: 1,
+      updateType: "tool_call",
+      toolCallId: "tc-1",
+      toolTitle: "Reading gateway restart logs",
+      toolStatus: "in_progress",
+    },
+  });
+
+  useSubagentStore.getState().spawnSubagent({
+    subagentId: "sa-done",
+    label: "slack-thread-audit",
+    objective: "Audit dropped Slack threads",
+    status: "completed",
+    conversationId: "sa-done-child",
+    parentConversationId: CONVERSATION_ID,
+    timestamp: T0 + 1_000,
+  });
+  // Load a timeline so the finished card settles into its terminal state
+  // instead of the detail-fetch placeholder.
+  useSubagentStore.getState().loadDetail({
+    subagentId: "sa-done",
+    events: [
+      {
+        id: "sa-done-e1",
+        type: "text",
+        content: "Found 12 dropped threads across 3 channels",
+        timestamp: T0 + 1_500,
+      },
+    ],
+  });
+}
+
+function resetActivity() {
+  useAcpRunStore.getState().reset();
+  useSubagentStore.getState().reset();
+}
+
+/**
+ * Placeholder for the injected `NotificationsBell` — same ghost icon-only
+ * `Button` and glyph, so the cluster's spacing and shrink behavior match the
+ * real header. See the file header for why the real component isn't imported.
+ */
+function NotificationsStandIn() {
+  return (
+    <Button
+      variant="ghost"
+      iconOnlyGlyphClassName="[&_svg]:size-4.5 touch-mobile:[&_svg]:size-4.5"
+      iconOnly={<Bell />}
+      aria-label="Notifications"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/**
+ * Seeds the assets query cache (so the Assets pill has something to show
+ * without a daemon) and, optionally, the activity stores. Stores are global
+ * singletons, so the teardown matters: without it a story leaks its fixtures
+ * into whichever story renders next.
+ */
+function Harness({
+  withActivity,
+  isMobile,
+}: {
+  withActivity: boolean;
+  isMobile: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [seeded] = useState(() => {
+    queryClient.setQueryData(
+      appsGetQueryKey({
+        path: { assistant_id: ASSISTANT_ID },
+        query: { conversationId: CONVERSATION_ID },
+      }),
+      {
+        apps: [
+          {
+            id: "app-1",
+            name: "Ingestion dashboard",
+            createdAt: T0,
+            updatedAt: T0,
+            version: "1",
+            contentId: "c1",
+            origin: "workspace",
+          },
+        ],
+      },
+    );
+    queryClient.setQueryData(
+      documentsGetQueryKey({
+        path: { assistant_id: ASSISTANT_ID },
+        query: { conversationId: CONVERSATION_ID },
+      }),
+      { documents: [] },
+    );
+    if (withActivity) {
+      seedMixedActivity();
+    }
+    return true;
+  });
+  void seeded;
+
+  useEffect(() => resetActivity, []);
+
+  return (
+    <ChatLayoutHeader
+      isMobile={isMobile}
+      drawerOpen={false}
+      collapsed={false}
+      toggleSidebar={() => {}}
+      topBarCenter={
+        <span className="min-w-0 truncate text-sm font-medium text-[var(--content-default)]">
+          {LONG_TITLE}
+        </span>
+      }
+      topBarRightSlot={
+        <>
+          <ConversationAssetsPill
+            assistantId={ASSISTANT_ID}
+            conversationId={CONVERSATION_ID}
+          />
+          <ConversationActivityPill conversationId={CONVERSATION_ID} />
+          <NotificationsStandIn />
+        </>
+      }
+    />
+  );
+}
+
+/** Swap `window.matchMedia`; `configurable` so the teardown can put it back. */
+function setMatchMedia(impl: typeof window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    value: impl,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/**
+ * Forces the mobile branch of `useIsMobile` for the duration of the story.
+ *
+ * Overriding the media query beats resizing the preview iframe: the story then
+ * shows the mobile composition regardless of the viewport the docs page happens
+ * to render at.
+ */
+function ForceMobile({ children }: { children: React.ReactNode }) {
+  // Installed from a `useState` initializer, which runs exactly once and during
+  // this component's render — i.e. before any child samples the query. An
+  // identity check against the saved original would not work here: `bind`
+  // returns a new function object, so it never compares equal to the global.
+  const [original] = useState(() => {
+    const saved = window.matchMedia.bind(window);
+    setMatchMedia(((query: string) => {
+      const result = saved(query);
+      if (query !== MOBILE_MEDIA_QUERY) {
+        return result;
+      }
+      return {
+        ...result,
+        media: query,
+        matches: true,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      } as MediaQueryList;
+    }) as typeof window.matchMedia);
+    return saved;
+  });
+  useEffect(() => {
+    return () => setMatchMedia(original);
+  }, [original]);
+  return <>{children}</>;
+}
+
+/** Click the Activity trigger so the story renders with its panel open. */
+const openActivityPanel = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  const trigger = canvasElement.querySelector<HTMLElement>(
+    '[data-testid="conversation-activity-pill"]',
+  );
+  trigger?.click();
+};
+
+const meta: Meta<typeof Harness> = {
+  title: "Chat/ChatLayoutHeader",
+  component: Harness,
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+type Story = StoryObj<typeof Harness>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/**
+ * The header with no agent activity at all: a long title, Assets, Notifications
+ * — and no Activity control, because the conversation has nothing to reopen.
+ * This is the baseline the control must not disturb.
+ */
+export const DesktopBaseline: Story = {
+  args: { withActivity: false, isMobile: false },
+};
+
+/**
+ * One running ACP run and one finished subagent. Closed, the trigger shows the
+ * live treatment and counts only the running work — the finished session is
+ * reachable but doesn't inflate the count or make the header look busy.
+ */
+export const DesktopMixedClosed: Story = {
+  args: { withActivity: true, isMobile: false },
+};
+
+/**
+ * The same data with the popover open: the running run carries a Stop control,
+ * the finished subagent doesn't, and either row opens the existing process
+ * detail viewer.
+ */
+export const DesktopMixedOpen: Story = {
+  args: { withActivity: true, isMobile: false },
+  play: openActivityPanel,
+};
+
+/**
+ * The mobile composition: the cluster collapses to icon-only triggers and
+ * Activity opens the bottom sheet rather than a popover.
+ */
+export const MobileMixedOpen: Story = {
+  args: { withActivity: true, isMobile: true },
+  decorators: [
+    (Story) => (
+      <ForceMobile>
+        <Story />
+      </ForceMobile>
+    ),
+  ],
+  play: openActivityPanel,
+};

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -436,10 +436,9 @@ export function ChatBody({
 
       {!isEmptyState && activeProcessOverlaysSlot && (
         <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
-          {/* Registry-driven row of active background-process overlays. Order is
-              owned by OVERLAY_PROCESS_KINDS (workflows, background tasks);
-              each overlay self-gates on its own active ids. Subagents and ACP
-              runs are not here — they live in the header Activity control. */}
+          {/* Registry-driven row of active background-process overlays. The
+              caller owns which kinds it covers and their order; each overlay
+              self-gates on its own active ids. */}
           {activeProcessOverlaysSlot}
         </div>
       )}

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -437,8 +437,9 @@ export function ChatBody({
       {!isEmptyState && activeProcessOverlaysSlot && (
         <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
           {/* Registry-driven row of active background-process overlays. Order is
-              owned by PROCESS_KINDS (subagents, acp runs, workflows, background
-              tasks); each overlay self-gates on its own active ids. */}
+              owned by OVERLAY_PROCESS_KINDS (workflows, background tasks);
+              each overlay self-gates on its own active ids. Subagents and ACP
+              runs are not here — they live in the header Activity control. */}
           {activeProcessOverlaysSlot}
         </div>
       )}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -58,10 +58,8 @@ import { recordCommit } from "@/lib/commit-pressure";
 import { NewChatPluginsSection } from "@/domains/chat/components/new-chat-plugins/new-chat-plugins-section";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
-import { PROCESS_KINDS } from "@/domains/chat/process-registry/registry";
+import { OVERLAY_PROCESS_KINDS } from "@/domains/chat/process-registry/registry";
 import type { ProcessKind } from "@/domains/chat/process-registry/types";
-import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
-import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
 import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
 import { BACKGROUND_TASK_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/background-task";
 import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
@@ -213,32 +211,33 @@ export type ChatRouteContentProps = ChatMainPanelProps;
  * active conversation internally, so the hooks are called here at the
  * orchestrator level (where the conversation lives in context). They must be
  * called explicitly per-kind — the Rules of Hooks forbid iterating
- * `PROCESS_KINDS` with hooks — and the results are keyed by `descriptor.kind`,
- * so the overlay row order follows `PROCESS_KINDS` without positional coupling.
+ * `OVERLAY_PROCESS_KINDS` with hooks — and the results are keyed by
+ * `descriptor.kind`, so the overlay row order follows the constant without
+ * positional coupling.
+ *
+ * Only the kinds in `OVERLAY_PROCESS_KINDS` are here: subagents and ACP runs
+ * moved to the header's `ConversationActivityPill` and no longer float over the
+ * transcript.
  *
  * `hasAny` lets the caller omit the row entirely when nothing is active, so the
  * absolutely-positioned container never mounts empty; the overlays themselves
  * also self-gate on their own ids.
  */
 function useActiveProcessSlots() {
-  const subagentIds = SUBAGENT_DESCRIPTOR.useActiveIds();
-  const acpRunIds = ACP_RUN_DESCRIPTOR.useActiveIds();
   const workflowIds = WORKFLOW_DESCRIPTOR.useActiveIds();
   const backgroundTaskIds = BACKGROUND_TASK_DESCRIPTOR.useActiveIds();
   // Keyed by `descriptor.kind` (not array position) so reordering
-  // `PROCESS_KINDS` can't silently feed an overlay the wrong kind's ids.
-  const idsByKind: Record<ProcessKind, string[]> = {
-    subagent: subagentIds,
-    "acp-run": acpRunIds,
+  // `OVERLAY_PROCESS_KINDS` can't silently feed an overlay the wrong kind's ids.
+  const idsByKind: Partial<Record<ProcessKind, string[]>> = {
     workflow: workflowIds,
     "background-task": backgroundTaskIds,
   };
   const hasAny = Object.values(idsByKind).some((ids) => ids.length > 0);
-  const overlays = PROCESS_KINDS.map((descriptor) => (
+  const overlays = OVERLAY_PROCESS_KINDS.map((descriptor) => (
     <ActiveProcessOverlay
       key={descriptor.kind}
       descriptor={descriptor}
-      ids={idsByKind[descriptor.kind]}
+      ids={idsByKind[descriptor.kind] ?? []}
     />
   ));
   return { overlays, hasAny };

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -58,8 +58,13 @@ import { recordCommit } from "@/lib/commit-pressure";
 import { NewChatPluginsSection } from "@/domains/chat/components/new-chat-plugins/new-chat-plugins-section";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
-import { OVERLAY_PROCESS_KINDS } from "@/domains/chat/process-registry/registry";
+import {
+  OVERLAY_PROCESS_KINDS,
+  POPOUT_OVERLAY_PROCESS_KINDS,
+} from "@/domains/chat/process-registry/registry";
 import type { ProcessKind } from "@/domains/chat/process-registry/types";
+import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
+import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
 import { WORKFLOW_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/workflow";
 import { BACKGROUND_TASK_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/background-task";
 import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
@@ -209,35 +214,43 @@ export type ChatRouteContentProps = ChatMainPanelProps;
  *
  * Each descriptor's `useActiveIds()` is a zero-arg hook that resolves the
  * active conversation internally, so the hooks are called here at the
- * orchestrator level (where the conversation lives in context). They must be
- * called explicitly per-kind — the Rules of Hooks forbid iterating
- * `OVERLAY_PROCESS_KINDS` with hooks — and the results are keyed by
- * `descriptor.kind`, so the overlay row order follows the constant without
- * positional coupling.
+ * orchestrator level (where the conversation lives in context). All four run
+ * unconditionally, since the Rules of Hooks forbid both iterating a descriptor
+ * list with hooks and calling a subset of them per render. The results are
+ * keyed by `descriptor.kind`, so the overlay row order follows the kind list
+ * without positional coupling.
  *
- * Only the kinds in `OVERLAY_PROCESS_KINDS` are here: subagents and ACP runs
- * moved to the header's `ConversationActivityPill` and no longer float over the
- * transcript.
+ * `isPopout` selects that kind list. A windowed chat carries subagent and ACP
+ * sessions in the header's `ConversationActivityPill`, so its overlay row holds
+ * only workflows and background tasks. A pop-out renders no header at all, so
+ * there the overlay covers every kind and stays the one ambient surface.
  *
  * `hasAny` lets the caller omit the row entirely when nothing is active, so the
  * absolutely-positioned container never mounts empty; the overlays themselves
  * also self-gate on their own ids.
  */
-function useActiveProcessSlots() {
+function useActiveProcessSlots(isPopout: boolean) {
+  const subagentIds = SUBAGENT_DESCRIPTOR.useActiveIds();
+  const acpRunIds = ACP_RUN_DESCRIPTOR.useActiveIds();
   const workflowIds = WORKFLOW_DESCRIPTOR.useActiveIds();
   const backgroundTaskIds = BACKGROUND_TASK_DESCRIPTOR.useActiveIds();
-  // Keyed by `descriptor.kind` (not array position) so reordering
-  // `OVERLAY_PROCESS_KINDS` can't silently feed an overlay the wrong kind's ids.
-  const idsByKind: Partial<Record<ProcessKind, string[]>> = {
+  // Keyed by `descriptor.kind` (not array position) so reordering a kind list
+  // can't silently feed an overlay the wrong kind's ids.
+  const idsByKind: Record<ProcessKind, string[]> = {
+    subagent: subagentIds,
+    "acp-run": acpRunIds,
     workflow: workflowIds,
     "background-task": backgroundTaskIds,
   };
-  const hasAny = Object.values(idsByKind).some((ids) => ids.length > 0);
-  const overlays = OVERLAY_PROCESS_KINDS.map((descriptor) => (
+  const kinds = isPopout ? POPOUT_OVERLAY_PROCESS_KINDS : OVERLAY_PROCESS_KINDS;
+  const hasAny = kinds.some(
+    (descriptor) => idsByKind[descriptor.kind].length > 0,
+  );
+  const overlays = kinds.map((descriptor) => (
     <ActiveProcessOverlay
       key={descriptor.kind}
       descriptor={descriptor}
-      ids={idsByKind[descriptor.kind] ?? []}
+      ids={idsByKind[descriptor.kind]}
     />
   ));
   return { overlays, hasAny };
@@ -274,7 +287,10 @@ export function ChatMainPanel({
 }: ChatMainPanelProps) {
   const location = useLocation();
   const navigate = useNavigate();
-  const statusBannerVisible = !isPopoutWindow(location.search);
+  // A pop-out renders no header and no status banner, which changes both what
+  // chrome is available and which kinds the overlay row has to carry.
+  const isPopout = isPopoutWindow(location.search);
+  const statusBannerVisible = !isPopout;
 
   // -------------------------------------------------------------------------
   // Derived UI state (provides assistantId, activeConversationId,
@@ -388,7 +404,7 @@ export function ChatMainPanel({
   );
 
   const { overlays: activeProcessOverlays, hasAny: hasActiveProcess } =
-    useActiveProcessSlots();
+    useActiveProcessSlots(isPopout);
 
   // Rehydrate ACP runs from the daemon on conversation load so completed and
   // in-progress runs reappear after a refresh / reconnect.

--- a/clients/web/src/domains/chat/components/conversation-activity-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Tests for `ConversationActivityPill` — the header control that reopens the
+ * current conversation's subagent and ACP sessions.
+ *
+ * The detailed per-status card matrix belongs to the descriptor/card tests; what
+ * is pinned down here is the control's own contract: when it exists at all, what
+ * the trigger claims, which rows it lists, and which of them may be stopped.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+const isMobileRef = { value: false };
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => isMobileRef.value,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+const { ConversationActivityPill, ACTIVITY_PILL_TESTID } = await import(
+  "@/domains/chat/components/conversation-activity-pill"
+);
+const { useSubagentStore } = await import("@/domains/chat/subagent-store");
+const { useAcpRunStore } = await import("@/domains/chat/acp-run-store");
+const { useViewerStore } = await import("@/stores/viewer-store");
+
+const CONV = "conv-A";
+const OTHER = "conv-B";
+const T0 = 1_700_000_000_000;
+
+const openProcessDetail =
+  mock<(ref: { kind: string; id: string }) => void>(() => {});
+const abortSubagent = mock(async (_id: string) => {});
+
+beforeEach(() => {
+  openProcessDetail.mockClear();
+  abortSubagent.mockClear();
+  useViewerStore.setState({ openProcessDetail });
+  useSubagentStore.setState({ abortSubagent });
+});
+
+afterEach(() => {
+  cleanup();
+  useSubagentStore.getState().reset();
+  useAcpRunStore.getState().reset();
+  isMobileRef.value = false;
+});
+
+/**
+ * A running subagent with a timeline, so its card projects as `loading` rather
+ * than sitting in the detail-fetch placeholder.
+ */
+function spawnRunningSubagent(id: string, parentConversationId = CONV) {
+  useSubagentStore.getState().spawnSubagent({
+    subagentId: id,
+    label: id,
+    objective: "",
+    status: "running",
+    conversationId: `${id}-child`,
+    parentConversationId,
+    timestamp: T0,
+  });
+  useSubagentStore.getState().loadDetail({
+    subagentId: id,
+    events: [
+      {
+        id: `${id}-e1`,
+        type: "text",
+        content: "working",
+        timestamp: T0,
+      },
+    ],
+  });
+}
+
+/**
+ * A finished subagent whose timeline has NOT been fetched. This is the case that
+ * projects a `loading` card state despite being terminal (see
+ * `use-subagent-card-data`), so it is the one that proves the stop button is
+ * gated on real status rather than on the card's visual state.
+ */
+function spawnUnfetchedCompletedSubagent(id: string) {
+  useSubagentStore.getState().spawnSubagent({
+    subagentId: id,
+    label: id,
+    objective: "",
+    status: "completed",
+    conversationId: `${id}-child`,
+    parentConversationId: CONV,
+    timestamp: T0 + 10,
+  });
+}
+
+function spawnAcpRun(id: string, parentConversationId = CONV, terminal = false) {
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId: id,
+    agent: "claude",
+    parentConversationId,
+    startedAt: T0 + 20,
+  });
+  if (terminal) {
+    useAcpRunStore.getState().setTerminal({
+      acpSessionId: id,
+      status: "completed",
+      completedAt: T0 + 30,
+    });
+  }
+}
+
+function renderPill(conversationId = CONV) {
+  return render(<ConversationActivityPill conversationId={conversationId} />);
+}
+
+/** Open the popover / sheet by clicking the trigger. */
+function openPanel() {
+  fireEvent.click(screen.getByTestId(ACTIVITY_PILL_TESTID));
+}
+
+describe("ConversationActivityPill — when it renders", () => {
+  test("renders nothing when the conversation has no activity", () => {
+    renderPill();
+    expect(screen.queryByTestId(ACTIVITY_PILL_TESTID)).toBeNull();
+  });
+
+  test("renders nothing when the only activity belongs to another conversation", () => {
+    spawnRunningSubagent("sa-theirs", OTHER);
+    spawnAcpRun("acp-theirs", OTHER);
+
+    renderPill();
+
+    expect(screen.queryByTestId(ACTIVITY_PILL_TESTID)).toBeNull();
+  });
+
+  test("appears once the conversation has activity", () => {
+    spawnRunningSubagent("sa-1");
+    renderPill();
+    expect(screen.getByTestId(ACTIVITY_PILL_TESTID)).toBeTruthy();
+  });
+});
+
+describe("ConversationActivityPill — trigger", () => {
+  test("counts only the running work while something is running", () => {
+    spawnRunningSubagent("sa-1");
+    spawnUnfetchedCompletedSubagent("sa-done");
+
+    renderPill();
+
+    const trigger = screen.getByTestId(ACTIVITY_PILL_TESTID);
+    expect(trigger.getAttribute("aria-label")).toBe(
+      "Conversation activity, 1 running",
+    );
+    expect(trigger.textContent).toContain("1 running");
+  });
+
+  test("reads as finished, not active, when only completed work remains", () => {
+    spawnUnfetchedCompletedSubagent("sa-done");
+    spawnAcpRun("acp-done", CONV, true);
+
+    renderPill();
+
+    const trigger = screen.getByTestId(ACTIVITY_PILL_TESTID);
+    expect(trigger.getAttribute("aria-label")).toBe(
+      "Conversation activity, 2 finished",
+    );
+    expect(trigger.textContent).toContain("2 sessions");
+    expect(trigger.textContent).not.toContain("running");
+  });
+});
+
+describe("ConversationActivityPill — panel", () => {
+  test("lists this conversation's sessions and not another's", () => {
+    spawnRunningSubagent("sa-mine");
+    spawnRunningSubagent("sa-theirs", OTHER);
+
+    renderPill();
+    openPanel();
+
+    expect(screen.getByTestId("activity-row-sa-mine")).toBeTruthy();
+    expect(screen.queryByTestId("activity-row-sa-theirs")).toBeNull();
+  });
+
+  test("shows running and completed work together", () => {
+    spawnRunningSubagent("sa-live");
+    spawnAcpRun("acp-done", CONV, true);
+
+    renderPill();
+    openPanel();
+
+    expect(screen.getByTestId("activity-row-sa-live")).toBeTruthy();
+    expect(screen.getByTestId("activity-row-acp-done")).toBeTruthy();
+  });
+
+  test("opening a row routes to the existing process detail viewer", () => {
+    spawnRunningSubagent("sa-live");
+
+    renderPill();
+    openPanel();
+    fireEvent.click(screen.getByLabelText("Open subagent"));
+
+    expect(openProcessDetail).toHaveBeenCalledWith({
+      kind: "subagent",
+      id: "sa-live",
+    });
+  });
+});
+
+describe("ConversationActivityPill — stop", () => {
+  test("a running row can be stopped", () => {
+    spawnRunningSubagent("sa-live");
+
+    renderPill();
+    openPanel();
+    const row = screen.getByTestId("activity-row-sa-live");
+    const stop = row.querySelector('[data-testid="inline-process-card-stop"]');
+    expect(stop).toBeTruthy();
+
+    fireEvent.click(stop as Element);
+    expect(abortSubagent).toHaveBeenCalledWith("sa-live");
+  });
+
+  test("a finished row offers no stop, even while its card still reads as loading", () => {
+    // `sa-done` is terminal but its timeline hasn't been fetched, so the shared
+    // card projects `state: "loading"`. `InlineProcessCard` keys its stop button
+    // off that state, so a row trusting the projection would show Stop on
+    // already-finished work.
+    spawnUnfetchedCompletedSubagent("sa-done");
+
+    renderPill();
+    openPanel();
+    const row = screen.getByTestId("activity-row-sa-done");
+
+    expect(
+      row.querySelector('[data-testid="inline-process-card-stop"]'),
+    ).toBeNull();
+  });
+});
+
+describe("ConversationActivityPill — mobile", () => {
+  test("uses the icon-only trigger and opens the bottom sheet", () => {
+    isMobileRef.value = true;
+    spawnRunningSubagent("sa-live");
+
+    renderPill();
+    const trigger = screen.getByTestId(ACTIVITY_PILL_TESTID);
+    // Icon-only: the count rides the aria-label rather than visible text.
+    expect(trigger.textContent).not.toContain("running");
+    expect(trigger.getAttribute("aria-label")).toBe(
+      "Conversation activity, 1 running",
+    );
+
+    fireEvent.click(trigger);
+    expect(screen.getByTestId("activity-row-sa-live")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/conversation-activity-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.test.tsx
@@ -17,9 +17,12 @@ mock.module("@/hooks/use-is-mobile", () => ({
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
 }));
 
-const { ConversationActivityPill, ACTIVITY_PILL_TESTID } = await import(
-  "@/domains/chat/components/conversation-activity-pill"
-);
+const {
+  ConversationActivityPill,
+  ACTIVITY_PILL_TESTID,
+  RUNNING_GROUP_TESTID,
+  COMPLETED_GROUP_TESTID,
+} = await import("@/domains/chat/components/conversation-activity-pill");
 const { useSubagentStore } = await import("@/domains/chat/subagent-store");
 const { useAcpRunStore } = await import("@/domains/chat/acp-run-store");
 const { useViewerStore } = await import("@/stores/viewer-store");
@@ -139,31 +142,56 @@ describe("ConversationActivityPill — when it renders", () => {
 });
 
 describe("ConversationActivityPill — trigger", () => {
-  test("counts only the running work while something is running", () => {
+  test("shows a running group and a finished group side by side", () => {
     spawnRunningSubagent("sa-1");
     spawnUnfetchedCompletedSubagent("sa-done");
 
     renderPill();
 
     const trigger = screen.getByTestId(ACTIVITY_PILL_TESTID);
+    // Both counts are named for assistive tech; the chips carry it visually.
     expect(trigger.getAttribute("aria-label")).toBe(
-      "Conversation activity, 1 running",
+      "Conversation activity, 1 running, 1 finished",
     );
-    expect(trigger.textContent).toContain("1 running");
+    expect(screen.getByTestId(RUNNING_GROUP_TESTID)).toBeTruthy();
+    expect(screen.getByTestId(COMPLETED_GROUP_TESTID)).toBeTruthy();
   });
 
-  test("reads as finished, not active, when only completed work remains", () => {
+  test("omits the finished group while everything is still running", () => {
+    spawnRunningSubagent("sa-1");
+
+    renderPill();
+
+    expect(screen.getByTestId(ACTIVITY_PILL_TESTID).getAttribute("aria-label"))
+      .toBe("Conversation activity, 1 running");
+    expect(screen.getByTestId(RUNNING_GROUP_TESTID)).toBeTruthy();
+    expect(screen.queryByTestId(COMPLETED_GROUP_TESTID)).toBeNull();
+  });
+
+  test("omits the running group, and its pulse, once everything has finished", () => {
     spawnUnfetchedCompletedSubagent("sa-done");
     spawnAcpRun("acp-done", CONV, true);
 
     renderPill();
 
-    const trigger = screen.getByTestId(ACTIVITY_PILL_TESTID);
-    expect(trigger.getAttribute("aria-label")).toBe(
-      "Conversation activity, 2 finished",
-    );
-    expect(trigger.textContent).toContain("2 sessions");
-    expect(trigger.textContent).not.toContain("running");
+    expect(screen.getByTestId(ACTIVITY_PILL_TESTID).getAttribute("aria-label"))
+      .toBe("Conversation activity, 2 finished");
+    expect(screen.queryByTestId(RUNNING_GROUP_TESTID)).toBeNull();
+    expect(screen.getByTestId(COMPLETED_GROUP_TESTID)).toBeTruthy();
+  });
+
+  test("mixes both kinds inside one status group rather than splitting by kind", () => {
+    // The running group holds an ACP run AND a subagent: grouping is by status,
+    // never by process kind.
+    spawnRunningSubagent("sa-live");
+    spawnAcpRun("acp-live");
+
+    renderPill();
+
+    const group = screen.getByTestId(RUNNING_GROUP_TESTID);
+    expect(group.querySelectorAll("img, svg").length).toBeGreaterThan(1);
+    expect(screen.getByTestId(ACTIVITY_PILL_TESTID).getAttribute("aria-label"))
+      .toBe("Conversation activity, 2 running");
   });
 });
 
@@ -242,11 +270,10 @@ describe("ConversationActivityPill — mobile", () => {
 
     renderPill();
     const trigger = screen.getByTestId(ACTIVITY_PILL_TESTID);
-    // Icon-only: the count rides the aria-label rather than visible text.
-    expect(trigger.textContent).not.toContain("running");
     expect(trigger.getAttribute("aria-label")).toBe(
       "Conversation activity, 1 running",
     );
+    expect(screen.getByTestId(RUNNING_GROUP_TESTID)).toBeTruthy();
 
     fireEvent.click(trigger);
     expect(screen.getByTestId("activity-row-sa-live")).toBeTruthy();

--- a/clients/web/src/domains/chat/components/conversation-activity-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for `ConversationActivityPill` — the header control that reopens the
+ * Tests for `ConversationActivityPill`, the header control that reopens the
  * current conversation's subagent and ACP sessions.
  *
  * The detailed per-status card matrix belongs to the descriptor/card tests; what
@@ -119,7 +119,7 @@ function openPanel() {
   fireEvent.click(screen.getByTestId(ACTIVITY_PILL_TESTID));
 }
 
-describe("ConversationActivityPill — when it renders", () => {
+describe("ConversationActivityPill: when it renders", () => {
   test("renders nothing when the conversation has no activity", () => {
     renderPill();
     expect(screen.queryByTestId(ACTIVITY_PILL_TESTID)).toBeNull();
@@ -141,7 +141,7 @@ describe("ConversationActivityPill — when it renders", () => {
   });
 });
 
-describe("ConversationActivityPill — trigger", () => {
+describe("ConversationActivityPill: trigger", () => {
   test("shows a running group and a finished group side by side", () => {
     spawnRunningSubagent("sa-1");
     spawnUnfetchedCompletedSubagent("sa-done");
@@ -195,7 +195,7 @@ describe("ConversationActivityPill — trigger", () => {
   });
 });
 
-describe("ConversationActivityPill — panel", () => {
+describe("ConversationActivityPill: panel", () => {
   test("lists this conversation's sessions and not another's", () => {
     spawnRunningSubagent("sa-mine");
     spawnRunningSubagent("sa-theirs", OTHER);
@@ -232,7 +232,7 @@ describe("ConversationActivityPill — panel", () => {
   });
 });
 
-describe("ConversationActivityPill — stop", () => {
+describe("ConversationActivityPill: stop", () => {
   test("a running row can be stopped", () => {
     spawnRunningSubagent("sa-live");
 
@@ -263,7 +263,7 @@ describe("ConversationActivityPill — stop", () => {
   });
 });
 
-describe("ConversationActivityPill — mobile", () => {
+describe("ConversationActivityPill: mobile", () => {
   test("uses the icon-only trigger and opens the bottom sheet", () => {
     isMobileRef.value = true;
     spawnRunningSubagent("sa-live");

--- a/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
@@ -1,6 +1,6 @@
 /**
- * Header control listing the current conversation's agent sessions — its
- * subagents and ACP runs — so a session can be reopened after it scrolls out of
+ * Header control listing the current conversation's agent sessions (its
+ * subagents and ACP runs), so a session can be reopened after it scrolls out of
  * the transcript, running or finished.
  *
  * Deliberately a sibling of {@link ConversationAssetsPill} rather than a section
@@ -9,8 +9,8 @@
  * rows) the process registry's own `InlineProcessCardRow`, descriptors, and
  * `onOpenDetail` routing. Nothing here is a new visual primitive.
  *
- * The trigger keeps the retired sticky overlay's stacked agent chips — a
- * subagent's avatar, an ACP run's brand mark — so you can see *who* is working
+ * The trigger keeps the retired sticky overlay's stacked agent chips (a
+ * subagent's avatar, an ACP run's brand mark), so you can see *who* is working
  * without opening anything. Because this control outlives the work (unlike the
  * overlay, which only existed while something ran), the chips are split into two
  * status groups: a pulsing `ThreeDotIndicator` ahead of the running agents, and
@@ -43,7 +43,7 @@ export const COMPLETED_GROUP_TESTID = "activity-trigger-completed";
 
 /**
  * The two kinds this control covers, keyed for row lookup. Workflows and
- * background tools are intentionally absent — they keep their own surfaces.
+ * background tools are intentionally absent. They keep their own surfaces.
  */
 const DESCRIPTORS: Record<
   ConversationActivityRow["kind"],
@@ -62,7 +62,7 @@ export interface ConversationActivityPillProps {
  * Visible chips per status group before the rest collapse into `+N`. Lower than
  * the overlay's {@link MAX_VISIBLE_STACKED_CHIPS} because the trigger can carry
  * two groups at once and shares the header row with the title, Assets, and the
- * notification bell — six chips per group would crowd all of them out.
+ * notification bell. Six chips per group would crowd all of them out.
  */
 const MAX_CHIPS_PER_GROUP = 3;
 
@@ -130,11 +130,11 @@ function SectionLabel({ children }: { children: string }) {
 /**
  * One session row.
  *
- * `canStop` comes from which group the row is in — its real status in the store
- * — not from the projected card state. `InlineProcessCard` gates its stop button
+ * `canStop` comes from which group the row is in, its real status in the store,
+ * not from the projected card state. `InlineProcessCard` gates its stop button
  * on `summary.state === "loading"`, and a *finished* subagent whose timeline
  * hasn't been fetched yet deliberately projects as `loading` ("Loading", rather
- * than claiming 0 steps — see `use-subagent-card-data`). Passing `onStop` for
+ * than claiming 0 steps, see `use-subagent-card-data`). Passing `onStop` for
  * those rows would put a Stop button on an already-finished session.
  */
 function ActivityRow({
@@ -266,7 +266,7 @@ export function ConversationActivityPill({
   );
 
   // Tint drives the label/chevron colour only; the chips carry their own.
-  // Primary while live, neutral once everything has settled — the same
+  // Primary while live, neutral once everything has settled. The same
   // treatment Assets uses, so finished work stays reachable without reading as
   // in-progress.
   const tintColor = isRunning

--- a/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
@@ -1,7 +1,12 @@
 /**
  * Header control listing the current conversation's agent sessions (its
- * subagents and ACP runs), so a session can be reopened after it scrolls out of
- * the transcript, running or finished.
+ * subagents and ACP runs), running or finished, so a session's details stay one
+ * click away once its transcript card has scrolled out of view.
+ *
+ * A navigation surface only. Rows open the same read-only detail viewer the
+ * transcript card opens, via `onOpenDetail`; nothing here starts, resumes, or
+ * restarts an agent. The one action on a live process is Stop, offered on
+ * running rows.
  *
  * Deliberately a sibling of {@link ConversationAssetsPill} rather than a section
  * inside it, and built from the same parts: the same ghost/`active` pill

--- a/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
@@ -1,0 +1,226 @@
+/**
+ * Header control listing the current conversation's agent sessions — its
+ * subagents and ACP runs — so a session can be reopened after it scrolls out of
+ * the transcript, running or finished.
+ *
+ * Deliberately a sibling of {@link ConversationAssetsPill} rather than a section
+ * inside it, and built from the same parts: the same ghost/`active` pill
+ * trigger, the same desktop-popover / mobile-bottom-sheet split, and (for the
+ * rows) the process registry's own `InlineProcessCardRow`, descriptors, and
+ * `onOpenDetail` routing. Nothing here is a new visual primitive.
+ *
+ * The trigger reads live only while something is running: the running case
+ * borrows the transcript's `ThreeDotIndicator` and the primary tint, while a
+ * conversation whose work has all finished falls back to the neutral tint Assets
+ * uses, so a finished session stays reachable without reading as in-progress.
+ * With nothing to show at all the control renders nothing.
+ */
+
+import { Activity } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { BottomSheet, Button, Popover, Typography } from "@vellumai/design-library";
+
+import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+import { useConversationActivity } from "@/domains/chat/hooks/use-conversation-activity";
+import { ACP_RUN_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/acp-run";
+import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
+import { InlineProcessCardRow } from "@/domains/chat/process-registry/inline-process-card-row";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+
+import type {
+  ConversationActivityRow,
+  ConversationActivity,
+} from "@/domains/chat/hooks/use-conversation-activity";
+import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registry/types";
+
+export const ACTIVITY_PILL_TESTID = "conversation-activity-pill";
+
+/**
+ * The two kinds this control covers, keyed for row lookup. Workflows and
+ * background tools are intentionally absent — they keep their own surfaces.
+ */
+const DESCRIPTORS: Record<
+  ConversationActivityRow["kind"],
+  BackgroundProcessDescriptor
+> = {
+  subagent: SUBAGENT_DESCRIPTOR,
+  "acp-run": ACP_RUN_DESCRIPTOR,
+};
+
+export interface ConversationActivityPillProps {
+  /** Conversation whose sessions are listed. */
+  conversationId: string;
+}
+
+/** Section heading inside the panel, matching the Assets popover's label. */
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <div className="px-3 pt-3 pb-1">
+      <Typography
+        variant="label-small-default"
+        className="text-[var(--content-tertiary)]"
+      >
+        {children}
+      </Typography>
+    </div>
+  );
+}
+
+/**
+ * One session row.
+ *
+ * `canStop` comes from which group the row is in — its real status in the store
+ * — not from the projected card state. `InlineProcessCard` gates its stop button
+ * on `summary.state === "loading"`, and a *finished* subagent whose timeline
+ * hasn't been fetched yet deliberately projects as `loading` ("Loading", rather
+ * than claiming 0 steps — see `use-subagent-card-data`). Passing `onStop` for
+ * those rows would put a Stop button on an already-finished session.
+ */
+function ActivityRow({
+  row,
+  canStop,
+  onClose,
+}: {
+  row: ConversationActivityRow;
+  canStop: boolean;
+  onClose: () => void;
+}) {
+  const descriptor = DESCRIPTORS[row.kind];
+  const onStop = canStop && descriptor.onStop ? descriptor.onStop : undefined;
+  return (
+    <InlineProcessCardRow
+      descriptor={descriptor}
+      id={row.id}
+      testId={`activity-row-${row.id}`}
+      onOpen={() => {
+        descriptor.onOpenDetail(row.id);
+        onClose();
+      }}
+      onStop={onStop && (() => onStop(row.id))}
+    />
+  );
+}
+
+/** Panel body shared by the popover and the bottom sheet. */
+function ActivityPanel({
+  activity,
+  onClose,
+}: {
+  activity: ConversationActivity;
+  onClose: () => void;
+}) {
+  const { running, completed } = activity;
+  // Headings only earn their space when both groups are present; a list that is
+  // all-running or all-finished is already self-describing.
+  const showLabels = running.length > 0 && completed.length > 0;
+  return (
+    <div className="flex min-w-0 flex-col">
+      {showLabels ? <SectionLabel>Running</SectionLabel> : null}
+      <div className="px-2 pb-1">
+        {running.map((row) => (
+          <ActivityRow
+            key={`${row.kind}:${row.id}`}
+            row={row}
+            canStop
+            onClose={onClose}
+          />
+        ))}
+      </div>
+      {showLabels ? <SectionLabel>Recent</SectionLabel> : null}
+      <div className="px-2 pb-2">
+        {completed.map((row) => (
+          <ActivityRow
+            key={`${row.kind}:${row.id}`}
+            row={row}
+            canStop={false}
+            onClose={onClose}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ConversationActivityPill({
+  conversationId,
+}: ConversationActivityPillProps) {
+  const activity = useConversationActivity(conversationId);
+  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const handleClose = useCallback(() => setOpen(false), []);
+
+  const { running, total } = activity;
+  if (total === 0) {
+    return null;
+  }
+
+  const isRunning = running.length > 0;
+  // Running counts the live work; otherwise the total is what's reopenable.
+  const count = isRunning ? running.length : total;
+  const noun = isRunning ? "running" : count === 1 ? "session" : "sessions";
+  const label = `${count} ${noun}`;
+  const ariaLabel = isRunning
+    ? `Conversation activity, ${count} running`
+    : `Conversation activity, ${count} finished`;
+
+  const glyph = isRunning ? (
+    <ThreeDotIndicator dotSize={4} gap={2} />
+  ) : (
+    <Activity />
+  );
+  const tintColor = isRunning
+    ? "var(--primary-base)"
+    : "var(--content-default)";
+
+  const panel = <ActivityPanel activity={activity} onClose={handleClose} />;
+
+  if (isMobile) {
+    return (
+      <BottomSheet.Root open={open} onOpenChange={setOpen}>
+        <BottomSheet.Trigger asChild>
+          <Button
+            variant="ghost"
+            active
+            iconOnly={glyph}
+            tintColor={tintColor}
+            aria-label={ariaLabel}
+            data-testid={ACTIVITY_PILL_TESTID}
+          />
+        </BottomSheet.Trigger>
+        <BottomSheet.Content className="max-h-[85dvh]">
+          <BottomSheet.Header>
+            <BottomSheet.Title>Activity</BottomSheet.Title>
+          </BottomSheet.Header>
+          <BottomSheet.Body className="pt-0">{panel}</BottomSheet.Body>
+        </BottomSheet.Content>
+      </BottomSheet.Root>
+    );
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button
+          variant="ghost"
+          active
+          leftIcon={glyph}
+          className="rounded-full"
+          tintColor={tintColor}
+          aria-label={ariaLabel}
+          data-testid={ACTIVITY_PILL_TESTID}
+        >
+          {label}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content
+        side="bottom"
+        align="center"
+        sideOffset={8}
+        className="w-80 p-0"
+      >
+        <div className="max-h-[280px] overflow-y-auto">{panel}</div>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
@@ -213,11 +213,15 @@ export function ConversationActivityPill({
           {label}
         </Button>
       </Popover.Trigger>
+      {/* `align="end"`, unlike the Assets pill's centred panel: Activity sits
+          further right in the cluster, so a centred 320px panel resolves flush
+          against the window edge. Anchoring the panel's trailing edge to the
+          trigger matches the notification bell, its neighbour on that side. */}
       <Popover.Content
         side="bottom"
-        align="center"
+        align="end"
         sideOffset={8}
-        className="w-80 p-0"
+        className="w-80 max-w-[calc(100vw-2rem)] p-0"
       >
         <div className="max-h-[280px] overflow-y-auto">{panel}</div>
       </Popover.Content>

--- a/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
@@ -9,15 +9,18 @@
  * rows) the process registry's own `InlineProcessCardRow`, descriptors, and
  * `onOpenDetail` routing. Nothing here is a new visual primitive.
  *
- * The trigger reads live only while something is running: the running case
- * borrows the transcript's `ThreeDotIndicator` and the primary tint, while a
- * conversation whose work has all finished falls back to the neutral tint Assets
- * uses, so a finished session stays reachable without reading as in-progress.
- * With nothing to show at all the control renders nothing.
+ * The trigger keeps the retired sticky overlay's stacked agent chips — a
+ * subagent's avatar, an ACP run's brand mark — so you can see *who* is working
+ * without opening anything. Because this control outlives the work (unlike the
+ * overlay, which only existed while something ran), the chips are split into two
+ * status groups: a pulsing `ThreeDotIndicator` ahead of the running agents, and
+ * the same green check the inline cards use ahead of the finished ones. Either
+ * group is omitted when empty, and with nothing at all the control renders
+ * nothing.
  */
 
-import { Activity } from "lucide-react";
-import { useCallback, useState } from "react";
+import { CheckCircle2, ChevronDown, ChevronUp } from "lucide-react";
+import { useCallback, useState, type ReactNode } from "react";
 
 import { BottomSheet, Button, Popover, Typography } from "@vellumai/design-library";
 
@@ -35,6 +38,8 @@ import type {
 import type { BackgroundProcessDescriptor } from "@/domains/chat/process-registry/types";
 
 export const ACTIVITY_PILL_TESTID = "conversation-activity-pill";
+export const RUNNING_GROUP_TESTID = "activity-trigger-running";
+export const COMPLETED_GROUP_TESTID = "activity-trigger-completed";
 
 /**
  * The two kinds this control covers, keyed for row lookup. Workflows and
@@ -51,6 +56,61 @@ const DESCRIPTORS: Record<
 export interface ConversationActivityPillProps {
   /** Conversation whose sessions are listed. */
   conversationId: string;
+}
+
+/**
+ * Visible chips per status group before the rest collapse into `+N`. Lower than
+ * the overlay's {@link MAX_VISIBLE_STACKED_CHIPS} because the trigger can carry
+ * two groups at once and shares the header row with the title, Assets, and the
+ * notification bell — six chips per group would crowd all of them out.
+ */
+const MAX_CHIPS_PER_GROUP = 3;
+
+/** The stacked chip a row contributes, from its own descriptor. */
+function rowChip(row: ConversationActivityRow): ReactNode {
+  const { pill } = DESCRIPTORS[row.kind];
+  // Both covered kinds are `stacked`; the guard is for the type, and degrades to
+  // no chip rather than throwing if a kind ever switches to a count pill.
+  return pill.variant === "stacked" ? pill.renderChip(row.id) : null;
+}
+
+/**
+ * One status group in the trigger: a status glyph followed by that group's
+ * overlapping agent chips, capped with a `+N` remainder. Renders nothing when
+ * the group is empty, so a conversation with only finished work shows only the
+ * check group and vice versa.
+ */
+function TriggerGroup({
+  rows,
+  glyph,
+  max,
+  testId,
+}: {
+  rows: ConversationActivityRow[];
+  glyph: ReactNode;
+  max: number;
+  testId: string;
+}) {
+  if (rows.length === 0) {
+    return null;
+  }
+  const overflow = rows.length - max;
+  return (
+    <span data-testid={testId} className="inline-flex items-center gap-1">
+      {glyph}
+      <span className="flex items-center">
+        {rows.slice(0, max).map(rowChip)}
+      </span>
+      {overflow > 0 ? (
+        <Typography
+          variant="body-small-default"
+          className="text-[var(--content-emphasised)]"
+        >
+          +{overflow}
+        </Typography>
+      ) : null}
+    </span>
+  );
 }
 
 /** Section heading inside the panel, matching the Assets popover's label. */
@@ -150,25 +210,65 @@ export function ConversationActivityPill({
   const isMobile = useIsMobile();
   const handleClose = useCallback(() => setOpen(false), []);
 
-  const { running, total } = activity;
+  const { running, completed, total } = activity;
   if (total === 0) {
     return null;
   }
 
   const isRunning = running.length > 0;
-  // Running counts the live work; otherwise the total is what's reopenable.
-  const count = isRunning ? running.length : total;
-  const noun = isRunning ? "running" : count === 1 ? "session" : "sessions";
-  const label = `${count} ${noun}`;
-  const ariaLabel = isRunning
-    ? `Conversation activity, ${count} running`
-    : `Conversation activity, ${count} finished`;
+  // Both counts are named, since the chips alone don't say which group is which
+  // to a screen reader.
+  const ariaLabel = [
+    "Conversation activity",
+    running.length > 0 ? `${running.length} running` : null,
+    completed.length > 0 ? `${completed.length} finished` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
 
-  const glyph = isRunning ? (
-    <ThreeDotIndicator dotSize={4} gap={2} />
-  ) : (
-    <Activity />
+  // One chip fewer per group on phones: the header there also carries the
+  // title, search, Assets and the bell in a much narrower row.
+  const maxChips = isMobile ? 2 : MAX_CHIPS_PER_GROUP;
+
+  const chips = (
+    <span className="pointer-events-none inline-flex items-center gap-2">
+      <TriggerGroup
+        rows={running}
+        max={maxChips}
+        testId={RUNNING_GROUP_TESTID}
+        glyph={<ThreeDotIndicator dotSize={4} gap={2} />}
+      />
+      <TriggerGroup
+        rows={completed}
+        max={maxChips}
+        testId={COMPLETED_GROUP_TESTID}
+        glyph={
+          <CheckCircle2
+            aria-hidden
+            className="h-3.5 w-3.5 shrink-0 text-[var(--system-positive-strong)]"
+          />
+        }
+      />
+      {/* Carried over from the overlay's stacked pill: without it a row of
+          avatars doesn't read as something you can open. */}
+      {open ? (
+        <ChevronUp
+          aria-hidden
+          className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]"
+        />
+      ) : (
+        <ChevronDown
+          aria-hidden
+          className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]"
+        />
+      )}
+    </span>
   );
+
+  // Tint drives the label/chevron colour only; the chips carry their own.
+  // Primary while live, neutral once everything has settled — the same
+  // treatment Assets uses, so finished work stays reachable without reading as
+  // in-progress.
   const tintColor = isRunning
     ? "var(--primary-base)"
     : "var(--content-default)";
@@ -179,14 +279,20 @@ export function ConversationActivityPill({
     return (
       <BottomSheet.Root open={open} onOpenChange={setOpen}>
         <BottomSheet.Trigger asChild>
+          {/* Not `iconOnly`: the chips are the content, and a square icon slot
+              would clip a stack of them. `size="compact"` + `rounded-full`
+              keeps it to a pill the width of its chips. */}
           <Button
             variant="ghost"
             active
-            iconOnly={glyph}
+            size="compact"
+            className="rounded-full"
             tintColor={tintColor}
             aria-label={ariaLabel}
             data-testid={ACTIVITY_PILL_TESTID}
-          />
+          >
+            {chips}
+          </Button>
         </BottomSheet.Trigger>
         <BottomSheet.Content className="max-h-[85dvh]">
           <BottomSheet.Header>
@@ -204,13 +310,12 @@ export function ConversationActivityPill({
         <Button
           variant="ghost"
           active
-          leftIcon={glyph}
           className="rounded-full"
           tintColor={tintColor}
           aria-label={ariaLabel}
           data-testid={ACTIVITY_PILL_TESTID}
         >
-          {label}
+          {chips}
         </Button>
       </Popover.Trigger>
       {/* `align="end"`, unlike the Assets pill's centred panel: Activity sits

--- a/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
@@ -26,6 +26,7 @@ import { isChannelConversation } from "@/domains/chat/utils/conversation-channel
 import { getChannelBindingDisplayText } from "@/domains/chat/utils/channel-conversation-display";
 import { getChannelLabel } from "@/utils/channel-presentation";
 import { ChannelSourceLinkPill } from "@/domains/chat/components/channel-source-link-pill";
+import { ConversationActivityPill } from "@/domains/chat/components/conversation-activity-pill";
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
 import { InChatPluginPill } from "@/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill";
 import { useSupportsInchatPluginEdit } from "@/lib/backwards-compat/use-supports-inchat-plugin-edit";
@@ -178,6 +179,9 @@ export function useChatHeaderRegistration({
           refreshKey={assetsRefreshKey}
           onOpenApp={handleOpenAppFromChat}
           onOpenDocument={handleOpenDocument}
+        />
+        <ConversationActivityPill
+          conversationId={activeConversation.conversationId}
         />
         {supportsPluginPill ? (
           <InChatPluginPill

--- a/clients/web/src/domains/chat/hooks/use-conversation-activity.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-activity.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Tests for `useConversationActivity` — the conversation-scoped subagent + ACP
+ * feed behind the header Activity control.
+ *
+ * Covers the three things the control depends on:
+ *  - conversation scoping (another conversation's work never leaks in),
+ *  - the running/completed split,
+ *  - the cross-kind merge and its ordering.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useConversationActivity } from "@/domains/chat/hooks/use-conversation-activity";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+
+import type { ConversationActivity } from "@/domains/chat/hooks/use-conversation-activity";
+
+const CONV = "conv-A";
+const OTHER = "conv-B";
+const T0 = 1_700_000_000_000;
+
+afterEach(() => {
+  cleanup();
+  useSubagentStore.getState().reset();
+  useAcpRunStore.getState().reset();
+});
+
+/** Render the hook for `conversationId` and return its latest result. */
+function readActivity(conversationId: string | null): ConversationActivity {
+  let latest: ConversationActivity | null = null;
+  function Harness() {
+    latest = useConversationActivity(conversationId);
+    return null;
+  }
+  render(<Harness />);
+  if (!latest) {
+    throw new Error("hook did not produce a result");
+  }
+  return latest;
+}
+
+function spawnSubagent(
+  subagentId: string,
+  status: "running" | "completed",
+  parentConversationId: string | undefined,
+  timestamp: number,
+) {
+  useSubagentStore.getState().spawnSubagent({
+    subagentId,
+    label: subagentId,
+    objective: "",
+    status,
+    parentConversationId,
+    timestamp,
+  });
+}
+
+function spawnAcpRun(
+  acpSessionId: string,
+  parentConversationId: string,
+  startedAt: number,
+  terminal?: boolean,
+) {
+  useAcpRunStore.getState().spawnRun({
+    acpSessionId,
+    agent: "claude",
+    parentConversationId,
+    startedAt,
+  });
+  if (terminal) {
+    useAcpRunStore.getState().setTerminal({
+      acpSessionId,
+      status: "completed",
+      completedAt: startedAt + 1_000,
+    });
+  }
+}
+
+describe("useConversationActivity — conversation scoping", () => {
+  test("excludes subagents and runs owned by another conversation", () => {
+    spawnSubagent("sa-mine", "running", CONV, T0);
+    spawnSubagent("sa-theirs", "running", OTHER, T0 + 1);
+    spawnAcpRun("acp-mine", CONV, T0 + 2);
+    spawnAcpRun("acp-theirs", OTHER, T0 + 3);
+
+    const { running, completed, total } = readActivity(CONV);
+
+    expect(running.map((r) => r.id)).toEqual(["sa-mine", "acp-mine"]);
+    expect(completed).toEqual([]);
+    expect(total).toBe(2);
+  });
+
+  test("keeps a subagent whose parent conversation is not yet known", () => {
+    // Mirrors `useActiveSubagentIds`: an unplaceable entry stays visible rather
+    // than disappearing from every conversation at once.
+    spawnSubagent("sa-unparented", "running", undefined, T0);
+
+    expect(readActivity(CONV).running.map((r) => r.id)).toEqual([
+      "sa-unparented",
+    ]);
+  });
+});
+
+describe("useConversationActivity — running/completed split", () => {
+  test("routes each process by status", () => {
+    spawnSubagent("sa-running", "running", CONV, T0);
+    spawnSubagent("sa-done", "completed", CONV, T0 + 1);
+    spawnAcpRun("acp-running", CONV, T0 + 2);
+    spawnAcpRun("acp-done", CONV, T0 + 3, true);
+
+    const { running, completed, total } = readActivity(CONV);
+
+    expect(running.map((r) => r.id).sort()).toEqual([
+      "acp-running",
+      "sa-running",
+    ]);
+    expect(completed.map((r) => r.id).sort()).toEqual(["acp-done", "sa-done"]);
+    expect(total).toBe(4);
+  });
+
+  test("reports nothing for a conversation with no activity", () => {
+    spawnSubagent("sa-theirs", "running", OTHER, T0);
+
+    const activity = readActivity(CONV);
+
+    expect(activity.total).toBe(0);
+    expect(activity.running).toEqual([]);
+    expect(activity.completed).toEqual([]);
+  });
+});
+
+describe("useConversationActivity — ordering", () => {
+  test("merges the two kinds by start time rather than grouping by kind", () => {
+    spawnAcpRun("acp-first", CONV, T0);
+    spawnSubagent("sa-second", "running", CONV, T0 + 100);
+    spawnAcpRun("acp-third", CONV, T0 + 200);
+
+    expect(readActivity(CONV).running.map((r) => r.id)).toEqual([
+      "acp-first",
+      "sa-second",
+      "acp-third",
+    ]);
+  });
+
+  test("lists finished work most-recent-first", () => {
+    spawnSubagent("sa-older", "completed", CONV, T0);
+    spawnAcpRun("acp-newest", CONV, T0 + 200, true);
+    spawnSubagent("sa-newer", "completed", CONV, T0 + 100);
+
+    expect(readActivity(CONV).completed.map((r) => r.id)).toEqual([
+      "acp-newest",
+      "sa-newer",
+      "sa-older",
+    ]);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-activity.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-activity.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for `useConversationActivity` — the conversation-scoped subagent + ACP
+ * Tests for `useConversationActivity`, the conversation-scoped subagent + ACP
  * feed behind the header Activity control.
  *
  * Covers the three things the control depends on:
@@ -78,7 +78,7 @@ function spawnAcpRun(
   }
 }
 
-describe("useConversationActivity — conversation scoping", () => {
+describe("useConversationActivity: conversation scoping", () => {
   test("excludes subagents and runs owned by another conversation", () => {
     spawnSubagent("sa-mine", "running", CONV, T0);
     spawnSubagent("sa-theirs", "running", OTHER, T0 + 1);
@@ -92,6 +92,29 @@ describe("useConversationActivity — conversation scoping", () => {
     expect(total).toBe(2);
   });
 
+  test("drops a finished ACP run that carries no owning conversation", () => {
+    // Rehydration stamps `parentConversationId: ""` for a persisted row with no
+    // parent, and the ACP store is never reset between conversations. Treating
+    // that as a match would pin the run to every conversation for the rest of
+    // the session.
+    useAcpRunStore.getState().spawnRun({
+      acpSessionId: "acp-orphan",
+      agent: "claude",
+      parentConversationId: "",
+      startedAt: T0,
+    });
+    useAcpRunStore.getState().setTerminal({
+      acpSessionId: "acp-orphan",
+      status: "completed",
+      completedAt: T0 + 10,
+    });
+
+    const activity = readActivity(CONV);
+
+    expect(activity.completed).toEqual([]);
+    expect(activity.total).toBe(0);
+  });
+
   test("keeps a subagent whose parent conversation is not yet known", () => {
     // Mirrors `useActiveSubagentIds`: an unplaceable entry stays visible rather
     // than disappearing from every conversation at once.
@@ -103,7 +126,7 @@ describe("useConversationActivity — conversation scoping", () => {
   });
 });
 
-describe("useConversationActivity — running/completed split", () => {
+describe("useConversationActivity: running/completed split", () => {
   test("routes each process by status", () => {
     spawnSubagent("sa-running", "running", CONV, T0);
     spawnSubagent("sa-done", "completed", CONV, T0 + 1);
@@ -131,7 +154,7 @@ describe("useConversationActivity — running/completed split", () => {
   });
 });
 
-describe("useConversationActivity — ordering", () => {
+describe("useConversationActivity: ordering", () => {
   test("merges the two kinds by start time rather than grouping by kind", () => {
     spawnAcpRun("acp-first", CONV, T0);
     spawnSubagent("sa-second", "running", CONV, T0 + 100);

--- a/clients/web/src/domains/chat/hooks/use-conversation-activity.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-activity.ts
@@ -6,8 +6,8 @@
  * The running halves delegate to `useActiveSubagentIds` / `useActiveAcpRunIds`
  * so the parent-scoping rules stay in one place per kind (they differ: a
  * subagent with no parent id is unknown-and-visible, an ACP run's parent is a
- * required-but-possibly-empty string). The completed halves mirror each of those
- * rules exactly, inverted on status.
+ * required-but-possibly-empty string). The completed halves invert those on
+ * status, and the ACP one additionally requires ownership; see its docstring.
  *
  * Only these two kinds are included. Workflows and background tools have their
  * own surfaces and are deliberately out of scope here.
@@ -34,9 +34,9 @@ export interface ConversationActivityRow {
 }
 
 export interface ConversationActivity {
-  /** Still-running processes, oldest first — the order they were spawned in. */
+  /** Still-running processes, oldest first: the order they were spawned in. */
   running: ConversationActivityRow[];
-  /** Finished processes, most recent first — the one just finished reads top. */
+  /** Finished processes, most recent first: the one just finished reads top. */
   completed: ConversationActivityRow[];
   /** Total across both halves; `0` means the control hides entirely. */
   total: number;
@@ -44,8 +44,8 @@ export interface ConversationActivity {
 
 /**
  * Finished subagent ids for `conversationId`. Mirrors `useActiveSubagentIds`'
- * scoping rule — including its treatment of an entry whose parent is not yet
- * known as belonging to whatever conversation is asking — inverted on status.
+ * scoping rule, including its treatment of an entry whose parent is not yet
+ * known as belonging to whatever conversation is asking, inverted on status.
  */
 export function useCompletedSubagentIds(
   conversationId: string | null,
@@ -67,9 +67,17 @@ export function useCompletedSubagentIds(
 }
 
 /**
- * Finished ACP run ids for `conversationId`. Mirrors `useActiveAcpRunIds`'
- * scoping rule (an empty `parentConversationId` can't be placed, so it stays
- * visible) inverted on status.
+ * Finished ACP run ids for `conversationId`.
+ *
+ * Ownership is required here, unlike `useActiveAcpRunIds`, which keeps a run
+ * whose `parentConversationId` is empty rather than hiding it. Rehydration
+ * stamps `""` when a persisted row carries no parent (`toRunEntry`), and the
+ * ACP store is never reset on a conversation change, so treating an empty
+ * parent as a match would leave every unattributable finished run in the list
+ * of every conversation for the rest of the session: an inflated count, and
+ * rows that open a run belonging to a different chat. A live run is worth
+ * surfacing on weaker evidence because it is short-lived and the user is
+ * waiting on it; a finished one is not.
  */
 export function useCompletedAcpRunIds(conversationId: string | null): string[] {
   return useAcpRunStore(
@@ -80,7 +88,7 @@ export function useCompletedAcpRunIds(conversationId: string | null): string[] {
           return false;
         }
         return (
-          !entry.parentConversationId ||
+          !!entry.parentConversationId &&
           entry.parentConversationId === conversationId
         );
       }),

--- a/clients/web/src/domains/chat/hooks/use-conversation-activity.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-activity.ts
@@ -1,0 +1,140 @@
+/**
+ * Conversation-scoped activity feed for the header Activity control: the
+ * subagents and ACP runs belonging to one conversation, split into still-running
+ * and finished.
+ *
+ * The running halves delegate to `useActiveSubagentIds` / `useActiveAcpRunIds`
+ * so the parent-scoping rules stay in one place per kind (they differ: a
+ * subagent with no parent id is unknown-and-visible, an ACP run's parent is a
+ * required-but-possibly-empty string). The completed halves mirror each of those
+ * rules exactly, inverted on status.
+ *
+ * Only these two kinds are included. Workflows and background tools have their
+ * own surfaces and are deliberately out of scope here.
+ */
+
+import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useActiveAcpRunIds } from "@/domains/chat/hooks/use-active-acp-run-ids";
+import { useActiveSubagentIds } from "@/domains/chat/hooks/use-active-subagent-ids";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { isActiveAcpStatus } from "@/utils/acp-run-status";
+import { isActiveStatus } from "@/utils/subagent-status";
+
+import type { ProcessKind } from "@/domains/chat/process-registry/types";
+
+/** One process in the conversation's activity list. */
+export interface ConversationActivityRow {
+  /** Which descriptor renders this row. */
+  kind: Extract<ProcessKind, "subagent" | "acp-run">;
+  /** Process id within that kind. */
+  id: string;
+}
+
+export interface ConversationActivity {
+  /** Still-running processes, oldest first — the order they were spawned in. */
+  running: ConversationActivityRow[];
+  /** Finished processes, most recent first — the one just finished reads top. */
+  completed: ConversationActivityRow[];
+  /** Total across both halves; `0` means the control hides entirely. */
+  total: number;
+}
+
+/**
+ * Finished subagent ids for `conversationId`. Mirrors `useActiveSubagentIds`'
+ * scoping rule — including its treatment of an entry whose parent is not yet
+ * known as belonging to whatever conversation is asking — inverted on status.
+ */
+export function useCompletedSubagentIds(
+  conversationId: string | null,
+): string[] {
+  return useSubagentStore(
+    useShallow((s) =>
+      s.orderedIds.filter((id) => {
+        const entry = s.byId[id];
+        if (entry?.status === undefined || isActiveStatus(entry.status)) {
+          return false;
+        }
+        return (
+          entry.parentConversationId === undefined ||
+          entry.parentConversationId === conversationId
+        );
+      }),
+    ),
+  );
+}
+
+/**
+ * Finished ACP run ids for `conversationId`. Mirrors `useActiveAcpRunIds`'
+ * scoping rule (an empty `parentConversationId` can't be placed, so it stays
+ * visible) inverted on status.
+ */
+export function useCompletedAcpRunIds(conversationId: string | null): string[] {
+  return useAcpRunStore(
+    useShallow((s) =>
+      s.orderedIds.filter((id) => {
+        const entry = s.byId[id];
+        if (entry?.status === undefined || isActiveAcpStatus(entry.status)) {
+          return false;
+        }
+        return (
+          !entry.parentConversationId ||
+          entry.parentConversationId === conversationId
+        );
+      }),
+    ),
+  );
+}
+
+/**
+ * Start timestamp for one row. Read non-reactively: `spawnedAt` / `startedAt`
+ * are stamped once at creation and never mutate, so a subscription would only
+ * add re-renders. A row whose entry has since been evicted sorts last rather
+ * than throwing.
+ */
+function startedAt(row: ConversationActivityRow): number {
+  if (row.kind === "subagent") {
+    return useSubagentStore.getState().byId[row.id]?.spawnedAt ?? 0;
+  }
+  return useAcpRunStore.getState().byId[row.id]?.startedAt ?? 0;
+}
+
+/**
+ * The conversation's subagents and ACP runs, merged across kinds and ordered by
+ * start time so the two read as one activity list rather than two concatenated
+ * per-kind blocks.
+ */
+export function useConversationActivity(
+  conversationId: string | null,
+): ConversationActivity {
+  const runningSubagentIds = useActiveSubagentIds(conversationId);
+  const runningAcpRunIds = useActiveAcpRunIds(conversationId);
+  const completedSubagentIds = useCompletedSubagentIds(conversationId);
+  const completedAcpRunIds = useCompletedAcpRunIds(conversationId);
+
+  return useMemo(() => {
+    const toRows = (
+      ids: string[],
+      kind: ConversationActivityRow["kind"],
+    ): ConversationActivityRow[] => ids.map((id) => ({ kind, id }));
+
+    const running = [
+      ...toRows(runningSubagentIds, "subagent"),
+      ...toRows(runningAcpRunIds, "acp-run"),
+    ].sort((a, b) => startedAt(a) - startedAt(b));
+
+    const completed = [
+      ...toRows(completedSubagentIds, "subagent"),
+      ...toRows(completedAcpRunIds, "acp-run"),
+    ].sort((a, b) => startedAt(b) - startedAt(a));
+
+    return { running, completed, total: running.length + completed.length };
+  }, [
+    runningSubagentIds,
+    runningAcpRunIds,
+    completedSubagentIds,
+    completedAcpRunIds,
+  ]);
+}

--- a/clients/web/src/domains/chat/process-registry/registry.test.ts
+++ b/clients/web/src/domains/chat/process-registry/registry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   OVERLAY_PROCESS_KINDS,
+  POPOUT_OVERLAY_PROCESS_KINDS,
   PROCESS_KINDS,
 } from "@/domains/chat/process-registry/registry";
 
@@ -26,10 +27,10 @@ describe("PROCESS_KINDS registry", () => {
 });
 
 describe("OVERLAY_PROCESS_KINDS", () => {
-  it("no longer floats subagents or ACP runs over the transcript", () => {
-    // Their doorway is the header's ConversationActivityPill. Re-adding either
-    // here would give one process two entry points and put the banner back on
-    // top of incoming messages (LUM-2800).
+  it("excludes subagents and ACP runs", () => {
+    // The header's ConversationActivityPill carries them. Adding either here
+    // gives one process two entry points and puts a floating banner back on top
+    // of incoming messages (LUM-2800).
     const kinds = OVERLAY_PROCESS_KINDS.map((descriptor) => descriptor.kind);
     expect(kinds).not.toContain("subagent");
     expect(kinds).not.toContain("acp-run");
@@ -46,5 +47,21 @@ describe("OVERLAY_PROCESS_KINDS", () => {
     for (const descriptor of OVERLAY_PROCESS_KINDS) {
       expect(PROCESS_KINDS).toContain(descriptor);
     }
+  });
+});
+
+describe("POPOUT_OVERLAY_PROCESS_KINDS", () => {
+  it("covers every kind", () => {
+    // A pop-out renders no header, so the overlay is its only ambient surface.
+    // Dropping a kind here makes that work invisible in a pop-out entirely.
+    expect(POPOUT_OVERLAY_PROCESS_KINDS.map((d) => d.kind).sort()).toEqual(
+      PROCESS_KINDS.map((d) => d.kind).sort(),
+    );
+  });
+
+  it("covers the kinds the windowed overlay leaves to the header", () => {
+    const popout = POPOUT_OVERLAY_PROCESS_KINDS.map((d) => d.kind);
+    expect(popout).toContain("subagent");
+    expect(popout).toContain("acp-run");
   });
 });

--- a/clients/web/src/domains/chat/process-registry/registry.test.ts
+++ b/clients/web/src/domains/chat/process-registry/registry.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { PROCESS_KINDS } from "@/domains/chat/process-registry/registry";
+import {
+  OVERLAY_PROCESS_KINDS,
+  PROCESS_KINDS,
+} from "@/domains/chat/process-registry/registry";
 
 describe("PROCESS_KINDS registry", () => {
   it("contains all four background-process descriptors", () => {
@@ -19,5 +22,29 @@ describe("PROCESS_KINDS registry", () => {
   it("has a unique kind per descriptor", () => {
     const kinds = PROCESS_KINDS.map((descriptor) => descriptor.kind);
     expect(new Set(kinds).size).toBe(kinds.length);
+  });
+});
+
+describe("OVERLAY_PROCESS_KINDS", () => {
+  it("no longer floats subagents or ACP runs over the transcript", () => {
+    // Their doorway is the header's ConversationActivityPill. Re-adding either
+    // here would give one process two entry points and put the banner back on
+    // top of incoming messages (LUM-2800).
+    const kinds = OVERLAY_PROCESS_KINDS.map((descriptor) => descriptor.kind);
+    expect(kinds).not.toContain("subagent");
+    expect(kinds).not.toContain("acp-run");
+  });
+
+  it("keeps the kinds Activity does not cover", () => {
+    expect(OVERLAY_PROCESS_KINDS.map((d) => d.kind)).toEqual([
+      "workflow",
+      "background-task",
+    ]);
+  });
+
+  it("only contains descriptors that are in the full registry", () => {
+    for (const descriptor of OVERLAY_PROCESS_KINDS) {
+      expect(PROCESS_KINDS).toContain(descriptor);
+    }
   });
 });

--- a/clients/web/src/domains/chat/process-registry/registry.ts
+++ b/clients/web/src/domains/chat/process-registry/registry.ts
@@ -20,19 +20,24 @@ export const PROCESS_KINDS: BackgroundProcessDescriptor[] = [
 ];
 
 /**
- * The kinds that still render a floating overlay above the transcript.
+ * The kinds that float an overlay above the transcript in a windowed chat.
  *
- * Subagents and ACP runs left: their doorway is now the header's
- * `ConversationActivityPill`, which covers finished sessions too and doesn't
- * sit on top of the transcript (the floating subagent banner covered incoming
- * messages — LUM-2800). Two entry points for one process is worse than one, so
- * the overlay yields rather than duplicating it.
- *
- * Workflows and background tasks keep theirs: the Activity control does not
- * cover them, so retiring their overlay too would leave them with no ambient
- * surface at all.
+ * Workflows and background tasks only. Subagent and ACP sessions are surfaced
+ * by the header's `ConversationActivityPill`, which also covers finished
+ * sessions and keeps the transcript clear, so overlaying them as well would
+ * give one process two entry points.
  */
 export const OVERLAY_PROCESS_KINDS: BackgroundProcessDescriptor[] = [
   WORKFLOW_DESCRIPTOR,
   BACKGROUND_TASK_DESCRIPTOR,
 ];
+
+/**
+ * The kinds that float an overlay in a pop-out window: every kind.
+ *
+ * A pop-out renders no header, so it has no `ConversationActivityPill` to carry
+ * subagent and ACP sessions. The overlay is the only ambient surface there, and
+ * it covers all four kinds so running work stays visible.
+ */
+export const POPOUT_OVERLAY_PROCESS_KINDS: BackgroundProcessDescriptor[] =
+  PROCESS_KINDS;

--- a/clients/web/src/domains/chat/process-registry/registry.ts
+++ b/clients/web/src/domains/chat/process-registry/registry.ts
@@ -18,3 +18,21 @@ export const PROCESS_KINDS: BackgroundProcessDescriptor[] = [
   WORKFLOW_DESCRIPTOR,
   BACKGROUND_TASK_DESCRIPTOR,
 ];
+
+/**
+ * The kinds that still render a floating overlay above the transcript.
+ *
+ * Subagents and ACP runs left: their doorway is now the header's
+ * `ConversationActivityPill`, which covers finished sessions too and doesn't
+ * sit on top of the transcript (the floating subagent banner covered incoming
+ * messages — LUM-2800). Two entry points for one process is worse than one, so
+ * the overlay yields rather than duplicating it.
+ *
+ * Workflows and background tasks keep theirs: the Activity control does not
+ * cover them, so retiring their overlay too would leave them with no ambient
+ * surface at all.
+ */
+export const OVERLAY_PROCESS_KINDS: BackgroundProcessDescriptor[] = [
+  WORKFLOW_DESCRIPTOR,
+  BACKGROUND_TASK_DESCRIPTOR,
+];


### PR DESCRIPTION
## TL;DR

Agent sessions were only reachable from the transcript, so a subagent or ACP run that scrolled out of view — or finished — was effectively lost unless you scrolled back to where it was spawned. This adds an **Activity** control to the conversation header, beside Assets, listing that conversation's subagents and ACP runs (running *and* finished), each one opening the detail viewer that already exists.

Subagents and ACP runs stop rendering in the floating overlay above the transcript, so each process has exactly one entry point.

This only changes how you reach a session. Nothing here starts, resumes, or restarts an agent: rows open the existing read-only detail viewer through `openProcessDetail`, and the only action on a live process is the Stop button that running rows already had.

Closes LUM-2848. Very likely closes LUM-2800 (the sticky banner that covered incoming messages *was* that floating overlay) — left open for its owner to confirm post-merge.

## What changes for you

| Before | After |
| --- | --- |
| A running subagent showed as a banner floating over the top of the transcript, covering incoming messages | Running work shows in the header, in its own row, overlapping nothing |
| A finished session's details were only reachable by scrolling back to its spawn point in the transcript | Finished sessions stay listed in Activity, and one click opens the same detail view |
| Nothing in the chrome told you a conversation had agent work in it | Header shows a live indicator and a running count while work is in flight |
| Mobile had no persistent running indicator at all | Mobile gets the same control as an icon-only trigger opening a bottom sheet (it joins the existing cluster, so a live voice session still collapses it behind the ⋯ popover, as it does Assets) |
| — | The control is absent entirely when a conversation has no agent activity |

While work is running the trigger reads live — the transcript's own three-dot indicator, primary tint, and a count of what's running. Once everything has finished it falls back to the neutral treatment Assets uses, so finished sessions stay reachable without the header looking busy.

## Why it's safe

**It reuses existing parts rather than adding a parallel UI.** The trigger, popover, and bottom-sheet split are the `ConversationAssetsPill` grammar; the rows are the process registry's own `InlineProcessCardRow` driven by the unmodified `SUBAGENT_DESCRIPTOR` / `ACP_RUN_DESCRIPTOR`; opening a row goes through the existing `openProcessDetail`. No new visual primitives and no changes to how a process's card renders.

**Conversation scoping reuses the rules that already exist.** The running half delegates to `useActiveSubagentIds` / `useActiveAcpRunIds` rather than reimplementing them — the two kinds genuinely differ in how they treat an entry whose parent conversation is unknown, and that difference stays in one place per kind. The completed half mirrors each rule, inverted on status.

**No store, daemon, migration, or event-plumbing changes.** Read-only projection over stores that already hold this state.

**Stop is gated on real status, not on the card's appearance.** `InlineProcessCard` keys its stop button off `summary.state === "loading"`, but `use-subagent-card-data` deliberately projects a *finished* subagent whose timeline hasn't been fetched as `loading` (so it doesn't claim "0 steps" for work that had steps). Trusting that gate would put a Stop button on completed sessions, so rows take a `canStop` from which group they're in. There's a test pinning exactly that case.

**Blast radius of the overlay removal is bounded** to which descriptors the overlay iterates; the overlay component itself is untouched and still covers workflows and background tasks.

## Deferred, and why

**Workflows and background tools are not in Activity.** Out of scope by product decision, but the code backs it up for workflows: `workflow_*` events are conversation-gated, workflow entries carry no conversation id, and `useActiveWorkflowRunIds` has no conversation filter at all. Including them would mean store schema changes, not a projection.

**The floating overlay is retired only for subagents and ACP runs.** The intent was to retire it outright, but it serves four kinds and Activity covers two — removing it wholesale would leave workflows and background tasks with no ambient surface. The split is explicit as `OVERLAY_PROCESS_KINDS` rather than an inline filter, with the reasoning on the constant.

**No cross-conversation or reload-durable view.** Descoped. For the record, that isn't a small follow-on: `/subagents/reconcile` requires a `parentConversationId` and there is no workspace-wide listing, so a durable global surface needs a new daemon endpoint.

**Two bugs found along the way are filed, not fixed here:**
- LUM-2930 — the transcript has the same Stop-on-finished-subagent trap, since `subagent-spawn-group` passes `onStop` unconditionally. Fixing it properly belongs inside `InlineProcessCardRow` so no caller has to know about it.
- LUM-2931 — the subagent store is wiped on every conversation switch, which is the real reason running work goes invisible when you navigate. This PR doesn't depend on it (the store rehydrates per conversation), so it stays separate.

## Testing

`bunx tsc --noEmit` and `bun run lint` clean (16 lint warnings, all pre-existing, none in touched files). Storybook builds and registers all four stories.

New: `use-conversation-activity.test.tsx` (6) covers conversation scoping, the running/completed split, and cross-kind ordering. `conversation-activity-pill.test.tsx` (11) covers hiding at zero, the running vs finished trigger, row listing and scoping, opening the viewer, stop on running rows, and no-stop on a finished row whose card still reads as loading. `registry.test.ts` gains coverage asserting subagents and ACP runs are *not* in the overlay set.

Re-run green: `active-process-overlay` (9), `chat-route-content` (5), `use-active-subagent-ids` (6), `use-active-acp-run-ids` (3), `use-conversation-change-effects` (5).

## Storybook

`Chat/ChatLayoutHeader` — `DesktopBaseline` (long title, Assets, Notifications, no Activity), `DesktopMixedClosed`, `DesktopMixedOpen`, `MobileMixedOpen`. The per-status card matrix stays in the component tests rather than being duplicated as stories. Notifications is a stand-in `Button` in the stories: the real `NotificationsBell` is a home-domain component that `routes.tsx` injects at runtime, and importing it from chat trips the cross-domain import rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

