### PR TITLE
web: in-transcript credits upsell card for credits-exhausted error rows

### DIFF
--- a/clients/web/src/domains/chat/components/credits-upsell-card.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.test.tsx
@@ -3,17 +3,22 @@
  * its own CTA mode (experiment arm + plan) and owns its Add Credits modal.
  *
  * The mode inputs are mocked at the hook seam (`useBillingCtaExperimentArm`,
- * `useIsFreePlan`) and toggled per-test: `mock.module` is process-global, so
- * a second registration would leak into the rest of the file. `useNavigate`
- * is mocked so the View-plans wiring can be asserted without a Router, and
- * the lazy `AddCreditsModal` is stubbed so opening it needs no query client.
+ * `useIsFreePlan`, `usePlatformGate`) and toggled per-test: `mock.module` is
+ * process-global, so a second registration would leak into the rest of the
+ * file. `useNavigate` is mocked so the View-plans wiring can be asserted
+ * without a Router, `PlatformLoginNotice` is stubbed (its login flow needs a
+ * Router + auth context), and the lazy `AddCreditsModal` is stubbed so
+ * opening it needs no query client.
  */
+import type { ReactNode } from "react";
 import * as reactRouter from "react-router";
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import * as billingCtaExperiment from "@/hooks/use-billing-cta-experiment";
+import * as platformGateModule from "@/hooks/use-platform-gate";
+import type { PlatformGateState } from "@/hooks/use-platform-gate";
 
 let navigateTargets: unknown[] = [];
 mock.module("react-router", () => ({
@@ -30,8 +35,24 @@ mock.module("@/hooks/use-billing-cta-experiment", () => ({
 }));
 
 let isFreePlan: boolean | undefined = true;
+let freePlanEnabledArgs: unknown[] = [];
 mock.module("@/hooks/use-is-free-plan", () => ({
-  useIsFreePlan: () => isFreePlan,
+  useIsFreePlan: (enabled?: boolean) => {
+    freePlanEnabledArgs.push(enabled);
+    return isFreePlan;
+  },
+}));
+
+let platformGate: PlatformGateState = "full";
+mock.module("@/hooks/use-platform-gate", () => ({
+  ...platformGateModule,
+  usePlatformGate: () => platformGate,
+}));
+
+mock.module("@/components/platform-login-notice", () => ({
+  PlatformLoginNotice: ({ children }: { children: ReactNode }) => (
+    <div data-testid="platform-login-notice-stub">{children}</div>
+  ),
 }));
 
 mock.module("@/components/add-credits-modal", () => ({
@@ -46,6 +67,8 @@ beforeEach(() => {
   navigateTargets = [];
   arm = "control";
   isFreePlan = true;
+  freePlanEnabledArgs = [];
+  platformGate = "full";
 });
 
 afterEach(() => {
@@ -76,7 +99,9 @@ describe("CreditsUpsellCard", () => {
     );
 
     expect(getByText("You’re out of credits")).toBeTruthy();
-    expect(getByText("Add credits to pick up where you left off.")).toBeTruthy();
+    expect(
+      getByText("Add credits to pick up where you left off."),
+    ).toBeTruthy();
 
     fireEvent.click(getByRole("button", { name: "Add credits" }));
     expect(await findByTestId("add-credits-modal-stub")).toBeTruthy();
@@ -102,5 +127,37 @@ describe("CreditsUpsellCard", () => {
   test("renders the leading credits icon", () => {
     const { getByText } = render(<CreditsUpsellCard />);
     expect(getByText("💰")).toBeTruthy();
+  });
+
+  test("full gate enables the subscription fetch behind useIsFreePlan", () => {
+    render(<CreditsUpsellCard />);
+    expect(freePlanEnabledArgs).toEqual([true]);
+  });
+
+  test("disabled gate renders the login treatment instead of a billing CTA", () => {
+    platformGate = "disabled";
+
+    const { getByTestId, getByText, queryByRole } = render(
+      <CreditsUpsellCard />,
+    );
+
+    expect(getByTestId("platform-login-notice-stub")).toBeTruthy();
+    expect(
+      getByText("Log in to the Vellum platform to add credits."),
+    ).toBeTruthy();
+    expect(queryByRole("button", { name: "Add credits" })).toBeNull();
+    expect(queryByRole("button", { name: "View plans" })).toBeNull();
+    // No platform session means the subscription request would go out
+    // unauthenticated; the gate must keep the fetch disabled.
+    expect(freePlanEnabledArgs).toEqual([false]);
+  });
+
+  test("gated (self-hosted assistant) renders nothing", () => {
+    platformGate = "gated";
+
+    const { container } = render(<CreditsUpsellCard />);
+
+    expect(container.innerHTML).toBe("");
+    expect(freePlanEnabledArgs).toEqual([false]);
   });
 });

--- a/clients/web/src/domains/chat/components/credits-upsell-card.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for `CreditsUpsellCard`, the in-transcript credit wall that resolves
+ * its own CTA mode (experiment arm + plan) and owns its Add Credits modal.
+ *
+ * The mode inputs are mocked at the hook seam (`useBillingCtaExperimentArm`,
+ * `useIsFreePlan`) and toggled per-test: `mock.module` is process-global, so
+ * a second registration would leak into the rest of the file. `useNavigate`
+ * is mocked so the View-plans wiring can be asserted without a Router, and
+ * the lazy `AddCreditsModal` is stubbed so opening it needs no query client.
+ */
+import * as reactRouter from "react-router";
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import * as billingCtaExperiment from "@/hooks/use-billing-cta-experiment";
+
+let navigateTargets: unknown[] = [];
+mock.module("react-router", () => ({
+  ...reactRouter,
+  useNavigate: () => (to: unknown) => {
+    navigateTargets.push(to);
+  },
+}));
+
+let arm = "control";
+mock.module("@/hooks/use-billing-cta-experiment", () => ({
+  ...billingCtaExperiment,
+  useBillingCtaExperimentArm: () => arm,
+}));
+
+let isFreePlan: boolean | undefined = true;
+mock.module("@/hooks/use-is-free-plan", () => ({
+  useIsFreePlan: () => isFreePlan,
+}));
+
+mock.module("@/components/add-credits-modal", () => ({
+  AddCreditsModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-credits-modal-stub" /> : null,
+}));
+
+import { CreditsUpsellCard } from "./credits-upsell-card";
+import { routes } from "@/utils/routes";
+
+beforeEach(() => {
+  navigateTargets = [];
+  arm = "control";
+  isFreePlan = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreditsUpsellCard", () => {
+  test("upgrade arm + free plan renders the View plans CTA and navigates to plans", () => {
+    arm = "upgrade-cta";
+
+    const { getByRole, getByText, queryByTestId } = render(
+      <CreditsUpsellCard />,
+    );
+
+    expect(getByText("You’re out of Free credits")).toBeTruthy();
+    expect(
+      getByText("Upgrade your plan to keep the conversation going."),
+    ).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "View plans" }));
+    expect(navigateTargets).toEqual([routes.plans]);
+    expect(queryByTestId("add-credits-modal-stub")).toBeNull();
+  });
+
+  test("free plan outside the upgrade arm renders the Add credits CTA and opens the modal", async () => {
+    const { getByRole, getByText, findByTestId } = render(
+      <CreditsUpsellCard />,
+    );
+
+    expect(getByText("You’re out of credits")).toBeTruthy();
+    expect(getByText("Add credits to pick up where you left off.")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "Add credits" }));
+    expect(await findByTestId("add-credits-modal-stub")).toBeTruthy();
+    expect(navigateTargets).toEqual([]);
+  });
+
+  test("paid or unresolved plan renders the Add credits CTA even in the upgrade arm", async () => {
+    arm = "upgrade-cta";
+    isFreePlan = undefined;
+
+    const { findByTestId, getByRole, getByText, queryByRole } = render(
+      <CreditsUpsellCard />,
+    );
+
+    expect(getByText("You’re out of credits")).toBeTruthy();
+    expect(queryByRole("button", { name: "View plans" })).toBeNull();
+
+    fireEvent.click(getByRole("button", { name: "Add credits" }));
+    expect(await findByTestId("add-credits-modal-stub")).toBeTruthy();
+    expect(navigateTargets).toEqual([]);
+  });
+
+  test("renders the leading credits icon", () => {
+    const { getByText } = render(<CreditsUpsellCard />);
+    expect(getByText("💰")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/credits-upsell-card.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.tsx
@@ -1,7 +1,9 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, useState } from "react";
 
 import { useNavigate } from "react-router";
 
+import { LazyBoundary } from "@/components/lazy-boundary";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
 import {
   resolveCreditPaywallCta,
@@ -12,6 +14,7 @@ import {
   useBillingCtaExperimentArm,
 } from "@/hooks/use-billing-cta-experiment";
 import { useIsFreePlan } from "@/hooks/use-is-free-plan";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { routes } from "@/utils/routes";
 
 // Lazy for the same reason as the composer-banner mount in
@@ -55,13 +58,39 @@ export function CreditsUpsellCard() {
   const navigate = useNavigate();
   const [showAddCredits, setShowAddCredits] = useState(false);
 
+  // Managed credits are platform-hosted billing, so the card follows the
+  // platform-hosted gate (like `MaintenanceModeBanner` and the billing
+  // settings tab): "full" renders the real CTA, "disabled" renders the login
+  // treatment, "gated" renders nothing. The gate also keys the subscription
+  // fetch inside `useIsFreePlan` — without a platform session `useIsOrgReady`
+  // still reports ready, so an ungated fetch would fire unauthenticated.
+  const platformGate = usePlatformGate({ platformHostedOnly: true });
   const billingCtaArm = useBillingCtaExperimentArm();
-  const isFreePlan = useIsFreePlan(true);
+  const isFreePlan = useIsFreePlan(platformGate === "full");
   const mode = resolveCreditPaywallCta({
     isUpgradeArm: isBillingCtaUpgradeArm(billingCtaArm),
     isFreePlan,
   });
   const copy = COPY[mode];
+
+  if (platformGate === "gated") {
+    // Self-hosted active assistant: managed-credits billing has no meaning
+    // here, and every recovery action the card could offer targets the
+    // platform. (Credits-exhausted rows are only persisted by managed
+    // billing, so this state is a defensive rail, not a normal path.)
+    return null;
+  }
+
+  if (platformGate === "disabled") {
+    // Platform reachable but no platform session (e.g. it expired): the
+    // add-credits / view-plans CTAs cannot complete a billing request, so
+    // offer the shared login affordance instead of a dead-end CTA.
+    return (
+      <PlatformLoginNotice className="mx-auto max-w-[calc(100%-24px)]">
+        Log in to the Vellum platform to add credits.
+      </PlatformLoginNotice>
+    );
+  }
 
   return (
     <>
@@ -79,12 +108,12 @@ export function CreditsUpsellCard() {
         detached={true}
       />
       {showAddCredits ? (
-        <Suspense fallback={null}>
+        <LazyBoundary>
           <AddCreditsModal
             open={showAddCredits}
             onOpenChange={setShowAddCredits}
           />
-        </Suspense>
+        </LazyBoundary>
       ) : null}
     </>
   );

--- a/clients/web/src/domains/chat/components/credits-upsell-card.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.tsx
@@ -1,0 +1,91 @@
+import { lazy, Suspense, useState } from "react";
+
+import { useNavigate } from "react-router";
+
+import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+import {
+  resolveCreditPaywallCta,
+  type CreditPaywallCtaMode,
+} from "@/domains/chat/utils/credit-paywall-cta";
+import {
+  isBillingCtaUpgradeArm,
+  useBillingCtaExperimentArm,
+} from "@/hooks/use-billing-cta-experiment";
+import { useIsFreePlan } from "@/hooks/use-is-free-plan";
+import { routes } from "@/utils/routes";
+
+// Lazy for the same reason as the composer-banner mount in
+// `active-chat-view.tsx`: the Stripe checkout modal stays out of the chat
+// bundle until a CTA actually opens it.
+const AddCreditsModal = lazy(() =>
+  import("@/components/add-credits-modal").then((m) => ({
+    default: m.AddCreditsModal,
+  })),
+);
+
+// Both add-credits modes share one copy set; the free/paid split only matters
+// for the harder-sell composer banner this card's wording deliberately softens.
+const ADD_CREDITS_COPY = {
+  title: "You’re out of credits",
+  subtitle: "Add credits to pick up where you left off.",
+  ctaLabel: "Add credits",
+};
+
+const COPY: Record<
+  CreditPaywallCtaMode,
+  { title: string; subtitle: string; ctaLabel: string }
+> = {
+  upgrade: {
+    title: "You’re out of Free credits",
+    subtitle: "Upgrade your plan to keep the conversation going.",
+    ctaLabel: "View plans",
+  },
+  "add-credits-free": ADD_CREDITS_COPY,
+  "add-credits-paid": ADD_CREDITS_COPY,
+};
+
+/**
+ * Friendly credits upsell card: a single-CTA credit wall built on
+ * {@link BillingErrorBanner}, rendered in the transcript in place of a
+ * persisted credits-exhausted provider-error row. Self-contained (it resolves
+ * its own CTA mode and mounts its own {@link AddCreditsModal} instance), so it
+ * can also be mounted outside the transcript with no transcript-specific props.
+ */
+export function CreditsUpsellCard() {
+  const navigate = useNavigate();
+  const [showAddCredits, setShowAddCredits] = useState(false);
+
+  const billingCtaArm = useBillingCtaExperimentArm();
+  const isFreePlan = useIsFreePlan(true);
+  const mode = resolveCreditPaywallCta({
+    isUpgradeArm: isBillingCtaUpgradeArm(billingCtaArm),
+    isFreePlan,
+  });
+  const copy = COPY[mode];
+
+  return (
+    <>
+      <BillingErrorBanner
+        ariaLabel={`${copy.title}. ${copy.subtitle}`}
+        icon={<span className="text-lg opacity-80">💰</span>}
+        title={copy.title}
+        subtitle={copy.subtitle}
+        ctaLabel={copy.ctaLabel}
+        onAction={
+          mode === "upgrade"
+            ? () => void navigate(routes.plans)
+            : () => setShowAddCredits(true)
+        }
+        detached={true}
+      />
+      {showAddCredits ? (
+        <Suspense fallback={null}>
+          <AddCreditsModal
+            open={showAddCredits}
+            onOpenChange={setShowAddCredits}
+          />
+        </Suspense>
+      ) : null}
+    </>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -643,6 +643,90 @@ describe("buildTranscriptItems", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Provider-error rows: credits-exhausted substitution
+  // ---------------------------------------------------------------------------
+
+  test("credits-exhausted provider-error rows emit a creditsUpsell item instead of a message row", () => {
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
+    const errorRow = makeMessage({
+      id: "m2",
+      role: "assistant",
+      ...textBody("I hit a snag: your credits ran out."),
+      providerError: { code: "PROVIDER_BILLING", category: "credits_exhausted" },
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [user, errorRow],
+    });
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toEqual({ kind: "message", key: "m1", message: user });
+    expect(items[1]).toEqual({
+      kind: "creditsUpsell",
+      key: "credits-upsell-m2",
+      messageId: "m2",
+    });
+    expectDistinctNonEmptyKeys(items);
+  });
+
+  test("provider-error rows of other categories keep the normal message rendering", () => {
+    const errorRow = makeMessage({
+      id: "m1",
+      role: "assistant",
+      ...textBody("The provider rejected the request."),
+      providerError: { code: "PROVIDER_ERROR", category: "rate_limited" },
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [errorRow],
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({
+      kind: "message",
+      key: "m1",
+      message: errorRow,
+    });
+  });
+
+  test("untagged rows (no providerError) keep the normal message rendering", () => {
+    const plain = makeMessage({
+      id: "m1",
+      role: "assistant",
+      ...textBody("A plain historical error bubble."),
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [plain],
+    });
+
+    expect(items).toHaveLength(1);
+    expect((items[0] as MessageItem).message).toBe(plain);
+  });
+
+  test("returns stable creditsUpsell item references for unchanged message objects across calls", () => {
+    const errorRow = makeMessage({
+      id: "m1",
+      role: "assistant",
+      providerError: { category: "credits_exhausted" },
+    });
+
+    const first = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [errorRow],
+    });
+    const second = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [errorRow],
+    });
+
+    expect(second[0]).toBe(first[0]!);
+  });
+
+  // ---------------------------------------------------------------------------
   // Confirmation path — inline attachment vs standalone fallback
   // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -7,6 +7,7 @@ import type {
   TranscriptItem,
 } from "@/domains/chat/transcript/types";
 
+import { mergeAdjacentAssistantMessages } from "@/domains/chat/utils/message-merge";
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 function makeMessage(
   overrides: Omit<DisplayMessage, "id"> & { id?: string },
@@ -652,7 +653,10 @@ describe("buildTranscriptItems", () => {
       id: "m2",
       role: "assistant",
       ...textBody("I hit a snag: your credits ran out."),
-      providerError: { code: "PROVIDER_BILLING", category: "credits_exhausted" },
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
     });
 
     const items = buildTranscriptItems({
@@ -662,6 +666,89 @@ describe("buildTranscriptItems", () => {
 
     expect(items).toHaveLength(2);
     expect(items[0]).toEqual({ kind: "message", key: "m1", message: user });
+    expect(items[1]).toEqual({
+      kind: "creditsUpsell",
+      key: "credits-upsell-m2",
+      messageId: "m2",
+    });
+    expectDistinctNonEmptyKeys(items);
+  });
+
+  test("code-only provider-error rows (no category) substitute the card too", () => {
+    // The daemon builds `providerError` with each field conditional on being
+    // a string, so a persisted row can carry a bare PROVIDER_BILLING code.
+    // The substitution shares `isCreditsExhaustedProviderError` with the live
+    // composer banner, which accepts that shape as managed credits.
+    const errorRow = makeMessage({
+      id: "m1",
+      role: "assistant",
+      ...textBody("I hit a snag: your credits ran out."),
+      providerError: { code: "PROVIDER_BILLING" },
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [errorRow],
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({
+      kind: "creditsUpsell",
+      key: "credits-upsell-m1",
+      messageId: "m1",
+    });
+  });
+
+  test("empty provider-error markers (no code, no category) keep the normal message rendering", () => {
+    const errorRow = makeMessage({
+      id: "m1",
+      role: "assistant",
+      ...textBody("Something went wrong."),
+      providerError: {},
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [errorRow],
+    });
+
+    expect(items).toHaveLength(1);
+    expect((items[0] as MessageItem).message).toBe(errorRow);
+  });
+
+  test("adjacent assistant + provider-error rows survive the client fold and still substitute the card", () => {
+    // The history-pagination fold must treat provider-error rows as
+    // standalone (mirroring the daemon's `isStandaloneAssistantRow`); a fold
+    // would drop the marker and with it the card.
+    const assistant = makeMessage({
+      id: "m1",
+      role: "assistant",
+      ...textBody("Partial answer before the failure."),
+    });
+    const errorRow = makeMessage({
+      id: "m2",
+      role: "assistant",
+      ...textBody("I hit a snag: your credits ran out."),
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
+    });
+
+    const folded = mergeAdjacentAssistantMessages([assistant, errorRow]);
+    expect(folded).toHaveLength(2);
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: folded,
+    });
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toEqual({
+      kind: "message",
+      key: "m1",
+      message: assistant,
+    });
     expect(items[1]).toEqual({
       kind: "creditsUpsell",
       key: "credits-upsell-m2",

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -13,7 +13,7 @@ import type {
   PendingContactRequestItem,
   TranscriptItem,
 } from "@/domains/chat/transcript/types";
-import { isCreditsExhaustedCategory } from "@/domains/chat/utils/error-classification";
+import { isCreditsExhaustedProviderError } from "@/domains/chat/utils/error-classification";
 
 export interface BuildTranscriptItemsInput {
   messages: DisplayMessage[];
@@ -151,9 +151,12 @@ export function buildTranscriptItems(
     // Persisted credits-exhausted provider-error rows render as the friendly
     // upsell card instead of a plain persona bubble. The row itself stays in
     // `messages` (history and the LLM context keep the text); only its
-    // transcript rendering is substituted. Provider errors of any other
-    // category, and untagged rows, keep the normal message rendering.
-    if (isCreditsExhaustedCategory(message.providerError?.category)) {
+    // transcript rendering is substituted. Classification is shared with the
+    // live composer banner (`isCreditsExhaustedProviderError`), so a bare
+    // `PROVIDER_BILLING` code with no category substitutes too. Provider
+    // errors of any other category, and untagged rows, keep the normal
+    // message rendering.
+    if (isCreditsExhaustedProviderError(message.providerError)) {
       items.push(toCreditsUpsellItem(message));
       continue;
     }

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -8,10 +8,12 @@ import type {
   EphemeralMetaResult,
 } from "@/domains/chat/types/types";
 import type {
+  CreditsUpsellItem,
   MessageItem,
   PendingContactRequestItem,
   TranscriptItem,
 } from "@/domains/chat/transcript/types";
+import { isCreditsExhaustedCategory } from "@/domains/chat/utils/error-classification";
 
 export interface BuildTranscriptItemsInput {
   messages: DisplayMessage[];
@@ -74,6 +76,24 @@ function toMessageItem(message: DisplayMessage): MessageItem {
   return item;
 }
 
+/** Same ref-keyed memoization as {@link toMessageItem}, for the upsell items
+ *  substituted in place of credits-exhausted provider-error rows. */
+const creditsUpsellItemCache = new WeakMap<DisplayMessage, CreditsUpsellItem>();
+
+function toCreditsUpsellItem(message: DisplayMessage): CreditsUpsellItem {
+  const cached = creditsUpsellItemCache.get(message);
+  if (cached) {
+    return cached;
+  }
+  const item: CreditsUpsellItem = {
+    kind: "creditsUpsell",
+    key: `credits-upsell-${message.clientMessageId ?? message.id}`,
+    messageId: message.id,
+  };
+  creditsUpsellItemCache.set(message, item);
+  return item;
+}
+
 /**
  * Project the chat state into an ordered flat list of transcript items.
  *
@@ -125,6 +145,16 @@ export function buildTranscriptItems(
       message.role === "user" && message.queueStatus === "queued";
 
     if (isQueuedUser) {
+      continue;
+    }
+
+    // Persisted credits-exhausted provider-error rows render as the friendly
+    // upsell card instead of a plain persona bubble. The row itself stays in
+    // `messages` (history and the LLM context keep the text); only its
+    // transcript rendering is substituted. Provider errors of any other
+    // category, and untagged rows, keep the normal message rendering.
+    if (isCreditsExhaustedCategory(message.providerError?.category)) {
+      items.push(toCreditsUpsellItem(message));
       continue;
     }
 

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Dispatch tests for `TranscriptRow`'s `creditsUpsell` kind. The card itself
+ * is stubbed (its CTA behavior is covered by `credits-upsell-card.test.tsx`);
+ * these tests pin that the transcript renders the substituted item through the
+ * card component rather than any message-body machinery.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+mock.module("@/domains/chat/components/credits-upsell-card", () => ({
+  CreditsUpsellCard: () => <div data-testid="credits-upsell-card-stub" />,
+}));
+
+import { TranscriptRow } from "@/domains/chat/transcript/transcript-row";
+import type { CreditsUpsellItem } from "@/domains/chat/transcript/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TranscriptRow creditsUpsell dispatch", () => {
+  test("renders a creditsUpsell item via CreditsUpsellCard", () => {
+    const item: CreditsUpsellItem = {
+      kind: "creditsUpsell",
+      key: "credits-upsell-m1",
+      messageId: "m1",
+    };
+
+    const { getByTestId } = render(
+      <TranscriptRow item={item} onSurfaceAction={() => {}} />,
+    );
+
+    expect(getByTestId("credits-upsell-card-stub")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -1,6 +1,7 @@
 import { memo, type ReactNode } from "react";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { CreditsUpsellCard } from "@/domains/chat/components/credits-upsell-card";
 import { StreamingShimmerText } from "@/domains/chat/components/streaming-shimmer-text";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
@@ -206,6 +207,12 @@ export const TranscriptRow = memo(function TranscriptRow({
         return <>{renderOnboardingChoice()}</>;
       }
       return null;
+
+    case "creditsUpsell":
+      // Substituted in place of a credits-exhausted provider-error row by
+      // `buildTranscriptItems`: a standalone card, outside the persona
+      // bubble/avatar/hover-action machinery like `SystemCardRow`.
+      return <CreditsUpsellCard />;
 
     default: {
       // Exhaustiveness guard — TypeScript narrows `item` to `never` here.

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -19,7 +19,8 @@ export type TranscriptItemKind =
   | "pendingContactRequest"
   | "surface"
   | "ephemeralMeta"
-  | "onboardingChoice";
+  | "onboardingChoice"
+  | "creditsUpsell";
 
 export interface TranscriptItemBase {
   key: string;
@@ -77,6 +78,16 @@ export interface OnboardingChoiceItem extends TranscriptItemBase {
   kind: "onboardingChoice";
 }
 
+/** Friendly credits upsell card, emitted in place of a persisted
+ *  credits-exhausted provider-error row (`providerError.category` matching
+ *  `credits_exhausted`). The row's text stays in message state (the LLM
+ *  transcript keeps it); only the rendering is substituted. */
+export interface CreditsUpsellItem extends TranscriptItemBase {
+  kind: "creditsUpsell";
+  /** Id of the provider-error message row this card renders in place of. */
+  messageId: string;
+}
+
 export interface EphemeralMetaItem extends TranscriptItemBase {
   kind: "ephemeralMeta";
   result: EphemeralMetaResult;
@@ -90,7 +101,8 @@ export type TranscriptItem =
   | PendingContactRequestItem
   | SurfaceItem
   | EphemeralMetaItem
-  | OnboardingChoiceItem;
+  | OnboardingChoiceItem
+  | CreditsUpsellItem;
 
 /** Result of splitting the transcript into stable history and the
  *  currently-in-progress turn. `anchorMessage` is the most recent user

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -153,6 +153,13 @@ export interface DisplayMessage {
    *  summarize-up-to results). Rendered as a standalone system notice —
    *  no avatar, no persona bubble — never as assistant speech. */
   isSystemCard?: boolean;
+  /** Provider-failure notice metadata, carried from the wire
+   *  `ConversationMessage["providerError"]`. `code` is the stable classified
+   *  error code (e.g. `"PROVIDER_BILLING"`), `category` the classified
+   *  category (e.g. `"credits_exhausted"`). Credits-exhausted rows render as
+   *  the upsell card instead of a persona bubble; other categories keep the
+   *  plain rendering. */
+  providerError?: { code?: string; category?: string };
 }
 
 /**

--- a/clients/web/src/domains/chat/utils/error-classification.test.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getChatBillingBannerDecision,
+  isCreditsExhaustedProviderError,
   isManagedCredentialChatError,
   shouldShowGenericChatErrorNotice,
   shouldSuppressGenericChatErrorNotice,
@@ -106,5 +107,45 @@ describe("chat error classification", () => {
     expect(
       shouldShowGenericChatErrorNotice({ code: "X", displayAs: "inline" }),
     ).toBe(true);
+  });
+});
+
+describe("isCreditsExhaustedProviderError", () => {
+  test("matches a credits_exhausted category, including namespaced suffixes", () => {
+    expect(
+      isCreditsExhaustedProviderError({ category: "credits_exhausted" }),
+    ).toBe(true);
+    expect(
+      isCreditsExhaustedProviderError({
+        code: "PROVIDER_BILLING",
+        category: "billing.credits_exhausted",
+      }),
+    ).toBe(true);
+  });
+
+  test("matches a bare PROVIDER_BILLING code with no category", () => {
+    expect(isCreditsExhaustedProviderError({ code: "PROVIDER_BILLING" })).toBe(
+      true,
+    );
+  });
+
+  test("category wins over the code fallback when both are present", () => {
+    expect(
+      isCreditsExhaustedProviderError({
+        code: "PROVIDER_BILLING",
+        category: "provider_billing",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects empty markers, other codes, and absent input", () => {
+    // The daemon builds each providerError field conditionally, so a numeric
+    // code plus null category persists as an empty object.
+    expect(isCreditsExhaustedProviderError({})).toBe(false);
+    expect(isCreditsExhaustedProviderError({ code: "PROVIDER_ERROR" })).toBe(
+      false,
+    );
+    expect(isCreditsExhaustedProviderError(undefined)).toBe(false);
+    expect(isCreditsExhaustedProviderError(null)).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -18,6 +18,17 @@ const MANAGED_CREDITS_EXHAUSTED_CATEGORY = "credits_exhausted";
 const PROVIDER_BILLING_CATEGORY = "provider_billing";
 const DAILY_LIMIT_REACHED_CATEGORY = "daily_limit_reached";
 
+/**
+ * Whether a classified error category denotes managed-credits exhaustion.
+ * Suffix match, shared with the live-error classification below, so persisted
+ * provider-error rows and live turn errors classify identically.
+ */
+export function isCreditsExhaustedCategory(
+  category: string | undefined,
+): boolean {
+  return category?.endsWith(MANAGED_CREDITS_EXHAUSTED_CATEGORY) ?? false;
+}
+
 function isManagedCreditsExhausted(
   error: ChatErrorLike | null | undefined,
 ): boolean {
@@ -25,7 +36,7 @@ function isManagedCreditsExhausted(
     return error?.code === PROVIDER_BILLING_CODE;
   }
 
-  return error.errorCategory.endsWith(MANAGED_CREDITS_EXHAUSTED_CATEGORY);
+  return isCreditsExhaustedCategory(error.errorCategory);
 }
 
 function isProviderBilling(error: ChatErrorLike | null | undefined): boolean {

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -18,25 +18,43 @@ const MANAGED_CREDITS_EXHAUSTED_CATEGORY = "credits_exhausted";
 const PROVIDER_BILLING_CATEGORY = "provider_billing";
 const DAILY_LIMIT_REACHED_CATEGORY = "daily_limit_reached";
 
-/**
- * Whether a classified error category denotes managed-credits exhaustion.
- * Suffix match, shared with the live-error classification below, so persisted
- * provider-error rows and live turn errors classify identically.
- */
-export function isCreditsExhaustedCategory(
-  category: string | undefined,
-): boolean {
+/** Whether a classified error category denotes managed-credits exhaustion
+ *  (suffix match, so namespaced categories like `billing.credits_exhausted`
+ *  classify too). */
+function isCreditsExhaustedCategory(category: string | undefined): boolean {
   return category?.endsWith(MANAGED_CREDITS_EXHAUSTED_CATEGORY) ?? false;
+}
+
+/**
+ * Whether a provider-error marker denotes managed-credits exhaustion. The
+ * category decides when present; a bare `PROVIDER_BILLING` code with no
+ * category also classifies (the daemon builds `providerError` with each field
+ * conditional on being a string, so persisted rows can carry a code alone).
+ * Shared by the live composer-banner classification and the transcript's
+ * persisted-row substitution so the two surfaces never disagree.
+ */
+export function isCreditsExhaustedProviderError(
+  providerError: { code?: string; category?: string } | null | undefined,
+): boolean {
+  if (!providerError) {
+    return false;
+  }
+  if (!providerError.category) {
+    return providerError.code === PROVIDER_BILLING_CODE;
+  }
+  return isCreditsExhaustedCategory(providerError.category);
 }
 
 function isManagedCreditsExhausted(
   error: ChatErrorLike | null | undefined,
 ): boolean {
-  if (!error?.errorCategory) {
-    return error?.code === PROVIDER_BILLING_CODE;
+  if (!error) {
+    return false;
   }
-
-  return isCreditsExhaustedCategory(error.errorCategory);
+  return isCreditsExhaustedProviderError({
+    code: error.code,
+    category: error.errorCategory,
+  });
 }
 
 function isProviderBilling(error: ChatErrorLike | null | undefined): boolean {

--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -172,6 +172,33 @@ describe("mapRuntimeToDisplayMessage", () => {
     expect(mapRuntimeToDisplayMessage(m).isSystemCard).toBe(true);
   });
 
+  test("carries providerError code and category onto the display message", () => {
+    const plain = makeMessage({ id: "m-plain", role: "assistant" });
+    expect(mapRuntimeToDisplayMessage(plain).providerError).toBeUndefined();
+
+    const m = makeMessage({
+      id: "m-err",
+      role: "assistant",
+      providerError: { code: "PROVIDER_BILLING", category: "credits_exhausted" },
+    });
+    expect(mapRuntimeToDisplayMessage(m).providerError).toEqual({
+      code: "PROVIDER_BILLING",
+      category: "credits_exhausted",
+    });
+  });
+
+  test("carries a partial providerError (fields optional on the wire)", () => {
+    const m = makeMessage({
+      id: "m-err-partial",
+      role: "assistant",
+      providerError: { category: "rate_limited" },
+    });
+    expect(mapRuntimeToDisplayMessage(m).providerError).toEqual({
+      code: undefined,
+      category: "rate_limited",
+    });
+  });
+
   test("carries server thinkingSegments and contentOrder onto the display message", () => {
     // GIVEN a persisted assistant message whose reasoning is reconstructed
     // from history as `thinkingSegments` + a `thinking` content-order entry

--- a/clients/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.ts
@@ -186,6 +186,12 @@ export function mapRuntimeToDisplayMessage(
   if (m.systemCard) {
     msg.isSystemCard = true;
   }
+  if (m.providerError) {
+    msg.providerError = {
+      code: m.providerError.code,
+      category: m.providerError.category,
+    };
+  }
   if (m.slackMessage) {
     msg.slackMessage = m.slackMessage;
   }

--- a/clients/web/src/domains/chat/utils/message-merge.test.ts
+++ b/clients/web/src/domains/chat/utils/message-merge.test.ts
@@ -97,6 +97,57 @@ describe("mergeAdjacentAssistantMessages · happy path", () => {
   });
 });
 
+describe("mergeAdjacentAssistantMessages · standalone rows", () => {
+  test("provider-error rows never fold, in either direction", () => {
+    // Mirrors the daemon's `isStandaloneAssistantRow`: a fold keeps only the
+    // survivor's metadata, so it would drop the donor's providerError marker
+    // or absorb real assistant text into the marked row.
+    const messages = [
+      makeAssistant({
+        id: "a-1",
+        ...textBody("real answer "),
+        timestamp: 1000,
+      }),
+      makeAssistant({
+        id: "err-1",
+        ...textBody("Your credits ran out."),
+        timestamp: 1010,
+        providerError: {
+          code: "PROVIDER_BILLING",
+          category: "credits_exhausted",
+        },
+      }),
+      makeAssistant({
+        id: "a-2",
+        ...textBody("later answer"),
+        timestamp: 1020,
+      }),
+    ];
+    const result = mergeAdjacentAssistantMessages(messages);
+    expect(result.map((m) => m.id)).toEqual(["a-1", "err-1", "a-2"]);
+    expect(result[1]!.providerError).toEqual({
+      code: "PROVIDER_BILLING",
+      category: "credits_exhausted",
+    });
+  });
+
+  test("system-card rows never fold, in either direction", () => {
+    const messages = [
+      makeAssistant({ id: "a-1", ...textBody("speech "), timestamp: 1000 }),
+      makeAssistant({
+        id: "card-1",
+        ...textBody("Context compacted."),
+        timestamp: 1010,
+        isSystemCard: true,
+      }),
+      makeAssistant({ id: "a-2", ...textBody("more speech"), timestamp: 1020 }),
+    ];
+    const result = mergeAdjacentAssistantMessages(messages);
+    expect(result.map((m) => m.id)).toEqual(["a-1", "card-1", "a-2"]);
+    expect(result[1]!.isSystemCard).toBe(true);
+  });
+});
+
 describe("mergeAdjacentAssistantMessages · referential stability", () => {
   test("returns the input array (by reference) when no adjacent pair exists", () => {
     const messages = [

--- a/clients/web/src/domains/chat/utils/message-merge.ts
+++ b/clients/web/src/domains/chat/utils/message-merge.ts
@@ -208,6 +208,21 @@ function canFoldAdjacentAssistant(
   ) {
     return false;
   }
+  // Standalone display turns — mirrors the daemon's
+  // `isStandaloneAssistantRow` (message-consolidation.ts): system cards and
+  // provider-error notices never merge with adjacent assistant rows. The fold
+  // keeps only the survivor's metadata, so merging would either drop the
+  // donor's marker (a credits-exhausted row silently loses its upsell card)
+  // or stamp the survivor's marker onto a bubble holding the donor's real
+  // assistant text (the transcript substitution would then hide that text).
+  if (
+    survivor.isSystemCard ||
+    donor.isSystemCard ||
+    survivor.providerError ||
+    donor.providerError
+  ) {
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Map the daemon providerError wire field onto DisplayMessage
- New CreditsUpsellCard (BillingErrorBanner-based) with upgrade / add-credits modes
- Transcript renders credits-exhausted error rows as the card instead of a plain persona bubble

Part of plan: credits-ux.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->