### PR TITLE
fix: prune dead search-lib surface (highlighter, mode field, double clamp)

### DIFF
--- a/clients/docs/scripts/generate-docs-search-index.ts
+++ b/clients/docs/scripts/generate-docs-search-index.ts
@@ -47,8 +47,7 @@ async function generateIndex(): Promise<GeneratedIndex> {
       continue;
     }
 
-    const extracted = extractDocsPageFromHtml(route, rendered.html);
-    chunks.push(...extracted.chunks);
+    chunks.push(...extractDocsPageFromHtml(route, rendered.html));
     pageCount += 1;
   }
 

--- a/clients/docs/src/app/docs/api/search/route.test.ts
+++ b/clients/docs/src/app/docs/api/search/route.test.ts
@@ -42,10 +42,9 @@ describe("GET /docs/api/search", () => {
 
     const request = new NextRequest("http://localhost/docs/api/search?q=a");
     const response = await GET(request);
-    const body = (await response.json()) as { mode: string; results: unknown[] };
+    const body = (await response.json()) as { results: unknown[] };
 
     expect(response.status).toBe(200);
-    expect(body.mode).toBe("lexical");
     expect(body.results).toHaveLength(0);
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
@@ -97,9 +96,8 @@ describe("GET /docs/api/search", () => {
 
     const request = new NextRequest("http://localhost/docs/api/search?q=installation");
     const response = await GET(request);
-    const body = (await response.json()) as { mode: string; results: Array<{ route: string }> };
+    const body = (await response.json()) as { results: Array<{ route: string }> };
 
-    expect(body.mode).toBe("lexical");
     expect(body.results[0]?.route).toBe("/docs/getting-started");
     expect(response.headers.get("cache-control")).toBe("private, max-age=30");
   });
@@ -128,6 +126,6 @@ describe("GET /docs/api/search", () => {
     const response = await GET(request);
     const body = (await response.json()) as Record<string, unknown>;
 
-    expect(Object.keys(body).sort()).toEqual(["mode", "query", "results", "tookMs"]);
+    expect(Object.keys(body).sort()).toEqual(["query", "results", "tookMs"]);
   });
 });

--- a/clients/docs/src/app/docs/api/search/route.ts
+++ b/clients/docs/src/app/docs/api/search/route.ts
@@ -7,19 +7,15 @@ import type { DocsSearchResponse } from "@/lib/docs/search/types";
 
 const MIN_QUERY_LENGTH = 2;
 const MAX_QUERY_LENGTH = 160;
-const DEFAULT_LIMIT = 10;
 
-function parseLimit(value: string | null): number {
+// Parses only; the ranker owns defaulting and clamping.
+function parseLimit(value: string | null): number | undefined {
   if (!value) {
-    return DEFAULT_LIMIT;
+    return undefined;
   }
 
   const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed)) {
-    return DEFAULT_LIMIT;
-  }
-
-  return Math.min(Math.max(parsed, 1), 20);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function buildResponse(body: DocsSearchResponse, cacheControl: string): NextResponse<DocsSearchResponse> {
@@ -46,7 +42,6 @@ export async function GET(request: NextRequest) {
       return buildResponse(
         {
           query,
-          mode: "lexical",
           tookMs: Math.round(performance.now() - startedAt),
           results: [],
         },
@@ -56,7 +51,7 @@ export async function GET(request: NextRequest) {
 
     const index = await loadDocsSearchIndex();
 
-    const { mode, results } = searchDocsIndex({
+    const results = searchDocsIndex({
       query,
       limit,
       index,
@@ -65,7 +60,6 @@ export async function GET(request: NextRequest) {
     return buildResponse(
       {
         query,
-        mode,
         tookMs: Math.round(performance.now() - startedAt),
         results,
       },
@@ -78,7 +72,6 @@ export async function GET(request: NextRequest) {
     return buildResponse(
       {
         query: "",
-        mode: "lexical",
         tookMs: Math.round(performance.now() - startedAt),
         results: [],
       },

--- a/clients/docs/src/lib/docs/search/extract.test.ts
+++ b/clients/docs/src/lib/docs/search/extract.test.ts
@@ -17,13 +17,13 @@ describe("extractDocsPageFromHtml", () => {
       </div>
     `;
 
-    const extracted = extractDocsPageFromHtml("/docs/getting-started", html);
+    const chunks = extractDocsPageFromHtml("/docs/getting-started", html);
 
-    expect(extracted.pageTitle).toBe("Getting Started");
-    expect(extracted.breadcrumb).toBe("Docs / Getting Started");
-    expect(extracted.chunks.length).toBeGreaterThanOrEqual(2);
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
 
-    const sectionChunk = extracted.chunks.find((chunk) => chunk.sectionId === "install");
+    const sectionChunk = chunks.find((chunk) => chunk.sectionId === "install");
+    expect(sectionChunk?.pageTitle).toBe("Getting Started");
+    expect(sectionChunk?.breadcrumb).toBe("Docs / Getting Started");
     expect(sectionChunk?.url).toBe("/docs/getting-started#install");
     expect(sectionChunk?.heading).toBe("Installation");
     expect(sectionChunk?.body).toContain("Run the installer");
@@ -47,10 +47,10 @@ describe("extractDocsPageFromHtml", () => {
       </div>
     `;
 
-    const extracted = extractDocsPageFromHtml("/docs/help/faq", html);
+    const chunks = extractDocsPageFromHtml("/docs/help/faq", html);
 
-    const h2Chunk = extracted.chunks.find((chunk) => chunk.sectionId === "top");
-    const h3Chunk = extracted.chunks.find((chunk) => chunk.sectionId === "billing");
+    const h2Chunk = chunks.find((chunk) => chunk.sectionId === "top");
+    const h3Chunk = chunks.find((chunk) => chunk.sectionId === "billing");
 
     expect(h2Chunk?.headingLevel).toBe(2);
     expect(h3Chunk?.headingLevel).toBe(3);
@@ -72,16 +72,16 @@ describe("extractDocsPageFromHtml", () => {
       </div>
     `;
 
-    const extracted = extractDocsPageFromHtml("/docs/guides", html);
+    const chunks = extractDocsPageFromHtml("/docs/guides", html);
 
-    const sectionChunk = extracted.chunks.find((chunk) => chunk.sectionId === "setup");
-    const standaloneChunk = extracted.chunks.find((chunk) => chunk.sectionId === "troubleshooting");
+    const sectionChunk = chunks.find((chunk) => chunk.sectionId === "setup");
+    const standaloneChunk = chunks.find((chunk) => chunk.sectionId === "troubleshooting");
 
     expect(sectionChunk?.url).toBe("/docs/guides#setup");
     expect(standaloneChunk?.url).toBe("/docs/guides#troubleshooting");
     expect(standaloneChunk?.heading).toBe("Troubleshooting");
 
-    const setupChunks = extracted.chunks.filter((chunk) => chunk.sectionId === "setup");
+    const setupChunks = chunks.filter((chunk) => chunk.sectionId === "setup");
     expect(setupChunks.length).toBe(1);
   });
 
@@ -99,10 +99,10 @@ describe("extractDocsPageFromHtml", () => {
       </div>
     `;
 
-    const extracted = extractDocsPageFromHtml("/docs/guides", html);
+    const chunks = extractDocsPageFromHtml("/docs/guides", html);
 
-    const installChunk = extracted.chunks.find((chunk) => chunk.sectionId === "install");
-    const uninstallChunk = extracted.chunks.find((chunk) => chunk.sectionId === "uninstall");
+    const installChunk = chunks.find((chunk) => chunk.sectionId === "install");
+    const uninstallChunk = chunks.find((chunk) => chunk.sectionId === "uninstall");
 
     expect(installChunk?.body).toContain("installer bundle");
     expect(installChunk?.body).not.toContain("zamboni");
@@ -124,13 +124,13 @@ describe("extractDocsPageFromHtml", () => {
       </div>
     `;
 
-    const extracted = extractDocsPageFromHtml("/docs/features", html);
+    const chunks = extractDocsPageFromHtml("/docs/features", html);
 
-    const sectionChunk = extracted.chunks.find((chunk) => chunk.sectionId === "list");
+    const sectionChunk = chunks.find((chunk) => chunk.sectionId === "list");
     expect(sectionChunk?.body).toContain("Alpha Beta");
     expect(sectionChunk?.body).not.toContain("AlphaBeta");
 
-    const pageChunk = extracted.chunks.find((chunk) => chunk.sectionId === null);
+    const pageChunk = chunks.find((chunk) => chunk.sectionId === null);
     expect(pageChunk?.body).toContain("Alpha Beta");
     expect(pageChunk?.body).not.toContain("AlphaBeta");
   });
@@ -149,9 +149,9 @@ describe("extractDocsPageFromHtml", () => {
       </div>
     `;
 
-    const extracted = extractDocsPageFromHtml("/docs/overview", html);
+    const chunks = extractDocsPageFromHtml("/docs/overview", html);
 
-    const sectionChunk = extracted.chunks.find((chunk) => chunk.sectionId === "intro");
+    const sectionChunk = chunks.find((chunk) => chunk.sectionId === "intro");
     expect(sectionChunk?.heading).toBe("Introduction");
     expect(sectionChunk?.body).toContain("Welcome to the product");
   });
@@ -171,14 +171,14 @@ describe("extractDocsPageFromHtml", () => {
       </div>
     `;
 
-    const extracted = extractDocsPageFromHtml("/docs/guides", html);
+    const chunks = extractDocsPageFromHtml("/docs/guides", html);
 
-    const parentChunk = extracted.chunks.find((chunk) => chunk.sectionId === "parent");
+    const parentChunk = chunks.find((chunk) => chunk.sectionId === "parent");
     expect(parentChunk).toBeDefined();
     expect(parentChunk?.body).toContain("Child body content");
     expect(parentChunk?.body).not.toContain("Sibling body content");
 
-    const childChunk = extracted.chunks.find((chunk) => chunk.sectionId === "child");
+    const childChunk = chunks.find((chunk) => chunk.sectionId === "child");
     expect(childChunk?.body).toContain("Child body content");
   });
 
@@ -194,10 +194,10 @@ describe("extractDocsPageFromHtml", () => {
       </div>
     `;
 
-    const extracted = extractDocsPageFromHtml("/docs", html);
+    const chunks = extractDocsPageFromHtml("/docs", html);
 
-    expect(extracted.chunks.length).toBeGreaterThan(0);
-    const pageChunk = extracted.chunks.find((chunk) => chunk.sectionId === null);
+    expect(chunks.length).toBeGreaterThan(0);
+    const pageChunk = chunks.find((chunk) => chunk.sectionId === null);
     expect(pageChunk).toBeDefined();
     expect(pageChunk?.url).toBe("/docs");
     expect(pageChunk?.body).toContain("Hello docs world");

--- a/clients/docs/src/lib/docs/search/extract.ts
+++ b/clients/docs/src/lib/docs/search/extract.ts
@@ -3,12 +3,6 @@ import { load, type Cheerio, type CheerioAPI } from "cheerio";
 import type { DocsSearchChunk } from "@/lib/docs/search/types";
 import { normalizeText, uniqueTokens } from "@/lib/docs/search/text";
 
-export interface ExtractedDocsPage {
-  pageTitle: string;
-  breadcrumb: string;
-  chunks: DocsSearchChunk[];
-}
-
 // Cheerio<AnyNode> derived without importing domhandler, which is not a direct dependency.
 type NodeSelection = ReturnType<Cheerio<never>["contents"]>;
 
@@ -89,7 +83,7 @@ function makeChunk(params: {
   };
 }
 
-export function extractDocsPageFromHtml(route: string, html: string): ExtractedDocsPage {
+export function extractDocsPageFromHtml(route: string, html: string): DocsSearchChunk[] {
   const $ = load(html);
   const main = $(".docs-main").first();
 
@@ -187,5 +181,5 @@ export function extractDocsPageFromHtml(route: string, html: string): ExtractedD
     );
   }
 
-  return { pageTitle, breadcrumb, chunks };
+  return chunks;
 }

--- a/clients/docs/src/lib/docs/search/ranker.test.ts
+++ b/clients/docs/src/lib/docs/search/ranker.test.ts
@@ -42,8 +42,7 @@ describe("searchDocsIndex", () => {
       limit: 5,
     });
 
-    expect(prefix.mode).toBe("lexical");
-    expect(prefix.results[0]?.route).toBe("/docs/getting-started");
+    expect(prefix[0]?.route).toBe("/docs/getting-started");
 
     const fuzzy = searchDocsIndex({
       query: "calender",
@@ -51,7 +50,7 @@ describe("searchDocsIndex", () => {
       limit: 5,
     });
 
-    expect(fuzzy.results[0]?.route).toBe("/docs/help/common-issues");
+    expect(fuzzy[0]?.route).toBe("/docs/help/common-issues");
   });
 
   test("builds fuzzy-match snippets from the matched term, not the raw query token", () => {
@@ -71,7 +70,7 @@ describe("searchDocsIndex", () => {
       limit: 5,
     });
 
-    expect(fuzzy.results[0]?.snippet.toLowerCase()).toContain("calendar");
+    expect(fuzzy[0]?.snippet.toLowerCase()).toContain("calendar");
   });
 
   test("boosts title/heading matches over body-only matches", () => {
@@ -101,12 +100,12 @@ describe("searchDocsIndex", () => {
       ],
     };
 
-    const result = searchDocsIndex({
+    const results = searchDocsIndex({
       query: "permissions",
       index,
       limit: 5,
     });
 
-    expect(result.results[0]?.route).toBe("/docs/title-match");
+    expect(results[0]?.route).toBe("/docs/title-match");
   });
 });

--- a/clients/docs/src/lib/docs/search/ranker.ts
+++ b/clients/docs/src/lib/docs/search/ranker.ts
@@ -75,8 +75,8 @@ function getMiniSearch(chunks: DocsSearchChunk[]): MiniSearch<SearchableChunk> {
   return mini;
 }
 
-function clampLimit(limit: number): number {
-  if (!Number.isFinite(limit) || limit <= 0) {
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit) || limit <= 0) {
     return 10;
   }
   return Math.min(Math.max(Math.floor(limit), 1), 20);
@@ -142,7 +142,6 @@ function toResult(query: string, candidate: RankedChunk): DocsSearchResult {
     sectionId: candidate.chunk.sectionId,
     snippet: extractSnippet(candidate.chunk.body, snippetQuery),
     score: candidate.score,
-    lexicalScore: candidate.lexicalScore,
   };
 }
 
@@ -150,15 +149,12 @@ export function searchDocsIndex(params: {
   query: string;
   limit?: number;
   index: DocsSearchIndexFile;
-}): { mode: "lexical"; results: DocsSearchResult[] } {
+}): DocsSearchResult[] {
   const query = normalizeText(params.query);
-  const limit = clampLimit(params.limit ?? 10);
+  const limit = clampLimit(params.limit);
 
   if (query.length < 2 || params.index.chunks.length === 0) {
-    return {
-      mode: "lexical",
-      results: [],
-    };
+    return [];
   }
 
   const lexicalTopK = Math.max(40, limit * 4);
@@ -168,8 +164,5 @@ export function searchDocsIndex(params: {
     topK: lexicalTopK,
   });
 
-  return {
-    mode: "lexical",
-    results: candidates.slice(0, limit).map((candidate) => toResult(query, candidate)),
-  };
+  return candidates.slice(0, limit).map((candidate) => toResult(query, candidate));
 }

--- a/clients/docs/src/lib/docs/search/text.ts
+++ b/clients/docs/src/lib/docs/search/text.ts
@@ -72,18 +72,3 @@ export function extractSnippet(body: string, query: string, maxLen = 180): strin
 
   return `${prefix}${snippet}${suffix}`;
 }
-
-export function highlightSnippet(snippet: string, query: string): string {
-  const tokens = uniqueTokens([query]).sort((a, b) => b.length - a.length);
-  if (tokens.length === 0 || !snippet) {
-    return snippet;
-  }
-
-  let output = snippet;
-  for (const token of tokens) {
-    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    output = output.replace(new RegExp(`(${escaped})`, "ig"), "<mark>$1</mark>");
-  }
-
-  return output;
-}

--- a/clients/docs/src/lib/docs/search/types.ts
+++ b/clients/docs/src/lib/docs/search/types.ts
@@ -26,12 +26,10 @@ export interface DocsSearchResult {
   sectionId: string | null;
   snippet: string;
   score: number;
-  lexicalScore: number;
 }
 
 export interface DocsSearchResponse {
   query: string;
-  mode: "lexical";
   tookMs: number;
   results: DocsSearchResult[];
 }


### PR DESCRIPTION
## Summary
Fixes reuse/slop gaps identified during plan review for docs-app-phase-1.md: dead highlightSnippet export, duplicate limit clamping, speculative mode/dual-score plumbing, unused extraction fields.