### PR TITLE
daemon: tag persisted provider-error messages and expose them on the messages wire

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19537,6 +19537,14 @@ paths:
                           additionalProperties: false
                         systemCard:
                           type: boolean
+                        providerError:
+                          type: object
+                          properties:
+                            code:
+                              type: string
+                            category:
+                              type: string
+                          additionalProperties: false
                         slackMessage:
                           type: object
                           properties:

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -349,6 +349,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   finalizeMessageContent: finalizeMessageContentMock,
   recordConversationPersistedSeq: () => {},
   getConversationPersistedSeq: () => null,
+  PROVIDER_ERROR_MESSAGE_KIND: "provider_error",
   // The real schema is a Zod object; tests don't exercise validation,
   // so a passthrough is sufficient — the production code at
   // `handleMessageComplete` only branches on `success` and reads two
@@ -2225,6 +2226,40 @@ describe("session-agent-loop", () => {
         .calls[0] as unknown as [string, string];
       expect(backfillCall[0]).toBe("test-conv");
       expect(backfillCall[1]).toBe("mock-msg-id");
+    });
+
+    test("stamps provider-error metadata onto the persisted synthetic assistant row", async () => {
+      mockConversationErrorClassification = {
+        code: "PROVIDER_BILLING",
+        userMessage:
+          "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+        retryable: false,
+        errorCategory: "credits_exhausted",
+      };
+
+      const ctx = makeCtx({
+        loopProvider: {
+          name: "mock-provider",
+          async sendMessage() {
+            throw new Error("Payment Required");
+          },
+        } as unknown as Provider,
+      });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(addMessageMock).toHaveBeenCalledTimes(1);
+      const addCall = addMessageMock.mock.calls[0] as unknown as [
+        string,
+        string,
+        string,
+        { metadata?: Record<string, unknown> },
+      ];
+      expect(addCall[1]).toBe("assistant");
+      expect(addCall[3]?.metadata).toMatchObject({
+        messageKind: "provider_error",
+        providerErrorCode: "PROVIDER_BILLING",
+        providerErrorCategory: "credits_exhausted",
+      });
     });
 
     test("does not persist managed credential refresh failures as assistant text", async () => {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2232,7 +2232,7 @@ describe("session-agent-loop", () => {
       mockConversationErrorClassification = {
         code: "PROVIDER_BILLING",
         userMessage:
-          "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+          "You're out of credits. Add credits in Settings → Billing to continue.",
         retryable: false,
         errorCategory: "credits_exhausted",
       };
@@ -2255,6 +2255,15 @@ describe("session-agent-loop", () => {
         { metadata?: Record<string, unknown> },
       ];
       expect(addCall[1]).toBe("assistant");
+      // The persisted row swaps the context-neutral classification copy for
+      // assistant-voice wording, since this turn truly ends with no reply.
+      const persistedBlocks = JSON.parse(addCall[2]) as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(persistedBlocks[0]?.text).toBe(
+        "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+      );
       expect(addCall[3]?.metadata).toMatchObject({
         messageKind: "provider_error",
         providerErrorCode: "PROVIDER_BILLING",

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -789,7 +789,7 @@ describe("classifyConversationError", () => {
       expect(result.errorCategory).toBe("credits_exhausted");
       expect(result.retryable).toBe(false);
       expect(result.userMessage).toBe(
-        "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+        "You're out of credits. Add credits in Settings → Billing to continue.",
       );
     });
 

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -788,8 +788,9 @@ describe("classifyConversationError", () => {
       expect(result.code).toBe("PROVIDER_BILLING");
       expect(result.errorCategory).toBe("credits_exhausted");
       expect(result.retryable).toBe(false);
-      expect(result.userMessage).toContain("Add funds");
-      expect(result.userMessage).toContain("assistant");
+      expect(result.userMessage).toBe(
+        "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+      );
     });
 
     it("classifies direct Anthropic, OpenAI, and OpenRouter 402 responses as provider_billing", () => {

--- a/assistant/src/__tests__/list-messages-provider-error.test.ts
+++ b/assistant/src/__tests__/list-messages-provider-error.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for handleListMessages provider-error projection.
+ *
+ * When a turn dies on the provider-error path the agent loop persists the
+ * classified error text as a synthetic assistant row stamped with
+ * `metadata.messageKind: "provider_error"` (plus the classified
+ * code/category). The history projection must surface that marker as the
+ * wire `providerError` field — asserted against the FINAL response payload,
+ * because a field carried only on the intermediate object is silently
+ * dropped by the final projection (the historical `systemCard` bug).
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { setConfig } from "./helpers/set-config.js";
+
+// Keep the memory system off so addMessage skips indexing side effects.
+setConfig("memory", { enabled: false });
+
+import { ConversationMessageSchema } from "../api/responses/conversation-message.js";
+import {
+  addMessage,
+  createConversation,
+  PROVIDER_ERROR_MESSAGE_KIND,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { handleListMessages } from "../runtime/routes/conversation-routes.js";
+
+await initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+interface ProjectedMessage {
+  role: string;
+  providerError?: { code?: string; category?: string };
+}
+
+describe("handleListMessages provider-error projection", () => {
+  beforeEach(resetTables);
+
+  test("surfaces providerError on tagged rows in the final payload", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "hello" }]),
+    );
+    // Mirror the agent loop's provider-error persist site: a synthetic
+    // assistant row carrying the classified error, tagged in metadata.
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        {
+          type: "text",
+          text: "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+        },
+      ]),
+      {
+        metadata: {
+          messageKind: PROVIDER_ERROR_MESSAGE_KIND,
+          providerErrorCode: "PROVIDER_BILLING",
+          providerErrorCategory: "credits_exhausted",
+        },
+      },
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    }) as { messages: ProjectedMessage[] };
+
+    // Every projected message validates against the wire schema.
+    for (const message of response.messages) {
+      expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
+    }
+
+    expect(response.messages).toHaveLength(2);
+    const [userRow, errorRow] = response.messages;
+    expect(userRow?.providerError).toBeUndefined();
+    expect(errorRow?.role).toBe("assistant");
+    expect(errorRow?.providerError).toEqual({
+      code: "PROVIDER_BILLING",
+      category: "credits_exhausted",
+    });
+  });
+
+  test("coerces non-string code/category to absent fields", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "something went wrong" }]),
+      {
+        metadata: {
+          messageKind: PROVIDER_ERROR_MESSAGE_KIND,
+          providerErrorCode: 402,
+          providerErrorCategory: null,
+        },
+      },
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    }) as { messages: ProjectedMessage[] };
+
+    expect(response.messages).toHaveLength(1);
+    expect(response.messages[0]?.providerError).toEqual({});
+    expect(() =>
+      ConversationMessageSchema.parse(response.messages[0]),
+    ).not.toThrow();
+  });
+
+  test("omits providerError on untagged rows", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "hello" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "hi there" }]),
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    }) as { messages: ProjectedMessage[] };
+
+    expect(response.messages).toHaveLength(2);
+    for (const message of response.messages) {
+      expect(message.providerError).toBeUndefined();
+      expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
+    }
+  });
+});

--- a/assistant/src/__tests__/list-messages-provider-error.test.ts
+++ b/assistant/src/__tests__/list-messages-provider-error.test.ts
@@ -5,9 +5,9 @@
  * classified error text as a synthetic assistant row stamped with
  * `metadata.messageKind: "provider_error"` (plus the classified
  * code/category). The history projection must surface that marker as the
- * wire `providerError` field — asserted against the FINAL response payload,
- * because a field carried only on the intermediate object is silently
- * dropped by the final projection (the historical `systemCard` bug).
+ * wire `providerError` field, asserted against the FINAL response payload:
+ * the final projection rebuilds each message object field by field, so a
+ * field carried only on the intermediate object is silently dropped.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -586,6 +586,17 @@ export const ConversationMessageSchema = z.object({
    *  system notices — no avatar, no persona bubble — and never group them
    *  with adjacent assistant turns. */
   systemCard: z.boolean().optional(),
+  /** Present when this assistant row is a daemon-persisted provider-failure
+   *  notice (`metadata.messageKind === "provider_error"`); clients may render
+   *  a themed card instead of a persona bubble. `code` is the stable
+   *  classified error code (e.g. `"PROVIDER_BILLING"`), `category` the
+   *  classified category (e.g. `"credits_exhausted"`). */
+  providerError: z
+    .object({
+      code: z.string().optional(),
+      category: z.string().optional(),
+    })
+    .optional(),
   slackMessage: ConversationSlackMessageSchema.optional(),
   /**
    * Queue state for a user message that is still waiting in the daemon's

--- a/assistant/src/conversations/__tests__/message-consolidation.test.ts
+++ b/assistant/src/conversations/__tests__/message-consolidation.test.ts
@@ -381,3 +381,57 @@ describe("system-card boundaries", () => {
     expect(findDisplayTurnEndIndex(rows, 0)).toBe(0);
   });
 });
+
+describe("provider-error boundaries", () => {
+  const errorMeta = JSON.stringify({
+    messageKind: "provider_error",
+    providerErrorCode: "PROVIDER_BILLING",
+    providerErrorCategory: "credits_exhausted",
+  });
+
+  test("a provider-error row never merges into the preceding assistant run", () => {
+    const { messages } = mergeConsecutiveAssistantMessages([
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "reply" }])),
+      makeMsg(
+        "assistant",
+        JSON.stringify([{ type: "text", text: "You're out of credits." }]),
+        { metadata: errorMeta },
+      ),
+    ]);
+    expect(messages).toHaveLength(2);
+    expect(messages[1]!.metadata).toBe(errorMeta);
+  });
+
+  test("an assistant row never merges into a preceding provider-error row", () => {
+    const { messages } = mergeConsecutiveAssistantMessages([
+      makeMsg(
+        "assistant",
+        JSON.stringify([{ type: "text", text: "You're out of credits." }]),
+        { metadata: errorMeta },
+      ),
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "reply" }])),
+    ]);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.metadata).toBe(errorMeta);
+  });
+
+  test("findDisplayTurnEndIndex treats a provider-error row as a single-row turn", () => {
+    const rows = [
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "error" }]), {
+        metadata: errorMeta,
+      }),
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "reply" }])),
+    ];
+    expect(findDisplayTurnEndIndex(rows, 0)).toBe(0);
+  });
+
+  test("findDisplayTurnEndIndex stops an assistant run before a provider-error row", () => {
+    const rows = [
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "reply" }])),
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "error" }]), {
+        metadata: errorMeta,
+      }),
+    ];
+    expect(findDisplayTurnEndIndex(rows, 0)).toBe(0);
+  });
+});

--- a/assistant/src/conversations/message-consolidation.ts
+++ b/assistant/src/conversations/message-consolidation.ts
@@ -32,7 +32,10 @@
  */
 
 import type { MessageRow } from "../persistence/conversation-crud.js";
-import { isSystemCardMessage } from "../persistence/conversation-crud.js";
+import {
+  isProviderErrorMessage,
+  isSystemCardMessage,
+} from "../persistence/conversation-crud.js";
 import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
@@ -46,6 +49,27 @@ const log = getLogger("message-consolidation");
  */
 export function isSystemCardRow(msg: MessageRow): boolean {
   return isSystemCardMessage(msg.role, msg.metadata);
+}
+
+/**
+ * True when a row is the synthetic assistant message the agent loop persists
+ * on the provider-error path (`messageKind: "provider_error"` metadata).
+ * Like system cards, these rows are standalone display turns: merging one
+ * into an adjacent assistant run would let the anchor's metadata win and
+ * drop the provider-error marker from the wire (or stamp it onto a bubble
+ * containing real assistant text).
+ */
+export function isProviderErrorRow(msg: MessageRow): boolean {
+  return isProviderErrorMessage(msg.role, msg.metadata);
+}
+
+/**
+ * True when an assistant row is a standalone display turn (system card or
+ * provider-error notice) that never merges with adjacent assistant rows in
+ * either direction.
+ */
+function isStandaloneAssistantRow(msg: MessageRow): boolean {
+  return isSystemCardRow(msg) || isProviderErrorRow(msg);
 }
 
 // ── Block predicates ────────────────────────────────────────────────
@@ -120,8 +144,9 @@ export function findDisplayTurnEndIndex(
   if (messages[startIdx]?.role !== "assistant") {
     return startIdx;
   }
-  // A system card is a single-row display turn — never spans neighbours.
-  if (isSystemCardRow(messages[startIdx]!)) {
+  // System cards and provider-error rows are single-row display turns that
+  // never span neighbours.
+  if (isStandaloneAssistantRow(messages[startIdx]!)) {
     return startIdx;
   }
 
@@ -131,7 +156,7 @@ export function findDisplayTurnEndIndex(
     if (!next) {
       break;
     }
-    if (next.role === "assistant" && !isSystemCardRow(next)) {
+    if (next.role === "assistant" && !isStandaloneAssistantRow(next)) {
       endIdx += 1;
       continue;
     }
@@ -297,15 +322,15 @@ export function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
 
   for (const msg of messages) {
     const lastIdx = result.length - 1;
-    // System cards stay standalone in both directions: a card never folds
-    // into the preceding assistant run, and the following assistant row
-    // never folds into a card.
+    // System cards and provider-error rows stay standalone in both
+    // directions: neither folds into the preceding assistant run, and the
+    // following assistant row never folds into them.
     const isConsecutiveAssistant =
       msg.role === "assistant" &&
-      !isSystemCardRow(msg) &&
+      !isStandaloneAssistantRow(msg) &&
       lastIdx >= 0 &&
       result[lastIdx].role === "assistant" &&
-      !isSystemCardRow(result[lastIdx]);
+      !isStandaloneAssistantRow(result[lastIdx]);
 
     if (!isConsecutiveAssistant) {
       result.push(msg);

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -224,6 +224,13 @@ export interface EventHandlerState {
    * path.
    */
   providerErrorCode: string | null;
+  /**
+   * Classified category of the most recent provider error
+   * (`classifyConversationError(...).errorCategory`). Stamped onto the
+   * synthetic error row's metadata alongside {@link providerErrorCode} when
+   * the loop persists the failure as an assistant message.
+   */
+  providerErrorCategory: string | null;
   persistProviderErrorAsAssistantMessage: boolean;
   lastAssistantMessageId: string | undefined;
   /**
@@ -560,6 +567,7 @@ export function createEventHandlerState(): EventHandlerState {
     model: "",
     providerErrorUserMessage: null,
     providerErrorCode: null,
+    providerErrorCategory: null,
     persistProviderErrorAsAssistantMessage: false,
     lastAssistantMessageId: undefined,
     assistantRowAwaitingFinalization: false,
@@ -2582,6 +2590,7 @@ function handleError(
   );
   state.providerErrorUserMessage = classified.userMessage;
   state.providerErrorCode = classified.code;
+  state.providerErrorCategory = classified.errorCategory;
   state.persistProviderErrorAsAssistantMessage =
     shouldPersistProviderErrorAsAssistantMessage(classified);
 }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -47,6 +47,7 @@ import {
   getLastUserTimestampBefore,
   getMessageById,
   provenanceFromTrustContext,
+  PROVIDER_ERROR_MESSAGE_KIND,
   resolveOverrideProfile,
   updateConversationContextWindow,
   updateConversationSlackContextWatermark,
@@ -1343,6 +1344,12 @@ export async function runAgentLoopImpl(
             capturedTurnInterfaceContext.userMessageInterface,
           assistantMessageInterface:
             capturedTurnInterfaceContext.assistantMessageInterface,
+          // Mark the synthetic row as a provider-failure notice so clients
+          // can render it as a themed card instead of persona speech
+          // (`isProviderErrorMetadata` -> the wire `providerError` field).
+          messageKind: PROVIDER_ERROR_MESSAGE_KIND,
+          providerErrorCode: state.providerErrorCode ?? undefined,
+          providerErrorCategory: state.providerErrorCategory ?? undefined,
         };
         const errorAssistantMessage = createAssistantMessage(
           state.providerErrorUserMessage,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -133,6 +133,17 @@ const log = getLogger("conversation-agent-loop");
 const DISK_PRESSURE_ERROR_CODE = "DISK_SPACE_CRITICAL" as const;
 const DISK_PRESSURE_ERROR_CATEGORY = "disk_pressure";
 
+/**
+ * Assistant-voice wording persisted as the synthetic assistant row when a
+ * turn terminates because managed credits ran out. The shared classification
+ * (`managedBalanceClassification` in conversation-error.ts) keeps its
+ * `userMessage` context-neutral because it also feeds the non-terminal
+ * memory-v3 degraded notice, where a normal reply still follows; here the
+ * turn truly ends with no reply, so first-person copy is accurate.
+ */
+const OUT_OF_CREDITS_ASSISTANT_REPLY =
+  "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.";
+
 /** Title-cased friendly labels for tool names, used in confirmation chips. */
 const TOOL_FRIENDLY_LABEL: Record<string, string> = {
   bash: "Run Command",
@@ -1351,9 +1362,16 @@ export async function runAgentLoopImpl(
           providerErrorCode: state.providerErrorCode ?? undefined,
           providerErrorCategory: state.providerErrorCategory ?? undefined,
         };
-        const errorAssistantMessage = createAssistantMessage(
-          state.providerErrorUserMessage,
-        );
+        // The persisted row re-enters LLM history and is displayed as
+        // assistant speech, so managed-credits exhaustion swaps the
+        // context-neutral classification copy for assistant-voice wording.
+        const persistedErrorText =
+          state.providerErrorCode === "PROVIDER_BILLING" &&
+          state.providerErrorCategory === "credits_exhausted"
+            ? OUT_OF_CREDITS_ASSISTANT_REPLY
+            : state.providerErrorUserMessage;
+        const errorAssistantMessage =
+          createAssistantMessage(persistedErrorText);
         const errorRow = await addMessage(
           ctx.conversationId,
           "assistant",

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -694,11 +694,14 @@ function managedBalanceClassification(): Omit<
 > {
   return {
     code: "PROVIDER_BILLING",
-    // This text is persisted as a real assistant message (it re-enters LLM
-    // history and is what older/native clients display), so it must read as
-    // the assistant speaking, not UI chrome.
+    // This classification feeds two surfaces with different semantics: the
+    // terminal provider-error path (the turn ends with no reply) and the
+    // non-terminal memory-v3 degraded notice (a normal reply still follows).
+    // Keep the wording context-neutral so it is true in both places; the
+    // terminal persist site in conversation-agent-loop.ts swaps in
+    // assistant-voice copy for the synthetic assistant row.
     userMessage:
-      "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+      "You're out of credits. Add credits in Settings → Billing to continue.",
     retryable: false,
     errorCategory: "credits_exhausted",
   };

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -694,8 +694,11 @@ function managedBalanceClassification(): Omit<
 > {
   return {
     code: "PROVIDER_BILLING",
+    // This text is persisted as a real assistant message (it re-enters LLM
+    // history and is what older/native clients display), so it must read as
+    // the assistant speaking, not UI chrome.
     userMessage:
-      "You've run out of credits. Add funds to continue using the assistant.",
+      "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
     retryable: false,
     errorCategory: "credits_exhausted",
   };

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -439,6 +439,28 @@ export function isSystemCardMessage(
 }
 
 /**
+ * Row-level variant of {@link isProviderErrorMetadata} for callers holding
+ * the raw persisted `metadata` JSON string. The single place the parse lives
+ * so display merging and wire projection agree on which rows carry the
+ * provider-error marker.
+ */
+export function isProviderErrorMessage(
+  role: string,
+  metadata: string | null,
+): boolean {
+  if (role !== "assistant" || !metadata) {
+    return false;
+  }
+  try {
+    return isProviderErrorMetadata(
+      JSON.parse(metadata) as Record<string, unknown>,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Parse a persisted message's metadata JSON against {@link messageMetadataSchema}
  * — the single source of truth for its shape — returning the validated fields,
  * or `undefined` when the column is absent, not valid JSON, or fails validation.

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -418,46 +418,48 @@ export function isProviderErrorMetadata(
 }
 
 /**
- * Row-level variant of {@link isSystemCardMetadata} for callers holding the
- * raw persisted `metadata` JSON string. The single place the parse lives so
- * display merging and turn grouping agree on what a card is.
+ * Parse an assistant row's raw persisted `metadata` JSON and apply a
+ * metadata-level predicate to it. The single place the assistant-role guard
+ * and malformed-JSON fallback live, so the row-level message-kind checks
+ * cannot diverge.
  */
-export function isSystemCardMessage(
+function assistantRowMetadataMatches(
   role: string,
   metadata: string | null,
+  predicate: (parsed: Record<string, unknown>) => boolean,
 ): boolean {
   if (role !== "assistant" || !metadata) {
     return false;
   }
   try {
-    return isSystemCardMetadata(
-      JSON.parse(metadata) as Record<string, unknown>,
-    );
+    return predicate(JSON.parse(metadata) as Record<string, unknown>);
   } catch {
     return false;
   }
 }
 
 /**
+ * Row-level variant of {@link isSystemCardMetadata} for callers holding the
+ * raw persisted `metadata` JSON string, so display merging and turn grouping
+ * agree on what a card is.
+ */
+export function isSystemCardMessage(
+  role: string,
+  metadata: string | null,
+): boolean {
+  return assistantRowMetadataMatches(role, metadata, isSystemCardMetadata);
+}
+
+/**
  * Row-level variant of {@link isProviderErrorMetadata} for callers holding
- * the raw persisted `metadata` JSON string. The single place the parse lives
- * so display merging and wire projection agree on which rows carry the
- * provider-error marker.
+ * the raw persisted `metadata` JSON string, so display merging and wire
+ * projection agree on which rows carry the provider-error marker.
  */
 export function isProviderErrorMessage(
   role: string,
   metadata: string | null,
 ): boolean {
-  if (role !== "assistant" || !metadata) {
-    return false;
-  }
-  try {
-    return isProviderErrorMetadata(
-      JSON.parse(metadata) as Record<string, unknown>,
-    );
-  } catch {
-    return false;
-  }
+  return assistantRowMetadataMatches(role, metadata, isProviderErrorMetadata);
 }
 
 /**

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -301,10 +301,25 @@ export const messageMetadataSchema = z
      * Discriminates daemon-authored rows from ordinary turns.
      * `"system_card"` marks pre-composed status cards (the /compact, /clean,
      * and summarize-up-to results); see {@link SYSTEM_CARD_MESSAGE_KIND}.
-     * Kept as a plain string so unknown future kinds never fail metadata
-     * validation.
+     * `"provider_error"` marks the synthetic assistant row the agent loop
+     * persists when a turn dies on the provider-error path; see
+     * {@link PROVIDER_ERROR_MESSAGE_KIND}. Kept as a plain string so unknown
+     * future kinds never fail metadata validation.
      */
     messageKind: z.string().optional(),
+    /**
+     * Stable classified error code (`ClassifiedConversationError.code`, e.g.
+     * `"PROVIDER_BILLING"`) stamped alongside
+     * `messageKind: "provider_error"` on persisted provider-failure rows.
+     */
+    providerErrorCode: z.string().optional(),
+    /**
+     * Classified error category (`ClassifiedConversationError.errorCategory`,
+     * e.g. `"credits_exhausted"`) stamped alongside
+     * `messageKind: "provider_error"`. Clients switch on this to pick a
+     * themed rendering for the row.
+     */
+    providerErrorCategory: z.string().optional(),
     /**
      * Structured terminal record stamped onto a `<background_event
      * source="background-tool">` wake so the web can rebuild the inline
@@ -370,6 +385,16 @@ export function isHiddenMessageMetadata(
 export const SYSTEM_CARD_MESSAGE_KIND = "system_card";
 
 /**
+ * `messageKind` value marking the synthetic assistant row the agent loop
+ * persists when a turn terminates on the provider-error path (see the
+ * `persistProviderErrorAsAssistantMessage` branch). The row's text stays in
+ * LLM history like any assistant message; the marker (plus the
+ * `providerErrorCode`/`providerErrorCategory` fields stamped next to it) lets
+ * clients render the row as a themed notice instead of persona speech.
+ */
+export const PROVIDER_ERROR_MESSAGE_KIND = "provider_error";
+
+/**
  * Shared predicate for the system-card marker on assistant-message metadata
  * (see the `messageKind` field on {@link messageMetadataSchema}). One
  * definition so display merging, transcript rendering, and turn grouping
@@ -379,6 +404,17 @@ export function isSystemCardMetadata(
   metadata: Record<string, unknown> | null | undefined,
 ): boolean {
   return metadata?.messageKind === SYSTEM_CARD_MESSAGE_KIND;
+}
+
+/**
+ * Shared predicate for the provider-error marker on assistant-message
+ * metadata (see the `messageKind` field on {@link messageMetadataSchema}).
+ * One definition so persistence stamping and wire projection cannot drift.
+ */
+export function isProviderErrorMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  return metadata?.messageKind === PROVIDER_ERROR_MESSAGE_KIND;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
@@ -418,7 +418,7 @@ describe("selectPool — infrastructure failures throw", () => {
       source: "memory_v3",
       code: "PROVIDER_BILLING",
       userMessage:
-        "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+        "You're out of credits. Add credits in Settings → Billing to continue.",
       errorCategory: "credits_exhausted",
     });
   });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
@@ -418,7 +418,7 @@ describe("selectPool — infrastructure failures throw", () => {
       source: "memory_v3",
       code: "PROVIDER_BILLING",
       userMessage:
-        "You've run out of credits. Add funds to continue using the assistant.",
+        "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
       errorCategory: "credits_exhausted",
     });
   });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -115,6 +115,7 @@ import {
   hasMessages,
   isConversationProcessing,
   isHiddenMessageMetadata,
+  isProviderErrorMetadata,
   isSystemCardMetadata,
   type MessageRow,
   recordConversationPersistedSeq,
@@ -890,6 +891,7 @@ export function handleListMessages({
     let backgroundEventNotification: boolean | undefined;
     let backgroundToolCompletion: ConversationMessage["backgroundToolCompletion"];
     let systemCard: boolean | undefined;
+    let providerError: ConversationMessage["providerError"];
     if (msg.metadata) {
       try {
         const meta = JSON.parse(msg.metadata);
@@ -900,6 +902,19 @@ export function handleListMessages({
         // render as standalone system notices, not persona speech.
         if (isSystemCardMetadata(meta)) {
           systemCard = true;
+        }
+        // Daemon-persisted provider-failure notices carry the classified
+        // error code/category so clients can render a themed card instead
+        // of a persona bubble.
+        if (isProviderErrorMetadata(meta)) {
+          providerError = {
+            ...(typeof meta.providerErrorCode === "string"
+              ? { code: meta.providerErrorCode }
+              : {}),
+            ...(typeof meta.providerErrorCategory === "string"
+              ? { category: meta.providerErrorCategory }
+              : {}),
+          };
         }
         // Every wake persists a `<background_event source="...">` trigger row
         // (see `persistWakeTriggerMessage`) that the LLM reads. Flag any such
@@ -973,6 +988,7 @@ export function handleListMessages({
       backgroundEventNotification,
       backgroundToolCompletion,
       systemCard,
+      providerError,
       slackMessage,
       clientMessageId: msg.clientMessageId ?? undefined,
     };
@@ -1169,6 +1185,7 @@ export function handleListMessages({
       ...(m.backgroundToolCompletion
         ? { backgroundToolCompletion: m.backgroundToolCompletion }
         : {}),
+      ...(m.providerError ? { providerError: m.providerError } : {}),
       ...(m.slackMessage ? { slackMessage: m.slackMessage } : {}),
     };
   });


### PR DESCRIPTION
## Summary
- Tag daemon-persisted provider-error assistant rows with messageKind provider_error + code/category metadata
- Expose providerError on the /messages wire (intermediate AND final projection) and in ConversationMessageSchema
- Friendlier managed-credits failure copy (errorCategory unchanged)

Part of plan: credits-ux.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->