### PR TITLE
web: useBillingBalanceStatus hook + per-turn billing summary refresh

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import {
   ChevronDown,
   ChevronUp,
@@ -20,13 +19,9 @@ import {
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { useIsOrgReady } from "@/hooks/use-is-org-ready";
-import {
-  useActiveAssistantIsPlatformHosted,
-  usePlatformGate,
-} from "@/hooks/use-platform-gate";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { isElectron } from "@/runtime/is-electron";
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
 import { openUrl } from "@/runtime/browser";
@@ -177,16 +172,8 @@ function PreferencesMenuContent({
   const navigate = useNavigate();
   const user = useAuthStore.use.user();
   const platformGate = usePlatformGate();
-  const billingPlatformGate = usePlatformGate({ platformHostedOnly: true });
-  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
-  const isOrgReady = useIsOrgReady();
-  const showBillingRows =
-    billingPlatformGate === "full" && isPlatformHosted && isOrgReady;
-  const { data: billingSummary } = useQuery({
-    ...organizationsBillingSummaryRetrieveOptions(),
-    enabled: showBillingRows,
-  });
-  const effectiveBalance = billingSummary?.effective_balance ?? null;
+  const { enabled: showBillingRows, balance: effectiveBalance } =
+    useBillingBalanceStatus();
 
   return (
     <>

--- a/clients/web/src/domains/chat/hooks/use-conversation-history-reconnect-refetch.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-reconnect-refetch.test.tsx
@@ -1,8 +1,17 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
+import { organizationsBillingSummaryRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
@@ -48,6 +57,14 @@ mock.module("@/domains/chat/transcript/use-history-pagination", () => ({
   useHistoryPagination: () => paginationStub(),
 }));
 
+// Drives the platform gate on the turn-end billing-summary invalidation; the
+// real gate reads auth/lifecycle/org stores that are out of scope here.
+let billingSummaryEnabled = true;
+
+mock.module("@/hooks/use-billing-balance-status", () => ({
+  useBillingBalanceQueryEnabled: () => billingSummaryEnabled,
+}));
+
 const { useConversationHistory } =
   await import("@/domains/chat/hooks/use-conversation-history");
 
@@ -73,9 +90,24 @@ function renderHistory(activeConversationId: string | null = "conv-A") {
   );
 }
 
+// Call-through spy on the shared client, recording billing-summary
+// invalidations issued by the turn-end effect.
+const invalidateQueriesSpy = spyOn(queryClient, "invalidateQueries");
+
+/** Calls to the QueryClient's `invalidateQueries` for the billing summary. */
+function billingInvalidations(): number {
+  const billingKey = organizationsBillingSummaryRetrieveQueryKey();
+  return invalidateQueriesSpy.mock.calls.filter(
+    ([filters]) =>
+      JSON.stringify(filters?.queryKey) === JSON.stringify(billingKey),
+  ).length;
+}
+
 beforeEach(() => {
   __resetForTesting();
   invalidateSpy = mock(async () => {});
+  billingSummaryEnabled = true;
+  invalidateQueriesSpy.mockClear();
 });
 
 afterEach(() => {
@@ -204,7 +236,57 @@ describe("useConversationHistory — refetch on SSE reopen", () => {
       useConversationStore.getState().removeProcessingConversationId("conv-A");
     });
 
-    // THEN the history query is invalidated so the snapshot reseeds.
+    // THEN the history query is invalidated so the snapshot reseeds, and the
+    // billing summary is invalidated once so balance surfaces reflect the
+    // turn's spend.
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(billingInvalidations()).toBe(1);
+  });
+
+  test("invalidates the billing summary once per falling edge, not per turn tick", () => {
+    /**
+     * The billing refresh rides the same falling edge as the history reseed:
+     * one invalidation per finished turn, none while the turn is streaming,
+     * and no repeats until another turn completes.
+     */
+    // GIVEN two back-to-back turns on the active conversation
+    renderHistory("conv-A");
+    for (let turn = 0; turn < 2; turn++) {
+      act(() => {
+        useConversationStore.getState().markConversationProcessing("conv-A");
+      });
+      // No refresh while the turn is still in progress.
+      expect(billingInvalidations()).toBe(turn);
+      act(() => {
+        useConversationStore
+          .getState()
+          .removeProcessingConversationId("conv-A");
+      });
+    }
+
+    // THEN exactly one billing invalidation per completed turn
+    expect(billingInvalidations()).toBe(2);
+  });
+
+  test("skips the billing invalidation when the billing query is gated off", () => {
+    /**
+     * Self-hosted / org-not-ready contexts never run the billing summary
+     * query, so the turn-end edge must not invalidate (and thereby fetch) it.
+     */
+    // GIVEN a context where the billing summary query is disabled
+    billingSummaryEnabled = false;
+    renderHistory("conv-A");
+
+    // WHEN a turn completes
+    act(() => {
+      useConversationStore.getState().markConversationProcessing("conv-A");
+    });
+    act(() => {
+      useConversationStore.getState().removeProcessingConversationId("conv-A");
+    });
+
+    // THEN history still reseeds but the billing summary is left alone
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(billingInvalidations()).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -25,6 +25,8 @@ import { useCallback, useEffect, useRef } from "react";
 
 import { type InfiniteData, useQueryClient } from "@tanstack/react-query";
 
+import { organizationsBillingSummaryRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import { useBillingBalanceQueryEnabled } from "@/hooks/use-billing-balance-status";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import {
   extractWirePendingAcpConnect,
@@ -434,13 +436,31 @@ export function useConversationHistory({
   // turn). The monotonic seq baseline makes the reseed a no-op when nothing new
   // landed, and the buffered event tail is replayed so anything that raced the
   // fetch isn't lost.
+  //
+  // The billing summary is invalidated on the same edge: every turn (including
+  // one that fails on exhausted credits) can move the credit balance, and the
+  // balance surfaces should reflect it without waiting for the staleTime
+  // window. Gated exactly like `useBillingBalanceStatus` so self-hosted /
+  // org-not-ready contexts, where the query never runs, skip it.
   // -------------------------------------------------------------------------
+  const billingSummaryEnabled = useBillingBalanceQueryEnabled();
   const refetchHistoryOnTurnEnd = useCallback(() => {
     if (!assistantId || !activeConversationId) {
       return;
     }
     void pagination.invalidate();
-  }, [assistantId, activeConversationId, pagination]);
+    if (billingSummaryEnabled) {
+      void queryClient.invalidateQueries({
+        queryKey: organizationsBillingSummaryRetrieveQueryKey(),
+      });
+    }
+  }, [
+    assistantId,
+    activeConversationId,
+    pagination,
+    billingSummaryEnabled,
+    queryClient,
+  ]);
 
   // A turn is in progress for the active conversation when either the local
   // turn store is sending (a `useSendMessage` turn this client started) or the

--- a/clients/web/src/hooks/use-billing-balance-status.test.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for `useBillingBalanceStatus`. The generated billing-summary query
+ * options are `mock.module`-replaced so the hook reads a seeded fixture and
+ * its fetches can be counted; the platform-gate and org-ready hooks are
+ * mocked so each gating leg can be flipped independently. The QueryClient
+ * uses `staleTime/gcTime: Infinity` + `retry: false` so a seeded cache
+ * resolves synchronously and an unseeded query stays unresolved (its
+ * `queryFn` hangs), modeling the loading state.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type { BillingSummaryResponse } from "@/generated/api/types.gen";
+import type { PlatformGateState } from "@/hooks/use-platform-gate";
+
+// Sentinel query key shared by the mocked options and the seeded cache.
+const BILLING_SUMMARY_KEY = ["billing-summary"];
+
+// The fixture the mocked retrieve options resolve; each test seeds it.
+let summaryFixture: BillingSummaryResponse | null = null;
+// Counts summary fetches so the `enabled: false` gate can be asserted.
+let summaryFetches = 0;
+// When true, the query never resolves, modeling the first load still in flight.
+let summaryHangs = false;
+// Drive the mocked gating hooks; the hook folds all three into `enabled`.
+let platformGate: PlatformGateState = "full";
+let isPlatformHosted = true;
+let orgReady = true;
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  organizationsBillingSummaryRetrieveOptions: () => ({
+    queryKey: BILLING_SUMMARY_KEY,
+    queryFn: () => {
+      summaryFetches += 1;
+      return summaryHangs ? new Promise(() => {}) : summaryFixture;
+    },
+  }),
+  // Not read by the hook, but `mock.module` is process-wide in bun: other
+  // suites sharing the process import this export from the same module.
+  organizationsBillingSummaryRetrieveQueryKey: () => BILLING_SUMMARY_KEY,
+}));
+
+mock.module("@/hooks/use-platform-gate", () => ({
+  usePlatformGate: () => platformGate,
+  useActiveAssistantIsPlatformHosted: () => isPlatformHosted,
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+
+const { useBillingBalanceStatus } = await import(
+  "./use-billing-balance-status"
+);
+
+function summary(
+  overrides: Partial<BillingSummaryResponse> = {},
+): BillingSummaryResponse {
+  return {
+    settled_balance: "20.00",
+    minimum_top_up: "5.00",
+    maximum_top_up: "100.00",
+    maximum_balance: "500.00",
+    allowed_top_up_amounts: ["5.00", "10.00", "25.00"],
+    settled_balance_usd: "20.00",
+    minimum_top_up_usd: "5.00",
+    maximum_top_up_usd: "100.00",
+    maximum_balance_usd: "500.00",
+    pending_compute: "0.00",
+    pending_compute_usd: "0.00",
+    effective_balance: "20.00",
+    effective_balance_usd: "20.00",
+    is_degraded: false,
+    daily_credit_limit_usd: null,
+    daily_spend_usd: "0.00",
+    daily_limit_reached: false,
+    low_balance_threshold_usd: "5.00",
+    low_balance_warning: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Render the hook against a fresh QueryClient. When `seed` is set the
+ * billing-summary cache is primed so the read resolves synchronously.
+ */
+function setup({ seed }: { seed?: BillingSummaryResponse } = {}) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+  if (seed) {
+    client.setQueryData(BILLING_SUMMARY_KEY, seed);
+  }
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  return renderHook(() => useBillingBalanceStatus(), { wrapper });
+}
+
+describe("useBillingBalanceStatus", () => {
+  beforeEach(() => {
+    summaryFetches = 0;
+    summaryHangs = false;
+    summaryFixture = summary();
+    platformGate = "full";
+    isPlatformHosted = true;
+    orgReady = true;
+  });
+
+  test("normal balance: both flags false, balance exposed", () => {
+    const { result } = setup({
+      seed: summary({ effective_balance: "20.00", low_balance_warning: false }),
+    });
+    expect(result.current).toEqual({
+      isExhausted: false,
+      isLowBalance: false,
+      balance: "20.00",
+      enabled: true,
+    });
+  });
+
+  test("low balance: reflects the server-computed warning flag", () => {
+    const { result } = setup({
+      seed: summary({ effective_balance: "3.00", low_balance_warning: true }),
+    });
+    expect(result.current).toEqual({
+      isExhausted: false,
+      isLowBalance: true,
+      balance: "3.00",
+      enabled: true,
+    });
+  });
+
+  test("exhausted: zero effective balance", () => {
+    const { result } = setup({
+      seed: summary({ effective_balance: "0.00", low_balance_warning: false }),
+    });
+    expect(result.current.isExhausted).toBe(true);
+    expect(result.current.isLowBalance).toBe(false);
+    expect(result.current.balance).toBe("0.00");
+  });
+
+  test("exhausted: negative effective balance", () => {
+    const { result } = setup({ seed: summary({ effective_balance: "-1.37" }) });
+    expect(result.current.isExhausted).toBe(true);
+  });
+
+  test("all-false while the summary is unresolved", () => {
+    // No seeded data + a hanging fetch keeps the query pending.
+    summaryHangs = true;
+    const { result } = setup();
+    expect(result.current).toEqual({
+      isExhausted: false,
+      isLowBalance: false,
+      balance: null,
+      enabled: true,
+    });
+  });
+
+  test.each([
+    ["the platform gate is not full", () => (platformGate = "gated")],
+    ["the platform gate is disabled", () => (platformGate = "disabled")],
+    ["the assistant is not platform-hosted", () => (isPlatformHosted = false)],
+    ["the org is not ready", () => (orgReady = false)],
+  ] as const)("inert and does not fetch when %s", (_label, gateOff) => {
+    gateOff();
+    const { result } = setup();
+    expect(summaryFetches).toBe(0);
+    expect(result.current).toEqual({
+      isExhausted: false,
+      isLowBalance: false,
+      balance: null,
+      enabled: false,
+    });
+  });
+
+  test("stays inert on cached data when gated off", () => {
+    // Even with a seeded (stale) summary in the cache, a gated-off hook must
+    // not surface it: unknown/ineligible state never flashes a billing card.
+    isPlatformHosted = false;
+    const { result } = setup({
+      seed: summary({ effective_balance: "0.00", low_balance_warning: true }),
+    });
+    expect(result.current).toEqual({
+      isExhausted: false,
+      isLowBalance: false,
+      balance: null,
+      enabled: false,
+    });
+  });
+});

--- a/clients/web/src/hooks/use-billing-balance-status.test.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.test.ts
@@ -167,10 +167,30 @@ describe("useBillingBalanceStatus", () => {
   });
 
   test.each([
-    ["the platform gate is not full", () => (platformGate = "gated")],
-    ["the platform gate is disabled", () => (platformGate = "disabled")],
-    ["the assistant is not platform-hosted", () => (isPlatformHosted = false)],
-    ["the org is not ready", () => (orgReady = false)],
+    [
+      "the platform gate is not full",
+      () => {
+        platformGate = "gated";
+      },
+    ],
+    [
+      "the platform gate is disabled",
+      () => {
+        platformGate = "disabled";
+      },
+    ],
+    [
+      "the assistant is not platform-hosted",
+      () => {
+        isPlatformHosted = false;
+      },
+    ],
+    [
+      "the org is not ready",
+      () => {
+        orgReady = false;
+      },
+    ],
   ] as const)("inert and does not fetch when %s", (_label, gateOff) => {
     gateOff();
     const { result } = setup();

--- a/clients/web/src/hooks/use-billing-balance-status.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import {
+  useActiveAssistantIsPlatformHosted,
+  usePlatformGate,
+} from "@/hooks/use-platform-gate";
+
+export interface BillingBalanceStatus {
+  /** Effective balance is at or below zero: the org is out of credits. */
+  isExhausted: boolean;
+  /**
+   * Server-computed low-balance warning: balance above zero but below the
+   * org's alert threshold, with auto-top-up off. The threshold lives on the
+   * platform; it is never re-derived client-side.
+   */
+  isLowBalance: boolean;
+  /** Effective balance as a decimal string, or null when unknown. */
+  balance: string | null;
+  /** Whether the billing summary query is allowed to run at all. */
+  enabled: boolean;
+}
+
+const INERT_STATUS: Omit<BillingBalanceStatus, "enabled"> = {
+  isExhausted: false,
+  isLowBalance: false,
+  balance: null,
+};
+
+/**
+ * Whether the org-scoped billing summary query may fire: the active assistant
+ * must be positively resolved as platform-hosted with a live platform session,
+ * and the org store must be ready to supply the `Vellum-Organization-Id`
+ * header. Shared by {@link useBillingBalanceStatus} and the turn-end billing
+ * invalidation in `use-conversation-history` so the two gates never drift.
+ */
+export function useBillingBalanceQueryEnabled(): boolean {
+  const billingPlatformGate = usePlatformGate({ platformHostedOnly: true });
+  const isPlatformHosted = useActiveAssistantIsPlatformHosted();
+  const isOrgReady = useIsOrgReady();
+  return billingPlatformGate === "full" && isPlatformHosted && isOrgReady;
+}
+
+/**
+ * Tri-state credit-balance status for the org's managed billing:
+ * normal (both flags false), low ({@link BillingBalanceStatus.isLowBalance}),
+ * or exhausted ({@link BillingBalanceStatus.isExhausted}).
+ *
+ * Inert (all-false, null balance) for self-hosted assistants, missing platform
+ * sessions, an unhydrated org store, and while the summary is loading: unknown
+ * state must never flash a billing surface. Freshness rides the QueryClient
+ * defaults (10s staleTime, refetch-on-focus) plus the turn-end invalidation in
+ * `use-conversation-history`.
+ */
+export function useBillingBalanceStatus(): BillingBalanceStatus {
+  const enabled = useBillingBalanceQueryEnabled();
+  const { data: summary } = useQuery({
+    ...organizationsBillingSummaryRetrieveOptions(),
+    enabled,
+  });
+  if (!enabled || !summary) {
+    return { ...INERT_STATUS, enabled };
+  }
+  return {
+    isExhausted: Number(summary.effective_balance) <= 0,
+    isLowBalance: summary.low_balance_warning === true,
+    balance: summary.effective_balance,
+    enabled,
+  };
+}


### PR DESCRIPTION
## Summary
- New useBillingBalanceStatus() hook deriving normal/low/exhausted from the billing summary (server-computed low_balance_warning)
- Invalidate the billing summary query on turn end so balance state updates after every turn
- Platform-gated: inert for self-hosted / org-not-ready

Part of plan: credits-ux.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->