### PR TITLE
perf(watcher): stop payload bounding from re-walking the whole payload

### DIFF
--- a/assistant/src/watcher/__tests__/payload-bounds.test.ts
+++ b/assistant/src/watcher/__tests__/payload-bounds.test.ts
@@ -127,8 +127,8 @@ describe("capPayloadForStorage", () => {
   test("the ceiling holds for a payload with no long string to trim", () => {
     // Numbers are individually tiny, so a wide, deep tree of them is bounded by
     // neither the text cap nor the field caps. Branching stays narrow: the tree
-    // only has to clear the row ceiling, and 12-way branching at this depth
-    // builds 88MB of JSON, which is a slow way to prove the same thing.
+    // only has to clear the row ceiling, which a 4-way tree at this depth does
+    // several times over.
     const build = (depth: number): unknown => {
       if (depth === 0) {
         return Array.from({ length: 40 }, (_, i) => i * 1_234_567);

--- a/assistant/src/watcher/__tests__/payload-bounds.test.ts
+++ b/assistant/src/watcher/__tests__/payload-bounds.test.ts
@@ -126,21 +126,26 @@ describe("capPayloadForStorage", () => {
 
   test("the ceiling holds for a payload with no long string to trim", () => {
     // Numbers are individually tiny, so a wide, deep tree of them is bounded by
-    // neither the text cap nor the field caps.
+    // neither the text cap nor the field caps. Branching stays narrow: the tree
+    // only has to clear the row ceiling, and 12-way branching at this depth
+    // builds 88MB of JSON, which is a slow way to prove the same thing.
     const build = (depth: number): unknown => {
       if (depth === 0) {
         return Array.from({ length: 40 }, (_, i) => i * 1_234_567);
       }
       const out: Record<string, unknown> = {};
-      for (let i = 0; i < 12; i++) {
+      for (let i = 0; i < 4; i++) {
         out[`n${i}`] = build(depth - 1);
       }
       return out;
     };
 
-    const stored = JSON.stringify(
-      capPayloadForStorage(build(5) as Record<string, unknown>),
+    const tree = build(5) as Record<string, unknown>;
+    expect(JSON.stringify(tree).length).toBeGreaterThan(
+      WATCHER_PAYLOAD_ROW_MAX_CHARS,
     );
+
+    const stored = JSON.stringify(capPayloadForStorage(tree));
 
     expect(stored.length).toBeLessThanOrEqual(WATCHER_PAYLOAD_ROW_MAX_CHARS);
   });

--- a/assistant/src/watcher/payload-bounds.ts
+++ b/assistant/src/watcher/payload-bounds.ts
@@ -193,12 +193,16 @@ const KEY_DISAMBIGUATOR = "~";
  * what the model actually reads, and an escape costs what it costs.
  */
 function prefixWithinLimit(text: string, limit: number): string {
-  if (JSON.stringify(text).length <= limit) {
+  // Both bounds here lean on escaping never shrinking a string: its serialized
+  // form is at least the text plus two quotes. So text already past the limit
+  // needs no measuring, and no prefix longer than the limit can fit either.
+  // Searching the whole text instead costs a stringify of it on every step.
+  if (text.length + 2 <= limit && JSON.stringify(text).length <= limit) {
     return text;
   }
 
   let low = 0;
-  let high = text.length;
+  let high = Math.min(text.length, limit);
   while (low < high) {
     const mid = Math.ceil((low + high) / 2);
     if (JSON.stringify(truncate(text, mid)).length <= limit) {
@@ -275,7 +279,7 @@ function shareBudget(costs: readonly number[], budget: number): number[] {
  */
 function renderEntry(
   key: string,
-  raw: unknown,
+  text: string,
   serialized: string,
   allowance: number,
   taken: Set<string>,
@@ -299,7 +303,7 @@ function renderEntry(
   const value =
     serialized.length <= valueLimit
       ? serialized
-      : serializeWithinLimit(stringify(raw), valueLimit);
+      : serializeWithinLimit(text, valueLimit);
   return `${uniqueKeyJson}:${value}`;
 }
 
@@ -360,7 +364,7 @@ export function capPayloadForRender(
   // escape walk below and fail the same pending row on every tick.
   const bounded = capRecord(parsed, 0);
 
-  const entries: Array<{ key: string; serialized: string; raw: unknown }> = [];
+  const entries: Array<{ key: string; serialized: string; text: string }> = [];
   for (const [rawKey, value] of Object.entries(bounded)) {
     // Keys are provider-authored in practice, but this payload was parsed back
     // out of the database, so treat them with the same suspicion as values.
@@ -368,10 +372,14 @@ export function capPayloadForRender(
       escapeContentBoundaries(rawKey),
       WATCHER_PAYLOAD_KEY_MAX_CHARS,
     );
+    // Escape once: the serialized form is what is measured, and the escaped
+    // text is what a truncated value is cut from.
+    const escaped = escapeStrings(value);
+    const serialized = JSON.stringify(escaped);
     entries.push({
       key,
-      serialized: JSON.stringify(escapeStrings(value)),
-      raw: value,
+      serialized,
+      text: typeof escaped === "string" ? escaped : serialized,
     });
   }
 
@@ -399,7 +407,7 @@ export function capPayloadForRender(
   const parts = kept.map((entry, index) =>
     renderEntry(
       entry.key,
-      entry.raw,
+      entry.text,
       entry.serialized,
       allowances[index] ?? 0,
       taken,
@@ -414,12 +422,6 @@ export function capPayloadForRender(
   // budget is derived from this ceiling, so enforce it rather than trust it.
   // Reaching it costs parseability, which is what the tests assert on.
   return truncate(`{${parts.join(",")}}`, budget);
-}
-
-/** Serialize a value to the text used when it has to be truncated. */
-function stringify(value: unknown): string {
-  const escaped = escapeStrings(value);
-  return typeof escaped === "string" ? escaped : JSON.stringify(escaped);
 }
 
 /** Escape fence-boundary sequences in every string within a value. */


### PR DESCRIPTION
## Why

`src/watcher/__tests__/payload-bounds.test.ts > capPayloadForStorage > the ceiling holds for a payload with no long string to trim` times out at 5s on CI (observed 7509ms). It passes locally in ~1.1s, so it sits right on the edge and fails whenever the runner is loaded.

Two things are wrong, and both are worth fixing.

## The cap does redundant work

The test hands `capPayloadForStorage` an 88MB tree. Profiling that input:

| | before | after |
|---|---|---|
| `capPayloadForStorage` | 1087ms | 603ms |

- `prefixWithinLimit` binary-searched over the *entire* text — `high = text.length` — stringifying megabytes on the first few steps. JSON escaping never shrinks a string, so no prefix longer than `limit` can ever fit inside it: `high = Math.min(text.length, limit)`. The same fact makes the early `JSON.stringify(text)` check skippable when `text.length + 2 > limit`.
- `renderEntry` called `stringify(raw)`, re-escaping and re-serializing a value that `capPayloadForRender` had *already* escaped and serialized in order to measure it. Escape once in the caller and pass the text down. `stringify` had no other caller, so it goes.

Output is byte-identical on the profiled input (60,555 chars both ways), and all 18 tests in the file still pass unchanged.

## The test is 1000x larger than its claim

The test only has to clear the 64,000-character row ceiling with a payload containing no long strings. It did that with 12-way branching at depth 5 — 88MB of JSON. Narrowed to 4-way: ~360KB, still ~5x over the ceiling, still a wide-and-deep all-numbers tree. It now also asserts the payload genuinely exceeds the ceiling, so shrinking it can't quietly stop testing anything.

Whole file: **1.54s → 0.20s**.

## Test plan

- `bun test src/watcher/__tests__/payload-bounds.test.ts` — 18 pass, 0 fail, 0.20s
- `bun test src/__tests__/google-calendar-watcher.test.ts` — 8 pass
- `bun test src/watcher/` — same 2 pre-existing failures as `main` (`engine.test.ts` / `engine-auth-notify.test.ts` `mock.module` interference when the whole directory runs in one bun process; verified identical before and after this change)
- `bunx tsc --noEmit`, `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sqqDSwAVxCXG2ygGuG1qg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->