### PR TITLE
fix: single-pass search ranking, drop dead llms.txt walker

### DIFF
--- a/clients/docs/scripts/generate-agent-markdown.ts
+++ b/clients/docs/scripts/generate-agent-markdown.ts
@@ -16,7 +16,7 @@
  * Runs before `next build` and `next dev` (see the prebuild/predev scripts in
  * package.json) so the generated files ship with the deploy.
  */
-import { mkdir, opendir, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -113,24 +113,6 @@ function outputPathForRoute(route: string): string {
   return join(OUTPUT_ROOT, `${route.replace(/^\//, "")}.md`);
 }
 
-async function removeGeneratedDocsLlmsFiles(dir: string): Promise<void> {
-  let entries;
-  try {
-    entries = await opendir(dir);
-  } catch {
-    return;
-  }
-
-  for await (const entry of entries) {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      await removeGeneratedDocsLlmsFiles(path);
-    } else if (entry.isFile() && entry.name === "llms.txt") {
-      await rm(path, { force: true });
-    }
-  }
-}
-
 async function main() {
   // Redirect stubs permanently redirect their HTML route; mirroring them
   // would point agents at a page that only says "moved". llms.txt and the
@@ -140,7 +122,6 @@ async function main() {
   );
 
   await rm(OUTPUT_ROOT, { recursive: true, force: true });
-  await removeGeneratedDocsLlmsFiles(DOCS_PUBLIC_ROOT);
 
   let written = 0;
   let fallbacks = 0;

--- a/clients/docs/src/lib/docs/search/ranker.ts
+++ b/clients/docs/src/lib/docs/search/ranker.ts
@@ -14,7 +14,6 @@ interface SearchableChunk extends DocsSearchChunk {
 interface RankedChunk {
   chunk: DocsSearchChunk;
   matchedTerms: string[];
-  lexicalScore: number;
   score: number;
 }
 
@@ -82,54 +81,6 @@ function clampLimit(limit: number | undefined): number {
   return Math.min(Math.max(Math.floor(limit), 1), 20);
 }
 
-function normalizeLexicalScores(candidates: RankedChunk[]): RankedChunk[] {
-  const maxLexical = Math.max(...candidates.map((candidate) => candidate.lexicalScore), 1);
-
-  return candidates.map((candidate) => ({
-    ...candidate,
-    score: candidate.lexicalScore / maxLexical,
-  }));
-}
-
-function lexicalSearch(params: {
-  query: string;
-  chunks: DocsSearchChunk[];
-  topK: number;
-}): RankedChunk[] {
-  const mini = getMiniSearch(params.chunks);
-  const chunkMap = getChunkMap(params.chunks);
-
-  const raw = mini.search(params.query, {
-    combineWith: "OR",
-    prefix: true,
-    fuzzy: (term) => (term.length >= 5 ? 0.2 : false),
-    boost: SEARCH_BOOSTS,
-  });
-
-  const ranked = raw
-    .slice(0, params.topK)
-    .map((result) => {
-      const chunk = chunkMap.get(String(result.id));
-      if (!chunk) {
-        return null;
-      }
-
-      return {
-        chunk,
-        matchedTerms: result.terms,
-        lexicalScore: result.score,
-        score: result.score,
-      } satisfies RankedChunk;
-    })
-    .filter((candidate): candidate is RankedChunk => candidate !== null);
-
-  if (ranked.length === 0) {
-    return [];
-  }
-
-  return normalizeLexicalScores(ranked).sort((a, b) => b.score - a.score);
-}
-
 function toResult(query: string, candidate: RankedChunk): DocsSearchResult {
   const snippetQuery = [...candidate.matchedTerms, query].join(" ").trim() || query;
 
@@ -157,12 +108,29 @@ export function searchDocsIndex(params: {
     return [];
   }
 
-  const lexicalTopK = Math.max(40, limit * 4);
-  const candidates = lexicalSearch({
-    query,
-    chunks: params.index.chunks,
-    topK: lexicalTopK,
+  const mini = getMiniSearch(params.index.chunks);
+  const chunkMap = getChunkMap(params.index.chunks);
+
+  const matches = mini.search(query, {
+    combineWith: "OR",
+    prefix: true,
+    fuzzy: (term) => (term.length >= 5 ? 0.2 : false),
+    boost: SEARCH_BOOSTS,
   });
 
-  return candidates.slice(0, limit).map((candidate) => toResult(query, candidate));
+  // Normalizes scores to 0..1 against the best match for the response shape.
+  const maxScore = Math.max(...matches.map((match) => match.score), 1);
+
+  return matches.slice(0, limit).flatMap((match) => {
+    const chunk = chunkMap.get(String(match.id));
+    if (!chunk) {
+      return [];
+    }
+
+    return toResult(query, {
+      chunk,
+      matchedTerms: match.terms,
+      score: match.score / maxScore,
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for docs-app-phase-1.md: the ranker is a single-pass lexical pipeline (no vestigial hybrid scaffolding, oversampling, or redundant sort) and the generator's dead recursive llms.txt cleanup walker is removed.