### PR TITLE
fix(voice): wait for late STT before discarding VAD speech

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -183,6 +183,20 @@ function createSessionWithTranscriber(
   return { frames, resolver, session, transcriber };
 }
 
+function createEmptyFinalizeGraceSession(emptyFinalizeGraceMs: number) {
+  const transcriber = new FinalizingMockStreamingTranscriber();
+  transcriber.respondToFinalize = false;
+  const startVoiceTurn = completingVoiceTurnStarter();
+  const { context, frames } = createContext({ turnDetection: "server_vad" });
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber: mock(async () => transcriber),
+    startVoiceTurn,
+    finalizeGraceMs: 20,
+    emptyFinalizeGraceMs,
+  });
+  return { frames, session, startVoiceTurn, transcriber };
+}
+
 async function waitFor(
   predicate: () => boolean,
   message = "Timed out waiting for live voice STT test condition",
@@ -1099,6 +1113,146 @@ describe("LiveVoiceSession STT", () => {
         frame.type === "stt_final" ? [frame.text] : [],
       ),
     ).toEqual(["collected before release"]);
+  });
+
+  test("waits past the fast finalize grace for a late final on a speech-bearing empty cycle", async () => {
+    const { frames, session, startVoiceTurn, transcriber } =
+      createEmptyFinalizeGraceSession(80);
+
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => transcriber.finalizeCalls === 1);
+    transcriber.emit({ type: "finalized" });
+
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    expect(frames.some((frame) => frame.type === "utterance_discarded")).toBe(
+      false,
+    );
+
+    transcriber.emit({ type: "final", text: "late usable transcript" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      content: "late usable transcript",
+    });
+    expect(frames.some((frame) => frame.type === "utterance_discarded")).toBe(
+      false,
+    );
+  });
+
+  test("discards a speech-bearing empty cycle exactly once at the bounded grace cap", async () => {
+    const { frames, session, startVoiceTurn, transcriber } =
+      createEmptyFinalizeGraceSession(60);
+
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => transcriber.finalizeCalls === 1);
+    transcriber.emit({ type: "finalized" });
+
+    await waitFor(
+      () =>
+        frames.filter((frame) => frame.type === "utterance_discarded")
+          .length === 1,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    expect(
+      frames.filter((frame) => frame.type === "utterance_discarded"),
+    ).toHaveLength(1);
+  });
+
+  test("drops an old stream final that arrives after empty-grace discard", async () => {
+    const first = new FinalizingMockStreamingTranscriber();
+    first.respondToFinalize = false;
+    const replacement = new FinalizingMockStreamingTranscriber();
+    const transcribers = [first, replacement];
+    const resolver = mock(async () => transcribers.shift() ?? replacement);
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+      finalizeGraceMs: 20,
+      emptyFinalizeGraceMs: 60,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => first.finalizeCalls === 1);
+    first.emit({ type: "finalized" });
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+    await waitFor(() => resolver.mock.calls.length === 2);
+
+    first.emit({ type: "final", text: "late transcript from old stream" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    expect(
+      frames.flatMap((frame) =>
+        frame.type === "stt_final" ? [frame.text] : [],
+      ),
+    ).toEqual([]);
+  });
+
+  test("keeps parked newer speech separate from an older late final", async () => {
+    const { frames, session, startVoiceTurn, transcriber } =
+      createEmptyFinalizeGraceSession(100);
+
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => transcriber.finalizeCalls === 1);
+    transcriber.emit({ type: "finalized" });
+
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+
+    transcriber.respondToFinalize = true;
+    transcriber.emit({ type: "final", text: "late first utterance" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(startVoiceTurn.mock.calls.map((call) => call[0].content)).toEqual([
+      "late first utterance",
+      "utterance 2",
+    ]);
+    expect(
+      frames.filter((frame) => frame.type === "utterance_discarded"),
+    ).toHaveLength(0);
+  });
+
+  test("cancels the empty finalize grace on close and interrupt", async () => {
+    for (const action of ["close", "interrupt"] as const) {
+      const { frames, session, transcriber } =
+        createEmptyFinalizeGraceSession(50);
+
+      await session.start();
+      await session.handleBinaryAudio(loudPcmChunk());
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => transcriber.finalizeCalls === 1);
+      transcriber.emit({ type: "finalized" });
+
+      if (action === "close") {
+        await session.close("websocket_close");
+      } else {
+        await session.handleClientFrame({ type: "interrupt" });
+      }
+      await new Promise((resolve) => setTimeout(resolve, 70));
+
+      expect(
+        frames.filter((frame) => frame.type === "utterance_discarded"),
+      ).toHaveLength(0);
+      expect(transcriber.stopCalls).toBe(1);
+    }
   });
 
   test("speech after a grace-timeout dispatch routes to the next cycle, not the timed-out one", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -1204,7 +1204,7 @@ describe("LiveVoiceSession STT", () => {
 
   test("keeps parked newer speech separate from an older late final", async () => {
     const { frames, session, startVoiceTurn, transcriber } =
-      createEmptyFinalizeGraceSession(100);
+      createEmptyFinalizeGraceSession(500);
 
     await session.start();
     await session.handleBinaryAudio(loudPcmChunk());
@@ -1212,8 +1212,12 @@ describe("LiveVoiceSession STT", () => {
     await waitFor(() => transcriber.finalizeCalls === 1);
     transcriber.emit({ type: "finalized" });
 
-    await session.handleBinaryAudio(loudPcmChunk());
+    const parkedChunks = 40;
+    for (let index = 0; index < parkedChunks; index += 1) {
+      await session.handleBinaryAudio(loudPcmChunk());
+    }
     await session.handleClientFrame({ type: "ptt_release" });
+    expect(transcriber.audioChunks).toHaveLength(1);
 
     transcriber.respondToFinalize = true;
     transcriber.emit({ type: "final", text: "late first utterance" });
@@ -1225,6 +1229,7 @@ describe("LiveVoiceSession STT", () => {
       "late first utterance",
       "utterance 2",
     ]);
+    expect(transcriber.audioChunks).toHaveLength(parkedChunks + 1);
     expect(
       frames.filter((frame) => frame.type === "utterance_discarded"),
     ).toHaveLength(0);

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -139,6 +139,15 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 }
 
+class EmptyFinalizingMockStreamingTranscriber extends MockStreamingTranscriber {
+  finalizeCalls = 0;
+
+  finalizeUtterance(): void {
+    this.finalizeCalls += 1;
+    this.emit({ type: "finalized" });
+  }
+}
+
 function createHarness(options: {
   startFrame?: LiveVoiceClientStartFrame;
   finals?: string[];
@@ -167,6 +176,13 @@ function createHarness(options: {
   getTurnTeardown?: (conversationId: string) => Promise<void> | undefined;
   detachTeardownSettleTimeoutMs?: number;
   continuationAnnounceSilenceMs?: number;
+  finalizeGraceMs?: number;
+  emptyFinalizeGraceMs?: number;
+  createTranscriber?: (
+    index: number,
+    finalText: string,
+    holdStopEvents: boolean,
+  ) => MockStreamingTranscriber;
 }) {
   const sequencer = createLiveVoiceServerFrameSequencer();
   const frames: LiveVoiceServerFrame[] = [];
@@ -186,10 +202,14 @@ function createHarness(options: {
   const resolveTranscriber = mock(async () => {
     const text =
       finals[transcribers.length] ?? `utterance ${transcribers.length + 1}`;
-    const transcriber = new MockStreamingTranscriber(
-      [{ type: "final", text }, { type: "closed" }],
-      options.holdStopEventsFor?.includes(transcribers.length) ?? false,
-    );
+    const holdStopEvents =
+      options.holdStopEventsFor?.includes(transcribers.length) ?? false;
+    const transcriber =
+      options.createTranscriber?.(transcribers.length, text, holdStopEvents) ??
+      new MockStreamingTranscriber(
+        [{ type: "final", text }, { type: "closed" }],
+        holdStopEvents,
+      );
     transcribers.push(transcriber);
     return transcriber;
   });
@@ -234,6 +254,12 @@ function createHarness(options: {
       ? {
           continuationAnnounceSilenceMs: options.continuationAnnounceSilenceMs,
         }
+      : {}),
+    ...(options.finalizeGraceMs !== undefined
+      ? { finalizeGraceMs: options.finalizeGraceMs }
+      : {}),
+    ...(options.emptyFinalizeGraceMs !== undefined
+      ? { emptyFinalizeGraceMs: options.emptyFinalizeGraceMs }
       : {}),
   };
   const session = options.viaFactory
@@ -3073,6 +3099,43 @@ describe("LiveVoiceSession server VAD", () => {
     const types = frameTypes(frames);
     expect(types.indexOf("utterance_end")).toBeLessThan(
       types.indexOf("utterance_discarded"),
+    );
+  });
+
+  test("a VAD utterance starts when STT final arrives after the fast finalize grace", async () => {
+    const { startVoiceTurn, calls } = makeAutoCompletingTurnStarter([
+      "Late transcript accepted.",
+    ]);
+    const { frames, session, transcribers } = createHarness({
+      startVoiceTurn,
+      finalizeGraceMs: 20,
+      emptyFinalizeGraceMs: 90,
+      createTranscriber: (_index, text, holdStopEvents) =>
+        new EmptyFinalizingMockStreamingTranscriber(
+          [{ type: "final", text }, { type: "closed" }],
+          holdStopEvents,
+        ),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => countType(frames, "utterance_end") === 1);
+    const transcriber =
+      transcribers[0] as EmptyFinalizingMockStreamingTranscriber;
+    expect(transcriber.finalizeCalls).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    expect(countType(frames, "utterance_discarded")).toBe(0);
+    expect(calls).toHaveLength(0);
+
+    transcriber?.emit({ type: "final", text: "late VAD transcript" });
+    await waitFor(() => calls.length === 1);
+
+    expect(calls[0]?.content).toBe("late VAD transcript");
+    expect(countType(frames, "utterance_discarded")).toBe(0);
+    const types = frameTypes(frames);
+    expect(types.indexOf("utterance_end")).toBeLessThan(
+      types.indexOf("stt_final"),
     );
   });
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -118,6 +118,11 @@ const SERVER_VAD_PRE_ROLL_MAX_CHUNKS = 25;
 // strict upper bound on the release→turn-start tail in persistent mode (the
 // provider keeps its own, longer, finalize fallback).
 const FINALIZE_GRACE_MS = 1_000;
+// Released speech with no usable final waits longer because some streaming
+// providers settle Finalize before delivering the ordinary final transcript.
+// The shared stream is retired if this cap expires so an unidentifiable late
+// final cannot attach to the next utterance.
+const EMPTY_FINALIZE_GRACE_MS = 3_000;
 // Consecutive speech (ms) required before speech during assistant playback
 // flushes it (speech_started) and cancels the turn, so a cough, a filler word,
 // or the assistant's own TTS bleeding through imperfect browser echo
@@ -256,6 +261,12 @@ export interface LiveVoiceSessionOptions {
    */
   finalizeGraceMs?: number;
   /**
+   * Overrides the bounded wait for a speech-bearing shared-transcriber cycle
+   * whose finalize settles without a usable transcript (test hook). Defaults
+   * to `EMPTY_FINALIZE_GRACE_MS`.
+   */
+  emptyFinalizeGraceMs?: number;
+  /**
    * Front-model presence tuning (semantic endpointing + spoken acks). The
    * production factory seeds this from `liveVoice.frontModel` config when
    * unset; absent fields fall back to the schema defaults (the constructor
@@ -322,6 +333,10 @@ interface UtteranceCycle {
   // one `finalized` signal is owed to it. At most one queued cycle has
   // this set at a time — see pumpFinalizeQueue.
   finalizeRequested: boolean;
+  // The shared stream emitted `finalized` for this cycle. An empty released
+  // cycle remains at the head of the finalize queue during its bounded
+  // late-final grace so ordinary finals keep their original owner.
+  finalizeSettled: boolean;
   transcriber: StreamingTranscriber | null;
   // Manual (push-to-talk) capture routed at least one chunk into this cycle.
   // It is the only evidence the user is mid-utterance before STT emits
@@ -773,6 +788,7 @@ function createUtteranceCycle(): UtteranceCycle {
     assistantTurnStarted: false,
     completed: false,
     finalizeRequested: false,
+    finalizeSettled: false,
     transcriber: null,
     manualAudioCaptured: false,
     speechRouted: false,
@@ -1036,6 +1052,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   /** The cycle whose grace timer is armed (only the newest release has one). */
   private finalizeGraceCycle: UtteranceCycle | null = null;
   private readonly finalizeGraceMs: number;
+  private emptyFinalizeGraceTimer: ReturnType<typeof setTimeout> | null = null;
+  private emptyFinalizeGraceCycle: UtteranceCycle | null = null;
+  private readonly emptyFinalizeGraceMs: number;
   // Rotates through the progress fallback phrases across the session's turns.
   private progressPhraseCounter = 0;
   // Front-model service: phrases spoken acks and progress narration; null
@@ -1105,6 +1124,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       options.bargeInMinSpeechMs ??
       DEFAULT_BARGE_IN_MIN_SPEECH_MS;
     this.finalizeGraceMs = options.finalizeGraceMs ?? FINALIZE_GRACE_MS;
+    this.emptyFinalizeGraceMs =
+      options.emptyFinalizeGraceMs ?? EMPTY_FINALIZE_GRACE_MS;
     this.frontDecider = options.frontDecider ?? null;
     this.frontModelConfig = LiveVoiceFrontModelConfigSchema.parse(
       options.frontModelConfig ?? {},
@@ -1402,6 +1423,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     transcriber: StreamingTranscriber,
   ): UtteranceCycle[] {
     this.clearFinalizeGraceTimer();
+    this.clearEmptyFinalizeGraceTimer();
     const drained = this.finalizeQueue;
     this.finalizeQueue = [];
     for (const finalizing of drained) {
@@ -2787,6 +2809,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance.phase = "released";
     this.finalizeQueue.push(utterance);
     this.armFinalizeGraceTimer(utterance);
+    if (
+      utterance.speechRouted &&
+      utterance.finalTranscriptSegments.length === 0
+    ) {
+      this.armEmptyFinalizeGraceTimer(utterance);
+    }
     this.pumpFinalizeQueue();
     await this.startAssistantTurnIfReady();
     await this.drainOutboundFrames();
@@ -2840,6 +2868,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (utterance === this.finalizeGraceCycle) {
       this.clearFinalizeGraceTimer();
     }
+    if (utterance === this.emptyFinalizeGraceCycle) {
+      this.clearEmptyFinalizeGraceTimer();
+    }
   }
 
   private armFinalizeGraceTimer(utterance: UtteranceCycle): void {
@@ -2860,6 +2891,33 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.finalizeGraceCycle = null;
   }
 
+  private armEmptyFinalizeGraceTimer(utterance: UtteranceCycle): void {
+    this.clearEmptyFinalizeGraceTimer();
+    this.emptyFinalizeGraceCycle = utterance;
+    this.emptyFinalizeGraceTimer = setTimeout(() => {
+      this.emptyFinalizeGraceTimer = null;
+      this.emptyFinalizeGraceCycle = null;
+      void this.handleEmptyFinalizeGraceTimeout(utterance).catch(() => {});
+    }, this.emptyFinalizeGraceMs);
+  }
+
+  private clearEmptyFinalizeGraceTimer(): void {
+    if (this.emptyFinalizeGraceTimer !== null) {
+      clearTimeout(this.emptyFinalizeGraceTimer);
+      this.emptyFinalizeGraceTimer = null;
+    }
+    this.emptyFinalizeGraceCycle = null;
+  }
+
+  private shouldWaitForLateEmptyFinal(utterance: UtteranceCycle): boolean {
+    return (
+      utterance.speechRouted &&
+      utterance.finalizeRequested &&
+      utterance.finalTranscriptSegments.length === 0 &&
+      utterance === this.emptyFinalizeGraceCycle
+    );
+  }
+
   // The finalize flush never arrived: proceed with the segments collected
   // so far. The cycle stays in the finalize queue so its late flush is
   // still attributed to (and dropped for) it instead of polluting a newer
@@ -2875,9 +2933,53 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     ) {
       return;
     }
+    if (this.shouldWaitForLateEmptyFinal(utterance)) {
+      log.warn(
+        "Live voice finalize flush timed out without a transcript; waiting for the bounded late-final grace",
+      );
+      return;
+    }
+    if (utterance === this.emptyFinalizeGraceCycle) {
+      this.clearEmptyFinalizeGraceTimer();
+    }
     log.warn(
       "Live voice finalize flush timed out; starting the turn with the transcript collected so far",
     );
+    utterance.phase = "transcriber_closed";
+    await this.startAssistantTurnIfReady();
+  }
+
+  private async handleEmptyFinalizeGraceTimeout(
+    utterance: UtteranceCycle,
+  ): Promise<void> {
+    if (
+      !this.finalizeQueue.includes(utterance) ||
+      this.isClosed ||
+      this.state === "failed" ||
+      this.state === "interrupted"
+    ) {
+      return;
+    }
+
+    this.clearFinalizeGraceTimer();
+    if (utterance.finalTranscriptSegments.length > 0) {
+      log.warn(
+        "Live voice empty-transcript finalize grace expired after receiving a transcript; starting the turn with the transcript collected so far",
+      );
+      utterance.phase = "transcriber_closed";
+      await this.startAssistantTurnIfReady();
+      return;
+    }
+
+    log.warn(
+      "Live voice empty-transcript finalize grace expired; discarding the utterance",
+    );
+    const shared = this.sharedTranscriber;
+    if (shared && utterance.transcriber === shared) {
+      this.retireSharedTranscriberForRedial(shared);
+    } else {
+      this.dropFromFinalizeQueue(utterance);
+    }
     utterance.phase = "transcriber_closed";
     await this.startAssistantTurnIfReady();
   }
@@ -3010,14 +3112,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // Completes the head's outstanding finalize request, whether or
         // not its flush final arrived (the provider may omit an empty
         // flush; its own fallback still emits `finalized`).
-        const owner = this.finalizeQueue.shift() ?? null;
-        if (owner && owner === this.finalizeGraceCycle) {
-          this.clearFinalizeGraceTimer();
+        const owner = this.finalizeQueue[0] ?? null;
+        if (owner) {
+          owner.finalizeSettled = true;
         }
         if (owner && owner.phase === "released") {
           // In persistent mode "transcriber_closed" means the cycle's
           // transcript is complete — the shared stream stays open.
           owner.phase = "transcriber_closed";
+        }
+        if (owner && this.shouldWaitForLateEmptyFinal(owner)) {
+          if (owner === this.finalizeGraceCycle) {
+            this.clearFinalizeGraceTimer();
+          }
+          return;
+        }
+        if (owner) {
+          this.dropFromFinalizeQueue(owner);
         }
         // The request slot is free again: send the next awaiting cycle's.
         this.pumpFinalizeQueue();
@@ -3081,6 +3192,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance.latestPartialText = null;
     this.markFinalTranscript(utterance);
     await this.sendFrame({ type: "stt_final", text });
+    if (transcript.length > 0 && utterance.finalizeSettled) {
+      this.dropFromFinalizeQueue(utterance);
+      this.pumpFinalizeQueue();
+    }
     // Fresh-final fast replay (unified front-door): a hold judged on the
     // pre-finalize partial is stale the moment the finalized transcript
     // extends it — the caller already finished, so waiting out the extension
@@ -3170,6 +3285,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // close(); persistent mode re-establishes itself on the next arm.
   private stopSessionTranscriber(): void {
     this.clearFinalizeGraceTimer();
+    this.clearEmptyFinalizeGraceTimer();
     this.finalizeQueue = [];
     const shared = this.sharedTranscriber;
     this.sharedTranscriber = null;
@@ -3236,6 +3352,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     const content = utterance.finalTranscriptSegments.join(" ").trim();
+    if (content.length === 0 && this.shouldWaitForLateEmptyFinal(utterance)) {
+      return;
+    }
     if (content.length === 0) {
       utterance.assistantTurnStarted = true;
       if (this.turnDetector) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -813,6 +813,18 @@ function createUtteranceCycle(): UtteranceCycle {
   };
 }
 
+function trimOldestAudioChunksToByteLimit(
+  chunks: Buffer[],
+  totalBytes: number,
+  maxBytes: number,
+): number {
+  while (totalBytes > maxBytes && chunks.length > 1) {
+    const dropped = chunks.shift();
+    totalBytes -= dropped?.byteLength ?? 0;
+  }
+  return totalBytes;
+}
+
 // Carrier cycle for an assistant-initiated turn: the turn machinery is
 // utterance-shaped (metrics marks, audio archival, turn ids all hang off a
 // cycle), but an announcement has no capture behind it. The record starts fully
@@ -1015,8 +1027,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // to an utterance so the metric lands on the right turn.
   private vadSpeechStartPending = false;
   // Bounded ring of idle-mic chunks skipped while the VAD detector is idle;
-  // flushed ahead of the first routed chunk on speech onset.
+  // flushed ahead of the first routed chunk on speech onset. Once it holds
+  // speech parked behind a released cycle, it expands to the pending-audio
+  // byte budget so a follow-up can outlast the idle pre-roll window.
   private vadPreRollChunks: Buffer[] = [];
+  private vadPreRollBytes = 0;
   // The ring holds speech parked during the release→turn-start window;
   // protected from silent-chunk eviction until it flushes.
   private vadPreRollHasSpeech = false;
@@ -1648,25 +1663,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private pushVadPreRoll(chunk: Buffer, hasSpeech: boolean): void {
-    // A full ring never lets idle silence evict parked speech.
-    if (
-      !hasSpeech &&
-      this.vadPreRollHasSpeech &&
-      this.vadPreRollChunks.length >= SERVER_VAD_PRE_ROLL_MAX_CHUNKS
-    ) {
-      return;
-    }
     if (hasSpeech) {
       this.vadPreRollHasSpeech = true;
     }
-    this.vadPreRollChunks.push(Buffer.from(chunk));
+    const copy = Buffer.from(chunk);
+    this.vadPreRollChunks.push(copy);
+    this.vadPreRollBytes += copy.byteLength;
+    if (this.vadPreRollHasSpeech) {
+      this.vadPreRollBytes = trimOldestAudioChunksToByteLimit(
+        this.vadPreRollChunks,
+        this.vadPreRollBytes,
+        this.maxPendingAudioBytes,
+      );
+      return;
+    }
     while (this.vadPreRollChunks.length > SERVER_VAD_PRE_ROLL_MAX_CHUNKS) {
-      this.vadPreRollChunks.shift();
+      const dropped = this.vadPreRollChunks.shift();
+      this.vadPreRollBytes -= dropped?.byteLength ?? 0;
     }
   }
 
   private takeVadPreRoll(): Buffer[] {
     this.vadPreRollHasSpeech = false;
+    this.vadPreRollBytes = 0;
     return this.vadPreRollChunks.splice(0);
   }
 
@@ -1691,13 +1710,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   ): void {
     utterance.pendingAudioChunks.push(Buffer.from(chunk));
     utterance.pendingAudioBytes += chunk.byteLength;
-    while (
-      utterance.pendingAudioBytes > this.maxPendingAudioBytes &&
-      utterance.pendingAudioChunks.length > 1
-    ) {
-      const dropped = utterance.pendingAudioChunks.shift();
-      utterance.pendingAudioBytes -= dropped?.byteLength ?? 0;
-    }
+    utterance.pendingAudioBytes = trimOldestAudioChunksToByteLimit(
+      utterance.pendingAudioChunks,
+      utterance.pendingAudioBytes,
+      this.maxPendingAudioBytes,
+    );
   }
 
   private async forwardAudioToTranscriber(


### PR DESCRIPTION
Part of the CLI Live Voice for Raspberry Pi plan. Fixes the late-STT/server-VAD discard race found by the Pi hardware spike before open-mic CLI support. Targets feature branch alex-nork/cli-live-voice.