### PR TITLE
ci(android): remove community SDK setup action

### DIFF
--- a/.github/actions/setup-android-sdk/action.yml
+++ b/.github/actions/setup-android-sdk/action.yml
@@ -1,0 +1,31 @@
+name: Setup Android SDK
+description: Install the Android SDK packages required by CI.
+
+inputs:
+  platform:
+    description: Android SDK platform version
+    required: false
+    default: '36'
+  build_tools:
+    description: Android SDK build-tools version
+    required: false
+    default: '36.0.0'
+
+runs:
+  using: composite
+  steps:
+    - name: Accept Android SDK licenses
+      shell: bash
+      run: |
+        set +o pipefail
+        yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
+          --sdk_root="${ANDROID_HOME}" --licenses >/dev/null
+        set -o pipefail
+
+    - name: Install Android SDK packages
+      shell: bash
+      run: |
+        "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
+          --sdk_root="${ANDROID_HOME}" \
+          "platforms;android-${{ inputs.platform }}" \
+          "build-tools;${{ inputs.build_tools }}"

--- a/.github/workflows/ci-main-android.yaml
+++ b/.github/workflows/ci-main-android.yaml
@@ -11,6 +11,7 @@ on:
       - 'clients/web/capacitor.config.ts'
       - 'clients/web/capacitor-shell/**'
       - 'clients/web/package.json'
+      - '.github/actions/setup-android-sdk/**'
       - '.github/workflows/ci-main-android.yaml'
 
 concurrency:
@@ -33,6 +34,9 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+
+      - name: Setup Android SDK
+        uses: ./.github/actions/setup-android-sdk
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/ci-main-android.yaml
+++ b/.github/workflows/ci-main-android.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     name: Build Dev Debug
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -33,9 +33,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/pr-android.yaml
+++ b/.github/workflows/pr-android.yaml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   build:
     name: Build Dev Debug
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -34,9 +34,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/pr-android.yaml
+++ b/.github/workflows/pr-android.yaml
@@ -11,6 +11,7 @@ on:
       - 'clients/web/capacitor.config.ts'
       - 'clients/web/capacitor-shell/**'
       - 'clients/web/package.json'
+      - '.github/actions/setup-android-sdk/**'
       - '.github/workflows/pr-android.yaml'
       - '.github/workflows/ci-main-android.yaml'
 
@@ -34,6 +35,9 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+
+      - name: Setup Android SDK
+        uses: ./.github/actions/setup-android-sdk
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
## Summary
- remove the disallowed community-owned Android SDK setup action from PR and main Android builds
- add a repo-owned composite action that accepts licenses and explicitly installs Android SDK platform 36 and build-tools 36.0.0 with Google sdkmanager
- pin Android jobs to the GitHub-maintained ubuntu-24.04 image

## Original prompt
Android CI was blocked because the organization policy does not allow android-actions/setup-android. Replace that community-owned action with a more trusted Android build setup, use an isolated worktree, and open a PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->