### PR TITLE
refactor(web): rename isLocalMode helper to isLocalClient

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -1098,7 +1098,7 @@ which UI surfaces are available:
 
 | Signal | Where | What it means |
 |--------|-------|---------------|
-| `isLocalMode()` | `src/lib/local-mode.ts` | `true` when `VITE_PLATFORM_MODE` is unset — the app is running against a local/self-hosted daemon, not the Vellum platform |
+| `isLocalClient()` | `src/lib/local-mode.ts` | `true` when `VITE_PLATFORM_MODE` is unset — the app is running against a local/self-hosted daemon, not the Vellum platform |
 | `hasPlatformSession` | `src/stores/auth-store.ts` | `true` when the user has a valid session with the Vellum platform (set asynchronously after probing the allauth session endpoint) |
 | `isPlatformDisabled()` | `src/lib/local-mode.ts` | Env var / config setting (`VITE_VELLUM_DISABLE_PLATFORM` or `__VELLUM_CONFIG__.disablePlatform`). When `true` in local mode, the API interceptor no-ops all platform client requests |
 

--- a/clients/web/src/assistant/lifecycle-service.test.ts
+++ b/clients/web/src/assistant/lifecycle-service.test.ts
@@ -106,7 +106,7 @@ mock.module("@/lib/auth/gateway-session", () => ({
   setRemoteGatewayToken: () => {},
 }));
 
-const isLocalModeMock = mock(() => false);
+const isLocalClientMock = mock(() => false);
 const isRemoteGatewayModeMock = mock(() => false);
 const getSelectedAssistantMock = mock(
   (): { assistantId: string } | undefined => undefined,
@@ -122,7 +122,7 @@ mock.module("@/lib/local-mode", () => ({
   getSelectedAssistant: getSelectedAssistantMock,
   hasAssistants: () => false,
   isLocalAssistant: () => false,
-  isLocalMode: isLocalModeMock,
+  isLocalClient: isLocalClientMock,
   isPlatformAssistant: () => false,
   isPlatformDisabled: () => false,
   isRemoteGatewayMode: isRemoteGatewayModeMock,
@@ -208,7 +208,7 @@ beforeEach(() => {
   // any new mocked dep added here MUST re-set its baseline below or
   // tests will silently inherit the previous test's stub.
   isGatewayAuthModeMock.mockImplementation(() => false);
-  isLocalModeMock.mockImplementation(() => false);
+  isLocalClientMock.mockImplementation(() => false);
   isRemoteGatewayModeMock.mockImplementation(() => false);
   getSelectedAssistantMock.mockImplementation(() => undefined);
   getLocalGatewayUrlMock.mockImplementation(() => undefined);

--- a/clients/web/src/assistant/operational-status.test.tsx
+++ b/clients/web/src/assistant/operational-status.test.tsx
@@ -39,7 +39,7 @@ const sdkMock = mock(
     response: new Response(null, { status: 200 }),
   }),
 );
-const isLocalModeMock = mock(() => false);
+const isLocalClientMock = mock(() => false);
 const isPlatformDisabledMock = mock(() => false);
 let isOrgReadyMock = true;
 const recordLifecycleDiagnosticMock = mock(
@@ -60,7 +60,7 @@ mock.module("@/stores/sse-connected-store", () => ({
 }));
 
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: isLocalModeMock,
+  isLocalClient: isLocalClientMock,
   isPlatformDisabled: isPlatformDisabledMock,
 }));
 
@@ -110,7 +110,7 @@ beforeEach(() => {
   sdkMock.mockClear();
   recordLifecycleDiagnosticMock.mockClear();
   sseConnectedSnapshotMock = false;
-  isLocalModeMock.mockImplementation(() => false);
+  isLocalClientMock.mockImplementation(() => false);
   isPlatformDisabledMock.mockImplementation(() => false);
   isOrgReadyMock = true;
   useAuthStore.setState(

--- a/clients/web/src/assistant/platform-assistants-sync.test.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.test.ts
@@ -3,12 +3,12 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { PlatformSessionStatus } from "@/stores/session-status";
 
 // Mode predicates that select whether the load runs.
-let mockIsLocalMode = false;
+let mockIsLocalClient = false;
 let mockIsRemoteGatewayMode = false;
 let mockIsGatewayAuthEnabled = false;
 
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: () => mockIsLocalMode,
+  isLocalClient: () => mockIsLocalClient,
   isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
 }));
 
@@ -99,7 +99,7 @@ const tick = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 0));
 
 beforeEach(() => {
-  mockIsLocalMode = false;
+  mockIsLocalClient = false;
   mockIsRemoteGatewayMode = false;
   mockIsGatewayAuthEnabled = false;
   mockListAssistantsResult = { ok: true, status: 200, data: [] };
@@ -173,7 +173,7 @@ describe("setupPlatformAssistantsSync", () => {
 
 describe("reloadPlatformAssistants", () => {
   test("early-returns in local mode without touching the resolved store", async () => {
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
 
     await reloadPlatformAssistants();
 

--- a/clients/web/src/assistant/platform-assistants-sync.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.ts
@@ -14,7 +14,7 @@
  */
 import { listAssistants } from "@/assistant/api";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
-import { isLocalMode, isRemoteGatewayMode } from "@/lib/local-mode";
+import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
@@ -42,7 +42,7 @@ let latestReload = 0;
  * skipping the write there is correct.
  */
 export async function reloadPlatformAssistants(): Promise<void> {
-  if (isLocalMode() || isRemoteGatewayMode() || isGatewayAuthEnabled()) {
+  if (isLocalClient() || isRemoteGatewayMode() || isGatewayAuthEnabled()) {
     return;
   }
   const gen = ++latestReload;

--- a/clients/web/src/assistant/retire-service.test.ts
+++ b/clients/web/src/assistant/retire-service.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // --- mutable mock state (set per test) --- //
 
-let isLocalModeValue = false;
+let isLocalClientValue = false;
 let lockfileAssistants: Array<{ assistantId: string; cloud?: string }> = [];
 let storeAssistants: Array<{ id: string }> = [];
 let retireByIdResult:
@@ -43,7 +43,7 @@ mock.module("@/lib/local-mode", () => ({
     activeAssistant: null,
   }),
   isLocalAssistant: (a: { cloud?: string }) => a.cloud === "local",
-  isLocalMode: () => isLocalModeValue,
+  isLocalClient: () => isLocalClientValue,
   retireLocalAssistant: retireLocalAssistantMock,
   syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
 }));
@@ -74,10 +74,10 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
     if (state.hasAssistants) {
       return {
         action: "redirect",
-        to: state.isLocalMode ? "/assistant/select-assistant" : "/assistant",
+        to: state.isLocalClient ? "/assistant/select-assistant" : "/assistant",
       };
     }
-    if (!state.isLocalMode) {
+    if (!state.isLocalClient) {
       return { action: "redirect", to: "/assistant/onboarding/privacy" };
     }
     if (state.platformSession === "present") {
@@ -88,7 +88,7 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
 }));
 mock.module("@/lib/navigation/build-state", () => ({
   buildNavigationState: () => ({
-    isLocalMode: isLocalModeValue,
+    isLocalClient: isLocalClientValue,
     isAuthenticated: false,
     platformSession: "absent",
     hasAssistants: storeAssistants.length > 0,
@@ -119,7 +119,7 @@ mock.module("@/utils/routes", () => ({
 const { retireAssistant } = await import("./retire-service");
 
 beforeEach(() => {
-  isLocalModeValue = false;
+  isLocalClientValue = false;
   lockfileAssistants = [];
   storeAssistants = [];
   retireByIdResult = { ok: true };
@@ -185,7 +185,7 @@ describe("retireAssistant", () => {
 
   test("local assistant in local mode routes through the local retire", async () => {
     // GIVEN a local target in local mode
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     lockfileAssistants = [{ assistantId: "l1", cloud: "local" }];
     storeAssistants = [{ id: "l1" }];
 
@@ -200,7 +200,7 @@ describe("retireAssistant", () => {
 
   test("routes by the TARGET assistant, not local-mode alone", async () => {
     // GIVEN local mode but the *target* is a platform assistant
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
     storeAssistants = [{ id: "p1" }];
 
@@ -241,7 +241,7 @@ describe("retireAssistant", () => {
   });
 
   test("post-retire redirects to select-assistant when other assistants remain", async () => {
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     lockfileAssistants = [
       { assistantId: "l1", cloud: "local" },
       { assistantId: "p1", cloud: "vellum" },
@@ -257,7 +257,7 @@ describe("retireAssistant", () => {
   });
 
   test("post-retire redirects to welcome when no assistants and not logged in", async () => {
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     lockfileAssistants = [{ assistantId: "l1", cloud: "local" }];
     storeAssistants = [{ id: "l1" }];
 

--- a/clients/web/src/assistant/retire-service.ts
+++ b/clients/web/src/assistant/retire-service.ts
@@ -2,7 +2,7 @@ import { listAssistants, retireAssistantById } from "@/assistant/api";
 import {
   getLockfile,
   isLocalAssistant,
-  isLocalMode,
+  isLocalClient,
   retireLocalAssistant,
   syncPlatformAssistantsToLockfile,
 } from "@/lib/local-mode";
@@ -64,7 +64,7 @@ export async function retireAssistant(
     const target = getLockfile().assistants.find(
       (a) => a.assistantId === assistantId,
     );
-    const useLocal = isLocalMode() && !!target && isLocalAssistant(target);
+    const useLocal = isLocalClient() && !!target && isLocalAssistant(target);
 
     if (useLocal) {
       const result = await retireLocalAssistant(assistantId);
@@ -85,7 +85,7 @@ export async function retireAssistant(
             : "Failed to retire assistant.";
         return { ok: false, error: detail };
       }
-      if (isLocalMode()) {
+      if (isLocalClient()) {
         try {
           const remaining = await listAssistants();
           if (remaining.ok) {

--- a/clients/web/src/assistant/use-lifecycle.ts
+++ b/clients/web/src/assistant/use-lifecycle.ts
@@ -19,7 +19,7 @@ import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useAssistantQuery } from "@/assistant/queries";
 import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
-import { getLocalAssistants, isLocalMode } from "@/lib/local-mode";
+import { getLocalAssistants, isLocalClient } from "@/lib/local-mode";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isAuthenticated, type SessionStatus } from "@/stores/session-status";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
@@ -47,7 +47,7 @@ export function useAssistantLifecycle({
   const shouldQueryServer =
     isAuthenticated(sessionStatus) &&
     !isGatewayAuthMode() &&
-    (hasPlatformSession || !isLocalMode()) &&
+    (hasPlatformSession || !isLocalClient()) &&
     isOrgReady;
 
   // Which platform assistant the user has selected, gated by the

--- a/clients/web/src/components/command-palette/command-palette-window-page.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette-window-page.test.tsx
@@ -61,7 +61,7 @@ const localSelectedRef = {
   value: null as { assistantId: string; name?: string } | null,
 };
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: () => false,
+  isLocalClient: () => false,
   getSelectedAssistant: () => localSelectedRef.value,
   getActiveAssistant: () =>
     resolvedRef.activeAssistantId

--- a/clients/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/clients/web/src/domains/account/pages/provider-callback-page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/domains/account/login-flow";
 import { classifyCallbackFlows } from "@/domains/account/social-auth";
 import {
-  isLocalMode,
+  isLocalClient,
   syncPlatformAssistantsToLockfile,
 } from "@/lib/local-mode";
 import { useAuthStore } from "@/stores/auth-store";
@@ -65,7 +65,7 @@ export function ProviderCallbackPage() {
           case "authenticated": {
             await refreshSession();
 
-            if (isLocalMode()) {
+            if (isLocalClient()) {
               try {
                 const assistants = await listAssistants();
                 if (assistants.ok && assistants.data.length > 0) {

--- a/clients/web/src/domains/onboarding/adopt-existing-assistant.ts
+++ b/clients/web/src/domains/onboarding/adopt-existing-assistant.ts
@@ -19,7 +19,7 @@ export function shouldAdoptExistingAssistant({
 }: {
   /** The research route's `?hosting` value, or null when absent. */
   hostingParam: string | null;
-  /** Build-time local mode (`isLocalMode()`). */
+  /** Build-time local mode (`isLocalClient()`). */
   localMode: boolean;
   /** A live local gateway session exists (`isGatewayAuthMode()`). */
   gatewayAuthSession: boolean;

--- a/clients/web/src/domains/onboarding/gate.ts
+++ b/clients/web/src/domains/onboarding/gate.ts
@@ -1,7 +1,7 @@
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { routes } from "@/utils/routes";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalClient } from "@/lib/local-mode";
 
 export function resolveOnboardingRedirect({
   intendedDestination,
@@ -16,5 +16,5 @@ export function resolveOnboardingRedirect({
 }
 
 export function getOnboardingEntrypoint(): string {
-  return isLocalMode() ? routes.welcome : routes.onboarding.privacy;
+  return isLocalClient() ? routes.welcome : routes.onboarding.privacy;
 }

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -47,7 +47,7 @@ const queryClientMock = {
 const writeSelectedVersionMock = mock(() => {});
 const connectLocalAssistantMock = mock(async (_assistantId: string) => {});
 
-let isLocalModeValue = false;
+let isLocalClientValue = false;
 let localGatewayUrlValue: string | undefined = undefined;
 let platformSessionValue: PlatformSessionStatus = "absent";
 
@@ -151,7 +151,7 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
 
 mock.module("@/lib/navigation/build-state", () => ({
   buildNavigationState: (overrides: Record<string, unknown> = {}) => ({
-    isLocalMode: isLocalModeValue,
+    isLocalClient: isLocalClientValue,
     isGatewayAuth: false,
     hasAssistants: false,
     sessionSettled: true,
@@ -169,7 +169,7 @@ mock.module("@/runtime/native-auth", () => ({
 }));
 
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: () => isLocalModeValue,
+  isLocalClient: () => isLocalClientValue,
   isRemoteGatewayMode: () => false,
   isLocalAssistant: () => false,
   isPlatformAssistant: () => false,
@@ -301,7 +301,7 @@ beforeEach(() => {
   checkAssistantImpl = async () => {};
   fetchTraitsImpl = async () => null;
   getAssistantImpl = async () => assistantResult("active");
-  isLocalModeValue = false;
+  isLocalClientValue = false;
   localGatewayUrlValue = undefined;
   platformSessionValue = "absent";
   sessionStorage.clear();
@@ -354,7 +354,7 @@ describe("onboarding lifecycle sync", () => {
   // full reload. The hatch flow must drive the same `connectLocalAssistant`
   // primitive the returning-user connect path uses.
   test("local hatch establishes the authenticated session via connectLocalAssistant", async () => {
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     localGatewayUrlValue = "http://127.0.0.1:7821";
     searchParams = new URLSearchParams("hosting=local");
 

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -33,7 +33,7 @@ const RESIZE_LABEL = "Setting up your machine…";
 const navigateMock = mock((_to: string, _opts?: unknown) => {});
 let searchParams = new URLSearchParams();
 
-let isLocalModeValue = false;
+let isLocalClientValue = false;
 
 // The observed subscription plan gates the free/no-wait decision (Fix 2).
 let subscriptionPlanId = "base";
@@ -301,7 +301,7 @@ mock.module("@/domains/onboarding/plugin-attribution", () => ({
 }));
 
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: () => isLocalModeValue,
+  isLocalClient: () => isLocalClientValue,
   loadLockfile: async () => {},
   primeLocalGatewayConnection: async () => {},
   probeLocalGatewayReady: async () => true,
@@ -439,7 +439,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     clearGatewayTokenMock.mockClear();
     setSelfHostedConnectionMock.mockClear();
     searchParams = new URLSearchParams();
-    isLocalModeValue = false;
+    isLocalClientValue = false;
     subscriptionPlanId = "base";
     subscriptionThrows = false;
     subscriptionNoData = false;
@@ -866,7 +866,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
   });
 
   test("local hatches never provision", async () => {
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     searchParams = new URLSearchParams("hosting=docker");
 
     render(<HatchingScreen />);
@@ -885,7 +885,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     // a reload onto an already-active assistant flows through the platform
     // preflight path into finishActiveHatch. Without the managed marker the
     // provisioning wait short-circuits — no billing reads, no resize wait.
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     preflightActive = true;
 
     render(<HatchingScreen />);
@@ -907,7 +907,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
   // the purchased machine and storage must land before the screen completes.
 
   test("a managed hatch in local mode waits for the purchased provisioning", async () => {
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     searchParams = new URLSearchParams("hosting=vellum-cloud");
     subscriptionPlanId = "pro";
     onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
@@ -932,7 +932,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     // entry. That entry is self-hosted, so it is never mistaken for the
     // managed assistant being hatched: the hatch still runs, and the only
     // lockfile write names the managed id.
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     searchParams = new URLSearchParams("hosting=vellum-cloud");
     preflightGatewaySelectedLocal = true;
     subscriptionPlanId = "base";
@@ -956,7 +956,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
   });
 
   test("a local hatch keeps its gateway session", async () => {
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     searchParams = new URLSearchParams("hosting=docker");
 
     render(<HatchingScreen />);
@@ -1052,7 +1052,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
   test("a managed hatch without the post-checkout marker completes on the first non-pro read", async () => {
     // Picking Vellum Cloud is not a purchase: a free managed hatch must never
     // be parked on the post-checkout wait.
-    isLocalModeValue = true;
+    isLocalClientValue = true;
     searchParams = new URLSearchParams("hosting=vellum-cloud");
     subscriptionPlanId = "base";
     onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -31,7 +31,7 @@ import {
   POLL_INTERVAL_MS,
 } from "@/domains/onboarding/purchased-provisioning";
 import {
-  isLocalMode,
+  isLocalClient,
   loadLockfile,
   primeLocalGatewayConnection,
   probeLocalGatewayReady,
@@ -148,7 +148,7 @@ export function HatchingScreen() {
   const pluginParam = searchParams.get(ATTRIBUTED_PLUGIN_PARAM);
   const electron = isElectron();
   const useLocalHatch =
-    isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
+    isLocalClient() && hostingParam !== null && hostingParam !== "vellum-cloud";
   // `hosting=vellum-cloud` names a managed hatch even in a local-mode build
   // (see `adopt-existing-assistant`): the assistant is provisioned on the
   // platform, so its purchased machine and storage are waited for.
@@ -225,7 +225,7 @@ export function HatchingScreen() {
     // healthz probes below) rewrite to the local gateway while a self-hosted
     // connection is primed. Dropping both is the same handoff the hosting
     // screen performs for its Vellum Cloud choice.
-    if (managedHatch && isLocalMode()) {
+    if (managedHatch && isLocalClient()) {
       clearGatewayToken();
       setSelfHostedConnection(null);
     }
@@ -329,7 +329,7 @@ export function HatchingScreen() {
           const existing = await getAssistant();
           const preflightState = resolveAssistantLifecycleState(existing);
           if (!cancelled && existing.ok && preflightState.kind === "active") {
-            if (isLocalMode()) {
+            if (isLocalClient()) {
               void saveManagedLockfileAssistant(
                 existing.data.id,
                 existing.data.name,
@@ -631,7 +631,7 @@ export function HatchingScreen() {
             if (createdFreshAssistant || preflightFoundNoAssistant) {
               void persistHatchAvatar(assistantId);
             }
-            if (isLocalMode()) {
+            if (isLocalClient()) {
               void saveManagedLockfileAssistant(
                 assistantId,
                 result.data.name,

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -63,7 +63,7 @@ mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
 // Mutable platform/flag state so individual tests can flip them.
 let nativePlatform = false;
 let localMode = false;
-mock.module("@/lib/local-mode", () => ({ isLocalMode: () => localMode }));
+mock.module("@/lib/local-mode", () => ({ isLocalClient: () => localMode }));
 mock.module("@/runtime/native-auth", () => ({
   useIsNativePlatform: () => nativePlatform,
 }));
@@ -570,7 +570,7 @@ describe("PrivacyScreen — Back navigation", () => {
 
   test("native platform shell: Back stays in-SPA (no marketing-host escape)", () => {
     // The environment-preservation case Codex flagged: on Capacitor
-    // staging/dev, isLocalMode() is false, so platform-mode Back applies. It
+    // staging/dev, isLocalClient() is false, so platform-mode Back applies. It
     // must remain an in-SPA navigation, never a full-document nav to `/`.
     localMode = false;
     nativePlatform = true;

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -22,7 +22,7 @@ import {
   readCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
 import { buildCustomCheckoutSearch } from "@/lib/billing/custom-checkout-params";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalClient } from "@/lib/local-mode";
 import { postCheckoutHatchReturnTo } from "@/lib/navigation/navigation-resolver";
 import {
   usePrivacyConsent,
@@ -110,7 +110,7 @@ export function PrivacyScreen() {
     // then redirects into the research flow. Vellum-Cloud goes straight to
     // research (managed background hatch).
     const isLocalHatch =
-      isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
+      isLocalClient() && hostingParam !== null && hostingParam !== "vellum-cloud";
     const destination = onboardingDestinationAfterConsent({
       isLocalHatch,
     });
@@ -245,7 +245,7 @@ export function PrivacyScreen() {
             fullWidth
             onClick={() =>
               navigate(
-                isLocalMode()
+                isLocalClient()
                   ? routes.onboarding.hosting
                   : routes.onboarding.start,
               )

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -141,7 +141,7 @@ mock.module("@/lib/auth/gateway-session", () => ({
 }));
 
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: () => false,
+  isLocalClient: () => false,
 }));
 
 // The real module builds its destinations from `routes` at import time, and the

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -29,7 +29,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalClient } from "@/lib/local-mode";
 import { POST_CHECKOUT_HATCH_PARAM } from "@/lib/navigation/navigation-resolver";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
@@ -283,7 +283,7 @@ export function ResearchOnboardingRoute() {
   const hostingParam = searchParams.get("hosting");
   const adoptExistingAssistant = shouldAdoptExistingAssistant({
     hostingParam,
-    localMode: isLocalMode(),
+    localMode: isLocalClient(),
     gatewayAuthSession: isGatewayAuthMode(),
   });
   // The hatching screen names the assistant it provisioned in the `assistant`

--- a/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.test.ts
@@ -63,7 +63,7 @@ mock.module("@/generated/api/sdk.gen", () => ({
 }));
 
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: () => localMode,
+  isLocalClient: () => localMode,
 }));
 
 const { awaitPurchasedProvisioning, MAX_HATCH_WAIT_MS, POLL_INTERVAL_MS } =

--- a/clients/web/src/domains/onboarding/purchased-provisioning.ts
+++ b/clients/web/src/domains/onboarding/purchased-provisioning.ts
@@ -29,7 +29,7 @@ import {
   targetsMet,
   type ProvisioningDimensions,
 } from "@/lib/billing/provisioning-targets";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalClient } from "@/lib/local-mode";
 
 // Owned here: `MAX_HATCH_WAIT_MS` decides the `health_timeout` outcome below.
 export const POLL_INTERVAL_MS = 3000;
@@ -92,7 +92,7 @@ export async function awaitPurchasedProvisioning(
   // local-mode run without the managed marker can reach here off a preflight
   // that resolved the lockfile assistant, which has no billing surface —
   // short-circuit there.
-  if (isLocalMode() && !managedHatch) {
+  if (isLocalClient() && !managedHatch) {
     return "ready";
   }
 

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -84,7 +84,7 @@ const saveLockfileAssistantMock = mock(
 mock.module("@/lib/local-mode", () => ({
   probeLocalGatewayReady: probeLocalGatewayReadyMock,
   getLockfileAssistant: getLockfileAssistantMock,
-  isLocalMode: () => localMode,
+  isLocalClient: () => localMode,
   // Surfaces the written entry to the assertions below; payload pinned by
   // `local-mode.test.ts`.
   saveManagedLockfileAssistant: async (

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -26,7 +26,7 @@ import {
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import {
   getLockfileAssistant,
-  isLocalMode,
+  isLocalClient,
   probeLocalGatewayReady,
   saveManagedLockfileAssistant,
 } from "@/lib/local-mode";
@@ -75,7 +75,7 @@ export interface UseBackgroundHatchOptions {
    * of running the managed `hatchAssistant()` here. When true we skip step 1 and
    * discover that live assistant via `getAssistant()`.
    *
-   * This must NOT be conflated with `isLocalMode()` (a build-time value): the
+   * This must NOT be conflated with `isLocalClient()` (a build-time value): the
    * desktop app runs in local mode but can still onboard a Vellum-Cloud
    * (managed) assistant, which needs the managed hatch. Derive this from the
    * chosen HOSTING, not the build (see the research route's `?hosting` read).
@@ -289,7 +289,7 @@ export function useBackgroundHatch({
       // assistant via getAssistant(). Running the managed `hatchAssistant()`
       // there would provision a SECOND (managed) assistant. Vellum-Cloud
       // onboarding (adoptExisting=false) still runs the managed hatch, even
-      // though the desktop build reports `isLocalMode()` — that's why this keys
+      // though the desktop build reports `isLocalClient()` — that's why this keys
       // on the chosen hosting, not the build.
       // When adopting, seed discovery with the id the hatching screen handed
       // off, so step 2 resolves that exact assistant (a stale id falls back to
@@ -311,7 +311,7 @@ export function useBackgroundHatch({
         // is primed. Same handoff the hatching screen performs for its managed
         // path. Both are module-level writes — idempotent under `retry()`, and
         // no auth/org store slice moves, so nothing remounts this hook.
-        if (isLocalMode()) {
+        if (isLocalClient()) {
           clearGatewayToken();
           setSelfHostedConnection(null);
         }
@@ -385,7 +385,7 @@ export function useBackgroundHatch({
             setAssistantId(activeAssistantId);
             // Desktop-only: the list and switcher read the lockfile. An adopted
             // assistant is already the hatching screen's own write.
-            if (!adoptExisting && isLocalMode()) {
+            if (!adoptExisting && isLocalClient()) {
               void saveManagedLockfileAssistant(
                 activeAssistantId,
                 result.data.name,

--- a/clients/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
@@ -6,7 +6,7 @@ import { hatchAssistant, listAssistants } from "@/assistant/api";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailCard } from "@/components/detail-card";
 import {
-  isLocalMode,
+  isLocalClient,
   syncPlatformAssistantsToLockfile,
 } from "@/lib/local-mode";
 import {
@@ -58,7 +58,7 @@ export function AssistantLifecyclePanel() {
         // newly hatched assistants stayed invisible to the tray until the next
         // session refresh. Best-effort and local-mode only; the hatch already
         // succeeded regardless of the sync outcome.
-        if (isLocalMode()) {
+        if (isLocalClient()) {
           try {
             const list = await listAssistants();
             if (list.ok) {

--- a/clients/web/src/domains/settings/pages/developer-page.tsx
+++ b/clients/web/src/domains/settings/pages/developer-page.tsx
@@ -6,7 +6,7 @@ import { AssistantLifecyclePanel } from "@/domains/settings/components/panels/as
 import { EnvironmentConfigPanel } from "@/domains/settings/components/panels/environment-config-panel";
 import { FeatureFlagsPanel } from "@/domains/settings/components/panels/feature-flags-panel";
 import { SentryTestingPanel } from "@/domains/settings/components/panels/sentry-testing-panel";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalClient } from "@/lib/local-mode";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { cn } from "@/utils/misc";
 import { routes } from "@/utils/routes";
@@ -79,7 +79,7 @@ export function DeveloperPage() {
             );
           })}
         </div>
-        {isLocalMode() && (
+        {isLocalClient() && (
           <Button
             variant="outlined"
             className="mb-1 shrink-0"

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -39,7 +39,7 @@ import {
 import {
   getSelectedAssistant,
   isLocalAssistant,
-  isLocalMode,
+  isLocalClient,
   isRemoteGatewayMode,
 } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
@@ -90,10 +90,10 @@ export function GeneralPage() {
   }, [searchParams, setSearchParams]);
 
   const platformAssistant =
-    assistant?.is_local && !isLocalMode() ? null : assistant;
+    assistant?.is_local && !isLocalClient() ? null : assistant;
   const selected = getSelectedAssistant();
   const hasSelectedLocalAssistant =
-    isLocalMode() && !!assistant && !!selected && isLocalAssistant(selected);
+    isLocalClient() && !!assistant && !!selected && isLocalAssistant(selected);
   const canRetireLocally = hasSelectedLocalAssistant;
   const canUpgradeLocally = hasSelectedLocalAssistant && !isRemoteGatewayMode();
   // Whether an upgrade panel (platform or local) is on screen. Both panels

--- a/clients/web/src/hooks/use-platform-gate.test.ts
+++ b/clients/web/src/hooks/use-platform-gate.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
-const isLocalModeMock = mock(() => false);
+const isLocalClientMock = mock(() => false);
 const isPlatformDisabledMock = mock(() => false);
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: isLocalModeMock,
+  isLocalClient: isLocalClientMock,
   isPlatformDisabled: isPlatformDisabledMock,
 }));
 
@@ -26,7 +26,7 @@ function setLifecycle(assistantState: AssistantState) {
 }
 
 beforeEach(() => {
-  isLocalModeMock.mockImplementation(() => false);
+  isLocalClientMock.mockImplementation(() => false);
   isPlatformDisabledMock.mockImplementation(() => false);
   useAuthStore.setState(initialAuthState, true);
   useAssistantLifecycleStore.setState(initialLifecycleState, true);
@@ -50,7 +50,7 @@ describe("usePlatformGate — default (standard pattern)", () => {
   });
 
   test('returns "full" in local mode when logged in and platform not disabled', () => {
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     useAuthStore.setState({ platformSession: "present" });
     isPlatformDisabledMock.mockImplementation(() => false);
     const { result } = renderHook(() => usePlatformGate());
@@ -58,7 +58,7 @@ describe("usePlatformGate — default (standard pattern)", () => {
   });
 
   test('returns "gated" in local mode when VELLUM_DISABLE_PLATFORM is set', () => {
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     useAuthStore.setState({ platformSession: "present" });
     isPlatformDisabledMock.mockImplementation(() => true);
     const { result } = renderHook(() => usePlatformGate());
@@ -71,7 +71,7 @@ describe("usePlatformGate — five documented user states (CONVENTIONS.md)", () 
   // five user states the platform gating contract documents (CONVENTIONS.md).
 
   test('1. platform-hosted + logged in → "full"', () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     isPlatformDisabledMock.mockImplementation(() => false);
     useAuthStore.setState({ platformSession: "present" });
     const { result } = renderHook(() => usePlatformGate());
@@ -79,7 +79,7 @@ describe("usePlatformGate — five documented user states (CONVENTIONS.md)", () 
   });
 
   test('2. platform-hosted + NOT logged in → "disabled"', () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     isPlatformDisabledMock.mockImplementation(() => false);
     useAuthStore.setState({ platformSession: "absent" });
     const { result } = renderHook(() => usePlatformGate());
@@ -87,7 +87,7 @@ describe("usePlatformGate — five documented user states (CONVENTIONS.md)", () 
   });
 
   test('3. self-hosted + platform ON + logged in → "full"', () => {
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     isPlatformDisabledMock.mockImplementation(() => false);
     useAuthStore.setState({ platformSession: "present" });
     const { result } = renderHook(() => usePlatformGate());
@@ -95,7 +95,7 @@ describe("usePlatformGate — five documented user states (CONVENTIONS.md)", () 
   });
 
   test('4. self-hosted + platform ON + NOT logged in → "disabled"', () => {
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     isPlatformDisabledMock.mockImplementation(() => false);
     useAuthStore.setState({ platformSession: "absent" });
     const { result } = renderHook(() => usePlatformGate());
@@ -103,7 +103,7 @@ describe("usePlatformGate — five documented user states (CONVENTIONS.md)", () 
   });
 
   test('5. self-hosted + platform OFF (VELLUM_DISABLE_PLATFORM) → "gated"', () => {
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     isPlatformDisabledMock.mockImplementation(() => true);
     // Session value is irrelevant once platform features are off; assert both.
     for (const platformSession of ["present", "absent"] as const) {
@@ -117,7 +117,7 @@ describe("usePlatformGate — five documented user states (CONVENTIONS.md)", () 
   test('pre-settle "unknown" session gates the surface as "disabled"', () => {
     // The optimistic tri-state: "unknown" is not a live session, so the
     // default branch treats it like "absent" until the probe settles.
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     isPlatformDisabledMock.mockImplementation(() => false);
     useAuthStore.setState({ platformSession: "unknown" });
     const { result } = renderHook(() => usePlatformGate());
@@ -202,7 +202,7 @@ describe("usePlatformGateWithPending", () => {
   test('"gated" wins over the unsettled window in both branches', () => {
     // Nothing the probe can answer changes a gated surface, so it must not
     // report a wait no caller should honor.
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     isPlatformDisabledMock.mockImplementation(() => true);
     useAuthStore.setState({ platformSession: "unknown" });
     const { result, unmount } = renderHook(() => usePlatformGateWithPending());
@@ -260,7 +260,7 @@ describe("usePlatformGate — { platformHostedOnly: true }", () => {
     // The local-mode gateway-auth short-circuit path:
     // lifecycle-service.applyGatewayAuthShortCircuit transitions to
     // { kind: "active", isLocal: true }.
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     setLifecycle({ kind: "active", isLocal: true });
     useAuthStore.setState({ platformSession: "present" });
     const { result } = renderHook(() =>
@@ -273,7 +273,7 @@ describe("usePlatformGate — { platformHostedOnly: true }", () => {
     // A local-mode app can be managing a platform-hosted assistant.
     // The lifecycle service projects { kind: "active", isLocal: false }
     // in that case — platform-hosted-only UI IS meaningful here.
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     setLifecycle({ kind: "active", isLocal: false });
     useAuthStore.setState({ platformSession: "present" });
     const { result } = renderHook(() =>
@@ -285,7 +285,7 @@ describe("usePlatformGate — { platformHostedOnly: true }", () => {
   test("ignores VELLUM_DISABLE_PLATFORM when active assistant is platform-hosted", () => {
     // The env var gates the daemon-side API interceptor in local mode —
     // it has no bearing on UI that targets a platform-hosted assistant.
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     setLifecycle({ kind: "active", isLocal: false });
     useAuthStore.setState({ platformSession: "present" });
     isPlatformDisabledMock.mockImplementation(() => true);

--- a/clients/web/src/hooks/use-platform-gate.ts
+++ b/clients/web/src/hooks/use-platform-gate.ts
@@ -5,7 +5,7 @@ import {
   useIsPlatformSessionSettled,
 } from "@/stores/auth-store";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
-import { isLocalMode, isPlatformDisabled } from "@/lib/local-mode";
+import { isLocalClient, isPlatformDisabled } from "@/lib/local-mode";
 
 /**
  * How a platform-dependent UI surface should behave, given the app mode,
@@ -318,7 +318,7 @@ function usePlatformGateDecision(
     return "full";
   }
 
-  const local = isLocalMode();
+  const local = isLocalClient();
   if (local && platformDisabled) {
     return "gated";
   }

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -24,7 +24,7 @@ import {
   test,
 } from "bun:test";
 
-const isLocalModeMock = mock(() => !process.env.VITE_PLATFORM_MODE);
+const isLocalClientMock = mock(() => !process.env.VITE_PLATFORM_MODE);
 const isPlatformDisabledMock = mock(() => false);
 const isRemoteGatewayModeMock = mock(
   () => window.__VELLUM_CONFIG__?.mode === "remote-gateway",
@@ -39,7 +39,7 @@ mock.module("@/lib/local-mode", () => ({
   getSelectedAssistant: () => undefined,
   hasAssistants: () => false,
   isLocalAssistant: () => false,
-  isLocalMode: isLocalModeMock,
+  isLocalClient: isLocalClientMock,
   isPlatformDisabled: isPlatformDisabledMock,
   isPlatformAssistant: () => false,
   isRemoteGatewayMode: isRemoteGatewayModeMock,
@@ -819,7 +819,7 @@ describe("api-interceptors / remote gateway direct requests", () => {
 // must NOT kill requests already rewritten to the self-hosted gateway.
 //
 // The test preload sets VITE_PLATFORM_MODE=true (platform mode).
-// These tests temporarily clear it so isLocalMode() returns true.
+// These tests temporarily clear it so isLocalClient() returns true.
 
 describe("api-interceptors / platform features gate", () => {
   let savedPlatformMode: string | undefined;
@@ -1046,7 +1046,7 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
         reloadCalls += 1;
       }),
     });
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     setSelfHostedConnection({ url: GATEWAY_URL, token: "tok" });
     sessionStorage.removeItem(GW_401_RELOAD_KEY);
     clearGatewayTokenStorage();
@@ -1058,7 +1058,7 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
       configurable: true,
       value: originalReload,
     });
-    isLocalModeMock.mockImplementation(() => !process.env.VITE_PLATFORM_MODE);
+    isLocalClientMock.mockImplementation(() => !process.env.VITE_PLATFORM_MODE);
     setSelfHostedConnection(null);
     sessionStorage.removeItem(GW_401_RELOAD_KEY);
     clearGatewayTokenStorage();
@@ -1111,7 +1111,7 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
      */
 
     // GIVEN platform mode is active
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
 
     // WHEN the daemon receives a 401
     localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
@@ -1254,7 +1254,7 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
 // being image/file uploads above ~1.5 MB hanging on "Stalled". A Blob is
 // passed by reference (blob handle), so there is no renderer-side data pipe to
 // block on. The preload sets VITE_PLATFORM_MODE=true; these tests clear it so
-// isLocalMode() returns true and the buffering path runs.
+// isLocalClient() returns true and the buffering path runs.
 
 describe("api-interceptors / local-mode body buffering", () => {
   let savedPlatformMode: string | undefined;

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -37,7 +37,7 @@ import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { ApiError, toApiError } from "@/utils/api-errors";
 import {
-  isLocalMode,
+  isLocalClient,
   isPlatformDisabled,
   isRemoteGatewayMode,
 } from "@/lib/local-mode";
@@ -224,7 +224,7 @@ export async function rewriteForSelfHostedIngress(
   // reference (blob handle) and read directly, with no renderer-side data
   // pipe to block on. Platform self-hosted uses TLS, so keep the streaming
   // body there to avoid buffering large uploads.
-  const body = isLocalMode()
+  const body = isLocalClient()
     ? request.body
       ? await request.blob()
       : null
@@ -240,7 +240,7 @@ export async function rewriteForSelfHostedIngress(
     redirect: request.redirect,
     signal: request.signal,
   };
-  if (!isLocalMode() && request.body) {
+  if (!isLocalClient() && request.body) {
     (init as RequestInit & { duplex: "half" }).duplex = "half";
   }
   return new Request(rewrittenUrl.toString(), init);
@@ -430,7 +430,7 @@ export function localGatewayAuthRecoveryInterceptor(
   if (gw401RecoveryFired) {
     return response;
   }
-  if (!isLocalMode()) {
+  if (!isLocalClient()) {
     return response;
   }
   const ingressUrl = getSelfHostedIngressUrl();
@@ -648,7 +648,7 @@ export function platformFeaturesGate(request: Request): Request {
     return new Request(request.url, { signal: aborted.signal });
   }
 
-  if (!isLocalMode()) {
+  if (!isLocalClient()) {
     return request;
   }
   if (arePlatformFeaturesEnabled()) {

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -3,7 +3,7 @@ import { createMemoryRouter } from "react-router";
 
 import type { LockfileAssistant } from "@/lib/local-mode";
 
-const isLocalModeMock = mock(() => true);
+const isLocalClientMock = mock(() => true);
 const hasAssistantsMock = mock(() => false);
 let mockSelectedAssistant: LockfileAssistant | undefined;
 
@@ -13,7 +13,7 @@ let mockSelectedAssistant: LockfileAssistant | undefined;
 const localModeActual = await import("@/lib/local-mode");
 mock.module("@/lib/local-mode", () => ({
   ...localModeActual,
-  isLocalMode: isLocalModeMock,
+  isLocalClient: isLocalClientMock,
   hasAssistants: hasAssistantsMock,
   getLocalGatewayUrl: () => undefined,
   getSelectedAssistant: () => mockSelectedAssistant,
@@ -121,7 +121,7 @@ const managedFunnel = `${routes.onboarding.research}?hosting=vellum-cloud&post_c
  * does not apply, yet the funnel decision still hangs on the probe.
  */
 function makeSelfHostedLocalReturn(): void {
-  isLocalModeMock.mockImplementation(() => true);
+  isLocalClientMock.mockImplementation(() => true);
   hasAssistantsMock.mockImplementation(() => true);
   mockGatewayAuthMode = true;
   mockSelectedAssistant = localAssistant;
@@ -207,7 +207,7 @@ async function runMiddleware(pathname: string): Promise<Response> {
 const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 
 beforeEach(() => {
-  isLocalModeMock.mockImplementation(() => true);
+  isLocalClientMock.mockImplementation(() => true);
   hasAssistantsMock.mockImplementation(() => false);
   consentPrefs.tos = true;
   consentPrefs.privacy = true;
@@ -355,7 +355,7 @@ describe("authMiddleware — app-access admit gate", () => {
   });
 
   test("still redirects a logged-out platform user with no reachable assistant to login", async () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     hasAssistantsMock.mockImplementation(() => false);
     mockSelectedAssistant = undefined;
     mockGatewayTokenPresent = false;
@@ -378,7 +378,7 @@ describe("authMiddleware — app-access admit gate", () => {
 
 describe("authMiddleware — post-checkout return with nothing provisioned", () => {
   function makePaidPlatformReturn(): void {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     useAuthStore.setState({
       sessionStatus: "authenticated",
       user: fakeUser,
@@ -401,7 +401,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
 
   test("funnels it under a gateway session too, which otherwise bypasses the pipeline", async () => {
     makePaidPlatformReturn();
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     mockGatewayAuthMode = true;
 
     const res = await runMiddleware(postCheckoutBilling);
@@ -415,7 +415,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
   // entry is untouched.
   test("funnels a local-mode return whose only assistant is self-hosted", async () => {
     makePaidPlatformReturn();
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     mockGatewayAuthMode = true;
     mockSelectedAssistant = localAssistant;
     useResolvedAssistantsStore.setState({
@@ -442,7 +442,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
   // stays on billing, whose login notice carries `session_id` through sign-in.
   test("admits a local-mode return with no platform session", async () => {
     makePaidPlatformReturn();
-    isLocalModeMock.mockImplementation(() => true);
+    isLocalClientMock.mockImplementation(() => true);
     mockGatewayAuthMode = true;
     mockSelectedAssistant = localAssistant;
     useAuthStore.setState({ platformSession: "absent" });
@@ -650,7 +650,7 @@ describe("authMiddleware — late-probe re-run through a real router", () => {
 
 describe("authMiddleware — hydration timeout", () => {
   test("a hung hydration degrades to a decision instead of re-entering the wait", async () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     useAuthStore.setState({
       sessionStatus: "authenticated",
       user: fakeUser,
@@ -690,7 +690,7 @@ describe("authMiddleware — hydration timeout", () => {
   // user's onboarding. It admits instead. The assistants list is hydrated here,
   // so the fail-open rests on the consent wait alone.
   test("admits a research funnel entry whose consent hydration hung", async () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     useAuthStore.setState({
       sessionStatus: "authenticated",
       user: fakeUser,
@@ -719,7 +719,7 @@ describe("authMiddleware — hydration timeout", () => {
   // on an unconsented user still bounces, carrying the funnel URL so the paid
   // markers survive the privacy screen.
   test("bounces the same entry once consent hydrates unconsented", async () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     useAuthStore.setState({
       sessionStatus: "authenticated",
       user: fakeUser,
@@ -750,7 +750,7 @@ describe("authMiddleware — hydration timeout", () => {
   // doing, so a stalled list must not launder an unconsented user past the gate
   // and into a hatch they would be charged for.
   test("bounces an unconsented research entry when only the assistants list stalls", async () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     useAuthStore.setState({
       sessionStatus: "authenticated",
       user: fakeUser,
@@ -793,7 +793,7 @@ describe("authMiddleware — hydration timeout", () => {
   // the time the guard recurses. Carrying the expired stall forward would fail
   // the gate open on a hydration that has since landed.
   test("bounces an unconsented research entry when consent lands during the assistants wait", async () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     useAuthStore.setState({
       sessionStatus: "authenticated",
       user: fakeUser,
@@ -834,7 +834,7 @@ describe("authMiddleware — hydration timeout", () => {
   // Both fetches hang, so the consent wait times out on its own account and the
   // entry falls back to its unconditional admission.
   test("admits the research entry when both hydration waits stall", async () => {
-    isLocalModeMock.mockImplementation(() => false);
+    isLocalClientMock.mockImplementation(() => false);
     useAuthStore.setState({
       sessionStatus: "authenticated",
       user: fakeUser,

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -6,7 +6,7 @@ import {
 
 import { useAuthStore, type AuthUser } from "@/stores/auth-store";
 import { isAuthenticated, isSessionSettled } from "@/stores/session-status";
-import { isLocalMode, hasAssistants } from "@/lib/local-mode";
+import { isLocalClient, hasAssistants } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { captureError } from "@/lib/sentry/capture-error";
@@ -125,7 +125,7 @@ const resolveWithGuard = async (
     let platformProbeStillUnknown = false;
     if (
       !timedOut.platformProbe &&
-      isLocalMode() &&
+      isLocalClient() &&
       (!hasAssistants() || decision.waitFor === "platform-session")
     ) {
       await whenStoreState(
@@ -150,7 +150,7 @@ const resolveWithGuard = async (
     let consentStillPending = false;
     let assistantsStillPending = false;
     if (
-      !isLocalMode() &&
+      !isLocalClient() &&
       isAuthenticated(useAuthStore.getState().sessionStatus)
     ) {
       if (!timedOut.consentHydration) {

--- a/clients/web/src/lib/auth/gateway-session.ts
+++ b/clients/web/src/lib/auth/gateway-session.ts
@@ -1,5 +1,5 @@
 import {
-  isLocalMode,
+  isLocalClient,
   getLocalGatewayUrl,
   isRemoteGatewayMode,
 } from "@/lib/local-mode";
@@ -60,7 +60,7 @@ export function isGatewayAuthEnabled(): boolean {
   if (isRemoteGatewayMode()) {
     return true;
   }
-  return isLocalMode() && getLocalGatewayUrl() != null;
+  return isLocalClient() && getLocalGatewayUrl() != null;
 }
 
 export function isGatewayAuthMode(): boolean {

--- a/clients/web/src/lib/auth/handle-logout.ts
+++ b/clients/web/src/lib/auth/handle-logout.ts
@@ -5,7 +5,7 @@ import { hardNavigate } from "@/lib/auth/hard-navigate";
 import {
   getActiveAssistant,
   isLocalAssistant,
-  isLocalMode,
+  isLocalClient,
 } from "@/lib/local-mode";
 import { setAssistantName } from "@/runtime/identity";
 import { setMenuPlatformSession } from "@/runtime/menu";
@@ -13,7 +13,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
 export async function handleLogout(navigate: NavigateFunction): Promise<void> {
-  if (isLocalMode()) {
+  if (isLocalClient()) {
     const active = getActiveAssistant();
     if (active && isLocalAssistant(active)) {
       await setMenuPlatformSession(false);

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -117,7 +117,7 @@ const commitLockfile = (data: Lockfile): void => {
 
 const PLATFORM_MODE_TRUTHY = new Set(["1", "true", "yes"]);
 
-export function isLocalMode(): boolean {
+export function isLocalClient(): boolean {
   const raw = import.meta.env.VITE_PLATFORM_MODE;
   if (!raw) {
     return true;
@@ -551,7 +551,7 @@ function expectsLocalGateway(
 ): assistant is LockfileAssistant {
   return (
     !!assistant &&
-    isLocalMode() &&
+    isLocalClient() &&
     !isRemoteGatewayMode() &&
     isLocalGatewayAssistant(assistant)
   );

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -20,7 +20,7 @@ let activeAssistant = {
   organizationId: ORGANIZATION_ID,
   resources: { gatewayPort: 20101 },
 };
-let isLocalModeValue = true;
+let isLocalClientValue = true;
 let isPlatformDisabledValue = false;
 let isRemoteGatewayModeValue = false;
 let selfHostedIngressUrl: string | null = GATEWAY_URL;
@@ -57,7 +57,7 @@ mock.module("@/lib/local-mode", () => ({
   getSelectedAssistant: () => activeAssistant,
   isLocalAssistant: (assistant: { cloud?: string }) =>
     assistant?.cloud === "local",
-  isLocalMode: () => isLocalModeValue,
+  isLocalClient: () => isLocalClientValue,
   isPlatformDisabled: () => isPlatformDisabledValue,
   isRemoteGatewayMode: () => isRemoteGatewayModeValue,
   primeLocalGatewayConnectionWithRepair:
@@ -131,7 +131,7 @@ beforeEach(() => {
     organizationId: ORGANIZATION_ID,
     resources: { gatewayPort: 20101 },
   };
-  isLocalModeValue = true;
+  isLocalClientValue = true;
   isPlatformDisabledValue = false;
   isRemoteGatewayModeValue = false;
   selfHostedIngressUrl = GATEWAY_URL;

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -5,7 +5,7 @@ import {
   getPlatformRuntimeUrl,
   getSelectedAssistant,
   isLocalAssistant,
-  isLocalMode,
+  isLocalClient,
   isPlatformDisabled,
   isRemoteGatewayMode,
   primeLocalGatewayConnectionWithRepair,
@@ -106,7 +106,7 @@ export async function resolveLocalAssistantPlatformIdentity(
   options: ResolveLocalAssistantPlatformIdentityOptions = {},
 ): Promise<string> {
   if (
-    !isLocalMode() ||
+    !isLocalClient() ||
     isRemoteGatewayMode() ||
     isPlatformDisabled() ||
     isUuid(assistantId)
@@ -140,7 +140,7 @@ export function bootstrapLocalAssistantPlatformIdentity(
   assistantId?: string,
   options: BootstrapLocalAssistantPlatformIdentityOptions = {},
 ): void {
-  if (!isLocalMode() || isRemoteGatewayMode() || isPlatformDisabled()) {
+  if (!isLocalClient() || isRemoteGatewayMode() || isPlatformDisabled()) {
     return;
   }
 

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -3,13 +3,13 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Spread the real `@/lib/local-mode` so every other export the dependency graph
 // pulls in stays available; override only the hosting-mode flags build-state
 // branches on.
-let mockIsLocalMode = true;
+let mockIsLocalClient = true;
 let mockIsRemoteGatewayMode = false;
 
 const localModeActual = await import("@/lib/local-mode");
 mock.module("@/lib/local-mode", () => ({
   ...localModeActual,
-  isLocalMode: () => mockIsLocalMode,
+  isLocalClient: () => mockIsLocalClient,
   isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
 }));
 
@@ -37,7 +37,7 @@ const { useResolvedAssistantsStore } =
 const initialAuthState = useAuthStore.getState();
 
 beforeEach(() => {
-  mockIsLocalMode = true;
+  mockIsLocalClient = true;
   mockIsRemoteGatewayMode = false;
   useAuthStore.setState(initialAuthState, true);
   useOrganizationStore.setState({

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -3,7 +3,7 @@ import { isSessionSettled, isAuthenticated } from "@/stores/session-status";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { remoteGatewayPublicPathPrefix } from "@/lib/auth/remote-gateway-session";
 import {
-  isLocalMode,
+  isLocalClient,
   isPlatformDisabled,
   isRemoteGatewayMode,
 } from "@/lib/local-mode";
@@ -49,7 +49,7 @@ export function buildNavigationState(
     useResolvedAssistantsStore.getState();
   const isRemoteGateway = isRemoteGatewayMode();
   return {
-    isLocalMode: isLocalMode(),
+    isLocalClient: isLocalClient(),
     isPlatformDisabled: isPlatformDisabled(),
     isRemoteGateway,
     remoteGatewayPublicPathPrefix: isRemoteGateway

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./navigation-resolver";
 
 const base: NavigationState = {
-  isLocalMode: false,
+  isLocalClient: false,
   isPlatformDisabled: false,
   isRemoteGateway: false,
   remoteGatewayPublicPathPrefix: "",
@@ -109,7 +109,7 @@ describe("resolveNavigation", () => {
       const result = guard(
         s({
           isAuthenticated: false,
-          isLocalMode: true,
+          isLocalClient: true,
           isRemoteGateway: true,
           hasAssistants: true,
         }),
@@ -126,7 +126,7 @@ describe("resolveNavigation", () => {
       const result = guard(
         s({
           isAuthenticated: false,
-          isLocalMode: true,
+          isLocalClient: true,
           isRemoteGateway: true,
           remoteGatewayPublicPathPrefix: "/assistant-123",
           hasAssistants: true,
@@ -145,7 +145,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isAuthenticated: false,
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: false,
           }),
           "/assistant/welcome",
@@ -156,7 +156,7 @@ describe("resolveNavigation", () => {
     test("allows unauthenticated local-mode user on select-assistant screen", () => {
       expect(
         guard(
-          s({ isAuthenticated: false, isLocalMode: true, hasAssistants: true }),
+          s({ isAuthenticated: false, isLocalClient: true, hasAssistants: true }),
           "/assistant/select-assistant",
         ),
       ).toEqual(ALLOW);
@@ -167,7 +167,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isAuthenticated: false,
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: false,
           }),
           "/assistant/select-assistant",
@@ -180,7 +180,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isAuthenticated: false,
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: false,
           }),
         ),
@@ -190,7 +190,7 @@ describe("resolveNavigation", () => {
     test("redirects unauthenticated local-mode returning user (has assistants) to select-assistant", () => {
       expect(
         guard(
-          s({ isAuthenticated: false, isLocalMode: true, hasAssistants: true }),
+          s({ isAuthenticated: false, isLocalClient: true, hasAssistants: true }),
         ),
       ).toEqual({ action: "redirect", to: "/assistant/select-assistant" });
     });
@@ -226,38 +226,38 @@ describe("resolveNavigation", () => {
     test("redirects authenticated user from select-assistant to hosting when no assistants", () => {
       expect(
         guard(
-          s({ isLocalMode: true, hasAssistants: false }),
+          s({ isLocalClient: true, hasAssistants: false }),
           "/assistant/select-assistant",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/hosting" });
     });
 
     test("redirects non-local user from local-only onboarding screen", () => {
-      expect(guard(s({ isLocalMode: false }), "/assistant/welcome")).toEqual({
+      expect(guard(s({ isLocalClient: false }), "/assistant/welcome")).toEqual({
         action: "redirect",
         to: "/assistant",
       });
       expect(
-        guard(s({ isLocalMode: false }), "/assistant/select-assistant"),
+        guard(s({ isLocalClient: false }), "/assistant/select-assistant"),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
-        guard(s({ isLocalMode: false }), "/assistant/onboarding/hosting"),
+        guard(s({ isLocalClient: false }), "/assistant/onboarding/hosting"),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
-        guard(s({ isLocalMode: false }), "/assistant/onboarding/api-key"),
+        guard(s({ isLocalClient: false }), "/assistant/onboarding/api-key"),
       ).toEqual({ action: "redirect", to: "/assistant" });
     });
 
     test("allows non-local user on onboarding screens regardless of assistant count", () => {
       expect(
-        guard(s({ isLocalMode: false }), "/assistant/onboarding/privacy"),
+        guard(s({ isLocalClient: false }), "/assistant/onboarding/privacy"),
       ).toEqual(ALLOW);
       expect(
-        guard(s({ isLocalMode: false }), "/assistant/onboarding/hatching"),
+        guard(s({ isLocalClient: false }), "/assistant/onboarding/hatching"),
       ).toEqual(ALLOW);
       expect(
         guard(
-          s({ isLocalMode: false, hasAssistants: false }),
+          s({ isLocalClient: false, hasAssistants: false }),
           "/assistant/onboarding/privacy",
         ),
       ).toEqual(ALLOW);
@@ -306,7 +306,7 @@ describe("resolveNavigation", () => {
     test("redirects from hatching without consent in local mode", () => {
       expect(
         guard(
-          s({ isLocalMode: true, tosAccepted: false, privacyConsent: false }),
+          s({ isLocalClient: true, tosAccepted: false, privacyConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
@@ -327,7 +327,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: false,
             platformSession: "unknown",
           }),
@@ -339,7 +339,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: false,
             platformSession: "present",
           }),
@@ -351,7 +351,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: false,
             platformSession: "absent",
           }),
@@ -360,7 +360,7 @@ describe("resolveNavigation", () => {
     });
 
     test("allows local mode with assistants", () => {
-      expect(guard(s({ isLocalMode: true, hasAssistants: true }))).toEqual(
+      expect(guard(s({ isLocalClient: true, hasAssistants: true }))).toEqual(
         ALLOW,
       );
     });
@@ -370,7 +370,7 @@ describe("resolveNavigation", () => {
     test("redirects platform-mode user without consent to review-terms with returnTo", () => {
       expect(
         guard(
-          s({ isLocalMode: false, tosAccepted: false, privacyConsent: false }),
+          s({ isLocalClient: false, tosAccepted: false, privacyConsent: false }),
         ),
       ).toEqual({
         action: "redirect",
@@ -381,7 +381,7 @@ describe("resolveNavigation", () => {
     test("redirects platform-mode user with partial consent to review-terms with returnTo", () => {
       expect(
         guard(
-          s({ isLocalMode: false, tosAccepted: true, privacyConsent: false }),
+          s({ isLocalClient: false, tosAccepted: true, privacyConsent: false }),
         ),
       ).toEqual({
         action: "redirect",
@@ -393,7 +393,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({
-            isLocalMode: false,
+            isLocalClient: false,
             tosAccepted: false,
             privacyConsent: false,
             hasAssistants: false,
@@ -482,7 +482,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: false,
             platformSession: "absent",
             assistantsHydrated: false,
@@ -495,7 +495,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: true,
             platformSession: "present",
             tosAccepted: false,
@@ -513,7 +513,7 @@ describe("resolveNavigation", () => {
 
     test("redirects platform user with current tos/ai but stale analytics toggle to review-terms", () => {
       expect(
-        guard(s({ isLocalMode: false, analyticsConsentCurrent: false })),
+        guard(s({ isLocalClient: false, analyticsConsentCurrent: false })),
       ).toEqual({
         action: "redirect",
         to: "/assistant/review-terms?returnTo=%2Fassistant",
@@ -522,7 +522,7 @@ describe("resolveNavigation", () => {
 
     test("redirects platform user with stale diagnostics toggle to review-terms", () => {
       expect(
-        guard(s({ isLocalMode: false, diagnosticsConsentCurrent: false })),
+        guard(s({ isLocalClient: false, diagnosticsConsentCurrent: false })),
       ).toEqual({
         action: "redirect",
         to: "/assistant/review-terms?returnTo=%2Fassistant",
@@ -533,7 +533,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({
-            isLocalMode: false,
+            isLocalClient: false,
             tosAccepted: true,
             privacyConsent: true,
             analyticsConsentCurrent: true,
@@ -544,12 +544,12 @@ describe("resolveNavigation", () => {
     });
 
     test("redirects local-mode user with a platform session and stale consent to review-terms", () => {
-      // Consent is gated on the platform session, NOT isLocalMode: a local-mode
+      // Consent is gated on the platform session, NOT isLocalClient: a local-mode
       // client logged into the platform still re-reviews stale terms.
       expect(
         guard(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: true,
             platformSession: "present",
             tosAccepted: false,
@@ -743,7 +743,7 @@ describe("resolveNavigation", () => {
     test("funnels a no-assistant post-checkout return even under gateway auth", () => {
       expect(
         guard(
-          s({ isGatewayAuth: true, isLocalMode: true, ...EMPTY_ORG }),
+          s({ isGatewayAuth: true, isLocalClient: true, ...EMPTY_ORG }),
           POST_CHECKOUT_BILLING,
         ),
       ).toEqual(MANAGED_FUNNEL);
@@ -756,7 +756,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isGatewayAuth: true,
-            isLocalMode: true,
+            isLocalClient: true,
             ...NO_MANAGED_ASSISTANT,
           }),
           POST_CHECKOUT_BILLING,
@@ -774,7 +774,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isGatewayAuth: true,
-            isLocalMode: true,
+            isLocalClient: true,
             platformSession: "unknown",
             ...NO_MANAGED_ASSISTANT,
           }),
@@ -791,7 +791,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isGatewayAuth: true,
-            isLocalMode: true,
+            isLocalClient: true,
             platformSession: "absent",
             ...NO_MANAGED_ASSISTANT,
           }),
@@ -805,7 +805,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isGatewayAuth: true,
-            isLocalMode: true,
+            isLocalClient: true,
             hasPlatformHostedAssistant: true,
           }),
           POST_CHECKOUT_BILLING,
@@ -813,7 +813,7 @@ describe("resolveNavigation", () => {
       ).toEqual(ALLOW);
       expect(
         guard(
-          s({ isGatewayAuth: true, isLocalMode: true, ...EMPTY_ORG }),
+          s({ isGatewayAuth: true, isLocalClient: true, ...EMPTY_ORG }),
           "/assistant/settings/billing",
         ),
       ).toEqual(ALLOW);
@@ -821,7 +821,7 @@ describe("resolveNavigation", () => {
         guard(
           s({
             isGatewayAuth: true,
-            isLocalMode: true,
+            isLocalClient: true,
             ...NO_MANAGED_ASSISTANT,
           }),
           "/assistant/settings/billing",
@@ -893,7 +893,7 @@ describe("resolveNavigation", () => {
       expect(
         guard(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             ...EMPTY_ORG,
             assistantsHydrated: false,
           }),
@@ -957,7 +957,7 @@ describe("resolveNavigation", () => {
     // `returnTo`, so its bounce stays bare.
     test("a local-mode hatching bounce keeps the bare welcome entrypoint", () => {
       expect(
-        guard(s({ isLocalMode: true, ...UNCONSENTED }), HATCHING_FUNNEL_URL),
+        guard(s({ isLocalClient: true, ...UNCONSENTED }), HATCHING_FUNNEL_URL),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
@@ -981,7 +981,7 @@ describe("resolveNavigation", () => {
       });
       expect(
         guard(
-          s({ isLocalMode: true, ...UNCONSENTED }),
+          s({ isLocalClient: true, ...UNCONSENTED }),
           "/assistant/onboarding/research",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
@@ -1124,13 +1124,13 @@ describe("resolveNavigation", () => {
     test("a local-mode research bounce decides without waiting on hydration", () => {
       expect(
         guard(
-          s({ isLocalMode: true, ...UNCONSENTED, consentHydrated: false }),
+          s({ isLocalClient: true, ...UNCONSENTED, consentHydrated: false }),
           RESEARCH_FUNNEL_URL,
         ),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
       expect(
         guard(
-          s({ isLocalMode: true, ...UNCONSENTED, consentHydrated: false }),
+          s({ isLocalClient: true, ...UNCONSENTED, consentHydrated: false }),
           "/assistant/onboarding/research",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
@@ -1143,7 +1143,7 @@ describe("resolveNavigation", () => {
     // local assistant, with a platform session to provision into.
     const ELECTRON_PAID = {
       isGatewayAuth: true,
-      isLocalMode: true,
+      isLocalClient: true,
       platformSession: "present",
       ...NO_MANAGED_ASSISTANT,
     } as const;
@@ -1273,7 +1273,7 @@ describe("resolveNavigation", () => {
 
     test("allows local mode with assistants", () => {
       expect(
-        intercept(s({ isLocalMode: true, hasAssistants: true }), "/assistant"),
+        intercept(s({ isLocalClient: true, hasAssistants: true }), "/assistant"),
       ).toEqual(ALLOW);
     });
 
@@ -1317,7 +1317,7 @@ describe("resolveNavigation", () => {
       expect(
         intercept(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             hasAssistants: false,
             tosAccepted: false,
             privacyConsent: false,
@@ -1379,7 +1379,7 @@ describe("resolveNavigation", () => {
     });
 
     test("redirects unauthenticated platform-mode user to login", () => {
-      expect(hatch(s({ isAuthenticated: false, isLocalMode: false }))).toEqual({
+      expect(hatch(s({ isAuthenticated: false, isLocalClient: false }))).toEqual({
         action: "redirect",
         to: "/account/login",
       });
@@ -1390,7 +1390,7 @@ describe("resolveNavigation", () => {
         hatch(
           s({
             isAuthenticated: false,
-            isLocalMode: true,
+            isLocalClient: true,
             tosAccepted: false,
             privacyConsent: false,
           }),
@@ -1418,7 +1418,7 @@ describe("resolveNavigation", () => {
     test("redirects to welcome in local mode when missing consent", () => {
       expect(
         hatch(
-          s({ isLocalMode: true, tosAccepted: false, privacyConsent: false }),
+          s({ isLocalClient: true, tosAccepted: false, privacyConsent: false }),
         ),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
@@ -1447,7 +1447,7 @@ describe("resolveNavigation", () => {
       expect(
         hatch(
           s({
-            isLocalMode: true,
+            isLocalClient: true,
             analyticsConsentCurrent: false,
             diagnosticsConsentCurrent: false,
           }),
@@ -1464,7 +1464,7 @@ describe("resolveNavigation", () => {
       resolveNavigation(state, { kind: "post-retire" });
 
     test("redirects to select-assistant in local mode when other assistants remain", () => {
-      expect(postRetire(s({ hasAssistants: true, isLocalMode: true }))).toEqual(
+      expect(postRetire(s({ hasAssistants: true, isLocalClient: true }))).toEqual(
         {
           action: "redirect",
           to: "/assistant/select-assistant",
@@ -1474,7 +1474,7 @@ describe("resolveNavigation", () => {
 
     test("redirects to /assistant in platform mode when other assistants remain", () => {
       expect(
-        postRetire(s({ hasAssistants: true, isLocalMode: false })),
+        postRetire(s({ hasAssistants: true, isLocalClient: false })),
       ).toEqual({
         action: "redirect",
         to: "/assistant",
@@ -1483,7 +1483,7 @@ describe("resolveNavigation", () => {
 
     test("redirects to privacy in platform mode when no assistants remain", () => {
       expect(
-        postRetire(s({ hasAssistants: false, isLocalMode: false })),
+        postRetire(s({ hasAssistants: false, isLocalClient: false })),
       ).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/privacy",
@@ -1495,7 +1495,7 @@ describe("resolveNavigation", () => {
         postRetire(
           s({
             hasAssistants: false,
-            isLocalMode: true,
+            isLocalClient: true,
             platformSession: "present",
           }),
         ),
@@ -1510,7 +1510,7 @@ describe("resolveNavigation", () => {
         postRetire(
           s({
             hasAssistants: false,
-            isLocalMode: true,
+            isLocalClient: true,
             platformSession: "absent",
           }),
         ),

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -9,7 +9,7 @@ import { routes } from "@/utils/routes";
 // ---------------------------------------------------------------------------
 
 export interface NavigationState {
-  isLocalMode: boolean;
+  isLocalClient: boolean;
   isPlatformDisabled: boolean;
   isRemoteGateway: boolean;
   remoteGatewayPublicPathPrefix: string;
@@ -124,8 +124,8 @@ function isOnboardingPath(pathname: string): boolean {
   );
 }
 
-function onboardingEntrypoint(isLocalMode: boolean): string {
-  return isLocalMode ? routes.welcome : routes.onboarding.privacy;
+function onboardingEntrypoint(isLocalClient: boolean): string {
+  return isLocalClient ? routes.welcome : routes.onboarding.privacy;
 }
 
 /**
@@ -422,7 +422,7 @@ function requirePostCheckoutProvisioning(
   // deciding on that default would funnel an established user out of their own
   // billing page. Local mode is excluded for the same reason as in
   // `requireAssistant` — its list is lockfile-driven.
-  if (!state.isLocalMode && !state.assistantsHydrated) {
+  if (!state.isLocalClient && !state.assistantsHydrated) {
     return { action: "wait" };
   }
   // A local-mode client reaches "authenticated" on its gateway session alone,
@@ -431,7 +431,7 @@ function requirePostCheckoutProvisioning(
   // probe boots `"unknown"`, so hold until it settles. When it settles absent
   // there is no account to provision into: fall through to billing, whose login
   // notice carries `session_id` through sign-in and lands back here.
-  if (state.isLocalMode) {
+  if (state.isLocalClient) {
     if (state.platformSession === "unknown") {
       return { action: "wait", waitFor: "platform-session" };
     }
@@ -513,7 +513,7 @@ function requireAuth(
   }
 
   if (
-    state.isLocalMode &&
+    state.isLocalClient &&
     (isOnboardingPath(path) || LOCAL_ONLY_STANDALONE_PATHS.has(path))
   ) {
     if (path === routes.selectAssistant && !state.hasAssistants) {
@@ -521,10 +521,10 @@ function requireAuth(
     }
     return { action: "allow" };
   }
-  if (state.isLocalMode && !state.hasAssistants) {
+  if (state.isLocalClient && !state.hasAssistants) {
     return { action: "redirect", to: routes.welcome };
   }
-  if (state.isLocalMode) {
+  if (state.isLocalClient) {
     return { action: "redirect", to: routes.selectAssistant };
   }
   return {
@@ -538,7 +538,7 @@ function enforceModeBoundary(
   path: string,
 ): NavigationDecision | null {
   if (LOCAL_ONLY_STANDALONE_PATHS.has(path)) {
-    if (!state.isLocalMode) {
+    if (!state.isLocalClient) {
       return { action: "redirect", to: routes.assistant };
     }
     if (path === routes.selectAssistant && !state.hasAssistants) {
@@ -547,7 +547,7 @@ function enforceModeBoundary(
     return { action: "allow" };
   }
 
-  if (LOCAL_ONLY_ONBOARDING_PATHS.has(path) && !state.isLocalMode) {
+  if (LOCAL_ONLY_ONBOARDING_PATHS.has(path) && !state.isLocalClient) {
     return { action: "redirect", to: routes.assistant };
   }
 
@@ -571,7 +571,7 @@ function consentBounceDestination(
   state: NavigationState,
   pathnameWithSearch: string,
 ): string {
-  const entrypoint = onboardingEntrypoint(state.isLocalMode);
+  const entrypoint = onboardingEntrypoint(state.isLocalClient);
   if (entrypoint !== routes.onboarding.privacy) {
     return entrypoint;
   }
@@ -626,7 +626,7 @@ function enforceFunnelConsent(
     // Local mode is excluded for the same reason as in `requireConsent`: its
     // consent either hydrates synchronously during session init or never does,
     // so waiting would hang navigation.
-    if (!state.isLocalMode && !state.consentHydrated) {
+    if (!state.isLocalClient && !state.consentHydrated) {
       return { action: "wait" };
     }
     // A hydration that never landed leaves those boot defaults behind a forced
@@ -688,7 +688,7 @@ function requireAssistant(
     return null;
   }
 
-  if (state.isLocalMode) {
+  if (state.isLocalClient) {
     if (state.platformSession === "unknown") {
       return { action: "wait", waitFor: "platform-session" };
     }
@@ -729,7 +729,7 @@ function requireConsent(
   // Consent is a platform-account concern: only enforce it when there is a
   // live platform session to consent against. A disabled platform or an
   // absent/unknown session has no server consent record to gate on. Note this
-  // is NOT gated on isLocalMode — a local-mode client with a platform session
+  // is NOT gated on isLocalClient — a local-mode client with a platform session
   // still re-reviews stale terms.
   if (
     state.isPlatformDisabled ||
@@ -744,7 +744,7 @@ function requireConsent(
   // Local mode decides immediately: its platform-session paths that enforce
   // consent hydrate synchronously during session init, and the gateway-probe
   // path never hydrates, so waiting there would hang navigation.
-  if (!state.consentHydrated && !state.isLocalMode) {
+  if (!state.consentHydrated && !state.isLocalClient) {
     return { action: "wait" };
   }
 
@@ -763,7 +763,7 @@ function resolveOnboardingIntercept(
   state: NavigationState,
   intendedDestination: string,
 ): NavigationDecision {
-  if (state.isLocalMode && state.hasAssistants) {
+  if (state.isLocalClient && state.hasAssistants) {
     return { action: "allow" };
   }
   if (hasCompletedOnboarding(state)) {
@@ -783,7 +783,7 @@ function resolveOnboardingIntercept(
 
   return {
     action: "redirect",
-    to: onboardingEntrypoint(state.isLocalMode),
+    to: onboardingEntrypoint(state.isLocalClient),
   };
 }
 
@@ -795,14 +795,14 @@ function resolveHatchGate(state: NavigationState): NavigationDecision {
   if (!state.sessionSettled) {
     return { action: "wait" };
   }
-  if (!state.isAuthenticated && !state.isLocalMode) {
+  if (!state.isAuthenticated && !state.isLocalClient) {
     return { action: "redirect", to: routes.account.login };
   }
   if (!hasCompletedOnboarding(state)) {
-    return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };
+    return { action: "redirect", to: onboardingEntrypoint(state.isLocalClient) };
   }
   // A stale toggle must be re-reviewed before hatching, even via direct navigation.
-  if (!state.isLocalMode && !consentIsCurrent(state)) {
+  if (!state.isLocalClient && !consentIsCurrent(state)) {
     return { action: "redirect", to: routes.reviewTerms };
   }
   return { action: "allow" };
@@ -857,10 +857,10 @@ function resolvePostRetire(state: NavigationState): NavigationDecision {
     // select-assistant is local-only; platform users go straight to /assistant
     return {
       action: "redirect",
-      to: state.isLocalMode ? routes.selectAssistant : routes.assistant,
+      to: state.isLocalClient ? routes.selectAssistant : routes.assistant,
     };
   }
-  if (!state.isLocalMode) {
+  if (!state.isLocalClient) {
     return { action: "redirect", to: routes.onboarding.privacy };
   }
   if (state.platformSession === "present") {

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -13,7 +13,7 @@ import { WindowDragRegion } from "@/components/window-drag-region";
 import { isChunkLoadError } from "@/lib/chunk-errors";
 import { setupClientFlagScopeSync } from "@/lib/feature-flags/client-flag-scope";
 import { installConsentRefreshListeners } from "@/lib/consent/consent-refresh";
-import { isLocalMode, loadLockfile } from "@/lib/local-mode";
+import { isLocalClient, loadLockfile } from "@/lib/local-mode";
 import { initSentry } from "@/lib/sentry/sentry-init";
 import { installTranslateDomGuard } from "@/lib/translate-dom-guard";
 import { initSessionReplay } from "@/lib/session-replay/session-replay-init";
@@ -59,7 +59,7 @@ async function boot() {
   // Register before initSession so the boot `unknown → present` transition it
   // drives is caught and the platform assistants list is loaded.
   setupPlatformAssistantsSync();
-  if (isLocalMode()) {
+  if (isLocalClient()) {
     await loadLockfile();
     await useAuthStore.getState().initSession();
   } else {

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -20,7 +20,7 @@ import {
   useHasPlatformSession,
 } from "@/stores/auth-store";
 import { handleLogout } from "@/lib/auth/handle-logout";
-import { getSelectedAssistant, isLocalMode } from "@/lib/local-mode";
+import { getSelectedAssistant, isLocalClient } from "@/lib/local-mode";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { setMenuPlatformSession } from "@/runtime/menu";
 import { useVellumCommands } from "@/runtime/vellum-commands";
@@ -234,7 +234,7 @@ export function RootLayout() {
       // The chooser route is local-only — navigation-resolver redirects
       // platform users away — so platform sessions switch via the Switch
       // Assistant picker on the settings page instead.
-      if (isLocalMode()) {
+      if (isLocalClient()) {
         void navigate(`${routes.selectAssistant}?noAutoSkip=1`);
       } else {
         void navigate(routes.settings.general);

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -9,7 +9,7 @@ import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
 import { resolveSignupCheckoutDestination } from "@/lib/billing/post-auth-checkout";
 import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalClient } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
 import { setMenuPlatformSession } from "@/runtime/menu";
 import { primeElectronSessionToken } from "@/runtime/session-token";
@@ -392,7 +392,7 @@ export async function startAuthFlow(
 
   // Standalone local mode (no local Django serving the SPA): redirect
   // through the platform's login page and back to a loopback callback.
-  if (isLocalMode() && !isPlatformLocal()) {
+  if (isLocalClient() && !isPlatformLocal()) {
     await startLoopbackAuth(options.returnTo ?? undefined, {
       intent: options.intent,
     });

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -21,7 +21,7 @@ let getSessionFailStatus: number | undefined = 401;
 let getSessionGates: Array<() => void> | null = null;
 
 let mockIsGatewayAuth = false;
-let mockIsLocalMode = false;
+let mockIsLocalClient = false;
 let mockIsRemoteGatewayMode = false;
 // The assistant `getSelectedAssistant()` resolves; `undefined` means none selected.
 let mockSelectedAssistant: { assistantId: string; cloud: string } | undefined;
@@ -194,7 +194,7 @@ mock.module("@/lib/auth/remote-gateway-session", () => ({
 }));
 
 mock.module("@/lib/local-mode", () => ({
-  isLocalMode: () => mockIsLocalMode,
+  isLocalClient: () => mockIsLocalClient,
   isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
   isLocalAssistant: (a: { cloud?: string }) => a.cloud === "local",
   isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
@@ -381,7 +381,7 @@ beforeEach(() => {
   localStorage.removeItem("device:share_diagnostics");
   localStorage.removeItem("device:diagnostics_reporting");
   mockIsGatewayAuth = false;
-  mockIsLocalMode = false;
+  mockIsLocalClient = false;
   mockIsRemoteGatewayMode = false;
   mockSelectedAssistant = undefined;
   mockPlatformAssistants = [];
@@ -517,7 +517,7 @@ describe("auth store onboarding flag reconciliation", () => {
     // The user had also signed into the platform; the platform session now
     // settles negative (401). The local session stays authenticated, but the
     // stale platform user and "present" status are cleared.
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockIsGatewayAuth = true; // isGatewayAuthEnabled() === true
     mockGatewayToken = null; // isGatewayAuthMode() === false (token not minted)
     sessionUser = null; // platform probe settles 401
@@ -538,7 +538,7 @@ describe("auth store onboarding flag reconciliation", () => {
     // Mid cold-start hatch: gateway enabled, token not minted, session not yet
     // established. A settled 401 must not promote to authenticated — the gateway
     // settles the session once its token mints (via connectLocalAssistant).
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockIsGatewayAuth = true;
     mockGatewayToken = null;
     sessionUser = null;
@@ -557,7 +557,7 @@ describe("auth store onboarding flag reconciliation", () => {
     // A local user who also signs into the platform (e.g. ProviderCallbackPage
     // after an allauth login) must have the successful probe update the store,
     // even while the gateway token isn't minted.
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockIsGatewayAuth = true;
     mockGatewayToken = null;
     sessionUser = { id: "user-1", email: "user@example.com" };
@@ -574,7 +574,7 @@ describe("auth store onboarding flag reconciliation", () => {
   });
 
   test("successful local platform probe bootstraps the selected local assistant identity", async () => {
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockIsGatewayAuth = true;
     mockGatewayToken = "access-token";
     mockSelectedAssistant = { assistantId: "local-a", cloud: "local" };
@@ -590,7 +590,7 @@ describe("auth store onboarding flag reconciliation", () => {
     // The boot restore must ride out the gateway's reboot startup window rather
     // than the bare prime, so a transient "starting" failure doesn't drop the
     // persisted local assistant to the recovery controls.
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockIsGatewayAuth = true;
 
     await useAuthStore.getState().initSession();
@@ -606,7 +606,7 @@ describe("auth store onboarding flag reconciliation", () => {
   test("initSession settles unauthenticated when the startup-retry prime is exhausted", async () => {
     // After the ride-out budget is spent the prime still throws; boot falls
     // through to the chooser exactly as before.
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockIsGatewayAuth = true;
     mockPrimeError = new Error("Gateway token request failed: 401");
 
@@ -1411,7 +1411,7 @@ describe("auth store onboarding flag reconciliation", () => {
   });
 
   test("initSession fetches server consent for local-mode platform sessions", async () => {
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
     mockFetchConsentResult = {
@@ -1457,7 +1457,7 @@ describe("auth store onboarding flag reconciliation", () => {
     // callback) must re-sync managed assistants into the lockfile — not only
     // cold `initSession` — so the macOS tray and CLI don't keep a stale list
     // until the next full boot.
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     sessionUser = { id: "user-3", email: "user@example.com" };
     mockListAssistantsResult = {
       ok: true,
@@ -1490,7 +1490,7 @@ describe("auth store onboarding flag reconciliation", () => {
 
   test("refreshSession skips lockfile sync outside local mode", async () => {
     // Platform mode has no lockfile host — the sync must not run there.
-    mockIsLocalMode = false;
+    mockIsLocalClient = false;
     sessionUser = { id: "user-4", email: "user@example.com" };
     mockListAssistantsResult = {
       ok: true,
@@ -1595,7 +1595,7 @@ describe("platform session probe resolution", () => {
   test("a re-run gateway probe retains the last status until it settles", async () => {
     mockIsGatewayAuth = true;
     mockGatewayToken = "access-token";
-    mockIsLocalMode = false;
+    mockIsLocalClient = false;
     sessionUser = { id: "user-1", email: "user@example.com" };
     useAuthStore.setState({ platformSession: "absent" });
 
@@ -1621,7 +1621,7 @@ describe("platform session probe resolution", () => {
   test("a stale probe completing after a newer one does not change status", async () => {
     mockIsGatewayAuth = true;
     mockGatewayToken = "access-token";
-    mockIsLocalMode = false;
+    mockIsLocalClient = false;
     sessionUser = { id: "user-1", email: "user@example.com" };
     useAuthStore.setState({ platformSession: "absent" });
 
@@ -1701,7 +1701,7 @@ describe("biometric session recovery", () => {
 
 describe("connectLocalAssistant", () => {
   test("primes the connection BEFORE selecting the assistant, then logs in", async () => {
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockPlatformAssistants = [];
     // Prime must complete before the selection write becomes observable —
     // the lifecycle's selection subscription republishes the connection
@@ -1732,7 +1732,7 @@ describe("connectLocalAssistant", () => {
     // the already-selected assistant — the common case after guardian-token
     // repair retries the same assistant — would otherwise leave the active id
     // stale, so `connectLocalAssistant` must drive `checkAssistant()` itself.
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockPlatformAssistants = [];
     // setSelectedAssistant is a no-op write here (already selected); the only
     // thing that publishes active state is the explicit checkAssistant call.
@@ -1744,7 +1744,7 @@ describe("connectLocalAssistant", () => {
   });
 
   test("bootstraps a newly connected local assistant when already signed into the platform", async () => {
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockPlatformAssistants = [];
     useAuthStore.setState({
       platformSession: "present",
@@ -1759,7 +1759,7 @@ describe("connectLocalAssistant", () => {
   });
 
   test("rethrows the prime failure without selecting or marking the session logged in", async () => {
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockPrimeError = new Error("Guardian token not found");
 
     await expect(
@@ -1904,7 +1904,7 @@ describe("offline session restore (LUM-2412)", () => {
   });
 
   test("local-mode platform-assistants boot also restores from cache on transport failure", async () => {
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
     getSessionThrows = true;
     mockElectronSessionToken = "tok-1";
@@ -1970,7 +1970,7 @@ describe("offline session restore (LUM-2412)", () => {
 // `kind` separates a real platform account from synthetic local gateway access.
 describe("identity kind (platform vs local gateway access)", () => {
   test("a local gateway session is kind 'local' and not a platform identity, but keeps its stable id", async () => {
-    mockIsLocalMode = true;
+    mockIsLocalClient = true;
     mockPlatformAssistants = [];
 
     await useAuthStore.getState().initSession();

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -44,7 +44,7 @@ import {
 } from "@/lib/auth/gateway-session";
 import { refreshRemoteGatewaySession } from "@/lib/auth/remote-gateway-session";
 import {
-  isLocalMode,
+  isLocalClient,
   isRemoteGatewayMode,
   getPlatformAssistants,
   getLocalAssistants,
@@ -640,7 +640,7 @@ function probePlatformSession(
         // late commit must not land after routing decisions were made on
         // the un-synced lockfile. `!isStale()` likewise keeps a
         // superseded probe from committing an out-of-date lockfile.
-        if (isLocalMode()) {
+        if (isLocalClient()) {
           let timedOut = false;
           const syncIsCurrent = (): boolean => !timedOut && !isStale();
           try {
@@ -740,7 +740,7 @@ function probePlatformSessionIfReachable(
   options?: { setUserOnSuccess?: boolean; clearOnFailure?: boolean },
 ): void {
   if (
-    !isLocalMode() ||
+    !isLocalClient() ||
     isGatewayAuthEnabled() ||
     getPlatformAssistants().length > 0
   ) {
@@ -796,7 +796,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       return;
     }
 
-    if (isLocalMode() && !isGatewayAuthEnabled()) {
+    if (isLocalClient() && !isGatewayAuthEnabled()) {
       const hasPlatformAssistants = getPlatformAssistants().length > 0;
       if (hasPlatformAssistants) {
         // Platform assistants require a valid session — await the check
@@ -1003,7 +1003,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
         // stale managed-assistant list until the next full boot. Best-effort
         // and local-mode only (platform mode has no lockfile host); the
         // refresh has already succeeded regardless of the sync outcome.
-        if (isLocalMode()) {
+        if (isLocalClient()) {
           try {
             await useOrganizationStore.getState().fetchOrganizations();
             const apiAssistants = await listAssistants();
@@ -1092,7 +1092,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
         await window.vellum?.auth?.signOut?.();
       }
       // Web loopback: drop the token the local server's proxy authenticates with.
-      if (isLocalMode() && !isElectron()) {
+      if (isLocalClient() && !isElectron()) {
         await clearLocalPlatformSession();
       }
       void deleteBiometricToken();

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -27,7 +27,7 @@ import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
 import {
-  isLocalMode,
+  isLocalClient,
   isLocalAssistant,
   isPlatformAssistant,
 } from "@/lib/local-mode";
@@ -311,7 +311,7 @@ function getEffectiveActiveLockfileAssistantId(
 // committed lockfiles count: the empty placeholder written when nothing has
 // loaded (e.g. a failed host read at boot) must not mark the list hydrated
 // and reconcile away a still-valid selection.
-if (isLocalMode()) {
+if (isLocalClient()) {
   useLockfileStore.subscribe((state) => {
     if (state.lockfile && state.committed) {
       useResolvedAssistantsStoreBase.getState().setFromLockfile(state.lockfile);

--- a/clients/web/test-setup.ts
+++ b/clients/web/test-setup.ts
@@ -33,7 +33,7 @@ const viteAssetUrlStub: BunPlugin = {
 plugin(viteAssetUrlStub);
 
 // Tests default to platform mode (matching CI/CD builds). Individual tests
-// that need local mode should mock isLocalMode() instead.
+// that need local mode should mock isLocalClient() instead.
 process.env.VITE_PLATFORM_MODE = "true";
 
 // Set a base URL so relative fetch requests (e.g. "/v1/assistants/...")


### PR DESCRIPTION
## Summary
- Renames the `isLocalMode()` helper in `clients/web/src/lib/local-mode.ts` to `isLocalClient()`, along with all ~48 call sites, the `NavigationState.isLocalMode` field, and the test mocks (`isLocalModeMock`/`isLocalModeValue`/`mockIsLocalMode` → `isLocalClientMock`/`isLocalClientValue`/`mockIsLocalClient`).
- Updates the signal table in `clients/web/docs/CONVENTIONS.md` to match.
- Deliberately leaves the unrelated `isLocalModeHostAvailable` host-transport helper (and the `local-mode.ts`/`local-mode-host.ts` module names) untouched — this is an identifier rename only, no behavior change.

## Original prompt
Rename the `isLocalMode` helper to `isLocalClient`. The helper answers "is this build a local (non-platform) client?" based on `VITE_PLATFORM_MODE`, and the new name states that more directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)