### PR TITLE
refactor(contracts): centralize interface identifiers

### DIFF
--- a/packages/service-contracts/src/__tests__/channels.test.ts
+++ b/packages/service-contracts/src/__tests__/channels.test.ts
@@ -1,6 +1,37 @@
 import { describe, expect, test } from "bun:test";
 
-import { CHANNEL_IDS, isChannelId } from "../channels.js";
+import {
+  CHANNEL_IDS,
+  INTERFACE_IDS,
+  isChannelId,
+  isInterfaceId,
+  parseInterfaceId,
+  type InterfaceId,
+} from "../channels.js";
+
+const EXPECTED_INTERFACE_IDS = [
+  "macos",
+  "ios",
+  "cli",
+  "telegram",
+  "phone",
+  "web",
+  "whatsapp",
+  "slack",
+  "email",
+  "chrome-extension",
+  "a2a",
+  "discord",
+  "route",
+] as const satisfies readonly InterfaceId[];
+
+type MissingInterfaceId = Exclude<
+  InterfaceId,
+  (typeof EXPECTED_INTERFACE_IDS)[number]
+>;
+const interfaceTupleIsComplete: MissingInterfaceId extends never
+  ? true
+  : false = true;
 
 describe("isChannelId", () => {
   test("accepts every canonical channel id", () => {
@@ -32,5 +63,49 @@ describe("isChannelId", () => {
     expect(isChannelId(undefined)).toBe(false);
     expect(isChannelId(null)).toBe(false);
     expect(isChannelId(42)).toBe(false);
+  });
+});
+
+describe("INTERFACE_IDS", () => {
+  test("contains the complete canonical interface vocabulary", () => {
+    expect(interfaceTupleIsComplete).toBe(true);
+    expect(INTERFACE_IDS).toEqual(EXPECTED_INTERFACE_IDS);
+  });
+});
+
+describe("isInterfaceId", () => {
+  test("accepts every canonical interface id", () => {
+    for (const id of EXPECTED_INTERFACE_IDS) {
+      expect(isInterfaceId(id)).toBe(true);
+    }
+  });
+
+  test("rejects the legacy alias, unknown strings, and non-string values", () => {
+    expect(isInterfaceId("vellum")).toBe(false);
+    expect(isInterfaceId("safari-extension")).toBe(false);
+    expect(isInterfaceId("")).toBe(false);
+    expect(isInterfaceId(undefined)).toBe(false);
+    expect(isInterfaceId(null)).toBe(false);
+    expect(isInterfaceId(42)).toBe(false);
+  });
+});
+
+describe("parseInterfaceId", () => {
+  test("returns every canonical interface id unchanged", () => {
+    for (const id of EXPECTED_INTERFACE_IDS) {
+      expect(parseInterfaceId(id)).toBe(id);
+    }
+  });
+
+  test("normalizes the legacy vellum alias to web", () => {
+    expect(parseInterfaceId("vellum")).toBe("web");
+  });
+
+  test("rejects unknown strings and non-string values", () => {
+    expect(parseInterfaceId("safari-extension")).toBeNull();
+    expect(parseInterfaceId("")).toBeNull();
+    expect(parseInterfaceId(undefined)).toBeNull();
+    expect(parseInterfaceId(null)).toBeNull();
+    expect(parseInterfaceId(42)).toBeNull();
   });
 });

--- a/packages/service-contracts/src/channels.ts
+++ b/packages/service-contracts/src/channels.ts
@@ -40,3 +40,51 @@ export function isChannelId(value: unknown): value is ChannelId {
     (CHANNEL_IDS as readonly string[]).includes(value)
   );
 }
+
+/**
+ * Canonical interface identifiers describe the client surface responsible for
+ * a turn. They are separate from channel IDs because a client surface and an
+ * external messaging transport answer different routing questions.
+ */
+export const INTERFACE_IDS = [
+  "macos",
+  "ios",
+  "cli",
+  "telegram",
+  "phone",
+  "web",
+  "whatsapp",
+  "slack",
+  "email",
+  "chrome-extension",
+  "a2a",
+  "discord",
+  "route",
+] as const;
+
+export type InterfaceId = (typeof INTERFACE_IDS)[number];
+
+const LEGACY_INTERFACE_ALIASES: Readonly<Record<string, InterfaceId>> = {
+  vellum: "web",
+};
+
+/**
+ * Returns true only for canonical interface identifiers. Use
+ * {@link parseInterfaceId} when legacy aliases should be normalized.
+ */
+export function isInterfaceId(value: unknown): value is InterfaceId {
+  return (
+    typeof value === "string" &&
+    (INTERFACE_IDS as readonly string[]).includes(value)
+  );
+}
+
+export function parseInterfaceId(value: unknown): InterfaceId | null {
+  if (isInterfaceId(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  return LEGACY_INTERFACE_ALIASES[value] ?? null;
+}


### PR DESCRIPTION
Part of the CLI Live Voice for Raspberry Pi plan. Makes service contracts the canonical interface identifier vocabulary without changing consumers yet. Targets feature branch alex-nork/cli-live-voice.