### PR TITLE
fix(web): show only the reasoning headline in thinking pills and headers

### DIFF
--- a/clients/web/src/domains/chat/components/activity-steps-panel.tsx
+++ b/clients/web/src/domains/chat/components/activity-steps-panel.tsx
@@ -49,6 +49,7 @@ import {
   toolDetailPayloadFromToolCall,
   type ToolCallCardStep,
 } from "@/domains/chat/utils/tool-call-card-utils";
+import { thinkingPreview } from "@/domains/chat/utils/thinking-preview";
 import { truncate } from "@/domains/chat/utils/truncate";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type {
@@ -223,7 +224,7 @@ function TimelineStep({
     return (
       <ToolStepPill
         iconName="brain"
-        label={truncate(step.text, THINKING_PILL_MAX_CHARS)}
+        label={truncate(thinkingPreview(step.text), THINKING_PILL_MAX_CHARS)}
         ariaLabel="View thinking"
         active={false}
         onClick={() =>

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -36,6 +36,7 @@ import {
   WebSearchErrorRow,
   WebSearchStepRow,
 } from "@/domains/chat/components/web-search/web-search-step-row";
+import { thinkingPreview } from "@/domains/chat/utils/thinking-preview";
 import type { ToolCallCardStep } from "@/domains/chat/utils/tool-call-card-utils";
 import { cn } from "@/utils/misc";
 
@@ -117,7 +118,7 @@ function latestThinkingText(section: PhaseSection): string | undefined {
   for (let i = section.steps.length - 1; i >= 0; i--) {
     const step = section.steps[i]!;
     if (step.kind === "thinking" && step.text) {
-      return step.text;
+      return thinkingPreview(step.text);
     }
   }
   return undefined;
@@ -564,7 +565,7 @@ const SubagentPhaseRow = memo(function SubagentPhaseRow({
                         key={stepKey(step, stepIdx)}
                         variant="tool"
                         iconName="brain"
-                        label={step.text}
+                        label={thinkingPreview(step.text)}
                         ariaLabel="View reasoning"
                         onClick={() => onStepDetailClick(detailKey)}
                       />

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -37,6 +37,7 @@ import { Tooltip, Typography } from "@vellumai/design-library";
 
 import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
+import { thinkingPreview } from "@/domains/chat/utils/thinking-preview";
 import {
   formatMs,
   type ToolCallCardStep,
@@ -635,7 +636,7 @@ export function DefaultStepPill({ step }: { step: ToolCallCardStep }) {
   if (step.kind === "thinking") {
     return (
       <StepPill>
-        <PillText>{step.text}</PillText>
+        <PillText>{thinkingPreview(step.text)}</PillText>
       </StepPill>
     );
   }

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.ts
@@ -42,6 +42,7 @@ import type { SubagentStatus } from "@vellumai/assistant-api";
 import { isActiveStatus } from "@/utils/subagent-status";
 import { deriveStepLabelFromName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
+import { thinkingPreview } from "@/domains/chat/utils/thinking-preview";
 import { truncate } from "@/domains/chat/utils/truncate";
 import {
   extractDomain,
@@ -668,7 +669,7 @@ function deriveCurrentStep(
     // the resting card doesn't read as live.
     return {
       currentStepTitle: isTerminal ? "Thought" : "Thinking",
-      currentStepInfo: latest.text,
+      currentStepInfo: thinkingPreview(latest.text),
     };
   }
 

--- a/clients/web/src/domains/chat/utils/thinking-preview.test.ts
+++ b/clients/web/src/domains/chat/utils/thinking-preview.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { thinkingPreview } from "./thinking-preview";
+
+describe("thinkingPreview", () => {
+  test("extracts just the headline from a bold-headlined summary", () => {
+    expect(
+      thinkingPreview(
+        "**Considering formatting options** I'm pondering how to present information effectively.",
+      ),
+    ).toBe("Considering formatting options");
+  });
+
+  test("ignores bold markers past the headline", () => {
+    expect(
+      thinkingPreview("**Planning edits** I need to run **several** checks."),
+    ).toBe("Planning edits");
+  });
+
+  test("passes text without a leading headline through unchanged", () => {
+    expect(thinkingPreview("Reading adidas-group.com")).toBe(
+      "Reading adidas-group.com",
+    );
+  });
+
+  test("tolerates leading whitespace before the headline", () => {
+    expect(thinkingPreview("\n**Clarifying table details** body")).toBe(
+      "Clarifying table details",
+    );
+  });
+
+  test("strips the marker while the headline is still streaming", () => {
+    expect(thinkingPreview("**Considering fo")).toBe("Considering fo");
+  });
+
+  test("falls back to the raw text when the headline is empty", () => {
+    expect(thinkingPreview("**** body text")).toBe("**** body text");
+  });
+
+  test("only uses the first headline of a merged multi-block segment", () => {
+    expect(
+      thinkingPreview("**First block** body\n**Second block** more body"),
+    ).toBe("First block");
+  });
+});

--- a/clients/web/src/domains/chat/utils/thinking-preview.ts
+++ b/clients/web/src/domains/chat/utils/thinking-preview.ts
@@ -1,0 +1,27 @@
+/**
+ * Single-line preview label for a thinking segment shown in pill / header
+ * chrome, which renders plain text — not markdown.
+ *
+ * Reasoning summaries usually open with a bold markdown headline
+ * (`**Considering formatting options** I'm pondering …`). Rendered as plain
+ * text the asterisks show literally and the body crowds the headline, so the
+ * preview extracts JUST the headline. Text without a leading bold headline
+ * (e.g. a web-synthesized "Reading …" step) passes through unchanged. The
+ * full markdown lives behind the drill-in detail views, which render it via
+ * `ChatMarkdownMessage`.
+ */
+export function thinkingPreview(text: string): string {
+  const trimmed = text.trimStart();
+  if (!trimmed.startsWith("**")) {
+    return text;
+  }
+  const close = trimmed.indexOf("**", 2);
+  if (close === -1) {
+    // The headline is still streaming (no closing marker yet) — show the
+    // partial headline without the literal asterisks. It settles to the
+    // extracted headline once the closing marker lands.
+    return trimmed.slice(2).trimStart();
+  }
+  const headline = trimmed.slice(2, close).trim();
+  return headline.length > 0 ? headline : text;
+}

--- a/clients/web/src/domains/chat/utils/thinking-preview.ts
+++ b/clients/web/src/domains/chat/utils/thinking-preview.ts
@@ -1,6 +1,6 @@
 /**
  * Single-line preview label for a thinking segment shown in pill / header
- * chrome, which renders plain text — not markdown.
+ * chrome, which renders plain text, not markdown.
  *
  * Reasoning summaries usually open with a bold markdown headline
  * (`**Considering formatting options** I'm pondering …`). Rendered as plain
@@ -17,7 +17,7 @@ export function thinkingPreview(text: string): string {
   }
   const close = trimmed.indexOf("**", 2);
   if (close === -1) {
-    // The headline is still streaming (no closing marker yet) — show the
+    // The headline is still streaming (no closing marker yet), so show the
     // partial headline without the literal asterisks. It settles to the
     // extracted headline once the closing marker lands.
     return trimmed.slice(2).trimStart();

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -19,6 +19,7 @@ import {
   type IconName,
 } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { isSubagentSpawnCall } from "@/domains/chat/transcript/message-content";
+import { thinkingPreview } from "@/domains/chat/utils/thinking-preview";
 import {
   extractDomain,
   parseWebSearchResultText,
@@ -890,7 +891,7 @@ export function computeToolCallCardDataFromItems(
   let currentStepKind: "thinking" | "tool";
   if (trailingThinkingText !== null) {
     currentStepTitle = "Thinking";
-    currentStepInfo = trailingThinkingText;
+    currentStepInfo = thinkingPreview(trailingThinkingText);
     currentStepKind = "thinking";
   } else {
     currentStepTitle = deriveCurrentStepTitle(


### PR DESCRIPTION
## Summary
- Adds `thinkingPreview()` (`clients/web/src/domains/chat/utils/thinking-preview.ts`): extracts the leading `**Headline**` from a reasoning summary for single-line pill/header chrome. Text without a leading bold headline (e.g. web-synthesized "Reading …" steps) passes through unchanged; while the headline is still streaming (no closing `**` yet) the markers are stripped and the partial headline shows.
- Applies it at every plain-text thinking surface: the activity-steps panel timeline pills, `DefaultStepPill`, the subagent phase timeline (pills + trailing carousel line), the subagent card header, and the collapsed `Thinking | … | N steps` activity header derivation in `tool-call-card-utils`.
- Drill-in detail views are untouched — they still render the full reasoning markdown via `ChatMarkdownMessage`.

## Original prompt
The user noticed thinking summaries rendering with literal `**` asterisks in the chat activity UI — both the collapsed `Thinking | **Considering formatting options** I'm pondering… | 9 steps` header and the step pills in the expanded Details timeline. Those surfaces render plain text, not markdown. Rather than just stripping the markers, the user wanted the pills/headers to show only the bold headline with the body text dropped, keeping the full formatted reasoning behind the drill-in detail views.