### PR TITLE
fix: banner precedence and modal ownership consolidation from plan review

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -61,12 +61,6 @@ import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
-const AddCreditsModal = lazy(() =>
-  import("@/components/add-credits-modal").then((m) => ({
-    default: m.AddCreditsModal,
-  })),
-);
-
 const DeployDialogs = lazy(() =>
   import("@/components/deploy-dialogs").then((m) => ({
     default: m.DeployDialogs,
@@ -107,7 +101,6 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
-  const [showAddCreditsModal, setShowAddCreditsModal] = useState(false);
 
   // -------------------------------------------------------------------------
   // Zustand store selectors
@@ -566,7 +559,6 @@ export function ActiveChatView() {
 
     // Upward signals
     setRefreshEpoch,
-    setShowAddCreditsModal,
 
     // Shared refs
     inputRef,
@@ -584,15 +576,6 @@ export function ActiveChatView() {
   return (
     <>
       <ChatContentLayout {...chatRouteProps} />
-
-      {showAddCreditsModal ? (
-        <LazyBoundary>
-          <AddCreditsModal
-            open={showAddCreditsModal}
-            onOpenChange={setShowAddCreditsModal}
-          />
-        </LazyBoundary>
-      ) : null}
 
       {assistantId && (isTokenDialogOpen || complexDeployApp) ? (
         <LazyBoundary>

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -73,10 +73,7 @@ import { ComposerSecretNotice } from "@/domains/chat/components/composer-secret-
 import { ComposerSettingsMenu } from "@/domains/chat/components/composer-settings-menu";
 import { ContextWindowIndicator } from "@/domains/chat/components/context-window-indicator";
 import { DailyLimitBanner } from "@/domains/chat/components/daily-limit-banner";
-import {
-  LowBalanceBanner,
-  shouldShowLowBalanceBanner,
-} from "@/domains/chat/components/low-balance-banner";
+import { LowBalanceBanner } from "@/domains/chat/components/low-balance-banner";
 import { MicPermissionPrimer } from "@/domains/chat/components/mic-permission-primer";
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner";
@@ -188,7 +185,6 @@ export interface ChatMainPanelProps {
 
   // Upward signals to ActiveChatView local state
   setRefreshEpoch: Dispatch<SetStateAction<number>>;
-  setShowAddCreditsModal: Dispatch<SetStateAction<boolean>>;
 
   // Shared refs (owned by ActiveChatView for debug API / keydown handler)
   inputRef: RefObject<HTMLTextAreaElement | null>;
@@ -263,7 +259,6 @@ export function ChatMainPanel({
   historyPagination,
   diskPressure,
   setRefreshEpoch,
-  setShowAddCreditsModal,
   inputRef,
   sanitizedMessagesRef,
   transcriptItemsRef,
@@ -1029,17 +1024,11 @@ export function ChatMainPanel({
   const billingBannerDecision =
     errorBillingBannerDecision ?? noticeBillingBannerDecision;
 
-  // Error-driven banners always take precedence over the proactive
-  // low-balance warning.
   const lowBalanceBannerDismissed = useLowBalanceBannerStore.use.dismissed();
-  const showLowBalanceBanner = shouldShowLowBalanceBanner({
+  const composerBillingBanner = resolveComposerBillingBanner({
     billingBannerDecision,
     isLowBalance: balanceStatus.isLowBalance,
     dismissed: lowBalanceBannerDismissed,
-  });
-  const composerBillingBanner = resolveComposerBillingBanner({
-    billingBannerDecision,
-    showLowBalanceBanner,
   });
 
   // -------------------------------------------------------------------------
@@ -1181,9 +1170,7 @@ export function ChatMainPanel({
               ) : composerBillingBanner === "provider_billing" ? (
                 <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
               ) : composerBillingBanner === "low_balance" ? (
-                <LowBalanceBanner
-                  onAddCredits={() => setShowAddCreditsModal(true)}
-                />
+                <LowBalanceBanner />
               ) : null
             }
             diskPressureBanner={diskPressureBannerSlot}

--- a/clients/web/src/domains/chat/components/credits-upsell-card.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.tsx
@@ -1,10 +1,10 @@
-import { lazy, useState } from "react";
+import { useState } from "react";
 
 import { useNavigate } from "react-router";
 
-import { LazyBoundary } from "@/components/lazy-boundary";
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+import { LazyAddCreditsModal } from "@/domains/chat/components/lazy-add-credits-modal";
 import {
   resolveCreditPaywallCta,
   type CreditPaywallCtaMode,
@@ -16,15 +16,6 @@ import {
 import { useIsFreePlan } from "@/hooks/use-is-free-plan";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { routes } from "@/utils/routes";
-
-// Lazy for the same reason as the `AddCreditsModal` mount in
-// `active-chat-view.tsx`: the Stripe checkout modal stays out of the chat
-// bundle until a CTA actually opens it.
-const AddCreditsModal = lazy(() =>
-  import("@/components/add-credits-modal").then((m) => ({
-    default: m.AddCreditsModal,
-  })),
-);
 
 // Both add-credits modes share one copy set: the card's soft-sell wording
 // does not vary by plan, only the upgrade experiment arm changes the CTA.
@@ -51,8 +42,9 @@ const COPY: Record<
  * Friendly credits upsell card: a single-CTA credit wall built on
  * {@link BillingErrorBanner}, rendered in the transcript in place of a
  * persisted credits-exhausted provider-error row. Self-contained (it resolves
- * its own CTA mode and mounts its own {@link AddCreditsModal} instance), so it
- * can also be mounted outside the transcript with no transcript-specific props.
+ * its own CTA mode and mounts its own {@link LazyAddCreditsModal} instance),
+ * so it can also be mounted outside the transcript with no transcript-specific
+ * props.
  */
 export function CreditsUpsellCard() {
   const navigate = useNavigate();
@@ -107,14 +99,10 @@ export function CreditsUpsellCard() {
         }
         detached={true}
       />
-      {showAddCredits ? (
-        <LazyBoundary>
-          <AddCreditsModal
-            open={showAddCredits}
-            onOpenChange={setShowAddCredits}
-          />
-        </LazyBoundary>
-      ) : null}
+      <LazyAddCreditsModal
+        open={showAddCredits}
+        onOpenChange={setShowAddCredits}
+      />
     </>
   );
 }

--- a/clients/web/src/domains/chat/components/lazy-add-credits-modal.tsx
+++ b/clients/web/src/domains/chat/components/lazy-add-credits-modal.tsx
@@ -1,0 +1,33 @@
+import { lazy } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+
+const AddCreditsModal = lazy(() =>
+  import("@/components/add-credits-modal").then((m) => ({
+    default: m.AddCreditsModal,
+  })),
+);
+
+interface LazyAddCreditsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Lazily mounted Add Credits modal for chat-surface CTAs. The Stripe checkout
+ * modal stays out of the chat bundle: nothing renders (and no chunk is
+ * fetched) until a CTA first opens it.
+ */
+export function LazyAddCreditsModal({
+  open,
+  onOpenChange,
+}: LazyAddCreditsModalProps) {
+  if (!open) {
+    return null;
+  }
+  return (
+    <LazyBoundary>
+      <AddCreditsModal open={open} onOpenChange={onOpenChange} />
+    </LazyBoundary>
+  );
+}

--- a/clients/web/src/domains/chat/components/low-balance-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/low-balance-banner.test.tsx
@@ -1,22 +1,25 @@
 /**
- * Tests for the proactive low-balance composer banner: the rendered banner
- * (copy, CTA, session dismissal via the store) and the visibility rule
- * `shouldShowLowBalanceBanner` that `chat-route-content` gates the slot with.
+ * Tests for the proactive low-balance composer banner: copy, the Add-credits
+ * CTA opening the banner's own modal, and session dismissal via the store.
+ * Visibility is decided by `resolveComposerBillingBanner`, tested in
+ * `error-classification.test.ts`.
  *
  * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
- * and drives the buttons with `fireEvent`. No jest-dom matchers: we assert
+ * and drives the buttons with `fireEvent`. The lazy `AddCreditsModal` is
+ * stubbed so opening it needs no query client. No jest-dom matchers: we assert
  * with plain bun `expect` against query results.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import type { ChatBillingBannerDecision } from "@/domains/chat/utils/error-classification";
 import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
 
-import {
-  LowBalanceBanner,
-  shouldShowLowBalanceBanner,
-} from "./low-balance-banner";
+mock.module("@/components/add-credits-modal", () => ({
+  AddCreditsModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-credits-modal-stub" /> : null,
+}));
+
+import { LowBalanceBanner } from "./low-balance-banner";
 
 beforeEach(() => {
   useLowBalanceBannerStore.setState({ dismissed: false });
@@ -27,62 +30,24 @@ afterEach(() => {
 });
 
 describe("LowBalanceBanner", () => {
-  test("renders the low-credits copy with an Add credits CTA", () => {
-    const onAddCredits = mock(() => {});
-
-    const { getByText, getByRole } = render(
-      <LowBalanceBanner onAddCredits={onAddCredits} />,
+  test("renders the low-credits copy with an Add credits CTA that opens the modal", async () => {
+    const { getByText, getByRole, findByTestId, queryByTestId } = render(
+      <LowBalanceBanner />,
     );
 
     expect(getByText("Your credits are running low")).toBeTruthy();
     expect(getByText("Add credits to avoid an interruption.")).toBeTruthy();
+    expect(queryByTestId("add-credits-modal-stub")).toBeNull();
 
     fireEvent.click(getByRole("button", { name: "Add credits" }));
-    expect(onAddCredits).toHaveBeenCalledTimes(1);
+    expect(await findByTestId("add-credits-modal-stub")).toBeTruthy();
     expect(useLowBalanceBannerStore.getState().dismissed).toBe(false);
   });
 
   test("the dismiss button latches the session dismissal in the store", () => {
-    const { getByRole } = render(<LowBalanceBanner onAddCredits={() => {}} />);
+    const { getByRole } = render(<LowBalanceBanner />);
 
     fireEvent.click(getByRole("button", { name: "Dismiss" }));
     expect(useLowBalanceBannerStore.getState().dismissed).toBe(true);
-  });
-});
-
-describe("shouldShowLowBalanceBanner", () => {
-  const visibleArgs = {
-    billingBannerDecision: null,
-    isLowBalance: true,
-    dismissed: false,
-  };
-
-  test("shows only in the warn band with no error banner and no dismissal", () => {
-    expect(shouldShowLowBalanceBanner(visibleArgs)).toBe(true);
-  });
-
-  test("hidden when the server flag is off (normal balance, auto-top-up, or gated-off query)", () => {
-    expect(
-      shouldShowLowBalanceBanner({ ...visibleArgs, isLowBalance: false }),
-    ).toBe(false);
-  });
-
-  test("hidden after a session dismissal", () => {
-    expect(
-      shouldShowLowBalanceBanner({ ...visibleArgs, dismissed: true }),
-    ).toBe(false);
-  });
-
-  test("hidden while any error-driven billing banner decision is active", () => {
-    const decisions: ChatBillingBannerDecision[] = [
-      "managed_credits",
-      "provider_billing",
-      "daily_limit",
-    ];
-    for (const billingBannerDecision of decisions) {
-      expect(
-        shouldShowLowBalanceBanner({ ...visibleArgs, billingBannerDecision }),
-      ).toBe(false);
-    }
   });
 });

--- a/clients/web/src/domains/chat/components/low-balance-banner.tsx
+++ b/clients/web/src/domains/chat/components/low-balance-banner.tsx
@@ -1,47 +1,35 @@
+import { useState } from "react";
+
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
-import type { ChatBillingBannerDecision } from "@/domains/chat/utils/error-classification";
+import { LazyAddCreditsModal } from "@/domains/chat/components/lazy-add-credits-modal";
 import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
 
 /**
- * Whether the proactive low-balance banner may render: only when no
- * error-driven billing banner is active (those always take precedence), the
- * server reports `low_balance_warning`, and the user has not dismissed the
- * banner this session. The exhausted-credits surfaces never overlap with this
- * one: the server keeps `low_balance_warning` false while the balance is
- * exhausted, and it is false for auto-top-up orgs and whenever the billing
- * query is gated off.
- */
-export function shouldShowLowBalanceBanner(args: {
-  billingBannerDecision: ChatBillingBannerDecision | null;
-  isLowBalance: boolean;
-  dismissed: boolean;
-}): boolean {
-  return (
-    args.billingBannerDecision === null && args.isLowBalance && !args.dismissed
-  );
-}
-
-interface LowBalanceBannerProps {
-  onAddCredits: () => void;
-}
-
-/**
  * Proactive composer-flush banner shown while the org's credit balance sits in
- * the server-computed warn band. Copy is deliberately phrased around the flag
- * rather than the numbers: `low_balance_warning` compares the raw balance
- * while display fields are rounded, so near band edges the displayed balance
- * can equal or exceed the displayed threshold while the flag is true.
+ * the server-computed warn band. Visibility is decided by
+ * `resolveComposerBillingBanner`; this component is purely presentational and
+ * owns its own Add Credits modal instance. Copy is deliberately phrased around
+ * the flag rather than the numbers: `low_balance_warning` compares the raw
+ * balance while display fields are rounded, so near band edges the displayed
+ * balance can equal or exceed the displayed threshold while the flag is true.
  */
-export function LowBalanceBanner({ onAddCredits }: LowBalanceBannerProps) {
+export function LowBalanceBanner() {
   const dismiss = useLowBalanceBannerStore.use.dismiss();
+  const [showAddCredits, setShowAddCredits] = useState(false);
   return (
-    <BillingErrorBanner
-      ariaLabel="Your credits are running low. Add credits to avoid an interruption."
-      title="Your credits are running low"
-      subtitle="Add credits to avoid an interruption."
-      ctaLabel="Add credits"
-      onAction={onAddCredits}
-      onDismiss={dismiss}
-    />
+    <>
+      <BillingErrorBanner
+        ariaLabel="Your credits are running low. Add credits to avoid an interruption."
+        title="Your credits are running low"
+        subtitle="Add credits to avoid an interruption."
+        ctaLabel="Add credits"
+        onAction={() => setShowAddCredits(true)}
+        onDismiss={dismiss}
+      />
+      <LazyAddCreditsModal
+        open={showAddCredits}
+        onOpenChange={setShowAddCredits}
+      />
+    </>
   );
 }

--- a/clients/web/src/domains/chat/utils/error-classification.test.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.test.ts
@@ -112,6 +112,9 @@ describe("chat error classification", () => {
 });
 
 describe("resolveComposerBillingBanner", () => {
+  // Inputs that would render the low-balance banner absent an error decision.
+  const lowBalanceInputs = { isLowBalance: true, dismissed: false };
+
   test("managed_credits renders no composer banner while the generic notice stays suppressed", () => {
     // The in-transcript credits upsell card is the exhausted-credits surface.
     const error = {
@@ -124,7 +127,8 @@ describe("resolveComposerBillingBanner", () => {
     expect(
       resolveComposerBillingBanner({
         billingBannerDecision,
-        showLowBalanceBanner: false,
+        isLowBalance: false,
+        dismissed: false,
       }),
     ).toBeNull();
     expect(shouldShowGenericChatErrorNotice(error)).toBe(false);
@@ -134,18 +138,18 @@ describe("resolveComposerBillingBanner", () => {
     expect(
       resolveComposerBillingBanner({
         billingBannerDecision: "managed_credits",
-        showLowBalanceBanner: true,
+        ...lowBalanceInputs,
       }),
     ).toBeNull();
   });
 
-  test("daily-limit and provider-billing errors keep their banners", () => {
+  test("daily-limit and provider-billing errors win over the low-balance warning", () => {
     expect(
       resolveComposerBillingBanner({
         billingBannerDecision: getChatBillingBannerDecision({
           errorCategory: "daily_limit_reached",
         }),
-        showLowBalanceBanner: false,
+        ...lowBalanceInputs,
       }),
     ).toBe("daily_limit");
     expect(
@@ -153,7 +157,7 @@ describe("resolveComposerBillingBanner", () => {
         billingBannerDecision: getChatBillingBannerDecision({
           errorCategory: "provider_billing",
         }),
-        showLowBalanceBanner: false,
+        ...lowBalanceInputs,
       }),
     ).toBe("provider_billing");
   });
@@ -162,13 +166,27 @@ describe("resolveComposerBillingBanner", () => {
     expect(
       resolveComposerBillingBanner({
         billingBannerDecision: null,
-        showLowBalanceBanner: true,
+        ...lowBalanceInputs,
       }),
     ).toBe("low_balance");
+  });
+
+  test("no low-balance banner when the server flag is off (normal balance, auto-top-up, or gated-off query)", () => {
     expect(
       resolveComposerBillingBanner({
         billingBannerDecision: null,
-        showLowBalanceBanner: false,
+        isLowBalance: false,
+        dismissed: false,
+      }),
+    ).toBeNull();
+  });
+
+  test("no low-balance banner after a session dismissal", () => {
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: null,
+        isLowBalance: true,
+        dismissed: true,
       }),
     ).toBeNull();
   });

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -105,10 +105,18 @@ export type ComposerBillingBanner =
  * precedence over the proactive low-balance warning. `managed_credits` maps
  * to no banner: the in-transcript credits upsell card owns that state, while
  * the classified error keeps the generic notice suppressed.
+ *
+ * The low-balance warning renders only when no error-driven decision is
+ * active, the server reports `low_balance_warning` (`isLowBalance`), and the
+ * user has not dismissed the banner this session. The exhausted-credits
+ * surfaces never overlap with it: the server keeps `low_balance_warning`
+ * false while the balance is exhausted, and it is false for auto-top-up orgs
+ * and whenever the billing query is gated off.
  */
 export function resolveComposerBillingBanner(args: {
   billingBannerDecision: ChatBillingBannerDecision | null;
-  showLowBalanceBanner: boolean;
+  isLowBalance: boolean;
+  dismissed: boolean;
 }): ComposerBillingBanner | null {
   if (args.billingBannerDecision === "daily_limit") {
     return "daily_limit";
@@ -119,7 +127,7 @@ export function resolveComposerBillingBanner(args: {
   if (args.billingBannerDecision === "managed_credits") {
     return null;
   }
-  return args.showLowBalanceBanner ? "low_balance" : null;
+  return args.isLowBalance && !args.dismissed ? "low_balance" : null;
 }
 
 export function shouldSuppressGenericChatErrorNotice(

--- a/clients/web/src/hooks/use-billing-balance-status.test.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.test.ts
@@ -53,8 +53,8 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 
 const { useBillingBalanceStatus } =
   await import("./use-billing-balance-status");
-const { shouldShowLowBalanceBanner } =
-  await import("@/domains/chat/components/low-balance-banner");
+const { resolveComposerBillingBanner } =
+  await import("@/domains/chat/utils/error-classification");
 
 function summary(
   overrides: Partial<BillingSummaryResponse> = {},
@@ -158,19 +158,19 @@ describe("useBillingBalanceStatus", () => {
   test("exhausted status never co-shows with the low-balance banner", () => {
     // Server contract: `low_balance_warning` is kept false while the balance
     // is exhausted, so an exhausted status (which drives the proactive upsell
-    // card) always fails the low-balance banner's visibility rule. The
-    // exclusivity lives server-side; this pins the client wiring to it.
+    // card) always fails the low-balance leg of the composer banner decision.
+    // The exclusivity lives server-side; this pins the client wiring to it.
     const { result } = setup({
       seed: summary({ effective_balance: "0.00", low_balance_warning: false }),
     });
     expect(result.current.isExhausted).toBe(true);
     expect(
-      shouldShowLowBalanceBanner({
+      resolveComposerBillingBanner({
         billingBannerDecision: null,
         isLowBalance: result.current.isLowBalance,
         dismissed: false,
       }),
-    ).toBe(false);
+    ).toBeNull();
   });
 
   test("all-false while the summary is unresolved", () => {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for credits-ux.md.

**Gap:** banner precedence enforced in two functions across two files; two parallel Add Credits modal mechanisms
**What was expected:** one decision function; one modal ownership pattern
**What was found:** shouldShowLowBalanceBanner duplicating resolveComposerBillingBanner's precedence; route-level modal state prop-drilled for a single consumer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->