### PR TITLE
fix(schedule): make a wake's denial hold on a resident conversation (LUM-2933)

### DIFF
--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -105,14 +105,16 @@ describe("scheduler wake mode", () => {
     // WHEN the scheduler fires
     await runDueSchedulesOnce();
 
-    // THEN the wake runs with no trust context at all, so the turn resolves the
-    // fail-closed `unknown` class and sensitive tools stay denied
+    // THEN the wake states that it recovered nothing, which pins the
+    // fail-closed `unknown` class on the woken turn so sensitive tools stay
+    // denied even if the target is still resident from a guardian turn
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledWith({
       conversationId: "conv-telegram",
       hint: "Follow up",
       source: "defer",
       persistTriggerAsEvent: true,
+      trustContext: null,
     });
   });
 

--- a/assistant/src/__tests__/wake-schedule-escalation.test.ts
+++ b/assistant/src/__tests__/wake-schedule-escalation.test.ts
@@ -122,6 +122,15 @@ function trustOfLastWake(): unknown {
   return (call?.[0] as Record<string, unknown> | undefined)?.trustContext;
 }
 
+/**
+ * A firing that recovered nothing states it: `null` pins the fail-closed class
+ * on the woken turn, so a target still resident at guardian from an earlier
+ * turn cannot lend the firing its capability.
+ */
+function expectLastWakeRanFailClosed(): void {
+  expect(trustOfLastWake()).toBeNull();
+}
+
 function resetAll(): void {
   const db = getDb();
   db.run("DELETE FROM cron_runs");
@@ -408,7 +417,7 @@ describe("the due tick honors durable row provenance", () => {
     await runDueSchedulesOnce();
 
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
-    expect(trustOfLastWake()).toBeUndefined();
+    expectLastWakeRanFailClosed();
   });
 
   test("a marked row whose target was corrupted in the DB fires without trust", async () => {
@@ -431,6 +440,6 @@ describe("the due tick honors durable row provenance", () => {
         >
       ).conversationId,
     ).toBe("conv-other-guardian-owned");
-    expect(trustOfLastWake()).toBeUndefined();
+    expectLastWakeRanFailClosed();
   });
 });

--- a/assistant/src/__tests__/wake-schedule-resident-trust.test.ts
+++ b/assistant/src/__tests__/wake-schedule-resident-trust.test.ts
@@ -1,0 +1,397 @@
+/**
+ * A scheduled wake must reach the same trust whether its target conversation is
+ * cold or still resident from an earlier guardian turn.
+ *
+ * `wake-schedule-trust.test.ts` covers what a row must prove to recover trust,
+ * asserted on the {@link WakeOptions} the row produces. That shape is only half
+ * the answer: the class a woken turn actually runs at is what tool setup reads
+ * off the conversation (`resolveEffectiveTurnTrust`), and a conversation that is
+ * still in memory from a guardian interaction is resting at guardian. So these
+ * tests drive the real wake against a resident target and assert the trust the
+ * tool executor would see mid-run, plus that the conversation is left exactly as
+ * the wake found it.
+ *
+ * The doubles stand in for the two halves of the live path:
+ * - `resolveTarget` mirrors `getOrCreateConversation`'s trust application
+ *   (`daemon/conversation-store.ts`), which the default resolver threads
+ *   `WakeOptions.trustContext` into. The threading itself is pinned by
+ *   `runtime/__tests__/agent-wake.test.ts`.
+ * - the conversation double carries the two trust fields tool setup reads and
+ *   records the effective trust at `agentLoop.run` time.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { TrustContext } from "../daemon/trust-context-types.js";
+import type { Message } from "../providers/types.js";
+
+/** Stored `origin_channel` per conversation id, read by resting-trust recovery. */
+const originChannels = new Map<string, string | null>();
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  getConversation: (conversationId: string) =>
+    originChannels.has(conversationId)
+      ? {
+          id: conversationId,
+          originChannel: originChannels.get(conversationId) ?? null,
+          archivedAt: null,
+        }
+      : undefined,
+  getConversationOverrideProfile: () => undefined,
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+}));
+
+// The wake's persistence and client-broadcast boundary. These tests are about
+// the trust the run executes under, so the boundary is stubbed out entirely.
+mock.module("../daemon/wake-conversation-ops.js", () => ({
+  persistWakeTriggerMessage: async () => {},
+  persistWakeTailMessage: async () => {},
+  emitWakeAgentEvent: () => {},
+  broadcastWakeSurface: () => {},
+  scopeWakeAllowedTools: () => () => {},
+}));
+
+import type { Conversation } from "../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import {
+  INTERNAL_GUARDIAN_TRUST_CONTEXT,
+  resolveEffectiveTurnTrust,
+  resolveTrustClass,
+} from "../daemon/trust-context.js";
+import {
+  __resetWakeChainForTests,
+  wakeAgentForOpportunity,
+  type WakeOptions,
+} from "../runtime/agent-wake.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
+import {
+  LEGACY_DEFER_CREATED_BY,
+  OWNER_DEFER_CREATED_BY,
+} from "../schedule/defer-provenance.js";
+import { buildWakeScheduleOptions } from "../schedule/wake-schedule-options.js";
+import { resolveSensitiveToolDecision } from "../tools/tool-approval-handler.js";
+
+const TARGET = "conv-guardian-owned";
+
+/** A row as `createOwnerDeferredWake` writes it. */
+const OWNER_WAKE_JOB = {
+  message: "Check back on this",
+  inferenceProfile: null,
+  createdBy: OWNER_DEFER_CREATED_BY,
+  createdFromConversationId: TARGET,
+};
+
+/** The guardian trust a conversation is resting at after an owner's turn. */
+const RESTING_GUARDIAN_TRUST: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+interface WakeTargetDouble {
+  conversation: Conversation;
+  /** Effective turn trust captured inside `agentLoop.run`, one per run. */
+  trustDuringRun: TrustContext[];
+  /** What each firing handed the conversation store to hydrate under. */
+  hydrationTrust: Array<TrustContext | undefined>;
+  /** `conversation.trustContext` as it stands now. */
+  restingTrust: () => TrustContext | undefined;
+  /** `conversation.currentTurnTrustContext` as it stands now. */
+  turnTrust: () => TrustContext | undefined;
+}
+
+/**
+ * A conversation double carrying the members the wake touches. `restingTrust`
+ * seeds both trust fields the way an in-memory conversation looks right after a
+ * turn by that actor finished: the persistent context plus the per-turn
+ * snapshot that turn left behind.
+ */
+function makeWakeTarget(options: {
+  conversationId: string;
+  restingTrust?: TrustContext;
+}): WakeTargetDouble {
+  const messages: Message[] = [];
+  let processing = false;
+  const trustDuringRun: TrustContext[] = [];
+
+  const conversation = {
+    conversationId: options.conversationId,
+    trustContext: options.restingTrust,
+    currentTurnTrustContext: options.restingTrust,
+    agentLoop: {
+      run: async ({ messages: input }: { messages: Message[] }) => {
+        trustDuringRun.push(resolveEffectiveTurnTrust(conversation));
+        return { history: input, exitReason: null, newMessages: [] };
+      },
+    },
+    messages,
+    getMessages: () => messages,
+    isProcessing: () => processing,
+    waitForIdle: async () => !processing,
+    setProcessing: (on: boolean) => {
+      processing = on;
+    },
+    setTrustContext(ctx: TrustContext | null) {
+      // Mirrors Conversation.setTrustContext (coerces null → undefined).
+      conversation.trustContext = ctx ?? undefined;
+    },
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+    drainQueue: async () => {},
+    maybeCompact: async () => null,
+    contextWindowManager: { estimateInputTokens: () => 0 },
+    buildCurrentSystemPrompt: () => "mock-system-prompt",
+    modelOverride: undefined,
+  } as unknown as Conversation & { trustContext?: TrustContext };
+
+  return {
+    conversation: conversation as Conversation,
+    trustDuringRun,
+    hydrationTrust: [],
+    restingTrust: () => conversation.trustContext,
+    turnTrust: () => conversation.currentTurnTrustContext,
+  };
+}
+
+/**
+ * Fire `options` against `target` through the resolution the default resolver
+ * performs: it hands `getOrCreateConversation` the wake's context or nothing at
+ * all, and the store applies that to a resident conversation only when it is
+ * something. A firing that recovered no trust must arrive as nothing, so the
+ * conversation's own resting trust survives the wake untouched.
+ */
+async function fireWake(
+  options: WakeOptions,
+  target: WakeTargetDouble,
+): Promise<void> {
+  await wakeAgentForOpportunity(options, {
+    resolveTarget: async (opts) => {
+      const hydrationTrust = opts.trustContext ?? undefined;
+      target.hydrationTrust.push(hydrationTrust);
+      if (hydrationTrust !== undefined) {
+        target.conversation.setTrustContext(hydrationTrust);
+      }
+      return target.conversation;
+    },
+  });
+}
+
+/** The decision the sensitive-tool gate reaches for a `bash` call at `trust`. */
+function gateDecision(
+  trust: TrustContext,
+  reach: "sandbox" | "host" = "sandbox",
+): string {
+  const { sensitiveToolApproval } = resolveCapabilities(
+    resolveTrustClass(trust),
+  );
+  return resolveSensitiveToolDecision({
+    reach,
+    cellThreshold: undefined,
+    sensitiveToolApproval,
+  });
+}
+
+/** Register `conversation` as resident for the duration of `run`. */
+async function withResidentConversation(
+  target: WakeTargetDouble,
+  run: () => Promise<void>,
+): Promise<void> {
+  setConversation(target.conversation.conversationId, target.conversation);
+  try {
+    await run();
+  } finally {
+    deleteConversation(target.conversation.conversationId);
+  }
+}
+
+beforeEach(() => {
+  __resetWakeChainForTests();
+  originChannels.clear();
+  originChannels.set(TARGET, null);
+});
+
+/**
+ * Every row shape that proves nothing: legacy provenance, an unmarked schedule,
+ * a marked row with no source binding, and a marked row retargeted away from
+ * the conversation it was created in. Each one fires against a guardian-owned
+ * target, so the only thing standing between it and the guardian's tools is the
+ * class its turn runs at.
+ */
+type WakeJob = Parameters<typeof buildWakeScheduleOptions>[0];
+
+const UNPROVEN_ROWS: Array<{ label: string; job: WakeJob }> = [
+  {
+    label: "a legacy defer",
+    job: { ...OWNER_WAKE_JOB, createdBy: LEGACY_DEFER_CREATED_BY },
+  },
+  {
+    label: "an unmarked wake schedule",
+    job: { ...OWNER_WAKE_JOB, createdBy: "agent" },
+  },
+  {
+    label: "a marked row with no source binding",
+    job: { ...OWNER_WAKE_JOB, createdFromConversationId: null },
+  },
+  {
+    label: "a marked row retargeted away from its source",
+    job: { ...OWNER_WAKE_JOB, createdFromConversationId: "conv-elsewhere" },
+  },
+];
+
+describe("a wake that recovers no trust runs fail-closed on a resident target", () => {
+  for (const { label, job } of UNPROVEN_ROWS) {
+    test(`${label} cannot reach sensitive tools`, async () => {
+      const target = makeWakeTarget({
+        conversationId: TARGET,
+        restingTrust: RESTING_GUARDIAN_TRUST,
+      });
+
+      await withResidentConversation(target, () =>
+        fireWake(buildWakeScheduleOptions(job, TARGET), target),
+      );
+
+      expect(target.trustDuringRun).toHaveLength(1);
+      expect(target.trustDuringRun[0]!.trustClass).toBe("unknown");
+      expect(gateDecision(target.trustDuringRun[0]!)).toBe("deny");
+    });
+  }
+
+  test("an owner-authored row on a remote-origin target cannot reach them either", async () => {
+    // The row proves its author, but trust comes from the conversation the wake
+    // lands in, and a remote-channel conversation recovers none. Residency must
+    // not substitute for what the target could not supply.
+    originChannels.set("conv-remote", "telegram");
+    const target = makeWakeTarget({
+      conversationId: "conv-remote",
+      restingTrust: RESTING_GUARDIAN_TRUST,
+    });
+
+    await withResidentConversation(target, () =>
+      fireWake(
+        buildWakeScheduleOptions(
+          { ...OWNER_WAKE_JOB, createdFromConversationId: "conv-remote" },
+          "conv-remote",
+        ),
+        target,
+      ),
+    );
+
+    expect(target.trustDuringRun[0]!.trustClass).toBe("unknown");
+  });
+
+  test("an unrecognized stored origin cannot reach them either", async () => {
+    // A value outside the canonical channel set (newer build, renamed channel,
+    // corrupted row) lands where a remote channel lands.
+    originChannels.set("conv-future", "channel-from-a-newer-build");
+    const target = makeWakeTarget({
+      conversationId: "conv-future",
+      restingTrust: RESTING_GUARDIAN_TRUST,
+    });
+
+    await withResidentConversation(target, () =>
+      fireWake(
+        buildWakeScheduleOptions(
+          { ...OWNER_WAKE_JOB, createdFromConversationId: "conv-future" },
+          "conv-future",
+        ),
+        target,
+      ),
+    );
+
+    expect(target.trustDuringRun[0]!.trustClass).toBe("unknown");
+  });
+
+  test("the cold target reaches the same class as the resident one", async () => {
+    // The parity this whole file exists for: same row, same verdict, whether or
+    // not the conversation was still in memory.
+    const cold = makeWakeTarget({ conversationId: TARGET });
+    const resident = makeWakeTarget({
+      conversationId: TARGET,
+      restingTrust: RESTING_GUARDIAN_TRUST,
+    });
+
+    const options = buildWakeScheduleOptions(
+      { ...OWNER_WAKE_JOB, createdBy: LEGACY_DEFER_CREATED_BY },
+      TARGET,
+    );
+    await fireWake(options, cold);
+    __resetWakeChainForTests();
+    await withResidentConversation(resident, () => fireWake(options, resident));
+
+    expect(resident.trustDuringRun[0]).toEqual(cold.trustDuringRun[0]!);
+  });
+});
+
+describe("the wake leaves a resident conversation as it found it", () => {
+  test("a fail-closed wake restores the turn snapshot and never rewrites the resting trust", async () => {
+    // The fail-closed class is scoped to the woken turn. A queued user message
+    // draining behind the wake reads the conversation's resting trust, so the
+    // wake must not leave its own class sitting on either field.
+    const target = makeWakeTarget({
+      conversationId: TARGET,
+      restingTrust: RESTING_GUARDIAN_TRUST,
+    });
+
+    await withResidentConversation(target, () =>
+      fireWake(
+        buildWakeScheduleOptions(
+          { ...OWNER_WAKE_JOB, createdBy: LEGACY_DEFER_CREATED_BY },
+          TARGET,
+        ),
+        target,
+      ),
+    );
+
+    // Nothing was handed to hydration either, so the resting trust was never
+    // rewritten on the way in and put back on the way out: it was never touched.
+    expect(target.hydrationTrust).toEqual([undefined]);
+    expect(target.restingTrust()).toEqual(RESTING_GUARDIAN_TRUST);
+    expect(target.turnTrust()).toEqual(RESTING_GUARDIAN_TRUST);
+    expect(gateDecision(resolveEffectiveTurnTrust(target.conversation))).toBe(
+      "proceed",
+    );
+  });
+
+  test("an elevating wake restores the prior turn snapshot too", async () => {
+    const target = makeWakeTarget({
+      conversationId: TARGET,
+      restingTrust: RESTING_GUARDIAN_TRUST,
+    });
+
+    await withResidentConversation(target, () =>
+      fireWake(buildWakeScheduleOptions(OWNER_WAKE_JOB, TARGET), target),
+    );
+
+    expect(target.trustDuringRun[0]).toEqual(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+    expect(target.turnTrust()).toEqual(RESTING_GUARDIAN_TRUST);
+    expect(target.restingTrust()).toEqual(RESTING_GUARDIAN_TRUST);
+  });
+});
+
+describe("an owner-authored defer still resumes at the target's own trust", () => {
+  test("a resident guardian-owned target keeps its sensitive tools", async () => {
+    const target = makeWakeTarget({
+      conversationId: TARGET,
+      restingTrust: RESTING_GUARDIAN_TRUST,
+    });
+
+    await withResidentConversation(target, () =>
+      fireWake(buildWakeScheduleOptions(OWNER_WAKE_JOB, TARGET), target),
+    );
+
+    expect(target.trustDuringRun[0]!.trustClass).toBe("guardian");
+    expect(gateDecision(target.trustDuringRun[0]!)).toBe("proceed");
+    expect(gateDecision(target.trustDuringRun[0]!, "host")).toBe("proceed");
+  });
+
+  test("a cold guardian-owned target reaches the same class", async () => {
+    const target = makeWakeTarget({ conversationId: TARGET });
+
+    await fireWake(buildWakeScheduleOptions(OWNER_WAKE_JOB, TARGET), target);
+
+    expect(target.trustDuringRun[0]).toEqual(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+  });
+});

--- a/assistant/src/__tests__/wake-schedule-trust.test.ts
+++ b/assistant/src/__tests__/wake-schedule-trust.test.ts
@@ -71,9 +71,11 @@ function writeRawOriginChannel(conversationId: string, raw: string): void {
 
 /**
  * The decision the sensitive-tool gate reaches for an invocation with the given
- * resting trust, with no channel approval cell to lift the floor. Absent trust
- * is what a wake with no `trustContext` resolves at tool-setup time
- * (`currentTurnTrustContext ?? trustContext ?? FALLBACK_TURN_TRUST`).
+ * resting trust, with no channel approval cell to lift the floor. A firing that
+ * recovered nothing carries `trustContext: null`, which the wake pins as
+ * {@link FALLBACK_TURN_TRUST} on the woken turn; the trust each row class then
+ * shows tool setup on a resident target is covered end to end in
+ * `wake-schedule-resident-trust.test.ts`.
  */
 function gateDecision(
   trustContext: TrustContext | null | undefined,
@@ -156,7 +158,7 @@ describe("a row without owner provenance recovers nothing", () => {
     // they never recover trust.
     const options = buildWakeScheduleOptions(LEGACY_WAKE_JOB, TARGET);
 
-    expect(options).not.toHaveProperty("trustContext");
+    expect(options.trustContext).toBeNull();
     expect(wakeGateDecision(options)).toBe("deny");
   });
 
@@ -166,7 +168,7 @@ describe("a row without owner provenance recovers nothing", () => {
       TARGET,
     );
 
-    expect(options).not.toHaveProperty("trustContext");
+    expect(options.trustContext).toBeNull();
     expect(wakeGateDecision(options)).toBe("deny");
   });
 
@@ -176,7 +178,7 @@ describe("a row without owner provenance recovers nothing", () => {
       TARGET,
     );
 
-    expect(options).not.toHaveProperty("trustContext");
+    expect(options.trustContext).toBeNull();
     expect(wakeGateDecision(options)).toBe("deny");
   });
 
@@ -190,7 +192,7 @@ describe("a row without owner provenance recovers nothing", () => {
       TARGET,
     );
 
-    expect(options).not.toHaveProperty("trustContext");
+    expect(options.trustContext).toBeNull();
     expect(wakeGateDecision(options)).toBe("deny");
   });
 });
@@ -215,10 +217,9 @@ describe("target provenance still bounds an owner-authored defer", () => {
       "conv-remote",
     );
 
-    // Absent, not `undefined`: a fabricated context would either hand a
-    // remote-origin conversation the guardian's capabilities or bury the reply
-    // under `unknown` provenance.
-    expect(options).not.toHaveProperty("trustContext");
+    // Fail-closed, not fabricated: a recovered context would hand a
+    // remote-origin conversation the guardian's capabilities.
+    expect(options.trustContext).toBeNull();
     expect(wakeGateDecision(options)).toBe("deny");
   });
 
@@ -232,8 +233,9 @@ describe("target provenance still bounds an owner-authored defer", () => {
 
     expect(recoverRestingTrustContext("conv-future")).toBeNull();
     expect(
-      buildWakeScheduleOptions(ownerJobFor("conv-future"), "conv-future"),
-    ).not.toHaveProperty("trustContext");
+      buildWakeScheduleOptions(ownerJobFor("conv-future"), "conv-future")
+        .trustContext,
+    ).toBeNull();
   });
 
   test("an empty-string origin recovers nothing", () => {
@@ -249,7 +251,8 @@ describe("target provenance still bounds an owner-authored defer", () => {
     // an absent row must never be one.
     expect(recoverRestingTrustContext("conv-missing")).toBeNull();
     expect(
-      buildWakeScheduleOptions(ownerJobFor("conv-missing"), "conv-missing"),
-    ).not.toHaveProperty("trustContext");
+      buildWakeScheduleOptions(ownerJobFor("conv-missing"), "conv-missing")
+        .trustContext,
+    ).toBeNull();
   });
 });

--- a/assistant/src/daemon/conversation-resting-trust.ts
+++ b/assistant/src/daemon/conversation-resting-trust.ts
@@ -31,11 +31,12 @@ const INTERNAL_ORIGIN_CHANNEL = "vellum";
  * empty, and the class the tool-approval gate reads to let the guardian's own
  * sensitive tools run.
  *
- * Everything else returns `null`, and the caller runs the turn under no
- * reconstructed context rather than a fabricated one, which would either grant
- * a low-trust conversation guardian capability or bury the reply under
- * `unknown` provenance. "Everything else" is deliberately the whole remainder,
- * not just the recognized remote channels:
+ * Everything else returns `null`: nothing is reconstructed, and the caller
+ * decides what an unrecoverable target means for its turn (a wake schedule runs
+ * it at the fail-closed class). What is never returned is a fabricated context,
+ * which would either grant a low-trust conversation guardian capability or bury
+ * the reply under `unknown` provenance. "Everything else" is deliberately the
+ * whole remainder, not just the recognized remote channels:
  *
  * - A **missing conversation row** recovers nothing. Callers reject it on their
  *   own path anyway (`wakeAgentForOpportunity` returns `not_found`), so this is

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -79,7 +79,10 @@ import {
   markDoordashStepInProgress,
 } from "./doordash-steps.js";
 import { runPostExecutionSideEffects } from "./tool-side-effects.js";
-import { FALLBACK_TURN_TRUST, resolveTrustClass } from "./trust-context.js";
+import {
+  resolveEffectiveTurnTrust,
+  resolveTrustClass,
+} from "./trust-context.js";
 
 const log = getLogger("conversation-tool-setup");
 
@@ -345,8 +348,7 @@ export function createToolExecutor(
     // Per-turn trust snapshot: prefer the snapshot captured at turn start so
     // a concurrent owner meta command (/status, /clean) that mutates the live
     // trustContext cannot elevate the in-flight turn to guardian.
-    const turnTrust =
-      ctx.currentTurnTrustContext ?? ctx.trustContext ?? FALLBACK_TURN_TRUST;
+    const turnTrust = resolveEffectiveTurnTrust(ctx);
 
     const toolContext: ToolContext = {
       workingDir: ctx.workingDir,

--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -39,6 +39,27 @@ export const FALLBACK_TURN_TRUST: TrustContext = {
 };
 
 /**
+ * The trust a turn actually runs under: the snapshot pinned for this turn when
+ * there is one, the conversation's resting trust otherwise, and
+ * {@link FALLBACK_TURN_TRUST} when neither exists.
+ *
+ * The per-turn snapshot wins so a concurrent write to the live `trustContext`
+ * (an owner meta command, a wake landing on the conversation) cannot change
+ * what an in-flight turn may do, and so a turn that pins a class can hold it
+ * for exactly its own duration. Resolved here rather than at each gate: the
+ * tool executor and the loop must never disagree about which actor's
+ * capabilities a turn is running with.
+ */
+export function resolveEffectiveTurnTrust(turn: {
+  currentTurnTrustContext?: TrustContext;
+  trustContext?: TrustContext;
+}): TrustContext {
+  return (
+    turn.currentTurnTrustContext ?? turn.trustContext ?? FALLBACK_TURN_TRUST
+  );
+}
+
+/**
  * Resolve the effective trust class for an actor.
  *
  * Trust is a property of the actor, never of the deployment's auth posture.

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -88,6 +88,7 @@ import type {
   SubagentToolGateMode,
   WakeToolContextPin,
 } from "../daemon/tool-setup-types.js";
+import { FALLBACK_TURN_TRUST } from "../daemon/trust-context.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { resolveTurnCallSite } from "../daemon/turn-call-site.js";
 import {
@@ -180,14 +181,31 @@ export interface WakeOptions {
   hint: string;
   source: string;
   /**
-   * Optional trust context to apply to the conversation before the agent
-   * loop runs. Required for internal background jobs that need elevated
-   * trust to invoke side-effect tools — without it the loop falls back to
-   * `trustClass: "unknown"` and side-effect tools are blocked. Caller
-   * should pass `{ sourceChannel: "vellum", trustClass: "guardian" }` for
-   * assistant-self-maintenance jobs.
+   * Trust to run the woken turn under. Three states, and the difference
+   * between the last two is what a wake on an already-resident conversation
+   * turns on:
+   *
+   * - **A context** applies that trust to the conversation before the agent
+   *   loop runs and pins it for the turn. Required for internal background
+   *   jobs that need elevated trust to invoke side-effect tools; pass
+   *   `{ sourceChannel: "vellum", trustClass: "guardian" }` for
+   *   assistant-self-maintenance jobs.
+   * - **`null`** pins {@link FALLBACK_TURN_TRUST} for the turn: the wake
+   *   states that it recovered no trust, so the turn runs at the fail-closed
+   *   `unknown` class and side-effect tools are blocked. The conversation's
+   *   own resting trust is left untouched, so a queued turn draining behind
+   *   the wake still reads it. Callers whose grant is conditional (a wake
+   *   schedule, whose row either proves an owner chose its target or does
+   *   not) pass this rather than omitting the field: a conversation still
+   *   resident from an earlier guardian turn is resting at guardian, so
+   *   omission would hand it the guardian's tools on exactly the rows that
+   *   failed the check, while a cold hydrate of the same row denies them.
+   * - **Omitted** leaves the conversation's own trust in place for the turn,
+   *   whatever residency it is at. For wakes that continue work the
+   *   conversation was already doing (a backgrounded command reporting back),
+   *   which must keep the capability the turn that started them had.
    */
-  trustContext?: TrustContext;
+  trustContext?: TrustContext | null;
   /**
    * Explicit local-owner metadata for rare direct wakes that are allowed to run
    * in cleanup mode. Omit for background jobs; they are paused under disk
@@ -462,8 +480,12 @@ async function defaultResolveTarget(
     // snapshot reads. Without this, fork-based memory retrospectives see
     // an empty history because loadFromDb ran with trustClass="unknown"
     // and filtered out every guardian-provenance message.
+    // A `null` trustContext is a fail-closed decision about the turn, not a
+    // context to hydrate under: hydration keeps the same no-context behavior
+    // omission has, so the conversation's stored provenance and resting trust
+    // are read exactly as they are.
     const conversation = await getOrCreateConversation(conversationId, {
-      trustContext: opts.trustContext,
+      trustContext: opts.trustContext ?? undefined,
     });
     return conversation;
   } catch (err) {
@@ -516,6 +538,20 @@ function classifyWakeDiskPressurePolicy(opts: WakeOptions): {
 }
 
 /**
+ * The trust to pin on the woken turn, or `null` to leave the conversation's
+ * own in place — see {@link WakeOptions.trustContext} for what each state
+ * means. A caller that recovered no trust (`trustContext: null`) still pins:
+ * the fail-closed class is a decision the wake made, not an absence, and only
+ * a pinned value survives a target that is already resident at guardian.
+ */
+function resolveWakeTurnTrust(opts: WakeOptions): TrustContext | null {
+  if (opts.trustContext === undefined) {
+    return null;
+  }
+  return opts.trustContext ?? FALLBACK_TURN_TRUST;
+}
+
+/**
  * Trust snapshot the wake hands to the agent loop. The wake's loop run has
  * no in-loop compaction path (it runs with overflow recovery disabled; the
  * wake compacts via the pre-run gate instead, which resolves trust from the
@@ -535,7 +571,7 @@ function buildWakeTrust(
     };
   }
   return (
-    opts.trustContext ??
+    resolveWakeTurnTrust(opts) ??
     ({
       sourceChannel: opts.sourceChannel ?? "vellum",
       trustClass: "guardian",
@@ -1343,10 +1379,15 @@ export async function wakeAgentForOpportunity(
       if (opts.clientless) {
         conversation.hasNoClient = true;
       }
-      // Per-turn guardian elevation for the wake's tools, set after the pre-run
-      // reads so a pre-run failure can't leak it; restored in the finally.
-      if (opts.trustContext) {
-        conversation.currentTurnTrustContext = opts.trustContext;
+      // The trust the wake's tools run under, set after the pre-run reads so a
+      // pre-run failure can't leak it; restored in the finally. A wake that
+      // states its trust (an elevation, or the fail-closed class of a wake that
+      // recovered none) overwrites whatever snapshot the conversation is
+      // carrying, so a target still resident from an earlier guardian turn
+      // resolves the same class a cold hydrate of it would.
+      const wakeTurnTrust = resolveWakeTurnTrust(opts);
+      if (wakeTurnTrust) {
+        conversation.currentTurnTrustContext = wakeTurnTrust;
       }
 
       let updatedHistory: Message[];

--- a/assistant/src/schedule/wake-schedule-options.ts
+++ b/assistant/src/schedule/wake-schedule-options.ts
@@ -70,6 +70,17 @@ function hasOwnerAuthoredWakeTarget(
  *   rise above its target: a remote-channel conversation recovers nothing and
  *   its turn resolves the fail-closed `unknown` class.
  *
+ * When either half is missing, the firing states so: `trustContext: null` runs
+ * the turn at the fail-closed `unknown` class instead of leaving whatever trust
+ * the conversation is resting at. Every class of row that recovers nothing goes
+ * out this way (a legacy defer, a wake schedule that was never a defer, a
+ * marked row whose source binding is missing or no longer matches its target,
+ * and any target whose stored origin is not positively local), because a target
+ * still resident from an earlier guardian turn is resting AT guardian: leaving
+ * its trust in place would hand those rows the guardian's sensitive tools,
+ * while a cold hydrate of the same row is denied them. Residency is a cache
+ * detail; it decides nothing about what a firing may do.
+ *
  * Callers are separately responsible for authorizing the firing itself. The
  * scheduler's due-tick has no caller to authorize; `schedules/:id/run` refuses
  * a non-owner before reaching this function.
@@ -86,7 +97,7 @@ export function buildWakeScheduleOptions(
     hint: job.message,
     source: "defer",
     persistTriggerAsEvent: true,
-    ...(trustContext ? { trustContext } : {}),
+    trustContext,
     ...(job.inferenceProfile
       ? { forceOverrideProfile: job.inferenceProfile }
       : {}),


### PR DESCRIPTION
## TL;DR

A scheduled wake that recovers no trust used to run at whatever trust its target conversation happened to be sitting at. A conversation still resident from a guardian interaction is sitting at **guardian**, so rows that failed every provenance check reached the guardian's sensitive tools on a warm target, while a cold hydrate of the exact same row was denied. A firing now states its trust either way: the recovered context, or `null` meaning "recovered nothing", which the wake pins as the fail-closed `unknown` class on the woken turn.

Closes LUM-2933

## The bug, reproduced

`buildWakeScheduleOptions` omitted `trustContext` when a row proved nothing, and an omitted context in `wakeAgentForOpportunity` means "leave the conversation's own trust in place for the turn". Tool setup resolves `currentTurnTrustContext ?? trustContext ?? FALLBACK_TURN_TRUST`, so residency decided the answer.

The new test file fails on `main` for 7 cases (each resident case resolves `guardian` where cold resolves `unknown`):

| Scheduled-wake class | Cold target (before) | Resident target (before) | Both (after) |
| --- | --- | --- | --- |
| Owner-authored defer, local target | guardian | guardian | guardian |
| Legacy defer (`createdBy: "defer"`) | unknown, denied | **guardian, sensitive tools proceed** | unknown, denied |
| Wake schedule that was never a defer | unknown, denied | **guardian** | unknown, denied |
| Owner-marked row, source binding missing | unknown, denied | **guardian** | unknown, denied |
| Owner-marked row retargeted off its source | unknown, denied | **guardian** | unknown, denied |
| Owner-authored defer, remote-origin target | unknown, denied | **guardian** | unknown, denied |
| Owner-authored defer, unrecognized/corrupt origin | unknown, denied | **guardian** | unknown, denied |

## What changes for the user

| Before | After |
| --- | --- |
| A deferral created before owner provenance existed could, on a conversation you had just been using, run shell and other guardian-only tools. Restart the assistant first and the same deferral was refused. | Those deferrals still fire, still keep their place in the defer list, and still can't use guardian-only tools, whether or not the conversation is still open. Re-creating the defer earns the capability back. |
| A wake schedule pointed at a conversation that came from a remote channel could borrow guardian capability from whoever used that conversation last. | It runs at the fail-closed class, as intended. |
| Your own deferrals on your own conversations resume with the tools they were using. | Unchanged. |
| Ordinary (non-wake) schedules, background-command wakes, interrupted-turn resumes, memory retrospectives. | Unchanged. |

## Why this is safe

- **Narrow surface.** The only caller that passes the new `trustContext: null` is the wake-schedule path (scheduler due-tick and `POST /v1/schedules/:id/run`, which share `buildWakeScheduleOptions`). Every other wake caller either passes a real context (interrupted-turn resume, memory retrospective, the local-IPC wake route) or omits the field, and omission behaves exactly as before.
- **Nothing else about the conversation moves.** A fail-closed firing hands `undefined` to `getOrCreateConversation`, so hydration, history scoping, and message provenance stamping (which read the *resting* trust) are untouched. Only the turn's own `currentTurnTrustContext` is pinned, and it is restored in the same `finally` that already restored the call site and profile stamps, so a queued user turn draining behind the wake still reads the conversation's real resting trust.
- **The pinned value is the class the cold path already produced**, `FALLBACK_TURN_TRUST` (`{ sourceChannel: "vellum", trustClass: "unknown" }`) — the same constant tool setup falls back to. Warm converges onto cold rather than onto a third behavior.
- **No migration.** Nothing persisted changed shape; the fix is entirely in how a firing is described to the wake. (I checked: no schema or stored-value change is implied, so none was added.)

## Tests

New `assistant/src/__tests__/wake-schedule-resident-trust.test.ts` drives the real `wakeAgentForOpportunity` against a resident target and asserts the effective trust **tool setup would read mid-run** (through `resolveEffectiveTurnTrust` plus the real sensitive-tool gate), not just the `WakeOptions` shape: every unproven row class, cold/warm parity on the same row, the owner-authored defer still clearing the gate at both reaches, and restoration of both trust fields after the wake.

Existing suites updated to the stated contract (`wake-schedule-trust`, `wake-schedule-escalation`, `scheduler-wake`). Run green: the schedule suites, the wake-caller suites (`agent-wake`, interrupted-turn reconciler, retrospective, fork retrospective), and the tool-setup suites. `bunx tsc --noEmit` and `bun run lint` clean.

## Deferred, deliberately

- **`resolveEffectiveTurnTrust` is adopted only at the tool-setup gate**, the boundary this ticket is about. `conversation-agent-loop.ts` repeats the same three-part chain against its own local copy of `FALLBACK_TURN_TRUST`; folding it in means a new import into that module's graph for no behavior change, so it stays as-is. Worth doing, not here.
- **Not in scope, but adjacent and worth a ticket:** `POST /v1/conversations/wake` has the same shape of gap. Its handler comments say a remote `actor` caller "stays `unknown`/interactive", but it omits `trustContext`, so on a resident guardian conversation that wake inherits guardian too. I did not touch it: it is a route-authority question rather than a schedule one, and it looks like LUM-2932 territory. I have no Linear access from this session, so please point it at 2932 or file it separately.
- **Not addressed (no capability impact):** a resident target keeps the history it was hydrated with, so a fail-closed wake on a warm conversation still sees guardian-provenance history a cold one would filter. Re-scoping history for the wake would mean a reload that cannot be undone afterwards, which is a much larger change than the trust gap this ticket describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->