### PR TITLE
fix: consolidate docs route discovery, close %5Fmd and /docs/api encoding gaps

### DIFF
--- a/clients/docs/next-config.test.ts
+++ b/clients/docs/next-config.test.ts
@@ -66,11 +66,16 @@ function docsPathForSource(source: string, pathname: string): string | null {
   }
 
   const docsPath = pathname.slice(prefix.length);
-  if (source === "/docs/:path((?!llms\\.txt$)(?!api\\/)(?!_md).*)") {
+  if (
+    source ===
+    "/docs/:path((?!llms\\.txt$)(?!api(?:\\/|$))(?!_md(?:\\/|$)).*)"
+  ) {
     if (
       docsPath === "llms.txt" ||
+      docsPath === "api" ||
       docsPath.startsWith("api/") ||
-      docsPath.startsWith("_md")
+      docsPath === "_md" ||
+      docsPath.startsWith("_md/")
     ) {
       return null;
     }
@@ -152,7 +157,7 @@ describe("next config rewrite sources", () => {
       "/docs/index.md",
       "/docs/:path*.md",
       "/docs",
-      "/docs/:path((?!llms\\.txt$)(?!api\\/)(?!_md).*)",
+      "/docs/:path((?!llms\\.txt$)(?!api(?:\\/|$))(?!_md(?:\\/|$)).*)",
     ]);
   });
 
@@ -266,6 +271,15 @@ describe("next config docs Markdown content negotiation", () => {
     ).resolves.toEqual([]);
   });
 
+  test("does not rewrite the bare /docs/api path", async () => {
+    await expect(
+      resolveBeforeFilesRewrite("/docs/api", "text/markdown")
+    ).resolves.toBeNull();
+    await expect(markdownRewriteDestinationsFor("/docs/api")).resolves.toEqual(
+      []
+    );
+  });
+
   test("does not re-enter the mirror route itself", async () => {
     await expect(
       resolveBeforeFilesRewrite("/docs/_md/pricing", "text/markdown")
@@ -273,5 +287,16 @@ describe("next config docs Markdown content negotiation", () => {
     await expect(
       markdownRewriteDestinationsFor("/docs/_md/pricing")
     ).resolves.toEqual([]);
+    await expect(
+      resolveBeforeFilesRewrite("/docs/_md", "text/markdown")
+    ).resolves.toBeNull();
+  });
+
+  test("the _md exclusion is anchored to the exact subtree", async () => {
+    // Only /docs/_md and /docs/_md/... are excluded; an _md-prefixed sibling
+    // path still negotiates.
+    await expect(
+      resolveBeforeFilesRewrite("/docs/_mdsomething", "text/markdown")
+    ).resolves.toBe("/docs/_md/_mdsomething");
   });
 });

--- a/clients/docs/next.config.ts
+++ b/clients/docs/next.config.ts
@@ -60,7 +60,10 @@ const nextConfig: NextConfig = {
           // Leave the generated agent index (/docs/llms.txt) to public-file
           // serving even when agents send Accept: text/markdown, and keep the
           // /docs/api subtree and the mirror route itself out of negotiation.
-          source: "/docs/:path((?!llms\\.txt$)(?!api\\/)(?!_md).*)",
+          // The lookaheads anchor on a following slash or end-of-path so the
+          // bare /docs/api and /docs/_md paths are excluded while sibling
+          // prefixes (e.g. a hypothetical /docs/api-guide) still negotiate.
+          source: "/docs/:path((?!llms\\.txt$)(?!api(?:\\/|$))(?!_md(?:\\/|$)).*)",
           destination: "/docs/_md/:path",
           has: [MARKDOWN_ACCEPT_HEADER],
         },

--- a/clients/docs/scripts/generate-agent-markdown.ts
+++ b/clients/docs/scripts/generate-agent-markdown.ts
@@ -28,13 +28,12 @@ import remarkStringify from "remark-stringify";
 import { unified } from "unified";
 
 import { agentMarkdownPathForPage } from "../src/lib/agent-markdown-paths";
-import { SITE_URL } from "../src/lib/metadata";
 import {
-  listPageFiles,
-  loadPageMetadata,
-  renderPage,
-  routeFromPageFile,
-} from "./lib/docs-pages";
+  discoverDocsPages,
+  REDIRECT_STUB_ROUTES,
+} from "../src/lib/discover-docs-routes";
+import { SITE_URL } from "../src/lib/metadata";
+import { loadPageMetadata, renderPage } from "./lib/docs-pages";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
@@ -51,12 +50,6 @@ interface DocsPageMeta {
   route: string;
   title: string;
   description: string;
-}
-
-/** The /docs/api subtree is reserved for non-page surfaces and is excluded
- *  from mirroring (the Accept rewrites in next.config.ts skip it too). */
-function isMirroredRoute(route: string): boolean {
-  return route !== "/docs/api" && !route.startsWith("/docs/api/");
 }
 
 const htmlToMarkdown = unified()
@@ -189,13 +182,12 @@ function buildLlmsText(pages: DocsPageMeta[]): string {
 }
 
 async function main() {
-  const pageFiles = (await listPageFiles(DOCS_PAGES_ROOT)).sort();
-  const pages = pageFiles
-    .map((pageFile) => ({
-      pageFile,
-      route: routeFromPageFile(pageFile, DOCS_PAGES_ROOT, "/docs"),
-    }))
-    .filter(({ route }) => isMirroredRoute(route));
+  // Redirect stubs permanently redirect their HTML route; mirroring them
+  // would point agents at a page that only says "moved". llms.txt and the
+  // mirror tree list the redirect targets instead.
+  const pages = discoverDocsPages(DOCS_PAGES_ROOT).filter(
+    ({ route }) => !REDIRECT_STUB_ROUTES.has(route)
+  );
 
   await rm(OUTPUT_ROOT, { recursive: true, force: true });
   await removeGeneratedDocsLlmsFiles(DOCS_PUBLIC_ROOT);

--- a/clients/docs/scripts/generate-docs-search-index.ts
+++ b/clients/docs/scripts/generate-docs-search-index.ts
@@ -1,19 +1,18 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, join, resolve, sep } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  discoverDocsPages,
+  REDIRECT_STUB_ROUTES,
+} from "../src/lib/discover-docs-routes";
 import { extractDocsPageFromHtml } from "../src/lib/docs/search/extract";
 import type { DocsSearchChunk, DocsSearchIndexFile } from "../src/lib/docs/search/types";
-import { listPageFiles, loadPageModule, renderPage, routeFromPageFile } from "./lib/docs-pages";
+import { loadPageModule, renderPage } from "./lib/docs-pages";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
-// Crawl the entire /docs subtree. Any Next route group living under docs/
-// (currently (documentation), (releases)) gets its pages indexed. Route-group
-// segments live in parentheses and do not affect the URL, so we strip them
-// when deriving the route. The api/ subtree holds route handlers, not pages.
 const DOCS_PAGES_ROOT = join(ROOT, "src", "app", "docs");
-const API_SUBTREE = join(DOCS_PAGES_ROOT, "api") + sep;
 const OUTPUT_PATH = join(ROOT, "public", "docs", "search-index.json");
 
 interface GeneratedIndex {
@@ -23,15 +22,16 @@ interface GeneratedIndex {
 }
 
 async function generateIndex(): Promise<GeneratedIndex> {
-  const pageFiles = (await listPageFiles(DOCS_PAGES_ROOT))
-    .filter((pageFile) => !pageFile.startsWith(API_SUBTREE))
-    .sort();
   const chunks: DocsSearchChunk[] = [];
   const skippedRoutes: string[] = [];
   let pageCount = 0;
 
-  for (const pageFile of pageFiles) {
-    const route = routeFromPageFile(pageFile, DOCS_PAGES_ROOT, "/docs");
+  for (const { pageFile, route } of discoverDocsPages(DOCS_PAGES_ROOT)) {
+    // Redirect stubs carry no content of their own; their targets are indexed.
+    if (REDIRECT_STUB_ROUTES.has(route)) {
+      skippedRoutes.push(`${route} (redirect stub)`);
+      continue;
+    }
 
     // Request-time pages (e.g. /docs/releases) serve content fetched per
     // request, so there is nothing stable to index at build time.
@@ -43,7 +43,7 @@ async function generateIndex(): Promise<GeneratedIndex> {
 
     const rendered = await renderPage(pageFile);
     if (!rendered) {
-      skippedRoutes.push(`${route} (redirect)`);
+      skippedRoutes.push(`${route} (suspended request-time page)`);
       continue;
     }
 

--- a/clients/docs/scripts/lib/docs-pages.ts
+++ b/clients/docs/scripts/lib/docs-pages.ts
@@ -1,66 +1,8 @@
-import { readdir } from "node:fs/promises";
-import { dirname, join, relative, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { Metadata } from "next";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-
-export function isRouteGroupSegment(segment: string): boolean {
-  return segment.startsWith("(") && segment.endsWith(")");
-}
-
-export function isPrivateSegment(segment: string): boolean {
-  return segment.startsWith("_");
-}
-
-/** Recursively list page.tsx files under a Next app directory, skipping
- *  private (underscore-prefixed) folders like _components. */
-export async function listPageFiles(dir: string): Promise<string[]> {
-  const entries = await readdir(dir, { withFileTypes: true });
-  const results: string[] = [];
-
-  for (const entry of entries) {
-    const absolute = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (isPrivateSegment(entry.name)) {
-        continue;
-      }
-      const nested = await listPageFiles(absolute);
-      results.push(...nested);
-      continue;
-    }
-
-    if (entry.isFile() && entry.name === "page.tsx") {
-      results.push(absolute);
-    }
-  }
-
-  return results;
-}
-
-/** Derive the URL route for a page file relative to a pages root, stripping
- *  route-group segments (parenthesized folders do not affect the URL). */
-export function routeFromPageFile(
-  pageFile: string,
-  pagesRoot: string,
-  baseRoute: string
-): string {
-  const relativeDir = relative(pagesRoot, dirname(pageFile));
-  if (!relativeDir || relativeDir === ".") {
-    return baseRoute;
-  }
-
-  const segments = relativeDir
-    .split(sep)
-    .filter((segment) => segment.length > 0 && !isRouteGroupSegment(segment));
-
-  if (segments.length === 0) {
-    return baseRoute;
-  }
-
-  return `${baseRoute}/${segments.join("/")}`;
-}
 
 export interface RenderedPage {
   html: string;
@@ -72,8 +14,8 @@ export async function loadPageModule(pageFile: string): Promise<Record<string, u
 }
 
 /** Import a page module and return its exported metadata without rendering.
- *  Used for pages that cannot be statically rendered (request-time pages and
- *  redirect stubs) so generators can still emit metadata-only entries. */
+ *  Used for pages that cannot be statically rendered (request-time pages) so
+ *  generators can still emit metadata-only entries. */
 export async function loadPageMetadata(pageFile: string): Promise<Metadata | undefined> {
   try {
     const pageModule = await loadPageModule(pageFile);

--- a/clients/docs/scripts/verify-parity.ts
+++ b/clients/docs/scripts/verify-parity.ts
@@ -148,6 +148,17 @@ async function verifyMarkdown(route: string): Promise<void> {
     return;
   }
 
+  // Redirect stubs are excluded from the mirror generation; their `.md` URL
+  // must 404 rather than serve a "moved" page to agents.
+  if (REDIRECT_STUB_ROUTES.has(route)) {
+    const stub = await fetchWithTimeout(`${baseUrl}${mdPath}`);
+    check(
+      stub.status === 404,
+      `${mdPath}: expected 404 for a redirect stub mirror, got ${stub.status}`,
+    );
+    return;
+  }
+
   const mirror = await fetchWithTimeout(`${baseUrl}${mdPath}`);
   check(mirror.status === 200, `${mdPath}: expected 200, got ${mirror.status}`);
   check(isMarkdownResponse(mirror), `${mdPath}: content-type is not markdown`);
@@ -180,6 +191,12 @@ async function verifyLlmsTxt(): Promise<void> {
     body.startsWith("# Vellum Docs"),
     "/docs/llms.txt: unexpected content",
   );
+  for (const route of REDIRECT_STUB_ROUTES) {
+    check(
+      !body.includes(`${route}.md`),
+      `/docs/llms.txt: lists the redirect stub ${route}`,
+    );
+  }
 }
 
 async function verifySitemap(): Promise<void> {

--- a/clients/docs/src/lib/discover-docs-routes.test.ts
+++ b/clients/docs/src/lib/discover-docs-routes.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import fs from "fs";
+import os from "os";
 import path from "path";
 
 import sitemap from "@/app/docs/sitemap";
 import {
+  discoverDocsPages,
   discoverDocsRoutes,
   REDIRECT_STUB_ROUTES,
 } from "@/lib/discover-docs-routes";
@@ -12,8 +14,8 @@ const DOCS_APP_DIR = path.join(process.cwd(), "src", "app", "docs");
 
 /**
  * Independently counts routable page.tsx files, applying the same exclusions
- * the discovery walk documents: dynamic segments, private folders, and the
- * api subtree directly under /docs.
+ * the discovery walk documents: dynamic segments, private folders (both `_`
+ * and URL-encoded `%5F` prefixes), and the api subtree directly under /docs.
  */
 function countPageFiles(dir: string, atDocsRoot: boolean): number {
   let count = 0;
@@ -30,7 +32,11 @@ function countPageFiles(dir: string, atDocsRoot: boolean): number {
     if (!entry.isDirectory()) {
       continue;
     }
-    if (entry.name.startsWith("[") || entry.name.startsWith("_")) {
+    if (
+      entry.name.startsWith("[") ||
+      entry.name.startsWith("_") ||
+      entry.name.toLowerCase().startsWith("%5f")
+    ) {
       continue;
     }
     if (atDocsRoot && entry.name === "api") {
@@ -71,6 +77,57 @@ describe("discoverDocsRoutes", () => {
 
   test("returns unique routes", () => {
     expect(new Set(routes).size).toBe(routes.length);
+  });
+});
+
+describe("discoverDocsPages", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "docs-discovery-"));
+
+  afterAll(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  function addPage(...segments: string[]): void {
+    const dir = path.join(fixtureRoot, ...segments);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "page.tsx"), "export default () => null;");
+  }
+
+  addPage();
+  addPage("(group)", "guide");
+  addPage("api");
+  addPage("api", "nested");
+  addPage("_private");
+  addPage("%5Fencoded");
+  addPage("[slug]");
+
+  const pages = discoverDocsPages(fixtureRoot);
+
+  test("pairs each route with its on-disk page file", () => {
+    expect(pages).toEqual([
+      { pageFile: path.join(fixtureRoot, "page.tsx"), route: "/docs" },
+      {
+        pageFile: path.join(fixtureRoot, "(group)", "guide", "page.tsx"),
+        route: "/docs/guide",
+      },
+    ]);
+  });
+
+  test("excludes the api subtree, private folders, %5F-encoded folders, and dynamic segments", () => {
+    const routes = pages.map((page) => page.route);
+    expect(routes).not.toContain("/docs/api");
+    expect(routes).not.toContain("/docs/api/nested");
+    expect(routes).not.toContain("/docs/_private");
+    expect(routes).not.toContain("/docs/%5Fencoded");
+    expect(routes).not.toContain("/docs/_encoded");
+  });
+
+  test("every page file discovered in the real docs tree exists on disk", () => {
+    const realPages = discoverDocsPages();
+    expect(realPages.length).toBeGreaterThan(0);
+    for (const { pageFile } of realPages) {
+      expect(fs.existsSync(pageFile)).toBe(true);
+    }
   });
 });
 

--- a/clients/docs/src/lib/discover-docs-routes.ts
+++ b/clients/docs/src/lib/discover-docs-routes.ts
@@ -5,38 +5,66 @@ const DOCS_APP_DIR = path.join(process.cwd(), "src", "app", "docs");
 
 /**
  * Routes whose page only issues a permanentRedirect. Redirect targets belong
- * in the sitemap; the stubs themselves do not.
+ * in the sitemap and the agent-markdown mirrors; the stubs themselves do not.
  */
 export const REDIRECT_STUB_ROUTES: ReadonlySet<string> = new Set([
   "/docs/getting-started/key-concepts",
 ]);
 
-/**
- * Recursively finds all page.tsx files under src/app/docs and converts them
- * to /docs/... URL paths. Strips route groups like (documentation) and
- * (releases), skips dynamic segments, private folders (underscore-prefixed,
- * e.g. _components and _md), and the api subtree directly under /docs
- * (route handlers, not pages).
- */
-export function discoverDocsRoutes(dir: string = DOCS_APP_DIR): string[] {
-  return walk(dir, "/docs").sort();
+/** A routable docs page: its on-disk page file and the URL route it serves. */
+export interface DiscoveredDocsPage {
+  pageFile: string;
+  route: string;
 }
 
-function walk(dir: string, basePath: string): string[] {
-  const routes: string[] = [];
+// Next treats underscore-prefixed folders as private. %5F is the URL-encoded
+// underscore, used on disk to register an _-prefixed URL segment as a real
+// route (e.g. %5Fmd serves /docs/_md), so it is just as private here.
+function isPrivateSegment(name: string): boolean {
+  return name.startsWith("_") || name.toLowerCase().startsWith("%5f");
+}
+
+// The api subtree directly under /docs holds route handlers, not pages.
+function isApiRoute(route: string): boolean {
+  return route === "/docs/api" || route.startsWith("/docs/api/");
+}
+
+/**
+ * Recursively finds all page files under src/app/docs and pairs each with its
+ * /docs/... URL route. Strips route groups like (documentation) and
+ * (releases), skips dynamic segments and private folders (underscore-prefixed
+ * like _components, including the URL-encoded %5F form like %5Fmd), and
+ * excludes the /docs/api subtree. Redirect stubs are included; consumers that
+ * must not surface them filter with REDIRECT_STUB_ROUTES.
+ */
+export function discoverDocsPages(
+  dir: string = DOCS_APP_DIR,
+): DiscoveredDocsPage[] {
+  return walk(dir, "/docs")
+    .filter((page) => !isApiRoute(page.route))
+    .sort((a, b) => (a.route < b.route ? -1 : a.route > b.route ? 1 : 0));
+}
+
+/** Routes of every discovered docs page, sorted. */
+export function discoverDocsRoutes(dir: string = DOCS_APP_DIR): string[] {
+  return discoverDocsPages(dir).map((page) => page.route);
+}
+
+function walk(dir: string, basePath: string): DiscoveredDocsPage[] {
+  const pages: DiscoveredDocsPage[] = [];
 
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
   } catch {
-    return routes;
+    return pages;
   }
 
-  const hasPage = entries.some(
+  const pageEntry = entries.find(
     (e) => e.isFile() && (e.name === "page.tsx" || e.name === "page.ts"),
   );
-  if (hasPage) {
-    routes.push(basePath);
+  if (pageEntry) {
+    pages.push({ pageFile: path.join(dir, pageEntry.name), route: basePath });
   }
 
   for (const entry of entries) {
@@ -46,18 +74,15 @@ function walk(dir: string, basePath: string): string[] {
 
     const name = entry.name;
 
-    if (name.startsWith("[") || name.startsWith("_")) {
-      continue;
-    }
-    if (basePath === "/docs" && name === "api") {
+    if (name.startsWith("[") || isPrivateSegment(name)) {
       continue;
     }
 
     const isRouteGroup = name.startsWith("(") && name.endsWith(")");
     const segment = isRouteGroup ? "" : `/${name}`;
 
-    routes.push(...walk(path.join(dir, name), `${basePath}${segment}`));
+    pages.push(...walk(path.join(dir, name), `${basePath}${segment}`));
   }
 
-  return routes;
+  return pages;
 }

--- a/clients/docs/src/proxy.test.ts
+++ b/clients/docs/src/proxy.test.ts
@@ -93,6 +93,7 @@ describe("docs proxy page_view logging", () => {
     ["/docs/api/health", "API route"],
     ["/docs/api/search", "API route"],
     ["/docs/_md/quickstart", "agent-markdown mirror"],
+    ["/docs/%5Fmd/quickstart", "percent-encoded agent-markdown mirror"],
     ["/docs/quickstart.md", "markdown variant"],
     ["/docs/sitemap.xml", "sitemap"],
     ["/docs/llms.txt", "llms.txt"],

--- a/clients/docs/src/proxy.ts
+++ b/clients/docs/src/proxy.ts
@@ -310,10 +310,6 @@ function inferUTMFromReferrer(
   };
 }
 
-function generateVisitorId(): string {
-  return crypto.randomUUID();
-}
-
 /**
  * Docs page paths only: exclude API routes, the agent-markdown mirror, and
  * file-like paths (static assets, `.md` variants, sitemap.xml, llms.txt).
@@ -372,7 +368,7 @@ function emitPageViewLog(
 }
 
 function resolveVisitorId(request: NextRequest): string {
-  return request.cookies.get(VID_COOKIE_NAME)?.value ?? generateVisitorId();
+  return request.cookies.get(VID_COOKIE_NAME)?.value ?? crypto.randomUUID();
 }
 
 function setVisitorIdCookie(
@@ -453,7 +449,18 @@ function resolveEntryAttribution(
 
 export function proxy(request: NextRequest) {
   const host = request.headers.get("host")?.split(":")[0] ?? "";
-  const { pathname } = request.nextUrl;
+  const rawPathname = request.nextUrl.pathname;
+
+  // skipMiddlewareUrlNormalize keeps the pathname percent-encoded, so decode
+  // once up front: the exclusion checks and the logged path must agree, or an
+  // encoded mirror path like /docs/%5Fmd/... would slip past the /docs/_md
+  // exclusion and log a phantom page_view.
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(rawPathname);
+  } catch {
+    pathname = rawPathname;
+  }
 
   const response = NextResponse.next();
   const vid = resolveVisitorId(request);
@@ -461,13 +468,7 @@ export function proxy(request: NextRequest) {
 
   const userAgent = request.headers.get("user-agent") || "";
   if (isPagePath(pathname) && !isbot(userAgent) && !isPrefetch(request)) {
-    let decodedPath: string;
-    try {
-      decodedPath = decodeURIComponent(pathname);
-    } catch {
-      decodedPath = pathname;
-    }
-    emitPageViewLog(request, vid, decodedPath, resolveEntryAttribution(request));
+    emitPageViewLog(request, vid, pathname, resolveEntryAttribution(request));
   }
   return response;
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for docs-app-phase-1.md.

- Single route-discovery module consumed by the sitemap walk and both generators (one /docs/api exclusion rule)
- %5F-encoded folders treated as private; proxy decodes before exclusion checks (no phantom _md page_views)
- llms.txt no longer lists the redirect stub; Accept rewrite excludes bare /docs/api