### PR TITLE
feat(cli): add echo-cancelled open-mic voice

### DIFF
--- a/cli/src/__tests__/live-voice-pipewire-audio.test.ts
+++ b/cli/src/__tests__/live-voice-pipewire-audio.test.ts
@@ -10,9 +10,12 @@ import {
   pcm16Rms,
 } from "../lib/live-voice/audio.js";
 import {
+  LIVE_VOICE_ECHO_CANCEL_SINK,
+  LIVE_VOICE_ECHO_CANCEL_SOURCE,
   PipeWireAudio,
   buildPipeWirePcmArgs,
   parsePipeWireDevices,
+  parsePipeWireEchoCancelPair,
   parsePipeWireVersion,
 } from "../lib/live-voice/pipewire-audio.js";
 import type {
@@ -165,6 +168,58 @@ const PIPEWIRE_DUMP = JSON.stringify([
   },
 ]);
 
+function echoCancelDump(
+  options: {
+    sourceModuleId?: number;
+    sinkModuleId?: number | string;
+    moduleName?: string;
+    sourceName?: string;
+    sinkName?: string;
+    sourceMediaClass?: string;
+    sinkMediaClass?: string;
+  } = {},
+): string {
+  const sourceModuleId = options.sourceModuleId ?? 41;
+  const sinkModuleId = options.sinkModuleId ?? sourceModuleId;
+  return JSON.stringify([
+    {
+      id: 41,
+      type: "PipeWire:Interface:Module",
+      info: {
+        props: {
+          "module.name": options.moduleName ?? "libpipewire-module-echo-cancel",
+        },
+      },
+    },
+    {
+      id: 51,
+      type: "PipeWire:Interface:Node",
+      info: {
+        props: {
+          "object.serial": 2001,
+          "node.name": options.sourceName ?? LIVE_VOICE_ECHO_CANCEL_SOURCE,
+          "node.description": "Echo-cancel capture",
+          "media.class": options.sourceMediaClass ?? "Audio/Source",
+          "module.id": sourceModuleId,
+        },
+      },
+    },
+    {
+      id: 52,
+      type: "PipeWire:Interface:Node",
+      info: {
+        props: {
+          "object.serial": 2002,
+          "node.name": options.sinkName ?? LIVE_VOICE_ECHO_CANCEL_SINK,
+          "node.description": "Echo-cancel playback",
+          "media.class": options.sinkMediaClass ?? "Audio/Sink",
+          "module.id": sinkModuleId,
+        },
+      },
+    },
+  ]);
+}
+
 describe("PCM framing", () => {
   test("uses exact 50 ms PCM16 frames and preserves odd chunk boundaries", () => {
     expect(LIVE_VOICE_PCM_FRAME_BYTES).toBe(1_600);
@@ -205,6 +260,41 @@ describe("PCM framing", () => {
 });
 
 describe("PipeWire device discovery and capture", () => {
+  test("accepts only the exact pair owned by one echo-cancel module", () => {
+    expect(parsePipeWireEchoCancelPair(echoCancelDump())).toMatchObject({
+      input: { nodeName: LIVE_VOICE_ECHO_CANCEL_SOURCE },
+      output: { nodeName: LIVE_VOICE_ECHO_CANCEL_SINK },
+      moduleId: 41,
+    });
+    expect(
+      parsePipeWireEchoCancelPair(echoCancelDump({ sinkModuleId: "41" })),
+    ).toMatchObject({ moduleId: 41 });
+    expect(
+      parsePipeWireEchoCancelPair(echoCancelDump({ sinkModuleId: 42 })),
+    ).toBeNull();
+    expect(
+      parsePipeWireEchoCancelPair(
+        echoCancelDump({ moduleName: "libpipewire-module-loopback" }),
+      ),
+    ).toBeNull();
+    expect(
+      parsePipeWireEchoCancelPair(
+        echoCancelDump({ sourceMediaClass: "Audio/Source/Virtual" }),
+      ),
+    ).toBeNull();
+  });
+
+  test("does not accept descriptive echo or headset labels as AEC proof", () => {
+    expect(
+      parsePipeWireEchoCancelPair(
+        echoCancelDump({
+          sourceName: "echo-cancel-headset-source",
+          sinkName: "echo-cancel-headset-sink",
+        }),
+      ),
+    ).toBeNull();
+  });
+
   test("preserves stable node names, serials, classes, and module ownership", () => {
     const devices = parsePipeWireDevices(PIPEWIRE_DUMP);
     expect(devices).toEqual({
@@ -479,6 +569,83 @@ describe("PipeWire playback", () => {
 });
 
 describe("PipeWire doctor", () => {
+  test("routes open-mic probes through the verified exact pair", async () => {
+    const probeTargets: string[][] = [];
+    const runCommand: AudioCommandRunner = async (_executable, args) => {
+      if (args.includes("--version")) {
+        return { code: 0, stdout: "pw-record 1.4.2", stderr: "" };
+      }
+      if (args.includes("is-active")) {
+        return { code: 0, stdout: "active", stderr: "" };
+      }
+      if (args.includes("show-user")) {
+        return { code: 0, stdout: "Linger=yes", stderr: "" };
+      }
+      return { code: 0, stdout: echoCancelDump(), stderr: "" };
+    };
+    const audio = new PipeWireAudio({
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      runCommand,
+      probeProcess: async (_executable, args) => {
+        probeTargets.push([...args]);
+        return { ok: true };
+      },
+      platform: "linux",
+      architecture: "arm64",
+      username: "user1",
+    });
+
+    const report = await audio.doctor({ mode: "open-mic" });
+
+    expect(report.ok).toBe(true);
+    expect(report.echoCancelPair?.moduleId).toBe(41);
+    expect(probeTargets[0]).toContain(
+      `--target=${LIVE_VOICE_ECHO_CANCEL_SOURCE}`,
+    );
+    expect(probeTargets[1]).toContain(
+      `--target=${LIVE_VOICE_ECHO_CANCEL_SINK}`,
+    );
+  });
+
+  test("fails open-mic diagnostics for mismatched module ownership", async () => {
+    const runCommand: AudioCommandRunner = async (_executable, args) => {
+      if (args.includes("--version")) {
+        return { code: 0, stdout: "pw-record 1.4.2", stderr: "" };
+      }
+      if (args.includes("is-active")) {
+        return { code: 0, stdout: "active", stderr: "" };
+      }
+      if (args.includes("show-user")) {
+        return { code: 0, stdout: "Linger=yes", stderr: "" };
+      }
+      return {
+        code: 0,
+        stdout: echoCancelDump({ sinkModuleId: 42 }),
+        stderr: "",
+      };
+    };
+    const audio = new PipeWireAudio({
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      runCommand,
+      probeProcess: async () => ({ ok: true }),
+      platform: "linux",
+      architecture: "arm64",
+      username: "user1",
+    });
+
+    const report = await audio.doctor({ mode: "open-mic" });
+
+    expect(report.ok).toBe(false);
+    expect(
+      report.checks.find((check) => check.id === "aec.module"),
+    ).toMatchObject({
+      status: "fail",
+    });
+    expect(
+      report.checks.find((check) => check.id === "aec.module")?.message,
+    ).toContain("--mode push-to-talk");
+  });
+
   test("parses PipeWire versions", () => {
     expect(parsePipeWireVersion("Compiled with libpipewire 1.4.2")).toEqual({
       major: 1,

--- a/cli/src/__tests__/live-voice-session.test.ts
+++ b/cli/src/__tests__/live-voice-session.test.ts
@@ -13,8 +13,9 @@ import type {
 } from "../lib/live-voice/audio.js";
 import {
   LIVE_VOICE_BUSY_RETRY_DELAYS_MS,
-  LiveVoicePushToTalkSession,
+  LiveVoiceForegroundSession,
   type LiveVoiceForegroundState,
+  type LiveVoiceMode,
   type LiveVoiceSessionChannel,
   type LiveVoiceTimingMetric,
 } from "../lib/live-voice/session.js";
@@ -81,6 +82,7 @@ type ConnectBehavior =
       type: "ready";
       sessionId: string;
       conversationId: string;
+      turnDetection?: "manual" | "server_vad";
     }
   | { type: "busy"; activeSessionId: string };
 
@@ -131,7 +133,7 @@ class FakeChannel implements LiveVoiceSessionChannel {
           seq: 1,
           sessionId: this.behavior.sessionId,
           conversationId: this.behavior.conversationId,
-          turnDetection: "manual",
+          turnDetection: this.behavior.turnDetection ?? "manual",
         });
       } else {
         this.emit("busy", {
@@ -191,6 +193,8 @@ function makeHarness(
   options: {
     captions?: "off" | "user" | "assistant" | "both";
     conversationId?: string;
+    mode?: LiveVoiceMode;
+    sleep?: (milliseconds: number, signal: AbortSignal) => Promise<void>;
   } = {},
 ) {
   const capture = new FakeCapture();
@@ -202,9 +206,12 @@ function makeHarness(
   const timings: LiveVoiceTimingMetric[] = [];
   const errors: Error[] = [];
   const sleeps: number[] = [];
+  const microphoneStates: boolean[] = [];
+  const modeChanges: Array<{ mode: LiveVoiceMode; reason: string }> = [];
+  const echoSummaries: unknown[] = [];
   let now = 100;
 
-  const session = new LiveVoicePushToTalkSession({
+  const session = new LiveVoiceForegroundSession({
     resolveEndpoint: async () => ({
       url: "wss://voice.example.com/v1/live-voice?token=secret-value",
     }),
@@ -219,20 +226,26 @@ function makeHarness(
     },
     capture,
     playback,
+    ...(options.mode ? { mode: options.mode } : {}),
     ...(options.conversationId
       ? { conversationId: options.conversationId }
       : {}),
     ...(options.captions ? { captions: options.captions } : {}),
     now: () => now,
-    sleep: async (milliseconds) => {
-      sleeps.push(milliseconds);
-      now += milliseconds;
-    },
+    sleep:
+      options.sleep ??
+      (async (milliseconds) => {
+        sleeps.push(milliseconds);
+        now += milliseconds;
+      }),
     onState: (state) => states.push(state),
     onCaption: (role, text) => captions.push({ role, text }),
     onCaptionMode: (mode) => captionModes.push(mode),
     onTiming: (metric) => timings.push(metric),
     onError: (error) => errors.push(error),
+    onMicrophoneState: (muted) => microphoneStates.push(muted),
+    onModeChange: (mode, reason) => modeChanges.push({ mode, reason }),
+    onEchoSummary: (summary) => echoSummaries.push(summary),
   });
 
   return {
@@ -246,6 +259,9 @@ function makeHarness(
     timings,
     errors,
     sleeps,
+    microphoneStates,
+    modeChanges,
+    echoSummaries,
     advance(milliseconds: number) {
       now += milliseconds;
     },
@@ -265,7 +281,7 @@ async function waitFor(
   throw new Error(`Timed out waiting for ${message}.`);
 }
 
-describe("LiveVoicePushToTalkSession", () => {
+describe("LiveVoiceForegroundSession", () => {
   test("retains the conversation and opens a fresh manual session after playback drains", async () => {
     const harness = makeHarness(
       [
@@ -501,6 +517,320 @@ describe("LiveVoicePushToTalkSession", () => {
     await harness.session.handleKey("interrupt");
     expect(harness.channels[0].interruptCount).toBe(1);
     expect(harness.playback.flushCount).toBe(1);
+    await harness.session.shutdown();
+  });
+
+  test("keeps two server-VAD turns on one socket with continuous capture", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-open",
+          conversationId: "conversation-open",
+          turnDetection: "server_vad",
+        },
+      ],
+      { mode: "open-mic" },
+    );
+
+    await harness.session.start();
+    expect(harness.channels[0].connectOptions).toEqual([
+      { turnDetection: "server_vad" },
+    ]);
+    expect(harness.capture.sessions).toHaveLength(1);
+    expect(harness.session.currentState).toBe("listening");
+    expect(harness.microphoneStates).toEqual([false]);
+
+    for (let turn = 1; turn <= 2; turn += 1) {
+      harness.capture.emit(Buffer.from([turn, turn]));
+      harness.channels[0].emit("frame", {
+        type: "speech_started",
+        seq: turn * 10,
+      });
+      harness.channels[0].emit("frame", {
+        type: "utterance_end",
+        seq: turn * 10 + 1,
+        reason: "silence",
+      });
+      harness.channels[0].emit("frame", {
+        type: "thinking",
+        seq: turn * 10 + 2,
+        turnId: `turn-${turn}`,
+      });
+      harness.channels[0].emit("frame", {
+        type: "tts_audio",
+        seq: turn * 10 + 3,
+        mimeType: "audio/pcm",
+        sampleRate: 16_000,
+        dataBase64: Buffer.from([turn, turn]).toString("base64"),
+      });
+      harness.channels[0].emit("frame", {
+        type: "tts_done",
+        seq: turn * 10 + 4,
+        turnId: `turn-${turn}`,
+      });
+      await waitFor(
+        () => harness.playback.drainCount === turn,
+        `turn ${turn} playback drain`,
+      );
+    }
+
+    expect(harness.channels).toHaveLength(1);
+    expect(harness.channels[0].endCount).toBe(0);
+    expect(harness.capture.sessions).toHaveLength(1);
+    expect(harness.capture.sessions[0].stopCount).toBe(0);
+    expect(harness.session.currentState).toBe("listening");
+    await harness.session.shutdown();
+  });
+
+  test("mutes with equal-duration zeros while preserving capture during TTS", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-open",
+          conversationId: "conversation-open",
+          turnDetection: "server_vad",
+        },
+      ],
+      { mode: "open-mic" },
+    );
+    await harness.session.start();
+
+    await harness.session.handleKey("mute");
+    harness.capture.emit(Buffer.from([1, 2, 3, 4]));
+    expect(harness.channels[0].audio[0]).toEqual(Buffer.alloc(4));
+    expect(harness.capture.sessions[0].muted).toBe(true);
+    expect(harness.microphoneStates.at(-1)).toBe(true);
+
+    harness.channels[0].emit("frame", {
+      type: "thinking",
+      seq: 2,
+      turnId: "turn-1",
+    });
+    harness.channels[0].emit("frame", {
+      type: "tts_audio",
+      seq: 3,
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+      dataBase64: Buffer.from([5, 6]).toString("base64"),
+    });
+    await waitFor(() => harness.playback.chunks.length === 1);
+    await harness.session.handleKey("mute");
+    harness.capture.emit(Buffer.from([7, 8, 9, 10]));
+
+    expect(harness.channels[0].audio[1]).toEqual(Buffer.from([7, 8, 9, 10]));
+    expect(harness.capture.sessions[0].stopCount).toBe(0);
+    await harness.session.shutdown();
+  });
+
+  test("drops late TTS after cancellation and reports scalar echo evidence", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-open",
+          conversationId: "conversation-open",
+          turnDetection: "server_vad",
+        },
+      ],
+      { mode: "open-mic" },
+    );
+    await harness.session.start();
+    harness.capture.emit(Buffer.alloc(1_600));
+
+    harness.channels[0].emit("frame", {
+      type: "thinking",
+      seq: 2,
+      turnId: "turn-1",
+    });
+    const audiblePcm = Buffer.alloc(1_600);
+    for (let offset = 0; offset < audiblePcm.length; offset += 2) {
+      audiblePcm.writeInt16LE(8_000, offset);
+    }
+    harness.channels[0].emit("frame", {
+      type: "tts_audio",
+      seq: 3,
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+      dataBase64: audiblePcm.toString("base64"),
+    });
+    await waitFor(() => harness.playback.chunks.length === 1);
+    harness.capture.emit(Buffer.alloc(1_600));
+    harness.channels[0].emit("frame", {
+      type: "tts_done",
+      seq: 4,
+      turnId: "turn-1",
+    });
+    await waitFor(() => harness.echoSummaries.length === 1);
+
+    harness.channels[0].emit("frame", {
+      type: "turn_cancelled",
+      seq: 5,
+      turnId: "turn-1",
+    });
+    harness.channels[0].emit("frame", {
+      type: "tts_audio",
+      seq: 6,
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+      dataBase64: Buffer.from([9, 10]).toString("base64"),
+    });
+    await waitFor(() => harness.playback.flushCount >= 1);
+
+    expect(harness.playback.chunks).toHaveLength(1);
+    expect(harness.echoSummaries[0]).toMatchObject({ sampleCount: 1 });
+    await harness.session.shutdown();
+  });
+
+  test("reconnects bounded retryable closes with mode, mute, and conversation", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-1",
+          conversationId: "conversation-open",
+          turnDetection: "server_vad",
+        },
+        {
+          type: "ready",
+          sessionId: "session-2",
+          conversationId: "conversation-open",
+          turnDetection: "server_vad",
+        },
+      ],
+      { mode: "open-mic", captions: "both" },
+    );
+    await harness.session.start();
+    await harness.session.handleKey("mute");
+
+    harness.channels[0].emit("closed", {
+      code: 1012,
+      reason: "service restart",
+      retryable: true,
+    });
+    await waitFor(
+      () =>
+        harness.channels.length === 2 && harness.capture.sessions.length === 2,
+      "open-mic reconnect",
+    );
+
+    expect(harness.channels[1].connectOptions).toEqual([
+      {
+        conversationId: "conversation-open",
+        turnDetection: "server_vad",
+      },
+    ]);
+    expect(harness.capture.sessions[0].stopCount).toBe(1);
+    expect(harness.capture.sessions[1].muted).toBe(true);
+    expect(harness.playback.flushCount).toBeGreaterThanOrEqual(1);
+    expect(harness.session.currentMode).toBe("open-mic");
+    harness.channels[1].emit("frame", {
+      type: "stt_final",
+      seq: 2,
+      text: "reconnected user caption",
+    });
+    harness.channels[1].emit("frame", {
+      type: "assistant_text_delta",
+      seq: 3,
+      text: "reconnected assistant caption",
+    });
+    await waitFor(() => harness.captions.length === 2);
+    expect(harness.captions).toEqual([
+      { role: "user", text: "reconnected user caption" },
+      { role: "assistant", text: "reconnected assistant caption" },
+    ]);
+    await harness.session.shutdown();
+  });
+
+  test("bounds reconnect attempts and fails after the retry schedule", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-1",
+          conversationId: "conversation-open",
+          turnDetection: "server_vad",
+        },
+      ],
+      { mode: "open-mic" },
+    );
+    await harness.session.start();
+
+    harness.channels[0].emit("closed", {
+      code: 1013,
+      reason: "try again later",
+      retryable: true,
+    });
+    await harness.session.waitUntilClosed();
+
+    expect(harness.sleeps).toEqual([...LIVE_VOICE_BUSY_RETRY_DELAYS_MS]);
+    expect(harness.session.currentState).toBe("failed");
+    expect(harness.errors[0]?.message).toContain(
+      "No fake channel behavior remains",
+    );
+  });
+
+  test("tears down cleanly while a reconnect delay is pending", async () => {
+    let resolveSleepStarted: (() => void) | undefined;
+    const sleepStarted = new Promise<void>((resolve) => {
+      resolveSleepStarted = resolve;
+    });
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-1",
+          conversationId: "conversation-open",
+          turnDetection: "server_vad",
+        },
+      ],
+      {
+        mode: "open-mic",
+        sleep: async (_milliseconds, signal) =>
+          await new Promise<void>((resolve, reject) => {
+            resolveSleepStarted?.();
+            const handleAbort = (): void => {
+              reject(new Error("aborted"));
+            };
+            signal.addEventListener("abort", handleAbort, { once: true });
+          }),
+      },
+    );
+    await harness.session.start();
+    harness.channels[0].emit("closed", {
+      code: 1012,
+      reason: "service restart",
+      retryable: true,
+    });
+    await sleepStarted;
+
+    await harness.session.shutdown();
+
+    expect(harness.session.currentState).toBe("ended");
+    expect(harness.playback.closeCount).toBe(1);
+    expect(harness.errors).toEqual([]);
+  });
+
+  test("falls back to push-to-talk when ready does not confirm server VAD", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-old",
+          conversationId: "conversation-old",
+          turnDetection: "manual",
+        },
+      ],
+      { mode: "open-mic" },
+    );
+
+    await harness.session.start();
+
+    expect(harness.session.currentMode).toBe("push-to-talk");
+    expect(harness.capture.sessions).toHaveLength(0);
+    expect(harness.modeChanges[0]).toMatchObject({ mode: "push-to-talk" });
+    expect(harness.modeChanges[0]?.reason).toContain("Falling back");
     await harness.session.shutdown();
   });
 

--- a/cli/src/__tests__/voice.test.ts
+++ b/cli/src/__tests__/voice.test.ts
@@ -64,8 +64,11 @@ class FakeSignalHost extends EventEmitter {
 class FakeCaptureSession implements LiveVoicePcmCaptureSession {
   readonly closed = new Promise<void>(() => {});
   stopCount = 0;
+  muted = false;
 
-  setMuted(): void {}
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+  }
 
   async stop(): Promise<Buffer | null> {
     this.stopCount += 1;
@@ -91,6 +94,14 @@ const PASSING_AUDIO_REPORT: LiveVoiceAudioDoctorReport = {
         description: "Input",
         mediaClass: "Audio/Source",
       },
+      {
+        direction: "input",
+        nodeName: "vellum_echo_cancel_source",
+        objectSerial: "301",
+        description: "Vellum echo-cancel source",
+        mediaClass: "Audio/Source",
+        moduleId: 41,
+      },
     ],
     outputs: [
       {
@@ -100,7 +111,34 @@ const PASSING_AUDIO_REPORT: LiveVoiceAudioDoctorReport = {
         description: "Output",
         mediaClass: "Audio/Sink",
       },
+      {
+        direction: "output",
+        nodeName: "vellum_echo_cancel_sink",
+        objectSerial: "302",
+        description: "Vellum echo-cancel sink",
+        mediaClass: "Audio/Sink",
+        moduleId: 41,
+      },
     ],
+  },
+  echoCancelPair: {
+    input: {
+      direction: "input",
+      nodeName: "vellum_echo_cancel_source",
+      objectSerial: "301",
+      description: "Vellum echo-cancel source",
+      mediaClass: "Audio/Source",
+      moduleId: 41,
+    },
+    output: {
+      direction: "output",
+      nodeName: "vellum_echo_cancel_sink",
+      objectSerial: "302",
+      description: "Vellum echo-cancel sink",
+      mediaClass: "Audio/Sink",
+      moduleId: 41,
+    },
+    moduleId: 41,
   },
 };
 
@@ -109,6 +147,8 @@ class FakeAudio {
   readonly captureOptions: LiveVoicePcmCaptureOptions[] = [];
   readonly captureSessions: FakeCaptureSession[] = [];
   readonly playbackTargets: Array<string | undefined> = [];
+  readonly playbackChunks: LiveVoicePlaybackChunk[] = [];
+  readonly events: string[] = [];
   playbackDrainCount = 0;
   playbackFlushCount = 0;
   playbackCloseCount = 0;
@@ -120,6 +160,7 @@ class FakeAudio {
   async doctor(options?: {
     inputDevice?: string;
     outputDevice?: string;
+    mode?: "push-to-talk" | "open-mic";
   }): Promise<LiveVoiceAudioDoctorReport> {
     this.doctorOptions.push(options);
     return PASSING_AUDIO_REPORT;
@@ -129,6 +170,7 @@ class FakeAudio {
     options: LiveVoicePcmCaptureOptions,
   ): Promise<LiveVoicePcmCaptureSession> {
     const session = new FakeCaptureSession();
+    this.events.push("capture");
     this.captureOptions.push(options);
     this.captureSessions.push(session);
     return session;
@@ -137,7 +179,10 @@ class FakeAudio {
   createPlayback(target?: string) {
     this.playbackTargets.push(target);
     return {
-      write: async (_chunk: LiveVoicePlaybackChunk) => {},
+      write: async (chunk: LiveVoicePlaybackChunk) => {
+        this.events.push("playback");
+        this.playbackChunks.push(chunk);
+      },
       drain: async () => {
         this.playbackDrainCount += 1;
       },
@@ -176,6 +221,7 @@ class FakeChannel implements LiveVoiceSessionChannel {
     private readonly sessionId = "session-1",
     private readonly conversationId = "conversation-1",
     private readonly autoReleaseConfirmation = true,
+    private readonly turnDetection: "manual" | "server_vad" = "manual",
   ) {}
 
   on<EventName extends LiveVoiceChannelClientEventName>(
@@ -199,7 +245,7 @@ class FakeChannel implements LiveVoiceSessionChannel {
         seq: 1,
         sessionId: this.sessionId,
         conversationId: this.conversationId,
-        turnDetection: "manual",
+        turnDetection: this.turnDetection,
       });
     });
   }
@@ -297,6 +343,7 @@ describe("vellum voice", () => {
     expect(stdout.value).toContain("vellum voice devices [--json]");
     expect(stdout.value).toContain("--input-device <node>");
     expect(stdout.value).toContain("--captions <mode>");
+    expect(stdout.value).toContain("--mode <mode>");
     expect(stdout.value).toContain(
       `--url http://127.0.0.1:${GATEWAY_PORT} --assistant-id assistant-123`,
     );
@@ -508,6 +555,153 @@ describe("vellum voice", () => {
       ok: true,
       target: { status: "ready" },
     });
+  });
+
+  test("validates and routes persistent open mic through the exact AEC pair", async () => {
+    const stdin = new FakeInput();
+    const stdout = new FakeOutput();
+    const stderr = new FakeOutput();
+    const signalHost = new FakeSignalHost();
+    const audio = new FakeAudio();
+    const channel = new FakeChannel(
+      "session-open",
+      "conversation-open",
+      true,
+      "server_vad",
+    );
+
+    const running = voice({
+      args: ["assistant-123", "--mode", "open-mic"],
+      stdin,
+      stdout,
+      stderr,
+      signalHost,
+      audio,
+      debug: true,
+      resolveConnection: async () => directConnection("never-print-me"),
+      createChannel: () => channel,
+    });
+
+    await waitFor(
+      () => stdin.isRaw && audio.captureSessions.length === 1,
+      "open-mic capture",
+    );
+    expect(audio.doctorOptions).toEqual([
+      {
+        inputDevice: undefined,
+        outputDevice: undefined,
+        mode: "open-mic",
+      },
+    ]);
+    expect(channel.connectOptions).toEqual([{ turnDetection: "server_vad" }]);
+    expect(audio.captureOptions[0].target).toBe("vellum_echo_cancel_source");
+    expect(audio.playbackTargets).toEqual(["vellum_echo_cancel_sink"]);
+    expect(stdout.value).toContain("[MIC LIVE]");
+
+    stdin.emit("data", Buffer.from("m"));
+    await waitFor(() => audio.captureSessions[0].muted);
+    audio.captureOptions[0].onFrame(Buffer.from([1, 2, 3, 4]), 0.2);
+    expect(channel.audio[0]).toEqual(Buffer.alloc(4));
+    stdin.emit("data", Buffer.from("m"));
+    await waitFor(() => !audio.captureSessions[0].muted);
+
+    channel.emit("frame", {
+      type: "thinking",
+      seq: 2,
+      turnId: "turn-1",
+    });
+    channel.emit("frame", {
+      type: "tts_audio",
+      seq: 3,
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+      dataBase64: Buffer.from([5, 6]).toString("base64"),
+    });
+    await waitFor(() => audio.playbackChunks.length === 1);
+    audio.captureOptions[0].onFrame(Buffer.from([7, 8]), 0.1);
+    channel.emit("frame", {
+      type: "tts_done",
+      seq: 4,
+      turnId: "turn-1",
+    });
+    await waitFor(() => stderr.value.includes("[voice:echo]"));
+    expect(audio.events).toEqual(["capture", "playback"]);
+    expect(stderr.value).toContain("source=vellum_echo_cancel_source");
+    expect(stderr.value).toContain("sink=vellum_echo_cancel_sink");
+    expect(stderr.value).not.toContain("never-print-me");
+
+    stdin.emit("data", Buffer.from("q"));
+    await running;
+  });
+
+  test("rejects custom audio routes for open mic before resolving a target", async () => {
+    let resolutionCount = 0;
+    await expect(
+      voice({
+        args: [
+          "assistant-123",
+          "--mode",
+          "open-mic",
+          "--input-device",
+          "headset-with-echo-label",
+        ],
+        resolveConnection: async () => {
+          resolutionCount += 1;
+          return directConnection();
+        },
+      }),
+    ).rejects.toThrow("always uses the verified Vellum echo-cancel");
+    expect(resolutionCount).toBe(0);
+  });
+
+  test("falls back to push-to-talk when an older assistant does not confirm server VAD", async () => {
+    const stdin = new FakeInput();
+    const stdout = new FakeOutput();
+    const stderr = new FakeOutput();
+    const audio = new FakeAudio();
+
+    const running = voice({
+      args: ["assistant-123", "--mode", "open-mic"],
+      stdin,
+      stdout,
+      stderr,
+      audio,
+      resolveConnection: async () => directConnection(),
+      createChannel: () => new FakeChannel(),
+    });
+
+    await waitFor(() => stdin.isRaw);
+    expect(audio.captureSessions).toHaveLength(0);
+    expect(stderr.value).toContain("Falling back to push-to-talk");
+    expect(stdout.value).toContain("Enter: talk or release");
+
+    stdin.emit("data", Buffer.from("q"));
+    await running;
+  });
+
+  test("open-mic doctor requires server-VAD confirmation without opening capture", async () => {
+    const stdout = new FakeOutput(false);
+    const signalHost = new FakeSignalHost();
+    const audio = new FakeAudio();
+
+    await voice({
+      args: ["doctor", "assistant-123", "--mode", "open-mic", "--json"],
+      stdout,
+      signalHost,
+      audio,
+      resolveConnection: async () => directConnection(),
+      createChannel: () => new FakeChannel(),
+    });
+
+    expect(JSON.parse(stdout.value)).toMatchObject({
+      ok: false,
+      target: {
+        status: "fail",
+      },
+    });
+    expect(stdout.value).toContain("server voice activity detection");
+    expect(audio.captureSessions).toHaveLength(0);
+    expect(signalHost.exitCode).toBe(1);
   });
 
   test("uses stored Vellum login routing and refreshes the managed endpoint for each turn", async () => {

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -10,17 +10,23 @@ import {
   resolveLiveVoiceConnection,
   type LiveVoiceResolvedConnection,
 } from "../lib/live-voice/connection.js";
-import { PipeWireAudio } from "../lib/live-voice/pipewire-audio.js";
+import {
+  LIVE_VOICE_ECHO_CANCEL_SINK,
+  LIVE_VOICE_ECHO_CANCEL_SOURCE,
+  PipeWireAudio,
+} from "../lib/live-voice/pipewire-audio.js";
 import {
   LIVE_VOICE_CAPTION_MODES,
-  LiveVoicePushToTalkSession,
+  LiveVoiceForegroundSession,
   type LiveVoiceCaptionMode,
   type LiveVoiceForegroundState,
+  type LiveVoiceMode,
   type LiveVoiceSessionChannel,
   type LiveVoiceSessionEndpoint,
   type LiveVoiceTimingMetric,
 } from "../lib/live-voice/session.js";
 import type {
+  EchoMeasurementSummary,
   LiveVoiceAudioDeviceDiscovery,
   LiveVoiceAudioDevices,
   LiveVoiceAudioDiagnostics,
@@ -34,6 +40,7 @@ const VALUE_FLAGS = [
   "--output-device",
   "--conversation",
   "--captions",
+  "--mode",
   "--url",
   "-u",
   "--assistant-id",
@@ -54,6 +61,7 @@ interface ParsedVoiceArgs {
   outputDevice?: string;
   conversationId?: string;
   captions: LiveVoiceCaptionMode;
+  mode: LiveVoiceMode;
   url?: string;
   assistantId?: string;
   guardianToken?: string;
@@ -164,7 +172,7 @@ export async function voice(
   const stdin = dependencyOverrides.stdin ?? (process.stdin as ReadStream);
   if (!stdin.isTTY || !stdout.isTTY) {
     throw new Error(
-      "Live voice requires an interactive terminal for push-to-talk controls.",
+      "Live voice requires an interactive terminal for foreground controls.",
     );
   }
 
@@ -172,6 +180,7 @@ export async function voice(
   const audioReport = await audio.doctor({
     inputDevice: args.inputDevice,
     outputDevice: args.outputDevice,
+    ...(args.mode === "open-mic" ? { mode: args.mode } : {}),
   });
   if (!audioReport.ok) {
     throw new Error(formatAudioDoctorFailure(audioReport));
@@ -182,19 +191,43 @@ export async function voice(
     connectionOptions,
     resolveConnection,
   );
-  const playback = audio.createPlayback(args.outputDevice);
+  const inputDevice =
+    args.mode === "open-mic"
+      ? audioReport.echoCancelPair?.input.nodeName
+      : args.inputDevice;
+  const outputDevice =
+    args.mode === "open-mic"
+      ? audioReport.echoCancelPair?.output.nodeName
+      : args.outputDevice;
+  if (
+    args.mode === "open-mic" &&
+    (inputDevice !== LIVE_VOICE_ECHO_CANCEL_SOURCE ||
+      outputDevice !== LIVE_VOICE_ECHO_CANCEL_SINK)
+  ) {
+    throw new Error(
+      "Open mic requires the verified Vellum PipeWire echo-cancel pair. Run 'vellum voice doctor --mode open-mic' and use --mode push-to-talk until it passes.",
+    );
+  }
+  const playback = audio.createPlayback(outputDevice);
   const writeLine = (value: string): void => {
     stdout.write(`${value}\n`);
   };
   const writeError = (value: string): void => {
     stderr.write(`${value}\n`);
   };
+  let microphoneIndicator =
+    args.mode === "open-mic" ? formatMicrophoneIndicator(false) : null;
+  const writeSessionLine = (value: string): void => {
+    writeLine(
+      microphoneIndicator === null ? value : `${microphoneIndicator} ${value}`,
+    );
+  };
   const debug =
     dependencyOverrides.debug ??
     ["1", "true", "yes", "on"].includes(
       (process.env.VELLUM_DEBUG ?? "").toLowerCase(),
     );
-  const session = new LiveVoicePushToTalkSession({
+  const session = new LiveVoiceForegroundSession({
     resolveEndpoint: endpointResolver,
     createChannel: (endpoint) =>
       createChannel({
@@ -203,21 +236,37 @@ export async function voice(
       }),
     capture: audio,
     playback,
-    ...(args.inputDevice ? { inputDevice: args.inputDevice } : {}),
+    mode: args.mode,
+    ...(inputDevice ? { inputDevice } : {}),
     ...(args.conversationId ? { conversationId: args.conversationId } : {}),
     captions: args.captions,
     onState: (state) => {
-      writeLine(formatVoiceState(state));
+      writeSessionLine(formatVoiceState(state));
     },
     onCaptionMode: (mode) => {
-      writeLine(`captions: ${mode}`);
+      writeSessionLine(`captions: ${mode}`);
     },
     onCaption: (role, text) => {
-      writeLine(`${role}: ${text}`);
+      writeSessionLine(`${role}: ${text}`);
     },
     onTiming: (metric) => {
       if (debug) {
         writeError(formatTimingMetric(metric));
+      }
+    },
+    onModeChange: (mode, reason) => {
+      if (mode === "push-to-talk") {
+        microphoneIndicator = null;
+      }
+      writeError(`voice mode: ${reason}`);
+    },
+    onMicrophoneState: (muted) => {
+      microphoneIndicator = formatMicrophoneIndicator(muted);
+      writeLine(microphoneIndicator);
+    },
+    onEchoSummary: (summary) => {
+      if (debug) {
+        writeError(formatEchoSummary(summary));
       }
     },
     onError: (error) => {
@@ -227,7 +276,20 @@ export async function voice(
 
   try {
     await session.start();
-    writeLine("Enter: talk or release | s: interrupt | c: captions | q: quit");
+    if (
+      debug &&
+      session.currentMode === "open-mic" &&
+      audioReport.echoCancelPair
+    ) {
+      writeError(
+        `[voice:aec] source=${audioReport.echoCancelPair.input.nodeName} sourceSerial=${audioReport.echoCancelPair.input.objectSerial} sink=${audioReport.echoCancelPair.output.nodeName} sinkSerial=${audioReport.echoCancelPair.output.objectSerial} module=${audioReport.echoCancelPair.moduleId}`,
+      );
+    }
+    writeSessionLine(
+      session.currentMode === "open-mic"
+        ? "m: mute | s: interrupt | c: captions | q: quit"
+        : "Enter: talk or release | s: interrupt | c: captions | q: quit",
+    );
     await runRawTerminal({
       session,
       stdin,
@@ -251,6 +313,7 @@ function parseVoiceArgs(rawArgs: readonly string[]): ParsedVoiceArgs {
   const parsed: ParsedVoiceArgs = {
     subcommand,
     captions: "off",
+    mode: "push-to-talk",
     json: false,
     help: false,
   };
@@ -301,7 +364,8 @@ function parseVoiceArgs(rawArgs: readonly string[]): ParsedVoiceArgs {
       parsed.url ||
       parsed.assistantId ||
       parsed.guardianToken ||
-      parsed.captions !== "off")
+      parsed.captions !== "off" ||
+      parsed.mode !== "push-to-talk")
   ) {
     throw new Error("voice devices accepts only --json and --help.");
   }
@@ -311,6 +375,14 @@ function parseVoiceArgs(rawArgs: readonly string[]): ParsedVoiceArgs {
   ) {
     throw new Error(
       "voice doctor does not accept --conversation or --captions.",
+    );
+  }
+  if (
+    parsed.mode === "open-mic" &&
+    (parsed.inputDevice !== undefined || parsed.outputDevice !== undefined)
+  ) {
+    throw new Error(
+      "Open mic always uses the verified Vellum echo-cancel source and sink. Remove --input-device and --output-device.",
     );
   }
   return parsed;
@@ -334,6 +406,13 @@ function assignValueFlag(
       );
     }
     parsed.captions = value as LiveVoiceCaptionMode;
+  } else if (flag === "--mode") {
+    if (value !== "push-to-talk" && value !== "open-mic") {
+      throw new Error(
+        `Invalid voice mode '${value}'. Expected push-to-talk or open-mic.`,
+      );
+    }
+    parsed.mode = value;
   } else if (flag === "--url" || flag === "-u") {
     parsed.url = value;
   } else if (flag === "--assistant-id" || flag === "-a") {
@@ -405,8 +484,9 @@ async function runDoctor(input: {
     input.audio.doctor({
       inputDevice: input.args.inputDevice,
       outputDevice: input.args.outputDevice,
+      ...(input.args.mode === "open-mic" ? { mode: input.args.mode } : {}),
     }),
-    probeReadiness(connection.webSocket, input.createChannel),
+    probeReadiness(connection.webSocket, input.createChannel, input.args.mode),
   ]);
   const target: VoiceTargetReport = {
     ...readiness,
@@ -432,6 +512,7 @@ async function probeReadiness(
   createChannel: (
     options: LiveVoiceChannelClientOptions,
   ) => VoiceCommandChannel,
+  mode: LiveVoiceMode,
 ): Promise<VoiceTargetReport> {
   const channel = createChannel({
     url: endpoint.url,
@@ -440,6 +521,7 @@ async function probeReadiness(
   return new Promise<VoiceTargetReport>((resolve) => {
     let settled = false;
     let readySessionId: string | null = null;
+    let readyResult: VoiceTargetReport = { status: "ready" };
     let releaseTimer: ReturnType<typeof setTimeout> | null = null;
     const finish = (result: VoiceTargetReport): void => {
       if (settled) {
@@ -453,6 +535,13 @@ async function probeReadiness(
       resolve(result);
     };
     channel.on("ready", (frame) => {
+      if (mode === "open-mic" && frame.turnDetection !== "server_vad") {
+        readyResult = {
+          status: "fail",
+          message:
+            "The assistant did not confirm server voice activity detection. Use --mode push-to-talk or update the assistant.",
+        };
+      }
       readySessionId = frame.sessionId;
       channel.requestEnd();
       releaseTimer = setTimeout(() => {
@@ -478,7 +567,7 @@ async function probeReadiness(
         frame.type === "session_released" &&
         frame.sessionId === readySessionId
       ) {
-        finish({ status: "ready" });
+        finish(readyResult);
         channel.close();
       }
     });
@@ -488,7 +577,9 @@ async function probeReadiness(
         message: event.reason || "The readiness connection closed.",
       });
     });
-    channel.connect({ turnDetection: "manual" });
+    channel.connect({
+      turnDetection: mode === "open-mic" ? "server_vad" : "manual",
+    });
   });
 }
 
@@ -544,7 +635,7 @@ function createEndpointResolver(
 }
 
 async function runRawTerminal(input: {
-  session: LiveVoicePushToTalkSession;
+  session: LiveVoiceForegroundSession;
   stdin: VoiceInput;
   signalHost: VoiceSignalHost;
 }): Promise<void> {
@@ -570,6 +661,8 @@ async function runRawTerminal(input: {
         const key = String.fromCharCode(byte).toLowerCase();
         if (key === "s") {
           void input.session.handleKey("interrupt");
+        } else if (key === "m") {
+          void input.session.handleKey("mute");
         } else if (key === "c") {
           void input.session.handleKey("captions");
         } else if (key === "q") {
@@ -627,7 +720,7 @@ function printVoiceHelp(stdout: VoiceOutput): void {
   stdout.write("       vellum voice doctor [<name-or-id>] [options]\n");
   stdout.write("\n");
   stdout.write(
-    "Talk to a local or Vellum-managed assistant with foreground push-to-talk.\n",
+    "Talk to a local or Vellum-managed assistant with foreground voice controls.\n",
   );
   stdout.write("\n");
   stdout.write("Arguments:\n");
@@ -649,6 +742,9 @@ function printVoiceHelp(stdout: VoiceOutput): void {
     "  --captions <mode>            off, user, assistant, or both. Default: off.\n",
   );
   stdout.write(
+    "  --mode <mode>                push-to-talk or open-mic. Default: push-to-talk.\n",
+  );
+  stdout.write(
     "  -u, --url <url>              Direct gateway URL. Requires an assistant ID.\n",
   );
   stdout.write(
@@ -666,11 +762,12 @@ function printVoiceHelp(stdout: VoiceOutput): void {
     "Vellum-managed assistants use the stored login from 'vellum login'.\n",
   );
   stdout.write(
-    "During a session, Enter starts or releases capture, s interrupts, c cycles captions, and q exits.\n",
+    "Push-to-talk uses Enter to start or release capture. Open mic uses m to mute. Both modes use s to interrupt, c to cycle captions, and q to exit.\n",
   );
   stdout.write("\n");
   stdout.write("Examples:\n");
   stdout.write("  vellum voice assistant-123\n");
+  stdout.write("  vellum voice doctor assistant-123 --mode open-mic\n");
   stdout.write(
     `  vellum voice --url http://127.0.0.1:${GATEWAY_PORT} --assistant-id assistant-123\n`,
   );
@@ -702,6 +799,16 @@ function formatVoiceState(state: LiveVoiceForegroundState): string {
 
 function formatTimingMetric(metric: LiveVoiceTimingMetric): string {
   return `[voice:timing] ${metric.name}=${metric.durationMs}ms`;
+}
+
+function formatMicrophoneIndicator(muted: boolean): string {
+  return muted ? "[MUTED]" : "[MIC LIVE]";
+}
+
+function formatEchoSummary(summary: EchoMeasurementSummary): string {
+  const format = (value: number | null): string =>
+    value === null ? "n/a" : value.toFixed(4);
+  return `[voice:echo] samples=${summary.sampleCount} floor=${format(summary.microphoneFloor)} mean=${format(summary.meanMicrophoneDuringPlayback)} peak=${format(summary.peakMicrophoneDuringPlayback)} dbAboveFloor=${format(summary.decibelsAboveFloor)} correlation=${format(summary.playbackMicrophoneCorrelation)}`;
 }
 
 function safeErrorMessage(error: unknown): string {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -138,7 +138,7 @@ function printHelp(): void {
   );
   console.log("  upgrade  Upgrade an assistant to a newer version");
   console.log("  use      Set the active assistant for commands");
-  console.log("  voice    Talk to an assistant with foreground push-to-talk");
+  console.log("  voice    Talk to an assistant with foreground voice controls");
   console.log("  wake     Start the assistant and gateway");
   console.log("  whoami   Show current logged-in user");
   console.log("  workflows Inspect and control workflow runs");

--- a/cli/src/lib/live-voice/audio.ts
+++ b/cli/src/lib/live-voice/audio.ts
@@ -11,6 +11,7 @@ export const LIVE_VOICE_PCM_FRAME_BYTES =
 export const LIVE_VOICE_PCM_MIME_TYPE = "audio/pcm";
 
 export type LiveVoiceAudioDirection = "input" | "output";
+export type LiveVoiceMode = "push-to-talk" | "open-mic";
 
 export interface LiveVoiceAudioDevice {
   direction: LiveVoiceAudioDirection;
@@ -43,12 +44,20 @@ export interface LiveVoiceAudioDoctorOptions {
   inputDevice?: string;
   outputDevice?: string;
   probeDurationMs?: number;
+  mode?: LiveVoiceMode;
+}
+
+export interface LiveVoiceEchoCancelPair {
+  input: LiveVoiceAudioDevice;
+  output: LiveVoiceAudioDevice;
+  moduleId: number;
 }
 
 export interface LiveVoiceAudioDoctorReport {
   ok: boolean;
   checks: LiveVoiceAudioDoctorCheck[];
   devices: LiveVoiceAudioDevices;
+  echoCancelPair?: LiveVoiceEchoCancelPair;
 }
 
 export interface LiveVoiceAudioDiagnostics {

--- a/cli/src/lib/live-voice/pipewire-audio.ts
+++ b/cli/src/lib/live-voice/pipewire-audio.ts
@@ -24,6 +24,7 @@ import type {
   LiveVoiceAudioDoctorCheck,
   LiveVoiceAudioDoctorOptions,
   LiveVoiceAudioDoctorReport,
+  LiveVoiceEchoCancelPair,
   LiveVoicePcmCaptureOptions,
   LiveVoicePcmCaptureSession,
   LiveVoicePcmPlayback,
@@ -39,6 +40,9 @@ const REQUIRED_EXECUTABLES = [
 ] as const;
 const MINIMUM_PIPEWIRE_VERSION = "1.4.0";
 const AUDIO_COMMAND_TIMEOUT_MS = 5_000;
+export const LIVE_VOICE_ECHO_CANCEL_SOURCE = "vellum_echo_cancel_source";
+export const LIVE_VOICE_ECHO_CANCEL_SINK = "vellum_echo_cancel_sink";
+const PIPEWIRE_ECHO_CANCEL_MODULE = "libpipewire-module-echo-cancel";
 
 export type AudioProcessFactory = (
   executable: string,
@@ -106,6 +110,12 @@ interface PipeWireDumpObject {
   info?: {
     props?: Record<string, unknown>;
   };
+}
+
+interface PipeWireDumpTopology {
+  devices: LiveVoiceAudioDevices;
+  echoCancelPair?: LiveVoiceEchoCancelPair;
+  echoCancelFailure?: string;
 }
 
 export class PipeWireAudio {
@@ -305,6 +315,8 @@ export class PipeWireAudio {
     }
 
     let devices: LiveVoiceAudioDevices = { inputs: [], outputs: [] };
+    let echoCancelPair: LiveVoiceEchoCancelPair | undefined;
+    let echoCancelFailure: string | undefined;
     const pwDump = executables.get("pw-dump");
     if (!pipewireSessionActive || pwDump === undefined) {
       addCheck(
@@ -325,7 +337,10 @@ export class PipeWireAudio {
         if (result.code !== 0) {
           throw new Error(result.stderr.trim() || "pw-dump failed");
         }
-        devices = parsePipeWireDevices(result.stdout);
+        const topology = parsePipeWireTopology(result.stdout);
+        devices = topology.devices;
+        echoCancelPair = topology.echoCancelPair;
+        echoCancelFailure = topology.echoCancelFailure;
         addCheck(
           "devices.input",
           devices.inputs.length > 0 ? "pass" : "fail",
@@ -355,8 +370,46 @@ export class PipeWireAudio {
       }
     }
 
-    const input = resolveExplicitDevice(devices.inputs, options.inputDevice);
-    const output = resolveExplicitDevice(devices.outputs, options.outputDevice);
+    if (options.mode === "open-mic") {
+      const source = devices.inputs.find(
+        (device) => device.nodeName === LIVE_VOICE_ECHO_CANCEL_SOURCE,
+      );
+      const sink = devices.outputs.find(
+        (device) => device.nodeName === LIVE_VOICE_ECHO_CANCEL_SINK,
+      );
+      addCheck(
+        "aec.source",
+        source?.mediaClass === "Audio/Source" ? "pass" : "fail",
+        source?.mediaClass === "Audio/Source"
+          ? `Found echo-cancel source ${LIVE_VOICE_ECHO_CANCEL_SOURCE}.`
+          : `Open mic requires an Audio/Source node named ${LIVE_VOICE_ECHO_CANCEL_SOURCE}.`,
+      );
+      addCheck(
+        "aec.sink",
+        sink?.mediaClass === "Audio/Sink" ? "pass" : "fail",
+        sink?.mediaClass === "Audio/Sink"
+          ? `Found echo-cancel sink ${LIVE_VOICE_ECHO_CANCEL_SINK}.`
+          : `Open mic requires an Audio/Sink node named ${LIVE_VOICE_ECHO_CANCEL_SINK}.`,
+      );
+      addCheck(
+        "aec.module",
+        echoCancelPair === undefined ? "fail" : "pass",
+        echoCancelPair === undefined
+          ? `${echoCancelFailure ?? "The required nodes do not share a verified echo-cancel module."} Configure one ${PIPEWIRE_ECHO_CANCEL_MODULE} instance with capture node ${LIVE_VOICE_ECHO_CANCEL_SOURCE} and playback node ${LIVE_VOICE_ECHO_CANCEL_SINK}. Use --mode push-to-talk until this check passes.`
+          : `The echo-cancel nodes share ${PIPEWIRE_ECHO_CANCEL_MODULE} module ${echoCancelPair.moduleId}.`,
+      );
+    }
+
+    const selectedInput =
+      options.mode === "open-mic"
+        ? LIVE_VOICE_ECHO_CANCEL_SOURCE
+        : options.inputDevice;
+    const selectedOutput =
+      options.mode === "open-mic"
+        ? LIVE_VOICE_ECHO_CANCEL_SINK
+        : options.outputDevice;
+    const input = resolveExplicitDevice(devices.inputs, selectedInput);
+    const output = resolveExplicitDevice(devices.outputs, selectedOutput);
     addExplicitDeviceCheck(checks, "input", options.inputDevice, input);
     addExplicitDeviceCheck(checks, "output", options.outputDevice, output);
 
@@ -366,7 +419,7 @@ export class PipeWireAudio {
       id: "probe.input",
       executable: pwRecord,
       deviceAvailable:
-        options.inputDevice === undefined
+        selectedInput === undefined
           ? devices.inputs.length > 0
           : input !== null,
       args: buildPipeWirePcmArgs(input?.nodeName),
@@ -380,7 +433,7 @@ export class PipeWireAudio {
       id: "probe.output",
       executable: executables.get("pw-play"),
       deviceAvailable:
-        options.outputDevice === undefined
+        selectedOutput === undefined
           ? devices.outputs.length > 0
           : output !== null,
       args: buildPipeWirePcmArgs(output?.nodeName),
@@ -399,6 +452,7 @@ export class PipeWireAudio {
       ),
       checks,
       devices,
+      ...(echoCancelPair ? { echoCancelPair } : {}),
     };
   }
 
@@ -470,6 +524,16 @@ export class PipeWireAudio {
 }
 
 export function parsePipeWireDevices(json: string): LiveVoiceAudioDevices {
+  return parsePipeWireTopology(json).devices;
+}
+
+export function parsePipeWireEchoCancelPair(
+  json: string,
+): LiveVoiceEchoCancelPair | null {
+  return parsePipeWireTopology(json).echoCancelPair ?? null;
+}
+
+function parsePipeWireTopology(json: string): PipeWireDumpTopology {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);
@@ -482,16 +546,27 @@ export function parsePipeWireDevices(json: string): LiveVoiceAudioDevices {
 
   const inputs: LiveVoiceAudioDevice[] = [];
   const outputs: LiveVoiceAudioDevice[] = [];
+  const echoCancelModuleIds = new Set<number>();
   for (const value of parsed as PipeWireDumpObject[]) {
-    if (
-      value === null ||
-      typeof value !== "object" ||
-      value.type !== "PipeWire:Interface:Node"
-    ) {
+    if (value === null || typeof value !== "object") {
       continue;
     }
     const properties = value.info?.props;
     if (properties === undefined) {
+      continue;
+    }
+    if (value.type === "PipeWire:Interface:Module") {
+      if (
+        typeof value.id === "number" &&
+        Number.isInteger(value.id) &&
+        readStringProperty(properties, "module.name") ===
+          PIPEWIRE_ECHO_CANCEL_MODULE
+      ) {
+        echoCancelModuleIds.add(value.id);
+      }
+      continue;
+    }
+    if (value.type !== "PipeWire:Interface:Node") {
       continue;
     }
     const nodeName = readStringProperty(properties, "node.name");
@@ -533,7 +608,52 @@ export function parsePipeWireDevices(json: string): LiveVoiceAudioDevices {
     }
   }
 
-  return { inputs, outputs };
+  const devices = { inputs, outputs };
+  const input = inputs.find(
+    (device) => device.nodeName === LIVE_VOICE_ECHO_CANCEL_SOURCE,
+  );
+  const output = outputs.find(
+    (device) => device.nodeName === LIVE_VOICE_ECHO_CANCEL_SINK,
+  );
+  if (input === undefined || output === undefined) {
+    return {
+      devices,
+      echoCancelFailure:
+        "The exact Vellum echo-cancel node pair was not found.",
+    };
+  }
+  if (
+    input.mediaClass !== "Audio/Source" ||
+    output.mediaClass !== "Audio/Sink"
+  ) {
+    return {
+      devices,
+      echoCancelFailure:
+        "The exact Vellum echo-cancel nodes have invalid media classes.",
+    };
+  }
+  if (input.moduleId === undefined || input.moduleId !== output.moduleId) {
+    return {
+      devices,
+      echoCancelFailure:
+        "The exact Vellum echo-cancel nodes are not owned by the same module instance.",
+    };
+  }
+  if (!echoCancelModuleIds.has(input.moduleId)) {
+    return {
+      devices,
+      echoCancelFailure:
+        "The exact Vellum echo-cancel nodes are not owned by libpipewire-module-echo-cancel.",
+    };
+  }
+  return {
+    devices,
+    echoCancelPair: {
+      input,
+      output,
+      moduleId: input.moduleId,
+    },
+  };
 }
 
 export function parsePipeWireVersion(output: string): PipeWireVersion | null {
@@ -854,7 +974,14 @@ function readIntegerProperty(
   key: string,
 ): number | null {
   const value = properties[key];
-  return typeof value === "number" && Number.isInteger(value) ? value : null;
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
+  return null;
 }
 
 function formatPipeWireVersion(version: PipeWireVersion): string {

--- a/cli/src/lib/live-voice/session.ts
+++ b/cli/src/lib/live-voice/session.ts
@@ -4,9 +4,16 @@ import type {
 } from "@vellumai/service-contracts/live-voice";
 
 import type {
+  EchoMeasurementSummary,
+  LiveVoiceMode,
   LiveVoicePcmCapture,
   LiveVoicePcmCaptureSession,
   LiveVoicePcmPlayback,
+} from "./audio.js";
+import {
+  EchoMeasurement,
+  LIVE_VOICE_PCM_FRAME_BYTES,
+  pcm16Rms,
 } from "./audio.js";
 import type {
   LiveVoiceChannelClientEventMap,
@@ -15,8 +22,10 @@ import type {
 
 export const LIVE_VOICE_BUSY_RETRY_DELAYS_MS = [100, 250, 500, 1_000] as const;
 const LIVE_VOICE_BUSY_RETRY_BUDGET_MS = 2_000;
+const MAX_ECHO_AMPLITUDE_SAMPLES = 1_200;
 
 export type LiveVoiceCaptionMode = "off" | "user" | "assistant" | "both";
+export type { LiveVoiceMode } from "./audio.js";
 
 export const LIVE_VOICE_CAPTION_MODES = [
   "off",
@@ -50,13 +59,14 @@ export interface LiveVoiceSessionEndpoint {
   readonly headers?: Readonly<Record<string, string>>;
 }
 
-export interface LiveVoicePushToTalkSessionOptions {
+export interface LiveVoiceForegroundSessionOptions {
   readonly resolveEndpoint: () => Promise<LiveVoiceSessionEndpoint>;
   readonly createChannel: (
     endpoint: LiveVoiceSessionEndpoint,
   ) => LiveVoiceSessionChannel;
   readonly capture: LiveVoicePcmCapture;
   readonly playback: LiveVoicePcmPlayback;
+  readonly mode?: LiveVoiceMode;
   readonly inputDevice?: string;
   readonly conversationId?: string;
   readonly captions?: LiveVoiceCaptionMode;
@@ -65,6 +75,9 @@ export interface LiveVoicePushToTalkSessionOptions {
   readonly onState?: (state: LiveVoiceForegroundState) => void;
   readonly onCaption?: (role: "user" | "assistant", text: string) => void;
   readonly onCaptionMode?: (mode: LiveVoiceCaptionMode) => void;
+  readonly onModeChange?: (mode: LiveVoiceMode, reason: string) => void;
+  readonly onMicrophoneState?: (muted: boolean) => void;
+  readonly onEchoSummary?: (summary: EchoMeasurementSummary) => void;
   readonly onTiming?: (metric: LiveVoiceTimingMetric) => void;
   readonly onError?: (error: Error) => void;
 }
@@ -73,7 +86,7 @@ type HandshakeResult =
   | { readonly type: "ready"; readonly frame: LiveVoiceReadyServerFrame }
   | { readonly type: "busy"; readonly frame: LiveVoiceBusyServerFrame };
 
-export class LiveVoicePushToTalkSession {
+export class LiveVoiceForegroundSession {
   private readonly now: () => number;
   private readonly sleep: (
     milliseconds: number,
@@ -85,6 +98,8 @@ export class LiveVoicePushToTalkSession {
 
   private state: LiveVoiceForegroundState = "ended";
   private captionMode: LiveVoiceCaptionMode;
+  private mode: LiveVoiceMode;
+  private muted = false;
   private channel: LiveVoiceSessionChannel | null = null;
   private captureSession: LiveVoicePcmCaptureSession | null = null;
   private conversationId: string | undefined;
@@ -97,11 +112,19 @@ export class LiveVoicePushToTalkSession {
   private failure: Error | null = null;
   private keyOperations: Promise<void> = Promise.resolve();
   private frameOperations: Promise<void> = Promise.resolve();
+  private reconnecting = false;
+  private playbackGeneration = 0;
+  private acceptingTts = true;
+  private readonly echoMeasurement = new EchoMeasurement();
+  private readonly playbackAmplitudes: number[] = [];
+  private playbackAmplitudeIndex = 0;
+  private lastMicrophoneAmplitude = 0;
 
-  constructor(private readonly options: LiveVoicePushToTalkSessionOptions) {
+  constructor(private readonly options: LiveVoiceForegroundSessionOptions) {
     this.now = options.now ?? (() => performance.now());
     this.sleep = options.sleep ?? abortableDelay;
     this.captionMode = options.captions ?? "off";
+    this.mode = options.mode ?? "push-to-talk";
     this.conversationId = options.conversationId;
     this.closedPromise = new Promise<void>((resolve) => {
       this.resolveClosed = resolve;
@@ -116,20 +139,32 @@ export class LiveVoicePushToTalkSession {
     return this.failure;
   }
 
+  get currentMode(): LiveVoiceMode {
+    return this.mode;
+  }
+
   async start(): Promise<void> {
     if (this.shuttingDown || this.channel !== null) {
       return;
     }
     try {
       await this.openChannel();
-      this.setState("ready");
+      if (this.reconnecting) {
+        return;
+      }
+      if (this.mode === "open-mic") {
+        await this.beginCapture();
+        this.options.onMicrophoneState?.(this.muted);
+      } else {
+        this.setState("ready");
+      }
     } catch (error) {
       await this.fail(toError(error));
       throw this.failure ?? new Error("Live voice failed to start.");
     }
   }
 
-  handleKey(key: "enter" | "interrupt" | "captions"): Promise<void> {
+  handleKey(key: "enter" | "interrupt" | "captions" | "mute"): Promise<void> {
     const operation = this.keyOperations.then(async () => {
       if (this.shuttingDown) {
         return;
@@ -140,6 +175,13 @@ export class LiveVoicePushToTalkSession {
       }
       if (key === "interrupt") {
         await this.interruptReply();
+        return;
+      }
+      if (key === "mute") {
+        this.toggleMute();
+        return;
+      }
+      if (this.mode === "open-mic") {
         return;
       }
       if (this.state === "ready") {
@@ -178,13 +220,15 @@ export class LiveVoicePushToTalkSession {
     this.setState("listening");
     const captureSession = await this.options.capture.startCapture({
       target: this.options.inputDevice,
-      onFrame: (frame) => {
+      onFrame: (frame, rmsAmplitude) => {
+        const microphoneAmplitude = this.muted ? 0 : rmsAmplitude;
+        this.recordEchoSample(microphoneAmplitude);
         if (
           generation === this.captureGeneration &&
-          this.state === "listening" &&
+          (this.mode === "open-mic" || this.state === "listening") &&
           this.channel === channel
         ) {
-          channel.sendAudio(frame);
+          channel.sendAudio(this.muted ? Buffer.alloc(frame.length) : frame);
         }
       },
     });
@@ -192,6 +236,7 @@ export class LiveVoicePushToTalkSession {
       await captureSession.stop();
       return;
     }
+    captureSession.setMuted(this.muted);
     this.captureSession = captureSession;
     void captureSession.closed.catch((error) => {
       if (!this.shuttingDown && this.captureSession === captureSession) {
@@ -230,8 +275,22 @@ export class LiveVoicePushToTalkSession {
     ) {
       return;
     }
+    this.cancelPlaybackGeneration();
     this.channel.interrupt();
     await this.options.playback.flush();
+    this.finishEchoMeasurement();
+    if (this.mode === "open-mic") {
+      this.setState("listening");
+    }
+  }
+
+  private toggleMute(): void {
+    if (this.mode !== "open-mic" || this.captureSession === null) {
+      return;
+    }
+    this.muted = !this.muted;
+    this.captureSession.setMuted(this.muted);
+    this.options.onMicrophoneState?.(this.muted);
   }
 
   private cycleCaptions(): void {
@@ -253,11 +312,31 @@ export class LiveVoicePushToTalkSession {
       const channel = this.options.createChannel(endpoint);
       this.channel = channel;
       const openedAt = this.now();
-      const result = await this.connectChannel(channel);
+      let result: HandshakeResult;
+      try {
+        result = await this.connectChannel(channel);
+      } catch (error) {
+        if (this.channel === channel) {
+          this.channel = null;
+        }
+        channel.close();
+        throw error;
+      }
 
       if (result.type === "ready") {
         this.previousSessionId = result.frame.sessionId;
         this.conversationId = result.frame.conversationId;
+        if (
+          this.mode === "open-mic" &&
+          result.frame.turnDetection !== "server_vad"
+        ) {
+          this.mode = "push-to-talk";
+          this.muted = false;
+          this.options.onModeChange?.(
+            this.mode,
+            "The assistant did not confirm server voice activity detection. Falling back to push-to-talk.",
+          );
+        }
         this.options.onTiming?.({
           name: "socket_ready",
           durationMs: nonNegativeDuration(this.now() - openedAt),
@@ -349,17 +428,22 @@ export class LiveVoicePushToTalkSession {
             ),
           );
         } else if (isActiveReadyChannel()) {
-          void this.fail(
-            new Error(
-              event.reason || "The live-voice connection closed unexpectedly.",
-            ),
-          );
+          if (event.retryable) {
+            void this.reconnectChannel(channel, event.reason);
+          } else {
+            void this.fail(
+              new Error(
+                event.reason ||
+                  "The live-voice connection closed unexpectedly.",
+              ),
+            );
+          }
         }
       });
 
       channel.connect({
         conversationId: this.conversationId,
-        turnDetection: "manual",
+        turnDetection: this.mode === "open-mic" ? "server_vad" : "manual",
       });
     });
   }
@@ -368,12 +452,25 @@ export class LiveVoicePushToTalkSession {
     channel: LiveVoiceSessionChannel,
     frame: LiveVoiceChannelClientEventMap["frame"],
   ): void {
+    const playbackGeneration = this.playbackGeneration;
+    const acceptingTts = this.acceptingTts;
+    if (frame.type === "speech_started" || frame.type === "turn_cancelled") {
+      this.cancelPlaybackGeneration();
+      void this.options.playback.flush();
+    } else if (frame.type === "thinking") {
+      this.acceptingTts = true;
+    }
     this.frameOperations = this.frameOperations
       .then(async () => {
         if (this.shuttingDown || this.channel !== channel) {
           return;
         }
-        await this.handleFrame(channel, frame);
+        await this.handleFrame(
+          channel,
+          frame,
+          playbackGeneration,
+          acceptingTts,
+        );
       })
       .catch(async (error) => {
         if (!this.shuttingDown) {
@@ -385,8 +482,20 @@ export class LiveVoicePushToTalkSession {
   private async handleFrame(
     channel: LiveVoiceSessionChannel,
     frame: LiveVoiceChannelClientEventMap["frame"],
+    playbackGeneration: number,
+    acceptingTts: boolean,
   ): Promise<void> {
     switch (frame.type) {
+      case "speech_started":
+        await this.options.playback.flush();
+        this.finishEchoMeasurement();
+        this.setState("listening");
+        return;
+      case "utterance_end":
+        this.inputEndedAt = this.now();
+        this.firstTtsRecorded = false;
+        this.setState("transcribing");
+        return;
       case "stt_partial":
       case "stt_final":
         this.setState("transcribing");
@@ -395,6 +504,7 @@ export class LiveVoicePushToTalkSession {
         }
         return;
       case "thinking":
+        this.acceptingTts = true;
         this.setState("thinking");
         return;
       case "assistant_text_delta":
@@ -403,6 +513,9 @@ export class LiveVoicePushToTalkSession {
         }
         return;
       case "tts_audio":
+        if (!acceptingTts || playbackGeneration !== this.playbackGeneration) {
+          return;
+        }
         if (!this.firstTtsRecorded && this.inputEndedAt !== null) {
           this.firstTtsRecorded = true;
           this.options.onTiming?.({
@@ -411,8 +524,10 @@ export class LiveVoicePushToTalkSession {
           });
         }
         this.setState("speaking");
+        const audio = Buffer.from(frame.dataBase64, "base64");
+        this.queuePlaybackAmplitudes(audio);
         await this.options.playback.write({
-          audio: Buffer.from(frame.dataBase64, "base64"),
+          audio,
           mimeType: frame.mimeType,
           sampleRate: frame.sampleRate,
         });
@@ -421,6 +536,8 @@ export class LiveVoicePushToTalkSession {
         await this.completeTurn(channel, true);
         return;
       case "utterance_discarded":
+        await this.completeTurn(channel, false);
+        return;
       case "turn_cancelled":
         await this.completeTurn(channel, false);
         return;
@@ -442,10 +559,17 @@ export class LiveVoicePushToTalkSession {
       return;
     }
 
-    this.channel = null;
-    channel.end();
+    this.finishEchoMeasurement();
     this.inputEndedAt = null;
     this.firstTtsRecorded = false;
+    if (this.mode === "open-mic") {
+      this.acceptingTts = false;
+      this.setState("listening");
+      return;
+    }
+
+    this.channel = null;
+    channel.end();
     await this.openChannel();
     if (!this.shuttingDown) {
       this.setState("ready");
@@ -458,6 +582,130 @@ export class LiveVoicePushToTalkSession {
     }
     this.state = state;
     this.options.onState?.(state);
+  }
+
+  private cancelPlaybackGeneration(): void {
+    this.playbackGeneration += 1;
+    this.acceptingTts = false;
+    this.playbackAmplitudes.length = 0;
+    this.playbackAmplitudeIndex = 0;
+  }
+
+  private queuePlaybackAmplitudes(audio: Buffer): void {
+    for (
+      let offset = 0;
+      offset < audio.length;
+      offset += LIVE_VOICE_PCM_FRAME_BYTES
+    ) {
+      if (
+        this.playbackAmplitudes.length - this.playbackAmplitudeIndex <
+        MAX_ECHO_AMPLITUDE_SAMPLES
+      ) {
+        this.playbackAmplitudes.push(
+          pcm16Rms(
+            audio.subarray(
+              offset,
+              Math.min(offset + LIVE_VOICE_PCM_FRAME_BYTES, audio.length),
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  private recordEchoSample(microphoneAmplitude: number): void {
+    this.lastMicrophoneAmplitude = microphoneAmplitude;
+    const playback = this.playbackAmplitudes[this.playbackAmplitudeIndex] ?? 0;
+    if (this.playbackAmplitudeIndex < this.playbackAmplitudes.length) {
+      this.playbackAmplitudeIndex += 1;
+      if (this.playbackAmplitudeIndex === this.playbackAmplitudes.length) {
+        this.playbackAmplitudes.length = 0;
+        this.playbackAmplitudeIndex = 0;
+      } else if (this.playbackAmplitudeIndex >= 256) {
+        this.playbackAmplitudes.splice(0, this.playbackAmplitudeIndex);
+        this.playbackAmplitudeIndex = 0;
+      }
+    }
+    const summary = this.echoMeasurement.addSample({
+      microphone: microphoneAmplitude,
+      playback,
+    });
+    if (summary !== null) {
+      this.options.onEchoSummary?.(summary);
+    }
+  }
+
+  private finishEchoMeasurement(): void {
+    this.playbackAmplitudes.length = 0;
+    this.playbackAmplitudeIndex = 0;
+    const summary = this.echoMeasurement.addSample({
+      microphone: this.lastMicrophoneAmplitude,
+      playback: 0,
+    });
+    if (summary !== null) {
+      this.options.onEchoSummary?.(summary);
+    }
+  }
+
+  private async reconnectChannel(
+    closedChannel: LiveVoiceSessionChannel,
+    reason: string,
+  ): Promise<void> {
+    if (
+      this.reconnecting ||
+      this.shuttingDown ||
+      this.channel !== closedChannel
+    ) {
+      return;
+    }
+    this.reconnecting = true;
+    this.channel = null;
+    this.captureGeneration += 1;
+    const captureSession = this.captureSession;
+    this.captureSession = null;
+    if (captureSession !== null) {
+      await captureSession.stop().catch(() => null);
+    }
+    this.cancelPlaybackGeneration();
+    await this.options.playback.flush().catch(() => {});
+    this.finishEchoMeasurement();
+
+    let lastError = new Error(
+      reason || "The live-voice connection is restarting.",
+    );
+    const reconnectDelays = [0, ...LIVE_VOICE_BUSY_RETRY_DELAYS_MS] as const;
+    try {
+      for (const delay of reconnectDelays) {
+        if (delay > 0) {
+          await this.sleep(delay, this.abortController.signal);
+        }
+        if (this.shuttingDown) {
+          return;
+        }
+        try {
+          await this.openChannel();
+          if (this.mode === "open-mic") {
+            await this.beginCapture();
+            this.options.onMicrophoneState?.(this.muted);
+          } else {
+            this.setState("ready");
+          }
+          return;
+        } catch (error) {
+          lastError = toError(error);
+        }
+      }
+    } catch (error) {
+      if (this.shuttingDown) {
+        return;
+      }
+      lastError = toError(error);
+    } finally {
+      this.reconnecting = false;
+    }
+    if (!this.shuttingDown) {
+      await this.fail(lastError);
+    }
   }
 
   private async fail(error: Error): Promise<void> {
@@ -475,6 +723,7 @@ export class LiveVoicePushToTalkSession {
     this.shuttingDown = true;
     this.abortController.abort();
     this.captureGeneration += 1;
+    this.cancelPlaybackGeneration();
 
     const captureSession = this.captureSession;
     this.captureSession = null;


### PR DESCRIPTION
## Summary

- add fail-closed open-mic mode backed by an exact PipeWire echo-cancel source and sink pair owned by one echo-cancel module instance
- keep one server-VAD session and capture stream across turns, with mute, interruption, playback cancellation, bounded reconnects, and push-to-talk fallback
- emit token-safe route and scalar echo diagnostics, plus persistent microphone status

## Validation

- `cd cli && bun test src/__tests__/live-voice-pipewire-audio.test.ts src/__tests__/live-voice-session.test.ts src/__tests__/voice.test.ts`
- `cd cli && bun run lint`
- `cd cli && bun run typecheck`
- `cd cli && bun run compile:check`

## Hardware gate

Physical Raspberry Pi AEC behavior was not testable in this environment. The final validation PR must verify that the configured PipeWire pair suppresses steady assistant playback without ghost turns while preserving real barge-in.