### PR TITLE
fix(web): use Stripe amount scaling for invoice display

### DIFF
--- a/clients/web/src/domains/settings/components/invoices-table.test.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.test.tsx
@@ -51,7 +51,7 @@ mock.module("@/generated/api/sdk.gen", () => ({
 
 import { InvoicesTable } from "./invoices-table";
 
-function makeInvoice(id: string): Invoice {
+function makeInvoice(id: string, overrides?: Partial<Invoice>): Invoice {
   return {
     id,
     number: `INV-${id}`,
@@ -63,13 +63,14 @@ function makeInvoice(id: string): Invoice {
     created: 1735689600,
     hosted_invoice_url: `https://invoice.example.com/${id}`,
     invoice_pdf: `https://invoice.example.com/${id}.pdf`,
+    ...overrides,
   };
 }
 
 /** Five invoices on page 1 with more behind cursor "5": invoices 6 and 7. */
 function seedTwoPages(): void {
   listResult = {
-    invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
+    invoices: ["1", "2", "3", "4", "5"].map((id) => makeInvoice(id)),
     has_more: true,
   };
   nextPages["5"] = {
@@ -170,6 +171,43 @@ describe("InvoicesTable collapse", () => {
   });
 });
 
+describe("InvoicesTable amount formatting", () => {
+  test("ISK uses Stripe's two-decimal scaling, not ISO zero-decimal", async () => {
+    listResult = {
+      invoices: [makeInvoice("1", { currency: "isk", amount_due: 500 })],
+      has_more: false,
+    };
+    const { getAllByTestId } = await openTable();
+
+    const row = getAllByTestId("invoice-row")[0]!;
+    expect(row.textContent).toMatch(/5[.,]00/);
+    expect(row.textContent).not.toContain("500");
+  });
+
+  test("JPY is zero-decimal: minor units render undivided", async () => {
+    listResult = {
+      invoices: [makeInvoice("1", { currency: "jpy", amount_due: 500 })],
+      has_more: false,
+    };
+    const { getAllByTestId } = await openTable();
+
+    const row = getAllByTestId("invoice-row")[0]!;
+    expect(row.textContent).toContain("500");
+    expect(row.textContent).not.toMatch(/5[.,]00/);
+  });
+
+  test("USD divides minor units by 100 with two decimals", async () => {
+    listResult = {
+      invoices: [makeInvoice("1", { currency: "usd", amount_due: 1234 })],
+      has_more: false,
+    };
+    const { getAllByTestId } = await openTable();
+
+    const row = getAllByTestId("invoice-row")[0]!;
+    expect(row.textContent).toMatch(/12[.,]34/);
+  });
+});
+
 describe("InvoicesTable pagination", () => {
   test("Load more requests the next page with starting_after and renders both pages", async () => {
     seedTwoPages();
@@ -195,7 +233,7 @@ describe("InvoicesTable pagination", () => {
 
   test("Load more is absent when has_more is false", async () => {
     listResult = {
-      invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
+      invoices: ["1", "2", "3", "4", "5"].map((id) => makeInvoice(id)),
       has_more: false,
     };
     const { getByTestId, queryByTestId } = await openTable({ showAll: true });
@@ -209,7 +247,7 @@ describe("InvoicesTable pagination", () => {
 
   test("Show less stays available and works while more server pages remain", async () => {
     listResult = {
-      invoices: ["1", "2", "3", "4", "5"].map(makeInvoice),
+      invoices: ["1", "2", "3", "4", "5"].map((id) => makeInvoice(id)),
       has_more: true,
     };
     const { getByTestId, queryByTestId, getAllByTestId } = await openTable({
@@ -384,7 +422,7 @@ describe("InvoicesTable pagination", () => {
       has_more: true,
     };
     nextPages["2"] = {
-      invoices: ["3", "4", "5"].map(makeInvoice),
+      invoices: ["3", "4", "5"].map((id) => makeInvoice(id)),
       has_more: false,
     };
     const { getByTestId, queryByTestId, getAllByTestId } = await openTable();

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -46,16 +46,68 @@ function statusTone(status: string | null): TagTone {
   }
 }
 
+/**
+ * These sets follow Stripe's amount scaling rules
+ * (https://docs.stripe.com/currencies), not ISO 4217 metadata. Notably,
+ * Stripe keeps two-decimal scaling for ISK, HUF, TWD, and UGX for backward
+ * compatibility even though ISO treats them as zero-decimal, so those codes
+ * are deliberately absent from the zero-decimal set.
+ */
+const STRIPE_ZERO_DECIMAL_CURRENCIES = new Set([
+  "BIF",
+  "CLP",
+  "DJF",
+  "GNF",
+  "JPY",
+  "KMF",
+  "KRW",
+  "MGA",
+  "PYG",
+  "RWF",
+  "VND",
+  "VUV",
+  "XAF",
+  "XOF",
+  "XPF",
+]);
+
+const STRIPE_THREE_DECIMAL_CURRENCIES = new Set([
+  "BHD",
+  "JOD",
+  "KWD",
+  "OMR",
+  "TND",
+]);
+
+function stripeScaleDigits(currencyCode: string): number {
+  if (STRIPE_ZERO_DECIMAL_CURRENCIES.has(currencyCode)) {
+    return 0;
+  }
+  if (STRIPE_THREE_DECIMAL_CURRENCIES.has(currencyCode)) {
+    return 3;
+  }
+  return 2;
+}
+
+/**
+ * Amounts are in Stripe's minor units; render as major units using Stripe's
+ * amount scaling rules (2 for USD, 0 for JPY, 3 for BHD). The display
+ * fraction digits are forced to match the same scale so Intl's ISO metadata
+ * cannot round Stripe's two-decimal special cases (ISK, HUF, TWD, UGX).
+ */
 function formatAmount(minorUnits: number, currency: string): string {
   const code = currency.toUpperCase();
+  const digits = stripeScaleDigits(code);
   try {
     const formatter = new Intl.NumberFormat(undefined, {
       style: "currency",
       currency: code,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
     });
-    const exponent = formatter.resolvedOptions().maximumFractionDigits ?? 2;
-    return formatter.format(minorUnits / 10 ** exponent);
+    return formatter.format(minorUnits / 10 ** digits);
   } catch {
+    // Intl.NumberFormat throws a RangeError on invalid currency codes.
     return `${(minorUnits / 100).toFixed(2)} ${code}`;
   }
 }


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for platform-invoices-cli.md.

**Gap:** web invoices table scales amounts by Intl ISO metadata while the new CLI follows Stripe's API scaling, so ISK/UGX amounts rendered 100x off on the web
**Fix:** formatAmount now uses Stripe's zero-decimal and three-decimal currency lists to pick the divisor and forces matching fraction digits, keeping web and CLI output consistent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->