### PR TITLE
refactor: share Stripe currency scaling rules between CLI and web

### DIFF
--- a/assistant/src/cli/commands/platform/invoices.ts
+++ b/assistant/src/cli/commands/platform/invoices.ts
@@ -1,3 +1,4 @@
+import { stripeScaleDigits } from "@vellumai/service-contracts/stripe-currency";
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
@@ -24,55 +25,11 @@ interface PlatformInvoicesListResult {
 }
 
 /**
- * These sets follow Stripe's amount scaling rules for charges and invoices
- * (https://docs.stripe.com/currencies), not ISO 4217 metadata: divide the
- * minor-unit integer by 100 for most currencies, by 1 for the zero-decimal
- * set (e.g. JPY, KRW), and by 1000 for the three-decimal set (e.g. BHD).
- * ISK, HUF, TWD, and UGX are deliberately absent from the zero-decimal set:
- * Stripe charges and invoices them as two-decimal amounts and treats them
- * as zero-decimal only for payouts, per Stripe's currency docs.
- */
-const STRIPE_ZERO_DECIMAL_CURRENCIES = new Set([
-  "BIF",
-  "CLP",
-  "DJF",
-  "GNF",
-  "JPY",
-  "KMF",
-  "KRW",
-  "MGA",
-  "PYG",
-  "RWF",
-  "VND",
-  "VUV",
-  "XAF",
-  "XOF",
-  "XPF",
-]);
-
-const STRIPE_THREE_DECIMAL_CURRENCIES = new Set([
-  "BHD",
-  "JOD",
-  "KWD",
-  "OMR",
-  "TND",
-]);
-
-function stripeScaleDigits(currencyCode: string): number {
-  if (STRIPE_ZERO_DECIMAL_CURRENCIES.has(currencyCode)) {
-    return 0;
-  }
-  if (STRIPE_THREE_DECIMAL_CURRENCIES.has(currencyCode)) {
-    return 3;
-  }
-  return 2;
-}
-
-/**
  * Render a Stripe minor-unit amount as major units, e.g. "USD 12.34". The
  * display fraction digits are forced to match stripeScaleDigits so Intl's
- * ISO metadata cannot apply a different scale (see the currency sets above).
- * Unknown currency codes fall back to the raw minor-unit amount.
+ * ISO metadata cannot apply a different scale (see the currency sets in
+ * @vellumai/service-contracts/stripe-currency). Unknown currency codes fall
+ * back to the raw minor-unit amount.
  */
 function formatInvoiceAmount(
   amountMinorUnits: number,

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -24,6 +24,7 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
+import { stripeScaleDigits } from "@vellumai/service-contracts/stripe-currency";
 
 const EMPTY_RESPONSE: InvoiceListResponse = { invoices: [], has_more: false };
 
@@ -44,49 +45,6 @@ function statusTone(status: string | null): TagTone {
     default:
       return "neutral";
   }
-}
-
-/**
- * These sets follow Stripe's amount scaling rules
- * (https://docs.stripe.com/currencies), not ISO 4217 metadata. Notably,
- * Stripe keeps two-decimal scaling for ISK, HUF, TWD, and UGX for backward
- * compatibility even though ISO treats them as zero-decimal, so those codes
- * are deliberately absent from the zero-decimal set.
- */
-const STRIPE_ZERO_DECIMAL_CURRENCIES = new Set([
-  "BIF",
-  "CLP",
-  "DJF",
-  "GNF",
-  "JPY",
-  "KMF",
-  "KRW",
-  "MGA",
-  "PYG",
-  "RWF",
-  "VND",
-  "VUV",
-  "XAF",
-  "XOF",
-  "XPF",
-]);
-
-const STRIPE_THREE_DECIMAL_CURRENCIES = new Set([
-  "BHD",
-  "JOD",
-  "KWD",
-  "OMR",
-  "TND",
-]);
-
-function stripeScaleDigits(currencyCode: string): number {
-  if (STRIPE_ZERO_DECIMAL_CURRENCIES.has(currencyCode)) {
-    return 0;
-  }
-  if (STRIPE_THREE_DECIMAL_CURRENCIES.has(currencyCode)) {
-    return 3;
-  }
-  return 2;
 }
 
 /**

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -18,6 +18,7 @@
     "./attachment-naming": "./src/attachment-naming.ts",
     "./redacted-credential": "./src/redacted-credential.ts",
     "./secret-detection": "./src/secret-detection.ts",
+    "./stripe-currency": "./src/stripe-currency.ts",
     "./error": "./src/error.ts"
   },
   "scripts": {

--- a/packages/service-contracts/src/__tests__/stripe-currency.test.ts
+++ b/packages/service-contracts/src/__tests__/stripe-currency.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  STRIPE_THREE_DECIMAL_CURRENCIES,
+  STRIPE_ZERO_DECIMAL_CURRENCIES,
+  stripeScaleDigits,
+} from "../stripe-currency.js";
+
+describe("stripeScaleDigits", () => {
+  test("zero-decimal currencies scale to 0 digits", () => {
+    expect(stripeScaleDigits("JPY")).toBe(0);
+    expect(stripeScaleDigits("KRW")).toBe(0);
+  });
+
+  test("three-decimal currencies scale to 3 digits", () => {
+    expect(stripeScaleDigits("BHD")).toBe(3);
+    expect(stripeScaleDigits("KWD")).toBe(3);
+  });
+
+  test("everything else scales to 2 digits", () => {
+    expect(stripeScaleDigits("USD")).toBe(2);
+    expect(stripeScaleDigits("EUR")).toBe(2);
+    expect(stripeScaleDigits("XYZ")).toBe(2);
+  });
+
+  test("Stripe's charge-side two-decimal special cases stay at 2 digits", () => {
+    for (const code of ["ISK", "HUF", "TWD", "UGX"]) {
+      expect(stripeScaleDigits(code)).toBe(2);
+    }
+  });
+
+  test("the currency sets do not overlap", () => {
+    for (const code of STRIPE_ZERO_DECIMAL_CURRENCIES) {
+      expect(STRIPE_THREE_DECIMAL_CURRENCIES.has(code)).toBe(false);
+    }
+  });
+});

--- a/packages/service-contracts/src/stripe-currency.ts
+++ b/packages/service-contracts/src/stripe-currency.ts
@@ -1,0 +1,55 @@
+/**
+ * Stripe amount scaling rules for charges and invoices.
+ *
+ * These sets follow Stripe's amount scaling rules
+ * (https://docs.stripe.com/currencies), not ISO 4217 metadata: divide the
+ * minor-unit integer by 100 for most currencies, by 1 for the zero-decimal
+ * set (e.g. JPY, KRW), and by 1000 for the three-decimal set (e.g. BHD).
+ * ISK, HUF, TWD, and UGX are deliberately absent from the zero-decimal set:
+ * Stripe charges and invoices them as two-decimal amounts and treats them
+ * as zero-decimal only for payouts, per Stripe's currency docs.
+ *
+ * Only the scaling data and digit selection live here; presentation (locale,
+ * symbol vs code display, fallbacks for unknown codes) belongs to each
+ * consumer.
+ */
+export const STRIPE_ZERO_DECIMAL_CURRENCIES: ReadonlySet<string> = new Set([
+  "BIF",
+  "CLP",
+  "DJF",
+  "GNF",
+  "JPY",
+  "KMF",
+  "KRW",
+  "MGA",
+  "PYG",
+  "RWF",
+  "VND",
+  "VUV",
+  "XAF",
+  "XOF",
+  "XPF",
+]);
+
+export const STRIPE_THREE_DECIMAL_CURRENCIES: ReadonlySet<string> = new Set([
+  "BHD",
+  "JOD",
+  "KWD",
+  "OMR",
+  "TND",
+]);
+
+/**
+ * Fraction digits Stripe uses when charging or invoicing in the given
+ * currency. Expects an uppercase ISO 4217 code; unknown codes get the
+ * two-decimal default.
+ */
+export function stripeScaleDigits(currencyCode: string): number {
+  if (STRIPE_ZERO_DECIMAL_CURRENCIES.has(currencyCode)) {
+    return 0;
+  }
+  if (STRIPE_THREE_DECIMAL_CURRENCIES.has(currencyCode)) {
+    return 3;
+  }
+  return 2;
+}


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review round 2 for platform-invoices-cli.md.

**Gap:** Stripe currency scaling sets and digit logic duplicated verbatim between the assistant CLI and the web invoices table
**Fix:** extracted into a shared workspace module consumed by both; presentation stays local to each formatter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->