### PR TITLE
fix: restore releases page header chrome and mobile navigation

### DIFF
--- a/clients/docs/src/app/docs/(releases)/layout.tsx
+++ b/clients/docs/src/app/docs/(releases)/layout.tsx
@@ -1,8 +1,15 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { type ReactNode } from "react";
 
 import { ReleasesNav } from "@/app/docs/_components/releases-nav";
+import { DocsNavProvider } from "@/app/docs/_components/docs-nav-context";
+import { DocsGithubLink } from "@/app/docs/_components/docs-github-link";
+import { DocsNavCta } from "@/app/docs/_components/docs-nav-cta";
+import { DocsSearch } from "@/app/docs/_components/docs-search";
+import { DocsThemePicker } from "@/app/docs/_components/docs-theme-picker";
+import { DocsMobileMenuButton } from "@/app/docs/_components/docs-mobile-menu-button";
 import { WWW_DOMAIN } from "@/lib/domains";
 import { fetchReleases } from "@/lib/releases-server";
 
@@ -23,60 +30,85 @@ export default async function ReleasesLayout({
   const releases = await fetchReleases();
 
   return (
-    <div className="docs-shell min-h-screen">
-      <header className="docs-header sticky top-0 z-20 border-b backdrop-blur">
-        {/* Top row in centered band */}
-        <div className="mx-auto max-w-[1280px]">
-          <div className="flex h-14 items-center">
-            <div className="docs-brand-area flex h-full items-center gap-2 px-4 md:w-64 md:shrink-0 md:px-6">
-              <Link
-                href="/docs"
-                className="docs-nav-title flex items-center gap-2 font-['DM_Sans',sans-serif] text-lg font-bold no-underline"
-              >
-                Vellum
-              </Link>
-            </div>
-          </div>
-        </div>
-        {/* Section nav band: border-t spans full viewport, content centered */}
-        <div className="docs-header-tabs hidden border-t md:block">
+    <DocsNavProvider>
+      <div className="docs-shell min-h-screen">
+        <header className="docs-header sticky top-0 z-20 border-b backdrop-blur">
+          {/* Top row in centered band */}
           <div className="mx-auto max-w-[1280px]">
-            <div className="flex h-11 items-center">
-              <div className="md:w-64 md:shrink-0" />
-              <div className="flex h-full flex-1 items-center gap-6 px-4 md:pl-8 md:pr-4">
-                <Link
-                  href="/docs"
-                  className="docs-header-link text-sm font-medium no-underline"
-                >
-                  Docs
-                </Link>
-                <Link
-                  href="/docs/releases"
-                  className="docs-header-link docs-header-link-active text-sm font-medium no-underline"
-                >
-                  Releases
-                </Link>
+            <div className="flex h-14 items-center">
+              <div className="docs-brand-area flex h-full items-center gap-2 px-4 md:w-64 md:shrink-0 md:px-6">
+                {/* Mobile: hamburger menu button */}
+                <DocsMobileMenuButton />
+                {/* Desktop: logo */}
                 <a
-                  href={`https://${WWW_DOMAIN}/skills`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="docs-header-link text-sm font-medium no-underline"
+                  href={`https://${WWW_DOMAIN}`}
+                  className="hidden md:flex items-center gap-2 no-underline"
                 >
-                  Skills
+                  <Image
+                    src="/docs/vellum-logo.svg"
+                    alt="Vellum"
+                    width={100}
+                    height={24}
+                    unoptimized
+                  />
                 </a>
+              </div>
+              <div className="flex h-full flex-1 items-center gap-6 px-4 md:pl-8 md:pr-4">
+                <div className="docs-header-search hidden md:block md:max-w-md md:flex-1">
+                  <DocsSearch />
+                </div>
+                <div className="flex items-center gap-3 md:ml-auto">
+                  <div className="hidden md:block">
+                    <DocsThemePicker />
+                  </div>
+                  <DocsNavCta />
+                  <div className="hidden md:block">
+                    <DocsGithubLink />
+                  </div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </header>
-      <div className="docs-layout mx-auto flex max-w-[1280px] min-h-[calc(100vh-57px)] md:min-h-[calc(100vh-101px)]">
-        <ReleasesNav releases={releases} />
-        <div className="docs-content-area min-w-0 flex-1">
-          <div className="flex items-start gap-6 px-4 py-6 md:px-10 md:py-10">
-            {children}
+          {/* Section nav band: border-t spans full viewport, content centered */}
+          <div className="docs-header-tabs hidden border-t md:block">
+            <div className="mx-auto max-w-[1280px]">
+              <div className="flex h-11 items-center">
+                <div className="md:w-64 md:shrink-0" />
+                <div className="flex h-full flex-1 items-center gap-6 px-4 md:pl-8 md:pr-4">
+                  <Link
+                    href="/docs"
+                    className="docs-header-link text-sm font-medium no-underline"
+                  >
+                    Docs
+                  </Link>
+                  <Link
+                    href="/docs/releases"
+                    className="docs-header-link docs-header-link-active text-sm font-medium no-underline"
+                  >
+                    Releases
+                  </Link>
+                  <a
+                    href={`https://${WWW_DOMAIN}/skills`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="docs-header-link text-sm font-medium no-underline"
+                  >
+                    Skills
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+        <div className="docs-layout mx-auto flex max-w-[1280px] min-h-[calc(100vh-57px)] md:min-h-[calc(100vh-101px)]">
+          <ReleasesNav releases={releases} />
+          <div className="docs-content-area min-w-0 flex-1">
+            <div className="flex items-start gap-6 px-4 py-6 md:px-10 md:py-10">
+              {children}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </DocsNavProvider>
   );
 }

--- a/clients/docs/src/app/docs/_components/releases-nav.tsx
+++ b/clients/docs/src/app/docs/_components/releases-nav.tsx
@@ -2,7 +2,12 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronRight, X } from "lucide-react";
 
+import { DocsSearch } from "@/app/docs/_components/docs-search";
+import { DocsThemePicker } from "@/app/docs/_components/docs-theme-picker";
+import { DocsGithubLink } from "@/app/docs/_components/docs-github-link";
+import { useDocsNav } from "@/app/docs/_components/docs-nav-context";
 import type { ApiRelease } from "@/lib/releases-server";
 import { groupApiReleasesByMonth, releaseAnchor } from "@/lib/releases-server";
 
@@ -15,39 +20,19 @@ function getCurrentMonth() {
   });
 }
 
-function ChevronRightIcon({ expanded }: { expanded: boolean }) {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      className={`shrink-0 transition-transform duration-200 ${
-        expanded ? "rotate-90" : ""
-      }`}
-    >
-      <path d="m9 18 6-6-6-6" />
-    </svg>
-  );
-}
-
 interface ReleasesNavProps {
   releases: ApiRelease[];
 }
 
 /**
- * Sticky sidebar listing releases grouped by month, with scroll-tracked
- * highlighting via an IntersectionObserver. Desktop-only; small viewports
- * navigate the releases list through in-page anchors.
+ * Releases sidebar grouped by month, with scroll-tracked highlighting via an
+ * IntersectionObserver. Renders as a sticky sidebar on desktop and as a
+ * slide-in drawer on mobile.
  */
 export function ReleasesNav({ releases }: ReleasesNavProps) {
   const groups = groupApiReleasesByMonth(releases);
   const [activeId, setActiveId] = useState<string>("");
+  const { visible, animating, close } = useDocsNav();
 
   const [expandedMonths, setExpandedMonths] = useState<Set<string>>(() => {
     const currentMonth = getCurrentMonth();
@@ -114,12 +99,19 @@ export function ReleasesNav({ releases }: ReleasesNavProps) {
     return () => observer.disconnect();
   }, [groups, releaseToMonth]);
 
-  return (
-    <nav className="docs-nav-panel hidden border-r md:sticky md:top-[101px] md:block md:h-[calc(100vh-101px)] md:w-64 md:shrink-0 md:self-start md:overflow-y-auto md:pb-8">
-      <div className="px-4 pb-4 pt-4 md:pt-8">
+  const navContent = (
+    <div className="flex h-full flex-col">
+      {/* Search only renders here on mobile; desktop has it in the header.
+          The header instance owns the global Cmd/Ctrl+K shortcut, so this
+          duplicate must not register it too. */}
+      <div className="shrink-0 px-4 pt-4 pb-3 md:hidden">
+        <DocsSearch registerShortcut={false} />
+      </div>
+      <div className="flex-1 overflow-y-auto px-4 pb-4 pt-4 md:pt-8">
         <div className="mb-5">
           <Link
             href="/docs/releases"
+            onClick={close}
             className="docs-nav-title font-['DM_Sans',sans-serif] text-lg font-bold no-underline"
           >
             Releases
@@ -135,7 +127,12 @@ export function ReleasesNav({ releases }: ReleasesNavProps) {
                   onClick={() => toggleMonth(group.month)}
                   className="docs-nav-section-label flex w-full items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-bold tracking-normal normal-case text-left transition-colors hover:bg-[var(--docs-surface)] cursor-pointer"
                 >
-                  <ChevronRightIcon expanded={isExpanded} />
+                  <ChevronRight
+                    size={14}
+                    className={`shrink-0 transition-transform duration-200 ${
+                      isExpanded ? "rotate-90" : ""
+                    }`}
+                  />
                   {group.month}
                 </button>
                 <div
@@ -153,6 +150,7 @@ export function ReleasesNav({ releases }: ReleasesNavProps) {
                           <li key={release.version} className="m-0 p-0">
                             <a
                               href={`#${anchor}`}
+                              onClick={close}
                               className={`flex items-center justify-between rounded-lg py-2 pl-7 pr-3 text-sm no-underline transition-colors ${
                                 isActive
                                   ? "docs-nav-link-active font-medium"
@@ -172,6 +170,49 @@ export function ReleasesNav({ releases }: ReleasesNavProps) {
           })}
         </ul>
       </div>
-    </nav>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Mobile drawer */}
+      {visible && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div
+            className={`docs-nav-overlay absolute inset-0 transition-opacity duration-250 ${
+              animating ? "opacity-100" : "opacity-0"
+            }`}
+            onClick={close}
+          />
+          <div
+            className={`docs-nav-panel absolute inset-y-0 left-0 w-72 overflow-y-auto border-r shadow-xl transition-transform duration-250 ease-out flex flex-col ${
+              animating ? "translate-x-0" : "-translate-x-full"
+            }`}
+          >
+            <button
+              type="button"
+              onClick={close}
+              className="docs-nav-close absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-lg"
+              aria-label="Close navigation"
+            >
+              <X size={18} />
+            </button>
+            <div className="flex-1 overflow-y-auto">{navContent}</div>
+            <div
+              className="docs-nav-mobile-footer flex items-center justify-between border-t px-4 py-3"
+              style={{ borderColor: "var(--docs-border)" }}
+            >
+              <DocsThemePicker />
+              <DocsGithubLink />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Desktop sidebar */}
+      <nav className="docs-nav-panel hidden border-r md:sticky md:top-[101px] md:block md:h-[calc(100vh-101px)] md:w-64 md:shrink-0 md:self-start md:overflow-y-auto md:pb-8">
+        {navContent}
+      </nav>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for docs-app-phase-1.md.

**Gap:** /docs/releases shipped without header chrome or mobile navigation
**What was expected:** platform-parity releases layout with shell header + mobile drawer
**What was found:** self-contained layout with no search/theme/CTA/GitHub and no mobile nav