### PR TITLE
fix: release the conversation processing lock before deferred turn-tail work

### DIFF
--- a/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
+++ b/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
@@ -88,6 +88,7 @@ function makeTarget(): Conversation {
     getTurnChannelContext: () => null,
     getTurnInterfaceContext: () => null,
     drainQueue: async () => {},
+    kickDrainQueue: async () => {},
     // Pre-run auto-compaction gate — no-op for these tests.
     maybeCompact: async () => null,
   };

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -100,6 +100,7 @@ function makeTarget(): {
     getTurnChannelContext: () => null,
     getTurnInterfaceContext: () => null,
     drainQueue: async () => {},
+    kickDrainQueue: async () => {},
     // Pre-run auto-compaction gate — no-op for these tests.
     maybeCompact: async () => null,
     buildCurrentSystemPrompt: () => "mock-system-prompt",

--- a/assistant/src/__tests__/canned-reply-release.test.ts
+++ b/assistant/src/__tests__/canned-reply-release.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The canned-reply routes (canned first greeting, unknown slash command) hold
+ * the processing lock themselves and release it from a deferred callback that
+ * also publishes their client event burst. That release is the only one those
+ * turns get: no agent loop runs, so a throw escaping the burst would latch the
+ * conversation "processing" for the life of the daemon and queue every later
+ * send behind an idle conversation.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { QueueDrainReason } from "../daemon/conversation-queue-manager.js";
+import { scheduleCannedReplyRelease } from "../runtime/routes/canned-reply-release.js";
+
+function makeConversation() {
+  let processing = true;
+  const drainOrigins: string[] = [];
+  return {
+    isProcessing: () => processing,
+    drainOrigins,
+    target: {
+      setProcessing: (value: boolean) => {
+        processing = value;
+      },
+      kickDrainQueue: (_reason?: QueueDrainReason, origin?: string) => {
+        drainOrigins.push(origin ?? "");
+        return Promise.resolve();
+      },
+    },
+  };
+}
+
+/** Let the scheduled `setTimeout(..., 0)` callback run. */
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("scheduleCannedReplyRelease", () => {
+  test("releases and drains after the deferred event burst", async () => {
+    const conversation = makeConversation();
+    const order: string[] = [];
+
+    scheduleCannedReplyRelease({
+      conversation: {
+        setProcessing: (value: boolean) => {
+          order.push("release");
+          conversation.target.setProcessing(value);
+        },
+        kickDrainQueue: conversation.target.kickDrainQueue,
+      },
+      origin: "canned_greeting",
+      emit: () => {
+        order.push("emit");
+      },
+      afterRelease: () => {
+        order.push("after");
+      },
+    });
+
+    // Nothing runs synchronously: the HTTP response has to reach the client
+    // before its events do.
+    expect(order).toEqual([]);
+
+    await nextTick();
+
+    expect(order).toEqual(["emit", "release", "after"]);
+    expect(conversation.isProcessing()).toBe(false);
+    expect(conversation.drainOrigins).toEqual(["canned_greeting"]);
+  });
+
+  test("still releases and drains when a broadcast throws", async () => {
+    const conversation = makeConversation();
+
+    scheduleCannedReplyRelease({
+      conversation: conversation.target,
+      origin: "slash_command",
+      emit: () => {
+        throw new Error("broadcast exploded");
+      },
+    });
+
+    await nextTick();
+
+    expect(conversation.isProcessing()).toBe(false);
+    expect(conversation.drainOrigins).toEqual(["slash_command"]);
+  });
+});

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -533,6 +533,8 @@ function makeCtx(
     },
     abortController: new AbortController(),
     currentRequestId: "test-req",
+    // The loop chains its detached end-of-turn tail here.
+    turnTailChain: Promise.resolve(),
 
     agentLoop,
     provider: {

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -533,8 +533,6 @@ function makeCtx(
     },
     abortController: new AbortController(),
     currentRequestId: "test-req",
-    // The loop chains its detached end-of-turn tail here.
-    turnTailChain: Promise.resolve(),
 
     agentLoop,
     provider: {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -667,6 +667,7 @@ import {
   applyCompactionResult,
   runAgentLoopImpl,
 } from "../daemon/conversation-agent-loop.js";
+import { settleTurnTail } from "../daemon/turn-tail-chain.js";
 import {
   createMockProvider,
   type ScriptedResponse,
@@ -733,9 +734,6 @@ function makeCtx(
     },
     abortController: new AbortController(),
     currentRequestId: "test-req",
-    // The loop chains its detached end-of-turn tail here. Tests that assert on
-    // tail effects await it via `settleTurnTail` after the loop returns.
-    turnTailChain: Promise.resolve(),
 
     agentLoop,
     provider: {
@@ -2327,7 +2325,7 @@ describe("session-agent-loop", () => {
       expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
 
       releaseFirstIndex?.();
-      await ctx.turnTailChain;
+      await settleTurnTail(ctx.conversationId);
       expect(indexMessageNowMock).toHaveBeenCalledTimes(2);
     });
 
@@ -2348,12 +2346,51 @@ describe("session-agent-loop", () => {
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
       // The chain settles rather than rejecting, so the throw can neither
       // surface as an unhandled rejection nor poison a later turn's tail.
-      await ctx.turnTailChain;
+      await settleTurnTail(ctx.conversationId);
 
       expect(ctx.isProcessing()).toBe(false);
       expect(drainReasons).toEqual(["loop_complete"]);
       // The tail continued past the failure: attention projection still ran.
       expect(projectAssistantMessageMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("the queue drain waits for the turn-boundary commit", async () => {
+      // `commitTurnChanges` attributes the working tree's changes to the turn
+      // that just finished, so a queued turn must not start writing files
+      // while it runs. The lock release above frees direct sends immediately;
+      // the drain is what has to wait.
+      let commitReached: (() => void) | undefined;
+      const commitStarted = new Promise<void>((resolve) => {
+        commitReached = resolve;
+      });
+      let releaseCommit: (() => void) | undefined;
+      const commitHangs = new Promise<void>((resolve) => {
+        releaseCommit = resolve;
+      });
+
+      const drainReasons: string[] = [];
+      const ctx = makeCtx({
+        providerResponses: [textResponse("first")],
+        commitTurnChanges: async () => {
+          commitReached?.();
+          await commitHangs;
+        },
+        drainQueue: async (reason?: string) => {
+          drainReasons.push(reason ?? "loop_complete");
+        },
+      });
+
+      const loop = runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+      await commitStarted;
+
+      // Released for direct sends…
+      expect(ctx.isProcessing()).toBe(false);
+      // …but the queue is untouched until the commit settles.
+      expect(drainReasons).toEqual([]);
+
+      releaseCommit?.();
+      await loop;
+      expect(drainReasons).toEqual(["loop_complete"]);
     });
   });
 
@@ -2385,7 +2422,7 @@ describe("session-agent-loop", () => {
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
       // The finalize effects run on the detached tail, so wait for the chain
       // rather than on the loop's own resolution.
-      await ctx.turnTailChain;
+      await settleTurnTail(ctx.conversationId);
 
       // Indexer fired with the reserved row's id + the finalized content.
       expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
@@ -2462,7 +2499,7 @@ describe("session-agent-loop", () => {
         providerResponses: [textResponse("indexed reply")],
       });
       await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
-      await ctx.turnTailChain;
+      await settleTurnTail(ctx.conversationId);
 
       // The deferred indexer runs exactly once…
       expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
@@ -2487,7 +2524,7 @@ describe("session-agent-loop", () => {
       // GIVEN a real loop that answers with a single finalized assistant turn
       const ctx = makeCtx({ providerResponses: [textResponse("quiet")] });
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
-      await ctx.turnTailChain;
+      await settleTurnTail(ctx.conversationId);
 
       expect(projectAssistantMessageMock).toHaveBeenCalledTimes(1);
       // The mock will still receive a `:messages` invalidation from the
@@ -2877,7 +2914,7 @@ describe("session-agent-loop", () => {
 
       // WHEN the orchestrator runs the turn to completion
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
-      await ctx.turnTailChain;
+      await settleTurnTail(ctx.conversationId);
 
       expect(snapshot).toBeDefined();
       // Indexer + projector were both ZERO during the mid-turn partial

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -733,6 +733,9 @@ function makeCtx(
     },
     abortController: new AbortController(),
     currentRequestId: "test-req",
+    // The loop chains its detached end-of-turn tail here. Tests that assert on
+    // tail effects await it via `settleTurnTail` after the loop returns.
+    turnTailChain: Promise.resolve(),
 
     agentLoop,
     provider: {
@@ -2271,6 +2274,89 @@ describe("session-agent-loop", () => {
     });
   });
 
+  describe("detached deferred turn tail", () => {
+    const reservedAssistantRow = {
+      id: "msg-reserve",
+      conversationId: "test-conv",
+      createdAt: 1_700_000_000_001,
+      role: "assistant" as const,
+      content: "[]",
+      metadata: null,
+    };
+
+    test("frees the conversation before the deferred tail finishes, and serializes tails", async () => {
+      mockMessageById = reservedAssistantRow;
+      // A tail effect that never settles on its own stands in for the
+      // production case this guards: memory indexing that takes tens of
+      // seconds against a slow embedding provider.
+      let releaseFirstIndex: (() => void) | undefined;
+      const firstIndexHangs = new Promise<void>((resolve) => {
+        releaseFirstIndex = resolve;
+      });
+      indexMessageNowMock.mockImplementationOnce(async () => {
+        await firstIndexHangs;
+        return { indexedSegments: 0, enqueuedJobs: 0 };
+      });
+
+      const drainReasons: string[] = [];
+      const ctx = makeCtx({
+        providerResponses: [textResponse("first"), textResponse("second")],
+        drainQueue: async (reason?: string) => {
+          drainReasons.push(reason ?? "loop_complete");
+        },
+      });
+
+      await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+
+      // The tail is still parked inside the indexer…
+      expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
+      // …yet the conversation is already released and the queue already
+      // kicked, so a send arriving now runs instead of being queued.
+      expect(ctx.isProcessing()).toBe(false);
+      expect(drainReasons).toEqual(["loop_complete"]);
+
+      // A follow-up turn runs to completion against the still-hung tail.
+      ctx.abortController = new AbortController();
+      ctx.setProcessing(true);
+      await runAgentLoopImpl(ctx, "again", "msg-2", () => {});
+      expect(ctx.isProcessing()).toBe(false);
+      expect(drainReasons).toEqual(["loop_complete", "loop_complete"]);
+
+      // The second turn's tail is chained behind the first, so it has not run
+      // its own indexing yet.
+      expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
+
+      releaseFirstIndex?.();
+      await ctx.turnTailChain;
+      expect(indexMessageNowMock).toHaveBeenCalledTimes(2);
+    });
+
+    test("a throwing tail effect neither latches the lock nor skips the drain", async () => {
+      mockMessageById = reservedAssistantRow;
+      indexMessageNowMock.mockImplementationOnce(async () => {
+        throw new Error("indexer exploded");
+      });
+
+      const drainReasons: string[] = [];
+      const ctx = makeCtx({
+        providerResponses: [textResponse("first")],
+        drainQueue: async (reason?: string) => {
+          drainReasons.push(reason ?? "loop_complete");
+        },
+      });
+
+      await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+      // The chain settles rather than rejecting, so the throw can neither
+      // surface as an unhandled rejection nor poison a later turn's tail.
+      await ctx.turnTailChain;
+
+      expect(ctx.isProcessing()).toBe(false);
+      expect(drainReasons).toEqual(["loop_complete"]);
+      // The tail continued past the failure: attention projection still ran.
+      expect(projectAssistantMessageMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("B3 pre-allocation: indexing + cleanup", () => {
     test("handleMessageComplete indexes and projects the finalized assistant row", async () => {
       // The pre-B3 path inserted assistant rows via `addMessage`, which ran
@@ -2297,6 +2383,9 @@ describe("session-agent-loop", () => {
         providerResponses: [textResponse("indexed reply")],
       });
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+      // The finalize effects run on the detached tail, so wait for the chain
+      // rather than on the loop's own resolution.
+      await ctx.turnTailChain;
 
       // Indexer fired with the reserved row's id + the finalized content.
       expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
@@ -2373,8 +2462,9 @@ describe("session-agent-loop", () => {
         providerResponses: [textResponse("indexed reply")],
       });
       await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
+      await ctx.turnTailChain;
 
-      // The deferred indexer runs exactly once, within the turn…
+      // The deferred indexer runs exactly once…
       expect(indexMessageNowMock).toHaveBeenCalledTimes(1);
       // …and only after the terminal SSE that re-enables the composer.
       expect(messageCompleteSeenWhenIndexed).toBe(true);
@@ -2397,6 +2487,7 @@ describe("session-agent-loop", () => {
       // GIVEN a real loop that answers with a single finalized assistant turn
       const ctx = makeCtx({ providerResponses: [textResponse("quiet")] });
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+      await ctx.turnTailChain;
 
       expect(projectAssistantMessageMock).toHaveBeenCalledTimes(1);
       // The mock will still receive a `:messages` invalidation from the
@@ -2786,6 +2877,7 @@ describe("session-agent-loop", () => {
 
       // WHEN the orchestrator runs the turn to completion
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+      await ctx.turnTailChain;
 
       expect(snapshot).toBeDefined();
       // Indexer + projector were both ZERO during the mid-turn partial

--- a/assistant/src/__tests__/conversation-wait-for-idle.test.ts
+++ b/assistant/src/__tests__/conversation-wait-for-idle.test.ts
@@ -306,25 +306,20 @@ describe("Conversation.waitForIdle", () => {
     expect(second.value).toBe(true);
   });
 
-  test("a clear whose persisted write throws does not release waiters", async () => {
+  test("a clear whose persisted write throws still releases waiters", async () => {
     const conversation = makeConversation();
     conversation.setProcessing(true);
 
     const waiter = observe(conversation.waitForIdle({ timeoutMs: 60_000 }));
 
     failNextProcessingWrite = true;
-    expect(() => conversation.setProcessing(false)).toThrow(
-      "database is locked",
-    );
+    expect(() => conversation.setProcessing(false)).not.toThrow();
     await flushMicrotasks();
-    // The write failed, so the flag reverted to processing — the waiter must
-    // still be pending.
-    expect(conversation.isProcessing()).toBe(true);
-    expect(waiter.settled).toBe(false);
 
-    // The retried clear commits and releases the waiter.
-    conversation.setProcessing(false);
-    await flushMicrotasks();
+    // The persisted column is advisory and the boot-time stale-processing
+    // sweep recovers it; the in-memory flag is the release every waiter (voice
+    // barge-in, drain) is parked on, so it has to stick.
+    expect(conversation.isProcessing()).toBe(false);
     expect(waiter.value).toBe(true);
   });
 });

--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `evictConversationsForReload` drops in-memory conversations after a
+ * config/prompt/skills reload so the next turn rebuilds them against the new
+ * config. Queued messages live only on the instance being disposed, so the
+ * same "not idle while a queue is pending" rule the periodic evictor applies
+ * has to hold here: `isProcessing()` reads false in the window between a turn
+ * releasing and its queued successor being dispatched.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../subagent/index.js", () => ({
+  getSubagentManager: () => ({
+    abortAllForParent: () => {},
+    getChildrenOf: () => [],
+  }),
+}));
+
+import type { Conversation } from "../daemon/conversation.js";
+import {
+  clearConversations,
+  conversationIds,
+  findConversation,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import { evictConversationsForReload } from "../daemon/conversation-store.js";
+
+interface FakeConversation {
+  disposed: boolean;
+  markedStale: boolean;
+}
+
+function register(
+  id: string,
+  state: { processing: boolean; queued: boolean },
+): FakeConversation {
+  const fake: FakeConversation & Record<string, unknown> = {
+    disposed: false,
+    markedStale: false,
+    conversationId: id,
+    isProcessing: () => state.processing,
+    hasQueuedMessages: () => state.queued,
+    dispose() {
+      fake.disposed = true;
+    },
+    markStale() {
+      fake.markedStale = true;
+    },
+  };
+  setConversation(id, fake as unknown as Conversation);
+  return fake;
+}
+
+describe("evictConversationsForReload", () => {
+  beforeEach(() => {
+    clearConversations();
+  });
+
+  test("disposes an idle conversation", () => {
+    const idle = register("reload-idle", { processing: false, queued: false });
+
+    evictConversationsForReload();
+
+    expect(idle.disposed).toBe(true);
+    expect(findConversation("reload-idle")).toBeUndefined();
+  });
+
+  test("keeps a conversation with queued messages and marks it stale", () => {
+    const queued = register("reload-queued", {
+      processing: false,
+      queued: true,
+    });
+
+    evictConversationsForReload();
+
+    // Disposing here would silently destroy the in-memory queue.
+    expect(queued.disposed).toBe(false);
+    expect(queued.markedStale).toBe(true);
+    expect(findConversation("reload-queued")).toBeDefined();
+  });
+
+  test("marks a mid-turn conversation stale instead of disposing it", () => {
+    const busy = register("reload-busy", { processing: true, queued: false });
+
+    evictConversationsForReload();
+
+    expect(busy.disposed).toBe(false);
+    expect(busy.markedStale).toBe(true);
+    expect([...conversationIds()]).toEqual(["reload-busy"]);
+  });
+});

--- a/assistant/src/__tests__/processing-flag-persist-failure.test.ts
+++ b/assistant/src/__tests__/processing-flag-persist-failure.test.ts
@@ -1,9 +1,15 @@
 /**
  * Regression: `Conversation.setProcessing(value)` flips the in-memory flag and
- * then persists it to the `processing_started_at` column. If that DB write
- * throws (e.g. SQLITE_BUSY under contention), the in-memory flag must not be
- * left stranded out of sync with the column — it reverts to its prior value
- * and the error re-throws so callers' existing failure handling still runs.
+ * then persists it to the `processing_started_at` column. The two directions
+ * treat a failed write differently, and both are covered here.
+ *
+ * Acquiring is strict: the in-memory flag reverts to its prior value and the
+ * error re-throws so callers' existing failure handling still runs.
+ *
+ * Clearing is not: the in-memory flag is this process's queue gate while the
+ * column is advisory state the boot-time stale-processing sweep recovers, so a
+ * failed mirror write must still leave the conversation released rather than
+ * latching it "busy" for the rest of the daemon's life.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -209,17 +215,16 @@ describe("Conversation.setProcessing persistence failure", () => {
     expect(conversation.isProcessing()).toBe(false);
   });
 
-  test("restores the prior value when clearing fails mid-turn", () => {
+  test("releases in memory when the clear's mirror write fails", () => {
     conversation.setProcessing(true);
     expect(conversation.isProcessing()).toBe(true);
 
     persistShouldThrow = true;
-    expect(() => conversation.setProcessing(false)).toThrow(
-      "database is locked",
-    );
+    expect(() => conversation.setProcessing(false)).not.toThrow();
 
-    // Clear didn't persist, so the flag stays consistent with the column.
-    expect(conversation.isProcessing()).toBe(true);
+    // The queue gate is the in-memory flag, so a failed advisory write must
+    // not leave the conversation rejecting every later send as "busy".
+    expect(conversation.isProcessing()).toBe(false);
   });
 
   test("commits the flag when the DB write succeeds", () => {

--- a/assistant/src/__tests__/queued-message-cancel-and-steer.test.ts
+++ b/assistant/src/__tests__/queued-message-cancel-and-steer.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Queue-cancellation and steer-recovery contracts on the shared handlers.
+ *
+ * `deleteQueuedMessage` broadcasts the cancellation so every client watching
+ * the conversation retires the queued row, not just the tab that issued the
+ * DELETE, and pairs that event with the same visibility predicate the enqueue
+ * ack used.
+ *
+ * `steerToMessage` promotes a queued message and then aborts the in-flight
+ * turn. When the flag is latched with no live controller there is nothing to
+ * abort and no agent-loop release coming, so the handler force-clears and
+ * drains itself instead of leaving the promoted message at the head of a queue
+ * that never runs.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantEvent } from "../api/index.js";
+
+const broadcasts: AssistantEvent[] = [];
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: AssistantEvent) => {
+    broadcasts.push(msg);
+  },
+}));
+
+import type { Conversation } from "../daemon/conversation.js";
+import type { QueuedMessage } from "../daemon/conversation-queue-manager.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import {
+  deleteQueuedMessage,
+  steerToMessage,
+} from "../daemon/handlers/conversations.js";
+
+const CONV = "queued-cancel-conv";
+
+function registerWithQueuedMessage(
+  removed: Partial<QueuedMessage> | undefined,
+): void {
+  const fake = {
+    conversationId: CONV,
+    isProcessing: () => false,
+    removeQueuedMessage: () => removed,
+  };
+  setConversation(CONV, fake as unknown as Conversation);
+}
+
+interface LatchedTurn {
+  cleared: () => boolean;
+  drainReasons: string[];
+  pendingSteerRepair: () => boolean;
+}
+
+/**
+ * Register a conversation whose processing flag is latched with no live
+ * controller: the shape a turn leaves behind when it tore its controller down
+ * (or died) without any release running.
+ */
+function registerLatchedTurn(): LatchedTurn {
+  let processing = true;
+  const drainReasons: string[] = [];
+  const fake = {
+    conversationId: CONV,
+    isProcessing: () => processing,
+    setProcessing: (value: boolean) => {
+      processing = value;
+    },
+    abortController: null,
+    queue: {
+      promoteToHead: (requestId: string) => ({ requestId }),
+    },
+    pendingSteerRepair: false,
+    kickDrainQueue: (reason: string) => {
+      drainReasons.push(reason);
+      return Promise.resolve();
+    },
+    denyAllPendingConfirmations: () => {},
+  };
+  setConversation(CONV, fake as unknown as Conversation);
+  return {
+    cleared: () => !processing,
+    drainReasons,
+    pendingSteerRepair: () => fake.pendingSteerRepair,
+  };
+}
+
+describe("deleteQueuedMessage", () => {
+  afterEach(() => {
+    broadcasts.length = 0;
+    deleteConversation(CONV);
+  });
+
+  test("broadcasts the cancellation so other clients drop the queued row", () => {
+    registerWithQueuedMessage({
+      requestId: "req-1",
+      clientMessageId: "client-1",
+      metadata: {},
+    });
+
+    expect(deleteQueuedMessage(CONV, "req-1")).toEqual({ removed: true });
+    expect(broadcasts).toEqual([
+      {
+        type: "message_queued_deleted",
+        conversationId: CONV,
+        requestId: "req-1",
+        clientMessageId: "client-1",
+      },
+    ]);
+  });
+
+  test("omits clientMessageId when the sender minted none", () => {
+    registerWithQueuedMessage({ requestId: "req-2", metadata: {} });
+
+    expect(deleteQueuedMessage(CONV, "req-2")).toEqual({ removed: true });
+    expect(broadcasts).toEqual([
+      {
+        type: "message_queued_deleted",
+        conversationId: CONV,
+        requestId: "req-2",
+      },
+    ]);
+  });
+
+  test("stays silent for an echo-suppressed entry", () => {
+    // A daemon-injected notification never produced a `message_queued` ack, so
+    // a delete event would be an unpaired retire for a row no client renders.
+    registerWithQueuedMessage({
+      requestId: "req-3",
+      metadata: { subagentNotification: { childId: "child-1" } },
+    });
+
+    expect(deleteQueuedMessage(CONV, "req-3")).toEqual({ removed: true });
+    expect(broadcasts).toEqual([]);
+  });
+
+  test("stays silent when nothing matched the request id", () => {
+    registerWithQueuedMessage(undefined);
+
+    expect(deleteQueuedMessage(CONV, "req-missing")).toEqual({
+      removed: false,
+      reason: "message_not_found",
+    });
+    expect(broadcasts).toEqual([]);
+  });
+});
+
+describe("steerToMessage with a latched processing flag", () => {
+  afterEach(() => {
+    broadcasts.length = 0;
+    deleteConversation(CONV);
+  });
+
+  test("force-clears and drains when no live controller can be aborted", () => {
+    const turn = registerLatchedTurn();
+
+    expect(steerToMessage(CONV, "req-steer")).toEqual({ steered: true });
+
+    // Without the force-clear the promoted message would sit behind a flag
+    // nothing is going to release.
+    expect(turn.cleared()).toBe(true);
+    expect(turn.drainReasons).toEqual(["loop_complete"]);
+    // The drain consumes the repair flag, so it must survive the force-clear.
+    expect(turn.pendingSteerRepair()).toBe(true);
+    expect(broadcasts).toEqual([
+      { type: "message_steered", conversationId: CONV, requestId: "req-steer" },
+    ]);
+  });
+});

--- a/assistant/src/__tests__/turn-tail-chain.test.ts
+++ b/assistant/src/__tests__/turn-tail-chain.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the per-conversation end-of-turn tail chain.
+ *
+ * The chain lives at module scope keyed by conversation id, which is the whole
+ * point: a tail runs after the agent loop released the processing lock, so the
+ * conversation reads idle and the live `Conversation` instance can be evicted
+ * and rebuilt underneath it. These tests pin the two properties that depend on
+ * that: tails scheduled from different instances of the same conversation still
+ * run in order, and the map does not accumulate an entry per conversation the
+ * daemon has ever served.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  __turnTailChainSizeForTests,
+  chainTurnTail,
+  settleTurnTail,
+} from "../daemon/turn-tail-chain.js";
+
+/** Unique per test so cases cannot chain onto each other's tails. */
+let nextConversationSeq = 0;
+function conversationId(): string {
+  nextConversationSeq += 1;
+  return `turn-tail-conv-${nextConversationSeq}`;
+}
+
+describe("turn-tail-chain", () => {
+  test("tails scheduled for one conversation run strictly in order", async () => {
+    const id = conversationId();
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstHangs = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    // The first instance schedules its tail and is then disposed, so the
+    // second tail is scheduled with no reference to the first.
+    chainTurnTail(id, async () => {
+      order.push("first:start");
+      await firstHangs;
+      order.push("first:end");
+    });
+    chainTurnTail(id, async () => {
+      order.push("second:start");
+      order.push("second:end");
+    });
+
+    // The second tail is parked behind the first rather than overlapping it.
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+
+    releaseFirst?.();
+    await settleTurnTail(id);
+    expect(order).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+    ]);
+  });
+
+  test("a rejected tail neither escapes nor poisons the tails behind it", async () => {
+    const id = conversationId();
+    const order: string[] = [];
+
+    chainTurnTail(id, async () => {
+      order.push("first");
+      throw new Error("tail exploded");
+    });
+    chainTurnTail(id, async () => {
+      order.push("second");
+    });
+
+    // The chain settles rather than rejecting, so the throw can neither surface
+    // as an unhandled rejection nor skip the queued tail.
+    await settleTurnTail(id);
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  test("separate conversations run their tails concurrently", async () => {
+    const first = conversationId();
+    const second = conversationId();
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstHangs = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    chainTurnTail(first, async () => {
+      order.push("first:start");
+      await firstHangs;
+      order.push("first:end");
+    });
+    chainTurnTail(second, async () => {
+      order.push("second");
+    });
+
+    await settleTurnTail(second);
+    expect(order).toEqual(["first:start", "second"]);
+
+    releaseFirst?.();
+    await settleTurnTail(first);
+    expect(order).toEqual(["first:start", "second", "first:end"]);
+  });
+
+  test("the chain entry is released once the last tail settles", async () => {
+    const id = conversationId();
+    const sizeBefore = __turnTailChainSizeForTests();
+
+    let releaseTail: (() => void) | undefined;
+    const tailHangs = new Promise<void>((resolve) => {
+      releaseTail = resolve;
+    });
+    chainTurnTail(id, () => tailHangs);
+    chainTurnTail(id, async () => {});
+
+    // Both tails share the one entry the conversation is allowed.
+    expect(__turnTailChainSizeForTests()).toBe(sizeBefore + 1);
+
+    releaseTail?.();
+    await settleTurnTail(id);
+    // The cleanup link runs a microtask after the tail body, so let it land.
+    await Promise.resolve();
+    expect(__turnTailChainSizeForTests()).toBe(sizeBefore);
+
+    // A later turn on the same conversation still chains normally.
+    const order: string[] = [];
+    chainTurnTail(id, async () => {
+      order.push("later");
+    });
+    await settleTurnTail(id);
+    expect(order).toEqual(["later"]);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -2799,10 +2799,9 @@ export async function handleMessageComplete(
   // The row was reserved at `llm_call_started` (with channel metadata
   // stamped at that point) and `state.lastAssistantMessageId` carries its
   // id. Flush the final content via `updateContent` instead of inserting a
-  // new row. No `syncToDisk` flag here — the orchestrator separately
-  // invokes `syncMessageToDisk` on `state.lastAssistantMessageId` after
-  // the loop completes (see
-  // `conversation-agent-loop.ts::syncLastAssistantMessageToDisk`).
+  // new row. No `syncToDisk` flag here: the orchestrator separately invokes
+  // `syncMessageToDisk` on `state.lastAssistantMessageId` after the loop
+  // completes (see `conversation-turn-finalize.ts::settleTurnContent`).
   const assistantMessageId = state.lastAssistantMessageId;
   if (!assistantMessageId) {
     throw new Error(

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -129,6 +129,7 @@ import {
   MEMORY_CONTEXT_PHASE_KEY,
   TurnLatencyTracker,
 } from "./turn-latency-tracker.js";
+import { chainTurnTail } from "./turn-tail-chain.js";
 
 const log = getLogger("conversation-agent-loop");
 
@@ -641,6 +642,10 @@ export async function runAgentLoopImpl(
    * back to the live seq counter once that registration is gone (safe because
    * `settlePendingPartialFlush` has already flushed the turn's content).
    * Idempotent, so the `finally` can call it unconditionally.
+   *
+   * The release frees direct sends only. Queued messages are drained from the
+   * loop's `finally`, after the turn-boundary commit, so a dequeued turn's
+   * first file writes cannot be swept into the finished turn's commit.
    */
   const releaseTurn = (): void => {
     if (turnReleased) {
@@ -661,59 +666,43 @@ export async function runAgentLoopImpl(
     }
     ctx.abortController = null;
     ctx.setProcessing(false);
-    // Everything below is bookkeeping the release does not depend on, so it
-    // runs under a `finally` that guarantees the drain kick: a throw in any of
-    // it would otherwise free the conversation while leaving the queue with
-    // nothing to re-trigger it.
-    try {
-      unregisterInflightTurn(ctx.conversationId, state);
+    unregisterInflightTurn(ctx.conversationId, state);
 
-      // Tear down the remaining per-turn state before the drain below, so a
-      // queued turn dequeued on this reused conversation cannot inherit stale
-      // turn scope (task-run permissions, allowed tools, override profile,
-      // command intent). Everything from the release above through the drain
-      // kick below is synchronous, so no other turn can observe a half-cleared
-      // conversation.
-      ctx.onConfirmationOutcome = undefined;
-      ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
-      ctx.approvedViaPromptThisTurn = false;
-      ctx.currentRequestId = undefined;
-      ctx.currentActiveSurfaceId = undefined;
-      ctx.allowedToolNames = undefined;
-      ctx.diskPressureCleanupModeActive = false;
-      ctx.preactivatedSkillIds = undefined;
-      ctx.currentTurnOverrideProfile = undefined;
-      ctx.currentTurnModelProfileNoticeKey = undefined;
-      // Turn-scoped interactivity. Clear it so paths that bypass this loop
-      // (e.g. opportunity wakes calling `agentLoop.run` directly) don't inherit
-      // a stale value and instead fall back to live client state in the tool
-      // context.
-      ctx.currentTurnIsNonInteractive = undefined;
-      // Turn-scoped request origin. Clear so a later turn on a reused
-      // conversation cannot inherit a stale origin-scoped permission grant.
-      ctx.currentTurnRequestOrigin = undefined;
-      // Channel command intents (e.g. Telegram /start) are single-turn
-      // metadata. Clear at turn end so they never leak into subsequent
-      // unrelated messages.
-      ctx.commandIntent = undefined;
-      // taskRunId scopes ephemeral task-run permissions to a single turn.
-      ctx.taskRunId = undefined;
+    // Tear down the remaining per-turn state in the same synchronous step as
+    // the release, so a turn that starts against the freed conversation cannot
+    // inherit stale turn scope (task-run permissions, allowed tools, override
+    // profile, command intent) or observe a half-cleared conversation.
+    ctx.onConfirmationOutcome = undefined;
+    ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
+    ctx.approvedViaPromptThisTurn = false;
+    ctx.currentRequestId = undefined;
+    ctx.currentActiveSurfaceId = undefined;
+    ctx.allowedToolNames = undefined;
+    ctx.diskPressureCleanupModeActive = false;
+    ctx.preactivatedSkillIds = undefined;
+    ctx.currentTurnOverrideProfile = undefined;
+    ctx.currentTurnModelProfileNoticeKey = undefined;
+    // Turn-scoped interactivity. Clear it so paths that bypass this loop
+    // (e.g. opportunity wakes calling `agentLoop.run` directly) don't inherit
+    // a stale value and instead fall back to live client state in the tool
+    // context.
+    ctx.currentTurnIsNonInteractive = undefined;
+    // Turn-scoped request origin. Clear so a later turn on a reused
+    // conversation cannot inherit a stale origin-scoped permission grant.
+    ctx.currentTurnRequestOrigin = undefined;
+    // Channel command intents (e.g. Telegram /start) are single-turn
+    // metadata. Clear at turn end so they never leak into subsequent
+    // unrelated messages.
+    ctx.commandIntent = undefined;
+    // taskRunId scopes ephemeral task-run permissions to a single turn.
+    ctx.taskRunId = undefined;
 
-      // Close the turn's profiling window here rather than after the drain:
-      // the profiler is per-conversation and the next turn's
-      // `startToolProfilingRequest` resets it, so a summary emitted after a
-      // drained turn started would report that turn's window under this turn's
-      // request id.
-      emitToolProfilingSummary(ctx.conversationId, reqId);
-    } finally {
-      // kickDrainQueue never rejects: a drain failure here would otherwise be
-      // an unhandled rejection that strands the queue with nothing left to
-      // re-trigger it.
-      void ctx.kickDrainQueue(
-        yieldedForHandoff ? "checkpoint_handoff" : "loop_complete",
-        "agent_loop_release",
-      );
-    }
+    // Close the turn's profiling window here rather than after the queue
+    // drain: the profiler is per-conversation and the next turn's
+    // `startToolProfilingRequest` resets it, so a summary emitted after a
+    // drained turn started would report that turn's window under this turn's
+    // request id.
+    emitToolProfilingSummary(ctx.conversationId, reqId);
   };
 
   const publishLoopMessagesChanged = (): void => {
@@ -1642,18 +1631,19 @@ export async function runAgentLoopImpl(
     // deferred tail rather than in the `finally`: the tail's memory indexing is
     // network-bound and unbounded, and holding the lock across it is what makes
     // a fully-delivered reply still answer a follow-up send with a queue slot.
+    // The queue itself is drained later, from the `finally` after the
+    // turn-boundary commit.
     const criticalSectionMs = Date.now() - generationCompletedAt;
     releaseTurn();
 
-    // Detached, and chained on the conversation's tail promise so two turns'
-    // tails run in turn order instead of concurrently. `.catch` is required:
-    // the chain outlives this function, so an unhandled rejection here would
-    // also poison every later turn's tail.
-    ctx.turnTailChain = ctx.turnTailChain
-      .then(() => runDeferredTurnTail({ state, rlog, criticalSectionMs }))
-      .catch((err: unknown) => {
-        rlog.warn({ err }, "Deferred turn tail failed (non-fatal)");
-      });
+    // Detached, and chained on the conversation's tail chain so two turns'
+    // tails run in turn order instead of concurrently. The chain is keyed by
+    // conversation id rather than held on this instance, because the tail runs
+    // while the conversation reads idle and can therefore outlive the instance
+    // that scheduled it.
+    chainTurnTail(ctx.conversationId, () =>
+      runDeferredTurnTail({ state, rlog, criticalSectionMs }),
+    );
   } catch (err) {
     clearConversationNotices(ctx.conversationId);
     const errorCtx = {
@@ -1703,48 +1693,65 @@ export async function runAgentLoopImpl(
   } finally {
     // Backstop release for the cancel/error paths, which throw out of the try
     // before the happy path's release runs. Idempotent, so the happy path
-    // reaches here already released. It stays first in the `finally` so nothing
-    // that can throw (the turn-boundary commit, profiling) can run ahead of it
-    // and leave the row latched "mid-turn".
+    // reaches here already released. It stays first in the `finally` so the
+    // turn-boundary commit below cannot throw ahead of it and leave the row
+    // latched "mid-turn".
     releaseTurn();
 
-    if (turnStarted) {
-      ctx.turnCount++;
-      const config = getConfig();
-      const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
-      const deadlineMs = Date.now() + maxWait;
+    // The queue drain runs after the turn-boundary commit, under a `finally`
+    // so a throw in the commit section cannot strand the queue with nothing
+    // left to re-trigger it. Ordering is load-bearing: `commitTurnChanges`
+    // attributes the working tree's changes to the finished turn, so a queued
+    // turn that started while it was preparing would have its first file
+    // writes swept into the wrong commit. The wait is deadline-bounded, and
+    // direct sends are already unblocked by the release above.
+    try {
+      if (turnStarted) {
+        ctx.turnCount++;
+        const config = getConfig();
+        const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
+        const deadlineMs = Date.now() + maxWait;
 
-      const commitTurnChangesFn = ctx.commitTurnChanges ?? commitTurnChanges;
-      const commitPromise = commitTurnChangesFn(
-        ctx.workingDir,
-        ctx.conversationId,
-        ctx.turnCount,
-        undefined,
-        deadlineMs,
-      );
-      const outcome = await raceWithTimeout(commitPromise, maxWait);
-      if (outcome === "timed_out") {
-        rlog.warn(
-          {
-            turnNumber: ctx.turnCount,
-            maxWaitMs: maxWait,
-            conversationId: ctx.conversationId,
-          },
-          "Turn-boundary commit timed out — continuing without waiting (commit still runs in background)",
+        const commitTurnChangesFn = ctx.commitTurnChanges ?? commitTurnChanges;
+        const commitPromise = commitTurnChangesFn(
+          ctx.workingDir,
+          ctx.conversationId,
+          ctx.turnCount,
+          undefined,
+          deadlineMs,
         );
+        const outcome = await raceWithTimeout(commitPromise, maxWait);
+        if (outcome === "timed_out") {
+          rlog.warn(
+            {
+              turnNumber: ctx.turnCount,
+              maxWaitMs: maxWait,
+              conversationId: ctx.conversationId,
+            },
+            "Turn-boundary commit timed out; continuing without waiting (commit still runs in background)",
+          );
+        }
+
+        // Recompute relationship-state.json at turn boundary (fire-and-forget).
+        // The writer swallows its own errors, but we still guard with catch()
+        // here so a regression in the writer can never bubble out of the
+        // agent loop and reject an otherwise-complete turn.
+        void writeRelationshipState().catch(() => {});
       }
 
-      // Recompute relationship-state.json at turn boundary (fire-and-forget).
-      // The writer swallows its own errors, but we still guard with catch()
-      // here so a regression in the writer can never bubble out of the
-      // agent loop and reject an otherwise-complete turn.
-      void writeRelationshipState().catch(() => {});
+      // Consolidation deferred to compaction: keeping assistant + tool_result
+      // messages unconsolidated preserves the exact message structure sent to
+      // the API, enabling stable prefix caching across turns.  Compaction
+      // consolidates when it summarizes old messages (cache miss is expected).
+    } finally {
+      // kickDrainQueue never rejects: a drain failure here would otherwise be
+      // an unhandled rejection that strands the queue with nothing left to
+      // re-trigger it.
+      void ctx.kickDrainQueue(
+        yieldedForHandoff ? "checkpoint_handoff" : "loop_complete",
+        "agent_loop_finally",
+      );
     }
-
-    // Consolidation deferred to compaction: keeping assistant + tool_result
-    // messages unconsolidated preserves the exact message structure sent to
-    // the API, enabling stable prefix caching across turns.  Compaction
-    // consolidates when it summarizes old messages (cache miss is expected).
   }
 }
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -109,7 +109,10 @@ import {
 } from "./conversation-runtime-assembly.js";
 import type { CurrentTurnSurface } from "./conversation-surfaces.js";
 import { markSurfaceCompleted } from "./conversation-surfaces.js";
-import { runDeferredTurnTail } from "./conversation-turn-finalize.js";
+import {
+  runDeferredTurnTail,
+  settleTurnContent,
+} from "./conversation-turn-finalize.js";
 import { recordUsage } from "./conversation-usage.js";
 import { resolveTurnTimezoneContext } from "./date-context.js";
 import { getDiskPressureStatus } from "./disk-pressure-guard.js";
@@ -617,9 +620,101 @@ export async function runAgentLoopImpl(
     | { outcome: "failed" | "cancelled"; failureCode?: string }
     | undefined;
   // True once a replied terminal SSE (message_complete / generation_handoff)
-  // has been emitted. Guards the catch block: an error thrown afterwards
-  // (deferred turn-tail bookkeeping) must not relabel a visibly-replied turn.
+  // has been emitted. Guards the catch block: an error thrown by the
+  // content-settle steps that run after it must not relabel a visibly-replied
+  // turn.
   let turnReplied = false;
+  // True once `releaseTurn` has run. The happy path releases as soon as the
+  // turn's content is settled; the `finally` calls it again as the backstop for
+  // the cancel/error paths that never reached the early release.
+  let turnReleased = false;
+
+  /**
+   * Free the conversation for its next turn.
+   *
+   * Ordering is load-bearing and identical on both call paths: stamp the
+   * turn's abnormal outcome first, because the telemetry reporter's
+   * settled-turn barrier only releases this turn once processing stops; null
+   * `abortController` before clearing the flag so a concurrent abort takes the
+   * force-clear branch rather than signalling a dead controller; unregister the
+   * in-flight turn only after processing stops, since daemon-side callers fall
+   * back to the live seq counter once that registration is gone (safe because
+   * `settlePendingPartialFlush` has already flushed the turn's content).
+   * Idempotent, so the `finally` can call it unconditionally.
+   */
+  const releaseTurn = (): void => {
+    if (turnReleased) {
+      return;
+    }
+    turnReleased = true;
+    if (abnormalOutcome) {
+      try {
+        stampTurnOutcome(userMessageId, abnormalOutcome.outcome, {
+          failureCode: abnormalOutcome.failureCode,
+        });
+      } catch (err) {
+        rlog.warn(
+          { err },
+          "Failed to stamp turn outcome (non-fatal); releasing the turn anyway",
+        );
+      }
+    }
+    ctx.abortController = null;
+    ctx.setProcessing(false);
+    // Everything below is bookkeeping the release does not depend on, so it
+    // runs under a `finally` that guarantees the drain kick: a throw in any of
+    // it would otherwise free the conversation while leaving the queue with
+    // nothing to re-trigger it.
+    try {
+      unregisterInflightTurn(ctx.conversationId, state);
+
+      // Tear down the remaining per-turn state before the drain below, so a
+      // queued turn dequeued on this reused conversation cannot inherit stale
+      // turn scope (task-run permissions, allowed tools, override profile,
+      // command intent). Everything from the release above through the drain
+      // kick below is synchronous, so no other turn can observe a half-cleared
+      // conversation.
+      ctx.onConfirmationOutcome = undefined;
+      ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
+      ctx.approvedViaPromptThisTurn = false;
+      ctx.currentRequestId = undefined;
+      ctx.currentActiveSurfaceId = undefined;
+      ctx.allowedToolNames = undefined;
+      ctx.diskPressureCleanupModeActive = false;
+      ctx.preactivatedSkillIds = undefined;
+      ctx.currentTurnOverrideProfile = undefined;
+      ctx.currentTurnModelProfileNoticeKey = undefined;
+      // Turn-scoped interactivity. Clear it so paths that bypass this loop
+      // (e.g. opportunity wakes calling `agentLoop.run` directly) don't inherit
+      // a stale value and instead fall back to live client state in the tool
+      // context.
+      ctx.currentTurnIsNonInteractive = undefined;
+      // Turn-scoped request origin. Clear so a later turn on a reused
+      // conversation cannot inherit a stale origin-scoped permission grant.
+      ctx.currentTurnRequestOrigin = undefined;
+      // Channel command intents (e.g. Telegram /start) are single-turn
+      // metadata. Clear at turn end so they never leak into subsequent
+      // unrelated messages.
+      ctx.commandIntent = undefined;
+      // taskRunId scopes ephemeral task-run permissions to a single turn.
+      ctx.taskRunId = undefined;
+
+      // Close the turn's profiling window here rather than after the drain:
+      // the profiler is per-conversation and the next turn's
+      // `startToolProfilingRequest` resets it, so a summary emitted after a
+      // drained turn started would report that turn's window under this turn's
+      // request id.
+      emitToolProfilingSummary(ctx.conversationId, reqId);
+    } finally {
+      // kickDrainQueue never rejects: a drain failure here would otherwise be
+      // an unhandled rejection that strands the queue with nothing left to
+      // re-trigger it.
+      void ctx.kickDrainQueue(
+        yieldedForHandoff ? "checkpoint_handoff" : "loop_complete",
+        "agent_loop_release",
+      );
+    }
+  };
 
   const publishLoopMessagesChanged = (): void => {
     if (
@@ -1406,10 +1501,10 @@ export async function runAgentLoopImpl(
     // compaction/overflow recovery (where a cache miss is expected).
     //
     // Post-turn tool-result truncation (spooling large results to disk and
-    // shrinking the next turn's context) is deferred to `runDeferredTurnTail`
+    // shrinking the next turn's context) is deferred to `settleTurnContent`
     // below. It only rewrites the in-memory history the NEXT turn is built
-    // from — never the just-delivered reply — so it must not sit on the
-    // critical path to the terminal SSE that re-enables the composer.
+    // from, never the just-delivered reply, so it must not sit on the critical
+    // path to the terminal SSE that re-enables the composer.
     ctx.messages = restoredHistory;
 
     emitUsage(
@@ -1439,7 +1534,7 @@ export async function runAgentLoopImpl(
     // Fast-path: when the user cancelled, skip expensive post-loop work
     // (attachment resolution) and emit the cancellation event immediately
     // so the client can re-enable the UI without delay. Disk sync and the rest
-    // of the bookkeeping run in `runDeferredTurnTail` after this SSE.
+    // of the bookkeeping run after this SSE.
     if (abortController.signal.aborted) {
       abnormalOutcome = { outcome: "cancelled" };
       ctx.emitActivityState("idle", "generation_cancelled", {
@@ -1534,14 +1629,31 @@ export async function runAgentLoopImpl(
 
     // The terminal SSE for this turn has now been emitted (message_complete,
     // generation_handoff, or generation_cancelled), so the composer is already
-    // re-enabling. Settle any pending debounced partial flush FIRST — a
+    // re-enabling. Settle any pending debounced partial flush FIRST: a
     // cancelled turn exits with the timer still pending, and a flush firing
-    // after the tail's stranded fold (or the voice bridge's transcript
-    // hygiene) would write raw content into an already-settled row. Then
-    // drain the deferred bookkeeping — after the SSE, before the `finally`
-    // commits and drains the queue for the next turn.
+    // after the stranded fold (or the voice bridge's transcript hygiene) would
+    // write raw content into an already-settled row. Then settle the rest of
+    // the turn's content, which rewrites state the next turn also writes and so
+    // has to complete under the processing lock.
     await settlePendingPartialFlush(state, deps);
-    await runDeferredTurnTail({ ctx, state, rlog, generationCompletedAt });
+    await settleTurnContent({ ctx, state, rlog });
+
+    // Content is settled, so the conversation is free. Release before the
+    // deferred tail rather than in the `finally`: the tail's memory indexing is
+    // network-bound and unbounded, and holding the lock across it is what makes
+    // a fully-delivered reply still answer a follow-up send with a queue slot.
+    const criticalSectionMs = Date.now() - generationCompletedAt;
+    releaseTurn();
+
+    // Detached, and chained on the conversation's tail promise so two turns'
+    // tails run in turn order instead of concurrently. `.catch` is required:
+    // the chain outlives this function, so an unhandled rejection here would
+    // also poison every later turn's tail.
+    ctx.turnTailChain = ctx.turnTailChain
+      .then(() => runDeferredTurnTail({ state, rlog, criticalSectionMs }))
+      .catch((err: unknown) => {
+        rlog.warn({ err }, "Deferred turn tail failed (non-fatal)");
+      });
   } catch (err) {
     clearConversationNotices(ctx.conversationId);
     const errorCtx = {
@@ -1549,9 +1661,9 @@ export async function runAgentLoopImpl(
       aborted: abortController.signal.aborted,
     };
     if (isUserCancellation(err, errorCtx)) {
-      // Only label the turn when it hadn't already replied — a cancellation
-      // surfacing after the terminal SSE (deferred turn-tail bookkeeping)
-      // must not relabel a visibly-replied turn.
+      // Only label the turn when it hadn't already replied: a cancellation
+      // surfacing after the terminal SSE (the content-settle steps) must not
+      // relabel a visibly-replied turn.
       if (!turnReplied) {
         abnormalOutcome = { outcome: "cancelled" };
       }
@@ -1589,24 +1701,12 @@ export async function runAgentLoopImpl(
       publishLoopMessagesChanged();
     }
   } finally {
-    // Clear the processing flag first. It is the release that frees the
-    // conversation for its next turn, so nothing that can throw (the
-    // turn-boundary commit, profiling) is allowed to run ahead of it and leave
-    // the row latched "mid-turn". Stamp the turn's abnormal outcome first
-    // because the telemetry reporter's settled-turn barrier only releases this
-    // turn once processing stops; null `abortController` first so a concurrent
-    // abort takes the force-clear branch rather than signalling a dead one.
-    if (abnormalOutcome) {
-      stampTurnOutcome(userMessageId, abnormalOutcome.outcome, {
-        failureCode: abnormalOutcome.failureCode,
-      });
-    }
-    ctx.abortController = null;
-    ctx.setProcessing(false);
-    // The turn's content is fully flushed by here (`settlePendingPartialFlush`
-    // ran inside the try), so daemon-side callers can safely fall back to the
-    // live seq counter once this registration is gone.
-    unregisterInflightTurn(ctx.conversationId, state);
+    // Backstop release for the cancel/error paths, which throw out of the try
+    // before the happy path's release runs. Idempotent, so the happy path
+    // reaches here already released. It stays first in the `finally` so nothing
+    // that can throw (the turn-boundary commit, profiling) can run ahead of it
+    // and leave the row latched "mid-turn".
+    releaseTurn();
 
     if (turnStarted) {
       ctx.turnCount++;
@@ -1641,51 +1741,10 @@ export async function runAgentLoopImpl(
       void writeRelationshipState().catch(() => {});
     }
 
-    emitToolProfilingSummary(ctx.conversationId, reqId);
-
-    // Tear down the remaining per-turn state. Abort reliably drives the loop to
-    // this `finally` within a bounded time — cooperative signal propagation
-    // (provider fetch + tool race) backed by the abort watchdog — so a
-    // cancelled turn always unwinds before any resend can start a new one.
-    // There is therefore only ever one turn alive, and clearing the shared
-    // state below cannot clobber a concurrent turn.
-    ctx.onConfirmationOutcome = undefined;
-    ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
-    ctx.approvedViaPromptThisTurn = false;
-    ctx.currentRequestId = undefined;
-    ctx.currentActiveSurfaceId = undefined;
-    ctx.allowedToolNames = undefined;
-    ctx.diskPressureCleanupModeActive = false;
-    ctx.preactivatedSkillIds = undefined;
-    ctx.currentTurnOverrideProfile = undefined;
-    ctx.currentTurnModelProfileNoticeKey = undefined;
-    // Turn-scoped interactivity. Clear it so paths that bypass this loop (e.g.
-    // opportunity wakes calling `agentLoop.run` directly) don't inherit a stale
-    // value and instead fall back to live client state in the tool context.
-    ctx.currentTurnIsNonInteractive = undefined;
-    // Turn-scoped request origin. Clear so a later turn on a reused
-    // conversation cannot inherit a stale origin-scoped permission grant.
-    ctx.currentTurnRequestOrigin = undefined;
-    // Channel command intents (e.g. Telegram /start) are single-turn metadata.
-    // Clear at turn end so they never leak into subsequent unrelated messages.
-    ctx.commandIntent = undefined;
-    // taskRunId scopes ephemeral task-run permissions to a single turn. Clear
-    // before drainQueue so queued/drained turns on a reused conversation can't
-    // inherit stale in-task-run scope from the turn that just finished.
-    ctx.taskRunId = undefined;
-
     // Consolidation deferred to compaction: keeping assistant + tool_result
     // messages unconsolidated preserves the exact message structure sent to
     // the API, enabling stable prefix caching across turns.  Compaction
     // consolidates when it summarizes old messages (cache miss is expected).
-
-    // kickDrainQueue never rejects — a drain failure here would otherwise be
-    // an unhandled rejection that strands the queue with nothing left to
-    // re-trigger it.
-    void ctx.kickDrainQueue(
-      yieldedForHandoff ? "checkpoint_handoff" : "loop_complete",
-      "agent_loop_finally",
-    );
   }
 }
 

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -129,6 +129,38 @@ export interface DisposeContext extends AbortContext {
 
 // ── abort ─────────────────────────────────────────────────────────────
 
+/** The conversation surface {@link forceClearStaleProcessing} needs. */
+export interface StaleProcessingContext {
+  readonly conversationId: string;
+  setProcessing(value: boolean): void;
+}
+
+/**
+ * Release a processing flag that no live turn owns.
+ *
+ * Callers reach this when `isProcessing()` is true but `abortController` is
+ * null: the turn that owned the flag already tore its controller down (the
+ * agent loop nulls `abortController` before clearing the flag) or died without
+ * ever installing one. Either way no agent-loop release is going to run to
+ * clear it, so signalling the controller would be a silent no-op (`?.abort()`
+ * on null does nothing) and the conversation would stay wedged: every later
+ * submit is rejected with "already processing" and Stop appears dead.
+ * `setProcessing(false)` also nulls the persisted column and emits the metadata
+ * invalidation that drives clients to idle.
+ *
+ * `origin` names the calling site for log correlation.
+ */
+export function forceClearStaleProcessing(
+  ctx: StaleProcessingContext,
+  origin: string,
+): void {
+  log.warn(
+    { conversationId: ctx.conversationId, origin },
+    "Processing latched with no live abort controller; force-clearing the stale processing flag",
+  );
+  ctx.setProcessing(false);
+}
+
 export function abortConversation(
   ctx: AbortContext,
   reason?: AbortReason,
@@ -153,21 +185,7 @@ export function abortConversation(
       // clear it here and risk clobbering a client's optimistic state.
       ctx.abortController.abort(effectiveReason);
     } else {
-      // The flag is set but there is no live controller to signal: the turn
-      // that owned it already tore its controller down (the agent-loop
-      // `finally` nulls `abortController` before clearing the flag) or died
-      // without ever installing one. Either way no agent-loop `finally` is
-      // going to run to clear the flag. Without this branch the abort is a
-      // silent no-op — `?.abort()` does nothing — and the conversation stays
-      // wedged: every later submit is rejected with "already processing" and
-      // Stop appears dead. Force-clear the flag directly so the conversation
-      // frees up. `setProcessing(false)` also nulls the persisted column and
-      // emits the metadata invalidation that drives clients to idle.
-      log.warn(
-        { conversationId: ctx.conversationId },
-        "Abort requested while processing but no live abort controller — force-clearing stale processing flag",
-      );
-      ctx.setProcessing(false);
+      forceClearStaleProcessing(ctx, "abortConversation");
     }
     ctx.prompter.dispose();
     ctx.secretPrompter.dispose();

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -738,9 +738,9 @@ export async function persistUserMessage(
     return result;
   } catch (err) {
     // Clear the flag, but never let a clear failure mask the original error
-    // or skip the bookkeeping reset. `setProcessing` reverts its own
-    // in-memory flag when its persist throws, so the conversation is left
-    // consistent either way.
+    // or skip the bookkeeping reset. `setProcessing(false)` releases in memory
+    // regardless of its advisory mirror write, so the guard here is purely
+    // defensive against future changes.
     try {
       ctx.setProcessing(false);
     } catch (clearErr) {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -2001,7 +2001,10 @@ export async function processMessage(
       throw err;
     } finally {
       conversation.setProcessing(false);
-      await drainQueue(conversation);
+      // `kickQueueDrain` never rejects, so a failed drain in this `finally`
+      // cannot mask the error the try block is unwinding, and its retry plus
+      // sender notification replace a silently stranded queue.
+      await kickQueueDrain(conversation, "loop_complete", "compact_command");
     }
   }
 
@@ -2075,7 +2078,8 @@ export async function processMessage(
       throw err;
     } finally {
       conversation.setProcessing(false);
-      await drainQueue(conversation);
+      // Same never-rejecting drain as the `/compact` branch above.
+      await kickQueueDrain(conversation, "loop_complete", "clean_command");
     }
   }
 

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -113,9 +113,17 @@ export async function getOrCreateConversation(
     mergeConversationOptions(conversationId, persistentOptions);
   }
 
+  // A stale conversation is rebuilt only once it is genuinely idle. Queued
+  // messages live in memory on the instance being disposed, and the queue
+  // drains via an async dispatch after the current turn releases, so
+  // `isProcessing()` can read false while a queued turn is still pending:
+  // rebuilding in that gap would silently drop those messages. The conversation
+  // stays stale and is rebuilt on a later call.
   if (
     !conversation ||
-    (conversation.isStale() && !conversation.isProcessing())
+    (conversation.isStale() &&
+      !conversation.isProcessing() &&
+      !conversation.hasQueuedMessages())
   ) {
     if (conversation) {
       // Stale rebuild: the conversation id lives on, so abort in-flight
@@ -318,7 +326,12 @@ export function clearAllActiveConversations(): number {
 export function evictConversationsForReload(): void {
   const subagentManager = getSubagentManager();
   for (const [id, conversation] of conversationEntries()) {
-    if (!conversation.isProcessing()) {
+    // A conversation with queued messages is not idle: the queue drains via an
+    // async dispatch after the current turn releases, so `isProcessing()` can
+    // read false while a queued turn is still pending. Disposing in that gap
+    // would silently drop the queued messages, so mark it stale instead and
+    // let it rebuild once the queue has run.
+    if (!conversation.isProcessing() && !conversation.hasQueuedMessages()) {
       subagentManager.abortAllForParent(id);
       conversation.dispose();
       deleteConversation(id);

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -1,5 +1,5 @@
 /**
- * End-of-turn finalize work that runs OFF the send-button critical path.
+ * End-of-turn finalize work that runs after the terminal SSE.
  *
  * The web/Capacitor/CLI clients re-enable the composer the moment they observe
  * the terminal `message_complete` / `assistant_activity_state("idle")` SSE, so
@@ -9,10 +9,20 @@
  * None of the work here gates delivery of the reply: memory/attention indexing
  * only feeds the NEXT turn's retrieval and a sidebar indicator, tool-result
  * truncation only reshapes the in-memory history the next turn is built from,
- * and the disk-view mirror is a durability convenience. The agent loop persists
- * the reply content synchronously and emits the terminal SSE first, then drains
- * this module's work before the turn's `finally` starts the next turn — so the
- * bookkeeping still completes within the turn, just after the composer is free.
+ * and the disk-view mirror is a durability convenience. The work is split by
+ * whether a step is safe to overlap the NEXT turn:
+ *
+ * - {@link settleTurnContent} runs while the turn still holds the processing
+ *   lock. Its steps rewrite `ctx.messages` and append to the conversation's disk
+ *   view, both of which the next turn also writes, so they must finish before
+ *   the lock releases. Every step is synchronous apart from the stranded-content
+ *   fold, so holding the lock across them costs the queue nothing: synchronous
+ *   work blocks the event loop either way.
+ * - {@link runDeferredTurnTail} runs detached, after the lock releases, chained
+ *   per conversation so two turns' tails never overlap each other. Its steps are
+ *   keyed by the message ids this turn produced and are network-bound
+ *   (embeddings, vector upserts), which is the work that must not hold the lock:
+ *   a slow index otherwise leaves the next send queued behind an idle-looking UI.
  */
 
 import type pino from "pino";
@@ -40,18 +50,22 @@ import {
 } from "./inflight-message-content.js";
 import { conversationMetadataSyncTag } from "./message-types/sync.js";
 
-/** Minimal live-conversation surface the deferred tail reads and rewrites. */
+/** Minimal live-conversation surface the finalize steps read and rewrite. */
 interface TurnTailContext {
   readonly conversationId: string;
   messages: Message[];
 }
 
-/** Minimal per-run handler state the deferred tail consumes. */
-interface TurnTailState {
-  readonly deferredFinalizeEffects: ReadonlyArray<() => Promise<void>>;
+/** Minimal per-run handler state {@link settleTurnContent} consumes. */
+interface TurnContentState {
   readonly lastAssistantMessageId: string | undefined;
   /** In-flight content writers the turn left behind (see EventHandlerState). */
   readonly inflightWriters: Map<string, InflightContentWriter>;
+}
+
+/** Minimal per-run handler state the detached tail consumes. */
+interface TurnTailState {
+  readonly deferredFinalizeEffects: ReadonlyArray<() => Promise<void>>;
 }
 
 /**
@@ -127,35 +141,22 @@ export function buildDeferredFinalizeEffect(params: {
 }
 
 /**
- * Drain a turn's deferred bookkeeping after the terminal SSE has re-enabled the
- * composer but before the agent loop's `finally` commits and drains the queue
- * for the next turn. Ordering with the next turn is preserved (this completes
- * before `drainQueue`), while the last-token→send-button latency no longer
- * includes it. Every step is best-effort.
+ * Settle the turn's content while the processing lock is still held.
  *
- * `generationCompletedAt` is stamped when the agent loop returns; the emitted
- * `criticalSectionMs` / `deferredTailMs` split makes the previously-uninstrumented
- * end-of-turn window measurable.
+ * These steps run after the terminal SSE (so they are off the last-token to
+ * composer-enabled path) but before the lock releases, because each one writes
+ * a resource the next turn also writes: the in-memory history array and the
+ * conversation's append-only disk view. The processing lock is the only
+ * per-conversation serialization those resources have, so letting these steps
+ * run past the release would let a fast follow-up turn interleave with them.
+ * Every step is best-effort.
  */
-export async function runDeferredTurnTail(params: {
+export async function settleTurnContent(params: {
   ctx: TurnTailContext;
-  state: TurnTailState;
+  state: TurnContentState;
   rlog: pino.Logger;
-  generationCompletedAt: number;
 }): Promise<void> {
-  const { ctx, state, rlog, generationCompletedAt } = params;
-  const tailStartedAt = Date.now();
-
-  // Per-message memory/attention finalize side-effects deferred from
-  // `handleMessageComplete` — one closure per assistant row produced this turn,
-  // in production order.
-  for (const effect of state.deferredFinalizeEffects) {
-    try {
-      await effect();
-    } catch (err) {
-      rlog.warn({ err }, "Deferred finalize side-effect failed (non-fatal)");
-    }
-  }
+  const { ctx, state, rlog } = params;
 
   // Post-turn tool-result truncation: spool oversized results to disk and
   // replace their in-context content with a stub + pointer, shrinking the next
@@ -217,10 +218,43 @@ export async function runDeferredTurnTail(params: {
   } catch (err) {
     rlog.warn({ err }, "Failed to sync assistant message to disk (non-fatal)");
   }
+}
+
+/**
+ * Drain a turn's deferred bookkeeping after the processing lock has released.
+ *
+ * Runs detached from the agent loop and chained on the conversation's tail
+ * promise, so a slow index never holds the next turn's send behind an idle
+ * composer, yet two turns' tails still run in turn order. Every step is
+ * best-effort and keyed by a message id this turn produced, so it neither reads
+ * nor writes state the next turn owns.
+ *
+ * `criticalSectionMs` is the lock-held window the agent loop measured from the
+ * end of generation; paired with `deferredTailMs` it splits the end-of-turn
+ * window into the part a waiting sender feels and the part it no longer does.
+ */
+export async function runDeferredTurnTail(params: {
+  state: TurnTailState;
+  rlog: pino.Logger;
+  criticalSectionMs: number;
+}): Promise<void> {
+  const { state, rlog, criticalSectionMs } = params;
+  const tailStartedAt = Date.now();
+
+  // Per-message memory/attention finalize side-effects deferred from
+  // `handleMessageComplete`: one closure per assistant row produced this turn,
+  // in production order.
+  for (const effect of state.deferredFinalizeEffects) {
+    try {
+      await effect();
+    } catch (err) {
+      rlog.warn({ err }, "Deferred finalize side-effect failed (non-fatal)");
+    }
+  }
 
   rlog.info(
     {
-      criticalSectionMs: tailStartedAt - generationCompletedAt,
+      criticalSectionMs,
       deferredTailMs: Date.now() - tailStartedAt,
     },
     "End-of-turn work complete",

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -19,8 +19,8 @@
  *   fold, so holding the lock across them costs the queue nothing: synchronous
  *   work blocks the event loop either way.
  * - {@link runDeferredTurnTail} runs detached, after the lock releases, chained
- *   per conversation so two turns' tails never overlap each other. Its steps are
- *   keyed by the message ids this turn produced and are network-bound
+ *   by `chainTurnTail` so two turns' tails never overlap each other. Its steps
+ *   are keyed by the message ids this turn produced and are network-bound
  *   (embeddings, vector upserts), which is the work that must not hold the lock:
  *   a slow index otherwise leaves the next send queued behind an idle-looking UI.
  */
@@ -223,11 +223,12 @@ export async function settleTurnContent(params: {
 /**
  * Drain a turn's deferred bookkeeping after the processing lock has released.
  *
- * Runs detached from the agent loop and chained on the conversation's tail
- * promise, so a slow index never holds the next turn's send behind an idle
- * composer, yet two turns' tails still run in turn order. Every step is
- * best-effort and keyed by a message id this turn produced, so it neither reads
- * nor writes state the next turn owns.
+ * Runs detached from the agent loop and chained through `chainTurnTail`, so a
+ * slow index never holds the next turn's send behind an idle composer, yet two
+ * turns' tails still run in turn order even when the second turn ran on a
+ * rebuilt `Conversation` instance. Every step is best-effort and keyed by a
+ * message id this turn produced, so it neither reads nor writes state the next
+ * turn owns.
  *
  * `criticalSectionMs` is the lock-held window the agent loop measured from the
  * end of generation; paired with `deferredTailMs` it splits the end-of-turn

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -314,16 +314,6 @@ export class Conversation {
    * instance itself), so waiters cannot miss a release.
    */
   private idleWaiters = new Set<() => void>();
-  /**
-   * Serialization point for the detached end-of-turn tails (memory/attention
-   * indexing) the agent loop schedules after releasing the processing lock.
-   * Each turn chains its tail onto this promise, so a turn's tail can overlap
-   * the NEXT turn's generation but never another tail on the same
-   * conversation. Always carries a `.catch`, so the chain cannot be poisoned
-   * by a rejected tail.
-   * @internal
-   */
-  turnTailChain: Promise<void> = Promise.resolve();
   private stale = false;
   /** @internal */ abortController: AbortController | null = null;
   /** @internal */ prompter: PermissionPrompter;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -96,6 +96,7 @@ import type { OnboardingContext } from "../types/onboarding-context.js";
 import type { AbortReason } from "../util/abort-reasons.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { withSqliteRetry } from "../util/sqlite-retry.js";
 import type { WorkspaceGitService } from "../workspace/git-service.js";
 import type { commitTurnChanges } from "../workspace/turn-commit.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
@@ -313,6 +314,16 @@ export class Conversation {
    * instance itself), so waiters cannot miss a release.
    */
   private idleWaiters = new Set<() => void>();
+  /**
+   * Serialization point for the detached end-of-turn tails (memory/attention
+   * indexing) the agent loop schedules after releasing the processing lock.
+   * Each turn chains its tail onto this promise, so a turn's tail can overlap
+   * the NEXT turn's generation but never another tail on the same
+   * conversation. Always carries a `.catch`, so the chain cannot be poisoned
+   * by a rejected tail.
+   * @internal
+   */
+  turnTailChain: Promise<void> = Promise.resolve();
   private stale = false;
   /** @internal */ abortController: AbortController | null = null;
   /** @internal */ prompter: PermissionPrompter;
@@ -1547,38 +1558,45 @@ export class Conversation {
    * Mutate the server-authoritative `processing` flag. Web/Capacitor/CLI
    * caches treat this flag as the source of truth for the avatar streaming
    * ring and thinking indicator, so the `true → false` clear must announce
-   * itself: the daemon flips it in the agent-loop `finally`, which runs after
-   * the user-visible terminal SSE events, and a racing metadata refetch can
-   * otherwise re-read the not-yet-cleared `true` and clobber the client's
+   * itself: the daemon flips it once the finished turn's content is settled,
+   * after the user-visible terminal SSE events, and a racing metadata refetch
+   * can otherwise re-read the not-yet-cleared `true` and clobber the client's
    * optimistic `false`.
    *
    * Emitting a metadata invalidation on the clear lets every client GET the
    * authoritative `false`, per the multi-client-sync contract in AGENTS.md
    * ("emit the invalidation after the canonical state write succeeds").
+   *
+   * The two directions have different failure semantics because the in-memory
+   * flag and the persisted column serve different readers. Acquiring is
+   * strict: a failed persist reverts the in-memory flag and re-throws, so the
+   * caller's existing failure handling runs and the two never disagree about a
+   * turn that is starting. Clearing is not: the in-memory flag is the queue
+   * gate this process enforces, while the column is advisory state for
+   * out-of-process readers that the boot-time stale-processing sweep already
+   * recovers. Reverting a clear because a mirror write lost a race with
+   * SQLITE_BUSY would latch the conversation into "busy" for the rest of the
+   * daemon's life, so the clear always sticks.
    */
   setProcessing(value: boolean): void {
     const wasProcessing = this._processing;
     this._processing = value;
     // Persist the cross-process source of truth so out-of-process callers
     // (retrospective CLI, future detached workers) can detect mid-turn state
-    // by reading the conversations row directly. If the write fails (e.g.
-    // SQLITE_BUSY), the persisted column keeps its prior value, so revert the
-    // in-memory flag to match rather than stranding `processing = true` in
-    // memory against a NULL column. Re-throw so callers' existing failure
-    // handling still runs.
-    try {
-      setConversationProcessingStartedAt(
-        this.conversationId,
-        value ? Date.now() : null,
-      );
-    } catch (err) {
-      this._processing = wasProcessing;
-      throw err;
+    // by reading the conversations row directly.
+    if (value) {
+      try {
+        setConversationProcessingStartedAt(this.conversationId, Date.now());
+      } catch (err) {
+        this._processing = wasProcessing;
+        throw err;
+      }
+    } else {
+      this.mirrorProcessingCleared();
     }
     if (!value && this.idleWaiters.size > 0) {
-      // Notify only after the persisted write above committed — a thrown
-      // write reverts the in-memory flag and re-throws, so waiters must not
-      // observe a release that never happened. Copy-and-clear so a waiter
+      // The in-memory flag is the release, so waiters are notified on it
+      // rather than on the advisory mirror write. Copy-and-clear so a waiter
       // registered from inside a notification can't be re-entered.
       const waiters = [...this.idleWaiters];
       this.idleWaiters.clear();
@@ -1591,6 +1609,37 @@ export class Conversation {
         conversationMetadataSyncTag(this.conversationId),
       ]);
     }
+  }
+
+  /**
+   * Mirror a released processing lock into the advisory `processing_started_at`
+   * column, without ever reporting failure back to the release.
+   *
+   * `withSqliteRetry` runs its first attempt synchronously, so the common case
+   * is the same single write the acquire direction performs; only a contended
+   * write falls back to the backoff retries, which run detached. The retry
+   * re-checks the in-memory flag because a new turn may have acquired the lock
+   * (and written its own timestamp) while the backoff slept, and a late clear
+   * would then blank a column that describes a live turn.
+   */
+  private mirrorProcessingCleared(): void {
+    void withSqliteRetry(
+      () => {
+        if (this._processing) {
+          return;
+        }
+        setConversationProcessingStartedAt(this.conversationId, null);
+      },
+      {
+        op: "conversation:clearProcessing",
+        context: { conversationId: this.conversationId },
+      },
+    ).catch((err: unknown) => {
+      log.error(
+        { err, conversationId: this.conversationId },
+        "Failed to clear the persisted processing marker; the conversation is released in memory and the boot-time stale-processing sweep recovers the column",
+      );
+    });
   }
 
   /**
@@ -1729,8 +1778,13 @@ export class Conversation {
     return this.queue.snapshot();
   }
 
-  removeQueuedMessage(requestId: string): boolean {
-    return this.queue.removeByRequestId(requestId) !== undefined;
+  /**
+   * Drop a queued message by request id. Returns the removed entry so callers
+   * can pair a cancellation event with the same visibility metadata the
+   * enqueue ack used, or `undefined` when nothing matched.
+   */
+  removeQueuedMessage(requestId: string): QueuedMessage | undefined {
+    return this.queue.removeByRequestId(requestId);
   }
 
   canHandoffAtCheckpoint(): boolean {

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -12,6 +12,7 @@ import { getSubagentManager } from "../../subagent/index.js";
 import { createAbortReason } from "../../util/abort-reasons.js";
 import { UserError } from "../../util/errors.js";
 import { touchConversation } from "../conversation-evictor.js";
+import { forceClearStaleProcessing } from "../conversation-lifecycle.js";
 import {
   buildSlashContext,
   formatCleanResult,
@@ -25,6 +26,7 @@ import {
   clearAllActiveConversations,
   getOrCreateConversation,
 } from "../conversation-store.js";
+import { isEchoSuppressedUserMessage } from "../message-metadata-predicates.js";
 import type { ConfirmationResponse } from "../message-protocol.js";
 import { normalizeConversationType } from "../message-protocol.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../trust-context.js";
@@ -259,6 +261,23 @@ export function deleteQueuedMessage(
   }
   const removed = conversation.removeQueuedMessage(requestId);
   if (removed) {
+    // Broadcast rather than answering only the caller: the queued row is
+    // rendered by every client watching the conversation, so a cancel issued
+    // from one tab has to retire it in the others too. Queue events come in
+    // pairs, so an entry that never produced a `message_queued` ack
+    // (echo-suppressed daemon-injected sends) must not produce a delete
+    // either: clients have no row to retire and an unpaired event would
+    // decrement a counter that was never incremented.
+    if (!isEchoSuppressedUserMessage(removed.metadata)) {
+      broadcastMessage({
+        type: "message_queued_deleted",
+        conversationId,
+        requestId,
+        ...(removed.clientMessageId
+          ? { clientMessageId: removed.clientMessageId }
+          : {}),
+      });
+    }
     return { removed: true };
   }
   log.warn(
@@ -328,16 +347,26 @@ export function steerToMessage(
     "Steering to queued message — aborting current generation",
   );
 
-  // Abort the in-flight generation. The agent loop's finally block calls
+  // Abort the in-flight generation. The agent loop's release calls
   // drainQueue, which will pick up the promoted message at the head.
   // Unlike abortConversation, we do NOT clear the queue or dispose
-  // prompters — we want the queue to drain with the promoted message first.
+  // prompters: we want the queue to drain with the promoted message first.
   const reason = createAbortReason(
     "preempted_by_new_message",
     "steerToMessage",
     conversationId,
   );
-  conversation.abortController?.abort(reason);
+  if (conversation.abortController) {
+    conversation.abortController.abort(reason);
+  } else {
+    // Processing is latched with no live turn to abort, so nothing is going to
+    // reach a drain on its own and the message promoted above would sit at the
+    // head of a queue that never runs. Release the flag and drain here instead.
+    // `pendingSteerRepair` stays set: the drain consumes it, repairing any
+    // tool_use blocks the dead turn stranded before the promoted head runs.
+    forceClearStaleProcessing(conversation, "steerToMessage");
+    void conversation.kickDrainQueue("loop_complete", "steer_force_clear");
+  }
   // Deny pending confirmations so the abort unblocks immediately.
   conversation.denyAllPendingConfirmations();
 

--- a/assistant/src/daemon/turn-tail-chain.ts
+++ b/assistant/src/daemon/turn-tail-chain.ts
@@ -1,0 +1,73 @@
+/**
+ * Per-conversation serialization for the detached end-of-turn tails the agent
+ * loop schedules after releasing the processing lock.
+ *
+ * The chain is keyed by conversation id and held at module scope rather than
+ * on the `Conversation` instance. A tail runs while the conversation reads
+ * idle, which is exactly the window in which `evictConversationsForReload` and
+ * the stale-instance rebuild in `conversation-store.ts` drop the live instance:
+ * an instance-scoped chain would let the rebuilt instance start an empty chain
+ * whose tail overlaps the previous instance's still-running one. The state
+ * those tails advance (memory segments, the conversation attention cursor) is
+ * per conversation, not per instance, so the serialization has to be too.
+ */
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("turn-tail-chain");
+
+/** Tail promise per conversation id. Entries exist only while a tail is live. */
+const chains = new Map<string, Promise<void>>();
+
+/**
+ * Queue `tail` behind any tail already running for this conversation.
+ *
+ * Returns immediately: the tail is detached by design, so its failure is
+ * logged rather than surfaced. The chain is `.catch`-terminated at every link,
+ * so a rejected tail can neither become an unhandled rejection nor poison the
+ * tails queued after it.
+ */
+export function chainTurnTail(
+  conversationId: string,
+  tail: () => Promise<void>,
+): void {
+  const previous = chains.get(conversationId) ?? Promise.resolve();
+  const next: Promise<void> = previous
+    .then(tail)
+    .catch((err: unknown) => {
+      log.warn(
+        { err, conversationId },
+        "Deferred turn tail failed (non-fatal)",
+      );
+    })
+    .then(() => {
+      // Drop the entry only when nothing chained onto this link while it ran,
+      // so the map holds an entry per conversation with a live tail rather
+      // than one per conversation the daemon has ever served.
+      if (chains.get(conversationId) === next) {
+        chains.delete(conversationId);
+      }
+    });
+  chains.set(conversationId, next);
+}
+
+/**
+ * Resolve once every tail currently queued for this conversation has settled.
+ *
+ * Tests use this to await work the agent loop deliberately detached. Callers
+ * that chain a new tail after awaiting get a fresh promise, so this is a
+ * point-in-time barrier, not a permanent quiesce.
+ */
+export function settleTurnTail(conversationId: string): Promise<void> {
+  return chains.get(conversationId) ?? Promise.resolve();
+}
+
+/**
+ * Number of conversations with a live tail. Lets tests assert the map is
+ * released rather than growing per conversation.
+ *
+ * @internal
+ */
+export function __turnTailChainSizeForTests(): number {
+  return chains.size;
+}

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -7,7 +7,7 @@
  * double typed as `Conversation` (`makeWakeConversation`) that stubs only the
  * handful of members the wake touches — `getMessages`, `messages.push`,
  * `isProcessing`/`setProcessing`/`waitForIdle`, `currentTurnTrustContext`,
- * `setSubagentAllowedTools`, `drainQueue`, `maybeCompact`,
+ * `setSubagentAllowedTools`, `kickDrainQueue`, `maybeCompact`,
  * `contextWindowManager.estimateInputTokens`, and a scripted `agentLoop.run()`.
  *
  * The wake's side effects flow through the daemon boundary, so the
@@ -62,7 +62,7 @@ interface WakeConversationProbe {
   processingToggles: boolean[];
   /** Tail messages persisted via `addMessage`, in call order. */
   persistedTailCalls: Message[];
-  /** Number of times `drainQueue` was invoked. */
+  /** Number of times `kickDrainQueue` was invoked. */
   drainQueueCalls: number;
   /**
    * Cross-hook call sequence tag. Each push/persist/drain (and the
@@ -71,7 +71,7 @@ interface WakeConversationProbe {
    */
   callSequence: string[];
   /**
-   * Snapshot of the processing flag at the moment `drainQueue` was
+   * Snapshot of the processing flag at the moment `kickDrainQueue` was
    * invoked. Lets tests prove drain ran AFTER setProcessing(false),
    * rather than just inferring it from the order of recorded toggles.
    */
@@ -380,7 +380,7 @@ function makeWakeConversation(options: {
   scriptedTail?: Message[];
   scriptedEvents?: AgentEvent[];
   isProcessing?: boolean;
-  /** When true, omit `drainQueue` so we can verify the wake handles its absence. */
+  /** When true, omit `kickDrainQueue` so we can verify the wake handles its absence. */
   omitDrainQueue?: boolean;
   initialAllowedTools?: Set<string>;
   /** Replaces the default scripted `agentLoop.run` body entirely. */
@@ -471,7 +471,7 @@ function makeWakeConversation(options: {
 
   const runBody = options.runImpl ?? defaultRun;
 
-  const drainQueue = options.omitDrainQueue
+  const kickDrainQueue = options.omitDrainQueue
     ? undefined
     : async () => {
         probe.drainQueueCalls += 1;
@@ -597,7 +597,7 @@ function makeWakeConversation(options: {
     },
     buildCurrentSystemPrompt: () => "mock-system-prompt",
     modelOverride: undefined,
-    ...(drainQueue ? { drainQueue } : {}),
+    ...(kickDrainQueue ? { kickDrainQueue } : {}),
   };
 
   return conversation as unknown as WakeConversation;
@@ -2116,11 +2116,11 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.persistedTailCalls).toHaveLength(0);
   });
 
-  test("drainQueue is called in finally after a successful run", async () => {
+  test("kickDrainQueue is called in finally after a successful run", async () => {
     // Verifies Gap 1 fix: messages queued during a wake (because the
     // wake set `processing = true`) must be picked up after the wake
     // completes. Mirrors the canonical user-turn `finally` path which
-    // sets `processing = false` then calls `drainQueue`.
+    // sets `processing = false` then calls `kickDrainQueue`.
     const conversation = makeWakeConversation({
       baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
       scriptedAssistant: {
@@ -2152,7 +2152,7 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.isProcessing()).toBe(false);
   });
 
-  test("drainQueue is called in finally even when the agent loop throws", async () => {
+  test("kickDrainQueue is called in finally even when the agent loop throws", async () => {
     // Verifies the drain is in the finally block, not just on success.
     // A wake that crashes mid-run must still flush queued messages —
     // otherwise a transient LLM error strands every concurrent send.
@@ -2180,7 +2180,7 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.processingToggles).toEqual([true, false]);
   });
 
-  test("missing drainQueue hook is tolerated (no-op fallback)", async () => {
+  test("missing kickDrainQueue hook is tolerated (no-op fallback)", async () => {
     // The hook is intentionally optional so test stubs without a queue
     // can omit it. Production daemon always wires it.
     const conversation = makeWakeConversation({
@@ -2206,7 +2206,7 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.drainQueueCalls).toBe(0);
   });
 
-  test("drainQueue rejection does not propagate from the wake", async () => {
+  test("kickDrainQueue rejection does not propagate from the wake", async () => {
     // Defense in depth: if the queue drain throws (e.g. a poisoned
     // message), the wake itself must still resolve normally — the
     // drain failure is logged but never surfaced.
@@ -2217,7 +2217,7 @@ describe("wakeAgentForOpportunity", () => {
         content: [{ type: "text", text: "reply" }],
       },
     });
-    conversation.drainQueue = async () => {
+    conversation.kickDrainQueue = async () => {
       throw new Error("drain blew up");
     };
 
@@ -2280,7 +2280,7 @@ describe("wakeAgentForOpportunity", () => {
   });
 
   test(
-    "tail messages are pushed and persisted BEFORE drainQueue runs " +
+    "tail messages are pushed and persisted BEFORE the queue drain runs " +
       "(so dequeued turns see updated history)",
     async () => {
       // Locks in the round-3 fix: a user message queued during the wake
@@ -2293,7 +2293,7 @@ describe("wakeAgentForOpportunity", () => {
       //
       // Mirrors the canonical user-turn pattern in
       // conversation-agent-loop.ts: messages updated →
-      // processing=false → drainQueue.
+      // processing=false → kickDrainQueue.
       const firstAssistant: Message = {
         role: "assistant",
         content: [
@@ -2355,13 +2355,13 @@ describe("wakeAgentForOpportunity", () => {
   );
 
   test(
-    "silent no-op: drainQueue still runs (in finally) but nothing is " +
+    "silent no-op: the queue drain still runs (in finally) but nothing is " +
       "pushed, persisted, or emitted",
     async () => {
       // The wake's silent-no-op semantics must be preserved by the
       // round-3 reordering: an empty assistant reply produces no
       // visible text and no tool calls, so no push/persist/emit should
-      // happen. drainQueue must still run in the finally block so a
+      // happen. The queue drain must still run in the finally block so a
       // racy queued message is not stranded.
       const conversation = makeWakeConversation({
         baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -77,6 +77,7 @@ import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { conversationSupportsDynamicUi } from "../daemon/channel-ui-capability.js";
 import type { Conversation } from "../daemon/conversation.js";
+import type { QueueDrainReason } from "../daemon/conversation-queue-manager.js";
 import { recordUsage } from "../daemon/conversation-usage.js";
 import { getDiskPressureStatus } from "../daemon/disk-pressure-guard.js";
 import {
@@ -475,6 +476,47 @@ async function defaultResolveTarget(
   }
 }
 
+// ── Queue drain kick ──────────────────────────────────────────────────
+
+/**
+ * The queue-drain surface the wake kicks on its way out.
+ *
+ * The hook is optional because the wake runs against whatever
+ * {@link WakeDeps.resolveTarget} hands it, which in tests is a partial
+ * conversation double. Production `Conversation` always provides it.
+ */
+interface WakeDrainTarget {
+  kickDrainQueue?: (
+    reason?: QueueDrainReason,
+    origin?: string,
+  ) => Promise<void>;
+}
+
+/**
+ * Drain the target's message queue once the wake has released the
+ * conversation.
+ *
+ * `Conversation.kickDrainQueue` retries a failed drain once and notifies the
+ * queued senders when the retry also fails, so a stalled wake-tail drain is
+ * visible instead of silently stranding the queue, and it never rejects. An
+ * injected target can still omit the hook or reject from it, and neither may
+ * fail the wake, whose own work is already complete by this point.
+ */
+async function kickWakeDrainQueue(
+  conversation: WakeDrainTarget,
+  origin: string,
+  logContext: { conversationId: string; source: string },
+): Promise<void> {
+  try {
+    await conversation.kickDrainQueue?.("loop_complete", origin);
+  } catch (err) {
+    log.warn(
+      { ...logContext, err },
+      "agent-wake: kickDrainQueue threw; continuing",
+    );
+  }
+}
+
 // ── Per-conversation single-flight lock ───────────────────────────────
 //
 // When a wake arrives and another run is in flight for the same
@@ -754,7 +796,7 @@ export async function wakeAgentForOpportunity(
     // Apply the caller's persona override for the duration of the run. The
     // prompt is built once before `agentLoop.run()` (via
     // `conversation.buildCurrentSystemPrompt()`), which reads this field;
-    // cleared (below, before drainQueue) so a queued user turn never builds
+    // cleared (below, before the queue drain) so a queued user turn never builds
     // its prompt under the wake's override. Assigned only AFTER the
     // profile/config reads above — those can throw, and they run before the
     // try/finally that clears the override, so an earlier assignment would
@@ -1444,7 +1486,7 @@ export async function wakeAgentForOpportunity(
       // Run completed cleanly. The canonical user-turn pattern
       // (conversation-agent-loop.ts:1860, 2106-2126) updates
       // `ctx.messages` first, then clears the flag via `ctx.setProcessing(false)`, then
-      // calls `ctx.drainQueue(...)`. We mirror that order so a message
+      // calls `ctx.kickDrainQueue(...)`. We mirror that order so a message
       // queued during the wake dequeues against an already-updated
       // history — otherwise `drainSingleMessage` reads `ctx.messages`
       // mid-tail and writes a DB row that lands out of chronological
@@ -1467,7 +1509,7 @@ export async function wakeAgentForOpportunity(
         // Silent no-op: drop buffered events, push nothing, persist
         // nothing, emit nothing. (No checkpoint fired during the run
         // since checkpoints only fire after tool turns and there were
-        // none.) The finally still runs drainQueue so a racy queued
+        // none.) The finally still kicks the queue drain so a racy queued
         // message isn't stranded.
         return { invoked: true, producedToolCalls: false };
       }
@@ -1498,21 +1540,21 @@ export async function wakeAgentForOpportunity(
           "agent-wake: setProcessing(false) threw; continuing",
         );
       }
-      // `kickDrainQueue` never rejects: it retries a failed drain once and
-      // notifies the queued senders when the retry also fails, so a stalled
-      // wake-tail drain is visible instead of silently stranding the queue.
-      await conversation.kickDrainQueue("loop_complete", "agent_wake_tail");
+      await kickWakeDrainQueue(conversation, "agent_wake_tail", {
+        conversationId,
+        source,
+      });
       drainedInTry = true;
 
       return { invoked: true, producedToolCalls };
     } finally {
       // Put the conversation's resting trust back on every exit path.
       restorePersistentWakeTrust();
-      // The success path (above) already called setProcessing(false)
-      // + drainQueue after tail persist. This catch-all handles the
-      // error and early-return paths where no tail was produced — those
-      // exit the try body before reaching the drain block, so
-      // `drainedInTry` is still false.
+      // The success path (above) already called setProcessing(false) and
+      // kicked the queue drain after tail persist. This catch-all handles the
+      // error and early-return paths where no tail was produced: those exit
+      // the try body before reaching the drain block, so `drainedInTry` is
+      // still false.
       if (!drainedInTry) {
         restoreWakeAllowedTools();
         clearWakePersonaOverride();
@@ -1524,10 +1566,10 @@ export async function wakeAgentForOpportunity(
             "agent-wake: setProcessing(false) threw; continuing",
           );
         }
-        await conversation.kickDrainQueue(
-          "loop_complete",
-          "agent_wake_cleanup",
-        );
+        await kickWakeDrainQueue(conversation, "agent_wake_cleanup", {
+          conversationId,
+          source,
+        });
       }
 
       const durationMs = nowFn() - startedAt;

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1498,14 +1498,10 @@ export async function wakeAgentForOpportunity(
           "agent-wake: setProcessing(false) threw; continuing",
         );
       }
-      try {
-        await conversation.drainQueue();
-      } catch (err) {
-        log.warn(
-          { conversationId, source, err },
-          "agent-wake: drainQueue threw; continuing",
-        );
-      }
+      // `kickDrainQueue` never rejects: it retries a failed drain once and
+      // notifies the queued senders when the retry also fails, so a stalled
+      // wake-tail drain is visible instead of silently stranding the queue.
+      await conversation.kickDrainQueue("loop_complete", "agent_wake_tail");
       drainedInTry = true;
 
       return { invoked: true, producedToolCalls };
@@ -1528,14 +1524,10 @@ export async function wakeAgentForOpportunity(
             "agent-wake: setProcessing(false) threw; continuing",
           );
         }
-        try {
-          await conversation.drainQueue();
-        } catch (err) {
-          log.warn(
-            { conversationId, source, err },
-            "agent-wake: drainQueue threw; continuing",
-          );
-        }
+        await conversation.kickDrainQueue(
+          "loop_complete",
+          "agent_wake_cleanup",
+        );
       }
 
       const durationMs = nowFn() - startedAt;

--- a/assistant/src/runtime/routes/canned-reply-release.ts
+++ b/assistant/src/runtime/routes/canned-reply-release.ts
@@ -1,0 +1,54 @@
+/**
+ * Deferred release for the canned-reply routes (canned first greeting, unknown
+ * slash command).
+ *
+ * These routes answer without an agent loop, so they hold the processing lock
+ * themselves and are the only thing that will ever clear it. They publish their
+ * client events on the next tick so the HTTP 202 reaches the client first and
+ * its `serverToLocalConversationMap` is populated before any SSE arrives, and
+ * they release only after that burst so the next queued message cannot start
+ * processing ahead of the reply the client is still being told about.
+ *
+ * The release therefore has to be unconditional: a throw from any broadcast in
+ * the burst would otherwise latch the conversation "processing" with no agent
+ * loop, no `finally`, and no later path left to clear it, so every subsequent
+ * send is queued behind an idle conversation for the life of the daemon.
+ */
+
+import type { Conversation } from "../../daemon/conversation.js";
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("canned-reply-release");
+
+/** The conversation surface {@link scheduleCannedReplyRelease} touches. */
+export type CannedReplyReleaseTarget = Pick<
+  Conversation,
+  "setProcessing" | "kickDrainQueue"
+>;
+
+export function scheduleCannedReplyRelease(params: {
+  conversation: CannedReplyReleaseTarget;
+  /** Names the release site in drain logs (e.g. `"canned_greeting"`). */
+  origin: string;
+  /** The deferred client event burst. Runs before the release. */
+  emit: () => void;
+  /** Optional work that only makes sense once the lock is free. */
+  afterRelease?: () => void;
+}): void {
+  const { conversation, origin, emit, afterRelease } = params;
+  setTimeout(() => {
+    try {
+      emit();
+    } catch (err) {
+      // Swallowed rather than rethrown: this runs from a timer with no caller
+      // left to handle it, so an escaping error is an uncaught exception in
+      // the daemon process. The reply is already persisted, and clients
+      // reconcile a missed event burst on their next fetch.
+      log.error({ err, origin }, "Canned reply event burst failed");
+    } finally {
+      conversation.setProcessing(false);
+      void conversation.kickDrainQueue("loop_complete", origin);
+    }
+    afterRelease?.();
+  }, 0);
+}

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -174,6 +174,7 @@ import {
   emitCannedMessageComplete,
   persistCannedAssistantCard,
 } from "./canned-message-complete.js";
+import { scheduleCannedReplyRelease } from "./canned-reply-release.js";
 import { buildChannelMetadata } from "./channel-metadata.js";
 import {
   BadRequestError,
@@ -1986,34 +1987,37 @@ export async function handleSendMessage(
         }
       }
 
-      setTimeout(() => {
-        broadcastMessage({
-          type: "user_message_echo",
-          text: rawContent,
-          conversationId,
-          messageId: persisted.id,
-          clientMessageId,
-        });
-        broadcastMessage({
-          type: "assistant_text_delta",
-          text: cannedGreeting,
-          conversationId,
-        });
-        emitCannedMessageComplete(
-          broadcastMessage,
-          conversationId,
-          persistedAssistant.id,
-        );
-        // Rows persisted before this deferred burst; advance the
-        // snapshot↔stream anchor past the events just emitted so `/messages`
-        // never returns these rows behind a stale anchor.
-        recordConversationPersistedSeq(conversationId, getCurrentSeq());
-        publishConversationMessagesChanged(conversationId, originClientId);
-        conversation.setProcessing(false);
-        void conversation.kickDrainQueue("loop_complete", "canned_greeting");
-
-        conversation.warmPromptCache();
-      }, 0);
+      scheduleCannedReplyRelease({
+        conversation,
+        origin: "canned_greeting",
+        emit: () => {
+          broadcastMessage({
+            type: "user_message_echo",
+            text: rawContent,
+            conversationId,
+            messageId: persisted.id,
+            clientMessageId,
+          });
+          broadcastMessage({
+            type: "assistant_text_delta",
+            text: cannedGreeting,
+            conversationId,
+          });
+          emitCannedMessageComplete(
+            broadcastMessage,
+            conversationId,
+            persistedAssistant.id,
+          );
+          // Rows persisted before this deferred burst; advance the
+          // snapshot↔stream anchor past the events just emitted so `/messages`
+          // never returns these rows behind a stale anchor.
+          recordConversationPersistedSeq(conversationId, getCurrentSeq());
+          publishConversationMessagesChanged(conversationId, originClientId);
+        },
+        afterRelease: () => {
+          conversation.warmPromptCache();
+        },
+      });
 
       log.info(
         { conversationId, personalized: !!body.onboarding },
@@ -2311,33 +2315,35 @@ export async function handleSendMessage(
       // starts processing.
       const conversationId = mapping.conversationId;
       const message = slashResult.message;
-      setTimeout(() => {
-        broadcastMessage({
-          type: "user_message_echo",
-          text: rawContent,
-          conversationId,
-          messageId: persisted.id,
-          clientMessageId,
-        });
-        if (modelInfoEvent) {
-          broadcastMessage(modelInfoEvent);
-        }
-        broadcastMessage({
-          type: "assistant_text_delta",
-          text: message,
-          conversationId,
-        });
-        emitCannedMessageComplete(
-          broadcastMessage,
-          conversationId,
-          persistedAssistant.id,
-        );
-        // Same anchor advance as the canned-greeting path above.
-        recordConversationPersistedSeq(conversationId, getCurrentSeq());
-        publishConversationMessagesChanged(conversationId, originClientId);
-        conversation.setProcessing(false);
-        void conversation.kickDrainQueue("loop_complete", "slash_command");
-      }, 0);
+      scheduleCannedReplyRelease({
+        conversation,
+        origin: "slash_command",
+        emit: () => {
+          broadcastMessage({
+            type: "user_message_echo",
+            text: rawContent,
+            conversationId,
+            messageId: persisted.id,
+            clientMessageId,
+          });
+          if (modelInfoEvent) {
+            broadcastMessage(modelInfoEvent);
+          }
+          broadcastMessage({
+            type: "assistant_text_delta",
+            text: message,
+            conversationId,
+          });
+          emitCannedMessageComplete(
+            broadcastMessage,
+            conversationId,
+            persistedAssistant.id,
+          );
+          // Same anchor advance as the canned-greeting path above.
+          recordConversationPersistedSeq(conversationId, getCurrentSeq());
+          publishConversationMessagesChanged(conversationId, originClientId);
+        },
+      });
 
       cleanupDeferred = true;
       return response;

--- a/clients/web/src/domains/chat/components/queued-messages-drawer.test.tsx
+++ b/clients/web/src/domains/chat/components/queued-messages-drawer.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Touch affordances for `QueuedMessagesDrawer`.
+ *
+ * Every per-row control in the drawer is destructive (cancel and steer remove
+ * the message from the queue; edit cancels it and moves its text back into the
+ * composer), and the drawer sits directly above the composer where a thumb
+ * travels. On a coarse pointer the controls therefore stay behind a reveal tap;
+ * on a fine pointer they are always available, exactly as before.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import { QueuedMessagesDrawer } from "@/domains/chat/components/queued-messages-drawer";
+
+const originalMatchMedia = window.matchMedia;
+
+function setPointer(coarse: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: coarse && query === "(pointer: coarse)",
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+function queued(id: string, text: string): DisplayMessage {
+  return {
+    id,
+    role: "user",
+    contentBlocks: [{ type: "text", text }],
+    queueStatus: "queued",
+    queuePosition: 1,
+  } as DisplayMessage;
+}
+
+const MESSAGES = [queued("m-1", "first queued"), queued("m-2", "second queued")];
+
+function renderDrawer(overrides: Partial<Parameters<typeof QueuedMessagesDrawer>[0]> = {}) {
+  const onCancelMessage = mock((_id: string) => {});
+  const onSteer = mock((_id: string) => {});
+  const onEditTail = mock(() => {});
+  render(
+    <QueuedMessagesDrawer
+      queuedMessages={MESSAGES}
+      onCancelMessage={onCancelMessage}
+      onCancelAll={() => {}}
+      onSteer={onSteer}
+      showSteer
+      onEditTail={onEditTail}
+      {...overrides}
+    />,
+  );
+  return { onCancelMessage, onSteer, onEditTail };
+}
+
+/** The row element that owns a given preview, i.e. the reveal tap target. */
+function rowFor(text: string): HTMLElement {
+  const preview = screen.getByText(text);
+  const row = preview.parentElement;
+  if (!row) {
+    throw new Error(`no row for ${text}`);
+  }
+  return row;
+}
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+describe("QueuedMessagesDrawer: fine pointer", () => {
+  beforeEach(() => setPointer(false));
+
+  test("keeps every per-row control available without a reveal step", () => {
+    const { onCancelMessage } = renderDrawer();
+
+    expect(screen.queryAllByLabelText("Show queued message actions")).toEqual(
+      [],
+    );
+    const cancels = screen.getAllByLabelText("Cancel queued message");
+    expect(cancels.length).toBe(2);
+    expect(screen.getAllByLabelText("Push to agent").length).toBe(2);
+    // Only the tail is editable.
+    expect(screen.getAllByLabelText("Edit queued message").length).toBe(1);
+
+    fireEvent.click(cancels[0]!);
+    expect(onCancelMessage).toHaveBeenCalledWith("m-1");
+  });
+});
+
+describe("QueuedMessagesDrawer: coarse pointer", () => {
+  beforeEach(() => setPointer(true));
+
+  test("hides the destructive controls until a row is tapped", () => {
+    renderDrawer();
+
+    expect(screen.queryAllByLabelText("Cancel queued message")).toEqual([]);
+    expect(screen.queryAllByLabelText("Push to agent")).toEqual([]);
+    expect(screen.queryAllByLabelText("Edit queued message")).toEqual([]);
+    expect(
+      screen.getAllByLabelText("Show queued message actions").length,
+    ).toBe(2);
+  });
+
+  test("first tap reveals only that row; a second tap activates a control", () => {
+    const { onCancelMessage } = renderDrawer();
+
+    fireEvent.click(rowFor("first queued"));
+    expect(onCancelMessage).not.toHaveBeenCalled();
+
+    const cancels = screen.getAllByLabelText("Cancel queued message");
+    expect(cancels.length).toBe(1);
+    // The untapped row keeps its controls hidden.
+    expect(
+      screen.getAllByLabelText("Show queued message actions").length,
+    ).toBe(1);
+
+    fireEvent.click(cancels[0]!);
+    expect(onCancelMessage).toHaveBeenCalledWith("m-1");
+  });
+
+  test("tapping another row moves the reveal instead of arming both", () => {
+    renderDrawer();
+
+    fireEvent.click(rowFor("first queued"));
+    fireEvent.click(rowFor("second queued"));
+
+    expect(screen.getAllByLabelText("Cancel queued message").length).toBe(1);
+    // The tail row is the editable one, so the reveal has moved to it.
+    expect(screen.getAllByLabelText("Edit queued message").length).toBe(1);
+  });
+
+  test("a tap outside the drawer disarms the revealed row", () => {
+    renderDrawer();
+
+    fireEvent.click(rowFor("first queued"));
+    expect(screen.getAllByLabelText("Cancel queued message").length).toBe(1);
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryAllByLabelText("Cancel queued message")).toEqual([]);
+    expect(
+      screen.getAllByLabelText("Show queued message actions").length,
+    ).toBe(2);
+  });
+});

--- a/clients/web/src/domains/chat/components/queued-messages-drawer.tsx
+++ b/clients/web/src/domains/chat/components/queued-messages-drawer.tsx
@@ -1,9 +1,18 @@
-import { ArrowUp, Pencil, X } from "lucide-react";
-import { useCallback, useMemo, type ReactNode } from "react";
+import { ArrowUp, MoreHorizontal, Pencil, X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
+import { isPointerCoarse } from "@/utils/pointer";
 import { Button } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library/utils/cn";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,6 +39,10 @@ interface QueuedMessageRowProps {
   onSteer: () => void;
   showSteer: boolean;
   onEdit: () => void;
+  /** Coarse pointer: this row's controls stay behind a reveal tap. */
+  twoStep: boolean;
+  revealed: boolean;
+  onReveal: () => void;
 }
 
 function QueuedMessageRow({
@@ -40,10 +53,23 @@ function QueuedMessageRow({
   onSteer,
   showSteer,
   onEdit,
+  twoStep,
+  revealed,
+  onReveal,
 }: QueuedMessageRowProps) {
   const preview = useMemo(() => messagePlainText(message), [message]);
+  const awaitingReveal = twoStep && !revealed;
   return (
-    <div className="flex items-center gap-1.5 rounded-md py-0.5 md:gap-2 md:px-2 md:py-1.5">
+    <div
+      className={cn(
+        "flex items-center gap-1.5 rounded-md py-0.5 md:gap-2 md:px-2 md:py-1.5",
+        awaitingReveal && "cursor-pointer",
+      )}
+      // Tapping anywhere on the row is the first of the two steps, so the
+      // reveal target is the whole row rather than only the small icon. The
+      // icon below is the accessible control; this is a convenience target.
+      onClick={awaitingReveal ? onReveal : undefined}
+    >
       {/* Accent bar */}
       <div className="h-4 w-0.5 shrink-0 rounded-full bg-[var(--system-mid-strong)] md:h-5" />
 
@@ -59,34 +85,47 @@ function QueuedMessageRow({
 
       {/* Action icons */}
       <div className="flex shrink-0 items-center gap-0.5">
-        {showSteer && (
+        {awaitingReveal ? (
           <Button
             variant="ghost"
             size="compact"
             className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
-            iconOnly={<ArrowUp className="h-3.5 w-3.5" />}
-            onClick={onSteer}
-            aria-label="Push to agent"
+            iconOnly={<MoreHorizontal className="h-3.5 w-3.5" />}
+            onClick={onReveal}
+            aria-label="Show queued message actions"
           />
+        ) : (
+          <>
+            {showSteer && (
+              <Button
+                variant="ghost"
+                size="compact"
+                className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
+                iconOnly={<ArrowUp className="h-3.5 w-3.5" />}
+                onClick={onSteer}
+                aria-label="Push to agent"
+              />
+            )}
+            {isTail && (
+              <Button
+                variant="ghost"
+                size="compact"
+                className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
+                iconOnly={<Pencil className="h-3.5 w-3.5" />}
+                onClick={onEdit}
+                aria-label="Edit queued message"
+              />
+            )}
+            <Button
+              variant="ghost"
+              size="compact"
+              className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
+              iconOnly={<X className="h-3.5 w-3.5" />}
+              onClick={onCancel}
+              aria-label="Cancel queued message"
+            />
+          </>
         )}
-        {isTail && (
-          <Button
-            variant="ghost"
-            size="compact"
-            className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
-            iconOnly={<Pencil className="h-3.5 w-3.5" />}
-            onClick={onEdit}
-            aria-label="Edit queued message"
-          />
-        )}
-        <Button
-          variant="ghost"
-          size="compact"
-          className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
-          iconOnly={<X className="h-3.5 w-3.5" />}
-          onClick={onCancel}
-          aria-label="Cancel queued message"
-        />
       </div>
     </div>
   );
@@ -96,6 +135,19 @@ function QueuedMessageRow({
 // Main component
 // ---------------------------------------------------------------------------
 
+/**
+ * The pending-queue list shown above the composer, with per-row steer, edit,
+ * and cancel controls.
+ *
+ * Every one of those controls is destructive: cancel and steer both take the
+ * message out of the queue, and edit moves its text back into the composer
+ * after cancelling it. On a fine pointer they are safe to leave visible, since
+ * a mouse click lands where it is aimed. On a coarse pointer they are not: the
+ * rows are small, the drawer sits directly above the composer, and a stray
+ * thumb on the way to the text field would otherwise fire one of them outright.
+ * So touch gets a two-step reveal (one tap arms a single row, the next
+ * activates a control on it), and a tap anywhere else disarms it again.
+ */
 export function QueuedMessagesDrawer({
   queuedMessages,
   onCancelMessage,
@@ -104,6 +156,14 @@ export function QueuedMessagesDrawer({
   showSteer,
   onEditTail,
 }: QueuedMessagesDrawerProps): ReactNode {
+  // Read once per mount: the primary pointer does not change under a live
+  // component, and re-reading per render would fight the reveal state.
+  const twoStep = useMemo(() => isPointerCoarse(), []);
+  const [revealedMessageId, setRevealedMessageId] = useState<string | null>(
+    null,
+  );
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
   const handleCancelMessage = useCallback(
     (messageId: string) => {
       onCancelMessage(messageId);
@@ -111,12 +171,48 @@ export function QueuedMessagesDrawer({
     [onCancelMessage],
   );
 
+  // A tap outside the drawer disarms the revealed row, so the controls are
+  // never left armed behind an unrelated interaction. Taps on another row
+  // re-target the reveal instead, which the row handler already does.
+  useEffect(() => {
+    if (revealedMessageId === null) {
+      return;
+    }
+    const onPointerDown = (event: PointerEvent) => {
+      const container = containerRef.current;
+      if (
+        container &&
+        event.target instanceof Node &&
+        container.contains(event.target)
+      ) {
+        return;
+      }
+      setRevealedMessageId(null);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [revealedMessageId]);
+
+  // A row that leaves the queue must not keep the reveal armed for whatever
+  // row inherits its position.
+  useEffect(() => {
+    if (
+      revealedMessageId !== null &&
+      !queuedMessages.some((m) => m.id === revealedMessageId)
+    ) {
+      setRevealedMessageId(null);
+    }
+  }, [queuedMessages, revealedMessageId]);
+
   if (queuedMessages.length === 0) {
     return null;
   }
 
   return (
-    <div className="animate-in slide-in-from-bottom-2 fade-in w-full duration-200">
+    <div
+      ref={containerRef}
+      className="animate-in slide-in-from-bottom-2 fade-in w-full duration-200"
+    >
       <div className="mb-1 rounded-xl border border-[var(--border-base)] bg-[var(--surface-overlay)] px-2 py-1 md:mb-2 md:px-3 md:py-2">
         {/* Header */}
         <div className="mb-0.5 flex items-center justify-between md:mb-1">
@@ -145,6 +241,9 @@ export function QueuedMessagesDrawer({
               onSteer={() => onSteer(msg.id)}
               showSteer={showSteer}
               onEdit={onEditTail}
+              twoStep={twoStep}
+              revealed={revealedMessageId === msg.id}
+              onReveal={() => setRevealedMessageId(msg.id)}
             />
           ))}
         </div>

--- a/clients/web/src/domains/chat/hooks/use-conversation-history-processing-revalidate.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-processing-revalidate.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Tests for the server-processing revalidation in `useConversationHistory`.
+ *
+ * `isAssistantBusy` treats the daemon's snapshot `processing: true` as
+ * authoritative, so when nothing local agrees with it (idle phase, conversation
+ * not flagged processing) that flag alone renders the busy affordances and no
+ * local signal is left to fall. This timer is the only exit from that state.
+ *
+ * bun:test ships no fake-timer API, so `setInterval` is stubbed to capture the
+ * armed timer and its delay instead of waiting one out.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+const realPaginationModule = await import(
+  "@/domains/chat/transcript/use-history-pagination"
+);
+
+let currentProcessing: boolean | undefined;
+let invalidateCalls = 0;
+
+function latestPageStub(): PaginatedHistoryResult {
+  return {
+    messages: [],
+    hasMore: false,
+    oldestTimestamp: null,
+    oldestMessageId: null,
+    seq: 10,
+    processing: currentProcessing,
+    backgroundToolCompletions: [],
+  };
+}
+
+function paginationStub(): HistoryPaginationResult {
+  return {
+    messages: [],
+    latestPage: latestPageStub(),
+    subagentNotifications: undefined,
+    backgroundToolCompletions: undefined,
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+    hasMore: false,
+    isFetchingOlderPages: false,
+    isFetching: false,
+    fetchOlderPage: () => {},
+    invalidate: async () => {
+      invalidateCalls += 1;
+    },
+    removeCache: () => {},
+    latestPageOldestTimestamp: null,
+    oldestLoadedTimestamp: null,
+    dataUpdatedAt: 1,
+  };
+}
+
+mock.module("@/domains/chat/transcript/use-history-pagination", () => ({
+  ...realPaginationModule,
+  useHistoryPagination: () => paginationStub(),
+}));
+
+mock.module("@/domains/chat/api/interactions", () => ({
+  getPendingInteractions: async () => ({}),
+}));
+
+const { SERVER_PROCESSING_REVALIDATE_MS, useConversationHistory } =
+  await import("@/domains/chat/hooks/use-conversation-history");
+
+// --- setInterval capture ----------------------------------------------------
+
+interface ArmedTimer {
+  handler: () => void;
+  delay: number;
+  cleared: boolean;
+}
+
+let armedTimers: ArmedTimer[] = [];
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+
+function revalidateTimers(): ArmedTimer[] {
+  return armedTimers.filter(
+    (timer) => timer.delay === SERVER_PROCESSING_REVALIDATE_MS,
+  );
+}
+
+const queryClient = new QueryClient();
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderHistory() {
+  return renderHook(
+    () =>
+      useConversationHistory({
+        assistantId: "asst-1",
+        assistantStateKind: "active",
+        activeConversationId: "conv-A",
+      }),
+    { wrapper: Wrapper },
+  );
+}
+
+beforeEach(() => {
+  currentProcessing = undefined;
+  invalidateCalls = 0;
+  armedTimers = [];
+  useTurnStore.setState({ ...INITIAL_TURN_STATE });
+  useConversationStore.setState({ processingConversationIds: new Set() });
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+
+  globalThis.setInterval = ((handler: () => void, delay: number) => {
+    const timer: ArmedTimer = { handler, delay, cleared: false };
+    armedTimers.push(timer);
+    return armedTimers.length as unknown as ReturnType<typeof setInterval>;
+  }) as typeof globalThis.setInterval;
+  globalThis.clearInterval = ((id: number) => {
+    const timer = armedTimers[id - 1];
+    if (timer) {
+      timer.cleared = true;
+    }
+  }) as typeof globalThis.clearInterval;
+});
+
+afterEach(() => {
+  globalThis.setInterval = realSetInterval;
+  globalThis.clearInterval = realClearInterval;
+  cleanup();
+  useTurnStore.setState({ ...INITIAL_TURN_STATE });
+  useConversationStore.setState({ processingConversationIds: new Set() });
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+});
+
+describe("useConversationHistory: server-processing revalidation", () => {
+  test("polls while the daemon flag is the only thing holding the UI busy", () => {
+    currentProcessing = true;
+
+    renderHistory();
+
+    const timers = revalidateTimers();
+    expect(timers.length).toBe(1);
+
+    act(() => {
+      timers[0]?.handler();
+    });
+    expect(invalidateCalls).toBe(1);
+  });
+
+  test("stops polling once a local turn takes over the busy state", () => {
+    // The turn store is reset by the conversation switch this hook performs,
+    // so the local turn has to start after the first render.
+    currentProcessing = true;
+
+    renderHistory();
+    expect(revalidateTimers().length).toBe(1);
+
+    act(() => {
+      useTurnStore.getState().requestSend("turn-1");
+    });
+
+    expect(revalidateTimers().every((timer) => timer.cleared)).toBe(true);
+  });
+
+  test("stops polling while the conversation is flagged processing", () => {
+    // The falling edge of `processingConversationIds` already reseeds, so a
+    // passively-observed external-channel turn needs no timer.
+    currentProcessing = true;
+
+    renderHistory();
+    expect(revalidateTimers().length).toBe(1);
+
+    act(() => {
+      useConversationStore.setState({
+        processingConversationIds: new Set(["conv-A"]),
+      });
+    });
+
+    expect(revalidateTimers().every((timer) => timer.cleared)).toBe(true);
+  });
+
+  test("does not poll once the daemon reports the conversation idle", () => {
+    currentProcessing = false;
+
+    renderHistory();
+
+    expect(revalidateTimers().length).toBe(0);
+  });
+
+  test("stops polling as soon as a reseed reports the conversation idle", () => {
+    currentProcessing = true;
+
+    renderHistory();
+    expect(revalidateTimers().length).toBe(1);
+
+    act(() => {
+      useChatSessionStore.setState((state) => ({
+        snapshot: state.snapshot
+          ? { ...state.snapshot, processing: false }
+          : state.snapshot,
+      }));
+    });
+
+    expect(revalidateTimers()[0]?.cleared).toBe(true);
+    expect(revalidateTimers().length).toBe(1);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -15,6 +15,11 @@
  *   reseeds the materialized snapshot from the authoritative server copy,
  *   replacing the client-folded turn with canonical ids/ordering.
  *
+ * - **The snapshot reporting `processing: true` with nothing local agreeing**:
+ *   the daemon's flag alone is holding the UI busy, so revalidate on a timer
+ *   until a reseed reports the conversation idle. This is the only exit from
+ *   that state, since no local signal is left to fall.
+ *
  * Conversation-switch resets are owned by the store's `switchToConversation()`.
  *
  * @see {@link https://tanstack.com/query/latest/docs/framework/react/guides/infinite-queries}
@@ -78,6 +83,22 @@ export interface ConversationHistoryResult {
 }
 
 type HistoryCache = InfiniteData<PaginatedHistoryResult>;
+
+/**
+ * How often the history snapshot is revalidated while the daemon's
+ * `processing: true` flag is the only thing holding the UI in its busy state
+ * (Stop button, spinner, no send affordance).
+ *
+ * `isAssistantBusy` treats that flag as authoritative, so nothing local can
+ * retire it: the local phase is already idle and no assistant row is streaming,
+ * which is precisely why the falling-edge reseed below never fires. Re-reading
+ * `/messages` on this cadence is what turns the flag back to `false` once the
+ * daemon releases the lock, bounding how long a stale `true` can hold the UI
+ * busy. Short enough that a user staring at a wedged Stop button gets out
+ * quickly, long enough that it costs one request per few seconds in a state
+ * that is already anomalous.
+ */
+export const SERVER_PROCESSING_REVALIDATE_MS = 4_000;
 
 /**
  * Structural equality for surface `data` payloads. Both sides come from the
@@ -464,6 +485,40 @@ export function useConversationHistory({
       refetchHistoryOnTurnEnd();
     }
   }, [activeInProgress, refetchHistoryOnTurnEnd]);
+
+  // -------------------------------------------------------------------------
+  // Server-processing revalidation. The daemon's snapshot `processing` flag is
+  // authoritative for `isAssistantBusy`, so when it reads `true` while nothing
+  // local agrees (idle phase, conversation not flagged processing) it is the
+  // sole thing rendering the busy affordances, and the falling-edge reseed
+  // above can never fire to retire it. Poll `/messages` for exactly as long as
+  // that holds: the first reseed carrying `processing: false` clears the busy
+  // state through the existing close-gate and stops the timer. `invalidate` is
+  // stable per conversation, so the interval is armed once per episode rather
+  // than restarted on every render.
+  // -------------------------------------------------------------------------
+  const snapshotProcessing = useChatSessionStore((s) => s.snapshot?.processing);
+  const serverProcessingIsSoleBusySignal =
+    snapshotProcessing === true && !activeInProgress;
+  const invalidateHistory = pagination.invalidate;
+  useEffect(() => {
+    if (
+      !serverProcessingIsSoleBusySignal ||
+      !assistantId ||
+      !activeConversationId
+    ) {
+      return;
+    }
+    const timer = setInterval(() => {
+      void invalidateHistory();
+    }, SERVER_PROCESSING_REVALIDATE_MS);
+    return () => clearInterval(timer);
+  }, [
+    serverProcessingIsSoleBusySignal,
+    assistantId,
+    activeConversationId,
+    invalidateHistory,
+  ]);
 
   // -------------------------------------------------------------------------
   // Refetch history when the SSE connection reopens after a disconnect.

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -32,6 +32,7 @@ import { routes } from "@/utils/routes";
 import { useNavigate } from "react-router";
 
 import { useConversationHistory } from "@/domains/chat/hooks/use-conversation-history";
+import { useTurnTimeout } from "@/domains/chat/hooks/use-turn-timeout";
 import type { AssistantStateKind } from "@/domains/chat/types";
 import { shouldSuppressGenericChatErrorNotice } from "@/domains/chat/utils/error-classification";
 import { useQueryClient } from "@tanstack/react-query";
@@ -86,6 +87,7 @@ interface UseConversationLoaderParams {
  *
  * Delegates to:
  * - `useConversationHistory` -- conversation switch, cache, and history loading
+ * - `useTurnTimeout` -- terminates a turn whose stream went silent
  *
  * Attention/processing-key tracking is owned by `useAttentionTracking`,
  * mounted in `ChatLayout` so the bus-driven `interaction_resolved`
@@ -414,6 +416,12 @@ export function useConversationLoader({
     assistantStateKind,
     activeConversationId,
   });
+
+  // -------------------------------------------------------------------------
+  // Delegate: stranded-turn watchdog. Terminates a turn whose stream went
+  // silent and revalidates history so the UI settles on server truth.
+  // -------------------------------------------------------------------------
+  useTurnTimeout({ assistantId, activeConversationId });
 
   // -------------------------------------------------------------------------
   // switchConversation

--- a/clients/web/src/domains/chat/hooks/use-message-queue.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.ts
@@ -103,9 +103,18 @@ export function useMessageQueue({
           requestId: targetRequestId,
           messageId,
           setOptimisticSends,
+          // The daemon broadcasts `message_queued_deleted` before answering
+          // the DELETE, so the stream handler can pop the mapping ahead of
+          // this callback. Whichever path pops it spends the queue slot, which
+          // keeps a cancel to exactly one decrement on this tab.
           onDeleted: () => {
-            useChatSessionStore.getState().popRequestIdMapping(targetRequestId);
-            useTurnStore.getState().deleteQueuedMessage();
+            if (
+              useChatSessionStore
+                .getState()
+                .popRequestIdMapping(targetRequestId)
+            ) {
+              useTurnStore.getState().deleteQueuedMessage();
+            }
           },
         });
       } else {

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -819,9 +819,17 @@ export function useSendMessage({
                 requestId,
                 messageId: userMessage.id,
                 setOptimisticSends,
+                // The daemon broadcasts the cancel before answering the
+                // DELETE, so the stream handler can pop the mapping first.
+                // Whichever path pops it spends the queue slot.
                 onDeleted: () => {
-                  useChatSessionStore.getState().popRequestIdMapping(requestId);
-                  useTurnStore.getState().deleteQueuedMessage();
+                  if (
+                    useChatSessionStore
+                      .getState()
+                      .popRequestIdMapping(requestId)
+                  ) {
+                    useTurnStore.getState().deleteQueuedMessage();
+                  }
                 },
               });
             }

--- a/clients/web/src/domains/chat/hooks/use-turn-timeout.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-turn-timeout.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for `useTurnTimeout`, the watchdog that terminates a turn whose stream
+ * has gone completely silent.
+ *
+ * bun:test ships no fake-timer API, so the hook's `timeoutMs` override drives
+ * the watchdog on a millisecond scale with real timers.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
+import {
+  TURN_SILENCE_TIMEOUT_MS,
+  useTurnTimeout,
+} from "@/domains/chat/hooks/use-turn-timeout";
+
+const TEST_TIMEOUT_MS = 20;
+
+let invalidatedKeys: unknown[][] = [];
+let queryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function mount(timeoutMs: number = TEST_TIMEOUT_MS) {
+  return renderHook(
+    () =>
+      useTurnTimeout({
+        assistantId: "asst-1",
+        activeConversationId: "conv-A",
+        timeoutMs,
+      }),
+    { wrapper: Wrapper },
+  );
+}
+
+function seedSnapshot(seq: number) {
+  useChatSessionStore.setState({
+    snapshot: {
+      messages: [],
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+      seq,
+    },
+  });
+}
+
+beforeEach(() => {
+  invalidatedKeys = [];
+  queryClient = new QueryClient();
+  queryClient.invalidateQueries = mock(
+    async (filters?: { queryKey?: unknown[] }) => {
+      invalidatedKeys.push(filters?.queryKey ?? []);
+    },
+  ) as unknown as QueryClient["invalidateQueries"];
+  useTurnStore.setState({ ...INITIAL_TURN_STATE });
+  useChatSessionStore.setState({ snapshot: null });
+});
+
+afterEach(() => {
+  cleanup();
+  useTurnStore.setState({ ...INITIAL_TURN_STATE });
+  useChatSessionStore.setState({ snapshot: null });
+});
+
+describe("useTurnTimeout", () => {
+  test("the shipped bound is minutes, not seconds", () => {
+    // A turn that pauses on a slow tool call must never be cut short; the
+    // watchdog exists for total silence, so the default has to be far above
+    // any plausible gap between events.
+    expect(TURN_SILENCE_TIMEOUT_MS).toBeGreaterThanOrEqual(60_000);
+  });
+
+  test("stays disarmed while the turn phase is idle", async () => {
+    mount();
+
+    await new Promise((resolve) => setTimeout(resolve, TEST_TIMEOUT_MS * 3));
+
+    expect(useTurnStore.getState().phase).toBe("idle");
+    expect(useTurnStore.getState().lastTerminalReason).toBeNull();
+  });
+
+  test("arms on turn start and terminates a silent turn", async () => {
+    mount();
+
+    act(() => {
+      useTurnStore.getState().requestSend("turn-1");
+    });
+    expect(useTurnStore.getState().phase).toBe("thinking");
+
+    await waitFor(() => {
+      expect(useTurnStore.getState().phase).toBe("idle");
+    });
+    expect(useTurnStore.getState().lastTerminalReason).toBe("timeout");
+    expect(useTurnStore.getState().activeTurnId).toBeNull();
+  });
+
+  test("revalidates history when it fires so the UI settles on server truth", async () => {
+    mount();
+
+    act(() => {
+      useTurnStore.getState().requestSend("turn-1");
+    });
+
+    await waitFor(() => {
+      expect(invalidatedKeys.length).toBeGreaterThan(0);
+    });
+    expect(invalidatedKeys[0]).toEqual([
+      "conversation-history",
+      "asst-1",
+      "conv-A",
+    ]);
+  });
+
+  test("a terminal event before the bound disarms it", async () => {
+    mount();
+
+    act(() => {
+      useTurnStore.getState().requestSend("turn-1");
+    });
+    act(() => {
+      useTurnStore.getState().completeTurn();
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, TEST_TIMEOUT_MS * 3));
+
+    expect(useTurnStore.getState().lastTerminalReason).toBe("complete");
+    expect(invalidatedKeys).toEqual([]);
+  });
+
+  test("stream activity re-arms it, so a long but live turn survives", async () => {
+    seedSnapshot(1);
+    mount();
+
+    act(() => {
+      useTurnStore.getState().requestSend("turn-1");
+    });
+
+    // Each folded event advances the snapshot's seq; keep advancing it for
+    // longer than the bound and the turn must still be running.
+    for (let seq = 2; seq <= 8; seq++) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.floor(TEST_TIMEOUT_MS / 2)),
+      );
+      act(() => {
+        seedSnapshot(seq);
+      });
+    }
+
+    expect(useTurnStore.getState().phase).toBe("thinking");
+    expect(invalidatedKeys).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-turn-timeout.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-turn-timeout.test.tsx
@@ -17,6 +17,7 @@ import {
   TURN_SILENCE_TIMEOUT_MS,
   useTurnTimeout,
 } from "@/domains/chat/hooks/use-turn-timeout";
+import { useConversationStore } from "@/stores/conversation-store";
 
 const TEST_TIMEOUT_MS = 20;
 
@@ -63,12 +64,14 @@ beforeEach(() => {
   ) as unknown as QueryClient["invalidateQueries"];
   useTurnStore.setState({ ...INITIAL_TURN_STATE });
   useChatSessionStore.setState({ snapshot: null });
+  useConversationStore.getState().removeProcessingConversationId("conv-A");
 });
 
 afterEach(() => {
   cleanup();
   useTurnStore.setState({ ...INITIAL_TURN_STATE });
   useChatSessionStore.setState({ snapshot: null });
+  useConversationStore.getState().removeProcessingConversationId("conv-A");
 });
 
 describe("useTurnTimeout", () => {
@@ -118,6 +121,29 @@ describe("useTurnTimeout", () => {
       "asst-1",
       "conv-A",
     ]);
+  });
+
+  test("clears the conversation's processing key so the reconciliation poll can run", async () => {
+    // `useConversationHistory` counts `processingConversationIds` into
+    // `activeInProgress`, which gates its periodic revalidation off. Leaving
+    // the key set would starve the poll, so the watchdog's own one-shot
+    // refetch would be the last word and a finished conversation could read
+    // busy forever.
+    act(() => {
+      useConversationStore.getState().addProcessingConversationId("conv-A");
+    });
+    mount();
+
+    act(() => {
+      useTurnStore.getState().requestSend("turn-1");
+    });
+
+    await waitFor(() => {
+      expect(useTurnStore.getState().phase).toBe("idle");
+    });
+    expect(
+      useConversationStore.getState().processingConversationIds.has("conv-A"),
+    ).toBe(false);
   });
 
   test("a terminal event before the bound disarms it", async () => {

--- a/clients/web/src/domains/chat/hooks/use-turn-timeout.ts
+++ b/clients/web/src/domains/chat/hooks/use-turn-timeout.ts
@@ -15,6 +15,17 @@
  * phase is the less trustworthy half of the state: the refetched snapshot
  * carries the daemon's authoritative `processing` flag, so the UI converges on
  * server truth (still busy, or genuinely idle) rather than on a guess.
+ *
+ * Firing therefore runs the same two-store terminal transition every other
+ * terminal path runs, via `endTurn`. Clearing the conversation's processing key
+ * is not cosmetic: `useConversationHistory` counts that set into
+ * `activeInProgress`, which gates its periodic `snapshotProcessing`
+ * revalidation off. Idling only the turn store would leave the watchdog's own
+ * one-shot refetch as the last word, so a conversation the daemon really did
+ * finish would stay busy forever. Leaving it asserts nothing about the server:
+ * if the daemon is still processing, the revalidation reseeds
+ * `snapshotProcessing`, which re-drives busy and re-arms the poll that keeps
+ * reconciling.
  */
 
 import { useEffect } from "react";
@@ -23,6 +34,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { conversationHistoryQueryKey } from "@/domains/chat/transcript/use-history-pagination";
+import { endTurn } from "@/domains/chat/turn-coordinator";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 import { recordDiagnostic } from "@/lib/diagnostics";
 
@@ -74,7 +86,7 @@ export function useTurnTimeout({
         snapshotSeq,
         timeoutMs,
       });
-      useTurnStore.getState().onTurnTimeout();
+      endTurn({ conversationId: activeConversationId, reason: "timeout" });
       if (assistantId && activeConversationId) {
         void queryClient.invalidateQueries({
           queryKey: conversationHistoryQueryKey(

--- a/clients/web/src/domains/chat/hooks/use-turn-timeout.ts
+++ b/clients/web/src/domains/chat/hooks/use-turn-timeout.ts
@@ -1,0 +1,98 @@
+/**
+ * Watchdog for a turn that has gone completely silent.
+ *
+ * The turn store's phase only leaves a sending state on a terminal signal
+ * (`message_complete`, `assistant_activity_state(idle)`, cancel, error). When
+ * every one of those is lost (the stream dies mid-turn, the daemon is killed,
+ * a reconnect lands outside the replay ring), the phase stays in a sending
+ * state indefinitely, which keeps the composer showing Stop instead of Send.
+ * `onTurnTimeout` is the store's terminal transition for exactly that case; this
+ * hook is what arms it.
+ *
+ * The timer measures silence, not turn duration: it is re-armed on every signal
+ * that a turn is making progress, so a legitimately long turn never trips it.
+ * Firing is deliberately paired with a history revalidation, because the local
+ * phase is the less trustworthy half of the state: the refetched snapshot
+ * carries the daemon's authoritative `processing` flag, so the UI converges on
+ * server truth (still busy, or genuinely idle) rather than on a guess.
+ */
+
+import { useEffect } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { conversationHistoryQueryKey } from "@/domains/chat/transcript/use-history-pagination";
+import { isSending, useTurnStore } from "@/domains/chat/turn-store";
+import { recordDiagnostic } from "@/lib/diagnostics";
+
+/**
+ * How long a turn may go without a single progress signal before it is treated
+ * as stranded. Every stream event for the active conversation advances the
+ * rolling snapshot's `seq`, and turn-level transitions move the phase or the
+ * tool-call count, so an active turn re-arms the timer continuously. Total
+ * silence for this long means the client has lost the turn, not that the agent
+ * is thinking: generous enough to sit out a slow tool call that emits nothing,
+ * short enough that a wedged composer recovers without a reload.
+ */
+export const TURN_SILENCE_TIMEOUT_MS = 180_000;
+
+interface UseTurnTimeoutParams {
+  assistantId: string | null;
+  activeConversationId: string | null;
+  /** Overridable so tests can drive the watchdog without waiting it out. */
+  timeoutMs?: number;
+}
+
+export function useTurnTimeout({
+  assistantId,
+  activeConversationId,
+  timeoutMs = TURN_SILENCE_TIMEOUT_MS,
+}: UseTurnTimeoutParams): void {
+  const queryClient = useQueryClient();
+
+  const phase = useTurnStore.use.phase();
+  const activeTurnId = useTurnStore.use.activeTurnId();
+  const activeToolCallCount = useTurnStore.use.activeToolCallCount();
+  // Every event folded into the active conversation's snapshot advances `seq`,
+  // making it the finest-grained progress signal available: text deltas, tool
+  // output chunks, and activity-state updates all re-arm the timer through it
+  // even when none of them change the turn phase.
+  const snapshotSeq = useChatSessionStore((s) => s.snapshot?.seq ?? null);
+
+  useEffect(() => {
+    if (!isSending(phase)) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      recordDiagnostic("turn_timeout_fired", {
+        assistantId,
+        conversationId: activeConversationId,
+        phase,
+        activeTurnId,
+        activeToolCallCount,
+        snapshotSeq,
+        timeoutMs,
+      });
+      useTurnStore.getState().onTurnTimeout();
+      if (assistantId && activeConversationId) {
+        void queryClient.invalidateQueries({
+          queryKey: conversationHistoryQueryKey(
+            assistantId,
+            activeConversationId,
+          ),
+        });
+      }
+    }, timeoutMs);
+    return () => clearTimeout(timer);
+  }, [
+    phase,
+    activeTurnId,
+    activeToolCallCount,
+    snapshotSeq,
+    assistantId,
+    activeConversationId,
+    timeoutMs,
+    queryClient,
+  ]);
+}

--- a/clients/web/src/domains/chat/turn-coordinator.ts
+++ b/clients/web/src/domains/chat/turn-coordinator.ts
@@ -18,14 +18,15 @@
  * paths can't accidentally skip the conversation-store cleanup — there
  * is only one call to make.
  *
- * The five terminal reasons map 1:1 onto turn-store's terminal actions:
+ * The six terminal reasons map 1:1 onto turn-store's terminal actions:
  *
  *   reason            | turn-store action       | extra args
  *   ------------------|-------------------------|------------------------
- *   "complete"        | completeTurn()          | —
- *   "cancelled"       | cancelGeneration()      | —
- *   "error"           | onStreamError()         | —
- *   "session_error"   | onSessionError()        | —
+ *   "complete"        | completeTurn()          | none
+ *   "cancelled"       | cancelGeneration()      | none
+ *   "error"           | onStreamError()         | none
+ *   "session_error"   | onSessionError()        | none
+ *   "timeout"         | onTurnTimeout()         | none
  *   "rescued"         | onPollReconciled(id)    | rescuedTurnId (required)
  */
 
@@ -33,7 +34,12 @@ import { useConversationStore } from "@/stores/conversation-store";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 
 export type TurnTerminalReason =
-  "complete" | "cancelled" | "error" | "session_error" | "rescued";
+  | "complete"
+  | "cancelled"
+  | "error"
+  | "session_error"
+  | "timeout"
+  | "rescued";
 
 export interface EndTurnArgs {
   /**
@@ -56,8 +62,8 @@ export interface EndTurnArgs {
 export function endTurn(args: EndTurnArgs): void {
   const turn = useTurnStore.getState();
 
-  // `rescued` is the only non-definitive reason. The other four
-  // (`complete`, `cancelled`, `error`, `session_error`) are sent
+  // `rescued` is the only non-definitive reason. The other five
+  // (`complete`, `cancelled`, `error`, `session_error`, `timeout`) are sent
   // from terminal-event handlers and represent definitive "this turn
   // is over" signals — the processing-key clear is always correct.
   //
@@ -92,6 +98,9 @@ export function endTurn(args: EndTurnArgs): void {
         break;
       case "session_error":
         turn.onSessionError();
+        break;
+      case "timeout":
+        turn.onTurnTimeout();
         break;
     }
   }

--- a/clients/web/src/domains/chat/turn-selectors.test.ts
+++ b/clients/web/src/domains/chat/turn-selectors.test.ts
@@ -90,6 +90,49 @@ describe("isAssistantBusy — authoritative processing close-gate", () => {
   });
 });
 
+describe("isAssistantBusy: authoritative processing open-gate", () => {
+  test("busy when the daemon reports processing and no local signal agrees", () => {
+    // A reloaded tab, or a daemon holding the processing lock past its last
+    // SSE event: the phase is idle and nothing is streaming, yet sends would
+    // be queued. The Stop button is the only escape, so this must read busy.
+    expect(isAssistantBusy("idle", ctx({ snapshotProcessing: true }))).toBe(
+      true,
+    );
+  });
+
+  test("a pending question still suppresses busy", () => {
+    // The prompt IS the UI: a queued-behind-a-prompt daemon must not also
+    // render a spinner and a Stop button over the question card.
+    expect(
+      isAssistantBusy(
+        "idle",
+        ctx({ snapshotProcessing: true, hasPendingQuestion: true }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a pending confirmation still suppresses busy", () => {
+    expect(
+      isAssistantBusy(
+        "idle",
+        ctx({ snapshotProcessing: true, hasPendingConfirmation: true }),
+      ),
+    ).toBe(false);
+  });
+
+  test("processing:false short-circuits from an idle phase", () => {
+    expect(isAssistantBusy("idle", ctx({ snapshotProcessing: false }))).toBe(
+      false,
+    );
+  });
+
+  test("undefined processing keeps an idle client not busy", () => {
+    expect(
+      isAssistantBusy("idle", ctx({ snapshotProcessing: undefined })),
+    ).toBe(false);
+  });
+});
+
 describe("isAssistantBusy — awaiting_user_input without a pending prompt", () => {
   test("stays busy when a prompt resolved but the turn keeps streaming (LUM-2786)", () => {
     // The incident state: the phase is stranded at `awaiting_user_input` after

--- a/clients/web/src/domains/chat/turn-selectors.ts
+++ b/clients/web/src/domains/chat/turn-selectors.ts
@@ -37,9 +37,12 @@ export interface UIContext {
   hasPendingAssistantResponse?: boolean;
   /** The daemon's authoritative per-conversation `processing` flag, carried on
    * the rolling snapshot (`PaginatedHistoryResult.processing`) and refreshed by
-   * every `/messages` reseed. Consumed as an authoritative CLOSE-gate: `false`
-   * means the server considers the turn over, so a `phase` left stuck by a
-   * dropped terminal SSE event stops driving the indicator. `undefined` (older
+   * every `/messages` reseed. Consumed as an authoritative gate in both
+   * directions: `false` means the server considers the turn over, so a `phase`
+   * left stuck by a dropped terminal SSE event stops driving the indicator;
+   * `true` means the daemon still holds this conversation's processing lock, so
+   * {@link isAssistantBusy} reports busy (and the composer offers Stop) even
+   * when this client never observed the turn locally. `undefined` (older
    * daemons, or a cold snapshot) leaves phase-only behavior untouched. */
   snapshotProcessing?: boolean;
 }
@@ -135,6 +138,16 @@ export function shouldShowThinkingIndicator(
  * says the turn is done, even if `phase` is stuck. The
  * `hasPendingAssistantResponse` guard keeps the window right after a send
  * (before the first token) covered.
+ *
+ * Authoritative open-gate: `snapshotProcessing === true` means the daemon still
+ * holds this conversation's processing lock, so further sends are queued rather
+ * than started. That has to read as busy even when no local signal agrees (a
+ * reloaded tab, or a lock the daemon holds past its last SSE event), because
+ * the Stop button is the only escape from a busy daemon and it is gated on this
+ * selector. The state cannot strand: the same flag is revalidated on a timer by
+ * `useConversationHistory` for exactly as long as it is the only thing holding
+ * the UI busy, and the refetched `processing: false` clears it through the
+ * close-gate above.
  */
 export function isAssistantBusy(phase: TurnPhase, ctx: UIContext): boolean {
   if (ctx.snapshotProcessing === false && !ctx.hasPendingAssistantResponse) {
@@ -157,7 +170,8 @@ export function isAssistantBusy(phase: TurnPhase, ctx: UIContext): boolean {
   return (
     isSending(phase) ||
     ctx.hasStreamingAssistantMessage ||
-    ctx.activeConversationIsProcessing === true
+    ctx.activeConversationIsProcessing === true ||
+    ctx.snapshotProcessing === true
   );
 }
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
@@ -233,7 +233,10 @@ describe("handleMessageDequeued", () => {
 });
 
 describe("handleMessageQueuedDeleted", () => {
-  it("removes queued message when messageId mapping exists", () => {
+  it("spends the queue slot on a tab that counted the enqueue but did not cancel", () => {
+    // A second tab watching the same conversation counted the enqueue, so its
+    // mapping is still present when the broadcast lands. That tab owes the
+    // decrement and the row removal.
     const ctx = makeCtx({
       requestIdToMessageId: new Map([["req-1", "stable-1"]]),
     });
@@ -245,12 +248,36 @@ describe("handleMessageQueuedDeleted", () => {
       },
       ctx,
     );
-    expect(ctx.turnActions.deleteQueuedMessage).toHaveBeenCalled();
+    expect(ctx.turnActions.deleteQueuedMessage).toHaveBeenCalledTimes(1);
     expect(ctx.popRequestIdMapping).toHaveBeenCalledWith("req-1");
     expect(ctx.setOptimisticSends).toHaveBeenCalled();
   });
 
-  it("skips setOptimisticSends when no messageId mapping exists", () => {
+  it("does not decrement twice on the tab that issued the cancel", () => {
+    // The cancelling tab pops the mapping in its own `onDeleted`, so the
+    // broadcast echo finds nothing to pair with. A second decrement would
+    // retire the turn at count 0 while a real message is still queued.
+    const ctx = makeCtx({
+      requestIdToMessageId: new Map([["req-1", "stable-1"]]),
+    });
+    expect(ctx.popRequestIdMapping("req-1")).toBe("stable-1");
+
+    handleMessageQueuedDeleted(
+      {
+        type: "message_queued_deleted",
+        conversationId: "conv-1",
+        requestId: "req-1",
+      },
+      ctx,
+    );
+    expect(ctx.turnActions.deleteQueuedMessage).not.toHaveBeenCalled();
+    expect(ctx.setOptimisticSends).not.toHaveBeenCalled();
+  });
+
+  it("does not spend a queue slot for a cancel this client never counted", () => {
+    // The daemon broadcasts to every subscriber, so a tab that never saw the
+    // enqueue (opened mid-turn, or another tab's send) receives this too and
+    // must leave its own count alone.
     const ctx = makeCtx();
     handleMessageQueuedDeleted(
       {
@@ -260,7 +287,7 @@ describe("handleMessageQueuedDeleted", () => {
       },
       ctx,
     );
-    expect(ctx.turnActions.deleteQueuedMessage).toHaveBeenCalled();
+    expect(ctx.turnActions.deleteQueuedMessage).not.toHaveBeenCalled();
     expect(ctx.setOptimisticSends).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
@@ -143,7 +143,11 @@ describe("handleMessageDequeued", () => {
     expect(ctx.setOptimisticSends).toHaveBeenCalled();
   });
 
-  it("skips setOptimisticSends when no messageId mapping exists", () => {
+  it("does not spend a queue slot for a dequeue this client never counted", () => {
+    // Only `handleMessageQueued` increments the counter, and only when it
+    // could bind the ack to a local row, in which case it also writes the
+    // requestId mapping. An unpaired dequeue (another tab's send, a
+    // daemon-internal enqueue) has no mapping and must leave the count alone.
     const ctx = makeCtx();
     handleMessageDequeued(
       {
@@ -153,7 +157,7 @@ describe("handleMessageDequeued", () => {
       },
       ctx,
     );
-    expect(ctx.turnActions.dequeueMessage).toHaveBeenCalled();
+    expect(ctx.turnActions.dequeueMessage).not.toHaveBeenCalled();
     expect(ctx.setOptimisticSends).not.toHaveBeenCalled();
   });
 
@@ -188,6 +192,43 @@ describe("handleMessageDequeued", () => {
     expect(message?.isOptimistic).toBe(true);
     expect(message?.queueStatus).toBeUndefined();
     expect(message?.queuePosition).toBeUndefined();
+  });
+
+  it("clears a snapshot-seeded queued row without touching the counter", () => {
+    // A row rendered from a `/messages` reseed is keyed by requestId and never
+    // ran through `handleMessageQueued`, so it owns no queue slot, but it is
+    // on screen and must stop reading as queued.
+    useChatSessionStore.setState({
+      snapshot: {
+        messages: [
+          {
+            id: "req-seeded",
+            role: "user",
+            queueStatus: "queued",
+            queuePosition: 1,
+          },
+        ],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      },
+    });
+    const ctx = makeCtx();
+
+    handleMessageDequeued(
+      {
+        type: "message_dequeued",
+        conversationId: "conv-1",
+        requestId: "req-seeded",
+      },
+      ctx,
+    );
+
+    expect(ctx.turnActions.dequeueMessage).not.toHaveBeenCalled();
+    expect(
+      useChatSessionStore.getState().snapshot?.messages[0]?.queueStatus,
+    ).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
@@ -65,13 +65,21 @@ export function handleMessageDequeued(
   event: MessageDequeuedEvent,
   ctx: StreamHandlerContext,
 ): void {
-  ctx.turnActions.dequeueMessage();
   const dequeuedMessageId = ctx.popRequestIdMapping(event.requestId);
+  // The requestId mapping is the record of a queued send this client counted:
+  // `handleMessageQueued` writes it in the same breath as `enqueueMessage()`,
+  // and writes neither for an ack it could not bind to a local row. Decrement
+  // only against that record, so a dequeue for another tab's send or a
+  // daemon-internal enqueue cannot spend a slot this client never took.
   if (dequeuedMessageId) {
+    ctx.turnActions.dequeueMessage();
     ctx.setOptimisticSends((prev) =>
       applyQueuedMessageDequeue(prev, dequeuedMessageId),
     );
   }
+  // Row removal is unconditional: a queued row seeded from a `/messages`
+  // reseed is keyed by requestId and never went through the counter, but it is
+  // rendered and must stop reading as queued.
   patchTranscriptMessages((prev) =>
     applyQueuedMessageDequeue(prev, dequeuedMessageId ?? event.requestId),
   );

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
@@ -46,9 +46,13 @@ export function handleMessageQueued(
         requestId,
         messageId,
         setOptimisticSends: ctx.setOptimisticSends,
+        // The daemon broadcasts the cancel before answering the DELETE, so
+        // `handleMessageQueuedDeleted` can pop the mapping first. Whichever
+        // path pops it spends the slot, so the pair never double-decrements.
         onDeleted: () => {
-          ctx.popRequestIdMapping(requestId);
-          ctx.turnActions.deleteQueuedMessage();
+          if (ctx.popRequestIdMapping(requestId)) {
+            ctx.turnActions.deleteQueuedMessage();
+          }
         },
       });
     }
@@ -89,13 +93,24 @@ export function handleMessageQueuedDeleted(
   event: MessageQueuedDeletedEvent,
   ctx: StreamHandlerContext,
 ): void {
-  ctx.turnActions.deleteQueuedMessage();
   const deletedMessageId = ctx.popRequestIdMapping(event.requestId);
+  // Same pairing rule as `handleMessageDequeued`: the requestId mapping is the
+  // record of a queued send this client counted, and popping it is what spends
+  // the slot. The daemon broadcasts the cancel to every subscriber, so this
+  // also lands on the tab that issued it, where the local cancel path pops the
+  // same mapping. Tying the decrement to the pop keeps that to exactly one
+  // decrement per cancel whichever path observes it first, and none at all on
+  // a tab that never counted the enqueue. Without the gate, a second decrement
+  // retires the turn while a real message is still queued.
   if (deletedMessageId) {
+    ctx.turnActions.deleteQueuedMessage();
     ctx.setOptimisticSends((prev) =>
       removeQueuedMessage(prev, deletedMessageId),
     );
   }
+  // Row removal is unconditional: a queued row seeded from a `/messages`
+  // reseed is keyed by requestId and never went through the counter, but it is
+  // rendered and must stop reading as queued.
   patchTranscriptMessages((prev) =>
     removeQueuedMessage(prev, deletedMessageId ?? event.requestId),
   );


### PR DESCRIPTION
## Problem

Confirmed in production (two LogRocket sessions, same release): after a reply is fully delivered, the daemon keeps holding the conversation processing lock while it awaits the deferred turn tail — memory/attention indexing and embeddings, every step unbounded. Any send in that window returns HTTP 202 queued while the UI correctly reads idle (terminal SSE already emitted). One affected user had a reply delivered 47+ seconds before the daemon still queued their next message; they hit "Cancel all" and gave up. A second session self-recovered after ~2 minutes when the tail finished.

Beyond the slow tail, the lock had several latch-forever paths (any of which wedges the conversation for the daemon's lifetime, invisibly, with the Stop button hidden because the UI thinks it's idle):

- the loop `finally` cleared the flag with unguarded DB writes; a throw skipped both the clear and the drain kick
- `setProcessing(false)` reverted the in-memory release when the advisory column write hit `SQLITE_BUSY`
- the canned-reply routes released from a bare `setTimeout` where a throwing broadcast skipped the release
- agent-wake and `/compact`/`/clean` drained with raw `drainQueue` (no retry, no sender notification)
- `steerToMessage` aborted via `abortController?.abort(...)` — a silent no-op when the flag is latched with no live controller

Per team decision there is deliberately NO watchdog: the fix removes the leak sources instead.

## Fix

**Release before the tail.** The turn tail is split by lock dependency:

- `settleTurnContent` (tool-result truncation, stranded-inflight fold, disk-view mirror) rewrites `ctx.messages` and appends to the conversation's disk view — state the next turn also writes, with the processing lock as their only serialization — so it stays under the lock. It is synchronous apart from the stranded fold, so this costs the queue nothing.
- `runDeferredTurnTail` (the network-bound indexing/embeddings) runs detached after an idempotent `releaseTurn()`: stamp outcome (throw-proof) → null controller → clear lock → tear down per-turn state → drain kick from a nested `finally`. Tails chain on a per-conversation promise so two turns' tails never interleave (the attention cursor is per-conversation). The loop `finally` keeps `releaseTurn()` as the backstop for cancel/error paths.

Note this extends an existing concurrency mode rather than introducing one: the next turn could already start between the old `finally`'s clear and its drain kick (turn commit/profiling window).

**Every clear path sticks.** The clear direction of `setProcessing` mirrors the advisory `processing_started_at` column via retried, detached writes and never reverts the in-memory release (the column is boot-recovered; the in-memory flag is the queue gate). Acquire stays strict. Canned-reply routes release via a shared `scheduleCannedReplyRelease` whose `finally` survives a throwing event burst. Agent-wake and `/compact`/`/clean` use the retrying, never-rejecting drain kick. `steerToMessage` force-clears a latched flag with no live controller and kicks the drain so the promoted message actually runs.

**Queue integrity.** Reload eviction and stale rebuild skip conversations with queued messages (their in-memory queue would be silently destroyed — the periodic evictor already documents this exact hazard). Cancelling a queued message broadcasts `message_queued_deleted` so other tabs retire the row (suppressed for echo-suppressed entries to keep queue events paired).

**Web client.**
- `snapshotProcessing === true` now drives the busy state (previously only `false` was consulted, as an idle gate), so a busy daemon shows the Stop button instead of an up-arrow that queues sends. While it is the only busy signal, a 4s revalidation poll re-fetches until the server reports idle — worst case ~4s of stale busy, no LUM-2786-style stranding.
- A 3-minute turn-silence timeout (first caller of the existing `onTurnTimeout`) reconciles a locally-stuck phase against server truth.
- `message_dequeued` only decrements the queued counter when this client counted the enqueue (fixes the multi-client counter edge Devin flagged on #39678).
- The queue drawer's steer/edit/cancel controls on coarse pointers sit behind a two-step reveal (ellipsis affordance), so an accidental tap can no longer destructively cancel a queued message or dump its text into the composer — the confirmed cause of the "text stayed in the composer + duplicate send" reports.

## Base branch

Stacked on #39678 (`fix-queue-subagent-notification-leak`) — both touch the queue event surfaces. Retarget to `main` after that merges.

## Tests

New suites: `queued-message-cancel-and-steer` (5), `evict-conversations-for-reload` (3), `canned-reply-release` (2), web `use-turn-timeout` (6), `use-conversation-history-processing-revalidate` (5), `queued-messages-drawer` (5). Extended: `conversation-agent-loop` (+2 detached-tail cases), `processing-flag-persist-failure` and `conversation-wait-for-idle` rewritten for the new clear semantics, `turn-selectors` and `queue-handlers` extended.

Verified: `typecheck:fast` (assistant) and `tsc --noEmit` (web) clean; 13 assistant suites + 6 web suites all passing scoped; lint clean both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->