### PR TITLE
fix(web): remove the ~0.45s composer reposition lag on the iOS shell

### DIFF
--- a/clients/web/src/hooks/use-visible-viewport.test.ts
+++ b/clients/web/src/hooks/use-visible-viewport.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for `readVisibleViewport`, the visual-viewport read behind the app
+ * shell's keyboard-aware sizing.
+ *
+ * The function is driven directly against a stubbed `window.visualViewport`,
+ * so nothing here mounts React. `referenceInnerHeight` and the anticipated
+ * keyboard height are module state, so each test pins `window.innerHeight` and
+ * resets anticipation rather than relying on ordering.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  readVisibleViewport,
+  setAnticipatedKeyboardHeight,
+} from "@/hooks/use-visible-viewport";
+
+const REFERENCE_HEIGHT = 800;
+const KEYBOARD_HEIGHT = 336;
+
+interface ViewportStub {
+  height: number;
+  offsetTop: number;
+  offsetLeft: number;
+  scale: number;
+}
+
+function stubViewport(overrides: Partial<ViewportStub> = {}): void {
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: {
+      height: REFERENCE_HEIGHT,
+      offsetTop: 0,
+      offsetLeft: 0,
+      scale: 1,
+      ...overrides,
+    },
+  });
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: REFERENCE_HEIGHT,
+  });
+  setAnticipatedKeyboardHeight(0);
+  stubViewport();
+  // Settle `referenceInnerHeight` on the keyboard-free height.
+  readVisibleViewport();
+});
+
+afterEach(() => {
+  setAnticipatedKeyboardHeight(0);
+});
+
+describe("readVisibleViewport", () => {
+  test("returns null when the VisualViewport API is unavailable", () => {
+    // GIVEN a browser without the API
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+
+    // WHEN the viewport is read
+    // THEN callers get null and fall back to their static sizing
+    expect(readVisibleViewport()).toBeNull();
+  });
+
+  test("derives the keyboard height from the shrunken visual viewport", () => {
+    // GIVEN a visual viewport shrunken by the soft keyboard
+    stubViewport({ height: REFERENCE_HEIGHT - KEYBOARD_HEIGHT, offsetTop: 40 });
+
+    // WHEN the viewport is read
+    const viewport = readVisibleViewport();
+
+    // THEN the delta against the reference height is the keyboard height
+    expect(viewport?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+    expect(viewport?.height).toBe(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+    expect(viewport?.offsetTop).toBe(40);
+  });
+
+  test("reports the anticipated height before the native resize lands", () => {
+    // GIVEN the native shell has announced the keyboard height while the web
+    // view frame is still at its full height
+    setAnticipatedKeyboardHeight(KEYBOARD_HEIGHT);
+    stubViewport({ height: REFERENCE_HEIGHT });
+
+    // WHEN the viewport is read
+    const viewport = readVisibleViewport();
+
+    // THEN layout is sized for the keyboard the user can already see
+    expect(viewport?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+    expect(viewport?.height).toBe(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+    expect(viewport?.offsetTop).toBe(0);
+  });
+
+  test("hands back to the derived values once the native resize lands", () => {
+    // GIVEN an anticipated keyboard height
+    setAnticipatedKeyboardHeight(KEYBOARD_HEIGHT);
+
+    // WHEN the web view frame catches up to it
+    stubViewport({ height: REFERENCE_HEIGHT - KEYBOARD_HEIGHT });
+    const landed = readVisibleViewport();
+
+    // THEN the measured viewport is reported, with no second jump
+    expect(landed?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+    expect(landed?.height).toBe(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+
+    // AND anticipation is retired, so a restored viewport reads as keyboard-free
+    stubViewport({ height: REFERENCE_HEIGHT });
+    const restored = readVisibleViewport();
+    expect(restored?.keyboardHeight).toBe(0);
+    expect(restored?.height).toBe(REFERENCE_HEIGHT);
+  });
+
+  test("returns to the derived path as soon as anticipation is cleared", () => {
+    // GIVEN an anticipated keyboard height being reported
+    setAnticipatedKeyboardHeight(KEYBOARD_HEIGHT);
+    expect(readVisibleViewport()?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+
+    // WHEN the keyboard hides and anticipation is cleared
+    setAnticipatedKeyboardHeight(0);
+
+    // THEN the measured viewport drives the restore immediately
+    const viewport = readVisibleViewport();
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(REFERENCE_HEIGHT);
+  });
+
+  test("reports no keyboard while pinch-zoomed even with anticipation pending", () => {
+    // GIVEN a pinch-zoomed viewport with an anticipated keyboard height
+    setAnticipatedKeyboardHeight(KEYBOARD_HEIGHT);
+    stubViewport({ height: 600, offsetTop: 30, offsetLeft: 10, scale: 1.5 });
+
+    // WHEN the viewport is read
+    const viewport = readVisibleViewport();
+
+    // THEN zoom-induced shrinkage is never mistaken for a keyboard
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(600);
+    expect(viewport?.offsetTop).toBe(0);
+    expect(viewport?.offsetLeft).toBe(0);
+  });
+});

--- a/clients/web/src/hooks/use-visible-viewport.test.ts
+++ b/clients/web/src/hooks/use-visible-viewport.test.ts
@@ -1,18 +1,21 @@
 /**
- * Tests for `readVisibleViewport`, the visual-viewport read behind the app
- * shell's keyboard-aware sizing.
+ * Tests for `readVisibleViewport` and `useVisibleViewport`, the visual-viewport
+ * read and subscription behind the app shell's keyboard-aware sizing.
  *
- * The function is driven directly against a stubbed `window.visualViewport`,
- * so nothing here mounts React. `referenceInnerHeight` and the anticipated
- * keyboard height are module state, so each test pins `window.innerHeight` and
- * resets anticipation rather than relying on ordering.
+ * The read is driven directly against a stubbed `window.visualViewport`, so
+ * only the subscriber-lifecycle tests mount the hook. `referenceInnerHeight`
+ * and the anticipated keyboard height are module state, so each test pins
+ * `window.innerHeight` and resets anticipation rather than relying on ordering.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
 
 import {
+  __resetKeyboardAnticipationForTests,
   readVisibleViewport,
   setAnticipatedKeyboardHeight,
+  useVisibleViewport,
 } from "@/hooks/use-visible-viewport";
 
 const REFERENCE_HEIGHT = 800;
@@ -33,6 +36,10 @@ function stubViewport(overrides: Partial<ViewportStub> = {}): void {
       offsetTop: 0,
       offsetLeft: 0,
       scale: 1,
+      // Mounting the hook attaches resize/scroll listeners; the tests drive
+      // `readVisibleViewport` directly, so these only need to exist.
+      addEventListener: () => {},
+      removeEventListener: () => {},
       ...overrides,
     },
   });
@@ -44,14 +51,15 @@ beforeEach(() => {
     writable: true,
     value: REFERENCE_HEIGHT,
   });
-  setAnticipatedKeyboardHeight(0);
+  __resetKeyboardAnticipationForTests();
   stubViewport();
   // Settle `referenceInnerHeight` on the keyboard-free height.
   readVisibleViewport();
 });
 
 afterEach(() => {
-  setAnticipatedKeyboardHeight(0);
+  cleanup();
+  __resetKeyboardAnticipationForTests();
 });
 
 describe("readVisibleViewport", () => {
@@ -141,5 +149,59 @@ describe("readVisibleViewport", () => {
     expect(viewport?.height).toBe(600);
     expect(viewport?.offsetTop).toBe(0);
     expect(viewport?.offsetLeft).toBe(0);
+  });
+});
+
+describe("useVisibleViewport", () => {
+  test("clears a pending anticipation when the last consumer unmounts", () => {
+    // GIVEN a mounted consumer with the keyboard already announced
+    const { unmount } = renderHook(() => useVisibleViewport());
+    setAnticipatedKeyboardHeight(KEYBOARD_HEIGHT);
+
+    // WHEN it unmounts before the keyboard hide ever arrives
+    unmount();
+
+    // THEN a later read of the restored viewport is keyboard-free, rather than
+    // reporting a height the remount could never retire
+    const viewport = readVisibleViewport();
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(REFERENCE_HEIGHT);
+  });
+
+  test("keeps anticipation while another consumer is still mounted", () => {
+    // GIVEN two concurrent consumers and an announced keyboard height
+    const shell = renderHook(() => useVisibleViewport());
+    const overlay = renderHook(() => useVisibleViewport());
+    setAnticipatedKeyboardHeight(KEYBOARD_HEIGHT);
+
+    // WHEN one of them unmounts with the keyboard genuinely open
+    overlay.unmount();
+
+    // THEN the survivor still sizes for the keyboard, with no jump back to the
+    // lagging derived measurement
+    const stillOpen = readVisibleViewport();
+    expect(stillOpen?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+    expect(stillOpen?.height).toBe(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+
+    // AND anticipation clears only once the last one goes away
+    shell.unmount();
+    expect(readVisibleViewport()?.keyboardHeight).toBe(0);
+  });
+
+  test("survives a mount, unmount, and remount cycle", () => {
+    // GIVEN a consumer that unmounts mid-keyboard
+    const first = renderHook(() => useVisibleViewport());
+    setAnticipatedKeyboardHeight(KEYBOARD_HEIGHT);
+    first.unmount();
+
+    // WHEN the shell remounts without a page reload and the keyboard opens
+    // again
+    const second = renderHook(() => useVisibleViewport());
+    setAnticipatedKeyboardHeight(KEYBOARD_HEIGHT);
+    expect(readVisibleViewport()?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+
+    // THEN the count is still balanced, so its own unmount clears anticipation
+    second.unmount();
+    expect(readVisibleViewport()?.keyboardHeight).toBe(0);
   });
 });

--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { subscribeNativeKeyboardHeight } from "@/runtime/native-keyboard-events";
+
 /**
  * Threshold (in px) below which an `innerHeight − visualViewport.height` delta
  * is treated as the soft keyboard opening. Below this we assume incidental
@@ -60,6 +62,28 @@ function isPortrait(): boolean {
 }
 let lastIsPortrait: boolean = isPortrait();
 
+// Keyboard height reported by `@capacitor/keyboard` at the leading edge of the
+// show animation, or `0` when nothing is anticipated.
+//
+// The plugin defers its own web view frame resize until the keyboard animation
+// duration plus 0.2s has elapsed, so `visualViewport` keeps reporting the
+// full-height, keyboard-free state for most of a second while the keyboard is
+// already sliding up. Reporting the anticipated height bridges that gap: layout
+// follows the keyboard as it animates, and the derived measurement takes back
+// over the moment the native resize lands.
+let anticipatedKeyboardHeight = 0;
+
+/**
+ * Record the keyboard height the native shell is about to animate to.
+ *
+ * `0` clears anticipation, which is what a keyboard dismissal reports: the
+ * native hide resize is near-instant, so the derived measurement drives the
+ * restore on its own.
+ */
+export function setAnticipatedKeyboardHeight(keyboardHeight: number): void {
+  anticipatedKeyboardHeight = keyboardHeight;
+}
+
 /**
  * Read the current visual-viewport state.
  *
@@ -91,13 +115,36 @@ export function readVisibleViewport(): VisibleViewport | null {
   // pixels, which would otherwise inflate keyboardHeight and falsely trigger
   // keyboard-open detection. Only derive keyboardHeight at ~1.0 scale.
   const isZoomed = Math.abs(vv.scale - 1) > 0.05;
+  const derivedKeyboardHeight = isZoomed
+    ? 0
+    : Math.max(0, referenceInnerHeight - vv.height);
+  const offsetTop = isZoomed ? 0 : vv.offsetTop;
+  const offsetLeft = isZoomed ? 0 : vv.offsetLeft;
+
+  // The deferred native frame resize has landed once the derived height
+  // catches up, so anticipation retires and the measurement takes over.
+  if (
+    anticipatedKeyboardHeight > 0 &&
+    derivedKeyboardHeight >= anticipatedKeyboardHeight
+  ) {
+    anticipatedKeyboardHeight = 0;
+  }
+
+  // A pinch-zoomed viewport reports no keyboard at all, anticipated or not.
+  if (!isZoomed && anticipatedKeyboardHeight > 0) {
+    return {
+      height: referenceInnerHeight - anticipatedKeyboardHeight,
+      keyboardHeight: anticipatedKeyboardHeight,
+      offsetTop,
+      offsetLeft,
+    };
+  }
+
   return {
     height: vv.height,
-    keyboardHeight: isZoomed
-      ? 0
-      : Math.max(0, referenceInnerHeight - vv.height),
-    offsetTop: isZoomed ? 0 : vv.offsetTop,
-    offsetLeft: isZoomed ? 0 : vv.offsetLeft,
+    keyboardHeight: derivedKeyboardHeight,
+    offsetTop,
+    offsetLeft,
   };
 }
 
@@ -112,6 +159,12 @@ export function readVisibleViewport(): VisibleViewport | null {
  * values together. The `referenceInnerHeight`
  * approach in `readVisibleViewport` handles both cases — see the module-level
  * comment above it.
+ *
+ * On the native iOS shell the plugin defers that frame resize until well after
+ * the keyboard animation has started, so the hook also subscribes to the
+ * plugin's own `keyboardWillShow` height and reports it until the deferred
+ * resize lands. Off that shell the subscription attaches no listeners and the
+ * derived measurement is the only source.
  *
  * Returns `null` in browsers that lack the API; callers should fall back to
  * `100dvh` (and no transform) in that case.
@@ -135,10 +188,15 @@ export function useVisibleViewport(): VisibleViewport | null {
     vv.addEventListener("resize", update);
     vv.addEventListener("scroll", update);
     window.addEventListener("resize", update);
+    const unsubscribe = subscribeNativeKeyboardHeight((keyboardHeight) => {
+      setAnticipatedKeyboardHeight(keyboardHeight);
+      update();
+    });
     return () => {
       vv.removeEventListener("resize", update);
       vv.removeEventListener("scroll", update);
       window.removeEventListener("resize", update);
+      unsubscribe();
     };
   }, []);
 

--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -73,6 +73,15 @@ let lastIsPortrait: boolean = isPortrait();
 // over the moment the native resize lands.
 let anticipatedKeyboardHeight = 0;
 
+// Number of mounted `useVisibleViewport` consumers. Anticipation only retires
+// against a measurement that catches up to it, so a consumer that unmounts
+// between `keyboardWillShow` and `keyboardWillHide` would strand a height that
+// no later read can clear: the next mount measures a restored, keyboard-free
+// viewport and never satisfies the retire condition. Clearing once the count
+// reaches zero closes that. Anything above zero has a live consumer whose
+// layout depends on the value, so it must survive.
+let subscriberCount = 0;
+
 /**
  * Record the keyboard height the native shell is about to animate to.
  *
@@ -82,6 +91,15 @@ let anticipatedKeyboardHeight = 0;
  */
 export function setAnticipatedKeyboardHeight(keyboardHeight: number): void {
   anticipatedKeyboardHeight = keyboardHeight;
+}
+
+/**
+ * Reset the anticipation state (the pending height and the subscriber count
+ * that retires it) so unit tests don't leak module state into each other.
+ */
+export function __resetKeyboardAnticipationForTests(): void {
+  anticipatedKeyboardHeight = 0;
+  subscriberCount = 0;
 }
 
 /**
@@ -192,11 +210,18 @@ export function useVisibleViewport(): VisibleViewport | null {
       setAnticipatedKeyboardHeight(keyboardHeight);
       update();
     });
+    subscriberCount += 1;
     return () => {
       vv.removeEventListener("resize", update);
       vv.removeEventListener("scroll", update);
       window.removeEventListener("resize", update);
       unsubscribe();
+      // Clamped so an unpaired cleanup can never drive the count negative and
+      // strand a genuine last unmount above zero.
+      subscriberCount = Math.max(0, subscriberCount - 1);
+      if (subscriberCount === 0) {
+        anticipatedKeyboardHeight = 0;
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- `useVisibleViewport` now takes the keyboard height from the Capacitor plugin's `keyboardWillShow` event, so the app shell resizes as the keyboard animates instead of waiting for the plugin's deferred native frame resize.
- The anticipated height is superseded by the derived `visualViewport` value as soon as the native resize lands, so there is no second jump and no double-shrink.
- Hide keeps using the derived path, which is already near-instant. Mobile Safari and desktop are untouched: the subscription is a no-op off the iOS shell.

Part of plan: ios-keyboard-lag-and-floating-sidebar.md (PR 2 of 5)