### PR TITLE
fix: shared nav panel shell, close drawer on desktop resize, shared month label

### DIFF
--- a/clients/docs/src/app/docs/_components/docs-nav-context.tsx
+++ b/clients/docs/src/app/docs/_components/docs-nav-context.tsx
@@ -65,6 +65,20 @@ export function DocsNavProvider({ children }: { children: ReactNode }) {
     return () => window.removeEventListener("hashchange", close);
   }, [close]);
 
+  // The drawer markup is md:hidden, so if the viewport is resized or rotated
+  // past the md breakpoint while the drawer is open, the drawer (and its close
+  // button) disappears while body scroll stays locked. Close on crossing.
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 768px)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        close();
+      }
+    };
+    mql.addEventListener("change", handleChange);
+    return () => mql.removeEventListener("change", handleChange);
+  }, [close]);
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {

--- a/clients/docs/src/app/docs/_components/docs-nav.tsx
+++ b/clients/docs/src/app/docs/_components/docs-nav.tsx
@@ -40,16 +40,13 @@ import {
   Wand2,
   Webhook,
   Wrench,
-  X,
 } from "lucide-react";
 import { type ReactNode, useMemo } from "react";
 
 import { routes } from "@/lib/routes";
 
-import { DocsSearch } from "@/app/docs/_components/docs-search";
-import { DocsThemePicker } from "@/app/docs/_components/docs-theme-picker";
-import { DocsGithubLink } from "@/app/docs/_components/docs-github-link";
 import { useDocsNav } from "@/app/docs/_components/docs-nav-context";
+import { NavPanelShell } from "@/app/docs/_components/nav-panel-shell";
 
 interface DocsNavChild {
   label: string;
@@ -593,7 +590,7 @@ function NavSection({
 
 export function DocsNav() {
   const pathname = usePathname();
-  const { visible, animating, close } = useDocsNav();
+  const { close } = useDocsNav();
 
   const navItems = useMemo(
     () =>
@@ -633,60 +630,11 @@ export function DocsNav() {
     [pathname, close],
   );
 
-  const navContent = (
-    <div className="flex h-full flex-col">
-      {/* Search only renders here on mobile; desktop has it in the header.
-          The header instance owns the global Cmd/Ctrl+K shortcut, so this
-          duplicate must not register it too. */}
-      <div className="shrink-0 px-4 pt-4 pb-3 md:hidden">
-        <DocsSearch registerShortcut={false} />
-      </div>
+  return (
+    <NavPanelShell>
       <ul className="docs-nav-list list-none px-4 pb-4 pt-4 md:pt-8 m-0 flex-1 overflow-y-auto">
         {navItems}
       </ul>
-    </div>
-  );
-
-  return (
-    <>
-      {/* Mobile overlay */}
-      {visible && (
-        <div className="fixed inset-0 z-50 md:hidden">
-          <div
-            className={`docs-nav-overlay absolute inset-0 transition-opacity duration-250 ${
-              animating ? "opacity-100" : "opacity-0"
-            }`}
-            onClick={close}
-          />
-          <div
-            className={`docs-nav-panel absolute inset-y-0 left-0 w-72 overflow-y-auto border-r shadow-xl transition-transform duration-250 ease-out flex flex-col ${
-              animating ? "translate-x-0" : "-translate-x-full"
-            }`}
-          >
-            <button
-              type="button"
-              onClick={close}
-              className="docs-nav-close absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-lg"
-              aria-label="Close navigation"
-            >
-              <X size={18} />
-            </button>
-            <div className="flex-1 overflow-y-auto">{navContent}</div>
-            <div
-              className="docs-nav-mobile-footer flex items-center justify-between border-t px-4 py-3"
-              style={{ borderColor: "var(--docs-border)" }}
-            >
-              <DocsThemePicker />
-              <DocsGithubLink />
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Desktop sidebar */}
-      <nav className="docs-nav-panel hidden border-r md:sticky md:top-[101px] md:block md:h-[calc(100vh-101px)] md:w-64 md:shrink-0 md:self-start md:overflow-y-auto md:pb-8">
-        {navContent}
-      </nav>
-    </>
+    </NavPanelShell>
   );
 }

--- a/clients/docs/src/app/docs/_components/nav-panel-shell.tsx
+++ b/clients/docs/src/app/docs/_components/nav-panel-shell.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { X } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { DocsSearch } from "@/app/docs/_components/docs-search";
+import { DocsThemePicker } from "@/app/docs/_components/docs-theme-picker";
+import { DocsGithubLink } from "@/app/docs/_components/docs-github-link";
+import { useDocsNav } from "@/app/docs/_components/docs-nav-context";
+
+/**
+ * Shared sidebar shell for docs-style navs: a slide-in drawer with overlay,
+ * close button, and theme/GitHub footer on mobile, and a sticky sidebar on
+ * desktop. Callers provide the scrollable nav list as children.
+ */
+export function NavPanelShell({ children }: { children: ReactNode }) {
+  const { visible, animating, close } = useDocsNav();
+
+  const navContent = (
+    <div className="flex h-full flex-col">
+      {/* Search only renders here on mobile; desktop has it in the header.
+          The header instance owns the global Cmd/Ctrl+K shortcut, so this
+          duplicate must not register it too. */}
+      <div className="shrink-0 px-4 pt-4 pb-3 md:hidden">
+        <DocsSearch registerShortcut={false} />
+      </div>
+      {children}
+    </div>
+  );
+
+  return (
+    <>
+      {/* Mobile drawer */}
+      {visible && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div
+            className={`docs-nav-overlay absolute inset-0 transition-opacity duration-250 ${
+              animating ? "opacity-100" : "opacity-0"
+            }`}
+            onClick={close}
+          />
+          <div
+            className={`docs-nav-panel absolute inset-y-0 left-0 w-72 overflow-y-auto border-r shadow-xl transition-transform duration-250 ease-out flex flex-col ${
+              animating ? "translate-x-0" : "-translate-x-full"
+            }`}
+          >
+            <button
+              type="button"
+              onClick={close}
+              className="docs-nav-close absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-lg"
+              aria-label="Close navigation"
+            >
+              <X size={18} />
+            </button>
+            <div className="flex-1 overflow-y-auto">{navContent}</div>
+            <div
+              className="docs-nav-mobile-footer flex items-center justify-between border-t px-4 py-3"
+              style={{ borderColor: "var(--docs-border)" }}
+            >
+              <DocsThemePicker />
+              <DocsGithubLink />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Desktop sidebar */}
+      <nav className="docs-nav-panel hidden border-r md:sticky md:top-[101px] md:block md:h-[calc(100vh-101px)] md:w-64 md:shrink-0 md:self-start md:overflow-y-auto md:pb-8">
+        {navContent}
+      </nav>
+    </>
+  );
+}

--- a/clients/docs/src/app/docs/_components/releases-content.tsx
+++ b/clients/docs/src/app/docs/_components/releases-content.tsx
@@ -1,7 +1,11 @@
 import { ReleaseMarkdown } from "@/app/docs/_components/release-markdown";
 import { WWW_DOMAIN } from "@/lib/domains";
 import type { ApiRelease } from "@/lib/releases-server";
-import { groupApiReleasesByMonth, releaseAnchor } from "@/lib/releases-server";
+import {
+  groupApiReleasesByMonth,
+  monthLabel,
+  releaseAnchor,
+} from "@/lib/releases-server";
 import { routes } from "@/lib/routes";
 
 function monthAnchor(releasedAt: string) {
@@ -22,15 +26,6 @@ function formatFullDate(releasedAt: string) {
   });
 }
 
-function getMonthYear(releasedAt: string) {
-  const d = new Date(releasedAt);
-  return d.toLocaleDateString("en-US", {
-    month: "long",
-    year: "numeric",
-    timeZone: "UTC",
-  });
-}
-
 interface ReleasesContentProps {
   releases: ApiRelease[];
 }
@@ -39,7 +34,7 @@ export function ReleasesContent({ releases }: ReleasesContentProps) {
   const groups = groupApiReleasesByMonth(releases);
   const firstRelease = groups[0]?.releases[0];
   const pageTitle = firstRelease
-    ? getMonthYear(firstRelease.released_at)
+    ? monthLabel(new Date(firstRelease.released_at))
     : "Releases";
 
   return (

--- a/clients/docs/src/app/docs/_components/releases-nav.tsx
+++ b/clients/docs/src/app/docs/_components/releases-nav.tsx
@@ -2,23 +2,16 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ChevronRight, X } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 
-import { DocsSearch } from "@/app/docs/_components/docs-search";
-import { DocsThemePicker } from "@/app/docs/_components/docs-theme-picker";
-import { DocsGithubLink } from "@/app/docs/_components/docs-github-link";
 import { useDocsNav } from "@/app/docs/_components/docs-nav-context";
+import { NavPanelShell } from "@/app/docs/_components/nav-panel-shell";
 import type { ApiRelease } from "@/lib/releases-server";
-import { groupApiReleasesByMonth, releaseAnchor } from "@/lib/releases-server";
-
-function getCurrentMonth() {
-  const now = new Date();
-  return now.toLocaleDateString("en-US", {
-    month: "long",
-    year: "numeric",
-    timeZone: "UTC",
-  });
-}
+import {
+  groupApiReleasesByMonth,
+  monthLabel,
+  releaseAnchor,
+} from "@/lib/releases-server";
 
 interface ReleasesNavProps {
   releases: ApiRelease[];
@@ -32,10 +25,10 @@ interface ReleasesNavProps {
 export function ReleasesNav({ releases }: ReleasesNavProps) {
   const groups = groupApiReleasesByMonth(releases);
   const [activeId, setActiveId] = useState<string>("");
-  const { visible, animating, close } = useDocsNav();
+  const { close } = useDocsNav();
 
   const [expandedMonths, setExpandedMonths] = useState<Set<string>>(() => {
-    const currentMonth = getCurrentMonth();
+    const currentMonth = monthLabel(new Date());
     const hasCurrentMonth = groups.some((g) => g.month === currentMonth);
     const initial = hasCurrentMonth ? currentMonth : groups[0]?.month;
     return initial ? new Set([initial]) : new Set();
@@ -99,14 +92,8 @@ export function ReleasesNav({ releases }: ReleasesNavProps) {
     return () => observer.disconnect();
   }, [groups, releaseToMonth]);
 
-  const navContent = (
-    <div className="flex h-full flex-col">
-      {/* Search only renders here on mobile; desktop has it in the header.
-          The header instance owns the global Cmd/Ctrl+K shortcut, so this
-          duplicate must not register it too. */}
-      <div className="shrink-0 px-4 pt-4 pb-3 md:hidden">
-        <DocsSearch registerShortcut={false} />
-      </div>
+  return (
+    <NavPanelShell>
       <div className="flex-1 overflow-y-auto px-4 pb-4 pt-4 md:pt-8">
         <div className="mb-5">
           <Link
@@ -170,49 +157,6 @@ export function ReleasesNav({ releases }: ReleasesNavProps) {
           })}
         </ul>
       </div>
-    </div>
-  );
-
-  return (
-    <>
-      {/* Mobile drawer */}
-      {visible && (
-        <div className="fixed inset-0 z-50 md:hidden">
-          <div
-            className={`docs-nav-overlay absolute inset-0 transition-opacity duration-250 ${
-              animating ? "opacity-100" : "opacity-0"
-            }`}
-            onClick={close}
-          />
-          <div
-            className={`docs-nav-panel absolute inset-y-0 left-0 w-72 overflow-y-auto border-r shadow-xl transition-transform duration-250 ease-out flex flex-col ${
-              animating ? "translate-x-0" : "-translate-x-full"
-            }`}
-          >
-            <button
-              type="button"
-              onClick={close}
-              className="docs-nav-close absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-lg"
-              aria-label="Close navigation"
-            >
-              <X size={18} />
-            </button>
-            <div className="flex-1 overflow-y-auto">{navContent}</div>
-            <div
-              className="docs-nav-mobile-footer flex items-center justify-between border-t px-4 py-3"
-              style={{ borderColor: "var(--docs-border)" }}
-            >
-              <DocsThemePicker />
-              <DocsGithubLink />
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Desktop sidebar */}
-      <nav className="docs-nav-panel hidden border-r md:sticky md:top-[101px] md:block md:h-[calc(100vh-101px)] md:w-64 md:shrink-0 md:self-start md:overflow-y-auto md:pb-8">
-        {navContent}
-      </nav>
-    </>
+    </NavPanelShell>
   );
 }

--- a/clients/docs/src/lib/releases-server.ts
+++ b/clients/docs/src/lib/releases-server.ts
@@ -78,17 +78,23 @@ export const fetchReleases = cache(async (): Promise<ApiRelease[]> => {
   }
 });
 
+// Single source for the "Month Year" release label, shared by the month
+// grouping below, the sidebar's current-month default, and the page title
+// so the labels never diverge.
+export function monthLabel(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 export function groupApiReleasesByMonth(releases: ApiRelease[]) {
   const groups: { month: string; releases: ApiRelease[] }[] = [];
   const monthMap = new Map<string, ApiRelease[]>();
 
   for (const release of releases) {
-    const d = new Date(release.released_at);
-    const label = d.toLocaleDateString("en-US", {
-      month: "long",
-      year: "numeric",
-      timeZone: "UTC",
-    });
+    const label = monthLabel(new Date(release.released_at));
     if (!monthMap.has(label)) {
       monthMap.set(label, []);
       groups.push({ month: label, releases: monthMap.get(label)! });


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for docs-app-phase-1.md: the duplicated drawer/sidebar shell is extracted into a shared component, the drawer closes (and unlocks body scroll) when the viewport crosses the md breakpoint, and the releases month label derives from one shared helper.