### PR TITLE
fix(gateway): admit Slack group DMs so they wake the assistant (LUM-2935)

### DIFF
--- a/gateway/src/__tests__/slack-channel-kind.test.ts
+++ b/gateway/src/__tests__/slack-channel-kind.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Observed-kind cache for Slack conversations (LUM-2935).
+ *
+ * Reaction payloads carry no `channel_type`, so group-DM admission depends on
+ * what the gateway learned from earlier events plus a `conversations.info`
+ * fallback. The subtle requirement pinned here: the reconnect replay path
+ * *synthesizes* a `channel_type` for `conversations.history` messages and
+ * falls back to `"channel"`, so that value must never be treated as evidence.
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+const fetchedUrls: string[] = [];
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => {
+    fetchedUrls.push(String(args[0]));
+    return fetchMock(...args);
+  },
+}));
+
+const {
+  recordSlackChannelKind,
+  resolveSlackChannelKind,
+  isKnownSlackMpimSync,
+  clearChannelInfoCache,
+  clearInFlightFetches,
+} = await import("../slack/user-directory.js");
+
+const TOKEN = "xoxb-test";
+const MPIM = "C0000000MP1";
+
+function conversationsInfoResponse(isMpim: boolean): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      channel: { name: "mpdm-group-dm-1", is_mpim: isMpim },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+beforeEach(() => {
+  clearChannelInfoCache();
+  clearInFlightFetches();
+  fetchedUrls.length = 0;
+  fetchMock = mock(async () => conversationsInfoResponse(true));
+});
+
+describe("Slack observed channel-kind cache", () => {
+  test("learns a group DM from a message event's channel_type", () => {
+    recordSlackChannelKind(MPIM, TOKEN, "mpim");
+    expect(isKnownSlackMpimSync(MPIM, TOKEN)).toBe(true);
+    // Answered from cache, no API call needed.
+    expect(fetchedUrls).toHaveLength(0);
+  });
+
+  test("learns a non-group DM from an im channel_type", () => {
+    recordSlackChannelKind("D0123ABCD", TOKEN, "im");
+    expect(isKnownSlackMpimSync("D0123ABCD", TOKEN)).toBe(false);
+    expect(fetchedUrls).toHaveLength(0);
+  });
+
+  test("ignores a synthesized 'channel' value rather than caching a guess", async () => {
+    // The replay path stamps "channel" for any history message it cannot
+    // classify. If that were recorded, a replayed MPIM would cache
+    // `isMpim: false` and re-break admission for the whole TTL.
+    recordSlackChannelKind(MPIM, TOKEN, "channel");
+    recordSlackChannelKind(MPIM, TOKEN, "group");
+
+    // Nothing was learned, so the authoritative lookup still runs and wins.
+    const kind = await resolveSlackChannelKind(MPIM, TOKEN);
+    expect(kind?.isMpim).toBe(true);
+    expect(isKnownSlackMpimSync(MPIM, TOKEN)).toBe(true);
+  });
+
+  test("a real 'mpim' observation survives a later synthesized 'channel'", () => {
+    recordSlackChannelKind(MPIM, TOKEN, "mpim");
+    recordSlackChannelKind(MPIM, TOKEN, "channel");
+    expect(isKnownSlackMpimSync(MPIM, TOKEN)).toBe(true);
+  });
+
+  test("resolves an unknown channel through conversations.info and caches it", async () => {
+    const kind = await resolveSlackChannelKind(MPIM, TOKEN);
+    expect(kind?.isMpim).toBe(true);
+    expect(fetchedUrls).toHaveLength(1);
+    expect(fetchedUrls[0]).toContain("conversations.info");
+
+    // Second read is served from cache.
+    await resolveSlackChannelKind(MPIM, TOKEN);
+    expect(fetchedUrls).toHaveLength(1);
+  });
+
+  test("caches the negative result so ordinary channels stop re-fetching", async () => {
+    fetchMock = mock(async () => conversationsInfoResponse(false));
+    const kind = await resolveSlackChannelKind("C-ordinary", TOKEN);
+    expect(kind?.isMpim).toBe(false);
+
+    expect(isKnownSlackMpimSync("C-ordinary", TOKEN)).toBe(false);
+    expect(fetchedUrls).toHaveLength(1);
+  });
+
+  test("sync miss reports false and warms the cache in the background", async () => {
+    expect(isKnownSlackMpimSync(MPIM, TOKEN)).toBe(false);
+
+    // The background warm settles, and the next read is correct. This is the
+    // documented cold-start gap: the first event in a never-seen MPIM can
+    // still be dropped.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(isKnownSlackMpimSync(MPIM, TOKEN)).toBe(true);
+  });
+
+  test("treats an unresolvable channel as not a group DM", async () => {
+    fetchMock = mock(async () => new Response("nope", { status: 500 }));
+    const kind = await resolveSlackChannelKind("C0000000BR1", TOKEN);
+    expect(kind).toBeUndefined();
+    // Fail closed: a Slack outage must not widen admission.
+    expect(isKnownSlackMpimSync("C0000000BR1", TOKEN)).toBe(false);
+  });
+
+  test("backs off after a failed lookup instead of re-fetching every event", async () => {
+    fetchMock = mock(async () => new Response("rate limited", { status: 429 }));
+    await resolveSlackChannelKind("C0000000RL1", TOKEN);
+    expect(fetchedUrls).toHaveLength(1);
+
+    // Admission runs per event. Without a cached failure marker each of these
+    // would re-fire a warm, and under a 429 that loop is self-sustaining.
+    for (let i = 0; i < 5; i++) {
+      expect(isKnownSlackMpimSync("C0000000RL1", TOKEN)).toBe(false);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchedUrls).toHaveLength(1);
+  });
+
+  test("a later channel_type observation overrides a failure marker", async () => {
+    fetchMock = mock(async () => new Response("nope", { status: 500 }));
+    await resolveSlackChannelKind(MPIM, TOKEN);
+    expect(isKnownSlackMpimSync(MPIM, TOKEN)).toBe(false);
+
+    recordSlackChannelKind(MPIM, TOKEN, "mpim");
+    expect(isKnownSlackMpimSync(MPIM, TOKEN)).toBe(true);
+  });
+});

--- a/gateway/src/__tests__/slack-socket-mode-group-dm.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-group-dm.test.ts
@@ -1,0 +1,424 @@
+/**
+ * LUM-2935: admission for Slack group DMs (multi-person IMs).
+ *
+ * An MPIM was not classified as direct-like, so nothing in one was admitted
+ * without an @-mention or a pre-tracked thread: a human's message and any
+ * reaction were dropped by the gateway filter before the daemon saw them, and
+ * the conversation never appeared at all.
+ *
+ * Pinned below alongside the negative cases that keep the fix from widening
+ * admission for ordinary channels.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import type { GatewayConfig } from "../config.js";
+import { SlackStore } from "../db/slack-store.js";
+import * as schema from "../db/schema.js";
+import type { RuntimeInboundPayload } from "../runtime/client.js";
+import type { NormalizedSlackEvent } from "../slack/message-schemas.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+function makeSlackUserResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      user: {
+        name: "example-user",
+        profile: { display_name: "Example User" },
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () =>
+  makeSlackUserResponse(),
+);
+const runtimePayloads: RuntimeInboundPayload[] = [];
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+mock.module("../runtime/client.js", () => ({
+  CircuitBreakerOpenError: class CircuitBreakerOpenError extends Error {
+    readonly retryAfterSecs: number;
+
+    constructor(retryAfterSecs: number) {
+      super("Circuit breaker is open");
+      this.name = "CircuitBreakerOpenError";
+      this.retryAfterSecs = retryAfterSecs;
+    }
+  },
+  forwardToRuntime: mock(
+    async (_config: GatewayConfig, payload: RuntimeInboundPayload) => {
+      runtimePayloads.push(payload);
+      return { accepted: true, duplicate: false, eventId: "runtime-event-1" };
+    },
+  ),
+}));
+
+mock.module("../logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+  }),
+}));
+
+mock.module("../verification/text-verification.js", () => ({
+  tryTextVerificationIntercept: mock(async () => ({ intercepted: false })),
+}));
+
+const { SlackSocketModeClient } = await import("../slack/socket-mode.js");
+const { clearChannelInfoCache, clearUserInfoCache, clearInFlightFetches } =
+  await import("../slack/user-directory.js");
+const { initGatewayDb, resetGatewayDb } = await import("../db/connection.js");
+const { initAdmissionPolicyCache, resetAdmissionPolicyCache } =
+  await import("../risk/admission-policy-cache.js");
+import type { SlackSocketModeConfig } from "../slack/socket-mode.js";
+
+type SocketModeHarness = {
+  config: SlackSocketModeConfig;
+  onEvent: (event: NormalizedSlackEvent) => void;
+  store: SlackStore;
+  handleMessage(raw: string, originWs: WebSocket): void;
+};
+
+/** A regular channel the bot posts into. Deliberately NOT a routing entry. */
+const CHANNEL = "C0000000CH1";
+/**
+ * A bot-opened group DM. `C`-prefixed on purpose: real workspaces mint MPIMs
+ * with a plain `C` prefix and `is_mpim: true`, which is why the classifier
+ * cannot fall back to an id prefix.
+ */
+const MPIM = "C0000000MP1";
+
+function makeConfig(): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1024 * 1024,
+    port: 7830,
+    // Intentionally empty: neither CHANNEL nor MPIM is a subscribed
+    // conversation_id, so `isChannelSubscribed` cannot mask the fix.
+    routingEntries: [],
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    trustProxy: false,
+  };
+}
+
+function createSlackStore(): { rawDb: Database; store: SlackStore } {
+  const rawDb = new Database(":memory:");
+  rawDb.exec(`
+    CREATE TABLE slack_active_threads (
+      thread_ts TEXT PRIMARY KEY,
+      channel_id TEXT,
+      tracked_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL,
+      detached_at INTEGER
+    );
+    CREATE TABLE slack_seen_events (
+      event_id TEXT PRIMARY KEY,
+      seen_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    );
+    CREATE TABLE slack_last_seen_ts (
+      key TEXT PRIMARY KEY,
+      ts TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE contact_channels (
+      id TEXT PRIMARY KEY,
+      contact_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      address TEXT NOT NULL,
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      external_user_id TEXT,
+      external_chat_id TEXT,
+      status TEXT NOT NULL DEFAULT 'unverified',
+      policy TEXT NOT NULL DEFAULT 'allow',
+      revoked_reason TEXT,
+      blocked_reason TEXT,
+      last_seen_at INTEGER,
+      last_interaction INTEGER,
+      interaction_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE channel_bot_identity (
+      channel_type TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      username TEXT,
+      metadata TEXT,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  return { rawDb, store: new SlackStore(drizzle(rawDb, { schema })) };
+}
+
+function createHarness(
+  store: SlackStore,
+  onEvent: (event: NormalizedSlackEvent) => void,
+): SocketModeHarness {
+  const harness = Object.create(
+    SlackSocketModeClient.prototype,
+  ) as SocketModeHarness;
+  harness.config = {
+    appToken: "xapp-test",
+    botToken: "xoxb-test",
+    botUserId: "UBOT",
+    botUsername: "assistant",
+    teamName: "Example Team",
+    gatewayConfig: makeConfig(),
+    threadMode: "mention_then_thread",
+  };
+  harness.onEvent = onEvent;
+  harness.store = store;
+  return harness;
+}
+
+function makeOpenSocket(): WebSocket {
+  return {
+    readyState: WebSocket.OPEN,
+    send: mock(() => {}),
+  } as unknown as WebSocket;
+}
+
+function flushAsyncEventEmission(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Feed one synthetic events_api envelope through the live ingress path. */
+function deliver(
+  client: SocketModeHarness,
+  ws: WebSocket,
+  eventId: string,
+  event: Record<string, unknown>,
+): void {
+  client.handleMessage(
+    JSON.stringify({
+      envelope_id: `env-${eventId}`,
+      type: "events_api",
+      payload: { event_id: eventId, event },
+    }),
+    ws,
+  );
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  resetAdmissionPolicyCache();
+  await initGatewayDb();
+  initAdmissionPolicyCache();
+  runtimePayloads.length = 0;
+  clearUserInfoCache();
+  clearChannelInfoCache();
+  clearInFlightFetches();
+  fetchMock = mock(async () => makeSlackUserResponse());
+});
+
+afterEach(() => {
+  resetAdmissionPolicyCache();
+  resetGatewayDb();
+});
+
+describe("LUM-2935: group DM (MPIM) admission", () => {
+  test("admits a reaction on a C-prefixed MPIM the bot opened with a top-level post", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    const botPostTs = "1785438192.541729";
+
+    try {
+      // The bot opens the MPIM with a top-level chat.postMessage. Slack echoes it
+      // back; the self-filter drops the event but learns from it.
+      deliver(client, ws, "Ev-bot-open", {
+        type: "message",
+        user: "UBOT",
+        text: "opening a group DM",
+        ts: botPostTs,
+        channel: MPIM,
+        channel_type: "mpim",
+      });
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(0);
+
+      // A participant reacts. Reaction payloads carry no channel_type at all.
+      deliver(client, ws, "Ev-reaction", {
+        type: "reaction_added",
+        user: "U0000000AL1",
+        reaction: "raised_hands",
+        item: { type: "message", channel: MPIM, ts: botPostTs },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.event.message.callbackData).toBe(
+        "reaction:raised_hands",
+      );
+      expect(emitted[0]?.event.message.conversationExternalId).toBe(MPIM);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("admits a reaction in an MPIM on a message the bot did not author", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    const humanTs = "1785438300.000100";
+
+    try {
+      // Isolates the classification fix from thread arming: this message is
+      // authored by a human, so no thread root is ever tracked for its ts.
+      deliver(client, ws, "Ev-human-msg", {
+        type: "message",
+        user: "U0000000AL2",
+        text: "what do you think?",
+        ts: humanTs,
+        channel: MPIM,
+        channel_type: "mpim",
+      });
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+      expect(store.hasThread(humanTs)).toBe(false);
+
+      deliver(client, ws, "Ev-reaction-2", {
+        type: "reaction_added",
+        user: "U0000000AL3",
+        reaction: "eyes",
+        item: { type: "message", channel: MPIM, ts: humanTs },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(2);
+      expect(emitted[1]?.event.message.callbackData).toBe("reaction:eyes");
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("admits a top-level human message in an MPIM and forwards chatType 'mpim'", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-mpim-msg", {
+        type: "message",
+        user: "U0000000AL2",
+        text: "no mention, no thread",
+        ts: "1785438400.000200",
+        channel: MPIM,
+        channel_type: "mpim",
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      // Not "im": the daemon branches on this value for group-chat etiquette
+      // (isGroupChatType) and the `private` permission cell
+      // (mapChatTypeToConversationType). Flattening to "im" would suppress
+      // both.
+      expect(emitted[0]?.event.source.chatType).toBe("mpim");
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not mint a thread-scoped conversation for a top-level MPIM message", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-mpim-flat", {
+        type: "message",
+        user: "U0000000AL2",
+        text: "top level",
+        ts: "1785438500.000300",
+        channel: MPIM,
+        channel_type: "mpim",
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      // An MPIM is one continuous conversation, like a DM: a top-level
+      // message must not fall back to its own ts as a thread id, or every
+      // message would resolve a separate daemon conversation.
+      expect(emitted[0]?.event.source.threadId).toBeUndefined();
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("still drops an unmentioned top-level message in an ordinary channel", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-channel-msg", {
+        type: "message",
+        user: "U0000000AL4",
+        text: "unrelated channel chatter",
+        ts: "1785438600.000400",
+        channel: CHANNEL,
+        channel_type: "channel",
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("still drops a reaction in an unsubscribed, untracked ordinary channel", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-channel-reaction", {
+        type: "reaction_added",
+        user: "U0000000AL4",
+        reaction: "tada",
+        item: {
+          type: "message",
+          channel: CHANNEL,
+          ts: "1785438700.000500",
+        },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+});

--- a/gateway/src/slack/channel.test.ts
+++ b/gateway/src/slack/channel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isSlackDmChannel } from "./channel.js";
+import { isSlackDmChannel, isSlackMpimChannel } from "./channel.js";
 
 describe("isSlackDmChannel", () => {
   it("classifies an explicit im channel_type as a DM", () => {
@@ -21,5 +21,27 @@ describe("isSlackDmChannel", () => {
   it("is not a DM when neither signal identifies one", () => {
     expect(isSlackDmChannel(undefined)).toBe(false);
     expect(isSlackDmChannel("")).toBe(false);
+  });
+});
+
+describe("isSlackMpimChannel", () => {
+  it("classifies an explicit mpim channel_type as a group DM", () => {
+    expect(isSlackMpimChannel("mpim")).toBe(true);
+  });
+
+  it("does not classify other conversation kinds as group DMs", () => {
+    expect(isSlackMpimChannel("im")).toBe(false);
+    expect(isSlackMpimChannel("channel")).toBe(false);
+    expect(isSlackMpimChannel("group")).toBe(false);
+  });
+
+  it("has no id-prefix fallback in either direction", () => {
+    // `G` is shared with private channels, and modern workspaces mint MPIMs
+    // with a plain `C` prefix, confirmed against `conversations.info`
+    // (`is_mpim: true, is_channel: true`). An id alone proves nothing, so
+    // payloads without a channel_type resolve through the observed-kind cache
+    // instead (see user-directory.ts).
+    expect(isSlackMpimChannel(undefined)).toBe(false);
+    expect(isSlackMpimChannel("")).toBe(false);
   });
 });

--- a/gateway/src/slack/channel.ts
+++ b/gateway/src/slack/channel.ts
@@ -7,6 +7,14 @@
  * `im` chat type. That decision is centralized here so every call site
  * answers it identically — a DM that one filter recognizes and another does
  * not is silently dropped.
+ *
+ * Multi-person IMs (`mpim`) are a second, distinct direct-like kind: like a
+ * DM, every message in one is addressed to its participants, so admission
+ * must not require an @-mention or a tracked thread. Unlike a DM, an MPIM is
+ * multi-party, so it keeps its own `mpim` chat type end to end rather than
+ * being flattened into `im`. The daemon already branches on that value
+ * (group-chat etiquette in `isGroupChatType`, and the `private`
+ * permission-matrix cell in `mapChatTypeToConversationType`).
  */
 
 /**
@@ -32,4 +40,22 @@ export function isSlackDmChannel(
     channelType === "im" ||
     (typeof channelId === "string" && channelId.startsWith("D"))
   );
+}
+
+/**
+ * True when a Slack conversation is a multi-person IM (group DM).
+ *
+ * Unlike {@link isSlackDmChannel} there is **no id-prefix fallback**. The
+ * documented prefix for an MPIM is `G`, but `G` is shared with private
+ * channels, and modern workspaces mint MPIMs with a plain `C` prefix
+ * (verified: `C0BMU5X5FEU` reports `is_mpim: true, is_channel: true`). An id
+ * alone therefore proves nothing in either direction, so this predicate reads
+ * only the explicit `channel_type` discriminator.
+ *
+ * `channel_type` is present on `message` events but absent from reaction and
+ * interactive payloads, so reaction admission cannot use this predicate on its
+ * own: it composes it with the observed-kind cache in `user-directory.ts`.
+ */
+export function isSlackMpimChannel(channelType?: string): boolean {
+  return channelType === "mpim";
 }

--- a/gateway/src/slack/message-normalizer.ts
+++ b/gateway/src/slack/message-normalizer.ts
@@ -14,21 +14,10 @@ import type { GatewayConfig } from "../config.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
 
-/**
- * Normalize a Slack DM (`message` with `channel_type: "im"`) into the
- * gateway's canonical inbound event shape. Used for guardian verification
- * code replies and direct conversations with the bot.
- *
- * Returns null if the event cannot be routed or should be ignored
- * (e.g. subtypes like message_changed, missing user).
- *
- * Bot's own messages are dropped by `processEventPayload` before
- * normalization.
- */
 /** The per-event-type differences across the plain-message normalizers. */
 type SlackMessageShape = {
   /** `source.chatType`; omitted for `app_mention`. */
-  chatType?: "im" | "channel";
+  chatType?: "im" | "channel" | "mpim";
   /** Stamp the sender's workspace id onto the actor (channel + app_mention). */
   stampTeam: boolean;
   /** Reply in the message's own ts when it has no `thread_ts` (channel + app_mention). */
@@ -128,6 +117,18 @@ function buildNormalizedSlackMessage(
   };
 }
 
+/**
+ * Normalize a Slack 1:1 DM (`message` with `channel_type: "im"`) into the
+ * gateway's canonical inbound event shape. Used for guardian verification
+ * code replies and direct conversations with the bot. Group DMs have their own
+ * normalizer, see {@link normalizeSlackGroupDirectMessage}.
+ *
+ * Returns null if the event cannot be routed or should be ignored
+ * (e.g. subtypes like message_changed, missing user).
+ *
+ * Bot's own messages are dropped by `processEventPayload` before
+ * normalization.
+ */
 export function normalizeSlackDirectMessage(
   event: unknown,
   eventId: string,
@@ -155,6 +156,60 @@ export function normalizeSlackDirectMessage(
     msg.channel,
     msg.user,
     { chatType: "im", stampTeam: false, fallbackThreadToTs: false },
+    botToken,
+    renderContext,
+  );
+}
+
+/**
+ * Normalize a Slack multi-person IM (`message` with `channel_type: "mpim"`)
+ * into the gateway's canonical inbound event shape.
+ *
+ * Shares the DM family's admission semantics (every message in a group DM is
+ * addressed to its participants, so no @-mention or tracked thread is needed)
+ * but forwards `chatType: "mpim"` rather than collapsing it to `im`. The
+ * daemon reads that value directly: `isGroupChatType` injects group-chat
+ * etiquette for it, and `mapChatTypeToConversationType` resolves it to the
+ * `private` permission-matrix cell. Reporting `im` for a multi-party room
+ * would suppress the etiquette and select the looser `dm` cell.
+ *
+ * `fallbackThreadToTs` is false, matching DMs and not channels: an MPIM is one
+ * continuous conversation, so top-level messages must share a conversation
+ * rather than each minting a thread-scoped one.
+ *
+ * `stampTeam` is true, matching channels and not DMs: an MPIM is multi-party
+ * and can include Slack Connect participants from another workspace, so the
+ * sender's team is a real trust signal here in a way it is not in a 1:1 IM
+ * with a known contact.
+ *
+ * Bot's own messages are dropped by `processEventPayload` before
+ * normalization.
+ */
+export function normalizeSlackGroupDirectMessage(
+  event: unknown,
+  eventId: string,
+  config: GatewayConfig,
+  botToken?: string,
+  renderContext?: SlackTextRenderContext,
+): NormalizedSlackEvent | null {
+  const parsed = slackMessageEventSchema.safeParse(event);
+  if (!parsed.success) return null;
+  const msg = parsed.data;
+
+  if (msg.subtype && msg.subtype !== "file_share") return null;
+  if (!msg.user || !msg.channel || !msg.ts) return null;
+
+  const routing = resolveAssistant(config, msg.channel, msg.user);
+  if (isRejection(routing)) return null;
+
+  return buildNormalizedSlackMessage(
+    msg,
+    event as Record<string, unknown>,
+    eventId,
+    routing,
+    msg.channel,
+    msg.user,
+    { chatType: "mpim", stampTeam: true, fallbackThreadToTs: false },
     botToken,
     renderContext,
   );

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -18,7 +18,7 @@ import {
   runWithConcurrency,
   type SlackHistoryMessage,
 } from "./slack-web.js";
-import { isSlackDmChannel } from "./channel.js";
+import { isSlackDmChannel, isSlackMpimChannel } from "./channel.js";
 import { parseSlackEnvelope } from "./envelope.js";
 import type { SlackEnvelopePayload, SlackInboundEvent } from "./envelope.js";
 import { classifySlackEvent } from "./classify-event.js";
@@ -28,6 +28,7 @@ import { stampSlackEventTeam } from "./event-team.js";
 import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
+  normalizeSlackGroupDirectMessage,
   normalizeSlackChannelMessage,
 } from "./message-normalizer.js";
 import {
@@ -49,9 +50,35 @@ import type {
   NormalizedSlackEvent,
 } from "./message-schemas.js";
 import type { SlackTextRenderContext } from "./render-text.js";
-import { resolveSlackChannel, resolveSlackUser } from "./user-directory.js";
+import {
+  isKnownSlackMpimSync,
+  recordSlackChannelKind,
+  resolveSlackChannel,
+  resolveSlackUser,
+} from "./user-directory.js";
 
 const log = getLogger("slack-socket-mode");
+
+/**
+ * Which admission filter matched an event, carried from `processEventPayload`
+ * through the emit queue to normalization.
+ *
+ * Passed as one object rather than re-derived downstream: normalization runs
+ * asynchronously, so any state the filter consulted (the observed-kind cache,
+ * the active-thread table) may have changed by the time it runs. Threading the
+ * decision keeps admission and normalization consistent by construction.
+ */
+type SlackAdmission = {
+  isAppMention: boolean;
+  isActiveThreadReply: boolean;
+  isReactionAdded: boolean;
+  isReactionRemoved: boolean;
+  isMessageChanged: boolean;
+  isMessageDeleted: boolean;
+  /** A 1:1 IM or a group DM. `isGroupDm` distinguishes the two. */
+  isDm: boolean;
+  isGroupDm: boolean;
+};
 
 const BASE_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
@@ -479,6 +506,34 @@ export class SlackSocketModeClient {
   }
 
   /**
+   * True when a conversation is a group DM (MPIM).
+   *
+   * Prefers the payload's own `channel_type` and falls back to the observed-
+   * kind cache for payloads that carry none (reactions, edits, deletes). The
+   * cache read is synchronous and warms itself in the background. See
+   * `isKnownSlackMpimSync` for the cold-start caveat.
+   */
+  private isGroupDmChannel(
+    channelId: string | undefined,
+    channelType?: string,
+  ): boolean {
+    if (isSlackMpimChannel(channelType)) return true;
+    if (!channelId) return false;
+    return isKnownSlackMpimSync(channelId, this.config.botToken);
+  }
+
+  /** DM or group DM: the conversations admitted without a mention. */
+  private isDirectLikeChannel(
+    channelId: string | undefined,
+    channelType?: string,
+  ): boolean {
+    return (
+      isSlackDmChannel(channelId, channelType) ||
+      this.isGroupDmChannel(channelId, channelType)
+    );
+  }
+
+  /**
    * Returns true when the gateway has a configured `conversation_id` routing
    * entry for the given channel — i.e. the bot is subscribed to that channel.
    *
@@ -504,7 +559,7 @@ export class SlackSocketModeClient {
    */
   private admitMessageEdit(event: SlackMessageChangedEvent): boolean {
     return (
-      isSlackDmChannel(event.channel, event.channel_type) ||
+      this.isDirectLikeChannel(event.channel, event.channel_type) ||
       (!!event.message?.thread_ts &&
         this.store.hasThread(event.message.thread_ts)) ||
       (!!event.message?.ts && this.store.hasThread(event.message.ts)) ||
@@ -520,7 +575,7 @@ export class SlackSocketModeClient {
   private admitMessageDelete(event: SlackMessageDeletedEvent): boolean {
     return (
       !!event.deleted_ts &&
-      (isSlackDmChannel(event.channel, event.channel_type) ||
+      (this.isDirectLikeChannel(event.channel, event.channel_type) ||
         (!!event.previous_message?.thread_ts &&
           this.store.hasThread(event.previous_message.thread_ts)) ||
         this.store.hasThread(event.deleted_ts) ||
@@ -529,11 +584,16 @@ export class SlackSocketModeClient {
   }
 
   /**
-   * Admit a reaction on a message in a tracked bot thread, a DM, or any channel
-   * the bot is subscribed to (a conversation_id routing entry, or any DM channel
-   * since DMs always route to the default assistant). Both reaction_added and
-   * reaction_removed share this filter; the daemon dispatches by callbackData
-   * prefix.
+   * Admit a reaction on a message in a tracked bot thread, a DM or group DM, or
+   * any channel the bot is subscribed to (a conversation_id routing entry, or
+   * any DM channel since DMs always route to the default assistant). Both
+   * reaction_added and reaction_removed share this filter; the daemon dispatches
+   * by callbackData prefix.
+   *
+   * Reaction payloads carry no `channel_type`, so the group-DM arm relies on
+   * the observed-kind cache and is evaluated **last**: the three preceding
+   * checks are pure local state, and short-circuiting on them keeps a reaction
+   * in an ordinary subscribed channel from firing a `conversations.info` warm.
    */
   private admitReaction(event: SlackReactionEvent): boolean {
     const targetChannel = event.item?.channel;
@@ -542,7 +602,8 @@ export class SlackSocketModeClient {
       !!targetChannel &&
       (isSlackDmChannel(targetChannel) ||
         this.isChannelSubscribed(targetChannel) ||
-        this.store.hasThread(event.item.ts))
+        this.store.hasThread(event.item.ts) ||
+        this.isGroupDmChannel(targetChannel))
     );
   }
 
@@ -579,7 +640,7 @@ export class SlackSocketModeClient {
       return;
     }
 
-    // Only a plain thread reply arms tracking — app_mentions, edits, deletes,
+    // Only a plain thread reply arms tracking. app_mentions, edits, deletes,
     // and reactions do not.
     const classified = classifySlackEvent(event);
     if (!classified || classified.kind !== "message") {
@@ -818,6 +879,19 @@ export class SlackSocketModeClient {
       return;
     }
 
+    // ── Learn the conversation's kind from any event that states it ────
+    // Runs before the self-filter so the bot's own echo (which is what opens
+    // a bot-initiated MPIM in the first place) teaches us the channel is a
+    // group DM, letting later reaction payloads (which carry no
+    // `channel_type`) be classified synchronously.
+    const classifiedForKind = classifySlackEvent(event);
+    if (classifiedForKind?.kind === "message") {
+      const { channel, channel_type: channelType } = classifiedForKind.event;
+      if (channel) {
+        recordSlackChannelKind(channel, this.config.botToken, channelType);
+      }
+    }
+
     // ── Single self-filter: drop the bot's own messages ────────────────
     // Slack's Socket Mode delivers the bot's own outbound messages back
     // as inbound events (DM echoes, thread reply echoes, etc.). This is
@@ -827,7 +901,7 @@ export class SlackSocketModeClient {
     if (eventUser === botUserId) {
       // Exception: the bot's own thread replies are used to arm thread
       // tracking (so follow-up human replies are forwarded). This is a
-      // side effect only — the event itself is still dropped.
+      // side effect only, the event itself is still dropped.
       this.maybeTrackBotOwnThreadReply(event);
       return;
     }
@@ -844,6 +918,7 @@ export class SlackSocketModeClient {
     let isReactionAdded = false;
     let isReactionRemoved = false;
     let isActiveThreadReply = false;
+    let isGroupDm = false;
 
     switch (classified?.kind) {
       case "app_mention":
@@ -866,8 +941,15 @@ export class SlackSocketModeClient {
         // unmentioned reply in an already-tracked bot thread. A mention of the
         // bot is handled by the app_mention event, not here.
         const msg = classified.event;
+        // DMs and group DMs are both admitted unconditionally: every message
+        // in one is addressed to its participants, so requiring a mention or a
+        // tracked thread would drop legitimate traffic. They diverge only at
+        // normalization, where an MPIM keeps its own `mpim` chat type.
         if (isSlackDmChannel(msg.channel, msg.channel_type)) {
           isDm = true;
+        } else if (this.isGroupDmChannel(msg.channel, msg.channel_type)) {
+          isDm = true;
+          isGroupDm = true;
         } else if (
           this.config.threadMode === "mention_then_thread" &&
           !msg.text?.includes(`<@${botUserId}>`) &&
@@ -900,20 +982,35 @@ export class SlackSocketModeClient {
                   : null;
 
     if (!matchedFilter) {
+      // Structural fields at info, message content at debug.
+      //
+      // Info, not debug, for the structure: a dropped event is the failure
+      // mode behind every "the assistant never saw my message" report, and at
+      // debug level it is absent from normal logs. LUM-2935's missed reaction
+      // was only found by reading `conversations.history` by hand.
+      //
+      // The body stays at debug because this fires for every event the filter
+      // rejects, including ordinary chatter and link-unfurl edits in channels
+      // the assistant is not part of. Promoting the structure must not persist
+      // workspace conversation content into normal-level logs.
+      const dropContext = {
+        eventId: eventPayload.event_id,
+        type: event.type,
+        subtype: (event as { subtype?: string }).subtype,
+        channel: (event as { channel?: string }).channel,
+        channelType: (event as { channel_type?: string }).channel_type,
+        user: (event as { user?: string }).user,
+        hasThreadTs: !!(event as { thread_ts?: string }).thread_ts,
+        threadTs: (event as { thread_ts?: string }).thread_ts,
+        kind: classified?.kind,
+      };
+      log.info(dropContext, "Slack event dropped by filter");
       log.debug(
         {
-          eventId: eventPayload.event_id,
-          type: event.type,
-          subtype: (event as { subtype?: string }).subtype,
-          channel: (event as { channel?: string }).channel,
-          channelType: (event as { channel_type?: string }).channel_type,
-          user: (event as { user?: string }).user,
-          hasThreadTs: !!(event as { thread_ts?: string }).thread_ts,
-          threadTs: (event as { thread_ts?: string }).thread_ts,
-          kind: classified?.kind,
+          ...dropContext,
           text: (event as { text?: string }).text?.slice(0, 80),
         },
-        "Slack event dropped by filter",
+        "Slack event dropped by filter (with content)",
       );
       return;
     }
@@ -1013,9 +1110,7 @@ export class SlackSocketModeClient {
       }
     }
 
-    this.enqueueNormalizeAndEmit(
-      event,
-      eventId,
+    this.enqueueNormalizeAndEmit(event, eventId, {
       isAppMention,
       isActiveThreadReply,
       isReactionAdded,
@@ -1023,7 +1118,8 @@ export class SlackSocketModeClient {
       isMessageChanged,
       isMessageDeleted,
       isDm,
-    );
+      isGroupDm,
+    });
   }
 
   private async resolveMentionLabelsForText(
@@ -1074,32 +1170,14 @@ export class SlackSocketModeClient {
   private enqueueNormalizeAndEmit(
     event: SlackInboundEvent,
     eventId: string,
-    isAppMention: boolean,
-    isActiveThreadReply: boolean,
-    isReactionAdded: boolean,
-    isReactionRemoved: boolean,
-    isMessageChanged: boolean,
-    isMessageDeleted: boolean,
-    isDm: boolean,
+    admission: SlackAdmission,
   ): void {
     const queues = (this.emitQueues ??= new Map());
     const orderingKey = slackEventOrderingKey(event, eventId);
     const previous = queues.get(orderingKey) ?? Promise.resolve();
     const current = previous
       .catch(() => undefined)
-      .then(() =>
-        this.normalizeAndEmit(
-          event,
-          eventId,
-          isAppMention,
-          isActiveThreadReply,
-          isReactionAdded,
-          isReactionRemoved,
-          isMessageChanged,
-          isMessageDeleted,
-          isDm,
-        ),
-      );
+      .then(() => this.normalizeAndEmit(event, eventId, admission));
 
     queues.set(orderingKey, current);
     void current
@@ -1116,14 +1194,18 @@ export class SlackSocketModeClient {
   private async normalizeAndEmit(
     event: SlackInboundEvent,
     eventId: string,
-    isAppMention: boolean,
-    isActiveThreadReply: boolean,
-    isReactionAdded: boolean,
-    isReactionRemoved: boolean,
-    isMessageChanged: boolean,
-    isMessageDeleted: boolean,
-    isDm: boolean,
+    admission: SlackAdmission,
   ): Promise<void> {
+    const {
+      isAppMention,
+      isActiveThreadReply,
+      isReactionAdded,
+      isReactionRemoved,
+      isMessageChanged,
+      isMessageDeleted,
+      isDm,
+      isGroupDm,
+    } = admission;
     const text = slackEventText(event);
     const renderContext = text ? await this.resolveTextRenderContext(text) : {};
     const userLabels = renderContext.userLabels ?? {};
@@ -1171,13 +1253,29 @@ export class SlackSocketModeClient {
         renderContext,
       );
     } else if (isDm) {
-      normalized = normalizeSlackDirectMessage(
-        event,
-        eventId,
-        this.config.gatewayConfig,
-        this.config.botToken,
-        renderContext,
-      );
+      // `isDm` covers both 1:1 IMs and group DMs; they split here so an MPIM
+      // is forwarded as `chatType: "mpim"` instead of being flattened into
+      // `im`. The decision is threaded down from admission rather than
+      // re-derived: normalization runs asynchronously behind the per-channel
+      // emit queue, and the kind cache can expire or be evicted in between, so
+      // re-deriving could normalize an admitted group DM as a 1:1 `im` and
+      // select the looser permission cell. Passing it makes the two agree by
+      // construction.
+      normalized = isGroupDm
+        ? normalizeSlackGroupDirectMessage(
+            event,
+            eventId,
+            this.config.gatewayConfig,
+            this.config.botToken,
+            renderContext,
+          )
+        : normalizeSlackDirectMessage(
+            event,
+            eventId,
+            this.config.gatewayConfig,
+            this.config.botToken,
+            renderContext,
+          );
     } else {
       log.warn(
         {
@@ -1422,8 +1520,11 @@ export class SlackSocketModeClient {
 
     const mentionsBot = msg.text?.includes(`<@${botUserId}>`) ?? false;
     // `conversations.history`/`replies` carry no `channel_type`, so classify
-    // DMs by the conversation ID prefix.
+    // DMs by the conversation ID prefix and group DMs from the observed-kind
+    // cache. The `"channel"` fallback below is therefore a guess, which is why
+    // `recordSlackChannelKind` refuses to learn from that value.
     const isDm = isSlackDmChannel(channel);
+    const isGroupDm = !isDm && this.isGroupDmChannel(channel);
     // Slack only emits `app_mention` in non-DM channels, even when the bot is
     // `<@U…>`-mentioned in a DM body. Keep DMs on the `message` path so they
     // normalize as direct messages rather than mentions.
@@ -1444,7 +1545,7 @@ export class SlackSocketModeClient {
       ts: msg.ts,
       thread_ts: msg.thread_ts,
       channel,
-      channel_type: isDm ? "im" : "channel",
+      channel_type: isDm ? "im" : isGroupDm ? "mpim" : "channel",
       team: msg.team,
       ...(msg.subtype ? { subtype: msg.subtype } : {}),
       ...(msg.files ? { files: msg.files } : {}),

--- a/gateway/src/slack/user-directory.ts
+++ b/gateway/src/slack/user-directory.ts
@@ -25,6 +25,23 @@ interface SlackChannelInfo {
   name: string;
 }
 
+/**
+ * Whether a conversation is a multi-person IM.
+ *
+ * Kept in its own cache rather than folded into {@link SlackChannelInfo}
+ * because the two are populated from different sources: the name only ever
+ * comes from `conversations.info`, while the kind is usually learned for free
+ * from a `message` event's `channel_type` (see
+ * {@link recordSlackChannelKind}) and only falls back to the API.
+ *
+ * `unresolved` marks a short-lived failure marker rather than a real answer,
+ * so a failing lookup backs off instead of retrying on every event.
+ */
+interface SlackChannelKind {
+  isMpim: boolean;
+  unresolved?: boolean;
+}
+
 interface CacheEntry<T> {
   value: T;
   expiresAt: number;
@@ -34,6 +51,8 @@ const USER_CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const USER_CACHE_MAX_SIZE = 500;
 const CHANNEL_CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const CHANNEL_CACHE_MAX_SIZE = 500;
+/** Back-off window for a `conversations.info` lookup that failed. */
+const CHANNEL_KIND_FAILURE_TTL_MS = 60 * 1000; // 1 minute
 
 /**
  * In-memory LRU cache for Slack user info lookups.
@@ -42,6 +61,7 @@ const CHANNEL_CACHE_MAX_SIZE = 500;
  */
 const userInfoCache = new Map<string, CacheEntry<SlackUserInfo>>();
 const channelInfoCache = new Map<string, CacheEntry<SlackChannelInfo>>();
+const channelKindCache = new Map<string, CacheEntry<SlackChannelKind>>();
 
 /**
  * Deduplicates concurrent fetches for the same userId so only one
@@ -51,9 +71,9 @@ const inFlightUserFetches = new Map<
   string,
   Promise<SlackUserInfo | undefined>
 >();
-const inFlightChannelFetches = new Map<
+const inFlightConversationInfoFetches = new Map<
   string,
-  Promise<SlackChannelInfo | undefined>
+  Promise<SlackConversationInfo | undefined>
 >();
 
 function slackUserCacheKey(userId: string, botToken: string): string {
@@ -220,6 +240,113 @@ export async function resolveSlackUser(
   }
 }
 
+/** The projections of one `conversations.info` response that callers need. */
+interface SlackConversationInfo {
+  name?: string;
+  isMpim: boolean;
+}
+
+/**
+ * Record that a conversation's kind could not be resolved.
+ *
+ * Without this, a channel whose lookup keeps failing re-fires a background
+ * warm on every subsequent event in it, and under an HTTP 429 that loop is
+ * self-sustaining: rate limited, nothing cached, retry, still rate limited.
+ * The marker reads as "not a group DM" (fail closed, a Slack outage must not
+ * widen admission) and carries a short TTL so a transient failure self-heals
+ * without a restart. A later `channel_type` observation overwrites it with the
+ * truth immediately.
+ */
+function cacheUnresolvedChannelKind(cacheKey: string): void {
+  cacheSet(
+    channelKindCache,
+    cacheKey,
+    { isMpim: false, unresolved: true },
+    CHANNEL_KIND_FAILURE_TTL_MS,
+    CHANNEL_CACHE_MAX_SIZE,
+  );
+}
+
+/**
+ * Single `conversations.info` request shared by the name and kind resolvers.
+ *
+ * One in-flight map, so a name resolution on the normalization path and a kind
+ * warm on the admission path for the same channel cannot both hit Slack. Both
+ * caches are populated from the one response.
+ */
+async function fetchSlackConversationInfo(
+  channelId: string,
+  botToken: string,
+): Promise<SlackConversationInfo | undefined> {
+  const cacheKey = slackChannelCacheKey(channelId, botToken);
+  const existing = inFlightConversationInfoFetches.get(cacheKey);
+  if (existing) return existing;
+
+  const fetchPromise = (async (): Promise<
+    SlackConversationInfo | undefined
+  > => {
+    try {
+      const resp = await fetchImpl(
+        `https://slack.com/api/conversations.info?channel=${encodeURIComponent(channelId)}`,
+        {
+          method: "GET",
+          headers: { Authorization: `Bearer ${botToken}` },
+        },
+      );
+      if (!resp.ok) {
+        cacheUnresolvedChannelKind(cacheKey);
+        return undefined;
+      }
+
+      const data = (await resp.json()) as {
+        ok?: boolean;
+        channel?: {
+          name?: string;
+          name_normalized?: string;
+          is_mpim?: boolean;
+        };
+      };
+      if (!data.ok || !data.channel) {
+        cacheUnresolvedChannelKind(cacheKey);
+        return undefined;
+      }
+
+      const info: SlackConversationInfo = {
+        name: data.channel.name || data.channel.name_normalized,
+        isMpim: data.channel.is_mpim === true,
+      };
+
+      cacheSet(
+        channelKindCache,
+        cacheKey,
+        { isMpim: info.isMpim },
+        CHANNEL_CACHE_TTL_MS,
+        CHANNEL_CACHE_MAX_SIZE,
+      );
+      if (info.name) {
+        cacheSet(
+          channelInfoCache,
+          cacheKey,
+          { name: info.name },
+          CHANNEL_CACHE_TTL_MS,
+          CHANNEL_CACHE_MAX_SIZE,
+        );
+      }
+      return info;
+    } catch {
+      cacheUnresolvedChannelKind(cacheKey);
+      return undefined;
+    }
+  })();
+
+  inFlightConversationInfoFetches.set(cacheKey, fetchPromise);
+  try {
+    return await fetchPromise;
+  } finally {
+    inFlightConversationInfoFetches.delete(cacheKey);
+  }
+}
+
 /**
  * Resolve a Slack channel name via `conversations.info`.
  * Results are cached to avoid repeated API calls.
@@ -235,52 +362,93 @@ export async function resolveSlackChannel(
   const cached = cacheGet(channelInfoCache, cacheKey);
   if (cached) return cached;
 
-  const existing = inFlightChannelFetches.get(cacheKey);
-  if (existing) return existing;
+  const info = await fetchSlackConversationInfo(channelId, botToken);
+  return info?.name ? { name: info.name } : undefined;
+}
 
-  const fetchPromise = (async (): Promise<SlackChannelInfo | undefined> => {
-    try {
-      const resp = await fetchImpl(
-        `https://slack.com/api/conversations.info?channel=${encodeURIComponent(channelId)}`,
-        {
-          method: "GET",
-          headers: { Authorization: `Bearer ${botToken}` },
-        },
-      );
-      if (!resp.ok) return undefined;
-
-      const data = (await resp.json()) as {
-        ok?: boolean;
-        channel?: {
-          name?: string;
-          name_normalized?: string;
-        };
-      };
-      if (!data.ok || !data.channel) return undefined;
-
-      const name = data.channel.name || data.channel.name_normalized;
-      if (!name) return undefined;
-
-      const info: SlackChannelInfo = { name };
-      cacheSet(
-        channelInfoCache,
-        cacheKey,
-        info,
-        CHANNEL_CACHE_TTL_MS,
-        CHANNEL_CACHE_MAX_SIZE,
-      );
-      return info;
-    } catch {
-      return undefined;
-    }
-  })();
-
-  inFlightChannelFetches.set(cacheKey, fetchPromise);
-  try {
-    return await fetchPromise;
-  } finally {
-    inFlightChannelFetches.delete(cacheKey);
+/**
+ * Record what a `message` event's `channel_type` proves about a conversation.
+ *
+ * Message events carry `channel_type`; reaction and interactive payloads do
+ * not. Seeding the kind cache from the events that *do* carry it means the
+ * reaction path can classify a group DM synchronously, with no API call, from
+ * the moment any message has been seen in that conversation, including the
+ * bot's own outbound echo, which is what opens a bot-initiated MPIM in the
+ * first place.
+ *
+ * Only `mpim` and `im` are recorded, the two values that are always Slack's
+ * own word. `channel` / `group` are deliberately ignored: the reconnect replay
+ * path *synthesizes* `channel_type` for `conversations.history` messages
+ * (which carry none) and falls back to `"channel"`, so treating that value as
+ * evidence would let a replayed MPIM cache `isMpim: false` and re-break
+ * admission for the length of the TTL. A miss is harmless, it just falls
+ * through to the authoritative `conversations.info` warm, which caches the
+ * negative result too.
+ */
+export function recordSlackChannelKind(
+  channelId: string,
+  botToken: string,
+  channelType: string | undefined,
+): void {
+  if (channelType !== "mpim" && channelType !== "im") {
+    return;
   }
+  cacheSet(
+    channelKindCache,
+    slackChannelCacheKey(channelId, botToken),
+    { isMpim: channelType === "mpim" },
+    CHANNEL_CACHE_TTL_MS,
+    CHANNEL_CACHE_MAX_SIZE,
+  );
+}
+
+/**
+ * Resolve whether a conversation is a multi-person IM via
+ * `conversations.info`. Used to warm the cache for payloads that carry no
+ * `channel_type` of their own.
+ *
+ * Returns undefined on failure. Callers treat an unresolved kind as "not a
+ * group DM" so a Slack outage cannot widen admission.
+ */
+export async function resolveSlackChannelKind(
+  channelId: string,
+  botToken: string,
+): Promise<SlackChannelKind | undefined> {
+  const cacheKey = slackChannelCacheKey(channelId, botToken);
+  const cached = cacheGet(channelKindCache, cacheKey);
+  if (cached) return cached.unresolved ? undefined : cached;
+
+  const info = await fetchSlackConversationInfo(channelId, botToken);
+  return info ? { isMpim: info.isMpim } : undefined;
+}
+
+/**
+ * Cache-only group-DM check for the synchronous admission filter.
+ *
+ * Returns what is already known and never blocks; on a miss it fires a
+ * background `conversations.info` warm so the next event in that conversation
+ * is classified. Mirrors {@link resolveSlackUserSync}, which makes the same
+ * trade on the normalization path.
+ *
+ * A cached failure marker counts as known, which is what stops a channel whose
+ * lookup keeps failing from re-firing a warm on every event.
+ *
+ * Consequence worth naming: the very first reaction in an MPIM the gateway has
+ * never seen a message in (immediately after a gateway restart, on someone
+ * else's message) can still miss and be dropped, and is admitted from the next
+ * event onward.
+ */
+export function isKnownSlackMpimSync(
+  channelId: string,
+  botToken: string,
+): boolean {
+  const cacheKey = slackChannelCacheKey(channelId, botToken);
+  const cached = cacheGet(channelKindCache, cacheKey);
+  if (!cached && !inFlightConversationInfoFetches.has(cacheKey)) {
+    // Fire-and-forget: warm the cache for next time.
+    resolveSlackChannelKind(channelId, botToken).catch(() => {});
+  }
+  return cached?.isMpim === true;
 }
 
 /**
@@ -309,12 +477,13 @@ export function clearUserInfoCache(): void {
 /** Exported for testing — clears the channel info cache. */
 export function clearChannelInfoCache(): void {
   channelInfoCache.clear();
+  channelKindCache.clear();
 }
 
-/** Exported for testing — clears the in-flight fetch map. */
+/** Exported for testing. Clears the in-flight fetch maps. */
 export function clearInFlightFetches(): void {
   inFlightUserFetches.clear();
-  inFlightChannelFetches.clear();
+  inFlightConversationInfoFetches.clear();
 }
 
 /** Exported for testing — returns current cache size. */


### PR DESCRIPTION
## TL;DR

A Slack group DM (multi-person IM) was never classified as direct-like, so nothing in one was admitted without an @-mention or a pre-tracked thread. Messages and reactions were dropped by the gateway's Socket Mode filter before the daemon saw them, and the conversation never appeared at all.

Part of [LUM-2935](https://linear.app/vellum/issue/LUM-2935).

> **Scope narrowed after review.** This PR originally also armed a thread root on the assistant's own top-level posts. Devin correctly flagged that every such root enters `slack_active_threads`, which `replayMissedEvents` enumerates into one tier-3 `conversations.replies` call per row on every reconnect. Since the assistant posts continuously, one reconnect could issue hundreds of Slack calls. That half is now split into its own PR where the fan-out can be designed for properly. This PR is the group-DM classification only, which is correct independently of anything about outbound.

## What was wrong

`isSlackDmChannel` admits only `channel_type === "im"` or a `D`-prefixed id. An MPIM is neither: real workspaces mint them with a plain `C` prefix and `is_mpim: true`, and `channel.test.ts` had explicitly pinned the exclusion. So a group DM was treated as a public channel:

- `admitReaction` rejected every reaction in one (reaction payloads carry no `channel_type` at all).
- The plain-message branch required a tracked thread, which a group DM never had.

## Before / after

| Situation | Before | After |
| --- | --- | --- |
| Someone posts in a group DM with the assistant (no @-mention) | Silently dropped; the conversation never appeared | Wakes the assistant; conversation appears |
| Someone reacts to a message in a group DM | Silently dropped | Wakes the assistant |
| Someone edits or deletes a message in a group DM | Silently dropped | Forwarded |
| Someone posts in an ordinary channel without mentioning the assistant | Dropped | Dropped (unchanged) |
| Someone reacts in an ordinary unsubscribed channel | Dropped | Dropped (unchanged) |
| A dropped event | Invisible at `debug` | Structure at `info`, body still `debug` |

## Why it's safe

- **Admission widens for exactly one conversation kind**: group DMs, rooms the assistant is already a participant in where every message is addressed to its participants, same as a DM. Ordinary channels are untouched, pinned by two negative tests.
- **The trust floor still applies.** Group DMs flow through the same `sourceMetadata.admissionPolicy` floor as every other forwarded inbound.
- **Fail-closed on the lookup.** An unresolvable `conversations.info` leaves the kind unknown, and unknown means "not a group DM", so a Slack outage cannot widen admission.
- **MPIMs keep their own `chatType`.** Forwarding `"mpim"` instead of flattening to `"im"` activates code the daemon already has and tests: `isGroupChatType("mpim")` is asserted at `conversation-runtime-assembly.test.ts:631`, and `mapChatTypeToConversationType` maps it to the **`private`** permission cell. Reporting `"im"` would have suppressed group-chat etiquette and selected the looser `dm` cell, so the obvious shortcut was the less safe one.
- **Admission and normalization agree by construction.** The decision is threaded down as one `SlackAdmission` object rather than re-derived after the async emit queue, so a cache entry expiring in between cannot normalize an admitted group DM as a 1:1 IM.
- **No schema change, no daemon change, no migration.** Gateway-only.

## How the kind is resolved without blocking ingress

Admission is synchronous and reaction payloads carry no `channel_type`, so rather than make the filter async the kind is learned from the message events that *do* state it, including the assistant's own outbound echo, and cached, with a background `conversations.info` warm as fallback. Same trade `resolveSlackUserSync` already makes on the normalization path.

Two subtleties worth a reviewer's eye:

- The reconnect replay path **synthesizes** `channel_type` and falls back to `"channel"`. Recording that would let a replayed MPIM cache `isMpim: false` and re-break admission for a full TTL, so `recordSlackChannelKind` only learns from `"mpim"` and `"im"`. Dedicated test.
- A failed lookup caches a short-lived marker. Without it, a channel whose lookup keeps failing re-fires a warm on every event, and under a 429 that loop is self-sustaining. Dedicated test.

**Known limitation, stated rather than hidden:** the first reaction in a group DM the gateway has never seen a message in (right after a restart, on someone else's message) can still miss the cache and drop, and works from the next event on. Documented at the call site.

## Review feedback addressed

| Finding | Resolution |
| --- | --- |
| Devin 🔴 reconnect fan-out from speculative roots | Split out of this PR entirely (see above) |
| Devin 🟡 no negative caching, retry loop under 429 | Short-TTL failure marker + back-off test |
| Devin 🟡 duplicate `conversations.info` sequence, racing in-flight maps | Extracted one `fetchSlackConversationInfo` with a single in-flight map that populates both caches |
| Devin 🟡 em dashes violate root `AGENTS.md` | Removed from every added line |
| Devin 🔍 `chatType` could regress to `im` if the cache lapses | Decision threaded via `SlackAdmission` instead of re-derived |
| Devin 🔍 `stampTeam` asymmetry undocumented | Documented: group DMs can include Slack Connect participants, so sender team is a real trust signal |
| Devin 🔍 / 🟨 info log persists message bodies | Structure at `info`, body at `debug` |
| Devin 🔍 arming widens reaction/edit/delete admission | Moot here, that change is split out |
| Codex P2 real Slack IDs and names in tests | Replaced with generic placeholders per root `AGENTS.md` |
| Codex P2 em dashes | Same as above |
| Codex P2 replayed MPIM mentions take the `app_mention` path | Not fixed here, filed as follow-up. `app_mention` omits `chatType` for **every** conversation kind, so mentions never carry group-chat etiquette even in ordinary channels. That is pre-existing and broader than this PR, and "fixing" only the replay branch would make replay diverge from live, which the shared-path design deliberately avoids. |

## Tests

`slack-socket-mode-group-dm.test.ts` (6) drives the repro end-to-end through the live ingress path, in a channel deliberately absent from `routingEntries` so `isChannelSubscribed` cannot mask the fix. `slack-channel-kind.test.ts` (10) covers the cache including the replay-poisoning guard and the failure back-off. Plus `isSlackMpimChannel` cases in `channel.test.ts`.

**Verified against the bug:** with `gateway/src/slack/` checked out at `main` and the tests kept, all 4 positive MPIM tests fail and all 10 kind-cache tests fail. The 2 that pass are the "still drops" negatives, which must hold in both states.

Full Slack suite green: 276 tests across 9 files, typecheck and lint clean.

## Follow-ups

- Thread-root arming for the assistant's own top-level posts, with the reconnect fan-out addressed (the other half of LUM-2935).
- Route Slack outbound through the gateway so conversation registration stops depending on echo-sniffing (the ticket's Option C, and the root cause of this bug class).
- Separate "is this conversation in scope" from "does this event kind warrant a wake" across the admission predicates. Today each event kind re-derives scope from a different subset of the same signals, which is why LUM-2485 and LUM-2498 are the same class as this ticket.
- `app_mention` carries no `chatType` for any conversation kind, so mentions never get group-chat etiquette (Codex P2 above).
- `reaction_removed` is handled by the gateway but absent from both app manifests, so those events never arrive.
- The self-filter keys only on `user`, so a `subtype: "bot_message"` echo (posting with a `username`/`icon_emoji` override) is neither self-filtered nor thread-arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
