### PR TITLE
feat(cli): add live-voice transport routing

### DIFF
--- a/cli/src/__tests__/live-voice-channel-client.test.ts
+++ b/cli/src/__tests__/live-voice-channel-client.test.ts
@@ -1,0 +1,553 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  LiveVoiceChannelClient,
+  type LiveVoiceChannelClientClosed,
+  type LiveVoiceChannelClientError,
+  type LiveVoiceWebSocketCloseEvent,
+  type LiveVoiceWebSocketConstructor,
+  type LiveVoiceWebSocketMessageEvent,
+  type LiveVoiceWebSocketOptions,
+} from "../lib/live-voice/channel-client.js";
+
+type FakeListener = (event?: unknown) => void;
+
+class FakeWebSocket {
+  static readonly instances: FakeWebSocket[] = [];
+
+  readonly sent: (string | ArrayBuffer | Uint8Array)[] = [];
+  readonly listeners = new Map<string, Set<FakeListener>>();
+  readyState = 0;
+  binaryType = "";
+  closeCalls = 0;
+
+  constructor(
+    readonly url: string | URL,
+    readonly options?: LiveVoiceWebSocketOptions,
+  ) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string | ArrayBuffer | Uint8Array): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+    this.readyState = 3;
+  }
+
+  addEventListener(type: string, listener: FakeListener): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: FakeListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.emit("open");
+  }
+
+  message(data: unknown): void {
+    this.emit("message", { data } satisfies LiveVoiceWebSocketMessageEvent);
+  }
+
+  remoteClose(code: number, reason: string): void {
+    this.readyState = 3;
+    this.emit("close", {
+      code,
+      reason,
+    } satisfies LiveVoiceWebSocketCloseEvent);
+  }
+
+  error(): void {
+    this.emit("error");
+  }
+
+  private emit(type: string, event?: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+function makeClient(options?: {
+  url?: string;
+  headers?: Readonly<Record<string, string>>;
+  connectTimeoutMs?: number;
+}): { client: LiveVoiceChannelClient; socket: () => FakeWebSocket } {
+  FakeWebSocket.instances.length = 0;
+  const client = new LiveVoiceChannelClient({
+    url: options?.url ?? "ws://127.0.0.1:7830/v1/live-voice",
+    headers: options?.headers,
+    connectTimeoutMs: options?.connectTimeoutMs,
+    webSocketConstructor:
+      FakeWebSocket as unknown as LiveVoiceWebSocketConstructor,
+  });
+  return {
+    client,
+    socket: () => {
+      const socket = FakeWebSocket.instances[0];
+      if (!socket) {
+        throw new Error("Expected a WebSocket");
+      }
+      return socket;
+    },
+  };
+}
+
+function readyFrame(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: "ready",
+    seq: 1,
+    sessionId: "session-123",
+    conversationId: "conversation-123",
+    ...overrides,
+  });
+}
+
+describe("live-voice channel client", () => {
+  test("constructs a direct socket with Bun headers", () => {
+    const { client, socket } = makeClient({
+      headers: { Authorization: "Bearer guardian-secret" },
+    });
+    client.connect();
+
+    expect(String(socket().url)).toBe("ws://127.0.0.1:7830/v1/live-voice");
+    expect(socket().options).toEqual({
+      headers: { Authorization: "Bearer guardian-secret" },
+    });
+    client.close();
+  });
+
+  test("sends the typed CLI start frame first", () => {
+    const { client, socket } = makeClient();
+    client.connect({
+      conversationId: "conversation-123",
+      turnDetection: "server_vad",
+      silenceThresholdMs: 750,
+      bargeInMinSpeechMs: 250,
+    });
+    socket().open();
+
+    expect(socket().sent).toHaveLength(1);
+    expect(JSON.parse(String(socket().sent[0]))).toEqual({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 16_000,
+        channels: 1,
+      },
+      sourceInterface: "cli",
+      conversationId: "conversation-123",
+      turnDetection: "server_vad",
+      silenceThresholdMs: 750,
+      bargeInMinSpeechMs: 250,
+    });
+    client.close();
+  });
+
+  test("preserves raw PCM binary identity", () => {
+    const { client, socket } = makeClient();
+    client.connect();
+    socket().open();
+    socket().message(readyFrame());
+
+    const pcm = new Uint8Array([1, 2, 3, 4]);
+    client.sendAudio(pcm);
+
+    expect(socket().sent[1]).toBe(pcm);
+    client.close();
+  });
+
+  test("sends controls in call order", () => {
+    const { client, socket } = makeClient();
+    client.connect();
+    socket().open();
+    socket().message(readyFrame());
+
+    client.pttRelease();
+    client.interrupt();
+    client.updateConfig({
+      silenceThresholdMs: 800,
+      bargeInMinSpeechMs: 300,
+    });
+    client.end();
+
+    expect(
+      socket()
+        .sent.slice(1)
+        .map((frame) => JSON.parse(String(frame))),
+    ).toEqual([
+      { type: "ptt_release" },
+      { type: "interrupt" },
+      {
+        type: "update_config",
+        silenceThresholdMs: 800,
+        bargeInMinSpeechMs: 300,
+      },
+      { type: "end" },
+    ]);
+  });
+
+  test("does not send audio or controls before ready", () => {
+    const { client, socket } = makeClient();
+    client.connect();
+    socket().open();
+
+    client.sendAudio(new Uint8Array([1, 2]));
+    client.pttRelease();
+    client.interrupt();
+    client.updateConfig({ silenceThresholdMs: 500 });
+
+    expect(socket().sent).toHaveLength(1);
+    client.close();
+  });
+
+  test("surfaces ready and forwards server frames in arrival order", () => {
+    const { client, socket } = makeClient();
+    const events: string[] = [];
+    client.on("ready", (frame) => {
+      events.push(`ready:${frame.sessionId}`);
+    });
+    client.on("frame", (frame) => {
+      events.push(`${frame.type}:${frame.seq}`);
+    });
+    client.connect();
+    socket().open();
+
+    socket().message(readyFrame());
+    socket().message(
+      JSON.stringify({ type: "thinking", seq: 2, turnId: "turn-123" }),
+    );
+    socket().message(
+      JSON.stringify({
+        type: "tts_done",
+        seq: 3,
+        turnId: "turn-123",
+      }),
+    );
+
+    expect(events).toEqual(["ready:session-123", "thinking:2", "tts_done:3"]);
+    client.close();
+  });
+
+  test("surfaces busy metadata and closes without stealing the session", () => {
+    const { client, socket } = makeClient();
+    const busyIds: string[] = [];
+    const closed: LiveVoiceChannelClientClosed[] = [];
+    client.on("busy", (frame) => {
+      busyIds.push(frame.activeSessionId);
+    });
+    client.on("closed", (event) => {
+      closed.push(event);
+    });
+    client.connect();
+    socket().open();
+    socket().message(
+      JSON.stringify({
+        type: "busy",
+        seq: 2,
+        activeSessionId: "other-session",
+      }),
+    );
+
+    expect(busyIds).toEqual(["other-session"]);
+    expect(closed).toEqual([
+      {
+        code: null,
+        reason: "client closed",
+        retryable: false,
+      },
+    ]);
+    expect(socket().sent).toHaveLength(1);
+  });
+
+  test("ignores unknown future and unexpected binary server frames", () => {
+    const { client, socket } = makeClient();
+    const errors: LiveVoiceChannelClientError[] = [];
+    const frames: string[] = [];
+    client.on("error", (error) => {
+      errors.push(error);
+    });
+    client.on("frame", (frame) => {
+      frames.push(frame.type);
+    });
+    client.connect();
+    socket().open();
+    socket().message(readyFrame());
+
+    socket().message(
+      JSON.stringify({ type: "future_frame", seq: 2, value: true }),
+    );
+    socket().message(new Uint8Array([1, 2, 3]));
+    socket().message(
+      JSON.stringify({ type: "thinking", seq: 3, turnId: "turn-123" }),
+    );
+
+    expect(errors).toEqual([]);
+    expect(frames).toEqual(["thinking"]);
+    client.close();
+  });
+
+  test("fails malformed JSON as a protocol error", () => {
+    const { client, socket } = makeClient();
+    const errors: LiveVoiceChannelClientError[] = [];
+    client.on("error", (error) => {
+      errors.push(error);
+    });
+    client.connect();
+    socket().open();
+    socket().message("{not-json");
+
+    expect(errors).toEqual([
+      {
+        reason: "protocol-error",
+        code: "invalid_json",
+        message: "Live voice server frame is not valid JSON",
+      },
+    ]);
+    expect(socket().closeCalls).toBe(1);
+  });
+
+  test("keeps the socket alive after a recoverable server error", () => {
+    const { client, socket } = makeClient();
+    const errors: LiveVoiceChannelClientError[] = [];
+    client.on("error", (error) => {
+      errors.push(error);
+    });
+    client.connect();
+    socket().open();
+    socket().message(readyFrame());
+    socket().message(
+      JSON.stringify({
+        type: "error",
+        seq: 2,
+        code: "temporary_failure",
+        message: "Try again",
+        recoverable: true,
+      }),
+    );
+    client.pttRelease();
+
+    expect(errors).toEqual([
+      {
+        reason: "protocol-error",
+        code: "temporary_failure",
+        message: "Try again",
+        recoverable: true,
+      },
+    ]);
+    expect(socket().closeCalls).toBe(0);
+    expect(JSON.parse(String(socket().sent.at(-1)))).toEqual({
+      type: "ptt_release",
+    });
+    client.close();
+  });
+
+  test("latches off unsupported update_config without ending the session", () => {
+    const { client, socket } = makeClient();
+    const errors: LiveVoiceChannelClientError[] = [];
+    client.on("error", (error) => {
+      errors.push(error);
+    });
+    client.connect();
+    socket().open();
+    socket().message(readyFrame());
+    client.updateConfig({ silenceThresholdMs: 500 });
+    socket().message(
+      JSON.stringify({
+        type: "error",
+        seq: 2,
+        code: "unknown_type",
+        message: "Unknown frame",
+      }),
+    );
+    client.updateConfig({ silenceThresholdMs: 600 });
+    client.pttRelease();
+
+    expect(errors).toEqual([]);
+    expect(
+      socket()
+        .sent.slice(1)
+        .map((frame) => JSON.parse(String(frame))),
+    ).toEqual([
+      { type: "update_config", silenceThresholdMs: 500 },
+      { type: "ptt_release" },
+    ]);
+    client.close();
+  });
+
+  test("times out when ready does not arrive", async () => {
+    const { client, socket } = makeClient({ connectTimeoutMs: 5 });
+    const errors: LiveVoiceChannelClientError[] = [];
+    client.on("error", (error) => {
+      errors.push(error);
+    });
+    client.connect();
+    socket().open();
+
+    await Bun.sleep(15);
+
+    expect(errors).toEqual([
+      {
+        reason: "timeout",
+        message: "Live voice did not become ready within 5ms.",
+      },
+    ]);
+    expect(socket().closeCalls).toBe(1);
+  });
+
+  test("classifies 1012 and 1013 closes as retryable", () => {
+    for (const code of [1012, 1013]) {
+      const { client, socket } = makeClient();
+      const closed: LiveVoiceChannelClientClosed[] = [];
+      client.on("closed", (event) => {
+        closed.push(event);
+      });
+      client.connect();
+      socket().open();
+      socket().message(readyFrame());
+      socket().remoteClose(code, "try again later");
+
+      expect(closed).toEqual([
+        {
+          code,
+          reason: "try again later",
+          retryable: true,
+        },
+      ]);
+    }
+  });
+
+  test("forwards retryable pre-ready closes without a terminal error", () => {
+    const { client, socket } = makeClient();
+    const errors: LiveVoiceChannelClientError[] = [];
+    const closed: LiveVoiceChannelClientClosed[] = [];
+    client.on("error", (error) => {
+      errors.push(error);
+    });
+    client.on("closed", (event) => {
+      closed.push(event);
+    });
+    client.connect();
+    socket().remoteClose(1013, "tunnel unavailable");
+
+    expect(errors).toEqual([]);
+    expect(closed).toEqual([
+      {
+        code: 1013,
+        reason: "tunnel unavailable",
+        retryable: true,
+      },
+    ]);
+  });
+
+  test("fails a non-retryable pre-ready close", () => {
+    const { client, socket } = makeClient();
+    const errors: LiveVoiceChannelClientError[] = [];
+    client.on("error", (error) => {
+      errors.push(error);
+    });
+    client.connect();
+    socket().remoteClose(1006, "abnormal");
+
+    expect(errors).toEqual([
+      {
+        reason: "connection-failed",
+        message: "The live-voice WebSocket closed before it became ready.",
+      },
+    ]);
+  });
+
+  test("makes end and close idempotent in every state", () => {
+    const idle = makeClient().client;
+    const idleClosed: LiveVoiceChannelClientClosed[] = [];
+    idle.on("closed", (event) => {
+      idleClosed.push(event);
+    });
+    idle.end();
+    idle.end();
+    idle.close();
+    expect(idleClosed).toHaveLength(1);
+
+    const active = makeClient();
+    const activeClosed: LiveVoiceChannelClientClosed[] = [];
+    active.client.on("closed", (event) => {
+      activeClosed.push(event);
+    });
+    active.client.connect();
+    active.socket().open();
+    active.socket().message(readyFrame());
+    active.client.end();
+    active.client.end();
+    active.client.close();
+    expect(activeClosed).toHaveLength(1);
+    expect(active.socket().closeCalls).toBe(1);
+    expect(
+      active
+        .socket()
+        .sent.filter(
+          (frame) =>
+            typeof frame === "string" && JSON.parse(frame).type === "end",
+        ),
+    ).toHaveLength(1);
+  });
+
+  test("redacts query and header credentials from surfaced errors", () => {
+    const token = "single-use secret";
+    const guardian = "guardian-secret";
+    const { client, socket } = makeClient({
+      url: `wss://velay.example.com/assistant-123/v1/live-voice?token=${encodeURIComponent(token)}`,
+      headers: { Authorization: `Bearer ${guardian}` },
+    });
+    const errors: LiveVoiceChannelClientError[] = [];
+    client.on("error", (error) => {
+      errors.push(error);
+    });
+    client.connect();
+    socket().open();
+    socket().message(readyFrame());
+    socket().message(
+      JSON.stringify({
+        type: "error",
+        seq: 2,
+        code: "server_error",
+        message: `failed ${token} ${encodeURIComponent(token)} ${token.replaceAll(" ", "+")} ${guardian}`,
+      }),
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).not.toContain(token);
+    expect(errors[0]?.message).not.toContain(encodeURIComponent(token));
+    expect(errors[0]?.message).not.toContain(token.replaceAll(" ", "+"));
+    expect(errors[0]?.message).not.toContain(guardian);
+  });
+
+  test("removes listeners and ignores late events after teardown", () => {
+    const { client, socket } = makeClient();
+    const frames: string[] = [];
+    client.on("frame", (frame) => {
+      frames.push(frame.type);
+    });
+    client.connect();
+    socket().open();
+    socket().message(readyFrame());
+    client.close();
+    socket().message(
+      JSON.stringify({ type: "thinking", seq: 2, turnId: "turn-123" }),
+    );
+    socket().remoteClose(1013, "late");
+
+    expect(frames).toEqual([]);
+    expect(
+      [...socket().listeners.values()].every(
+        (listeners) => listeners.size === 0,
+      ),
+    ).toBe(true);
+  });
+});

--- a/cli/src/__tests__/live-voice-connection.test.ts
+++ b/cli/src/__tests__/live-voice-connection.test.ts
@@ -1,0 +1,543 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AssistantEntry } from "../lib/assistant-config.js";
+import {
+  buildDirectLiveVoiceWebSocketUrl,
+  buildManagedLiveVoiceWebSocketUrl,
+  LiveVoiceConnectionError,
+  preflightLiveVoice,
+  resolveLiveVoiceConnection,
+  type LiveVoiceConnectionDependencyOverrides,
+} from "../lib/live-voice/connection.js";
+
+const LOCAL_ENTRY: AssistantEntry = {
+  assistantId: "assistant-123",
+  name: "Example Assistant",
+  cloud: "local",
+  runtimeUrl: "http://localhost:7830",
+  localUrl: "http://127.0.0.1:7830",
+  species: "vellum",
+};
+
+const MANAGED_ENTRY: AssistantEntry = {
+  assistantId: "assistant-456",
+  name: "Managed Assistant",
+  cloud: "vellum",
+  runtimeUrl: "https://platform.vellum.ai",
+  species: "vellum",
+};
+
+function makeDependencies(
+  overrides: LiveVoiceConnectionDependencyOverrides = {},
+): LiveVoiceConnectionDependencyOverrides {
+  return {
+    resolveTargetAssistant: () => LOCAL_ENTRY,
+    loadGuardianSessionAccessToken: () => "guardian-secret",
+    resolveGuardianSessionAuth: async ({ accessToken }) => ({
+      ok: true,
+      accessToken,
+      refreshed: false,
+    }),
+    readPlatformToken: () => "platform-session-secret",
+    getPlatformUrl: () => "https://platform.vellum.ai",
+    mintLiveVoiceToken: async () => ({
+      token: "single-use-secret",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    }),
+    fetch: async () => Response.json({ status: "ready" }),
+    getVelayBaseUrl: () => undefined,
+    ...overrides,
+  };
+}
+
+describe("live-voice connection routing", () => {
+  test("routes an explicit URL and assistant ID directly", async () => {
+    const connection = await resolveLiveVoiceConnection(
+      {
+        url: "http://127.0.0.1:7830/",
+        assistantId: "assistant-123",
+      },
+      makeDependencies(),
+    );
+
+    expect(connection).toMatchObject({
+      topology: "direct",
+      assistantId: "assistant-123",
+      gatewayUrl: "http://127.0.0.1:7830/",
+      webSocket: {
+        url: "ws://127.0.0.1:7830/v1/live-voice",
+        logSafeUrl: "ws://127.0.0.1:7830/v1/live-voice",
+        headers: { Authorization: "Bearer guardian-secret" },
+      },
+    });
+  });
+
+  test("resolves a target name for an explicit direct URL", async () => {
+    const connection = await resolveLiveVoiceConnection(
+      {
+        target: "Example Assistant",
+        url: "http://localhost:7830",
+      },
+      makeDependencies({
+        resolveTargetAssistant: (target) => {
+          expect(target).toBe("Example Assistant");
+          return LOCAL_ENTRY;
+        },
+      }),
+    );
+
+    expect(connection.assistantId).toBe("assistant-123");
+    expect(connection.topology).toBe("direct");
+  });
+
+  test("requires an assistant ID with an unbound explicit URL", async () => {
+    await expect(
+      resolveLiveVoiceConnection(
+        { url: "http://127.0.0.1:7830" },
+        makeDependencies(),
+      ),
+    ).rejects.toMatchObject({
+      name: "LiveVoiceConnectionError",
+      code: "assistant_id_required",
+    });
+  });
+
+  test("routes a standard local entry through its local gateway", async () => {
+    const connection = await resolveLiveVoiceConnection({}, makeDependencies());
+
+    expect(connection.topology).toBe("direct");
+    if (connection.topology === "direct") {
+      expect(connection.gatewayUrl).toBe("http://127.0.0.1:7830/");
+      expect(connection.preflight).toEqual({ status: "ready" });
+    }
+  });
+
+  test("keeps an IS_PLATFORM local assistant on the direct path", async () => {
+    const previous = process.env.IS_PLATFORM;
+    process.env.IS_PLATFORM = "1";
+    try {
+      const connection = await resolveLiveVoiceConnection(
+        {},
+        makeDependencies({
+          resolveTargetAssistant: () => ({
+            ...LOCAL_ENTRY,
+            runtimeUrl: "http://127.0.0.1:7930",
+            localUrl: undefined,
+          }),
+        }),
+      );
+
+      expect(connection.topology).toBe("direct");
+      expect(connection.webSocket.url).toBe(
+        "ws://127.0.0.1:7930/v1/live-voice",
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.IS_PLATFORM;
+      } else {
+        process.env.IS_PLATFORM = previous;
+      }
+    }
+  });
+
+  test("an explicit URL stays direct even for a managed lockfile target", async () => {
+    let minted = false;
+    const connection = await resolveLiveVoiceConnection(
+      {
+        url: "http://127.0.0.1:7830",
+        target: "Managed Assistant",
+      },
+      makeDependencies({
+        resolveTargetAssistant: () => MANAGED_ENTRY,
+        mintLiveVoiceToken: async () => {
+          minted = true;
+          throw new Error("should not mint");
+        },
+      }),
+    );
+
+    expect(connection.topology).toBe("direct");
+    expect(minted).toBe(false);
+  });
+
+  test("routes managed assistants through environment-correct Velay", async () => {
+    const mintCalls: string[][] = [];
+    const connection = await resolveLiveVoiceConnection(
+      {},
+      makeDependencies({
+        resolveTargetAssistant: () => MANAGED_ENTRY,
+        getPlatformUrl: () => "https://staging-platform.vellum.ai",
+        mintLiveVoiceToken: async (sessionToken, assistantId, platformUrl) => {
+          mintCalls.push([sessionToken, assistantId, platformUrl ?? ""]);
+          return {
+            token: "single-use-secret",
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          };
+        },
+      }),
+    );
+
+    expect(connection.topology).toBe("vellum-managed");
+    expect(connection.webSocket.url).toBe(
+      "wss://velay-staging.vellum.ai/assistant-456/v1/live-voice?token=single-use-secret",
+    );
+    expect(connection.webSocket.logSafeUrl).toBe(
+      "wss://velay-staging.vellum.ai/assistant-456/v1/live-voice?token=%5BREDACTED%5D",
+    );
+    expect(connection.webSocket.headers).toBeUndefined();
+    expect(mintCalls).toEqual([
+      [
+        "platform-session-secret",
+        "assistant-456",
+        "https://staging-platform.vellum.ai",
+      ],
+    ]);
+    expect(connection.webSocket.url).not.toContain("platform-session-secret");
+  });
+
+  test("uses plain ws only for an explicit loopback Velay endpoint", async () => {
+    const connection = await resolveLiveVoiceConnection(
+      {},
+      makeDependencies({
+        resolveTargetAssistant: () => MANAGED_ENTRY,
+        getPlatformUrl: () => "http://127.0.0.1:8000",
+        getVelayBaseUrl: () => "http://127.0.0.1:8501",
+      }),
+    );
+
+    expect(connection.webSocket.url).toBe(
+      "ws://127.0.0.1:8501/assistant-456/v1/live-voice?token=single-use-secret",
+    );
+  });
+
+  test("permits a secure explicit remote Velay endpoint", () => {
+    expect(
+      buildManagedLiveVoiceWebSocketUrl({
+        assistantId: "assistant-123",
+        token: "single-use-secret",
+        platformUrl: "https://platform.vellum.ai",
+        velayBaseUrl: "https://voice.example.com",
+      }),
+    ).toBe(
+      "wss://voice.example.com/assistant-123/v1/live-voice?token=single-use-secret",
+    );
+  });
+
+  test("rejects insecure remote gateway and Velay endpoints", async () => {
+    await expect(
+      resolveLiveVoiceConnection(
+        {
+          url: "http://gateway.example.com",
+          assistantId: "assistant-123",
+        },
+        makeDependencies(),
+      ),
+    ).rejects.toMatchObject({ code: "remote_tls_required" });
+
+    expect(() =>
+      buildManagedLiveVoiceWebSocketUrl({
+        assistantId: "assistant-123",
+        token: "single-use-secret",
+        platformUrl: "https://platform.vellum.ai",
+        velayBaseUrl: "ws://voice.example.com",
+      }),
+    ).toThrow("Remote live-voice endpoints must use TLS.");
+  });
+
+  test("requires guardian authentication for a remote direct gateway", async () => {
+    await expect(
+      resolveLiveVoiceConnection(
+        {
+          url: "https://gateway.example.com",
+          assistantId: "assistant-123",
+        },
+        makeDependencies({
+          loadGuardianSessionAccessToken: () => undefined,
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "guardian_auth_required",
+    });
+  });
+
+  test("allows an intentionally unauthenticated loopback gateway", async () => {
+    const connection = await resolveLiveVoiceConnection(
+      {
+        url: "http://127.0.0.1:7830",
+        assistantId: "assistant-123",
+      },
+      makeDependencies({
+        loadGuardianSessionAccessToken: () => undefined,
+      }),
+    );
+
+    expect(connection.topology).toBe("direct");
+    expect(connection.webSocket.headers).toBeUndefined();
+    expect(connection.webSocket.url).not.toContain("token=");
+  });
+
+  test("blocks an explicit not-ready preflight verdict", async () => {
+    await expect(
+      resolveLiveVoiceConnection(
+        {
+          url: "http://127.0.0.1:7830",
+          assistantId: "assistant-123",
+        },
+        makeDependencies({
+          fetch: async () =>
+            Response.json({
+              status: "not-ready",
+              userMessage: "Connect speech providers.",
+            }),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "not_ready",
+      message:
+        "Live voice is not ready. Configure speech-to-text and text-to-speech providers first.",
+    });
+  });
+
+  test("fails open when direct preflight transport is unavailable", async () => {
+    const connection = await resolveLiveVoiceConnection(
+      {
+        url: "http://127.0.0.1:7830",
+        assistantId: "assistant-123",
+      },
+      makeDependencies({
+        fetch: async () => {
+          throw new Error("offline");
+        },
+      }),
+    );
+
+    expect(connection.topology).toBe("direct");
+    if (connection.topology === "direct") {
+      expect(connection.preflight).toEqual({ status: "unavailable" });
+    }
+  });
+
+  test("passes guardian authentication in headers, never the URL", async () => {
+    const preflightAuthorizations: (string | null)[] = [];
+    const connection = await resolveLiveVoiceConnection(
+      {
+        url: "https://gateway.example.com",
+        assistantId: "assistant-123",
+        guardianToken: "ephemeral-guardian-secret",
+      },
+      makeDependencies({
+        fetch: async (_input, init) => {
+          preflightAuthorizations.push(
+            new Headers(init?.headers).get("Authorization"),
+          );
+          return Response.json({ status: "ready" });
+        },
+      }),
+    );
+
+    expect(connection.webSocket.headers).toEqual({
+      Authorization: "Bearer ephemeral-guardian-secret",
+    });
+    expect(connection.webSocket.url).toBe(
+      "wss://gateway.example.com/v1/live-voice",
+    );
+    expect(connection.webSocket.url).not.toContain("ephemeral-guardian-secret");
+    expect(preflightAuthorizations).toEqual([
+      "Bearer ephemeral-guardian-secret",
+    ]);
+  });
+
+  test("rejects Docker and paired targets before network access", async () => {
+    let networkCalls = 0;
+    const deps = makeDependencies({
+      fetch: async () => {
+        networkCalls += 1;
+        return Response.json({ status: "ready" });
+      },
+      mintLiveVoiceToken: async () => {
+        networkCalls += 1;
+        return {
+          token: "single-use-secret",
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        };
+      },
+    });
+
+    for (const cloud of ["docker", "paired"] as const) {
+      await expect(
+        resolveLiveVoiceConnection(
+          {},
+          {
+            ...deps,
+            resolveTargetAssistant: () => ({
+              ...LOCAL_ENTRY,
+              cloud,
+            }),
+          },
+        ),
+      ).rejects.toMatchObject({
+        code: "unsupported_topology",
+      });
+    }
+    expect(networkCalls).toBe(0);
+  });
+
+  test("requires a stored user session for managed assistants", async () => {
+    await expect(
+      resolveLiveVoiceConnection(
+        {},
+        makeDependencies({
+          resolveTargetAssistant: () => MANAGED_ENTRY,
+          readPlatformToken: () => null,
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "platform_login_required",
+    });
+  });
+
+  test("redacts credentials from routing errors and diagnostic URLs", async () => {
+    const guardianToken = "guardian-secret-value";
+    await expect(
+      resolveLiveVoiceConnection(
+        {
+          url: "https://gateway.example.com",
+          assistantId: "assistant-123",
+          guardianToken,
+        },
+        makeDependencies({
+          resolveGuardianSessionAuth: async () => ({
+            ok: false,
+            accessToken: guardianToken,
+            error: Object.assign(new Error(`failed for ${guardianToken}`), {
+              name: "GuardianSessionAuthError",
+              code: "refresh_failed" as const,
+            }),
+          }),
+        }),
+      ),
+    ).rejects.not.toThrow(guardianToken);
+
+    await expect(
+      resolveLiveVoiceConnection(
+        {},
+        makeDependencies({
+          resolveTargetAssistant: () => MANAGED_ENTRY,
+          mintLiveVoiceToken: async () => {
+            throw new Error("platform-session-secret");
+          },
+        }),
+      ),
+    ).rejects.not.toThrow("platform-session-secret");
+  });
+});
+
+describe("direct live-voice preflight", () => {
+  test("returns ready and preserves assistant-scoped guardian auth", async () => {
+    let requestUrl = "";
+    const requestAuthorizations: (string | null)[] = [];
+    const result = await preflightLiveVoice(
+      "https://gateway.example.com",
+      "guardian-secret",
+      async (input, init) => {
+        requestUrl = String(input);
+        requestAuthorizations.push(
+          new Headers(init?.headers).get("Authorization"),
+        );
+        return Response.json({ status: "ready" });
+      },
+    );
+
+    expect(result).toEqual({ status: "ready" });
+    expect(requestUrl).toBe(
+      "https://gateway.example.com/v1/live-voice/preflight",
+    );
+    expect(requestAuthorizations).toEqual(["Bearer guardian-secret"]);
+  });
+
+  test("returns an explicit not-ready verdict", async () => {
+    const result = await preflightLiveVoice(
+      "http://127.0.0.1:7830",
+      undefined,
+      async () =>
+        Response.json({
+          status: "not-ready",
+          missing: [
+            {
+              kind: "stt",
+              providerId: "example-stt",
+              reason: "not configured",
+            },
+          ],
+          userMessage: "Configure speech providers.",
+        }),
+    );
+
+    expect(result).toEqual({
+      status: "not-ready",
+      missing: [
+        {
+          kind: "stt",
+          providerId: "example-stt",
+          reason: "not configured",
+        },
+      ],
+      userMessage: "Configure speech providers.",
+    });
+  });
+
+  test("fails open on transport, HTTP, and malformed response failures", async () => {
+    expect(
+      await preflightLiveVoice("http://127.0.0.1:7830", undefined, async () => {
+        throw new Error("offline");
+      }),
+    ).toEqual({ status: "unavailable" });
+
+    expect(
+      await preflightLiveVoice(
+        "http://127.0.0.1:7830",
+        undefined,
+        async () => new Response("", { status: 503 }),
+      ),
+    ).toEqual({ status: "unavailable" });
+
+    expect(
+      await preflightLiveVoice("http://127.0.0.1:7830", undefined, async () =>
+        Response.json({ status: "future-status" }),
+      ),
+    ).toEqual({ status: "unavailable" });
+  });
+});
+
+describe("live-voice URL builders", () => {
+  test("normalizes direct gateway origins and drops paths and queries", () => {
+    expect(
+      buildDirectLiveVoiceWebSocketUrl(
+        "https://gateway.example.com/prefix?secret=value",
+      ),
+    ).toBe("wss://gateway.example.com/v1/live-voice");
+  });
+
+  test("encodes managed assistant IDs and the single-use token", () => {
+    expect(
+      buildManagedLiveVoiceWebSocketUrl({
+        assistantId: "assistant/id",
+        token: "token with spaces",
+        platformUrl: "https://platform.vellum.ai",
+      }),
+    ).toBe(
+      "wss://velay.vellum.ai/assistant%2Fid/v1/live-voice?token=token+with+spaces",
+    );
+  });
+
+  test("uses generic URL errors without reflecting credentials", () => {
+    const secret = "secret-value";
+    try {
+      buildDirectLiveVoiceWebSocketUrl(`not a URL?token=${secret}`);
+      throw new Error("Expected URL validation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(LiveVoiceConnectionError);
+      expect(String(error)).not.toContain(secret);
+    }
+  });
+});

--- a/cli/src/lib/live-voice/channel-client.ts
+++ b/cli/src/lib/live-voice/channel-client.ts
@@ -1,0 +1,496 @@
+import type {
+  LiveVoiceBusyServerFrame,
+  LiveVoiceClientControlFrame,
+  LiveVoiceClientStartFrame,
+  LiveVoiceClientUpdateConfigFrame,
+  LiveVoiceErrorServerFrame,
+  LiveVoiceReadyServerFrame,
+  LiveVoiceServerFrame,
+  LiveVoiceTurnDetectionMode,
+} from "@vellumai/service-contracts/live-voice";
+import {
+  LIVE_VOICE_AUDIO_FORMAT,
+  parseLiveVoiceServerFrame,
+} from "@vellumai/service-contracts/live-voice";
+
+const CONNECT_TIMEOUT_MS = 10_000;
+const WEB_SOCKET_OPEN = 1;
+
+export const RETRYABLE_LIVE_VOICE_CLOSE_CODES: ReadonlySet<number> = new Set([
+  1012, 1013,
+]);
+
+export interface LiveVoiceWebSocketOptions {
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
+export interface LiveVoiceWebSocketMessageEvent {
+  readonly data: unknown;
+}
+
+export interface LiveVoiceWebSocketCloseEvent {
+  readonly code: number;
+  readonly reason: string;
+}
+
+export interface LiveVoiceWebSocketLike {
+  binaryType: string;
+  readonly readyState: number;
+  send(data: string | ArrayBuffer | Uint8Array): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(
+    type: "message",
+    listener: (event: LiveVoiceWebSocketMessageEvent) => void,
+  ): void;
+  addEventListener(type: "error", listener: () => void): void;
+  addEventListener(
+    type: "close",
+    listener: (event: LiveVoiceWebSocketCloseEvent) => void,
+  ): void;
+  removeEventListener(type: "open", listener: () => void): void;
+  removeEventListener(
+    type: "message",
+    listener: (event: LiveVoiceWebSocketMessageEvent) => void,
+  ): void;
+  removeEventListener(type: "error", listener: () => void): void;
+  removeEventListener(
+    type: "close",
+    listener: (event: LiveVoiceWebSocketCloseEvent) => void,
+  ): void;
+}
+
+export type LiveVoiceWebSocketConstructor = new (
+  url: string | URL,
+  options?: LiveVoiceWebSocketOptions,
+) => LiveVoiceWebSocketLike;
+
+export type LiveVoiceChannelClientErrorReason =
+  | "connection-failed"
+  | "protocol-error"
+  | "timeout";
+
+export interface LiveVoiceChannelClientError {
+  readonly reason: LiveVoiceChannelClientErrorReason;
+  readonly code?: string;
+  readonly message: string;
+  readonly recoverable?: boolean;
+}
+
+export interface LiveVoiceChannelClientClosed {
+  readonly code: number | null;
+  readonly reason: string;
+  readonly retryable: boolean;
+}
+
+type ForwardedLiveVoiceServerFrame = Exclude<
+  LiveVoiceServerFrame,
+  | LiveVoiceReadyServerFrame
+  | LiveVoiceBusyServerFrame
+  | LiveVoiceErrorServerFrame
+>;
+
+export interface LiveVoiceChannelClientEventMap {
+  ready: LiveVoiceReadyServerFrame;
+  busy: LiveVoiceBusyServerFrame;
+  frame: ForwardedLiveVoiceServerFrame;
+  error: LiveVoiceChannelClientError;
+  closed: LiveVoiceChannelClientClosed;
+}
+
+export type LiveVoiceChannelClientEventName =
+  keyof LiveVoiceChannelClientEventMap;
+
+export type LiveVoiceChannelClientEventHandler<
+  EventName extends LiveVoiceChannelClientEventName,
+> = (payload: LiveVoiceChannelClientEventMap[EventName]) => void;
+
+export interface LiveVoiceChannelClientOptions {
+  readonly url: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly webSocketConstructor?: LiveVoiceWebSocketConstructor;
+  readonly connectTimeoutMs?: number;
+}
+
+export interface LiveVoiceChannelConnectOptions {
+  readonly conversationId?: string;
+  readonly turnDetection?: LiveVoiceTurnDetectionMode;
+  readonly silenceThresholdMs?: number;
+  readonly bargeInMinSpeechMs?: number;
+}
+
+type SessionState = "idle" | "connecting" | "active" | "closed";
+
+export class LiveVoiceChannelClient {
+  private readonly webSocketConstructor: LiveVoiceWebSocketConstructor;
+  private readonly connectTimeoutMs: number;
+  private readonly sensitiveValues: readonly string[];
+
+  private state: SessionState = "idle";
+  private webSocket: LiveVoiceWebSocketLike | null = null;
+  private connectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private closeEmitted = false;
+  private configUpdatesUnsupported = false;
+  private sentConfigUpdate = false;
+  private pendingConnectOptions: LiveVoiceChannelConnectOptions = {};
+
+  private readonly listeners: {
+    [EventName in LiveVoiceChannelClientEventName]: Set<
+      LiveVoiceChannelClientEventHandler<EventName>
+    >;
+  } = {
+    ready: new Set(),
+    busy: new Set(),
+    frame: new Set(),
+    error: new Set(),
+    closed: new Set(),
+  };
+
+  constructor(private readonly options: LiveVoiceChannelClientOptions) {
+    this.webSocketConstructor =
+      options.webSocketConstructor ??
+      (WebSocket as unknown as LiveVoiceWebSocketConstructor);
+    this.connectTimeoutMs = options.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
+    this.sensitiveValues = collectSensitiveValues(options.url, options.headers);
+  }
+
+  on<EventName extends LiveVoiceChannelClientEventName>(
+    event: EventName,
+    handler: LiveVoiceChannelClientEventHandler<EventName>,
+  ): () => void {
+    this.listeners[event].add(handler);
+    return () => {
+      this.listeners[event].delete(handler);
+    };
+  }
+
+  connect(options: LiveVoiceChannelConnectOptions = {}): void {
+    if (this.state !== "idle") {
+      return;
+    }
+    this.state = "connecting";
+    this.pendingConnectOptions = options;
+
+    let webSocket: LiveVoiceWebSocketLike;
+    try {
+      webSocket = new this.webSocketConstructor(
+        this.options.url,
+        this.options.headers ? { headers: this.options.headers } : undefined,
+      );
+    } catch {
+      this.fail(
+        "connection-failed",
+        "Failed to open the live-voice WebSocket.",
+      );
+      return;
+    }
+
+    this.webSocket = webSocket;
+    webSocket.binaryType = "arraybuffer";
+    webSocket.addEventListener("open", this.handleOpen);
+    webSocket.addEventListener("message", this.handleMessage);
+    webSocket.addEventListener("error", this.handleError);
+    webSocket.addEventListener("close", this.handleClose);
+
+    this.connectTimeout = setTimeout(() => {
+      if (this.state === "connecting") {
+        this.fail(
+          "timeout",
+          `Live voice did not become ready within ${this.connectTimeoutMs}ms.`,
+        );
+      }
+    }, this.connectTimeoutMs);
+  }
+
+  sendAudio(pcm: ArrayBuffer | Uint8Array): void {
+    if (this.state !== "active") {
+      return;
+    }
+    this.trySend(pcm);
+  }
+
+  pttRelease(): void {
+    this.sendControlFrame({ type: "ptt_release" });
+  }
+
+  interrupt(): void {
+    this.sendControlFrame({ type: "interrupt" });
+  }
+
+  updateConfig(config: Omit<LiveVoiceClientUpdateConfigFrame, "type">): void {
+    if (this.state !== "active" || this.configUpdatesUnsupported) {
+      return;
+    }
+    const frame: LiveVoiceClientUpdateConfigFrame = {
+      type: "update_config",
+      ...config,
+    };
+    this.sentConfigUpdate = true;
+    this.trySend(JSON.stringify(frame));
+  }
+
+  end(): void {
+    if (this.state === "closed") {
+      return;
+    }
+    if (this.state === "connecting" || this.state === "active") {
+      this.trySend(
+        JSON.stringify({
+          type: "end",
+        } satisfies LiveVoiceClientControlFrame),
+      );
+    }
+    this.close();
+  }
+
+  close(): void {
+    if (this.state === "closed") {
+      return;
+    }
+    this.teardown();
+    this.emitClosed({
+      code: null,
+      reason: "client closed",
+      retryable: false,
+    });
+  }
+
+  private readonly handleOpen = (): void => {
+    if (this.state !== "connecting") {
+      return;
+    }
+    const options = this.pendingConnectOptions;
+    const startFrame: LiveVoiceClientStartFrame = {
+      type: "start",
+      audio: LIVE_VOICE_AUDIO_FORMAT,
+      sourceInterface: "cli",
+      ...(options.conversationId
+        ? { conversationId: options.conversationId }
+        : {}),
+      ...(options.turnDetection
+        ? { turnDetection: options.turnDetection }
+        : {}),
+      ...(options.silenceThresholdMs !== undefined
+        ? { silenceThresholdMs: options.silenceThresholdMs }
+        : {}),
+      ...(options.bargeInMinSpeechMs !== undefined
+        ? { bargeInMinSpeechMs: options.bargeInMinSpeechMs }
+        : {}),
+    };
+    this.trySend(JSON.stringify(startFrame));
+  };
+
+  private readonly handleMessage = (
+    event: LiveVoiceWebSocketMessageEvent,
+  ): void => {
+    if (this.state === "closed" || typeof event.data !== "string") {
+      return;
+    }
+
+    const frame = parseLiveVoiceServerFrame(event.data);
+    if (frame.type === "unknown_frame") {
+      return;
+    }
+    if (frame.type === "ready") {
+      if (this.state !== "connecting") {
+        return;
+      }
+      this.clearConnectTimeout();
+      this.state = "active";
+      this.emit("ready", frame);
+      return;
+    }
+    if (frame.type === "busy") {
+      this.emit("busy", frame);
+      this.close();
+      return;
+    }
+    if (frame.type === "error") {
+      if (
+        frame.code === "unknown_type" &&
+        this.state === "active" &&
+        this.sentConfigUpdate
+      ) {
+        this.configUpdatesUnsupported = true;
+        return;
+      }
+      if (
+        "recoverable" in frame &&
+        frame.recoverable === true &&
+        this.state === "active"
+      ) {
+        this.emit("error", {
+          reason: "protocol-error",
+          code: frame.code,
+          message: this.redact(frame.message),
+          recoverable: true,
+        });
+        return;
+      }
+      this.fail("protocol-error", this.redact(frame.message), frame.code);
+      return;
+    }
+
+    this.emit("frame", frame);
+  };
+
+  private readonly handleError = (): void => {
+    this.fail(
+      "connection-failed",
+      "The live-voice WebSocket encountered an error.",
+    );
+  };
+
+  private readonly handleClose = (
+    event: LiveVoiceWebSocketCloseEvent,
+  ): void => {
+    if (this.state === "closed") {
+      return;
+    }
+    const retryable = RETRYABLE_LIVE_VOICE_CLOSE_CODES.has(event.code);
+    if (this.state === "connecting" && !retryable) {
+      this.fail(
+        "connection-failed",
+        "The live-voice WebSocket closed before it became ready.",
+      );
+      return;
+    }
+
+    this.teardown(false);
+    this.emitClosed({
+      code: event.code,
+      reason: this.redact(event.reason),
+      retryable,
+    });
+  };
+
+  private sendControlFrame(frame: LiveVoiceClientControlFrame): void {
+    if (this.state !== "active") {
+      return;
+    }
+    this.trySend(JSON.stringify(frame));
+  }
+
+  private trySend(data: string | ArrayBuffer | Uint8Array): void {
+    if (this.webSocket && this.webSocket.readyState === WEB_SOCKET_OPEN) {
+      this.webSocket.send(data);
+    }
+  }
+
+  private fail(
+    reason: LiveVoiceChannelClientErrorReason,
+    message: string,
+    code?: string,
+  ): void {
+    if (this.state === "closed") {
+      return;
+    }
+    const safeMessage = this.redact(message);
+    this.teardown();
+    this.emit("error", {
+      reason,
+      message: safeMessage,
+      ...(code ? { code } : {}),
+    });
+    this.emitClosed({
+      code: null,
+      reason: safeMessage,
+      retryable: false,
+    });
+  }
+
+  private teardown(closeSocket = true): void {
+    if (this.state === "closed") {
+      return;
+    }
+    this.state = "closed";
+    this.clearConnectTimeout();
+
+    const webSocket = this.webSocket;
+    this.webSocket = null;
+    if (!webSocket) {
+      return;
+    }
+    webSocket.removeEventListener("open", this.handleOpen);
+    webSocket.removeEventListener("message", this.handleMessage);
+    webSocket.removeEventListener("error", this.handleError);
+    webSocket.removeEventListener("close", this.handleClose);
+    if (closeSocket) {
+      webSocket.close();
+    }
+  }
+
+  private clearConnectTimeout(): void {
+    if (this.connectTimeout !== null) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+  }
+
+  private emit<EventName extends LiveVoiceChannelClientEventName>(
+    event: EventName,
+    payload: LiveVoiceChannelClientEventMap[EventName],
+  ): void {
+    for (const handler of this.listeners[event]) {
+      handler(payload);
+    }
+  }
+
+  private emitClosed(payload: LiveVoiceChannelClientClosed): void {
+    if (this.closeEmitted) {
+      return;
+    }
+    this.closeEmitted = true;
+    this.emit("closed", payload);
+    for (const listeners of Object.values(this.listeners)) {
+      listeners.clear();
+    }
+  }
+
+  private redact(value: string): string {
+    let redacted = value;
+    for (const sensitiveValue of this.sensitiveValues) {
+      redacted = redacted.replaceAll(sensitiveValue, "[REDACTED]");
+    }
+    return redacted;
+  }
+}
+
+function collectSensitiveValues(
+  rawUrl: string,
+  headers: Readonly<Record<string, string>> | undefined,
+): string[] {
+  const values = new Set<string>();
+  try {
+    const url = new URL(rawUrl);
+    for (const [name, value] of url.searchParams) {
+      if (
+        value &&
+        (name.toLowerCase() === "token" || name.toLowerCase().includes("key"))
+      ) {
+        values.add(value);
+        values.add(encodeURIComponent(value));
+        values.add(
+          new URLSearchParams({ value }).toString().slice("value=".length),
+        );
+      }
+    }
+  } catch {
+    // URL validation belongs to the connection resolver.
+  }
+
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    if (
+      name.toLowerCase() === "authorization" ||
+      name.toLowerCase().includes("token")
+    ) {
+      values.add(value);
+      const bearer = /^Bearer\s+(.+)$/i.exec(value);
+      if (bearer?.[1]) {
+        values.add(bearer[1]);
+        values.add(encodeURIComponent(bearer[1]));
+      }
+    }
+  }
+  return [...values].filter((value) => value.length > 0);
+}

--- a/cli/src/lib/live-voice/connection.ts
+++ b/cli/src/lib/live-voice/connection.ts
@@ -1,0 +1,515 @@
+import { velayHostForPlatformHost } from "@vellumai/service-contracts/ingress";
+
+import {
+  resolveTargetAssistant,
+  type AssistantEntry,
+} from "../assistant-config.js";
+import {
+  loadGuardianSessionAccessToken,
+  resolveGuardianSessionAuth,
+} from "../guardian-session-auth.js";
+import { isLoopbackUrl, loopbackSafeFetch } from "../loopback-fetch.js";
+import { getPlatformUrl, readPlatformToken } from "../platform-client.js";
+import { normalizeRuntimeUrl } from "../runtime-url.js";
+import { mintLiveVoiceToken } from "./platform-auth.js";
+
+const PREFLIGHT_TIMEOUT_MS = 10_000;
+const LIVE_VOICE_PATH = "/v1/live-voice";
+const LIVE_VOICE_PREFLIGHT_PATH = "/v1/live-voice/preflight";
+
+export type LiveVoiceConnectionErrorCode =
+  | "assistant_id_required"
+  | "invalid_url"
+  | "remote_tls_required"
+  | "unsupported_topology"
+  | "guardian_auth_required"
+  | "guardian_auth_failed"
+  | "platform_login_required"
+  | "platform_auth_failed"
+  | "velay_host_unavailable"
+  | "not_ready";
+
+export class LiveVoiceConnectionError extends Error {
+  readonly code: LiveVoiceConnectionErrorCode;
+
+  constructor(code: LiveVoiceConnectionErrorCode, message: string) {
+    super(message);
+    this.name = "LiveVoiceConnectionError";
+    this.code = code;
+  }
+}
+
+export interface LiveVoiceMissingProvider {
+  readonly kind: "stt" | "tts";
+  readonly providerId: string;
+  readonly reason: string;
+}
+
+export type LiveVoicePreflightResult =
+  | { readonly status: "ready" }
+  | {
+      readonly status: "not-ready";
+      readonly missing?: readonly LiveVoiceMissingProvider[];
+      readonly userMessage?: string;
+    }
+  | { readonly status: "unavailable" };
+
+export interface LiveVoiceWebSocketEndpoint {
+  readonly url: string;
+  readonly logSafeUrl: string;
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
+interface LiveVoiceResolvedConnectionBase {
+  readonly assistantId: string;
+  readonly webSocket: LiveVoiceWebSocketEndpoint;
+}
+
+export interface DirectLiveVoiceConnection extends LiveVoiceResolvedConnectionBase {
+  readonly topology: "direct";
+  readonly gatewayUrl: string;
+  readonly preflight: LiveVoicePreflightResult;
+}
+
+export interface ManagedLiveVoiceConnection extends LiveVoiceResolvedConnectionBase {
+  readonly topology: "vellum-managed";
+  readonly platformUrl: string;
+}
+
+export type LiveVoiceResolvedConnection =
+  | DirectLiveVoiceConnection
+  | ManagedLiveVoiceConnection;
+
+export interface ResolveLiveVoiceConnectionOptions {
+  /** Assistant display name or ID. Uses the active assistant when omitted. */
+  readonly target?: string;
+  /** Direct gateway override. Requires an assistant ID or resolvable target. */
+  readonly url?: string;
+  /** Assistant ID paired with an explicit direct gateway URL. */
+  readonly assistantId?: string;
+  /** Ephemeral guardian token for a direct gateway. */
+  readonly guardianToken?: string;
+}
+
+export type LiveVoiceFetch = (
+  url: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+interface LiveVoiceConnectionDependencies {
+  readonly resolveTargetAssistant: (target?: string) => AssistantEntry;
+  readonly loadGuardianSessionAccessToken: (
+    assistantId: string,
+  ) => string | undefined;
+  readonly resolveGuardianSessionAuth: typeof resolveGuardianSessionAuth;
+  readonly readPlatformToken: () => string | null;
+  readonly getPlatformUrl: () => string;
+  readonly mintLiveVoiceToken: typeof mintLiveVoiceToken;
+  readonly fetch: LiveVoiceFetch;
+  readonly getVelayBaseUrl: () => string | undefined;
+}
+
+const defaultDependencies: LiveVoiceConnectionDependencies = {
+  resolveTargetAssistant,
+  loadGuardianSessionAccessToken,
+  resolveGuardianSessionAuth,
+  readPlatformToken,
+  getPlatformUrl,
+  mintLiveVoiceToken,
+  fetch: loopbackSafeFetch,
+  getVelayBaseUrl: () => process.env.VELAY_BASE_URL?.trim() || undefined,
+};
+
+export type LiveVoiceConnectionDependencyOverrides =
+  Partial<LiveVoiceConnectionDependencies>;
+
+function parseUrl(value: string): URL {
+  try {
+    const url = new URL(normalizeRuntimeUrl(value));
+    if (url.username || url.password) {
+      throw new Error("URL credentials are not supported");
+    }
+    return url;
+  } catch {
+    throw new LiveVoiceConnectionError(
+      "invalid_url",
+      "The live-voice endpoint URL is invalid.",
+    );
+  }
+}
+
+function isHttpOrWebSocketProtocol(protocol: string): boolean {
+  return (
+    protocol === "http:" ||
+    protocol === "https:" ||
+    protocol === "ws:" ||
+    protocol === "wss:"
+  );
+}
+
+function requireSecureRemote(url: URL): void {
+  if (!isHttpOrWebSocketProtocol(url.protocol)) {
+    throw new LiveVoiceConnectionError(
+      "invalid_url",
+      "The live-voice endpoint must use HTTP or WebSocket transport.",
+    );
+  }
+  if (
+    !isLoopbackUrl(url.toString()) &&
+    url.protocol !== "https:" &&
+    url.protocol !== "wss:"
+  ) {
+    throw new LiveVoiceConnectionError(
+      "remote_tls_required",
+      "Remote live-voice endpoints must use TLS.",
+    );
+  }
+}
+
+function gatewayHttpOrigin(value: string): URL {
+  const url = parseUrl(value);
+  requireSecureRemote(url);
+  if (url.protocol === "ws:") {
+    url.protocol = "http:";
+  } else if (url.protocol === "wss:") {
+    url.protocol = "https:";
+  }
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url;
+}
+
+export function buildDirectLiveVoiceWebSocketUrl(gatewayUrl: string): string {
+  const url = gatewayHttpOrigin(gatewayUrl);
+  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
+  url.pathname = LIVE_VOICE_PATH;
+  return url.toString();
+}
+
+function validateMissingProviders(
+  value: unknown,
+): LiveVoiceMissingProvider[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const missing: LiveVoiceMissingProvider[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const candidate = item as Record<string, unknown>;
+    if (
+      (candidate.kind === "stt" || candidate.kind === "tts") &&
+      typeof candidate.providerId === "string" &&
+      typeof candidate.reason === "string"
+    ) {
+      missing.push({
+        kind: candidate.kind,
+        providerId: candidate.providerId,
+        reason: candidate.reason,
+      });
+    }
+  }
+  return missing.length > 0 ? missing : undefined;
+}
+
+/**
+ * Probe configured speech providers through a direct gateway. Only an
+ * explicit not-ready verdict blocks voice. Network, HTTP, and version-skew
+ * failures leave the WebSocket handshake authoritative.
+ */
+export async function preflightLiveVoice(
+  gatewayUrl: string,
+  accessToken?: string,
+  fetchImpl: LiveVoiceFetch = loopbackSafeFetch,
+): Promise<LiveVoicePreflightResult> {
+  let url: URL;
+  try {
+    url = gatewayHttpOrigin(gatewayUrl);
+  } catch {
+    return { status: "unavailable" };
+  }
+  url.pathname = LIVE_VOICE_PREFLIGHT_PATH;
+
+  try {
+    const response = await fetchImpl(url.toString(), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+      signal: AbortSignal.timeout(PREFLIGHT_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return { status: "unavailable" };
+    }
+
+    const body: unknown = await response.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+      return { status: "unavailable" };
+    }
+    const candidate = body as Record<string, unknown>;
+    if (candidate.status === "ready") {
+      return { status: "ready" };
+    }
+    if (candidate.status !== "not-ready") {
+      return { status: "unavailable" };
+    }
+
+    const missing = validateMissingProviders(candidate.missing);
+    return {
+      status: "not-ready",
+      ...(missing ? { missing } : {}),
+      ...(typeof candidate.userMessage === "string"
+        ? { userMessage: candidate.userMessage }
+        : {}),
+    };
+  } catch {
+    return { status: "unavailable" };
+  }
+}
+
+function unsupportedTopologyMessage(cloud: string): string {
+  if (cloud === "docker") {
+    return "Live voice does not support Docker assistants yet. Run it against a host-local or Vellum-managed assistant.";
+  }
+  if (cloud === "paired") {
+    return "Live voice does not support assistants paired from another machine yet. Run it on the assistant's host.";
+  }
+  return `Live voice does not support the '${cloud}' assistant topology yet.`;
+}
+
+function resolveExplicitDirectTarget(
+  options: ResolveLiveVoiceConnectionOptions,
+  deps: LiveVoiceConnectionDependencies,
+): { assistantId: string; entry?: AssistantEntry } {
+  if (options.assistantId) {
+    return { assistantId: options.assistantId };
+  }
+  if (options.target) {
+    const entry = deps.resolveTargetAssistant(options.target);
+    return { assistantId: entry.assistantId, entry };
+  }
+  throw new LiveVoiceConnectionError(
+    "assistant_id_required",
+    "An explicit live-voice URL requires an assistant ID.",
+  );
+}
+
+async function resolveDirectConnection(
+  gatewayUrl: string,
+  assistantId: string,
+  entry: AssistantEntry | undefined,
+  guardianToken: string | undefined,
+  deps: LiveVoiceConnectionDependencies,
+): Promise<DirectLiveVoiceConnection> {
+  const httpOrigin = gatewayHttpOrigin(gatewayUrl);
+  const loopback = isLoopbackUrl(httpOrigin.toString());
+  const storedToken =
+    guardianToken ??
+    deps.loadGuardianSessionAccessToken(assistantId) ??
+    entry?.bearerToken;
+  const auth = await deps.resolveGuardianSessionAuth({
+    runtimeUrl: httpOrigin.toString(),
+    assistantId,
+    accessToken: storedToken,
+    cloud: "direct",
+  });
+  if (!auth.ok) {
+    throw new LiveVoiceConnectionError(
+      "guardian_auth_failed",
+      "The guardian session could not authenticate live voice.",
+    );
+  }
+  if (!loopback && !auth.accessToken) {
+    throw new LiveVoiceConnectionError(
+      "guardian_auth_required",
+      "A remote direct gateway requires guardian authentication.",
+    );
+  }
+
+  const preflight = await preflightLiveVoice(
+    httpOrigin.toString(),
+    auth.accessToken,
+    deps.fetch,
+  );
+  if (preflight.status === "not-ready") {
+    throw new LiveVoiceConnectionError(
+      "not_ready",
+      "Live voice is not ready. Configure speech-to-text and text-to-speech providers first.",
+    );
+  }
+
+  const webSocketUrl = buildDirectLiveVoiceWebSocketUrl(httpOrigin.toString());
+  return {
+    topology: "direct",
+    assistantId,
+    gatewayUrl: httpOrigin.toString(),
+    preflight,
+    webSocket: {
+      url: webSocketUrl,
+      logSafeUrl: webSocketUrl,
+      ...(auth.accessToken
+        ? { headers: { Authorization: `Bearer ${auth.accessToken}` } }
+        : {}),
+    },
+  };
+}
+
+function resolveExplicitVelayBaseUrl(value: string): {
+  host: string;
+  scheme: "ws" | "wss";
+} {
+  const url = parseUrl(value);
+  requireSecureRemote(url);
+  const scheme =
+    url.protocol === "http:" || url.protocol === "ws:" ? "ws" : "wss";
+  return { host: url.host, scheme };
+}
+
+function resolveVelayEndpoint(
+  platformUrl: string,
+  explicitVelayBaseUrl: string | undefined,
+): { host: string; scheme: "ws" | "wss" } {
+  const platform = parseUrl(platformUrl);
+  requireSecureRemote(platform);
+
+  if (explicitVelayBaseUrl) {
+    return resolveExplicitVelayBaseUrl(explicitVelayBaseUrl);
+  }
+
+  const host = velayHostForPlatformHost(platform.hostname);
+  if (!host) {
+    throw new LiveVoiceConnectionError(
+      "velay_host_unavailable",
+      "The configured Vellum platform does not map to a live-voice ingress.",
+    );
+  }
+  return { host, scheme: "wss" };
+}
+
+export function buildManagedLiveVoiceWebSocketUrl(options: {
+  readonly assistantId: string;
+  readonly token: string;
+  readonly platformUrl: string;
+  readonly velayBaseUrl?: string;
+}): string {
+  const endpoint = resolveVelayEndpoint(
+    options.platformUrl,
+    options.velayBaseUrl,
+  );
+  return buildManagedUrlFromEndpoint(
+    options.assistantId,
+    options.token,
+    endpoint,
+  );
+}
+
+function buildManagedUrlFromEndpoint(
+  assistantId: string,
+  token: string,
+  endpoint: { host: string; scheme: "ws" | "wss" },
+): string {
+  const url = new URL(
+    `${endpoint.scheme}://${endpoint.host}/${encodeURIComponent(assistantId)}${LIVE_VOICE_PATH}`,
+  );
+  url.searchParams.set("token", token);
+  return url.toString();
+}
+
+function redactManagedUrl(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.searchParams.has("token")) {
+    parsed.searchParams.set("token", "[REDACTED]");
+  }
+  return parsed.toString();
+}
+
+async function resolveManagedConnection(
+  entry: AssistantEntry,
+  deps: LiveVoiceConnectionDependencies,
+): Promise<ManagedLiveVoiceConnection> {
+  const sessionToken = deps.readPlatformToken();
+  if (!sessionToken) {
+    throw new LiveVoiceConnectionError(
+      "platform_login_required",
+      "Live voice for a Vellum-managed assistant requires login. Run 'vellum login'.",
+    );
+  }
+
+  const platformUrl = deps.getPlatformUrl();
+  const velayBaseUrl = deps.getVelayBaseUrl();
+  const velayEndpoint = resolveVelayEndpoint(platformUrl, velayBaseUrl);
+  let minted: Awaited<ReturnType<typeof mintLiveVoiceToken>>;
+  try {
+    minted = await deps.mintLiveVoiceToken(
+      sessionToken,
+      entry.assistantId,
+      platformUrl,
+    );
+  } catch {
+    throw new LiveVoiceConnectionError(
+      "platform_auth_failed",
+      "The Vellum platform could not authenticate live voice. Run 'vellum login' to refresh.",
+    );
+  }
+  const url = buildManagedUrlFromEndpoint(
+    entry.assistantId,
+    minted.token,
+    velayEndpoint,
+  );
+
+  return {
+    topology: "vellum-managed",
+    assistantId: entry.assistantId,
+    platformUrl,
+    webSocket: {
+      url,
+      logSafeUrl: redactManagedUrl(url),
+    },
+  };
+}
+
+/**
+ * Resolve the transport and credentials before audio capture begins. Provider
+ * ownership is intentionally absent: a local assistant using managed speech
+ * still routes through its directly reachable gateway.
+ */
+export async function resolveLiveVoiceConnection(
+  options: ResolveLiveVoiceConnectionOptions = {},
+  dependencyOverrides: LiveVoiceConnectionDependencyOverrides = {},
+): Promise<LiveVoiceResolvedConnection> {
+  const deps = { ...defaultDependencies, ...dependencyOverrides };
+
+  if (options.url) {
+    const target = resolveExplicitDirectTarget(options, deps);
+    return resolveDirectConnection(
+      options.url,
+      target.assistantId,
+      target.entry,
+      options.guardianToken,
+      deps,
+    );
+  }
+
+  const entry = deps.resolveTargetAssistant(options.target);
+  if (entry.cloud === "local") {
+    return resolveDirectConnection(
+      entry.localUrl || entry.runtimeUrl,
+      entry.assistantId,
+      entry,
+      options.guardianToken,
+      deps,
+    );
+  }
+  if (entry.cloud === "vellum") {
+    return resolveManagedConnection(entry, deps);
+  }
+
+  throw new LiveVoiceConnectionError(
+    "unsupported_topology",
+    unsupportedTopologyMessage(entry.cloud),
+  );
+}


### PR DESCRIPTION
## Summary

- route explicit and local assistant targets directly through guardian-authenticated gateway WebSockets
- route Vellum-managed assistants through environment-correct Velay using single-use live-voice tokens
- add a URL-agnostic typed channel client with CLI attribution, raw PCM frames, ready timeout, recoverable errors, retryable closes, and idempotent cleanup
- reject unsupported Docker and paired topologies before audio access and keep long-lived credentials out of URLs and diagnostics

## Testing

- `cd cli && bun test src/__tests__/live-voice-connection.test.ts src/__tests__/live-voice-channel-client.test.ts`
- `cd cli && bun run lint`
- `cd cli && bun run typecheck`
- `cd cli && bun run compile:check`

## Review focus

The main risk boundary is credential routing. Direct guardian tokens use Bun WebSocket headers, while only the short-lived single-use Velay token is placed in a managed query string.