### PR TITLE
chore(cli): finish platform test scaffold migration and dedupe help arguments block

### DIFF
--- a/assistant/src/cli/commands/platform/__tests__/callback-routes-list.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/callback-routes-list.test.ts
@@ -1,73 +1,25 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import { Command } from "commander";
+import {
+  runPlatform,
+  runPlatformCaught,
+  setupPlatformIpcMock,
+} from "./helpers.js";
 
-// ---------------------------------------------------------------------------
-// Mock state
-// ---------------------------------------------------------------------------
-
-let mockCalls: Array<[string, Record<string, unknown>]> = [];
-let mockResponse: unknown = { ok: true, result: { routes: [] } };
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-mock.module("../../../../ipc/cli-client.js", () => ({
-  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
-    mockCalls.push([method, params]);
-    return mockResponse;
-  },
-  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
-    throw new Error("exitFromIpcResult called");
-  },
-}));
-
-const { registerPlatformCommand } = await import("../index.js");
-
-function buildProgram(): Command {
-  const program = new Command();
-  program.exitOverride();
-  registerPlatformCommand(program);
-  return program;
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const ipc = setupPlatformIpcMock();
 
 describe("assistant platform callback-routes list", () => {
   beforeEach(() => {
-    mockCalls = [];
-    mockResponse = { ok: true, result: { routes: [] } };
-    process.exitCode = 0;
+    ipc.calls = [];
+    ipc.response = { ok: true, result: { routes: [] } };
   });
 
   test("returns empty list when no routes registered", async () => {
-    const program = buildProgram();
-    const stdoutChunks: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: unknown) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    }) as typeof process.stdout.write;
+    const out = await runPlatform(["callback-routes", "list", "--json"]);
 
-    try {
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "callback-routes",
-        "list",
-        "--json",
-      ]);
-    } finally {
-      process.stdout.write = origWrite;
-    }
+    expect(ipc.calls[0][0]).toBe("platform_callback_routes_list");
 
-    expect(mockCalls[0][0]).toBe("platform_callback_routes_list");
-
-    const parsed = JSON.parse(stdoutChunks.join(""));
+    const parsed = JSON.parse(out.join(""));
     expect(parsed.ok).toBe(true);
     expect(parsed.routes).toEqual([]);
   });
@@ -91,30 +43,11 @@ describe("assistant platform callback-routes list", () => {
           "https://dev-platform.vellum.ai/v1/gateway/callbacks/019d6d4f-6dbd-779f-91d3-cb273b9429a5/webhooks/telegram/",
       },
     ];
-    mockResponse = { ok: true, result: { routes } };
+    ipc.response = { ok: true, result: { routes } };
 
-    const program = buildProgram();
-    const stdoutChunks: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: unknown) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    }) as typeof process.stdout.write;
+    const out = await runPlatform(["callback-routes", "list", "--json"]);
 
-    try {
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "callback-routes",
-        "list",
-        "--json",
-      ]);
-    } finally {
-      process.stdout.write = origWrite;
-    }
-
-    const parsed = JSON.parse(stdoutChunks.join(""));
+    const parsed = JSON.parse(out.join(""));
     expect(parsed.ok).toBe(true);
     expect(parsed.routes).toHaveLength(2);
     expect(parsed.routes[0].type).toBe("email");
@@ -122,27 +55,23 @@ describe("assistant platform callback-routes list", () => {
   });
 
   test("fails when platform credentials are missing", async () => {
-    mockResponse = {
+    ipc.response = {
       ok: false,
       error: "Platform credentials not available",
       statusCode: 422,
     };
 
-    const program = buildProgram();
-    await expect(
-      program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "callback-routes",
-        "list",
-        "--json",
-      ]),
-    ).rejects.toThrow("exitFromIpcResult called");
+    const { thrown } = await runPlatformCaught([
+      "callback-routes",
+      "list",
+      "--json",
+    ]);
+
+    expect((thrown as Error).message).toBe("exitFromIpcResult called");
   });
 
   test("callback-routes register calls platform_callback_routes_register", async () => {
-    mockResponse = {
+    ipc.response = {
       ok: true,
       result: {
         callbackUrl:
@@ -152,40 +81,25 @@ describe("assistant platform callback-routes list", () => {
       },
     };
 
-    const program = buildProgram();
-    const stdoutChunks: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: unknown) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    }) as typeof process.stdout.write;
+    const out = await runPlatform([
+      "callback-routes",
+      "register",
+      "--path",
+      "webhooks/telegram",
+      "--type",
+      "telegram",
+      "--json",
+    ]);
 
-    try {
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "callback-routes",
-        "register",
-        "--path",
-        "webhooks/telegram",
-        "--type",
-        "telegram",
-        "--json",
-      ]);
-    } finally {
-      process.stdout.write = origWrite;
-    }
-
-    expect(mockCalls[0][0]).toBe("platform_callback_routes_register");
-    expect((mockCalls[0][1].body as Record<string, unknown>).path).toBe(
+    expect(ipc.calls[0][0]).toBe("platform_callback_routes_register");
+    expect((ipc.calls[0][1].body as Record<string, unknown>).path).toBe(
       "webhooks/telegram",
     );
-    expect((mockCalls[0][1].body as Record<string, unknown>).type).toBe(
+    expect((ipc.calls[0][1].body as Record<string, unknown>).type).toBe(
       "telegram",
     );
 
-    const parsed = JSON.parse(stdoutChunks.join(""));
+    const parsed = JSON.parse(out.join(""));
     expect(parsed.ok).toBe(true);
     expect(parsed.callbackPath).toBe("webhooks/telegram");
   });

--- a/assistant/src/cli/commands/platform/__tests__/helpers.ts
+++ b/assistant/src/cli/commands/platform/__tests__/helpers.ts
@@ -61,9 +61,30 @@ export function captureStdout(fn: () => Promise<void>): Promise<string[]> {
 }
 
 /** Run 'assistant platform <args>' against a fresh program, capturing stdout. */
-export function runPlatform(args: string[]): Promise<string[]> {
-  return captureStdout(async () => {
+export async function runPlatform(args: string[]): Promise<string[]> {
+  const { out, thrown } = await runPlatformCaught(args);
+  if (thrown !== undefined) {
+    throw thrown;
+  }
+  return out;
+}
+
+/**
+ * Like {@link runPlatform}, but capture whatever the parse throws instead of
+ * propagating it (the mocked exitFromIpcResult error, Commander's exitOverride
+ * on --help), so tests can assert on both the output and the thrown value.
+ */
+export async function runPlatformCaught(
+  args: string[],
+): Promise<{ out: string[]; thrown: unknown }> {
+  let thrown: unknown;
+  const out = await captureStdout(async () => {
     const program = await buildPlatformProgram();
-    await program.parseAsync(["node", "assistant", "platform", ...args]);
+    try {
+      await program.parseAsync(["node", "assistant", "platform", ...args]);
+    } catch (err) {
+      thrown = err;
+    }
   });
+  return { out, thrown };
 }

--- a/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/invoices.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
-  buildPlatformProgram,
-  captureStdout,
   runPlatform,
+  runPlatformCaught,
   setupPlatformIpcMock,
 } from "./helpers.js";
 
@@ -203,43 +202,18 @@ describe("assistant platform invoices error handling", () => {
   });
 
   test("list exits via exitFromIpcResult on IPC failure without writing output", async () => {
-    let thrown: unknown;
-    const out = await captureStdout(async () => {
-      const program = await buildPlatformProgram();
-      try {
-        await program.parseAsync([
-          "node",
-          "assistant",
-          "platform",
-          "invoices",
-          "list",
-        ]);
-      } catch (err) {
-        thrown = err;
-      }
-    });
+    const { out, thrown } = await runPlatformCaught(["invoices", "list"]);
 
     expect((thrown as Error).message).toBe("exitFromIpcResult called");
     expect(out.join("")).toBe("");
   });
 
   test("get exits via exitFromIpcResult on IPC failure without writing output", async () => {
-    let thrown: unknown;
-    const out = await captureStdout(async () => {
-      const program = await buildPlatformProgram();
-      try {
-        await program.parseAsync([
-          "node",
-          "assistant",
-          "platform",
-          "invoices",
-          "get",
-          "in_missing",
-        ]);
-      } catch (err) {
-        thrown = err;
-      }
-    });
+    const { out, thrown } = await runPlatformCaught([
+      "invoices",
+      "get",
+      "in_missing",
+    ]);
 
     expect((thrown as Error).message).toBe("exitFromIpcResult called");
     expect(out.join("")).toBe("");
@@ -248,20 +222,7 @@ describe("assistant platform invoices error handling", () => {
 
 describe("assistant platform invoices --help", () => {
   test("group help renders both subcommands", async () => {
-    const out = await captureStdout(async () => {
-      const program = await buildPlatformProgram();
-      try {
-        await program.parseAsync([
-          "node",
-          "assistant",
-          "platform",
-          "invoices",
-          "--help",
-        ]);
-      } catch {
-        // exitOverride throws on --help; ignore
-      }
-    });
+    const { out } = await runPlatformCaught(["invoices", "--help"]);
     const text = out.join("");
 
     expect(text).toContain("list");
@@ -270,21 +231,7 @@ describe("assistant platform invoices --help", () => {
   });
 
   test("list help renders the --starting-after option", async () => {
-    const out = await captureStdout(async () => {
-      const program = await buildPlatformProgram();
-      try {
-        await program.parseAsync([
-          "node",
-          "assistant",
-          "platform",
-          "invoices",
-          "list",
-          "--help",
-        ]);
-      } catch {
-        // exitOverride throws on --help; ignore
-      }
-    });
+    const { out } = await runPlatformCaught(["invoices", "list", "--help"]);
 
     expect(out.join("")).toContain("--starting-after <invoice-id>");
   });

--- a/assistant/src/cli/commands/platform/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/status.test.ts
@@ -1,57 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import { Command } from "commander";
+import { runPlatform, setupPlatformIpcMock } from "./helpers.js";
 
-// ---------------------------------------------------------------------------
-// Mock state
-// ---------------------------------------------------------------------------
-
-let mockCalls: Array<[string, Record<string, unknown>]> = [];
-let mockResponse: unknown = {
-  ok: true,
-  result: {
-    isPlatform: false,
-    baseUrl: "",
-    assistantId: "",
-    hasAssistantApiKey: false,
-    hasWebhookSecret: false,
-    available: false,
-    organizationId: null,
-    userId: null,
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-mock.module("../../../../ipc/cli-client.js", () => ({
-  cliIpcCall: async (method: string, params: Record<string, unknown>) => {
-    mockCalls.push([method, params]);
-    return mockResponse;
-  },
-  exitFromIpcResult: (_r: unknown, _cmd: unknown) => {
-    throw new Error("exitFromIpcResult called");
-  },
-}));
-
-const { registerPlatformCommand } = await import("../index.js");
-
-function buildProgram(): Command {
-  const program = new Command();
-  program.exitOverride();
-  registerPlatformCommand(program);
-  return program;
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const ipc = setupPlatformIpcMock();
 
 describe("assistant platform status", () => {
   beforeEach(() => {
-    mockCalls = [];
-    mockResponse = {
+    ipc.calls = [];
+    ipc.response = {
       ok: true,
       result: {
         isPlatform: false,
@@ -64,11 +20,10 @@ describe("assistant platform status", () => {
         userId: null,
       },
     };
-    process.exitCode = 0;
   });
 
   test("platform pod returns full status from context", async () => {
-    mockResponse = {
+    ipc.response = {
       ok: true,
       result: {
         isPlatform: true,
@@ -82,29 +37,11 @@ describe("assistant platform status", () => {
       },
     };
 
-    const program = buildProgram();
-    const stdoutChunks: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: unknown) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    }) as typeof process.stdout.write;
+    const out = await runPlatform(["status", "--json"]);
 
-    try {
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "status",
-        "--json",
-      ]);
-    } finally {
-      process.stdout.write = origWrite;
-    }
+    expect(ipc.calls[0][0]).toBe("platform_status");
 
-    expect(mockCalls[0][0]).toBe("platform_status");
-
-    const parsed = JSON.parse(stdoutChunks.join(""));
+    const parsed = JSON.parse(out.join(""));
     expect(parsed.isPlatform).toBe(true);
     expect(parsed.baseUrl).toBe("https://platform.vellum.ai");
     expect(parsed.assistantId).toBe("asst-abc-123");
@@ -116,21 +53,9 @@ describe("assistant platform status", () => {
   });
 
   test("plain text mode does not emit JSON to stdout", async () => {
-    const program = buildProgram();
-    const stdoutChunks: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: unknown) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    }) as typeof process.stdout.write;
+    const out = await runPlatform(["status"]);
 
-    try {
-      await program.parseAsync(["node", "assistant", "platform", "status"]);
-    } finally {
-      process.stdout.write = origWrite;
-    }
-
-    // Plain-text mode logs via log.info — verify writeOutput (JSON) was NOT called
-    expect(() => JSON.parse(stdoutChunks.join("").trim())).toThrow();
+    // Plain-text mode logs via log.info; verify writeOutput (JSON) was NOT called
+    expect(() => JSON.parse(out.join("").trim())).toThrow();
   });
 });

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -223,10 +223,6 @@ Examples:
             },
           ],
           helpText: `
-Arguments:
-  <invoice-id>  Stripe invoice ID (e.g. in_1AbCdEfGh); run 'assistant
-                platform invoices list' to find it
-
 The platform has no per-invoice endpoint, so the assistant pages through
 the org's invoice list (newest first) until the ID matches. The lookup
 searches the most recent 2,500 invoices (25 pages) and errors if the ID


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review round 2 for platform-invoices-cli.md.

**Gaps:** status and callback-routes-list test suites still carried the scaffold that helpers.ts replaced; invoices.test.ts repeated a 15-line caught-run block four times; invoices get --help rendered its argument description twice (structured entry plus manual Arguments block)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->