### PR TITLE
feat(voice): bare voice-surface controls on touch, and an edge-to-edge pill row (JARVIS-1386)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -275,6 +275,21 @@ describe("VoiceComposerBar — structure and accessibility", () => {
     }
   });
 
+  test("controls stay bare on touch, at full tap size", () => {
+    // On touch the design library gives an icon-only ghost Button an opaque
+    // chip and a theme foreground, which reads as a tile floating on the
+    // block's avatar-colored fill. The override drops the chip and keeps the
+    // 40px target, which comes from a separate pair of classes.
+    renderBar("listening", { onExpand: () => {} });
+    const { className } = screen.getByRole("button", {
+      name: "End voice session",
+    });
+    expect(className).not.toContain("touch-mobile:bg-[var(--surface-lift)]");
+    expect(className).toContain("touch-mobile:bg-transparent");
+    expect(className).toContain("touch-mobile:[--vbtn-fg:var(--room-fg-muted");
+    expect(className).toContain("touch-mobile:h-10");
+  });
+
   test("the band fades at both edges instead of hard-clipping", () => {
     // Includes the -webkit- prefix: the iOS client is a WKWebView and drops
     // the unprefixed property, which would silently disable the fade there.

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -55,6 +55,7 @@ import {
   VoiceMeshWaves,
 } from "@/domains/chat/voice/voice-room/voice-mesh-waves";
 import { BAND_VOICE } from "@/domains/chat/voice/voice-room/voice-room-eyes";
+import { VOICE_SURFACE_CONTROL_CLASS } from "@/domains/chat/voice/voice-room/voice-surface-paint";
 
 // Between turns (mic muted, assistant silent) the band reads a steady zero,
 // which is the room's empty floor: no ink at all until a voice is present.
@@ -115,13 +116,6 @@ export interface VoiceComposerBarProps {
 const BLOCK_HEIGHT_CLASS = "h-[5.25rem]";
 
 /**
- * Control chrome toned for the avatar color under it, via the `--room-*` vars
- * the composer publishes from `toneForBg`. Theme tokens cannot be used here:
- * the block is painted an arbitrary avatar color, so `--content-default` is as
- * likely to be invisible on it as legible. The token fallbacks only apply if a
- * caller renders the block without the vars, which the composer never does.
- */
-/**
  * Ink for a control that is currently *off* (mic muted, assistant muted).
  *
  * Not the negative theme token: that is a mid-tone red, and the block is
@@ -131,21 +125,16 @@ const BLOCK_HEIGHT_CLASS = "h-[5.25rem]";
  * on every palette color.
  *
  * Applied as an inline style rather than another utility: it competes with the
- * resting `--vbtn-fg` in {@link VOICE_CONTROL_CLASS}, and two
+ * resting `--vbtn-fg` in {@link VOICE_SURFACE_CONTROL_CLASS}, and two
  * arbitrary-property classes setting the same variable are ordered by
- * Tailwind's own sort, not by the order they are passed in.
+ * Tailwind's own sort, not by the order they are passed in. An inline style
+ * outranks both, on touch as well as on desktop.
  */
 function mutedInk(fillIsLight: boolean): CSSProperties {
   return {
     "--vbtn-fg": fillIsLight ? "#991B1B" : "#FCA5A5",
   } as CSSProperties;
 }
-
-const VOICE_CONTROL_CLASS = [
-  "[--vbtn-fg:var(--room-fg-muted,var(--content-secondary))]",
-  "hover:[--vbtn-fg:var(--room-fg,var(--content-default))]",
-  "hover:bg-[var(--room-wash,var(--surface-hover))]",
-].join(" ");
 
 export function VoiceComposerBar({
   state,
@@ -219,7 +208,7 @@ export function VoiceComposerBar({
           aria-label={muted ? "Unmute microphone" : "Mute microphone"}
           aria-pressed={muted}
           tooltip={muted ? "Unmute microphone" : "Mute microphone"}
-          className={VOICE_CONTROL_CLASS}
+          className={VOICE_SURFACE_CONTROL_CLASS}
           style={muted ? mutedInk(fillIsLight) : undefined}
         />
       </div>
@@ -249,7 +238,7 @@ export function VoiceComposerBar({
           aria-label={outputMuted ? "Unmute assistant" : "Mute assistant"}
           aria-pressed={outputMuted}
           tooltip={outputMuted ? "Unmute assistant" : "Mute assistant"}
-          className={VOICE_CONTROL_CLASS}
+          className={VOICE_SURFACE_CONTROL_CLASS}
           style={outputMuted ? mutedInk(fillIsLight) : undefined}
         />
         {onExpand ? (
@@ -259,7 +248,7 @@ export function VoiceComposerBar({
             onClick={onExpand}
             aria-label="Open voice room"
             tooltip="Open voice room"
-            className={VOICE_CONTROL_CLASS}
+            className={VOICE_SURFACE_CONTROL_CLASS}
           />
         ) : null}
         <Button
@@ -268,7 +257,7 @@ export function VoiceComposerBar({
           onClick={onEnd}
           aria-label="End voice session"
           tooltip="End voice session"
-          className={VOICE_CONTROL_CLASS}
+          className={VOICE_SURFACE_CONTROL_CLASS}
         />
       </div>
     </div>

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -355,10 +355,17 @@ describe("VoiceSessionPillHost: row variant (above the phone header)", () => {
   test("lays the band out in flow so it pushes the page down", () => {
     startSession("listening");
     const { container } = render(<VoiceSessionPillHost variant="row" />);
-    // The band itself is the host's root here: nothing wraps it in a `fixed`
-    // or `absolute` box, which is what keeps it taking its own space in the
-    // layout column rather than covering the header under it.
-    expect(container.firstChild).toBe(pill());
+    // The wrapper is a plain in-flow box carrying only the side inset: no
+    // `fixed` or `absolute`, which is what keeps the pill taking its own space
+    // in the layout column rather than covering the header under it.
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("shrink-0");
+    expect(wrapper.className).not.toContain("fixed");
+    expect(wrapper.className).not.toContain("absolute");
+    // A small inset, so the pill's caps clear the screen edges while the
+    // surface still reads as spanning the width.
+    expect(wrapper.className).toContain("px-2");
+    expect(wrapper.firstChild).toBe(pill());
     expect((pill() as HTMLElement).className).toContain("w-full");
   });
 

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -201,12 +201,15 @@ export function VoiceSessionPillHost({
 
   if (variant === "row") {
     // In flow above the thread header, so a live session pushes the page down
-    // instead of covering any of it. The band paints itself edge to edge; the
-    // failure chip does not, so it gets the header's own inset to sit on.
-    return showFailure ? (
-      <div className="shrink-0 px-4 pt-2">{content}</div>
-    ) : (
-      content
+    // instead of covering any of it. The pill takes a small inset rather than
+    // running into the screen edges: a shade tighter than the header's own
+    // `px-4`, so the surface still reads as spanning the width. The failure
+    // chip keeps the header's inset, plus the gap above that the pill gets
+    // from the header's own top padding.
+    return (
+      <div className={showFailure ? "shrink-0 px-4 pt-2" : "shrink-0 px-2"}>
+        {content}
+      </div>
     );
   }
 

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -131,14 +131,52 @@ describe("VoiceSessionPill: layouts", () => {
     expect(root().className).toContain("rounded-full");
   });
 
-  test("row: a full-width band that takes its own space in flow", () => {
+  test("row: the same pill stretched edge to edge, taking its own space in flow", () => {
     renderPill({ layout: "row" });
-    // Full width and no radius: the row is the page's top edge on a phone, and
-    // `shrink-0` is what keeps it pushing the page down rather than being
-    // squeezed out of the column.
+    // Edge to edge, and still a pill: the row is one shape with the header
+    // pill rather than a squared-off band. `shrink-0` is what keeps it pushing
+    // the page down rather than being squeezed out of the column.
     expect(root().className).toContain("w-full");
     expect(root().className).toContain("shrink-0");
-    expect(root().className).not.toContain("rounded-full");
+    expect(root().className).toContain("rounded-full");
+  });
+});
+
+describe("VoiceSessionPill: controls on touch", () => {
+  // The design library gives an icon-only ghost Button an opaque chip on touch
+  // (`touch-mobile:bg-[var(--surface-lift)]` plus a theme foreground). That is
+  // right on app chrome and wrong on a surface painted an arbitrary avatar
+  // color, where it lands as a theme-colored tile floating on the fill. These
+  // assert the merge outcome, which is the whole of the bug: the overrides are
+  // only worth anything if tailwind-merge drops the library's classes.
+  test("no theme chip survives on the row's controls", () => {
+    renderPill({ layout: "row", paint: NAVY_PAINT });
+    for (const name of [
+      "Mute microphone",
+      "Mute assistant",
+      "End voice session",
+    ]) {
+      const { className } = screen.getByRole("button", { name });
+      expect(className).not.toContain("touch-mobile:bg-[var(--surface-lift)]");
+      expect(className).not.toContain(
+        "touch-mobile:[--vbtn-fg:var(--content-default)]",
+      );
+      expect(className).toContain("touch-mobile:bg-transparent");
+      expect(className).toContain(
+        "touch-mobile:[--vbtn-fg:var(--room-fg-muted",
+      );
+    }
+  });
+
+  test("the 40px touch target survives the override", () => {
+    // The tap target comes from a separate `touch-mobile:h-10 w-10` pair, so
+    // dropping the chip must not shrink the control back to desktop size.
+    renderPill({ layout: "row", paint: NAVY_PAINT });
+    const { className } = screen.getByRole("button", {
+      name: "End voice session",
+    });
+    expect(className).toContain("touch-mobile:h-10");
+    expect(className).toContain("touch-mobile:w-10");
   });
 });
 

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -129,6 +129,9 @@ describe("VoiceSessionPill: layouts", () => {
     expect(root().className).toContain("[-webkit-app-region:no-drag]");
     expect(root().className).toContain("h-8");
     expect(root().className).toContain("rounded-full");
+    // Held off its neighbours in the cluster: the header's own gap is tuned
+    // for icon buttons, not for a painted capsule.
+    expect(root().className).toContain("mx-2");
   });
 
   test("row: the same pill stretched edge to edge, taking its own space in flow", () => {
@@ -139,6 +142,9 @@ describe("VoiceSessionPill: layouts", () => {
     expect(root().className).toContain("w-full");
     expect(root().className).toContain("shrink-0");
     expect(root().className).toContain("rounded-full");
+    // No side margin here: the header pill's breathing room would pull this
+    // one off both edges.
+    expect(root().className).not.toContain("mx-2");
   });
 });
 

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -20,9 +20,11 @@
  * - `"pill"`: an elongated pill in the header's right cluster. Height is
  *   capped at `h-8` (32px), because the header's Electron title-bar row is 44px
  *   min-height with 32px controls, so the pill must never stretch it.
- * - `"row"`: a full-bleed band above the thread header on a phone, where the
- *   header has no width to give. It is laid out in flow and pushes the page
- *   down rather than overlaying it, so a live session hides nothing.
+ * - `"row"`: the same pill stretched edge to edge above the thread header on a
+ *   phone, where the header has no width to give. It keeps the pill's radius
+ *   rather than squaring off into a band, so the two layouts read as one shape
+ *   at two widths. It is laid out in flow and pushes the page down rather than
+ *   overlaying it, so a live session hides nothing.
  *
  * The paint arrives as a prop rather than being resolved here: the fill is an
  * arbitrary avatar color, so chrome on it reads the `--room-*` vars the paint
@@ -87,7 +89,11 @@ const SILENT_AMPLITUDE = () => 0;
  */
 const PILL_WIDTH_CLASS = "w-56";
 
-/** Band height on a phone: a 44px row clears the touch target the controls want. */
+/**
+ * Pill height on a phone: a 44px row clears the touch target the controls want.
+ * The radius follows the height (`rounded-full`), so the caps are 22px and the
+ * row keeps its `px-3` inset to hold the outer glyphs clear of that curve.
+ */
 const ROW_HEIGHT_CLASS = "h-11";
 
 export interface VoiceSessionPillProps {
@@ -133,8 +139,8 @@ export interface VoiceSessionPillProps {
    */
   paint?: VoiceSurfacePaint | null;
   /**
-   * `"pill"` (default) for the header's right cluster, `"row"` for the
-   * full-bleed band a phone shows above the thread header.
+   * `"pill"` (default) for the header's right cluster, `"row"` for the same
+   * pill stretched edge to edge above a phone's thread header.
    */
   layout?: "pill" | "row";
 }
@@ -209,10 +215,10 @@ export function VoiceSessionPill({
       data-theme={voiceSurfaceTheme(paint)}
       style={paint ? voiceSurfaceStyle(paint) : undefined}
       className={cn(
-        "relative flex items-center gap-1 overflow-hidden transition-colors duration-300 [-webkit-app-region:no-drag]",
+        "relative flex items-center gap-1 overflow-hidden rounded-full transition-colors duration-300 [-webkit-app-region:no-drag]",
         isRow
-          ? `w-full shrink-0 px-2 ${ROW_HEIGHT_CLASS}`
-          : `h-8 rounded-full px-1 ${PILL_WIDTH_CLASS}`,
+          ? `w-full shrink-0 px-3 ${ROW_HEIGHT_CLASS}`
+          : `h-8 px-1 ${PILL_WIDTH_CLASS}`,
         // Until the avatar resolves there is no room color to paint, so the
         // surface holds the app's own raised surface.
         !paint && "bg-[var(--surface-lift)]",

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -90,6 +90,15 @@ const SILENT_AMPLITUDE = () => 0;
 const PILL_WIDTH_CLASS = "w-56";
 
 /**
+ * Breathing room either side of the header pill. The right cluster's own
+ * `gap-2` is tuned for icon buttons, and a painted 224px capsule pressed that
+ * close reads as jammed between the centre title and the search button. This
+ * takes the separation to 16px on the trailing side and holds the title off
+ * the leading cap.
+ */
+const PILL_MARGIN_CLASS = "mx-2";
+
+/**
  * Pill height on a phone: a 44px row clears the touch target the controls want.
  * The radius follows the height (`rounded-full`), so the caps are 22px and the
  * row keeps its `px-3` inset to hold the outer glyphs clear of that curve.
@@ -218,7 +227,7 @@ export function VoiceSessionPill({
         "relative flex items-center gap-1 overflow-hidden rounded-full transition-colors duration-300 [-webkit-app-region:no-drag]",
         isRow
           ? `w-full shrink-0 px-3 ${ROW_HEIGHT_CLASS}`
-          : `h-8 px-1 ${PILL_WIDTH_CLASS}`,
+          : `h-8 px-1 ${PILL_WIDTH_CLASS} ${PILL_MARGIN_CLASS}`,
         // Until the avatar resolves there is no room color to paint, so the
         // surface holds the app's own raised surface.
         !paint && "bg-[var(--surface-lift)]",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -561,6 +561,22 @@ describe("VoiceRoom: mobile sheet", () => {
     removeHeader();
   });
 
+  test("opening does not land focus on the exit", () => {
+    // Radix focuses the first focusable child on open, which is the top-right
+    // exit. That lit its focus ring and popped its "End voice session"
+    // tooltip, so the first thing a freshly opened room said was how to leave
+    // it. Focus belongs on the sheet itself.
+    const removeHeader = mountHeader();
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="sheet" />);
+
+    const sheet = screen.getByRole("dialog", { name: "Voice session" });
+    const exit = screen.getByRole("button", { name: "Exit voice session" });
+    expect(document.activeElement).not.toBe(exit);
+    expect(document.activeElement).toBe(sheet);
+    removeHeader();
+  });
+
   test("with no header present the sheet rests at the top edge", () => {
     // Pop-outs render no header. They never show the room, but a zero offset
     // is the right answer for a surface with nothing above it either way.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -201,6 +201,19 @@ function VoiceRoomSheet({
         className="top-[var(--voice-sheet-top)] max-h-none min-h-0 overflow-hidden border-t-0 bg-transparent p-0"
         onEscapeKeyDown={(event) => event.preventDefault()}
         onInteractOutside={(event) => event.preventDefault()}
+        // Radix focuses the first focusable child on open, which here is the
+        // top-right exit. That drew its focus ring and popped its "End voice
+        // session" tooltip over a room the user had only just opened, so the
+        // first thing the room said was how to leave it. Focus goes to the
+        // sheet itself instead (Radix gives the content `tabIndex={-1}`), which
+        // still announces the room and leaves Escape to the window handler
+        // above.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          if (event.currentTarget instanceof HTMLElement) {
+            event.currentTarget.focus();
+          }
+        }}
         style={{ "--voice-sheet-top": `${headerBottom}px` } as CSSProperties}
         aria-label="Voice session"
         // The room narrates itself through its own live region; a description

--- a/clients/web/src/domains/chat/voice/voice-room/voice-surface-paint.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-surface-paint.ts
@@ -77,9 +77,27 @@ export function voiceSurfaceMutedInk(paint: VoiceSurfacePaint | null): string {
  * Control chrome toned for the fill under it. The token fallbacks only apply
  * if a caller renders a control without the vars, which no painted surface
  * does.
+ *
+ * The `touch-mobile:` half is not a duplicate of the resting half. An icon-only
+ * ghost Button that expands on mobile takes an opaque chip there
+ * (`touch-mobile:bg-[var(--surface-lift)]` plus a `--content-default`
+ * foreground, see the design library's compound variants), which is right on
+ * app chrome and wrong here: on a surface painted an arbitrary avatar color it
+ * lands as a theme-colored tile floating on the fill. These re-state the
+ * resting tones under the same variant so they win, and tailwind-merge drops
+ * the library's conflicting classes rather than stacking them. The `40px` tap
+ * target comes from a separate `touch-mobile:h-10 touch-mobile:w-10` pair, so
+ * it survives untouched.
+ *
+ * Press feedback moves to `active:`, because `hover:` sits inside
+ * `@media (hover: hover)` and a touch device never matches it, leaving a touch
+ * control with no acknowledgement at all.
  */
 export const VOICE_SURFACE_CONTROL_CLASS = [
   "[--vbtn-fg:var(--room-fg-muted,var(--content-secondary))]",
   "hover:[--vbtn-fg:var(--room-fg,var(--content-default))]",
   "hover:bg-[var(--room-wash,var(--surface-hover))]",
+  "touch-mobile:bg-transparent",
+  "touch-mobile:[--vbtn-fg:var(--room-fg-muted,var(--content-secondary))]",
+  "touch-mobile:active:bg-[var(--room-wash,var(--surface-hover))]",
 ].join(" ");


### PR DESCRIPTION
Closes JARVIS-1386.

iOS parity for the voice surfaces. The layouts were already close; the button backgrounds were not.

## The chip

The design library gives an icon-only ghost `Button` an opaque chip on touch (`touch-mobile:bg-[var(--surface-lift)]`, `touch-mobile:rounded-full`, `touch-mobile:[--vbtn-fg:var(--content-default)]`). That is right on app chrome and wrong on a painted voice surface, where the fill is an arbitrary avatar color: every quiet control came out as a theme-colored tile floating on it, with a theme foreground. Desktop was unaffected, because those classes are touch-only.

`VOICE_SURFACE_CONTROL_CLASS` now re-states the surface's own tones under the same `touch-mobile` variant, so tailwind-merge drops the library's classes rather than stacking them:

- background stays transparent, so the glyph sits on the fill
- foreground stays `--room-fg-muted`
- press feedback moves to `active:` with `--room-wash`, because `hover:` sits inside `@media (hover: hover)` and a touch device never matches it, which would otherwise leave a touch control with no acknowledgement at all

The 40px tap target comes from a separate `touch-mobile:h-10 touch-mobile:w-10` pair and survives untouched.

The minimized composer block held a byte-identical copy of the constant, so it imports the shared one instead of growing a second copy of the override. Its local muted-ink helper stays: it keys off a boolean rather than a paint, so folding it into `voiceSurfaceMutedInk` is a separate tidy.

## The row

The off-conversation row keeps the header pill's radius instead of squaring off into a band: one shape at two widths, stretched edge to edge above a phone's thread header. Its inset goes to `px-3` to hold the outer glyphs clear of the 22px caps. The header pill takes an `mx-2` so a painted 224px capsule is not jammed against the centre title and the search button; the row deliberately takes none.

## Scope

The room itself is unaffected: its controls are raw `button` elements with their own chrome, never the design library's. The header's `NATIVE_IOS_BARE_ICON_BUTTON` is the same idea for unpainted app chrome, but scoped to `native-ios:`; the voice surfaces use `touch-mobile:` because they exist on mobile web too, and the two agree inside the iOS shell.

## Testing

- `bun test` on `voice-session-pill.test.tsx`, `voice-session-pill-host.test.tsx`, `voice-composer-bar.test.tsx`: 89 pass, 0 fail
- new tests assert the merge outcome, which is the whole of the bug: the library's chip classes are gone from the rendered `className` and the tap-target classes remain
- `bun run typecheck` and `bun run lint` clean
- Not visually verified in a live session: the Simulator cannot do audio, so that needs a device, a daemon and a mic

🤖 Generated with [Claude Code](https://claude.com/claude-code)