### PR TITLE
fix(web): stop the sidebar wrapper from clipping live drag-resize

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -325,19 +325,29 @@ export function ChatLayout({
   // lags the SideMenu nav's live drag-resize and, with the wrapper's
   // overflow clip, pins the visible edge at the stale width whenever the
   // nav is dragged wider.
-  const sideMenuAsideRef = useRef<HTMLElement | null>(null);
+  // The node lives in state (callback ref) so the effect re-runs when the
+  // desktop aside leaves and re-enters the tree (mobile layout swaps), not
+  // only when the focus flag flips.
+  const [sideMenuAside, setSideMenuAside] = useState<HTMLElement | null>(null);
   const railFocusAnimationsRef = useRef<Animation[]>([]);
   const prevChatFocusRef = useRef(chatFocusActive);
   useEffect(() => {
-    const aside = sideMenuAsideRef.current;
-    if (!aside) {
+    if (!sideMenuAside) {
+      // Drop animations that target the departed node so a remount
+      // reinitializes from scratch.
+      for (const animation of railFocusAnimationsRef.current) {
+        animation.cancel();
+      }
+      railFocusAnimationsRef.current = [];
       return;
     }
+    const aside = sideMenuAside;
     const prev = prevChatFocusRef.current;
     prevChatFocusRef.current = chatFocusActive;
     if (prev === chatFocusActive) {
       if (chatFocusActive && railFocusAnimationsRef.current.length === 0) {
-        // Mounted while already focused: hold the hidden state, no motion.
+        // Mounted (or remounted) while already focused: hold the hidden
+        // state, no motion.
         railFocusAnimationsRef.current = [
           aside.animate(
             { width: "0px", opacity: "0", marginRight: "-16px" },
@@ -392,7 +402,7 @@ export function ChatLayout({
         }),
       ];
     }
-  }, [chatFocusActive]);
+  }, [chatFocusActive, sideMenuAside]);
 
   const isMobile = useIsMobile();
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
@@ -1072,7 +1082,7 @@ export function ChatLayout({
         <div className="flex min-w-0 flex-1 gap-4 p-4 min-h-0 overflow-hidden flex-col md:flex-row">
           <aside
             id="chat-side-menu"
-            ref={sideMenuAsideRef}
+            ref={setSideMenuAside}
             // No width of its own: the wrapper shrink-wraps the SideMenu
             // nav, which owns the rail width (drag-resize mutates it outside
             // React until pointer-up). The tour's slide-away effect animates

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -332,6 +332,11 @@ export function ChatLayout({
   const railFocusAnimationsRef = useRef<Animation[]>([]);
   const prevChatFocusRef = useRef(chatFocusActive);
   useEffect(() => {
+    // Snapshot before the null check: focus flips that land while the aside
+    // is absent must still be recorded, so a later remount settles into the
+    // current state instead of replaying the missed transition.
+    const prev = prevChatFocusRef.current;
+    prevChatFocusRef.current = chatFocusActive;
     if (!sideMenuAside) {
       // Drop animations that target the departed node so a remount
       // reinitializes from scratch.
@@ -342,8 +347,6 @@ export function ChatLayout({
       return;
     }
     const aside = sideMenuAside;
-    const prev = prevChatFocusRef.current;
-    prevChatFocusRef.current = chatFocusActive;
     if (prev === chatFocusActive) {
       if (chatFocusActive && railFocusAnimationsRef.current.length === 0) {
         // Mounted (or remounted) while already focused: hold the hidden

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -388,14 +388,17 @@ export function ChatLayout({
       ];
     } else {
       // Reveal: a back-ease so the rail lands with a slight bounce. The
-      // hidden rail's inner menu keeps its full layout width, so scrollWidth
-      // gives the landing width up front; no fill, so the wrapper returns to
-      // shrink-wrapping the nav the moment the animation ends.
+      // landing width comes from state, not DOM measurement: skipping the
+      // tour un-forces a collapsed rail in this same commit, so the nav's
+      // measured width still reads expanded while it is already collapsing
+      // to 48px. No fill, so the wrapper returns to shrink-wrapping the nav
+      // the moment the animation ends.
+      const targetWidth = effectiveCollapsed ? 48 : sidebarWidth;
       railFocusAnimationsRef.current = [
         aside.animate(
           [
             { width: fromWidth, marginRight: fromMargin },
-            { width: `${aside.scrollWidth}px`, marginRight: "0px" },
+            { width: `${targetWidth}px`, marginRight: "0px" },
           ],
           { duration: 550, easing: "cubic-bezier(0.34, 1.56, 0.64, 1)" },
         ),
@@ -405,7 +408,7 @@ export function ChatLayout({
         }),
       ];
     }
-  }, [chatFocusActive, sideMenuAside]);
+  }, [chatFocusActive, sideMenuAside, effectiveCollapsed, sidebarWidth]);
 
   const isMobile = useIsMobile();
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -318,6 +318,82 @@ export function ChatLayout({
     setLocalNumber(SIDEBAR_WIDTH_STORAGE_KEY, Math.round(width));
   }, []);
 
+  // The tour's focused stage slides the whole rail away and bounces it back
+  // on reveal. Driven with the Web Animations API rather than a standing
+  // inline width + transition on the rail's wrapper: React only learns new
+  // widths when a drag commits on pointer-up, so a standing wrapper width
+  // lags the SideMenu nav's live drag-resize and, with the wrapper's
+  // overflow clip, pins the visible edge at the stale width whenever the
+  // nav is dragged wider.
+  const sideMenuAsideRef = useRef<HTMLElement | null>(null);
+  const railFocusAnimationsRef = useRef<Animation[]>([]);
+  const prevChatFocusRef = useRef(chatFocusActive);
+  useEffect(() => {
+    const aside = sideMenuAsideRef.current;
+    if (!aside) {
+      return;
+    }
+    const prev = prevChatFocusRef.current;
+    prevChatFocusRef.current = chatFocusActive;
+    if (prev === chatFocusActive) {
+      if (chatFocusActive && railFocusAnimationsRef.current.length === 0) {
+        // Mounted while already focused: hold the hidden state, no motion.
+        railFocusAnimationsRef.current = [
+          aside.animate(
+            { width: "0px", opacity: "0", marginRight: "-16px" },
+            { duration: 0, fill: "forwards" },
+          ),
+        ];
+      }
+      return;
+    }
+    // Sample mid-flight values before cancelling so a reversal starts from
+    // where the rail visually is.
+    const style = getComputedStyle(aside);
+    const fromWidth = style.width;
+    const fromMargin = style.marginRight;
+    const fromOpacity = style.opacity;
+    for (const animation of railFocusAnimationsRef.current) {
+      animation.cancel();
+    }
+    if (chatFocusActive) {
+      // Hide: ease away smoothly and hold width 0 while focused. The
+      // negative margin cancels the row gap so the chat goes full-width.
+      railFocusAnimationsRef.current = [
+        aside.animate(
+          [
+            { width: fromWidth, marginRight: fromMargin },
+            { width: "0px", marginRight: "-16px" },
+          ],
+          { duration: 500, easing: "ease-in-out", fill: "forwards" },
+        ),
+        aside.animate([{ opacity: fromOpacity }, { opacity: "0" }], {
+          duration: 300,
+          easing: "ease-in-out",
+          fill: "forwards",
+        }),
+      ];
+    } else {
+      // Reveal: a back-ease so the rail lands with a slight bounce. The
+      // hidden rail's inner menu keeps its full layout width, so scrollWidth
+      // gives the landing width up front; no fill, so the wrapper returns to
+      // shrink-wrapping the nav the moment the animation ends.
+      railFocusAnimationsRef.current = [
+        aside.animate(
+          [
+            { width: fromWidth, marginRight: fromMargin },
+            { width: `${aside.scrollWidth}px`, marginRight: "0px" },
+          ],
+          { duration: 550, easing: "cubic-bezier(0.34, 1.56, 0.64, 1)" },
+        ),
+        aside.animate([{ opacity: fromOpacity }, { opacity: "1" }], {
+          duration: 250,
+          easing: "ease-out",
+        }),
+      ];
+    }
+  }, [chatFocusActive]);
+
   const isMobile = useIsMobile();
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
   // True while a left-edge swipe is dragging the drawer in from off-screen but
@@ -996,25 +1072,14 @@ export function ChatLayout({
         <div className="flex min-w-0 flex-1 gap-4 p-4 min-h-0 overflow-hidden flex-col md:flex-row">
           <aside
             id="chat-side-menu"
-            className="shrink-0 overflow-hidden"
+            ref={sideMenuAsideRef}
+            // No width of its own: the wrapper shrink-wraps the SideMenu
+            // nav, which owns the rail width (drag-resize mutates it outside
+            // React until pointer-up). The tour's slide-away effect animates
+            // this element imperatively; overflow-hidden clips the nav
+            // mid-slide.
+            className="w-fit shrink-0 overflow-hidden"
             aria-label="Navigation"
-            // Explicit width (matching the rail's own) so the onboarding
-            // prototype's focused stage can slide the whole rail away; the
-            // negative margin cancels the row gap so the chat goes full-width.
-            // Hiding eases smoothly; revealing uses a back-ease so the rail
-            // lands with a slight bounce (the tour's takeover moment).
-            style={{
-              width: chatFocusActive
-                ? 0
-                : effectiveCollapsed
-                  ? 48
-                  : sidebarWidth,
-              opacity: chatFocusActive ? 0 : 1,
-              marginRight: chatFocusActive ? -16 : 0,
-              transition: chatFocusActive
-                ? "width 500ms ease-in-out, opacity 300ms ease-in-out, margin-right 500ms ease-in-out"
-                : "width 550ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 250ms ease-out, margin-right 550ms cubic-bezier(0.34, 1.56, 0.64, 1)",
-            }}
           >
             {renderSideMenu({
               collapsed: effectiveCollapsed,


### PR DESCRIPTION
## Summary
- The `#chat-side-menu` wrapper no longer carries a standing inline width and an always-on 550ms width transition. It now shrink-wraps the design-library `SideMenu` nav, which owns the rail width. The wrapper's width only updated when a drag committed on pointer-up, so mid-drag it clipped (via `overflow-hidden`) any rightward resize past the last committed width: the sidebar edge froze under the cursor and only snapped out after release, on both web and Electron.
- The onboarding tour's focused-stage rail slide keeps its exact motion (500ms ease-in-out hide holding width 0, 550ms back-ease bounce on reveal, per-property opacity timing) but is now driven imperatively with the Web Animations API in an effect watching `chatFocusActive`. The reveal uses no fill, so the wrapper returns to shrink-wrapped sizing the moment it lands; mounting mid-focus holds the hidden state without motion.
- Side effects: the main content column now reflows live while dragging left (previously it waited for pointer-up), and collapse/expand animates with the nav's own 150ms transition instead of incidentally inheriting the wrapper's bouncy 550ms ease.

## Original prompt
The user reported (with a screen recording) that dragging the sidebar on web and Electron sometimes stops tracking the cursor to the right and only jumps to the new width after release. Frame-by-frame analysis of the clip traced the freeze to chat-layout's aside restating the sidebar width from React state, which commits only on pointer-up, while the SideMenu nav resizes itself imperatively during the drag; the stale wrapper width plus `overflow-hidden` clipped the live updates. The user asked for the fix to be implemented on a feature branch in a worktree and opened as a PR, following React and Electron best practices.