### PR TITLE
fix: credits card substitution gaps from plan review

### DIFF
--- a/clients/web/src/domains/chat/components/credits-upsell-card.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.tsx
@@ -5,10 +5,7 @@ import { useNavigate } from "react-router";
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
-import {
-  resolveCreditPaywallCta,
-  type CreditPaywallCtaMode,
-} from "@/domains/chat/utils/credit-paywall-cta";
+import { resolveCreditPaywallCta } from "@/domains/chat/utils/credit-paywall-cta";
 import {
   isBillingCtaUpgradeArm,
   useBillingCtaExperimentArm,
@@ -26,25 +23,16 @@ const AddCreditsModal = lazy(() =>
   })),
 );
 
-// Both add-credits modes share one copy set: the card's soft-sell wording
-// does not vary by plan, only the upgrade experiment arm changes the CTA.
+const UPGRADE_COPY = {
+  title: "You’re out of Free credits",
+  subtitle: "Upgrade your plan to keep the conversation going.",
+  ctaLabel: "View plans",
+};
+
 const ADD_CREDITS_COPY = {
   title: "You’re out of credits",
   subtitle: "Add credits to pick up where you left off.",
   ctaLabel: "Add credits",
-};
-
-const COPY: Record<
-  CreditPaywallCtaMode,
-  { title: string; subtitle: string; ctaLabel: string }
-> = {
-  upgrade: {
-    title: "You’re out of Free credits",
-    subtitle: "Upgrade your plan to keep the conversation going.",
-    ctaLabel: "View plans",
-  },
-  "add-credits-free": ADD_CREDITS_COPY,
-  "add-credits-paid": ADD_CREDITS_COPY,
 };
 
 /**
@@ -71,13 +59,15 @@ export function CreditsUpsellCard() {
     isUpgradeArm: isBillingCtaUpgradeArm(billingCtaArm),
     isFreePlan,
   });
-  const copy = COPY[mode];
+  const copy = mode === "upgrade" ? UPGRADE_COPY : ADD_CREDITS_COPY;
 
   if (platformGate === "gated") {
-    // Self-hosted active assistant: managed-credits billing has no meaning
-    // here, and every recovery action the card could offer targets the
-    // platform. (Credits-exhausted rows are only persisted by managed
-    // billing, so this state is a defensive rail, not a normal path.)
+    // Self-hosted active assistant: every recovery action the card could
+    // offer targets the platform, so there is nothing useful to render.
+    // Defensive rail: every mount point (transcript substitution, proactive
+    // tail, empty state) keys off `useBillingBalanceStatus().isExhausted`,
+    // which stays false without a platform billing read, so gated contexts
+    // never mount the card through a normal path.
     return null;
   }
 

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.test.ts
@@ -3,7 +3,8 @@
  * balance exhausted, an open conversation gets the card at the transcript
  * tail, a fresh conversation does not (the empty state owns the card there),
  * an in-flight turn suppresses the card until it settles, and a just-failed
- * turn's substituted card is never doubled. The projection
+ * turn's substituted card is never doubled. The flag also gates the per-row
+ * card substitution for tagged provider-error rows. The projection
  * itself (`buildTranscriptItems`) is real; only the two chat stores the hook
  * reads are stubbed inert.
  */
@@ -130,5 +131,28 @@ describe("useTranscriptData proactive credits upsell", () => {
     );
     expect(cards).toHaveLength(1);
     expect(cards[0]!.key).toBe("credits-upsell-m2");
+  });
+
+  test("a tagged provider-error row renders as a plain message while the balance is not exhausted", () => {
+    // Gated/self-hosted contexts leave the billing hook inert and a top-up
+    // clears the flag; in both, the persisted row must keep its visible
+    // historical bubble instead of substituting a card that could render
+    // nothing.
+    const errorRow: DisplayMessage = {
+      ...makeMessage("m2", "assistant", "I hit a snag: your credits ran out."),
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
+    };
+    const { result } = setup(
+      [makeMessage("m1", "user", "Hello"), errorRow],
+      false,
+    );
+
+    expect(result.current.transcriptItems.map((i) => i.kind)).toEqual([
+      "message",
+      "message",
+    ]);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -45,6 +45,9 @@ export interface UseTranscriptDataParams {
    * conversations; empty conversations surface the card through the
    * empty-state slots instead. Suppressed while a turn is in flight
    * (`turnActive`) so the card never sits under the live progress indicator.
+   * Also gates the substitution of credits-exhausted provider-error rows:
+   * tagged rows render as the card only while the balance is currently
+   * exhausted, and as plain historical bubbles otherwise.
    */
   creditsExhausted: boolean;
 }
@@ -122,6 +125,7 @@ export function useTranscriptData({
         thinkingLabel,
         ephemeralMetaResults,
         showOnboardingChoice,
+        creditsExhausted,
         // The proactive card is an open-conversation surface: with no
         // messages the chat renders the empty state (which mounts its own
         // card), not the transcript. In-flight turns suppress it so a credit

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -645,9 +645,13 @@ describe("buildTranscriptItems", () => {
 
   // ---------------------------------------------------------------------------
   // Provider-error rows: credits-exhausted substitution
+  //
+  // The substitution requires the live `creditsExhausted` flag alongside the
+  // persisted row tag, so gated/self-hosted contexts (inert billing hook) and
+  // recovered balances keep the plain historical bubble.
   // ---------------------------------------------------------------------------
 
-  test("credits-exhausted provider-error rows emit a creditsUpsell item instead of a message row", () => {
+  test("credits-exhausted provider-error rows emit a creditsUpsell item while the balance is exhausted", () => {
     const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
     const errorRow = makeMessage({
       id: "m2",
@@ -662,6 +666,7 @@ describe("buildTranscriptItems", () => {
     const items = buildTranscriptItems({
       ...emptyInput(),
       messages: [user, errorRow],
+      creditsExhausted: true,
     });
 
     expect(items).toHaveLength(2);
@@ -689,6 +694,7 @@ describe("buildTranscriptItems", () => {
     const items = buildTranscriptItems({
       ...emptyInput(),
       messages: [errorRow],
+      creditsExhausted: true,
     });
 
     expect(items).toHaveLength(1);
@@ -710,6 +716,7 @@ describe("buildTranscriptItems", () => {
     const items = buildTranscriptItems({
       ...emptyInput(),
       messages: [errorRow],
+      creditsExhausted: true,
     });
 
     expect(items).toHaveLength(1);
@@ -741,6 +748,7 @@ describe("buildTranscriptItems", () => {
     const items = buildTranscriptItems({
       ...emptyInput(),
       messages: folded,
+      creditsExhausted: true,
     });
 
     expect(items).toHaveLength(2);
@@ -768,6 +776,7 @@ describe("buildTranscriptItems", () => {
     const items = buildTranscriptItems({
       ...emptyInput(),
       messages: [errorRow],
+      creditsExhausted: true,
     });
 
     expect(items).toHaveLength(1);
@@ -804,13 +813,46 @@ describe("buildTranscriptItems", () => {
     const first = buildTranscriptItems({
       ...emptyInput(),
       messages: [errorRow],
+      creditsExhausted: true,
     });
     const second = buildTranscriptItems({
       ...emptyInput(),
       messages: [errorRow],
+      creditsExhausted: true,
     });
 
     expect(second[0]).toBe(first[0]!);
+  });
+
+  test("tagged rows keep the normal message rendering while the balance is not exhausted", () => {
+    // Covers both a topped-up balance and contexts where the billing hook is
+    // inert (self-hosted/gated assistants, no platform session): the
+    // persisted assistant-voice text renders as a plain historical bubble
+    // instead of a live-looking card the context cannot act on.
+    const errorRow = makeMessage({
+      id: "m1",
+      role: "assistant",
+      ...textBody("I hit a snag: your credits ran out."),
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
+    });
+
+    for (const creditsExhausted of [false, undefined]) {
+      const items = buildTranscriptItems({
+        ...emptyInput(),
+        messages: [errorRow],
+        creditsExhausted,
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0]).toEqual({
+        kind: "message",
+        key: "m1",
+        message: errorRow,
+      });
+    }
   });
 
   // ---------------------------------------------------------------------------
@@ -874,6 +916,7 @@ describe("buildTranscriptItems", () => {
     const items = buildTranscriptItems({
       ...emptyInput(),
       messages: [user, errorRow],
+      creditsExhausted: true,
       appendCreditsUpsell: true,
     });
 
@@ -905,6 +948,7 @@ describe("buildTranscriptItems", () => {
       ...emptyInput(),
       messages: [user, errorRow],
       showOnboardingChoice: true,
+      creditsExhausted: true,
       appendCreditsUpsell: true,
     });
 
@@ -931,6 +975,7 @@ describe("buildTranscriptItems", () => {
       ...emptyInput(),
       messages: [errorRow],
       turnActive: true,
+      creditsExhausted: true,
       appendCreditsUpsell: true,
     });
 
@@ -957,6 +1002,7 @@ describe("buildTranscriptItems", () => {
     const items = buildTranscriptItems({
       ...emptyInput(),
       messages: [errorRow, later],
+      creditsExhausted: true,
       appendCreditsUpsell: true,
     });
 

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -53,6 +53,20 @@ export interface BuildTranscriptItemsInput {
    * its provider-error row, so an open conversation never shows two cards.
    */
   appendCreditsUpsell?: boolean;
+  /**
+   * Whether the org's credit balance is currently exhausted (from the same
+   * `useBillingBalanceStatus().isExhausted` read that drives
+   * `appendCreditsUpsell`). Gates the per-row card substitution for
+   * credits-exhausted provider-error rows: only while true does a tagged row
+   * render as a `creditsUpsell` card. When false, tagged rows keep the normal
+   * message rendering, whose persisted assistant-voice text reads as
+   * historical context. That covers both a balance that has since been topped
+   * up and contexts where the billing hook is inert (self-hosted/gated
+   * assistants, no platform session), so the card, which renders nothing when
+   * platform billing is unreachable, is never substituted for a visible
+   * bubble it cannot replace.
+   */
+  creditsExhausted?: boolean;
 }
 
 /**
@@ -165,15 +179,19 @@ export function buildTranscriptItems(
       continue;
     }
 
-    // Persisted credits-exhausted provider-error rows render as the friendly
+    // While the balance is currently exhausted (`creditsExhausted`),
+    // persisted credits-exhausted provider-error rows render as the friendly
     // upsell card instead of a plain persona bubble. The row itself stays in
     // `messages` (history and the LLM context keep the text); only its
     // transcript rendering is substituted. Classification goes through the
     // shared `isCreditsExhaustedProviderError`, so a bare
     // `PROVIDER_BILLING` code with no category substitutes too. Provider
-    // errors of any other category, and untagged rows, keep the normal
-    // message rendering.
-    if (isCreditsExhaustedProviderError(message.providerError)) {
+    // errors of any other category, untagged rows, and tagged rows without
+    // the live flag keep the normal message rendering.
+    if (
+      input.creditsExhausted &&
+      isCreditsExhaustedProviderError(message.providerError)
+    ) {
       items.push(toCreditsUpsellItem(message));
       continue;
     }

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -32,4 +32,38 @@ describe("TranscriptRow creditsUpsell dispatch", () => {
 
     expect(getByTestId("credits-upsell-card-stub")).toBeTruthy();
   });
+
+  test("substituted cards keep the msg-<id> anchor of the row they replace", () => {
+    // `TranscriptHandle.scrollToMessage` and the `?message=<id>` deep link
+    // resolve rows via `getElementById("msg-<id>")`, so the substitution must
+    // not drop the anchor the underlying message row would have had.
+    const item: CreditsUpsellItem = {
+      kind: "creditsUpsell",
+      key: "credits-upsell-m1",
+      messageId: "m1",
+    };
+
+    const { container } = render(
+      <TranscriptRow item={item} onSurfaceAction={() => {}} />,
+    );
+
+    const anchor = container.querySelector("#msg-m1");
+    expect(anchor).toBeTruthy();
+    expect(anchor!.querySelector('[data-testid="credits-upsell-card-stub"]'))
+      .toBeTruthy();
+  });
+
+  test("the proactive card (no messageId) renders without a msg anchor", () => {
+    const item: CreditsUpsellItem = {
+      kind: "creditsUpsell",
+      key: "credits-upsell-proactive",
+    };
+
+    const { container, getByTestId } = render(
+      <TranscriptRow item={item} onSurfaceAction={() => {}} />,
+    );
+
+    expect(getByTestId("credits-upsell-card-stub")).toBeTruthy();
+    expect(container.querySelector('[id^="msg-"]')).toBeNull();
+  });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -211,7 +211,18 @@ export const TranscriptRow = memo(function TranscriptRow({
     case "creditsUpsell":
       // Substituted in place of a credits-exhausted provider-error row by
       // `buildTranscriptItems`: a standalone card, outside the persona
-      // bubble/avatar/hover-action machinery like `SystemCardRow`.
+      // bubble/avatar/hover-action machinery like `SystemCardRow`. Substituted
+      // items carry the underlying row's `messageId`, so they keep the
+      // `msg-<id>` DOM anchor that `TranscriptHandle.scrollToMessage` and the
+      // `?message=<id>` deep link resolve via `getElementById`; the proactive
+      // tail card has no backing message and needs no anchor.
+      if (item.messageId) {
+        return (
+          <div id={`msg-${item.messageId}`} data-message-id={item.messageId}>
+            <CreditsUpsellCard />
+          </div>
+        );
+      }
       return <CreditsUpsellCard />;
 
     default: {

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -80,10 +80,11 @@ export interface OnboardingChoiceItem extends TranscriptItemBase {
 
 /** Friendly credits upsell card. Emitted in place of a persisted
  *  credits-exhausted provider-error row (`providerError.category` matching
- *  `credits_exhausted`), where the row's text stays in message state (the LLM
- *  transcript keeps it) and only the rendering is substituted. Also appended
- *  proactively at the transcript tail while the org's balance is exhausted,
- *  so the credit wall shows before the next send fails. */
+ *  `credits_exhausted`) while the org's balance is currently exhausted, where
+ *  the row's text stays in message state (the LLM transcript keeps it) and
+ *  only the rendering is substituted. Also appended proactively at the
+ *  transcript tail while the balance is exhausted, so the credit wall shows
+ *  before the next send fails. */
 export interface CreditsUpsellItem extends TranscriptItemBase {
   kind: "creditsUpsell";
   /** Id of the provider-error message row this card renders in place of.

--- a/clients/web/src/domains/chat/utils/credit-paywall-cta.test.ts
+++ b/clients/web/src/domains/chat/utils/credit-paywall-cta.test.ts
@@ -9,33 +9,21 @@ describe("resolveCreditPaywallCta", () => {
     ).toBe("upgrade");
   });
 
-  test("upgrade arm + paid plan → add-credits-paid", () => {
+  test("upgrade arm + paid plan → add-credits", () => {
     expect(
       resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: false }),
-    ).toBe("add-credits-paid");
+    ).toBe("add-credits");
   });
 
-  test("upgrade arm + unresolved plan → add-credits-paid", () => {
+  test("upgrade arm + unresolved plan → add-credits", () => {
     expect(
       resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: undefined }),
-    ).toBe("add-credits-paid");
+    ).toBe("add-credits");
   });
 
-  test("control arm + free plan → add-credits-free", () => {
+  test("control arm + free plan → add-credits", () => {
     expect(
       resolveCreditPaywallCta({ isUpgradeArm: false, isFreePlan: true }),
-    ).toBe("add-credits-free");
-  });
-
-  test("control arm + paid plan → add-credits-paid", () => {
-    expect(
-      resolveCreditPaywallCta({ isUpgradeArm: false, isFreePlan: false }),
-    ).toBe("add-credits-paid");
-  });
-
-  test("control arm + unresolved plan → add-credits-paid", () => {
-    expect(
-      resolveCreditPaywallCta({ isUpgradeArm: false, isFreePlan: undefined }),
-    ).toBe("add-credits-paid");
+    ).toBe("add-credits");
   });
 });

--- a/clients/web/src/domains/chat/utils/credit-paywall-cta.ts
+++ b/clients/web/src/domains/chat/utils/credit-paywall-cta.ts
@@ -1,17 +1,15 @@
-export type CreditPaywallCtaMode =
-  "add-credits-free" | "add-credits-paid" | "upgrade";
+export type CreditPaywallCtaMode = "add-credits" | "upgrade";
 
 /**
  * Upgrade CTA shows ONLY in the experiment upgrade arm AND for a free-plan
- * org. Everything else gets Add Credits, whose copy differs for free vs paid
- * orgs; an unknown/unresolved plan / unhydrated flags count as paid.
+ * org; an unknown/unresolved plan / unhydrated flags count as paid. Everything
+ * else gets Add Credits.
  */
 export function resolveCreditPaywallCta(args: {
   isUpgradeArm: boolean;
   isFreePlan: boolean | undefined;
 }): CreditPaywallCtaMode {
-  if (args.isUpgradeArm && args.isFreePlan === true) {
-    return "upgrade";
-  }
-  return args.isFreePlan === true ? "add-credits-free" : "add-credits-paid";
+  return args.isUpgradeArm && args.isFreePlan === true
+    ? "upgrade"
+    : "add-credits";
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for credits-ux.md.

**Gap:** silent failure for gated/self-hosted contexts; permanent present-tense card; lost msg-<id> anchors; dead CTA mode split
**What was expected:** every failure visibly surfaced; historical rows read historically; deep links work; no dead differentiation
**What was found:** unconditional substitution into a card that can render null; metadata-only keying; bare card without anchor; two CTA modes with identical copy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->