### PR TITLE
refactor(channels): adopt shared interface identifiers

### DIFF
--- a/assistant/src/channels/types.test.ts
+++ b/assistant/src/channels/types.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import { INTERFACE_IDS as CANONICAL_INTERFACE_IDS } from "@vellumai/service-contracts/channels";
+
 import {
   CLIENT_OS_VALUES,
   INTERACTIVE_INTERFACES,
@@ -8,28 +10,15 @@ import {
   parseClientOs,
   parseInterfaceId,
   supportsHostProxy,
-} from "../types.js";
+} from "./types.js";
 
 describe("INTERFACE_IDS", () => {
-  test("includes chrome-extension", () => {
-    expect(
-      (INTERFACE_IDS as readonly string[]).includes("chrome-extension"),
-    ).toBe(true);
-  });
+  test("accepts the complete canonical interface set", () => {
+    expect(INTERFACE_IDS).toBe(CANONICAL_INTERFACE_IDS);
 
-  test("still includes macos and other existing interfaces", () => {
-    for (const id of [
-      "macos",
-      "ios",
-      "cli",
-      "telegram",
-      "phone",
-      "web",
-      "whatsapp",
-      "slack",
-      "email",
-    ]) {
-      expect((INTERFACE_IDS as readonly string[]).includes(id)).toBe(true);
+    for (const id of CANONICAL_INTERFACE_IDS) {
+      expect(isInterfaceId(id)).toBe(true);
+      expect(parseInterfaceId(id)).toBe(id);
     }
   });
 });

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -1,13 +1,25 @@
 import {
   CHANNEL_IDS,
   type ChannelId,
+  INTERFACE_IDS,
+  type InterfaceId,
   isChannelId,
+  isInterfaceId,
+  parseInterfaceId,
 } from "@vellumai/service-contracts/channels";
 
-// The assistant understands the full canonical channel set, so it adopts the
-// shared vocabulary wholesale. `parseChannelId` stays local — it is only used
-// daemon-side and is a thin convenience over the shared guard.
-export { CHANNEL_IDS, type ChannelId, isChannelId };
+// The assistant understands the full canonical channel and interface sets, so
+// it adopts the shared vocabularies wholesale. `parseChannelId` stays local
+// because it is a thin convenience over the shared guard.
+export {
+  CHANNEL_IDS,
+  type ChannelId,
+  INTERFACE_IDS,
+  type InterfaceId,
+  isChannelId,
+  isInterfaceId,
+  parseInterfaceId,
+};
 
 export function parseChannelId(value: unknown): ChannelId | null {
   return isChannelId(value) ? value : null;
@@ -137,64 +149,6 @@ export const CHANNEL_METADATA: Partial<Record<ChannelId, ChannelInfo>> = {
     },
   },
 };
-
-export const INTERFACE_IDS = [
-  "macos",
-  "ios",
-  "cli",
-  "telegram",
-  "phone",
-  "web",
-  "whatsapp",
-  "slack",
-  "email",
-  "chrome-extension",
-  "a2a",
-  "discord",
-  // Turns injected by workspace custom routes (webhook receivers, cron jobs,
-  // device/service callbacks). Non-interactive — permission prompts route
-  // through the guardian system, not an interactive client — and non-host-proxy.
-  "route",
-] as const;
-
-export type InterfaceId = (typeof INTERFACE_IDS)[number];
-
-/**
- * Interface IDs that older clients or persisted data may still use.
- * `normalizeInterfaceId` maps these to their canonical replacements.
- */
-const LEGACY_INTERFACE_ALIASES: Record<string, InterfaceId> = {
-  // The web client used to report "vellum" as its interface ID. Older
-  // conversation records and in-flight SSE connections may still carry this
-  // value. Normalize to "web" so downstream logic only needs one branch.
-  vellum: "web",
-};
-
-/**
- * Strict type guard — returns `true` only for canonical `InterfaceId`
- * values. Legacy aliases like `"vellum"` return `false`; use
- * `parseInterfaceId` to accept and normalize those.
- */
-export function isInterfaceId(value: unknown): value is InterfaceId {
-  return (
-    typeof value === "string" &&
-    (INTERFACE_IDS as readonly string[]).includes(value)
-  );
-}
-
-export function parseInterfaceId(value: unknown): InterfaceId | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  if ((INTERFACE_IDS as readonly string[]).includes(value)) {
-    return value as InterfaceId;
-  }
-  const alias = LEGACY_INTERFACE_ALIASES[value];
-  if (alias) {
-    return alias;
-  }
-  return null;
-}
 
 /**
  * Client OS surfaces — the value set for the message-body `clientOs` field.

--- a/gateway/src/channels/types.test.ts
+++ b/gateway/src/channels/types.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  INTERFACE_IDS as CANONICAL_INTERFACE_IDS,
+  type InterfaceId as CanonicalInterfaceId,
+} from "@vellumai/service-contracts/channels";
+
+import { INTERFACE_IDS, isInterfaceId, parseInterfaceId } from "./types.js";
+
+const EXPECTED_INTERFACE_IDS = [
+  "macos",
+  "ios",
+  "cli",
+  "telegram",
+  "phone",
+  "web",
+  "whatsapp",
+  "slack",
+  "email",
+  "a2a",
+] as const satisfies readonly CanonicalInterfaceId[];
+
+describe("gateway interface IDs", () => {
+  test("accepts exactly the admitted subset", () => {
+    expect(INTERFACE_IDS).toEqual(EXPECTED_INTERFACE_IDS);
+
+    for (const id of EXPECTED_INTERFACE_IDS) {
+      expect(isInterfaceId(id)).toBe(true);
+      expect(parseInterfaceId(id)).toBe(id);
+    }
+  });
+
+  test("rejects canonical interfaces outside the admitted subset", () => {
+    const admitted = new Set<string>(EXPECTED_INTERFACE_IDS);
+    const rejectedCanonicalIds = CANONICAL_INTERFACE_IDS.filter(
+      (id) => !admitted.has(id),
+    );
+
+    expect(rejectedCanonicalIds).toEqual([
+      "chrome-extension",
+      "discord",
+      "route",
+    ]);
+    for (const id of rejectedCanonicalIds) {
+      expect(isInterfaceId(id)).toBe(false);
+      expect(parseInterfaceId(id)).toBeNull();
+    }
+  });
+
+  test("normalizes the legacy vellum alias through the admitted parser", () => {
+    expect(isInterfaceId("vellum")).toBe(false);
+    expect(parseInterfaceId("vellum")).toBe("web");
+  });
+
+  test("rejects unknown and non-string values", () => {
+    for (const value of ["safari-extension", "", undefined, null, 42]) {
+      expect(isInterfaceId(value)).toBe(false);
+      expect(parseInterfaceId(value)).toBeNull();
+    }
+  });
+});

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -1,4 +1,8 @@
-import type { ChannelId as CanonicalChannelId } from "@vellumai/service-contracts/channels";
+import {
+  type ChannelId as CanonicalChannelId,
+  type InterfaceId as CanonicalInterfaceId,
+  parseInterfaceId as parseCanonicalInterfaceId,
+} from "@vellumai/service-contracts/channels";
 
 /**
  * Channels the gateway can ingress — a strict subset of the canonical
@@ -39,23 +43,14 @@ export const INTERFACE_IDS = [
   "slack",
   "email",
   "a2a",
-] as const;
+] as const satisfies readonly CanonicalInterfaceId[];
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];
 
 /**
- * Interface IDs that older clients or persisted data may still use.
- * Maps legacy values to their canonical replacements.
- */
-const LEGACY_INTERFACE_ALIASES: Record<string, InterfaceId> = {
-  // The web client used to report "vellum" as its interface ID.
-  vellum: "web",
-};
-
-/**
- * Strict type guard — returns `true` only for canonical `InterfaceId`
- * values. Legacy aliases like `"vellum"` return `false`; use
- * `parseInterfaceId` to accept and normalize those.
+ * Strict type guard for gateway-admitted `InterfaceId` values. Canonical
+ * values outside the local subset and legacy aliases like `"vellum"` return
+ * `false`; use `parseInterfaceId` to accept and normalize admitted aliases.
  */
 export function isInterfaceId(value: unknown): value is InterfaceId {
   return (
@@ -64,17 +59,9 @@ export function isInterfaceId(value: unknown): value is InterfaceId {
   );
 }
 
-export function normalizeInterfaceId(value: InterfaceId): InterfaceId {
-  return (LEGACY_INTERFACE_ALIASES[value] as InterfaceId) ?? value;
-}
-
 export function parseInterfaceId(value: unknown): InterfaceId | null {
-  if (typeof value !== "string") return null;
-  if ((INTERFACE_IDS as readonly string[]).includes(value))
-    return value as InterfaceId;
-  const alias = LEGACY_INTERFACE_ALIASES[value];
-  if (alias) return alias;
-  return null;
+  const canonical = parseCanonicalInterfaceId(value);
+  return canonical !== null && isInterfaceId(canonical) ? canonical : null;
 }
 
 export interface TurnInterfaceContext {


### PR DESCRIPTION
PR 3 of the CLI live voice parity plan.

- Re-export the canonical interface tuple, type, guard, and parser from the assistant channel boundary.
- Keep the gateway interface vocabulary as a compile-time checked admitted subset.
- Delegate gateway alias normalization to the shared parser, then reject canonical IDs outside the admitted subset.
- Add regressions for the complete assistant vocabulary, the exact gateway subset, and the legacy vellum alias.

Validation:
- cd assistant && bun test src/channels/types.test.ts
- cd assistant && bunx eslint src/channels/types.ts src/channels/types.test.ts
- cd assistant && bunx tsc --noEmit
- cd gateway && bun test src/channels/types.test.ts
- cd gateway && bunx eslint src/channels/types.ts src/channels/types.test.ts
- cd gateway && bunx tsc --noEmit