### PR TITLE
web: proactive low-credits composer banner (session-dismissable)

### DIFF
--- a/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
@@ -55,6 +55,26 @@ describe("BillingErrorBanner", () => {
     expect(queryByTestId("banner-icon")).toBeNull();
   });
 
+  test("renders a dismiss button only when onDismiss is provided", () => {
+    const onAction = mock(() => {});
+    const onDismiss = mock(() => {});
+
+    const { getByRole } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
   test("exposes role=status with the provided aria-label", () => {
     const { getByRole } = render(
       <BillingErrorBanner

--- a/clients/web/src/domains/chat/components/billing-error-banner.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { X } from "lucide-react";
+
 import { Button } from "@vellumai/design-library";
 
 interface BillingErrorBannerProps {
@@ -9,6 +11,8 @@ interface BillingErrorBannerProps {
   subtitle: string;
   ctaLabel: string;
   onAction: () => void;
+  /** When provided, renders a small dismiss (X) button after the CTA. */
+  onDismiss?: () => void;
   /**
    * Render as a standalone, centered card ~24px narrower than the composer with
    * full rounding, instead of a full-width banner flush-mounted above the
@@ -24,6 +28,7 @@ export function BillingErrorBanner({
   subtitle,
   ctaLabel,
   onAction,
+  onDismiss,
   detached = false,
 }: BillingErrorBannerProps) {
   return (
@@ -69,7 +74,7 @@ export function BillingErrorBanner({
           </p>
         </div>
 
-        <div className="flex items-center shrink-0">
+        <div className="flex items-center gap-1 shrink-0">
           <Button
             variant="primary"
             size="regular"
@@ -78,6 +83,16 @@ export function BillingErrorBanner({
           >
             {ctaLabel}
           </Button>
+          {onDismiss ? (
+            <Button
+              variant="ghost"
+              size="compact"
+              iconOnly={<X />}
+              tooltip="Dismiss"
+              aria-label="Dismiss"
+              onClick={onDismiss}
+            />
+          ) : null}
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -74,6 +74,10 @@ import { ComposerSettingsMenu } from "@/domains/chat/components/composer-setting
 import { ContextWindowIndicator } from "@/domains/chat/components/context-window-indicator";
 import { CreditsExhaustedBanner } from "@/domains/chat/components/credits-exhausted-banner";
 import { DailyLimitBanner } from "@/domains/chat/components/daily-limit-banner";
+import {
+  LowBalanceBanner,
+  shouldShowLowBalanceBanner,
+} from "@/domains/chat/components/low-balance-banner";
 import { MicPermissionPrimer } from "@/domains/chat/components/mic-permission-primer";
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner";
@@ -110,6 +114,7 @@ import {
   isBillingCtaUpgradeArm,
   useBillingCtaExperimentArm,
 } from "@/hooks/use-billing-cta-experiment";
+import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useIsFreePlan } from "@/hooks/use-is-free-plan";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import type {
@@ -152,6 +157,7 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
+import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
 
 // ---------------------------------------------------------------------------
 // Props — only values that cannot be owned locally
@@ -1026,6 +1032,17 @@ export function ChatMainPanel({
   const billingBannerDecision =
     errorBillingBannerDecision ?? noticeBillingBannerDecision;
 
+  // Single balance-status read shared by every proactive billing surface in
+  // this component. Error-driven banners always take precedence over the
+  // proactive low-balance warning.
+  const balanceStatus = useBillingBalanceStatus();
+  const lowBalanceBannerDismissed = useLowBalanceBannerStore.use.dismissed();
+  const showLowBalanceBanner = shouldShowLowBalanceBanner({
+    billingBannerDecision,
+    isLowBalance: balanceStatus.isLowBalance,
+    dismissed: lowBalanceBannerDismissed,
+  });
+
   // Credit-paywall CTA: single CTA gated by experiment arm + plan. Only fetch
   // the subscription when the credit paywall is actually shown.
   const billingCtaArm = useBillingCtaExperimentArm();
@@ -1111,8 +1128,9 @@ export function ChatMainPanel({
       textareaMaxHeightPx={isEmptyConversation ? 320 : undefined}
       suggestion={suggestion}
       hasBillingBanner={
-        billingBannerDecision !== null &&
-        billingBannerDecision !== "managed_credits"
+        (billingBannerDecision !== null &&
+          billingBannerDecision !== "managed_credits") ||
+        showLowBalanceBanner
       }
       thresholdPickerSlot={
         assistantId ? (
@@ -1182,6 +1200,10 @@ export function ChatMainPanel({
                 />
               ) : billingBannerDecision === "provider_billing" ? (
                 <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
+              ) : showLowBalanceBanner ? (
+                <LowBalanceBanner
+                  onAddCredits={() => setShowAddCreditsModal(true)}
+                />
               ) : null
             }
             diskPressureBanner={diskPressureBannerSlot}

--- a/clients/web/src/domains/chat/components/low-balance-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/low-balance-banner.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for the proactive low-balance composer banner: the rendered banner
+ * (copy, CTA, session dismissal via the store) and the visibility rule
+ * `shouldShowLowBalanceBanner` that `chat-route-content` gates the slot with.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the buttons with `fireEvent`. No jest-dom matchers: we assert
+ * with plain bun `expect` against query results.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { ChatBillingBannerDecision } from "@/domains/chat/utils/error-classification";
+import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
+
+import {
+  LowBalanceBanner,
+  shouldShowLowBalanceBanner,
+} from "./low-balance-banner";
+
+beforeEach(() => {
+  useLowBalanceBannerStore.setState({ dismissed: false });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LowBalanceBanner", () => {
+  test("renders the low-credits copy with an Add credits CTA", () => {
+    const onAddCredits = mock(() => {});
+
+    const { getByText, getByRole } = render(
+      <LowBalanceBanner onAddCredits={onAddCredits} />,
+    );
+
+    expect(getByText("Your credits are running low")).toBeTruthy();
+    expect(getByText("Add credits to avoid an interruption.")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "Add credits" }));
+    expect(onAddCredits).toHaveBeenCalledTimes(1);
+    expect(useLowBalanceBannerStore.getState().dismissed).toBe(false);
+  });
+
+  test("the dismiss button latches the session dismissal in the store", () => {
+    const { getByRole } = render(<LowBalanceBanner onAddCredits={() => {}} />);
+
+    fireEvent.click(getByRole("button", { name: "Dismiss" }));
+    expect(useLowBalanceBannerStore.getState().dismissed).toBe(true);
+  });
+});
+
+describe("shouldShowLowBalanceBanner", () => {
+  const visibleArgs = {
+    billingBannerDecision: null,
+    isLowBalance: true,
+    dismissed: false,
+  };
+
+  test("shows only in the warn band with no error banner and no dismissal", () => {
+    expect(shouldShowLowBalanceBanner(visibleArgs)).toBe(true);
+  });
+
+  test("hidden when the server flag is off (normal balance, auto-top-up, or gated-off query)", () => {
+    expect(
+      shouldShowLowBalanceBanner({ ...visibleArgs, isLowBalance: false }),
+    ).toBe(false);
+  });
+
+  test("hidden after a session dismissal", () => {
+    expect(
+      shouldShowLowBalanceBanner({ ...visibleArgs, dismissed: true }),
+    ).toBe(false);
+  });
+
+  test("hidden while any error-driven billing banner decision is active", () => {
+    const decisions: ChatBillingBannerDecision[] = [
+      "managed_credits",
+      "provider_billing",
+      "daily_limit",
+    ];
+    for (const billingBannerDecision of decisions) {
+      expect(
+        shouldShowLowBalanceBanner({ ...visibleArgs, billingBannerDecision }),
+      ).toBe(false);
+    }
+  });
+});

--- a/clients/web/src/domains/chat/components/low-balance-banner.tsx
+++ b/clients/web/src/domains/chat/components/low-balance-banner.tsx
@@ -1,0 +1,47 @@
+import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+import type { ChatBillingBannerDecision } from "@/domains/chat/utils/error-classification";
+import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
+
+/**
+ * Whether the proactive low-balance banner may render: only when no
+ * error-driven billing banner is active (those always take precedence), the
+ * server reports `low_balance_warning`, and the user has not dismissed the
+ * banner this session. The exhausted-credits surfaces never overlap with this
+ * one: the server keeps `low_balance_warning` false while the balance is
+ * exhausted, and it is false for auto-top-up orgs and whenever the billing
+ * query is gated off.
+ */
+export function shouldShowLowBalanceBanner(args: {
+  billingBannerDecision: ChatBillingBannerDecision | null;
+  isLowBalance: boolean;
+  dismissed: boolean;
+}): boolean {
+  return (
+    args.billingBannerDecision === null && args.isLowBalance && !args.dismissed
+  );
+}
+
+interface LowBalanceBannerProps {
+  onAddCredits: () => void;
+}
+
+/**
+ * Proactive composer-flush banner shown while the org's credit balance sits in
+ * the server-computed warn band. Copy is deliberately phrased around the flag
+ * rather than the numbers: `low_balance_warning` compares the raw balance
+ * while display fields are rounded, so near band edges the displayed balance
+ * can equal or exceed the displayed threshold while the flag is true.
+ */
+export function LowBalanceBanner({ onAddCredits }: LowBalanceBannerProps) {
+  const dismiss = useLowBalanceBannerStore.use.dismiss();
+  return (
+    <BillingErrorBanner
+      ariaLabel="Your credits are running low. Add credits to avoid an interruption."
+      title="Your credits are running low"
+      subtitle="Add credits to avoid an interruption."
+      ctaLabel="Add credits"
+      onAction={onAddCredits}
+      onDismiss={dismiss}
+    />
+  );
+}

--- a/clients/web/src/stores/low-balance-banner-store.test.ts
+++ b/clients/web/src/stores/low-balance-banner-store.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
+
+beforeEach(() => {
+  useLowBalanceBannerStore.setState({ dismissed: false });
+});
+
+describe("useLowBalanceBannerStore", () => {
+  it("starts undismissed", () => {
+    expect(useLowBalanceBannerStore.getState().dismissed).toBe(false);
+  });
+
+  it("dismiss() latches dismissed on for the session", () => {
+    useLowBalanceBannerStore.getState().dismiss();
+    expect(useLowBalanceBannerStore.getState().dismissed).toBe(true);
+
+    // Idempotent: repeated dismissals keep the latch set.
+    useLowBalanceBannerStore.getState().dismiss();
+    expect(useLowBalanceBannerStore.getState().dismissed).toBe(true);
+  });
+
+  it("exposes a reactive dismissed selector", () => {
+    const { result } = renderHook(useLowBalanceBannerStore.use.dismissed);
+    expect(result.current).toBe(false);
+
+    act(() => useLowBalanceBannerStore.getState().dismiss());
+    expect(result.current).toBe(true);
+  });
+});

--- a/clients/web/src/stores/low-balance-banner-store.ts
+++ b/clients/web/src/stores/low-balance-banner-store.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+/**
+ * Zustand store for the session-scoped dismissal of the proactive low-balance
+ * composer banner. "Session" means until the page or app reloads: the store is
+ * deliberately in-memory only (no persistence), so a fresh load shows the
+ * banner again while the server still reports a low balance.
+ *
+ * Reference: {@link https://zustand.docs.pmnd.rs/}
+ */
+interface LowBalanceBannerState {
+  /** True once the user dismisses the banner for the rest of this session. */
+  dismissed: boolean;
+}
+
+interface LowBalanceBannerActions {
+  dismiss: () => void;
+}
+
+const useLowBalanceBannerStoreBase = create<
+  LowBalanceBannerState & LowBalanceBannerActions
+>()((set) => ({
+  dismissed: false,
+
+  dismiss: () => set({ dismissed: true }),
+}));
+
+export const useLowBalanceBannerStore = createSelectors(
+  useLowBalanceBannerStoreBase,
+);


### PR DESCRIPTION
## Summary
- New LowBalanceBanner shown when the server reports low_balance_warning
- In-memory session dismissal store; error-driven banners always take precedence
- No banner for auto-top-up users (server flag) or self-hosted (gating)

Part of plan: credits-ux.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->