### PR TITLE
fix(providers): drop adaptive thinking for pre-adaptive Claude models

### DIFF
--- a/assistant/src/__tests__/retry-thinking-preadaptive.test.ts
+++ b/assistant/src/__tests__/retry-thinking-preadaptive.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Verifies that `RetryProvider.normalizeSendMessageOptions` drops an adaptive
+ * thinking config for pre-adaptive Claude models (Haiku 4.5, Opus 4.5,
+ * Sonnet 4.5), preventing an Anthropic 400: these models reject
+ * `thinking: { type: "adaptive" }` and only support the legacy
+ * `{ type: "enabled", budget_tokens }` form, which Vellum never sends.
+ *
+ * The legacy budget_tokens form supplied by pass-through callers is preserved,
+ * as is adaptive thinking on models that support it.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { RetryProvider } from "../providers/retry.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
+import { setConfig } from "./helpers/set-config.js";
+
+function setLlmConfig(raw: unknown): void {
+  setConfig("llm", raw);
+}
+
+beforeEach(() => {
+  setConfig("llm", {});
+});
+
+function makePipeline(providerName: string): {
+  provider: Provider;
+  lastConfig: () => Record<string, unknown> | undefined;
+} {
+  let captured: Record<string, unknown> | undefined;
+  const inner: Provider = {
+    name: providerName,
+    async sendMessage(
+      _messages: Message[],
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      captured = options?.config as Record<string, unknown> | undefined;
+      return {
+        content: [],
+        model: "test",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "stop",
+      };
+    },
+  };
+  return {
+    provider: new RetryProvider(inner),
+    lastConfig: () => captured,
+  };
+}
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+};
+
+describe("retry normalization: pre-adaptive thinking models", () => {
+  test("drops resolved thinking: enabled for Haiku 4.5", async () => {
+    // GIVEN a call-site config that enables thinking for Haiku 4.5, which
+    // rejects the adaptive wire shape the config normalizes to
+    setLlmConfig({
+      callSites: {
+        memoryExtraction: {
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+          thinking: { enabled: true },
+          effort: "high",
+        },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN a request resolves through the call-site config
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "memoryExtraction" },
+    });
+
+    // THEN the adaptive thinking config is dropped so the request goes out
+    // without thinking instead of 400-ing
+    expect(lastConfig()?.thinking).toBeUndefined();
+    // AND effort is still forwarded
+    expect(lastConfig()?.effort).toBe("high");
+  });
+
+  test("drops explicit wire-shape adaptive thinking from pass-through callers for Haiku 4.5", async () => {
+    // GIVEN a pass-through caller supplying the wire-shape adaptive config
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN sending against Haiku 4.5
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-haiku-4-5-20251001",
+        thinking: { type: "adaptive" },
+      },
+    });
+
+    // THEN the adaptive thinking config is dropped
+    expect(lastConfig()?.thinking).toBeUndefined();
+  });
+
+  test("preserves legacy budget_tokens thinking for Haiku 4.5", async () => {
+    // GIVEN a pass-through caller supplying the legacy budget form, which
+    // Haiku 4.5 does support
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN sending against Haiku 4.5
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-haiku-4-5-20251001",
+        thinking: { type: "enabled", budget_tokens: 4096 },
+      },
+    });
+
+    // THEN the legacy config is forwarded untouched
+    expect(lastConfig()?.thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 4096,
+    });
+  });
+
+  test("drops adaptive thinking for OpenRouter-proxied Haiku 4.5", async () => {
+    // GIVEN a call-site config enabling thinking on the OpenRouter-proxied
+    // Haiku id
+    setLlmConfig({
+      callSites: {
+        memoryExtraction: {
+          provider: "openrouter",
+          model: "anthropic/claude-haiku-4.5",
+          thinking: { enabled: true },
+        },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openrouter");
+
+    // WHEN a request resolves through the call-site config
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "memoryExtraction" },
+    });
+
+    // THEN the adaptive thinking config is dropped
+    expect(lastConfig()?.thinking).toBeUndefined();
+  });
+
+  test("drops adaptive thinking for Opus 4.5 and Sonnet 4.5", async () => {
+    for (const model of [
+      "claude-opus-4-5-20251101",
+      "claude-sonnet-4-5-20250929",
+    ]) {
+      const { provider, lastConfig } = makePipeline("anthropic");
+
+      await provider.sendMessage([userMessage], {
+        config: { model, thinking: { type: "adaptive" } },
+      });
+
+      expect(lastConfig()?.thinking).toBeUndefined();
+    }
+  });
+
+  test("preserves adaptive thinking for models that support it", async () => {
+    // GIVEN a call-site config that enables thinking for Opus 4.8
+    setLlmConfig({
+      callSites: {
+        memoryExtraction: {
+          provider: "anthropic",
+          model: "claude-opus-4-8",
+          thinking: { enabled: true },
+        },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN a request resolves through the call-site config
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "memoryExtraction" },
+    });
+
+    // THEN adaptive thinking is preserved
+    expect(lastConfig()?.thinking).toEqual({ type: "adaptive" });
+  });
+});

--- a/assistant/src/__tests__/retry-thinking-preadaptive.test.ts
+++ b/assistant/src/__tests__/retry-thinking-preadaptive.test.ts
@@ -161,6 +161,25 @@ describe("retry normalization: pre-adaptive thinking models", () => {
     }
   });
 
+  test("drops adaptive thinking for undated model aliases", async () => {
+    // Anthropic serves undated aliases for dated catalog IDs, and profiles
+    // and the CLI accept either form (inference.help.ts advertises
+    // `--model claude-haiku-4-5`)
+    for (const model of [
+      "claude-haiku-4-5",
+      "claude-opus-4-5",
+      "claude-sonnet-4-5",
+    ]) {
+      const { provider, lastConfig } = makePipeline("anthropic");
+
+      await provider.sendMessage([userMessage], {
+        config: { model, thinking: { type: "adaptive" } },
+      });
+
+      expect(lastConfig()?.thinking).toBeUndefined();
+    }
+  });
+
   test("preserves adaptive thinking for models that support it", async () => {
     // GIVEN a call-site config that enables thinking for Opus 4.8
     setLlmConfig({

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -52,7 +52,7 @@ export interface CatalogModel {
   adaptiveThinkingOnly?: boolean;
   /**
    * When true, the model predates adaptive thinking and rejects
-   * `thinking: { type: "adaptive" }` (Anthropic 400s such calls) — it only
+   * `thinking: { type: "adaptive" }` (Anthropic 400s such calls). It only
    * supports the legacy `{ type: "enabled", budget_tokens }` form, which
    * Vellum never sends. The daemon drops an enabled thinking config for these
    * models before dispatching to the Anthropic wire. Mutually exclusive with
@@ -2256,12 +2256,19 @@ export function isAdaptiveThinkingOnlyModel(modelId: string): boolean {
  * Whether the given model predates adaptive thinking and rejects
  * `thinking: { type: "adaptive" }`, driven by the `adaptiveThinkingUnsupported`
  * capability in the catalog. Matches the model ID across every provider (same
- * pattern as {@link isAdaptiveThinkingOnlyModel}).
+ * pattern as {@link isAdaptiveThinkingOnlyModel}), and also matches the
+ * undated aliases Anthropic serves for dated catalog IDs (`claude-haiku-4-5`
+ * resolves the same model as `claude-haiku-4-5-20251001`), since profiles and
+ * the CLI accept either form.
  */
 export function isAdaptiveThinkingUnsupportedModel(modelId: string): boolean {
+  const stripDateSuffix = (id: string): string => id.replace(/-\d{8}$/, "");
+  const normalized = stripDateSuffix(modelId);
   return PROVIDER_CATALOG.some((p) =>
     p.models.some(
-      (m) => m.id === modelId && m.adaptiveThinkingUnsupported === true,
+      (m) =>
+        m.adaptiveThinkingUnsupported === true &&
+        (m.id === modelId || stripDateSuffix(m.id) === normalized),
     ),
   );
 }

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -50,6 +50,15 @@ export interface CatalogModel {
    * before dispatching. Implies `supportsThinking`.
    */
   adaptiveThinkingOnly?: boolean;
+  /**
+   * When true, the model predates adaptive thinking and rejects
+   * `thinking: { type: "adaptive" }` (Anthropic 400s such calls) — it only
+   * supports the legacy `{ type: "enabled", budget_tokens }` form, which
+   * Vellum never sends. The daemon drops an enabled thinking config for these
+   * models before dispatching to the Anthropic wire. Mutually exclusive with
+   * `adaptiveThinkingOnly`.
+   */
+  adaptiveThinkingUnsupported?: boolean;
   supportsCaching?: boolean;
   supportsVision?: boolean;
   /**
@@ -296,6 +305,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 64000,
         supportsThinking: true,
+        adaptiveThinkingUnsupported: true,
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
@@ -312,6 +322,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 64000,
         supportsThinking: true,
+        adaptiveThinkingUnsupported: true,
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
@@ -328,6 +339,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 64000,
         supportsThinking: true,
+        adaptiveThinkingUnsupported: true,
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
@@ -1140,6 +1152,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 64000,
         supportsThinking: true,
+        adaptiveThinkingUnsupported: true,
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
@@ -1156,6 +1169,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 64000,
         supportsThinking: true,
+        adaptiveThinkingUnsupported: true,
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
@@ -1172,6 +1186,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 64000,
         supportsThinking: true,
+        adaptiveThinkingUnsupported: true,
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
@@ -1873,6 +1888,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 200000,
         maxOutputTokens: 64000,
         supportsThinking: true,
+        adaptiveThinkingUnsupported: true,
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
@@ -2233,6 +2249,20 @@ export function getCatalogProviderForModel(
 export function isAdaptiveThinkingOnlyModel(modelId: string): boolean {
   return PROVIDER_CATALOG.some((p) =>
     p.models.some((m) => m.id === modelId && m.adaptiveThinkingOnly === true),
+  );
+}
+
+/**
+ * Whether the given model predates adaptive thinking and rejects
+ * `thinking: { type: "adaptive" }`, driven by the `adaptiveThinkingUnsupported`
+ * capability in the catalog. Matches the model ID across every provider (same
+ * pattern as {@link isAdaptiveThinkingOnlyModel}).
+ */
+export function isAdaptiveThinkingUnsupportedModel(modelId: string): boolean {
+  return PROVIDER_CATALOG.some((p) =>
+    p.models.some(
+      (m) => m.id === modelId && m.adaptiveThinkingUnsupported === true,
+    ),
   );
 }
 

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -560,7 +560,7 @@ function normalizeSendMessageOptions(
   // never sends the legacy budget_tokens form. Drop an adaptive thinking
   // config for these models so the request goes out without thinking instead
   // of failing. A pass-through `{ type: "enabled", budget_tokens }` config is
-  // left intact — these models do support that shape.
+  // left intact: these models do support that shape.
   if (
     typeof nextConfig.model === "string" &&
     isAdaptiveThinkingUnsupportedModel(nextConfig.model) &&

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -18,8 +18,12 @@ import {
   isAnthropicModel,
 } from "./anthropic-gateway-shared.js";
 import { resolveLogitBiasPreset } from "./inference/logit-bias.js";
-import { isAdaptiveThinkingOnlyModel } from "./model-catalog.js";
 import {
+  isAdaptiveThinkingOnlyModel,
+  isAdaptiveThinkingUnsupportedModel,
+} from "./model-catalog.js";
+import {
+  isThinkingConfigAdaptive,
   isThinkingConfigDisabled,
   normalizeThinkingConfigForWire,
 } from "./thinking-config.js";
@@ -547,6 +551,21 @@ function normalizeSendMessageOptions(
     typeof nextConfig.model === "string" &&
     isAdaptiveThinkingOnlyModel(nextConfig.model) &&
     isThinkingConfigDisabled(nextConfig.thinking)
+  ) {
+    delete nextConfig.thinking;
+  }
+
+  // Pre-adaptive Claude models (Haiku 4.5, Opus 4.5, Sonnet 4.5) reject
+  // `thinking: { type: "adaptive" }` (Anthropic 400s the request), and Vellum
+  // never sends the legacy budget_tokens form. Drop an adaptive thinking
+  // config for these models so the request goes out without thinking instead
+  // of failing. A pass-through `{ type: "enabled", budget_tokens }` config is
+  // left intact — these models do support that shape.
+  if (
+    typeof nextConfig.model === "string" &&
+    isAdaptiveThinkingUnsupportedModel(nextConfig.model) &&
+    isThinkingConfigAdaptive(nextConfig.thinking) &&
+    targetsAnthropicWire(providerName, nextConfig.model)
   ) {
     delete nextConfig.thinking;
   }

--- a/assistant/src/providers/thinking-config.ts
+++ b/assistant/src/providers/thinking-config.ts
@@ -55,6 +55,10 @@ export function isThinkingConfigDisabled(thinking: unknown): boolean {
   return normalizeThinkingConfigForWire(thinking)?.type === "disabled";
 }
 
+export function isThinkingConfigAdaptive(thinking: unknown): boolean {
+  return normalizeThinkingConfigForWire(thinking)?.type === "adaptive";
+}
+
 export function isThinkingConfigEnabled(thinking: unknown): boolean {
   const normalized = normalizeThinkingConfigForWire(thinking);
   return normalized !== undefined && normalized.type !== "disabled";


### PR DESCRIPTION
## Problem

A profile (or call-site config) that pins Claude Haiku 4.5, Opus 4.5, or Sonnet 4.5 with thinking enabled fails every request with an Anthropic 400. These pre-4.6 models reject `thinking: { type: "adaptive" }` — they only support the legacy `{ type: "enabled", budget_tokens }` form, which Vellum never sends — but the retry-layer normalization converted `thinking: { enabled: true }` to the adaptive wire shape unconditionally, with no per-model gate.

This bites in practice because the managed-profile boot repair (`adaptive-thinking-repair.ts`) enables adaptive thinking on managed Anthropic profiles checking only the provider, not the model — so a managed profile pointed at Haiku 4.5 gets a config that can never dispatch.

## Fix

- New `adaptiveThinkingUnsupported` catalog capability, set on the Haiku 4.5 / Opus 4.5 / Sonnet 4.5 entries (dated Anthropic IDs plus the `anthropic/claude-*.5` OpenRouter/gateway aliases), with an `isAdaptiveThinkingUnsupportedModel()` helper mirroring `isAdaptiveThinkingOnlyModel()`.
- New guard in `RetryProvider` normalization (next to the existing Fable disabled-thinking guard): when the model is flagged, the normalized config is adaptive, and the request targets the Anthropic wire, drop the thinking config so the request goes out without thinking instead of 400-ing.
- A pass-through `{ type: "enabled", budget_tokens }` config is deliberately preserved — these models do support that shape. `effort` and other params are unaffected.

## Testing

- New `retry-thinking-preadaptive.test.ts` (6 cases): call-site path, wire-shape pass-through, budget_tokens preservation, OpenRouter-proxied ID, Opus/Sonnet 4.5, and adaptive preservation on Opus 4.8.
- Existing `retry-thinking-adaptive-only.test.ts` and `llm-catalog-parity.test.ts` pass; `tsc --noEmit` clean.

## Out of scope (follow-ups)

- The boot repair still writes `thinking: { enabled: true }` onto managed profiles pinned to these models — harmless now (dispatch drops it) but cosmetically wrong in config.
- Client UI still shows the thinking toggle for these models; hiding it (as `adaptiveThinkingOnly` does for Fable) would be a client catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015teAcMnFAvtSv7uW93rqoR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->