### PR TITLE
fix(workspace): convert vellum-default installs and re-enabled stubs in the BYOK profile ensure pass

### DIFF
--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -985,6 +985,58 @@ describe("ensureByokDefaultProfiles", () => {
     expectSecondRunNoop();
   });
 
+  test("a copy for an endpoint-supplied provider is kept even when body-identical to the template", () => {
+    // Legacy onboarding wrote copies for providers outside
+    // DEFAULT_PROVIDER_CHOICES; their connection can carry a base URL the
+    // bare key cannot recover, so they must never retire.
+    const body = hatchBody("balanced", "anthropic") as Record<string, unknown>;
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        profiles: {
+          "custom-balanced": {
+            ...body,
+            provider: "openai-compatible",
+            provider_connection: "openai-compatible-personal",
+          },
+        },
+      },
+    });
+    const before = readFileSync(configPath(), "utf-8");
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("a copy disable wins over a re-enabled hatch stub on the same key", () => {
+    // Contradictory overlays: the stub arm deletes the re-enabled stub, so
+    // the disable carried off the copy (the rail dispatch actually used)
+    // lands on the bare key.
+    const config = uneditedByokConfig();
+    const profileMap = (config.llm as Record<string, unknown>)
+      .profiles as Record<string, Record<string, unknown>>;
+    profileMap["quality-optimized"] = {
+      source: "managed",
+      status: "active",
+      label: "Quality (Managed)",
+    };
+    profileMap["custom-quality-optimized"] = {
+      ...profileMap["custom-quality-optimized"],
+      status: "disabled",
+    };
+    writeConfig(config);
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-quality-optimized"]).toBeUndefined();
+    expect(profiles()["quality-optimized"]).toEqual({
+      source: "managed",
+      status: "disabled",
+    });
+    expectSecondRunNoop();
+  });
+
   test("a copy pointing at a non-conventional connection is kept", () => {
     // Any connection reference other than `<provider>-personal`, the bare
     // provider name, or absence could be an explicit selection among several

--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -537,10 +537,8 @@ describe("ensureByokDefaultProfiles", () => {
   });
 
   test("a re-enabled hatch stub is deleted", () => {
-    // The status toggle is the only writable field on a managed stub; the
-    // enable only meant something while the stub-vs-active split existed,
-    // and the bare key resolves active post-conversion, so deletion
-    // preserves the user's intent while dropping the stale suffixed label.
+    // The bare key resolves active post-conversion, so deleting the
+    // re-enabled stub preserves the enable.
     writeConfig({
       llm: {
         defaultProvider: { provider: "anthropic" },
@@ -822,12 +820,9 @@ describe("ensureByokDefaultProfiles", () => {
 
   test("a real vellum-default workspace with re-enabled stubs and mixed connection stamps converts (specimen shape)", () => {
     // Mirrors a live 2026-07 workspace: hatched BYOK anthropic, later
-    // platform-connected (vellum default), all three hatch stubs re-enabled
-    // through the UI (status "active", two carrying the migration-097
-    // thinking stamp), the onboarding-authored copy stamped with the bare
-    // "anthropic" connection while the seeded copies carry
-    // "anthropic-personal", an unrelated managed os-beta overlay, and call
-    // sites pinned at custom-balanced.
+    // platform-connected, stubs re-enabled through the UI, the
+    // onboarding-authored copy stamped with the bare "anthropic" connection,
+    // and call sites pinned at custom-balanced.
     writeConfig({
       llm: {
         defaultProvider: { provider: "vellum", connectionName: "vellum" },
@@ -943,10 +938,8 @@ describe("ensureByokDefaultProfiles", () => {
   });
 
   test("a custom copy for a different BYOK provider than the current default is kept", () => {
-    // A copy the user re-provisioned to another provider (standard model,
-    // template tuning) is indistinguishable from a hatch copy for that
-    // provider, so on a BYOK default only copies matching the default
-    // provider are positively hatch-written.
+    // A re-provisioned copy is indistinguishable from a hatch copy for that
+    // provider, so only copies matching the default provider convert.
     writeConfig({
       llm: {
         defaultProvider: { provider: "openai" },
@@ -963,8 +956,8 @@ describe("ensureByokDefaultProfiles", () => {
   });
 
   test("a vellum default keeps a singleton copy (incomplete set is not hatch provenance)", () => {
-    // With two copies deleted through the profile routes, a lone surviving
-    // copy is trivially uniform; the complete-set requirement keeps it.
+    // A lone surviving copy is trivially uniform; the complete-set
+    // requirement keeps it.
     const config = uneditedByokConfig();
     const llmConfig = config.llm as Record<string, unknown>;
     llmConfig.defaultProvider = { provider: "vellum" };
@@ -986,9 +979,8 @@ describe("ensureByokDefaultProfiles", () => {
   });
 
   test("a vellum default keeps all copies when one was re-provisioned to another provider", () => {
-    // Provider uniformity across the set is the hatch-provenance signal on
-    // a vellum default; a re-provisioned copy breaks it and conservatively
-    // keeps the whole set. The stubs still delete.
+    // A re-provisioned copy breaks provider uniformity and keeps the whole
+    // set; the stubs still delete.
     const config = uneditedByokConfig();
     const llmConfig = config.llm as Record<string, unknown>;
     llmConfig.defaultProvider = { provider: "vellum" };
@@ -1012,9 +1004,7 @@ describe("ensureByokDefaultProfiles", () => {
   });
 
   test("the pre-#39516 onboarding bare-provider connection stamp converts", () => {
-    // Old web onboarding created the connection as `name: "anthropic"` and
-    // stamped that onto the copy it authored, while daemon seeding wrote
-    // `anthropic-personal` on its copies; both are machinery-written.
+    // Pre-#39516 web onboarding stamped the bare connection name.
     writeConfig({
       llm: {
         defaultProvider: { provider: "anthropic" },
@@ -1036,9 +1026,7 @@ describe("ensureByokDefaultProfiles", () => {
   });
 
   test("a copy for an endpoint-supplied provider is kept even when body-identical to the template", () => {
-    // Legacy onboarding wrote copies for providers outside
-    // DEFAULT_PROVIDER_CHOICES; their connection can carry a base URL the
-    // bare key cannot recover, so they must never retire.
+    // Its connection can carry a base URL the bare key cannot recover.
     const body = hatchBody("balanced", "anthropic") as Record<string, unknown>;
     writeConfig({
       llm: {
@@ -1060,9 +1048,6 @@ describe("ensureByokDefaultProfiles", () => {
   });
 
   test("a copy disable wins over a re-enabled hatch stub on the same key", () => {
-    // Contradictory overlays: the stub arm deletes the re-enabled stub, so
-    // the disable carried off the copy (the rail dispatch actually used)
-    // lands on the bare key.
     const config = uneditedByokConfig();
     const profileMap = (config.llm as Record<string, unknown>)
       .profiles as Record<string, Record<string, unknown>>;
@@ -1088,9 +1073,8 @@ describe("ensureByokDefaultProfiles", () => {
   });
 
   test("a copy pointing at a non-conventional connection is kept", () => {
-    // Any connection reference other than `<provider>-personal`, the bare
-    // provider name, or absence could be an explicit selection among several
-    // keys; retiring the copy could silently switch which key gets billed.
+    // A non-conventional reference could be an explicit selection among
+    // several keys; retiring it could switch which key gets billed.
     writeConfig({
       llm: {
         defaultProvider: { provider: "anthropic" },

--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -964,7 +964,7 @@ describe("ensureByokDefaultProfiles", () => {
   test("the pre-#39516 onboarding bare-provider connection stamp converts", () => {
     // Old web onboarding created the connection as `name: "anthropic"` and
     // stamped that onto the copy it authored, while daemon seeding wrote
-    // `anthropic-personal` on its copies — both are machinery-written.
+    // `anthropic-personal` on its copies; both are machinery-written.
     writeConfig({
       llm: {
         defaultProvider: { provider: "anthropic" },

--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -962,6 +962,29 @@ describe("ensureByokDefaultProfiles", () => {
     expect(readFileSync(configPath(), "utf-8")).toBe(before);
   });
 
+  test("a vellum default keeps a singleton copy (incomplete set is not hatch provenance)", () => {
+    // With two copies deleted through the profile routes, a lone surviving
+    // copy is trivially uniform; the complete-set requirement keeps it.
+    const config = uneditedByokConfig();
+    const llmConfig = config.llm as Record<string, unknown>;
+    llmConfig.defaultProvider = { provider: "vellum" };
+    const profileMap = llmConfig.profiles as Record<
+      string,
+      Record<string, unknown>
+    >;
+    delete profileMap["custom-quality-optimized"];
+    delete profileMap["custom-cost-optimized"];
+    writeConfig(config);
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-balanced"]).toBeDefined();
+    expect(llm().activeProfile).toBe("custom-balanced");
+    // The stubs are hatch residue regardless and still delete.
+    expect(profiles().balanced).toBeUndefined();
+    expectSecondRunNoop();
+  });
+
   test("a vellum default keeps all copies when one was re-provisioned to another provider", () => {
     // Provider uniformity across the set is the hatch-provenance signal on
     // a vellum default; a re-provisioned copy breaks it and conservatively

--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -942,10 +942,11 @@ describe("ensureByokDefaultProfiles", () => {
     expect(readFileSync(configPath(), "utf-8")).toBe(before);
   });
 
-  test("a custom copy for a different provider than the current default converts", () => {
-    // The copy is judged against its own recorded provider: an unedited
-    // anthropic hatch copy is hatch residue even after the user switched
-    // the default provider to openai.
+  test("a custom copy for a different BYOK provider than the current default is kept", () => {
+    // A copy the user re-provisioned to another provider (standard model,
+    // template tuning) is indistinguishable from a hatch copy for that
+    // provider, so on a BYOK default only copies matching the default
+    // provider are positively hatch-written.
     writeConfig({
       llm: {
         defaultProvider: { provider: "openai" },
@@ -954,10 +955,36 @@ describe("ensureByokDefaultProfiles", () => {
         },
       },
     });
+    const before = readFileSync(configPath(), "utf-8");
 
     ensureByokDefaultProfiles(workspaceDir);
 
-    expect(profiles()["custom-balanced"]).toBeUndefined();
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("a vellum default keeps all copies when one was re-provisioned to another provider", () => {
+    // Provider uniformity across the set is the hatch-provenance signal on
+    // a vellum default; a re-provisioned copy breaks it and conservatively
+    // keeps the whole set. The stubs still delete.
+    const config = uneditedByokConfig();
+    const llmConfig = config.llm as Record<string, unknown>;
+    llmConfig.defaultProvider = { provider: "vellum" };
+    const profileMap = llmConfig.profiles as Record<
+      string,
+      Record<string, unknown>
+    >;
+    profileMap["custom-balanced"] = hatchBody("balanced", "openai");
+    writeConfig(config);
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles().balanced).toBeUndefined();
+    expect(profiles()["quality-optimized"]).toBeUndefined();
+    expect(profiles()["cost-optimized"]).toBeUndefined();
+    expect(profiles()["custom-balanced"]).toBeDefined();
+    expect(profiles()["custom-quality-optimized"]).toBeDefined();
+    expect(profiles()["custom-cost-optimized"]).toBeDefined();
+    expect(llm().activeProfile).toBe("custom-balanced");
     expectSecondRunNoop();
   });
 

--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -536,7 +536,11 @@ describe("ensureByokDefaultProfiles", () => {
     expectSecondRunNoop();
   });
 
-  test("a re-enabled hatch stub is kept", () => {
+  test("a re-enabled hatch stub is deleted", () => {
+    // The status toggle is the only writable field on a managed stub; the
+    // enable only meant something while the stub-vs-active split existed,
+    // and the bare key resolves active post-conversion, so deletion
+    // preserves the user's intent while dropping the stale suffixed label.
     writeConfig({
       llm: {
         defaultProvider: { provider: "anthropic" },
@@ -549,11 +553,11 @@ describe("ensureByokDefaultProfiles", () => {
         },
       },
     });
-    const before = readFileSync(configPath(), "utf-8");
 
     ensureByokDefaultProfiles(workspaceDir);
 
-    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+    expect(profiles()["quality-optimized"]).toBeUndefined();
+    expectSecondRunNoop();
   });
 
   test("a label-only hatch stub with no status key is deleted", () => {
@@ -710,17 +714,62 @@ describe("ensureByokDefaultProfiles", () => {
     expect(readFileSync(configPath(), "utf-8")).toBe(before);
   });
 
-  test("no-op when the default provider is vellum", () => {
+  test("a vellum-default install (hatched BYOK, later platform-connected) converts fully", () => {
     const config = uneditedByokConfig();
     (config.llm as Record<string, unknown>).defaultProvider = {
       provider: "vellum",
     };
     writeConfig(config);
-    const before = readFileSync(configPath(), "utf-8");
 
     ensureByokDefaultProfiles(workspaceDir);
 
-    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+    for (const name of [
+      "balanced",
+      "quality-optimized",
+      "cost-optimized",
+      "custom-balanced",
+      "custom-quality-optimized",
+      "custom-cost-optimized",
+    ]) {
+      expect(profiles()[name]).toBeUndefined();
+    }
+    expect(llm().activeProfile).toBe("balanced");
+    expect(llm().advisorProfile).toBe("quality-optimized");
+    // With the stub gone, the default resolves active from the vellum column.
+    const resolved = resolveDefaultProfileForProvider(
+      profiles() as Record<string, ProfileEntry>,
+      "balanced",
+      { provider: "vellum" },
+    );
+    expect(resolved?.source).toBe("managed");
+    expect(resolved?.status).toBeUndefined();
+    expectSecondRunNoop();
+  });
+
+  test("a vellum-default install keeps a user-edited copy untouched", () => {
+    const config = uneditedByokConfig();
+    const llmConfig = config.llm as Record<string, unknown>;
+    llmConfig.defaultProvider = { provider: "vellum" };
+    const profileMap = llmConfig.profiles as Record<
+      string,
+      Record<string, unknown>
+    >;
+    profileMap["custom-balanced"] = {
+      ...profileMap["custom-balanced"],
+      model: "claude-opus-4-6",
+    };
+    writeConfig(config);
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-balanced"]).toEqual({
+      ...hatchBody("balanced", "anthropic"),
+      model: "claude-opus-4-6",
+    });
+    expect(llm().activeProfile).toBe("custom-balanced");
+    expect(profiles()["custom-quality-optimized"]).toBeUndefined();
+    expect(profiles()["custom-cost-optimized"]).toBeUndefined();
+    expectSecondRunNoop();
   });
 
   test("no-op when llm.defaultProvider is absent or invalid", () => {
@@ -771,6 +820,107 @@ describe("ensureByokDefaultProfiles", () => {
     expect(readFileSync(configPath(), "utf-8")).toBe(before);
   });
 
+  test("a real vellum-default workspace with re-enabled stubs and mixed connection stamps converts (specimen shape)", () => {
+    // Mirrors a live 2026-07 workspace: hatched BYOK anthropic, later
+    // platform-connected (vellum default), all three hatch stubs re-enabled
+    // through the UI (status "active", two carrying the migration-097
+    // thinking stamp), the onboarding-authored copy stamped with the bare
+    // "anthropic" connection while the seeded copies carry
+    // "anthropic-personal", an unrelated managed os-beta overlay, and call
+    // sites pinned at custom-balanced.
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum", connectionName: "vellum" },
+        activeProfile: "balanced",
+        advisorProfile: "quality-optimized",
+        profileOrder: [
+          "balanced",
+          "os-beta",
+          "quality-optimized",
+          "cost-optimized",
+          "custom-balanced",
+          "custom-quality-optimized",
+          "custom-cost-optimized",
+        ],
+        callSites: {
+          subagentSpawn: { profile: "custom-balanced" },
+          memoryRouter: {
+            profile: "custom-balanced",
+            contextWindow: { maxInputTokens: 1000000 },
+          },
+        },
+        profiles: {
+          balanced: {
+            source: "managed",
+            status: "active",
+            label: "Balanced (Managed)",
+            thinking: { enabled: true, streamThinking: true },
+          },
+          "quality-optimized": {
+            source: "managed",
+            status: "active",
+            label: "Quality (Managed)",
+            thinking: { enabled: true, streamThinking: true },
+          },
+          "cost-optimized": {
+            source: "managed",
+            status: "active",
+            label: "Speed (Managed)",
+          },
+          "custom-balanced": {
+            ...hatchBody("balanced", "anthropic"),
+            provider_connection: "anthropic",
+          },
+          "custom-quality-optimized": hatchBody(
+            "quality-optimized",
+            "anthropic",
+          ),
+          "custom-cost-optimized": hatchBody("cost-optimized", "anthropic"),
+          "os-beta": {
+            source: "managed",
+            status: "active",
+            label: "OS Beta (Managed)",
+          },
+        },
+      },
+    });
+    // The live workspace booted with completion baking the copies first.
+    ensureCompleteCustomProfiles(workspaceDir);
+    const osBetaBefore = { ...profiles()["os-beta"] };
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    for (const name of [
+      "balanced",
+      "quality-optimized",
+      "cost-optimized",
+      "custom-balanced",
+      "custom-quality-optimized",
+      "custom-cost-optimized",
+    ]) {
+      expect(profiles()[name]).toBeUndefined();
+    }
+    expect(profiles()["os-beta"]).toEqual(osBetaBefore);
+    expect(llm().activeProfile).toBe("balanced");
+    expect(llm().advisorProfile).toBe("quality-optimized");
+    expect(llm().profileOrder).toEqual([
+      "balanced",
+      "os-beta",
+      "quality-optimized",
+      "cost-optimized",
+    ]);
+    const callSites = llm().callSites as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(callSites.subagentSpawn?.profile).toBe("balanced");
+    expect(callSites.memoryRouter?.profile).toBe("balanced");
+    expect(callSites.memoryRouter?.contextWindow).toEqual({
+      maxInputTokens: 1000000,
+    });
+    expectSecondRunNoop();
+  });
+
   test("a managed-source default entry with body keys is left alone", () => {
     writeConfig({
       llm: {
@@ -792,12 +942,61 @@ describe("ensureByokDefaultProfiles", () => {
     expect(readFileSync(configPath(), "utf-8")).toBe(before);
   });
 
-  test("a custom copy for a different provider is kept", () => {
+  test("a custom copy for a different provider than the current default converts", () => {
+    // The copy is judged against its own recorded provider: an unedited
+    // anthropic hatch copy is hatch residue even after the user switched
+    // the default provider to openai.
     writeConfig({
       llm: {
         defaultProvider: { provider: "openai" },
         profiles: {
           "custom-balanced": hatchBody("balanced", "anthropic"),
+        },
+      },
+    });
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-balanced"]).toBeUndefined();
+    expectSecondRunNoop();
+  });
+
+  test("the pre-#39516 onboarding bare-provider connection stamp converts", () => {
+    // Old web onboarding created the connection as `name: "anthropic"` and
+    // stamped that onto the copy it authored, while daemon seeding wrote
+    // `anthropic-personal` on its copies — both are machinery-written.
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        activeProfile: "custom-balanced",
+        profiles: {
+          "custom-balanced": {
+            ...hatchBody("balanced", "anthropic"),
+            provider_connection: "anthropic",
+          },
+        },
+      },
+    });
+
+    ensureByokDefaultProfiles(workspaceDir);
+
+    expect(profiles()["custom-balanced"]).toBeUndefined();
+    expect(llm().activeProfile).toBe("balanced");
+    expectSecondRunNoop();
+  });
+
+  test("a copy pointing at a non-conventional connection is kept", () => {
+    // Any connection reference other than `<provider>-personal`, the bare
+    // provider name, or absence could be an explicit selection among several
+    // keys; retiring the copy could silently switch which key gets billed.
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        profiles: {
+          "custom-balanced": {
+            ...hatchBody("balanced", "anthropic"),
+            provider_connection: "anthropic-work",
+          },
         },
       },
     });

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -50,7 +50,7 @@ export const LLMProvider = z
     "chatgpt",
   ])
   .meta({ id: "LLMProvider" });
-type LLMProvider = z.infer<typeof LLMProvider>;
+export type LLMProvider = z.infer<typeof LLMProvider>;
 
 /**
  * Providers that can back `llm.defaultProvider`: the named columns of the
@@ -81,6 +81,17 @@ export const DEFAULT_PROVIDER_CHOICES: readonly LLMProvider[] = [
 
 export function isDefaultProviderChoice(value: string): value is LLMProvider {
   return (DEFAULT_PROVIDER_CHOICES as readonly string[]).includes(value);
+}
+
+/**
+ * Default-provider choices whose profiles materialize from the shared BYOK
+ * templates: every choice except the `vellum` routing identity, whose
+ * defaults are pinned managed models.
+ */
+export function isByokDefaultProviderChoice(
+  value: string,
+): value is LLMProvider {
+  return value !== "vellum" && isDefaultProviderChoice(value);
 }
 
 const DefaultProviderEnum = z.enum(

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -79,7 +79,7 @@ export const DEFAULT_PROVIDER_CHOICES: readonly LLMProvider[] = [
   ]),
 ];
 
-export function isDefaultProviderChoice(value: string): boolean {
+export function isDefaultProviderChoice(value: string): value is LLMProvider {
   return (DEFAULT_PROVIDER_CHOICES as readonly string[]).includes(value);
 }
 

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -16,8 +16,9 @@ import { invalidateConfigCache } from "../config/loader.js";
 import {
   type DefaultProviderConfig,
   DefaultProviderSchema,
-  isDefaultProviderChoice,
+  isByokDefaultProviderChoice,
   LLMConfigBase,
+  type LLMProvider,
   type ProfileEntry,
 } from "../config/schemas/llm.js";
 import { getLogger } from "../util/logger.js";
@@ -249,10 +250,14 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 
   // The default provider on a BYOK default, or the uniform hatch provider
   // across the complete copy set on a vellum default; null converts nothing.
-  const convertibleProvider =
+  const candidateProvider =
     parsedDefault.data.provider !== "vellum"
       ? parsedDefault.data.provider
       : uniformCopyProvider(profiles);
+  const convertibleProvider =
+    candidateProvider !== null && isByokDefaultProviderChoice(candidateProvider)
+      ? candidateProvider
+      : null;
 
   const retired = new Map<string, string>();
   const carriedDisables = new Set<DefaultProfileKey>();
@@ -314,7 +319,7 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 function isKnownUneditedBody(
   entry: Record<string, unknown>,
   key: DefaultProfileKey,
-  convertibleProvider: string | null,
+  convertibleProvider: LLMProvider | null,
   completionBase: LLMConfigBase | undefined,
 ): boolean {
   if (typeof entry.model !== "string") {
@@ -322,20 +327,12 @@ function isKnownUneditedBody(
   }
   // The comparison template comes from the copy's own recorded provider
   // (hatch materialized it once; the default provider may have changed
-  // since), with `convertibleProvider` corroborating hatch provenance over
-  // a user re-provision. The choice guard keeps keyless and
-  // endpoint-supplied providers (ollama, openai-compatible) from ever
-  // retiring: their `provider_connection` can carry a base URL the bare key
-  // cannot recover. `vellum` never had hatch copies.
-  const copyProvider = entry.provider;
-  if (
-    typeof copyProvider !== "string" ||
-    copyProvider !== convertibleProvider ||
-    !isDefaultProviderChoice(copyProvider) ||
-    copyProvider === "vellum"
-  ) {
+  // since); equality with the corroborated provider rules out a user
+  // re-provision.
+  if (convertibleProvider === null || entry.provider !== convertibleProvider) {
     return false;
   }
+  const copyProvider = convertibleProvider;
   const template = USER_PROFILE_TEMPLATES[`custom-${key}`];
   if (template === undefined) {
     return false;

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -34,20 +34,11 @@ const log = getLogger("byok-default-profile-ensure");
 // repointed at the bare key. A `custom-*` copy the user edited is kept
 // untouched as an ordinary user profile, references included.
 //
-// The pass runs regardless of the CURRENT default provider: an install that
-// hatched BYOK and later connected to platform (default provider `vellum`)
-// carries the same hatch residue and converts the same way; its default
-// keys then resolve from the vellum column instead. The copy is compared
-// against the provider recorded in its own body (it was materialized once
-// at hatch from the hatch provider's column), but a body-matches-template
-// copy is only positively hatch-written when that provider is corroborated:
-// on a BYOK default it must equal the default provider (a copy the user
-// re-provisioned to another provider, picking that provider's standard
-// model in the editor, reproduces the template exactly and must not lose
-// its explicit provider selection), and on a vellum default the complete
-// copy set must be present and record one provider, since one hatch wrote
-// all three from a single provider; a re-provisioned copy breaks the
-// uniformity and a user-curated (incomplete) set withholds it entirely.
+// The pass also runs on installs whose default provider is now `vellum`
+// (hatched BYOK, later platform-connected): the copy is compared against
+// the provider recorded in its own body, with corroboration that the
+// provider is hatch provenance and not a user re-provision (see
+// `isKnownUneditedBody` / `uniformCopyProvider`).
 //
 // "Unedited" is judged against what hatch seeding actually left on disk, not
 // the raw template: both the copy and the template are normalized through the
@@ -77,19 +68,17 @@ const log = getLogger("byok-default-profile-ensure");
  * The exact stub shapes BYOK hatching left on each default key: thin (only
  * the workspace-owned overlay fields), `source: "managed"`, the frozen
  * per-key label, and a `status` of `"disabled"` (seeded at hatch, #30367),
- * `"active"` (the hatch disable toggled back on through the UI, the only
- * writable field on a managed stub, and only meaningful while the
- * stub-vs-active split existed; post-conversion the bare key resolves
- * active anyway, so deleting it preserves the enable), or no `status` key
- * at all (installs that already existed when #30367 landed got only the
- * label rewrite; migration 126 thinned those bodies to `{ source, label }`).
- * Deletion requires the full shape: a thin managed entry differing in any
- * other way (a guard-side edit on the bare key, or a non-frozen label or
- * status carried off a retired copy by this pass) is user overlay state and
- * stays. The carry arm below never writes the frozen label, so a match is
- * always hatch-written modulo the status toggle. A managed-source entry
- * with any other key (a platform overlay body) is not a stub and is
- * likewise left alone.
+ * `"active"` (re-enabled through the guard; safe to delete because the bare
+ * key resolves active post-conversion), or no `status` key at all (installs
+ * that already existed when #30367 landed got only the label rewrite;
+ * migration 126 thinned those bodies to `{ source, label }`). Deletion
+ * requires the full shape: a thin managed entry differing in any other way
+ * (a guard-side edit on the bare key, or a non-frozen label or status
+ * carried off a retired copy by this pass) is user overlay state and stays.
+ * The carry arm below never writes the frozen label, so a match is always
+ * hatch-written modulo the status toggle. A managed-source entry with any
+ * other key (a platform overlay body) is not a stub and is likewise left
+ * alone.
  */
 const STUB_ONLY_KEYS = new Set(["source", "status", "label", "thinking"]);
 const HATCH_STUB_LABELS: Record<DefaultProfileKey, string> = {
@@ -228,9 +217,6 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
   if (llm === null) {
     return;
   }
-  // The parsed default provider is only needed to resolve the
-  // post-conversion selections; conversion itself judges copies against
-  // their own recorded provider, so a vellum default does not gate it.
   const parsedDefault = DefaultProviderSchema.safeParse(llm.defaultProvider);
   if (!parsedDefault.success) {
     return;
@@ -244,9 +230,6 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 
   // Deleting a hatch stub makes the default key resolve active from the
   // default provider's catalog column (and drops the stub's suffixed label).
-  // Only the exact frozen hatch shapes (modulo the status toggle the guard
-  // exposes on managed stubs) are classified hatch-written; anything else
-  // stays.
   for (const key of DEFAULT_PROFILE_KEYS) {
     const entry = readObject(profiles[key]);
     if (entry === null || !isHatchStub(key, entry)) {
@@ -264,9 +247,8 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
   // onto user-source profiles (see `withCompletionBaked`).
   const completionBase = LLMConfigBase.safeParse(llm.default ?? {}).data;
 
-  // The one provider whose copies may convert this boot (see the header):
-  // the default provider itself on a BYOK default, or the uniform provider
-  // across all present copies on a vellum default. Null converts nothing.
+  // The default provider on a BYOK default, or the uniform hatch provider
+  // across the complete copy set on a vellum default; null converts nothing.
   const convertibleProvider =
     parsedDefault.data.provider !== "vellum"
       ? parsedDefault.data.provider
@@ -291,11 +273,10 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
       // indistinguishable from a genuine hatch stub and would be deleted by
       // the stub arm on the next boot, so the colliding label is never
       // carried. A carried disable survives as a label-less stub; a
-      // rename-only collision leaves no overlay worth writing. When the
-      // user both re-enabled the hatch stub and disabled the copy, the
-      // copy's disable wins (the stub arm already deleted the re-enabled
-      // stub, clearing the bare key for this carry): the copy governed the
-      // rail dispatch actually used, so its overlay is the meaningful one.
+      // rename-only collision leaves no overlay worth writing. When a
+      // disabled copy meets a re-enabled stub, the copy's disable wins
+      // (the stub arm already cleared the key): the copy governed the rail
+      // dispatch actually used.
       if (isHatchStub(key, stub)) {
         delete stub.label;
       }
@@ -339,17 +320,13 @@ function isKnownUneditedBody(
   if (typeof entry.model !== "string") {
     return false;
   }
-  // Hatch seeding materialized the copy from the HATCH provider's column and
-  // recorded that provider on the body, so the comparison template comes
-  // from the copy's own provider; `convertibleProvider` corroborates that
-  // the provider is hatch provenance and not a user re-provision (see the
-  // header). Only providers that can back the code-defined defaults are
-  // candidates: it keeps the comparison off the catalog/fallback
-  // default-model path, and legacy onboarding copies for keyless or
-  // endpoint-supplied providers (ollama, openai-compatible) must never
-  // retire, since their `provider_connection` can carry a base URL the bare
-  // key cannot recover. `vellum` never had hatch copies, so a body claiming
-  // it is not one.
+  // The comparison template comes from the copy's own recorded provider
+  // (hatch materialized it once; the default provider may have changed
+  // since), with `convertibleProvider` corroborating hatch provenance over
+  // a user re-provision. The choice guard keeps keyless and
+  // endpoint-supplied providers (ollama, openai-compatible) from ever
+  // retiring: their `provider_connection` can carry a base URL the bare key
+  // cannot recover. `vellum` never had hatch copies.
   const copyProvider = entry.provider;
   if (
     typeof copyProvider !== "string" ||
@@ -365,7 +342,7 @@ function isKnownUneditedBody(
   }
   const materialized = materializeProfile(
     template,
-    copyProvider as NonNullable<ProfileEntry["provider"]>,
+    copyProvider,
     `${copyProvider}-personal`,
   ) as Record<string, unknown>;
   if (
@@ -392,15 +369,11 @@ function isKnownUneditedBody(
 }
 
 /**
- * The single provider recorded across the COMPLETE `custom-*` set, or null
- * when any copy is absent, any provider string is missing, or the copies
- * disagree. One hatch wrote all three copies from one provider, so only
- * the full uniform set corroborates hatch provenance for a vellum default;
- * an incomplete set means the user curated it (deletion is only reachable
- * through the profile routes), and a lone surviving copy re-provisioned to
- * another provider's standard body would otherwise count as trivially
- * uniform and retire, silently switching the provider and credentials it
- * selected.
+ * One hatch wrote all three copies from one provider, so only the complete
+ * uniform set corroborates hatch provenance for a vellum default. An
+ * absent copy means the user curated the set, and a lone surviving copy
+ * would otherwise count as trivially uniform and retire even when
+ * re-provisioned; both return null and keep everything.
  */
 function uniformCopyProvider(profiles: Record<string, unknown>): string | null {
   let provider: string | null = null;
@@ -434,14 +407,11 @@ function uniformCopyProvider(profiles: Record<string, unknown>): string | null {
  *   `<provider>-personal` stamp from every entry (dispatch auto-resolves
  *   the same row from `provider`).
  * - `provider_connection` naming the bare provider: web onboarding before
- *   #39516 (2026-07-29) created the connection as `name: "<provider>"` and
- *   stamped that name onto the copy it authored, while daemon-side seeding
- *   independently wrote `<provider>-personal`; real workspaces carry both
- *   stamps side by side. Safe to accept: an api-key connection named
- *   exactly the provider resolves the same `credential/<provider>/api_key`
- *   slot as the conventional row, so retiring the copy cannot switch keys.
- *   A body carrying any other connection value is a user edit and never
- *   matches.
+ *   #39516 (2026-07-29) stamped the connection name `"<provider>"` onto the
+ *   copy it authored. Safe to accept: that row resolves the same
+ *   `credential/<provider>/api_key` slot as `<provider>-personal`, so
+ *   retiring the copy cannot switch keys. Any other connection value is a
+ *   user edit and never matches.
  *
  * The final hatch-written deviation, `source: "managed"` from the earliest
  * templates, is handled by the caller's source normalization.

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -35,7 +35,7 @@ const log = getLogger("byok-default-profile-ensure");
 //
 // The pass runs regardless of the CURRENT default provider: an install that
 // hatched BYOK and later connected to platform (default provider `vellum`)
-// carries the same hatch residue and converts the same way — its default
+// carries the same hatch residue and converts the same way; its default
 // keys then resolve from the vellum column instead. That is why "unedited"
 // is judged against the provider recorded in each copy's own body, not the
 // current default: the copy was materialized once at hatch from the hatch
@@ -69,7 +69,7 @@ const log = getLogger("byok-default-profile-ensure");
  * The exact stub shapes BYOK hatching left on each default key: thin (only
  * the workspace-owned overlay fields), `source: "managed"`, the frozen
  * per-key label, and a `status` of `"disabled"` (seeded at hatch, #30367),
- * `"active"` (the hatch disable toggled back on through the UI — the only
+ * `"active"` (the hatch disable toggled back on through the UI, the only
  * writable field on a managed stub, and only meaningful while the
  * stub-vs-active split existed; post-conversion the bare key resolves
  * active anyway, so deleting it preserves the enable), or no `status` key
@@ -236,8 +236,8 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 
   // Deleting a hatch stub makes the default key resolve active from the
   // default provider's catalog column (and drops the stub's suffixed label).
-  // Only the exact frozen hatch shapes — modulo the status toggle the guard
-  // exposes on managed stubs — are classified hatch-written; anything else
+  // Only the exact frozen hatch shapes (modulo the status toggle the guard
+  // exposes on managed stubs) are classified hatch-written; anything else
   // stays.
   for (const key of DEFAULT_PROFILE_KEYS) {
     const entry = readObject(profiles[key]);
@@ -370,7 +370,7 @@ function isKnownUneditedBody(
  * - `provider_connection` naming the bare provider: web onboarding before
  *   #39516 (2026-07-29) created the connection as `name: "<provider>"` and
  *   stamped that name onto the copy it authored, while daemon-side seeding
- *   independently wrote `<provider>-personal` — real workspaces carry both
+ *   independently wrote `<provider>-personal`; real workspaces carry both
  *   stamps side by side. Safe to accept: an api-key connection named
  *   exactly the provider resolves the same `credential/<provider>/api_key`
  *   slot as the conventional row, so retiring the copy cannot switch keys.

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -44,9 +44,10 @@ const log = getLogger("byok-default-profile-ensure");
 // on a BYOK default it must equal the default provider (a copy the user
 // re-provisioned to another provider, picking that provider's standard
 // model in the editor, reproduces the template exactly and must not lose
-// its explicit provider selection), and on a vellum default every present
-// copy must record the same provider, since one hatch wrote the whole set
-// from a single provider and a re-provisioned copy breaks that uniformity.
+// its explicit provider selection), and on a vellum default the complete
+// copy set must be present and record one provider, since one hatch wrote
+// all three from a single provider; a re-provisioned copy breaks the
+// uniformity and a user-curated (incomplete) set withholds it entirely.
 //
 // "Unedited" is judged against what hatch seeding actually left on disk, not
 // the raw template: both the copy and the template are normalized through the
@@ -391,19 +392,22 @@ function isKnownUneditedBody(
 }
 
 /**
- * The single provider recorded across every present `custom-*` copy, or
- * null when the copies disagree (or none carries a provider string). One
- * hatch wrote the whole set from one provider, so uniformity is the
- * provenance signal for converting copies whose provider cannot be checked
- * against a vellum default; a copy the user re-provisioned to another
- * provider breaks it and conservatively keeps the whole set.
+ * The single provider recorded across the COMPLETE `custom-*` set, or null
+ * when any copy is absent, any provider string is missing, or the copies
+ * disagree. One hatch wrote all three copies from one provider, so only
+ * the full uniform set corroborates hatch provenance for a vellum default;
+ * an incomplete set means the user curated it (deletion is only reachable
+ * through the profile routes), and a lone surviving copy re-provisioned to
+ * another provider's standard body would otherwise count as trivially
+ * uniform and retire, silently switching the provider and credentials it
+ * selected.
  */
 function uniformCopyProvider(profiles: Record<string, unknown>): string | null {
   let provider: string | null = null;
   for (const key of DEFAULT_PROFILE_KEYS) {
     const entry = readObject(profiles[`custom-${key}`]);
     if (entry === null) {
-      continue;
+      return null;
     }
     if (typeof entry.provider !== "string") {
       return null;

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -37,10 +37,16 @@ const log = getLogger("byok-default-profile-ensure");
 // The pass runs regardless of the CURRENT default provider: an install that
 // hatched BYOK and later connected to platform (default provider `vellum`)
 // carries the same hatch residue and converts the same way; its default
-// keys then resolve from the vellum column instead. That is why "unedited"
-// is judged against the provider recorded in each copy's own body, not the
-// current default: the copy was materialized once at hatch from the hatch
-// provider's column, and the default provider may have changed since.
+// keys then resolve from the vellum column instead. The copy is compared
+// against the provider recorded in its own body (it was materialized once
+// at hatch from the hatch provider's column), but a body-matches-template
+// copy is only positively hatch-written when that provider is corroborated:
+// on a BYOK default it must equal the default provider (a copy the user
+// re-provisioned to another provider, picking that provider's standard
+// model in the editor, reproduces the template exactly and must not lose
+// its explicit provider selection), and on a vellum default every present
+// copy must record the same provider, since one hatch wrote the whole set
+// from a single provider and a re-provisioned copy breaks that uniformity.
 //
 // "Unedited" is judged against what hatch seeding actually left on disk, not
 // the raw template: both the copy and the template are normalized through the
@@ -257,12 +263,23 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
   // onto user-source profiles (see `withCompletionBaked`).
   const completionBase = LLMConfigBase.safeParse(llm.default ?? {}).data;
 
+  // The one provider whose copies may convert this boot (see the header):
+  // the default provider itself on a BYOK default, or the uniform provider
+  // across all present copies on a vellum default. Null converts nothing.
+  const convertibleProvider =
+    parsedDefault.data.provider !== "vellum"
+      ? parsedDefault.data.provider
+      : uniformCopyProvider(profiles);
+
   const retired = new Map<string, string>();
   const carriedDisables = new Set<DefaultProfileKey>();
   for (const key of DEFAULT_PROFILE_KEYS) {
     const name = `custom-${key}`;
     const entry = readObject(profiles[name]);
-    if (entry === null || !isKnownUneditedBody(entry, key, completionBase)) {
+    if (
+      entry === null ||
+      !isKnownUneditedBody(entry, key, convertibleProvider, completionBase)
+    ) {
       continue;
     }
     const overlay = userOverlayState(entry, key);
@@ -315,24 +332,27 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 function isKnownUneditedBody(
   entry: Record<string, unknown>,
   key: DefaultProfileKey,
+  convertibleProvider: string | null,
   completionBase: LLMConfigBase | undefined,
 ): boolean {
   if (typeof entry.model !== "string") {
     return false;
   }
   // Hatch seeding materialized the copy from the HATCH provider's column and
-  // recorded that provider on the body; the current default provider may
-  // have changed since (most commonly to `vellum` after connecting to
-  // platform), so the copy is compared against its own recorded provider.
-  // Only providers that can back the code-defined defaults are candidates:
-  // it keeps the comparison off the catalog/fallback default-model path, and
-  // legacy onboarding copies for keyless or endpoint-supplied providers
-  // (ollama, openai-compatible) must never retire, since their
-  // `provider_connection` can carry a base URL the bare key cannot recover.
-  // `vellum` never had hatch copies, so a body claiming it is not one.
+  // recorded that provider on the body, so the comparison template comes
+  // from the copy's own provider; `convertibleProvider` corroborates that
+  // the provider is hatch provenance and not a user re-provision (see the
+  // header). Only providers that can back the code-defined defaults are
+  // candidates: it keeps the comparison off the catalog/fallback
+  // default-model path, and legacy onboarding copies for keyless or
+  // endpoint-supplied providers (ollama, openai-compatible) must never
+  // retire, since their `provider_connection` can carry a base URL the bare
+  // key cannot recover. `vellum` never had hatch copies, so a body claiming
+  // it is not one.
   const copyProvider = entry.provider;
   if (
     typeof copyProvider !== "string" ||
+    copyProvider !== convertibleProvider ||
     !isDefaultProviderChoice(copyProvider) ||
     copyProvider === "vellum"
   ) {
@@ -368,6 +388,33 @@ function isKnownUneditedBody(
   return hatchBodyVariants(known, key, copyProvider).some((variant) =>
     isDeepStrictEqual(body, variant),
   );
+}
+
+/**
+ * The single provider recorded across every present `custom-*` copy, or
+ * null when the copies disagree (or none carries a provider string). One
+ * hatch wrote the whole set from one provider, so uniformity is the
+ * provenance signal for converting copies whose provider cannot be checked
+ * against a vellum default; a copy the user re-provisioned to another
+ * provider breaks it and conservatively keeps the whole set.
+ */
+function uniformCopyProvider(profiles: Record<string, unknown>): string | null {
+  let provider: string | null = null;
+  for (const key of DEFAULT_PROFILE_KEYS) {
+    const entry = readObject(profiles[`custom-${key}`]);
+    if (entry === null) {
+      continue;
+    }
+    if (typeof entry.provider !== "string") {
+      return null;
+    }
+    if (provider === null) {
+      provider = entry.provider;
+    } else if (provider !== entry.provider) {
+      return null;
+    }
+  }
+  return provider;
 }
 
 /**

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_PROFILE_KEYS,
   type DefaultProfileKey,
 } from "../config/default-profile-names.js";
-import { resolveDefaultConnectionName } from "../config/default-provider-resolution.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { invalidateConfigCache } from "../config/loader.js";
 import {
@@ -25,14 +24,22 @@ import { completedProfileBody } from "./custom-profile-ensure.js";
 
 const log = getLogger("byok-default-profile-ensure");
 
-// Converts BYOK installs from the hatch-era profile layout (disabled managed
-// stubs for the default keys plus editable `custom-*` copies) onto the
-// code-defined default profiles: the stubs and unedited copies are removed so
-// `balanced`/`quality-optimized`/`cost-optimized` resolve active and
-// read-only from the default provider's column of the intent x provider
+// Converts BYOK-hatched installs from the hatch-era profile layout (disabled
+// managed stubs for the default keys plus editable `custom-*` copies) onto
+// the code-defined default profiles: the stubs and unedited copies are
+// removed so `balanced`/`quality-optimized`/`cost-optimized` resolve active
+// and read-only from the default provider's column of the intent x provider
 // matrix, and every named reference to a removed `custom-*` entry is
 // repointed at the bare key. A `custom-*` copy the user edited is kept
 // untouched as an ordinary user profile, references included.
+//
+// The pass runs regardless of the CURRENT default provider: an install that
+// hatched BYOK and later connected to platform (default provider `vellum`)
+// carries the same hatch residue and converts the same way — its default
+// keys then resolve from the vellum column instead. That is why "unedited"
+// is judged against the provider recorded in each copy's own body, not the
+// current default: the copy was materialized once at hatch from the hatch
+// provider's column, and the default provider may have changed since.
 //
 // "Unedited" is judged against what hatch seeding actually left on disk, not
 // the raw template: both the copy and the template are normalized through the
@@ -61,17 +68,20 @@ const log = getLogger("byok-default-profile-ensure");
 /**
  * The exact stub shapes BYOK hatching left on each default key: thin (only
  * the workspace-owned overlay fields), `source: "managed"`, the frozen
- * per-key label, and either `status: "disabled"` (seeded at hatch, #30367)
- * or no `status` key at all (installs that already existed when #30367
- * landed got only the label rewrite; migration 126 thinned those bodies to
- * `{ source, label }`). Deletion requires the full shape: a thin managed
- * entry differing in any other way (a re-enabled stub with
- * `status: "active"`, a guard-side edit on the bare key, or a non-frozen
- * label or status carried off a retired copy by this pass) is user overlay
- * state and stays. The carry arm below never writes a stub matching this
- * shape, so a match is always hatch-written. A managed-source entry with
- * any other key (a platform overlay body) is not a stub and is likewise
- * left alone.
+ * per-key label, and a `status` of `"disabled"` (seeded at hatch, #30367),
+ * `"active"` (the hatch disable toggled back on through the UI — the only
+ * writable field on a managed stub, and only meaningful while the
+ * stub-vs-active split existed; post-conversion the bare key resolves
+ * active anyway, so deleting it preserves the enable), or no `status` key
+ * at all (installs that already existed when #30367 landed got only the
+ * label rewrite; migration 126 thinned those bodies to `{ source, label }`).
+ * Deletion requires the full shape: a thin managed entry differing in any
+ * other way (a guard-side edit on the bare key, or a non-frozen label or
+ * status carried off a retired copy by this pass) is user overlay state and
+ * stays. The carry arm below never writes the frozen label, so a match is
+ * always hatch-written modulo the status toggle. A managed-source entry
+ * with any other key (a platform overlay body) is not a stub and is
+ * likewise left alone.
  */
 const STUB_ONLY_KEYS = new Set(["source", "status", "label", "thinking"]);
 const HATCH_STUB_LABELS: Record<DefaultProfileKey, string> = {
@@ -98,7 +108,9 @@ function isHatchStub(
   return (
     entry.source === "managed" &&
     Object.keys(entry).every((k) => STUB_ONLY_KEYS.has(k)) &&
-    (!("status" in entry) || entry.status === "disabled") &&
+    (!("status" in entry) ||
+      entry.status === "disabled" ||
+      entry.status === "active") &&
     (!("thinking" in entry) ||
       isDeepStrictEqual(entry.thinking, REPAIR_WRITTEN_THINKING)) &&
     entry.label === HATCH_STUB_LABELS[key]
@@ -208,8 +220,11 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
   if (llm === null) {
     return;
   }
+  // The parsed default provider is only needed to resolve the
+  // post-conversion selections; conversion itself judges copies against
+  // their own recorded provider, so a vellum default does not gate it.
   const parsedDefault = DefaultProviderSchema.safeParse(llm.defaultProvider);
-  if (!parsedDefault.success || parsedDefault.data.provider === "vellum") {
+  if (!parsedDefault.success) {
     return;
   }
   const profiles = readObject(llm.profiles);
@@ -221,8 +236,8 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 
   // Deleting a hatch stub makes the default key resolve active from the
   // default provider's catalog column (and drops the stub's suffixed label).
-  // Only the exact frozen hatch shapes are classified hatch-written;
-  // anything else (including a stub the user re-enabled through the guard)
+  // Only the exact frozen hatch shapes — modulo the status toggle the guard
+  // exposes on managed stubs — are classified hatch-written; anything else
   // stays.
   for (const key of DEFAULT_PROFILE_KEYS) {
     const entry = readObject(profiles[key]);
@@ -246,10 +261,7 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
   for (const key of DEFAULT_PROFILE_KEYS) {
     const name = `custom-${key}`;
     const entry = readObject(profiles[name]);
-    if (
-      entry === null ||
-      !isKnownUneditedBody(entry, key, parsedDefault.data, completionBase)
-    ) {
+    if (entry === null || !isKnownUneditedBody(entry, key, completionBase)) {
       continue;
     }
     const overlay = userOverlayState(entry, key);
@@ -298,10 +310,17 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 function isKnownUneditedBody(
   entry: Record<string, unknown>,
   key: DefaultProfileKey,
-  defaultProvider: DefaultProviderConfig,
   completionBase: LLMConfigBase | undefined,
 ): boolean {
   if (typeof entry.model !== "string") {
+    return false;
+  }
+  // Hatch seeding materialized the copy from the HATCH provider's column and
+  // recorded that provider on the body; the current default provider may
+  // have changed since (most commonly to `vellum` after connecting to
+  // platform), so the copy is compared against its own recorded provider.
+  const copyProvider = entry.provider;
+  if (typeof copyProvider !== "string") {
     return false;
   }
   const template = USER_PROFILE_TEMPLATES[`custom-${key}`];
@@ -310,14 +329,12 @@ function isKnownUneditedBody(
   }
   const materialized = materializeProfile(
     template,
-    defaultProvider.provider,
-    resolveDefaultConnectionName(defaultProvider),
+    copyProvider as NonNullable<ProfileEntry["provider"]>,
+    `${copyProvider}-personal`,
   ) as Record<string, unknown>;
   if (
     entry.model !== materialized.model &&
-    !(HISTORICAL_INTENT_MODELS[key][defaultProvider.provider] ?? []).includes(
-      entry.model,
-    )
+    !(HISTORICAL_INTENT_MODELS[key][copyProvider] ?? []).includes(entry.model)
   ) {
     return false;
   }
@@ -333,7 +350,7 @@ function isKnownUneditedBody(
   const known = comparableBody(
     withCompletionBaked(materialized, completionBase),
   );
-  return hatchBodyVariants(known, key).some((variant) =>
+  return hatchBodyVariants(known, key, copyProvider).some((variant) =>
     isDeepStrictEqual(body, variant),
   );
 }
@@ -349,15 +366,24 @@ function isKnownUneditedBody(
  * - absent `provider_connection`: hatches before #30232 (2026-05-10) never
  *   stamped one, and migration 133 drops the conventional
  *   `<provider>-personal` stamp from every entry (dispatch auto-resolves
- *   the same row from `provider`). A body carrying any other connection
- *   value is a user edit and never matches.
+ *   the same row from `provider`).
+ * - `provider_connection` naming the bare provider: web onboarding before
+ *   #39516 (2026-07-29) created the connection as `name: "<provider>"` and
+ *   stamped that name onto the copy it authored, while daemon-side seeding
+ *   independently wrote `<provider>-personal` — real workspaces carry both
+ *   stamps side by side. Safe to accept: an api-key connection named
+ *   exactly the provider resolves the same `credential/<provider>/api_key`
+ *   slot as the conventional row, so retiring the copy cannot switch keys.
+ *   A body carrying any other connection value is a user edit and never
+ *   matches.
  *
- * The third hatch-written deviation, `source: "managed"` from the earliest
+ * The final hatch-written deviation, `source: "managed"` from the earliest
  * templates, is handled by the caller's source normalization.
  */
 function hatchBodyVariants(
   known: Record<string, unknown>,
   key: DefaultProfileKey,
+  copyProvider: string,
 ): Record<string, unknown>[] {
   let variants = [known];
   if (key === "quality-optimized") {
@@ -365,7 +391,7 @@ function hatchBodyVariants(
   }
   return variants.flatMap((v) => {
     const { provider_connection: _pc, ...bare } = v;
-    return [v, bare];
+    return [v, bare, { ...v, provider_connection: copyProvider }];
   });
 }
 

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -16,6 +16,7 @@ import { invalidateConfigCache } from "../config/loader.js";
 import {
   type DefaultProviderConfig,
   DefaultProviderSchema,
+  isDefaultProviderChoice,
   LLMConfigBase,
   type ProfileEntry,
 } from "../config/schemas/llm.js";
@@ -272,7 +273,11 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
       // indistinguishable from a genuine hatch stub and would be deleted by
       // the stub arm on the next boot, so the colliding label is never
       // carried. A carried disable survives as a label-less stub; a
-      // rename-only collision leaves no overlay worth writing.
+      // rename-only collision leaves no overlay worth writing. When the
+      // user both re-enabled the hatch stub and disabled the copy, the
+      // copy's disable wins (the stub arm already deleted the re-enabled
+      // stub, clearing the bare key for this carry): the copy governed the
+      // rail dispatch actually used, so its overlay is the meaningful one.
       if (isHatchStub(key, stub)) {
         delete stub.label;
       }
@@ -319,8 +324,18 @@ function isKnownUneditedBody(
   // recorded that provider on the body; the current default provider may
   // have changed since (most commonly to `vellum` after connecting to
   // platform), so the copy is compared against its own recorded provider.
+  // Only providers that can back the code-defined defaults are candidates:
+  // it keeps the comparison off the catalog/fallback default-model path, and
+  // legacy onboarding copies for keyless or endpoint-supplied providers
+  // (ollama, openai-compatible) must never retire, since their
+  // `provider_connection` can carry a base URL the bare key cannot recover.
+  // `vellum` never had hatch copies, so a body claiming it is not one.
   const copyProvider = entry.provider;
-  if (typeof copyProvider !== "string") {
+  if (
+    typeof copyProvider !== "string" ||
+    !isDefaultProviderChoice(copyProvider) ||
+    copyProvider === "vellum"
+  ) {
     return false;
   }
   const template = USER_PROFILE_TEMPLATES[`custom-${key}`];


### PR DESCRIPTION
## Summary
- The BYOK default-profile conversion (`byok-default-profile-ensure.ts`, from #39598) now runs for installs whose current default provider is `vellum`: each `custom-*` copy is judged against the provider recorded in its own body (the hatch provider) rather than the current default, so installs that hatched BYOK and later connected to platform shed their hatch stubs and unedited copies like everyone else.
- Re-enabled hatch stubs (`status: "active"` — the only writable field on a managed stub) are now recognized and deleted; the bare key resolves active post-conversion, so the user's enable is preserved while the stale `(Managed)`-suffixed label goes away.
- The bare-provider `provider_connection` stamp written by pre-#39516 web onboarding (`name: "<provider>"`, same `credential/<provider>/api_key` slot as `<provider>-personal`) is accepted as a git-verified machinery variant; any other connection reference still counts as a user edit and conservatively keeps the copy, since retiring it could switch which key gets billed.
- Tests: flipped the three behavior-pinning cases, plus new coverage for vellum-default pristine/edited/re-enabled shapes, the bare-connection stamp, a non-conventional connection kept, and a specimen test mirroring a real vellum-default workspace (mixed connection stamps, thinking-stamped active stubs, untouched `os-beta` overlay, call-site repoints). Also smoke-ran the pass against a copy of the real workspace config: converts fully, second run byte-identical.

## Original prompt
A self-hosted user who hatched BYOK (anthropic) and later connected to platform still saw duplicate profile rows after updating to a dev build containing #39598: disabled/re-enabled `(Managed)` stubs alongside the old `custom-*` copies. Root cause: the ensure pass's early return for vellum-default installs skipped both the stub deletion and the copy conversion. The fix was requested to make conversion default-provider-agnostic (judge copies by their own recorded provider), handle stubs the user re-enabled through the UI, stay conservative on anything not positively identified as machinery-written, and validate against the real affected workspace.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->