### PR TITLE
feat(web): make the composer secret guard native, retire its feature flag

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -514,7 +514,7 @@ export function ChatMainPanel({
   const queueSteering = useAssistantFeatureFlagStore.use.queueSteering();
 
   // -------------------------------------------------------------------------
-  // Draft secret detection — owns the composer warning's matches/dismissal
+  // Draft secret detection: owns the composer warning's matches/dismissal
   // plus the pre-send gate state.
   // -------------------------------------------------------------------------
   const draftSecretDetection = useDraftSecretDetection({

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -514,8 +514,8 @@ export function ChatMainPanel({
   const queueSteering = useAssistantFeatureFlagStore.use.queueSteering();
 
   // -------------------------------------------------------------------------
-  // Draft secret detection (flag-gated) — owns the composer warning's
-  // matches/dismissal plus the pre-send gate state.
+  // Draft secret detection — owns the composer warning's matches/dismissal
+  // plus the pre-send gate state.
   // -------------------------------------------------------------------------
   const draftSecretDetection = useDraftSecretDetection({
     conversationId: activeConversationId,
@@ -882,8 +882,8 @@ export function ChatMainPanel({
     assistantId,
     activeConversationId,
     // Synchronous pre-send gate: re-scans the outgoing content so pastes
-    // sent inside the detection debounce window are still caught. Flag off
-    // or no secrets → returns true, fully inert.
+    // sent inside the detection debounce window are still caught. No
+    // secrets → returns true, fully inert.
     beforeSend: draftSecretDetection.checkBeforeSend,
   });
 

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
@@ -1,17 +1,15 @@
 /**
  * Tests for the draft secret-detection hook and its pure scan policy.
  *
- * Uses the real composer and assistant-feature-flag stores (reset between
- * tests) so the hook's store subscription, flag gating, and dismissal
- * lifecycle are exercised end to end. All tokens are synthetic values
- * invented for these tests.
+ * Uses the real composer store (reset between tests) so the hook's store
+ * subscription and dismissal lifecycle are exercised end to end. All tokens
+ * are synthetic values invented for these tests.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import { useComposerStore } from "@/domains/chat/composer-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 import {
   SECRET_SCAN_MIN_DRAFT_LENGTH,
@@ -23,13 +21,6 @@ import {
 const SYNTHETIC_PROJECT_KEY =
   "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3A";
 const SYNTHETIC_GITHUB_TOKEN = "ghp_Zx9Wv8Ut7Sr6Qp5On4Ml3Kj2Ih1Gf0EdCbA9";
-
-function seedFlags(flags: {
-  composerSecretGuard: boolean;
-  hasHydrated: boolean;
-}) {
-  useAssistantFeatureFlagStore.setState(flags);
-}
 
 function setDraft(text: string) {
   act(() => {
@@ -58,7 +49,6 @@ function renderDetection(
 const NEVER_ELAPSES_MS = 60_000;
 
 beforeEach(() => {
-  seedFlags({ composerSecretGuard: false, hasHydrated: false });
   useComposerStore.getState().setInput("");
 });
 
@@ -71,46 +61,17 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("scanDraftForSecrets", () => {
-  test("returns nothing when disabled, regardless of content", () => {
-    expect(
-      scanDraftForSecrets(`deploy with ${SYNTHETIC_PROJECT_KEY}`, false),
-    ).toEqual([]);
-  });
-
   test("skips drafts shorter than the minimum scan length", () => {
     const short = "a".repeat(SECRET_SCAN_MIN_DRAFT_LENGTH - 1);
-    expect(scanDraftForSecrets(short, true)).toEqual([]);
+    expect(scanDraftForSecrets(short)).toEqual([]);
   });
 
-  test("detects a token in a long-enough enabled draft", () => {
+  test("detects a token in a long-enough draft", () => {
     const matches = scanDraftForSecrets(
       `here is ${SYNTHETIC_PROJECT_KEY} for you`,
-      true,
     );
     expect(matches).toHaveLength(1);
     expect(matches[0]?.value).toBe(SYNTHETIC_PROJECT_KEY);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Hook — flag gating
-// ---------------------------------------------------------------------------
-
-describe("useDraftSecretDetection flag gating", () => {
-  test("flag off: no matches even with a key in the draft", () => {
-    seedFlags({ composerSecretGuard: false, hasHydrated: true });
-    setDraft(`deploy with ${SYNTHETIC_PROJECT_KEY}`);
-    const { result } = renderDetection();
-    expect(result.current.matches).toEqual([]);
-    expect(result.current.dismissed).toBe(false);
-    expect(result.current.sendBlocked).toBe(false);
-  });
-
-  test("flag on but store not hydrated: inert", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: false });
-    setDraft(`deploy with ${SYNTHETIC_PROJECT_KEY}`);
-    const { result } = renderDetection();
-    expect(result.current.matches).toEqual([]);
   });
 });
 
@@ -119,8 +80,7 @@ describe("useDraftSecretDetection flag gating", () => {
 // ---------------------------------------------------------------------------
 
 describe("useDraftSecretDetection detection", () => {
-  test("flag on: match surfaces, dismiss hides, deletion resets", async () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+  test("match surfaces, dismiss hides, deletion resets", async () => {
     setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
     const { result } = renderDetection();
 
@@ -142,7 +102,6 @@ describe("useDraftSecretDetection detection", () => {
   });
 
   test("a newly flagged value re-surfaces a dismissed notice", async () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     setDraft(`first ${SYNTHETIC_PROJECT_KEY}`);
     const { result } = renderDetection();
     act(() => {
@@ -158,7 +117,6 @@ describe("useDraftSecretDetection detection", () => {
   });
 
   test("dismissal resets when the conversation changes", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
     const { result, rerender } = renderDetection("conv-1");
     act(() => {
@@ -171,7 +129,6 @@ describe("useDraftSecretDetection detection", () => {
   });
 
   test("conversation switch clears stale matches synchronously — even dismissed ones", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
     const { result, rerender } = renderDetection("conv-1", NEVER_ELAPSES_MS);
     expect(result.current.matches).toHaveLength(1);
@@ -194,7 +151,6 @@ describe("useDraftSecretDetection detection", () => {
   });
 
   test("a restored draft with a secret warns immediately after a switch", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     setDraft(`conversation A: ${SYNTHETIC_PROJECT_KEY}`);
     const { result, rerender } = renderDetection("conv-1", NEVER_ELAPSES_MS);
     expect(result.current.matches).toHaveLength(1);
@@ -218,7 +174,6 @@ describe("useDraftSecretDetection detection", () => {
   });
 
   test("an identical restored draft with the same secret warns immediately after a switch", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     // The same pasted key is drafted in both conversations, so the restored
     // draft is byte-identical to the outgoing one.
     const sharedDraft = `here is ${SYNTHETIC_PROJECT_KEY}`;
@@ -247,7 +202,6 @@ describe("useDraftSecretDetection detection", () => {
   });
 
   test("a switch to an empty draft still clears matches (identity fix does not resurrect)", async () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     setDraft(`conversation A: ${SYNTHETIC_PROJECT_KEY}`);
     const { result, rerender } = renderDetection("conv-1", 0);
     expect(result.current.matches).toHaveLength(1);
@@ -264,7 +218,6 @@ describe("useDraftSecretDetection detection", () => {
   });
 
   test("scanning waits out the debounce between keystrokes", async () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     const { result } = renderDetection();
     expect(result.current.matches).toEqual([]);
 
@@ -283,7 +236,6 @@ describe("useDraftSecretDetection detection", () => {
 
 describe("useDraftSecretDetection checkBeforeSend", () => {
   test("blocks a send containing a secret and sets sendBlocked", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     const { result } = renderDetection();
 
     let allowed = true;
@@ -296,7 +248,6 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
   });
 
   test("allowOnce arms a single-use bypass for the blocked content", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     const { result } = renderDetection();
 
     act(() => {
@@ -323,7 +274,6 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
   });
 
   test("the bypass is content-bound: different content is scanned and re-blocked", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     const { result } = renderDetection();
 
     // Block on key A, then approve via Send anyway.
@@ -349,7 +299,6 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
   });
 
   test("allowOnce without a recorded block arms nothing", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     const { result } = renderDetection();
 
     act(() => {
@@ -364,7 +313,6 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
   });
 
   test("a draft edit after a block clears sendBlocked and disarms the bypass", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     // Never-elapsing debounce: only the synchronous subscription runs, so
     // the resets below prove the edit itself cleared the state.
     const { result } = renderDetection("conv-1", NEVER_ELAPSES_MS);
@@ -394,7 +342,6 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
   });
 
   test("dismissing a blocked notice clears sendBlocked but keeps dismissal", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
     const { result } = renderDetection();
     act(() => {
@@ -410,7 +357,6 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
   });
 
   test("a blocked send after dismissal re-blocks (dismissal never bypasses)", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
     const { result } = renderDetection();
     act(() => {
@@ -429,7 +375,6 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
   });
 
   test("passes clean text and clears sendBlocked", () => {
-    seedFlags({ composerSecretGuard: true, hasHydrated: true });
     const { result } = renderDetection();
     act(() => {
       result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
@@ -439,17 +384,6 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
     let allowed = false;
     act(() => {
       allowed = result.current.checkBeforeSend("all clear now");
-    });
-    expect(allowed).toBe(true);
-    expect(result.current.sendBlocked).toBe(false);
-  });
-
-  test("passes everything while the flag is off", () => {
-    seedFlags({ composerSecretGuard: false, hasHydrated: true });
-    const { result } = renderDetection();
-    let allowed = false;
-    act(() => {
-      allowed = result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
     });
     expect(allowed).toBe(true);
     expect(result.current.sendBlocked).toBe(false);

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
@@ -3,10 +3,6 @@
  * owns the notice/dismissal + pre-send gate state for the composer secret
  * guard.
  *
- * Gated on the `composer-secret-guard` assistant flag: while the flag is off
- * (or the flag store has not hydrated yet) the hook is inert — no store
- * subscription, no scanning work, `matches` is always empty.
- *
  * Draft scanning subscribes to the composer store directly (debounced,
  * non-reactive) instead of taking the draft as a reactive prop: the
  * orchestrator that mounts this hook deliberately does not subscribe to
@@ -33,7 +29,6 @@ import {
 } from "@vellumai/service-contracts/secret-detection";
 
 import { useComposerStore } from "@/domains/chat/composer-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 // ---------------------------------------------------------------------------
 // Pure scan policy (DOM-free, exported for tests)
@@ -49,15 +44,11 @@ export const SECRET_SCAN_MIN_DRAFT_LENGTH = 16;
 export const SECRET_SCAN_DEBOUNCE_MS = 250;
 
 /**
- * Scan decision + prefilter: returns the secrets to surface for a draft, or
- * an empty list when scanning is disabled or the draft is too short to
- * contain a detectable token.
+ * Scan prefilter: returns the secrets to surface for a draft, or an empty
+ * list when the draft is too short to contain a detectable token.
  */
-export function scanDraftForSecrets(
-  text: string,
-  enabled: boolean,
-): DetectedSecret[] {
-  if (!enabled || text.length < SECRET_SCAN_MIN_DRAFT_LENGTH) {
+export function scanDraftForSecrets(text: string): DetectedSecret[] {
+  if (text.length < SECRET_SCAN_MIN_DRAFT_LENGTH) {
     return [];
   }
   return detectSecretsInText(text);
@@ -97,10 +88,7 @@ export interface UseDraftSecretDetectionParams {
 }
 
 export interface DraftSecretDetectionResult {
-  /**
-   * Secrets currently detected in the draft, ordered by position. Empty
-   * while the flag is off or the flag store has not hydrated.
-   */
+  /** Secrets currently detected in the draft, ordered by position. */
   matches: DetectedSecret[];
   /** True when the user dismissed the notice for every flagged value. */
   dismissed: boolean;
@@ -127,8 +115,8 @@ export interface DraftSecretDetectionResult {
   /**
    * Arm a single-use bypass bound to the exact content the last
    * {@link checkBeforeSend} blocked. A no-op when nothing is blocked.
-   * Invalidated by any subsequent draft edit, flag flip, or conversation
-   * switch — the bypass approves the content as it stood when armed.
+   * Invalidated by any subsequent draft edit or conversation switch — the
+   * bypass approves the content as it stood when armed.
    */
   allowOnce: () => void;
 }
@@ -137,11 +125,6 @@ export function useDraftSecretDetection({
   conversationId,
   debounceMs = SECRET_SCAN_DEBOUNCE_MS,
 }: UseDraftSecretDetectionParams): DraftSecretDetectionResult {
-  const composerSecretGuard =
-    useAssistantFeatureFlagStore.use.composerSecretGuard();
-  const hasHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
-  const enabled = hasHydrated && composerSecretGuard;
-
   const [matches, setMatches] = useState<DetectedSecret[]>([]);
   const [dismissedValues, setDismissedValues] =
     useState<ReadonlySet<string>>(EMPTY_VALUE_SET);
@@ -159,15 +142,15 @@ export function useDraftSecretDetection({
   const scanNextInputImmediatelyRef = useRef(false);
   const prevConversationIdRef = useRef(conversationId);
 
-  // Dismissal and send-block state are scoped to one conversation's draft
-  // under one flag state — any transition of either invalidates them.
-  // Layout effect: the reset must land before the switched route paints.
+  // Dismissal and send-block state are scoped to one conversation's draft —
+  // a conversation switch invalidates them. Layout effect: the reset must
+  // land before the switched route paints.
   useLayoutEffect(() => {
     allowOnceContentRef.current = null;
     blockedContentRef.current = null;
     setSendBlocked(false);
     setDismissedValues(EMPTY_VALUE_SET);
-  }, [enabled, conversationId]);
+  }, [conversationId]);
 
   // Conversation switches swap the draft in a parent post-render effect,
   // after this effect runs — the composer store still holds the outgoing
@@ -186,13 +169,8 @@ export function useDraftSecretDetection({
   }, [conversationId]);
 
   useEffect(() => {
-    if (!enabled) {
-      setMatches([]);
-      return;
-    }
-
     const applyScan = (text: string) => {
-      const next = scanDraftForSecrets(text, true);
+      const next = scanDraftForSecrets(text);
       setMatches((prev) => (sameMatches(prev, next) ? prev : next));
       if (next.length === 0) {
         // The flagged values left the draft: reset dismissal and any block.
@@ -253,7 +231,7 @@ export function useDraftSecretDetection({
       }
       unsubscribe();
     };
-  }, [enabled, debounceMs]);
+  }, [debounceMs]);
 
   const dismiss = useCallback(() => {
     setDismissedValues(new Set(matches.map((m) => m.value)));
@@ -272,33 +250,27 @@ export function useDraftSecretDetection({
     setSendBlocked(false);
   }, []);
 
-  const checkBeforeSend = useCallback(
-    (text: string): boolean => {
-      if (!enabled) {
-        return true;
-      }
-      // Single-use: consumed on this attempt whether or not it applies.
-      const approvedContent = allowOnceContentRef.current;
-      allowOnceContentRef.current = null;
-      if (approvedContent !== null && approvedContent === text) {
-        blockedContentRef.current = null;
-        setSendBlocked(false);
-        return true;
-      }
-      // Anything other than the exact approved content is scanned as usual.
-      const found = scanDraftForSecrets(text, true);
-      if (found.length === 0) {
-        blockedContentRef.current = null;
-        setSendBlocked(false);
-        return true;
-      }
-      blockedContentRef.current = text;
-      setMatches((prev) => (sameMatches(prev, found) ? prev : found));
-      setSendBlocked(true);
-      return false;
-    },
-    [enabled],
-  );
+  const checkBeforeSend = useCallback((text: string): boolean => {
+    // Single-use: consumed on this attempt whether or not it applies.
+    const approvedContent = allowOnceContentRef.current;
+    allowOnceContentRef.current = null;
+    if (approvedContent !== null && approvedContent === text) {
+      blockedContentRef.current = null;
+      setSendBlocked(false);
+      return true;
+    }
+    // Anything other than the exact approved content is scanned as usual.
+    const found = scanDraftForSecrets(text);
+    if (found.length === 0) {
+      blockedContentRef.current = null;
+      setSendBlocked(false);
+      return true;
+    }
+    blockedContentRef.current = text;
+    setMatches((prev) => (sameMatches(prev, found) ? prev : found));
+    setSendBlocked(true);
+    return false;
+  }, []);
 
   const dismissed =
     matches.length > 0 && matches.every((m) => dismissedValues.has(m.value));

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
@@ -115,7 +115,7 @@ export interface DraftSecretDetectionResult {
   /**
    * Arm a single-use bypass bound to the exact content the last
    * {@link checkBeforeSend} blocked. A no-op when nothing is blocked.
-   * Invalidated by any subsequent draft edit or conversation switch — the
+   * Invalidated by any subsequent draft edit or conversation switch: the
    * bypass approves the content as it stood when armed.
    */
   allowOnce: () => void;
@@ -142,8 +142,8 @@ export function useDraftSecretDetection({
   const scanNextInputImmediatelyRef = useRef(false);
   const prevConversationIdRef = useRef(conversationId);
 
-  // Dismissal and send-block state are scoped to one conversation's draft —
-  // a conversation switch invalidates them. Layout effect: the reset must
+  // Dismissal and send-block state are scoped to one conversation's draft,
+  // so a conversation switch invalidates them. Layout effect: the reset must
   // land before the switched route paints.
   useLayoutEffect(() => {
     allowOnceContentRef.current = null;

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -342,14 +342,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "composer-secret-guard",
-      "scope": "assistant",
-      "key": "composer-secret-guard",
-      "label": "Composer Secret Guard",
-      "description": "Detect API keys/secrets typed into the chat composer and offer secure credential storage before send",
-      "defaultEnabled": false
-    },
-    {
       "id": "marketing-pricing-takeover",
       "scope": "client",
       "key": "marketing-pricing-takeover",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -342,14 +342,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "composer-secret-guard",
-      "scope": "assistant",
-      "key": "composer-secret-guard",
-      "label": "Composer Secret Guard",
-      "description": "Detect API keys/secrets typed into the chat composer and offer secure credential storage before send",
-      "defaultEnabled": false
-    },
-    {
       "id": "marketing-pricing-takeover",
       "scope": "client",
       "key": "marketing-pricing-takeover",


### PR DESCRIPTION
## Summary

Retires the `composer-secret-guard` assistant feature flag by making the composer draft secret-detection UI native web behavior:

- `useDraftSecretDetection` no longer reads the assistant feature-flag store — the warning notice, pre-send block (with the content-bound Send-anyway bypass), and Store-securely flow are always active. The `scanDraftForSecrets` prefilter drops its now-meaningless `enabled` parameter.
- The `composer-secret-guard` entry is removed from the flag registry and all bundled copies (meta, assistant, web, gateway — hand-edited in lockstep, copies verified byte-identical).
- The daemon-side secret ingress check (`secret_blocked` / `bypassSecretCheck`) was never gated on this flag and is unchanged.

## Rollout ordering

A companion `vellum-assistant-platform` PR removes the flag's Terraform entry (retiring it in LaunchDarkly). That PR must merge **after** this change ships: clients running older builds still gate the UI on the flag, and deleting it from LD early would resolve them to the registry default (off) and turn the feature off for them.

## Testing

- `use-draft-secret-detection.test.tsx`: 18 pass (flag-gating tests removed with the gate)
- Web feature-flag store/catalog tests: 42 pass
- Assistant registry guard tests: 12 pass; gateway feature-flag suites (env-overrides, IPC routes, remote sync, defaults sync, route): all pass per-file
- `tsc --noEmit` clean in `clients/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)