### PR TITLE
fix(web): clamp keyboard anticipation to the measured viewport

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -557,39 +557,46 @@ describe("AssistantSideMenu · overlay iOS floating glyph row", () => {
     return match;
   };
 
+  // Whole class tokens, so an assertion matches a utility rather than a prefix
+  // of one: `top-4` must not be satisfied by `top-40`.
+  const classTokens = (element: Element | null): string[] =>
+    element ? Array.from(element.classList) : [];
+
   test("the glyph row carries the floating placement utilities", () => {
     const container = overlayDom();
-    const row = glyph(container, "Close navigation").parentElement;
+    const row = classTokens(glyph(container, "Close navigation").parentElement);
 
-    expect(row?.className).toContain("native-ios:absolute");
-    expect(row?.className).toContain("native-ios:inset-x-4");
-    expect(row?.className).toContain("native-ios:top-4");
-    expect(row?.className).toContain("native-ios:z-10");
-    expect(row?.className).toContain("native-ios:pointer-events-none");
+    expect(row).toContain("native-ios:absolute");
+    expect(row).toContain("native-ios:inset-x-4");
+    expect(row).toContain("native-ios:top-4");
+    expect(row).toContain("native-ios:z-10");
+    expect(row).toContain("native-ios:pointer-events-none");
   });
 
   test("both glyphs opt back into pointer events", () => {
     const container = overlayDom();
 
-    expect(glyph(container, "Close navigation").className).toContain(
+    expect(classTokens(glyph(container, "Close navigation"))).toContain(
       "pointer-events-auto",
     );
-    expect(glyph(container, "Search (⌘K)").className).toContain(
+    expect(classTokens(glyph(container, "Search (⌘K)"))).toContain(
       "pointer-events-auto",
     );
   });
 
   test("the scroll body reserves the glyph band and carries both mask declarations", () => {
-    const body = overlayDom().querySelector<HTMLElement>(
-      '[data-slot="side-menu-body"]',
+    const body = classTokens(
+      overlayDom().querySelector('[data-slot="side-menu-body"]'),
     );
 
-    expect(body?.className).toContain("native-ios:pt-14");
-    // Anchored on the `native-ios:[` prefix so the unprefixed assertion is not
-    // satisfied by the `-webkit-` spelling, which contains it as a substring.
-    expect(body?.className).toContain("native-ios:[mask-image:linear-gradient");
-    expect(body?.className).toContain(
-      "native-ios:[-webkit-mask-image:linear-gradient",
+    expect(body).toContain("native-ios:pt-14");
+    // Complete declarations, so the fade geometry is pinned too: a different
+    // stop or gradient direction is a different token.
+    expect(body).toContain(
+      "native-ios:[mask-image:linear-gradient(to_bottom,transparent,black_3.5rem)]",
+    );
+    expect(body).toContain(
+      "native-ios:[-webkit-mask-image:linear-gradient(to_bottom,transparent,black_3.5rem)]",
     );
   });
 });

--- a/clients/web/src/hooks/use-visible-viewport.test.ts
+++ b/clients/web/src/hooks/use-visible-viewport.test.ts
@@ -182,6 +182,33 @@ describe("useVisibleViewport", () => {
     expect(viewport?.height).toBe(REFERENCE_HEIGHT - tallerHeight);
   });
 
+  test("never anticipates past the frame the viewport is currently measured in", () => {
+    // GIVEN a tall keyboard whose deferred resize has landed
+    renderHook(() => useVisibleViewport());
+    announce(KEYBOARD_HEIGHT);
+    stubViewport({ height: REFERENCE_HEIGHT - KEYBOARD_HEIGHT });
+    expect(readVisibleViewport()?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+
+    // WHEN it shrinks, as the predictive bar closing or a numeric pad taking
+    // focus does, and the shell re-announces while the frame is still sized for
+    // the tall one
+    const shorterHeight = KEYBOARD_HEIGHT - 86;
+    announce(shorterHeight);
+
+    // THEN the shell holds the measured height rather than growing past the
+    // frame it lives in, which would push the composer below the frame's bottom
+    // edge for the whole deferred resize
+    const pending = readVisibleViewport();
+    expect(pending?.height).toBe(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+    expect(pending?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+
+    // AND the resize landing is what grows it
+    stubViewport({ height: REFERENCE_HEIGHT - shorterHeight });
+    const landed = readVisibleViewport();
+    expect(landed?.height).toBe(REFERENCE_HEIGHT - shorterHeight);
+    expect(landed?.keyboardHeight).toBe(shorterHeight);
+  });
+
   test("retires anticipation when the landed resize is shorter than announced", () => {
     // GIVEN an announced height the native resize never quite reaches, which
     // is what iPad Stage Manager produces: the plugin measures the keyboard's

--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -176,13 +176,17 @@ export function readVisibleViewport(): VisibleViewport | null {
   // A pinch-zoomed viewport reports no keyboard at all, anticipated or not, and
   // a reference no taller than the announced keyboard describes no visible
   // region: both defer to the measurement rather than sizing the shell to a
-  // height CSS would reject.
+  // height CSS would reject. Anticipation only ever shrinks the shell against
+  // the current measurement, so a keyboard announced shorter than the one the
+  // frame is still sized for cannot overshoot that frame and push the composer
+  // below its bottom edge.
   const anticipatedVisibleHeight =
     referenceInnerHeight - anticipatedKeyboardHeight;
   if (
     !isZoomed &&
     anticipatedKeyboardHeight > 0 &&
-    anticipatedVisibleHeight > 0
+    anticipatedVisibleHeight > 0 &&
+    anticipatedVisibleHeight < vv.height
   ) {
     return {
       height: anticipatedVisibleHeight,

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -13,10 +13,6 @@
 /* Base element styles — theme-aware defaults inherited by all descendants. */
 body {
   color: var(--content-default);
-  /* The app shell can be shorter than the page (it tracks the visual viewport
-     while the keyboard animates in), so the canvas behind it has to be the same
-     surface rather than the host web view's own background. */
-  background: var(--surface-base);
 }
 
 /* Electron prechat onboarding typography — mirror the lighter DM Sans (Swift


### PR DESCRIPTION
## Summary
- Anticipation can now only shrink the app shell relative to the current measurement, so a keyboard that shrinks mid-session no longer oversizes the shell and pushes the composer below the web view frame.
- Reverts an ungated `body` background that propagated to the canvas and painted three transparent macOS floating windows opaque.
- Strengthens the sidebar class assertions so numeric drift in the positioning and mask geometry cannot pass silently.

Fixes gaps found during plan self-review for ios-keyboard-lag-and-floating-sidebar.md