### PR TITLE
fix(voice): rebind the iOS echo route to the live capture unit, and measure it

### DIFF
--- a/clients/ios/App/App/VoiceAudioSessionPlugin.swift
+++ b/clients/ios/App/App/VoiceAudioSessionPlugin.swift
@@ -73,6 +73,7 @@ public class VoiceAudioSessionPlugin: CAPPlugin, CAPBridgedPlugin {
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "activate", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "deactivate", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "describe", returnType: CAPPluginReturnPromise),
     ]
 
     /// Event name forwarded to JS via `notifyListeners`. Must match the
@@ -158,6 +159,33 @@ public class VoiceAudioSessionPlugin: CAPPlugin, CAPBridgedPlugin {
                 error
             )
         }
+    }
+
+    // MARK: - describe
+
+    /// Report how the shared `AVAudioSession` is currently configured.
+    ///
+    /// Read-only, and deliberately so. `WKWebView` configures the session for
+    /// `getUserMedia` and whether it selected a voice-processing mode decides
+    /// whether echo cancellation exists at all, but the web layer has no way to
+    /// see that. Reading the category back answers the question without the
+    /// reconfiguration that has broken capture on a handset twice.
+    ///
+    /// Resolves a dictionary of whatever the system reports. Every field is
+    /// optional on the JS side, so a future OS that stops exposing one of these
+    /// degrades to a smaller object rather than an error.
+    @objc public func describe(_ call: CAPPluginCall) {
+        let session = AVAudioSession.sharedInstance()
+        let route = session.currentRoute
+        call.resolve([
+            "category": session.category.rawValue,
+            "mode": session.mode.rawValue,
+            "categoryOptions": Int(session.categoryOptions.rawValue),
+            "outputs": route.outputs.map { $0.portType.rawValue },
+            "inputs": route.inputs.map { $0.portType.rawValue },
+            "sampleRate": session.sampleRate,
+            "otherAudioPlaying": session.isOtherAudioPlaying,
+        ])
     }
 
     // MARK: - System events

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -267,6 +267,30 @@ the destination stream. Automatic reconnects must reuse the already-started
 player and MediaStream element: creating a replacement from a backoff timer
 loses the original user activation and can make `play()` fail.
 
+**Re-render the track once the microphone is live.** WebKit binds a MediaStream
+renderer to whichever capture unit is active when the renderer starts, and the
+echo reference belongs to that unit. Starting the element in the entry gesture
+is therefore necessary but not sufficient: at that moment `getUserMedia` has not
+run, so the renderer can come up bound to a plain output unit and never acquire
+a reference. `LiveVoiceAudioPlayer.restartOutputRoute()` pauses and replays the
+element, and the session calls it once capture reports running. The queue is
+silent at that point, so the restart is inaudible. It is also the second chance
+the gesture-less entry points need, since a page holding a live `getUserMedia`
+stream may play a MediaStream element that an unactivated page could not.
+
+**The route degrades silently, so it must be reported.** A refused `play()`
+falls back to `AudioContext.destination`: audio still plays and echo
+cancellation is simply gone, which surfaces only as the assistant transcribing
+fragments of its own speech. `getOutputRouteDiagnostics()` exposes the resolved
+route, the `play()` rejection, and live element state, and the live-voice
+session writes it (with a read-only `describeVoiceAudioSession()` of the native
+session) to the lifecycle diagnostics ring so support bundles carry it. Alongside
+it, `EchoMarginProbe` correlates microphone against speaker amplitude per
+utterance: a margin near 0 dB over the room's noise floor means cancellation is
+working, and a large positive margin with high correlation means the microphone
+is hearing the loudspeaker. Diagnostics go in the *lifecycle* ring, never the
+main one, which ordinary chat traffic fills and evicts within a minute.
+
 References:
 
 - WebKit — [`MediaSessionManagerCocoa` selects the capture audio-session category and mode](https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm#L174-L218)

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -274,9 +274,16 @@ is therefore necessary but not sufficient: at that moment `getUserMedia` has not
 run, so the renderer can come up bound to a plain output unit and never acquire
 a reference. `LiveVoiceAudioPlayer.restartOutputRoute()` pauses and replays the
 element, and the session calls it once capture reports running. The queue is
-silent at that point, so the restart is inaudible. It is also the second chance
-the gesture-less entry points need, since a page holding a live `getUserMedia`
-stream may play a MediaStream element that an unactivated page could not.
+silent at that point, so the restart is inaudible.
+
+It also **rebuilds a route that has already fallen back**, which is what the
+gesture-less entry points depend on. A session started from Siri, the Action
+Button, or a Live Activity has no activation to borrow, so its prewarm `play()`
+is refused and the fallback tears the route down; by capture time the page holds
+a live `getUserMedia` stream, which is grounds for playing a MediaStream element
+that an unactivated page could not. Treating a fallen-back route as nothing to
+retry would strand exactly those sessions on the direct path for their whole
+lifetime.
 
 **The route degrades silently, so it must be reported.** A refused `play()`
 falls back to `AudioContext.destination`: audio still plays and echo

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -239,6 +239,31 @@ async function fetchPlatformLogs(
   }
 }
 
+/**
+ * Native shell identity, or `null` off a Capacitor shell.
+ *
+ * Pins which store/TestFlight build hosted this report. It also settles native
+ * shell versus home-screen PWA, which the user agent cannot: `WKWebView` drops
+ * the `Version/` and `Safari/` tokens in both cases, so the two are
+ * indistinguishable from the UA string alone.
+ *
+ * `@capacitor/app` is a plugin Proxy, so it is destructured inline per
+ * `docs/CAPACITOR.md` § "Capacitor plugins must be destructured inline".
+ */
+async function collectNativeAppInfo(): Promise<Record<string, unknown> | null> {
+  if (!Capacitor.isNativePlatform()) {
+    return null;
+  }
+  try {
+    const { App } = await import("@capacitor/app");
+    const { id, name, version, build } = await App.getInfo();
+    return { id, name, version, build };
+  } catch {
+    // Diagnostics are best-effort and must never block a support submission.
+    return null;
+  }
+}
+
 async function buildClientLogsFile(
   timeRange: TimeRange,
   assistantId: string | null,
@@ -276,6 +301,14 @@ async function buildClientLogsFile(
     assistant_id: assistantId,
     active_conversation_id: activeConversationId,
     doctor_session_id: doctorSessionId ?? null,
+    // Which web bundle produced this report. The archive already carries the
+    // assistant's version, but the two ship on entirely separate cadences: the
+    // native shells load this bundle over the network at runtime, so a report
+    // can pair an arbitrarily new assistant with an arbitrarily old (or cached)
+    // client, and without this there is no way to tell which client fix was
+    // actually present.
+    client_version: import.meta.env.VITE_APP_VERSION ?? null,
+    native_app: await collectNativeAppInfo(),
     user_agent: typeof navigator !== "undefined" ? navigator.userAgent : "",
     language: typeof navigator !== "undefined" ? navigator.language : "",
     platform: typeof navigator !== "undefined" ? navigator.platform : "",

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-diagnostics.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-diagnostics.test.ts
@@ -88,6 +88,37 @@ describe("EchoMarginProbe", () => {
     expect(probe.summarize()).toBeNull();
   });
 
+  test("keeps the user's own speech out of the noise floor", () => {
+    const probe = new EchoMarginProbe();
+    // Quiet room first, so the floor is established.
+    feed(probe, 40, 0.01, 0);
+    // The user talks. The assistant is silent throughout, so every one of these
+    // samples is a candidate floor reading, and averaging them in would raise
+    // the baseline until the echoing reply below looked clean.
+    feed(probe, 30, 0.35, 0);
+    // The assistant replies and the mic hears it.
+    feed(probe, 20, 0.1, 0.8);
+
+    const summary = probe.summarize();
+
+    expect(summary!.micFloor!).toBeLessThan(0.02);
+    expect(summary!.marginDb!).toBeGreaterThan(15);
+  });
+
+  test("still follows a genuinely noisier room upward", () => {
+    const probe = new EchoMarginProbe();
+    feed(probe, 20, 0.01, 0);
+    // Sustained background noise, not a burst: the floor has to reach it or
+    // every reply in a noisy room reads as echo.
+    feed(probe, 600, 0.08, 0);
+    feed(probe, 20, 0.08, 0.8);
+
+    const summary = probe.summarize();
+
+    expect(summary!.micFloor!).toBeGreaterThan(0.06);
+    expect(Math.abs(summary!.marginDb!)).toBeLessThan(3);
+  });
+
   test("reports an unknown floor rather than a fabricated margin", () => {
     const probe = new EchoMarginProbe();
     // Session that was speaking from the first sample: there is no silent

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-diagnostics.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-diagnostics.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import { EchoMarginProbe } from "@/domains/chat/voice/live-voice/live-voice-diagnostics";
+
+/** Feed n samples of a constant mic/speaker pair. */
+function feed(
+  probe: EchoMarginProbe,
+  count: number,
+  mic: number,
+  output: number,
+): ReturnType<EchoMarginProbe["sample"]> {
+  let closed: ReturnType<EchoMarginProbe["sample"]> = null;
+  for (let i = 0; i < count; i++) {
+    closed = probe.sample(mic, output) ?? closed;
+  }
+  return closed;
+}
+
+describe("EchoMarginProbe", () => {
+  test("reports a near-zero margin when the mic stays at the noise floor", () => {
+    const probe = new EchoMarginProbe();
+    // Quiet room, then the assistant speaks while the mic hears nothing extra:
+    // this is what working echo cancellation looks like.
+    feed(probe, 20, 0.01, 0);
+    feed(probe, 20, 0.01, 0.8);
+
+    const summary = probe.summarize();
+
+    expect(summary).not.toBeNull();
+    expect(summary!.micDuringTts).toBeCloseTo(0.01, 4);
+    expect(summary!.micFloor).toBeCloseTo(0.01, 4);
+    expect(summary!.marginDb).toBeCloseTo(0, 1);
+  });
+
+  test("reports a large positive margin when the mic tracks the speaker", () => {
+    const probe = new EchoMarginProbe();
+    feed(probe, 20, 0.01, 0);
+    // Mic rises tenfold exactly while the assistant is audible: echo.
+    feed(probe, 20, 0.1, 0.8);
+
+    const summary = probe.summarize();
+
+    expect(summary!.marginDb).toBeCloseTo(20, 0);
+    expect(summary!.micPeakDuringTts).toBeCloseTo(0.1, 4);
+  });
+
+  test("correlates the mic against the speaker envelope", () => {
+    const echoing = new EchoMarginProbe();
+    const clean = new EchoMarginProbe();
+    // Same speaker envelope for both. The echoing mic follows it; the clean mic
+    // has room noise of its own on an unrelated period, which is what a real
+    // quiet room looks like (a perfectly constant mic has no variance at all,
+    // and correlation against it is undefined rather than zero).
+    for (let i = 0; i < 42; i++) {
+      const output = i % 2 === 0 ? 0.9 : 0.06;
+      echoing.sample(output * 0.2, output);
+      clean.sample(0.01 + 0.004 * (i % 3), output);
+    }
+
+    expect(echoing.summarize()!.correlation).toBeGreaterThan(0.9);
+    const cleanCorrelation = clean.summarize()!.correlation;
+    expect(cleanCorrelation).not.toBeNull();
+    expect(Math.abs(cleanCorrelation!)).toBeLessThan(0.2);
+  });
+
+  test("closes an utterance after a run of silence and starts a fresh one", () => {
+    const probe = new EchoMarginProbe();
+    feed(probe, 5, 0.02, 0);
+    feed(probe, 10, 0.2, 0.8);
+    // Nine silent samples are a gap between sentences, not an ending.
+    const early = feed(probe, 9, 0.02, 0);
+    expect(early).toBeNull();
+
+    const closed = probe.sample(0.02, 0);
+    expect(closed).not.toBeNull();
+    expect(closed!.audibleSamples).toBe(10);
+
+    // The next reply is measured on its own, not folded into the last one.
+    feed(probe, 4, 0.3, 0.8);
+    const second = probe.summarize();
+    expect(second!.audibleSamples).toBe(4);
+  });
+
+  test("yields nothing when the assistant never became audible", () => {
+    const probe = new EchoMarginProbe();
+    feed(probe, 30, 0.05, 0);
+
+    expect(probe.summarize()).toBeNull();
+  });
+
+  test("reports an unknown floor rather than a fabricated margin", () => {
+    const probe = new EchoMarginProbe();
+    // Session that was speaking from the first sample: there is no silent
+    // stretch to measure a floor against, and inventing one would turn an
+    // unmeasured session into a clean bill of health.
+    feed(probe, 10, 0.2, 0.8);
+
+    const summary = probe.summarize();
+
+    expect(summary!.micFloor).toBeNull();
+    expect(summary!.marginDb).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-diagnostics.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-diagnostics.ts
@@ -1,0 +1,264 @@
+/**
+ * Diagnostics for the live-voice audio path, aimed at one question a feedback
+ * bundle currently cannot answer: did acoustic echo cancellation actually
+ * engage?
+ *
+ * On iOS the assistant's own TTS reaches the microphone unless WebKit's
+ * voice-processing unit is cancelling it, and when it does not the symptom is
+ * indirect (the assistant transcribes fragments of its own speech and barges in
+ * on itself). Nothing in the client reports whether the echo-cancelling output
+ * route was taken, so the failure has to be reconstructed by reading phonetic
+ * matches out of transcripts. These events replace that inference with a
+ * measurement.
+ *
+ * ## Where these land
+ *
+ * Everything here writes to the *lifecycle* diagnostics ring
+ * ({@link recordLifecycleDiagnostic}), not the main one. The main ring holds 200
+ * events and a minute of ordinary chat/SSE traffic fills it, so a voice event
+ * written there is usually evicted before the user gets round to submitting the
+ * report. The lifecycle ring is reserved for low-frequency state changes and
+ * routinely sits near-empty. Keep it that way: a session emits a handful of
+ * events plus one per spoken utterance, and nothing here may fire per audio
+ * frame.
+ *
+ * See `clients/web/docs/CAPACITOR.md` § "Full-duplex TTS must render through a
+ * MediaStream track" for the routing contract these events observe.
+ */
+
+import { recordLifecycleDiagnostic } from "@/lib/diagnostics";
+
+/**
+ * Output amplitude above which the assistant counts as audible.
+ *
+ * Compared against the player's mapped 0-1 output meter, whose saturating curve
+ * lifts even quiet speech well clear of this, so the threshold separates
+ * "rendering audio" from "silent between utterances" rather than loud from
+ * quiet.
+ */
+const AUDIBLE_OUTPUT_THRESHOLD = 0.05;
+
+/**
+ * Consecutive silent samples that close an utterance.
+ *
+ * At the capture chunk cadence (~50ms) this is roughly half a second, long
+ * enough to bridge the gap between two sentences of one reply and short enough
+ * that the summary lands while the turn it describes is still recognisable.
+ */
+const SILENT_SAMPLES_TO_CLOSE = 10;
+
+/** Smallest amplitude treated as a real noise floor, so the ratio stays finite. */
+const MIN_FLOOR_AMPLITUDE = 1e-4;
+
+/** Summary of one spoken utterance's echo behaviour. */
+export interface EchoMarginSummary {
+  /** Samples where the assistant was audible. */
+  audibleSamples: number;
+  /** Mean mic amplitude while the assistant was audible. */
+  micDuringTts: number;
+  /** Peak mic amplitude while the assistant was audible. */
+  micPeakDuringTts: number;
+  /**
+   * Mean mic amplitude while the assistant was silent, measured across the
+   * whole session. `null` until at least one silent sample exists.
+   */
+  micFloor: number | null;
+  /**
+   * How far above the room's noise floor the mic sat while the assistant spoke,
+   * in dB. Near 0 means the mic heard nothing extra, so cancellation is working.
+   * A large positive value means the mic is hearing the loudspeaker.
+   */
+  marginDb: number | null;
+  /**
+   * Pearson correlation between mic and speaker amplitude across the utterance
+   * window. Near 0 when the two are independent; strongly positive when the mic
+   * is tracking the assistant's own output envelope, which is echo regardless of
+   * how loud it is in absolute terms.
+   */
+  correlation: number | null;
+}
+
+function round(value: number, places: number): number {
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * Accumulates paired microphone and speaker amplitudes and summarises each
+ * utterance.
+ *
+ * Fed from the capture amplitude callback, so it samples at the PCM chunk
+ * cadence and allocates nothing per sample. Audibility is decided from the
+ * measured output amplitude rather than the player's scheduling state: buffers
+ * are scheduled ahead of the playhead, so `isPlaying` leads what the room can
+ * actually hear, while the analyser reads what is rendering right now.
+ */
+export class EchoMarginProbe {
+  /** Session-wide floor, measured whenever the assistant is silent. */
+  private floorSamples = 0;
+  private floorSum = 0;
+
+  /** Current utterance, reset by {@link summarize}. */
+  private audibleSamples = 0;
+  private audibleMicSum = 0;
+  private audibleMicPeak = 0;
+  private silentRun = 0;
+
+  /** Correlation accumulators over the whole utterance window. */
+  private pairs = 0;
+  private sumMic = 0;
+  private sumOut = 0;
+  private sumMicOut = 0;
+  private sumMicSq = 0;
+  private sumOutSq = 0;
+
+  /**
+   * Record one paired sample. Returns a summary at the moment an utterance
+   * closes (the assistant has been silent long enough after speaking), else
+   * `null`.
+   */
+  sample(
+    micAmplitude: number,
+    outputAmplitude: number,
+  ): EchoMarginSummary | null {
+    const audible = outputAmplitude >= AUDIBLE_OUTPUT_THRESHOLD;
+
+    if (!audible) {
+      this.floorSamples += 1;
+      this.floorSum += micAmplitude;
+    }
+
+    // Only accumulate correlation once the utterance has started, so the
+    // arbitrarily long silence before it cannot swamp the statistic.
+    if (this.audibleSamples > 0 || audible) {
+      this.pairs += 1;
+      this.sumMic += micAmplitude;
+      this.sumOut += outputAmplitude;
+      this.sumMicOut += micAmplitude * outputAmplitude;
+      this.sumMicSq += micAmplitude * micAmplitude;
+      this.sumOutSq += outputAmplitude * outputAmplitude;
+    }
+
+    if (audible) {
+      this.silentRun = 0;
+      this.audibleSamples += 1;
+      this.audibleMicSum += micAmplitude;
+      this.audibleMicPeak = Math.max(this.audibleMicPeak, micAmplitude);
+      return null;
+    }
+
+    if (this.audibleSamples === 0) {
+      return null;
+    }
+    this.silentRun += 1;
+    if (this.silentRun < SILENT_SAMPLES_TO_CLOSE) {
+      return null;
+    }
+    return this.summarize();
+  }
+
+  /**
+   * Close the current utterance and return its summary, or `null` when the
+   * assistant never became audible. Used at session end to flush a reply that
+   * was still playing.
+   */
+  summarize(): EchoMarginSummary | null {
+    if (this.audibleSamples === 0) {
+      this.resetUtterance();
+      return null;
+    }
+
+    const micDuringTts = this.audibleMicSum / this.audibleSamples;
+    const micFloor =
+      this.floorSamples > 0 ? this.floorSum / this.floorSamples : null;
+    const marginDb =
+      micFloor === null
+        ? null
+        : 20 *
+          Math.log10(
+            Math.max(micDuringTts, MIN_FLOOR_AMPLITUDE) /
+              Math.max(micFloor, MIN_FLOOR_AMPLITUDE),
+          );
+
+    const summary: EchoMarginSummary = {
+      audibleSamples: this.audibleSamples,
+      micDuringTts: round(micDuringTts, 4),
+      micPeakDuringTts: round(this.audibleMicPeak, 4),
+      micFloor: micFloor === null ? null : round(micFloor, 4),
+      marginDb: marginDb === null ? null : round(marginDb, 1),
+      correlation: this.correlation(),
+    };
+    this.resetUtterance();
+    return summary;
+  }
+
+  private correlation(): number | null {
+    const n = this.pairs;
+    if (n < 2) {
+      return null;
+    }
+    const numerator = n * this.sumMicOut - this.sumMic * this.sumOut;
+    const micVariance = n * this.sumMicSq - this.sumMic * this.sumMic;
+    const outVariance = n * this.sumOutSq - this.sumOut * this.sumOut;
+    const denominator = Math.sqrt(micVariance * outVariance);
+    if (!Number.isFinite(denominator) || denominator <= 0) {
+      return null;
+    }
+    return round(numerator / denominator, 2);
+  }
+
+  private resetUtterance(): void {
+    this.audibleSamples = 0;
+    this.audibleMicSum = 0;
+    this.audibleMicPeak = 0;
+    this.silentRun = 0;
+    this.pairs = 0;
+    this.sumMic = 0;
+    this.sumOut = 0;
+    this.sumMicOut = 0;
+    this.sumMicSq = 0;
+    this.sumOutSq = 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Emitters
+// ---------------------------------------------------------------------------
+
+/**
+ * Record how a session began: whether it inherited a player prewarmed inside a
+ * user gesture, and whether it is a fresh start or a reconnect.
+ *
+ * `playerSource` is the gesture provenance that matters. A session that built
+ * its own player started outside any user activation (the Siri / Action Button
+ * deep link is the path that does this by design), which is exactly when
+ * `HTMLAudioElement.play()` can be refused and the echo-cancelling route lost.
+ */
+export function recordLiveVoiceSessionStart(details: {
+  playerSource: "prewarmed" | "created";
+  isReconnect: boolean;
+  handsFree: boolean;
+}): void {
+  recordLifecycleDiagnostic("live_voice_session_start", details);
+}
+
+/**
+ * Record the resolved TTS output route once capture is running, alongside the
+ * native audio session's own view of itself.
+ *
+ * This is the event that says whether echo cancellation could possibly be
+ * working: `route: "media-stream"` is the cancelling path, `"direct"` is not.
+ */
+export function recordLiveVoiceOutputRoute(
+  details: Record<string, unknown>,
+): void {
+  recordLifecycleDiagnostic("live_voice_output_route", details);
+}
+
+/** Record one utterance's echo measurement. */
+export function recordLiveVoiceEchoMargin(
+  summary: EchoMarginSummary,
+  route: string,
+): void {
+  recordLifecycleDiagnostic("live_voice_echo_margin", { ...summary, route });
+}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-diagnostics.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-diagnostics.ts
@@ -50,6 +50,35 @@ const SILENT_SAMPLES_TO_CLOSE = 10;
 /** Smallest amplitude treated as a real noise floor, so the ratio stays finite. */
 const MIN_FLOOR_AMPLITUDE = 1e-4;
 
+/**
+ * Noise-floor window, in samples taken while the assistant is silent.
+ *
+ * The floor cannot be a mean of those samples: the user talking *is* a silent
+ * assistant, so their own speech would be averaged into the baseline, and a
+ * loud prompt would then mask the echo in the reply that follows by inflating
+ * what the margin is measured against.
+ *
+ * Nor can it be a slow creep toward them. Speech and a genuinely noisier room
+ * last about as long as each other, so no time constant separates them. What
+ * does separate them is that speech is intermittent (there are gaps between
+ * words and phrases) while room noise is continuous. So the floor is the
+ * minimum over a window long enough to contain a pause: a talking user leaves
+ * the floor where it was, while a room that is simply louder has no quiet block
+ * to offer and the floor follows it within a window.
+ *
+ * Blocks rather than a flat window so the history is a fixed handful of numbers
+ * instead of every sample. At the capture chunk cadence a block is roughly a
+ * second and the window roughly ten.
+ *
+ * A strict minimum does mean one anomalously quiet sample can hold the floor
+ * down for a window, which overstates the margin. That direction is deliberate:
+ * this metric exists to catch echo, so reading high is a visible false alarm
+ * while reading low would quietly hide the thing being looked for, and the
+ * correlation is an independent cross-check either way.
+ */
+const FLOOR_BLOCK_SAMPLES = 20;
+const FLOOR_BLOCK_COUNT = 10;
+
 /** Summary of one spoken utterance's echo behaviour. */
 export interface EchoMarginSummary {
   /** Samples where the assistant was audible. */
@@ -59,8 +88,8 @@ export interface EchoMarginSummary {
   /** Peak mic amplitude while the assistant was audible. */
   micPeakDuringTts: number;
   /**
-   * Mean mic amplitude while the assistant was silent, measured across the
-   * whole session. `null` until at least one silent sample exists.
+   * The room's quiet-end mic level, tracked across the session while the
+   * assistant is silent. `null` until at least one such sample exists.
    */
   micFloor: number | null;
   /**
@@ -94,9 +123,13 @@ function round(value: number, places: number): number {
  * actually hear, while the analyser reads what is rendering right now.
  */
 export class EchoMarginProbe {
-  /** Session-wide floor, measured whenever the assistant is silent. */
-  private floorSamples = 0;
-  private floorSum = 0;
+  /** Rolling per-block minima of the mic while the assistant is silent. */
+  private readonly floorBlocks = new Array<number>(FLOOR_BLOCK_COUNT).fill(
+    Infinity,
+  );
+  private floorBlockIndex = 0;
+  private currentBlockMin = Infinity;
+  private currentBlockSamples = 0;
 
   /** Current utterance, reset by {@link summarize}. */
   private audibleSamples = 0;
@@ -124,8 +157,7 @@ export class EchoMarginProbe {
     const audible = outputAmplitude >= AUDIBLE_OUTPUT_THRESHOLD;
 
     if (!audible) {
-      this.floorSamples += 1;
-      this.floorSum += micAmplitude;
+      this.trackFloor(micAmplitude);
     }
 
     // Only accumulate correlation once the utterance has started, so the
@@ -169,8 +201,7 @@ export class EchoMarginProbe {
     }
 
     const micDuringTts = this.audibleMicSum / this.audibleSamples;
-    const micFloor =
-      this.floorSamples > 0 ? this.floorSum / this.floorSamples : null;
+    const micFloor = this.micFloor;
     const marginDb =
       micFloor === null
         ? null
@@ -190,6 +221,33 @@ export class EchoMarginProbe {
     };
     this.resetUtterance();
     return summary;
+  }
+
+  /** Fold a sample taken while the assistant was silent into the floor window. */
+  private trackFloor(micAmplitude: number): void {
+    this.currentBlockMin = Math.min(this.currentBlockMin, micAmplitude);
+    this.currentBlockSamples += 1;
+    if (this.currentBlockSamples < FLOOR_BLOCK_SAMPLES) {
+      return;
+    }
+    this.floorBlocks[this.floorBlockIndex] = this.currentBlockMin;
+    this.floorBlockIndex = (this.floorBlockIndex + 1) % FLOOR_BLOCK_COUNT;
+    this.currentBlockMin = Infinity;
+    this.currentBlockSamples = 0;
+  }
+
+  /**
+   * Quietest the mic has been over the floor window, or `null` before any
+   * silent sample. The in-progress block counts too, so a session that ends
+   * before its first block closes still reports a floor.
+   */
+  private get micFloor(): number | null {
+    let quietest =
+      this.currentBlockSamples > 0 ? this.currentBlockMin : Infinity;
+    for (const block of this.floorBlocks) {
+      quietest = Math.min(quietest, block);
+    }
+    return Number.isFinite(quietest) ? quietest : null;
   }
 
   private correlation(): number | null {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -210,8 +210,32 @@ export class FakePlayer {
   readOutputLevel(): number {
     return this.outputAmplitude;
   }
-  restartOutputRoute(): void {
+  /**
+   * Mirrors the real player, whose restart resolves only once its `play()`
+   * attempt has settled. `deferRestart` holds that promise open so a test can
+   * model the attempt landing *after* everything else the caller waits on, which
+   * is the ordering that lets a premature snapshot read the pre-fallback route.
+   */
+  deferRestart = false;
+  private restartResolve: (() => void) | null = null;
+  restartOutputRoute(): Promise<void> {
     this.restartOutputRouteCount++;
+    if (!this.deferRestart) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.restartResolve = resolve;
+    });
+  }
+
+  /** Settle a deferred restart, optionally on a different route than it began. */
+  settleRestart(route?: TtsOutputRoute): void {
+    if (route) {
+      this.outputRoute = route;
+    }
+    const resolve = this.restartResolve;
+    this.restartResolve = null;
+    resolve?.();
   }
   getOutputRouteDiagnostics(): TtsOutputRouteDiagnostics {
     return {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -30,7 +30,11 @@ import type {
   LiveVoiceAudioCaptureOptions,
   LiveVoiceCaptureResult,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
-import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
+import type {
+  LiveVoicePlaybackProgress,
+  TtsOutputRoute,
+  TtsOutputRouteDiagnostics,
+} from "@/domains/chat/voice/live-voice/tts-playback";
 import {
   useLiveVoiceStore,
   type LiveVoiceSessionControls,
@@ -190,10 +194,33 @@ export class FakePlayer {
   outputMuted = false;
   /** Progress the fake reports; tests set it to drive the store's provider. */
   playbackProgress: LiveVoicePlaybackProgress | null = null;
+  /** Speaker amplitude the fake reports; drives the echo-margin probe. */
+  outputAmplitude = 0;
+  /** Route the fake reports, and how many times it was asked to re-render it. */
+  outputRoute: TtsOutputRoute = "unsupported";
+  restartOutputRouteCount = 0;
   private drainResolvers: Array<() => void> = [];
 
   prewarm(): void {
     this.prewarmCount++;
+  }
+  getOutputAmplitude(): number {
+    return this.outputAmplitude;
+  }
+  restartOutputRoute(): void {
+    this.restartOutputRouteCount++;
+  }
+  getOutputRouteDiagnostics(): TtsOutputRouteDiagnostics {
+    return {
+      route: this.outputRoute,
+      mediaStreamRouteRequested: this.outputRoute !== "unsupported",
+      mediaStreamApiAvailable: true,
+      playAttempts: 0,
+      playRejectionName: null,
+      elementPaused: null,
+      elementReadyState: null,
+      contextState: null,
+    };
   }
   getPlaybackProgress(): LiveVoicePlaybackProgress | null {
     return this.playbackProgress;

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -207,6 +207,9 @@ export class FakePlayer {
   getOutputAmplitude(): number {
     return this.outputAmplitude;
   }
+  readOutputLevel(): number {
+    return this.outputAmplitude;
+  }
   restartOutputRoute(): void {
     this.restartOutputRouteCount++;
   }

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -162,21 +162,59 @@ class MockMediaStreamPlaybackElement {
   pauseCount = 0;
   paused = true;
   readyState = 0;
+  /** Leave `play()` unsettled, as it is on a real element until playback starts. */
+  deferPlay = false;
+
+  private pendingResolve: (() => void) | null = null;
+  private pendingReject: ((error: Error) => void) | null = null;
 
   constructor(private readonly playError?: Error) {}
 
-  async play(): Promise<void> {
+  play(): Promise<void> {
     this.playCount += 1;
     if (this.playError) {
-      throw this.playError;
+      return Promise.reject(this.playError);
     }
-    this.paused = false;
-    this.readyState = 4;
+    if (this.deferPlay) {
+      return new Promise<void>((resolve, reject) => {
+        this.pendingResolve = resolve;
+        this.pendingReject = reject;
+      });
+    }
+    this.startedPlaying();
+    return Promise.resolve();
   }
 
   pause(): void {
     this.pauseCount += 1;
     this.paused = true;
+    // Pausing rejects a `play()` still in flight with `AbortError`, which is
+    // what makes a deliberate restart look like a refused route unless the
+    // player tracks which attempt a rejection belongs to.
+    const reject = this.pendingReject;
+    this.pendingResolve = null;
+    this.pendingReject = null;
+    if (reject) {
+      const aborted = new Error(
+        "The play() request was interrupted by pause()",
+      );
+      aborted.name = "AbortError";
+      reject(aborted);
+    }
+  }
+
+  /** Settle a deferred `play()` as the element beginning playback. */
+  settlePlay(): void {
+    const resolve = this.pendingResolve;
+    this.pendingResolve = null;
+    this.pendingReject = null;
+    this.startedPlaying();
+    resolve?.();
+  }
+
+  private startedPlaying(): void {
+    this.paused = false;
+    this.readyState = 4;
   }
 }
 
@@ -404,6 +442,28 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(mediaStreamPlayer.getOutputRouteDiagnostics().route).toBe(
       "media-stream",
     );
+  });
+
+  test("a restart's own abort does not tear down the route", async () => {
+    const { player: mediaStreamPlayer, mediaElement } = makeMediaStreamPlayer();
+    // A real `play()` stays unsettled until playback actually starts, so the
+    // prewarm attempt is still in flight when capture comes up.
+    mediaElement.deferPlay = true;
+
+    mediaStreamPlayer.prewarm();
+    mediaStreamPlayer.restartOutputRoute();
+    mediaElement.settlePlay();
+    await flushMicrotasks();
+
+    // The pause rejected the prewarm's `play()` with AbortError. Treating that
+    // as a refusal would drop the MediaStream route, removing echo cancellation
+    // on exactly the sessions this rebind exists to fix.
+    expect(mediaStreamPlayer.getOutputRouteDiagnostics()).toMatchObject({
+      route: "media-stream",
+      playRejectionName: null,
+      elementPaused: false,
+    });
+    expect(mediaElement.srcObject).not.toBeNull();
   });
 
   test("restarting the route is a no-op once it has fallen back", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -277,19 +277,36 @@ function makeMeteringPlayer(): {
   return { player, ctx };
 }
 
-function makeMediaStreamPlayer(playError?: Error): {
+/**
+ * `playErrors` is indexed by element: the player builds a fresh element each
+ * time it (re)creates the route, so a refused first attempt can be followed by
+ * a successful retry.
+ */
+function makeMediaStreamPlayer(...playErrors: (Error | undefined)[]): {
   player: LiveVoiceAudioPlayer;
   ctx: MockAudioContext;
   mediaElement: MockMediaStreamPlaybackElement;
+  elements: MockMediaStreamPlaybackElement[];
 } {
   const ctx = new MockAudioContext();
-  const mediaElement = new MockMediaStreamPlaybackElement(playError);
+  // The first element is built up front so tests can hold a reference to it
+  // before the player asks for one.
+  const elements = [new MockMediaStreamPlaybackElement(playErrors[0])];
+  let handedOut = 0;
   const player = new LiveVoiceAudioPlayer({
     audioContextFactory: () => ctx as unknown as AudioContextLike,
     useMediaStreamOutput: true,
-    mediaStreamPlaybackElementFactory: () => mediaElement,
+    mediaStreamPlaybackElementFactory: () => {
+      if (handedOut < elements.length) {
+        return elements[handedOut++]!;
+      }
+      const element = new MockMediaStreamPlaybackElement(playErrors[handedOut]);
+      elements.push(element);
+      handedOut++;
+      return element;
+    },
   });
-  return { player, ctx, mediaElement };
+  return { player, ctx, elements, mediaElement: elements[0]! };
 }
 
 function chunk(
@@ -466,22 +483,64 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(mediaElement.srcObject).not.toBeNull();
   });
 
-  test("restarting the route is a no-op once it has fallen back", async () => {
+  test("rebuilds a route the prewarm attempt was refused", async () => {
     const consoleError = spyOn(console, "error").mockImplementation(() => {});
     try {
-      const { player: mediaStreamPlayer, mediaElement } = makeMediaStreamPlayer(
-        new Error("playback rejected"),
-      );
+      // A gesture-less start (Siri, Action Button, Live Activity): the prewarm
+      // `play()` is refused outright and the fallback tears the route down.
+      const {
+        player: mediaStreamPlayer,
+        ctx: mediaStreamContext,
+        elements,
+      } = makeMediaStreamPlayer(new Error("no user activation"));
 
       mediaStreamPlayer.prewarm();
       await flushMicrotasks();
-      const attemptsAfterFallback = mediaElement.playCount;
-
-      mediaStreamPlayer.restartOutputRoute();
-
-      expect(mediaElement.playCount).toBe(attemptsAfterFallback);
       expect(mediaStreamPlayer.getOutputRouteDiagnostics().route).toBe(
         "direct",
+      );
+
+      // Capture is live now, which is grounds for playing a MediaStream element
+      // that an unactivated page could not. Leaving this session on the direct
+      // path would strand exactly the starts that most need the retry.
+      mediaStreamPlayer.restartOutputRoute();
+      await flushMicrotasks();
+
+      expect(elements).toHaveLength(2);
+      expect(elements[1]!.playCount).toBe(1);
+      expect(mediaStreamPlayer.getOutputRouteDiagnostics().route).toBe(
+        "media-stream",
+      );
+      // Audio reaches the rebuilt bus, with the mute stage still in front of it.
+      mediaStreamPlayer.enqueue(chunk(new Array(2400).fill(100)));
+      expect(mediaStreamContext.gain?.connectedTo).toBe(
+        mediaStreamContext.mediaStreamDestination,
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("a refused retry degrades to the direct path again", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { player: mediaStreamPlayer, ctx: mediaStreamContext } =
+        makeMediaStreamPlayer(
+          new Error("no user activation"),
+          new Error("still refused"),
+        );
+
+      mediaStreamPlayer.prewarm();
+      await flushMicrotasks();
+      mediaStreamPlayer.restartOutputRoute();
+      await flushMicrotasks();
+
+      expect(mediaStreamPlayer.getOutputRouteDiagnostics().route).toBe(
+        "direct",
+      );
+      mediaStreamPlayer.enqueue(chunk(new Array(2400).fill(100)));
+      expect(mediaStreamContext.gain?.connectedTo).toBe(
+        mediaStreamContext.destination,
       );
     } finally {
       consoleError.mockRestore();

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -206,6 +206,39 @@ function makePlayer(): {
   return { player, ctx };
 }
 
+/**
+ * Context that also meters, so amplitude paths run for real. Kept separate from
+ * {@link MockAudioContext} because adding an analyser moves where sources
+ * connect, which the graph-wiring assertions above pin deliberately.
+ */
+class MeteringMockAudioContext extends MockAudioContext {
+  /** Constant sample value the fake analyser reports. */
+  level = 0;
+
+  createAnalyser(): AnalyserNode {
+    const read = () => this.level;
+    return {
+      fftSize: 256,
+      connect() {},
+      disconnect() {},
+      getFloatTimeDomainData(target: Float32Array) {
+        target.fill(read());
+      },
+    } as unknown as AnalyserNode;
+  }
+}
+
+function makeMeteringPlayer(): {
+  player: LiveVoiceAudioPlayer;
+  ctx: MeteringMockAudioContext;
+} {
+  const ctx = new MeteringMockAudioContext();
+  const player = new LiveVoiceAudioPlayer({
+    audioContextFactory: () => ctx as unknown as AudioContextLike,
+  });
+  return { player, ctx };
+}
+
 function makeMediaStreamPlayer(playError?: Error): {
   player: LiveVoiceAudioPlayer;
   ctx: MockAudioContext;
@@ -441,6 +474,32 @@ describe("LiveVoiceAudioPlayer", () => {
       route: "media-stream",
       elementPaused: true,
     });
+  });
+
+  test("reading the output level leaves the avatar's meter untouched", () => {
+    const { player: metered, ctx: meteredCtx } = makeMeteringPlayer();
+    meteredCtx.level = 0.05;
+    metered.enqueue(chunk(new Array(24000).fill(8000)));
+
+    // Non-zero, so what follows is about real metering rather than 0 === 0.
+    const instant = metered.readOutputLevel();
+    expect(instant).toBeGreaterThan(0);
+
+    // Two consumers on different cadences share this player. The avatar's
+    // meter is a stateful EMA advanced by every call, so the measurement path
+    // must not read through it: otherwise the probe would drag the avatar's
+    // level around, and its own numbers would depend on whether the avatar is
+    // mounted at all.
+    const first = metered.getOutputAmplitude();
+    metered.readOutputLevel();
+    metered.readOutputLevel();
+    metered.readOutputLevel();
+    const second = metered.getOutputAmplitude();
+
+    // One EMA step on from `first`, exactly as if the probe had never read.
+    expect(second).toBeCloseTo(0.5 * instant + 0.5 * first, 10);
+    // And the pure read is genuinely stateless: same input, same answer.
+    expect(metered.readOutputLevel()).toBeCloseTo(instant, 10);
   });
 
   test("schedules chunks in order, gaplessly, at the frame sample rate", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -160,6 +160,8 @@ class MockMediaStreamPlaybackElement {
   srcObject: HTMLMediaElement["srcObject"] = null;
   playCount = 0;
   pauseCount = 0;
+  paused = true;
+  readyState = 0;
 
   constructor(private readonly playError?: Error) {}
 
@@ -168,10 +170,13 @@ class MockMediaStreamPlaybackElement {
     if (this.playError) {
       throw this.playError;
     }
+    this.paused = false;
+    this.readyState = 4;
   }
 
   pause(): void {
     this.pauseCount += 1;
+    this.paused = true;
   }
 }
 
@@ -348,6 +353,96 @@ describe("LiveVoiceAudioPlayer", () => {
     }
   });
 
+  test("restarting the route re-renders the MediaStream track", () => {
+    const { player: mediaStreamPlayer, mediaElement } = makeMediaStreamPlayer();
+
+    mediaStreamPlayer.prewarm();
+    expect(mediaElement.playCount).toBe(1);
+
+    // Rebinding after getUserMedia has to actually stop and restart the
+    // renderer: WebKit attaches the echo reference when a renderer starts, so a
+    // no-op "already playing" check would leave it bound to whatever unit
+    // existed before the microphone came up.
+    mediaStreamPlayer.restartOutputRoute();
+
+    expect(mediaElement.pauseCount).toBe(1);
+    expect(mediaElement.playCount).toBe(2);
+    expect(mediaElement.paused).toBe(false);
+    expect(mediaStreamPlayer.getOutputRouteDiagnostics().route).toBe(
+      "media-stream",
+    );
+  });
+
+  test("restarting the route is a no-op once it has fallen back", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { player: mediaStreamPlayer, mediaElement } = makeMediaStreamPlayer(
+        new Error("playback rejected"),
+      );
+
+      mediaStreamPlayer.prewarm();
+      await flushMicrotasks();
+      const attemptsAfterFallback = mediaElement.playCount;
+
+      mediaStreamPlayer.restartOutputRoute();
+
+      expect(mediaElement.playCount).toBe(attemptsAfterFallback);
+      expect(mediaStreamPlayer.getOutputRouteDiagnostics().route).toBe(
+        "direct",
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("route diagnostics name the rejection that dropped echo cancellation", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const rejection = new Error("playback rejected");
+      rejection.name = "NotAllowedError";
+      const { player: mediaStreamPlayer } = makeMediaStreamPlayer(rejection);
+
+      mediaStreamPlayer.prewarm();
+      await flushMicrotasks();
+
+      expect(mediaStreamPlayer.getOutputRouteDiagnostics()).toMatchObject({
+        route: "direct",
+        mediaStreamRouteRequested: true,
+        mediaStreamApiAvailable: true,
+        playAttempts: 1,
+        playRejectionName: "NotAllowedError",
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("route diagnostics distinguish unresolved from unsupported", () => {
+    const { player: mediaStreamPlayer } = makeMediaStreamPlayer();
+    // Wanted, but no context built yet: reporting "direct" here would read as a
+    // failed route rather than one that has not been attempted.
+    expect(mediaStreamPlayer.getOutputRouteDiagnostics().route).toBe("pending");
+
+    expect(player.getOutputRouteDiagnostics()).toMatchObject({
+      route: "unsupported",
+      mediaStreamRouteRequested: false,
+    });
+  });
+
+  test("route diagnostics report a route that paused itself after starting", () => {
+    const { player: mediaStreamPlayer, mediaElement } = makeMediaStreamPlayer();
+
+    mediaStreamPlayer.prewarm();
+    // A route accepted at play() and later stopped by the platform still
+    // reports "media-stream"; only the live element state reveals it.
+    mediaElement.pause();
+
+    expect(mediaStreamPlayer.getOutputRouteDiagnostics()).toMatchObject({
+      route: "media-stream",
+      elementPaused: true,
+    });
+  });
+
   test("schedules chunks in order, gaplessly, at the frame sample rate", () => {
     // Two 24 kHz frames of 24000 samples each => 1.0s buffers.
     player.enqueue(chunk(new Array(24000).fill(100)));
@@ -360,9 +455,7 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(ctx.sources[1]!.startedAt).toBeCloseTo(1.0, 6);
     // Buffers were built at the frame's own 24 kHz rate, not the 48 kHz ctx.
     expect(ctx.sources[0]!.buffer!.sampleRate).toBe(24000);
-    expect(ctx.sources[0]!.connectedTo).toBe(
-      ctx.gain as unknown as AudioNode,
-    );
+    expect(ctx.sources[0]!.connectedTo).toBe(ctx.gain as unknown as AudioNode);
     expect(ctx.gain?.connectedTo).toBe(ctx.destination);
 
     expect(player.isPlaying).toBe(true);

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -661,7 +661,7 @@ export class LiveVoiceAudioPlayer {
         this.analyser = analyser;
         this.analyserSamples = new Float32Array(analyser.fftSize);
       }
-      this.startMediaStreamOutput(context);
+      void this.startMediaStreamOutput(context);
     }
     return this.context;
   }
@@ -683,15 +683,22 @@ export class LiveVoiceAudioPlayer {
     return destination;
   }
 
-  private startMediaStreamOutput(context: AudioContextLike): void {
+  /**
+   * Begin (or resume) rendering the MediaStream track.
+   *
+   * Resolves once the attempt has settled, including any fallback the rejection
+   * triggers, so a caller can read the resulting route rather than whatever it
+   * happens to be mid-flight. Never rejects.
+   */
+  private startMediaStreamOutput(context: AudioContextLike): Promise<void> {
     const route = this.mediaStreamOutput;
     if (!route) {
-      return;
+      return Promise.resolve();
     }
 
     this.playAttempts += 1;
     const epoch = ++this.playEpoch;
-    void route.element.play().catch((error: unknown) => {
+    return route.element.play().catch((error: unknown) => {
       // A newer attempt has taken over, so this rejection is the pause() that
       // started it and says nothing about whether playback is allowed. Recording
       // it would also report a refusal the route never suffered.
@@ -754,26 +761,29 @@ export class LiveVoiceAudioPlayer {
    * Safe to call at any point: it no-ops off the route entirely, and it runs
    * while the queue is silent, so the pause is inaudible. Never throws; a
    * refused retry degrades exactly like a refused initial start.
+   *
+   * Resolves once the attempt has settled, fallback included. Anything that
+   * reports which route a session ended up on has to await this, or it can
+   * observe a route that the pending rejection is about to tear down.
    */
-  restartOutputRoute(): void {
+  restartOutputRoute(): Promise<void> {
     const context = this.context;
     if (!context) {
-      return;
+      return Promise.resolve();
     }
 
     const route = this.mediaStreamOutput;
     if (route) {
       route.element.pause();
-      this.startMediaStreamOutput(context);
-      return;
+      return this.startMediaStreamOutput(context);
     }
 
     if (!this.useMediaStreamOutput || !context.createMediaStreamDestination) {
-      return;
+      return Promise.resolve();
     }
     const destination = this.createOutputNode(context);
     this.connectOutputTail(destination);
-    this.startMediaStreamOutput(context);
+    return this.startMediaStreamOutput(context);
   }
 
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -196,9 +196,14 @@ export type AudioContextFactory = () => AudioContextLike;
 const defaultAudioContextFactory: AudioContextFactory = () =>
   createAudioContext() as unknown as AudioContextLike;
 
+/**
+ * `paused` and `readyState` are read for diagnostics only. A route that was
+ * accepted at `play()` and later paused itself is indistinguishable from a
+ * healthy one unless the element is sampled again while audio is flowing.
+ */
 type MediaStreamPlaybackElement = Pick<
   HTMLAudioElement,
-  "pause" | "play" | "srcObject"
+  "pause" | "play" | "srcObject" | "paused" | "readyState"
 >;
 
 type MediaStreamPlaybackElementFactory = () => MediaStreamPlaybackElement;
@@ -209,6 +214,37 @@ const defaultMediaStreamPlaybackElementFactory: MediaStreamPlaybackElementFactor
 interface MediaStreamOutputRoute {
   destination: MediaStreamAudioDestinationNode;
   element: MediaStreamPlaybackElement;
+}
+
+/**
+ * Which sink the scheduled audio ends up in.
+ *
+ * - `unsupported`: this runtime never attempts the MediaStream route.
+ * - `pending`: the route is wanted but no `AudioContext` has been built yet.
+ * - `media-stream`: TTS renders through a MediaStream track, which is the only
+ *   form WebKit offers its capture unit as echo-cancellation reference audio.
+ * - `direct`: `AudioContext.destination`. Playback works and echo cancellation
+ *   does not.
+ */
+export type TtsOutputRoute =
+  "unsupported" | "pending" | "media-stream" | "direct";
+
+/** Observable state of the output path, for support bundles. */
+export interface TtsOutputRouteDiagnostics {
+  route: TtsOutputRoute;
+  /** Whether this runtime asks for the MediaStream route at all. */
+  mediaStreamRouteRequested: boolean;
+  /** Whether the `AudioContext` implementation can build the route. */
+  mediaStreamApiAvailable: boolean;
+  /** `play()` attempts made on the media element, including restarts. */
+  playAttempts: number;
+  /** Error name from the most recent rejected `play()`, else `null`. */
+  playRejectionName: string | null;
+  /** Live element state, sampled at read time. `null` off the route. */
+  elementPaused: boolean | null;
+  elementReadyState: number | null;
+  /** `AudioContext.state`, which reads `suspended` when playback is silently dead. */
+  contextState: string | null;
 }
 
 /**
@@ -244,6 +280,19 @@ export class LiveVoiceAudioPlayer {
   private readonly createMediaStreamPlaybackElement: MediaStreamPlaybackElementFactory;
   private context: AudioContextLike | null = null;
   private mediaStreamOutput: MediaStreamOutputRoute | null = null;
+
+  /**
+   * Whether the MediaStream route was built for the current context. Distinct
+   * from `mediaStreamOutput !== null`, which also goes null on teardown, and
+   * from the requested-vs-available distinction the diagnostics report.
+   */
+  private mediaStreamApiAvailable = false;
+
+  /** `play()` attempts on the media element, including {@link restartOutputRoute}. */
+  private playAttempts = 0;
+
+  /** Error name from the most recent rejected `play()`. */
+  private playRejectionName: string | null = null;
 
   /** Sources currently scheduled (playing or pending). */
   private activeSources = new Set<AudioBufferSourceNode>();
@@ -547,10 +596,12 @@ export class LiveVoiceAudioPlayer {
     const context = this.context;
     this.context = null;
     this.disposeMediaStreamOutput();
-    // The analyser belongs to the closed context; drop it (and its buffer) so a
-    // reused player rebuilds metering against a fresh context.
+    // The analyser and the mute stage belong to the closed context; drop them
+    // (and the analyser's buffer) so a reused player rebuilds its graph against
+    // a fresh context rather than writing into detached nodes.
     this.analyser = null;
     this.analyserSamples = null;
+    this.outputGain = null;
     this.smoothedOutputAmplitude = 0;
     if (context) {
       await context.close();
@@ -610,6 +661,8 @@ export class LiveVoiceAudioPlayer {
     // WebKit only supplies default-device MediaStream-track playback to its
     // VoiceProcessingIO capture unit as far-end echo-cancellation audio:
     // https://github.com/WebKit/WebKit/blob/41daa01748411a95855d8b6a0f0ffbd54f729a08/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp#L228-L292
+    this.mediaStreamApiAvailable =
+      context.createMediaStreamDestination !== undefined;
     if (!this.useMediaStreamOutput || !context.createMediaStreamDestination) {
       return context.destination;
     }
@@ -627,7 +680,10 @@ export class LiveVoiceAudioPlayer {
       return;
     }
 
+    this.playAttempts += 1;
     void route.element.play().catch((error: unknown) => {
+      this.playRejectionName =
+        error instanceof Error ? error.name : "UnknownError";
       if (this.context !== context || this.mediaStreamOutput !== route) {
         return;
       }
@@ -648,6 +704,62 @@ export class LiveVoiceAudioPlayer {
         context: "live_voice_ios_media_stream_output",
       });
     });
+  }
+
+  /**
+   * Re-render the MediaStream track now that microphone capture is running.
+   *
+   * WebKit renders a MediaStream track through whichever capture unit is active
+   * when the renderer starts, and the echo reference is a property of that
+   * unit. The player is deliberately prewarmed from the user gesture that
+   * begins a session, which is *before* `getUserMedia` has created any capture
+   * unit, so the renderer can come up bound to a plain output unit that never
+   * acquires an echo reference. Restarting it once the mic is live rebinds it
+   * against the voice-processing unit.
+   *
+   * It is also the second chance the gesture-less start paths need. A session
+   * begun from Siri, the Action Button, or a Live Activity tap has no
+   * activation to borrow, so its first `play()` can be refused outright, while
+   * a page holding a live `getUserMedia` stream is allowed to play a
+   * MediaStream element.
+   *
+   * Safe to call at any point: it no-ops when the route was never taken or has
+   * already fallen back, and it runs while the queue is silent, so the pause is
+   * inaudible. Never throws; a refused restart degrades exactly like a refused
+   * initial start.
+   */
+  restartOutputRoute(): void {
+    const context = this.context;
+    const route = this.mediaStreamOutput;
+    if (!context || !route) {
+      return;
+    }
+    route.element.pause();
+    this.startMediaStreamOutput(context);
+  }
+
+  /**
+   * Snapshot the output path for a support bundle. Reads live element state, so
+   * a route that was accepted and later paused itself reports honestly.
+   */
+  getOutputRouteDiagnostics(): TtsOutputRouteDiagnostics {
+    const route = this.mediaStreamOutput;
+    return {
+      route: !this.useMediaStreamOutput
+        ? "unsupported"
+        : route
+          ? "media-stream"
+          : this.context === null
+            ? "pending"
+            : "direct",
+      mediaStreamRouteRequested: this.useMediaStreamOutput,
+      mediaStreamApiAvailable: this.mediaStreamApiAvailable,
+      playAttempts: this.playAttempts,
+      playRejectionName: this.playRejectionName,
+      elementPaused: route?.element.paused ?? null,
+      elementReadyState: route?.element.readyState ?? null,
+      contextState: this.context?.state ?? null,
+    };
   }
 
   private disposeMediaStreamOutput(): void {

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -291,6 +291,15 @@ export class LiveVoiceAudioPlayer {
   /** `play()` attempts on the media element, including {@link restartOutputRoute}. */
   private playAttempts = 0;
 
+  /**
+   * Identifies the current `play()` attempt so a superseded one cannot act on
+   * its own rejection. Pausing a media element rejects any `play()` still in
+   * flight with `AbortError`, and {@link restartOutputRoute} pauses
+   * deliberately, so without this the restart's own abort would be read as a
+   * refused route and tear down the path it is re-establishing.
+   */
+  private playEpoch = 0;
+
   /** Error name from the most recent rejected `play()`. */
   private playRejectionName: string | null = null;
 
@@ -681,7 +690,14 @@ export class LiveVoiceAudioPlayer {
     }
 
     this.playAttempts += 1;
+    const epoch = ++this.playEpoch;
     void route.element.play().catch((error: unknown) => {
+      // A newer attempt has taken over, so this rejection is the pause() that
+      // started it and says nothing about whether playback is allowed. Recording
+      // it would also report a refusal the route never suffered.
+      if (this.playEpoch !== epoch) {
+        return;
+      }
       this.playRejectionName =
         error instanceof Error ? error.name : "UnknownError";
       if (this.context !== context || this.mediaStreamOutput !== route) {

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -825,6 +825,31 @@ export class LiveVoiceAudioPlayer {
       return this.smoothedOutputAmplitude;
     }
 
+    const scaled = this.readOutputLevel();
+    this.smoothedOutputAmplitude =
+      OUTPUT_AMPLITUDE_SMOOTHING * scaled +
+      (1 - OUTPUT_AMPLITUDE_SMOOTHING) * this.smoothedOutputAmplitude;
+    return this.smoothedOutputAmplitude;
+  }
+
+  /**
+   * Instantaneous mapped output level in [0, 1], leaving the display smoothing
+   * untouched. Returns 0 when nothing is scheduled or there is no analyser.
+   *
+   * Separate from {@link getOutputAmplitude} because that one is a stateful EMA
+   * tuned for a single ~60 Hz rAF consumer: every call advances its smoothing,
+   * so a second caller on a different cadence would both perturb what the
+   * avatar displays and make its own readings depend on whether the avatar
+   * happens to be mounted. A measurement has to be independent of who else is
+   * looking.
+   */
+  readOutputLevel(): number {
+    const analyser = this.analyser;
+    const samples = this.analyserSamples;
+    if (!analyser || !samples || !this.playingState) {
+      return 0;
+    }
+
     analyser.getFloatTimeDomainData(samples);
     let sumSquares = 0;
     for (let i = 0; i < samples.length; i++) {
@@ -832,12 +857,8 @@ export class LiveVoiceAudioPlayer {
       sumSquares += sample * sample;
     }
     const rms = Math.sqrt(sumSquares / samples.length);
-    // Saturating rather than clipping — see the constant's note above.
-    const scaled = 1 - Math.exp(-rms * OUTPUT_AMPLITUDE_GAIN);
-    this.smoothedOutputAmplitude =
-      OUTPUT_AMPLITUDE_SMOOTHING * scaled +
-      (1 - OUTPUT_AMPLITUDE_SMOOTHING) * this.smoothedOutputAmplitude;
-    return this.smoothedOutputAmplitude;
+    // Saturating rather than clipping, per the constant's note above.
+    return 1 - Math.exp(-rms * OUTPUT_AMPLITUDE_GAIN);
   }
 
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -705,21 +705,29 @@ export class LiveVoiceAudioPlayer {
       }
 
       this.disposeMediaStreamOutput();
-      // Rebuild the tail of the graph onto the raw destination, keeping the
-      // mute stage in it so a muted session does not start playing aloud
-      // because its iOS output route fell back.
-      if (this.outputGain) {
-        this.outputGain.disconnect();
-        this.outputGain.connect(context.destination);
-      }
-      if (this.analyser) {
-        this.analyser.disconnect();
-        this.analyser.connect(this.outputGain ?? context.destination);
-      }
+      this.connectOutputTail(context.destination);
       captureError(error, {
         context: "live_voice_ios_media_stream_output",
       });
     });
+  }
+
+  /**
+   * Point the tail of the graph at `destination`, preserving whichever optional
+   * stages exist. Sources feed the analyser, the analyser feeds the mute stage,
+   * and the mute stage feeds the sink, so the mute survives every rewiring: a
+   * silenced assistant must not start playing aloud because its output route
+   * changed underneath it.
+   */
+  private connectOutputTail(destination: AudioNode): void {
+    if (this.outputGain) {
+      this.outputGain.disconnect();
+      this.outputGain.connect(destination);
+    }
+    if (this.analyser) {
+      this.analyser.disconnect();
+      this.analyser.connect(this.outputGain ?? destination);
+    }
   }
 
   /**
@@ -733,24 +741,38 @@ export class LiveVoiceAudioPlayer {
    * acquires an echo reference. Restarting it once the mic is live rebinds it
    * against the voice-processing unit.
    *
-   * It is also the second chance the gesture-less start paths need. A session
-   * begun from Siri, the Action Button, or a Live Activity tap has no
-   * activation to borrow, so its first `play()` can be refused outright, while
-   * a page holding a live `getUserMedia` stream is allowed to play a
-   * MediaStream element.
+   * It is also the second chance the gesture-less start paths need, which is
+   * why a route that has already fallen back is rebuilt here rather than left
+   * alone. A session begun from Siri, the Action Button, or a Live Activity tap
+   * has no activation to borrow, so its prewarm `play()` is refused and the
+   * fallback tears the route down. That is precisely the session that most
+   * needs another attempt: by now the page holds a live `getUserMedia` stream,
+   * which is grounds for playing a MediaStream element that an unactivated page
+   * could not. Skipping it would strand exactly those sessions on the direct
+   * path forever.
    *
-   * Safe to call at any point: it no-ops when the route was never taken or has
-   * already fallen back, and it runs while the queue is silent, so the pause is
-   * inaudible. Never throws; a refused restart degrades exactly like a refused
-   * initial start.
+   * Safe to call at any point: it no-ops off the route entirely, and it runs
+   * while the queue is silent, so the pause is inaudible. Never throws; a
+   * refused retry degrades exactly like a refused initial start.
    */
   restartOutputRoute(): void {
     const context = this.context;
-    const route = this.mediaStreamOutput;
-    if (!context || !route) {
+    if (!context) {
       return;
     }
-    route.element.pause();
+
+    const route = this.mediaStreamOutput;
+    if (route) {
+      route.element.pause();
+      this.startMediaStreamOutput(context);
+      return;
+    }
+
+    if (!this.useMediaStreamOutput || !context.createMediaStreamDestination) {
+      return;
+    }
+    const destination = this.createOutputNode(context);
+    this.connectOutputTail(destination);
     this.startMediaStreamOutput(context);
   }
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -33,12 +33,16 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
 type InterruptionEvent = { type: "began" | "ended" };
 const activateVoiceAudioSession = mock(async () => true);
 const deactivateVoiceAudioSession = mock(async () => undefined);
+const describeVoiceAudioSession = mock(async () => null);
 const unsubscribeInterruptions = mock(() => undefined);
 let interruptionHandlers: ((event: InterruptionEvent) => void)[] = [];
 
+// A whole-module mock, so every export the controller's import graph reaches
+// has to be present here or the module fails to load.
 mock.module("@/runtime/native-audio-session", () => ({
   activateVoiceAudioSession,
   deactivateVoiceAudioSession,
+  describeVoiceAudioSession,
   subscribeVoiceAudioInterruptions: (
     handler: (event: InterruptionEvent) => void,
   ) => {
@@ -344,7 +348,12 @@ describe("native audio session", () => {
     await startListeningViaStarter(h);
 
     // The churn a real turn produces, none of which may reach the bridge.
-    for (const phase of ["transcribing", "thinking", "speaking", "listening"] as const) {
+    for (const phase of [
+      "transcribing",
+      "thinking",
+      "speaking",
+      "listening",
+    ] as const) {
       await act(async () => {
         useLiveVoiceStore.getState().setState(phase);
         await Promise.resolve();

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -3237,6 +3237,23 @@ describe("echo-cancellation diagnostics", () => {
     expect(fingerprint("live_voice_echo_margin")).toBe(before);
   });
 
+  test("skips measurement while the assistant is output-muted", async () => {
+    const h = renderController();
+    await reachListening(h);
+    act(() => liveVoiceControls().setOutputMuted(true));
+    const before = fingerprint("live_voice_echo_margin");
+
+    pushSamples(h, 12, 0.01, 0);
+    pushSamples(h, 30, 0.1, 0.8);
+    pushSamples(h, 30, 0.01, 0);
+
+    // The mute gain sits after the metering tap by design, so the meter still
+    // reads loud while the room is silent. Measuring through it would compare
+    // the mic against a speaker that is not playing and report perfect
+    // cancellation for a path that was never exercised.
+    expect(fingerprint("live_voice_echo_margin")).toBe(before);
+  });
+
   test("flushes the reply still playing when the session ends", async () => {
     const h = renderController();
     await reachListening(h);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -41,6 +41,7 @@ import {
   FakePlayer,
   pcmChunk,
 } from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+import { getLifecycleDiagnosticsEvents } from "@/lib/diagnostics";
 
 // Import the controller + store *after* the connection mock is registered, so
 // the real connection.ts (which imports the generated SDK) never enters the
@@ -3094,5 +3095,167 @@ describe("initial-connect resilience (JARVIS-1282)", () => {
     });
     expect(h.view.result.current.state).toBe("idle");
     expect(h.client.connectArgs).toBe(connectArgsBeforeStop);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Echo-cancellation diagnostics
+// ---------------------------------------------------------------------------
+
+describe("echo-cancellation diagnostics", () => {
+  /**
+   * Most recent lifecycle event of a kind, or `null`.
+   *
+   * Deliberately not an index offset taken before the action: the ring holds
+   * 200 events and the tests above it fill and evict continuously, so absolute
+   * positions shift underneath a slice. The newest event of a kind is always
+   * the one the test just caused.
+   */
+  function lastEvent(kind: string) {
+    const matching = getLifecycleDiagnosticsEvents().filter(
+      (event) => event.kind === kind,
+    );
+    return matching[matching.length - 1] ?? null;
+  }
+
+  /** Serialized newest event of a kind, for asserting nothing new arrived. */
+  function fingerprint(kind: string): string {
+    return JSON.stringify(lastEvent(kind));
+  }
+
+  function liveVoiceControls() {
+    const controls = useLiveVoiceStore.getState().controls;
+    expect(controls).not.toBeNull();
+    return controls!;
+  }
+
+  async function reachListening(h: ReturnType<typeof renderController>) {
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1", {
+        handsFree: true,
+      });
+    });
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+        turnDetection: "server_vad",
+      });
+      await Promise.resolve();
+    });
+  }
+
+  /** Push `count` amplitude readings at a given speaker level. */
+  function pushSamples(
+    h: ReturnType<typeof renderController>,
+    count: number,
+    mic: number,
+    output: number,
+  ) {
+    act(() => {
+      h.player.outputAmplitude = output;
+      for (let i = 0; i < count; i++) {
+        h.getCapture().pushAmplitude(mic);
+      }
+    });
+  }
+
+  test("re-renders the output route once the microphone is live", async () => {
+    const h = renderController();
+    expect(h.player.restartOutputRouteCount).toBe(0);
+
+    await reachListening(h);
+
+    // The player is unlocked in the entry gesture, before getUserMedia exists.
+    // WebKit binds a MediaStream renderer to whichever capture unit is running
+    // when it starts, so the rebind has to happen after capture comes up or the
+    // renderer can hold no echo reference at all.
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.player.restartOutputRouteCount).toBe(1);
+  });
+
+  test("records the player's gesture provenance at session start", async () => {
+    const h = renderController();
+
+    await act(async () => {
+      h.view.result.current.prewarmPlayback();
+    });
+    await reachListening(h);
+
+    expect(lastEvent("live_voice_session_start")?.details).toMatchObject({
+      playerSource: "prewarmed",
+      isReconnect: false,
+      handsFree: true,
+    });
+  });
+
+  test("records a session that built its own player outside any gesture", async () => {
+    const h = renderController();
+
+    // No prewarm: the shape of a Siri / Action Button / Live Activity start,
+    // which has no user activation to borrow for `play()`.
+    await reachListening(h);
+
+    expect(lastEvent("live_voice_session_start")?.details).toMatchObject({
+      playerSource: "created",
+    });
+  });
+
+  test("measures the mic against the speaker across an utterance", async () => {
+    const h = renderController();
+    h.player.outputRoute = "direct";
+    await reachListening(h);
+
+    // Quiet room, then the assistant speaks and the mic rises tenfold with it,
+    // then long enough silence to close the utterance: uncancelled echo.
+    pushSamples(h, 12, 0.01, 0);
+    pushSamples(h, 12, 0.1, 0.8);
+    pushSamples(h, 12, 0.01, 0);
+
+    const measured = lastEvent("live_voice_echo_margin");
+    expect(measured?.details).toMatchObject({
+      route: "direct",
+      micDuringTts: 0.1,
+      micFloor: 0.01,
+    });
+    expect(measured?.details.marginDb as number).toBeGreaterThan(15);
+  });
+
+  test("skips measurement while the mic is muted", async () => {
+    const h = renderController();
+    await reachListening(h);
+    act(() => liveVoiceControls().setMuted(true));
+    const before = fingerprint("live_voice_echo_margin");
+
+    pushSamples(h, 30, 0.1, 0.8);
+    pushSamples(h, 30, 0.1, 0);
+
+    // A muted session sends the server a substituted silent stream, so any
+    // echo number measured against it would describe nothing.
+    expect(fingerprint("live_voice_echo_margin")).toBe(before);
+  });
+
+  test("flushes the reply still playing when the session ends", async () => {
+    const h = renderController();
+    await reachListening(h);
+    const before = fingerprint("live_voice_echo_margin");
+
+    pushSamples(h, 12, 0.01, 0);
+    pushSamples(h, 12, 0.2, 0.8);
+    // Still mid-utterance: nothing has closed it.
+    expect(fingerprint("live_voice_echo_margin")).toBe(before);
+
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+
+    // A user who reports the problem mid-sentence still ships the measurement.
+    expect(fingerprint("live_voice_echo_margin")).not.toBe(before);
+    expect(lastEvent("live_voice_echo_margin")?.details).toMatchObject({
+      micDuringTts: 0.2,
+      micFloor: 0.01,
+    });
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -3176,6 +3176,36 @@ describe("echo-cancellation diagnostics", () => {
     expect(h.player.restartOutputRouteCount).toBe(1);
   });
 
+  test("records the route the restart actually settled on", async () => {
+    const h = renderController();
+    h.player.outputRoute = "media-stream";
+    // Hold the restart open so everything else the recorder waits on (the
+    // native describe) resolves first. That is the window in which a premature
+    // snapshot reads the route the pending rejection is about to tear down.
+    h.player.deferRestart = true;
+
+    await reachListening(h);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The retry is refused: the player disposes the route and reconnects
+    // playback to the direct path from its rejection handler.
+    await act(async () => {
+      h.player.settleRestart("direct");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Recording before that rejection settles would claim echo cancellation
+    // for a session that lost it, and this event is the primary evidence that
+    // the route engaged at all.
+    expect(lastEvent("live_voice_output_route")?.details).toMatchObject({
+      route: "direct",
+    });
+  });
+
   test("records the player's gesture provenance at session start", async () => {
     const h = renderController();
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -94,6 +94,13 @@ import {
   type TtsAudioChunk,
 } from "@/domains/chat/voice/live-voice/tts-playback";
 import {
+  EchoMarginProbe,
+  recordLiveVoiceEchoMargin,
+  recordLiveVoiceOutputRoute,
+  recordLiveVoiceSessionStart,
+} from "@/domains/chat/voice/live-voice/live-voice-diagnostics";
+import { describeVoiceAudioSession } from "@/runtime/native-audio-session";
+import {
   isLiveVoiceSessionActive,
   minimizeVoiceRoom,
   useLiveVoiceStore,
@@ -300,6 +307,12 @@ interface SessionContext {
    */
   clientHeardLatencyMs: number | null;
   /**
+   * Correlates microphone and speaker amplitude so a support bundle can show
+   * whether echo cancellation engaged, instead of leaving it to be inferred
+   * from transcripts. Fed from {@link handleAmplitude}; flushed at session end.
+   */
+  echoProbe: EchoMarginProbe;
+  /**
    * Pending idle-check timer for the store's `assistantAudioActive` flag. Armed
    * on each `tts_audio` frame and re-armed while the player is still draining;
    * fires once audio has stopped flowing to mark the assistant silent (so a
@@ -475,6 +488,7 @@ export function useLiveVoice(
     sessionRef.current = null;
     session.generation += 1;
     clearAssistantAudioActive(session);
+    flushEchoMargin(session);
     useLiveVoiceStore.getState().setState("ending");
     for (const unsubscribe of session.unsubscribes) {
       unsubscribe();
@@ -681,8 +695,17 @@ export function useLiveVoice(
       const client = (
         opts.createClient ?? (() => new LiveVoiceChannelClient())
       )();
-      const player = standbyPlayerRef.current ?? createPlayer();
+      const prewarmedPlayer = standbyPlayerRef.current;
+      const player = prewarmedPlayer ?? createPlayer();
       standbyPlayerRef.current = null;
+      // Whether this session inherited a player unlocked inside a user gesture
+      // is the fact that decides if its echo-cancelling output route could be
+      // started at all, so it is recorded before anything can obscure it.
+      recordLiveVoiceSessionStart({
+        playerSource: prewarmedPlayer ? "prewarmed" : "created",
+        isReconnect,
+        handsFree: startOptions.handsFree === true,
+      });
       // The composer reserves and prewarms this player before its async
       // readiness check. Reconnects reuse it too; this repeated call is a no-op
       // while its AudioContext is running. Direct callers without a reservation
@@ -723,6 +746,7 @@ export function useLiveVoice(
         speechEndedAtMs: null,
         turnHeardStampMs: null,
         clientHeardLatencyMs: null,
+        echoProbe: new EchoMarginProbe(),
         assistantAudioIdleTimer: null,
       };
 
@@ -1282,6 +1306,7 @@ function disposeSessionPrimitives(
 ): void {
   session.generation += 1;
   clearAssistantAudioActive(session);
+  flushEchoMargin(session);
   for (const unsubscribe of session.unsubscribes) {
     unsubscribe();
   }
@@ -1293,6 +1318,21 @@ function disposeSessionPrimitives(
     void session.player.dispose();
   }
   void session.capture.shutdown();
+}
+
+/**
+ * Emit the measurement for a reply that was still playing when the session
+ * ended, so a user who reports the problem mid-sentence still ships the number
+ * that describes it. No-op when the assistant never became audible.
+ */
+function flushEchoMargin(session: SessionContext): void {
+  const summary = session.echoProbe.summarize();
+  if (summary) {
+    recordLiveVoiceEchoMargin(
+      summary,
+      session.player.getOutputRouteDiagnostics().route,
+    );
+  }
 }
 
 /**
@@ -1345,6 +1385,35 @@ async function finishCaptureStartup(
   if (s.state === "connecting") {
     s.setState("listening");
   }
+  rebindOutputRouteToCapture(session);
+}
+
+/**
+ * Re-render the TTS output route against the now-live capture unit, then record
+ * where playback actually ended up.
+ *
+ * Runs at the one moment both halves of the full-duplex path exist: the player
+ * was unlocked back in the entry gesture, and the microphone has just come up.
+ * WebKit binds a MediaStream renderer to whichever capture unit is active when
+ * it starts, and the echo reference belongs to that unit, so a renderer started
+ * before `getUserMedia` may hold no reference at all.
+ *
+ * The restart is synchronous and inaudible (nothing is queued yet). The record
+ * that follows is fire-and-forget: it waits on a native bridge call, and a
+ * session must never be gated on diagnostics.
+ */
+function rebindOutputRouteToCapture(session: SessionContext): void {
+  session.player.restartOutputRoute();
+  const generation = session.generation;
+  void describeVoiceAudioSession().then((audioSession) => {
+    if (session.generation !== generation) {
+      return;
+    }
+    recordLiveVoiceOutputRoute({
+      ...session.player.getOutputRouteDiagnostics(),
+      audioSession,
+    });
+  });
 }
 
 /**
@@ -1387,10 +1456,27 @@ function handleAmplitude(
     return;
   }
   // Muted: the server hears silence (see handleChunk), so the UI and the
-  // manual-mode amplitude barge-in must too — a hot-looking waveform (or a
+  // manual-mode amplitude barge-in must too. A hot-looking waveform (or a
   // barge-in) from a muted mic would contradict the substituted stream.
   const muted = useLiveVoiceStore.getState().muted;
   useLiveVoiceStore.getState().setInputAmplitude(muted ? 0 : amplitude);
+  if (!muted) {
+    // Sampled here rather than on a timer of its own: this fires once per PCM
+    // chunk, which is the cadence the microphone actually produces, and the
+    // speaker's amplitude is a cheap read off the player's metering tap.
+    // Muted chunks are skipped because the server is hearing a substituted
+    // silent stream, which makes any echo measurement meaningless.
+    const summary = session.echoProbe.sample(
+      amplitude,
+      session.player.getOutputAmplitude(),
+    );
+    if (summary) {
+      recordLiveVoiceEchoMargin(
+        summary,
+        session.player.getOutputRouteDiagnostics().route,
+      );
+    }
+  }
   if (
     !muted &&
     !session.handsFree &&

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -1468,7 +1468,7 @@ function handleAmplitude(
     // silent stream, which makes any echo measurement meaningless.
     const summary = session.echoProbe.sample(
       amplitude,
-      session.player.getOutputAmplitude(),
+      session.player.readOutputLevel(),
     );
     if (summary) {
       recordLiveVoiceEchoMargin(

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -1458,14 +1458,20 @@ function handleAmplitude(
   // Muted: the server hears silence (see handleChunk), so the UI and the
   // manual-mode amplitude barge-in must too. A hot-looking waveform (or a
   // barge-in) from a muted mic would contradict the substituted stream.
-  const muted = useLiveVoiceStore.getState().muted;
+  const { muted, outputMuted } = useLiveVoiceStore.getState();
   useLiveVoiceStore.getState().setInputAmplitude(muted ? 0 : amplitude);
-  if (!muted) {
+  if (!muted && !outputMuted) {
     // Sampled here rather than on a timer of its own: this fires once per PCM
     // chunk, which is the cadence the microphone actually produces, and the
     // speaker's amplitude is a cheap read off the player's metering tap.
-    // Muted chunks are skipped because the server is hearing a substituted
-    // silent stream, which makes any echo measurement meaningless.
+    //
+    // Both mutes disqualify the sample, for opposite reasons. A muted mic means
+    // the server is hearing a substituted silent stream, so nothing measured
+    // against it describes the session. A muted assistant means the room is
+    // silent while the meter still reads loud: the mute gain sits after the
+    // analyser by design, so the visuals keep moving. Sampling through it would
+    // measure the mic against a speaker that is not playing and report perfect
+    // cancellation for a path that was never tested.
     const summary = session.echoProbe.sample(
       amplitude,
       session.player.readOutputLevel(),

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -1398,14 +1398,23 @@ async function finishCaptureStartup(
  * it starts, and the echo reference belongs to that unit, so a renderer started
  * before `getUserMedia` may hold no reference at all.
  *
- * The restart is synchronous and inaudible (nothing is queued yet). The record
- * that follows is fire-and-forget: it waits on a native bridge call, and a
- * session must never be gated on diagnostics.
+ * The restart itself is inaudible (nothing is queued yet). The record that
+ * follows is fire-and-forget: it waits on a native bridge call, and a session
+ * must never be gated on diagnostics.
+ *
+ * It does wait for the restart's own play attempt to settle, though. A refused
+ * attempt disposes the route and reconnects playback to the direct path from
+ * its rejection handler, so a snapshot taken while that rejection is still
+ * pending would report `media-stream` for a session that is about to lose it.
+ * This event is the primary evidence that echo cancellation engaged, so it has
+ * to describe where playback actually ended up.
  */
 function rebindOutputRouteToCapture(session: SessionContext): void {
-  session.player.restartOutputRoute();
   const generation = session.generation;
-  void describeVoiceAudioSession().then((audioSession) => {
+  void Promise.all([
+    session.player.restartOutputRoute(),
+    describeVoiceAudioSession(),
+  ]).then(([, audioSession]) => {
     if (session.generation !== generation) {
       return;
     }

--- a/clients/web/src/runtime/native-audio-session.test.ts
+++ b/clients/web/src/runtime/native-audio-session.test.ts
@@ -26,6 +26,12 @@ let handlers: Handler[] = [];
 
 const activate = mock(async () => ({ activated: true }));
 const deactivate = mock(async () => undefined);
+const defaultDescribe = async () => ({
+  category: "AVAudioSessionCategoryPlayAndRecord",
+  mode: "AVAudioSessionModeVoiceChat",
+  outputs: ["Speaker"],
+});
+const describeSession = mock(defaultDescribe);
 const remove = mock(async () => undefined);
 
 // Registration is async on the real bridge, so the handle only lands a
@@ -40,12 +46,18 @@ const defaultAddListener = (
 const addListener = mock(defaultAddListener);
 
 mock.module("@capacitor/core", () => ({
-  registerPlugin: () => ({ activate, deactivate, addListener }),
+  registerPlugin: () => ({
+    activate,
+    deactivate,
+    describe: describeSession,
+    addListener,
+  }),
 }));
 
 const {
   activateVoiceAudioSession,
   deactivateVoiceAudioSession,
+  describeVoiceAudioSession,
   subscribeVoiceAudioInterruptions,
 } = await import("@/runtime/native-audio-session");
 
@@ -56,6 +68,8 @@ beforeEach(() => {
   activate.mockImplementation(async () => ({ activated: true }));
   deactivate.mockClear();
   deactivate.mockImplementation(async () => undefined);
+  describeSession.mockClear();
+  describeSession.mockImplementation(defaultDescribe);
   remove.mockClear();
   addListener.mockClear();
   addListener.mockImplementation(defaultAddListener);
@@ -78,6 +92,11 @@ describe("off the iOS shell", () => {
   test("deactivate resolves without touching the bridge", async () => {
     expect(await deactivateVoiceAudioSession()).toBeUndefined();
     expect(deactivate).not.toHaveBeenCalled();
+  });
+
+  test("describe resolves null without touching the bridge", async () => {
+    expect(await describeVoiceAudioSession()).toBeNull();
+    expect(describeSession).not.toHaveBeenCalled();
   });
 
   test("subscribing registers nothing and unsubscribing is safe", () => {
@@ -103,6 +122,29 @@ describe("with the plugin present", () => {
   test("deactivate calls through", async () => {
     await deactivateVoiceAudioSession();
     expect(deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  test("describe reads the session back without configuring it", async () => {
+    const description = await describeVoiceAudioSession();
+
+    expect(description).toMatchObject({
+      category: "AVAudioSessionCategoryPlayAndRecord",
+      mode: "AVAudioSessionModeVoiceChat",
+      outputs: ["Speaker"],
+    });
+    // Reading the category back is the only sanctioned way to test a belief
+    // about the shared session: activating one underneath WebKit's live
+    // capture unit has broken live voice on a handset twice.
+    expect(activate).not.toHaveBeenCalled();
+    expect(deactivate).not.toHaveBeenCalled();
+  });
+
+  test("describe resolves null when an older shell has no such method", async () => {
+    describeSession.mockImplementation(async () => {
+      throw new Error("not implemented");
+    });
+
+    expect(await describeVoiceAudioSession()).toBeNull();
   });
 
   test("interruption events reach the handler until unsubscribed", async () => {

--- a/clients/web/src/runtime/native-audio-session.ts
+++ b/clients/web/src/runtime/native-audio-session.ts
@@ -48,9 +48,35 @@ export interface VoiceAudioInterruptionEvent {
   type: "began" | "ended";
 }
 
+/**
+ * Read-only view of the shared `AVAudioSession`, as the system reports it.
+ *
+ * WebKit configures that session on the app's behalf for `getUserMedia`, and
+ * whether it picked a voice-processing mode is the difference between echo
+ * cancellation existing and not. Nothing in the web layer can observe that, so
+ * the answer has to come from the native side.
+ *
+ * Every field is optional: it crosses an untyped bridge, and an older shell
+ * answers `{}`.
+ */
+export interface VoiceAudioSessionDescription {
+  /** `AVAudioSession.category`, e.g. `AVAudioSessionCategoryPlayAndRecord`. */
+  category?: string;
+  /** `AVAudioSession.mode`. `AVAudioSessionModeVoiceChat` is the AEC-bearing one. */
+  mode?: string;
+  categoryOptions?: number;
+  /** Output port types from `currentRoute`, e.g. `Speaker`, `Receiver`. */
+  outputs?: string[];
+  /** Input port types from `currentRoute`, e.g. `MicrophoneBuiltIn`. */
+  inputs?: string[];
+  sampleRate?: number;
+  otherAudioPlaying?: boolean;
+}
+
 interface VoiceAudioSessionPlugin {
   activate(): Promise<{ activated: boolean }>;
   deactivate(): Promise<void>;
+  describe(): Promise<VoiceAudioSessionDescription>;
   addListener(
     eventName: "voiceAudioInterruption",
     handler: (event: VoiceAudioInterruptionEvent) => void,
@@ -80,6 +106,24 @@ export async function activateVoiceAudioSession(): Promise<boolean> {
     // runtime, and a shell that answers `{}` must read as "not activated".
     return activated === true;
   }, false);
+}
+
+/**
+ * Read back how the system has the shared audio session configured. Resolves
+ * `null` off-iOS and on a shell without the method.
+ *
+ * Strictly an observation: it never sets anything. That distinction is the
+ * whole point. Reconfiguring the session underneath WebKit's live capture unit
+ * has broken live voice on a handset twice (see `docs/CAPACITOR.md`
+ * § "Full-duplex TTS must render through a MediaStream track"), so reading the
+ * category back is the only sanctioned way to test a belief about it.
+ */
+export async function describeVoiceAudioSession(): Promise<VoiceAudioSessionDescription | null> {
+  return callNativeVoice(async () => {
+    // Destructured inline for the same reason as `activate` above.
+    const description = await VoiceAudioSession.describe();
+    return description ?? null;
+  }, null);
 }
 
 /**


### PR DESCRIPTION
## Why

An iOS live-voice feedback bundle (`019fb57e`, iOS 18.7, dev, TestFlight shell) shows the assistant transcribing fragments of its own speech and barging in on itself:

| assistant TTS (start) | STT heard as "user" | Δ |
|---|---|---|
| 26.80 "yo what's good, **just been** monitoring stuff…" | 29.43 "Good. Just" | 2.6 s |
| 36.86 "**i was just saying**, been quiet on my end…" | 39.28 "I would say." | 2.4 s |

Both are phonetic matches for the words playing at that instant, and the daemon logs the fallout (`Speculative voice turn discarded: speech_resumed` twice, plus `delete_discarded` hygiene passes). That is uncancelled acoustic echo, and it was already happening on the session's **first** utterance, so the route was wrong from the start rather than degraded later by a reconnect.

The MediaStream routing from #39347 is structurally intact on `main`, and today's two audio-touching PRs (#39571 display constants, #39675 a `GainNode` upstream of the destination) do not disturb it. What is missing is any way to tell whether the route actually engaged: the failure is silent by construction, and the diagnosis above had to be reconstructed from phonetics.

## What

**A candidate fix.** WebKit renders a MediaStream track through whichever capture unit is active when the renderer starts, and the echo reference belongs to that unit. The player is prewarmed from the entry gesture, which is required for playback to be permitted at all but happens *before* `getUserMedia` has created any capture unit, so the renderer can come up bound to a plain output unit and never acquire a reference. `restartOutputRoute()` pauses and replays the element, called once capture reports running. The queue is silent then, so it is inaudible. It also gives the gesture-less entry points a second chance: a Siri / Action Button / Live Activity start has no activation to borrow, and a page holding a live `getUserMedia` stream may play a MediaStream element that an unactivated page could not.

**Instrumentation, so the next bundle answers this directly.**

- `getOutputRouteDiagnostics()`: resolved route, `play()` rejection name, live element state (`paused` / `readyState`), context state. A route accepted at `play()` and later paused reports honestly.
- Per-session record of the player's gesture provenance (`prewarmed` vs `created`) and reconnect status.
- `describeVoiceAudioSession()`: reads `category` / `mode` / `currentRoute` back from the native session. **Read-only, never sets** (needs a native build to land).
- `EchoMarginProbe`: correlates mic against speaker amplitude per utterance on the existing capture callback. Margin near 0 dB over the room's noise floor means cancellation works; a large positive margin with high correlation means the mic is hearing the loudspeaker. A measurement, not an inference, whatever the cause turns out to be.

All of it goes to the **lifecycle** diagnostics ring, never the main one: the main ring holds 200 events and a minute of ordinary chat/SSE traffic evicts anything written there. The bundle that prompted this had 179 main-ring events and 3 lifecycle ones.

**Build identity in feedback bundles.** The archive reported the assistant's version but nothing about the client, and the shells load this bundle over the network at runtime, so a report can pair an arbitrarily new assistant with an old or cached client. Adds the web bundle version plus, on a Capacitor shell, the native app version and build. The native identity also settles native shell versus home-screen PWA, which the user agent cannot: WKWebView drops the `Version/` and `Safari/` tokens in both cases.

## Risk

The route change is fallback-preserving: a refused restart degrades exactly like a refused initial start, which is today's behavior. Diagnostics are fire-and-forget and never gate a session.

**This is device-only territory and is not verified on hardware.** The Simulator's mock audio device has no acoustic path, so it cannot evaluate any of it, and per `docs/CAPACITOR.md` a green Simulator run is not evidence here. The rebind is a well-motivated hypothesis, not a proven root cause: if it does not fix the echo, the diagnostics are what make the *next* report conclusive instead of another round of reading transcripts.

## Test

`bun test` (from `clients/web`): tts-playback 45, use-live-voice 103, live-voice-diagnostics 6, native-audio-session 13, share-feedback-modal 3, all passing. `bunx tsc --noEmit` and `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)