### PR TITLE
Clarify BYOK and managed API key failures

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -794,7 +794,7 @@ describe("classifyConversationError", () => {
 
       expect(result.code).toBe("MANAGED_KEY_INVALID");
       expect(result.userMessage).toBe(
-        "The Vellum assistant API key used for managed inference was rejected. No personal provider API key was used. Reconnect your Vellum account in Settings → Models & Services.",
+        "Vellum's managed inference credential was rejected. This isn't a personal provider API key — Vellum provisions this one, so there's nothing to update in Settings.",
       );
       expect(result.retryable).toBe(false);
       expect(result.errorCategory).toBe("managed_key_invalid");
@@ -814,7 +814,7 @@ describe("classifyConversationError", () => {
       expect(result.code).toBe("MANAGED_KEY_INVALID");
       expect(result.errorCategory).toBe("managed_key_invalid");
       expect(result.userMessage).toBe(
-        "The Vellum assistant API key used for managed inference was rejected. No personal provider API key was used. Reconnect your Vellum account in Settings → Models & Services.",
+        "Vellum's managed inference credential was rejected. This isn't a personal provider API key — Vellum provisions this one, so there's nothing to update in Settings.",
       );
     });
 
@@ -883,7 +883,7 @@ describe("classifyConversationError", () => {
 
       expect(result.code).toBe("MANAGED_KEY_INVALID");
       expect(result.userMessage).toBe(
-        "The Vellum assistant API key used for managed inference was rejected. No personal provider API key was used. Reconnect your Vellum account in Settings → Models & Services.",
+        "Vellum's managed inference credential was rejected. This isn't a personal provider API key — Vellum provisions this one, so there's nothing to update in Settings.",
       );
     });
 

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -777,6 +777,9 @@ describe("classifyConversationError", () => {
       expect(result.code).toBe("PROVIDER_INVALID_KEY");
       expect(result.retryable).toBe(false);
       expect(result.errorCategory).toBe("provider_invalid_key");
+      expect(result.userMessage).toBe(
+        "Your personal Anthropic API key was rejected by Anthropic. Update that key in Settings → Models & Services.",
+      );
     });
 
     it("classifies managed-proxy auth failures as managed credential refresh failures", () => {
@@ -791,10 +794,28 @@ describe("classifyConversationError", () => {
 
       expect(result.code).toBe("MANAGED_KEY_INVALID");
       expect(result.userMessage).toBe(
-        "Couldn't refresh assistant credentials.",
+        "The Vellum assistant API key used for managed inference was rejected. No personal provider API key was used. Reconnect your Vellum account in Settings → Models & Services.",
       );
       expect(result.retryable).toBe(false);
       expect(result.errorCategory).toBe("managed_key_invalid");
+    });
+
+    it("keeps credential-shaped 4xx failures on the request's managed route", () => {
+      providerRoutingSources.anthropic = "user-key";
+      const err = new ProviderError(
+        "Authentication error: invalid API key",
+        "anthropic",
+        400,
+      );
+      err.attachRouteAttribution({ credentialSource: "vellum-managed" });
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("MANAGED_KEY_INVALID");
+      expect(result.errorCategory).toBe("managed_key_invalid");
+      expect(result.userMessage).toBe(
+        "The Vellum assistant API key used for managed inference was rejected. No personal provider API key was used. Reconnect your Vellum account in Settings → Models & Services.",
+      );
     });
 
     it("classifies ProviderError 401 with 'invalid x-api-key' message as PROVIDER_INVALID_KEY", () => {
@@ -814,6 +835,8 @@ describe("classifyConversationError", () => {
       const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_INVALID_KEY");
       expect(result.errorCategory).toBe("provider_invalid_key");
+      expect(result.userMessage).toContain("personal OpenAI API key");
+      expect(result.userMessage).toContain("rejected by OpenAI");
     });
 
     it("includes connection/profile attribution in PROVIDER_INVALID_KEY when provided", () => {
@@ -826,7 +849,84 @@ describe("classifyConversationError", () => {
       expect(result.code).toBe("PROVIDER_INVALID_KEY");
       expect(result.connectionName).toBe("my-anthropic");
       expect(result.profileName).toBe("personal");
-      expect(result.userMessage).toContain("personal");
+      expect(result.userMessage).toBe(
+        'Your personal Anthropic API key for profile "personal" (connection "my-anthropic") was rejected by Anthropic. Update that key in Settings → Models & Services.',
+      );
+    });
+
+    it("uses the request's BYOK attribution when the same provider also has a managed route", () => {
+      providerRoutingSources.anthropic = "managed-proxy";
+      const err = new ProviderError("Unauthorized", "anthropic", 401);
+      err.attachRouteAttribution({
+        credentialSource: "byok",
+        connectionName: "anthropic-personal",
+      });
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_INVALID_KEY");
+      expect(result.connectionName).toBe("anthropic-personal");
+      expect(result.userMessage).toBe(
+        'Your personal Anthropic API key for connection "anthropic-personal" was rejected by Anthropic. Update that key in Settings → Models & Services.',
+      );
+    });
+
+    it("uses the request's managed attribution when the same provider also has a BYOK route", () => {
+      providerRoutingSources.anthropic = "user-key";
+      const err = new ProviderError("Unauthorized", "anthropic", 401);
+      err.attachRouteAttribution({
+        credentialSource: "vellum-managed",
+        connectionName: "vellum",
+      });
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("MANAGED_KEY_INVALID");
+      expect(result.userMessage).toBe(
+        "The Vellum assistant API key used for managed inference was rejected. No personal provider API key was used. Reconnect your Vellum account in Settings → Models & Services.",
+      );
+    });
+
+    it("uses subscription-specific recovery when the same provider also has a managed route", () => {
+      providerRoutingSources.openai = "managed-proxy";
+      const err = new ProviderError("Unauthorized", "openai", 401, {
+        reason: "invalid_credentials",
+      });
+      err.attachRouteAttribution({
+        credentialSource: "oauth-subscription",
+        connectionName: "chatgpt-subscription",
+      });
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.errorCategory).toBe("provider_subscription_auth");
+      expect(result.retryable).toBe(false);
+      expect(result.connectionName).toBe("chatgpt-subscription");
+      expect(result.userMessage).toBe(
+        'Your OpenAI subscription login for connection "chatgpt-subscription" was rejected by OpenAI. Reconnect that account in Settings → Models & Services.',
+      );
+    });
+
+    it("explains when a no-auth endpoint rejects an unauthenticated request", () => {
+      providerRoutingSources["openai-compatible"] = "managed-proxy";
+      const err = new ProviderError("Unauthorized", "openai-compatible", 401, {
+        reason: "invalid_credentials",
+      });
+      err.attachRouteAttribution({
+        credentialSource: "no-auth",
+        connectionName: "local-model-server",
+      });
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.errorCategory).toBe("provider_endpoint_auth_required");
+      expect(result.retryable).toBe(false);
+      expect(result.connectionName).toBe("local-model-server");
+      expect(result.userMessage).toBe(
+        'The OpenAI-compatible endpoint for connection "local-model-server" requires authentication, but that connection is configured without credentials. Configure authentication for that endpoint in Settings → Models & Services.',
+      );
     });
 
     it("classifies direct ProviderError with 402 as provider_billing (non-retryable)", () => {

--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -232,6 +232,28 @@ describe("RetryProvider — rate limit backoff", () => {
     }
   });
 
+  test("attributes the credential selected for the failed request", async () => {
+    const inner = makeFailing(
+      new ProviderError("invalid key", "anthropic", 401),
+    );
+    const provider = new RetryProvider(inner, {
+      credentialSource: "byok",
+      connectionName: "anthropic-personal",
+    });
+
+    try {
+      await provider.sendMessage(MESSAGES);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      const providerError = err as ProviderError;
+      expect(providerError.routeAttribution).toMatchObject({
+        credentialSource: "byok",
+        connectionName: "anthropic-personal",
+      });
+    }
+  });
+
   test("tags final error with retriesExhausted=true after retry loop gives up (JARVIS-513)", async () => {
     // Transient socket flap from Bun's native fetch: wrapped in a
     // ProviderError but still network-retryable via message pattern match.
@@ -330,6 +352,124 @@ describe("RetryProvider — rate limit backoff", () => {
     const sleepCalls = sleepSpy.mock.calls;
     const lastDelay = sleepCalls[sleepCalls.length - 1][0];
     expect(lastDelay).toBe(60_000);
+  });
+});
+
+describe("RetryProvider managed credential refresh", () => {
+  test("reloads managed credentials once and keeps the refreshed provider", async () => {
+    sleepSpy.mockClear();
+    const initial = makeFailing(
+      new ProviderError("assistant key expired", "anthropic", 403, {
+        reason: "invalid_credentials",
+      }),
+      "anthropic",
+    );
+    const refreshed = makeFlaky(
+      0,
+      new ProviderError("unused", "anthropic"),
+      "anthropic",
+    );
+    let refreshCalls = 0;
+    const provider = new RetryProvider(initial, {
+      credentialSource: "vellum-managed",
+      connectionName: "vellum",
+      refreshCredentialProvider: async () => {
+        refreshCalls++;
+        return refreshed;
+      },
+    });
+
+    await expect(provider.sendMessage(MESSAGES)).resolves.toMatchObject({
+      model: "test-model",
+    });
+    await expect(provider.sendMessage(MESSAGES)).resolves.toMatchObject({
+      model: "test-model",
+    });
+
+    expect(initial.calls).toBe(1);
+    expect(refreshed.calls).toBe(2);
+    expect(refreshCalls).toBe(1);
+    expect(sleepSpy).not.toHaveBeenCalled();
+  });
+
+  test("surfaces a managed auth failure when refreshed credentials are also rejected", async () => {
+    const initial = makeFailing(
+      new ProviderError("old key rejected", "gemini", 401),
+      "gemini",
+    );
+    const refreshed = makeFailing(
+      new ProviderError("new key rejected", "gemini", 403),
+      "gemini",
+    );
+    let refreshCalls = 0;
+    const provider = new RetryProvider(initial, {
+      credentialSource: "vellum-managed",
+      connectionName: "vellum",
+      refreshCredentialProvider: async () => {
+        refreshCalls++;
+        return refreshed;
+      },
+    });
+
+    try {
+      await provider.sendMessage(MESSAGES);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      const providerError = error as ProviderError;
+      expect(providerError.message).toBe("new key rejected");
+      expect(providerError.routeAttribution).toMatchObject({
+        credentialSource: "vellum-managed",
+        connectionName: "vellum",
+      });
+    }
+    expect(initial.calls).toBe(1);
+    expect(refreshed.calls).toBe(1);
+    expect(refreshCalls).toBe(1);
+  });
+
+  test("does not reload credentials for a personal provider key rejection", async () => {
+    const initial = makeFailing(
+      new ProviderError("personal key rejected", "anthropic", 401),
+      "anthropic",
+    );
+    let refreshCalls = 0;
+    const provider = new RetryProvider(initial, {
+      credentialSource: "byok",
+      refreshCredentialProvider: async () => {
+        refreshCalls++;
+        return null;
+      },
+    });
+
+    await expect(provider.sendMessage(MESSAGES)).rejects.toThrow(
+      "personal key rejected",
+    );
+    expect(initial.calls).toBe(1);
+    expect(refreshCalls).toBe(0);
+  });
+
+  test("does not reload managed credentials for a model restriction", async () => {
+    const initial = makeFailing(
+      new ProviderError("model unavailable", "anthropic", 403, {
+        reason: "model_restricted",
+      }),
+      "anthropic",
+    );
+    let refreshCalls = 0;
+    const provider = new RetryProvider(initial, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => {
+        refreshCalls++;
+        return null;
+      },
+    });
+
+    await expect(provider.sendMessage(MESSAGES)).rejects.toThrow(
+      "model unavailable",
+    );
+    expect(initial.calls).toBe(1);
+    expect(refreshCalls).toBe(0);
   });
 });
 

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -12,9 +12,11 @@ import {
   isImageUnprocessableError,
 } from "../plugins/defaults/image-recovery/detect.js";
 import { ConnectionResolutionError } from "../providers/connection-resolution.js";
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { getProviderRoutingSource } from "../providers/registry.js";
 import { isAbortReason } from "../util/abort-reasons.js";
 import {
+  type ProviderCredentialSource,
   ProviderError,
   type ProviderErrorReason,
   ProviderNotConfiguredError,
@@ -65,6 +67,12 @@ export interface ConversationErrorAttribution {
   profileName?: string;
   /** Whether the resolved turn route uses Vellum-managed inference. */
   isManagedRoute?: boolean;
+  /**
+   * Which credential the failed request presented. Splits the non-managed side
+   * of `isManagedRoute` into personal keys, subscription logins, and keyless
+   * endpoints so rejection copy names the right thing to fix.
+   */
+  credentialSource?: ProviderCredentialSource;
 }
 
 // Network-level error patterns (connection refused, timeout, DNS, reset)
@@ -273,6 +281,9 @@ export function classifyConversationError(
     ...(connectionName ? { connectionName } : {}),
     ...(profileName ? { profileName } : {}),
     ...(isManagedRoute !== undefined ? { isManagedRoute } : {}),
+    ...(providerRoute?.credentialSource
+      ? { credentialSource: providerRoute.credentialSource }
+      : {}),
   };
 
   // Dedicated classification for missing provider API key
@@ -375,6 +386,12 @@ function classifyCore(
     error instanceof ProviderError &&
     (attribution.isManagedRoute ??
       getProviderRoutingSource(error.provider) === "managed-proxy");
+  // Which credential the request actually presented. Only rejection copy needs
+  // this finer axis; every other branch keys off `isManagedRoute`. Routes that
+  // predate per-request stamping collapse to the managed/personal split.
+  const credentialSource: ProviderCredentialSource =
+    attribution.credentialSource ??
+    (isManagedRoute ? "vellum-managed" : "byok");
 
   // Prefer the semantic reason stamped by the provider layer, regardless of
   // HTTP status — statusless errors (e.g. SDK streaming failures) still carry a
@@ -383,8 +400,10 @@ function classifyCore(
   if (error instanceof ProviderError && error.reason) {
     const c = reasonToClassification(error.reason, {
       isManagedRoute,
+      credentialSource,
       attribution,
       message,
+      providerName: error.provider,
     });
     if (c) {
       return c;
@@ -398,16 +417,15 @@ function classifyCore(
       return contextTooLargeClassification();
     }
     if (error.statusCode === 401 || error.statusCode === 403) {
-      // Both managed-proxy and user-key 401/403s reach this branch.
-      // Managed-proxy routes through the assistant API key; if that
-      // credential is stale, the user cannot fix it from model settings.
-      // Everything else is a user-set credential that the upstream provider
-      // rejected, so emit `PROVIDER_INVALID_KEY` and let the chat banner point
-      // at Settings.
-      if (isManagedRoute) {
-        return managedKeyInvalidClassification();
-      }
-      return invalidApiKeyClassification(attribution);
+      // Managed routes through the assistant API key; if that credential is
+      // stale, the user cannot fix it from model settings. Everything else is
+      // a credential the user owns, so the copy names which one to update and
+      // the chat banner points at Settings.
+      return rejectedCredentialClassification(
+        error.provider,
+        credentialSource,
+        attribution,
+      );
     }
     if (error.statusCode === 402) {
       if (isManagedRoute) {
@@ -473,7 +491,11 @@ function classifyCore(
         // Mirror the 401/403 branch: a credential-shaped 4xx is an
         // "invalid key" surface (banner: "Invalid API key"), distinct
         // from "no key configured" (banner: "API key required").
-        return invalidApiKeyClassification(attribution);
+        return rejectedCredentialClassification(
+          error.provider,
+          credentialSource,
+          attribution,
+        );
       }
       if (isImageDimensionsTooLargeError(message)) {
         return {
@@ -562,16 +584,20 @@ function reasonToClassification(
   reason: ProviderErrorReason,
   args: {
     isManagedRoute: boolean;
+    credentialSource: ProviderCredentialSource;
     attribution?: ConversationErrorAttribution;
     message: string;
+    providerName: string;
   },
 ): Omit<ClassifiedConversationError, "debugDetails"> | null {
   const managed = args.isManagedRoute;
   switch (reason) {
     case "invalid_credentials":
-      return managed
-        ? managedKeyInvalidClassification()
-        : invalidApiKeyClassification(args.attribution);
+      return rejectedCredentialClassification(
+        args.providerName,
+        args.credentialSource,
+        args.attribution,
+      );
     case "rate_limited":
       // Match managed usage-limit body patterns, as the legacy path does.
       if (
@@ -784,7 +810,8 @@ function managedKeyInvalidClassification(): Omit<
 > {
   return {
     code: "MANAGED_KEY_INVALID",
-    userMessage: "Couldn't refresh assistant credentials.",
+    userMessage:
+      "The Vellum assistant API key used for managed inference was rejected. No personal provider API key was used. Reconnect your Vellum account in Settings → Models & Services.",
     retryable: false,
     errorCategory: "managed_key_invalid",
   };
@@ -867,6 +894,76 @@ function describeAttribution(
   return "";
 }
 
+function providerDisplayName(providerName: string): string {
+  return (
+    PROVIDER_CATALOG.find((provider) => provider.id === providerName)
+      ?.displayName ?? providerName
+  );
+}
+
+function classificationAttribution(
+  attribution: ConversationErrorAttribution | undefined,
+): Pick<ClassifiedConversationError, "connectionName" | "profileName"> {
+  return {
+    ...(attribution?.connectionName
+      ? { connectionName: attribution.connectionName }
+      : {}),
+    ...(attribution?.profileName
+      ? { profileName: attribution.profileName }
+      : {}),
+  };
+}
+
+function rejectedCredentialClassification(
+  providerName: string,
+  credentialSource: ProviderCredentialSource,
+  attribution?: ConversationErrorAttribution,
+): Omit<ClassifiedConversationError, "debugDetails"> {
+  switch (credentialSource) {
+    case "vellum-managed":
+      return managedKeyInvalidClassification();
+    case "oauth-subscription":
+      return subscriptionLoginRejectedClassification(providerName, attribution);
+    case "no-auth":
+      return endpointAuthenticationRequiredClassification(
+        providerName,
+        attribution,
+      );
+    case "byok":
+      return invalidApiKeyClassification(providerName, attribution);
+  }
+}
+
+function endpointAuthenticationRequiredClassification(
+  providerName: string,
+  attribution?: ConversationErrorAttribution,
+): Omit<ClassifiedConversationError, "debugDetails"> {
+  const provider = providerDisplayName(providerName);
+  const target = describeAttribution(attribution);
+  return {
+    code: "PROVIDER_API",
+    userMessage: `The ${provider} endpoint${target} requires authentication, but that connection is configured without credentials. Configure authentication for that endpoint in Settings → Models & Services.`,
+    retryable: false,
+    errorCategory: "provider_endpoint_auth_required",
+    ...classificationAttribution(attribution),
+  };
+}
+
+function subscriptionLoginRejectedClassification(
+  providerName: string,
+  attribution?: ConversationErrorAttribution,
+): Omit<ClassifiedConversationError, "debugDetails"> {
+  const provider = providerDisplayName(providerName);
+  const target = describeAttribution(attribution);
+  return {
+    code: "PROVIDER_API",
+    userMessage: `Your ${provider} subscription login${target} was rejected by ${provider}. Reconnect that account in Settings → Models & Services.`,
+    retryable: false,
+    errorCategory: "provider_subscription_auth",
+    ...classificationAttribution(attribution),
+  };
+}
+
 /**
  * Classification for an invalid (rejected by the upstream provider, e.g.
  * Anthropic 401/403) API key. Distinct from `PROVIDER_NOT_CONFIGURED`
@@ -875,22 +972,17 @@ function describeAttribution(
  * different recovery actions (update vs. add).
  */
 function invalidApiKeyClassification(
+  providerName: string,
   attribution?: ConversationErrorAttribution,
 ): Omit<ClassifiedConversationError, "debugDetails"> {
+  const provider = providerDisplayName(providerName);
   const target = describeAttribution(attribution);
   return {
     code: "PROVIDER_INVALID_KEY",
-    userMessage: target
-      ? `The API key${target} was rejected by the provider. Update it in Settings → Models & Services.`
-      : "Your API key was rejected by the provider. Update it in Settings → Models & Services.",
+    userMessage: `Your personal ${provider} API key${target} was rejected by ${provider}. Update that key in Settings → Models & Services.`,
     retryable: false,
     errorCategory: "provider_invalid_key",
-    ...(attribution?.connectionName
-      ? { connectionName: attribution.connectionName }
-      : {}),
-    ...(attribution?.profileName
-      ? { profileName: attribution.profileName }
-      : {}),
+    ...classificationAttribution(attribution),
   };
 }
 

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -804,6 +804,13 @@ function managedUsageLimitClassification(): Omit<
   };
 }
 
+/**
+ * Deliberately instruction-free. The assistant API key is provisioned and
+ * pushed by the platform — the assistant only ever reads it — so there is no
+ * Settings affordance to re-provision it and no user action that would help.
+ * The copy's job is to rule out the user's own provider key as the cause;
+ * clients that can offer a real next step attach one (web renders Doctor).
+ */
 function managedKeyInvalidClassification(): Omit<
   ClassifiedConversationError,
   "debugDetails"
@@ -811,7 +818,7 @@ function managedKeyInvalidClassification(): Omit<
   return {
     code: "MANAGED_KEY_INVALID",
     userMessage:
-      "The Vellum assistant API key used for managed inference was rejected. No personal provider API key was used. Reconnect your Vellum account in Settings → Models & Services.",
+      "Vellum's managed inference credential was rejected. This isn't a personal provider API key — Vellum provisions this one, so there's nothing to update in Settings.",
     retryable: false,
     errorCategory: "managed_key_invalid",
   };

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1207,8 +1207,16 @@ describe("LiveVoiceSession server VAD", () => {
     });
     // The barge-in utterance transcribes to nothing, so no follow-up turn
     // consumes the stash before the interrupt lands.
+    //
+    // "third question" is repeated because finals are handed out by transcriber
+    // creation order, and the session pre-arms a transcriber for the next
+    // utterance. The interrupt below can discard that pre-armed one and re-arm,
+    // which shifts the final utterance onto the following index — with a
+    // 3-entry list it would fall off the end and transcribe to the "utterance
+    // N" placeholder, so the wait for "third question" would time out rather
+    // than fail on the assertion. Both landing spots carry the same text.
     const { frames, session } = createHarness({
-      finals: ["first question", "", "third question"],
+      finals: ["first question", "", "third question", "third question"],
       startVoiceTurn,
       streamTtsAudio,
       spawnBackgroundContinuation,

--- a/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
+++ b/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
@@ -7,7 +7,33 @@ import {
 } from "../adapter-factory.js";
 import type { ProviderConnection, ResolvedAuth } from "../auth.js";
 
-describe("openai-compatible adapter factory", () => {
+interface RetryOptions {
+  credentialSource?: string;
+  connectionName?: string;
+  refreshCredentialProvider?: () => Promise<unknown>;
+}
+
+/**
+ * Read the `RetryProvider` options the factory stamped. Walks the `inner`
+ * chain rather than assuming a fixed wrapper nesting, so reordering the
+ * wrappers fails a behavior assertion instead of this accessor.
+ */
+function retryOptions(adapter: unknown): RetryOptions {
+  let node = adapter;
+  for (let depth = 0; node && depth < 8; depth++) {
+    const { options, inner } = node as {
+      options?: RetryOptions;
+      inner?: unknown;
+    };
+    if (options) {
+      return options;
+    }
+    node = inner;
+  }
+  throw new Error("no RetryProvider found in the adapter wrapper chain");
+}
+
+describe("adapter factory", () => {
   test("buildProviderAdapter returns an OpenAIChatCompletionsProvider", () => {
     const adapter = buildProviderAdapter("openai-compatible", {
       apiKey: "test-key",
@@ -71,6 +97,10 @@ describe("openai-compatible adapter factory", () => {
     });
 
     expect(adapter).not.toBeNull();
+    expect(retryOptions(adapter)).toMatchObject({
+      credentialSource: "no-auth",
+      connectionName: "my-vllm",
+    });
   });
 
   test("createAdapterFromConnection still rejects 'none' auth for keyed catalog providers", () => {
@@ -93,5 +123,101 @@ describe("openai-compatible adapter factory", () => {
     );
 
     expect(adapter).toBeNull();
+  });
+
+  test("attributes OAuth subscription credentials separately from API keys", () => {
+    const connection: ProviderConnection = {
+      name: "chatgpt-subscription",
+      provider: "openai",
+      auth: {
+        type: "oauth_subscription",
+        credential: "chatgpt-subscription-oauth",
+      },
+      label: "ChatGPT",
+      baseUrl: null,
+      models: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isManaged: false,
+    };
+
+    const adapter = createAdapterFromConnection(
+      connection,
+      {
+        kind: "header",
+        headers: { Authorization: "Bearer test-token" },
+      },
+      { model: "gpt-5.4" },
+    );
+
+    expect(adapter).not.toBeNull();
+    expect(retryOptions(adapter)).toMatchObject({
+      credentialSource: "oauth-subscription",
+      connectionName: "chatgpt-subscription",
+    });
+  });
+
+  test("wires managed connections to reload rotated assistant credentials", () => {
+    const connection: ProviderConnection = {
+      name: "vellum",
+      provider: "vellum",
+      auth: { type: "platform" },
+      label: "Vellum",
+      baseUrl: null,
+      models: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isManaged: true,
+    };
+
+    const adapter = createAdapterFromConnection(
+      connection,
+      {
+        kind: "header",
+        headers: { Authorization: "Bearer managed-key" },
+        baseUrl: "https://example.com/runtime-proxy/anthropic",
+      },
+      { model: "claude-opus-4-8", provider: "anthropic" },
+    );
+
+    expect(adapter).not.toBeNull();
+    const options = retryOptions(adapter);
+    expect(options).toMatchObject({
+      credentialSource: "vellum-managed",
+      connectionName: "vellum",
+    });
+    expect(typeof options.refreshCredentialProvider).toBe("function");
+  });
+
+  test("credential refresh declines when it cannot re-read a changed key", async () => {
+    const connection: ProviderConnection = {
+      name: "vellum",
+      provider: "vellum",
+      auth: { type: "platform" },
+      label: "Vellum",
+      baseUrl: null,
+      models: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isManaged: true,
+    };
+
+    const adapter = createAdapterFromConnection(
+      connection,
+      {
+        kind: "header",
+        headers: { Authorization: "Bearer managed-key" },
+        baseUrl: "https://example.com/runtime-proxy/anthropic",
+      },
+      { model: "claude-opus-4-8", provider: "anthropic" },
+    );
+
+    // Guards the doubled-upstream-call regression: a refresh that cannot
+    // produce a credential different from the one that just failed must
+    // hand back nothing, so the retry loop surfaces the auth error instead
+    // of replaying the request against an identical key.
+    const refresh = retryOptions(adapter).refreshCredentialProvider;
+    expect(await refresh?.()).toBeNull();
+    expect(await refresh?.()).toBeNull();
   });
 });

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -37,6 +37,7 @@ import { UsageTrackingProvider } from "../usage-tracking.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
 import type { ResolvedAuth } from "./auth.js";
 import type { ProviderConnection } from "./auth.js";
+import { resolveAuth } from "./resolve-auth.js";
 
 /** Unified construction opts. Adapters ignore fields they don't consume. */
 export interface AdapterCreateOpts {
@@ -227,6 +228,74 @@ export function createAdapterFromConnection(
   },
 ): Provider | null {
   const provider = opts.provider ?? connection.provider;
+  const adapter = buildConnectionAdapter(connection, resolvedAuth, opts);
+  if (!adapter) {
+    return null;
+  }
+
+  /**
+   * Re-read the managed credential after an auth rejection and rebuild the
+   * adapter around it, so a key rotated out-of-band is picked up without a
+   * restart. Returns `null` when the store hands back the same credential
+   * that just failed — otherwise a proxy 401 from any other cause (platform
+   * auth degraded, revoked account) would make every request pay a second
+   * doomed upstream call forever.
+   */
+  function makeCredentialRefresher(): () => Promise<Provider | null> {
+    let lastAuth = JSON.stringify(resolvedAuth);
+    return async (): Promise<Provider | null> => {
+      const refreshedAuth = await resolveAuth(connection.auth, provider, {
+        baseUrl: connection.baseUrl,
+      });
+      if (!refreshedAuth.ok) {
+        return null;
+      }
+      const nextAuth = JSON.stringify(refreshedAuth.resolved);
+      if (nextAuth === lastAuth) {
+        return null;
+      }
+      lastAuth = nextAuth;
+      return buildConnectionAdapter(connection, refreshedAuth.resolved, opts);
+    };
+  }
+
+  // Usage-attribution headers (`X-Vellum-*`) are only meaningful when the
+  // request is routed through the Vellum-managed proxy. They carry billing
+  // metadata for our own backend. Forwarding them to a third-party endpoint
+  // would leak internal Vellum metadata, so gate on the auth type:
+  // `platform` is the only auth that flows through our proxy.
+  const isManagedProxy = connection.auth.type === "platform";
+  return new UsageTrackingProvider(
+    new RetryProvider(adapter, {
+      forwardUsageAttributionHeaders: isManagedProxy,
+      credentialSource: isManagedProxy
+        ? "vellum-managed"
+        : connection.auth.type === "api_key"
+          ? "byok"
+          : connection.auth.type === "oauth_subscription"
+            ? "oauth-subscription"
+            : connection.auth.type === "none"
+              ? "no-auth"
+              : undefined,
+      connectionName: connection.name,
+      ...(isManagedProxy
+        ? { refreshCredentialProvider: makeCredentialRefresher() }
+        : {}),
+    }),
+  );
+}
+
+function buildConnectionAdapter(
+  connection: ProviderConnection,
+  resolvedAuth: ResolvedAuth,
+  opts: {
+    model: string;
+    streamTimeoutMs?: number;
+    useNativeWebSearch?: boolean;
+    provider?: string;
+  },
+): Provider | null {
+  const provider = opts.provider ?? connection.provider;
   const entry = PROVIDER_CATALOG.find((e) => e.id === provider);
   if (!entry) {
     return null;
@@ -264,16 +333,5 @@ export function createAdapterFromConnection(
   if (!adapter) {
     return null;
   }
-
-  // Usage-attribution headers (`X-Vellum-*`) are only meaningful when the
-  // request is routed through the Vellum-managed proxy — they carry billing
-  // metadata for our own backend. Forwarding them to a third-party endpoint
-  // would leak internal Vellum metadata, so gate on the auth type:
-  // `platform` is the only auth that flows through our proxy.
-  const isManagedProxy = connection.auth.type === "platform";
-  return new UsageTrackingProvider(
-    new RetryProvider(adapter, {
-      forwardUsageAttributionHeaders: isManagedProxy,
-    }),
-  );
+  return adapter;
 }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -265,6 +265,14 @@ export async function initializeProviders(
       entry.id,
       new RetryProvider(adapter, {
         forwardUsageAttributionHeaders: source === "managed-proxy",
+        // A keyless provider booted without a key has no credential to blame,
+        // so don't let its rejections render as "update your personal key".
+        credentialSource:
+          source === "managed-proxy"
+            ? "vellum-managed"
+            : isKeyless && !apiKey
+              ? "no-auth"
+              : "byok",
       }),
     );
     routingSources.set(entry.id, source);

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -4,7 +4,11 @@ import {
   resolveUsageAttribution,
   sanitizeUsageMetadataValue,
 } from "../usage/attribution.js";
-import { ProviderError, type ProviderErrorReason } from "../util/errors.js";
+import {
+  type ProviderCredentialSource,
+  ProviderError,
+  type ProviderErrorReason,
+} from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
   computeRetryDelay,
@@ -824,6 +828,8 @@ function addSanitizedHeader(
 export class RetryProvider implements Provider {
   public readonly name: string;
 
+  private inner: Provider;
+
   get tokenEstimationProvider(): string | undefined {
     return this.inner.tokenEstimationProvider;
   }
@@ -842,24 +848,63 @@ export class RetryProvider implements Provider {
   // the wrapper chain (callers gate on its presence). Bound straight to the
   // inner provider — count_tokens is a cheap separate endpoint and its caller
   // already falls back on error, so it needs no retry wrapping.
+  // Deliberately not re-bound when a credential refresh swaps `inner`: every
+  // outer wrapper snapshots this the same way at construction, so a re-bind
+  // here would never reach callers. count_tokens on the pre-refresh credential
+  // fails soft — its caller falls back to estimation.
   public readonly countInputTokens?: NonNullable<Provider["countInputTokens"]>;
 
   constructor(
-    private readonly inner: Provider,
-    private readonly options: { forwardUsageAttributionHeaders?: boolean } = {},
+    inner: Provider,
+    private readonly options: {
+      forwardUsageAttributionHeaders?: boolean;
+      credentialSource?: ProviderCredentialSource;
+      connectionName?: string;
+      refreshCredentialProvider?: () => Promise<Provider | null>;
+    } = {},
   ) {
+    this.inner = inner;
     this.name = inner.name;
     if (inner.countInputTokens) {
       this.countInputTokens = inner.countInputTokens.bind(inner);
     }
   }
 
+  private shouldRefreshManagedCredential(error: unknown): boolean {
+    return (
+      this.options.credentialSource === "vellum-managed" &&
+      this.options.refreshCredentialProvider !== undefined &&
+      error instanceof ProviderError &&
+      (error.statusCode === 401 || error.statusCode === 403) &&
+      (error.reason === undefined ||
+        error.reason === "unknown" ||
+        error.reason === "invalid_credentials")
+    );
+  }
+
+  private attributeCredential(error: unknown): void {
+    const { credentialSource, connectionName } = this.options;
+    if (
+      !(error instanceof ProviderError) ||
+      (!credentialSource && !connectionName)
+    ) {
+      return;
+    }
+    // Merges under whatever a closer layer already stamped, so a route
+    // resolved at dispatch keeps precedence over this adapter's own view.
+    error.attachRouteAttribution({
+      ...(credentialSource ? { credentialSource } : {}),
+      ...(connectionName ? { connectionName } : {}),
+    });
+  }
+
   async sendMessage(
     messages: Message[],
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
-    let lastError: unknown;
     let didRetry = false;
+    let retryAttempt = 0;
+    let credentialRefreshAttempted = false;
     let messagesForAttempt = messages;
 
     const normalizedOptions = normalizeSendMessageOptions(this.name, options, {
@@ -867,7 +912,7 @@ export class RetryProvider implements Provider {
         this.options.forwardUsageAttributionHeaders === true,
     });
 
-    for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
+    while (true) {
       try {
         const result = await this.inner.sendMessage(
           messagesForAttempt,
@@ -875,9 +920,37 @@ export class RetryProvider implements Provider {
         );
         return result;
       } catch (error) {
-        lastError = error;
+        if (
+          !credentialRefreshAttempted &&
+          this.shouldRefreshManagedCredential(error)
+        ) {
+          credentialRefreshAttempted = true;
+          try {
+            const refreshed = await this.options.refreshCredentialProvider?.();
+            if (refreshed) {
+              this.inner = refreshed;
+              log.info(
+                {
+                  provider: this.name,
+                  connectionName: this.options.connectionName,
+                },
+                "Retrying managed inference with refreshed assistant credentials",
+              );
+              continue;
+            }
+          } catch (refreshError) {
+            log.warn(
+              {
+                provider: this.name,
+                connectionName: this.options.connectionName,
+                refreshError,
+              },
+              "Failed to reload managed assistant credentials",
+            );
+          }
+        }
 
-        if (attempt < DEFAULT_MAX_RETRIES && isRetryableError(error)) {
+        if (retryAttempt < DEFAULT_MAX_RETRIES && isRetryableError(error)) {
           // Malformed tool-argument JSON is conditioned on the request, so
           // resend with the corrective note. Built from the original
           // `messages` each time — the note appears exactly once no matter
@@ -890,7 +963,8 @@ export class RetryProvider implements Provider {
             error instanceof ProviderError ? error.retryAfterMs : undefined;
           const MAX_RETRY_DELAY_MS = 60_000; // Cap server-suggested delays at 60s
           const delay = Math.min(
-            retryAfter ?? computeRetryDelay(attempt, DEFAULT_BASE_DELAY_MS),
+            retryAfter ??
+              computeRetryDelay(retryAttempt, DEFAULT_BASE_DELAY_MS),
             MAX_RETRY_DELAY_MS,
           );
           const errorType =
@@ -909,7 +983,7 @@ export class RetryProvider implements Provider {
                       : "network_error";
           log.warn(
             {
-              attempt: attempt + 1,
+              attempt: retryAttempt + 1,
               maxRetries: DEFAULT_MAX_RETRIES,
               delay,
               retryAfterHeader: retryAfter !== undefined,
@@ -921,6 +995,7 @@ export class RetryProvider implements Provider {
             "Retrying after transient error",
           );
           didRetry = true;
+          retryAttempt++;
           await sleep(delay);
           continue;
         }
@@ -936,16 +1011,9 @@ export class RetryProvider implements Provider {
             true;
         }
 
+        this.attributeCredential(error);
         throw error;
       }
     }
-
-    // Unreachable in practice — the loop body always either returns or throws —
-    // but mark the last error in case execution somehow falls through.
-    if (lastError instanceof Error && isRetryableError(lastError)) {
-      (lastError as Error & { retriesExhausted?: boolean }).retriesExhausted =
-        true;
-    }
-    throw lastError;
   }
 }

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -123,10 +123,22 @@ export type ProviderErrorReason =
   | "network_error"
   | "unknown";
 
+export type ProviderCredentialSource =
+  | "byok"
+  | "no-auth"
+  | "oauth-subscription"
+  | "vellum-managed";
+
 export interface ProviderRouteAttribution {
   connectionName?: string;
   profileName?: string;
   isManagedRoute?: boolean;
+  /**
+   * Credential surface used for this request. Finer than `isManagedRoute`:
+   * it separates personal provider keys, keyless endpoints, and subscription
+   * logins from each other so error copy can name what the user must fix.
+   */
+  credentialSource?: ProviderCredentialSource;
 }
 
 export class ProviderError extends AssistantError {

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -151,6 +151,7 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
+import { useDoctorHandoffStore } from "@/stores/doctor-handoff-store";
 import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
 
 // ---------------------------------------------------------------------------
@@ -688,6 +689,31 @@ export function ChatMainPanel({
     </Button>
   ) : undefined;
 
+  // The assistant API key is provisioned by the platform, so unlike a rejected
+  // personal key there is nothing for the user to fix in Settings — the Doctor
+  // is the only surface that can re-issue it. Hands the request off through the
+  // same one-shot store `/doctor <message>` uses, so the panel auto-starts a
+  // session already on topic instead of opening on a blank prompt.
+  //
+  // Shares `showDoctorAction`'s gate: the Doctor is platform-hosted only, so a
+  // self-hosted assistant gets the banner with no action. Its recovery is the
+  // CLI (`assistant keys set credential/vellum/assistant_api_key <key>`), which
+  // no chat affordance can drive.
+  const reprovisionAssistantKeyAction = showDoctorAction ? (
+    <Button asChild variant="outlined" size="compact">
+      <Link
+        to={`${routes.settings.debug}?tab=doctor`}
+        onClick={() =>
+          useDoctorHandoffStore
+            .getState()
+            .setPendingPrompt("Help me re-provision my assistant's API key")
+        }
+      >
+        Ask the Doctor
+      </Link>
+    </Button>
+  ) : undefined;
+
   // Blocked automatic opens (see `handleOpenUrl`) carry the URL in
   // `actionUrl`; the button click is a real user gesture, so the re-open
   // always succeeds and the banner clears itself.
@@ -717,7 +743,10 @@ export function ChatMainPanel({
           actions:
             buildOpenUrlAction(error.actionUrl, () =>
               useChatSessionStore.getState().setError(null),
-            ) ?? doctorAction,
+            ) ??
+            (isManagedCredentialChatError(error)
+              ? reprovisionAssistantKeyAction
+              : doctorAction),
         }
       : null;
   const hasGenericChatError = genericChatError !== null;
@@ -730,7 +759,9 @@ export function ChatMainPanel({
             buildOpenUrlAction(notice.actionUrl, () =>
               useChatSessionStore.getState().setNotice(null),
             ) ??
-            (isManagedCredentialChatError(notice) ? doctorAction : undefined),
+            (isManagedCredentialChatError(notice)
+              ? reprovisionAssistantKeyAction
+              : undefined),
         }
       : null;
   const genericChatBanner = genericChatError ?? genericChatNotice;

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -55,6 +55,7 @@ import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attach
 import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachment-gate";
 import { useSupportsNewChatPlugins } from "@/lib/backwards-compat/use-supports-new-chat-plugins";
 import { recordCommit } from "@/lib/commit-pressure";
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { NewChatPluginsSection } from "@/domains/chat/components/new-chat-plugins/new-chat-plugins-section";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
@@ -153,6 +154,14 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useDoctorHandoffStore } from "@/stores/doctor-handoff-store";
 import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
+
+/**
+ * Self-hosted recovery for a rejected assistant API key. Mirrors the hint the
+ * daemon returns from its own auth route (`runtime/routes/auth-routes.ts`) —
+ * keep the two in step.
+ */
+const REPROVISION_ASSISTANT_KEY_COMMAND =
+  "assistant keys set credential/vellum/assistant_api_key <key>";
 
 // ---------------------------------------------------------------------------
 // Props — only values that cannot be owned locally
@@ -690,15 +699,16 @@ export function ChatMainPanel({
   ) : undefined;
 
   // The assistant API key is provisioned by the platform, so unlike a rejected
-  // personal key there is nothing for the user to fix in Settings — the Doctor
-  // is the only surface that can re-issue it. Hands the request off through the
-  // same one-shot store `/doctor <message>` uses, so the panel auto-starts a
-  // session already on topic instead of opening on a blank prompt.
+  // personal key there is nothing for the user to fix in Settings. Recovery
+  // differs by how the assistant is hosted, so the banner offers one of two
+  // actions rather than a single link:
   //
-  // Shares `showDoctorAction`'s gate: the Doctor is platform-hosted only, so a
-  // self-hosted assistant gets the banner with no action. Its recovery is the
-  // CLI (`assistant keys set credential/vellum/assistant_api_key <key>`), which
-  // no chat affordance can drive.
+  //   platform-hosted → the Doctor, which can re-issue the key. The request is
+  //     parked in the same one-shot store `/doctor <message>` uses, so the
+  //     panel auto-starts a session already on topic, not on a blank prompt.
+  //   self-hosted → the Doctor tab doesn't exist (it is platform-hosted only),
+  //     but `assistant keys set` does. Copying the command is the whole fix, so
+  //     the banner hands it over rather than leaving the user with no action.
   const reprovisionAssistantKeyAction = showDoctorAction ? (
     <Button asChild variant="outlined" size="compact">
       <Link
@@ -711,6 +721,19 @@ export function ChatMainPanel({
       >
         Ask the Doctor
       </Link>
+    </Button>
+  ) : assistantState.kind === "active" ? (
+    <Button
+      variant="outlined"
+      size="compact"
+      onClick={() =>
+        copyToClipboard(REPROVISION_ASSISTANT_KEY_COMMAND, {
+          successMessage: "Command copied. Run it where the assistant runs.",
+          errorMessage: "Couldn't copy the command.",
+        })
+      }
+    >
+      Copy CLI fix
     </Button>
   ) : undefined;
 


### PR DESCRIPTION
## Summary

- carry the request-specific credential source and provider connection into provider errors
- name rejected personal provider keys separately from the Vellum assistant API key
- use provider-neutral copy for managed inference failures
- reload rotated Vellum assistant credentials and retry managed inference once before showing an error
- cover mixed managed, BYOK, subscription, and no-auth routing with focused regression tests

## Original prompt

Clarify voice-mode API key failures so users can tell whether their own provider key or the Vellum-managed credential failed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->