### PR TITLE
fix(voice): stop a wedged Live Activity asserting a phase it cannot know (JARVIS-1377)

### DIFF
--- a/clients/ios/App/App/VoiceLiveActivityPlugin.swift
+++ b/clients/ios/App/App/VoiceLiveActivityPlugin.swift
@@ -77,13 +77,32 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     /// `VoiceSessionLiveActivity` renders as "no longer current" instead of a
     /// live phase.
     ///
-    /// Two minutes is the shortest horizon that does not accuse a *healthy*
-    /// session of being wedged: a real conversation changes phase every few
-    /// seconds, and the only silence longer than this is a session nobody is
-    /// talking to — which the island may as well show as idle. Shorter would
-    /// flag long pauses; much longer and the wedged case, the one this exists
-    /// for, keeps lying past the point the user would act on it.
-    private static let contentStaleAfter: TimeInterval = 120
+    /// The horizon sits just past normal conversational rhythm rather than
+    /// past the longest thing a session can legitimately do, because the two
+    /// ways of being wrong do not cost the same:
+    ///
+    /// - Marking a *healthy* session stale costs the phase wording for a while.
+    ///   The assistant name, the accent and the avatar stay, and tapping
+    ///   through still returns to the session — see
+    ///   `ContentState.displayLabel(isStale:)`.
+    /// - Leaving a *wedged* session unmarked is a standing claim that a socket
+    ///   and a microphone are live. "Listening…" on a Lock Screen is read as an
+    ///   invitation to keep talking, and there is nothing on the island that
+    ///   would tell the user otherwise.
+    ///
+    /// Being early is bounded; being late is not. So forty-five seconds: long
+    /// enough to clear a pause between turns and a short tool call, and **not**
+    /// long enough for every legitimately long phase — a multi-minute agentic
+    /// turn parked in `thinking`, or a long TTS answer, drops its label while
+    /// perfectly healthy. That is the accepted cost; a phase-aware horizon (a
+    /// longer one for `thinking`) is the refinement to reach for if it proves
+    /// annoying in practice.
+    ///
+    /// None of this makes a wedged island *correct*. The horizon only bounds
+    /// how long it can be wrong: whether the web layer keeps pushing at all
+    /// once iOS suspends it is unmeasured on hardware — see
+    /// `docs/CAPACITOR.md` § "The background-audio contract".
+    private static let contentStaleAfter: TimeInterval = 45
 
     /// Wrap a content state with the staleness horizon every push shares.
     private static func content(

--- a/clients/ios/App/App/VoiceLiveActivityPlugin.swift
+++ b/clients/ios/App/App/VoiceLiveActivityPlugin.swift
@@ -83,7 +83,7 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     ///
     /// - Marking a *healthy* session stale costs the phase wording for a while.
     ///   The assistant name, the accent and the avatar stay, and tapping
-    ///   through still returns to the session — see
+    ///   through still returns to the session. See
     ///   `ContentState.displayLabel(isStale:)`.
     /// - Leaving a *wedged* session unmarked is a standing claim that a socket
     ///   and a microphone are live. "Listening…" on a Lock Screen is read as an
@@ -92,7 +92,7 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     ///
     /// Being early is bounded; being late is not. So forty-five seconds: long
     /// enough to clear a pause between turns and a short tool call, and **not**
-    /// long enough for every legitimately long phase — a multi-minute agentic
+    /// long enough for every legitimately long phase: a multi-minute agentic
     /// turn parked in `thinking`, or a long TTS answer, drops its label while
     /// perfectly healthy. That is the accepted cost; a phase-aware horizon (a
     /// longer one for `thinking`) is the refinement to reach for if it proves
@@ -100,7 +100,7 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     ///
     /// None of this makes a wedged island *correct*. The horizon only bounds
     /// how long it can be wrong: whether the web layer keeps pushing at all
-    /// once iOS suspends it is unmeasured on hardware — see
+    /// once iOS suspends it is unmeasured on hardware. See
     /// `docs/CAPACITOR.md` § "The background-audio contract".
     private static let contentStaleAfter: TimeInterval = 45
 

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -392,9 +392,16 @@ drives the phase is suspended at the same time.
 That symmetry is also the hazard: a suspended web layer stops pushing, and an
 island frozen on "Listening…" is a claim about a live socket and a live mic that
 nothing is checking. Every push therefore carries a `staleDate`
-(`VoiceLiveActivityPlugin.contentStaleAfter`, two minutes), and the views drop
+(`VoiceLiveActivityPlugin.contentStaleAfter`, 45 seconds), and the views drop
 the phase label once `context.isStale` goes true. It does not make the island
 correct — only honest about not knowing.
+
+That horizon was two minutes until JARVIS-1377, which reported the island frozen
+on the phase it opened with. Two minutes is the shortest horizon that never
+accuses a *healthy* session, and that is the wrong thing to optimize while the
+wedged case is the common one: being early costs the phase wording, being late
+sustains a false claim that the mic is live. The constant's docstring carries
+the full reasoning and the phase-aware refinement to reach for next.
 
 ### 2. No App Group
 
@@ -508,7 +515,7 @@ The Simulator does not faithfully reproduce any of these.
 | Interruption handling | Take a real phone call mid-session; the session should end, not keep "listening" into a dead mic |
 | Bluetooth / AirPods routing | `.voiceChat` HFP routing needs real hardware |
 | No stranded island | Force-quit mid-session; the `applicationWillTerminate` end is fire-and-forget, so it may or may not win the race — relaunch and confirm `load()`'s sweep clears whatever survived. Same check after a crash |
-| Stale island | Background a session and leave it long enough for iOS to suspend the web view; past the two-minute `staleDate` the island must stop showing a phase label rather than keep claiming "Listening…" |
+| Stale island | Background a session and leave it long enough for iOS to suspend the web view; past the 45-second `staleDate` the island must stop showing a phase label rather than keep claiming "Listening…" |
 
 ## Shipping prerequisites
 


### PR DESCRIPTION
The Live Activity renders the phase it opened with — "Listening…" — and never advances through thinking/speaking on the Lock Screen or the Dynamic Island (JARVIS-1377).

This PR does **not** fix that. It bounds how long the island can be wrong while the root cause is still unmeasured.

## Prompt / plan

Instrument whether `updateVoiceLiveActivity` is called at all after the app backgrounds, then act on what that shows.

**The push path is not the bug.** I built a temporary probe — a `localStorage`-backed ring rendered into a fixed DOM overlay (WKWebView console output never reaches the system log), a 1s heartbeat with gap detection, raw `visibilitychange` versus the same signal as it reaches the event bus, and a driver that moves the real live-voice store's phase so the actual mirror does the pushing. Backgrounded on the Simulator, the whole production chain — `subscribeSettledLiveVoiceState` → mirror → `sameContent` gate → bridge → plugin → ActivityKit — delivered every push: `sync` 9ms after each store transition, `✓upd` round trips of 2–7ms, 20+ consecutive pushes at one per 5s, zero drops. The island cycled Listening… → Thinking… → Transcribing… throughout. No defect in the mirror, the gate, the bridge, or ActivityKit rate limiting.

**But the Simulator cannot answer the real question.** Control run: with *no audio at all* — no `getUserMedia`, no playback — a backgrounded app still ran timers and landed updates for 2+ minutes. A device suspends such an app in ~30s. The Simulator does not suspend backgrounded apps, so it can neither reproduce nor refute the WebKit-suspension hypothesis. This extends the rule in `clients/web/docs/CAPACITOR.md` § "The background-audio contract": the Simulator can't evaluate backgrounding either, for the same reason it can't evaluate audio.

So the remaining hypothesis is device-only, and worth stating because it reframes the ticket: if the web layer is suspended, the same suspension stops the socket and the mic, so the session is dead too. The island would be honestly reporting a stalled session rather than failing to update — "the island is stuck" and "voice doesn't survive backgrounding" may be one bug.

## The change

`contentStaleAfter` 120s → 45s. Past the `staleDate` ActivityKit sets `context.isStale` and `displayLabel(isStale:)` drops the phase wording.

Two minutes was picked as the shortest horizon that never accuses a *healthy* session of being wedged. That is the wrong optimum while the wedged case is the common one, because the two errors do not cost the same:

- Marking a healthy session stale costs the phase wording for a while. Assistant name, accent, avatar and tap-through all survive.
- Leaving a wedged session unmarked is a standing claim that a socket and a microphone are live. "Listening…" on a Lock Screen is read as an invitation to keep talking, and nothing on the island says otherwise.

Being early is bounded; being late is not. 45s sits just past normal conversational rhythm — long enough to clear a pause between turns and a short tool call.

**Accepted cost, recorded in the docstring:** a multi-minute agentic turn parked in `thinking`, or a long TTS answer, drops its label while perfectly healthy. A phase-aware horizon (a longer one for `thinking`) is the refinement if that proves annoying. 45s is a judgement call, not a measurement — I have no data on real phase durations, and 60–90s is defensible with the same reasoning intact if you'd rather bias the other way.

## Test plan

- Instrumented Simulator runs as described above (iPhone 17 Pro, iOS 26.5), reading the island by screenshot — the compact trailing slot renders `ContentState.label`, so a wall-clock stamp in the label makes the island report when its last update landed.
- Incidental verification along the way: `endActivitiesStrandedByAPreviousLaunch()` swept an island stranded by a killed app on next launch, and the JARVIS-1373 avatar rendered in the compact slot.
- `use-live-activity-mirror` unit tests pass (23/23) — untouched by the final diff, which is native-only.
- **Not verified on hardware.** The staleness horizon is a native constant on a path the Simulator does exercise, but the failure it mitigates is device-only by the finding above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
