### PR TITLE
feat(web): move the Advisor selection from the profile cards into Action Overrides

### DIFF
--- a/clients/web/src/domains/settings/ai/advisor-profile-row.stories.tsx
+++ b/clients/web/src/domains/settings/ai/advisor-profile-row.stories.tsx
@@ -29,7 +29,7 @@ export default meta;
 type Story = StoryObj<typeof AdvisorProfileRow>;
 
 /**
- * Interactive wrapper — the row is controlled, so a story that passes a bare
+ * Interactive wrapper. The row is controlled, so a story that passes a bare
  * `value` renders a picker that won't move when clicked.
  */
 function Controlled(props: {
@@ -55,7 +55,7 @@ export const Default: Story = {
 
 /**
  * No selection. Only reachable between deleting the profile the advisor
- * pointed at — which clears the reference so no dangling name survives — and
+ * pointed at (which clears the reference so no dangling name survives) and
  * the next daemon boot, whose seeding re-fills the key.
  */
 export const NoSelection: Story = {

--- a/clients/web/src/domains/settings/ai/advisor-profile-row.stories.tsx
+++ b/clients/web/src/domains/settings/ai/advisor-profile-row.stories.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AdvisorProfileRow } from "@/domains/settings/ai/advisor-profile-row";
+
+// Mirrors what `visibleProfilesForPicker` + `profilePickerLabel` produce in
+// the Action Overrides panel, including the "(Disabled)" suffix the picker
+// appends when the current selection is a disabled profile.
+const PROFILE_OPTIONS = [
+  { value: "quality-optimized", label: "Quality" },
+  { value: "balanced", label: "Balanced" },
+  { value: "speed-tier", label: "Speed" },
+  { value: "my-custom", label: "My Custom" },
+];
+
+const meta: Meta<typeof AdvisorProfileRow> = {
+  title: "Settings/AI/AdvisorProfileRow",
+  component: AdvisorProfileRow,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 520, padding: 24 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AdvisorProfileRow>;
+
+/**
+ * Interactive wrapper — the row is controlled, so a story that passes a bare
+ * `value` renders a picker that won't move when clicked.
+ */
+function Controlled(props: {
+  initial: string;
+  options?: { value: string; label: string }[];
+  disabled?: boolean;
+}) {
+  const [value, setValue] = useState(props.initial);
+  return (
+    <AdvisorProfileRow
+      value={value}
+      profileOptions={props.options ?? PROFILE_OPTIONS}
+      disabled={props.disabled}
+      onChange={setValue}
+    />
+  );
+}
+
+/** The common case: `llm.advisorProfile` is seeded, so a profile is selected. */
+export const Default: Story = {
+  render: () => <Controlled initial="quality-optimized" />,
+};
+
+/**
+ * No selection. Only reachable between deleting the profile the advisor
+ * pointed at — which clears the reference so no dangling name survives — and
+ * the next daemon boot, whose seeding re-fills the key.
+ */
+export const NoSelection: Story = {
+  render: () => <Controlled initial="" />,
+};
+
+/**
+ * The current selection is a disabled profile. The picker keeps it visible
+ * (and suffixed) so the trigger has a label and there's a way back out.
+ */
+export const DisabledProfileSelected: Story = {
+  render: () => (
+    <Controlled
+      initial="speed-tier"
+      options={[
+        { value: "quality-optimized", label: "Quality" },
+        { value: "balanced", label: "Balanced" },
+        { value: "speed-tier", label: "Speed (Disabled)" },
+      ]}
+    />
+  ),
+};
+
+/** Held inert while the panel's Save is in flight. */
+export const Saving: Story = {
+  render: () => <Controlled initial="balanced" disabled />,
+};

--- a/clients/web/src/domains/settings/ai/advisor-profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/advisor-profile-row.tsx
@@ -17,7 +17,7 @@ export interface AdvisorProfileRowProps {
  * The Advisor setting in the Action Overrides panel: which profile the
  * second-opinion consult runs on (`llm.advisorProfile`).
  *
- * Shaped like `CallSiteOverrideRow` but deliberately picker-only — no
+ * Shaped like `CallSiteOverrideRow` but deliberately picker-only: no
  * toggle, no off state, no Custom provider/model branch:
  *
  * - `llm.advisorProfile` holds a profile name and nothing else, so there is
@@ -40,7 +40,7 @@ export function AdvisorProfileRow({
     <div className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-base)] p-3">
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
-          {/* typography: off-scale — matches the call-site row's name treatment */}
+          {/* typography: off-scale. Matches the call-site row's name treatment */}
           <p className="text-body-medium-default font-medium text-[var(--content-default)]">
             Advisor
           </p>

--- a/clients/web/src/domains/settings/ai/advisor-profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/advisor-profile-row.tsx
@@ -1,0 +1,67 @@
+import { Dropdown } from "@vellumai/design-library/components/dropdown";
+
+interface ProfileOption {
+  value: string;
+  label: string;
+}
+
+export interface AdvisorProfileRowProps {
+  /** Current `llm.advisorProfile` draft value; empty renders the placeholder. */
+  value: string;
+  profileOptions: ProfileOption[];
+  disabled?: boolean;
+  onChange: (profile: string) => void;
+}
+
+/**
+ * The Advisor setting in the Action Overrides panel: which profile the
+ * second-opinion consult runs on (`llm.advisorProfile`).
+ *
+ * Shaped like `CallSiteOverrideRow` but deliberately picker-only — no
+ * toggle, no off state, no Custom provider/model branch:
+ *
+ * - `llm.advisorProfile` holds a profile name and nothing else, so there is
+ *   nowhere to persist a bare provider + model pin.
+ * - There is no durable off state to offer. `seedInferenceProfiles` runs on
+ *   every daemon boot and re-fills the key whenever it is absent, so an
+ *   "off" choice would silently revert on the next restart.
+ *
+ * The value therefore renders empty only in the window between deleting the
+ * advisor's profile (which clears the reference so no dangling name
+ * survives) and the next boot's reseed.
+ */
+export function AdvisorProfileRow({
+  value,
+  profileOptions,
+  disabled,
+  onChange,
+}: AdvisorProfileRowProps) {
+  return (
+    <div className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-base)] p-3">
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          {/* typography: off-scale — matches the call-site row's name treatment */}
+          <p className="text-body-medium-default font-medium text-[var(--content-default)]">
+            Advisor
+          </p>
+          <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+            The profile your assistant consults for a second opinion when it
+            wants to check a plan or review its own work.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Dropdown
+            value={value}
+            onChange={onChange}
+            options={profileOptions}
+            placeholder="Choose profile…"
+            className="w-44"
+            menuMinWidth={280}
+            menuAlign="end"
+            disabled={disabled}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.stories.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.stories.tsx
@@ -1,0 +1,123 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  configGetOptions,
+  configLlmCallsitesGetOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type {
+  ConfigGetResponse,
+  ConfigLlmCallsitesGetResponse,
+} from "@/generated/daemon/types.gen";
+import { OverridesDetailPanel } from "@/domains/settings/ai/overrides-detail-panel";
+
+const ASSISTANT_ID = "story-assistant";
+
+// Both queries are seeded directly into the cache — Storybook has no daemon,
+// and an unresolved config query renders the panel's loading state instead of
+// the thing this story documents.
+const CATALOG: ConfigLlmCallsitesGetResponse = {
+  domains: [{ id: "agentLoop", displayName: "Agent Loop" }],
+  callSites: [
+    {
+      // Filtered out by the panel — the chat model is picked via the profile
+      // picker, not here. Present so the story proves it stays hidden.
+      id: "mainAgent",
+      displayName: "Main Agent",
+      description: "The primary conversation agent that handles user messages.",
+      domain: "agentLoop",
+    },
+    {
+      id: "subagentSpawn",
+      displayName: "Subagent Spawn",
+      description: "Spawns a subagent to handle a delegated subtask.",
+      domain: "agentLoop",
+      defaultProfile: "balanced",
+    },
+    {
+      id: "heartbeatAgent",
+      displayName: "Heartbeat Agent",
+      description: "Runs background tasks and proactive checks on a schedule.",
+      domain: "agentLoop",
+      defaultProfile: "speed-tier",
+    },
+  ],
+};
+
+// The three managed defaults a stock install ships with, hence
+// `provider: "vellum"` on each.
+const CONFIG: ConfigGetResponse = {
+  llm: {
+    profiles: {
+      "quality-optimized": {
+        label: "Quality",
+        provider: "vellum",
+        model: "gpt-5.6-sol",
+        source: "managed",
+        status: "active",
+      },
+      balanced: {
+        label: "Balanced",
+        provider: "vellum",
+        model: "glm-5.2",
+        source: "managed",
+        status: "active",
+      },
+      "speed-tier": {
+        label: "Speed",
+        provider: "vellum",
+        model: "deepseek-v4-flash",
+        source: "managed",
+        status: "active",
+      },
+    },
+    profileOrder: ["quality-optimized", "balanced", "speed-tier"],
+    activeProfile: "balanced",
+    advisorProfile: "quality-optimized",
+    callSites: {},
+  },
+};
+
+// Seed through the generated options factories rather than a hand-written
+// key — HeyAPI bakes the path params into the query key, so a literal
+// `[{ _id: "configGet" }]` misses and the panel renders its error state.
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  const path = { assistant_id: ASSISTANT_ID };
+  client.setQueryData(configLlmCallsitesGetOptions({ path }).queryKey, CATALOG);
+  client.setQueryData(configGetOptions({ path }).queryKey, CONFIG);
+  return client;
+}
+
+const meta: Meta<typeof OverridesDetailPanel> = {
+  title: "Settings/AI/OverridesDetailPanel",
+  component: OverridesDetailPanel,
+  args: { assistantId: ASSISTANT_ID, onClose: () => {} },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={seededClient()}>
+        <div style={{ maxWidth: 560, height: 720 }}>
+          <Story />
+        </div>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof OverridesDetailPanel>;
+
+/**
+ * The Advisor setting sits above the call-site groups: a top-level
+ * `llm.advisorProfile` selection that rides this panel's Save button but
+ * never enters the `llm.callSites` patch.
+ */
+export const Default: Story = {};

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.stories.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.stories.tsx
@@ -13,14 +13,14 @@ import { OverridesDetailPanel } from "@/domains/settings/ai/overrides-detail-pan
 
 const ASSISTANT_ID = "story-assistant";
 
-// Both queries are seeded directly into the cache — Storybook has no daemon,
+// Both queries are seeded directly into the cache. Storybook has no daemon,
 // and an unresolved config query renders the panel's loading state instead of
 // the thing this story documents.
 const CATALOG: ConfigLlmCallsitesGetResponse = {
   domains: [{ id: "agentLoop", displayName: "Agent Loop" }],
   callSites: [
     {
-      // Filtered out by the panel — the chat model is picked via the profile
+      // Filtered out by the panel: the chat model is picked via the profile
       // picker, not here. Present so the story proves it stays hidden.
       id: "mainAgent",
       displayName: "Main Agent",
@@ -79,7 +79,7 @@ const CONFIG: ConfigGetResponse = {
 };
 
 // Seed through the generated options factories rather than a hand-written
-// key — HeyAPI bakes the path params into the query key, so a literal
+// key. HeyAPI bakes the path params into the query key, so a literal
 // `[{ _id: "configGet" }]` misses and the panel renders its error state.
 function seededClient() {
   const client = new QueryClient({

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -262,7 +262,7 @@ describe("OverridesDetailPanel - advisor", () => {
     expect(optionLabels).toEqual(["My BYOK", "Quality"]);
   });
 
-  test("changing the advisor PATCHes llm.advisorProfile alongside callSites", async () => {
+  test("an advisor-only save omits callSites entirely", async () => {
     render(
       <Wrapper>
         <OverridesDetailPanel assistantId="asst-1" onClose={() => {}} />
@@ -284,14 +284,11 @@ describe("OverridesDetailPanel - advisor", () => {
     await waitFor(() => {
       expect(configPatchBodies.length).toBe(1);
     });
-    const body = configPatchBodies[0] as {
-      llm: { advisorProfile: string; callSites: Record<string, unknown> };
-    };
+    const body = configPatchBodies[0] as { llm: Record<string, unknown> };
     expect(body.llm.advisorProfile).toBe("my-byok");
-    // No call site was touched, so every gated entry clears to null.
-    expect(body.llm.callSites).toEqual({
-      workflowLeaf: null,
-      heartbeatAgent: null,
-    });
+    // No call site was touched. Sending the map anyway would rewrite each
+    // entry from the picker's three fields and drop any tuning field
+    // (effort, thinking, maxTokens) a persisted entry carries.
+    expect("callSites" in body.llm).toBe(false);
   });
 });

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -55,9 +55,15 @@ const CONFIG = {
         provider: "anthropic",
         model: "claude-fable-5",
       },
+      quality: {
+        label: "Quality",
+        provider: "anthropic",
+        model: "claude-opus-5",
+      },
     },
-    profileOrder: ["my-byok"],
+    profileOrder: ["my-byok", "quality"],
     activeProfile: null,
+    advisorProfile: "quality",
     callSites: {},
   },
 };
@@ -161,7 +167,8 @@ describe("OverridesDetailPanel - apply to all", () => {
     // Before a profile is chosen the apply button is inert.
     expect(getButton("Apply to all").disabled).toBe(true);
 
-    // The apply-all dropdown is the only combobox while no override is on.
+    // With no override toggled on, the only comboboxes are the apply-all
+    // dropdown and the Advisor row's - and apply-all renders first.
     const trigger = document.querySelector<HTMLElement>(
       'button[role="combobox"]',
     );
@@ -184,5 +191,107 @@ describe("OverridesDetailPanel - apply to all", () => {
       heartbeatAgent: { profile: "my-byok", provider: null, model: null },
     });
     expect("mainAgent" in body.llm.callSites).toBe(false);
+  });
+
+  test("apply-to-all leaves the advisor selection alone", async () => {
+    render(
+      <Wrapper>
+        <OverridesDetailPanel assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(renderedText()).toContain("Use one profile for all actions");
+    });
+
+    const trigger = document.querySelector<HTMLElement>(
+      'button[role="combobox"]',
+    );
+    if (!trigger) {
+      throw new Error("expected the apply-all dropdown trigger");
+    }
+    pickOption(trigger, "My BYOK");
+    fireEvent.click(getButton("Apply to all"));
+    fireEvent.click(getButton("Save"));
+
+    await waitFor(() => {
+      expect(configPatchBodies.length).toBe(1);
+    });
+    const body = configPatchBodies[0] as { llm: Record<string, unknown> };
+    expect("advisorProfile" in body.llm).toBe(false);
+  });
+});
+
+describe("OverridesDetailPanel - advisor", () => {
+  test("renders the advisor row seeded from llm.advisorProfile", async () => {
+    render(
+      <Wrapper>
+        <OverridesDetailPanel assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(renderedText()).toContain("Advisor");
+    });
+    expect(renderedText()).toContain("second opinion");
+    // Seeded selection is visible in the row's dropdown trigger.
+    const triggers = Array.from(
+      document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+    );
+    expect(triggers.some((t) => t.textContent?.includes("Quality"))).toBe(true);
+  });
+
+  test("the advisor row offers no off state", async () => {
+    render(
+      <Wrapper>
+        <OverridesDetailPanel assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(renderedText()).toContain("Advisor");
+    });
+
+    const advisorTrigger = Array.from(
+      document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+    ).find((t) => t.textContent?.includes("Quality"));
+    if (!advisorTrigger) {
+      throw new Error("expected the advisor dropdown trigger");
+    }
+    fireEvent.click(advisorTrigger);
+    const optionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(optionLabels).toEqual(["My BYOK", "Quality"]);
+  });
+
+  test("changing the advisor PATCHes llm.advisorProfile alongside callSites", async () => {
+    render(
+      <Wrapper>
+        <OverridesDetailPanel assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(renderedText()).toContain("Advisor");
+    });
+
+    const advisorTrigger = Array.from(
+      document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+    ).find((t) => t.textContent?.includes("Quality"));
+    if (!advisorTrigger) {
+      throw new Error("expected the advisor dropdown trigger");
+    }
+    pickOption(advisorTrigger, "My BYOK");
+    fireEvent.click(getButton("Save"));
+
+    await waitFor(() => {
+      expect(configPatchBodies.length).toBe(1);
+    });
+    const body = configPatchBodies[0] as {
+      llm: { advisorProfile: string; callSites: Record<string, unknown> };
+    };
+    expect(body.llm.advisorProfile).toBe("my-byok");
+    // No call site was touched, so every gated entry clears to null.
+    expect(body.llm.callSites).toEqual({
+      workflowLeaf: null,
+      heartbeatAgent: null,
+    });
   });
 });

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -9,6 +9,7 @@ import {
   visibleProfilesForPicker,
 } from "@/assistant/profile-pickers";
 import { getDefaultModelForProvider } from "@/assistant/llm-model-catalog";
+import { AdvisorProfileRow } from "@/domains/settings/ai/advisor-profile-row";
 import {
   CUSTOM_SENTINEL,
   draftsEqual,
@@ -100,6 +101,9 @@ export function OverridesDetailPanel({
   const [draftEdits, setDraftEdits] = useState<
     Record<string, CallSiteOverrideDraft | null>
   >({});
+  // `undefined` means "untouched this session" — the row falls through to the
+  // persisted `llm.advisorProfile` rather than pinning a stale snapshot.
+  const [advisorEdit, setAdvisorEdit] = useState<string | undefined>(undefined);
   const [saving, setSaving] = useState(false);
   const [showResetConfirmation, setShowResetConfirmation] = useState(false);
 
@@ -159,6 +163,29 @@ export function OverridesDetailPanel({
     [catalogCallSiteIds],
   );
 
+  // The advisor is a top-level `llm.advisorProfile` selection, not a call-site
+  // override — it rides this panel's draft/Save cycle but never enters the
+  // `llm.callSites` patch, the apply-to-all sweep, or the Overrides count.
+  const persistedAdvisor = daemonConfig?.llm?.advisorProfile ?? "";
+  const advisorProfile = advisorEdit ?? persistedAdvisor;
+  const advisorDirty = advisorProfile !== persistedAdvisor;
+
+  const advisorOptions = useMemo(
+    () =>
+      visibleProfilesForPicker(orderedProfiles, [persistedAdvisor]).map((p) => ({
+        value: p.name,
+        label: profilePickerLabel(p),
+      })),
+    [orderedProfiles, persistedAdvisor],
+  );
+
+  // "advisor" isn't in the call-site catalog, so its row filters on its own
+  // copy rather than falling out of `filteredCallSites`.
+  const advisorMatchesSearch = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return q === "" || "advisor".includes(q) || "second opinion".includes(q);
+  }, [search]);
+
   const hasAnyPersistedOverride = useMemo(
     () =>
       Object.entries(persistedOverrides).some(
@@ -170,6 +197,9 @@ export function OverridesDetailPanel({
   );
 
   const hasUnsavedDrafts = useMemo(() => {
+    if (advisorDirty) {
+      return true;
+    }
     if (!isSeeded) {
       return false;
     }
@@ -179,7 +209,7 @@ export function OverridesDetailPanel({
       }
     }
     return false;
-  }, [isSeeded, drafts, persistedOverrides]);
+  }, [advisorDirty, isSeeded, drafts, persistedOverrides]);
 
   const hasValidationError = useMemo(
     () =>
@@ -321,7 +351,14 @@ export function OverridesDetailPanel({
       }
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
-        body: { llm: { callSites: patch } },
+        body: {
+          llm: {
+            callSites: patch,
+            // Only when the user actually moved it — a no-op key would still
+            // rewrite the config file on every Save.
+            ...(advisorDirty ? { advisorProfile } : {}),
+          },
+        },
       });
       onClose();
       toast.success("Overrides saved.");
@@ -331,7 +368,14 @@ export function OverridesDetailPanel({
     } finally {
       setSaving(false);
     }
-  }, [drafts, onClose, configMutation, assistantId]);
+  }, [
+    drafts,
+    advisorDirty,
+    advisorProfile,
+    onClose,
+    configMutation,
+    assistantId,
+  ]);
 
   const handleReset = useCallback(async () => {
     setSaving(true);
@@ -434,6 +478,24 @@ export function OverridesDetailPanel({
           </div>
         )}
 
+        {/* Advisor — a top-level selection, not a catalog call site, so it
+            renders off `daemonConfig` alone and stays put if the call-site
+            catalog fails to load. */}
+        {daemonConfigLoaded && advisorMatchesSearch && (
+          <div className="mb-4">
+            {/* typography: off-scale — matches the domain section label below */}
+            <p className="mb-2 text-body-small-default font-semibold uppercase tracking-wider text-[var(--content-tertiary)]">
+              Advisor
+            </p>
+            <AdvisorProfileRow
+              value={advisorProfile}
+              profileOptions={advisorOptions}
+              disabled={saving}
+              onChange={setAdvisorEdit}
+            />
+          </div>
+        )}
+
         {/* Loading */}
         {isLoading && (
           <div className="flex items-center justify-center py-12">
@@ -464,9 +526,13 @@ export function OverridesDetailPanel({
         {!isLoading && !isError && catalog && (
           <div className="space-y-4">
             {groupedCallSites.length === 0 ? (
-              <p className="py-8 text-center text-body-medium-lighter text-[var(--content-tertiary)]">
-                No actions match your search.
-              </p>
+              // Suppressed when the Advisor row above already answered the
+              // search — "no matches" next to a visible match reads as a bug.
+              advisorMatchesSearch ? null : (
+                <p className="py-8 text-center text-body-medium-lighter text-[var(--content-tertiary)]">
+                  No actions match your search.
+                </p>
+              )
             ) : (
               groupedCallSites.map(({ domain, sites }) => (
                 <div key={domain.id}>

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -101,7 +101,7 @@ export function OverridesDetailPanel({
   const [draftEdits, setDraftEdits] = useState<
     Record<string, CallSiteOverrideDraft | null>
   >({});
-  // `undefined` means "untouched this session" — the row falls through to the
+  // `undefined` means "untouched this session": the row falls through to the
   // persisted `llm.advisorProfile` rather than pinning a stale snapshot.
   const [advisorEdit, setAdvisorEdit] = useState<string | undefined>(undefined);
   const [saving, setSaving] = useState(false);
@@ -164,7 +164,7 @@ export function OverridesDetailPanel({
   );
 
   // The advisor is a top-level `llm.advisorProfile` selection, not a call-site
-  // override — it rides this panel's draft/Save cycle but never enters the
+  // override. It rides this panel's draft/Save cycle but never enters the
   // `llm.callSites` patch, the apply-to-all sweep, or the Overrides count.
   const persistedAdvisor = daemonConfig?.llm?.advisorProfile ?? "";
   const advisorProfile = advisorEdit ?? persistedAdvisor;
@@ -196,10 +196,7 @@ export function OverridesDetailPanel({
     [persistedOverrides, gatedCallSiteIdSet],
   );
 
-  const hasUnsavedDrafts = useMemo(() => {
-    if (advisorDirty) {
-      return true;
-    }
+  const callSiteDraftsDirty = useMemo(() => {
     if (!isSeeded) {
       return false;
     }
@@ -209,7 +206,9 @@ export function OverridesDetailPanel({
       }
     }
     return false;
-  }, [advisorDirty, isSeeded, drafts, persistedOverrides]);
+  }, [isSeeded, drafts, persistedOverrides]);
+
+  const hasUnsavedDrafts = advisorDirty || callSiteDraftsDirty;
 
   const hasValidationError = useMemo(
     () =>
@@ -353,9 +352,12 @@ export function OverridesDetailPanel({
         path: { assistant_id: assistantId },
         body: {
           llm: {
-            callSites: patch,
-            // Only when the user actually moved it — a no-op key would still
-            // rewrite the config file on every Save.
+            // Each key is rewritten from the picker's three fields, which
+            // drops any tuning field (effort, thinking, maxTokens) a
+            // persisted entry carries. Send the map only when a call-site
+            // row actually moved, so an Advisor-only Save cannot reach it.
+            ...(callSiteDraftsDirty ? { callSites: patch } : {}),
+            // Likewise: a no-op key would still rewrite the config file.
             ...(advisorDirty ? { advisorProfile } : {}),
           },
         },
@@ -370,6 +372,7 @@ export function OverridesDetailPanel({
     }
   }, [
     drafts,
+    callSiteDraftsDirty,
     advisorDirty,
     advisorProfile,
     onClose,
@@ -478,12 +481,12 @@ export function OverridesDetailPanel({
           </div>
         )}
 
-        {/* Advisor — a top-level selection, not a catalog call site, so it
+        {/* Advisor: a top-level selection, not a catalog call site, so it
             renders off `daemonConfig` alone and stays put if the call-site
             catalog fails to load. */}
         {daemonConfigLoaded && advisorMatchesSearch && (
           <div className="mb-4">
-            {/* typography: off-scale — matches the domain section label below */}
+            {/* typography: off-scale. Matches the domain section label below */}
             <p className="mb-2 text-body-small-default font-semibold uppercase tracking-wider text-[var(--content-tertiary)]">
               Advisor
             </p>
@@ -527,7 +530,7 @@ export function OverridesDetailPanel({
           <div className="space-y-4">
             {groupedCallSites.length === 0 ? (
               // Suppressed when the Advisor row above already answered the
-              // search — "no matches" next to a visible match reads as a bug.
+              // search: "no matches" next to a visible match reads as a bug.
               advisorMatchesSearch ? null : (
                 <p className="py-8 text-center text-body-medium-lighter text-[var(--content-tertiary)]">
                   No actions match your search.

--- a/clients/web/src/domains/settings/ai/profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/profile-row.tsx
@@ -29,18 +29,17 @@ interface ProfileRowProps {
 /**
  * One row of the Profiles section (Figma 7412:133380): label, a
  * "{model} • Managed by Vellum" subtitle, the Default chip, and a kebab
- * menu showing only the actions valid for this row (Rok's annotation on
- * Light 738). Clicking the row opens the profile in the sidepanel.
+ * menu showing only the actions valid for this row (per the design
+ * annotation on Light 738). Clicking the row opens the profile in the
+ * sidepanel.
  *
  * Wording note: the chip for `llm.activeProfile` reads "Default" - the
  * default profile for chats that haven't picked one. "Active"/"Disabled"
  * is the orthogonal `status` dimension (picker visibility), rendered as
  * the dimmed title + "Disabled" chip + Enable/Disable menu items.
  *
- * The advisor selection (`llm.advisorProfile`) is deliberately absent here.
- * It carried no explanation of what an advisor is or why a profile would be
- * one, and it is not a per-profile property — it lives in the Action
- * Overrides panel alongside the other per-action model choices.
+ * The advisor (`llm.advisorProfile`) is a per-action model choice, not a
+ * per-profile property, so it lives in the Action Overrides panel.
  */
 export function ProfileRow({
   profile,

--- a/clients/web/src/domains/settings/ai/profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/profile-row.tsx
@@ -15,8 +15,6 @@ interface ProfileRowProps {
   profile: InferenceProfileSummary;
   /** This profile is `llm.activeProfile` - the main-chat default. */
   isActiveProfile: boolean;
-  /** This profile is `llm.advisorProfile` - the second-opinion consult. */
-  isAdvisorProfile: boolean;
   /** The row's panel is currently open in the sidepanel. */
   selected: boolean;
   /** Connection rows, for resolving openai-compatible model display names. */
@@ -24,33 +22,33 @@ interface ProfileRowProps {
   /** Open the profile in the sidepanel (view for managed, edit for user). */
   onOpen: () => void;
   onMakeActive: () => void;
-  onMakeAdvisor: () => void;
-  onClearAdvisor: () => void;
   onSetStatus: (active: boolean) => void;
   onDelete: () => void;
 }
 
 /**
  * One row of the Profiles section (Figma 7412:133380): label, a
- * "{model} • Managed by Vellum" subtitle, Default/Advisor chips, and a
- * kebab menu showing only the actions valid for this row (Rok's annotation
- * on Light 738). Clicking the row opens the profile in the sidepanel.
+ * "{model} • Managed by Vellum" subtitle, the Default chip, and a kebab
+ * menu showing only the actions valid for this row (Rok's annotation on
+ * Light 738). Clicking the row opens the profile in the sidepanel.
  *
  * Wording note: the chip for `llm.activeProfile` reads "Default" - the
  * default profile for chats that haven't picked one. "Active"/"Disabled"
  * is the orthogonal `status` dimension (picker visibility), rendered as
  * the dimmed title + "Disabled" chip + Enable/Disable menu items.
+ *
+ * The advisor selection (`llm.advisorProfile`) is deliberately absent here.
+ * It carried no explanation of what an advisor is or why a profile would be
+ * one, and it is not a per-profile property — it lives in the Action
+ * Overrides panel alongside the other per-action model choices.
  */
 export function ProfileRow({
   profile,
   isActiveProfile,
-  isAdvisorProfile,
   selected,
   connections,
   onOpen,
   onMakeActive,
-  onMakeAdvisor,
-  onClearAdvisor,
   onSetStatus,
   onDelete,
 }: ProfileRowProps) {
@@ -106,7 +104,6 @@ export function ProfileRow({
           ) : null}
           {isDisabled ? <Tag tone="neutral">Disabled</Tag> : null}
           {isActiveProfile ? <Tag tone="positive">Default</Tag> : null}
-          {isAdvisorProfile ? <Tag tone="warning">Advisor</Tag> : null}
           <Menu.Root>
             <Menu.Trigger asChild>
               <Button
@@ -122,14 +119,6 @@ export function ProfileRow({
               </Menu.Item>
               {!isActiveProfile && !isDisabled ? (
                 <Menu.Item onSelect={onMakeActive}>Make Default</Menu.Item>
-              ) : null}
-              {!isAdvisorProfile && !isDisabled ? (
-                <Menu.Item onSelect={onMakeAdvisor}>Make Advisor</Menu.Item>
-              ) : null}
-              {isAdvisorProfile ? (
-                <Menu.Item onSelect={onClearAdvisor}>
-                  Remove as Advisor
-                </Menu.Item>
               ) : null}
               {/* Managed profiles are enable-only: the daemon rejects the
                   disable direction. */}

--- a/clients/web/src/domains/settings/ai/profiles-section.test.tsx
+++ b/clients/web/src/domains/settings/ai/profiles-section.test.tsx
@@ -4,8 +4,12 @@
  *
  * Invariant (managed) profiles expose enable-only actions and no Delete,
  * user profiles get the full kebab, the status re-enable PATCHes exactly
- * `{status: "active"}`, and the Default/Advisor chips track
- * `llm.activeProfile` / `llm.advisorProfile`.
+ * `{status: "active"}`, and the Default chip tracks `llm.activeProfile`.
+ *
+ * The advisor selection is not surfaced here at all - it lives in the
+ * Action Overrides panel. `llm.advisorProfile` still appears below because
+ * deleting the profile it points at must clear the reference in the same
+ * patch, which is this section's job.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -180,9 +184,8 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("ProfilesSection - chips", () => {
-  test("Default and Advisor chips track the config selections", () => {
+  test("the Default chip tracks llm.activeProfile", () => {
     activeProfileState = "balanced";
-    advisorProfileState = "my-custom";
     renderSection();
 
     const rows = Array.from(
@@ -191,12 +194,18 @@ describe("ProfilesSection - chips", () => {
     const balancedRow = rows.find((r) => r.textContent?.includes("Balanced"));
     const customRow = rows.find((r) => r.textContent?.includes("My Custom"));
     expect(balancedRow?.textContent).toContain("Default");
-    expect(balancedRow?.textContent).not.toContain("Advisor");
-    expect(customRow?.textContent).toContain("Advisor");
     expect(customRow?.textContent).not.toContain("Default");
   });
 
-  test("a disabled profile shows the Disabled chip and no Default/Advisor chip", () => {
+  test("no row carries an Advisor chip, whatever llm.advisorProfile says", () => {
+    activeProfileState = "balanced";
+    advisorProfileState = "my-custom";
+    renderSection();
+
+    expect(document.body.textContent).not.toContain("Advisor");
+  });
+
+  test("a disabled profile shows the Disabled chip", () => {
     renderSection();
     const rows = Array.from(
       document.querySelectorAll<HTMLElement>('[data-slot="list-row"]'),
@@ -218,26 +227,25 @@ describe("ProfilesSection - chips", () => {
 });
 
 describe("ProfilesSection - kebab menus", () => {
-  test("an active managed profile offers View/Make Default/Make Advisor but no Disable or Delete", async () => {
+  test("an active managed profile offers View/Make Default but no Disable or Delete", async () => {
     renderSection();
     const menu = await openKebab("Balanced");
     const items = menuItems(menu);
     expect(items).toContain("View");
     expect(items).toContain("Make Default");
-    expect(items).toContain("Make Advisor");
+    expect(items).not.toContain("Make Advisor");
     expect(items).not.toContain("Disable");
     expect(items).not.toContain("Delete");
     expect(items).not.toContain("Edit");
   });
 
-  test("a disabled managed profile offers Enable and hides Make Default/Advisor", async () => {
+  test("a disabled managed profile offers Enable and hides Make Default", async () => {
     renderSection();
     const menu = await openKebab("Speed");
     const items = menuItems(menu);
     expect(items).toContain("Enable");
     expect(items).not.toContain("Disable");
     expect(items).not.toContain("Make Default");
-    expect(items).not.toContain("Make Advisor");
     expect(items).not.toContain("Delete");
   });
 
@@ -251,7 +259,7 @@ describe("ProfilesSection - kebab menus", () => {
     expect(items).not.toContain("View");
   });
 
-  test("the current default profile hides Make Default; the advisor gains Remove as Advisor", async () => {
+  test("the current default profile hides Make Default and offers no advisor actions", async () => {
     activeProfileState = "my-custom";
     advisorProfileState = "my-custom";
     renderSection();
@@ -259,7 +267,7 @@ describe("ProfilesSection - kebab menus", () => {
     const items = menuItems(menu);
     expect(items).not.toContain("Make Default");
     expect(items).not.toContain("Make Advisor");
-    expect(items).toContain("Remove as Advisor");
+    expect(items).not.toContain("Remove as Advisor");
   });
 
   test("re-enabling a disabled invariant profile PATCHes status:'active' and nothing else", async () => {

--- a/clients/web/src/domains/settings/ai/profiles-section.tsx
+++ b/clients/web/src/domains/settings/ai/profiles-section.tsx
@@ -33,7 +33,7 @@ interface ProfilesSectionProps {
 /**
  * The inline Profiles list of the V2 Language Model card (Figma
  * 7412:133358). Rows open the profile sidepanel; the kebab menu carries
- * Make Active / Make Advisor / Enable / Disable / Delete.
+ * Make Default / Enable / Disable / Delete.
  */
 export function ProfilesSection({
   assistantId,
@@ -51,7 +51,6 @@ export function ProfilesSection({
   });
 
   const activeProfile = config?.llm?.activeProfile ?? null;
-  const advisorProfile = config?.llm?.advisorProfile ?? null;
 
   return (
     <>
@@ -98,13 +97,10 @@ export function ProfilesSection({
               key={profile.name}
               profile={profile}
               isActiveProfile={profile.name === activeProfile}
-              isAdvisorProfile={profile.name === advisorProfile}
               selected={profile.name === selectedProfileName}
               connections={connections}
               onOpen={() => onOpenProfile(profile.name)}
               onMakeActive={() => void actions.makeActive(profile.name)}
-              onMakeAdvisor={() => void actions.makeAdvisor(profile.name)}
-              onClearAdvisor={() => void actions.clearAdvisor()}
               onSetStatus={(active) =>
                 void actions.setStatus(profile.name, active)
               }

--- a/clients/web/src/domains/settings/ai/use-profile-actions.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-actions.ts
@@ -7,9 +7,6 @@ import type { ConfigPatchRequest } from "@/generated/daemon/types.gen";
 export interface ProfileActions {
   /** Set `llm.activeProfile` - the main-chat default. */
   makeActive: (name: string) => Promise<void>;
-  /** Set `llm.advisorProfile` - the second-opinion consult. */
-  makeAdvisor: (name: string) => Promise<void>;
-  clearAdvisor: () => Promise<void>;
   /** Enable/disable a profile via a deep-merge status patch. */
   setStatus: (name: string, active: boolean) => Promise<void>;
   /**
@@ -63,18 +60,6 @@ export function useProfileActions(assistantId: string): ProfileActions {
         { activeProfile: name },
         "settings-ai-profile-make-active",
         "Failed to set the active profile. Please try again.",
-      ),
-    makeAdvisor: (name) =>
-      patchLlm(
-        { advisorProfile: name },
-        "settings-ai-profile-make-advisor",
-        "Failed to set the advisor profile. Please try again.",
-      ),
-    clearAdvisor: () =>
-      patchLlm(
-        { advisorProfile: null },
-        "settings-ai-profile-clear-advisor",
-        "Failed to clear the advisor profile. Please try again.",
       ),
     setStatus: (name, active) =>
       patchLlm(


### PR DESCRIPTION
## TL;DR

The `Advisor` chip comes off the model profile cards, along with the `Make Advisor` / `Remove as Advisor` menu items. The selection moves into the **Action Overrides** panel as a labeled row with a description that actually says what an advisor is.

Web-only. No schema, seeding, or daemon changes — `llm.advisorProfile` is read and written exactly as before.

## Why

The chip sat on a profile card with nothing to explain what an advisor is or why a profile would be one, and it's not a property of a profile — it's a per-action model choice, which is what Action Overrides is for.

## Before / after

| | Before | After |
|---|---|---|
| Seeing which profile advises | An unexplained amber `Advisor` chip on a card | A named row in Action Overrides with a one-line description of what it does |
| Changing it | Profile card kebab → `Make Advisor` | Action Overrides → Advisor → pick a profile, Save |
| Clearing it | Profile card kebab → `Remove as Advisor` | Not offered — see below |
| Everything else in the panel | — | Unchanged |

## The one behavior change

`Remove as Advisor` is gone and the new row has no off state. That's deliberate: `seedInferenceProfiles` runs on every daemon boot and re-fills `llm.advisorProfile` whenever it's absent, so clearing it only held until the next restart. Rather than move a control that silently reverts, the row is a picker over the available profiles.

Deleting the profile the advisor points at still clears the reference in the same patch, so no dangling name survives — that path is untouched.

## Why it's safe

- Nothing outside `clients/web/src/domains/settings/ai/` is touched.
- The advisor never enters the `llm.callSites` patch, the apply-to-all sweep, or the Overrides count badge — it's a top-level key and is treated as one.
- `advisorProfile` is only included in the PATCH body when the user actually moved it, so an unrelated Save doesn't rewrite it.
- The row renders off `configGet` alone, above the catalog-dependent list, so a call-site catalog fetch failure doesn't take it down with it.

## Verification

- `bun test src/domains/settings/ai/*` — 250 pass, per-file. New coverage: the row renders seeded from `llm.advisorProfile`, offers no off state, PATCHes alongside `callSites`, and is left alone by apply-to-all. Existing coverage flipped to assert the chip and both menu items are gone.
- `bunx tsc --noEmit` clean; `bun run lint` 0 errors.
- Two new Storybook stories — `Settings/AI/AdvisorProfileRow` (default, no selection, disabled-profile-selected, saving) and `Settings/AI/OverridesDetailPanel` — rendered and screenshotted below.

## Deferred

`llm.advisorProfile` is still a bespoke top-level key rather than a member of `LLMCallSiteEnum`, so the panel special-cases it. Promoting it to a real call site would delete that special case, but it needs a workspace migration and a change to how the consult resolves its profile — out of scope for this release, worth a ticket after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->