### PR TITLE
fix(platform): pass invoice 400 hint only for caller-supplied cursors

### DIFF
--- a/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/platform-invoice-routes.test.ts
@@ -31,7 +31,8 @@ mock.module("../../../inbound/platform-callback-registration.js", () => ({
   }),
 }));
 
-const { ROUTES } = await import("../platform-routes.js");
+const { INVOICE_WALK_DEADLINE_MS, MAX_INVOICE_PAGES, ROUTES } =
+  await import("../platform-routes.js");
 
 const listHandler = ROUTES.find(
   (r) => r.operationId === "platform_invoices_list",
@@ -41,8 +42,6 @@ const getHandler = ROUTES.find(
 )!.handler;
 
 const INVOICES_URL = "https://platform.test/v1/organizations/billing/invoices/";
-const MAX_INVOICE_PAGES = 25;
-const INVOICE_WALK_DEADLINE_MS = 30_000;
 
 function invoice(id: string) {
   return {
@@ -169,6 +168,17 @@ describe("platform_invoices_list", () => {
     expect(err.message).toMatch(
       /use the id of the last invoice from the previous page/,
     );
+  });
+
+  test("rejects with InternalError, not BadRequestError, on a 400 without a cursor", async () => {
+    stubFetch(() => new Response("malformed request", { status: 400 }));
+
+    const err = await expectRejection(() => listHandler({}));
+    // Without a caller-supplied starting_after there is nothing
+    // caller-correctable in a 400, so it stays an internal failure.
+    expect(err).not.toBeInstanceOf(BadRequestError);
+    expect(err).toBeInstanceOf(InternalError);
+    expect(err.message).toMatch(/HTTP 400/);
   });
 });
 

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -571,13 +571,16 @@ async function fetchPlatformInvoicesPage(
 async function handlePlatformInvoicesList(
   args: RouteHandlerArgs,
 ): Promise<PlatformInvoicesListResponse> {
-  return await fetchPlatformInvoicesPage(args.queryParams?.starting_after, {
+  const startingAfter = args.queryParams?.starting_after;
+  return await fetchPlatformInvoicesPage(startingAfter, {
     signal: args.abortSignal,
     // The platform returns 400 for an invalid or expired starting_after
-    // cursor. The cursor is caller-supplied here, so keep that a client
-    // error instead of masking it as a 500.
-    badRequestHint:
-      "If you passed starting_after, use the id of the last invoice from the previous page.",
+    // cursor. Only a caller-supplied cursor is caller-correctable, so the
+    // hint (and the BadRequestError it triggers) applies just when one was
+    // passed; a 400 on a cursor-less request stays an InternalError.
+    badRequestHint: startingAfter
+      ? "If you passed starting_after, use the id of the last invoice from the previous page."
+      : undefined,
   });
 }
 
@@ -585,7 +588,7 @@ async function handlePlatformInvoicesList(
  * Runaway guard for the invoices_get cursor walk: 25 pages is 2,500
  * invoices at the platform's 100-per-page size.
  */
-const MAX_INVOICE_PAGES = 25;
+export const MAX_INVOICE_PAGES = 25;
 
 /**
  * Aggregate wall-clock deadline for the invoices_get cursor walk, matching
@@ -593,7 +596,7 @@ const MAX_INVOICE_PAGES = 25;
  * running long after the caller has given up, since a gateway IPC timeout
  * does not abort the request signal.
  */
-const INVOICE_WALK_DEADLINE_MS = 30_000;
+export const INVOICE_WALK_DEADLINE_MS = 30_000;
 
 function invoiceWalkTimeoutError(id: string): InternalError {
   return new InternalError(


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review round 2 for platform-invoices-cli.md.

**Gap:** badRequestHint applied to cursor-less list requests, converting non-caller-correctable 400s into BadRequestError
**Fix:** hint is now gated on a supplied starting_after; also exports MAX_INVOICE_PAGES and INVOICE_WALK_DEADLINE_MS so the route test imports them instead of re-declaring literals
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->