### PR TITLE
feat(cli): add foreground push-to-talk voice

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-connection.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-connection.test.ts
@@ -189,15 +189,53 @@ describe("createLiveVoiceConnection", () => {
     });
   });
 
-  test("clears the session id on an end frame", async () => {
-    const { sessions } = installFakeManager();
-    const { connection } = createConnection();
+  test("acknowledges end only after the manager releases the session slot", async () => {
+    let finishClose!: () => void;
+    const closeGate = new Promise<void>((resolve) => {
+      finishClose = resolve;
+    });
+    const { manager, sessions } = installFakeManager((session) => ({
+      close: mock(async (reason: LiveVoiceSessionCloseReason) => {
+        session.closeReasons.push(reason);
+        await closeGate;
+      }),
+    }));
+    const { connection, frames } = createConnection();
 
     await connection.handleMessage(START_MESSAGE);
-    await connection.handleMessage(JSON.stringify({ type: "end" }));
+    const ending = connection.handleMessage(JSON.stringify({ type: "end" }));
+    await Promise.resolve();
+
+    expect(manager.activeSessionId).toBe("session-1");
+    expect(frames.some((frame) => frame.type === "session_released")).toBe(
+      false,
+    );
+
+    const contender = createConnection();
+    await contender.connection.handleMessage(START_MESSAGE);
+    expect(contender.frames.at(-1)).toMatchObject({
+      type: "busy",
+      activeSessionId: "session-1",
+    });
+
+    finishClose();
+    await ending;
 
     expect(connection.sessionId).toBeUndefined();
+    expect(manager.activeSessionId).toBeNull();
     expect(sessions[0]?.clientFrames).toEqual([{ type: "end" }]);
+    expect(sessions[0]?.closeReasons).toEqual(["client_end"]);
+    expect(frames.at(-1)).toMatchObject({
+      type: "session_released",
+      sessionId: "session-1",
+    });
+
+    const next = createConnection();
+    await next.connection.handleMessage(START_MESSAGE);
+    expect(next.frames.at(-1)).toMatchObject({
+      type: "ready",
+      sessionId: "session-2",
+    });
   });
 
   test("heals a stale binding when the manager dropped the session", async () => {

--- a/assistant/src/live-voice/live-voice-connection.ts
+++ b/assistant/src/live-voice/live-voice-connection.ts
@@ -196,6 +196,11 @@ class LiveVoiceConnectionImpl implements LiveVoiceConnection {
 
     if (frame.type === "end") {
       this.activeSessionId = undefined;
+      this.sendFrame({
+        type: "session_released",
+        seq: this.lastSeq + 1,
+        sessionId,
+      });
     }
   }
 

--- a/cli/src/__tests__/live-voice-channel-client.test.ts
+++ b/cli/src/__tests__/live-voice-channel-client.test.ts
@@ -220,18 +220,12 @@ describe("live-voice channel client", () => {
 
     socket().message(
       JSON.stringify({
-        type: "metrics",
+        type: "session_released",
         seq: 2,
-        event: "session_ended",
         sessionId: "session-123",
-        turnId: "session",
-        sttMs: null,
-        llmFirstDeltaMs: null,
-        ttsFirstAudioMs: null,
-        totalMs: 0,
       }),
     );
-    expect(frames).toEqual(["metrics"]);
+    expect(frames).toEqual(["session_released"]);
     client.close();
   });
 

--- a/cli/src/__tests__/live-voice-channel-client.test.ts
+++ b/cli/src/__tests__/live-voice-channel-client.test.ts
@@ -194,6 +194,47 @@ describe("live-voice channel client", () => {
     ]);
   });
 
+  test("can request end while keeping the socket open for release confirmation", () => {
+    const { client, socket } = makeClient();
+    const frames: string[] = [];
+    client.on("frame", (frame) => {
+      frames.push(frame.type);
+    });
+    client.connect();
+    socket().open();
+    socket().message(readyFrame());
+
+    client.requestEnd();
+    client.requestEnd();
+
+    expect(JSON.parse(String(socket().sent.at(-1)))).toEqual({
+      type: "end",
+    });
+    expect(
+      socket().sent.filter(
+        (frame) =>
+          typeof frame === "string" && JSON.parse(frame).type === "end",
+      ),
+    ).toHaveLength(1);
+    expect(socket().closeCalls).toBe(0);
+
+    socket().message(
+      JSON.stringify({
+        type: "metrics",
+        seq: 2,
+        event: "session_ended",
+        sessionId: "session-123",
+        turnId: "session",
+        sttMs: null,
+        llmFirstDeltaMs: null,
+        ttsFirstAudioMs: null,
+        totalMs: 0,
+      }),
+    );
+    expect(frames).toEqual(["metrics"]);
+    client.close();
+  });
+
   test("does not send audio or controls before ready", () => {
     const { client, socket } = makeClient();
     client.connect();

--- a/cli/src/__tests__/live-voice-session.test.ts
+++ b/cli/src/__tests__/live-voice-session.test.ts
@@ -139,6 +139,7 @@ class FakeChannel implements LiveVoiceSessionChannel {
           seq: 1,
           activeSessionId: this.behavior.activeSessionId,
         });
+        this.close();
       }
     });
   }
@@ -168,6 +169,11 @@ class FakeChannel implements LiveVoiceSessionChannel {
 
   close(): void {
     this.closeCount += 1;
+    this.emit("closed", {
+      code: null,
+      reason: "client closed",
+      retryable: false,
+    });
   }
 
   emit<EventName extends LiveVoiceChannelClientEventName>(
@@ -332,7 +338,7 @@ describe("LiveVoicePushToTalkSession", () => {
     await harness.session.shutdown();
   });
 
-  test("retries a busy response only when it belongs to the just-ended session", async () => {
+  test("retries when a same-session busy frame is followed by the client's immediate close", async () => {
     const harness = makeHarness([
       {
         type: "ready",
@@ -361,8 +367,31 @@ describe("LiveVoicePushToTalkSession", () => {
       "same-session retry",
     );
     expect(harness.sleeps).toEqual([100, 250]);
+    expect(harness.channels[1].closeCount).toBe(1);
+    expect(harness.channels[2].closeCount).toBe(1);
     expect(harness.errors).toEqual([]);
     await harness.session.shutdown();
+  });
+
+  test("still treats a close after ready as fatal", async () => {
+    const harness = makeHarness([
+      {
+        type: "ready",
+        sessionId: "session-1",
+        conversationId: "conversation-1",
+      },
+    ]);
+
+    await harness.session.start();
+    harness.channels[0].emit("closed", {
+      code: 1006,
+      reason: "network connection lost",
+      retryable: false,
+    });
+
+    await harness.session.waitUntilClosed();
+    expect(harness.session.currentState).toBe("failed");
+    expect(harness.errors[0]?.message).toBe("network connection lost");
   });
 
   test("does not steal a different active session", async () => {

--- a/cli/src/__tests__/live-voice-session.test.ts
+++ b/cli/src/__tests__/live-voice-session.test.ts
@@ -1,0 +1,501 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  LiveVoiceChannelClientEventHandler,
+  LiveVoiceChannelClientEventMap,
+  LiveVoiceChannelClientEventName,
+} from "../lib/live-voice/channel-client.js";
+import type {
+  LiveVoicePcmCaptureOptions,
+  LiveVoicePcmCaptureSession,
+  LiveVoicePcmPlayback,
+  LiveVoicePlaybackChunk,
+} from "../lib/live-voice/audio.js";
+import {
+  LIVE_VOICE_BUSY_RETRY_DELAYS_MS,
+  LiveVoicePushToTalkSession,
+  type LiveVoiceForegroundState,
+  type LiveVoiceSessionChannel,
+  type LiveVoiceTimingMetric,
+} from "../lib/live-voice/session.js";
+
+class FakeCaptureSession implements LiveVoicePcmCaptureSession {
+  readonly closed = new Promise<void>(() => {});
+  readonly tail = Buffer.from([5, 6]);
+  stopCount = 0;
+  muted = false;
+
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+  }
+
+  async stop(): Promise<Buffer | null> {
+    this.stopCount += 1;
+    return this.tail;
+  }
+}
+
+class FakeCapture {
+  readonly sessions: FakeCaptureSession[] = [];
+  readonly options: LiveVoicePcmCaptureOptions[] = [];
+
+  async startCapture(
+    options: LiveVoicePcmCaptureOptions,
+  ): Promise<LiveVoicePcmCaptureSession> {
+    const session = new FakeCaptureSession();
+    this.options.push(options);
+    this.sessions.push(session);
+    return session;
+  }
+
+  emit(frame: Buffer): void {
+    this.options.at(-1)?.onFrame(frame, 0.1);
+  }
+}
+
+class FakePlayback implements LiveVoicePcmPlayback {
+  readonly chunks: LiveVoicePlaybackChunk[] = [];
+  drainCount = 0;
+  flushCount = 0;
+  closeCount = 0;
+
+  async write(chunk: LiveVoicePlaybackChunk): Promise<void> {
+    this.chunks.push(chunk);
+  }
+
+  async drain(): Promise<void> {
+    this.drainCount += 1;
+  }
+
+  async flush(): Promise<void> {
+    this.flushCount += 1;
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+type ConnectBehavior =
+  | {
+      type: "ready";
+      sessionId: string;
+      conversationId: string;
+    }
+  | { type: "busy"; activeSessionId: string };
+
+class FakeChannel implements LiveVoiceSessionChannel {
+  readonly connectOptions: Array<{
+    readonly conversationId?: string;
+    readonly turnDetection?: "manual" | "server_vad";
+  }> = [];
+  readonly audio: Uint8Array[] = [];
+  pttReleaseCount = 0;
+  interruptCount = 0;
+  endCount = 0;
+  closeCount = 0;
+
+  private readonly listeners: {
+    [EventName in LiveVoiceChannelClientEventName]: Set<
+      LiveVoiceChannelClientEventHandler<EventName>
+    >;
+  } = {
+    ready: new Set(),
+    busy: new Set(),
+    frame: new Set(),
+    error: new Set(),
+    closed: new Set(),
+  };
+
+  constructor(private readonly behavior: ConnectBehavior) {}
+
+  on<EventName extends LiveVoiceChannelClientEventName>(
+    event: EventName,
+    handler: LiveVoiceChannelClientEventHandler<EventName>,
+  ): () => void {
+    this.listeners[event].add(handler);
+    return () => {
+      this.listeners[event].delete(handler);
+    };
+  }
+
+  connect(options: {
+    readonly conversationId?: string;
+    readonly turnDetection?: "manual" | "server_vad";
+  }): void {
+    this.connectOptions.push(options);
+    queueMicrotask(() => {
+      if (this.behavior.type === "ready") {
+        this.emit("ready", {
+          type: "ready",
+          seq: 1,
+          sessionId: this.behavior.sessionId,
+          conversationId: this.behavior.conversationId,
+          turnDetection: "manual",
+        });
+      } else {
+        this.emit("busy", {
+          type: "busy",
+          seq: 1,
+          activeSessionId: this.behavior.activeSessionId,
+        });
+      }
+    });
+  }
+
+  sendAudio(pcm: ArrayBuffer | Uint8Array): void {
+    this.audio.push(
+      pcm instanceof Uint8Array ? Buffer.from(pcm) : new Uint8Array(pcm),
+    );
+  }
+
+  pttRelease(): void {
+    this.pttReleaseCount += 1;
+  }
+
+  interrupt(): void {
+    this.interruptCount += 1;
+  }
+
+  end(): void {
+    this.endCount += 1;
+    this.emit("closed", {
+      code: null,
+      reason: "client closed",
+      retryable: false,
+    });
+  }
+
+  close(): void {
+    this.closeCount += 1;
+  }
+
+  emit<EventName extends LiveVoiceChannelClientEventName>(
+    event: EventName,
+    payload: LiveVoiceChannelClientEventMap[EventName],
+  ): void {
+    for (const listener of this.listeners[event]) {
+      listener(payload);
+    }
+  }
+}
+
+function makeHarness(
+  behaviors: ConnectBehavior[],
+  options: {
+    captions?: "off" | "user" | "assistant" | "both";
+    conversationId?: string;
+  } = {},
+) {
+  const capture = new FakeCapture();
+  const playback = new FakePlayback();
+  const channels: FakeChannel[] = [];
+  const states: LiveVoiceForegroundState[] = [];
+  const captions: Array<{ role: "user" | "assistant"; text: string }> = [];
+  const captionModes: string[] = [];
+  const timings: LiveVoiceTimingMetric[] = [];
+  const errors: Error[] = [];
+  const sleeps: number[] = [];
+  let now = 100;
+
+  const session = new LiveVoicePushToTalkSession({
+    resolveEndpoint: async () => ({
+      url: "wss://voice.example.com/v1/live-voice?token=secret-value",
+    }),
+    createChannel: () => {
+      const behavior = behaviors.shift();
+      if (behavior === undefined) {
+        throw new Error("No fake channel behavior remains.");
+      }
+      const channel = new FakeChannel(behavior);
+      channels.push(channel);
+      return channel;
+    },
+    capture,
+    playback,
+    ...(options.conversationId
+      ? { conversationId: options.conversationId }
+      : {}),
+    ...(options.captions ? { captions: options.captions } : {}),
+    now: () => now,
+    sleep: async (milliseconds) => {
+      sleeps.push(milliseconds);
+      now += milliseconds;
+    },
+    onState: (state) => states.push(state),
+    onCaption: (role, text) => captions.push({ role, text }),
+    onCaptionMode: (mode) => captionModes.push(mode),
+    onTiming: (metric) => timings.push(metric),
+    onError: (error) => errors.push(error),
+  });
+
+  return {
+    session,
+    capture,
+    playback,
+    channels,
+    states,
+    captions,
+    captionModes,
+    timings,
+    errors,
+    sleeps,
+    advance(milliseconds: number) {
+      now += milliseconds;
+    },
+  };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  message = "condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+    await Bun.sleep(1);
+  }
+  throw new Error(`Timed out waiting for ${message}.`);
+}
+
+describe("LiveVoicePushToTalkSession", () => {
+  test("retains the conversation and opens a fresh manual session after playback drains", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-1",
+          conversationId: "conversation-1",
+        },
+        {
+          type: "ready",
+          sessionId: "session-2",
+          conversationId: "conversation-1",
+        },
+      ],
+      { conversationId: "conversation-requested" },
+    );
+
+    await harness.session.start();
+    expect(harness.channels[0].connectOptions).toEqual([
+      {
+        conversationId: "conversation-requested",
+        turnDetection: "manual",
+      },
+    ]);
+
+    await harness.session.handleKey("enter");
+    harness.capture.emit(Buffer.from([1, 2, 3, 4]));
+    harness.advance(10);
+    await harness.session.handleKey("enter");
+    expect(harness.channels[0].audio.map((value) => [...value])).toEqual([
+      [1, 2, 3, 4],
+      [5, 6],
+    ]);
+    expect(harness.channels[0].pttReleaseCount).toBe(1);
+
+    harness.advance(400);
+    harness.channels[0].emit("frame", {
+      type: "tts_audio",
+      seq: 2,
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+      dataBase64: Buffer.from([7, 8]).toString("base64"),
+    });
+    harness.channels[0].emit("frame", {
+      type: "tts_done",
+      seq: 3,
+      turnId: "turn-1",
+    });
+
+    await waitFor(
+      () =>
+        harness.channels.length === 2 &&
+        harness.session.currentState === "ready",
+      "the next ready session",
+    );
+    expect(harness.playback.chunks[0].audio).toEqual(Buffer.from([7, 8]));
+    expect(harness.playback.drainCount).toBe(1);
+    expect(harness.channels[0].endCount).toBe(1);
+    expect(harness.channels[1].connectOptions).toEqual([
+      {
+        conversationId: "conversation-1",
+        turnDetection: "manual",
+      },
+    ]);
+    expect(harness.timings).toContainEqual({
+      name: "input_end_to_first_tts",
+      durationMs: 400,
+    });
+
+    await harness.session.shutdown();
+  });
+
+  test("retries a busy response only when it belongs to the just-ended session", async () => {
+    const harness = makeHarness([
+      {
+        type: "ready",
+        sessionId: "session-1",
+        conversationId: "conversation-1",
+      },
+      { type: "busy", activeSessionId: "session-1" },
+      { type: "busy", activeSessionId: "session-1" },
+      {
+        type: "ready",
+        sessionId: "session-2",
+        conversationId: "conversation-1",
+      },
+    ]);
+
+    await harness.session.start();
+    harness.channels[0].emit("frame", {
+      type: "utterance_discarded",
+      seq: 2,
+    });
+
+    await waitFor(
+      () =>
+        harness.channels.length === 4 &&
+        harness.session.currentState === "ready",
+      "same-session retry",
+    );
+    expect(harness.sleeps).toEqual([100, 250]);
+    expect(harness.errors).toEqual([]);
+    await harness.session.shutdown();
+  });
+
+  test("does not steal a different active session", async () => {
+    const harness = makeHarness([
+      {
+        type: "ready",
+        sessionId: "session-1",
+        conversationId: "conversation-1",
+      },
+      { type: "busy", activeSessionId: "session-other" },
+    ]);
+
+    await harness.session.start();
+    harness.channels[0].emit("frame", {
+      type: "utterance_discarded",
+      seq: 2,
+    });
+
+    await harness.session.waitUntilClosed();
+    expect(harness.session.currentState).toBe("failed");
+    expect(harness.errors[0]?.message).toContain("session-other");
+    expect(harness.sleeps).toEqual([]);
+  });
+
+  test("stops retrying after the bounded release schedule", async () => {
+    const harness = makeHarness([
+      {
+        type: "ready",
+        sessionId: "session-1",
+        conversationId: "conversation-1",
+      },
+      ...Array.from({ length: 5 }, () => ({
+        type: "busy" as const,
+        activeSessionId: "session-1",
+      })),
+    ]);
+
+    await harness.session.start();
+    harness.channels[0].emit("frame", {
+      type: "utterance_discarded",
+      seq: 2,
+    });
+
+    await harness.session.waitUntilClosed();
+    expect(harness.sleeps).toEqual([...LIVE_VOICE_BUSY_RETRY_DELAYS_MS]);
+    expect(harness.errors[0]?.message).toContain("still releasing");
+  });
+
+  test("keeps captions off by default and cycles caption visibility", async () => {
+    const harness = makeHarness([
+      {
+        type: "ready",
+        sessionId: "session-1",
+        conversationId: "conversation-1",
+      },
+    ]);
+    await harness.session.start();
+
+    harness.channels[0].emit("frame", {
+      type: "stt_final",
+      seq: 2,
+      text: "hidden user caption",
+    });
+    harness.channels[0].emit("frame", {
+      type: "assistant_text_delta",
+      seq: 3,
+      text: "hidden assistant caption",
+    });
+    await waitFor(() => harness.states.includes("transcribing"));
+    expect(harness.captions).toEqual([]);
+
+    await harness.session.handleKey("captions");
+    harness.channels[0].emit("frame", {
+      type: "stt_final",
+      seq: 4,
+      text: "visible user caption",
+    });
+    harness.channels[0].emit("frame", {
+      type: "assistant_text_delta",
+      seq: 5,
+      text: "still hidden",
+    });
+    await waitFor(() => harness.captions.length === 1);
+    expect(harness.captionModes).toEqual(["user"]);
+    expect(harness.captions).toEqual([
+      { role: "user", text: "visible user caption" },
+    ]);
+    await harness.session.shutdown();
+  });
+
+  test("interrupts an active reply and flushes playback", async () => {
+    const harness = makeHarness([
+      {
+        type: "ready",
+        sessionId: "session-1",
+        conversationId: "conversation-1",
+      },
+    ]);
+    await harness.session.start();
+    harness.channels[0].emit("frame", {
+      type: "thinking",
+      seq: 2,
+      turnId: "turn-1",
+    });
+    await waitFor(() => harness.session.currentState === "thinking");
+
+    await harness.session.handleKey("interrupt");
+    expect(harness.channels[0].interruptCount).toBe(1);
+    expect(harness.playback.flushCount).toBe(1);
+    await harness.session.shutdown();
+  });
+
+  test("cleans up capture, playback, and the channel idempotently", async () => {
+    const harness = makeHarness([
+      {
+        type: "ready",
+        sessionId: "session-1",
+        conversationId: "conversation-1",
+      },
+    ]);
+    await harness.session.start();
+    await harness.session.handleKey("enter");
+
+    await Promise.all([
+      harness.session.shutdown(),
+      harness.session.shutdown(),
+      harness.session.shutdown(),
+    ]);
+
+    expect(harness.capture.sessions[0].stopCount).toBe(1);
+    expect(harness.channels[0].endCount).toBe(1);
+    expect(harness.playback.flushCount).toBe(1);
+    expect(harness.playback.closeCount).toBe(1);
+    expect(harness.session.currentState).toBe("ended");
+  });
+});

--- a/cli/src/__tests__/voice.test.ts
+++ b/cli/src/__tests__/voice.test.ts
@@ -156,6 +156,7 @@ class FakeChannel implements LiveVoiceSessionChannel {
   pttReleaseCount = 0;
   interruptCount = 0;
   endCount = 0;
+  requestEndCount = 0;
   closeCount = 0;
 
   private readonly listeners: {
@@ -173,6 +174,7 @@ class FakeChannel implements LiveVoiceSessionChannel {
   constructor(
     private readonly sessionId = "session-1",
     private readonly conversationId = "conversation-1",
+    private readonly autoReleaseConfirmation = true,
   ) {}
 
   on<EventName extends LiveVoiceChannelClientEventName>(
@@ -215,6 +217,15 @@ class FakeChannel implements LiveVoiceSessionChannel {
     this.interruptCount += 1;
   }
 
+  requestEnd(): void {
+    this.requestEndCount += 1;
+    if (this.autoReleaseConfirmation) {
+      queueMicrotask(() => {
+        this.emitSessionEnded();
+      });
+    }
+  }
+
   end(): void {
     this.endCount += 1;
     this.emit("closed", {
@@ -235,6 +246,20 @@ class FakeChannel implements LiveVoiceSessionChannel {
     for (const listener of this.listeners[event]) {
       listener(payload);
     }
+  }
+
+  emitSessionEnded(): void {
+    this.emit("frame", {
+      type: "metrics",
+      seq: 2,
+      event: "session_ended",
+      sessionId: this.sessionId,
+      turnId: "session",
+      sttMs: null,
+      llmFirstDeltaMs: null,
+      ttsFirstAudioMs: null,
+      totalMs: 0,
+    });
   }
 }
 
@@ -441,8 +466,51 @@ describe("vellum voice", () => {
     });
     expect(stdout.value).not.toContain("never-print-me");
     expect(audio.captureSessions).toHaveLength(0);
-    expect(channels[0].endCount).toBe(1);
+    expect(channels[0].requestEndCount).toBe(1);
+    expect(channels[0].closeCount).toBe(1);
     expect(signalHost.exitCode).toBeUndefined();
+  });
+
+  test("doctor waits for server session release confirmation before returning", async () => {
+    const stdout = new FakeOutput(false);
+    const signalHost = new FakeSignalHost();
+    const audio = new FakeAudio();
+    const channel = new FakeChannel(
+      "doctor-session",
+      "doctor-conversation",
+      false,
+    );
+    let completed = false;
+
+    const running = voice({
+      args: ["doctor", "assistant-123", "--json"],
+      stdout,
+      signalHost,
+      audio,
+      resolveConnection: async () => directConnection(),
+      createChannel: () => channel,
+    }).then(() => {
+      completed = true;
+    });
+
+    await waitFor(
+      () => channel.requestEndCount === 1,
+      "the doctor end request",
+    );
+    await Promise.resolve();
+    expect(completed).toBe(false);
+    expect(stdout.value).toBe("");
+    expect(channel.closeCount).toBe(0);
+
+    channel.emitSessionEnded();
+    await running;
+
+    expect(completed).toBe(true);
+    expect(channel.closeCount).toBe(1);
+    expect(JSON.parse(stdout.value)).toMatchObject({
+      ok: true,
+      target: { status: "ready" },
+    });
   });
 
   test("uses stored Vellum login routing and refreshes the managed endpoint for each turn", async () => {

--- a/cli/src/__tests__/voice.test.ts
+++ b/cli/src/__tests__/voice.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import { describe, expect, test } from "bun:test";
 
 import { voice } from "../commands/voice.js";
+import { GATEWAY_PORT } from "../lib/constants.js";
 import type {
   LiveVoiceChannelClientEventHandler,
   LiveVoiceChannelClientEventMap,
@@ -296,7 +297,9 @@ describe("vellum voice", () => {
     expect(stdout.value).toContain("vellum voice devices [--json]");
     expect(stdout.value).toContain("--input-device <node>");
     expect(stdout.value).toContain("--captions <mode>");
-    expect(stdout.value).toContain("--assistant-id assistant-123");
+    expect(stdout.value).toContain(
+      `--url http://127.0.0.1:${GATEWAY_PORT} --assistant-id assistant-123`,
+    );
   });
 
   test("lists PipeWire devices as JSON without requiring a TTY", async () => {

--- a/cli/src/__tests__/voice.test.ts
+++ b/cli/src/__tests__/voice.test.ts
@@ -1,0 +1,535 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, test } from "bun:test";
+
+import { voice } from "../commands/voice.js";
+import type {
+  LiveVoiceChannelClientEventHandler,
+  LiveVoiceChannelClientEventMap,
+  LiveVoiceChannelClientEventName,
+} from "../lib/live-voice/channel-client.js";
+import type {
+  LiveVoiceAudioDoctorReport,
+  LiveVoicePcmCaptureOptions,
+  LiveVoicePcmCaptureSession,
+  LiveVoicePlaybackChunk,
+} from "../lib/live-voice/audio.js";
+import type { LiveVoiceSessionChannel } from "../lib/live-voice/session.js";
+
+class FakeInput extends EventEmitter {
+  readonly isTTY: boolean;
+  isRaw = false;
+  readonly rawModes: boolean[] = [];
+  resumeCount = 0;
+  pauseCount = 0;
+
+  constructor(isTTY = true) {
+    super();
+    this.isTTY = isTTY;
+  }
+
+  setRawMode(mode: boolean): void {
+    this.isRaw = mode;
+    this.rawModes.push(mode);
+  }
+
+  resume(): void {
+    this.resumeCount += 1;
+  }
+
+  pause(): void {
+    this.pauseCount += 1;
+  }
+}
+
+class FakeOutput {
+  readonly isTTY: boolean;
+  value = "";
+
+  constructor(isTTY = true) {
+    this.isTTY = isTTY;
+  }
+
+  write(value: string): boolean {
+    this.value += value;
+    return true;
+  }
+}
+
+class FakeSignalHost extends EventEmitter {
+  exitCode: string | number | null | undefined;
+}
+
+class FakeCaptureSession implements LiveVoicePcmCaptureSession {
+  readonly closed = new Promise<void>(() => {});
+  stopCount = 0;
+
+  setMuted(): void {}
+
+  async stop(): Promise<Buffer | null> {
+    this.stopCount += 1;
+    return Buffer.from([9, 10]);
+  }
+}
+
+const PASSING_AUDIO_REPORT: LiveVoiceAudioDoctorReport = {
+  ok: true,
+  checks: [
+    {
+      id: "runtime",
+      status: "pass",
+      message: "Linux ARM64 is supported.",
+    },
+  ],
+  devices: {
+    inputs: [
+      {
+        direction: "input",
+        nodeName: "input.node",
+        objectSerial: "101",
+        description: "Input",
+        mediaClass: "Audio/Source",
+      },
+    ],
+    outputs: [
+      {
+        direction: "output",
+        nodeName: "output.node",
+        objectSerial: "202",
+        description: "Output",
+        mediaClass: "Audio/Sink",
+      },
+    ],
+  },
+};
+
+class FakeAudio {
+  readonly doctorOptions: unknown[] = [];
+  readonly captureOptions: LiveVoicePcmCaptureOptions[] = [];
+  readonly captureSessions: FakeCaptureSession[] = [];
+  readonly playbackTargets: Array<string | undefined> = [];
+  playbackDrainCount = 0;
+  playbackFlushCount = 0;
+  playbackCloseCount = 0;
+
+  async discoverDevices() {
+    return PASSING_AUDIO_REPORT.devices;
+  }
+
+  async doctor(options?: {
+    inputDevice?: string;
+    outputDevice?: string;
+  }): Promise<LiveVoiceAudioDoctorReport> {
+    this.doctorOptions.push(options);
+    return PASSING_AUDIO_REPORT;
+  }
+
+  async startCapture(
+    options: LiveVoicePcmCaptureOptions,
+  ): Promise<LiveVoicePcmCaptureSession> {
+    const session = new FakeCaptureSession();
+    this.captureOptions.push(options);
+    this.captureSessions.push(session);
+    return session;
+  }
+
+  createPlayback(target?: string) {
+    this.playbackTargets.push(target);
+    return {
+      write: async (_chunk: LiveVoicePlaybackChunk) => {},
+      drain: async () => {
+        this.playbackDrainCount += 1;
+      },
+      flush: async () => {
+        this.playbackFlushCount += 1;
+      },
+      close: async () => {
+        this.playbackCloseCount += 1;
+      },
+    };
+  }
+}
+
+class FakeChannel implements LiveVoiceSessionChannel {
+  readonly connectOptions: unknown[] = [];
+  readonly audio: Uint8Array[] = [];
+  pttReleaseCount = 0;
+  interruptCount = 0;
+  endCount = 0;
+  closeCount = 0;
+
+  private readonly listeners: {
+    [EventName in LiveVoiceChannelClientEventName]: Set<
+      LiveVoiceChannelClientEventHandler<EventName>
+    >;
+  } = {
+    ready: new Set(),
+    busy: new Set(),
+    frame: new Set(),
+    error: new Set(),
+    closed: new Set(),
+  };
+
+  constructor(
+    private readonly sessionId = "session-1",
+    private readonly conversationId = "conversation-1",
+  ) {}
+
+  on<EventName extends LiveVoiceChannelClientEventName>(
+    event: EventName,
+    handler: LiveVoiceChannelClientEventHandler<EventName>,
+  ): () => void {
+    this.listeners[event].add(handler);
+    return () => {
+      this.listeners[event].delete(handler);
+    };
+  }
+
+  connect(options?: {
+    readonly conversationId?: string;
+    readonly turnDetection?: "manual" | "server_vad";
+  }): void {
+    this.connectOptions.push(options);
+    queueMicrotask(() => {
+      this.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: this.sessionId,
+        conversationId: this.conversationId,
+        turnDetection: "manual",
+      });
+    });
+  }
+
+  sendAudio(pcm: ArrayBuffer | Uint8Array): void {
+    this.audio.push(
+      pcm instanceof Uint8Array ? Buffer.from(pcm) : new Uint8Array(pcm),
+    );
+  }
+
+  pttRelease(): void {
+    this.pttReleaseCount += 1;
+  }
+
+  interrupt(): void {
+    this.interruptCount += 1;
+  }
+
+  end(): void {
+    this.endCount += 1;
+    this.emit("closed", {
+      code: null,
+      reason: "client closed",
+      retryable: false,
+    });
+  }
+
+  close(): void {
+    this.closeCount += 1;
+  }
+
+  emit<EventName extends LiveVoiceChannelClientEventName>(
+    event: EventName,
+    payload: LiveVoiceChannelClientEventMap[EventName],
+  ): void {
+    for (const listener of this.listeners[event]) {
+      listener(payload);
+    }
+  }
+}
+
+function directConnection(secret = "guardian-secret") {
+  return {
+    topology: "direct" as const,
+    assistantId: "assistant-123",
+    gatewayUrl: "http://127.0.0.1:7821/",
+    preflight: { status: "ready" as const },
+    webSocket: {
+      url: "ws://127.0.0.1:7821/v1/live-voice",
+      logSafeUrl: "ws://127.0.0.1:7821/v1/live-voice",
+      headers: { Authorization: `Bearer ${secret}` },
+    },
+  };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  message = "condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+    await Bun.sleep(1);
+  }
+  throw new Error(`Timed out waiting for ${message}.`);
+}
+
+describe("vellum voice", () => {
+  test("prints complete help for sessions, devices, and doctor", async () => {
+    const stdout = new FakeOutput();
+
+    await voice({ args: ["--help"], stdout });
+
+    expect(stdout.value).toContain(
+      "Usage: vellum voice [<name-or-id>] [options]",
+    );
+    expect(stdout.value).toContain("vellum voice devices [--json]");
+    expect(stdout.value).toContain("--input-device <node>");
+    expect(stdout.value).toContain("--captions <mode>");
+    expect(stdout.value).toContain("--assistant-id assistant-123");
+  });
+
+  test("lists PipeWire devices as JSON without requiring a TTY", async () => {
+    const stdout = new FakeOutput(false);
+    const audio = new FakeAudio();
+
+    await voice({
+      args: ["devices", "--json"],
+      stdout,
+      audio,
+    });
+
+    const result = JSON.parse(stdout.value) as {
+      inputs: Array<{ nodeName: string }>;
+      outputs: Array<{ nodeName: string }>;
+    };
+    expect(result.inputs[0].nodeName).toBe("input.node");
+    expect(result.outputs[0].nodeName).toBe("output.node");
+  });
+
+  test("requires a TTY before target resolution or audio capture", async () => {
+    const audio = new FakeAudio();
+    let resolutionCount = 0;
+
+    await expect(
+      voice({
+        args: ["assistant-123"],
+        stdin: new FakeInput(false),
+        stdout: new FakeOutput(false),
+        audio,
+        resolveConnection: async () => {
+          resolutionCount += 1;
+          return directConnection();
+        },
+      }),
+    ).rejects.toThrow("interactive terminal");
+
+    expect(resolutionCount).toBe(0);
+    expect(audio.doctorOptions).toEqual([]);
+    expect(audio.captureSessions).toEqual([]);
+  });
+
+  test("runs target and audio diagnostics before raw mode and capture", async () => {
+    const stdin = new FakeInput();
+    const stdout = new FakeOutput();
+    const stderr = new FakeOutput();
+    const signalHost = new FakeSignalHost();
+    const audio = new FakeAudio();
+    const channels: FakeChannel[] = [];
+    const events: string[] = [];
+    let resolvedOptions: unknown;
+
+    const running = voice({
+      args: [
+        "Example",
+        "Assistant",
+        "--input-device",
+        "input.node",
+        "--output-device",
+        "output.node",
+        "--conversation",
+        "conversation-requested",
+        "--captions",
+        "off",
+        "--url",
+        "http://127.0.0.1:7821",
+        "--assistant-id",
+        "assistant-123",
+        "--token",
+        "guardian-secret",
+      ],
+      stdin,
+      stdout,
+      stderr,
+      signalHost,
+      audio: {
+        ...audio,
+        discoverDevices: audio.discoverDevices.bind(audio),
+        doctor: async (options) => {
+          events.push("doctor");
+          return audio.doctor(options);
+        },
+        startCapture: audio.startCapture.bind(audio),
+        createPlayback: audio.createPlayback.bind(audio),
+      },
+      resolveConnection: async (options) => {
+        events.push("resolve");
+        resolvedOptions = options;
+        return directConnection();
+      },
+      createChannel: () => {
+        events.push("channel");
+        const channel = new FakeChannel();
+        channels.push(channel);
+        return channel;
+      },
+    });
+
+    await waitFor(() => stdin.isRaw, "raw terminal mode");
+    expect(events.slice(0, 3)).toEqual(["resolve", "doctor", "channel"]);
+    expect(resolvedOptions).toEqual({
+      target: "Example Assistant",
+      url: "http://127.0.0.1:7821",
+      assistantId: "assistant-123",
+      guardianToken: "guardian-secret",
+    });
+    expect(audio.doctorOptions).toEqual([
+      { inputDevice: "input.node", outputDevice: "output.node" },
+    ]);
+    expect(audio.captureSessions).toHaveLength(0);
+    expect(audio.playbackTargets).toEqual(["output.node"]);
+    expect(channels[0].connectOptions).toEqual([
+      {
+        conversationId: "conversation-requested",
+        turnDetection: "manual",
+      },
+    ]);
+
+    stdin.emit("data", Buffer.from("q"));
+    await running;
+    expect(stdin.rawModes).toEqual([true, false]);
+    expect(signalHost.listenerCount("SIGINT")).toBe(0);
+    expect(signalHost.listenerCount("SIGTERM")).toBe(0);
+    expect(signalHost.listenerCount("SIGHUP")).toBe(0);
+  });
+
+  test("doctor returns token-safe JSON readiness without opening capture", async () => {
+    const stdout = new FakeOutput(false);
+    const signalHost = new FakeSignalHost();
+    const audio = new FakeAudio();
+    const channels: FakeChannel[] = [];
+
+    await voice({
+      args: ["doctor", "assistant-123", "--json"],
+      stdout,
+      signalHost,
+      audio,
+      resolveConnection: async () => directConnection("never-print-me"),
+      createChannel: () => {
+        const channel = new FakeChannel();
+        channels.push(channel);
+        return channel;
+      },
+    });
+
+    const result = JSON.parse(stdout.value) as {
+      ok: boolean;
+      target: {
+        status: string;
+        topology: string;
+        assistantId: string;
+      };
+    };
+    expect(result).toMatchObject({
+      ok: true,
+      target: {
+        status: "ready",
+        topology: "direct",
+        assistantId: "assistant-123",
+      },
+    });
+    expect(stdout.value).not.toContain("never-print-me");
+    expect(audio.captureSessions).toHaveLength(0);
+    expect(channels[0].endCount).toBe(1);
+    expect(signalHost.exitCode).toBeUndefined();
+  });
+
+  test("uses stored Vellum login routing and refreshes the managed endpoint for each turn", async () => {
+    const stdin = new FakeInput();
+    const stdout = new FakeOutput();
+    const signalHost = new FakeSignalHost();
+    const audio = new FakeAudio();
+    const channels: FakeChannel[] = [];
+    const resolutionOptions: unknown[] = [];
+    let tokenNumber = 0;
+
+    const running = voice({
+      args: ["assistant-managed"],
+      stdin,
+      stdout,
+      signalHost,
+      audio,
+      resolveConnection: async (options) => {
+        resolutionOptions.push(options);
+        tokenNumber += 1;
+        return {
+          topology: "vellum-managed",
+          assistantId: "assistant-managed",
+          platformUrl: "https://app.example.com",
+          webSocket: {
+            url: `wss://voice.example.com/assistant-managed/v1/live-voice?token=token-${tokenNumber}`,
+            logSafeUrl:
+              "wss://voice.example.com/assistant-managed/v1/live-voice?token=%5BREDACTED%5D",
+          },
+        };
+      },
+      createChannel: () => {
+        const channel = new FakeChannel(
+          `session-${channels.length + 1}`,
+          "conversation-managed",
+        );
+        channels.push(channel);
+        return channel;
+      },
+    });
+
+    await waitFor(() => stdin.isRaw);
+    channels[0].emit("frame", {
+      type: "utterance_discarded",
+      seq: 2,
+    });
+    await waitFor(() => channels.length === 2, "managed endpoint refresh");
+    expect(resolutionOptions).toEqual([
+      { target: "assistant-managed" },
+      { target: "assistant-managed" },
+    ]);
+
+    stdin.emit("data", Buffer.from("q"));
+    await running;
+  });
+
+  test("restores the terminal and reaps capture on SSH loss", async () => {
+    const stdin = new FakeInput();
+    const stdout = new FakeOutput();
+    const signalHost = new FakeSignalHost();
+    const audio = new FakeAudio();
+
+    const running = voice({
+      args: ["assistant-123"],
+      stdin,
+      stdout,
+      signalHost,
+      audio,
+      resolveConnection: async () => directConnection(),
+      createChannel: () => new FakeChannel(),
+    });
+
+    await waitFor(() => stdin.isRaw);
+    stdin.emit("data", Buffer.from("\r"));
+    await waitFor(
+      () => audio.captureSessions.length === 1,
+      "microphone capture",
+    );
+    signalHost.emit("SIGHUP");
+    await running;
+
+    expect(audio.captureSessions[0].stopCount).toBe(1);
+    expect(audio.playbackFlushCount).toBe(1);
+    expect(audio.playbackCloseCount).toBe(1);
+    expect(stdin.isRaw).toBe(false);
+    expect(stdin.pauseCount).toBe(1);
+    expect(signalHost.exitCode).toBe(129);
+    expect(signalHost.listenerCount("SIGHUP")).toBe(0);
+  });
+});

--- a/cli/src/__tests__/voice.test.ts
+++ b/cli/src/__tests__/voice.test.ts
@@ -221,7 +221,7 @@ class FakeChannel implements LiveVoiceSessionChannel {
     this.requestEndCount += 1;
     if (this.autoReleaseConfirmation) {
       queueMicrotask(() => {
-        this.emitSessionEnded();
+        this.emitSessionReleased();
       });
     }
   }
@@ -248,17 +248,11 @@ class FakeChannel implements LiveVoiceSessionChannel {
     }
   }
 
-  emitSessionEnded(): void {
+  emitSessionReleased(): void {
     this.emit("frame", {
-      type: "metrics",
+      type: "session_released",
       seq: 2,
-      event: "session_ended",
       sessionId: this.sessionId,
-      turnId: "session",
-      sttMs: null,
-      llmFirstDeltaMs: null,
-      ttsFirstAudioMs: null,
-      totalMs: 0,
     });
   }
 }
@@ -502,7 +496,7 @@ describe("vellum voice", () => {
     expect(stdout.value).toBe("");
     expect(channel.closeCount).toBe(0);
 
-    channel.emitSessionEnded();
+    channel.emitSessionReleased();
     await running;
 
     expect(completed).toBe(true);

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -1,0 +1,682 @@
+import type { ReadStream, WriteStream } from "node:tty";
+
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
+import {
+  LiveVoiceChannelClient,
+  type LiveVoiceChannelClientOptions,
+} from "../lib/live-voice/channel-client.js";
+import {
+  resolveLiveVoiceConnection,
+  type LiveVoiceResolvedConnection,
+} from "../lib/live-voice/connection.js";
+import { PipeWireAudio } from "../lib/live-voice/pipewire-audio.js";
+import {
+  LIVE_VOICE_CAPTION_MODES,
+  LiveVoicePushToTalkSession,
+  type LiveVoiceCaptionMode,
+  type LiveVoiceForegroundState,
+  type LiveVoiceSessionChannel,
+  type LiveVoiceSessionEndpoint,
+  type LiveVoiceTimingMetric,
+} from "../lib/live-voice/session.js";
+import type {
+  LiveVoiceAudioDeviceDiscovery,
+  LiveVoiceAudioDevices,
+  LiveVoiceAudioDiagnostics,
+  LiveVoiceAudioDoctorReport,
+  LiveVoicePcmCapture,
+  LiveVoicePcmPlaybackFactory,
+} from "../lib/live-voice/audio.js";
+
+const VALUE_FLAGS = [
+  "--input-device",
+  "--output-device",
+  "--conversation",
+  "--captions",
+  "--url",
+  "-u",
+  "--assistant-id",
+  "-a",
+  "--token",
+  "-t",
+] as const;
+
+type VoiceSubcommand = "session" | "devices" | "doctor";
+
+interface ParsedVoiceArgs {
+  subcommand: VoiceSubcommand;
+  target?: string;
+  inputDevice?: string;
+  outputDevice?: string;
+  conversationId?: string;
+  captions: LiveVoiceCaptionMode;
+  url?: string;
+  assistantId?: string;
+  guardianToken?: string;
+  json: boolean;
+  help: boolean;
+}
+
+interface VoiceInput {
+  readonly isTTY?: boolean;
+  readonly isRaw?: boolean;
+  setRawMode(mode: boolean): void;
+  resume(): void;
+  pause(): void;
+  on(event: "data", listener: (chunk: Buffer | string) => void): this;
+  on(event: "end" | "close", listener: () => void): this;
+  off(event: "data", listener: (chunk: Buffer | string) => void): this;
+  off(event: "end" | "close", listener: () => void): this;
+}
+
+interface VoiceOutput {
+  readonly isTTY?: boolean;
+  write(value: string): boolean;
+}
+
+interface VoiceSignalHost {
+  exitCode?: string | number | null;
+  on(event: NodeJS.Signals, listener: () => void): unknown;
+  off(event: NodeJS.Signals, listener: () => void): unknown;
+}
+
+type VoiceAudio = LiveVoiceAudioDeviceDiscovery &
+  LiveVoiceAudioDiagnostics &
+  LiveVoicePcmCapture &
+  LiveVoicePcmPlaybackFactory;
+
+export interface VoiceCommandDependencies {
+  readonly args?: readonly string[];
+  readonly audio?: VoiceAudio;
+  readonly resolveConnection?: typeof resolveLiveVoiceConnection;
+  readonly createChannel?: (
+    options: LiveVoiceChannelClientOptions,
+  ) => LiveVoiceSessionChannel;
+  readonly stdin?: VoiceInput;
+  readonly stdout?: VoiceOutput;
+  readonly stderr?: VoiceOutput;
+  readonly signalHost?: VoiceSignalHost;
+  readonly debug?: boolean;
+}
+
+interface VoiceTargetReport {
+  readonly status: "ready" | "busy" | "fail";
+  readonly assistantId?: string;
+  readonly topology?: LiveVoiceResolvedConnection["topology"];
+  readonly preflight?: string;
+  readonly message?: string;
+}
+
+interface VoiceDoctorReport {
+  readonly ok: boolean;
+  readonly target: VoiceTargetReport;
+  readonly audio?: LiveVoiceAudioDoctorReport;
+}
+
+export async function voice(
+  dependencyOverrides: VoiceCommandDependencies = {},
+): Promise<void> {
+  const args = parseVoiceArgs(
+    dependencyOverrides.args ?? process.argv.slice(3),
+  );
+  const stdout = dependencyOverrides.stdout ?? (process.stdout as WriteStream);
+  const stderr = dependencyOverrides.stderr ?? (process.stderr as WriteStream);
+  const audio = dependencyOverrides.audio ?? new PipeWireAudio();
+  const resolveConnection =
+    dependencyOverrides.resolveConnection ?? resolveLiveVoiceConnection;
+  const createChannel =
+    dependencyOverrides.createChannel ??
+    ((options) => new LiveVoiceChannelClient(options));
+
+  if (args.help) {
+    printVoiceHelp(stdout);
+    return;
+  }
+  if (args.subcommand === "devices") {
+    await showDevices(args, audio, stdout);
+    return;
+  }
+
+  const connectionOptions = {
+    ...(args.target ? { target: args.target } : {}),
+    ...(args.url ? { url: args.url } : {}),
+    ...(args.assistantId ? { assistantId: args.assistantId } : {}),
+    ...(args.guardianToken ? { guardianToken: args.guardianToken } : {}),
+  };
+
+  if (args.subcommand === "doctor") {
+    await runDoctor({
+      args,
+      audio,
+      stdout,
+      resolveConnection,
+      createChannel,
+      connectionOptions,
+      signalHost: dependencyOverrides.signalHost ?? process,
+    });
+    return;
+  }
+
+  const stdin = dependencyOverrides.stdin ?? (process.stdin as ReadStream);
+  if (!stdin.isTTY || !stdout.isTTY) {
+    throw new Error(
+      "Live voice requires an interactive terminal for push-to-talk controls.",
+    );
+  }
+
+  const initialConnection = await resolveConnection(connectionOptions);
+  const audioReport = await audio.doctor({
+    inputDevice: args.inputDevice,
+    outputDevice: args.outputDevice,
+  });
+  if (!audioReport.ok) {
+    throw new Error(formatAudioDoctorFailure(audioReport));
+  }
+
+  const endpointResolver = createEndpointResolver(
+    initialConnection,
+    connectionOptions,
+    resolveConnection,
+  );
+  const playback = audio.createPlayback(args.outputDevice);
+  const writeLine = (value: string): void => {
+    stdout.write(`${value}\n`);
+  };
+  const writeError = (value: string): void => {
+    stderr.write(`${value}\n`);
+  };
+  const debug =
+    dependencyOverrides.debug ??
+    ["1", "true", "yes", "on"].includes(
+      (process.env.VELLUM_DEBUG ?? "").toLowerCase(),
+    );
+  const session = new LiveVoicePushToTalkSession({
+    resolveEndpoint: endpointResolver,
+    createChannel: (endpoint) =>
+      createChannel({
+        url: endpoint.url,
+        ...(endpoint.headers ? { headers: endpoint.headers } : {}),
+      }),
+    capture: audio,
+    playback,
+    ...(args.inputDevice ? { inputDevice: args.inputDevice } : {}),
+    ...(args.conversationId ? { conversationId: args.conversationId } : {}),
+    captions: args.captions,
+    onState: (state) => {
+      writeLine(formatVoiceState(state));
+    },
+    onCaptionMode: (mode) => {
+      writeLine(`captions: ${mode}`);
+    },
+    onCaption: (role, text) => {
+      writeLine(`${role}: ${text}`);
+    },
+    onTiming: (metric) => {
+      if (debug) {
+        writeError(formatTimingMetric(metric));
+      }
+    },
+    onError: (error) => {
+      writeError(`voice error: ${error.message}`);
+    },
+  });
+
+  try {
+    await session.start();
+    writeLine("Enter: talk or release | s: interrupt | c: captions | q: quit");
+    await runRawTerminal({
+      session,
+      stdin,
+      signalHost: dependencyOverrides.signalHost ?? process,
+    });
+  } finally {
+    await session.shutdown();
+  }
+  if (session.fatalError !== null) {
+    throw session.fatalError;
+  }
+}
+
+function parseVoiceArgs(rawArgs: readonly string[]): ParsedVoiceArgs {
+  const args = [...rawArgs];
+  let subcommand: VoiceSubcommand = "session";
+  if (args[0] === "devices" || args[0] === "doctor") {
+    subcommand = args.shift() as "devices" | "doctor";
+  }
+
+  const parsed: ParsedVoiceArgs = {
+    subcommand,
+    captions: "off",
+    json: false,
+    help: false,
+  };
+  const positionalArgs: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === "--json") {
+      if (subcommand === "session") {
+        throw new Error(
+          "--json is supported only by voice devices and doctor.",
+        );
+      }
+      parsed.json = true;
+      continue;
+    }
+    if ((VALUE_FLAGS as readonly string[]).includes(arg)) {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("-")) {
+        throw new Error(`${arg} requires a value.`);
+      }
+      index += 1;
+      assignValueFlag(parsed, arg, value);
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown voice option '${arg}'.`);
+    }
+    positionalArgs.push(arg);
+  }
+
+  parsed.target = parseAssistantTargetArg(positionalArgs);
+  if (parsed.assistantId && !parsed.url) {
+    parsed.target = parsed.assistantId;
+  }
+  if (subcommand === "devices" && parsed.target) {
+    throw new Error("voice devices does not accept an assistant target.");
+  }
+  if (
+    subcommand === "devices" &&
+    (parsed.inputDevice ||
+      parsed.outputDevice ||
+      parsed.conversationId ||
+      parsed.url ||
+      parsed.assistantId ||
+      parsed.guardianToken ||
+      parsed.captions !== "off")
+  ) {
+    throw new Error("voice devices accepts only --json and --help.");
+  }
+  if (
+    subcommand === "doctor" &&
+    (parsed.conversationId || parsed.captions !== "off")
+  ) {
+    throw new Error(
+      "voice doctor does not accept --conversation or --captions.",
+    );
+  }
+  return parsed;
+}
+
+function assignValueFlag(
+  parsed: ParsedVoiceArgs,
+  flag: string,
+  value: string,
+): void {
+  if (flag === "--input-device") {
+    parsed.inputDevice = value;
+  } else if (flag === "--output-device") {
+    parsed.outputDevice = value;
+  } else if (flag === "--conversation") {
+    parsed.conversationId = value;
+  } else if (flag === "--captions") {
+    if (!(LIVE_VOICE_CAPTION_MODES as readonly string[]).includes(value)) {
+      throw new Error(
+        `Invalid captions mode '${value}'. Expected off, user, assistant, or both.`,
+      );
+    }
+    parsed.captions = value as LiveVoiceCaptionMode;
+  } else if (flag === "--url" || flag === "-u") {
+    parsed.url = value;
+  } else if (flag === "--assistant-id" || flag === "-a") {
+    parsed.assistantId = value;
+  } else if (flag === "--token" || flag === "-t") {
+    parsed.guardianToken = value;
+  }
+}
+
+async function showDevices(
+  args: ParsedVoiceArgs,
+  audio: VoiceAudio,
+  stdout: VoiceOutput,
+): Promise<void> {
+  const devices = await audio.discoverDevices();
+  if (args.json) {
+    stdout.write(`${JSON.stringify(devices, null, 2)}\n`);
+    return;
+  }
+  printDeviceGroup(stdout, "Input devices", devices.inputs);
+  printDeviceGroup(stdout, "Output devices", devices.outputs);
+}
+
+function printDeviceGroup(
+  stdout: VoiceOutput,
+  title: string,
+  devices: LiveVoiceAudioDevices["inputs"],
+): void {
+  stdout.write(`${title}:\n`);
+  if (devices.length === 0) {
+    stdout.write("  none\n");
+    return;
+  }
+  for (const device of devices) {
+    stdout.write(
+      `  ${device.nodeName}  ${device.description}  serial=${device.objectSerial}\n`,
+    );
+  }
+}
+
+async function runDoctor(input: {
+  args: ParsedVoiceArgs;
+  audio: VoiceAudio;
+  stdout: VoiceOutput;
+  resolveConnection: typeof resolveLiveVoiceConnection;
+  createChannel: (
+    options: LiveVoiceChannelClientOptions,
+  ) => LiveVoiceSessionChannel;
+  connectionOptions: Parameters<typeof resolveLiveVoiceConnection>[0];
+  signalHost: VoiceSignalHost;
+}): Promise<void> {
+  let connection: LiveVoiceResolvedConnection;
+  try {
+    connection = await input.resolveConnection(input.connectionOptions);
+  } catch (error) {
+    const report: VoiceDoctorReport = {
+      ok: false,
+      target: {
+        status: "fail",
+        message: safeErrorMessage(error),
+      },
+    };
+    printDoctorReport(input.stdout, report, input.args.json);
+    input.signalHost.exitCode = 1;
+    return;
+  }
+
+  const [audioReport, readiness] = await Promise.all([
+    input.audio.doctor({
+      inputDevice: input.args.inputDevice,
+      outputDevice: input.args.outputDevice,
+    }),
+    probeReadiness(connection.webSocket, input.createChannel),
+  ]);
+  const target: VoiceTargetReport = {
+    ...readiness,
+    assistantId: connection.assistantId,
+    topology: connection.topology,
+    ...(connection.topology === "direct"
+      ? { preflight: connection.preflight.status }
+      : {}),
+  };
+  const report: VoiceDoctorReport = {
+    ok: audioReport.ok && readiness.status === "ready",
+    target,
+    audio: audioReport,
+  };
+  printDoctorReport(input.stdout, report, input.args.json);
+  if (!report.ok) {
+    input.signalHost.exitCode = 1;
+  }
+}
+
+async function probeReadiness(
+  endpoint: LiveVoiceSessionEndpoint,
+  createChannel: (
+    options: LiveVoiceChannelClientOptions,
+  ) => LiveVoiceSessionChannel,
+): Promise<VoiceTargetReport> {
+  const channel = createChannel({
+    url: endpoint.url,
+    ...(endpoint.headers ? { headers: endpoint.headers } : {}),
+  });
+  return new Promise<VoiceTargetReport>((resolve) => {
+    let settled = false;
+    const finish = (result: VoiceTargetReport): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(result);
+    };
+    channel.on("ready", () => {
+      finish({ status: "ready" });
+      channel.end();
+    });
+    channel.on("busy", (frame) => {
+      finish({
+        status: "busy",
+        message: `Another live-voice session is active (${frame.activeSessionId}).`,
+      });
+    });
+    channel.on("error", (event) => {
+      finish({ status: "fail", message: event.message });
+    });
+    channel.on("closed", (event) => {
+      finish({
+        status: "fail",
+        message: event.reason || "The readiness connection closed.",
+      });
+    });
+    channel.connect({ turnDetection: "manual" });
+  });
+}
+
+function printDoctorReport(
+  stdout: VoiceOutput,
+  report: VoiceDoctorReport,
+  json: boolean,
+): void {
+  if (json) {
+    stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+  stdout.write(`Target: ${report.target.status}\n`);
+  if (report.target.assistantId && report.target.topology) {
+    stdout.write(
+      `  ${report.target.assistantId} (${report.target.topology})\n`,
+    );
+  }
+  if (report.target.preflight) {
+    stdout.write(`  preflight: ${report.target.preflight}\n`);
+  }
+  if (report.target.message) {
+    stdout.write(`  ${report.target.message}\n`);
+  }
+  for (const check of report.audio?.checks ?? []) {
+    stdout.write(`Audio ${check.status}: ${check.message}\n`);
+  }
+  stdout.write(report.ok ? "Voice doctor passed.\n" : "Voice doctor failed.\n");
+}
+
+function createEndpointResolver(
+  initialConnection: LiveVoiceResolvedConnection,
+  connectionOptions: Parameters<typeof resolveLiveVoiceConnection>[0],
+  resolveConnection: typeof resolveLiveVoiceConnection,
+): () => Promise<LiveVoiceSessionEndpoint> {
+  let firstEndpoint: LiveVoiceSessionEndpoint | null =
+    initialConnection.webSocket;
+  return async () => {
+    if (firstEndpoint !== null) {
+      const endpoint = firstEndpoint;
+      firstEndpoint = null;
+      return endpoint;
+    }
+    if (initialConnection.topology === "direct") {
+      return initialConnection.webSocket;
+    }
+    const refreshed = await resolveConnection(connectionOptions);
+    if (refreshed.topology !== "vellum-managed") {
+      throw new Error("The live-voice target topology changed.");
+    }
+    return refreshed.webSocket;
+  };
+}
+
+async function runRawTerminal(input: {
+  session: LiveVoicePushToTalkSession;
+  stdin: VoiceInput;
+  signalHost: VoiceSignalHost;
+}): Promise<void> {
+  const wasRaw = input.stdin.isRaw === true;
+  let stopping = false;
+  const stop = (exitCode?: number): void => {
+    if (stopping) {
+      return;
+    }
+    stopping = true;
+    if (exitCode !== undefined) {
+      input.signalHost.exitCode = exitCode;
+    }
+    void input.session.shutdown();
+  };
+  const handleData = (chunk: Buffer | string): void => {
+    for (const byte of Buffer.from(chunk)) {
+      if (byte === 3) {
+        stop(130);
+      } else if (byte === 10 || byte === 13) {
+        void input.session.handleKey("enter");
+      } else {
+        const key = String.fromCharCode(byte).toLowerCase();
+        if (key === "s") {
+          void input.session.handleKey("interrupt");
+        } else if (key === "c") {
+          void input.session.handleKey("captions");
+        } else if (key === "q") {
+          stop();
+        }
+      }
+    }
+  };
+  const handleInputLoss = (): void => {
+    stop(1);
+  };
+  const signalHandlers = new Map<NodeJS.Signals, () => void>([
+    ["SIGINT", () => stop(130)],
+    ["SIGTERM", () => stop(143)],
+    ["SIGHUP", () => stop(129)],
+  ]);
+
+  let rawModeSet = false;
+  let listenersInstalled = false;
+  try {
+    input.stdin.setRawMode(true);
+    rawModeSet = true;
+    listenersInstalled = true;
+    input.stdin.on("data", handleData);
+    input.stdin.on("end", handleInputLoss);
+    input.stdin.on("close", handleInputLoss);
+    for (const [signal, handler] of signalHandlers) {
+      input.signalHost.on(signal, handler);
+    }
+    input.stdin.resume();
+    await input.session.waitUntilClosed();
+  } finally {
+    try {
+      if (listenersInstalled) {
+        input.stdin.off("data", handleData);
+        input.stdin.off("end", handleInputLoss);
+        input.stdin.off("close", handleInputLoss);
+        for (const [signal, handler] of signalHandlers) {
+          input.signalHost.off(signal, handler);
+        }
+      }
+      if (rawModeSet) {
+        input.stdin.setRawMode(wasRaw);
+      }
+      input.stdin.pause();
+    } finally {
+      await input.session.shutdown();
+    }
+  }
+}
+
+function printVoiceHelp(stdout: VoiceOutput): void {
+  stdout.write("Usage: vellum voice [<name-or-id>] [options]\n");
+  stdout.write("       vellum voice devices [--json]\n");
+  stdout.write("       vellum voice doctor [<name-or-id>] [options]\n");
+  stdout.write("\n");
+  stdout.write(
+    "Talk to a local or Vellum-managed assistant with foreground push-to-talk.\n",
+  );
+  stdout.write("\n");
+  stdout.write("Arguments:\n");
+  stdout.write(
+    "  <name-or-id>                 Assistant display name or exact ID. Uses the active assistant when omitted.\n",
+  );
+  stdout.write("\n");
+  stdout.write("Options:\n");
+  stdout.write(
+    "  --input-device <node>        PipeWire input node name or object serial.\n",
+  );
+  stdout.write(
+    "  --output-device <node>       PipeWire output node name or object serial.\n",
+  );
+  stdout.write(
+    "  --conversation <id>          Continue an existing conversation ID.\n",
+  );
+  stdout.write(
+    "  --captions <mode>            off, user, assistant, or both. Default: off.\n",
+  );
+  stdout.write(
+    "  -u, --url <url>              Direct gateway URL. Requires an assistant ID.\n",
+  );
+  stdout.write(
+    "  -a, --assistant-id <id>      Exact assistant ID or ID paired with --url.\n",
+  );
+  stdout.write(
+    "  -t, --token <token>          Ephemeral guardian token for a direct gateway. Never persisted.\n",
+  );
+  stdout.write(
+    "  --json                       Machine-readable output for devices or doctor.\n",
+  );
+  stdout.write("  -h, --help                   Show this help.\n");
+  stdout.write("\n");
+  stdout.write(
+    "Vellum-managed assistants use the stored login from 'vellum login'.\n",
+  );
+  stdout.write(
+    "During a session, Enter starts or releases capture, s interrupts, c cycles captions, and q exits.\n",
+  );
+  stdout.write("\n");
+  stdout.write("Examples:\n");
+  stdout.write("  vellum voice assistant-123\n");
+  stdout.write(
+    "  vellum voice --url http://127.0.0.1:7821 --assistant-id assistant-123\n",
+  );
+  stdout.write("  vellum voice doctor assistant-123 --json\n");
+}
+
+function formatAudioDoctorFailure(report: LiveVoiceAudioDoctorReport): string {
+  const failures = report.checks
+    .filter((check) => check.status === "fail")
+    .map((check) => check.message);
+  return failures.length > 0
+    ? `Voice audio diagnostics failed: ${failures.join(" ")}`
+    : "Voice audio diagnostics failed.";
+}
+
+function formatVoiceState(state: LiveVoiceForegroundState): string {
+  const messages: Record<LiveVoiceForegroundState, string> = {
+    ready: "ready",
+    listening: "listening",
+    transcribing: "transcribing",
+    thinking: "thinking",
+    speaking: "speaking",
+    busy: "busy: waiting for the previous session to release",
+    failed: "failed",
+    ended: "ended",
+  };
+  return messages[state];
+}
+
+function formatTimingMetric(metric: LiveVoiceTimingMetric): string {
+  return `[voice:timing] ${metric.name}=${metric.durationMs}ms`;
+}
+
+function safeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -473,11 +473,9 @@ async function probeReadiness(
       channel.close();
     });
     channel.on("frame", (frame) => {
-      // Session close drains this metric at the server's release boundary.
       if (
-        frame.type === "metrics" &&
-        frame.event === "session_ended" &&
-        (frame.sessionId === undefined || frame.sessionId === readySessionId)
+        frame.type === "session_released" &&
+        frame.sessionId === readySessionId
       ) {
         finish({ status: "ready" });
         channel.close();

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -40,8 +40,11 @@ const VALUE_FLAGS = [
   "--token",
   "-t",
 ] as const;
+const DOCTOR_SESSION_RELEASE_TIMEOUT_MS = 2_000;
 
 type VoiceSubcommand = "session" | "devices" | "doctor";
+type VoiceCommandChannel = LiveVoiceSessionChannel &
+  Pick<LiveVoiceChannelClient, "requestEnd">;
 
 interface ParsedVoiceArgs {
   subcommand: VoiceSubcommand;
@@ -91,7 +94,7 @@ export interface VoiceCommandDependencies {
   readonly resolveConnection?: typeof resolveLiveVoiceConnection;
   readonly createChannel?: (
     options: LiveVoiceChannelClientOptions,
-  ) => LiveVoiceSessionChannel;
+  ) => VoiceCommandChannel;
   readonly stdin?: VoiceInput;
   readonly stdout?: VoiceOutput;
   readonly stderr?: VoiceOutput;
@@ -377,7 +380,7 @@ async function runDoctor(input: {
   resolveConnection: typeof resolveLiveVoiceConnection;
   createChannel: (
     options: LiveVoiceChannelClientOptions,
-  ) => LiveVoiceSessionChannel;
+  ) => VoiceCommandChannel;
   connectionOptions: Parameters<typeof resolveLiveVoiceConnection>[0];
   signalHost: VoiceSignalHost;
 }): Promise<void> {
@@ -427,7 +430,7 @@ async function probeReadiness(
   endpoint: LiveVoiceSessionEndpoint,
   createChannel: (
     options: LiveVoiceChannelClientOptions,
-  ) => LiveVoiceSessionChannel,
+  ) => VoiceCommandChannel,
 ): Promise<VoiceTargetReport> {
   const channel = createChannel({
     url: endpoint.url,
@@ -435,16 +438,29 @@ async function probeReadiness(
   });
   return new Promise<VoiceTargetReport>((resolve) => {
     let settled = false;
+    let readySessionId: string | null = null;
+    let releaseTimer: ReturnType<typeof setTimeout> | null = null;
     const finish = (result: VoiceTargetReport): void => {
       if (settled) {
         return;
       }
       settled = true;
+      if (releaseTimer !== null) {
+        clearTimeout(releaseTimer);
+        releaseTimer = null;
+      }
       resolve(result);
     };
-    channel.on("ready", () => {
-      finish({ status: "ready" });
-      channel.end();
+    channel.on("ready", (frame) => {
+      readySessionId = frame.sessionId;
+      channel.requestEnd();
+      releaseTimer = setTimeout(() => {
+        finish({
+          status: "fail",
+          message: `The readiness session did not confirm release within ${DOCTOR_SESSION_RELEASE_TIMEOUT_MS}ms.`,
+        });
+        channel.close();
+      }, DOCTOR_SESSION_RELEASE_TIMEOUT_MS);
     });
     channel.on("busy", (frame) => {
       finish({
@@ -454,6 +470,18 @@ async function probeReadiness(
     });
     channel.on("error", (event) => {
       finish({ status: "fail", message: event.message });
+      channel.close();
+    });
+    channel.on("frame", (frame) => {
+      // Session close drains this metric at the server's release boundary.
+      if (
+        frame.type === "metrics" &&
+        frame.event === "session_ended" &&
+        (frame.sessionId === undefined || frame.sessionId === readySessionId)
+      ) {
+        finish({ status: "ready" });
+        channel.close();
+      }
     });
     channel.on("closed", (event) => {
       finish({

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -1,6 +1,7 @@
 import type { ReadStream, WriteStream } from "node:tty";
 
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
+import { GATEWAY_PORT } from "../lib/constants.js";
 import {
   LiveVoiceChannelClient,
   type LiveVoiceChannelClientOptions,
@@ -671,7 +672,7 @@ function printVoiceHelp(stdout: VoiceOutput): void {
   stdout.write("Examples:\n");
   stdout.write("  vellum voice assistant-123\n");
   stdout.write(
-    "  vellum voice --url http://127.0.0.1:7821 --assistant-id assistant-123\n",
+    `  vellum voice --url http://127.0.0.1:${GATEWAY_PORT} --assistant-id assistant-123\n`,
   );
   stdout.write("  vellum voice doctor assistant-123 --json\n");
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -38,6 +38,7 @@ import { tunnel } from "./commands/tunnel";
 import { unpair } from "./commands/unpair";
 import { upgrade } from "./commands/upgrade";
 import { use } from "./commands/use";
+import { voice } from "./commands/voice.js";
 import { wake } from "./commands/wake";
 import { workflows } from "./commands/workflows";
 import { resolveAssistant, setActiveAssistant } from "./lib/assistant-config";
@@ -78,6 +79,7 @@ const commands = {
   unpair,
   upgrade,
   use,
+  voice,
   wake,
   whoami,
   workflows,
@@ -136,6 +138,7 @@ function printHelp(): void {
   );
   console.log("  upgrade  Upgrade an assistant to a newer version");
   console.log("  use      Set the active assistant for commands");
+  console.log("  voice    Talk to an assistant with foreground push-to-talk");
   console.log("  wake     Start the assistant and gateway");
   console.log("  whoami   Show current logged-in user");
   console.log("  workflows Inspect and control workflow runs");

--- a/cli/src/lib/live-voice/channel-client.ts
+++ b/cli/src/lib/live-voice/channel-client.ts
@@ -132,6 +132,7 @@ export class LiveVoiceChannelClient {
   private closeEmitted = false;
   private configUpdatesUnsupported = false;
   private sentConfigUpdate = false;
+  private endRequested = false;
   private pendingConnectOptions: LiveVoiceChannelConnectOptions = {};
 
   private readonly listeners: {
@@ -229,17 +230,26 @@ export class LiveVoiceChannelClient {
     this.trySend(JSON.stringify(frame));
   }
 
-  end(): void {
-    if (this.state === "closed") {
-      return;
-    }
-    if (this.state === "connecting" || this.state === "active") {
+  /** Send the end request while keeping the transport open for server frames. */
+  requestEnd(): void {
+    if (
+      !this.endRequested &&
+      (this.state === "connecting" || this.state === "active")
+    ) {
+      this.endRequested = true;
       this.trySend(
         JSON.stringify({
           type: "end",
         } satisfies LiveVoiceClientControlFrame),
       );
     }
+  }
+
+  end(): void {
+    if (this.state === "closed") {
+      return;
+    }
+    this.requestEnd();
     this.close();
   }
 

--- a/cli/src/lib/live-voice/session.ts
+++ b/cli/src/lib/live-voice/session.ts
@@ -1,0 +1,531 @@
+import type {
+  LiveVoiceBusyServerFrame,
+  LiveVoiceReadyServerFrame,
+} from "@vellumai/service-contracts/live-voice";
+
+import type {
+  LiveVoicePcmCapture,
+  LiveVoicePcmCaptureSession,
+  LiveVoicePcmPlayback,
+} from "./audio.js";
+import type {
+  LiveVoiceChannelClientEventMap,
+  LiveVoiceChannelClient,
+} from "./channel-client.js";
+
+export const LIVE_VOICE_BUSY_RETRY_DELAYS_MS = [100, 250, 500, 1_000] as const;
+const LIVE_VOICE_BUSY_RETRY_BUDGET_MS = 2_000;
+
+export type LiveVoiceCaptionMode = "off" | "user" | "assistant" | "both";
+
+export const LIVE_VOICE_CAPTION_MODES = [
+  "off",
+  "user",
+  "assistant",
+  "both",
+] as const satisfies readonly LiveVoiceCaptionMode[];
+
+export type LiveVoiceForegroundState =
+  | "ready"
+  | "listening"
+  | "transcribing"
+  | "thinking"
+  | "speaking"
+  | "busy"
+  | "failed"
+  | "ended";
+
+export interface LiveVoiceTimingMetric {
+  readonly name: "socket_ready" | "input_end_to_first_tts";
+  readonly durationMs: number;
+}
+
+export type LiveVoiceSessionChannel = Pick<
+  LiveVoiceChannelClient,
+  "on" | "connect" | "sendAudio" | "pttRelease" | "interrupt" | "end" | "close"
+>;
+
+export interface LiveVoiceSessionEndpoint {
+  readonly url: string;
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
+export interface LiveVoicePushToTalkSessionOptions {
+  readonly resolveEndpoint: () => Promise<LiveVoiceSessionEndpoint>;
+  readonly createChannel: (
+    endpoint: LiveVoiceSessionEndpoint,
+  ) => LiveVoiceSessionChannel;
+  readonly capture: LiveVoicePcmCapture;
+  readonly playback: LiveVoicePcmPlayback;
+  readonly inputDevice?: string;
+  readonly conversationId?: string;
+  readonly captions?: LiveVoiceCaptionMode;
+  readonly now?: () => number;
+  readonly sleep?: (milliseconds: number, signal: AbortSignal) => Promise<void>;
+  readonly onState?: (state: LiveVoiceForegroundState) => void;
+  readonly onCaption?: (role: "user" | "assistant", text: string) => void;
+  readonly onCaptionMode?: (mode: LiveVoiceCaptionMode) => void;
+  readonly onTiming?: (metric: LiveVoiceTimingMetric) => void;
+  readonly onError?: (error: Error) => void;
+}
+
+type HandshakeResult =
+  | { readonly type: "ready"; readonly frame: LiveVoiceReadyServerFrame }
+  | { readonly type: "busy"; readonly frame: LiveVoiceBusyServerFrame };
+
+export class LiveVoicePushToTalkSession {
+  private readonly now: () => number;
+  private readonly sleep: (
+    milliseconds: number,
+    signal: AbortSignal,
+  ) => Promise<void>;
+  private readonly abortController = new AbortController();
+  private readonly closedPromise: Promise<void>;
+  private resolveClosed!: () => void;
+
+  private state: LiveVoiceForegroundState = "ended";
+  private captionMode: LiveVoiceCaptionMode;
+  private channel: LiveVoiceSessionChannel | null = null;
+  private captureSession: LiveVoicePcmCaptureSession | null = null;
+  private conversationId: string | undefined;
+  private previousSessionId: string | undefined;
+  private inputEndedAt: number | null = null;
+  private firstTtsRecorded = false;
+  private captureGeneration = 0;
+  private shuttingDown = false;
+  private shutdownPromise: Promise<void> | null = null;
+  private failure: Error | null = null;
+  private keyOperations: Promise<void> = Promise.resolve();
+  private frameOperations: Promise<void> = Promise.resolve();
+
+  constructor(private readonly options: LiveVoicePushToTalkSessionOptions) {
+    this.now = options.now ?? (() => performance.now());
+    this.sleep = options.sleep ?? abortableDelay;
+    this.captionMode = options.captions ?? "off";
+    this.conversationId = options.conversationId;
+    this.closedPromise = new Promise<void>((resolve) => {
+      this.resolveClosed = resolve;
+    });
+  }
+
+  get currentState(): LiveVoiceForegroundState {
+    return this.state;
+  }
+
+  get fatalError(): Error | null {
+    return this.failure;
+  }
+
+  async start(): Promise<void> {
+    if (this.shuttingDown || this.channel !== null) {
+      return;
+    }
+    try {
+      await this.openChannel();
+      this.setState("ready");
+    } catch (error) {
+      await this.fail(toError(error));
+      throw this.failure ?? new Error("Live voice failed to start.");
+    }
+  }
+
+  handleKey(key: "enter" | "interrupt" | "captions"): Promise<void> {
+    const operation = this.keyOperations.then(async () => {
+      if (this.shuttingDown) {
+        return;
+      }
+      if (key === "captions") {
+        this.cycleCaptions();
+        return;
+      }
+      if (key === "interrupt") {
+        await this.interruptReply();
+        return;
+      }
+      if (this.state === "ready") {
+        await this.beginCapture();
+      } else if (this.state === "listening") {
+        await this.releaseCapture();
+      }
+    });
+    this.keyOperations = operation.catch(async (error) => {
+      if (!this.shuttingDown) {
+        await this.fail(toError(error));
+      }
+    });
+    return this.keyOperations;
+  }
+
+  waitUntilClosed(): Promise<void> {
+    return this.closedPromise;
+  }
+
+  shutdown(): Promise<void> {
+    if (this.shutdownPromise !== null) {
+      return this.shutdownPromise;
+    }
+    this.shutdownPromise = this.shutdownOnce();
+    return this.shutdownPromise;
+  }
+
+  private async beginCapture(): Promise<void> {
+    const channel = this.channel;
+    if (channel === null) {
+      throw new Error("Live voice is not connected.");
+    }
+
+    const generation = ++this.captureGeneration;
+    this.setState("listening");
+    const captureSession = await this.options.capture.startCapture({
+      target: this.options.inputDevice,
+      onFrame: (frame) => {
+        if (
+          generation === this.captureGeneration &&
+          this.state === "listening" &&
+          this.channel === channel
+        ) {
+          channel.sendAudio(frame);
+        }
+      },
+    });
+    if (this.shuttingDown || generation !== this.captureGeneration) {
+      await captureSession.stop();
+      return;
+    }
+    this.captureSession = captureSession;
+    void captureSession.closed.catch((error) => {
+      if (!this.shuttingDown && this.captureSession === captureSession) {
+        void this.fail(toError(error));
+      }
+    });
+  }
+
+  private async releaseCapture(): Promise<void> {
+    const channel = this.channel;
+    const captureSession = this.captureSession;
+    if (channel === null || captureSession === null) {
+      return;
+    }
+
+    const tail = await captureSession.stop();
+    if (this.captureSession === captureSession) {
+      this.captureSession = null;
+    }
+    if (this.shuttingDown || this.channel !== channel) {
+      return;
+    }
+    if (tail !== null) {
+      channel.sendAudio(tail);
+    }
+    this.inputEndedAt = this.now();
+    this.firstTtsRecorded = false;
+    channel.pttRelease();
+    this.setState("transcribing");
+  }
+
+  private async interruptReply(): Promise<void> {
+    if (
+      this.channel === null ||
+      (this.state !== "thinking" && this.state !== "speaking")
+    ) {
+      return;
+    }
+    this.channel.interrupt();
+    await this.options.playback.flush();
+  }
+
+  private cycleCaptions(): void {
+    const index = LIVE_VOICE_CAPTION_MODES.indexOf(this.captionMode);
+    this.captionMode =
+      LIVE_VOICE_CAPTION_MODES[(index + 1) % LIVE_VOICE_CAPTION_MODES.length];
+    this.options.onCaptionMode?.(this.captionMode);
+  }
+
+  private async openChannel(): Promise<void> {
+    const retryStartedAt = this.now();
+    let retryIndex = 0;
+
+    while (!this.shuttingDown) {
+      const endpoint = await this.options.resolveEndpoint();
+      if (this.shuttingDown) {
+        throw new Error("Live voice stopped before connecting.");
+      }
+      const channel = this.options.createChannel(endpoint);
+      this.channel = channel;
+      const openedAt = this.now();
+      const result = await this.connectChannel(channel);
+
+      if (result.type === "ready") {
+        this.previousSessionId = result.frame.sessionId;
+        this.conversationId = result.frame.conversationId;
+        this.options.onTiming?.({
+          name: "socket_ready",
+          durationMs: nonNegativeDuration(this.now() - openedAt),
+        });
+        return;
+      }
+
+      this.channel = null;
+      const activeSessionId = result.frame.activeSessionId;
+      if (
+        this.previousSessionId === undefined ||
+        activeSessionId !== this.previousSessionId
+      ) {
+        throw new Error(
+          `Another live-voice session is active (${activeSessionId}). Try again after it ends.`,
+        );
+      }
+
+      const delay = LIVE_VOICE_BUSY_RETRY_DELAYS_MS[retryIndex];
+      const elapsed = this.now() - retryStartedAt;
+      if (
+        delay === undefined ||
+        elapsed + delay > LIVE_VOICE_BUSY_RETRY_BUDGET_MS
+      ) {
+        throw new Error(
+          "The previous live-voice session is still releasing. Try again in a moment.",
+        );
+      }
+      retryIndex += 1;
+      this.setState("busy");
+      await this.sleep(delay, this.abortController.signal);
+    }
+
+    throw new Error("Live voice stopped before connecting.");
+  }
+
+  private connectChannel(
+    channel: LiveVoiceSessionChannel,
+  ): Promise<HandshakeResult> {
+    return new Promise<HandshakeResult>((resolve, reject) => {
+      let settled = false;
+      const settle = (result: HandshakeResult): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve(result);
+      };
+      const rejectOnce = (error: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        reject(error);
+      };
+
+      channel.on("ready", (frame) => {
+        settle({ type: "ready", frame });
+      });
+      channel.on("busy", (frame) => {
+        settle({ type: "busy", frame });
+      });
+      channel.on("frame", (frame) => {
+        if (!settled || this.channel !== channel) {
+          return;
+        }
+        this.enqueueFrame(channel, frame);
+      });
+      channel.on("error", (event) => {
+        const error = new Error(event.message);
+        if (!settled) {
+          rejectOnce(error);
+        } else if (event.recoverable) {
+          this.options.onError?.(error);
+        } else if (this.channel === channel && !this.shuttingDown) {
+          void this.fail(error);
+        }
+      });
+      channel.on("closed", (event) => {
+        if (!settled) {
+          rejectOnce(
+            new Error(
+              event.reason || "The live-voice connection closed unexpectedly.",
+            ),
+          );
+        } else if (this.channel === channel && !this.shuttingDown) {
+          void this.fail(
+            new Error(
+              event.reason || "The live-voice connection closed unexpectedly.",
+            ),
+          );
+        }
+      });
+
+      channel.connect({
+        conversationId: this.conversationId,
+        turnDetection: "manual",
+      });
+    });
+  }
+
+  private enqueueFrame(
+    channel: LiveVoiceSessionChannel,
+    frame: LiveVoiceChannelClientEventMap["frame"],
+  ): void {
+    this.frameOperations = this.frameOperations
+      .then(async () => {
+        if (this.shuttingDown || this.channel !== channel) {
+          return;
+        }
+        await this.handleFrame(channel, frame);
+      })
+      .catch(async (error) => {
+        if (!this.shuttingDown) {
+          await this.fail(toError(error));
+        }
+      });
+  }
+
+  private async handleFrame(
+    channel: LiveVoiceSessionChannel,
+    frame: LiveVoiceChannelClientEventMap["frame"],
+  ): Promise<void> {
+    switch (frame.type) {
+      case "stt_partial":
+      case "stt_final":
+        this.setState("transcribing");
+        if (this.captionMode === "user" || this.captionMode === "both") {
+          this.options.onCaption?.("user", frame.text);
+        }
+        return;
+      case "thinking":
+        this.setState("thinking");
+        return;
+      case "assistant_text_delta":
+        if (this.captionMode === "assistant" || this.captionMode === "both") {
+          this.options.onCaption?.("assistant", frame.text);
+        }
+        return;
+      case "tts_audio":
+        if (!this.firstTtsRecorded && this.inputEndedAt !== null) {
+          this.firstTtsRecorded = true;
+          this.options.onTiming?.({
+            name: "input_end_to_first_tts",
+            durationMs: nonNegativeDuration(this.now() - this.inputEndedAt),
+          });
+        }
+        this.setState("speaking");
+        await this.options.playback.write({
+          audio: Buffer.from(frame.dataBase64, "base64"),
+          mimeType: frame.mimeType,
+          sampleRate: frame.sampleRate,
+        });
+        return;
+      case "tts_done":
+        await this.completeTurn(channel, true);
+        return;
+      case "utterance_discarded":
+      case "turn_cancelled":
+        await this.completeTurn(channel, false);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private async completeTurn(
+    channel: LiveVoiceSessionChannel,
+    drainPlayback: boolean,
+  ): Promise<void> {
+    if (drainPlayback) {
+      await this.options.playback.drain();
+    } else {
+      await this.options.playback.flush();
+    }
+    if (this.shuttingDown || this.channel !== channel) {
+      return;
+    }
+
+    this.channel = null;
+    channel.end();
+    this.inputEndedAt = null;
+    this.firstTtsRecorded = false;
+    await this.openChannel();
+    if (!this.shuttingDown) {
+      this.setState("ready");
+    }
+  }
+
+  private setState(state: LiveVoiceForegroundState): void {
+    if (this.state === state) {
+      return;
+    }
+    this.state = state;
+    this.options.onState?.(state);
+  }
+
+  private async fail(error: Error): Promise<void> {
+    if (this.failure === null) {
+      this.failure = error;
+      try {
+        this.setState("failed");
+        this.options.onError?.(error);
+      } catch {}
+    }
+    await this.shutdown();
+  }
+
+  private async shutdownOnce(): Promise<void> {
+    this.shuttingDown = true;
+    this.abortController.abort();
+    this.captureGeneration += 1;
+
+    const captureSession = this.captureSession;
+    this.captureSession = null;
+    if (captureSession !== null) {
+      await captureSession.stop().catch(() => null);
+    }
+
+    const channel = this.channel;
+    this.channel = null;
+    if (channel !== null) {
+      try {
+        channel.end();
+      } catch {
+        try {
+          channel.close();
+        } catch {}
+      }
+    }
+
+    await this.options.playback.flush().catch(() => {});
+    await this.options.playback.close().catch(() => {});
+    try {
+      if (this.failure === null) {
+        this.setState("ended");
+      }
+    } finally {
+      this.resolveClosed();
+    }
+  }
+}
+
+function nonNegativeDuration(value: number): number {
+  return Math.max(0, Math.round(value));
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function abortableDelay(
+  milliseconds: number,
+  signal: AbortSignal,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("Live voice stopped."));
+      return;
+    }
+    const handleAbort = (): void => {
+      clearTimeout(timer);
+      reject(new Error("Live voice stopped."));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", handleAbort);
+      resolve();
+    }, milliseconds);
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+}

--- a/cli/src/lib/live-voice/session.ts
+++ b/cli/src/lib/live-voice/session.ts
@@ -298,19 +298,24 @@ export class LiveVoicePushToTalkSession {
     channel: LiveVoiceSessionChannel,
   ): Promise<HandshakeResult> {
     return new Promise<HandshakeResult>((resolve, reject) => {
-      let settled = false;
+      let handshakeState: HandshakeResult["type"] | "pending" | "failed" =
+        "pending";
+      const isActiveReadyChannel = (): boolean =>
+        handshakeState === "ready" &&
+        this.channel === channel &&
+        !this.shuttingDown;
       const settle = (result: HandshakeResult): void => {
-        if (settled) {
+        if (handshakeState !== "pending") {
           return;
         }
-        settled = true;
+        handshakeState = result.type;
         resolve(result);
       };
       const rejectOnce = (error: Error): void => {
-        if (settled) {
+        if (handshakeState !== "pending") {
           return;
         }
-        settled = true;
+        handshakeState = "failed";
         reject(error);
       };
 
@@ -321,29 +326,29 @@ export class LiveVoicePushToTalkSession {
         settle({ type: "busy", frame });
       });
       channel.on("frame", (frame) => {
-        if (!settled || this.channel !== channel) {
+        if (!isActiveReadyChannel()) {
           return;
         }
         this.enqueueFrame(channel, frame);
       });
       channel.on("error", (event) => {
         const error = new Error(event.message);
-        if (!settled) {
+        if (handshakeState === "pending") {
           rejectOnce(error);
-        } else if (event.recoverable) {
+        } else if (handshakeState === "ready" && event.recoverable) {
           this.options.onError?.(error);
-        } else if (this.channel === channel && !this.shuttingDown) {
+        } else if (isActiveReadyChannel()) {
           void this.fail(error);
         }
       });
       channel.on("closed", (event) => {
-        if (!settled) {
+        if (handshakeState === "pending") {
           rejectOnce(
             new Error(
               event.reason || "The live-voice connection closed unexpectedly.",
             ),
           );
-        } else if (this.channel === channel && !this.shuttingDown) {
+        } else if (isActiveReadyChannel()) {
           void this.fail(
             new Error(
               event.reason || "The live-voice connection closed unexpectedly.",

--- a/docs/proposals/live-voice-channel.md
+++ b/docs/proposals/live-voice-channel.md
@@ -422,6 +422,7 @@ export type LiveVoiceServerFrame =
       totalMs?: number;
     }
   | { type: "archived"; conversationId: string; sessionId: string }
+  | { type: "session_released"; sessionId: string }
   | { type: "error"; code: string; message: string };
 ```
 

--- a/packages/service-contracts/src/__tests__/live-voice.test.ts
+++ b/packages/service-contracts/src/__tests__/live-voice.test.ts
@@ -164,8 +164,13 @@ describe("parseLiveVoiceServerFrame", () => {
       warning: { code: "archive_failed", message: "Archive unavailable" },
     },
     {
-      type: "error",
+      type: "session_released",
       seq: 16,
+      sessionId: "session-123",
+    },
+    {
+      type: "error",
+      seq: 17,
       code: "invalid_field",
       message: "Invalid field",
       recoverable: true,

--- a/packages/service-contracts/src/live-voice.ts
+++ b/packages/service-contracts/src/live-voice.ts
@@ -85,6 +85,7 @@ export const LIVE_VOICE_SERVER_FRAME_TYPES = [
   "minimize_room",
   "metrics",
   "archived",
+  "session_released",
   "error",
 ] as const;
 
@@ -219,6 +220,12 @@ export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {
   readonly warning?: LiveVoiceArchiveWarning;
 }
 
+/** Confirms that an ended session no longer owns the process-wide voice slot. */
+export interface LiveVoiceSessionReleasedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "session_released";
+  readonly sessionId: string;
+}
+
 export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "error";
   readonly code: string;
@@ -242,6 +249,7 @@ export type LiveVoiceServerFrame =
   | LiveVoiceMinimizeRoomServerFrame
   | LiveVoiceMetricsServerFrame
   | LiveVoiceArchivedServerFrame
+  | LiveVoiceSessionReleasedServerFrame
   | LiveVoiceErrorServerFrame;
 
 type WithoutSeq<T> = T extends LiveVoiceServerFrameBase


### PR DESCRIPTION
## Summary

- add `vellum voice [name-or-id]`, `vellum voice devices`, and `vellum voice doctor`
- run target and PipeWire diagnostics before terminal raw mode or long-lived capture
- provide repeated manual push-to-talk turns with conversation continuity, fresh managed tokens, playback drain, captions, interruption, and bounded same-session busy retries
- restore terminal and audio resources across normal exit, Ctrl+C, SIGTERM, SIGHUP, and input loss
- emit token-safe debug timings for socket readiness and input end to first TTS

## Validation

- `cd cli && bun test src/__tests__/live-voice-session.test.ts src/__tests__/voice.test.ts`
- `cd cli && bun run lint`
- `cd cli && bun run typecheck`
- `cd cli && bun run compile:check`
- `cd cli && bun src/index.ts voice --help`

## Hardware gate

This change adds the Pi timing instrumentation but was not exercised against physical Raspberry Pi audio hardware in this isolated implementation clone. The final plan gate must compare measured per-turn socket setup p95 with the spike baseline of 9 ms and validate a complete direct-local and Vellum-managed session before support is announced.
