### PR TITLE
feat(voice): the mobile sheet slides up already wearing its avatar (JARVIS-1389)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-entrance.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-entrance.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the room's entrance choreography.
+ *
+ * The behaviour being pinned is "presented means nothing introduces itself":
+ * the sheet already has an entrance of its own, so a look that also animates in
+ * gives the user two competing arrivals. `initial === false` is how a Motion
+ * element declares it starts at rest, so that is what these assert on.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import type { VoiceRoomVariant } from "./voice-room";
+
+import {
+  bodyGrowMotion,
+  colorFillMotion,
+  eyesEntranceMotion,
+  resolveVoiceRoomChoreography,
+  resolveVoiceRoomEntrance,
+  voidAvatarMotion,
+  withReducedMotion,
+} from "./voice-room-entrance";
+
+const VARIANTS: readonly VoiceRoomVariant[] = [
+  "fullscreen",
+  "content",
+  "sheet",
+];
+
+const BODY = { startScale: 0.2, startX: -120, startY: 80 };
+const EYES = { startX: -120, startY: 80, dipY: 12 };
+
+describe("resolveVoiceRoomEntrance", () => {
+  it("presents the sheet: its slide-up is the entrance", () => {
+    expect(resolveVoiceRoomEntrance("sheet", false)).toBe("presented");
+  });
+
+  it("grows the variants whose box has no entrance of its own", () => {
+    expect(resolveVoiceRoomEntrance("content", false)).toBe("grow");
+    expect(resolveVoiceRoomEntrance("fullscreen", false)).toBe("grow");
+  });
+
+  for (const variant of VARIANTS) {
+    it(`presents ${variant} under reduced motion`, () => {
+      expect(resolveVoiceRoomEntrance(variant, true)).toBe("presented");
+    });
+  }
+});
+
+describe("withReducedMotion", () => {
+  it("overrides a grow the caller asked for", () => {
+    expect(withReducedMotion("grow", true)).toBe("presented");
+  });
+
+  it("leaves the mode alone otherwise", () => {
+    expect(withReducedMotion("grow", false)).toBe("grow");
+    expect(withReducedMotion("presented", false)).toBe("presented");
+  });
+});
+
+describe("presented layers start at rest", () => {
+  it("paints the colour fill with no fade", () => {
+    expect(colorFillMotion("presented").initial).toBe(false);
+  });
+
+  it("leaves the body silhouette covering the room", () => {
+    expect(bodyGrowMotion("presented", BODY).initial).toBe(false);
+  });
+
+  it("leaves the void look's avatar centred", () => {
+    expect(voidAvatarMotion("presented").initial).toBe(false);
+  });
+
+  it("holds the eyes at their resting pose", () => {
+    const eyes = eyesEntranceMotion("presented", EYES, false);
+    expect(eyes.initial).toBe(false);
+    expect(eyes.animate).toEqual({ x: 0, y: 0, scale: 1 });
+  });
+
+  it("gives the look no exit of its own, the surface carries it off", () => {
+    expect(colorFillMotion("presented").exit).toBeUndefined();
+    expect(bodyGrowMotion("presented", BODY).exit).toBeUndefined();
+    expect(voidAvatarMotion("presented").exit).toBeUndefined();
+    expect(eyesEntranceMotion("presented", EYES, false).exit).toBeUndefined();
+  });
+});
+
+describe("the grow travels from the entry origin and back to it", () => {
+  it("starts the body at the tapped point, scaled down", () => {
+    expect(bodyGrowMotion("grow", BODY).initial).toEqual({
+      scale: BODY.startScale,
+      x: BODY.startX,
+      y: BODY.startY,
+    });
+  });
+
+  it("collapses the body back to where it came from", () => {
+    expect(bodyGrowMotion("grow", BODY).exit).toMatchObject({
+      scale: BODY.startScale,
+      x: BODY.startX,
+      y: BODY.startY,
+    });
+  });
+
+  it("collapses the eyes back to the same point", () => {
+    expect(eyesEntranceMotion("grow", EYES, true).exit).toMatchObject({
+      x: EYES.startX,
+      y: EYES.startY,
+      opacity: 0,
+    });
+  });
+});
+
+describe("the eyes stop handing Motion keyframes once the entrance lands", () => {
+  // A keyframe array restarts whenever Motion is handed a new one, and the eyes
+  // re-render on every session-state change. Left in place they would replay
+  // part of the entrance mid-session, the lurch this latch exists to stop.
+  it("plays keyframe arrays while the entrance is running", () => {
+    const animate = eyesEntranceMotion("grow", EYES, false).animate as Record<
+      string,
+      unknown
+    >;
+    expect(animate.x).toEqual([EYES.startX, 0, 0]);
+    expect(animate.y).toEqual([EYES.startY, EYES.dipY, 0]);
+  });
+
+  it("settles to a static target that re-renders can repeat", () => {
+    expect(eyesEntranceMotion("grow", EYES, true).animate).toEqual({
+      x: 0,
+      y: 0,
+      scale: 1,
+    });
+  });
+});
+
+describe("resolveVoiceRoomChoreography", () => {
+  it("hands the sheet's travel to its chrome, not to the room's box", () => {
+    const { shell, sheetChrome } = resolveVoiceRoomChoreography("sheet", false);
+    // The room's box holds still: sliding it inside the sheet would expose the
+    // page behind the look.
+    expect(shell.initial).toBe(false);
+    expect(shell.exit).toBeUndefined();
+    expect(sheetChrome?.exit).toMatchObject({ y: "100%" });
+  });
+
+  it("keeps the chrome from fighting Radix's slide-up on open", () => {
+    const { sheetChrome } = resolveVoiceRoomChoreography("sheet", false);
+    expect(sheetChrome?.initial).toBe(false);
+  });
+
+  it("drops the sheet's travel under reduced motion rather than shortening it", () => {
+    const { sheetChrome } = resolveVoiceRoomChoreography("sheet", true);
+    expect(sheetChrome?.exit).toEqual({
+      opacity: 0,
+      transition: { duration: 0 },
+    });
+  });
+
+  it("gives the variants with no chrome none to animate", () => {
+    for (const variant of ["fullscreen", "content"] as const) {
+      expect(
+        resolveVoiceRoomChoreography(variant, false).sheetChrome,
+      ).toBeNull();
+    }
+  });
+
+  it("fades the room's own box on the variants that own their exit", () => {
+    const { shell } = resolveVoiceRoomChoreography("content", false);
+    expect(shell.initial).toEqual({ opacity: 0 });
+    expect(shell.exit).toEqual({ opacity: 0 });
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-entrance.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-entrance.ts
@@ -1,0 +1,277 @@
+/**
+ * How the voice room comes and goes, per placement variant.
+ *
+ * The room's look (the colour fill, the body silhouette, the giant eyes) can
+ * introduce itself two ways:
+ *
+ * - `"grow"`: the onboarding Introduction grow. The body springs from the
+ *   avatar the user tapped until it covers the room, the colour fades in behind
+ *   it, and the eyes rise into the centre and settle. The room's box holds
+ *   still and the look is what moves; closing reverses it, collapsing the whole
+ *   shape back toward the tapped control.
+ * - `"presented"`: the look is fully painted on its first frame, and the
+ *   surface's own chrome carries it on and off. Nothing inside the room
+ *   animates itself in.
+ *
+ * The mobile sheet wants `"presented"`, because it already has an entrance: it
+ * slides up. Playing the grow inside it means two animations competing for the
+ * same moment: the sheet arrives, and only then does its content assemble
+ * itself. It comes up already wearing its colour and eyes instead.
+ *
+ * This lives outside `voice-room-eyes.tsx` so the choreography is a single
+ * thing that can be swapped per surface rather than a `variant` check threaded
+ * through every animated layer of the look. The look takes an entrance mode and
+ * never learns which variant it is rendering under; a new surface picks a mode
+ * here and nothing downstream changes.
+ *
+ * Desktop (`content`, `fullscreen`) grows, which is what the `entryOrigin`
+ * pipeline serves: the live-voice store field, the composer's
+ * `measureVoiceOriginAvatar`, `ChatAvatar`'s `originAnchor`, and `toRoomLocal`
+ * together give the grow the point to travel from.
+ */
+
+import type { MotionProps } from "motion/react";
+
+import { AVATAR_ENTER_SPRING } from "./voice-motion";
+import type { VoiceRoomVariant } from "./voice-room";
+
+/** See the module docstring. */
+export type VoiceRoomEntrance = "grow" | "presented";
+
+/**
+ * Duration of the sheet's slide, mirroring the design library's `bottomSheetIn`
+ * keyframe (`packages/design-library/src/tokens.css`). Radix plays that
+ * keyframe on open; the exit here has to match it or the sheet leaves at a
+ * different speed than it arrived.
+ */
+const SHEET_SLIDE_SECONDS = 0.18;
+
+/** Room-box fade, used by the variants whose own box is the outermost thing. */
+const SHELL_FADE_SECONDS = 0.4;
+
+/**
+ * Everything the room needs to know about its own motion, resolved once from
+ * the placement variant.
+ */
+export interface VoiceRoomChoreography {
+  /** How the look introduces itself. Passed down to `VoiceRoomColorLook`. */
+  entrance: VoiceRoomEntrance;
+  /** Motion props for the room's own box. */
+  shell: MotionProps;
+  /**
+   * Motion props for the sheet's chrome, or null for the variants that have no
+   * chrome of their own. The sheet's box is Radix's content element, which sits
+   * outside the room's box (it is portalled and `fixed`), so the slide has to
+   * be applied there: sliding the room's box instead would move the look inside
+   * a stationary sheet and expose the page behind it.
+   */
+  sheetChrome: MotionProps | null;
+}
+
+export function resolveVoiceRoomChoreography(
+  variant: VoiceRoomVariant,
+  reduceMotion: boolean,
+): VoiceRoomChoreography {
+  const entrance = resolveVoiceRoomEntrance(variant, reduceMotion);
+  const sheet = variant === "sheet";
+  return {
+    entrance,
+    shell: shellMotion(sheet, reduceMotion),
+    sheetChrome: sheet ? sheetChromeMotion(reduceMotion) : null,
+  };
+}
+
+/** Which choreography a placement variant uses. See the module docstring. */
+export function resolveVoiceRoomEntrance(
+  variant: VoiceRoomVariant,
+  reduceMotion: boolean,
+): VoiceRoomEntrance {
+  return withReducedMotion(
+    variant === "sheet" ? "presented" : "grow",
+    reduceMotion,
+  );
+}
+
+/**
+ * Reduced motion presents, whatever the surface asked for. The look applies
+ * this to whatever mode it is handed rather than trusting the caller to have
+ * checked, so a surface that renders the look directly (the stories, a future
+ * mount) cannot forget to honour the preference.
+ */
+export function withReducedMotion(
+  entrance: VoiceRoomEntrance,
+  reduceMotion: boolean,
+): VoiceRoomEntrance {
+  return reduceMotion ? "presented" : entrance;
+}
+
+/**
+ * The room's box. Under the sheet it neither fades in nor out: the chrome owns
+ * both halves, and a fade layered on top of the slide would dim the look
+ * mid-travel.
+ */
+function shellMotion(sheet: boolean, reduceMotion: boolean): MotionProps {
+  if (sheet) {
+    return { initial: false };
+  }
+  return {
+    initial: reduceMotion ? false : { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: reduceMotion ? 0 : SHELL_FADE_SECONDS },
+  };
+}
+
+/**
+ * The sheet's chrome. Radix owns the entrance through its
+ * `data-[state=open]:animate-[bottomSheetIn]` class, and `initial: false` keeps
+ * Motion from fighting it on mount. This owns the exit, which is the same
+ * travel in reverse so the sheet leaves the way it came.
+ */
+function sheetChromeMotion(reduceMotion: boolean): MotionProps {
+  return {
+    initial: false,
+    exit: reduceMotion
+      ? // Not a shorter slide: no travel at all, gone on the next frame.
+        { opacity: 0, transition: { duration: 0 } }
+      : {
+          y: "100%",
+          opacity: 0,
+          transition: { duration: SHEET_SLIDE_SECONDS, ease: "easeIn" },
+        },
+  };
+}
+
+/**
+ * The ambient-void look's centred avatar, the fallback for custom-image and
+ * "none" avatars, which have no colour or eyes to grow.
+ *
+ * It has no entry origin to fly from, so its grow is a plain rise-and-scale
+ * spring rather than the colour look's travel. Presented, it is simply there:
+ * a custom-image assistant should ride the sheet up as settled as a character
+ * one does.
+ */
+export function voidAvatarMotion(entrance: VoiceRoomEntrance): MotionProps {
+  if (entrance === "presented") {
+    return { initial: false };
+  }
+  const start = { scale: 0.8, y: 24, opacity: 0 };
+  return {
+    initial: start,
+    animate: { scale: 1, y: 0, opacity: 1 },
+    // The inverse of the entry spring: the avatar settles back down and shrinks
+    // away rather than fading in place.
+    exit: { ...start, transition: { duration: 0.32, ease: "easeIn" } },
+    transition: AVATAR_ENTER_SPRING,
+  };
+}
+
+/** Geometry the grow needs for the body silhouette. See `voice-room-eyes.tsx`. */
+export interface BodyGrowGeometry {
+  startScale: number;
+  startX: number;
+  startY: number;
+}
+
+/** Geometry the grow needs for the eyes. See `eyeLayout`. */
+export interface EyesGrowGeometry {
+  startX: number;
+  startY: number;
+  /** A small settle dip below rest as the eyes land. */
+  dipY: number;
+}
+
+/** The eyes' resting pose: where `"presented"` starts and the grow ends. */
+const EYES_AT_REST = { x: 0, y: 0, scale: 1 };
+
+/**
+ * The avatar colour behind the body, which fills the room end to end so
+ * coverage survives the gaps and spikes in the body shape.
+ *
+ * Under the grow it fades in *behind* the growing body, so it is deliberately
+ * late (the delay) and slow: leading with it would flood the room with colour
+ * before the shape that is supposed to be delivering it has arrived. On close
+ * it clears early, so what collapses toward the origin is the body silhouette
+ * rather than a shrinking rectangle.
+ */
+export function colorFillMotion(entrance: VoiceRoomEntrance): MotionProps {
+  if (entrance === "presented") {
+    return { initial: false };
+  }
+  return {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0, transition: { duration: 0.2, ease: "easeIn" } },
+    transition: { duration: 0.6, delay: 0.35 },
+  };
+}
+
+/** The body silhouette: springs from "avatar on the screen" to covering it. */
+export function bodyGrowMotion(
+  entrance: VoiceRoomEntrance,
+  geometry: BodyGrowGeometry,
+): MotionProps {
+  if (entrance === "presented") {
+    return { initial: false };
+  }
+  const start = {
+    scale: geometry.startScale,
+    x: geometry.startX,
+    y: geometry.startY,
+  };
+  return {
+    initial: start,
+    animate: { scale: 1, x: 0, y: 0 },
+    exit: { ...start, transition: { duration: 0.4, ease: "easeIn" } },
+    transition: { type: "spring", stiffness: 78, damping: 18, mass: 1 },
+  };
+}
+
+/**
+ * The eyes' entrance.
+ *
+ * `entranceDone` matters because the grow is expressed as keyframe *arrays*,
+ * and Motion restarts a keyframe animation whenever it is handed a new one. The
+ * eyes re-render on every session-state change (`sizeScale`), and a state
+ * change lands inside the one-second entrance often (`connecting` to
+ * `listening` almost always does), so leaving the arrays in place means the
+ * eyes lurch back toward the origin partway and snap forward. Once the entrance
+ * lands the caller flips `entranceDone` and this returns a stable static target
+ * that re-renders are free to repeat.
+ */
+export function eyesEntranceMotion(
+  entrance: VoiceRoomEntrance,
+  geometry: EyesGrowGeometry,
+  entranceDone: boolean,
+): MotionProps {
+  // A presented look neither enters nor leaves under its own power. The exit
+  // below belongs to the grow: the eyes shrink back to the entry origin
+  // alongside the body, so the whole avatar shape collapses to one point.
+  if (entrance === "presented") {
+    return {
+      initial: false,
+      animate: EYES_AT_REST,
+      transition: { duration: 0 },
+    };
+  }
+  const start = { x: geometry.startX, y: geometry.startY, scale: 0.35 };
+  const playing = !entranceDone;
+  return {
+    initial: start,
+    animate: playing
+      ? {
+          x: [geometry.startX, 0, 0],
+          y: [geometry.startY, geometry.dipY, 0],
+          scale: [0.35, 1, 1],
+        }
+      : EYES_AT_REST,
+    exit: {
+      ...start,
+      opacity: 0,
+      transition: { duration: 0.4, ease: "easeIn" },
+    },
+    transition: playing
+      ? { duration: 1, times: [0, 0.7, 1], ease: "easeInOut" }
+      : { duration: 0 },
+  };
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -5,7 +5,10 @@
  * `resolveVoiceRoomLook` maps the assistant's avatar data to the look; the
  * {@link VoiceRoomColorLook} component plays the onboarding Introduction
  * step's entrance on mount, so opening the room reads as the avatar growing
- * from "on the screen" to BEING the screen:
+ * from "on the screen" to BEING the screen, unless the surface already has an
+ * entrance of its own, in which case the look is simply painted and rides it.
+ * Which one a surface gets is `voice-room-entrance.ts`'s call, arriving here as
+ * the `entrance` prop; the steps below describe the grow:
  *
  * 1. the room starts on a dark surface,
  * 2. the avatar's body shape springs from its small on-screen size up to
@@ -38,8 +41,9 @@
  * ambient-void look — what that look should become is an open design
  * question.
  *
- * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe (no
- * entrance, no parallax; the blink is a discrete squish, kept).
+ * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe. It
+ * resolves to the presented entrance (no grow), and drops the parallax; the
+ * blink is a discrete squish, kept.
  *
  * Everything here is sized against the box it is given, not the window. The
  * room is an inset panel on desktop (see `voice-room.tsx`), so "the screen" the
@@ -66,6 +70,13 @@ import {
   type VoiceWaveStyle,
 } from "./voice-listening-waves";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
+import {
+  bodyGrowMotion,
+  colorFillMotion,
+  eyesEntranceMotion,
+  withReducedMotion,
+  type VoiceRoomEntrance,
+} from "./voice-room-entrance";
 import { createAmplitudeSmoother } from "./voice-motion";
 import { useReactiveEyes, type VoiceEyeReaction } from "./use-reactive-eyes";
 import { VoiceReactiveWaves } from "./voice-reactive-waves";
@@ -327,6 +338,7 @@ export function VoiceRoomColorLook({
   showStateCaption = true,
   captionEmphasis = "hidden",
   entryOrigin = null,
+  entrance: requestedEntrance = "grow",
   waveEngine = "mesh",
   viewport,
 }: {
@@ -351,8 +363,11 @@ export function VoiceRoomColorLook({
   captionEmphasis?: VoiceCaptionEmphasis;
   /** Point the entrance grows from (the tapped control), in ROOM-LOCAL space.
    *  the caller converts from the viewport point it captured. Null → the fixed
-   *  room-center origin. */
+   *  room-center origin. Unread when {@link entrance} is `"presented"`. */
   entryOrigin?: { x: number; y: number } | null;
+  /** How the look introduces itself. See `voice-room-entrance.ts`. Defaults to
+   *  the grow; a surface with an entrance of its own passes `"presented"`. */
+  entrance?: VoiceRoomEntrance;
   /** Which wave band to draw. See {@link VoiceWaveEngine}. */
   waveEngine?: VoiceWaveEngine;
   /** The room box to lay out against. The room measures its own panel and
@@ -362,6 +377,7 @@ export function VoiceRoomColorLook({
   const reduce = useReducedMotion();
   const measured = useViewportSize();
   const { w, h } = viewport ?? measured;
+  const entrance = withReducedMotion(requestedEntrance, reduce === true);
 
   // Where the entrance grows from: the tapped control's point in room-local
   // space, or the fixed picker-height room center when none was captured (or in
@@ -431,14 +447,7 @@ export function VoiceRoomColorLook({
       <motion.div
         className="absolute inset-0"
         style={{ backgroundColor: look.bgHex }}
-        initial={reduce ? false : { opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={
-          reduce
-            ? { opacity: 0 }
-            : { opacity: 0, transition: { duration: 0.2, ease: "easeIn" } }
-        }
-        transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.35 }}
+        {...colorFillMotion(entrance)}
       />
 
       {/* Body — springs from "avatar on the screen" to covering it. */}
@@ -454,33 +463,7 @@ export function VoiceRoomColorLook({
             top: bodyGeometry.top,
             transformOrigin: "center",
           }}
-          initial={
-            reduce
-              ? false
-              : {
-                  scale: bodyGeometry.startScale,
-                  x: bodyGeometry.startX,
-                  y: bodyGeometry.startY,
-                }
-          }
-          animate={{ scale: 1, x: 0, y: 0 }}
-          // Close reverses the grow: the body shrinks back to its "avatar on the
-          // screen" size at the entry origin.
-          exit={
-            reduce
-              ? { opacity: 0 }
-              : {
-                  scale: bodyGeometry.startScale,
-                  x: bodyGeometry.startX,
-                  y: bodyGeometry.startY,
-                  transition: { duration: 0.4, ease: "easeIn" },
-                }
-          }
-          transition={
-            reduce
-              ? { duration: 0 }
-              : { type: "spring", stiffness: 78, damping: 18, mass: 1 }
-          }
+          {...bodyGrowMotion(entrance, bodyGeometry)}
         >
           <path d={look.body.svgPath} fill={look.bgHex} />
         </motion.svg>
@@ -564,6 +547,7 @@ export function VoiceRoomColorLook({
         placement={eyePlacement}
         viewport={{ w, h }}
         entranceOrigin={origin}
+        entrance={entrance}
         // The centered eyes never move — they express the state by size.
         sizeScale={sizeScale}
         // Reconnecting: fade the eyes back — presence dimmed while away.
@@ -1045,6 +1029,7 @@ export function VoiceRoomEyes({
   viewport,
   placement = "center",
   entranceOrigin,
+  entrance: requestedEntrance = "grow",
   sizeScale = 1,
   dimmed = false,
   eyeReaction = null,
@@ -1054,8 +1039,11 @@ export function VoiceRoomEyes({
   /** The room box the eyes are framed in (the caller's live viewport size). */
   viewport: { w: number; h: number };
   placement?: VoiceEyePlacement;
-  /** Room-local point the eyes grow from on entrance. Defaults to room center. */
+  /** Room-local point the eyes grow from on entrance. Defaults to room center.
+   *  Unread when {@link entrance} is `"presented"`. */
   entranceOrigin?: { x: number; y: number };
+  /** How the eyes arrive. See `voice-room-entrance.ts`. */
+  entrance?: VoiceRoomEntrance;
   /**
    * Audio gesture the eyes express — `listening` widens them with the mic,
    * `responding` pulses them with the assistant's own voice, `null` holds them
@@ -1072,7 +1060,8 @@ export function VoiceRoomEyes({
 }) {
   const reduce = useReducedMotion();
   const { w, h } = viewport;
-  const playEntrance = !reduce;
+  const entrance = withReducedMotion(requestedEntrance, reduce === true);
+  const playEntrance = entrance === "grow";
   const reactiveRef = useReactiveEyes(eyeReaction, getAmplitude);
 
   // The parallax offset and the blink are decorative, so both drive the DOM
@@ -1214,43 +1203,7 @@ export function VoiceRoomEyes({
         height: geometry.eyesH,
         transformOrigin: "center",
       }}
-      initial={
-        playEntrance
-          ? { x: geometry.startX, y: geometry.startY, scale: 0.35 }
-          : false
-      }
-      // Play the grow-in keyframes only until the entrance lands, then hold a
-      // stable static target. Otherwise every re-render (a `visual`/`sizeScale`
-      // change) hands Motion a fresh keyframe array and it replays part of the
-      // entrance — the eyes lurch toward the origin and snap back, fighting the
-      // smooth per-state resize.
-      animate={
-        playEntrance && !entranceDone
-          ? {
-              x: [geometry.startX, 0, 0],
-              y: [geometry.startY, geometry.dipY, 0],
-              scale: [0.35, 1, 1],
-            }
-          : { x: 0, y: 0, scale: 1 }
-      }
-      // Close reverses the grow: the eyes shrink back to the entry origin
-      // alongside the body, so the whole avatar shape collapses to the point.
-      exit={
-        reduce
-          ? { opacity: 0 }
-          : {
-              x: geometry.startX,
-              y: geometry.startY,
-              scale: 0.35,
-              opacity: 0,
-              transition: { duration: 0.4, ease: "easeIn" },
-            }
-      }
-      transition={
-        playEntrance && !entranceDone
-          ? { duration: 1, times: [0, 0.7, 1], ease: "easeInOut" }
-          : { duration: 0 }
-      }
+      {...eyesEntranceMotion(entrance, geometry, entranceDone)}
       onAnimationComplete={() => setEntranceDone(true)}
     >
       {/* Per-state size: the eyes stay put and resize, on the same motion tween

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -504,6 +504,18 @@ describe("VoiceRoom: mobile sheet", () => {
     return () => header.remove();
   }
 
+  /** The room's own box, held by the sheet's content wrapper as its child. */
+  function roomBox(): HTMLElement {
+    const inner = document.querySelector(
+      '[data-slot="bottom-sheet-content-inner"]',
+    );
+    const box = inner?.firstElementChild;
+    if (!(box instanceof HTMLElement)) {
+      throw new Error("the sheet rendered no room box");
+    }
+    return box;
+  }
+
   test("rests at the header's bottom edge, not its height", () => {
     // The sheet is `fixed` against the viewport, so the offset has to be the
     // header's bottom in viewport coordinates. Positioning by height alone
@@ -629,6 +641,47 @@ describe("VoiceRoom: mobile sheet", () => {
     expect(
       document.querySelector('[data-slot="bottom-sheet-overlay"]'),
     ).toBeNull();
+    removeHeader();
+  });
+
+  // The sheet slides up, so anything inside it that also animates in is a
+  // second, competing arrival: the sheet lands and only then does its content
+  // assemble itself. The room rides up already painted instead. See
+  // `voice-room-entrance.ts`.
+  test("the room is painted before the sheet has finished sliding", () => {
+    const removeHeader = mountHeader();
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="sheet" />);
+
+    // Motion writes `initial` straight into inline style at mount, so a room
+    // that fades in is observable as `opacity: 0` on its first frame.
+    expect(roomBox().style.opacity).not.toBe("0");
+    removeHeader();
+  });
+
+  test("the avatar is on the sheet from the first frame, not popped in after", () => {
+    const removeHeader = mountHeader();
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="sheet" />);
+
+    const avatarBox = screen.getByTestId("voice-avatar").parentElement;
+    expect(avatarBox).not.toBeNull();
+    expect(avatarBox?.style.opacity).not.toBe("0");
+    // The grow starts the avatar low and small; presented, it is simply there.
+    expect(avatarBox?.style.transform ?? "").not.toContain("scale");
+    removeHeader();
+  });
+
+  test("Radix keeps the slide-up, Motion does not claim the entrance", () => {
+    const removeHeader = mountHeader();
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="sheet" />);
+
+    // The exit is Motion's, but the entrance stays the library's keyframe.
+    // A Motion `initial` here would write a transform that fights it.
+    const sheet = screen.getByRole("dialog", { name: "Voice session" });
+    expect(sheet.className).toContain("bottomSheetIn");
+    expect(sheet.style.transform ?? "").toBe("");
     removeHeader();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -30,7 +30,8 @@
  *   ends ({@link useChatHeaderBottom}) rather than inheriting that edge from
  *   the DOM. Non-modal, so the header it rests below stays lit and usable,
  *   which takes suppressing several of Radix's modal reflexes: see
- *   {@link VoiceRoomSheet}.
+ *   {@link VoiceRoomSheet}. Because the slide IS its entrance, the look inside
+ *   is painted rather than grown. See `voice-room-entrance.ts`.
  * - `"fullscreen"`: `fixed inset-0` over the whole viewport, modal, with
  *   safe-area padding for notched iOS shells. No longer mounted by the chat
  *   layout; kept as the variant a surface with no chrome to sit under would
@@ -40,7 +41,8 @@
  * {@link useRoomBox}. As a panel those are different rectangles, so the color
  * look's field, its giant eyes, and the responding rings are all sized to the
  * panel, and the entry origin (published in viewport space by the composer) is
- * converted to room-local space before the entrance grows from it.
+ * converted to room-local space before the entrance grows from it. The sheet
+ * reads no origin: it presents the look rather than growing it.
  *
  * The room is not exit-only. Minimizing (the "show transcript" control or
  * Escape) dismisses the room while the session keeps running, handing the
@@ -68,7 +70,12 @@
  */
 
 import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  AnimatePresence,
+  motion,
+  useReducedMotion,
+  type MotionProps,
+} from "motion/react";
 import { Captions, Mic, MicOff, Volume2, VolumeX, X } from "lucide-react";
 
 import { BottomSheet, Tooltip, cn } from "@vellumai/design-library";
@@ -104,10 +111,13 @@ import {
 } from "./voice-room-layout";
 
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
+import {
+  resolveVoiceRoomChoreography,
+  voidAvatarMotion,
+} from "./voice-room-entrance";
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceAvatar } from "./voice-avatar";
 import { VoiceMeshWaves } from "./voice-mesh-waves";
-import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import {
   VoiceRespondingRings,
@@ -141,6 +151,15 @@ const SESSION_CONTROL_NEUTRAL_CLASS =
 
 /** Placement variant. See the module docstring. */
 export type VoiceRoomVariant = "fullscreen" | "content" | "sheet";
+
+/**
+ * `BottomSheet.Content` with Motion attached, so `AnimatePresence` can play the
+ * sheet's exit on the element Radix positions. The primitive forwards its ref
+ * and spreads the rest onto Radix's content element, which is what
+ * `motion.create` needs. Created at module scope: rebuilding it per render
+ * would remount the sheet on every commit.
+ */
+const MotionBottomSheetContent = motion.create(BottomSheet.Content);
 
 export function VoiceRoom({
   variant = "fullscreen",
@@ -180,18 +199,27 @@ export function VoiceRoom({
  *
  * Escape is therefore left to the room's own handler, shared with the other
  * variants, rather than Radix's, so one keypress is one minimize.
+ *
+ * The exit rides this element rather than the room's box inside it. Radix
+ * portals the content out of the layout and positions it `fixed`, so it is the
+ * outermost thing the sheet owns; sliding the room's box instead would travel
+ * the look downward inside a stationary sheet and expose the page behind it.
  */
 function VoiceRoomSheet({
   headerBottom,
+  motionProps,
   children,
 }: {
   /** Where the sheet's top edge rests. See {@link useChatHeaderBottom}. */
   headerBottom: number;
+  /** The slide-down exit. See `voice-room-entrance.ts`. */
+  motionProps: MotionProps;
   children: ReactNode;
 }) {
   return (
     <BottomSheet.Root open modal={false} onOpenChange={minimizeVoiceRoom}>
-      <BottomSheet.Content
+      <MotionBottomSheetContent
+        {...motionProps}
         // The room is a surface in its own right: a full-bleed color fill and
         // bands that must reach the sheet's rounded corners.
         padded={false}
@@ -221,7 +249,7 @@ function VoiceRoomSheet({
         aria-describedby={undefined}
       >
         {children}
-      </BottomSheet.Content>
+      </MotionBottomSheetContent>
     </BottomSheet.Root>
   );
 }
@@ -325,6 +353,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // Radix's own Escape handling and leaves the key to this one handler. One
   // keypress, one minimize, same behavior on every surface.
   const sheet = variant === "sheet";
+  // How this surface comes and goes. The sheet already has an entrance, the
+  // slide up, so its look is presented rather than grown and the slide-down
+  // exit rides the sheet chrome. See `voice-room-entrance.ts`.
+  const choreography = resolveVoiceRoomChoreography(variant, reduce === true);
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
@@ -383,14 +415,13 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         ...toneVars,
         ...(accentHex ? { [AVATAR_ACCENT_CSS_VAR]: accentHex } : {}),
       }}
-      initial={reduce ? false : { opacity: 0 }}
-      animate={{ opacity: 1 }}
       // On close the chrome and rectangular backgrounds fade, while the avatar
       // shape itself shrinks back toward the entry origin — the color look's
       // body + eyes and the void look's centered avatar each own that exit — so
-      // the room collapses into the avatar, not a shrinking rectangle.
-      exit={{ opacity: 0 }}
-      transition={{ duration: reduce ? 0 : 0.4 }}
+      // the room collapses into the avatar, not a shrinking rectangle. Under
+      // the sheet none of that applies: the chrome slides the whole room out in
+      // one piece, and this box holds still.
+      {...choreography.shell}
     >
       {/* The color look (body grow entrance + color fade + centered waves +
           centered eyes) is the entire cast; the void look expresses the
@@ -417,6 +448,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             // state).
             showStateCaption={!showAssistantTranscript}
             entryOrigin={localEntryOrigin}
+            entrance={choreography.entrance}
             viewport={box}
           />
         ) : null
@@ -528,21 +560,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       {!look ? (
         <motion.div
           className="relative z-0"
-          initial={reduce ? false : { scale: 0.8, y: 24, opacity: 0 }}
-          animate={{ scale: 1, y: 0, opacity: 1 }}
-          // Exit is the inverse of the entry spring: the centered avatar settles
-          // back down and shrinks away rather than fading in place.
-          exit={
-            reduce
-              ? { opacity: 0 }
-              : {
-                  scale: 0.8,
-                  y: 24,
-                  opacity: 0,
-                  transition: { duration: 0.32, ease: "easeIn" },
-                }
-          }
-          transition={reduce ? { duration: 0 } : AVATAR_ENTER_SPRING}
+          {...voidAvatarMotion(choreography.entrance)}
         >
           <VoiceAvatar
             assistantId={assistantId}
@@ -664,8 +682,13 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
     </motion.div>
   );
 
-  return sheet ? (
-    <VoiceRoomSheet headerBottom={headerBottom}>{body}</VoiceRoomSheet>
+  return sheet && choreography.sheetChrome ? (
+    <VoiceRoomSheet
+      headerBottom={headerBottom}
+      motionProps={choreography.sheetChrome}
+    >
+      {body}
+    </VoiceRoomSheet>
   ) : (
     body
   );


### PR DESCRIPTION
The mobile voice room is a `BottomSheet` that slides up, and the avatar's colour
and eyes played their grow-in entrance inside it. Two arrivals competing for the
same moment: the sheet lands, and only then does its content assemble itself.
The grow also sometimes stuck partway.

The sheet now comes up already painted and carries the look with it.

## The seam

Entrance choreography moves out of the inline JSX in `voice-room-eyes.tsx` into
a new `voice-room-entrance.ts`, which owns two modes:

- **`grow`**: the onboarding Introduction entrance, unchanged. The body springs
  from the tapped avatar to cover the room, the colour fades in behind it, the
  eyes rise and settle.
- **`presented`**: painted on the first frame; the surface's own chrome carries
  it on and off. Nothing inside the room animates itself in.

`resolveVoiceRoomChoreography(variant, reduceMotion)` returns the mode plus the
motion bundles for the room's box and the sheet chrome. The look takes a mode
and never learns which variant it renders under, so this is a module boundary
rather than a `variant === "sheet"` check threaded through every animated layer.

Reduced motion resolves to `presented` on every variant, which is what it
already did in all but name, since each layer separately skipped its entrance.

## Scope

Deliberately the sheet only. `content` and `fullscreen` still grow.

Moving desktop over is one line in `resolveVoiceRoomEntrance`, at which point
the `entryOrigin` pipeline that only the grow reads has no readers left and
should come out with it: the live-voice store field, `use-live-voice`'s carry
across the reconnect reset, the composer's `measureVoiceOriginAvatar`,
`ChatAvatar`'s `originAnchor` / `data-voice-origin`, and `toRoomLocal`. That
half reaches into the composer, the store, and a shared avatar component, so it
wants its own PR and its own look at how desktop should feel. Tracked on
JARVIS-1389.

## Notes for review

- **The exit rides `BottomSheet.Content`**, wrapped with `motion.create`, rather
  than the room's box. Radix portals the content and positions it `fixed`, so
  sliding the inner box would travel the look downward inside a stationary sheet
  and expose the page behind it. Radix keeps the entrance (`bottomSheetIn`);
  Motion has `initial: false` so it does not fight it, and owns the exit.
- **The void look is presented too.** A custom-image assistant should ride up as
  settled as a character one. Separate code path from the colour look.
- **The stuck-ness has a suspected cause, not a proven one.** The eyes swap
  `animate` between a keyframe array and a static target on `entranceDone`, and
  Motion restarts a keyframe animation whenever handed a new one; a `connecting`
  to `listening` transition lands inside the one-second entrance often.
  Presenting sidesteps it on the sheet rather than fixing it, so desktop can
  still hit it.

Two things found along the way: `useReducedMotion()` returns `boolean | null`
and the old ternaries let `null` fall through as false; and the sheet's
reduced-motion close would have picked up Motion's default duration once the
room box stopped carrying `transition: { duration: 0 }`.

## Testing

- 22 new tests in `voice-room-entrance.test.ts`: mode resolution, that presented
  layers declare neither entrance nor exit, that the grow still round-trips to
  the entry origin, and the eyes' keyframe latch.
- 3 rendering tests in the sheet block of `voice-room.test.tsx`.
- Confirmed the new tests are not vacuous: reverting the resolver to always
  `grow` fails both "already painted" tests, and they pass again restored.
- `bun run typecheck` clean, eslint clean, all 14 voice-room test files green.
- Checked visually in the browser at a mobile width. The sheet arrives wearing
  its colour and eyes, and closes by sliding back down.

## Review feedback addressed

Both Codex P2 comments on `dc0d47f823`:

- em dashes stripped from every added line, the commit message, and this body
  (`AGENTS.md:138`)
- the module docstring's forward-looking cleanup note rewritten as present-tense
  documentation of why the `entryOrigin` pipeline exists (`AGENTS.md:127`). The
  cleanup plan lives on the Linear ticket instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)