### PR TITLE
feat(voice): minimized voice takes over the chat input as a painted block (JARVIS-1381)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -45,7 +45,7 @@ import {
   restoreVoiceRoom,
   setLiveVoiceEntryOrigin,
   setLiveVoiceMuted,
-  stopLiveVoiceResponse,
+  setLiveVoiceOutputMuted,
   useIsLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -365,11 +365,10 @@ export function ChatComposer({
   // plain theme tokens (the live transcript's body text) by flipping the whole
   // card's polarity to match the fill.
   const voiceCardTone = voiceCardBg ? toneForBg(voiceCardBg) : null;
-  // Mic mute state (controller-published) for the voice bar's toggle.
+  // The two mute states (controller-published) behind the block's toggles: one
+  // per direction of the conversation, like the room's.
   const liveVoiceMuted = useLiveVoiceStore.use.muted();
-  // Hands-free sessions get the turn-scoped ■ stop; a manual (version-skew
-  // fallback) session must not — its interrupt ends the whole session.
-  const liveVoiceHandsFree = useLiveVoiceStore.use.handsFree();
+  const liveVoiceOutputMuted = useLiveVoiceStore.use.outputMuted();
   // Whether the session has any speech transcript to show. A boolean
   // *presence* subscription, not the text itself: zustand only re-renders
   // when the selected value changes identity, so per-delta transcript
@@ -397,7 +396,7 @@ export function ChatComposer({
   // Session verbs go through the store seams registered by the layout-owned
   // controller: `starter` (registered for the controller's whole mount) to
   // start, per-session `controls` to end/interrupt — the latter via the shared
-  // module-level `endLiveVoiceSession`/`stopLiveVoiceResponse` helpers, which
+  // module-level `endLiveVoiceSession` helper, which
   // read the store with `getState()` per STATE_MANAGEMENT.md (no subscription
   // needed for callback-only reads).
   // First-run interception: the very first voice-mode entry opens a
@@ -1023,10 +1022,11 @@ export function ChatComposer({
                 getOutputAmplitude={getLiveVoiceOutputAmplitude}
                 muted={liveVoiceMuted}
                 onToggleMute={() => setLiveVoiceMuted(!liveVoiceMuted)}
+                outputMuted={liveVoiceOutputMuted}
+                onToggleOutputMute={() =>
+                  setLiveVoiceOutputMuted(!liveVoiceOutputMuted)
+                }
                 onEnd={endLiveVoiceSession}
-                // Turn-scoped stop is hands-free-only; a manual session's
-                // interrupt ends the whole session (✕ owns that).
-                onStop={liveVoiceHandsFree ? stopLiveVoiceResponse : undefined}
                 // Expand back to the full-screen room — omitted in pop-out
                 // windows, where the room never renders (the standalone pill
                 // is their only session surface).

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -1022,6 +1022,7 @@ export function ChatComposer({
                 getOutputAmplitude={getLiveVoiceOutputAmplitude}
                 muted={liveVoiceMuted}
                 onToggleMute={() => setLiveVoiceMuted(!liveVoiceMuted)}
+                fillIsLight={voiceCardTone?.isLight ?? false}
                 outputMuted={liveVoiceOutputMuted}
                 onToggleOutputMute={() =>
                   setLiveVoiceOutputMuted(!liveVoiceOutputMuted)

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -40,6 +40,7 @@ import {
   dismissLiveVoiceFailure,
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
+  getLiveVoiceOutputAmplitude,
   isLiveVoiceSessionActive,
   restoreVoiceRoom,
   setLiveVoiceEntryOrigin,
@@ -51,7 +52,6 @@ import {
 import { preflightLiveVoice } from "@/domains/chat/voice/live-voice/live-voice-preflight-api";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { VoiceFirstRunCard } from "@/domains/chat/voice/voice-room/voice-first-run-card";
-import { resolveWaveAccentHex } from "@/domains/chat/voice/voice-room/wave-accent";
 import {
   VOICE_SURFACE_DARK,
   resolveVoiceRoomLook,
@@ -325,21 +325,17 @@ export function ChatComposer({
   // shares the global live-voice store but must never swap its row.
   const ownsLiveVoiceSession = useIsLiveVoiceSessionOwnedBy(conversationId);
   const isLiveVoiceActive = showVoiceInput && ownsLiveVoiceSession;
-  // Wave accent for the voice bar's listening waves — the same avatar-matched
-  // tint the room resolves (see wave-accent.ts), so the minimized session
-  // keeps the room's color language. Fetch-gated to live sessions; the query
-  // is shared with every other avatar consumer.
+  // The session assistant's avatar, which is where the block's fill comes from.
+  // Fetch-gated to live sessions; the query is shared with every other avatar
+  // consumer. The band no longer takes an accent from it: the block is painted
+  // that color, so its ink has to contrast with the fill instead (see
+  // `BAND_VOICE` in voice-composer-bar.tsx).
   const {
     components: avatarComponents,
     traits: avatarTraits,
     customImageUrl: avatarCustomImageUrl,
     isLoading: avatarLoading,
   } = useAssistantAvatar(isLiveVoiceActive ? assistantId : null);
-  const voiceWaveAccentHex = resolveWaveAccentHex(
-    avatarComponents,
-    avatarTraits,
-    avatarCustomImageUrl,
-  );
   // The minimized session paints the whole composer card in the room's own
   // background color, so the two surfaces are one thing at two sizes. The look
   // resolves to null for assistants with no character color (custom-image /
@@ -1024,6 +1020,7 @@ export function ChatComposer({
               <VoiceComposerBar
                 state={liveVoiceState}
                 getAmplitude={getLiveVoiceInputAmplitude}
+                getOutputAmplitude={getLiveVoiceOutputAmplitude}
                 muted={liveVoiceMuted}
                 onToggleMute={() => setLiveVoiceMuted(!liveVoiceMuted)}
                 onEnd={endLiveVoiceSession}
@@ -1034,7 +1031,6 @@ export function ChatComposer({
                 // windows, where the room never renders (the standalone pill
                 // is their only session surface).
                 onExpand={isPopout ? undefined : restoreVoiceRoom}
-                waveAccentHex={voiceWaveAccentHex}
                 standalone={hideTextareaForLiveVoice}
               />
             ) : (

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -1,5 +1,6 @@
 import { ArrowUp, Square } from "lucide-react";
 import {
+  type CSSProperties,
   type FormEvent,
   type ReactNode,
   type RefObject,
@@ -51,6 +52,11 @@ import { preflightLiveVoice } from "@/domains/chat/voice/live-voice/live-voice-p
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { VoiceFirstRunCard } from "@/domains/chat/voice/voice-room/voice-first-run-card";
 import { resolveWaveAccentHex } from "@/domains/chat/voice/voice-room/wave-accent";
+import {
+  VOICE_SURFACE_DARK,
+  resolveVoiceRoomLook,
+} from "@/domains/chat/voice/voice-room/voice-room-eyes";
+import { toneForBg } from "@/utils/avatar-tone";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
@@ -327,12 +333,42 @@ export function ChatComposer({
     components: avatarComponents,
     traits: avatarTraits,
     customImageUrl: avatarCustomImageUrl,
+    isLoading: avatarLoading,
   } = useAssistantAvatar(isLiveVoiceActive ? assistantId : null);
   const voiceWaveAccentHex = resolveWaveAccentHex(
     avatarComponents,
     avatarTraits,
     avatarCustomImageUrl,
   );
+  // The minimized session paints the whole composer card in the room's own
+  // background color, so the two surfaces are one thing at two sizes. The look
+  // resolves to null for assistants with no character color (custom-image /
+  // "none"), which is exactly when the room falls back to its deep ambient
+  // surface, so the card follows it there.
+  //
+  // Gated on the avatar query having settled: `resolveVoiceRoomLook` returns
+  // null both for "no character color" and for "not fetched yet", so painting
+  // on the in-flight read would flash the card to the ambient dark and then
+  // again to the avatar color. Hold the normal card surface until the answer
+  // is real, and the card changes color once.
+  const voiceRoomLook =
+    isLiveVoiceActive && !avatarLoading
+      ? resolveVoiceRoomLook(
+          avatarComponents,
+          avatarTraits,
+          avatarCustomImageUrl,
+        )
+      : null;
+  const voiceCardBg =
+    isLiveVoiceActive && !avatarLoading
+      ? (voiceRoomLook?.bgHex ?? VOICE_SURFACE_DARK)
+      : null;
+  // Foreground tone for that fill. Published as the `--room-*` vars, the same
+  // contract the room uses, so the block's chrome contrasts against whichever
+  // avatar color it landed on. `data-theme` covers the descendants that read
+  // plain theme tokens (the live transcript's body text) by flipping the whole
+  // card's polarity to match the fill.
+  const voiceCardTone = voiceCardBg ? toneForBg(voiceCardBg) : null;
   // Mic mute state (controller-published) for the voice bar's toggle.
   const liveVoiceMuted = useLiveVoiceStore.use.muted();
   // Hands-free sessions get the turn-scoped ■ stop; a manual (version-skew
@@ -698,9 +734,30 @@ export function ChatComposer({
           <form
             data-slot="chat-composer"
             onSubmit={onSubmit}
-            className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
-              hasBillingBanner ? "rounded-b-[10px]" : "rounded-[10px]"
-            }`}
+            // A live session repaints the card in the room's color (see
+            // `voiceCardBg`); `overflow-hidden` clips that fill to the card's
+            // radius, so the block reads as a solid rounded panel rather than
+            // a strip inside a white card.
+            className={`overflow-hidden shadow-[0px_2px_2px_rgba(0,0,0,0.05)] transition-colors duration-300 ${
+              voiceCardBg ? "" : "bg-[var(--surface-lift)]"
+            } ${hasBillingBanner ? "rounded-b-[10px]" : "rounded-[10px]"}`}
+            data-theme={
+              voiceCardTone
+                ? voiceCardTone.isLight
+                  ? "light"
+                  : "dark"
+                : undefined
+            }
+            style={
+              voiceCardBg && voiceCardTone
+                ? ({
+                    backgroundColor: voiceCardBg,
+                    "--room-fg": voiceCardTone.fg,
+                    "--room-fg-muted": voiceCardTone.fgMuted,
+                    "--room-wash": voiceCardTone.wash,
+                  } as CSSProperties)
+                : undefined
+            }
           >
             <ChatAttachmentsStrip
               attachments={attachments}

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -51,6 +51,7 @@ function renderBar(
     onEnd?: () => void;
     outputMuted?: boolean;
     onToggleOutputMute?: () => void;
+    fillIsLight?: boolean;
     onExpand?: () => void;
     standalone?: boolean;
   },
@@ -65,6 +66,7 @@ function renderBar(
       onEnd={overrides?.onEnd ?? (() => {})}
       outputMuted={overrides?.outputMuted ?? false}
       onToggleOutputMute={overrides?.onToggleOutputMute ?? (() => {})}
+      fillIsLight={overrides?.fillIsLight ?? false}
       onExpand={overrides?.onExpand}
       standalone={overrides?.standalone}
     />,
@@ -331,5 +333,39 @@ describe("VoiceComposerBar: the band", () => {
   test("a muted mic reads silent, not frozen", () => {
     renderBar("listening", { muted: true });
     expect(lastBandProps?.getAmplitude()).toBe(0);
+  });
+});
+
+describe("VoiceComposerBar: muted controls stay visible", () => {
+  test("a muted control inks itself against the fill, not the theme", () => {
+    // The negative token is a mid-tone red and the block is painted an
+    // arbitrary avatar color, so the two can land close enough that the muted
+    // glyph vanishes into the fill. Inline, so it beats the resting
+    // `--vbtn-fg` regardless of how Tailwind orders the two utilities.
+    renderBar("listening", { muted: true });
+    const style =
+      screen
+        .getByRole("button", { name: "Unmute microphone" })
+        .getAttribute("style") ?? "";
+    expect(style).toContain("--vbtn-fg");
+    expect(style.toUpperCase()).toContain("#FCA5A5");
+  });
+
+  test("a light fill gets the deep red instead of the pale one", () => {
+    renderBar("listening", { muted: true, fillIsLight: true });
+    const style =
+      screen
+        .getByRole("button", { name: "Unmute microphone" })
+        .getAttribute("style") ?? "";
+    expect(style.toUpperCase()).toContain("#991B1B");
+  });
+
+  test("a muted assistant inks itself the same way", () => {
+    renderBar("speaking", { outputMuted: true });
+    const style =
+      screen
+        .getByRole("button", { name: "Unmute assistant" })
+        .getAttribute("style") ?? "";
+    expect(style.toUpperCase()).toContain("#FCA5A5");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -49,7 +49,8 @@ function renderBar(
     muted?: boolean;
     onToggleMute?: () => void;
     onEnd?: () => void;
-    onStop?: () => void;
+    outputMuted?: boolean;
+    onToggleOutputMute?: () => void;
     onExpand?: () => void;
     standalone?: boolean;
   },
@@ -62,18 +63,12 @@ function renderBar(
       muted={overrides?.muted ?? false}
       onToggleMute={overrides?.onToggleMute ?? (() => {})}
       onEnd={overrides?.onEnd ?? (() => {})}
-      onStop={overrides?.onStop}
+      outputMuted={overrides?.outputMuted ?? false}
+      onToggleOutputMute={overrides?.onToggleOutputMute ?? (() => {})}
       onExpand={overrides?.onExpand}
       standalone={overrides?.standalone}
     />,
   );
-}
-
-/** The painted state word, as distinct from the `sr-only` live region. */
-function visibleLabel(): HTMLElement | undefined {
-  return screen
-    .getAllByText(/…|Muted/)
-    .find((el) => !el.className.includes("sr-only"));
 }
 
 /** The `sr-only` live region that announces the state. */
@@ -83,7 +78,7 @@ function liveRegion(): HTMLElement | undefined {
     .find((el) => el.className.includes("sr-only"));
 }
 
-describe("VoiceComposerBar — state label", () => {
+describe("VoiceComposerBar: state announcement", () => {
   const labels: Array<[LiveVoiceSessionState, string]> = [
     ["connecting", "Connecting…"],
     ["listening", "Listening…"],
@@ -94,29 +89,25 @@ describe("VoiceComposerBar — state label", () => {
   ];
 
   for (const [state, label] of labels) {
-    test(`shows "${label}" for the ${state} state`, () => {
+    test(`announces "${label}" for the ${state} state`, () => {
       renderBar(state);
-      expect(visibleLabel()?.textContent).toBe(label);
+      expect(liveRegion()?.textContent).toBe(label);
     });
   }
 
-  test("the state word is painted in the block", () => {
-    // The block is a surface, not a toolbar: the state word sits in it beside
-    // the band, so the minimized session says what it is doing.
+  test("paints no state word: the band is the readout", () => {
+    // The block says what it is doing by moving. A word over the band competed
+    // with it and gave the surface one more thing to read.
     renderBar("listening");
-    expect(visibleLabel()).toBeTruthy();
+    const painted = screen
+      .getAllByText(/…|Muted/)
+      .filter((el) => !el.className.includes("sr-only"));
+    expect(painted).toEqual([]);
   });
 
-  test("announces state changes via a separate aria-live region", () => {
+  test("announces state changes via an aria-live region", () => {
     renderBar("listening");
     expect(liveRegion()?.getAttribute("aria-live")).toBe("polite");
-  });
-
-  test("the painted word is hidden from assistive tech, so it is not read twice", () => {
-    // The live region already announces the state. Leaving the painted copy
-    // exposed would have a screen reader read it a second time.
-    renderBar("listening");
-    expect(visibleLabel()?.getAttribute("aria-hidden")).toBe("true");
   });
 });
 
@@ -170,38 +161,51 @@ describe("VoiceComposerBar — mute toggle", () => {
     expect(onToggleMute).toHaveBeenCalledTimes(1);
   });
 
-  test("muted: offers unmute and replaces the state label with 'Muted'", () => {
+  test("muted: offers unmute and announces 'Muted' in place of the state", () => {
     renderBar("listening", { muted: true });
     expect(
       screen.getByRole("button", { name: "Unmute microphone" }),
     ).toBeTruthy();
-    expect(visibleLabel()?.textContent).toBe("Muted");
     expect(liveRegion()?.textContent).toBe("Muted");
     expect(screen.queryByText("Listening…")).toBeNull();
   });
 });
 
-describe("VoiceComposerBar — stop response", () => {
-  test("■ renders only while speaking with onStop wired, and fires it", () => {
-    const onStop = mock(() => {});
-    renderBar("speaking", { onStop });
-    fireEvent.click(
-      screen.getByRole("button", { name: "Stop assistant response" }),
-    );
-    expect(onStop).toHaveBeenCalledTimes(1);
+describe("VoiceComposerBar: assistant mute", () => {
+  test("offers the mute and fires it, in every state", () => {
+    // Persistent, like the room's: the pair of mutes never changes shape
+    // mid-turn, so neither moves out from under a reaching finger.
+    for (const state of ["listening", "thinking", "speaking"] as const) {
+      const onToggleOutputMute = mock(() => {});
+      const { unmount } = renderBar(state, { onToggleOutputMute });
+      fireEvent.click(screen.getByRole("button", { name: "Mute assistant" }));
+      expect(onToggleOutputMute).toHaveBeenCalledTimes(1);
+      unmount();
+    }
   });
 
-  test("no ■ outside speaking, or without onStop (manual session)", () => {
-    const { unmount } = renderBar("listening", { onStop: () => {} });
-    expect(
-      screen.queryByRole("button", { name: "Stop assistant response" }),
-    ).toBeNull();
-    unmount();
+  test("muted: offers unmute and reflects the pressed state", () => {
+    renderBar("speaking", { outputMuted: true });
+    const toggle = screen.getByRole("button", { name: "Unmute assistant" });
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+  });
+});
 
-    renderBar("speaking");
-    expect(
-      screen.queryByRole("button", { name: "Stop assistant response" }),
-    ).toBeNull();
+describe("VoiceComposerBar: no transient stop", () => {
+  test("offers no ■ in any state", () => {
+    // Muting the assistant replaced it: a control that appeared and vanished
+    // with the reply changed the row's shape twice a turn.
+    for (const state of [
+      "listening",
+      "thinking",
+      "speaking",
+    ] as LiveVoiceSessionState[]) {
+      const { unmount } = renderBar(state);
+      expect(
+        screen.queryByRole("button", { name: "Stop assistant response" }),
+      ).toBeNull();
+      unmount();
+    }
   });
 });
 
@@ -259,6 +263,7 @@ describe("VoiceComposerBar — structure and accessibility", () => {
     renderBar("listening", { onExpand: () => {} });
     for (const name of [
       "Mute microphone",
+      "Mute assistant",
       "Open voice room",
       "End voice session",
     ]) {
@@ -277,13 +282,16 @@ describe("VoiceComposerBar — structure and accessibility", () => {
     expect(band.className).toContain("-webkit-mask-image:linear-gradient");
   });
 
-  test("resting bar is exactly mute + expand + end", () => {
+  test("the block holds the room's control set, and nothing else", () => {
+    // Same four as the room, in the same reading order: the two mutes (one per
+    // direction of the conversation), the way back into the room, and end.
     renderBar("listening", { onExpand: () => {} });
     const names = screen
       .getAllByRole("button")
       .map((b) => b.getAttribute("aria-label"));
     expect(names).toEqual([
       "Mute microphone",
+      "Mute assistant",
       "Open voice room",
       "End voice session",
     ]);

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -3,20 +3,45 @@
  *
  * The bar is purely presentational, so tests drive it prop-by-prop: state
  * label mapping, control presence, callback wiring, and accessibility
- * attributes. The embedded `VoiceReactiveWaves` is SVG + a rAF loop writing
- * a CSS var — inert under happy-dom, so no harness is needed here.
+ * attributes.
+ *
+ * `VoiceMeshWaves` is a canvas plus a rAF loop, inert under happy-dom, so the
+ * band is stubbed with a probe that records the props it was handed. That is
+ * the only way to assert what the band is drawing (its ink and which voice it
+ * rides), which is otherwise invisible to a DOM test.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
-import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+let lastBandProps: {
+  getAmplitude: () => number;
+  color?: string;
+  peakOpacity?: number;
+} | null = null;
+mock.module("@/domains/chat/voice/voice-room/voice-mesh-waves", () => ({
+  MESH_INLINE_TUNING: {},
+  VoiceMeshWaves: (props: {
+    getAmplitude: () => number;
+    color?: string;
+    peakOpacity?: number;
+  }) => {
+    lastBandProps = props;
+    return null;
+  },
+}));
+
+const { VoiceComposerBar } =
+  await import("@/domains/chat/components/chat-composer/voice-composer-bar");
 import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 afterEach(() => {
   cleanup();
 });
+
+const INPUT_LEVEL = 0.5;
+const OUTPUT_LEVEL = 0.25;
 
 function renderBar(
   state: LiveVoiceSessionState,
@@ -32,7 +57,8 @@ function renderBar(
   return render(
     <VoiceComposerBar
       state={state}
-      getAmplitude={() => 0.5}
+      getAmplitude={() => INPUT_LEVEL}
+      getOutputAmplitude={() => OUTPUT_LEVEL}
       muted={overrides?.muted ?? false}
       onToggleMute={overrides?.onToggleMute ?? (() => {})}
       onEnd={overrides?.onEnd ?? (() => {})}
@@ -202,11 +228,13 @@ describe("VoiceComposerBar — structure and accessibility", () => {
     expect(group).toBeTruthy();
   });
 
-  test("renders the room's listening waves inline", () => {
-    const { container } = renderBar("listening");
-    expect(
-      container.querySelector(".voice-listening-waves--inline"),
-    ).toBeTruthy();
+  test("renders the room's band across the block", () => {
+    renderBar("listening");
+    const band = screen.getByTestId("voice-session-band");
+    // Filling the block, behind everything: the color and the motion are one
+    // surface, not a strip in a middle column.
+    expect(band.className).toContain("absolute inset-0");
+    expect(lastBandProps).not.toBeNull();
   });
 
   test("standalone takes the composer's footprint, otherwise it is a control row", () => {
@@ -234,21 +262,19 @@ describe("VoiceComposerBar — structure and accessibility", () => {
       "Open voice room",
       "End voice session",
     ]) {
-      expect(
-        screen.getByRole("button", { name }).className,
-      ).toContain("--room-fg-muted");
+      expect(screen.getByRole("button", { name }).className).toContain(
+        "--room-fg-muted",
+      );
     }
   });
 
-  test("wave strip fades at both edges instead of hard-clipping", () => {
+  test("the band fades at both edges instead of hard-clipping", () => {
     // Includes the -webkit- prefix: the iOS client is a WKWebView and drops
     // the unprefixed property, which would silently disable the fade there.
-    const { container } = renderBar("listening");
-    const strip = container.querySelector(
-      ".voice-listening-waves--inline",
-    )?.parentElement;
-    expect(strip?.className).toContain("mask-image:linear-gradient");
-    expect(strip?.className).toContain("-webkit-mask-image:linear-gradient");
+    renderBar("listening");
+    const band = screen.getByTestId("voice-session-band");
+    expect(band.className).toContain("mask-image:linear-gradient");
+    expect(band.className).toContain("-webkit-mask-image:linear-gradient");
   });
 
   test("resting bar is exactly mute + expand + end", () => {
@@ -261,5 +287,41 @@ describe("VoiceComposerBar — structure and accessibility", () => {
       "Open voice room",
       "End voice session",
     ]);
+  });
+});
+
+describe("VoiceComposerBar: the band", () => {
+  test("rides the mic in a pale ink while listening", () => {
+    renderBar("listening");
+    // Pale over the fill, per the room's own pairing. The block is painted the
+    // avatar color, so an accent-tinted band would be that same hue and paint
+    // nothing at all.
+    expect(lastBandProps?.color).toBe("#FFFFFF");
+    expect(lastBandProps?.getAmplitude()).toBe(INPUT_LEVEL);
+  });
+
+  test("rides the reply in a darker ink while the assistant speaks", () => {
+    renderBar("speaking");
+    expect(lastBandProps?.color).toBe("#000000");
+    // The mic is closed through the reply, so a band on the input level would
+    // sit flat for that whole half of the turn.
+    expect(lastBandProps?.getAmplitude()).toBe(OUTPUT_LEVEL);
+  });
+
+  test("keeps riding the mic while the turn is being worked on", () => {
+    // The mic is open through transcribing/thinking (barge-in), so the block
+    // stays alive with the user's own level rather than flattening.
+    renderBar("thinking");
+    expect(lastBandProps?.getAmplitude()).toBe(INPUT_LEVEL);
+  });
+
+  test("empties the floor when neither voice is present", () => {
+    renderBar("connecting");
+    expect(lastBandProps?.getAmplitude()).toBe(0);
+  });
+
+  test("a muted mic reads silent, not frozen", () => {
+    renderBar("listening", { muted: true });
+    expect(lastBandProps?.getAmplitude()).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -43,6 +43,20 @@ function renderBar(
   );
 }
 
+/** The painted state word, as distinct from the `sr-only` live region. */
+function visibleLabel(): HTMLElement | undefined {
+  return screen
+    .getAllByText(/…|Muted/)
+    .find((el) => !el.className.includes("sr-only"));
+}
+
+/** The `sr-only` live region that announces the state. */
+function liveRegion(): HTMLElement | undefined {
+  return screen
+    .getAllByText(/…|Muted/)
+    .find((el) => el.className.includes("sr-only"));
+}
+
 describe("VoiceComposerBar — state label", () => {
   const labels: Array<[LiveVoiceSessionState, string]> = [
     ["connecting", "Connecting…"],
@@ -54,23 +68,29 @@ describe("VoiceComposerBar — state label", () => {
   ];
 
   for (const [state, label] of labels) {
-    test(`announces "${label}" for the ${state} state`, () => {
+    test(`shows "${label}" for the ${state} state`, () => {
       renderBar(state);
-      expect(screen.getByText(label)).toBeTruthy();
+      expect(visibleLabel()?.textContent).toBe(label);
     });
   }
 
-  test("announces state changes via an aria-live region", () => {
+  test("the state word is painted in the block", () => {
+    // The block is a surface, not a toolbar: the state word sits in it beside
+    // the band, so the minimized session says what it is doing.
     renderBar("listening");
-    const label = screen.getByText("Listening…");
-    expect(label.getAttribute("aria-live")).toBe("polite");
+    expect(visibleLabel()).toBeTruthy();
   });
 
-  test("the state label is visually hidden, not painted", () => {
-    // The mic glyph and the animating waves carry "listening" on their own,
-    // so the text stays in the tree for assistive tech only.
+  test("announces state changes via a separate aria-live region", () => {
     renderBar("listening");
-    expect(screen.getByText("Listening…").className).toContain("sr-only");
+    expect(liveRegion()?.getAttribute("aria-live")).toBe("polite");
+  });
+
+  test("the painted word is hidden from assistive tech, so it is not read twice", () => {
+    // The live region already announces the state. Leaving the painted copy
+    // exposed would have a screen reader read it a second time.
+    renderBar("listening");
+    expect(visibleLabel()?.getAttribute("aria-hidden")).toBe("true");
   });
 });
 
@@ -129,7 +149,8 @@ describe("VoiceComposerBar — mute toggle", () => {
     expect(
       screen.getByRole("button", { name: "Unmute microphone" }),
     ).toBeTruthy();
-    expect(screen.getByText("Muted")).toBeTruthy();
+    expect(visibleLabel()?.textContent).toBe("Muted");
+    expect(liveRegion()?.textContent).toBe("Muted");
     expect(screen.queryByText("Listening…")).toBeNull();
   });
 });
@@ -188,19 +209,35 @@ describe("VoiceComposerBar — structure and accessibility", () => {
     ).toBeTruthy();
   });
 
-  test("standalone supplies its own top padding", () => {
-    // When the textarea collapses away for the session the bar is the card's
-    // only row, so it can no longer lean on the textarea's top padding.
+  test("standalone takes the composer's footprint, otherwise it is a control row", () => {
+    // Owning the card, the block holds the height the composer it replaced
+    // had, so minimizing does not shift the thread above it. Sharing the card
+    // with the live transcript, it stays a row under it.
     const { unmount } = renderBar("listening", { standalone: true });
     expect(
       screen.getByRole("group", { name: "Voice session" }).className,
-    ).toContain("pt-3");
+    ).toContain("h-[5.25rem]");
     unmount();
 
     renderBar("listening");
     expect(
       screen.getByRole("group", { name: "Voice session" }).className,
-    ).not.toContain("pt-3");
+    ).not.toContain("h-[5.25rem]");
+  });
+
+  test("controls are toned for the avatar color, not theme tokens", () => {
+    // The block is painted an arbitrary avatar color, so chrome that read
+    // `--content-default` would be as likely to vanish into it as contrast.
+    renderBar("listening", { onExpand: () => {} });
+    for (const name of [
+      "Mute microphone",
+      "Open voice room",
+      "End voice session",
+    ]) {
+      expect(
+        screen.getByRole("button", { name }).className,
+      ).toContain("--room-fg-muted");
+    }
   });
 
   test("wave strip fades at both edges instead of hard-clipping", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -29,8 +29,6 @@
  * interrupting a reply in progress has no silent equivalent.
  */
 
-import type { CSSProperties } from "react";
-
 import { Maximize2, Mic, MicOff, Square, X } from "lucide-react";
 
 import { Button, cn } from "@vellumai/design-library";
@@ -45,17 +43,22 @@ import {
   MESH_INLINE_TUNING,
   VoiceMeshWaves,
 } from "@/domains/chat/voice/voice-room/voice-mesh-waves";
-import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
+import { BAND_VOICE } from "@/domains/chat/voice/voice-room/voice-room-eyes";
 
-// While the mic is not live (muted, assistant speaking) the waves read a
-// steady zero and settle into their quiet drift — the room's own resting
-// listening band — instead of freezing.
+// Between turns (mic muted, assistant silent) the band reads a steady zero,
+// which is the room's empty floor: no ink at all until a voice is present.
 const SILENT_AMPLITUDE = () => 0;
 
 export interface VoiceComposerBarProps {
   state: LiveVoiceSessionState;
-  /** Polled ~30 Hz by the waveform's draw loop — no re-render per sample. */
+  /** Mic level, polled ~30 Hz by the band's draw loop. No re-render per sample. */
   getAmplitude: () => number;
+  /**
+   * Assistant-playback level, same polling contract. The band rides this while
+   * the assistant speaks, so the block keeps moving through the half of the
+   * turn the mic is silent for, exactly as the room's two bands do.
+   */
+  getOutputAmplitude: () => number;
   /** Whether the mic is muted — drives the left-side mute toggle. */
   muted: boolean;
   /** Toggle the mic mute without ending the session. */
@@ -74,12 +77,6 @@ export interface VoiceComposerBarProps {
    * ships dead.
    */
   onExpand?: () => void;
-  /**
-   * Accent hex matching the avatar the voice room renders (see
-   * `resolveWaveAccentHex`), so the bar's waves keep the room's tint.
-   * Null/omitted falls back to the app-wide accent, then aurora.
-   */
-  waveAccentHex?: string | null;
   /**
    * Whether the block is the composer card's only content, which it is unless
    * the user opted into seeing their own words (the live transcript keeps the
@@ -114,14 +111,31 @@ const VOICE_CONTROL_CLASS = [
 export function VoiceComposerBar({
   state,
   getAmplitude,
+  getOutputAmplitude,
   muted,
   onToggleMute,
   onEnd,
   onStop,
   onExpand,
-  waveAccentHex,
   standalone = false,
 }: VoiceComposerBarProps) {
+  // Which voice the band is drawing, in the room's own terms: the user lifts a
+  // pale sheet off the floor, the assistant answers in a darker one, and in
+  // silence the floor is empty. Ink cannot come from the avatar accent here:
+  // the block is painted that exact color, so an accent-tinted band is the
+  // fill's own hue and paints nothing at all.
+  //
+  // The reply wins the surface while it plays. The mic stays open through it
+  // for barge-in (`isLiveVoiceMicLive` spans listening→speaking), so keying off
+  // the mic alone would draw the user's voice over the assistant's.
+  const replying = state === "speaking";
+  const micLive = isLiveVoiceMicLive(state) && !muted;
+  const ink = replying ? BAND_VOICE.responding : BAND_VOICE.listening;
+  const bandAmplitude = replying
+    ? getOutputAmplitude
+    : micLive
+      ? getAmplitude
+      : SILENT_AMPLITUDE;
   return (
     <div
       role="group"
@@ -138,23 +152,18 @@ export function VoiceComposerBar({
           so the color and the motion read as one surface. Behind the controls
           and the state word, which is why it is first and inert. */}
       <div
+        data-testid="voice-session-band"
         className={cn(
           "pointer-events-none absolute inset-0 overflow-hidden",
           VOICE_WAVE_EDGE_FADE_CLASS,
         )}
-        style={
-          waveAccentHex
-            ? ({ [AVATAR_ACCENT_CSS_VAR]: waveAccentHex } as CSSProperties)
-            : undefined
-        }
       >
         <VoiceMeshWaves
-          getAmplitude={
-            isLiveVoiceMicLive(state) ? getAmplitude : SILENT_AMPLITUDE
-          }
-          palette="accent"
+          getAmplitude={bandAmplitude}
+          color={ink.color}
+          peakOpacity={ink.peakOpacity}
           placement="inline"
-          tuning={MESH_INLINE_TUNING}
+          tuning={{ ...MESH_INLINE_TUNING, opacityKnee: ink.opacityKnee }}
         />
       </div>
 

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -38,6 +38,8 @@
  * advertise an action the user never needs.
  */
 
+import type { CSSProperties } from "react";
+
 import { Maximize2, Mic, MicOff, Volume2, VolumeX, X } from "lucide-react";
 
 import { Button, cn } from "@vellumai/design-library";
@@ -89,6 +91,12 @@ export interface VoiceComposerBarProps {
    */
   onExpand?: () => void;
   /**
+   * Whether the card's fill is a light color, from the same `toneForBg` read
+   * that paints it. Only the muted controls consult it: their red has to
+   * contrast with the fill rather than with the theme.
+   */
+  fillIsLight: boolean;
+  /**
    * Whether the block is the composer card's only content, which it is unless
    * the user opted into seeing their own words (the live transcript keeps the
    * textarea row above). Standing alone it owns the card's whole footprint and
@@ -113,6 +121,26 @@ const BLOCK_HEIGHT_CLASS = "h-[5.25rem]";
  * likely to be invisible on it as legible. The token fallbacks only apply if a
  * caller renders the block without the vars, which the composer never does.
  */
+/**
+ * Ink for a control that is currently *off* (mic muted, assistant muted).
+ *
+ * Not the negative theme token: that is a mid-tone red, and the block is
+ * painted an arbitrary avatar color, so the two can land close enough that the
+ * muted glyph disappears into the fill. This is the room's own choice instead,
+ * a pale red on dark fills and a deep one on light, which keeps "off" legible
+ * on every palette color.
+ *
+ * Applied as an inline style rather than another utility: it competes with the
+ * resting `--vbtn-fg` in {@link VOICE_CONTROL_CLASS}, and two
+ * arbitrary-property classes setting the same variable are ordered by
+ * Tailwind's own sort, not by the order they are passed in.
+ */
+function mutedInk(fillIsLight: boolean): CSSProperties {
+  return {
+    "--vbtn-fg": fillIsLight ? "#991B1B" : "#FCA5A5",
+  } as CSSProperties;
+}
+
 const VOICE_CONTROL_CLASS = [
   "[--vbtn-fg:var(--room-fg-muted,var(--content-secondary))]",
   "hover:[--vbtn-fg:var(--room-fg,var(--content-default))]",
@@ -129,6 +157,7 @@ export function VoiceComposerBar({
   onToggleOutputMute,
   onEnd,
   onExpand,
+  fillIsLight,
   standalone = false,
 }: VoiceComposerBarProps) {
   // Which voice the band is drawing, in the room's own terms: the user lifts a
@@ -190,10 +219,8 @@ export function VoiceComposerBar({
           aria-label={muted ? "Unmute microphone" : "Mute microphone"}
           aria-pressed={muted}
           tooltip={muted ? "Unmute microphone" : "Mute microphone"}
-          className={cn(
-            VOICE_CONTROL_CLASS,
-            muted && "[--vbtn-fg:var(--system-negative-strong)]",
-          )}
+          className={VOICE_CONTROL_CLASS}
+          style={muted ? mutedInk(fillIsLight) : undefined}
         />
       </div>
 
@@ -222,10 +249,8 @@ export function VoiceComposerBar({
           aria-label={outputMuted ? "Unmute assistant" : "Mute assistant"}
           aria-pressed={outputMuted}
           tooltip={outputMuted ? "Unmute assistant" : "Mute assistant"}
-          className={cn(
-            VOICE_CONTROL_CLASS,
-            outputMuted && "[--vbtn-fg:var(--system-negative-strong)]",
-          )}
+          className={VOICE_CONTROL_CLASS}
+          style={outputMuted ? mutedInk(fillIsLight) : undefined}
         />
         {onExpand ? (
           <Button

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -5,31 +5,40 @@
  * It is a block, not a toolbar. The whole chat input is given over to it,
  * painted in the room's own background color (the session assistant's avatar
  * color, or {@link VOICE_SURFACE_DARK} for an assistant with no character
- * color), with the mesh band and the state word inside it. Minimizing therefore
- * reads as the room shrinking into the composer rather than as a row swap, and
- * expanding is the same surface growing back.
+ * color), with the mesh band running through it. Minimizing therefore reads as
+ * the room shrinking into the composer rather than as a row swap, and expanding
+ * is the same surface growing back.
+ *
+ * The band is the block's whole readout. It is inked the way the room inks its
+ * two: the user lifts a pale sheet off the floor while the mic is live, the
+ * assistant answers in a darker one, and in silence the floor is empty. Nothing
+ * is painted over it, so the block says what it is doing by moving; the state
+ * string reaches assistive tech through an `sr-only` live region instead.
  *
  * Because the block is painted in an arbitrary avatar color, its chrome cannot
  * use theme tokens: the composer tones the card with `toneForBg` and publishes
  * `--room-*` (the same contract the room itself uses), and everything here
- * reads those. See `chat-composer.tsx` for the card.
+ * reads those. The band cannot take the avatar accent for the same reason. It
+ * would be the fill's own hue and paint nothing at all. See `chat-composer.tsx`
+ * for the card.
  *
  * The controls sit quiet at the edges so the color and the band hold the
- * middle: mic mute on the left (stop input), and on the right the stop slot
- * (stop output, present only while the assistant speaks), expand back to the
- * room, and end session.
+ * middle, and they are the room's own set at block scale: mute the mic on the
+ * left, and on the right mute the assistant, expand back to the room, and end.
+ * The two mutes are a symmetric pair, one per direction of the conversation,
+ * and every control is persistent, so none of them moves out from under a
+ * reaching finger mid-turn.
  *
  * Purely presentational: the composer observes the live-voice store and wires
- * `state`, an amplitude poll function, and the callbacks. Ending is always
- * available.
+ * `state`, the two amplitude poll functions, and the callbacks. Ending is
+ * always available.
  *
  * There is no manual "send now": turns release themselves (server VAD
  * hands-free, auto-release in the manual fallback), so a send button would
- * advertise an action the user never needs. Stop output earns its place because
- * interrupting a reply in progress has no silent equivalent.
+ * advertise an action the user never needs.
  */
 
-import { Maximize2, Mic, MicOff, Square, X } from "lucide-react";
+import { Maximize2, Mic, MicOff, Volume2, VolumeX, X } from "lucide-react";
 
 import { Button, cn } from "@vellumai/design-library";
 
@@ -65,12 +74,14 @@ export interface VoiceComposerBarProps {
   onToggleMute: () => void;
   /** Red ✕ — end the voice session. */
   onEnd: () => void;
+  /** Whether the assistant's audio is muted. Drives the right-side toggle. */
+  outputMuted: boolean;
   /**
-   * ■ — stop the in-flight assistant response without ending the session.
-   * Occupies the stop slot only while `speaking`; the composer passes it only
-   * for hands-free sessions, where the interrupt is turn-scoped.
+   * Mute (or unmute) the assistant without ending the session or stopping the
+   * reply. The turn keeps running and the transcript keeps filling, so
+   * unmuting drops the user back in wherever it has reached.
    */
-  onStop?: () => void;
+  onToggleOutputMute: () => void;
   /**
    * Return to the full-screen voice room. The composer passes it only where
    * the room can render (never in pop-out windows), so the control never
@@ -114,8 +125,9 @@ export function VoiceComposerBar({
   getOutputAmplitude,
   muted,
   onToggleMute,
+  outputMuted,
+  onToggleOutputMute,
   onEnd,
-  onStop,
   onExpand,
   standalone = false,
 }: VoiceComposerBarProps) {
@@ -185,34 +197,36 @@ export function VoiceComposerBar({
         />
       </div>
 
-      {/* The state word, centered in the block over the band. `aria-hidden`
-          because the live region below already announces it: rendering both
-          would have a screen reader read the state twice. */}
-      <div className="relative flex min-w-0 flex-1 items-center justify-center">
-        <span
-          aria-hidden
-          className="truncate text-sm font-medium text-[var(--room-fg-muted,var(--content-secondary))]"
-        >
-          {muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
-        </span>
-      </div>
+      {/* The band holds the middle. Nothing is painted over it: the block says
+          what it is doing by moving, and the state string reaches assistive
+          tech through the live region below. */}
+      <div className="relative min-w-0 flex-1" />
       <span aria-live="polite" className="sr-only">
         {muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
       </span>
 
       <div className="relative flex shrink-0 items-center gap-1">
-        {/* Stop slot: interrupts a reply in progress, and is present only
-            while one is playing. Nothing occupies the slot otherwise. */}
-        {onStop && state === "speaking" ? (
-          <Button
-            variant="ghost"
-            iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
-            onClick={onStop}
-            aria-label="Stop assistant response"
-            tooltip="Stop assistant response"
-            className={VOICE_CONTROL_CLASS}
-          />
-        ) : null}
+        {/* Mute the assistant, the room's own pairing for the mic mute: one
+            control per direction of the conversation, both persistent, so
+            neither moves out from under a reaching finger mid-turn. */}
+        <Button
+          variant="ghost"
+          iconOnly={
+            outputMuted ? (
+              <VolumeX className="h-4 w-4" />
+            ) : (
+              <Volume2 className="h-4 w-4" />
+            )
+          }
+          onClick={onToggleOutputMute}
+          aria-label={outputMuted ? "Unmute assistant" : "Mute assistant"}
+          aria-pressed={outputMuted}
+          tooltip={outputMuted ? "Unmute assistant" : "Mute assistant"}
+          className={cn(
+            VOICE_CONTROL_CLASS,
+            outputMuted && "[--vbtn-fg:var(--system-negative-strong)]",
+          )}
+        />
         {onExpand ? (
           <Button
             variant="ghost"

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -1,29 +1,32 @@
 /**
- * Voice-session composer bar (Light 53): while a live-voice session is
- * active the composer's action row is replaced by this bar — a mic mute
- * toggle on the left, the voice room's listening waves filling the middle
- * (the same layered accent-tinted band, scaled to the strip), and the
- * session controls on the right: optional expand back to the voice room,
- * end (✕), and the stop slot — ■ stop-response, present only while the
- * assistant speaks.
+ * Minimized live-voice surface (Light 740 desktop, Light 741 mobile): while a
+ * session is active and the room is dismissed, this block is the composer.
  *
- * Purely presentational: the composer observes the live-voice store and
- * wires `state`, an amplitude poll function, and the callbacks. The red ✕
- * ends the session and is always available.
+ * It is a block, not a toolbar. The whole chat input is given over to it,
+ * painted in the room's own background color (the session assistant's avatar
+ * color, or {@link VOICE_SURFACE_DARK} for an assistant with no character
+ * color), with the mesh band and the state word inside it. Minimizing therefore
+ * reads as the room shrinking into the composer rather than as a row swap, and
+ * expanding is the same surface growing back.
  *
- * Textless, matching the title-bar pill: the mic glyph and the animating
- * waves carry the session state on their own, and the waves want the width on
- * a phone-width composer. The state string reaches assistive tech through an
- * `sr-only` live region instead.
+ * Because the block is painted in an arbitrary avatar color, its chrome cannot
+ * use theme tokens: the composer tones the card with `toneForBg` and publishes
+ * `--room-*` (the same contract the room itself uses), and everything here
+ * reads those. See `chat-composer.tsx` for the card.
  *
- * The bar offers no manual "send now" — turns release themselves (server VAD
- * hands-free, auto-release in the manual fallback), so a primary-weight send
- * button would advertise an action the user never needs. ■ earns its place:
+ * The controls sit quiet at the edges so the color and the band hold the
+ * middle: mic mute on the left (stop input), and on the right the stop slot
+ * (stop output, present only while the assistant speaks), expand back to the
+ * room, and end session.
+ *
+ * Purely presentational: the composer observes the live-voice store and wires
+ * `state`, an amplitude poll function, and the callbacks. Ending is always
+ * available.
+ *
+ * There is no manual "send now": turns release themselves (server VAD
+ * hands-free, auto-release in the manual fallback), so a send button would
+ * advertise an action the user never needs. Stop output earns its place because
  * interrupting a reply in progress has no silent equivalent.
- *
- * Layout mirrors the composer's bottom action row (`px-2 pb-2`, regular
- * `h-8` icon buttons) so swapping the rows in during a session causes no
- * layout shift.
  */
 
 import type { CSSProperties } from "react";
@@ -78,13 +81,35 @@ export interface VoiceComposerBarProps {
    */
   waveAccentHex?: string | null;
   /**
-   * Whether the bar is the composer card's only row — set when the textarea
-   * collapses away for the session. The bar normally sits beneath the
-   * textarea's own top padding; standing alone it has to supply its own, or
-   * it renders flush against the card's top edge.
+   * Whether the block is the composer card's only content, which it is unless
+   * the user opted into seeing their own words (the live transcript keeps the
+   * textarea row above). Standing alone it owns the card's whole footprint and
+   * takes the full block height; sharing the card it sits under the transcript
+   * and only takes the control row's height.
    */
   standalone?: boolean;
 }
+
+/**
+ * Block height when the surface owns the whole card, chosen to match the
+ * footprint of the composer it replaces (one textarea row plus the action row).
+ * Holding that height is what keeps minimizing from shifting the transcript
+ * above it.
+ */
+const BLOCK_HEIGHT_CLASS = "h-[5.25rem]";
+
+/**
+ * Control chrome toned for the avatar color under it, via the `--room-*` vars
+ * the composer publishes from `toneForBg`. Theme tokens cannot be used here:
+ * the block is painted an arbitrary avatar color, so `--content-default` is as
+ * likely to be invisible on it as legible. The token fallbacks only apply if a
+ * caller renders the block without the vars, which the composer never does.
+ */
+const VOICE_CONTROL_CLASS = [
+  "[--vbtn-fg:var(--room-fg-muted,var(--content-secondary))]",
+  "hover:[--vbtn-fg:var(--room-fg,var(--content-default))]",
+  "hover:bg-[var(--room-wash,var(--surface-hover))]",
+].join(" ");
 
 export function VoiceComposerBar({
   state,
@@ -101,35 +126,20 @@ export function VoiceComposerBar({
     <div
       role="group"
       aria-label="Voice session"
-      className={cn("flex items-center gap-3 px-2 pb-2", standalone && "pt-3")}
+      className={cn(
+        "relative flex items-center gap-3 px-2",
+        // Standing alone the block owns the card, so it takes the composer's
+        // footprint. Sharing the card with the live transcript it stays a
+        // control row under it.
+        standalone ? BLOCK_HEIGHT_CLASS : "pb-2",
+      )}
     >
-      {/* pl-1 keeps the toggle roughly on the textarea's px-4 text inset. */}
-      <div className="flex shrink-0 items-center gap-2 pl-1">
-        <Button
-          variant="ghost"
-          iconOnly={
-            muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />
-          }
-          onClick={onToggleMute}
-          aria-label={muted ? "Unmute microphone" : "Mute microphone"}
-          aria-pressed={muted}
-          tooltip={muted ? "Unmute microphone" : "Mute microphone"}
-          className={
-            muted ? "[--vbtn-fg:var(--system-negative-strong)]" : undefined
-          }
-        />
-        {/* The bar paints no text, so the session state reaches assistive
-            tech here instead. Announced on change, like the title-bar pill. */}
-        <span aria-live="polite" className="sr-only">
-          {muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
-        </span>
-      </div>
-      {/* The room's listening-wave band, inline: needs a positioned box to
-          fill (the component is absolutely positioned) and overflow-hidden so
-          the drifting layers clip to the strip. */}
+      {/* The mesh band fills the block rather than sitting in a middle column,
+          so the color and the motion read as one surface. Behind the controls
+          and the state word, which is why it is first and inert. */}
       <div
         className={cn(
-          "relative h-6 min-w-0 flex-1 overflow-hidden",
+          "pointer-events-none absolute inset-0 overflow-hidden",
           VOICE_WAVE_EDGE_FADE_CLASS,
         )}
         style={
@@ -147,7 +157,53 @@ export function VoiceComposerBar({
           tuning={MESH_INLINE_TUNING}
         />
       </div>
-      <div className="flex shrink-0 items-center gap-1">
+
+      {/* pl-1 keeps the toggle roughly on the textarea's px-4 text inset. */}
+      <div className="relative flex shrink-0 items-center gap-2 pl-1">
+        <Button
+          variant="ghost"
+          iconOnly={
+            muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />
+          }
+          onClick={onToggleMute}
+          aria-label={muted ? "Unmute microphone" : "Mute microphone"}
+          aria-pressed={muted}
+          tooltip={muted ? "Unmute microphone" : "Mute microphone"}
+          className={cn(
+            VOICE_CONTROL_CLASS,
+            muted && "[--vbtn-fg:var(--system-negative-strong)]",
+          )}
+        />
+      </div>
+
+      {/* The state word, centered in the block over the band. `aria-hidden`
+          because the live region below already announces it: rendering both
+          would have a screen reader read the state twice. */}
+      <div className="relative flex min-w-0 flex-1 items-center justify-center">
+        <span
+          aria-hidden
+          className="truncate text-sm font-medium text-[var(--room-fg-muted,var(--content-secondary))]"
+        >
+          {muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
+        </span>
+      </div>
+      <span aria-live="polite" className="sr-only">
+        {muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
+      </span>
+
+      <div className="relative flex shrink-0 items-center gap-1">
+        {/* Stop slot: interrupts a reply in progress, and is present only
+            while one is playing. Nothing occupies the slot otherwise. */}
+        {onStop && state === "speaking" ? (
+          <Button
+            variant="ghost"
+            iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
+            onClick={onStop}
+            aria-label="Stop assistant response"
+            tooltip="Stop assistant response"
+            className={VOICE_CONTROL_CLASS}
+          />
+        ) : null}
         {onExpand ? (
           <Button
             variant="ghost"
@@ -155,25 +211,17 @@ export function VoiceComposerBar({
             onClick={onExpand}
             aria-label="Open voice room"
             tooltip="Open voice room"
+            className={VOICE_CONTROL_CLASS}
           />
         ) : null}
         <Button
-          variant="danger"
+          variant="ghost"
           iconOnly={<X className="h-4 w-4" strokeWidth={2.5} />}
           onClick={onEnd}
           aria-label="End voice session"
+          tooltip="End voice session"
+          className={VOICE_CONTROL_CLASS}
         />
-        {/* Stop slot: ■ interrupts a reply in progress, and is present only
-            while one is playing — nothing occupies the slot otherwise. */}
-        {onStop && state === "speaking" ? (
-          <Button
-            variant="primary"
-            iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
-            onClick={onStop}
-            aria-label="Stop assistant response"
-            tooltip="Stop assistant response"
-          />
-        ) : null}
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
@@ -529,6 +529,7 @@ function ComposerBarScene(args: SceneArgs) {
           onToggleMute={() => {}}
           outputMuted={false}
           onToggleOutputMute={() => {}}
+          fillIsLight={false}
           onEnd={() => {}}
           onExpand={() => {}}
           standalone

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
@@ -524,6 +524,7 @@ function ComposerBarScene(args: SceneArgs) {
         <VoiceComposerBar
           state={state}
           getAmplitude={getAmplitude}
+          getOutputAmplitude={getAmplitude}
           muted={false}
           onToggleMute={() => {}}
           onEnd={() => {}}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
@@ -527,6 +527,8 @@ function ComposerBarScene(args: SceneArgs) {
           getOutputAmplitude={getAmplitude}
           muted={false}
           onToggleMute={() => {}}
+          outputMuted={false}
+          onToggleOutputMute={() => {}}
           onEnd={() => {}}
           onExpand={() => {}}
           standalone

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -660,8 +660,13 @@ const CAPTION_EMPHASIS: Record<
  *   stopped responding to amplitude at all. It stays closer to linear.
  *
  * Both still reach zero in silence, so the floor is empty between turns.
+ *
+ * Exported because every painted voice surface inks its band this way, not just
+ * the room: the fill is the avatar color, so a band tinted with the avatar
+ * accent is the fill's own hue and paints nothing visible on it. The minimized
+ * composer block borrows both entries for the same reason the room has them.
  */
-const BAND_VOICE = {
+export const BAND_VOICE = {
   listening: { color: "#FFFFFF", peakOpacity: 0.4, opacityKnee: 3 },
   responding: { color: "#000000", peakOpacity: 0.45, opacityKnee: 1.3 },
 } as const;

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -191,9 +191,18 @@ const EYE_STATE_CAPTION: Partial<Record<VoiceAvatarVisual, string>> = {
  *  eyes from this vertical center — onboarding's picker geometry. */
 const ENTER_FROM_SIZE = 200;
 const ENTER_FROM_CENTER_VH = 40;
-/** The room's own dark base, under the color fade (matches the ambient look's
- *  deep surface so the first frames read the same for both looks). */
-const DARK_SURFACE = "#17191C";
+/**
+ * The room's own dark base, under the color fade (matches the ambient look's
+ * deep surface so the first frames read the same for both looks).
+ *
+ * Exported as the surface any voice surface paints when the assistant has no
+ * character color to borrow, which is what `resolveVoiceRoomLook` returning
+ * null means: custom-image and "none" avatars. The minimized composer bar
+ * shares it so a colorless assistant minimizes into the same deep surface the
+ * room shows it on.
+ */
+export const VOICE_SURFACE_DARK = "#17191C";
+const DARK_SURFACE = VOICE_SURFACE_DARK;
 
 export interface VoiceRoomEyeArt {
   paths: { svgPath: string; color: string }[];


### PR DESCRIPTION
The minimized bar replaced the composer's action row inside the existing card, which read as a toolbar swap. The designs replace the whole chat input: one block filling the composer's footprint, painted in the room's own background colour, with the mesh band running through it, so minimizing reads as the room shrinking into the composer.

Reference: Light 740 (desktop), Light 741 (mobile).

Rebased onto `main` now that JARVIS-1379 (#39675) has landed, so the block carries that room's control set.

## What changed

**The card is painted in the room's colour.** The composer form takes the session assistant's avatar colour, or the room's deep ambient surface for an assistant with no character colour to borrow. That constant is now exported from the room (`VOICE_SURFACE_DARK`) rather than redefined, so the two surfaces cannot drift apart.

**Chrome tones instead of using theme tokens.** The block is painted an arbitrary avatar colour, so `--content-default` is as likely to vanish into it as to contrast. The composer runs `toneForBg` and publishes `--room-*`, the same contract the room already uses, and the controls read those. `data-theme` on the card covers descendants that read plain theme tokens (the live transcript's body text) by flipping the whole card's polarity to match the fill.

**The band fills the block** instead of sitting in a middle column, so the colour and the motion read as one surface.

**The band is inked like the room's, not tinted with the accent.** This was the bug behind "I only see the status text, no waveform": the band asked for `--avatar-accent` while the card is painted that exact colour, so a mesh stroked in the fill's own hue drew nothing. It now uses the room's own pairing (`BAND_VOICE`, exported for this): the user lifts a pale sheet off the floor, the assistant answers in a darker one, each with the opacity pairing its polarity needs. The band also rode the mic level only, so it sat flat through the entire reply; the reply now wins the surface while it plays and rides the playback level. Keying off `isLiveVoiceMicLive` alone would draw the user over the assistant, since the mic stays open through a reply for barge-in.

**No state word.** The band is the readout: the block says what it is doing by moving, and a word over it competed with the motion. The state still reaches assistive tech through the `sr-only` live region, so nothing is lost for screen readers.

**The room's controls, at block scale.** The transient stop is gone, replaced by the persistent assistant mute the merged room now carries. The block holds the same four in the same reading order: mute the mic, mute the assistant, back into the room, end. The two mutes are a symmetric pair, one per direction of the conversation, and nothing changes shape mid-turn.

**The paint is gated on the avatar query settling.** `resolveVoiceRoomLook` returns null both for "no character colour" and for "not fetched yet", so painting on the in-flight read would flash the card to the ambient dark and then again to the avatar colour. The card changes colour once.

## Design library

Uses the existing `Button` primitive throughout, overriding only its `--vbtn-fg` and hover fill to tone against the avatar colour. No new components.

## Testing

`bun run typecheck` clean; lint clean on the touched files (the one warning in `chat-composer.tsx` is pre-existing and unrelated). 29 bar tests and 81 composer tests pass, run individually per the `mock.module` isolation gotcha.

The band is a canvas plus a rAF loop and is inert under happy-dom, so the bar's tests stub it with a probe that records the props it was handed. That is the only way to assert what the band is drawing: its ink, and which voice it rides in each state.

**Not visually verified.** A live-voice session needs a daemon and a mic. Two things worth eyes on:

- `MESH_INLINE_TUNING` was tuned for a 24px strip and now fills an 84px block. It may want retuning at this height, and the pale/dark opacity ceilings were chosen for the room's full-bleed field rather than a block this size.
- The block height is 84px, derived to match the composer it replaces (one textarea row plus the action row) so minimizing does not shift the thread. If the design wants a different height, that number is the one to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
