### PR TITLE
fix(service-contracts): repair package typecheck and put it under CI

### DIFF
--- a/.github/workflows/ci-main-service-contracts.yaml
+++ b/.github/workflows/ci-main-service-contracts.yaml
@@ -1,0 +1,39 @@
+name: CI Main Service Contracts Checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'bun.lock'
+      - 'patches/**'
+      - 'packages/service-contracts/**'
+      - '.github/workflows/ci-main-service-contracts.yaml'
+
+jobs:
+  checks:
+    name: Type Check & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: packages/service-contracts
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter=@vellumai/service-contracts
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test

--- a/.github/workflows/pr-service-contracts.yaml
+++ b/.github/workflows/pr-service-contracts.yaml
@@ -1,0 +1,41 @@
+name: PR Service Contracts Checks
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened]
+    paths:
+      - 'package.json'
+      - 'bun.lock'
+      - 'patches/**'
+      - 'packages/service-contracts/**'
+      - '.github/workflows/pr-service-contracts.yaml'
+
+concurrency:
+  group: pr-service-contracts-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Type Check & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/service-contracts
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter=@vellumai/service-contracts
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -17,7 +17,7 @@ import qrcodeTerminal from "qrcode-terminal";
 
 import {
   buildRemoteWebPairingUrl,
-  normalizePublicBaseUrl,
+  normalizePairingBaseUrl,
   resolvePublicBaseUrl,
   tunnelProviderWebsiteName,
   type PublicBaseUrlRejection,
@@ -414,7 +414,7 @@ export async function pair(): Promise<void> {
 
     let publicBaseUrl: string;
     try {
-      publicBaseUrl = normalizePublicBaseUrl(advertisedUrl);
+      publicBaseUrl = normalizePairingBaseUrl(advertisedUrl);
     } catch {
       console.error(`Error: invalid --url value '${advertisedUrl}'.`);
       process.exit(1);

--- a/clients/web/src/domains/settings/pair-device/pair-device-url.test.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-url.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, test } from "bun:test";
 import {
   buildRemoteWebPairingUrl,
   isLoopbackUrl,
-  normalizePublicBaseUrl,
+  normalizePairingBaseUrl,
   publicBaseUrlRejectionMessage,
   resolvePublicBaseUrl,
 } from "./pair-device-url";
 
-describe("normalizePublicBaseUrl", () => {
+describe("normalizePairingBaseUrl", () => {
   test("strips query, hash, and the assistant path segment", () => {
     expect(
-      normalizePublicBaseUrl(
+      normalizePairingBaseUrl(
         "https://foo.ts.net/assistant/pair?x=1#device_code=abc",
       ),
     ).toBe("https://foo.ts.net");
@@ -19,18 +19,18 @@ describe("normalizePublicBaseUrl", () => {
 
   test("preserves a deployment path prefix before /assistant", () => {
     expect(
-      normalizePublicBaseUrl("https://foo.example.com/vellum/assistant/"),
+      normalizePairingBaseUrl("https://foo.example.com/vellum/assistant/"),
     ).toBe("https://foo.example.com/vellum");
   });
 
   test("trims trailing slashes", () => {
-    expect(normalizePublicBaseUrl("https://foo.ts.net///")).toBe(
+    expect(normalizePairingBaseUrl("https://foo.ts.net///")).toBe(
       "https://foo.ts.net",
     );
   });
 
   test("throws on an unparseable value", () => {
-    expect(() => normalizePublicBaseUrl("not a url")).toThrow();
+    expect(() => normalizePairingBaseUrl("not a url")).toThrow();
   });
 });
 

--- a/clients/web/src/domains/settings/pair-device/pair-device-url.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-url.ts
@@ -9,7 +9,7 @@
 export {
   buildRemoteWebPairingUrl,
   isLoopbackPublicUrl as isLoopbackUrl,
-  normalizePublicBaseUrl,
+  normalizePairingBaseUrl,
   resolvePublicBaseUrl,
   type PublicBaseUrlRejection,
   type PublicBaseUrlResult,

--- a/packages/service-contracts/src/__tests__/redacted-credential.test.ts
+++ b/packages/service-contracts/src/__tests__/redacted-credential.test.ts
@@ -8,7 +8,7 @@ import {
   parseRedactedSentinel,
   REDACTED_SENTINEL_CLOSE,
   REDACTED_SENTINEL_OPEN,
-} from "../redacted-credential";
+} from "../redacted-credential.js";
 
 describe("buildRedactedSentinel", () => {
   test("plain shape carries only the type", () => {

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -204,7 +204,7 @@ export function isLoopbackPublicUrl(url: string): boolean {
  * removed so a pasted pair-page URL collapses to its base, and trailing
  * slashes trimmed. Throws if the value is not a parseable URL.
  */
-export function normalizePublicBaseUrl(value: string): string {
+export function normalizePairingBaseUrl(value: string): string {
   const url = new URL(value);
   url.search = "";
   url.hash = "";
@@ -225,7 +225,7 @@ export function normalizePublicBaseUrl(value: string): string {
 export function resolvePublicBaseUrl(raw: string): PublicBaseUrlResult {
   let normalized: string;
   try {
-    normalized = normalizePublicBaseUrl(raw);
+    normalized = normalizePairingBaseUrl(raw);
   } catch {
     return { ok: false, reason: "unparseable" };
   }


### PR DESCRIPTION
## TL;DR

`cd packages/service-contracts && bunx tsc --noEmit` has been failing on main with two errors. Both are fixed here, and the package now has its own CI workflows so it cannot silently break again.

## The two errors

**1. Export collision in the aggregate barrel (TS2308).** `src/index.ts` star-exports every submodule. Both `ingress.ts` and `remote-web-pairing.ts` exported a function named `normalizePublicBaseUrl`, with different signatures and genuinely different behavior:

| Module | Signature | What it does |
| --- | --- | --- |
| `ingress.ts` | `(value: unknown) => string \| undefined` | Lenient: trims whitespace and trailing slashes, returns `undefined` on junk |
| `remote-web-pairing.ts` | `(value: string) => string` | Strict: parses the URL, strips query/hash and the `assistant` path segment, throws on junk |

`export * from "./ingress.js"` and `export * from "./remote-web-pairing.js"` therefore conflicted.

Fixed by renaming the pairing one to `normalizePairingBaseUrl`. That name describes what it actually does and matches its siblings in the module (`buildRemoteWebPairingUrl`, `resolvePublicBaseUrl`). The ingress function keeps its name, so its four consumers in `assistant/` and `gateway/` are untouched.

I chose the rename over an explicit disambiguating re-export in `index.ts`. The re-export would silence the compiler but leave two different functions sharing one name in one package, which is the actual hazard: a wrong auto-import compiles fine and misbehaves at runtime, since one returns `undefined` on bad input and the other throws.

**2. Missing import extension (TS2835).** `src/__tests__/redacted-credential.test.ts` imported `"../redacted-credential"` without the `.js` extension NodeNext requires. Added.

## Why CI never caught this

The `exports` map points at `./src/*.ts`, so a consuming package's `tsc` only typechecks the shared-package files it actually imports. The two broken files were exactly the ones nothing imports:

- `src/index.ts` is banned. `assistant/src/__tests__/service-contracts-import-guard.test.ts` fails the build if `assistant/`, `gateway/`, or `credential-executor/` import the aggregate root, and its allowlist is empty. `clients/web` and `cli` do not import it either.
- `src/__tests__/` is not on any import path.

And no workflow ran this package at all. `pr-credential-executor.yaml` triggers on `packages/service-contracts/**`, but its `working-directory` is `credential-executor`, so it typechecks that package instead. The 172 tests in `packages/service-contracts` were never running in CI.

Added `pr-service-contracts.yaml` and `ci-main-service-contracts.yaml`, mirroring the existing `pr-environments.yaml` / `ci-main-environments.yaml` pair. Both run `bun run typecheck` and `bun run test`.

## What changes for the user

| Before | After |
| --- | --- |
| Nothing. This is a build-tooling fix with no runtime behavior change. | Nothing. |

The rename is a compile-time symbol change only. Both functions keep their exact bodies, and `resolvePublicBaseUrl` (the wrapper the pairing UI and `vellum pair --qr` actually call) is unchanged, so device pairing behaves identically.

## Why it is safe

- No behavior changed. The rename moved zero lines of logic, and the extension fix is resolution-only.
- The package is `private: true`, so there is no external consumer whose import could break. All four in-repo references to the renamed function are updated in this PR: its own internal caller, `cli/src/commands/pair.ts`, and the web re-export plus its test.
- `gateway/` also imports `remote-web-pairing`, but only for types and the challenge-store helpers, never the renamed function.

## Verification

| Check | Result |
| --- | --- |
| `packages/service-contracts` typecheck | passes (was 2 errors) |
| `packages/service-contracts` tests | 172 pass, 0 fail |
| `cli` typecheck | passes |
| `clients/web` typecheck | passes |
| `gateway` typecheck | passes |
| `pair-device-url.test.ts` | 15 pass, 0 fail |
| eslint on all changed `.ts` files | clean |
| CI install step (`bun install --frozen-lockfile --filter=@vellumai/service-contracts` then typecheck then test) | verified locally |

## Deferred, with issues filed

Two things I deliberately did not fold into this PR:

- **[LUM-2947](https://linear.app/vellum/issue/LUM-2947/packages-8-shared-packages-have-typechecktest-scripts-that-no-ci)** — eight more packages under `packages/` (`assistant-client`, `ces-client`, `credential-storage`, `egress-proxy`, `gateway-client`, `ipc-server-utils`, `slack-text`, `twilio-client`) define `typecheck` and `test` scripts that no workflow runs. Deferred because the right fix is one matrix job plus a guard, not eight more copy-pasted workflow files, and that is a bigger change than unblocking this package. All eight pass `tsc` today, so the gap is latent rather than actively broken.
- **[LUM-2948](https://linear.app/vellum/issue/LUM-2948/delete-the-dead-aggregate-barrel-packagesservice-contractssrcindexts)** — `src/index.ts` is dead. I verified across every file type in the repo that nothing imports the bare specifier, and a guard test already bans it. Deleting it would remove this entire class of failure permanently, since the collision only became a build error because of the barrel. Deferred because removing a package entry point is an API decision rather than a build fix, and this PR already reaches into `cli/` and `clients/web/`.

Related to LUM-2947, LUM-2948
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->