### PR TITLE
polish(web): lead both Assistant Access key lines with the ask

### DIFF
--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -28,8 +28,8 @@ import type { RiskThreshold } from "@/utils/threshold-presets";
  * capability floor.
  *
  * The capability floor (code, the owner's computer or accounts, unvetted
- * skills always escalate) needs no inventory here — "asks before anything
- * beyond …" already covers everything the exception does not name.
+ * skills always escalate) needs no inventory here: "asks before anything
+ * beyond ..." already covers everything the exception does not name.
  */
 function tierDescription(tier: RiskThreshold): string {
   return tier === "none"

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -14,22 +14,27 @@ import type { RiskThreshold } from "@/utils/threshold-presets";
  * the owner. The per-level lines are the whole key (LUM-2905); the card
  * header carries the Trust Rules pointer.
  *
- * Grounded in what a channel cell can actually delegate
+ * Both lines lead with the ask, so the only thing that differs between levels
+ * is the exception clause and the levels stay comparable at a glance.
+ *
+ * The exception is grounded in what a channel cell can actually delegate
  * (`assistant/src/tools/tool-approval-handler.ts` → `isChannelLiftable`): only
  * non-executing side effects in the assistant's own workspace (reads, public
- * `web_fetch`, and ordinary in-workspace file writes). "Takes notes" describes
- * those writes without implying documents: the document tools run on the host
- * and stay on the capability floor.
+ * `web_fetch`, and ordinary in-workspace file writes). "Saving files in its
+ * own workspace" is the wording the global Conservative preset already uses
+ * (`utils/threshold-presets.ts`), so both surfaces name the delegated work the
+ * same way; the workspace scope is what keeps it from reading as document
+ * authoring, since the document tools run on the host and stay on the
+ * capability floor.
  *
  * The capability floor (code, the owner's computer or accounts, unvetted
- * skills always escalate) compresses to "asks first for anything bigger":
- * accurate without the inventory, and it keeps the two lines the same weight:
- * both name what runs on its own, then that everything else asks.
+ * skills always escalate) needs no inventory here — "asks before anything
+ * beyond …" already covers everything the exception does not name.
  */
 function tierDescription(tier: RiskThreshold): string {
   return tier === "none"
-    ? "Replies, but asks first for anything else, even a web search."
-    : "Looks things up and takes notes on its own; asks first for anything bigger.";
+    ? "Asks before every action, even a web search."
+    : "Asks before anything beyond looking things up and saving files in its own workspace.";
 }
 
 export interface SlackChannelTierLegendProps {


### PR DESCRIPTION
## TL;DR

The per-level lines in the Slack channel **Assistant Access** key described Conservative as *"takes notes on its own; asks first for anything bigger."* Both halves were wrong. This rewrites the two lines so each leads with the ask and names its exception, using the same vocabulary the global Assistant Access presets already use.

Copy only: two string constants and the comment above them.

## What was wrong

Checked against the two things this copy has to stay true to: `isChannelLiftable` in `assistant/src/tools/tool-approval-handler.ts` (what a channel cell may actually delegate), and `THRESHOLD_PRESETS` in `clients/web/src/utils/threshold-presets.ts` (what the global setting calls the same levels).

1. **"takes notes" is a euphemism.** The delegable set is ordinary file writes in the assistant's own workspace. The global Conservative preset says it plainly, "reading and writing files in its own workspace", so the key was the only surface using a softer word for the same capability. "Notes" was originally chosen to avoid implying *document* authoring (documents run on the host and stay on the capability floor), but "in its own workspace" already carries that scope.
2. **"anything bigger" is a comparative with no referent.** Bigger than notes? The actual rule is that everything not named asks, which is the same rule Strict already stated as "anything else". Two names for one rule made the levels look like they differ in more ways than they do.
3. **The lines weren't parallel**, so the single axis separating the levels didn't read at a glance in the two-column key.

## Before / after

| | Before | After |
|---|---|---|
| **Conservative** *(· default)* | Looks things up and takes notes on its own; asks first for anything bigger. | Asks before anything beyond looking things up and saving files in its own workspace. |
| **Strict** | Replies, but asks first for anything else, even a web search. | Asks before every action, even a web search. |

What changes for the reader: the level's *exception* is now the only thing that varies between the two entries, and the exception names the real capability instead of a stand-in for it.

## Why this is safe

- No behavior change. `tierDescription()` returns strings that are rendered into an existing `<Typography>`. No props, classnames, layout, or conditionals touched.
- No test or snapshot referenced the old strings (`grep` across `*.ts`/`*.tsx`/`*.md` found only this file).
- `bun run lint` in `clients/web` passes with 0 errors, and the pre-commit hook re-linted the changed file.
- The comment above the function was rewritten in the same commit. It existed specifically to justify "takes notes" and "anything bigger", so leaving it would have left a comment defending copy that no longer exists.

## Not verified / follow-ups

- **Not render-verified.** Reaching this panel needs a running daemon with a connected Slack workspace. The change is two string constants with no structural change, so layout risk is low, but Conservative's line grew from ~76 to ~85 chars and will still wrap to two lines in the two-column grid. That is why the line uses `body-small-lighter` rather than a variant that would clip: the `-default` and `-emphasised` variants are line-height-1 single-line label styles.
- **Deliberately dropped: the "it still replies" reassurance at Strict.** The old Strict line opened with "Replies, but...". The new one doesn't, which trades a little reassurance for parallelism with Conservative. If anyone reads "Asks before every action" as "the assistant goes silent in this channel", the fix is a short lead-in: `Replies. Asks before every action, even a web search.` Left out for now because it's speculative and the two-column key is tight. Worth revisiting only if that confusion actually shows up, the same way the scope line was traded away in LUM-2905.

Related to LUM-2905
