### PR TITLE
feat(cli): add PipeWire audio primitives for live voice

### DIFF
--- a/cli/src/__tests__/live-voice-pipewire-audio.test.ts
+++ b/cli/src/__tests__/live-voice-pipewire-audio.test.ts
@@ -1,0 +1,715 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+import {
+  EchoMeasurement,
+  LIVE_VOICE_PCM_FRAME_BYTES,
+  PcmFrameRechunker,
+  pcm16Rms,
+} from "../lib/live-voice/audio.js";
+import {
+  PipeWireAudio,
+  buildPipeWirePcmArgs,
+  parsePipeWireDevices,
+  parsePipeWireVersion,
+} from "../lib/live-voice/pipewire-audio.js";
+import type {
+  AudioCommandRunner,
+  AudioProcessFactory,
+  AudioProcessProbe,
+} from "../lib/live-voice/pipewire-audio.js";
+
+interface FakeProcessOptions {
+  holdWrites?: boolean;
+  closeOnStdinEnd?: boolean;
+}
+
+class FakeProcess extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly writes: Buffer[] = [];
+  readonly pendingWrites: Array<() => void> = [];
+  readonly killSignals: NodeJS.Signals[] = [];
+  readonly stdin: Writable;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  private processClosed = false;
+
+  constructor(options: FakeProcessOptions = {}) {
+    super();
+    this.stdin = new Writable({
+      highWaterMark: options.holdWrites ? 1 : 64 * 1024,
+      write: (chunk: Buffer, _encoding, callback) => {
+        this.writes.push(Buffer.from(chunk));
+        if (options.holdWrites) {
+          this.pendingWrites.push(callback);
+        } else {
+          callback();
+        }
+      },
+    });
+    if (options.closeOnStdinEnd ?? true) {
+      this.stdin.once("finish", () => {
+        queueMicrotask(() => {
+          this.finish(0);
+        });
+      });
+    }
+  }
+
+  releaseWrite(): void {
+    this.pendingWrites.shift()?.();
+  }
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    if (this.processClosed) {
+      return false;
+    }
+    this.killed = true;
+    this.killSignals.push(signal);
+    queueMicrotask(() => {
+      this.finish(null, signal);
+    });
+    return true;
+  }
+
+  finish(code: number | null, signal: NodeJS.Signals | null = null): void {
+    if (this.processClosed) {
+      return;
+    }
+    this.processClosed = true;
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit("close", code, signal);
+  }
+
+  fail(error: Error): void {
+    this.emit("error", error);
+  }
+
+  asChild(): ChildProcessWithoutNullStreams {
+    return this as unknown as ChildProcessWithoutNullStreams;
+  }
+}
+
+function createProcessFactory(processOptions: FakeProcessOptions[] = []): {
+  spawn: AudioProcessFactory;
+  processes: FakeProcess[];
+  calls: Array<{
+    executable: string;
+    args: readonly string[];
+    shell: boolean | undefined;
+  }>;
+} {
+  const processes: FakeProcess[] = [];
+  const calls: Array<{
+    executable: string;
+    args: readonly string[];
+    shell: boolean | undefined;
+  }> = [];
+  const spawn: AudioProcessFactory = (executable, args, options) => {
+    calls.push({ executable, args: [...args], shell: options.shell });
+    const child = new FakeProcess(processOptions[processes.length]);
+    processes.push(child);
+    return child.asChild();
+  };
+  return { spawn, processes, calls };
+}
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+const PIPEWIRE_DUMP = JSON.stringify([
+  {
+    id: 31,
+    type: "PipeWire:Interface:Node",
+    info: {
+      props: {
+        "object.serial": 1001,
+        "node.name": "capture.node",
+        "node.description": "USB Microphone",
+        "media.class": "Audio/Source",
+        "module.id": 8,
+      },
+    },
+  },
+  {
+    id: 32,
+    type: "PipeWire:Interface:Node",
+    info: {
+      props: {
+        "object.serial": "1002",
+        "node.name": "playback.node",
+        "node.nick": "USB Speaker",
+        "media.class": "Audio/Sink",
+        "module.id": 8,
+      },
+    },
+  },
+  {
+    id: 33,
+    type: "PipeWire:Interface:Node",
+    info: {
+      props: {
+        "object.serial": 1003,
+        "node.name": "video.node",
+        "media.class": "Video/Source",
+      },
+    },
+  },
+]);
+
+describe("PCM framing", () => {
+  test("uses exact 50 ms PCM16 frames and preserves odd chunk boundaries", () => {
+    expect(LIVE_VOICE_PCM_FRAME_BYTES).toBe(1_600);
+    const source = Buffer.alloc(1_701);
+    for (let index = 0; index < source.length; index += 1) {
+      source[index] = index % 251;
+    }
+    const framer = new PcmFrameRechunker();
+
+    expect(framer.push(source.subarray(0, 1))).toEqual([]);
+    const frames = framer.push(source.subarray(1, 1_600));
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual(source.subarray(0, 1_600));
+    expect(framer.push(source.subarray(1_600))).toEqual([]);
+
+    const tail = framer.flush();
+    expect(tail).toEqual(source.subarray(1_600, 1_700));
+    expect(framer.flush()).toBeNull();
+  });
+
+  test("generates equal-size zero frames and an aligned muted tail", () => {
+    const framer = new PcmFrameRechunker();
+    const frames = framer.push(Buffer.alloc(1_600, 0x7f), true);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual(Buffer.alloc(1_600));
+
+    framer.push(Buffer.alloc(5, 0x7f));
+    expect(framer.flush(true)).toEqual(Buffer.alloc(4));
+  });
+
+  test("measures PCM16 RMS without retaining audio", () => {
+    const pcm = Buffer.alloc(4);
+    pcm.writeInt16LE(16_384, 0);
+    pcm.writeInt16LE(-16_384, 2);
+    expect(pcm16Rms(pcm)).toBeCloseTo(0.5, 8);
+    expect(pcm16Rms(Buffer.alloc(0))).toBe(0);
+  });
+});
+
+describe("PipeWire device discovery and capture", () => {
+  test("preserves stable node names, serials, classes, and module ownership", () => {
+    const devices = parsePipeWireDevices(PIPEWIRE_DUMP);
+    expect(devices).toEqual({
+      inputs: [
+        {
+          direction: "input",
+          nodeName: "capture.node",
+          objectSerial: "1001",
+          description: "USB Microphone",
+          mediaClass: "Audio/Source",
+          objectId: 31,
+          moduleId: 8,
+        },
+      ],
+      outputs: [
+        {
+          direction: "output",
+          nodeName: "playback.node",
+          objectSerial: "1002",
+          description: "USB Speaker",
+          mediaClass: "Audio/Sink",
+          objectId: 32,
+          moduleId: 8,
+        },
+      ],
+    });
+  });
+
+  test("rejects malformed pw-dump payloads", () => {
+    expect(() => parsePipeWireDevices("{")).toThrow(
+      "pw-dump returned invalid JSON",
+    );
+    expect(() => parsePipeWireDevices("{}")).toThrow(
+      "pw-dump returned an unexpected payload",
+    );
+  });
+
+  test("passes a selected target as one argument without a shell", async () => {
+    const factory = createProcessFactory();
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const frames: Buffer[] = [];
+    const target = "capture.node; touch /tmp/example";
+    const capture = await audio.startCapture({
+      target,
+      onFrame: (frame) => {
+        frames.push(frame);
+      },
+    });
+
+    expect(factory.calls[0]).toEqual({
+      executable: "/usr/bin/pw-record",
+      args: [
+        "--raw",
+        "--rate=16000",
+        "--channels=1",
+        "--format=s16",
+        "--latency=50ms",
+        `--target=${target}`,
+        "-",
+      ],
+      shell: false,
+    });
+
+    factory.processes[0].stdout.write(Buffer.alloc(1));
+    factory.processes[0].stdout.write(Buffer.alloc(1_599, 1));
+    await nextEventLoop();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toHaveLength(1_600);
+
+    const firstStop = capture.stop();
+    const secondStop = capture.stop();
+    expect(firstStop).toBe(secondStop);
+    expect(await firstStop).toBeNull();
+    expect(factory.processes[0].killSignals).toEqual(["SIGTERM"]);
+  });
+
+  test("flushes an aligned capture tail and reports child failure", async () => {
+    const factory = createProcessFactory();
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const capture = await audio.startCapture({ onFrame: () => {} });
+    factory.processes[0].stdout.write(Buffer.from([1, 2, 3, 4, 5]));
+    await nextEventLoop();
+
+    expect(await capture.stop()).toEqual(Buffer.from([1, 2, 3, 4]));
+
+    const failedCapture = await audio.startCapture({ onFrame: () => {} });
+    factory.processes[1].finish(2);
+    await expect(failedCapture.closed).rejects.toThrow(
+      "pw-record stopped unexpectedly with code 2",
+    );
+  });
+
+  test("builds the protocol capture cadence without an explicit target", () => {
+    expect(buildPipeWirePcmArgs()).toEqual([
+      "--raw",
+      "--rate=16000",
+      "--channels=1",
+      "--format=s16",
+      "--latency=50ms",
+      "-",
+    ]);
+  });
+});
+
+describe("PipeWire playback", () => {
+  test("serializes writes and waits for stdin backpressure", async () => {
+    const factory = createProcessFactory([{ holdWrites: true }]);
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const playback = audio.createPlayback("playback.node");
+
+    const first = playback.write({
+      audio: Buffer.from([1, 2]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+    const second = playback.write({
+      audio: Buffer.from([3, 4]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+    await nextEventLoop();
+
+    expect(factory.processes[0].writes).toEqual([Buffer.from([1, 2])]);
+    factory.processes[0].releaseWrite();
+    await first;
+    await nextEventLoop();
+    expect(factory.processes[0].writes).toEqual([
+      Buffer.from([1, 2]),
+      Buffer.from([3, 4]),
+    ]);
+    factory.processes[0].releaseWrite();
+    await second;
+
+    const drained = playback.drain();
+    await nextEventLoop();
+    await drained;
+    expect(factory.calls[0].args).toContain("--target=playback.node");
+  });
+
+  test("restarts lazily when the sample rate changes", async () => {
+    const factory = createProcessFactory();
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const playback = audio.createPlayback();
+
+    await playback.write({
+      audio: Buffer.from([1, 2]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+    await playback.write({
+      audio: Buffer.from([3, 4]),
+      mimeType: "audio/pcm",
+      sampleRate: 24_000,
+    });
+
+    expect(factory.processes).toHaveLength(2);
+    expect(factory.processes[0].killSignals).toEqual(["SIGTERM"]);
+    expect(factory.calls[0].args).toContain("--rate=16000");
+    expect(factory.calls[1].args).toContain("--rate=24000");
+    await playback.close();
+  });
+
+  test("flushes immediately, drops buffered writes, and recreates playback", async () => {
+    const factory = createProcessFactory([{ holdWrites: true }, {}]);
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const target = "playback.node; touch /tmp/example";
+    const playback = audio.createPlayback(target);
+
+    const buffered = playback.write({
+      audio: Buffer.from([1, 2]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+    const queued = playback.write({
+      audio: Buffer.from([3, 4]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+    await nextEventLoop();
+    const flushed = playback.flush();
+    expect(factory.processes[0].killSignals).toEqual(["SIGTERM"]);
+    await Promise.all([buffered, queued, flushed]);
+
+    await playback.write({
+      audio: Buffer.from([9, 10]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+    expect(factory.processes).toHaveLength(2);
+    expect(factory.processes[1].writes).toEqual([Buffer.from([9, 10])]);
+    expect(factory.calls[1].args).toContain(`--target=${target}`);
+    expect(factory.calls[1].shell).toBe(false);
+    await playback.close();
+    await playback.close();
+    expect(factory.processes[1].killSignals).toEqual(["SIGTERM"]);
+  });
+
+  test("rejects unsupported provider output with format details", async () => {
+    const audio = new PipeWireAudio({
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const playback = audio.createPlayback();
+    await expect(
+      playback.write({
+        audio: Buffer.from([1]),
+        mimeType: "audio/mpeg",
+        sampleRate: 24_000,
+        provider: "Example TTS",
+      }),
+    ).rejects.toThrow(
+      "Example TTS returned unsupported live voice audio audio/mpeg at 24000 Hz. Expected audio/pcm.",
+    );
+  });
+
+  test("surfaces an unexpected child failure", async () => {
+    const factory = createProcessFactory([{ holdWrites: true }]);
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const playback = audio.createPlayback();
+    const write = playback.write({
+      audio: Buffer.from([1, 2]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+    await nextEventLoop();
+    factory.processes[0].finish(1);
+    await expect(write).rejects.toThrow(
+      "pw-play stopped while audio was buffered",
+    );
+  });
+
+  test("does not silently replace a failed playback process", async () => {
+    const factory = createProcessFactory();
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const playback = audio.createPlayback();
+    await playback.write({
+      audio: Buffer.from([1, 2]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+    factory.processes[0].finish(7);
+
+    await expect(
+      playback.write({
+        audio: Buffer.from([3, 4]),
+        mimeType: "audio/pcm",
+        sampleRate: 16_000,
+      }),
+    ).rejects.toThrow("pw-play stopped unexpectedly with code 7");
+    expect(factory.processes).toHaveLength(1);
+  });
+});
+
+describe("PipeWire doctor", () => {
+  test("parses PipeWire versions", () => {
+    expect(parsePipeWireVersion("Compiled with libpipewire 1.4.2")).toEqual({
+      major: 1,
+      minor: 4,
+      patch: 2,
+    });
+    expect(parsePipeWireVersion("pw-record 0.3")).toEqual({
+      major: 0,
+      minor: 3,
+      patch: 0,
+    });
+    expect(parsePipeWireVersion("unknown")).toBeNull();
+  });
+
+  test("distinguishes a missing user session from missing hardware", async () => {
+    const runCommand: AudioCommandRunner = async (_executable, args) => {
+      if (args.includes("--version")) {
+        return { code: 0, stdout: "pw-record 1.4.2", stderr: "" };
+      }
+      if (args.includes("is-active")) {
+        return { code: 3, stdout: "inactive", stderr: "" };
+      }
+      if (args.includes("show-user")) {
+        return { code: 0, stdout: "Linger=no\n", stderr: "" };
+      }
+      if (args.length === 0) {
+        return { code: 0, stdout: PIPEWIRE_DUMP, stderr: "" };
+      }
+      throw new Error(`Unexpected command: ${args.join(" ")}`);
+    };
+    const audio = new PipeWireAudio({
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      runCommand,
+      probeProcess: async () => ({ ok: true }),
+      platform: "linux",
+      architecture: "arm64",
+      username: "user1",
+      runtimeDirectory: "/run/user/1000",
+      pathExists: () => false,
+    });
+
+    const report = await audio.doctor();
+    expect(
+      report.checks.find((check) => check.id === "session.pipewire"),
+    ).toMatchObject({ status: "fail" });
+    expect(
+      report.checks.find((check) => check.id === "session.wireplumber"),
+    ).toMatchObject({ status: "fail" });
+    expect(
+      report.checks.find((check) => check.id === "session.linger"),
+    ).toMatchObject({ status: "fail" });
+    expect(
+      report.checks.find((check) => check.id === "devices.input"),
+    ).toMatchObject({ status: "skip" });
+    expect(
+      report.checks.find((check) => check.id === "probe.input"),
+    ).toMatchObject({ status: "skip" });
+  });
+
+  test("reports missing hardware separately when the user session is active", async () => {
+    const runCommand: AudioCommandRunner = async (_executable, args) => {
+      if (args.includes("--version")) {
+        return { code: 0, stdout: "pw-record 1.4.0", stderr: "" };
+      }
+      if (args.includes("is-active")) {
+        return { code: 0, stdout: "active\n", stderr: "" };
+      }
+      if (args.includes("show-user")) {
+        return { code: 0, stdout: "Linger=yes\n", stderr: "" };
+      }
+      return { code: 0, stdout: "[]", stderr: "" };
+    };
+    const audio = new PipeWireAudio({
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      runCommand,
+      probeProcess: async () => ({ ok: true }),
+      platform: "linux",
+      architecture: "arm64",
+      username: "user1",
+    });
+
+    const report = await audio.doctor();
+    expect(
+      report.checks.find((check) => check.id === "session.pipewire"),
+    ).toMatchObject({ status: "pass" });
+    expect(
+      report.checks.find((check) => check.id === "devices.input"),
+    ).toMatchObject({ status: "fail" });
+    expect(
+      report.checks.find((check) => check.id === "devices.output"),
+    ).toMatchObject({ status: "fail" });
+  });
+
+  test("validates explicit devices and runs in-memory process probes", async () => {
+    const probeCalls: Array<{
+      executable: string;
+      args: readonly string[];
+      input?: Buffer;
+      requireOutput?: boolean;
+    }> = [];
+    const probeProcess: AudioProcessProbe = async (
+      executable,
+      args,
+      options,
+    ) => {
+      probeCalls.push({
+        executable,
+        args: [...args],
+        input: options.input,
+        requireOutput: options.requireOutput,
+      });
+      return { ok: true };
+    };
+    const runCommand: AudioCommandRunner = async (_executable, args) => {
+      if (args.includes("--version")) {
+        return { code: 0, stdout: "pw-record 1.4.1", stderr: "" };
+      }
+      if (args.includes("is-active")) {
+        return { code: 0, stdout: "active", stderr: "" };
+      }
+      if (args.includes("show-user")) {
+        return { code: 0, stdout: "Linger=yes", stderr: "" };
+      }
+      return { code: 0, stdout: PIPEWIRE_DUMP, stderr: "" };
+    };
+    const audio = new PipeWireAudio({
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      runCommand,
+      probeProcess,
+      platform: "linux",
+      architecture: "arm64",
+      username: "user1",
+    });
+
+    const report = await audio.doctor({
+      inputDevice: "1001",
+      outputDevice: "playback.node",
+    });
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.find((check) => check.id === "device.input.selected"),
+    ).toMatchObject({ status: "pass" });
+    expect(probeCalls).toHaveLength(2);
+    expect(probeCalls[0].args).toContain("--target=capture.node");
+    expect(probeCalls[0].requireOutput).toBe(true);
+    expect(probeCalls[1].args).toContain("--target=playback.node");
+    expect(probeCalls[1].input).toEqual(Buffer.alloc(1_600));
+  });
+
+  test("rejects PipeWire older than 1.4 and an invalid explicit device", async () => {
+    const runCommand: AudioCommandRunner = async (_executable, args) => {
+      if (args.includes("--version")) {
+        return { code: 0, stdout: "pw-record 1.3.9", stderr: "" };
+      }
+      if (args.includes("is-active")) {
+        return { code: 0, stdout: "active", stderr: "" };
+      }
+      if (args.includes("show-user")) {
+        return { code: 0, stdout: "Linger=yes", stderr: "" };
+      }
+      return { code: 0, stdout: PIPEWIRE_DUMP, stderr: "" };
+    };
+    const audio = new PipeWireAudio({
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      runCommand,
+      probeProcess: async () => ({ ok: true }),
+      platform: "linux",
+      architecture: "arm64",
+      username: "user1",
+    });
+
+    const report = await audio.doctor({ inputDevice: "missing.node" });
+    expect(
+      report.checks.find((check) => check.id === "pipewire.version"),
+    ).toMatchObject({ status: "fail" });
+    expect(
+      report.checks.find((check) => check.id === "device.input.selected"),
+    ).toMatchObject({ status: "fail" });
+  });
+});
+
+describe("echo measurements", () => {
+  test("reports scalar floor, margin, peak, and correlation after silence", () => {
+    const measurement = new EchoMeasurement();
+    expect(measurement.addSample({ microphone: 0.1, playback: 0 })).toBeNull();
+    expect(measurement.addSample({ microphone: 0.1, playback: 0 })).toBeNull();
+    expect(
+      measurement.addSample({ microphone: 0.2, playback: 0.2 }),
+    ).toBeNull();
+    expect(
+      measurement.addSample({ microphone: 0.4, playback: 0.4 }),
+    ).toBeNull();
+    expect(
+      measurement.addSample({ microphone: 0.6, playback: 0.6 }),
+    ).toBeNull();
+
+    const summary = measurement.addSample({
+      microphone: 0.1,
+      playback: 0,
+    });
+    expect(summary).not.toBeNull();
+    expect(summary?.sampleCount).toBe(3);
+    expect(summary?.microphoneFloor).toBeCloseTo(0.1, 8);
+    expect(summary?.meanMicrophoneDuringPlayback).toBeCloseTo(0.4, 8);
+    expect(summary?.peakMicrophoneDuringPlayback).toBeCloseTo(0.6, 8);
+    expect(summary?.decibelsAboveFloor).toBeCloseTo(20 * Math.log10(4), 8);
+    expect(summary?.playbackMicrophoneCorrelation).toBeCloseTo(1, 8);
+    expect(measurement.addSample({ microphone: 0.1, playback: 0 })).toBeNull();
+    expect(
+      Object.values(measurement).some(
+        (value) => Buffer.isBuffer(value) || Array.isArray(value),
+      ),
+    ).toBe(false);
+  });
+
+  test("emits once per utterance and resets scalar accumulators", () => {
+    const measurement = new EchoMeasurement();
+    measurement.addSample({ microphone: 0.01, playback: 0 });
+    measurement.addSample({ microphone: 0.2, playback: 0.5 });
+    const first = measurement.addSample({ microphone: 0.02, playback: 0 });
+    expect(first?.sampleCount).toBe(1);
+    expect(measurement.addSample({ microphone: 0.03, playback: 0 })).toBeNull();
+
+    measurement.addSample({ microphone: 0.3, playback: 0.2 });
+    measurement.addSample({ microphone: 0.1, playback: 0.4 });
+    const second = measurement.addSample({
+      microphone: 0.02,
+      playback: 0,
+    });
+    expect(second?.sampleCount).toBe(2);
+    expect(second?.peakMicrophoneDuringPlayback).toBeCloseTo(0.3, 8);
+    expect(second?.playbackMicrophoneCorrelation).toBeCloseTo(-1, 8);
+  });
+});

--- a/cli/src/lib/live-voice/audio.ts
+++ b/cli/src/lib/live-voice/audio.ts
@@ -1,0 +1,319 @@
+export const LIVE_VOICE_PCM_SAMPLE_RATE = 16_000;
+export const LIVE_VOICE_PCM_CHANNELS = 1;
+export const LIVE_VOICE_PCM_BYTES_PER_SAMPLE = 2;
+export const LIVE_VOICE_PCM_FRAME_DURATION_MS = 50;
+export const LIVE_VOICE_PCM_FRAME_BYTES =
+  (LIVE_VOICE_PCM_SAMPLE_RATE *
+    LIVE_VOICE_PCM_CHANNELS *
+    LIVE_VOICE_PCM_BYTES_PER_SAMPLE *
+    LIVE_VOICE_PCM_FRAME_DURATION_MS) /
+  1_000;
+export const LIVE_VOICE_PCM_MIME_TYPE = "audio/pcm";
+
+export type LiveVoiceAudioDirection = "input" | "output";
+
+export interface LiveVoiceAudioDevice {
+  direction: LiveVoiceAudioDirection;
+  nodeName: string;
+  objectSerial: string;
+  description: string;
+  mediaClass: string;
+  objectId?: number;
+  moduleId?: number;
+}
+
+export interface LiveVoiceAudioDevices {
+  inputs: LiveVoiceAudioDevice[];
+  outputs: LiveVoiceAudioDevice[];
+}
+
+export interface LiveVoiceAudioDeviceDiscovery {
+  discoverDevices(): Promise<LiveVoiceAudioDevices>;
+}
+
+export type LiveVoiceAudioDoctorStatus = "pass" | "warning" | "fail" | "skip";
+
+export interface LiveVoiceAudioDoctorCheck {
+  id: string;
+  status: LiveVoiceAudioDoctorStatus;
+  message: string;
+}
+
+export interface LiveVoiceAudioDoctorOptions {
+  inputDevice?: string;
+  outputDevice?: string;
+  probeDurationMs?: number;
+}
+
+export interface LiveVoiceAudioDoctorReport {
+  ok: boolean;
+  checks: LiveVoiceAudioDoctorCheck[];
+  devices: LiveVoiceAudioDevices;
+}
+
+export interface LiveVoiceAudioDiagnostics {
+  doctor(
+    options?: LiveVoiceAudioDoctorOptions,
+  ): Promise<LiveVoiceAudioDoctorReport>;
+}
+
+export interface LiveVoicePcmCaptureOptions {
+  target?: string;
+  onFrame(frame: Buffer, rmsAmplitude: number): void;
+}
+
+export interface LiveVoicePcmCaptureSession {
+  readonly closed: Promise<void>;
+  setMuted(muted: boolean): void;
+  stop(): Promise<Buffer | null>;
+}
+
+export interface LiveVoicePcmCapture {
+  startCapture(
+    options: LiveVoicePcmCaptureOptions,
+  ): Promise<LiveVoicePcmCaptureSession>;
+}
+
+export interface LiveVoicePlaybackChunk {
+  audio: Buffer;
+  mimeType: string;
+  sampleRate: number;
+  provider?: string;
+}
+
+export interface LiveVoicePcmPlayback {
+  write(chunk: LiveVoicePlaybackChunk): Promise<void>;
+  drain(): Promise<void>;
+  flush(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface LiveVoicePcmPlaybackFactory {
+  createPlayback(target?: string): LiveVoicePcmPlayback;
+}
+
+export class PcmFrameRechunker {
+  private pending = Buffer.alloc(0);
+
+  push(chunk: Uint8Array, muted = false): Buffer[] {
+    if (chunk.byteLength === 0) {
+      return [];
+    }
+
+    const incoming = Buffer.from(
+      chunk.buffer,
+      chunk.byteOffset,
+      chunk.byteLength,
+    );
+    const combined =
+      this.pending.length === 0
+        ? Buffer.from(incoming)
+        : Buffer.concat([this.pending, incoming]);
+    const completeFrameBytes =
+      Math.floor(combined.length / LIVE_VOICE_PCM_FRAME_BYTES) *
+      LIVE_VOICE_PCM_FRAME_BYTES;
+    const frames: Buffer[] = [];
+
+    for (
+      let offset = 0;
+      offset < completeFrameBytes;
+      offset += LIVE_VOICE_PCM_FRAME_BYTES
+    ) {
+      frames.push(
+        muted
+          ? Buffer.alloc(LIVE_VOICE_PCM_FRAME_BYTES)
+          : Buffer.from(
+              combined.subarray(offset, offset + LIVE_VOICE_PCM_FRAME_BYTES),
+            ),
+      );
+    }
+
+    this.pending = Buffer.from(combined.subarray(completeFrameBytes));
+    return frames;
+  }
+
+  flush(muted = false): Buffer | null {
+    const alignedBytes =
+      this.pending.length -
+      (this.pending.length % LIVE_VOICE_PCM_BYTES_PER_SAMPLE);
+    const tail =
+      alignedBytes === 0
+        ? null
+        : muted
+          ? Buffer.alloc(alignedBytes)
+          : Buffer.from(this.pending.subarray(0, alignedBytes));
+    this.pending = Buffer.alloc(0);
+    return tail;
+  }
+}
+
+export function pcm16Rms(pcm: Uint8Array): number {
+  const sampleCount = Math.floor(
+    pcm.byteLength / LIVE_VOICE_PCM_BYTES_PER_SAMPLE,
+  );
+  if (sampleCount === 0) {
+    return 0;
+  }
+
+  const bytes = Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+  let sumSquares = 0;
+  for (let index = 0; index < sampleCount; index += 1) {
+    const sample = bytes.readInt16LE(index * LIVE_VOICE_PCM_BYTES_PER_SAMPLE);
+    const normalized = sample / 32_768;
+    sumSquares += normalized * normalized;
+  }
+  return Math.sqrt(sumSquares / sampleCount);
+}
+
+export interface EchoAmplitudeSample {
+  microphone: number;
+  playback: number;
+}
+
+export interface EchoMeasurementSummary {
+  sampleCount: number;
+  microphoneFloor: number | null;
+  meanMicrophoneDuringPlayback: number;
+  peakMicrophoneDuringPlayback: number;
+  decibelsAboveFloor: number | null;
+  playbackMicrophoneCorrelation: number | null;
+}
+
+export interface EchoMeasurementOptions {
+  audibleThreshold?: number;
+}
+
+export class EchoMeasurement {
+  private readonly audibleThreshold: number;
+  private floorCount = 0;
+  private floorSum = 0;
+  private active = false;
+  private sampleCount = 0;
+  private microphoneSum = 0;
+  private microphonePeak = 0;
+  private playbackSum = 0;
+  private playbackSquares = 0;
+  private microphoneSquares = 0;
+  private productSum = 0;
+  private utteranceFloor: number | null = null;
+
+  constructor(options: EchoMeasurementOptions = {}) {
+    this.audibleThreshold = options.audibleThreshold ?? 1e-6;
+  }
+
+  addSample(sample: EchoAmplitudeSample): EchoMeasurementSummary | null {
+    const microphone = sanitizeAmplitude(sample.microphone);
+    const playback = sanitizeAmplitude(sample.playback);
+    const audible = playback > this.audibleThreshold;
+
+    if (!audible) {
+      if (this.active) {
+        const summary = this.finishUtterance();
+        this.addFloorSample(microphone);
+        return summary;
+      }
+      this.addFloorSample(microphone);
+      return null;
+    }
+
+    if (!this.active) {
+      this.active = true;
+      this.utteranceFloor =
+        this.floorCount === 0 ? null : this.floorSum / this.floorCount;
+    }
+
+    this.sampleCount += 1;
+    this.microphoneSum += microphone;
+    this.microphonePeak = Math.max(this.microphonePeak, microphone);
+    this.playbackSum += playback;
+    this.playbackSquares += playback * playback;
+    this.microphoneSquares += microphone * microphone;
+    this.productSum += playback * microphone;
+    return null;
+  }
+
+  reset(): void {
+    this.floorCount = 0;
+    this.floorSum = 0;
+    this.resetUtterance();
+  }
+
+  private addFloorSample(microphone: number): void {
+    this.floorCount += 1;
+    this.floorSum += microphone;
+  }
+
+  private finishUtterance(): EchoMeasurementSummary {
+    const meanMicrophone =
+      this.sampleCount === 0 ? 0 : this.microphoneSum / this.sampleCount;
+    const floor = this.utteranceFloor;
+    const decibelsAboveFloor =
+      floor === null
+        ? null
+        : 20 *
+          Math.log10(
+            Math.max(meanMicrophone, Number.EPSILON) /
+              Math.max(floor, Number.EPSILON),
+          );
+    const correlation = pearsonCorrelationFromSums({
+      count: this.sampleCount,
+      sumX: this.playbackSum,
+      sumY: this.microphoneSum,
+      sumXX: this.playbackSquares,
+      sumYY: this.microphoneSquares,
+      sumXY: this.productSum,
+    });
+    const summary: EchoMeasurementSummary = {
+      sampleCount: this.sampleCount,
+      microphoneFloor: floor,
+      meanMicrophoneDuringPlayback: meanMicrophone,
+      peakMicrophoneDuringPlayback: this.microphonePeak,
+      decibelsAboveFloor,
+      playbackMicrophoneCorrelation: correlation,
+    };
+    this.floorCount = 0;
+    this.floorSum = 0;
+    this.resetUtterance();
+    return summary;
+  }
+
+  private resetUtterance(): void {
+    this.active = false;
+    this.sampleCount = 0;
+    this.microphoneSum = 0;
+    this.microphonePeak = 0;
+    this.playbackSum = 0;
+    this.playbackSquares = 0;
+    this.microphoneSquares = 0;
+    this.productSum = 0;
+    this.utteranceFloor = null;
+  }
+}
+
+function sanitizeAmplitude(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+interface CorrelationSums {
+  count: number;
+  sumX: number;
+  sumY: number;
+  sumXX: number;
+  sumYY: number;
+  sumXY: number;
+}
+
+function pearsonCorrelationFromSums(sums: CorrelationSums): number | null {
+  if (sums.count < 2) {
+    return null;
+  }
+
+  const numerator = sums.count * sums.sumXY - sums.sumX * sums.sumY;
+  const xVariance = sums.count * sums.sumXX - sums.sumX * sums.sumX;
+  const yVariance = sums.count * sums.sumYY - sums.sumY * sums.sumY;
+  const denominator = Math.sqrt(xVariance * yVariance);
+  if (denominator <= Number.EPSILON) {
+    return null;
+  }
+  return Math.max(-1, Math.min(1, numerator / denominator));
+}

--- a/cli/src/lib/live-voice/pipewire-audio.ts
+++ b/cli/src/lib/live-voice/pipewire-audio.ts
@@ -1,0 +1,1109 @@
+import { spawn } from "node:child_process";
+import type {
+  ChildProcessWithoutNullStreams,
+  SpawnOptionsWithoutStdio,
+} from "node:child_process";
+import { constants as fsConstants, existsSync } from "node:fs";
+import { access } from "node:fs/promises";
+import { delimiter, isAbsolute, join } from "node:path";
+import { userInfo } from "node:os";
+
+import { compareVersions, parseVersion } from "../version-compat.js";
+import {
+  LIVE_VOICE_PCM_CHANNELS,
+  LIVE_VOICE_PCM_FRAME_BYTES,
+  LIVE_VOICE_PCM_FRAME_DURATION_MS,
+  LIVE_VOICE_PCM_MIME_TYPE,
+  LIVE_VOICE_PCM_SAMPLE_RATE,
+  PcmFrameRechunker,
+  pcm16Rms,
+} from "./audio.js";
+import type {
+  LiveVoiceAudioDevice,
+  LiveVoiceAudioDevices,
+  LiveVoiceAudioDoctorCheck,
+  LiveVoiceAudioDoctorOptions,
+  LiveVoiceAudioDoctorReport,
+  LiveVoicePcmCaptureOptions,
+  LiveVoicePcmCaptureSession,
+  LiveVoicePcmPlayback,
+  LiveVoicePlaybackChunk,
+} from "./audio.js";
+
+const REQUIRED_EXECUTABLES = [
+  "pw-record",
+  "pw-play",
+  "pw-dump",
+  "systemctl",
+  "loginctl",
+] as const;
+const MINIMUM_PIPEWIRE_VERSION = "1.4.0";
+const AUDIO_COMMAND_TIMEOUT_MS = 5_000;
+
+export type AudioProcessFactory = (
+  executable: string,
+  args: readonly string[],
+  options: SpawnOptionsWithoutStdio & {
+    stdio: ["pipe", "pipe", "pipe"];
+    shell: false;
+  },
+) => ChildProcessWithoutNullStreams;
+
+export type AudioExecutableLookup = (
+  executable: string,
+) => Promise<string | null>;
+
+export interface AudioCommandResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type AudioCommandRunner = (
+  executable: string,
+  args: readonly string[],
+  options?: { timeoutMs?: number },
+) => Promise<AudioCommandResult>;
+
+export interface AudioProcessProbeOptions {
+  durationMs: number;
+  input?: Buffer;
+  requireOutput?: boolean;
+}
+
+export interface AudioProcessProbeResult {
+  ok: boolean;
+  detail?: string;
+}
+
+export type AudioProcessProbe = (
+  executable: string,
+  args: readonly string[],
+  options: AudioProcessProbeOptions,
+) => Promise<AudioProcessProbeResult>;
+
+export interface PipeWireAudioDependencies {
+  spawnProcess?: AudioProcessFactory;
+  findExecutable?: AudioExecutableLookup;
+  runCommand?: AudioCommandRunner;
+  probeProcess?: AudioProcessProbe;
+  platform?: NodeJS.Platform;
+  architecture?: string;
+  username?: string;
+  runtimeDirectory?: string;
+  pathExists?: (path: string) => boolean;
+}
+
+export interface PipeWireVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+interface PipeWireDumpObject {
+  id?: unknown;
+  type?: unknown;
+  info?: {
+    props?: Record<string, unknown>;
+  };
+}
+
+export class PipeWireAudio {
+  private readonly spawnProcess: AudioProcessFactory;
+  private readonly findExecutable: AudioExecutableLookup;
+  private readonly runCommand: AudioCommandRunner;
+  private readonly probeProcess: AudioProcessProbe;
+  private readonly platform: NodeJS.Platform;
+  private readonly architecture: string;
+  private readonly username: string;
+  private readonly runtimeDirectory: string | undefined;
+  private readonly pathExists: (path: string) => boolean;
+
+  constructor(dependencies: PipeWireAudioDependencies = {}) {
+    this.spawnProcess = dependencies.spawnProcess ?? defaultSpawnProcess;
+    this.findExecutable =
+      dependencies.findExecutable ?? defaultExecutableLookup;
+    this.runCommand =
+      dependencies.runCommand ?? createDefaultCommandRunner(this.spawnProcess);
+    this.probeProcess =
+      dependencies.probeProcess ?? createDefaultProcessProbe(this.spawnProcess);
+    this.platform = dependencies.platform ?? process.platform;
+    this.architecture = dependencies.architecture ?? process.arch;
+    this.username = dependencies.username ?? userInfo().username;
+    this.runtimeDirectory =
+      dependencies.runtimeDirectory ?? process.env.XDG_RUNTIME_DIR;
+    this.pathExists = dependencies.pathExists ?? existsSync;
+  }
+
+  async discoverDevices(): Promise<LiveVoiceAudioDevices> {
+    const executable = await this.requireExecutable("pw-dump");
+    const result = await this.runCommand(executable, [], {
+      timeoutMs: AUDIO_COMMAND_TIMEOUT_MS,
+    });
+    if (result.code !== 0) {
+      throw new Error(
+        result.stderr.trim() ||
+          "PipeWire device discovery failed. Check the user audio session.",
+      );
+    }
+    return parsePipeWireDevices(result.stdout);
+  }
+
+  async startCapture(
+    options: LiveVoicePcmCaptureOptions,
+  ): Promise<LiveVoicePcmCaptureSession> {
+    const executable = await this.requireExecutable("pw-record");
+    const child = this.spawnProcess(
+      executable,
+      buildPipeWirePcmArgs(options.target),
+      pipeProcessOptions(),
+    );
+    return new PipeWireCaptureSession(child, options);
+  }
+
+  createPlayback(target?: string): LiveVoicePcmPlayback {
+    return new PipeWirePlayback(this.spawnProcess, this.findExecutable, target);
+  }
+
+  async doctor(
+    options: LiveVoiceAudioDoctorOptions = {},
+  ): Promise<LiveVoiceAudioDoctorReport> {
+    const checks: LiveVoiceAudioDoctorCheck[] = [];
+    const executables = new Map<string, string>();
+    const addCheck = (
+      id: string,
+      status: LiveVoiceAudioDoctorCheck["status"],
+      message: string,
+    ): void => {
+      checks.push({ id, status, message });
+    };
+
+    const supportedRuntime =
+      this.platform === "linux" && this.architecture === "arm64";
+    addCheck(
+      "runtime",
+      supportedRuntime ? "pass" : "fail",
+      supportedRuntime
+        ? "Linux ARM64 is supported."
+        : `Expected Linux ARM64, found ${this.platform} ${this.architecture}.`,
+    );
+
+    const resolvedExecutables = await Promise.all(
+      REQUIRED_EXECUTABLES.map(
+        async (name) => [name, await this.findExecutable(name)] as const,
+      ),
+    );
+    for (const [name, resolved] of resolvedExecutables) {
+      if (resolved === null) {
+        addCheck(
+          `executable.${name}`,
+          "fail",
+          `${name} is not installed or is not executable.`,
+        );
+      } else {
+        executables.set(name, resolved);
+        addCheck(`executable.${name}`, "pass", `${name} is available.`);
+      }
+    }
+
+    const pwRecord = executables.get("pw-record");
+    if (pwRecord !== undefined) {
+      const result = await this.runCommand(pwRecord, ["--version"], {
+        timeoutMs: AUDIO_COMMAND_TIMEOUT_MS,
+      });
+      const version = parsePipeWireVersion(
+        `${result.stdout}\n${result.stderr}`,
+      );
+      const versionComparison =
+        version === null
+          ? null
+          : compareVersions(
+              formatPipeWireVersion(version),
+              MINIMUM_PIPEWIRE_VERSION,
+            );
+      const supported =
+        result.code === 0 &&
+        versionComparison !== null &&
+        versionComparison >= 0;
+      addCheck(
+        "pipewire.version",
+        supported ? "pass" : "fail",
+        version === null
+          ? "Could not determine the PipeWire version. Version 1.4 or newer is required."
+          : `PipeWire ${formatPipeWireVersion(version)} ${
+              supported
+                ? "is supported."
+                : "is too old; version 1.4 or newer is required."
+            }`,
+      );
+    } else {
+      addCheck(
+        "pipewire.version",
+        "skip",
+        "PipeWire version was not checked because pw-record is unavailable.",
+      );
+    }
+
+    const systemctl = executables.get("systemctl");
+    const pipewireUnitActive =
+      systemctl !== undefined &&
+      (await this.anyUserUnitActive(systemctl, [
+        "pipewire.service",
+        "pipewire.socket",
+      ]));
+    const pipewireSocketActive =
+      this.runtimeDirectory !== undefined &&
+      this.pathExists(join(this.runtimeDirectory, "pipewire-0"));
+    const pipewireSessionActive = pipewireUnitActive || pipewireSocketActive;
+    addCheck(
+      "session.pipewire",
+      pipewireSessionActive ? "pass" : "fail",
+      pipewireSessionActive
+        ? "The PipeWire user session is active."
+        : "The PipeWire user session is inactive. Start the user service or socket before checking hardware.",
+    );
+
+    const wirePlumberActive =
+      systemctl !== undefined &&
+      (await this.anyUserUnitActive(systemctl, [
+        "wireplumber.service",
+        "wireplumber.socket",
+      ]));
+    addCheck(
+      "session.wireplumber",
+      wirePlumberActive ? "pass" : "fail",
+      wirePlumberActive
+        ? "The WirePlumber user session is active."
+        : "The WirePlumber user session is inactive. Start it before checking hardware.",
+    );
+
+    const loginctl = executables.get("loginctl");
+    if (loginctl === undefined) {
+      addCheck(
+        "session.linger",
+        "fail",
+        "Headless user persistence could not be checked because loginctl is unavailable.",
+      );
+    } else {
+      const result = await this.runCommand(
+        loginctl,
+        ["show-user", this.username, "-p", "Linger"],
+        {
+          timeoutMs: AUDIO_COMMAND_TIMEOUT_MS,
+        },
+      );
+      const lingerEnabled =
+        result.code === 0 &&
+        /(?:^|\n)(?:Linger=)?yes(?:\n|$)/i.test(result.stdout.trim());
+      addCheck(
+        "session.linger",
+        lingerEnabled ? "pass" : "fail",
+        lingerEnabled
+          ? "Headless user persistence is enabled."
+          : "Headless user persistence is disabled. Enable login linger for the audio user.",
+      );
+    }
+
+    let devices: LiveVoiceAudioDevices = { inputs: [], outputs: [] };
+    const pwDump = executables.get("pw-dump");
+    if (!pipewireSessionActive || pwDump === undefined) {
+      addCheck(
+        "devices.input",
+        "skip",
+        "Capture hardware was not checked because the PipeWire session is unavailable.",
+      );
+      addCheck(
+        "devices.output",
+        "skip",
+        "Playback hardware was not checked because the PipeWire session is unavailable.",
+      );
+    } else {
+      try {
+        const result = await this.runCommand(pwDump, [], {
+          timeoutMs: AUDIO_COMMAND_TIMEOUT_MS,
+        });
+        if (result.code !== 0) {
+          throw new Error(result.stderr.trim() || "pw-dump failed");
+        }
+        devices = parsePipeWireDevices(result.stdout);
+        addCheck(
+          "devices.input",
+          devices.inputs.length > 0 ? "pass" : "fail",
+          devices.inputs.length > 0
+            ? `Found ${devices.inputs.length} capture source(s).`
+            : "The PipeWire session is active, but no capture source was found.",
+        );
+        addCheck(
+          "devices.output",
+          devices.outputs.length > 0 ? "pass" : "fail",
+          devices.outputs.length > 0
+            ? `Found ${devices.outputs.length} playback sink(s).`
+            : "The PipeWire session is active, but no playback sink was found.",
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        addCheck(
+          "devices.input",
+          "fail",
+          `Capture source discovery failed: ${message}`,
+        );
+        addCheck(
+          "devices.output",
+          "fail",
+          `Playback sink discovery failed: ${message}`,
+        );
+      }
+    }
+
+    const input = resolveExplicitDevice(devices.inputs, options.inputDevice);
+    const output = resolveExplicitDevice(devices.outputs, options.outputDevice);
+    addExplicitDeviceCheck(checks, "input", options.inputDevice, input);
+    addExplicitDeviceCheck(checks, "output", options.outputDevice, output);
+
+    const probeDurationMs = options.probeDurationMs ?? 250;
+    await this.addProbeCheck({
+      checks,
+      id: "probe.input",
+      executable: pwRecord,
+      deviceAvailable:
+        options.inputDevice === undefined
+          ? devices.inputs.length > 0
+          : input !== null,
+      args: buildPipeWirePcmArgs(input?.nodeName),
+      options: { durationMs: probeDurationMs, requireOutput: true },
+      successMessage: "Capture process produced in-memory PCM.",
+      unavailableMessage:
+        "Capture was not probed because its tool, session, or selected device is unavailable.",
+    });
+    await this.addProbeCheck({
+      checks,
+      id: "probe.output",
+      executable: executables.get("pw-play"),
+      deviceAvailable:
+        options.outputDevice === undefined
+          ? devices.outputs.length > 0
+          : output !== null,
+      args: buildPipeWirePcmArgs(output?.nodeName),
+      options: {
+        durationMs: probeDurationMs,
+        input: Buffer.alloc(LIVE_VOICE_PCM_FRAME_BYTES),
+      },
+      successMessage: "Playback process accepted in-memory PCM.",
+      unavailableMessage:
+        "Playback was not probed because its tool, session, or selected device is unavailable.",
+    });
+
+    return {
+      ok: checks.every(
+        (check) => check.status === "pass" || check.status === "warning",
+      ),
+      checks,
+      devices,
+    };
+  }
+
+  private async requireExecutable(name: string): Promise<string> {
+    const executable = await this.findExecutable(name);
+    if (executable === null) {
+      throw new Error(
+        `${name} is required for live voice. Install PipeWire 1.4 or newer.`,
+      );
+    }
+    return executable;
+  }
+
+  private async anyUserUnitActive(
+    systemctl: string,
+    units: readonly string[],
+  ): Promise<boolean> {
+    const results = await Promise.all(
+      units.map(
+        async (unit) =>
+          await this.runCommand(systemctl, ["--user", "is-active", unit], {
+            timeoutMs: AUDIO_COMMAND_TIMEOUT_MS,
+          }),
+      ),
+    );
+    return results.some(
+      (result) => result.code === 0 && result.stdout.trim() === "active",
+    );
+  }
+
+  private async addProbeCheck(input: {
+    checks: LiveVoiceAudioDoctorCheck[];
+    id: string;
+    executable: string | undefined;
+    deviceAvailable: boolean;
+    args: readonly string[];
+    options: AudioProcessProbeOptions;
+    successMessage: string;
+    unavailableMessage: string;
+  }): Promise<void> {
+    if (
+      input.executable === undefined ||
+      !input.deviceAvailable ||
+      !input.checks.some(
+        (check) => check.id === "session.pipewire" && check.status === "pass",
+      )
+    ) {
+      input.checks.push({
+        id: input.id,
+        status: "skip",
+        message: input.unavailableMessage,
+      });
+      return;
+    }
+
+    const result = await this.probeProcess(
+      input.executable,
+      input.args,
+      input.options,
+    );
+    input.checks.push({
+      id: input.id,
+      status: result.ok ? "pass" : "fail",
+      message: result.ok
+        ? input.successMessage
+        : result.detail || `${input.id} failed.`,
+    });
+  }
+}
+
+export function parsePipeWireDevices(json: string): LiveVoiceAudioDevices {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("pw-dump returned invalid JSON.");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("pw-dump returned an unexpected payload.");
+  }
+
+  const inputs: LiveVoiceAudioDevice[] = [];
+  const outputs: LiveVoiceAudioDevice[] = [];
+  for (const value of parsed as PipeWireDumpObject[]) {
+    if (
+      value === null ||
+      typeof value !== "object" ||
+      value.type !== "PipeWire:Interface:Node"
+    ) {
+      continue;
+    }
+    const properties = value.info?.props;
+    if (properties === undefined) {
+      continue;
+    }
+    const nodeName = readStringProperty(properties, "node.name");
+    const mediaClass = readStringProperty(properties, "media.class");
+    const objectSerial = readScalarProperty(properties, "object.serial");
+    if (nodeName === null || mediaClass === null || objectSerial === null) {
+      continue;
+    }
+
+    const direction = mediaClass.startsWith("Audio/Source")
+      ? "input"
+      : mediaClass.startsWith("Audio/Sink")
+        ? "output"
+        : null;
+    if (direction === null) {
+      continue;
+    }
+
+    const description =
+      readStringProperty(properties, "node.description") ??
+      readStringProperty(properties, "node.nick") ??
+      nodeName;
+    const device: LiveVoiceAudioDevice = {
+      direction,
+      nodeName,
+      objectSerial,
+      description,
+      mediaClass,
+      objectId:
+        typeof value.id === "number" && Number.isInteger(value.id)
+          ? value.id
+          : undefined,
+      moduleId: readIntegerProperty(properties, "module.id") ?? undefined,
+    };
+    if (direction === "input") {
+      inputs.push(device);
+    } else {
+      outputs.push(device);
+    }
+  }
+
+  return { inputs, outputs };
+}
+
+export function parsePipeWireVersion(output: string): PipeWireVersion | null {
+  const match = output.match(/\b(\d+)\.(\d+)(?:\.(\d+))?\b/);
+  if (match === null) {
+    return null;
+  }
+  const parsed = parseVersion(match[0]);
+  if (parsed === null) {
+    return null;
+  }
+  return {
+    major: parsed.major,
+    minor: parsed.minor,
+    patch: parsed.patch,
+  };
+}
+
+export function buildPipeWirePcmArgs(target?: string): string[] {
+  const args = [
+    "--raw",
+    `--rate=${LIVE_VOICE_PCM_SAMPLE_RATE}`,
+    `--channels=${LIVE_VOICE_PCM_CHANNELS}`,
+    "--format=s16",
+    `--latency=${LIVE_VOICE_PCM_FRAME_DURATION_MS}ms`,
+  ];
+  if (target !== undefined) {
+    args.push(`--target=${target}`);
+  }
+  args.push("-");
+  return args;
+}
+
+class PipeWireCaptureSession implements LiveVoicePcmCaptureSession {
+  readonly closed: Promise<void>;
+  private readonly framer = new PcmFrameRechunker();
+  private muted = false;
+  private stopping = false;
+  private stopped: Promise<Buffer | null> | null = null;
+
+  constructor(
+    private readonly child: ChildProcessWithoutNullStreams,
+    private readonly options: LiveVoicePcmCaptureOptions,
+  ) {
+    this.closed = new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const settle = (error?: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (error === undefined) {
+          resolve();
+        } else {
+          reject(error);
+        }
+      };
+      child.once("error", (error) => {
+        settle(error);
+      });
+      child.once("close", (code, signal) => {
+        if (this.stopping || code === 0) {
+          settle();
+        } else {
+          settle(
+            new Error(
+              `pw-record stopped unexpectedly with ${
+                signal === null ? `code ${String(code)}` : `signal ${signal}`
+              }.`,
+            ),
+          );
+        }
+      });
+    });
+    void this.closed.catch(() => {});
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      for (const frame of this.framer.push(chunk, this.muted)) {
+        this.options.onFrame(frame, pcm16Rms(frame));
+      }
+    });
+  }
+
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+  }
+
+  stop(): Promise<Buffer | null> {
+    if (this.stopped !== null) {
+      return this.stopped;
+    }
+    this.stopped = this.stopOnce();
+    return this.stopped;
+  }
+
+  private async stopOnce(): Promise<Buffer | null> {
+    this.stopping = true;
+    if (this.child.exitCode === null && !this.child.killed) {
+      this.child.kill("SIGTERM");
+    }
+    await this.closed;
+    return this.framer.flush(this.muted);
+  }
+}
+
+class PipeWirePlayback implements LiveVoicePcmPlayback {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private sampleRate: number | null = null;
+  private generation = 0;
+  private operations: Promise<void> = Promise.resolve();
+  private closed = false;
+
+  constructor(
+    private readonly spawnProcess: AudioProcessFactory,
+    private readonly findExecutable: AudioExecutableLookup,
+    private readonly target?: string,
+  ) {}
+
+  write(chunk: LiveVoicePlaybackChunk): Promise<void> {
+    if (chunk.mimeType !== LIVE_VOICE_PCM_MIME_TYPE) {
+      const source = chunk.provider ?? "configured speech provider";
+      return Promise.reject(
+        new Error(
+          `${source} returned unsupported live voice audio ${chunk.mimeType} at ${chunk.sampleRate} Hz. Expected ${LIVE_VOICE_PCM_MIME_TYPE}.`,
+        ),
+      );
+    }
+    if (!Number.isInteger(chunk.sampleRate) || chunk.sampleRate <= 0) {
+      return Promise.reject(
+        new Error(`Invalid live voice PCM sample rate ${chunk.sampleRate}.`),
+      );
+    }
+    if (this.closed) {
+      return Promise.reject(new Error("Live voice playback is closed."));
+    }
+
+    const generation = this.generation;
+    const operation = this.enqueue(async () => {
+      if (generation !== this.generation) {
+        return;
+      }
+      if (
+        this.child !== null &&
+        this.sampleRate !== null &&
+        this.sampleRate !== chunk.sampleRate
+      ) {
+        await this.stopActiveProcess("SIGTERM");
+      }
+      const child = await this.ensureProcess(chunk.sampleRate);
+      if (generation !== this.generation) {
+        await this.stopActiveProcess("SIGTERM");
+        return;
+      }
+      try {
+        await writeWithBackpressure(child, chunk.audio);
+      } catch (error) {
+        if (generation === this.generation) {
+          throw error;
+        }
+      }
+    });
+    return operation;
+  }
+
+  drain(): Promise<void> {
+    return this.enqueue(async () => {
+      const child = this.child;
+      if (child === null) {
+        return;
+      }
+      this.child = null;
+      this.sampleRate = null;
+      child.stdin.end();
+      await waitForProcessClose(child, false);
+    });
+  }
+
+  flush(): Promise<void> {
+    this.generation += 1;
+    const child = this.child;
+    this.child = null;
+    this.sampleRate = null;
+    if (child !== null && child.exitCode === null && !child.killed) {
+      child.kill("SIGTERM");
+    }
+    return this.enqueue(async () => {
+      if (child !== null) {
+        await waitForProcessClose(child, true);
+      }
+    });
+  }
+
+  close(): Promise<void> {
+    if (this.closed) {
+      return this.operations;
+    }
+    this.closed = true;
+    return this.flush();
+  }
+
+  private enqueue(operation: () => Promise<void>): Promise<void> {
+    const result = this.operations.catch(() => {}).then(operation);
+    this.operations = result.catch(() => {});
+    return result;
+  }
+
+  private async ensureProcess(
+    sampleRate: number,
+  ): Promise<ChildProcessWithoutNullStreams> {
+    if (this.child !== null) {
+      if (this.child.exitCode === null && this.child.signalCode === null) {
+        return this.child;
+      }
+      const failed = this.child;
+      this.child = null;
+      this.sampleRate = null;
+      throw playbackExitError(failed.exitCode, failed.signalCode);
+    }
+    const executable = await this.findExecutable("pw-play");
+    if (executable === null) {
+      throw new Error(
+        "pw-play is required for live voice. Install PipeWire 1.4 or newer.",
+      );
+    }
+    const child = this.spawnProcess(
+      executable,
+      buildPipeWirePcmArgsForRate(sampleRate, this.target),
+      pipeProcessOptions(),
+    );
+    child.stdin.on("error", () => {});
+    this.child = child;
+    this.sampleRate = sampleRate;
+    return child;
+  }
+
+  private async stopActiveProcess(signal: NodeJS.Signals): Promise<void> {
+    const child = this.child;
+    this.child = null;
+    this.sampleRate = null;
+    if (child === null) {
+      return;
+    }
+    if (child.exitCode === null && !child.killed) {
+      child.kill(signal);
+    }
+    await waitForProcessClose(child, true);
+  }
+}
+
+function buildPipeWirePcmArgsForRate(
+  sampleRate: number,
+  target?: string,
+): string[] {
+  const args = buildPipeWirePcmArgs(target);
+  const rateIndex = args.findIndex((arg) => arg.startsWith("--rate="));
+  args[rateIndex] = `--rate=${sampleRate}`;
+  return args;
+}
+
+function resolveExplicitDevice(
+  devices: readonly LiveVoiceAudioDevice[],
+  selected: string | undefined,
+): LiveVoiceAudioDevice | null {
+  if (selected === undefined) {
+    return null;
+  }
+  return (
+    devices.find(
+      (device) =>
+        device.nodeName === selected || device.objectSerial === selected,
+    ) ?? null
+  );
+}
+
+function addExplicitDeviceCheck(
+  checks: LiveVoiceAudioDoctorCheck[],
+  direction: "input" | "output",
+  selected: string | undefined,
+  resolved: LiveVoiceAudioDevice | null,
+): void {
+  if (selected === undefined) {
+    return;
+  }
+  checks.push({
+    id: `device.${direction}.selected`,
+    status: resolved === null ? "fail" : "pass",
+    message:
+      resolved === null
+        ? `The selected ${direction} device was not found.`
+        : `Selected ${direction} device ${resolved.nodeName}.`,
+  });
+}
+
+function readStringProperty(
+  properties: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = properties[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readScalarProperty(
+  properties: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = properties[key];
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function readIntegerProperty(
+  properties: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = properties[key];
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function formatPipeWireVersion(version: PipeWireVersion): string {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+function pipeProcessOptions(): SpawnOptionsWithoutStdio & {
+  stdio: ["pipe", "pipe", "pipe"];
+  shell: false;
+} {
+  return {
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: false,
+  };
+}
+
+const defaultSpawnProcess: AudioProcessFactory = (executable, args, options) =>
+  spawn(executable, [...args], options);
+
+async function defaultExecutableLookup(
+  executable: string,
+): Promise<string | null> {
+  const candidates = isAbsolute(executable)
+    ? [executable]
+    : (process.env.PATH ?? "")
+        .split(delimiter)
+        .filter(Boolean)
+        .map((directory) => join(directory, executable));
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function createDefaultCommandRunner(
+  spawnProcess: AudioProcessFactory,
+): AudioCommandRunner {
+  return async (executable, args, options = {}) =>
+    await new Promise<AudioCommandResult>((resolve) => {
+      const child = spawnProcess(executable, args, pipeProcessOptions());
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = (result: AudioCommandResult): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timer !== undefined) {
+          clearTimeout(timer);
+        }
+        resolve(result);
+      };
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        stdout.push(Buffer.from(chunk));
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr.push(Buffer.from(chunk));
+      });
+      child.once("error", (error) => {
+        finish({ code: null, stdout: "", stderr: error.message });
+      });
+      child.once("close", (code) => {
+        finish({
+          code,
+          stdout: Buffer.concat(stdout).toString("utf8"),
+          stderr: Buffer.concat(stderr).toString("utf8"),
+        });
+      });
+      child.stdin.end();
+
+      if (options.timeoutMs !== undefined) {
+        if (!settled) {
+          timer = setTimeout(() => {
+            child.kill("SIGTERM");
+            finish({
+              code: null,
+              stdout: Buffer.concat(stdout).toString("utf8"),
+              stderr: `${executable} timed out.`,
+            });
+          }, options.timeoutMs);
+        }
+      }
+    });
+}
+
+function createDefaultProcessProbe(
+  spawnProcess: AudioProcessFactory,
+): AudioProcessProbe {
+  return async (executable, args, options) =>
+    await new Promise<AudioProcessProbeResult>((resolve) => {
+      const child = spawnProcess(executable, args, pipeProcessOptions());
+      let outputBytes = 0;
+      let settled = false;
+      let stopRequested = false;
+      const timers: {
+        stop?: ReturnType<typeof setTimeout>;
+        force?: ReturnType<typeof setTimeout>;
+      } = {};
+      const finish = (result: AudioProcessProbeResult): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timers.stop !== undefined) {
+          clearTimeout(timers.stop);
+        }
+        if (timers.force !== undefined) {
+          clearTimeout(timers.force);
+        }
+        resolve(result);
+      };
+      child.stdout.on("data", (chunk: Buffer) => {
+        outputBytes += chunk.length;
+      });
+      child.once("error", (error) => {
+        finish({ ok: false, detail: error.message });
+      });
+      child.once("close", (code, _signal) => {
+        const outputSatisfied =
+          options.requireOutput !== true || outputBytes > 0;
+        finish({
+          ok: (code === 0 || stopRequested) && outputSatisfied,
+          detail: outputSatisfied
+            ? undefined
+            : "The capture probe produced no PCM.",
+        });
+      });
+      child.stdin.on("error", () => {});
+      if (options.input === undefined) {
+        child.stdin.end();
+      } else {
+        child.stdin.end(options.input);
+      }
+      timers.stop = setTimeout(() => {
+        if (child.exitCode === null && !child.killed) {
+          stopRequested = true;
+          child.kill("SIGTERM");
+          timers.force = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              child.kill("SIGKILL");
+            }
+          }, 1_000);
+        }
+      }, options.durationMs);
+    });
+}
+
+function waitForProcessClose(
+  child: ChildProcessWithoutNullStreams,
+  acceptTermination: boolean,
+): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return acceptTermination ||
+      (child.exitCode === 0 && child.signalCode === null)
+      ? Promise.resolve()
+      : Promise.reject(playbackExitError(child.exitCode, child.signalCode));
+  }
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (error === undefined) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    };
+    child.once("close", (code, signal) => {
+      if (acceptTermination || (code === 0 && signal === null)) {
+        finish();
+      } else {
+        finish(playbackExitError(code, signal));
+      }
+    });
+    child.once("error", (error) => {
+      finish(error);
+    });
+  });
+}
+
+function writeWithBackpressure(
+  child: ChildProcessWithoutNullStreams,
+  audio: Buffer,
+): Promise<void> {
+  if (
+    child.exitCode !== null ||
+    child.signalCode !== null ||
+    child.stdin.destroyed
+  ) {
+    return Promise.reject(
+      new Error("pw-play stopped before audio could be written."),
+    );
+  }
+  const accepted = child.stdin.write(audio);
+  if (accepted) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      child.stdin.off("drain", onDrain);
+      child.stdin.off("error", onError);
+      child.off("close", onClose);
+    };
+    const finish = (error?: Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (error === undefined) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    };
+    const onDrain = (): void => {
+      finish();
+    };
+    const onError = (error: Error): void => {
+      finish(error);
+    };
+    const onClose = (): void => {
+      finish(new Error("pw-play stopped while audio was buffered."));
+    };
+    child.stdin.once("drain", onDrain);
+    child.stdin.once("error", onError);
+    child.once("close", onClose);
+  });
+}
+
+function playbackExitError(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): Error {
+  return new Error(
+    `pw-play stopped unexpectedly with ${
+      signal === null ? `code ${String(code)}` : `signal ${signal}`
+    }.`,
+  );
+}


### PR DESCRIPTION
Part of the CLI Live Voice for Raspberry Pi plan. Adds host-owned PipeWire capture, playback, diagnostics, and scalar echo measurements. Targets feature branch alex-nork/cli-live-voice.