### PR TITLE
web: show the credits upsell card proactively when the balance is exhausted

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.test.tsx
@@ -161,6 +161,7 @@ function Harness({
     mainView: "chat",
     openedAppState: null,
     isAssistantBusy: false,
+    showCreditsUpsell: false,
     onSelectStarter: () => {},
     onSelectSuggestion: setSelected,
   });

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -609,12 +609,18 @@ export function ChatMainPanel({
   // -------------------------------------------------------------------------
   // Transcript data (sanitise + build items)
   // -------------------------------------------------------------------------
+  // Single balance-status read shared by every proactive billing surface in
+  // this component: the transcript's tail card, the empty state's card, and
+  // the low-balance composer banner.
+  const balanceStatus = useBillingBalanceStatus();
+
   const { sanitizedMessages, transcriptItems } = useTranscriptData({
     messages,
     showThinking,
     turnActive: isAssistantBusy,
     thinkingLabel,
     showOnboardingChoice,
+    creditsExhausted: balanceStatus.isExhausted,
   });
 
   // --- Ref writes (connect hook outputs to ActiveChatView's debug refs) ---
@@ -1005,6 +1011,7 @@ export function ChatMainPanel({
     mainView,
     openedAppState,
     isAssistantBusy,
+    showCreditsUpsell: balanceStatus.isExhausted,
     onSelectStarter: handleSelectStarter,
     onSelectSuggestion: newThreadSuggestionsEnabled
       ? setSelectedSuggestion
@@ -1032,10 +1039,8 @@ export function ChatMainPanel({
   const billingBannerDecision =
     errorBillingBannerDecision ?? noticeBillingBannerDecision;
 
-  // Single balance-status read shared by every proactive billing surface in
-  // this component. Error-driven banners always take precedence over the
-  // proactive low-balance warning.
-  const balanceStatus = useBillingBalanceStatus();
+  // Error-driven banners always take precedence over the proactive
+  // low-balance warning.
   const lowBalanceBannerDismissed = useLowBalanceBannerStore.use.dismissed();
   const showLowBalanceBanner = shouldShowLowBalanceBanner({
     billingBannerDecision,

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
@@ -41,8 +41,17 @@ const STARTER: ConversationStarter = {
   batch: 0,
 };
 
+const startersRef = { value: [STARTER] };
+
 mock.module("@/domains/chat/hooks/use-conversation-starters", () => ({
-  useConversationStarters: () => ({ starters: [STARTER] }),
+  useConversationStarters: () => ({ starters: startersRef.value }),
+}));
+
+// The real card mounts platform gates, subscription queries, and a router
+// navigate; the hook only decides whether/where it renders, so a sentinel div
+// keeps the test on the slot-composition logic.
+mock.module("@/domains/chat/components/credits-upsell-card", () => ({
+  CreditsUpsellCard: () => <div data-slot="credits-upsell-card" />,
 }));
 
 const FEATURED: ThreadSuggestion = {
@@ -76,6 +85,7 @@ function baseParams(
     mainView: "chat",
     openedAppState: null,
     isAssistantBusy: false,
+    showCreditsUpsell: false,
     onSelectStarter: () => {},
     ...overrides,
   };
@@ -83,6 +93,7 @@ function baseParams(
 
 beforeEach(() => {
   flagRef.value = false;
+  startersRef.value = [STARTER];
 });
 
 afterEach(() => {
@@ -172,5 +183,75 @@ describe("useChatEmptyState startersSlot", () => {
     expect(
       container.querySelector('[data-slot="suggestion-library"]'),
     ).toBeNull();
+  });
+});
+
+describe("useChatEmptyState credits upsell card", () => {
+  test("showCreditsUpsell renders the card above the starter chips", () => {
+    const { result } = renderHook(() =>
+      useChatEmptyState(baseParams({ showCreditsUpsell: true })),
+    );
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    // Card first, chips after it.
+    expect(
+      container.firstElementChild?.querySelector(
+        '[data-slot="credits-upsell-card"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
+    ).not.toBeNull();
+  });
+
+  test("showCreditsUpsell with no starters still renders the card alone", () => {
+    startersRef.value = [];
+    const { result } = renderHook(() =>
+      useChatEmptyState(baseParams({ showCreditsUpsell: true })),
+    );
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="credits-upsell-card"]'),
+    ).not.toBeNull();
+  });
+
+  test("no card when showCreditsUpsell is false (normal balance, loading, or gated-off billing query)", () => {
+    // `useBillingBalanceStatus` is inert (isExhausted false) while the summary
+    // is loading and for self-hosted / logged-out assistants, so those states
+    // all arrive here as `showCreditsUpsell: false` and never flash the card.
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="credits-upsell-card"]'),
+    ).toBeNull();
+  });
+
+  test("no card on the app-editing empty state", () => {
+    const { result } = renderHook(() =>
+      useChatEmptyState(
+        baseParams({
+          showCreditsUpsell: true,
+          mainView: "app-editing",
+          openedAppState: { name: "My App" },
+        }),
+      ),
+    );
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="credits-upsell-card"]'),
+    ).toBeNull();
+  });
+
+  test("no card once the conversation has messages (the transcript owns it)", () => {
+    const { result } = renderHook(() =>
+      useChatEmptyState(
+        baseParams({ showCreditsUpsell: true, isEmptyConversation: false }),
+      ),
+    );
+
+    expect(result.current.startersSlot).toBeUndefined();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -13,6 +13,7 @@ import { type ReactNode, useMemo } from "react";
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import type { ChatEmptyStateProps } from "@/domains/chat/components/chat-empty-state";
 import { ComposerPeek } from "@/domains/chat/components/composer-peek";
+import { CreditsUpsellCard } from "@/domains/chat/components/credits-upsell-card";
 import { ConversationStarterGrid } from "@/domains/chat/components/conversation-starter-grid";
 import {
   SuggestionFeaturedRow,
@@ -46,6 +47,15 @@ export interface UseChatEmptyStateParams {
   /** Opened app state from viewer-store (non-null when editing an app). */
   openedAppState: { name: string; dirName?: string } | null;
   isAssistantBusy: boolean;
+  /**
+   * Whether the org's credit balance is exhausted (from the shared
+   * `useBillingBalanceStatus()` read in `chat-route-content`). While true,
+   * the plain empty state mounts the credits upsell card above the starters
+   * so a fresh conversation shows the credit wall before the first send.
+   * Inert while the billing query is loading or gated off (self-hosted, no
+   * platform session), so the card never flashes.
+   */
+  showCreditsUpsell: boolean;
   onSelectStarter: (starter: ConversationStarter) => void;
   /**
    * Behind the new-thread-suggestions flag, clicking a library card invokes
@@ -93,6 +103,7 @@ export function useChatEmptyState({
   mainView,
   openedAppState,
   isAssistantBusy,
+  showCreditsUpsell,
   onSelectStarter,
   onSelectSuggestion,
 }: UseChatEmptyStateParams): ChatEmptyStateResult {
@@ -121,11 +132,10 @@ export function useChatEmptyState({
       ? { name: openedAppState.name, dirName: openedAppState.dirName }
       : null;
 
-  // The avatar's presence on the empty state lives entirely in
-  // `ComposerPeek` (hanging from the top of the screen while idle,
-  // peeking behind the input while it's focused) — the greeting headline
-  // renders alone.
-  const actsEnabled = isEmptyConversation && !editingApp;
+  // The plain chat empty state: a fresh conversation outside the app-editing
+  // side panel. Gates the composer peek, the suggestions library, and the
+  // proactive credits upsell card.
+  const isPlainEmptyState = isEmptyConversation && !editingApp;
 
   // Behind the flag, the new suggestions library replaces the starter chips
   // on a fresh thread. The app-editing override keeps its bespoke chips
@@ -134,8 +144,7 @@ export function useChatEmptyState({
   // back to the chip grid.
   const showSuggestionLibrary =
     newThreadSuggestionsEnabled &&
-    isEmptyConversation &&
-    !editingApp &&
+    isPlainEmptyState &&
     onSelectSuggestion != null;
 
   // Gate the daemon fetch by `isEmptyConversation` so non-empty chats stop
@@ -204,6 +213,23 @@ export function useChatEmptyState({
     }
   }
 
+  // Proactive credit wall for a fresh conversation: the card rides the
+  // starters slot, ahead of whatever occupies it (or alone when there are no
+  // starters yet), so it lands above the starters dock. The empty state
+  // suppresses `bannerSlot` (see `chat-body.tsx`), which is why the card
+  // mounts here rather than as a banner. The app-editing side panel is
+  // excluded; a send there still fails into the in-transcript card.
+  if (showCreditsUpsell && isPlainEmptyState) {
+    startersSlot = (
+      <>
+        <div className="mb-3">
+          <CreditsUpsellCard />
+        </div>
+        {startersSlot}
+      </>
+    );
+  }
+
   // Stable callback so the latest-turn avatar slot isn't rebuilt on every
   // transcript render. Paired with `memo(ChatAvatar)`, the avatar
   // re-renders only when its inputs actually change.
@@ -228,14 +254,17 @@ export function useChatEmptyState({
     [avatarComponents, avatarImageUrl, avatarTraits, isAssistantBusy],
   );
 
-  // Portal component — mounting location doesn't matter, but it only runs
+  // Portal component: mounting location doesn't matter, but it only runs
   // on the plain empty state (never over the app-editing side panel, whose
-  // composer shares the same DOM anchor).
-  const composerPeekSlot = actsEnabled ? (
+  // composer shares the same DOM anchor). The avatar's presence on the empty
+  // state lives entirely in `ComposerPeek` (hanging from the top of the
+  // screen while idle, peeking behind the input while it's focused); the
+  // greeting headline renders alone.
+  const composerPeekSlot = isPlainEmptyState ? (
     <ComposerPeek
       components={avatarComponents}
       traits={avatarTraits}
-      active={actsEnabled}
+      active={isPlainEmptyState}
     />
   ) : undefined;
 
@@ -248,7 +277,7 @@ export function useChatEmptyState({
     // side panel keeps them inline under the composer.
     dockStartersToBottom:
       showSuggestionLibrary ||
-      (isEmptyConversation && !editingApp && emptyStateStarters.length > 0),
+      (isPlainEmptyState && emptyStateStarters.length > 0),
     renderAvatar,
     emptyStatePlaceholder,
     composerPeekSlot,

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for `useTranscriptData`'s proactive credits-upsell append: with the
+ * balance exhausted, an open conversation gets the card at the transcript
+ * tail, a fresh conversation does not (the empty state owns the card there),
+ * and a just-failed turn's substituted card is never doubled. The projection
+ * itself (`buildTranscriptItems`) is real; only the two chat stores the hook
+ * reads are stubbed inert.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import { textBody } from "@/domains/chat/utils/message-test-helpers";
+
+mock.module("@/domains/chat/chat-session-store", () => ({
+  useChatSessionStore: {
+    use: { ephemeralMetaResults: () => [] },
+  },
+}));
+
+mock.module("@/domains/chat/interaction-store", () => ({
+  useInteractionStore: {
+    use: {
+      pendingSecret: () => null,
+      pendingConfirmation: () => null,
+      pendingContactRequest: () => null,
+    },
+  },
+}));
+
+const { useTranscriptData } = await import("./use-transcript-data");
+
+function makeMessage(
+  id: string,
+  role: DisplayMessage["role"],
+  text: string,
+): DisplayMessage {
+  return { id, role, ...textBody(text) };
+}
+
+function setup(messages: DisplayMessage[], creditsExhausted: boolean) {
+  return renderHook(() =>
+    useTranscriptData({
+      messages,
+      showThinking: false,
+      turnActive: false,
+      thinkingLabel: null,
+      showOnboardingChoice: false,
+      creditsExhausted,
+    }),
+  );
+}
+
+describe("useTranscriptData proactive credits upsell", () => {
+  test("exhausted balance appends the card at the tail of an open conversation", () => {
+    const { result } = setup(
+      [
+        makeMessage("m1", "user", "Hello"),
+        makeMessage("m2", "assistant", "Hi"),
+      ],
+      true,
+    );
+
+    const items = result.current.transcriptItems;
+    expect(items).toHaveLength(3);
+    expect(items[2]).toEqual({
+      kind: "creditsUpsell",
+      key: "credits-upsell-proactive",
+    });
+  });
+
+  test("no card in a fresh conversation (the empty state renders its own)", () => {
+    const { result } = setup([], true);
+    expect(result.current.transcriptItems).toEqual([]);
+  });
+
+  test("no card while the balance is not exhausted", () => {
+    const { result } = setup([makeMessage("m1", "user", "Hello")], false);
+    expect(
+      result.current.transcriptItems.filter((i) => i.kind === "creditsUpsell"),
+    ).toHaveLength(0);
+  });
+
+  test("a just-failed turn's substituted card is not doubled", () => {
+    const errorRow: DisplayMessage = {
+      ...makeMessage("m2", "assistant", "I hit a snag: your credits ran out."),
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
+    };
+    const { result } = setup(
+      [makeMessage("m1", "user", "Hello"), errorRow],
+      true,
+    );
+
+    const cards = result.current.transcriptItems.filter(
+      (i) => i.kind === "creditsUpsell",
+    );
+    expect(cards).toHaveLength(1);
+    expect(cards[0]!.key).toBe("credits-upsell-m2");
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.test.ts
@@ -2,7 +2,8 @@
  * Tests for `useTranscriptData`'s proactive credits-upsell append: with the
  * balance exhausted, an open conversation gets the card at the transcript
  * tail, a fresh conversation does not (the empty state owns the card there),
- * and a just-failed turn's substituted card is never doubled. The projection
+ * an in-flight turn suppresses the card until it settles, and a just-failed
+ * turn's substituted card is never doubled. The projection
  * itself (`buildTranscriptItems`) is real; only the two chat stores the hook
  * reads are stubbed inert.
  */
@@ -38,16 +39,22 @@ function makeMessage(
   return { id, role, ...textBody(text) };
 }
 
-function setup(messages: DisplayMessage[], creditsExhausted: boolean) {
-  return renderHook(() =>
-    useTranscriptData({
-      messages,
-      showThinking: false,
-      turnActive: false,
-      thinkingLabel: null,
-      showOnboardingChoice: false,
-      creditsExhausted,
-    }),
+function setup(
+  messages: DisplayMessage[],
+  creditsExhausted: boolean,
+  turnActive = false,
+) {
+  return renderHook(
+    (props: { turnActive: boolean }) =>
+      useTranscriptData({
+        messages,
+        showThinking: false,
+        turnActive: props.turnActive,
+        thinkingLabel: null,
+        showOnboardingChoice: false,
+        creditsExhausted,
+      }),
+    { initialProps: { turnActive } },
   );
 }
 
@@ -79,6 +86,30 @@ describe("useTranscriptData proactive credits upsell", () => {
     expect(
       result.current.transcriptItems.filter((i) => i.kind === "creditsUpsell"),
     ).toHaveLength(0);
+  });
+
+  test("no proactive card while a turn is in flight; it appears once the turn settles", () => {
+    const messages = [
+      makeMessage("m1", "user", "Hello"),
+      makeMessage("m2", "assistant", "Hi"),
+    ];
+    const { result, rerender } = setup(messages, true, true);
+
+    // In flight: only the thinking slot trails the messages, no credit wall
+    // under the live progress indicator.
+    expect(result.current.transcriptItems.map((i) => i.kind)).toEqual([
+      "message",
+      "message",
+      "thinking",
+    ]);
+
+    rerender({ turnActive: false });
+
+    expect(result.current.transcriptItems.map((i) => i.kind)).toEqual([
+      "message",
+      "message",
+      "creditsUpsell",
+    ]);
   });
 
   test("a just-failed turn's substituted card is not doubled", () => {

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -43,7 +43,8 @@ export interface UseTranscriptDataParams {
    * `useBillingBalanceStatus()` read in `chat-route-content`). While true, a
    * proactive credits upsell card is appended at the transcript tail of open
    * conversations; empty conversations surface the card through the
-   * empty-state slots instead.
+   * empty-state slots instead. Suppressed while a turn is in flight
+   * (`turnActive`) so the card never sits under the live progress indicator.
    */
   creditsExhausted: boolean;
 }
@@ -123,8 +124,11 @@ export function useTranscriptData({
         showOnboardingChoice,
         // The proactive card is an open-conversation surface: with no
         // messages the chat renders the empty state (which mounts its own
-        // card), not the transcript.
-        appendCreditsUpsell: creditsExhausted && sanitizedMessages.length > 0,
+        // card), not the transcript. In-flight turns suppress it so a credit
+        // wall never renders under the live progress indicator; the
+        // turn-settled billing refetch re-shows it as soon as the turn ends.
+        appendCreditsUpsell:
+          creditsExhausted && !turnActive && sanitizedMessages.length > 0,
       }),
     [
       creditsExhausted,

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -38,6 +38,14 @@ export interface UseTranscriptDataParams {
   thinkingLabel: string | null;
   /** Whether the onboarding choice card should appear in the transcript. */
   showOnboardingChoice: boolean;
+  /**
+   * Whether the org's credit balance is exhausted (from the shared
+   * `useBillingBalanceStatus()` read in `chat-route-content`). While true, a
+   * proactive credits upsell card is appended at the transcript tail of open
+   * conversations; empty conversations surface the card through the
+   * empty-state slots instead.
+   */
+  creditsExhausted: boolean;
 }
 
 export interface TranscriptData {
@@ -55,6 +63,7 @@ export function useTranscriptData({
   turnActive,
   thinkingLabel,
   showOnboardingChoice,
+  creditsExhausted,
 }: UseTranscriptDataParams): TranscriptData {
   // --- Store reads --------------------------------------------------------
   const ephemeralMetaResults = useChatSessionStore.use.ephemeralMetaResults();
@@ -112,8 +121,13 @@ export function useTranscriptData({
         thinkingLabel,
         ephemeralMetaResults,
         showOnboardingChoice,
+        // The proactive card is an open-conversation surface: with no
+        // messages the chat renders the empty state (which mounts its own
+        // card), not the transcript.
+        appendCreditsUpsell: creditsExhausted && sanitizedMessages.length > 0,
       }),
     [
+      creditsExhausted,
       sanitizedMessages,
       pendingSecret,
       pendingConfirmation,

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -814,6 +814,105 @@ describe("buildTranscriptItems", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Proactive exhausted-balance card (appendCreditsUpsell)
+  // ---------------------------------------------------------------------------
+
+  test("appendCreditsUpsell appends the proactive card at the very end", () => {
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
+    const assistant = makeMessage({
+      id: "m2",
+      role: "assistant",
+      ...textBody("Hi"),
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [user, assistant],
+      appendCreditsUpsell: true,
+    });
+
+    expect(items).toHaveLength(3);
+    expect(items[2]).toEqual({
+      kind: "creditsUpsell",
+      key: "credits-upsell-proactive",
+    });
+    expectDistinctNonEmptyKeys(items);
+  });
+
+  test("no proactive card when the last item is already the substituted upsell (just-failed turn)", () => {
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
+    const errorRow = makeMessage({
+      id: "m2",
+      role: "assistant",
+      ...textBody("I hit a snag: your credits ran out."),
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [user, errorRow],
+      appendCreditsUpsell: true,
+    });
+
+    // Exactly one card: the substituted one from the failed turn.
+    expect(items.filter((i) => i.kind === "creditsUpsell")).toHaveLength(1);
+    expect(items[items.length - 1]).toEqual({
+      kind: "creditsUpsell",
+      key: "credits-upsell-m2",
+      messageId: "m2",
+    });
+  });
+
+  test("an old substituted upsell followed by later messages still gets the proactive tail card", () => {
+    // The dedupe is against the transcript TAIL only: a historical exhaustion
+    // (topped up, conversation continued, exhausted again) should not
+    // suppress the new tail card.
+    const errorRow = makeMessage({
+      id: "m1",
+      role: "assistant",
+      providerError: { category: "credits_exhausted" },
+    });
+    const later = makeMessage({
+      id: "m2",
+      role: "assistant",
+      ...textBody("Back in business."),
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [errorRow, later],
+      appendCreditsUpsell: true,
+    });
+
+    expect(items.map((i) => i.kind)).toEqual([
+      "creditsUpsell",
+      "message",
+      "creditsUpsell",
+    ]);
+    expectDistinctNonEmptyKeys(items);
+  });
+
+  test("returns a stable proactive item reference across calls", () => {
+    const message = makeMessage({ id: "m1", role: "user", ...textBody("Hi") });
+
+    const first = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [message],
+      appendCreditsUpsell: true,
+    });
+    const second = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [message],
+      appendCreditsUpsell: true,
+    });
+
+    expect(second[1]).toBe(first[1]!);
+  });
+
+  // ---------------------------------------------------------------------------
   // Confirmation path — inline attachment vs standalone fallback
   // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -817,7 +817,7 @@ describe("buildTranscriptItems", () => {
   // Proactive exhausted-balance card (appendCreditsUpsell)
   // ---------------------------------------------------------------------------
 
-  test("appendCreditsUpsell appends the proactive card at the very end", () => {
+  test("appendCreditsUpsell appends the proactive card after the messages", () => {
     const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
     const assistant = makeMessage({
       id: "m2",
@@ -836,6 +836,26 @@ describe("buildTranscriptItems", () => {
       kind: "creditsUpsell",
       key: "credits-upsell-proactive",
     });
+    expectDistinctNonEmptyKeys(items);
+  });
+
+  test("proactive card lands before trailers (thinking slot, onboarding choice)", () => {
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [user],
+      isThinking: true,
+      showOnboardingChoice: true,
+      appendCreditsUpsell: true,
+    });
+
+    expect(items.map((i) => i.kind)).toEqual([
+      "message",
+      "creditsUpsell",
+      "thinking",
+      "onboardingChoice",
+    ]);
     expectDistinctNonEmptyKeys(items);
   });
 
@@ -866,10 +886,63 @@ describe("buildTranscriptItems", () => {
     });
   });
 
+  test("trailers after the substituted upsell do not defeat the dedupe", () => {
+    // The dedupe consults the last message-derived item, so trailer rows
+    // (onboarding choice, thinking slot, pending prompts) between the
+    // substituted card and the tail must not produce a second card.
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
+    const errorRow = makeMessage({
+      id: "m2",
+      role: "assistant",
+      ...textBody("I hit a snag: your credits ran out."),
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [user, errorRow],
+      showOnboardingChoice: true,
+      appendCreditsUpsell: true,
+    });
+
+    expect(items.map((i) => i.kind)).toEqual([
+      "message",
+      "creditsUpsell",
+      "onboardingChoice",
+    ]);
+    expectDistinctNonEmptyKeys(items);
+  });
+
+  test("the thinking slot of a still-busy failed turn does not defeat the dedupe", () => {
+    const errorRow = makeMessage({
+      id: "m1",
+      role: "assistant",
+      ...textBody("I hit a snag: your credits ran out."),
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [errorRow],
+      turnActive: true,
+      appendCreditsUpsell: true,
+    });
+
+    expect(items.map((i) => i.kind)).toEqual(["creditsUpsell", "thinking"]);
+    expect(items.filter((i) => i.kind === "creditsUpsell")).toHaveLength(1);
+    expectDistinctNonEmptyKeys(items);
+  });
+
   test("an old substituted upsell followed by later messages still gets the proactive tail card", () => {
-    // The dedupe is against the transcript TAIL only: a historical exhaustion
-    // (topped up, conversation continued, exhausted again) should not
-    // suppress the new tail card.
+    // The dedupe consults only the LAST message-derived item: a historical
+    // exhaustion (topped up, conversation continued, exhausted again) should
+    // not suppress the new tail card.
     const errorRow = makeMessage({
       id: "m1",
       role: "assistant",

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -47,9 +47,10 @@ export interface BuildTranscriptItemsInput {
   showOnboardingChoice?: boolean;
   /**
    * When true (the org's credit balance is exhausted), append the proactive
-   * credits upsell card at the very end of the list, unless the last item is
-   * already a `creditsUpsell` (the card substituted for a just-failed turn's
-   * provider-error row), so an open conversation never shows two cards.
+   * credits upsell card directly after the message-derived items, ahead of
+   * trailers (thinking slot, pending prompts, onboarding choice). Skipped
+   * when the last message row already substituted a `creditsUpsell` card for
+   * its provider-error row, so an open conversation never shows two cards.
    */
   appendCreditsUpsell?: boolean;
 }
@@ -101,8 +102,8 @@ function toCreditsUpsellItem(message: DisplayMessage): CreditsUpsellItem {
   return item;
 }
 
-/** Singleton for the proactive exhausted-balance card appended at the
- *  transcript tail (see `appendCreditsUpsell`). Not tied to any message row;
+/** Singleton for the proactive exhausted-balance card appended after the
+ *  message-derived items (see `appendCreditsUpsell`). Not tied to any message row;
  *  the stable reference keeps `TranscriptRow`'s `memo()` effective across
  *  rebuilds. */
 const PROACTIVE_CREDITS_UPSELL_ITEM: CreditsUpsellItem = {
@@ -180,6 +181,17 @@ export function buildTranscriptItems(
     items.push(toMessageItem(message));
   }
 
+  // The proactive exhausted-balance card lands directly after the message
+  // rows; deduping here means trailers pushed below (thinking slot, pending
+  // prompts, onboarding choice) can never mask a just-failed turn's
+  // substituted card and cause a doubled card.
+  if (
+    input.appendCreditsUpsell &&
+    items[items.length - 1]?.kind !== "creditsUpsell"
+  ) {
+    items.push(PROACTIVE_CREDITS_UPSELL_ITEM);
+  }
+
   for (const result of input.ephemeralMetaResults ?? []) {
     items.push({
       kind: "ephemeralMeta",
@@ -233,13 +245,6 @@ export function buildTranscriptItems(
       kind: "onboardingChoice",
       key: "onboarding-choice",
     });
-  }
-
-  if (
-    input.appendCreditsUpsell &&
-    items[items.length - 1]?.kind !== "creditsUpsell"
-  ) {
-    items.push(PROACTIVE_CREDITS_UPSELL_ITEM);
   }
 
   return items;

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -45,6 +45,13 @@ export interface BuildTranscriptItemsInput {
    *  the transcript tail. Not persisted; cleared on the next send/switch. */
   ephemeralMetaResults?: EphemeralMetaResult[];
   showOnboardingChoice?: boolean;
+  /**
+   * When true (the org's credit balance is exhausted), append the proactive
+   * credits upsell card at the very end of the list, unless the last item is
+   * already a `creditsUpsell` (the card substituted for a just-failed turn's
+   * provider-error row), so an open conversation never shows two cards.
+   */
+  appendCreditsUpsell?: boolean;
 }
 
 /**
@@ -93,6 +100,15 @@ function toCreditsUpsellItem(message: DisplayMessage): CreditsUpsellItem {
   creditsUpsellItemCache.set(message, item);
   return item;
 }
+
+/** Singleton for the proactive exhausted-balance card appended at the
+ *  transcript tail (see `appendCreditsUpsell`). Not tied to any message row;
+ *  the stable reference keeps `TranscriptRow`'s `memo()` effective across
+ *  rebuilds. */
+const PROACTIVE_CREDITS_UPSELL_ITEM: CreditsUpsellItem = {
+  kind: "creditsUpsell",
+  key: "credits-upsell-proactive",
+};
 
 /**
  * Project the chat state into an ordered flat list of transcript items.
@@ -217,6 +233,13 @@ export function buildTranscriptItems(
       kind: "onboardingChoice",
       key: "onboarding-choice",
     });
+  }
+
+  if (
+    input.appendCreditsUpsell &&
+    items[items.length - 1]?.kind !== "creditsUpsell"
+  ) {
+    items.push(PROACTIVE_CREDITS_UPSELL_ITEM);
   }
 
   return items;

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -78,14 +78,17 @@ export interface OnboardingChoiceItem extends TranscriptItemBase {
   kind: "onboardingChoice";
 }
 
-/** Friendly credits upsell card, emitted in place of a persisted
+/** Friendly credits upsell card. Emitted in place of a persisted
  *  credits-exhausted provider-error row (`providerError.category` matching
- *  `credits_exhausted`). The row's text stays in message state (the LLM
- *  transcript keeps it); only the rendering is substituted. */
+ *  `credits_exhausted`), where the row's text stays in message state (the LLM
+ *  transcript keeps it) and only the rendering is substituted. Also appended
+ *  proactively at the transcript tail while the org's balance is exhausted,
+ *  so the credit wall shows before the next send fails. */
 export interface CreditsUpsellItem extends TranscriptItemBase {
   kind: "creditsUpsell";
-  /** Id of the provider-error message row this card renders in place of. */
-  messageId: string;
+  /** Id of the provider-error message row this card renders in place of.
+   *  Absent on the proactive tail card, which has no backing message row. */
+  messageId?: string;
 }
 
 export interface EphemeralMetaItem extends TranscriptItemBase {

--- a/clients/web/src/hooks/use-billing-balance-status.test.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.test.ts
@@ -51,9 +51,10 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
 }));
 
-const { useBillingBalanceStatus } = await import(
-  "./use-billing-balance-status"
-);
+const { useBillingBalanceStatus } =
+  await import("./use-billing-balance-status");
+const { shouldShowLowBalanceBanner } =
+  await import("@/domains/chat/components/low-balance-banner");
 
 function summary(
   overrides: Partial<BillingSummaryResponse> = {},
@@ -152,6 +153,24 @@ describe("useBillingBalanceStatus", () => {
   test("exhausted: negative effective balance", () => {
     const { result } = setup({ seed: summary({ effective_balance: "-1.37" }) });
     expect(result.current.isExhausted).toBe(true);
+  });
+
+  test("exhausted status never co-shows with the low-balance banner", () => {
+    // Server contract: `low_balance_warning` is kept false while the balance
+    // is exhausted, so an exhausted status (which drives the proactive upsell
+    // card) always fails the low-balance banner's visibility rule. The
+    // exclusivity lives server-side; this pins the client wiring to it.
+    const { result } = setup({
+      seed: summary({ effective_balance: "0.00", low_balance_warning: false }),
+    });
+    expect(result.current.isExhausted).toBe(true);
+    expect(
+      shouldShowLowBalanceBanner({
+        billingBannerDecision: null,
+        isLowBalance: result.current.isLowBalance,
+        dismissed: false,
+      }),
+    ).toBe(false);
   });
 
   test("all-false while the summary is unresolved", () => {


### PR DESCRIPTION
## Summary
- Empty state renders the CreditsUpsellCard above the starters dock when the balance is exhausted
- Open conversations append a synthetic creditsUpsell item, deduped against a just-failed turn's card
- Never flashes during load; platform-gated

Part of plan: credits-ux.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->