### PR TITLE
feat(voice): inset the voice room into the content area (JARVIS-1378)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -837,16 +837,38 @@ export function ChatLayout({
     />
   );
 
-  // Blur + freeze the chat body under the MOBILE voice room, which is a
-  // full-viewport takeover mounted outside `<main>`. The room is an opaque
-  // overlay, so this mainly matters for the fade transition and to stop stray
-  // interaction with the covered chat. Desktop is deliberately excluded: its
-  // room is an inset panel mounted INSIDE `<main>`, so blurring `<main>` would
-  // blur the room along with the chat behind it.
+  // Blur the chat body under the MOBILE voice room, which is a full-viewport
+  // takeover mounted outside `<main>`. The room is an opaque overlay, so this
+  // mainly matters for the fade transition. Desktop is deliberately excluded:
+  // its room is an inset panel mounted INSIDE `<main>`, so blurring `<main>`
+  // would blur the room along with the chat behind it. Reachability is handled
+  // by `chatContent` below on both platforms, not here.
   const mainRoomClass =
     voiceRoomVisible && isMobile
-      ? "pointer-events-none blur-sm opacity-40 transition-[filter,opacity]"
+      ? "blur-sm opacity-40 transition-[filter,opacity]"
       : "";
+
+  // The route content, held inert while the voice room covers it.
+  //
+  // The room paints over the chat but does not remove it from the page, so
+  // without this the composer, transcript and their controls stay tabbable and
+  // screen-reader reachable behind an opaque panel. `inert` takes the whole
+  // subtree out of the tab order and the accessibility tree at once, which
+  // neither the blur nor `aria-modal` does: the desktop room is deliberately
+  // non-modal so the header and sidenav stay usable, and scoping the gate to
+  // this wrapper is what keeps that chrome reachable while the content under
+  // the panel is not.
+  //
+  // The wrapper carries `<main>`'s own flex classes so the route content sees
+  // the same flex parent it would without it.
+  const chatContent = (
+    <div
+      className="flex min-h-0 min-w-0 flex-1 flex-col"
+      inert={voiceRoomVisible}
+    >
+      <Outlet />
+    </div>
+  );
 
   return (
     <>
@@ -904,7 +926,7 @@ export function ChatLayout({
         <main
           className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
         >
-          <Outlet />
+          {chatContent}
           {/* A popout narrowed below the mobile breakpoint lands in this
               branch — still headerless, so it still needs the floating
               session surface (see the desktop popout branch below). */}
@@ -961,7 +983,7 @@ export function ChatLayout({
         <main
           className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4 ${mainRoomClass}`}
         >
-          <Outlet />
+          {chatContent}
           {/* Pop-outs render no header, but they DO support in-window
               conversation switching (Cmd+Up/Down) — so a live session started
               here can lose its owning composer exactly like in the main
@@ -1004,7 +1026,7 @@ export function ChatLayout({
           <main
             className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
           >
-            <Outlet />
+            {chatContent}
             {/* Live-voice room, desktop: an inset panel scoped to the content
                 area, so the title bar above and the sidenav beside it stay
                 visible and interactive. Self-gates on

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -837,12 +837,16 @@ export function ChatLayout({
     />
   );
 
-  // Blur + freeze the chat body under the voice room, a full-viewport
-  // takeover. The room is an opaque overlay, so this mainly matters for the
-  // fade transition and to stop stray interaction with the covered chat.
-  const mainRoomClass = voiceRoomVisible
-    ? "pointer-events-none blur-sm opacity-40 transition-[filter,opacity]"
-    : "";
+  // Blur + freeze the chat body under the MOBILE voice room, which is a
+  // full-viewport takeover mounted outside `<main>`. The room is an opaque
+  // overlay, so this mainly matters for the fade transition and to stop stray
+  // interaction with the covered chat. Desktop is deliberately excluded: its
+  // room is an inset panel mounted INSIDE `<main>`, so blurring `<main>` would
+  // blur the room along with the chat behind it.
+  const mainRoomClass =
+    voiceRoomVisible && isMobile
+      ? "pointer-events-none blur-sm opacity-40 transition-[filter,opacity]"
+      : "";
 
   return (
     <>
@@ -1001,6 +1005,12 @@ export function ChatLayout({
             className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
           >
             <Outlet />
+            {/* Live-voice room, desktop: an inset panel scoped to the content
+                area, so the title bar above and the sidenav beside it stay
+                visible and interactive. Self-gates on
+                `useIsVoiceRoomVisible()`; the composer's voice bar and
+                transcript render underneath, hidden by it. */}
+            <VoiceRoom variant="content" />
           </main>
         </div>
       )}
@@ -1011,11 +1021,12 @@ export function ChatLayout({
           overlay; it never remounts the chat, so a suggestion click's
           navigate + `?prompt=` auto-send isn't raced by a remount. */}
       {isFocused ? <ResearchResultsOverlay /> : null}
-      {/* Live-voice room — a full-viewport takeover mounted at layout scope,
-          next to the other full-viewport overlays. Self-gates on
-          `useIsVoiceRoomVisible()` (which excludes pop-outs); the composer's
-          voice bar and transcript render underneath, hidden by it. */}
-      <VoiceRoom />
+      {/* Live-voice room, mobile: still a full-viewport takeover, so it mounts
+          at layout scope next to the other full-viewport overlays rather than
+          inside `<main>` (JARVIS-1383 turns this into a bottom sheet). The
+          desktop room is the inset panel mounted inside `<main>` above; the two
+          mounts are mutually exclusive, so the room never double-mounts. */}
+      {isMobile ? <VoiceRoom variant="fullscreen" /> : null}
       {/* First step of the focused flow: the gcal "Let's chat tomorrow" page,
           shown over the streaming research output until connect/skip. Self-gates
           on `checkinPending`; top-level so it can compose the onboarding screen. */}

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
@@ -1,7 +1,7 @@
 /**
  * Single source of truth for whether the live-voice room is visible. (Placement
- * is the room's own concern — an inset panel on desktop, full-screen on mobile;
- * see `voice-room.tsx`.)
+ * is the room's own concern: an inset panel on desktop, full-screen on mobile.
+ * See `voice-room.tsx`.)
  *
  * The room is the owning-composer's voice surface: it shows exactly when a
  * session is active AND the composer currently on screen owns it AND this is
@@ -29,9 +29,9 @@
  *
  * Pop-outs: the room fills whichever box it is mounted in, so in an Electron
  * pop-out thread window it would cover the `variant="standalone"` pill that
- * headerless pop-outs rely on — insetting it to the content area doesn't help,
+ * headerless pop-outs rely on. Insetting it to the content area does not help,
  * because the content area is the whole pop-out. Pop-outs therefore never show
- * the room — the standalone
+ * the room. The standalone
  * pill is their only session surface — so the room predicate ANDs in
  * `!isPopout`. The pill keeps its own popout-free complement
  * ({@link useOwningComposerSurfaceVisible}), so in a pop-out it still hides

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
@@ -1,6 +1,7 @@
 /**
- * Single source of truth for whether the full-screen live-voice room is
- * visible.
+ * Single source of truth for whether the live-voice room is visible. (Placement
+ * is the room's own concern — an inset panel on desktop, full-screen on mobile;
+ * see `voice-room.tsx`.)
  *
  * The room is the owning-composer's voice surface: it shows exactly when a
  * session is active AND the composer currently on screen owns it AND this is
@@ -26,9 +27,11 @@
  * - `activeComposerOwnsSession` — the on-screen composer's conversation owns
  *   the session (`isLiveVoiceSessionOwnedBy`), covering the draft case too.
  *
- * Pop-outs: the room is a `fixed inset-0` overlay, so in an Electron pop-out
- * thread window it would cover the `variant="standalone"` pill that headerless
- * pop-outs rely on. Pop-outs therefore never show the room — the standalone
+ * Pop-outs: the room fills whichever box it is mounted in, so in an Electron
+ * pop-out thread window it would cover the `variant="standalone"` pill that
+ * headerless pop-outs rely on — insetting it to the content area doesn't help,
+ * because the content area is the whole pop-out. Pop-outs therefore never show
+ * the room — the standalone
  * pill is their only session surface — so the room predicate ANDs in
  * `!isPopout`. The pill keeps its own popout-free complement
  * ({@link useOwningComposerSurfaceVisible}), so in a pop-out it still hides

--- a/clients/web/src/domains/chat/voice/voice-room/use-room-box.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-room-box.test.ts
@@ -1,15 +1,15 @@
 /**
- * Tests for {@link toRoomLocal} — the viewport→room-local conversion the inset
+ * Tests for {@link toRoomLocal}, the viewport to room-local conversion the inset
  * voice room depends on.
  *
  * This is the arithmetic that stops the room's entrance from growing out of the
  * wrong place. The composer captures the entry origin in viewport coordinates
  * (a `getBoundingClientRect()` on the avatar the user tapped) and the room's
  * look positions everything against its own box, so the two only agree once the
- * point is shifted by the panel's offset. When the room was a `fixed inset-0`
- * takeover those coordinate spaces were identical and the bug was unreachable;
- * as a panel inset behind a header and sidenav, an unconverted origin is off by
- * exactly the chrome around it.
+ * point is shifted by the panel's offset. The offset is exactly the chrome the
+ * panel sits inside: skip the conversion and the entrance is off by the header
+ * and sidenav. It is zero for the fullscreen room, where the two coordinate
+ * spaces coincide.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -42,7 +42,7 @@ describe("toRoomLocal", () => {
 
   test("returns null when either input is missing", () => {
     // No origin was captured (a keyboard-started session), or the box has not
-    // been measured yet — the look falls back to its own centered origin.
+    // been measured yet. The look falls back to its own centered origin.
     expect(toRoomLocal(null, PANEL)).toBeNull();
     expect(toRoomLocal({ x: 300, y: 100 }, null)).toBeNull();
     expect(toRoomLocal(null, null)).toBeNull();

--- a/clients/web/src/domains/chat/voice/voice-room/use-room-box.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-room-box.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for {@link toRoomLocal} — the viewport→room-local conversion the inset
+ * voice room depends on.
+ *
+ * This is the arithmetic that stops the room's entrance from growing out of the
+ * wrong place. The composer captures the entry origin in viewport coordinates
+ * (a `getBoundingClientRect()` on the avatar the user tapped) and the room's
+ * look positions everything against its own box, so the two only agree once the
+ * point is shifted by the panel's offset. When the room was a `fixed inset-0`
+ * takeover those coordinate spaces were identical and the bug was unreachable;
+ * as a panel inset behind a header and sidenav, an unconverted origin is off by
+ * exactly the chrome around it.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { toRoomLocal, type RoomBox } from "./use-room-box";
+
+/** A panel inset by a 56px-tall title bar and a 260px sidenav. */
+const PANEL: RoomBox = { w: 1000, h: 700, left: 260, top: 56 };
+/** The fullscreen (mobile) room: the panel IS the viewport. */
+const FULLSCREEN: RoomBox = { w: 390, h: 844, left: 0, top: 0 };
+
+describe("toRoomLocal", () => {
+  test("shifts a viewport point by the panel's offset", () => {
+    expect(toRoomLocal({ x: 300, y: 100 }, PANEL)).toEqual({ x: 40, y: 44 });
+  });
+
+  test("is a no-op for a zero-offset (fullscreen) room", () => {
+    expect(toRoomLocal({ x: 195, y: 400 }, FULLSCREEN)).toEqual({
+      x: 195,
+      y: 400,
+    });
+  });
+
+  test("keeps a point that lands outside the panel outside it", () => {
+    // A tap in the sidenav, left of the room's left edge. Clamping this into
+    // the panel would make the entrance grow from the panel's edge instead of
+    // flying in from where the user actually tapped.
+    expect(toRoomLocal({ x: 120, y: 300 }, PANEL)).toEqual({ x: -140, y: 244 });
+  });
+
+  test("returns null when either input is missing", () => {
+    // No origin was captured (a keyboard-started session), or the box has not
+    // been measured yet — the look falls back to its own centered origin.
+    expect(toRoomLocal(null, PANEL)).toBeNull();
+    expect(toRoomLocal({ x: 300, y: 100 }, null)).toBeNull();
+    expect(toRoomLocal(null, null)).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/use-room-box.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-room-box.ts
@@ -1,0 +1,128 @@
+/**
+ * Live measurement of the voice room's own box.
+ *
+ * The room used to be a `fixed inset-0` takeover, so "the room box" and "the
+ * window" were the same rectangle and every piece of the room's geometry — eye
+ * sizing, the body's cover scale, the responding rings, the entrance origin —
+ * could read `window.innerWidth`/`innerHeight` directly. As an inset panel
+ * (desktop mounts the room inside the layout's `<main>`, leaving the header and
+ * sidenav visible) they are different rectangles, and sizing against the window
+ * would overshoot the panel: the eyes would be drawn for a viewport the room no
+ * longer owns and the entrance would grow from a point outside it.
+ *
+ * `useRoomBox` gives the room its own rectangle instead. It reports both the
+ * size — what the geometry scales against — and the viewport offset, which is
+ * what converts a viewport-space point (the entry origin published by the
+ * composer from a `getBoundingClientRect()`) into the room-local space the look
+ * lays out in.
+ *
+ * Measurement is synchronous in `useLayoutEffect`, before paint, so the room's
+ * entrance animation starts from a real box on its first painted frame rather
+ * than growing from a zero-sized one. After mount a `ResizeObserver` tracks the
+ * panel's own size (the sidebar collapsing, a rail drag) and a window `resize`
+ * listener catches offset changes the observer doesn't fire for — the box can
+ * slide without changing size.
+ */
+
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+
+export interface RoomBox {
+  /** Room width in CSS px — what the look's geometry scales against. */
+  w: number;
+  /** Room height in CSS px. */
+  h: number;
+  /** Viewport x of the room's left edge; subtract to get room-local x. */
+  left: number;
+  /** Viewport y of the room's top edge; subtract to get room-local y. */
+  top: number;
+}
+
+/**
+ * Convert a viewport-space point into the room's local space.
+ *
+ * The composer publishes the entry origin as a viewport point (it measures the
+ * avatar the user tapped with `getBoundingClientRect()`), but the look lays out
+ * against the room box — so an unconverted origin would place the entrance
+ * outside the panel by however far the panel is inset, and the room would grow
+ * from the wrong corner. Pure so the arithmetic is testable without a DOM.
+ *
+ * Not clamped: an origin genuinely outside the panel (a tap in the sidenav)
+ * should stay outside it, so the entrance flies in from that direction.
+ */
+export function toRoomLocal(
+  point: { x: number; y: number } | null,
+  box: RoomBox | null,
+): { x: number; y: number } | null {
+  if (!point || !box) {
+    return null;
+  }
+  return { x: point.x - box.left, y: point.y - box.top };
+}
+
+/**
+ * Measure the element the returned ref is attached to. `box` is `null` until
+ * the first (pre-paint) measurement lands, so callers can hold geometry-
+ * dependent children back for that one commit rather than render them against
+ * a zero box.
+ */
+export function useRoomBox(): {
+  ref: (node: HTMLElement | null) => void;
+  box: RoomBox | null;
+} {
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const [box, setBox] = useState<RoomBox | null>(null);
+
+  const measure = useCallback(() => {
+    const node = nodeRef.current;
+    if (!node) {
+      return;
+    }
+    const rect = node.getBoundingClientRect();
+    setBox((prev) =>
+      prev &&
+      prev.w === rect.width &&
+      prev.h === rect.height &&
+      prev.left === rect.left &&
+      prev.top === rect.top
+        ? prev
+        : {
+            w: rect.width,
+            h: rect.height,
+            left: rect.left,
+            top: rect.top,
+          },
+    );
+  }, []);
+
+  // Callback ref rather than `useRef` + effect: the node must be captured and
+  // measured in the same commit the room first renders in, so the entrance has
+  // a box to grow inside.
+  const ref = useCallback(
+    (node: HTMLElement | null) => {
+      nodeRef.current = node;
+      if (node) {
+        measure();
+      }
+    },
+    [measure],
+  );
+
+  useLayoutEffect(() => {
+    const node = nodeRef.current;
+    if (!node) {
+      return;
+    }
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    // A ResizeObserver only fires on size changes; the panel's viewport offset
+    // also moves when the window itself resizes around a same-sized room.
+    window.addEventListener("resize", measure);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [measure]);
+
+  return { ref, box };
+}

--- a/clients/web/src/domains/chat/voice/voice-room/use-room-box.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-room-box.ts
@@ -1,33 +1,30 @@
 /**
  * Live measurement of the voice room's own box.
  *
- * The room used to be a `fixed inset-0` takeover, so "the room box" and "the
- * window" were the same rectangle and every piece of the room's geometry — eye
- * sizing, the body's cover scale, the responding rings, the entrance origin —
- * could read `window.innerWidth`/`innerHeight` directly. As an inset panel
- * (desktop mounts the room inside the layout's `<main>`, leaving the header and
- * sidenav visible) they are different rectangles, and sizing against the window
- * would overshoot the panel: the eyes would be drawn for a viewport the room no
- * longer owns and the entrance would grow from a point outside it.
+ * On desktop the room is a panel inset inside the layout's `<main>`, so its box
+ * and the window are different rectangles. Every piece of the room's geometry
+ * (eye sizing, the body's cover scale, the responding rings, the entrance
+ * origin) scales against the room, and reading `window.innerWidth`/`innerHeight`
+ * instead would overshoot it: the eyes would be drawn for a viewport the room
+ * does not own, and the entrance would grow from a point outside it.
  *
- * `useRoomBox` gives the room its own rectangle instead. It reports both the
- * size — what the geometry scales against — and the viewport offset, which is
- * what converts a viewport-space point (the entry origin published by the
- * composer from a `getBoundingClientRect()`) into the room-local space the look
- * lays out in.
+ * `useRoomBox` reports both the size, which the geometry scales against, and the
+ * viewport offset, which converts a viewport-space point (the entry origin the
+ * composer publishes from a `getBoundingClientRect()`) into the room-local space
+ * the look lays out in.
  *
  * Measurement is synchronous in `useLayoutEffect`, before paint, so the room's
  * entrance animation starts from a real box on its first painted frame rather
  * than growing from a zero-sized one. After mount a `ResizeObserver` tracks the
- * panel's own size (the sidebar collapsing, a rail drag) and a window `resize`
- * listener catches offset changes the observer doesn't fire for — the box can
- * slide without changing size.
+ * panel's own size (the sidebar collapsing, a rail drag), and a window `resize`
+ * listener catches offset changes the observer does not fire for, since the box
+ * can slide without changing size.
  */
 
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 export interface RoomBox {
-  /** Room width in CSS px — what the look's geometry scales against. */
+  /** Room width in CSS px. The look's geometry scales against this. */
   w: number;
   /** Room height in CSS px. */
   h: number;
@@ -42,9 +39,9 @@ export interface RoomBox {
  *
  * The composer publishes the entry origin as a viewport point (it measures the
  * avatar the user tapped with `getBoundingClientRect()`), but the look lays out
- * against the room box — so an unconverted origin would place the entrance
- * outside the panel by however far the panel is inset, and the room would grow
- * from the wrong corner. Pure so the arithmetic is testable without a DOM.
+ * against the room box, so an unconverted origin lands outside the panel by
+ * however far the panel is inset and the room grows from the wrong corner. Pure
+ * so the arithmetic is testable without a DOM.
  *
  * Not clamped: an origin genuinely outside the panel (a tap in the sidenav)
  * should stay outside it, so the entrance flies in from that direction.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -286,7 +286,7 @@ function windowSize(): { w: number; h: number } {
 }
 
 /**
- * The window box, kept live on resize — the fallback for callers that render at
+ * The window box, kept live on resize. The fallback for callers that render at
  * full-viewport scale. The room itself measures its own panel and passes it in
  * as `viewport`; see `use-room-box.ts`.
  */
@@ -340,7 +340,7 @@ export function VoiceRoomColorLook({
   showStateCaption?: boolean;
   /** How prominent that caption is while audio flows. See {@link VoiceCaptionEmphasis}. */
   captionEmphasis?: VoiceCaptionEmphasis;
-  /** Point the entrance grows from (the tapped control), in ROOM-LOCAL space —
+  /** Point the entrance grows from (the tapped control), in ROOM-LOCAL space.
    *  the caller converts from the viewport point it captured. Null → the fixed
    *  room-center origin. */
   entryOrigin?: { x: number; y: number } | null;
@@ -388,7 +388,7 @@ export function VoiceRoomColorLook({
   const bodyGeometry = useMemo(() => {
     // A degenerate box (a not-yet-laid-out panel, a test renderer that reports
     // no extent) would make `startScale` divide by zero and hand Motion an
-    // `Infinity` scale. Skip the body grow rather than animate garbage — the
+    // `Infinity` scale. Skip the body grow rather than animate garbage. The
     // color fill still covers the room.
     if (!look.body || w <= 0 || h <= 0) {
       return null;

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -39,9 +39,13 @@
  * question.
  *
  * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe (no
- * entrance, no parallax; the blink is a discrete squish, kept). Sized against
- * the window — the room is a `fixed inset-0` overlay, so the window IS its
- * box — unless a `viewport` override is passed (Storybook renders in a box).
+ * entrance, no parallax; the blink is a discrete squish, kept).
+ *
+ * Everything here is sized against the box it is given, not the window. The
+ * room is an inset panel on desktop (see `voice-room.tsx`), so "the screen" the
+ * avatar grows to BE is the panel; the room measures itself and passes that
+ * box, and Storybook passes its frame. `useViewportSize` remains only as the
+ * fallback for callers that render at full-viewport scale.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -281,7 +285,11 @@ function windowSize(): { w: number; h: number } {
   return { w: window.innerWidth, h: window.innerHeight };
 }
 
-/** The window box, kept live on resize — the room is a full-viewport overlay. */
+/**
+ * The window box, kept live on resize — the fallback for callers that render at
+ * full-viewport scale. The room itself measures its own panel and passes it in
+ * as `viewport`; see `use-room-box.ts`.
+ */
 function useViewportSize(): { w: number; h: number } {
   const [size, setSize] = useState(windowSize);
   useEffect(() => {
@@ -332,20 +340,23 @@ export function VoiceRoomColorLook({
   showStateCaption?: boolean;
   /** How prominent that caption is while audio flows. See {@link VoiceCaptionEmphasis}. */
   captionEmphasis?: VoiceCaptionEmphasis;
-  /** Viewport point the entrance grows from (the tapped control). Null → the
-   *  fixed screen-center origin. */
+  /** Point the entrance grows from (the tapped control), in ROOM-LOCAL space —
+   *  the caller converts from the viewport point it captured. Null → the fixed
+   *  room-center origin. */
   entryOrigin?: { x: number; y: number } | null;
   /** Which wave band to draw. See {@link VoiceWaveEngine}. */
   waveEngine?: VoiceWaveEngine;
-  /** Override the room box (Storybook renders in a box, not the full window). */
+  /** The room box to lay out against. The room measures its own panel and
+   *  passes it; omitted, this falls back to the window. */
   viewport?: { w: number; h: number };
 }) {
   const reduce = useReducedMotion();
   const measured = useViewportSize();
   const { w, h } = viewport ?? measured;
 
-  // Where the entrance grows from: the tapped control's viewport point, or the
-  // fixed picker-height screen center when none was captured (or in Storybook).
+  // Where the entrance grows from: the tapped control's point in room-local
+  // space, or the fixed picker-height room center when none was captured (or in
+  // Storybook).
   const origin = entryOrigin ?? {
     x: w / 2,
     y: (ENTER_FROM_CENTER_VH / 100) * h,
@@ -375,7 +386,11 @@ export function VoiceRoomColorLook({
   // user tapped. The body's rest center is the screen center (w/2, h/2), so it
   // starts offset by (origin − center) and slides to 0.
   const bodyGeometry = useMemo(() => {
-    if (!look.body) {
+    // A degenerate box (a not-yet-laid-out panel, a test renderer that reports
+    // no extent) would make `startScale` divide by zero and hand Motion an
+    // `Infinity` scale. Skip the body grow rather than animate garbage — the
+    // color fill still covers the room.
+    if (!look.body || w <= 0 || h <= 0) {
       return null;
     }
     const coverSize = 1.25 * Math.max(w, h);
@@ -952,9 +967,10 @@ function VoiceRespondingTreatment({
 
 /**
  * The `rings` responding treatment as a self-contained layer: the concentric
- * rings radiating outward from screen center on the TTS-output amplitude, sized
- * against the live window (pass `viewport` to size against a box instead —
- * Storybook). Exported for the void look, which renders it behind the centered
+ * rings radiating outward from the room's center on the TTS-output amplitude.
+ * Pass `viewport` to size against the room's own box (the room passes its
+ * measured panel; Storybook its frame); omitted, it falls back to the live
+ * window. Exported for the void look, which renders it behind the centered
  * avatar so a custom avatar emits the same rings the eyes do in the color look.
  */
 export function VoiceRespondingRings({
@@ -963,7 +979,7 @@ export function VoiceRespondingRings({
 }: {
   /** TTS (output) amplitude source (0–1) — drives the rings' presence. */
   getAmplitude?: () => number;
-  /** Override the room box (Storybook renders in a box, not the full window). */
+  /** The room box to size against; omitted, falls back to the window. */
   viewport?: { w: number; h: number };
 }) {
   const measured = useViewportSize();
@@ -1028,7 +1044,7 @@ export function VoiceRoomEyes({
   /** The room box the eyes are framed in (the caller's live viewport size). */
   viewport: { w: number; h: number };
   placement?: VoiceEyePlacement;
-  /** Viewport point the eyes grow from on entrance. Defaults to screen center. */
+  /** Room-local point the eyes grow from on entrance. Defaults to room center. */
   entranceOrigin?: { x: number; y: number };
   /**
    * Audio gesture the eyes express — `listening` widens them with the mic,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -414,9 +414,9 @@ describe("VoiceRoom — visibility", () => {
   });
 
   test("renders nothing in an Electron pop-out even when the composer owns the session", () => {
-    // The `fixed inset-0` room would cover the pop-out's standalone pill, so
-    // pop-outs never show it — the standalone pill is their only session
-    // surface. The owning composer's voice bar still renders underneath.
+    // The room fills whichever box it is mounted in, and in a pop-out that box
+    // is the whole window — it would cover the standalone pill, so pop-outs
+    // never show it. The owning composer's voice bar still renders underneath.
     startOwnedSession("listening");
     mockSearch = "?popout=1";
     render(<VoiceRoom />);
@@ -431,6 +431,58 @@ describe("VoiceRoom — visibility", () => {
     render(<VoiceRoom />);
     expect(roomDialog()).toBeNull();
     expect(useLiveVoiceStore.getState().state).toBe("listening");
+  });
+});
+
+// Placement is the whole point of the two variants: desktop insets the room
+// into the content area so the title bar and sidenav stay visible AND usable,
+// mobile keeps the full-viewport takeover. The modality flag has to follow the
+// placement — a non-modal room that claimed `aria-modal` would tell assistive
+// tech the chrome beside it is inert when it is in fact the way out.
+describe("VoiceRoom — placement variants", () => {
+  test("content: inset panel, non-modal", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="content" />);
+
+    const room = roomDialog();
+    expect(room).not.toBeNull();
+    expect(room?.className).toContain("absolute inset-0");
+    expect(room?.className).not.toContain("fixed");
+    // Rounded corners are what make it read as a panel set inside the chrome.
+    expect(room?.className).toContain("rounded-xl");
+    expect(room?.getAttribute("aria-modal")).toBeNull();
+  });
+
+  test("fullscreen: full-viewport takeover, modal", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="fullscreen" />);
+
+    const room = roomDialog();
+    expect(room?.className).toContain("fixed inset-0");
+    expect(room?.className).not.toContain("rounded-xl");
+    expect(room?.getAttribute("aria-modal")).toBe("true");
+  });
+
+  test("defaults to fullscreen", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    expect(roomDialog()?.className).toContain("fixed inset-0");
+  });
+
+  test("both variants keep Escape-to-minimize — the content room is dismissible too", () => {
+    // The content variant is non-modal, but Escape is still the platform
+    // "leave the overlay" key; it must not degrade into ending the call.
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="content" />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(controls.stop).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -415,7 +415,7 @@ describe("VoiceRoom — visibility", () => {
 
   test("renders nothing in an Electron pop-out even when the composer owns the session", () => {
     // The room fills whichever box it is mounted in, and in a pop-out that box
-    // is the whole window — it would cover the standalone pill, so pop-outs
+    // is the whole window, so it would cover the standalone pill and pop-outs
     // never show it. The owning composer's voice bar still renders underneath.
     startOwnedSession("listening");
     mockSearch = "?popout=1";
@@ -437,9 +437,9 @@ describe("VoiceRoom — visibility", () => {
 // Placement is the whole point of the two variants: desktop insets the room
 // into the content area so the title bar and sidenav stay visible AND usable,
 // mobile keeps the full-viewport takeover. The modality flag has to follow the
-// placement — a non-modal room that claimed `aria-modal` would tell assistive
+// placement. A non-modal room that claimed `aria-modal` would tell assistive
 // tech the chrome beside it is inert when it is in fact the way out.
-describe("VoiceRoom — placement variants", () => {
+describe("VoiceRoom: placement variants", () => {
   test("content: inset panel, non-modal", () => {
     startOwnedSession("listening");
     render(<VoiceRoom variant="content" />);
@@ -470,7 +470,7 @@ describe("VoiceRoom — placement variants", () => {
     expect(roomDialog()?.className).toContain("fixed inset-0");
   });
 
-  test("both variants keep Escape-to-minimize — the content room is dismissible too", () => {
+  test("both variants keep Escape-to-minimize, so the content room is dismissible too", () => {
     // The content variant is non-modal, but Escape is still the platform
     // "leave the overlay" key; it must not degrade into ending the call.
     startOwnedSession("listening");

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -19,15 +19,15 @@
  *
  * Two placement variants (see `chat-layout.tsx` for the mounts):
  *
- * - `"content"` (desktop) — `absolute inset-0` inside the layout's `<main>`,
+ * - `"content"` (desktop): `absolute inset-0` inside the layout's `<main>`,
  *   an inset panel that leaves the title bar and left sidenav visible AND
  *   interactive, so the user can keep navigating; navigating away hands the
  *   session off to the title-bar pill. Deliberately not `aria-modal`: the
  *   surrounding chrome stays usable.
- * - `"fullscreen"` (mobile) — `fixed inset-0` over the whole viewport, modal,
+ * - `"fullscreen"` (mobile): `fixed inset-0` over the whole viewport, modal,
  *   with safe-area padding for notched iOS shells.
  *
- * The look is laid out against the ROOM's box, not the window's — see
+ * The look is laid out against the ROOM's box, not the window's. See
  * {@link useRoomBox}. As a panel those are different rectangles, so the color
  * look's field, its giant eyes, and the responding rings are all sized to the
  * panel, and the entry origin (published in viewport space by the composer) is
@@ -121,7 +121,7 @@ const SESSION_CONTROL_CLASS =
 const SESSION_CONTROL_NEUTRAL_CLASS =
   "border-[var(--room-border)] text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]";
 
-/** Placement variant — see the module docstring. */
+/** Placement variant. See the module docstring. */
 export type VoiceRoomVariant = "fullscreen" | "content";
 
 export function VoiceRoom({
@@ -171,7 +171,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const [entryOrigin] = useState(liveEntryOrigin);
 
   // The room's own rectangle. Everything in the look lays out against this, not
-  // the window — as an inset panel they differ (see the module docstring).
+  // the window. As an inset panel they differ (see the module docstring).
   const { ref: roomRef, box } = useRoomBox();
   // The entry origin is a viewport point; the look lays out in room-local
   // space. Fullscreen's offset is zero, which makes this a no-op there.
@@ -248,7 +248,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       ref={roomRef}
       className={cn(
         "z-50 flex items-center justify-center overflow-hidden",
-        // Both variants sit at z-50 — the highest tier used inside the chat
+        // Both variants sit at z-50, the highest tier used inside the chat
         // layout. The content variant rounds its corners so it reads as a panel
         // set inside the surrounding chrome; `overflow-hidden` above is what
         // clips the full-bleed color/wave layers to that radius.
@@ -299,7 +299,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           color + eyes. Both draw the waves only while `listening`, from live mic
           amplitude. */}
       {look ? (
-        // Held back until the box is measured — one pre-paint commit, so the
+        // Held back until the box is measured. That is one pre-paint commit, so the
         // entrance still plays from the room's first painted frame, but it
         // grows inside a real rectangle rather than a zero-sized one.
         box ? (

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -17,9 +17,23 @@
  *   void with the state-driven avatar at its center and the listening waves —
  *   what this look should become is an open design question.
  *
- * The room is a full-app takeover on every platform — `fixed inset-0`, modal,
- * covering the header and sidebar, with safe-area padding for notched iOS
- * shells. It is not exit-only: minimizing (the − control or Escape) dismisses
+ * Two placement variants (see `chat-layout.tsx` for the mounts):
+ *
+ * - `"content"` (desktop) — `absolute inset-0` inside the layout's `<main>`,
+ *   an inset panel that leaves the title bar and left sidenav visible AND
+ *   interactive, so the user can keep navigating; navigating away hands the
+ *   session off to the title-bar pill. Deliberately not `aria-modal`: the
+ *   surrounding chrome stays usable.
+ * - `"fullscreen"` (mobile) — `fixed inset-0` over the whole viewport, modal,
+ *   with safe-area padding for notched iOS shells.
+ *
+ * The look is laid out against the ROOM's box, not the window's — see
+ * {@link useRoomBox}. As a panel those are different rectangles, so the color
+ * look's field, its giant eyes, and the responding rings are all sized to the
+ * panel, and the entry origin (published in viewport space by the composer) is
+ * converted to room-local space before the entrance grows from it.
+ *
+ * The room is not exit-only: minimizing (the − control or Escape) dismisses
  * the room while the session keeps running — the composer's voice bar / the
  * title-bar pill become the session surfaces — and ending the session (the ✕
  * control) tears the whole call down.
@@ -66,6 +80,7 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { toneForBg } from "@/utils/avatar-tone";
 
 import { useActiveConnectSurface } from "./use-active-connect-surface";
+import { toRoomLocal, useRoomBox } from "./use-room-box";
 import { resolveWaveAccentHex } from "./wave-accent";
 
 import {
@@ -106,12 +121,20 @@ const SESSION_CONTROL_CLASS =
 const SESSION_CONTROL_NEUTRAL_CLASS =
   "border-[var(--room-border)] text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]";
 
-export function VoiceRoom() {
+/** Placement variant — see the module docstring. */
+export type VoiceRoomVariant = "fullscreen" | "content";
+
+export function VoiceRoom({
+  variant = "fullscreen",
+}: {
+  /** Placement variant. Defaults to the fullscreen (mobile) mount. */
+  variant?: VoiceRoomVariant;
+}) {
   const visible = useIsVoiceRoomVisible();
 
   return (
     <AnimatePresence>
-      {visible ? <VoiceRoomOverlay key="voice-room" /> : null}
+      {visible ? <VoiceRoomOverlay key="voice-room" variant={variant} /> : null}
     </AnimatePresence>
   );
 }
@@ -121,7 +144,7 @@ export function VoiceRoom() {
  * only exist while the room is actually visible and are torn down cleanly on
  * exit.
  */
-function VoiceRoomOverlay() {
+function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
   // `speaking` stays set across a mid-turn tool run; gate `responding` on audio
@@ -146,6 +169,13 @@ function VoiceRoomOverlay() {
   // the room's whole lifetime (both are session-constant).
   const [assistantId] = useState(liveAssistantId);
   const [entryOrigin] = useState(liveEntryOrigin);
+
+  // The room's own rectangle. Everything in the look lays out against this, not
+  // the window — as an inset panel they differ (see the module docstring).
+  const { ref: roomRef, box } = useRoomBox();
+  // The entry origin is a viewport point; the look lays out in room-local
+  // space. Fullscreen's offset is zero, which makes this a no-op there.
+  const localEntryOrigin = toRoomLocal(entryOrigin, box);
 
   const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
   // The label + sr-only announcement must follow the same audio-aware mapping as
@@ -211,25 +241,43 @@ function VoiceRoomOverlay() {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
 
+  const fullscreen = variant === "fullscreen";
+
   return (
     <motion.div
-      className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden"
+      ref={roomRef}
+      className={cn(
+        "z-50 flex items-center justify-center overflow-hidden",
+        // Both variants sit at z-50 — the highest tier used inside the chat
+        // layout. The content variant rounds its corners so it reads as a panel
+        // set inside the surrounding chrome; `overflow-hidden` above is what
+        // clips the full-bleed color/wave layers to that radius.
+        fullscreen ? "fixed inset-0" : "absolute inset-0 rounded-xl",
+      )}
       // Theme tokens (the connect label, the ambient transcript) follow the
       // look: dark over the void and the dark avatar colors, light over the
       // light one (yellow).
       data-theme={tone?.isLight ? "light" : "dark"}
       role="dialog"
-      aria-modal
+      // Only the fullscreen room is modal. The content variant deliberately
+      // leaves the header and sidenav usable, so claiming the rest of the app
+      // is inert would be a lie to assistive tech.
+      aria-modal={fullscreen || undefined}
       aria-label="Voice session"
-      // The overlay covers `ChatLayoutHeader`, so it loses the header's
+      // Fullscreen covers `ChatLayoutHeader`, so it loses the header's
       // safe-area protection — pad the centered avatar inside the
       // notch/home-indicator per docs/CAPACITOR.md. The background layers are
-      // `absolute inset-0` and stay full-bleed behind the padding.
+      // `absolute inset-0` and stay full-bleed behind the padding. The content
+      // variant sits inside the layout, which already handles its own insets.
       style={{
-        paddingTop: SAFE_AREA_TOP,
-        paddingBottom: SAFE_AREA_BOTTOM,
-        paddingLeft: SAFE_AREA_LEFT,
-        paddingRight: SAFE_AREA_RIGHT,
+        ...(fullscreen
+          ? {
+              paddingTop: SAFE_AREA_TOP,
+              paddingBottom: SAFE_AREA_BOTTOM,
+              paddingLeft: SAFE_AREA_LEFT,
+              paddingRight: SAFE_AREA_RIGHT,
+            }
+          : null),
         ...toneVars,
         ...(accentHex ? { [AVATAR_ACCENT_CSS_VAR]: accentHex } : {}),
       }}
@@ -251,18 +299,25 @@ function VoiceRoomOverlay() {
           color + eyes. Both draw the waves only while `listening`, from live mic
           amplitude. */}
       {look ? (
-        <VoiceRoomColorLook
-          look={look}
-          visual={visual}
-          getAmplitude={getLiveVoiceInputAmplitude}
-          getResponseAmplitude={getLiveVoiceOutputAmplitude}
-          // While assistant captions are on, the transcript's lower zone already
-          // narrates the turn from the caption's own baseline, so the caption
-          // stands down rather than doubling it. The user-only caption pref
-          // leaves it up (a user pill alone doesn't name the assistant's state).
-          showStateCaption={!showAssistantTranscript}
-          entryOrigin={entryOrigin}
-        />
+        // Held back until the box is measured — one pre-paint commit, so the
+        // entrance still plays from the room's first painted frame, but it
+        // grows inside a real rectangle rather than a zero-sized one.
+        box ? (
+          <VoiceRoomColorLook
+            look={look}
+            visual={visual}
+            getAmplitude={getLiveVoiceInputAmplitude}
+            getResponseAmplitude={getLiveVoiceOutputAmplitude}
+            // While assistant captions are on, the transcript's lower zone
+            // already narrates the turn from the caption's own baseline, so the
+            // caption stands down rather than doubling it. The user-only caption
+            // pref leaves it up (a user pill alone doesn't name the assistant's
+            // state).
+            showStateCaption={!showAssistantTranscript}
+            entryOrigin={localEntryOrigin}
+            viewport={box}
+          />
+        ) : null
       ) : (
         <>
           <VoiceRoomAmbientBackground />
@@ -280,8 +335,11 @@ function VoiceRoomOverlay() {
               behind the eyes, here behind the centered avatar (both centered, so
               they emanate from the centerpiece the same way). Rendered before the
               avatar so it paints them behind it; rides the TTS-output amplitude. */}
-          {visual === "responding" ? (
-            <VoiceRespondingRings getAmplitude={getLiveVoiceOutputAmplitude} />
+          {visual === "responding" && box ? (
+            <VoiceRespondingRings
+              getAmplitude={getLiveVoiceOutputAmplitude}
+              viewport={box}
+            />
           ) : null}
           {/* Same state caption + gating as the color look (stands down while
               the assistant transcript is on), in the same shared lower zone —


### PR DESCRIPTION
The voice room covered the whole app (`fixed inset-0`). The designs inset it: the title bar and left sidenav stay visible, the room sits inside them with rounded corners. Reference: Light 738.

This reverses the full-app takeover from JARVIS-1269 to JARVIS-1270 (#37917), which is the load-bearing decision in the "Design parity: room, minimized bar, and pill" milestone. **Confirmed with Alex before building**, since the rest of the milestone sits on it.

Desktop only. Mobile keeps the full-viewport takeover until JARVIS-1383 turns it into a bottom sheet.

## What changed

**Placement.** A `variant` prop, restoring the split the original JARVIS-1269 shipped:

- `"content"` (desktop): `absolute inset-0 rounded-xl` inside the layout's `<main>`. It inherits the layout's existing `p-4 gap-4`, so the inset comes from the surrounding chrome rather than a new magic number.
- `"fullscreen"` (mobile): unchanged `fixed inset-0`, modal, safe-area padded.

**Modality follows placement.** Only the fullscreen room claims `aria-modal`. The content room deliberately leaves the header and sidenav usable, since the sidenav is now a legitimate way out, so claiming the rest of the app is inert would be false to assistive tech.

**The look lays out against the room's box, not the window's.** This is the bulk of the diff. `VoiceRoomColorLook` sized everything off `window.innerWidth`/`innerHeight` on the premise that the room *was* the window: the eyes, the body's cover scale, the responding rings. New `useRoomBox` measures the panel in `useLayoutEffect` (pre-paint, so the entrance still animates from a real rectangle on its first painted frame) and tracks it with a `ResizeObserver` plus a window `resize` listener, since the panel's offset can move without its size changing.

**The entry origin needed converting.** The composer publishes it as a viewport point from `getBoundingClientRect()`; the look positions in room-local space. Identical rectangles before, off by exactly the header and sidenav now, so the entrance would have grown from a point outside the panel. Extracted as `toRoomLocal` and unit-tested, including that a point genuinely outside the panel stays outside it (a tap in the sidenav should fly in from that direction, not clamp to the edge).

**Blur is now mobile-only.** On desktop the room is *inside* `<main>`, so blurring `<main>` would blur the room along with the chat behind it.

## Found along the way

**`bodyGeometry` could divide by zero.** It computes `ENTER_FROM_SIZE / coverSize`, which is `Infinity` on a zero-extent box. Unreachable when the box was `window.innerWidth`; reachable now that it is a measured element. It skips the body grow instead, and the color fill still covers the room.

**The covered chat was reachable behind the panel** (from Codex review). The room paints over the chat but does not remove it from the page, so the composer, transcript and their controls stayed tabbable and screen-reader reachable. This was already true on mobile, where `pointer-events-none` blocked the mouse but not the keyboard or AT. The route content is now wrapped in an `inert` gate driven by room visibility, scoped to a wrapper around `<Outlet />` rather than `<main>` (the desktop room lives inside `<main>`, so gating there would inert the room itself). The header and sidenav stay reachable.

## Design library

No new controls or surfaces. This is placement and geometry on an existing component, so there was nothing new to source from `@vellumai/design-library`.

## Testing

`bun run typecheck` clean; lint clean on all touched files. Suites run individually (per the `mock.module` isolation gotcha): 57 room, 4 room-box, 4 eyes, 10 mesh, 20 transcript, all passing.

Four new tests cover the placement contract: inset and non-modal, fullscreen and modal, the default, and that Escape-to-minimize survives in the non-modal variant (it must not degrade into ending the call).

The `inert` gate is not unit-tested: `chat-layout.tsx` has no render harness, and standing one up for a three-line typechecked change needs the full layout mock graph.

**Not visually verified.** A live-voice session needs a daemon and a mic. The judgment call worth eyes on is whether the color-with-eyes look reads at panel scale: the eyes cap at `EYE_MAX_HEIGHT_PX = 240` and target 22% of the smaller dimension, so they will be proportionally similar but absolutely smaller, and they now anchor to the panel's bottom edge rather than the window's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)