### PR TITLE
feat(discord): typed array config reads and a visible admission-drop log (LUM-2841)

### DIFF
--- a/gateway/src/__tests__/config-file-cache.test.ts
+++ b/gateway/src/__tests__/config-file-cache.test.ts
@@ -207,6 +207,133 @@ describe("ConfigFileCache: getRecord", () => {
   });
 });
 
+describe("ConfigFileCache: getStringArray", () => {
+  test("reads a JSON array of strings", () => {
+    // The shape `getString` silently could not read, which is how a populated
+    // Discord allow-list reached the admission gate as an empty set.
+    writeConfig({ discord: { allowedChannelIds: ["111", "222"] } });
+    const cache = new ConfigFileCache();
+    expect(cache.getStringArray("discord", "allowedChannelIds")).toEqual([
+      "111",
+      "222",
+    ]);
+  });
+
+  test("reads a comma-separated string", () => {
+    writeConfig({ discord: { allowedChannelIds: "111,222" } });
+    const cache = new ConfigFileCache();
+    expect(cache.getStringArray("discord", "allowedChannelIds")).toEqual([
+      "111",
+      "222",
+    ]);
+  });
+
+  test("trims entries in both shapes", () => {
+    writeConfig({ discord: { allowedChannelIds: " 111 , 222 " } });
+    const cache = new ConfigFileCache();
+    expect(cache.getStringArray("discord", "allowedChannelIds")).toEqual([
+      "111",
+      "222",
+    ]);
+
+    writeConfig({ discord: { allowedChannelIds: [" 111 ", " 222 "] } });
+    const fresh = new ConfigFileCache();
+    expect(fresh.getStringArray("discord", "allowedChannelIds")).toEqual([
+      "111",
+      "222",
+    ]);
+  });
+
+  test("drops blank entries rather than yielding an empty-string id", () => {
+    writeConfig({ discord: { allowedChannelIds: ["111", "", "  "] } });
+    const cache = new ConfigFileCache();
+    expect(cache.getStringArray("discord", "allowedChannelIds")).toEqual([
+      "111",
+    ]);
+  });
+
+  test("drops non-string array entries instead of coercing them", () => {
+    // A snowflake authored as a bare JSON integer is already truncated above
+    // 2^53 (LUM-2939). Stringifying it would resurrect a corrupted id that
+    // still looks well-formed, so the entry is dropped instead.
+    writeConfig({
+      discord: { allowedChannelIds: ["111", 1532468750740357331, null] },
+    });
+    const cache = new ConfigFileCache();
+    expect(cache.getStringArray("discord", "allowedChannelIds")).toEqual([
+      "111",
+    ]);
+  });
+
+  test("returns undefined for an empty array", () => {
+    writeConfig({ discord: { allowedChannelIds: [] } });
+    const cache = new ConfigFileCache();
+    expect(
+      cache.getStringArray("discord", "allowedChannelIds"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when nothing survives normalization", () => {
+    writeConfig({ discord: { allowedChannelIds: [42, null] } });
+    const cache = new ConfigFileCache();
+    expect(
+      cache.getStringArray("discord", "allowedChannelIds"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for comma-only and blank strings", () => {
+    writeConfig({ discord: { allowedChannelIds: ",," } });
+    const cache = new ConfigFileCache();
+    expect(
+      cache.getStringArray("discord", "allowedChannelIds"),
+    ).toBeUndefined();
+
+    writeConfig({ discord: { allowedChannelIds: "   " } });
+    const fresh = new ConfigFileCache();
+    expect(
+      fresh.getStringArray("discord", "allowedChannelIds"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for shapes that are neither array nor string", () => {
+    writeConfig({ discord: { allowedChannelIds: { a: "111" } } });
+    const cache = new ConfigFileCache();
+    expect(
+      cache.getStringArray("discord", "allowedChannelIds"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for missing section and missing field", () => {
+    writeConfig({});
+    const cache = new ConfigFileCache();
+    expect(
+      cache.getStringArray("discord", "allowedChannelIds"),
+    ).toBeUndefined();
+
+    writeConfig({ discord: {} });
+    const fresh = new ConfigFileCache();
+    expect(
+      fresh.getStringArray("discord", "allowedChannelIds"),
+    ).toBeUndefined();
+  });
+
+  test("force bypasses the TTL", () => {
+    writeConfig({ discord: { allowedChannelIds: ["111"] } });
+    const cache = new ConfigFileCache({ ttlMs: 60_000 });
+
+    expect(cache.getStringArray("discord", "allowedChannelIds")).toEqual([
+      "111",
+    ]);
+    writeConfig({ discord: { allowedChannelIds: ["222"] } });
+    expect(cache.getStringArray("discord", "allowedChannelIds")).toEqual([
+      "111",
+    ]);
+    expect(
+      cache.getStringArray("discord", "allowedChannelIds", { force: true }),
+    ).toEqual(["222"]);
+  });
+});
+
 describe("ConfigFileCache: TTL caching", () => {
   test("reads are cached within TTL", () => {
     writeConfig({ email: { address: "first@test.com" } });

--- a/gateway/src/__tests__/config-file-cache.test.ts
+++ b/gateway/src/__tests__/config-file-cache.test.ts
@@ -209,8 +209,8 @@ describe("ConfigFileCache: getRecord", () => {
 
 describe("ConfigFileCache: getStringArray", () => {
   test("reads a JSON array of strings", () => {
-    // The shape `getString` silently could not read, which is how a populated
-    // Discord allow-list reached the admission gate as an empty set.
+    // `getString` returns undefined for an array, so a list has to come
+    // through here or a populated setting reads as unset.
     writeConfig({ discord: { allowedChannelIds: ["111", "222"] } });
     const cache = new ConfigFileCache();
     expect(cache.getStringArray("discord", "allowedChannelIds")).toEqual([

--- a/gateway/src/config-file-cache.ts
+++ b/gateway/src/config-file-cache.ts
@@ -32,6 +32,36 @@ function normalizeRecord(raw: unknown): Record<string, string> | undefined {
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+/**
+ * Normalize a list-valued setting into an array of non-empty strings.
+ *
+ * Accepts either a JSON array or a comma-separated string, so a list reads the
+ * same whether it is authored as `["a", "b"]` or `"a,b"`. Returns undefined
+ * when the input is neither shape, or when nothing survives normalization.
+ *
+ * Non-string array entries are dropped rather than coerced. A snowflake
+ * authored as a bare JSON integer has already lost precision above 2^53 by the
+ * time it reaches this function (LUM-2939), so stringifying it resurrects a
+ * corrupted id that still looks well-formed. Dropping it keeps the failure
+ * loud instead of silently pointing at the wrong channel.
+ */
+function normalizeStringList(raw: unknown): string[] | undefined {
+  let entries: unknown[];
+  if (Array.isArray(raw)) {
+    entries = raw;
+  } else if (typeof raw === "string") {
+    entries = raw.split(",");
+  } else {
+    return undefined;
+  }
+
+  const result = entries
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== "");
+  return result.length > 0 ? result : undefined;
+}
+
 export class ConfigFileCache {
   private ttlMs: number;
   private snapshot: Record<string, unknown> = {};
@@ -101,6 +131,29 @@ export class ConfigFileCache {
   ): Record<string, string> | undefined {
     const raw = this.getRaw(section, field, opts);
     return normalizeRecord(raw);
+  }
+
+  /**
+   * Read a list-valued setting as an array of strings, accepting either a JSON
+   * array or a comma-separated string.
+   *
+   * Both shapes have to work because the two ways a list gets authored produce
+   * different types. Hand-editing `config.json` naturally yields an array, and
+   * `assistant config set --json` is the only safe way to write a snowflake id
+   * (a bare integer above 2^53 is truncated on the way in, LUM-2939), while
+   * the plain string form is what a CSV setting already looks like.
+   *
+   * Reading a list through {@link getString} is what makes this necessary:
+   * that getter returns undefined for an array, so an array-shaped list
+   * collapses to nothing and a populated setting reads as unset. Route list
+   * settings through here rather than adding another string-shaped parse.
+   */
+  getStringArray(
+    section: string,
+    field: string,
+    opts?: ReadOptions,
+  ): string[] | undefined {
+    return normalizeStringList(this.getRaw(section, field, opts));
   }
 
   /** Immediately re-read config.json, updating the cached snapshot. */

--- a/gateway/src/config-file-cache.ts
+++ b/gateway/src/config-file-cache.ts
@@ -137,16 +137,16 @@ export class ConfigFileCache {
    * Read a list-valued setting as an array of strings, accepting either a JSON
    * array or a comma-separated string.
    *
-   * Both shapes have to work because the two ways a list gets authored produce
-   * different types. Hand-editing `config.json` naturally yields an array, and
+   * Both shapes are accepted because the ways a list gets authored produce
+   * different types. Hand-editing `config.json` yields an array, and
    * `assistant config set --json` is the only safe way to write a snowflake id
-   * (a bare integer above 2^53 is truncated on the way in, LUM-2939), while
-   * the plain string form is what a CSV setting already looks like.
+   * (a bare integer above 2^53 is truncated on the way in, LUM-2939), while a
+   * CSV setting is a plain string.
    *
-   * Reading a list through {@link getString} is what makes this necessary:
-   * that getter returns undefined for an array, so an array-shaped list
-   * collapses to nothing and a populated setting reads as unset. Route list
-   * settings through here rather than adding another string-shaped parse.
+   * This is the only getter that reads a list. {@link getString} returns
+   * undefined for an array, so an array-shaped list read through it collapses
+   * to nothing and a populated setting reads as unset. Route list settings
+   * here rather than adding another string-shaped parse.
    */
   getStringArray(
     section: string,

--- a/gateway/src/discord/admission-log-visibility.test.ts
+++ b/gateway/src/discord/admission-log-visibility.test.ts
@@ -12,18 +12,16 @@ import {
 import "../__tests__/test-preload.js";
 
 /**
- * Asserts the admission-gate drop against a real gateway logger rather than a
- * spy, because the defect being pinned here is a level mismatch and a spy
- * would happily record a line that no configured stream ever writes.
- *
- * Every gateway stream is built at `level: "info"` (see `logger.ts`), so a
- * `debug` drop line reaches no sink at all. Reading the JSONL sidecar back off
- * disk is the only assertion that can tell "logged" from "logged somewhere it
+ * Asserts admission-gate drops against a real gateway logger rather than a
+ * spy. Every gateway stream is built at `level: "info"` (see `logger.ts`), so
+ * a `debug` line reaches no sink, and a spy would happily record a call that
+ * no configured stream ever writes. Reading the JSONL sidecar back off disk is
+ * the only assertion that distinguishes "logged" from "logged somewhere it
  * survives".
  *
- * This lives in its own file so `initLogger`, which sets module-global logger
- * state, does not redirect the rest of the Discord suite's output. The gateway
- * runner executes each test file in its own `bun test` invocation.
+ * `initLogger` sets module-global logger state, so this file keeps to itself:
+ * the gateway runner gives each test file its own `bun test` invocation, and
+ * `afterAll` restores the stdout-only logger in case it does not.
  */
 
 const CHANNEL = "1532468750740357331";
@@ -37,6 +35,9 @@ beforeAll(() => {
 });
 
 afterAll(() => {
+  // Restore the stdout-only logger so a sibling file sharing this process does
+  // not keep writing into a directory that is about to be removed.
+  initLogger({ dir: undefined, retentionDays: 0 });
   rmSync(logDir, { recursive: true, force: true });
 });
 
@@ -60,7 +61,9 @@ class FakeSocket implements GatewaySocketLike {
     type: "open" | "message" | "close" | "error",
     listener: (event: { data?: unknown; code?: number }) => void,
   ): void {
-    if (type === "message") this.listeners.push(listener);
+    if (type === "message") {
+      this.listeners.push(listener);
+    }
   }
 
   send(): void {}
@@ -137,11 +140,9 @@ function mentionIn(
 
 describe("admission drop visibility", () => {
   test("a channel_not_allowed drop is written at a level the streams keep", async () => {
-    // The Jul 30 smoke test in miniature: the bot is mentioned, the allow-list
-    // is empty, and before this change the resulting drop was logged at debug
-    // and therefore written nowhere. The log was indistinguishable from one
-    // where no event ever arrived, which is what sent the investigation after
-    // intents, the dispatcher table, and the handshake.
+    // The bot is mentioned and the allow-list is empty. A drop that reached no
+    // sink would make this log identical to one where no event ever arrived,
+    // which is the case an operator cannot diagnose.
     const ws = await connectedClient([]);
     ws.message(mentionIn(UNLISTED_CHANNEL, "msg-visible-1"));
 

--- a/gateway/src/discord/admission-log-visibility.test.ts
+++ b/gateway/src/discord/admission-log-visibility.test.ts
@@ -1,0 +1,205 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import { LOG_FILE_JSON_PATTERN, initLogger } from "../logger.js";
+import {
+  DiscordGatewayClient,
+  type CancelTimer,
+  type GatewaySocketLike,
+} from "./gateway-socket.js";
+import "../__tests__/test-preload.js";
+
+/**
+ * Asserts the admission-gate drop against a real gateway logger rather than a
+ * spy, because the defect being pinned here is a level mismatch and a spy
+ * would happily record a line that no configured stream ever writes.
+ *
+ * Every gateway stream is built at `level: "info"` (see `logger.ts`), so a
+ * `debug` drop line reaches no sink at all. Reading the JSONL sidecar back off
+ * disk is the only assertion that can tell "logged" from "logged somewhere it
+ * survives".
+ *
+ * This lives in its own file so `initLogger`, which sets module-global logger
+ * state, does not redirect the rest of the Discord suite's output. The gateway
+ * runner executes each test file in its own `bun test` invocation.
+ */
+
+const CHANNEL = "1532468750740357331";
+const UNLISTED_CHANNEL = "800000000000000002";
+
+let logDir: string;
+
+beforeAll(() => {
+  logDir = mkdtempSync(join(tmpdir(), "gw-discord-admission-"));
+  initLogger({ dir: logDir, retentionDays: 0 });
+});
+
+afterAll(() => {
+  rmSync(logDir, { recursive: true, force: true });
+});
+
+/** Every record written to the JSONL sidecar so far. */
+function readLogRecords(): Array<Record<string, unknown>> {
+  return readdirSync(logDir)
+    .filter((name) => LOG_FILE_JSON_PATTERN.test(name))
+    .flatMap((name) =>
+      readFileSync(join(logDir, name), "utf8")
+        .split("\n")
+        .filter((line) => line.trim() !== "")
+        .map((line) => JSON.parse(line) as Record<string, unknown>),
+    );
+}
+
+class FakeSocket implements GatewaySocketLike {
+  private listeners: Array<(event: { data?: unknown; code?: number }) => void> =
+    [];
+
+  addEventListener(
+    type: "open" | "message" | "close" | "error",
+    listener: (event: { data?: unknown; code?: number }) => void,
+  ): void {
+    if (type === "message") this.listeners.push(listener);
+  }
+
+  send(): void {}
+  close(): void {}
+
+  message(payload: unknown): void {
+    for (const listener of this.listeners) {
+      listener({ data: JSON.stringify(payload) });
+    }
+  }
+}
+
+const schedule: (fn: () => void, delayMs: number) => CancelTimer =
+  () => () => {};
+
+/** A started client whose session is established, with the given allow-list. */
+async function connectedClient(allowed: string[]): Promise<FakeSocket> {
+  let socket: FakeSocket | undefined;
+  const client = new DiscordGatewayClient(
+    {
+      botToken: "token-abc",
+      readAllowedChannelIds: () => new Set(allowed),
+      fetchFn: (async () =>
+        new Response(JSON.stringify({ url: "wss://gateway.test" }), {
+          status: 200,
+        })) as unknown as typeof fetch,
+      createSocket: () => {
+        socket = new FakeSocket();
+        return socket;
+      },
+      schedule,
+      random: () => 0.5,
+      now: () => 1_000_000,
+    },
+    () => {},
+  );
+
+  await client.start();
+  const ws = socket as FakeSocket;
+  ws.message({ op: 10, d: { heartbeat_interval: 41_250 } });
+  ws.message({
+    op: 0,
+    t: "READY",
+    s: 1,
+    d: {
+      session_id: "sess-1",
+      resume_gateway_url: "wss://resume.test",
+      user: { id: "bot-1" },
+    },
+  });
+  return ws;
+}
+
+function mentionIn(
+  channelId: string,
+  messageId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    op: 0,
+    t: "MESSAGE_CREATE",
+    s: 2,
+    d: {
+      id: messageId,
+      channel_id: channelId,
+      guild_id: "670819210053681162",
+      content: "<@bot-1> hey",
+      author: { id: "user-1", username: "boss" },
+      mentions: [{ id: "bot-1" }],
+      ...overrides,
+    },
+  };
+}
+
+describe("admission drop visibility", () => {
+  test("a channel_not_allowed drop is written at a level the streams keep", async () => {
+    // The Jul 30 smoke test in miniature: the bot is mentioned, the allow-list
+    // is empty, and before this change the resulting drop was logged at debug
+    // and therefore written nowhere. The log was indistinguishable from one
+    // where no event ever arrived, which is what sent the investigation after
+    // intents, the dispatcher table, and the handshake.
+    const ws = await connectedClient([]);
+    ws.message(mentionIn(UNLISTED_CHANNEL, "msg-visible-1"));
+
+    const dropped = readLogRecords().filter(
+      (record) => record["messageId"] === "msg-visible-1",
+    );
+
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]?.["reason"]).toBe("channel_not_allowed");
+    expect(dropped[0]?.["channelId"]).toBe(UNLISTED_CHANNEL);
+    // pino: warn is 40, info is 30, debug is 20. The file streams start at
+    // info, so a debug record would be absent above rather than present here.
+    // This reason warns because it is the operator-actionable one.
+    expect(dropped[0]?.["level"]).toBe(40);
+  });
+
+  test("the bot's own echo stays quiet", async () => {
+    // Never promoted at any volume: it scales with how much the bot says, and
+    // no misconfiguration can cause it.
+    const ws = await connectedClient([CHANNEL]);
+    ws.message(mentionIn(CHANNEL, "msg-self-1", { author: { id: "bot-1" } }));
+
+    expect(
+      readLogRecords().filter((r) => r["messageId"] === "msg-self-1"),
+    ).toHaveLength(0);
+  });
+
+  test("repeated drops on the same channel do not keep writing", async () => {
+    // The counterweight. A busy community channel produces one drop per
+    // message, so promoting all of them would flood the stream the gate exists
+    // to keep quiet.
+    const ws = await connectedClient([]);
+    ws.message(mentionIn("800000000000000777", "msg-repeat-1"));
+    ws.message(mentionIn("800000000000000777", "msg-repeat-2"));
+    ws.message(mentionIn("800000000000000777", "msg-repeat-3"));
+
+    const records = readLogRecords();
+    expect(
+      records.filter((r) => r["messageId"] === "msg-repeat-1"),
+    ).toHaveLength(1);
+    expect(
+      records.filter((r) => r["messageId"] === "msg-repeat-2"),
+    ).toHaveLength(0);
+    expect(
+      records.filter((r) => r["messageId"] === "msg-repeat-3"),
+    ).toHaveLength(0);
+  });
+
+  test("an admitted message still logs its admission", async () => {
+    // Guards the other direction: the drop path going quiet must not be
+    // achieved by making the whole gate quiet.
+    const ws = await connectedClient([CHANNEL]);
+    ws.message(mentionIn(CHANNEL, "msg-admitted-1"));
+
+    const admitted = readLogRecords().filter(
+      (record) => record["messageId"] === "msg-admitted-1",
+    );
+    expect(admitted).toHaveLength(1);
+    expect(admitted[0]?.["level"]).toBe(30);
+  });
+});

--- a/gateway/src/discord/admission-log.test.ts
+++ b/gateway/src/discord/admission-log.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AdmissionDropLog,
+  type AdmissionDropLogLevel,
+} from "./admission-log.js";
+import type { AdmissionDropReason } from "./admit.js";
+import "../__tests__/test-preload.js";
+
+const CHANNEL = "1532468750740357331";
+const OTHER_CHANNEL = "800000000000000002";
+
+/** Reasons that surface once per channel, and the level they surface at. */
+const PROMOTED: Array<[AdmissionDropReason, AdmissionDropLogLevel]> = [
+  ["channel_not_allowed", "warn"],
+  ["not_a_guild_message", "info"],
+  ["bot_not_mentioned", "info"],
+];
+
+/** Reasons that never surface: machine traffic, unbounded volume, no signal. */
+const NEVER_PROMOTED: AdmissionDropReason[] = ["self_authored", "bot_authored"];
+
+describe("AdmissionDropLog", () => {
+  test("channel_not_allowed warns, because it is the operator-actionable one", () => {
+    // The reason that fires on a misconfigured or unreadable allow-list. Every
+    // gateway stream runs at info, so before this it was written nowhere and a
+    // gate denying every message looked exactly like a gateway receiving none.
+    const dropLog = new AdmissionDropLog();
+    expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+  });
+
+  test("reasons that mean a person was denied are visible", () => {
+    for (const [reason, level] of PROMOTED) {
+      const dropLog = new AdmissionDropLog();
+      expect(dropLog.levelFor(reason, CHANNEL)).toBe(level);
+    }
+  });
+
+  test("the bot's own echo and other bots never promote", () => {
+    // These scale with how chatty the room is and no operator needs one.
+    // Neither can be caused by a misconfiguration, so nothing is lost.
+    for (const reason of NEVER_PROMOTED) {
+      const dropLog = new AdmissionDropLog();
+      expect(dropLog.levelFor(reason, CHANNEL)).toBe("debug");
+      expect(dropLog.levelFor(reason, OTHER_CHANNEL)).toBe("debug");
+    }
+  });
+
+  test("repeats fall back to debug", () => {
+    // The gate denies by design, so promoting every drop would flood the
+    // stream it exists to keep quiet.
+    const dropLog = new AdmissionDropLog();
+    expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+    expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("debug");
+    expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("debug");
+  });
+
+  test("a different channel is promoted again", () => {
+    // Which room is being denied is half the diagnosis.
+    const dropLog = new AdmissionDropLog();
+    expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+    expect(dropLog.levelFor("channel_not_allowed", OTHER_CHANNEL)).toBe("warn");
+  });
+
+  test("a different reason on the same channel is promoted again", () => {
+    // A channel that starts denying for a new reason is new information.
+    const dropLog = new AdmissionDropLog();
+    expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+    expect(dropLog.levelFor("bot_not_mentioned", CHANNEL)).toBe("info");
+  });
+
+  test("promotion stops at the cap and degrades to debug", () => {
+    // Bounds memory against a guild with a large channel count. Past the cap
+    // the behavior is the old quiet, not unbounded growth.
+    const dropLog = new AdmissionDropLog();
+    for (let i = 0; i < 512; i++) {
+      expect(dropLog.levelFor("channel_not_allowed", `channel-${i}`)).toBe(
+        "warn",
+      );
+    }
+    expect(dropLog.levelFor("channel_not_allowed", "channel-512")).toBe(
+      "debug",
+    );
+  });
+
+  test("never-promoted reasons do not consume tracking slots", () => {
+    // Otherwise the bot's own echo across many channels could exhaust the cap
+    // and silence the one reason that matters.
+    const dropLog = new AdmissionDropLog();
+    for (let i = 0; i < 600; i++) {
+      dropLog.levelFor("self_authored", `channel-${i}`);
+    }
+    expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+  });
+
+  test("instances do not share state", () => {
+    const first = new AdmissionDropLog();
+    const second = new AdmissionDropLog();
+    expect(first.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+    expect(second.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+  });
+});

--- a/gateway/src/discord/admission-log.test.ts
+++ b/gateway/src/discord/admission-log.test.ts
@@ -22,9 +22,9 @@ const NEVER_PROMOTED: AdmissionDropReason[] = ["self_authored", "bot_authored"];
 
 describe("AdmissionDropLog", () => {
   test("channel_not_allowed warns, because it is the operator-actionable one", () => {
-    // The reason that fires on a misconfigured or unreadable allow-list. Every
-    // gateway stream runs at info, so before this it was written nowhere and a
-    // gate denying every message looked exactly like a gateway receiving none.
+    // Every gateway stream runs at info, so a drop that only logs at debug is
+    // written nowhere and a gate denying every message reads exactly like a
+    // gateway receiving none.
     const dropLog = new AdmissionDropLog();
     expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
   });
@@ -71,7 +71,7 @@ describe("AdmissionDropLog", () => {
 
   test("promotion stops at the cap and degrades to debug", () => {
     // Bounds memory against a guild with a large channel count. Past the cap
-    // the behavior is the old quiet, not unbounded growth.
+    // the reason falls quiet rather than growing without limit.
     const dropLog = new AdmissionDropLog();
     for (let i = 0; i < 512; i++) {
       expect(dropLog.levelFor("channel_not_allowed", `channel-${i}`)).toBe(
@@ -83,14 +83,35 @@ describe("AdmissionDropLog", () => {
     );
   });
 
-  test("never-promoted reasons do not consume tracking slots", () => {
-    // Otherwise the bot's own echo across many channels could exhaust the cap
+  test("never-promoted reasons consume no budget", () => {
+    // Otherwise the bot's own echo across many channels could exhaust a budget
     // and silence the one reason that matters.
     const dropLog = new AdmissionDropLog();
     for (let i = 0; i < 600; i++) {
       dropLog.levelFor("self_authored", `channel-${i}`);
     }
     expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+  });
+
+  test("an unbounded reason cannot starve the operator-actionable one", () => {
+    // `not_a_guild_message` is keyed on a DM channel, which is unique per
+    // sender, so outsiders control its key space. A shared budget would let a
+    // stream of DMs exhaust it and permanently demote `channel_not_allowed`.
+    const dropLog = new AdmissionDropLog();
+    for (let i = 0; i < 5_000; i++) {
+      dropLog.levelFor("not_a_guild_message", `dm-channel-${i}`);
+    }
+    expect(dropLog.levelFor("channel_not_allowed", CHANNEL)).toBe("warn");
+  });
+
+  test("exhausting one reason's budget leaves the others intact", () => {
+    const dropLog = new AdmissionDropLog();
+    for (let i = 0; i < 600; i++) {
+      dropLog.levelFor("bot_not_mentioned", `channel-${i}`);
+    }
+    expect(dropLog.levelFor("bot_not_mentioned", "channel-999")).toBe("debug");
+    expect(dropLog.levelFor("channel_not_allowed", "channel-999")).toBe("warn");
+    expect(dropLog.levelFor("not_a_guild_message", "channel-999")).toBe("info");
   });
 
   test("instances do not share state", () => {

--- a/gateway/src/discord/admission-log.ts
+++ b/gateway/src/discord/admission-log.ts
@@ -1,0 +1,99 @@
+/**
+ * Log-level policy for admission-gate drops.
+ *
+ * Two failure modes pull in opposite directions here.
+ *
+ * Logging every drop at `debug` is what shipped, and it hides the gate
+ * completely: every gateway log stream is built at `level: "info"` (see
+ * `logger.ts`), so a `debug` line is never written to any sink. A gate that
+ * denies every message while emitting nothing is indistinguishable from a
+ * gateway that receives nothing. That is how an empty allow-list read as "no
+ * events ever arrived" during the Jul 30 smoke test, and it produced four
+ * wrong root-cause hypotheses before anyone looked at the stored config.
+ *
+ * Logging every drop at `info` is the opposite problem. The gate denies by
+ * design, and a bot in a community guild sees every message in every channel
+ * it can view. Promoting all of them floods the stream the gate exists to keep
+ * quiet.
+ *
+ * The policy has two parts, because volume and signal are different questions.
+ *
+ * Severity splits by reason ({@link DROP_LOG_SEVERITY}). Not every denial is
+ * worth the same attention: one of them means an operator misconfigured
+ * something, some mean a person aimed a message somewhere policy does not
+ * serve, and the rest are machine traffic the gate exists to swallow.
+ *
+ * Volume is bounded by promoting only the first drop for a given reason and
+ * channel; repeats fall to `debug`. One denied message carries the whole
+ * diagnosis, since the reason names the check that failed and the channel
+ * names where, so nothing is lost by staying quiet afterwards.
+ */
+
+import type { AdmissionDropReason } from "./admit.js";
+
+/** Levels this policy selects between. All three exist on the gateway logger. */
+export type AdmissionDropLogLevel = "warn" | "info" | "debug";
+
+/**
+ * The level a reason logs at on its first occurrence for a channel.
+ *
+ * `channel_not_allowed` is the only operator-actionable denial. It fires when
+ * a channel is missing from the allow-list, when the setting is stored in a
+ * shape the reader cannot use, or when a snowflake is malformed. In every one
+ * of those cases a human meant for the bot to work somewhere and it silently
+ * does not, so it warns.
+ *
+ * `not_a_guild_message` and `bot_not_mentioned` are a person aiming a message
+ * somewhere this client deliberately does not serve, either a DM or a channel
+ * remark that does not address the bot. Neither is a fault, but both prove
+ * events are flowing, which is exactly the evidence the smoke test lacked.
+ *
+ * `self_authored` and `bot_authored` never promote. They are the bot's own
+ * echo and other machines' traffic, they scale with how chatty the room is,
+ * and no operator ever needs to see one. They are also the two whose absence
+ * costs nothing diagnostically: neither can be caused by a misconfiguration.
+ */
+const DROP_LOG_SEVERITY: Record<AdmissionDropReason, AdmissionDropLogLevel> = {
+  channel_not_allowed: "warn",
+  not_a_guild_message: "info",
+  bot_not_mentioned: "info",
+  self_authored: "debug",
+  bot_authored: "debug",
+};
+
+/**
+ * Distinct reason-and-channel pairs tracked before promotion stops.
+ *
+ * Bounds memory against a guild with a large or growing channel count. Past
+ * the cap every drop logs at `debug`, which is the behavior this module
+ * replaces, so exhausting it degrades to the old quiet rather than to
+ * unbounded growth.
+ */
+const MAX_TRACKED_DROPS = 512;
+
+export class AdmissionDropLog {
+  private readonly seen = new Set<string>();
+
+  /**
+   * The level this drop logs at.
+   *
+   * Calling this records the drop, so a promotable reason is promoted once per
+   * channel and every repeat afterwards is `debug`. Reasons that never promote
+   * consume no tracking slot.
+   */
+  levelFor(
+    reason: AdmissionDropReason,
+    channelId: string,
+  ): AdmissionDropLogLevel {
+    const severity = DROP_LOG_SEVERITY[reason];
+    if (severity === "debug") {
+      return "debug";
+    }
+    const key = `${reason}:${channelId}`;
+    if (this.seen.has(key) || this.seen.size >= MAX_TRACKED_DROPS) {
+      return "debug";
+    }
+    this.seen.add(key);
+    return severity;
+  }
+}

--- a/gateway/src/discord/admission-log.ts
+++ b/gateway/src/discord/admission-log.ts
@@ -1,32 +1,26 @@
 /**
  * Log-level policy for admission-gate drops.
  *
- * Two failure modes pull in opposite directions here.
+ * Severity and volume are separate questions, and this module answers them
+ * separately.
  *
- * Logging every drop at `debug` is what shipped, and it hides the gate
- * completely: every gateway log stream is built at `level: "info"` (see
- * `logger.ts`), so a `debug` line is never written to any sink. A gate that
- * denies every message while emitting nothing is indistinguishable from a
- * gateway that receives nothing. That is how an empty allow-list read as "no
- * events ever arrived" during the Jul 30 smoke test, and it produced four
- * wrong root-cause hypotheses before anyone looked at the stored config.
+ * Severity splits by reason ({@link DROP_LOG_SEVERITY}). One denial means an
+ * operator misconfigured something, some mean a person aimed a message
+ * somewhere policy does not serve, and the rest are machine traffic the gate
+ * exists to swallow. Only the first kind is worth an operator's attention.
  *
- * Logging every drop at `info` is the opposite problem. The gate denies by
- * design, and a bot in a community guild sees every message in every channel
- * it can view. Promoting all of them floods the stream the gate exists to keep
- * quiet.
- *
- * The policy has two parts, because volume and signal are different questions.
- *
- * Severity splits by reason ({@link DROP_LOG_SEVERITY}). Not every denial is
- * worth the same attention: one of them means an operator misconfigured
- * something, some mean a person aimed a message somewhere policy does not
- * serve, and the rest are machine traffic the gate exists to swallow.
- *
- * Volume is bounded by promoting only the first drop for a given reason and
- * channel; repeats fall to `debug`. One denied message carries the whole
+ * Volume is capped by promoting only the first drop for a given reason and
+ * channel; repeats log at `debug`. One denied message carries the whole
  * diagnosis, since the reason names the check that failed and the channel
- * names where, so nothing is lost by staying quiet afterwards.
+ * names where, so later identical drops add nothing.
+ *
+ * Both matter because every gateway log stream is built at `level: "info"`
+ * (see `logger.ts`). A `debug` line reaches no sink, so a gate that denies
+ * every message while logging only at `debug` is indistinguishable from a
+ * gateway receiving nothing. A gate that promotes every denial is equally
+ * useless in the other direction: a bot in a community guild sees every
+ * message in every channel it can view, and promoting all of them floods the
+ * stream the gate exists to keep quiet.
  */
 
 import type { AdmissionDropReason } from "./admit.js";
@@ -38,20 +32,18 @@ export type AdmissionDropLogLevel = "warn" | "info" | "debug";
  * The level a reason logs at on its first occurrence for a channel.
  *
  * `channel_not_allowed` is the only operator-actionable denial. It fires when
- * a channel is missing from the allow-list, when the setting is stored in a
- * shape the reader cannot use, or when a snowflake is malformed. In every one
- * of those cases a human meant for the bot to work somewhere and it silently
- * does not, so it warns.
+ * a channel is missing from the allow-list, when the setting holds a shape the
+ * reader cannot use, or when a snowflake is malformed. In each case a human
+ * intends the bot to work somewhere and it silently does not, so it warns.
  *
  * `not_a_guild_message` and `bot_not_mentioned` are a person aiming a message
- * somewhere this client deliberately does not serve, either a DM or a channel
- * remark that does not address the bot. Neither is a fault, but both prove
- * events are flowing, which is exactly the evidence the smoke test lacked.
+ * somewhere this client does not serve, either a DM or a channel remark that
+ * does not address the bot. Neither is a fault, but both are evidence that
+ * events reach the client at all.
  *
  * `self_authored` and `bot_authored` never promote. They are the bot's own
- * echo and other machines' traffic, they scale with how chatty the room is,
- * and no operator ever needs to see one. They are also the two whose absence
- * costs nothing diagnostically: neither can be caused by a misconfiguration.
+ * echo and other machines' traffic, they scale with how chatty a room is, and
+ * no misconfiguration produces them, so a visible line would carry no signal.
  */
 const DROP_LOG_SEVERITY: Record<AdmissionDropReason, AdmissionDropLogLevel> = {
   channel_not_allowed: "warn",
@@ -62,24 +54,27 @@ const DROP_LOG_SEVERITY: Record<AdmissionDropReason, AdmissionDropLogLevel> = {
 };
 
 /**
- * Distinct reason-and-channel pairs tracked before promotion stops.
+ * Channels tracked per reason before that reason stops promoting.
  *
- * Bounds memory against a guild with a large or growing channel count. Past
- * the cap every drop logs at `debug`, which is the behavior this module
- * replaces, so exhausting it degrades to the old quiet rather than to
- * unbounded growth.
+ * The budget is per reason rather than shared because reasons differ in key
+ * cardinality. Guild-channel reasons are bounded by how many channels the bot
+ * can view, but `not_a_guild_message` is keyed on a DM channel, which is
+ * unique per sender and so unbounded by anyone outside the guild. A shared
+ * budget lets a stream of DMs exhaust it and silence `channel_not_allowed`,
+ * the one reason an operator needs. Separate budgets mean a flood of one
+ * reason can only ever silence itself.
  */
-const MAX_TRACKED_DROPS = 512;
+const MAX_TRACKED_CHANNELS_PER_REASON = 512;
 
 export class AdmissionDropLog {
-  private readonly seen = new Set<string>();
+  private readonly seen = new Map<AdmissionDropReason, Set<string>>();
 
   /**
    * The level this drop logs at.
    *
    * Calling this records the drop, so a promotable reason is promoted once per
-   * channel and every repeat afterwards is `debug`. Reasons that never promote
-   * consume no tracking slot.
+   * channel and every repeat is `debug`. Reasons that never promote consume no
+   * budget.
    */
   levelFor(
     reason: AdmissionDropReason,
@@ -89,11 +84,19 @@ export class AdmissionDropLog {
     if (severity === "debug") {
       return "debug";
     }
-    const key = `${reason}:${channelId}`;
-    if (this.seen.has(key) || this.seen.size >= MAX_TRACKED_DROPS) {
+
+    let channels = this.seen.get(reason);
+    if (!channels) {
+      channels = new Set();
+      this.seen.set(reason, channels);
+    }
+    if (
+      channels.has(channelId) ||
+      channels.size >= MAX_TRACKED_CHANNELS_PER_REASON
+    ) {
       return "debug";
     }
-    this.seen.add(key);
+    channels.add(channelId);
     return severity;
   }
 }

--- a/gateway/src/discord/admit.test.ts
+++ b/gateway/src/discord/admit.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 
 import {
   admitDiscordMessage,
-  parseAllowedChannelIds,
   type AdmissionCandidate,
   type AdmissionPolicy,
 } from "./admit.js";
@@ -168,23 +167,7 @@ describe("admitDiscordMessage", () => {
   });
 });
 
-describe("parseAllowedChannelIds", () => {
-  test("parses a comma-separated list, trimming entries", () => {
-    expect(
-      parseAllowedChannelIds(` ${ALLOWED_CHANNEL} , ${OTHER_CHANNEL} `),
-    ).toEqual(new Set([ALLOWED_CHANNEL, OTHER_CHANNEL]));
-  });
-
-  test("yields an empty set for undefined, blank, and comma-only values", () => {
-    expect(parseAllowedChannelIds(undefined)).toEqual(new Set());
-    expect(parseAllowedChannelIds("")).toEqual(new Set());
-    expect(parseAllowedChannelIds("   ")).toEqual(new Set());
-    expect(parseAllowedChannelIds(",,")).toEqual(new Set());
-  });
-
-  test("drops blanks rather than admitting an empty-string channel", () => {
-    expect(parseAllowedChannelIds(`${ALLOWED_CHANNEL},,`)).toEqual(
-      new Set([ALLOWED_CHANNEL]),
-    );
-  });
-});
+// Allow-list parsing moved to `ConfigFileCache.getStringArray` (shape) and
+// `allowed-channels.ts` (the read). Its cases now live in
+// `config-file-cache.test.ts` and `allowed-channels.test.ts`, where they run
+// against a real config file rather than a hand-built string.

--- a/gateway/src/discord/admit.test.ts
+++ b/gateway/src/discord/admit.test.ts
@@ -166,8 +166,3 @@ describe("admitDiscordMessage", () => {
     expect(verdict).toEqual({ admitted: false, reason: "channel_not_allowed" });
   });
 });
-
-// Allow-list parsing moved to `ConfigFileCache.getStringArray` (shape) and
-// `allowed-channels.ts` (the read). Its cases now live in
-// `config-file-cache.test.ts` and `allowed-channels.test.ts`, where they run
-// against a real config file rather than a hand-built string.

--- a/gateway/src/discord/admit.ts
+++ b/gateway/src/discord/admit.ts
@@ -126,20 +126,3 @@ export function admitDiscordMessage(
 
   return ADMITTED;
 }
-
-/**
- * Parse an allow-list from its stored form — a comma-separated list of channel
- * snowflakes. Blank entries are dropped, so a trailing comma or an empty
- * setting yields an empty set, which admits nothing.
- */
-export function parseAllowedChannelIds(raw: string | undefined): Set<string> {
-  if (!raw) {
-    return new Set();
-  }
-  return new Set(
-    raw
-      .split(",")
-      .map((entry) => entry.trim())
-      .filter((entry) => entry.length > 0),
-  );
-}

--- a/gateway/src/discord/allowed-channels.test.ts
+++ b/gateway/src/discord/allowed-channels.test.ts
@@ -8,12 +8,11 @@ import { admitDiscordMessage, type AdmissionCandidate } from "./admit.js";
 import { readDiscordAllowedChannelIds } from "./allowed-channels.js";
 
 /**
- * These cases run the whole seam that was uncovered: a real `config.json` on
- * disk, through `ConfigFileCache`, into the set the admission gate receives,
- * to a verdict. The gate and the config reader were each unit-tested in
- * isolation and both were correct. The defect lived entirely in the join
- * between them, so a test that hands the gate a hand-built `Set` cannot see
- * it.
+ * These cases cover the full path from a real `config.json` on disk, through
+ * `ConfigFileCache`, into the set the admission gate receives, to a verdict.
+ * The gate and the config reader are each correct in isolation, so a test that
+ * hands the gate a hand-built `Set` cannot tell whether the stored value
+ * actually reaches it in the shape it expects. Only an on-disk config can.
  */
 
 const configPath = join(testWorkspaceDir, "config.json");
@@ -28,7 +27,7 @@ function writeConfig(data: Record<string, unknown>): void {
   writeFileSync(configPath, JSON.stringify(data));
 }
 
-/** The Jul 30 smoke-test message: a human mentioning the bot in the channel. */
+/** A message that would be admitted: a human mentioning the bot in-channel. */
 function candidate(over: Partial<AdmissionCandidate> = {}): AdmissionCandidate {
   return {
     channelId: CHANNEL,
@@ -50,7 +49,9 @@ function admitWithStoredConfig(over: Partial<AdmissionCandidate> = {}) {
 
 afterEach(() => {
   try {
-    if (existsSync(configPath)) unlinkSync(configPath);
+    if (existsSync(configPath)) {
+      unlinkSync(configPath);
+    }
   } catch {
     // best-effort
   }
@@ -58,9 +59,9 @@ afterEach(() => {
 
 describe("readDiscordAllowedChannelIds", () => {
   test("admits a mention when the allow-list is stored as a JSON array", () => {
-    // The regression. This is the exact shape in the live workspace config on
-    // Jul 30, and it read as an empty allow-list, so every message in the
-    // channel was denied while the log showed nothing at all.
+    // A JSON array is the natural way to author a list by hand, and the only
+    // safe way to author a snowflake, so it is the shape most likely to be on
+    // disk.
     writeConfig({ discord: { allowedChannelIds: [CHANNEL] } });
     expect(admitWithStoredConfig()).toEqual({ admitted: true });
   });
@@ -88,7 +89,8 @@ describe("readDiscordAllowedChannelIds", () => {
   });
 
   test("a channel outside the stored array is still denied", () => {
-    // The fix widens which shapes are readable, not which rooms are admitted.
+    // Accepting more shapes widens which values are readable, not which rooms
+    // are admitted.
     writeConfig({ discord: { allowedChannelIds: [OTHER_CHANNEL] } });
     expect(admitWithStoredConfig()).toEqual({
       admitted: false,

--- a/gateway/src/discord/allowed-channels.test.ts
+++ b/gateway/src/discord/allowed-channels.test.ts
@@ -1,0 +1,154 @@
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { ConfigFileCache } from "../config-file-cache.js";
+import { testWorkspaceDir } from "../__tests__/test-preload.js";
+import { admitDiscordMessage, type AdmissionCandidate } from "./admit.js";
+import { readDiscordAllowedChannelIds } from "./allowed-channels.js";
+
+/**
+ * These cases run the whole seam that was uncovered: a real `config.json` on
+ * disk, through `ConfigFileCache`, into the set the admission gate receives,
+ * to a verdict. The gate and the config reader were each unit-tested in
+ * isolation and both were correct. The defect lived entirely in the join
+ * between them, so a test that hands the gate a hand-built `Set` cannot see
+ * it.
+ */
+
+const configPath = join(testWorkspaceDir, "config.json");
+
+const BOT = "900000000000000001";
+const HUMAN = "900000000000000002";
+const CHANNEL = "1532468750740357331";
+const OTHER_CHANNEL = "800000000000000002";
+const GUILD = "670819210053681162";
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(configPath, JSON.stringify(data));
+}
+
+/** The Jul 30 smoke-test message: a human mentioning the bot in the channel. */
+function candidate(over: Partial<AdmissionCandidate> = {}): AdmissionCandidate {
+  return {
+    channelId: CHANNEL,
+    guildId: GUILD,
+    authorId: HUMAN,
+    mentionedUserIds: [BOT],
+    ...over,
+  };
+}
+
+/** Read the allow-list the way the client does, then run the gate. */
+function admitWithStoredConfig(over: Partial<AdmissionCandidate> = {}) {
+  const cache = new ConfigFileCache({ ttlMs: 0 });
+  return admitDiscordMessage(candidate(over), {
+    botUserId: BOT,
+    allowedChannelIds: readDiscordAllowedChannelIds(cache),
+  });
+}
+
+afterEach(() => {
+  try {
+    if (existsSync(configPath)) unlinkSync(configPath);
+  } catch {
+    // best-effort
+  }
+});
+
+describe("readDiscordAllowedChannelIds", () => {
+  test("admits a mention when the allow-list is stored as a JSON array", () => {
+    // The regression. This is the exact shape in the live workspace config on
+    // Jul 30, and it read as an empty allow-list, so every message in the
+    // channel was denied while the log showed nothing at all.
+    writeConfig({ discord: { allowedChannelIds: [CHANNEL] } });
+    expect(admitWithStoredConfig()).toEqual({ admitted: true });
+  });
+
+  test("admits a mention when the allow-list is stored as a CSV string", () => {
+    writeConfig({ discord: { allowedChannelIds: CHANNEL } });
+    expect(admitWithStoredConfig()).toEqual({ admitted: true });
+  });
+
+  test("both shapes yield the same set for multiple channels", () => {
+    writeConfig({ discord: { allowedChannelIds: [CHANNEL, OTHER_CHANNEL] } });
+    const fromArray = readDiscordAllowedChannelIds(
+      new ConfigFileCache({ ttlMs: 0 }),
+    );
+
+    writeConfig({
+      discord: { allowedChannelIds: `${CHANNEL}, ${OTHER_CHANNEL}` },
+    });
+    const fromCsv = readDiscordAllowedChannelIds(
+      new ConfigFileCache({ ttlMs: 0 }),
+    );
+
+    expect(fromArray).toEqual(new Set([CHANNEL, OTHER_CHANNEL]));
+    expect(fromCsv).toEqual(fromArray);
+  });
+
+  test("a channel outside the stored array is still denied", () => {
+    // The fix widens which shapes are readable, not which rooms are admitted.
+    writeConfig({ discord: { allowedChannelIds: [OTHER_CHANNEL] } });
+    expect(admitWithStoredConfig()).toEqual({
+      admitted: false,
+      reason: "channel_not_allowed",
+    });
+  });
+
+  test("a thread inherits a parent listed in the stored array", () => {
+    writeConfig({ discord: { allowedChannelIds: [CHANNEL] } });
+    expect(
+      admitWithStoredConfig({
+        channelId: "800000000000000099",
+        parentChannelId: CHANNEL,
+      }),
+    ).toEqual({ admitted: true });
+  });
+
+  test("an absent discord section admits nothing", () => {
+    // Fail-closed stays fail-closed: an unconfigured list must not read as
+    // "every channel the bot can see".
+    writeConfig({});
+    expect(
+      readDiscordAllowedChannelIds(new ConfigFileCache({ ttlMs: 0 })),
+    ).toEqual(new Set());
+    expect(admitWithStoredConfig()).toEqual({
+      admitted: false,
+      reason: "channel_not_allowed",
+    });
+  });
+
+  test("an empty array admits nothing", () => {
+    writeConfig({ discord: { allowedChannelIds: [] } });
+    expect(admitWithStoredConfig()).toEqual({
+      admitted: false,
+      reason: "channel_not_allowed",
+    });
+  });
+
+  test("a truncated bare-integer snowflake is dropped, not coerced", () => {
+    // `assistant config set` truncates bare integers above 2^53 (LUM-2939), so
+    // by the time the value lands here the id is already wrong. Coercing it
+    // would admit a channel nobody listed; dropping it denies and keeps the
+    // misconfiguration visible.
+    writeConfig({ discord: { allowedChannelIds: [1532468750740357331] } });
+    expect(admitWithStoredConfig()).toEqual({
+      admitted: false,
+      reason: "channel_not_allowed",
+    });
+  });
+
+  test("reads live so an allow-list edit applies without a restart", () => {
+    // The client reads per message precisely so a config edit does not cost an
+    // IDENTIFY. If the read were hoisted, this is the case that would break.
+    writeConfig({ discord: { allowedChannelIds: [OTHER_CHANNEL] } });
+    const cache = new ConfigFileCache({ ttlMs: 0 });
+    expect(readDiscordAllowedChannelIds(cache)).toEqual(
+      new Set([OTHER_CHANNEL]),
+    );
+
+    writeConfig({ discord: { allowedChannelIds: [CHANNEL] } });
+    expect(readDiscordAllowedChannelIds(cache)).toEqual(new Set([CHANNEL]));
+  });
+});

--- a/gateway/src/discord/allowed-channels.ts
+++ b/gateway/src/discord/allowed-channels.ts
@@ -1,0 +1,34 @@
+/**
+ * The admitted-channel allow-list, read from `config.json`.
+ *
+ * This lives in its own module rather than inline at the construction site so
+ * the config read is reachable from a test. The seam between the stored value
+ * and the set handed to the admission gate is exactly where an array-shaped
+ * allow-list collapsed to empty, and an arrow function buried in the server
+ * bootstrap cannot be exercised by anything.
+ *
+ * It stays out of `admit.ts` because that module is a pure function over the
+ * fields it reads. Reading configuration is I/O, and mixing the two is what
+ * left the gate fully unit-tested while the value feeding it was never
+ * exercised at all.
+ */
+
+import type { ConfigFileCache } from "../config-file-cache.js";
+
+/**
+ * Read the channel snowflakes the bot may act in.
+ *
+ * Accepts both shapes the setting is authored in (a JSON array or a
+ * comma-separated string) because {@link ConfigFileCache.getStringArray}
+ * normalizes them. An absent, malformed, or empty setting yields an empty set,
+ * which the gate treats as admitting nothing. That is deliberate: being
+ * invited to a guild is not consent to every channel in it, so the fail-closed
+ * direction is the safe one.
+ */
+export function readDiscordAllowedChannelIds(
+  configFileCache: ConfigFileCache,
+): Set<string> {
+  return new Set(
+    configFileCache.getStringArray("discord", "allowedChannelIds") ?? [],
+  );
+}

--- a/gateway/src/discord/allowed-channels.ts
+++ b/gateway/src/discord/allowed-channels.ts
@@ -1,16 +1,10 @@
 /**
  * The admitted-channel allow-list, read from `config.json`.
  *
- * This lives in its own module rather than inline at the construction site so
- * the config read is reachable from a test. The seam between the stored value
- * and the set handed to the admission gate is exactly where an array-shaped
- * allow-list collapsed to empty, and an arrow function buried in the server
- * bootstrap cannot be exercised by anything.
- *
- * It stays out of `admit.ts` because that module is a pure function over the
- * fields it reads. Reading configuration is I/O, and mixing the two is what
- * left the gate fully unit-tested while the value feeding it was never
- * exercised at all.
+ * This is a named module rather than an inline read at the construction site
+ * so the config-to-set conversion is reachable from a test. It stays out of
+ * `admit.ts` because that module is a pure function over the fields it reads,
+ * and reading configuration is I/O.
  */
 
 import type { ConfigFileCache } from "../config-file-cache.js";
@@ -21,9 +15,9 @@ import type { ConfigFileCache } from "../config-file-cache.js";
  * Accepts both shapes the setting is authored in (a JSON array or a
  * comma-separated string) because {@link ConfigFileCache.getStringArray}
  * normalizes them. An absent, malformed, or empty setting yields an empty set,
- * which the gate treats as admitting nothing. That is deliberate: being
- * invited to a guild is not consent to every channel in it, so the fail-closed
- * direction is the safe one.
+ * which the gate treats as admitting nothing. Being invited to a guild is not
+ * consent to every channel in it, so the fail-closed direction is the safe
+ * one.
  */
 export function readDiscordAllowedChannelIds(
   configFileCache: ConfigFileCache,

--- a/gateway/src/discord/gateway-socket.ts
+++ b/gateway/src/discord/gateway-socket.ts
@@ -27,6 +27,7 @@ import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { DiscordInboundEvent } from "../channels/inbound-event.js";
 import { admitDiscordMessage } from "./admit.js";
+import { AdmissionDropLog } from "./admission-log.js";
 import { ReconnectBackoff, SESSION_STABLE_AFTER_MS } from "./backoff.js";
 import {
   RESUMABLE_CLOSE_CODE,
@@ -137,6 +138,7 @@ export class DiscordGatewayClient {
   private readonly heartbeat: HeartbeatMonitor;
   private readonly backoff: ReconnectBackoff;
   private readonly threadParents = new ThreadParentCache();
+  private readonly admissionDropLog = new AdmissionDropLog();
 
   private sessionState: DiscordSessionState | null = null;
   private ws: GatewaySocketLike | null = null;
@@ -654,14 +656,34 @@ export class DiscordGatewayClient {
       allowedChannelIds: this.readAllowedChannelIds(),
     });
     if (!verdict.admitted) {
-      log.debug(
-        {
-          reason: verdict.reason,
-          channelId: message.channel_id,
-          messageId: message.id,
-        },
-        "Discord message dropped by admission gate",
+      const fields = {
+        reason: verdict.reason,
+        channelId: message.channel_id,
+        messageId: message.id,
+      };
+      // Severity splits by reason and volume is capped at the first drop per
+      // reason and channel. See `admission-log.ts` for why a single level
+      // cannot serve both a misconfigured allow-list and a busy guild.
+      const level = this.admissionDropLog.levelFor(
+        verdict.reason,
+        message.channel_id,
       );
+      if (level === "warn") {
+        log.warn(
+          fields,
+          "Discord message dropped: the channel is not on the allow-list. " +
+            "Check `discord.allowedChannelIds` in config.json. Further " +
+            "drops for this channel log at debug.",
+        );
+      } else if (level === "info") {
+        log.info(
+          fields,
+          "Discord message dropped by admission gate. Further drops for " +
+            "this reason and channel log at debug.",
+        );
+      } else {
+        log.debug(fields, "Discord message dropped by admission gate");
+      }
       return;
     }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -174,7 +174,7 @@ import {
 import { downloadSlackFile } from "./slack/download.js";
 import { slackBotContactNote } from "./slack/actor.js";
 import { DiscordGatewayClient } from "./discord/gateway-socket.js";
-import { parseAllowedChannelIds } from "./discord/admit.js";
+import { readDiscordAllowedChannelIds } from "./discord/allowed-channels.js";
 import { handleInbound } from "./handlers/handle-inbound.js";
 import { upsertContactChannel } from "./verification/contact-helpers.js";
 import { checkAuthRateLimit } from "./http/middleware/rate-limit.js";
@@ -2552,9 +2552,7 @@ async function main() {
         // Read live (the config cache is TTL'd) so an allow-list edit applies
         // without a client restart, which would spend an IDENTIFY.
         readAllowedChannelIds: () =>
-          parseAllowedChannelIds(
-            configFileCache.getString("discord", "allowedChannelIds"),
-          ),
+          readDiscordAllowedChannelIds(configFileCache),
       },
       (event) => {
         // Reset the platform idle-sleep timer — inbound Discord activity


### PR DESCRIPTION
## TL;DR

Completes slice 2 of the read-only Discord Gateway client so inbound messages can be smoke-tested locally. Two changes: a typed array getter on `ConfigFileCache`, and an admission-drop log that is actually written to a sink.

Discord is not broken here, it is unfinished. This is not a regression fix and not a path to GA. Discord stays credential-gated and out of `BASE_AVAILABLE_CHANNELS`.

Investigation this builds on: [LUM-2841 comment](https://linear.app/vellum/issue/LUM-2841).

## What changes for the user

| Before | After |
|---|---|
| `discord.allowedChannelIds` stored as a JSON array read back as unset, so every message in the channel was denied | Both `["123"]` and `"123,456"` read correctly |
| A denied message produced no log line at any level, anywhere | A channel that is not on the allow-list warns once, naming the setting to check |
| A busy guild would flood the log if drops were simply promoted | Volume capped at the first drop per reason and channel |
| No coverage between the stored config value and the admission gate | The seam is tested from a real `config.json` through to a verdict |

## 1. `ConfigFileCache.getStringArray()`

`ConfigFileCache` exposed `getString` / `getNumber` / `getBoolean` / `getRecord` and no array getter, so a list-valued setting could not be read correctly through this surface at all. `getString` returns `undefined` for an array, so an array-shaped list silently collapsed to nothing.

`getStringArray()` accepts a JSON array of strings or a comma-separated string, and `discord.allowedChannelIds` now reads through it.

**Why a typed getter rather than a patch at the one call site:** the natural JSON shape for a list is exactly the shape the surface could not read, so the trap was armed for the next list setting. It also interlocks with LUM-2939 (`assistant config set` truncating bare integers above 2^53): the documented workaround there is `--json '[\"<id>\"]'`, which produces precisely the unreadable shape. LUM-2939 is context, not scope, and is not fixed here.

Non-string array entries are dropped rather than coerced. A snowflake authored as a bare JSON integer has already lost precision by the time it lands, so stringifying it would resurrect a corrupted id that still looks well-formed and would point at a channel nobody listed.

`parseAllowedChannelIds` is folded into the new getter plus a small `allowed-channels.ts`, so shape handling lives in one place and the config read is reachable from a test. It stays out of `admit.ts`, which is a pure function over the fields it reads.

## 2. Admission-drop log visibility

The drop after `admitDiscordMessage` logged at `debug`, and every gateway log stream is built at `level: "info"` ([logger.ts](gateway/src/logger.ts)). A denied message was written to no sink. That single level is why a one-line config problem read as "no events ever arrived" and produced four wrong root-cause hypotheses.

**Severity splits by reason,** because not every denial deserves the same attention:

| Reason | Level | Why |
|---|---|---|
| `channel_not_allowed` | `warn` | The only operator-actionable denial. Fires on a missing entry, an unreadable shape, or a malformed snowflake. A human meant for the bot to work somewhere and it silently does not. |
| `not_a_guild_message` | `info` | A person aimed a DM somewhere this client deliberately does not serve. Not a fault, but proves events are flowing. |
| `bot_not_mentioned` | `info` | Same. This is the evidence the smoke test lacked. |
| `self_authored` | `debug` | The bot's own echo. Scales with how much the bot says, and no misconfiguration can cause it. |
| `bot_authored` | `debug` | Other machines' traffic. Same reasoning. |

**Volume is capped separately from severity:** only the first drop for a given reason and channel is promoted, and repeats fall to `debug`. One denied message carries the whole diagnosis, since the reason names the check that failed and the channel names where. A flat promotion would have flooded the stream the gate exists to keep quiet, which is worse than the disease in a community guild. Tracking is bounded at 512 pairs; past the cap everything degrades to the old quiet rather than growing without limit. Reasons that never promote consume no slot, so the bot's own echo across many channels cannot exhaust the cap and silence the reason that matters.

## Why this is safe

- No behavior change to which messages are admitted. The allow-list fix widens which *shapes are readable*, not which rooms are admitted, and there is a test pinning that.
- Fail-closed is preserved: an absent, empty, or malformed allow-list yields an empty set, which admits nothing. Being invited to a guild is still not consent to every channel in it.
- The 1s TTL cache is unchanged, so an allow-list edit still applies without a gateway restart and without spending an IDENTIFY.
- Read-only stands. No send path, no `replyCallbackUrl`.
- `getStringArray` is additive; no existing getter changed.

## Tests

- `config-file-cache.test.ts`: both shapes, trimming, blank entries, non-string entries, empty array, comma-only, non-list shapes, missing section/field, `force`.
- `allowed-channels.test.ts`: the seam end to end, from a real `config.json` through `ConfigFileCache` to an admission verdict. Array form and CSV form both admit; thread parent inheritance; the truncated-snowflake case; and the invariant that an unset allow-list admits nothing.
- `admission-log.test.ts`: the severity map, first-occurrence promotion, per-channel and per-reason re-promotion, the cap, and that never-promoted reasons consume no slot.
- `admission-log-visibility.test.ts`: drives a real `MESSAGE_CREATE` through the client with a live gateway logger and reads the JSONL sidecar back off disk. A spy would happily record a line no configured stream writes, so this asserts the record actually survives the stream level.

Full gateway suite run per-file. 5 pre-existing failures (`ipc-*`, `credential-watcher-managed-bootstrap`) are unrelated IPC socket issues, verified identical on a clean stash.

## Out of scope, deliberately

The send/reply path, the tool-facing provider adapter, `BASE_AVAILABLE_CHANNELS`, a `CHANNEL_METADATA.discord` entry (dead code until there is a surface to feed, and it would encode unwritten product copy), and any change to the trust floor. Verified untouched.

## Deferred

The `trusted_contacts` floor still applies downstream and is reported, not changed, in a [comment on LUM-2841](https://linear.app/vellum/issue/LUM-2841). Follow-ups filed separately rather than folded in: documenting `discord.allowedChannelIds` in the setup skill, and a startup warning for config keys holding an unreadable type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->