### PR TITLE
refactor(voice): add a shared live-voice wire contract

### DIFF
--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -11,6 +11,7 @@
     "./client-metadata": "./src/client-metadata.ts",
     "./credential-rpc": "./src/credential-rpc.ts",
     "./ingress": "./src/ingress.ts",
+    "./live-voice": "./src/live-voice.ts",
     "./remote-web-pairing": "./src/remote-web-pairing.ts",
     "./twilio-ingress": "./src/twilio-ingress.ts",
     "./trust-rules": "./src/trust-rules.ts",

--- a/packages/service-contracts/src/__tests__/live-voice.test.ts
+++ b/packages/service-contracts/src/__tests__/live-voice.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+
+import { isInterfaceId } from "../channels.js";
+import {
+  LIVE_VOICE_AUDIO_FORMAT,
+  LIVE_VOICE_SERVER_FRAME_TYPES,
+  LIVE_VOICE_TURN_DETECTION_MODES,
+  LiveVoiceProtocolErrorCode,
+  MAX_BARGE_IN_MIN_SPEECH_MS,
+  MAX_SILENCE_THRESHOLD_MS,
+  MIN_BARGE_IN_MIN_SPEECH_MS,
+  MIN_SILENCE_THRESHOLD_MS,
+  parseLiveVoiceServerFrame,
+  type LiveVoiceClientControlFrame,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceLegacyBase64AudioFrame,
+  type LiveVoiceMetricsServerFrame,
+  type LiveVoiceServerFrame,
+} from "../live-voice.js";
+
+describe("live voice client contract", () => {
+  test("defines the canonical PCM capture format", () => {
+    expect(LIVE_VOICE_AUDIO_FORMAT).toEqual({
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+      channels: 1,
+    });
+  });
+
+  test("defines manual and server VAD modes", () => {
+    expect(LIVE_VOICE_TURN_DETECTION_MODES).toEqual(["manual", "server_vad"]);
+  });
+
+  test("exports the current turn-detection bounds", () => {
+    expect({
+      silence: [MIN_SILENCE_THRESHOLD_MS, MAX_SILENCE_THRESHOLD_MS],
+      bargeIn: [MIN_BARGE_IN_MIN_SPEECH_MS, MAX_BARGE_IN_MIN_SPEECH_MS],
+    }).toEqual({
+      silence: [100, 5_000],
+      bargeIn: [0, 3_000],
+    });
+  });
+
+  test("types every JSON control frame", () => {
+    const frames = [
+      {
+        type: "start",
+        conversationId: "conversation-123",
+        audio: LIVE_VOICE_AUDIO_FORMAT,
+        sourceInterface: "cli",
+        turnDetection: "server_vad",
+        silenceThresholdMs: 900,
+        bargeInMinSpeechMs: 200,
+      },
+      { type: "ptt_release" },
+      { type: "interrupt" },
+      { type: "end" },
+      {
+        type: "update_config",
+        silenceThresholdMs: 1_200,
+        bargeInMinSpeechMs: 400,
+      },
+    ] as const satisfies readonly LiveVoiceClientControlFrame[];
+
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "start",
+      "ptt_release",
+      "interrupt",
+      "end",
+      "update_config",
+    ]);
+  });
+
+  test("keeps sourceInterface optional for older clients", () => {
+    const frame = {
+      type: "start",
+      audio: LIVE_VOICE_AUDIO_FORMAT,
+    } satisfies LiveVoiceClientStartFrame;
+
+    expect(frame).not.toHaveProperty("sourceInterface");
+  });
+
+  test("accepts canonical source interfaces and rejects invalid values", () => {
+    const sourceInterface: LiveVoiceClientStartFrame["sourceInterface"] = "cli";
+    type AcceptsInvalidInterface =
+      "browser" extends NonNullable<
+        LiveVoiceClientStartFrame["sourceInterface"]
+      >
+        ? true
+        : false;
+    const acceptsInvalidInterface: AcceptsInvalidInterface = false;
+
+    expect(isInterfaceId(sourceInterface)).toBe(true);
+    expect(isInterfaceId("browser")).toBe(false);
+    expect(acceptsInvalidInterface).toBe(false);
+  });
+
+  test("names legacy base64 audio separately from controls", () => {
+    const frame = {
+      type: "audio",
+      dataBase64: "AQIDBA==",
+    } satisfies LiveVoiceLegacyBase64AudioFrame;
+
+    expect(frame.type).toBe("audio");
+  });
+});
+
+describe("parseLiveVoiceServerFrame", () => {
+  const frames = [
+    {
+      type: "ready",
+      seq: 1,
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+      turnDetection: "server_vad",
+    },
+    { type: "busy", seq: 2, activeSessionId: "session-456" },
+    { type: "speech_started", seq: 3 },
+    { type: "utterance_end", seq: 4, reason: "silence" },
+    { type: "utterance_discarded", seq: 5 },
+    { type: "stt_partial", seq: 6, text: "hel" },
+    { type: "stt_final", seq: 7, text: "hello" },
+    { type: "thinking", seq: 8, turnId: "turn-123" },
+    { type: "assistant_text_delta", seq: 9, text: "Hello" },
+    {
+      type: "tts_audio",
+      seq: 10,
+      mimeType: "audio/pcm",
+      sampleRate: 24_000,
+      dataBase64: "AAAA",
+    },
+    { type: "tts_done", seq: 11, turnId: "turn-123" },
+    { type: "turn_cancelled", seq: 12, turnId: "turn-123" },
+    { type: "minimize_room", seq: 13, turnId: "turn-123" },
+    {
+      type: "metrics",
+      seq: 14,
+      event: "turn_completed",
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+      turnId: "turn-123",
+      metrics: { summary: { completedTurnCount: 1 } },
+      sttMs: 100,
+      llmFirstDeltaMs: 200,
+      dispatchToFirstDeltaMs: 180,
+      dispatchToFirstAudioMs: 240,
+      ttsFirstAudioMs: 50,
+      roundTripMs: 350,
+      totalMs: 400,
+      endpointHoldCount: 1,
+      endpointDecisionMaxLatencyMs: 20,
+      ackSpoken: "first_delta",
+      progressUpdatesSpoken: 2,
+    },
+    {
+      type: "archived",
+      seq: 15,
+      conversationId: "conversation-123",
+      sessionId: "session-123",
+      turnId: "turn-123",
+      role: "assistant",
+      attachmentId: "attachment-123",
+      attachmentIds: ["attachment-123"],
+      warning: { code: "archive_failed", message: "Archive unavailable" },
+    },
+    {
+      type: "error",
+      seq: 16,
+      code: "invalid_field",
+      message: "Invalid field",
+      recoverable: true,
+    },
+  ] as const satisfies readonly LiveVoiceServerFrame[];
+
+  test("covers every current server discriminator", () => {
+    expect(frames.map((frame) => frame.type)).toEqual([
+      ...LIVE_VOICE_SERVER_FRAME_TYPES,
+    ]);
+  });
+
+  test("exports every current protocol error code", () => {
+    expect(Object.values(LiveVoiceProtocolErrorCode)).toEqual([
+      "invalid_json",
+      "invalid_frame",
+      "unknown_type",
+      "missing_required_field",
+      "invalid_field",
+      "invalid_audio_payload",
+      "credentials_unavailable",
+    ]);
+  });
+
+  for (const frame of frames) {
+    test(`round-trips ${frame.type}`, () => {
+      expect(parseLiveVoiceServerFrame(JSON.stringify(frame))).toEqual(frame);
+    });
+  }
+
+  test("allows metrics fields that older frames omit", () => {
+    const frame = {
+      type: "metrics",
+      seq: 1,
+      turnId: "turn-123",
+      sttMs: null,
+      llmFirstDeltaMs: null,
+      ttsFirstAudioMs: null,
+      totalMs: null,
+    } satisfies LiveVoiceMetricsServerFrame;
+
+    expect(parseLiveVoiceServerFrame(JSON.stringify(frame))).toEqual(frame);
+  });
+
+  test.each(["{", "null", "[]", "42", '"text"'])(
+    "returns invalid_json for malformed input %s",
+    (raw) => {
+      expect(parseLiveVoiceServerFrame(raw)).toEqual({
+        type: "error",
+        code: "invalid_json",
+        message: expect.any(String),
+      });
+    },
+  );
+
+  test.each([{}, { seq: 1 }, { type: 42, seq: 1 }])(
+    "returns invalid_json without a string discriminator",
+    (frame) => {
+      expect(parseLiveVoiceServerFrame(JSON.stringify(frame))).toEqual({
+        type: "error",
+        code: "invalid_json",
+        message: expect.any(String),
+      });
+    },
+  );
+
+  test("returns unknown_frame for structurally valid future frames", () => {
+    expect(
+      parseLiveVoiceServerFrame(
+        JSON.stringify({
+          type: "voice_activity",
+          seq: 17,
+          confidence: 0.98,
+        }),
+      ),
+    ).toEqual({
+      type: "unknown_frame",
+      frameType: "voice_activity",
+    });
+  });
+
+  test("passes known frames through without strict field validation", () => {
+    const frame = { type: "thinking", seq: 18, futureField: true } as const;
+    expect(parseLiveVoiceServerFrame(JSON.stringify(frame))).toEqual(
+      frame as unknown as LiveVoiceServerFrame,
+    );
+  });
+});

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -8,6 +8,7 @@
  *   - `@vellumai/service-contracts/trust-rules`     — trust-rule types and parsing helpers
  *   - `@vellumai/service-contracts/twilio-ingress`  — shared Twilio ingress config constants
  *   - `@vellumai/service-contracts/ingress`         — shared public ingress URL helpers
+ *   - `@vellumai/service-contracts/live-voice`: shared live-voice wire contract
  *
  * Fine-grained subpaths are also available for low-friction migration:
  *   `./rpc`, `./handles`, `./error`, `./trust-rules`, `./ingress`, `./twilio-ingress`
@@ -27,5 +28,6 @@ export * from "./handles.js";
 export * from "./rpc.js";
 export * from "./trust-rules.js";
 export * from "./ingress.js";
+export * from "./live-voice.js";
 export * from "./remote-web-pairing.js";
 export * from "./twilio-ingress.js";

--- a/packages/service-contracts/src/live-voice.ts
+++ b/packages/service-contracts/src/live-voice.ts
@@ -1,0 +1,311 @@
+import type { InterfaceId } from "./channels.js";
+
+export interface LiveVoiceAudioConfig {
+  readonly mimeType: "audio/pcm";
+  readonly sampleRate: number;
+  readonly channels: 1;
+}
+
+export const LIVE_VOICE_AUDIO_FORMAT = {
+  mimeType: "audio/pcm",
+  sampleRate: 16_000,
+  channels: 1,
+} as const satisfies LiveVoiceAudioConfig;
+
+export const LIVE_VOICE_TURN_DETECTION_MODES = [
+  "manual",
+  "server_vad",
+] as const;
+
+export type LiveVoiceTurnDetectionMode =
+  (typeof LIVE_VOICE_TURN_DETECTION_MODES)[number];
+
+export const MIN_SILENCE_THRESHOLD_MS = 100;
+export const MAX_SILENCE_THRESHOLD_MS = 5_000;
+export const MIN_BARGE_IN_MIN_SPEECH_MS = 0;
+export const MAX_BARGE_IN_MIN_SPEECH_MS = 3_000;
+
+export interface LiveVoiceClientStartFrame {
+  readonly type: "start";
+  readonly conversationId?: string;
+  readonly audio: LiveVoiceAudioConfig;
+  readonly sourceInterface?: InterfaceId;
+  readonly turnDetection?: LiveVoiceTurnDetectionMode;
+  readonly silenceThresholdMs?: number;
+  readonly bargeInMinSpeechMs?: number;
+}
+
+export interface LiveVoiceClientPttReleaseFrame {
+  readonly type: "ptt_release";
+}
+
+export interface LiveVoiceClientInterruptFrame {
+  readonly type: "interrupt";
+}
+
+export interface LiveVoiceClientEndFrame {
+  readonly type: "end";
+}
+
+export interface LiveVoiceClientUpdateConfigFrame {
+  readonly type: "update_config";
+  readonly silenceThresholdMs?: number;
+  readonly bargeInMinSpeechMs?: number;
+}
+
+export type LiveVoiceClientControlFrame =
+  | LiveVoiceClientStartFrame
+  | LiveVoiceClientPttReleaseFrame
+  | LiveVoiceClientInterruptFrame
+  | LiveVoiceClientEndFrame
+  | LiveVoiceClientUpdateConfigFrame;
+
+/**
+ * Compatibility frame for clients that send audio as base64 JSON. Current
+ * clients send PCM bytes in binary WebSocket frames.
+ */
+export interface LiveVoiceLegacyBase64AudioFrame {
+  readonly type: "audio";
+  readonly dataBase64: string;
+}
+
+export const LIVE_VOICE_SERVER_FRAME_TYPES = [
+  "ready",
+  "busy",
+  "speech_started",
+  "utterance_end",
+  "utterance_discarded",
+  "stt_partial",
+  "stt_final",
+  "thinking",
+  "assistant_text_delta",
+  "tts_audio",
+  "tts_done",
+  "turn_cancelled",
+  "minimize_room",
+  "metrics",
+  "archived",
+  "error",
+] as const;
+
+export type LiveVoiceServerFrameType =
+  (typeof LIVE_VOICE_SERVER_FRAME_TYPES)[number];
+
+export const LiveVoiceProtocolErrorCode = {
+  InvalidJson: "invalid_json",
+  InvalidFrame: "invalid_frame",
+  UnknownType: "unknown_type",
+  MissingRequiredField: "missing_required_field",
+  InvalidField: "invalid_field",
+  InvalidAudioPayload: "invalid_audio_payload",
+  CredentialsUnavailable: "credentials_unavailable",
+} as const;
+
+export type LiveVoiceProtocolErrorCode =
+  (typeof LiveVoiceProtocolErrorCode)[keyof typeof LiveVoiceProtocolErrorCode];
+
+export interface LiveVoiceProtocolError {
+  readonly code: LiveVoiceProtocolErrorCode;
+  readonly message: string;
+  readonly field?: string;
+  readonly frameType?: string;
+}
+
+interface LiveVoiceServerFrameBase {
+  readonly type: LiveVoiceServerFrameType;
+  readonly seq: number;
+}
+
+export interface LiveVoiceReadyServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "ready";
+  readonly sessionId: string;
+  readonly conversationId: string;
+  readonly turnDetection?: LiveVoiceTurnDetectionMode;
+}
+
+export interface LiveVoiceBusyServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "busy";
+  readonly activeSessionId: string;
+}
+
+export interface LiveVoiceSpeechStartedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "speech_started";
+}
+
+export interface LiveVoiceUtteranceEndServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "utterance_end";
+  readonly reason: "silence" | "max-duration";
+}
+
+export interface LiveVoiceUtteranceDiscardedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "utterance_discarded";
+}
+
+export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "stt_partial";
+  readonly text: string;
+}
+
+export interface LiveVoiceSttFinalServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "stt_final";
+  readonly text: string;
+}
+
+export interface LiveVoiceThinkingServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "thinking";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceAssistantTextDeltaServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "assistant_text_delta";
+  readonly text: string;
+}
+
+export interface LiveVoiceTtsAudioServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "tts_audio";
+  readonly mimeType: string;
+  readonly sampleRate: number;
+  readonly dataBase64: string;
+}
+
+export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "tts_done";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceTurnCancelledServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "turn_cancelled";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceMinimizeRoomServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "minimize_room";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "metrics";
+  readonly event?: string;
+  readonly sessionId?: string;
+  readonly conversationId?: string;
+  readonly turnId: string;
+  readonly metrics?: unknown;
+  readonly sttMs: number | null;
+  readonly llmFirstDeltaMs: number | null;
+  readonly dispatchToFirstDeltaMs?: number | null;
+  readonly dispatchToFirstAudioMs?: number | null;
+  readonly ttsFirstAudioMs: number | null;
+  readonly roundTripMs?: number | null;
+  readonly totalMs: number | null;
+  readonly endpointHoldCount?: number;
+  readonly endpointDecisionMaxLatencyMs?: number;
+  readonly ackSpoken?: "first_delta" | "tool_use";
+  readonly progressUpdatesSpoken?: number;
+}
+
+export interface LiveVoiceArchiveWarning {
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "archived";
+  readonly conversationId: string;
+  readonly sessionId: string;
+  readonly turnId?: string;
+  readonly role?: "user" | "assistant";
+  readonly attachmentId?: string;
+  readonly attachmentIds?: string[];
+  readonly warning?: LiveVoiceArchiveWarning;
+}
+
+export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "error";
+  readonly code: string;
+  readonly message: string;
+  readonly recoverable?: boolean;
+}
+
+export type LiveVoiceServerFrame =
+  | LiveVoiceReadyServerFrame
+  | LiveVoiceBusyServerFrame
+  | LiveVoiceSpeechStartedServerFrame
+  | LiveVoiceUtteranceEndServerFrame
+  | LiveVoiceUtteranceDiscardedServerFrame
+  | LiveVoiceSttPartialServerFrame
+  | LiveVoiceSttFinalServerFrame
+  | LiveVoiceThinkingServerFrame
+  | LiveVoiceAssistantTextDeltaServerFrame
+  | LiveVoiceTtsAudioServerFrame
+  | LiveVoiceTtsDoneServerFrame
+  | LiveVoiceTurnCancelledServerFrame
+  | LiveVoiceMinimizeRoomServerFrame
+  | LiveVoiceMetricsServerFrame
+  | LiveVoiceArchivedServerFrame
+  | LiveVoiceErrorServerFrame;
+
+type WithoutSeq<T> = T extends LiveVoiceServerFrameBase
+  ? Omit<T, "seq">
+  : never;
+
+export type LiveVoiceServerFramePayload = WithoutSeq<LiveVoiceServerFrame>;
+
+export interface LiveVoiceInvalidJsonFrame {
+  readonly type: "error";
+  readonly code: "invalid_json";
+  readonly message: string;
+}
+
+export interface LiveVoiceUnknownServerFrame {
+  readonly type: "unknown_frame";
+  readonly frameType: string;
+}
+
+export type LiveVoiceParsedServerFrame =
+  | LiveVoiceServerFrame
+  | LiveVoiceInvalidJsonFrame
+  | LiveVoiceUnknownServerFrame;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isLiveVoiceServerFrameType(
+  value: string,
+): value is LiveVoiceServerFrameType {
+  return (LIVE_VOICE_SERVER_FRAME_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Parses a server text frame by its discriminator. Known frames pass through
+ * without strict field validation so clients can remain tolerant of version
+ * skew and additional fields.
+ */
+export function parseLiveVoiceServerFrame(
+  raw: string,
+): LiveVoiceParsedServerFrame {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      type: "error",
+      code: "invalid_json",
+      message: "Live voice server frame is not valid JSON",
+    };
+  }
+
+  if (!isRecord(parsed) || typeof parsed.type !== "string") {
+    return {
+      type: "error",
+      code: "invalid_json",
+      message: "Live voice server frame has a missing or non-string type",
+    };
+  }
+
+  if (!isLiveVoiceServerFrameType(parsed.type)) {
+    return { type: "unknown_frame", frameType: parsed.type };
+  }
+
+  return parsed as unknown as LiveVoiceServerFrame;
+}


### PR DESCRIPTION
## Summary
- add the client-neutral live-voice audio, control-frame, and server-frame contract
- type optional CLI source attribution while preserving older start frames
- expose a tolerant server parser that distinguishes invalid JSON from future frame types
- declare the current latency, archive, and recoverable-error fields

## Plan context
PR 4 of the CLI live voice parity plan. Depends on the shared interface vocabulary and unblocks assistant, web, and CLI transport adoption.

## Tests
- cd packages/service-contracts && bun test src/__tests__/live-voice.test.ts src/__tests__/package-boundary.test.ts
- cd packages/service-contracts && bunx tsc --noEmit
- service-contracts live-voice subpath import smoke test