### PR TITLE
fix: provider-error turn-grouping consistency from plan review

### DIFF
--- a/assistant/src/__tests__/turn-boundary-resolution.test.ts
+++ b/assistant/src/__tests__/turn-boundary-resolution.test.ts
@@ -4,6 +4,8 @@ import {
   addMessage,
   createConversation,
   getAssistantMessageIdsInTurn,
+  PROVIDER_ERROR_MESSAGE_KIND,
+  SYSTEM_CARD_MESSAGE_KIND,
 } from "../persistence/conversation-crud.js";
 import { getDb, getLogsDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -153,5 +155,56 @@ describe("getAssistantMessageIdsInTurn", () => {
     // Query first turn → should only include a1
     const firstTurnResult = getAssistantMessageIdsInTurn(a1.id);
     expect(firstTurnResult).toEqual([a1.id]);
+  });
+
+  test("provider-error row after an assistant row: not grouped into the turn", async () => {
+    const conv = createConversation("provider-error-after");
+    await addMessage(conv.id, "user", "Do the thing", {
+      skipIndexing: true,
+    });
+    const a1 = await addMessage(conv.id, "assistant", "Partial progress...", {
+      skipIndexing: true,
+    });
+    const pe = await addMessage(conv.id, "assistant", "Provider failed.", {
+      skipIndexing: true,
+      metadata: { messageKind: PROVIDER_ERROR_MESSAGE_KIND },
+    });
+
+    expect(getAssistantMessageIdsInTurn(a1.id)).toEqual([a1.id]);
+    expect(getAssistantMessageIdsInTurn(pe.id)).toEqual([pe.id]);
+  });
+
+  test("assistant row after a provider-error row: earlier standalone row excluded", async () => {
+    const conv = createConversation("provider-error-before");
+    await addMessage(conv.id, "user", "Do the thing", {
+      skipIndexing: true,
+    });
+    const pe = await addMessage(conv.id, "assistant", "Provider failed.", {
+      skipIndexing: true,
+      metadata: { messageKind: PROVIDER_ERROR_MESSAGE_KIND },
+    });
+    const a1 = await addMessage(conv.id, "assistant", "Recovered reply", {
+      skipIndexing: true,
+    });
+
+    expect(getAssistantMessageIdsInTurn(a1.id)).toEqual([a1.id]);
+    expect(getAssistantMessageIdsInTurn(pe.id)).toEqual([pe.id]);
+  });
+
+  test("system card adjacent to an assistant row: not grouped into the turn", async () => {
+    const conv = createConversation("system-card-adjacent");
+    await addMessage(conv.id, "user", "Summarize please", {
+      skipIndexing: true,
+    });
+    const a1 = await addMessage(conv.id, "assistant", "Working on it...", {
+      skipIndexing: true,
+    });
+    const card = await addMessage(conv.id, "assistant", "Compacted.", {
+      skipIndexing: true,
+      metadata: { messageKind: SYSTEM_CARD_MESSAGE_KIND },
+    });
+
+    expect(getAssistantMessageIdsInTurn(a1.id)).toEqual([a1.id]);
+    expect(getAssistantMessageIdsInTurn(card.id)).toEqual([card.id]);
   });
 });

--- a/assistant/src/conversations/message-consolidation.ts
+++ b/assistant/src/conversations/message-consolidation.ts
@@ -32,44 +32,21 @@
  */
 
 import type { MessageRow } from "../persistence/conversation-crud.js";
-import {
-  isProviderErrorMessage,
-  isSystemCardMessage,
-} from "../persistence/conversation-crud.js";
+import { isStandaloneAssistantMessage } from "../persistence/conversation-crud.js";
 import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("message-consolidation");
 
 /**
- * True when a row is a daemon-authored system card (`messageKind:
- * "system_card"` metadata). Cards are standalone display turns: they never
- * fold into an adjacent assistant run and adjacent assistant rows never
- * fold into them.
- */
-export function isSystemCardRow(msg: MessageRow): boolean {
-  return isSystemCardMessage(msg.role, msg.metadata);
-}
-
-/**
- * True when a row is the synthetic assistant message the agent loop persists
- * on the provider-error path (`messageKind: "provider_error"` metadata).
- * Like system cards, these rows are standalone display turns: merging one
- * into an adjacent assistant run would let the anchor's metadata win and
- * drop the provider-error marker from the wire (or stamp it onto a bubble
- * containing real assistant text).
- */
-export function isProviderErrorRow(msg: MessageRow): boolean {
-  return isProviderErrorMessage(msg.role, msg.metadata);
-}
-
-/**
  * True when an assistant row is a standalone display turn (system card or
  * provider-error notice) that never merges with adjacent assistant rows in
- * either direction.
+ * either direction. Merging one into an adjacent run would let the anchor's
+ * metadata win and drop the `messageKind` marker from the wire (or stamp it
+ * onto a bubble containing real assistant text).
  */
 function isStandaloneAssistantRow(msg: MessageRow): boolean {
-  return isSystemCardRow(msg) || isProviderErrorRow(msg);
+  return isStandaloneAssistantMessage(msg.role, msg.metadata);
 }
 
 // ── Block predicates ────────────────────────────────────────────────

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -463,6 +463,23 @@ export function isProviderErrorMessage(
 }
 
 /**
+ * True when an assistant row is a standalone display turn: a system card or
+ * a provider-error notice. Standalone rows never merge with adjacent
+ * assistant rows, and turn grouping closes on them, so display merging and
+ * the turn resolver agree on boundaries.
+ */
+export function isStandaloneAssistantMessage(
+  role: string,
+  metadata: string | null,
+): boolean {
+  return assistantRowMetadataMatches(
+    role,
+    metadata,
+    (parsed) => isSystemCardMetadata(parsed) || isProviderErrorMetadata(parsed),
+  );
+}
+
+/**
  * Parse a persisted message's metadata JSON against {@link messageMetadataSchema}
  * — the single source of truth for its shape — returning the validated fields,
  * or `undefined` when the column is absent, not valid JSON, or fails validation.
@@ -4269,8 +4286,10 @@ export function getTurnTimeBounds(
 /**
  * Resolve all assistant message IDs that belong to the same agent turn
  * as the given `messageId`. A "turn" is bounded by:
- *   - The start of the conversation, or
- *   - A user message whose content is NOT a tool_result array.
+ *   - The start of the conversation,
+ *   - A user message whose content is NOT a tool_result array, or
+ *   - A standalone assistant row (see {@link isStandaloneAssistantMessage}),
+ *     which always forms its own single-row turn.
  *
  * Within a multi-step agent loop, the pattern is:
  *   user msg → assistant A1 → user (tool_result) → assistant A2 → ...
@@ -4289,9 +4308,10 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
     return [messageId];
   }
 
-  // A system card is its own single-row group — its linked calls (e.g. the
-  // summarize-up-to compaction call) never mix into a neighbouring turn.
-  if (isSystemCardMessage(target.role, target.metadata)) {
+  // A standalone row (system card or provider-error notice) is its own
+  // single-row group: its linked calls (e.g. the summarize-up-to compaction
+  // call) never mix into a neighbouring turn.
+  if (isStandaloneAssistantMessage(target.role, target.metadata)) {
     return [target.id];
   }
 
@@ -4321,9 +4341,9 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
 
   for (const row of backwardRows) {
     if (row.role === "assistant") {
-      if (isSystemCardMessage(row.role, row.metadata)) {
-        // A system card closes the groups on either side of it — rows
-        // before the card belong to an earlier display group.
+      if (isStandaloneAssistantMessage(row.role, row.metadata)) {
+        // A standalone row closes the groups on either side of it: rows
+        // before it belong to an earlier display group.
         boundaryCreatedAt = row.createdAt;
         break;
       }
@@ -4363,10 +4383,10 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
 
   for (const row of forwardRows) {
     if (row.role === "assistant") {
-      if (isSystemCardMessage(row.role, row.metadata)) {
-        // A card that is the queried user message's only reply (e.g. the
-        // /compact result) IS the turn's response; otherwise the card
-        // closes the group.
+      if (isStandaloneAssistantMessage(row.role, row.metadata)) {
+        // A standalone row that is the queried user message's only reply
+        // (e.g. the /compact result card, or a provider-error notice) IS
+        // the turn's response; otherwise it closes the group.
         if (assistantIds.length === 0) {
           assistantIds.push(row.id);
         }
@@ -4410,7 +4430,7 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
     for (const row of gapRows) {
       if (
         row.role === "assistant" &&
-        !isSystemCardMessage(row.role, row.metadata) &&
+        !isStandaloneAssistantMessage(row.role, row.metadata) &&
         !assistantIds.includes(row.id)
       ) {
         assistantIds.push(row.id);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for credits-ux.md.

**Gap:** getAssistantMessageIdsInTurn groups provider-error rows into adjacent assistant turns; consolidation predicates exported without consumers
**What was expected:** turn grouping mirrors the display layer's standalone-row rule; module surface matches use
**What was found:** system-card-only special cases; two unconsumed exports
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->