### PR TITLE
chore(cli): consolidate invoice scaling docs and dedupe platform test scaffold

### DIFF
--- a/assistant/src/cli/commands/platform/__tests__/credits.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/credits.test.ts
@@ -1,69 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import { Command } from "commander";
+import { runPlatform, setupPlatformIpcMock } from "./helpers.js";
 
-// ---------------------------------------------------------------------------
-// Mock state
-// ---------------------------------------------------------------------------
-
-let mockCalls: Array<[string, Record<string, unknown>]> = [];
-let mockResponse: unknown = {
-  ok: true,
-  result: {
-    remaining: 42.17,
-    settled: 50,
-    pending: 7.83,
-    unit: "USD",
-    stale: false,
-    as_of: "2026-07-06T00:00:00.000Z",
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-mock.module("../../../../ipc/cli-client.js", () => ({
-  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
-    mockCalls.push([method, params]);
-    return mockResponse;
-  },
-  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
-    throw new Error("exitFromIpcResult called");
-  },
-}));
-
-const { registerPlatformCommand } = await import("../index.js");
-
-function buildProgram(): Command {
-  const program = new Command();
-  program.exitOverride();
-  registerPlatformCommand(program);
-  return program;
-}
-
-function captureStdout(fn: () => Promise<void>): Promise<string[]> {
-  const chunks: string[] = [];
-  const origWrite = process.stdout.write.bind(process.stdout);
-  process.stdout.write = ((chunk: unknown) => {
-    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof process.stdout.write;
-  return fn()
-    .then(() => chunks)
-    .finally(() => {
-      process.stdout.write = origWrite;
-    });
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const ipc = setupPlatformIpcMock();
 
 describe("assistant platform credits", () => {
   beforeEach(() => {
-    mockCalls = [];
-    mockResponse = {
+    ipc.calls = [];
+    ipc.response = {
       ok: true,
       result: {
         remaining: 42.17,
@@ -74,22 +18,12 @@ describe("assistant platform credits", () => {
         as_of: "2026-07-06T00:00:00.000Z",
       },
     };
-    process.exitCode = 0;
   });
 
   test("calls platform_credits and emits balance JSON with --json", async () => {
-    const out = await captureStdout(async () => {
-      const program = buildProgram();
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "credits",
-        "--json",
-      ]);
-    });
+    const out = await runPlatform(["credits", "--json"]);
 
-    expect(mockCalls[0][0]).toBe("platform_credits");
+    expect(ipc.calls[0][0]).toBe("platform_credits");
 
     const parsed = JSON.parse(out.join(""));
     expect(parsed.remaining).toBe(42.17);
@@ -100,12 +34,9 @@ describe("assistant platform credits", () => {
   });
 
   test("plain text mode does not emit JSON to stdout", async () => {
-    const out = await captureStdout(async () => {
-      const program = buildProgram();
-      await program.parseAsync(["node", "assistant", "platform", "credits"]);
-    });
+    const out = await runPlatform(["credits"]);
 
-    // Plain-text mode logs via log.info — verify writeOutput (JSON) was NOT called
+    // Plain-text mode logs via log.info; verify writeOutput (JSON) was NOT called
     expect(() => JSON.parse(out.join("").trim())).toThrow();
   });
 });

--- a/assistant/src/cli/commands/platform/__tests__/helpers.ts
+++ b/assistant/src/cli/commands/platform/__tests__/helpers.ts
@@ -1,0 +1,69 @@
+import { mock } from "bun:test";
+
+import { Command } from "commander";
+
+/** Mutable per-file mock state returned by {@link setupPlatformIpcMock}. */
+export interface PlatformIpcMockState {
+  /** Every (method, params) pair passed to the mocked cliIpcCall. */
+  calls: Array<[string, Record<string, unknown>]>;
+  /** The value the mocked cliIpcCall resolves with. */
+  response: unknown;
+}
+
+/**
+ * Install the shared IPC client mock for a platform command test file.
+ *
+ * bun's mock.module is global per test file, so each file must call this
+ * once at module top level (before importing ../index.js) and drive the
+ * mock through the returned state object. The mocked exitFromIpcResult
+ * throws so tests can assert the error path without exiting the process.
+ */
+export function setupPlatformIpcMock(): PlatformIpcMockState {
+  const state: PlatformIpcMockState = { calls: [], response: undefined };
+  mock.module("../../../../ipc/cli-client.js", () => ({
+    cliIpcCall: async (method: string, params: Record<string, unknown>) => {
+      state.calls.push([method, params]);
+      return state.response;
+    },
+    exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
+      throw new Error("exitFromIpcResult called");
+    },
+  }));
+  return state;
+}
+
+/**
+ * Build a fresh commander program with the platform command registered.
+ * Imported lazily so the file-level mock installed by
+ * {@link setupPlatformIpcMock} is in place first.
+ */
+export async function buildPlatformProgram(): Promise<Command> {
+  const { registerPlatformCommand } = await import("../index.js");
+  const program = new Command();
+  program.exitOverride();
+  registerPlatformCommand(program);
+  return program;
+}
+
+/** Capture everything written to stdout while fn runs. */
+export function captureStdout(fn: () => Promise<void>): Promise<string[]> {
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown) => {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  return fn()
+    .then(() => chunks)
+    .finally(() => {
+      process.stdout.write = origWrite;
+    });
+}
+
+/** Run 'assistant platform <args>' against a fresh program, capturing stdout. */
+export function runPlatform(args: string[]): Promise<string[]> {
+  return captureStdout(async () => {
+    const program = await buildPlatformProgram();
+    await program.parseAsync(["node", "assistant", "platform", ...args]);
+  });
+}

--- a/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
@@ -1,6 +1,11 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import { Command } from "commander";
+import {
+  buildPlatformProgram,
+  captureStdout,
+  runPlatform,
+  setupPlatformIpcMock,
+} from "./helpers.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -32,64 +37,10 @@ const invoiceB = {
   invoice_pdf: null,
 };
 
-// ---------------------------------------------------------------------------
-// Mock state
-// ---------------------------------------------------------------------------
+const ipc = setupPlatformIpcMock();
 
-let mockCalls: Array<[string, Record<string, unknown>]> = [];
-let mockResponse: unknown = {
-  ok: true,
-  result: { invoices: [invoiceA, invoiceB], has_more: false },
-};
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-mock.module("../../../../ipc/cli-client.js", () => ({
-  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
-    mockCalls.push([method, params]);
-    return mockResponse;
-  },
-  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
-    throw new Error("exitFromIpcResult called");
-  },
-}));
-
-const { registerPlatformCommand } = await import("../index.js");
-
-function buildProgram(): Command {
-  const program = new Command();
-  program.exitOverride();
-  registerPlatformCommand(program);
-  return program;
-}
-
-function captureStdout(fn: () => Promise<void>): Promise<string[]> {
-  const chunks: string[] = [];
-  const origWrite = process.stdout.write.bind(process.stdout);
-  process.stdout.write = ((chunk: unknown) => {
-    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof process.stdout.write;
-  return fn()
-    .then(() => chunks)
-    .finally(() => {
-      process.stdout.write = origWrite;
-    });
-}
-
-async function runInvoices(args: string[]): Promise<string[]> {
-  return captureStdout(async () => {
-    const program = buildProgram();
-    await program.parseAsync([
-      "node",
-      "assistant",
-      "platform",
-      "invoices",
-      ...args,
-    ]);
-  });
+function runInvoices(args: string[]): Promise<string[]> {
+  return runPlatform(["invoices", ...args]);
 }
 
 // ---------------------------------------------------------------------------
@@ -98,19 +49,18 @@ async function runInvoices(args: string[]): Promise<string[]> {
 
 describe("assistant platform invoices list", () => {
   beforeEach(() => {
-    mockCalls = [];
-    mockResponse = {
+    ipc.calls = [];
+    ipc.response = {
       ok: true,
       result: { invoices: [invoiceA, invoiceB], has_more: false },
     };
-    process.exitCode = 0;
   });
 
   test("calls platform_invoices_list and emits the page as JSON with --json", async () => {
     const out = await runInvoices(["list", "--json"]);
 
-    expect(mockCalls[0][0]).toBe("platform_invoices_list");
-    expect(mockCalls[0][1]).toEqual({});
+    expect(ipc.calls[0][0]).toBe("platform_invoices_list");
+    expect(ipc.calls[0][1]).toEqual({});
 
     const parsed = JSON.parse(out.join(""));
     expect(parsed.invoices).toHaveLength(2);
@@ -121,8 +71,8 @@ describe("assistant platform invoices list", () => {
   test("forwards --starting-after as the starting_after query param", async () => {
     await runInvoices(["list", "--starting-after", "in_a", "--json"]);
 
-    expect(mockCalls[0][0]).toBe("platform_invoices_list");
-    expect(mockCalls[0][1]).toEqual({
+    expect(ipc.calls[0][0]).toBe("platform_invoices_list");
+    expect(ipc.calls[0][1]).toEqual({
       queryParams: { starting_after: "in_a" },
     });
   });
@@ -143,7 +93,7 @@ describe("assistant platform invoices list", () => {
   });
 
   test("plain text mode reports an empty page", async () => {
-    mockResponse = { ok: true, result: { invoices: [], has_more: false } };
+    ipc.response = { ok: true, result: { invoices: [], has_more: false } };
 
     const out = await runInvoices(["list"]);
 
@@ -151,7 +101,7 @@ describe("assistant platform invoices list", () => {
   });
 
   test("plain text mode ends with a paging hint when has_more is true", async () => {
-    mockResponse = {
+    ipc.response = {
       ok: true,
       result: { invoices: [invoiceA, invoiceB], has_more: true },
     };
@@ -172,16 +122,15 @@ describe("assistant platform invoices list", () => {
 
 describe("assistant platform invoices get", () => {
   beforeEach(() => {
-    mockCalls = [];
-    mockResponse = { ok: true, result: invoiceA };
-    process.exitCode = 0;
+    ipc.calls = [];
+    ipc.response = { ok: true, result: invoiceA };
   });
 
   test("calls platform_invoices_get with the id path param and emits JSON with --json", async () => {
     const out = await runInvoices(["get", "in_123", "--json"]);
 
-    expect(mockCalls[0][0]).toBe("platform_invoices_get");
-    expect(mockCalls[0][1]).toEqual({ pathParams: { id: "in_123" } });
+    expect(ipc.calls[0][0]).toBe("platform_invoices_get");
+    expect(ipc.calls[0][1]).toEqual({ pathParams: { id: "in_123" } });
 
     const parsed = JSON.parse(out.join(""));
     expect(parsed.id).toBe("in_a");
@@ -199,7 +148,7 @@ describe("assistant platform invoices get", () => {
   });
 
   test("plain text mode scales zero-decimal currencies without dividing by 100", async () => {
-    mockResponse = {
+    ipc.response = {
       ok: true,
       result: { ...invoiceA, currency: "jpy", amount_due: 1200 },
     };
@@ -210,7 +159,7 @@ describe("assistant platform invoices get", () => {
   });
 
   test("plain text mode uses three decimals for three-decimal currencies", async () => {
-    mockResponse = {
+    ipc.response = {
       ok: true,
       result: { ...invoiceA, currency: "bhd", amount_due: 12345 },
     };
@@ -221,7 +170,7 @@ describe("assistant platform invoices get", () => {
   });
 
   test("plain text mode keeps Stripe's two-decimal scaling for ISK despite ISO zero-decimal metadata", async () => {
-    mockResponse = {
+    ipc.response = {
       ok: true,
       result: { ...invoiceA, currency: "isk", amount_due: 500 },
     };
@@ -232,7 +181,7 @@ describe("assistant platform invoices get", () => {
   });
 
   test("plain text mode falls back to raw minor units for invalid currency codes", async () => {
-    mockResponse = {
+    ipc.response = {
       ok: true,
       result: { ...invoiceA, currency: "zz", amount_due: 1234 },
     };
@@ -245,19 +194,18 @@ describe("assistant platform invoices get", () => {
 
 describe("assistant platform invoices error handling", () => {
   beforeEach(() => {
-    mockCalls = [];
-    mockResponse = {
+    ipc.calls = [];
+    ipc.response = {
       ok: false,
       error: "Platform credentials not available",
       statusCode: 422,
     };
-    process.exitCode = 0;
   });
 
   test("list exits via exitFromIpcResult on IPC failure without writing output", async () => {
     let thrown: unknown;
     const out = await captureStdout(async () => {
-      const program = buildProgram();
+      const program = await buildPlatformProgram();
       try {
         await program.parseAsync([
           "node",
@@ -278,7 +226,7 @@ describe("assistant platform invoices error handling", () => {
   test("get exits via exitFromIpcResult on IPC failure without writing output", async () => {
     let thrown: unknown;
     const out = await captureStdout(async () => {
-      const program = buildProgram();
+      const program = await buildPlatformProgram();
       try {
         await program.parseAsync([
           "node",
@@ -301,7 +249,7 @@ describe("assistant platform invoices error handling", () => {
 describe("assistant platform invoices --help", () => {
   test("group help renders both subcommands", async () => {
     const out = await captureStdout(async () => {
-      const program = buildProgram();
+      const program = await buildPlatformProgram();
       try {
         await program.parseAsync([
           "node",
@@ -323,7 +271,7 @@ describe("assistant platform invoices --help", () => {
 
   test("list help renders the --starting-after option", async () => {
     const out = await captureStdout(async () => {
-      const program = buildProgram();
+      const program = await buildPlatformProgram();
       try {
         await program.parseAsync([
           "node",

--- a/assistant/src/cli/commands/platform/__tests__/plans.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/plans.test.ts
@@ -1,79 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import { Command } from "commander";
+import { runPlatform, setupPlatformIpcMock } from "./helpers.js";
 
-// ---------------------------------------------------------------------------
-// Mock state
-// ---------------------------------------------------------------------------
-
-let mockCalls: Array<[string, Record<string, unknown>]> = [];
-let mockResponse: unknown = {
-  ok: true,
-  result: {
-    plans: [
-      {
-        id: "base",
-        name: "Base",
-        price_cents: 0,
-        billing_interval: "month",
-        included_features: ["Pay-as-you-go credits"],
-      },
-      {
-        id: "pro",
-        name: "Pro",
-        base_price_cents: 2000,
-        billing_interval: "month",
-        included_features: ["Configurable machine size"],
-      },
-    ],
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-mock.module("../../../../ipc/cli-client.js", () => ({
-  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
-    mockCalls.push([method, params]);
-    return mockResponse;
-  },
-  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
-    throw new Error("exitFromIpcResult called");
-  },
-}));
-
-const { registerPlatformCommand } = await import("../index.js");
-
-function buildProgram(): Command {
-  const program = new Command();
-  program.exitOverride();
-  registerPlatformCommand(program);
-  return program;
-}
-
-function captureStdout(fn: () => Promise<void>): Promise<string[]> {
-  const chunks: string[] = [];
-  const origWrite = process.stdout.write.bind(process.stdout);
-  process.stdout.write = ((chunk: unknown) => {
-    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof process.stdout.write;
-  return fn()
-    .then(() => chunks)
-    .finally(() => {
-      process.stdout.write = origWrite;
-    });
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const ipc = setupPlatformIpcMock();
 
 describe("assistant platform plans", () => {
   beforeEach(() => {
-    mockCalls = [];
-    mockResponse = {
+    ipc.calls = [];
+    ipc.response = {
       ok: true,
       result: {
         plans: [
@@ -94,22 +28,12 @@ describe("assistant platform plans", () => {
         ],
       },
     };
-    process.exitCode = 0;
   });
 
   test("calls platform_plans and emits catalog JSON with --json", async () => {
-    const out = await captureStdout(async () => {
-      const program = buildProgram();
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "plans",
-        "--json",
-      ]);
-    });
+    const out = await runPlatform(["plans", "--json"]);
 
-    expect(mockCalls[0][0]).toBe("platform_plans");
+    expect(ipc.calls[0][0]).toBe("platform_plans");
 
     const parsed = JSON.parse(out.join(""));
     expect(parsed.plans).toHaveLength(2);
@@ -118,12 +42,9 @@ describe("assistant platform plans", () => {
   });
 
   test("plain text mode does not emit JSON to stdout", async () => {
-    const out = await captureStdout(async () => {
-      const program = buildProgram();
-      await program.parseAsync(["node", "assistant", "platform", "plans"]);
-    });
+    const out = await runPlatform(["plans"]);
 
-    // Plain-text mode logs via log.info — verify writeOutput (JSON) was NOT called
+    // Plain-text mode logs via log.info; verify writeOutput (JSON) was NOT called
     expect(() => JSON.parse(out.join("").trim())).toThrow();
   });
 });

--- a/assistant/src/cli/commands/platform/__tests__/subscription.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/subscription.test.ts
@@ -1,72 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import { Command } from "commander";
+import { runPlatform, setupPlatformIpcMock } from "./helpers.js";
 
-// ---------------------------------------------------------------------------
-// Mock state
-// ---------------------------------------------------------------------------
-
-let mockCalls: Array<[string, Record<string, unknown>]> = [];
-let mockResponse: unknown = {
-  ok: true,
-  result: {
-    planId: "pro",
-    status: "active",
-    renewalDate: "2026-08-01T00:00:00.000Z",
-    currentPeriodEnd: "2026-08-01T00:00:00.000Z",
-    cancelAtPeriodEnd: false,
-    cancelAt: null,
-    selectedCreditTier: "credits_50",
-    package: { key: "super", name: "Super", version: 2, customized: false },
-    entitlements: { managedEmail: true, phoneNumber: false },
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-mock.module("../../../../ipc/cli-client.js", () => ({
-  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
-    mockCalls.push([method, params]);
-    return mockResponse;
-  },
-  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
-    throw new Error("exitFromIpcResult called");
-  },
-}));
-
-const { registerPlatformCommand } = await import("../index.js");
-
-function buildProgram(): Command {
-  const program = new Command();
-  program.exitOverride();
-  registerPlatformCommand(program);
-  return program;
-}
-
-function captureStdout(fn: () => Promise<void>): Promise<string[]> {
-  const chunks: string[] = [];
-  const origWrite = process.stdout.write.bind(process.stdout);
-  process.stdout.write = ((chunk: unknown) => {
-    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof process.stdout.write;
-  return fn()
-    .then(() => chunks)
-    .finally(() => {
-      process.stdout.write = origWrite;
-    });
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const ipc = setupPlatformIpcMock();
 
 describe("assistant platform subscription", () => {
   beforeEach(() => {
-    mockCalls = [];
-    mockResponse = {
+    ipc.calls = [];
+    ipc.response = {
       ok: true,
       result: {
         planId: "pro",
@@ -80,22 +21,12 @@ describe("assistant platform subscription", () => {
         entitlements: { managedEmail: true, phoneNumber: false },
       },
     };
-    process.exitCode = 0;
   });
 
   test("calls platform_subscription and emits plan JSON with --json", async () => {
-    const out = await captureStdout(async () => {
-      const program = buildProgram();
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "subscription",
-        "--json",
-      ]);
-    });
+    const out = await runPlatform(["subscription", "--json"]);
 
-    expect(mockCalls[0][0]).toBe("platform_subscription");
+    expect(ipc.calls[0][0]).toBe("platform_subscription");
 
     const parsed = JSON.parse(out.join(""));
     expect(parsed.planId).toBe("pro");
@@ -105,17 +36,9 @@ describe("assistant platform subscription", () => {
   });
 
   test("plain text mode does not emit JSON to stdout", async () => {
-    const out = await captureStdout(async () => {
-      const program = buildProgram();
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "subscription",
-      ]);
-    });
+    const out = await runPlatform(["subscription"]);
 
-    // Plain-text mode logs via log.info — verify writeOutput (JSON) was NOT called
+    // Plain-text mode logs via log.info; verify writeOutput (JSON) was NOT called
     expect(() => JSON.parse(out.join("").trim())).toThrow();
   });
 });

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -151,11 +151,9 @@ Examples:
       description: "Read the organization's Stripe invoice history",
       helpText: `
 Invoices are read from the platform's billing invoices endpoint using this
-assistant's platform API key. Amounts are Stripe-scaled integers: divide
-by 100 for most currencies, by 1 for Stripe zero-decimal currencies
-(e.g. JPY, KRW), and by 1000 for three-decimal ones (e.g. BHD). ISK, HUF,
-TWD, and UGX stay two-decimal in Stripe's API for backward compatibility.
-'created' is a Unix timestamp in seconds.
+assistant's platform API key. Amounts are Stripe-scaled integers; see
+'assistant platform invoices list --help' for the scaling rules. 'created'
+is a Unix timestamp in seconds.
 
 The platform returns one page of invoices at a time (newest first). When
 the response's 'has_more' is true, pass the last invoice's id via
@@ -196,7 +194,9 @@ Fields:
                       100 for most currencies, by 1 for Stripe
                       zero-decimal currencies (e.g. JPY, KRW), and by
                       1000 for three-decimal ones (e.g. BHD); ISK, HUF,
-                      TWD, and UGX stay two-decimal in Stripe's API
+                      TWD, and UGX are two-decimal for charges and
+                      invoices (Stripe treats them as zero-decimal
+                      only for payouts)
   amount_paid         Amount paid, same Stripe scaling as amount_due
   amount_remaining    Amount still owed, same Stripe scaling as amount_due
   created             Creation time as a Unix timestamp in seconds

--- a/assistant/src/cli/commands/platform/invoices.ts
+++ b/assistant/src/cli/commands/platform/invoices.ts
@@ -24,11 +24,13 @@ interface PlatformInvoicesListResult {
 }
 
 /**
- * These lists follow Stripe's amount scaling rules
- * (https://docs.stripe.com/currencies), not ISO 4217 metadata. Notably,
- * Stripe keeps two-decimal scaling for ISK, HUF, TWD, and UGX for backward
- * compatibility even though ISO treats them as zero-decimal, so those codes
- * are deliberately absent from the zero-decimal list.
+ * These sets follow Stripe's amount scaling rules for charges and invoices
+ * (https://docs.stripe.com/currencies), not ISO 4217 metadata: divide the
+ * minor-unit integer by 100 for most currencies, by 1 for the zero-decimal
+ * set (e.g. JPY, KRW), and by 1000 for the three-decimal set (e.g. BHD).
+ * ISK, HUF, TWD, and UGX are deliberately absent from the zero-decimal set:
+ * Stripe charges and invoices them as two-decimal amounts and treats them
+ * as zero-decimal only for payouts, per Stripe's currency docs.
  */
 const STRIPE_ZERO_DECIMAL_CURRENCIES = new Set([
   "BIF",
@@ -67,11 +69,10 @@ function stripeScaleDigits(currencyCode: string): number {
 }
 
 /**
- * Amounts are in Stripe's minor units; render as major units using Stripe's
- * amount scaling rules (2 for USD, 0 for JPY, 3 for BHD), e.g. "USD 12.34".
- * The display fraction digits are forced to match the same scale so Intl's
- * ISO metadata cannot round Stripe's two-decimal special cases (ISK, HUF,
- * TWD, UGX). Unknown currency codes fall back to the raw minor-unit amount.
+ * Render a Stripe minor-unit amount as major units, e.g. "USD 12.34". The
+ * display fraction digits are forced to match stripeScaleDigits so Intl's
+ * ISO metadata cannot apply a different scale (see the currency sets above).
+ * Unknown currency codes fall back to the raw minor-unit amount.
  */
 function formatInvoiceAmount(
   amountMinorUnits: number,
@@ -126,10 +127,7 @@ export function registerPlatformInvoicesCommands(platform: Command): void {
           : {},
       );
       if (!r.ok) {
-        return exitFromIpcResult(
-          { ok: false, error: r.error, statusCode: r.statusCode },
-          cmd,
-        );
+        return exitFromIpcResult(r, cmd);
       }
 
       const result = r.result!;
@@ -161,10 +159,7 @@ export function registerPlatformInvoicesCommands(platform: Command): void {
         pathParams: { id: invoiceId },
       });
       if (!r.ok) {
-        return exitFromIpcResult(
-          { ok: false, error: r.error, statusCode: r.statusCode },
-          cmd,
-        );
+        return exitFromIpcResult(r, cmd);
       }
 
       if (shouldOutputJson(cmd)) {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for platform-invoices-cli.md.

**Gaps:** Stripe-scaling explanation duplicated in 4 places; redundant IPC result re-wrap before exitFromIpcResult; unasserted process.exitCode resets; platform CLI test scaffold duplicated across 4 files. Also documents the verified charge/payout distinction for ISK/HUF/TWD/UGX scaling (the external review finding suggesting zero-decimal HUF/TWD was incorrect per Stripe docs).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->