### PR TITLE
fix(runtime): surface trusted-defer field-edit refusal as HTTP 400 (LUM-2940)

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -37,6 +37,7 @@ import {
   listSchedules,
   updateSchedule,
 } from "../schedule/schedule-store.js";
+import { UserError } from "../util/errors.js";
 
 await initializeDb();
 
@@ -1445,6 +1446,11 @@ describe("owner-defer provenance", () => {
 
   test("a trusted row refuses a trigger-text rewrite", async () => {
     const job = await trustedDefer();
+    // UserError specifically: transport surfaces map it to a 4xx that carries
+    // the actionable message, rather than a generic 500.
+    await expect(
+      updateSchedule(job.id, { message: "do something else" }),
+    ).rejects.toThrow(UserError);
     await expect(
       updateSchedule(job.id, { message: "do something else" }),
     ).rejects.toThrow(/fixed at creation/);

--- a/assistant/src/__tests__/wake-schedule-escalation.test.ts
+++ b/assistant/src/__tests__/wake-schedule-escalation.test.ts
@@ -60,6 +60,7 @@ import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { createConversation } from "../persistence/conversation-crud.js";
 import { getDb, getSqliteFrom } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
 import { ROUTES as SCHEDULE_ROUTES } from "../runtime/routes/schedule-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
 import { LEGACY_DEFER_CREATED_BY } from "../schedule/defer-provenance.js";
@@ -229,6 +230,46 @@ describe("a non-owner cannot retarget a schedule onto a guardian conversation", 
         (c) => (c[0] as Record<string, unknown>).conversationId === TARGET,
       ),
     ).toHaveLength(0);
+  });
+});
+
+describe("a locked-field edit is refused as a caller error, not a daemon fault", () => {
+  beforeEach(resetAll);
+
+  test("an owner PATCHing a locked field gets a 400 with the actionable refusal", async () => {
+    const defer = await seedOwnerDefer();
+
+    const err = await callRoute("updateSchedule", {
+      pathParams: { id: defer.id },
+      body: { message: "do something else" },
+      headers: LOCAL_CALLER,
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    // The refusal itself is correct; what matters here is the shape: a
+    // BadRequestError (HTTP 400) whose message names the invariant and the
+    // cancel-and-recreate workaround, not a generic InternalError (500).
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).statusCode).toBe(400);
+    expect((err as BadRequestError).message).toMatch(
+      /fixed at creation; cancel and re-create it/,
+    );
+    expect(getSchedule(defer.id)?.message).toBe("check the build");
+  });
+
+  test("same-value and unrelated edits still succeed for the owner", async () => {
+    const defer = await seedOwnerDefer();
+
+    await callRoute("updateSchedule", {
+      pathParams: { id: defer.id },
+      body: { message: "check the build", name: "renamed" },
+      headers: LOCAL_CALLER,
+    });
+
+    expect(getSchedule(defer.id)?.name).toBe("renamed");
+    expect(getSchedule(defer.id)?.message).toBe("check the build");
   });
 });
 

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -44,6 +44,7 @@ import {
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
 import { buildWakeScheduleOptions } from "../../schedule/wake-schedule-options.js";
 import { initializeTools } from "../../tools/registry.js";
+import { UserError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { normalizeCapabilityManifest } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
@@ -649,6 +650,11 @@ async function handleUpdateSchedule(
   } catch (err) {
     if (err instanceof NotFoundError || err instanceof BadRequestError) {
       throw err;
+    }
+    // Store-layer refusals (e.g. the trusted-defer immutable-field refusal)
+    // are caller mistakes with an actionable message, not daemon faults.
+    if (err instanceof UserError) {
+      throw new BadRequestError(err.message);
     }
     if (
       err instanceof Error &&

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -8,6 +8,7 @@ import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
 import { rawChanges } from "../persistence/raw-query.js";
 import { scheduleJobs, scheduleRuns } from "../persistence/schema/index.js";
 import { publishSchedulesChanged } from "../runtime/sync/resource-sync-events.js";
+import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { withSqliteRetry } from "../util/sqlite-retry.js";
 import {
@@ -494,7 +495,9 @@ export async function updateSchedule(
     const rewritesMode =
       updates.mode !== undefined && updates.mode !== existing.mode;
     if (rewritesTrigger || rewritesTarget || rewritesMode) {
-      throw new Error(
+      // UserError: a caller-facing refusal, not a daemon fault — transport
+      // surfaces map it to a 4xx carrying this message, not a generic 500.
+      throw new UserError(
         "A trusted deferred wake's target, trigger text, and mode are fixed at creation; cancel and re-create it",
       );
     }
@@ -526,7 +529,7 @@ export async function updateSchedule(
       timezone: newTimezone,
     };
     if (!isValidScheduleExpression(spec)) {
-      throw new Error(`Invalid ${newSyntax} expression: "${newExpr}"`);
+      throw new UserError(`Invalid ${newSyntax} expression: "${newExpr}"`);
     }
   }
 

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -495,7 +495,7 @@ export async function updateSchedule(
     const rewritesMode =
       updates.mode !== undefined && updates.mode !== existing.mode;
     if (rewritesTrigger || rewritesTarget || rewritesMode) {
-      // UserError: a caller-facing refusal, not a daemon fault — transport
+      // UserError: a caller-facing refusal, not a daemon fault. Transport
       // surfaces map it to a 4xx carrying this message, not a generic 500.
       throw new UserError(
         "A trusted deferred wake's target, trigger text, and mode are fixed at creation; cancel and re-create it",


### PR DESCRIPTION
Fixes LUM-2940.

## TL;DR

`PATCH /schedules/:id` changing a trusted deferred wake's locked fields (`message`, `wakeConversationId`, `mode`) returned a generic **500 InternalError**. It now returns **400 BadRequest** carrying the store's actionable refusal message ("…fixed at creation; cancel and re-create it"). The immutability enforcement itself (PR #39601 / LUM-2929) is unchanged.

## What changes for the caller

| | Before | After |
|---|---|---|
| PATCH a locked field on a trusted defer | `500 InternalError` (reads as "the daemon broke") | `400 BAD_REQUEST` with "A trusted deferred wake's target, trigger text, and mode are fixed at creation; cancel and re-create it" |
| PATCH an invalid cron/rrule expression | `400` (via the route's message-substring sniffing) | `400` (typed, no message sniffing needed) |
| Same-value / unrelated edits on a trusted defer | Succeed | Succeed (unchanged, now regression-tested) |
| The refusal itself | Enforced | Enforced (unchanged) |

## Design

The store's two user-facing refusals in `updateSchedule` (the trusted-defer locked-field refusal and the invalid-expression refusal) now throw `UserError` from the existing `VellumError` hierarchy: `docs/error-handling.md` prescribes typed errors over bare `Error`, and `UserError` is documented as "user-facing constraints… present an actionable message". `handleUpdateSchedule` maps `UserError → BadRequestError`, mirroring the established store→route pattern (`conversation-crud.ts` throws `UserError`; conversation routes map it to a 4xx).

This keeps the type coupling in the domain layer's own hierarchy: the store does not import transport error classes, and the route does not sniff message substrings for these paths. The pre-existing `"Invalid"`-substring fallback in the catch is retained for errors raised by other layers.

## Why it's safe

- No behavior change to the enforcement, only the error's class and wire status.
- The agent-facing `schedule_update` tool catches all errors generically and formats `err.message`, so its output is byte-identical.
- The IPC surface gains the same structured `BAD_REQUEST` code instead of a generic internal error (adapters already map `RouteError` subclasses).
- Covered by new tests: a store-level assertion that the refusal is a `UserError`, and route-level regression tests (owner PATCH on a locked field → `BadRequestError` with status 400 and the actionable message; same-value/unrelated edits still succeed). Existing schedule-store, wake-escalation, and create-route suites pass.

## Not in scope

- The create-path catch blocks in `handleCreateSchedule` blanket-map every `Error` to 400 (over-broad in the opposite direction: a genuine store fault would masquerade as a caller error). Pre-existing shape, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
