### PR TITLE
feat(docs): build-time search index and /docs/api/search route

### DIFF
--- a/clients/docs/.gitignore
+++ b/clients/docs/.gitignore
@@ -1,0 +1,2 @@
+# Generated at build time by scripts/generate-docs-search-index.ts
+public/docs/search-index.json

--- a/clients/docs/package.json
+++ b/clients/docs/package.json
@@ -3,8 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "bun run docs:search:index",
     "dev": "next dev --port 3005",
+    "prebuild": "bun run docs:search:index",
     "build": "next build",
+    "docs:search:index": "bun scripts/generate-docs-search-index.ts",
     "start": "next start",
     "lint": "eslint",
     "typecheck": "bunx tsc --noEmit",

--- a/clients/docs/scripts/generate-docs-search-index.ts
+++ b/clients/docs/scripts/generate-docs-search-index.ts
@@ -1,0 +1,83 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { extractDocsPageFromHtml } from "../src/lib/docs/search/extract";
+import type { DocsSearchChunk, DocsSearchIndexFile } from "../src/lib/docs/search/types";
+import { listPageFiles, loadPageModule, renderPage, routeFromPageFile } from "./lib/docs-pages";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SCRIPT_DIR, "..");
+// Crawl the entire /docs subtree. Any Next route group living under docs/
+// (currently (documentation), (releases)) gets its pages indexed. Route-group
+// segments live in parentheses and do not affect the URL, so we strip them
+// when deriving the route. The api/ subtree holds route handlers, not pages.
+const DOCS_PAGES_ROOT = join(ROOT, "src", "app", "docs");
+const API_SUBTREE = join(DOCS_PAGES_ROOT, "api") + sep;
+const OUTPUT_PATH = join(ROOT, "public", "docs", "search-index.json");
+
+interface GeneratedIndex {
+  index: DocsSearchIndexFile;
+  pageCount: number;
+  skippedRoutes: string[];
+}
+
+async function generateIndex(): Promise<GeneratedIndex> {
+  const pageFiles = (await listPageFiles(DOCS_PAGES_ROOT))
+    .filter((pageFile) => !pageFile.startsWith(API_SUBTREE))
+    .sort();
+  const chunks: DocsSearchChunk[] = [];
+  const skippedRoutes: string[] = [];
+  let pageCount = 0;
+
+  for (const pageFile of pageFiles) {
+    const route = routeFromPageFile(pageFile, DOCS_PAGES_ROOT, "/docs");
+
+    // Request-time pages (e.g. /docs/releases) serve content fetched per
+    // request, so there is nothing stable to index at build time.
+    const pageModule = await loadPageModule(pageFile);
+    if (pageModule.dynamic === "force-dynamic") {
+      skippedRoutes.push(`${route} (force-dynamic)`);
+      continue;
+    }
+
+    const rendered = await renderPage(pageFile);
+    if (!rendered) {
+      skippedRoutes.push(`${route} (redirect)`);
+      continue;
+    }
+
+    const extracted = extractDocsPageFromHtml(route, rendered.html);
+    chunks.push(...extracted.chunks);
+    pageCount += 1;
+  }
+
+  return {
+    index: {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      chunks,
+    },
+    pageCount,
+    skippedRoutes,
+  };
+}
+
+async function main() {
+  const { index, pageCount, skippedRoutes } = await generateIndex();
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(index, null, 2)}\n`, "utf8");
+
+  for (const skipped of skippedRoutes) {
+    console.log(`[docs-search] Skipped ${skipped}`);
+  }
+  console.log(
+    `[docs-search] Indexed ${pageCount} pages into ${index.chunks.length} chunks -> ${OUTPUT_PATH}`
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? (error.stack ?? error.message) : "unknown error";
+  console.error(`[docs-search] Failed to generate docs index: ${message}`);
+  process.exitCode = 1;
+});

--- a/clients/docs/scripts/lib/docs-pages.ts
+++ b/clients/docs/scripts/lib/docs-pages.ts
@@ -1,0 +1,117 @@
+import { readdir } from "node:fs/promises";
+import { dirname, join, relative, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { Metadata } from "next";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+export function isRouteGroupSegment(segment: string): boolean {
+  return segment.startsWith("(") && segment.endsWith(")");
+}
+
+export function isPrivateSegment(segment: string): boolean {
+  return segment.startsWith("_");
+}
+
+/** Recursively list page.tsx files under a Next app directory, skipping
+ *  private (underscore-prefixed) folders like _components. */
+export async function listPageFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results: string[] = [];
+
+  for (const entry of entries) {
+    const absolute = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (isPrivateSegment(entry.name)) {
+        continue;
+      }
+      const nested = await listPageFiles(absolute);
+      results.push(...nested);
+      continue;
+    }
+
+    if (entry.isFile() && entry.name === "page.tsx") {
+      results.push(absolute);
+    }
+  }
+
+  return results;
+}
+
+/** Derive the URL route for a page file relative to a pages root, stripping
+ *  route-group segments (parenthesized folders do not affect the URL). */
+export function routeFromPageFile(
+  pageFile: string,
+  pagesRoot: string,
+  baseRoute: string
+): string {
+  const relativeDir = relative(pagesRoot, dirname(pageFile));
+  if (!relativeDir || relativeDir === ".") {
+    return baseRoute;
+  }
+
+  const segments = relativeDir
+    .split(sep)
+    .filter((segment) => segment.length > 0 && !isRouteGroupSegment(segment));
+
+  if (segments.length === 0) {
+    return baseRoute;
+  }
+
+  return `${baseRoute}/${segments.join("/")}`;
+}
+
+export interface RenderedPage {
+  html: string;
+  metadata: Metadata | undefined;
+}
+
+export async function loadPageModule(pageFile: string): Promise<Record<string, unknown>> {
+  return (await import(pathToFileURL(pageFile).href)) as Record<string, unknown>;
+}
+
+/** Import a page module and return its exported metadata without rendering.
+ *  Useful as a fallback for pages that import cleanly but are not rendered
+ *  (e.g. request-time pages excluded from static generation). */
+export async function loadPageMetadata(pageFile: string): Promise<Metadata | undefined> {
+  try {
+    const pageModule = await loadPageModule(pageFile);
+    return pageModule.metadata as Metadata | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRedirectError(error: unknown): boolean {
+  const digest = (error as { digest?: unknown })?.digest;
+  if (typeof digest === "string" && digest.startsWith("NEXT_REDIRECT")) {
+    return true;
+  }
+  return error instanceof Error && error.message.includes("NEXT_REDIRECT");
+}
+
+/** Import a page module and render its default export to static HTML.
+ *  Returns null for pages that redirect or lack a default export; any other
+ *  render failure propagates to the caller. Only the page component is
+ *  rendered: layouts (nav, header, footer) are not included. */
+export async function renderPage(pageFile: string): Promise<RenderedPage | null> {
+  const pageModule = await loadPageModule(pageFile);
+  const Page = pageModule.default as React.ComponentType | undefined;
+
+  if (!Page) {
+    return null;
+  }
+
+  try {
+    return {
+      html: renderToStaticMarkup(React.createElement(Page)),
+      metadata: pageModule.metadata as Metadata | undefined,
+    };
+  } catch (error) {
+    if (isRedirectError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/clients/docs/scripts/lib/docs-pages.ts
+++ b/clients/docs/scripts/lib/docs-pages.ts
@@ -2,7 +2,6 @@ import { readdir } from "node:fs/promises";
 import { dirname, join, relative, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import type { Metadata } from "next";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -64,23 +63,10 @@ export function routeFromPageFile(
 
 export interface RenderedPage {
   html: string;
-  metadata: Metadata | undefined;
 }
 
 export async function loadPageModule(pageFile: string): Promise<Record<string, unknown>> {
   return (await import(pathToFileURL(pageFile).href)) as Record<string, unknown>;
-}
-
-/** Import a page module and return its exported metadata without rendering.
- *  Useful as a fallback for pages that import cleanly but are not rendered
- *  (e.g. request-time pages excluded from static generation). */
-export async function loadPageMetadata(pageFile: string): Promise<Metadata | undefined> {
-  try {
-    const pageModule = await loadPageModule(pageFile);
-    return pageModule.metadata as Metadata | undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function isRedirectError(error: unknown): boolean {
@@ -106,7 +92,6 @@ export async function renderPage(pageFile: string): Promise<RenderedPage | null>
   try {
     return {
       html: renderToStaticMarkup(React.createElement(Page)),
-      metadata: pageModule.metadata as Metadata | undefined,
     };
   } catch (error) {
     if (isRedirectError(error)) {

--- a/clients/docs/src/app/docs/api/search/route.test.ts
+++ b/clients/docs/src/app/docs/api/search/route.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { NextRequest } from "next/server";
+
+import { resetDocsSearchIndexCache } from "@/lib/docs/search/index-loader";
+import type { DocsSearchIndexFile } from "@/lib/docs/search/types";
+
+import { GET } from "@/app/docs/api/search/route";
+
+let tempDir = "";
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "docs-search-test-"));
+  resetDocsSearchIndexCache();
+});
+
+afterEach(async () => {
+  resetDocsSearchIndexCache();
+  delete process.env.DOCS_SEARCH_INDEX_PATH;
+
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+async function writeIndex(index: DocsSearchIndexFile): Promise<void> {
+  const file = join(tempDir, "search-index.json");
+  await writeFile(file, JSON.stringify(index), "utf8");
+  process.env.DOCS_SEARCH_INDEX_PATH = file;
+}
+
+describe("GET /docs/api/search", () => {
+  test("returns empty results for invalid short query", async () => {
+    await writeIndex({
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      chunks: [],
+    });
+
+    const request = new NextRequest("http://localhost/docs/api/search?q=a");
+    const response = await GET(request);
+    const body = (await response.json()) as { mode: string; results: unknown[] };
+
+    expect(response.status).toBe(200);
+    expect(body.mode).toBe("lexical");
+    expect(body.results).toHaveLength(0);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  test("clamps limit to 20", async () => {
+    await writeIndex({
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      chunks: Array.from({ length: 30 }).map((_, index) => ({
+        id: `/docs/test-${index}`,
+        route: "/docs/test",
+        url: `/docs/test#${index}`,
+        pageTitle: "Test",
+        breadcrumb: "Docs / Test",
+        heading: `Heading ${index}`,
+        headingLevel: 2,
+        sectionId: String(index),
+        body: "installation guide and setup",
+        keywords: ["installation"],
+      })),
+    });
+
+    const request = new NextRequest("http://localhost/docs/api/search?q=installation&limit=200");
+    const response = await GET(request);
+    const body = (await response.json()) as { results: unknown[] };
+
+    expect(body.results.length).toBeLessThanOrEqual(20);
+  });
+
+  test("returns lexical results with private caching", async () => {
+    await writeIndex({
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      chunks: [
+        {
+          id: "/docs/getting-started#__page",
+          route: "/docs/getting-started",
+          url: "/docs/getting-started",
+          pageTitle: "Getting Started",
+          breadcrumb: "Docs / Getting Started",
+          heading: "Installation",
+          headingLevel: 1,
+          sectionId: null,
+          body: "Install and start quickly.",
+          keywords: ["installation"],
+        },
+      ],
+    });
+
+    const request = new NextRequest("http://localhost/docs/api/search?q=installation");
+    const response = await GET(request);
+    const body = (await response.json()) as { mode: string; results: Array<{ route: string }> };
+
+    expect(body.mode).toBe("lexical");
+    expect(body.results[0]?.route).toBe("/docs/getting-started");
+    expect(response.headers.get("cache-control")).toBe("private, max-age=30");
+  });
+
+  test("returns stable response schema", async () => {
+    await writeIndex({
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      chunks: [
+        {
+          id: "/docs/help#oauth",
+          route: "/docs/help",
+          url: "/docs/help#oauth",
+          pageTitle: "Help",
+          breadcrumb: "Docs / Help",
+          heading: "OAuth",
+          headingLevel: 2,
+          sectionId: "oauth",
+          body: "Reconnect OAuth provider.",
+          keywords: ["oauth"],
+        },
+      ],
+    });
+
+    const request = new NextRequest("http://localhost/docs/api/search?q=oauth");
+    const response = await GET(request);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(Object.keys(body).sort()).toEqual(["mode", "query", "results", "tookMs"]);
+  });
+});

--- a/clients/docs/src/app/docs/api/search/route.ts
+++ b/clients/docs/src/app/docs/api/search/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { loadDocsSearchIndex } from "@/lib/docs/search/index-loader";
+import { searchDocsIndex } from "@/lib/docs/search/ranker";
+import { isRateLimited, resolveClientIp } from "@/lib/docs/search/rate-limit";
+import type { DocsSearchResponse } from "@/lib/docs/search/types";
+
+const MIN_QUERY_LENGTH = 2;
+const MAX_QUERY_LENGTH = 160;
+const DEFAULT_LIMIT = 10;
+
+function parseLimit(value: string | null): number {
+  if (!value) {
+    return DEFAULT_LIMIT;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_LIMIT;
+  }
+
+  return Math.min(Math.max(parsed, 1), 20);
+}
+
+function buildResponse(body: DocsSearchResponse, cacheControl: string): NextResponse<DocsSearchResponse> {
+  return NextResponse.json(body, {
+    headers: {
+      "Cache-Control": cacheControl,
+    },
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const startedAt = performance.now();
+
+  const ip = resolveClientIp(request.headers.get("x-forwarded-for"));
+  if (isRateLimited(ip)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429, headers: { "Retry-After": "60" } });
+  }
+
+  try {
+    const query = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+    const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
+
+    if (query.length < MIN_QUERY_LENGTH || query.length > MAX_QUERY_LENGTH) {
+      return buildResponse(
+        {
+          query,
+          mode: "lexical",
+          tookMs: Math.round(performance.now() - startedAt),
+          results: [],
+        },
+        "no-store"
+      );
+    }
+
+    const index = await loadDocsSearchIndex();
+
+    const { mode, results } = searchDocsIndex({
+      query,
+      limit,
+      index,
+    });
+
+    return buildResponse(
+      {
+        query,
+        mode,
+        tookMs: Math.round(performance.now() - startedAt),
+        results,
+      },
+      "private, max-age=30"
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    console.error(`[docs-search] search endpoint error: ${message}`);
+
+    return buildResponse(
+      {
+        query: "",
+        mode: "lexical",
+        tookMs: Math.round(performance.now() - startedAt),
+        results: [],
+      },
+      "no-store"
+    );
+  }
+}

--- a/clients/docs/tsconfig.json
+++ b/clients/docs/tsconfig.json
@@ -34,6 +34,7 @@
   },
   "include": [
     "next-env.d.ts",
+    "scripts/**/*.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     ".next/types/**/*.ts",


### PR DESCRIPTION
## Summary
- Build-time search index generation (prebuild/predev) rendering every docs page, failing loudly on render errors
- /docs/api/search route with rate limiting and private caching, adapted to the lexical-only search lib

Part of plan: docs-app-phase-1.md (PR 9 of 15)