### PR TITLE
docs(cli): validate Raspberry Pi live voice

### DIFF
--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -11,6 +11,11 @@ on:
       - 'cli/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      - 'packages/service-contracts/**'
+      - 'meta/bin/vellum.js'
+      - 'meta/package.json'
+      - 'scripts/strip-bundled-field-from-tarball.mjs'
+      - 'scripts/test-cli-package-install.ts'
       - '.github/workflows/ci-main-cli.yaml'
 
 jobs:
@@ -48,9 +53,50 @@ jobs:
       - name: Test with coverage
         run: bun test --coverage
 
+  arm64-package-install:
+    name: Linux ARM64 Voice Package Install
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: cli
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter=@vellumai/cli
+
+      - name: Test live voice
+        run: >-
+          bun test
+          src/__tests__/guardian-session-auth.test.ts
+          src/__tests__/platform-client.test.ts
+          src/__tests__/live-voice-platform-auth.test.ts
+          src/__tests__/live-voice-pipewire-audio.test.ts
+          src/__tests__/live-voice-connection.test.ts
+          src/__tests__/live-voice-channel-client.test.ts
+          src/__tests__/live-voice-session.test.ts
+          src/__tests__/voice.test.ts
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Compile check
+        run: bun run compile:check
+
+      - name: Verify installed package
+        run: bun ../scripts/test-cli-package-install.ts
+
   pack-cli:
     name: Pack CLI Tarball
-    needs: [checks]
+    needs: [checks, arm64-package-install]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -96,7 +142,7 @@ jobs:
 
   notify-cli:
     name: Slack Notification (CLI)
-    needs: [checks]
+    needs: [checks, arm64-package-install]
     if: always()
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -108,12 +154,14 @@ jobs:
         id: slack-id
         run: |
           GITHUB_USER="${{ github.actor }}"
+          CHECKS_RESULT="${{ needs.checks.result }}"
+          ARM64_RESULT="${{ needs.arm64-package-install.result }}"
 
-          if [[ "${{ needs.checks.result }}" == "failure" ]]; then
+          if [[ "$CHECKS_RESULT" == "failure" || "$ARM64_RESULT" == "failure" ]]; then
             STATUS="failure"
-          elif [[ "${{ needs.checks.result }}" == "cancelled" ]]; then
+          elif [[ "$CHECKS_RESULT" == "cancelled" || "$ARM64_RESULT" == "cancelled" ]]; then
             STATUS="cancelled"
-          elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
+          elif [[ "$CHECKS_RESULT" == "skipped" || "$ARM64_RESULT" == "skipped" ]]; then
             STATUS="skipped"
           else
             STATUS="success"

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -10,6 +10,11 @@ on:
       - 'cli/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      - 'packages/service-contracts/**'
+      - 'meta/bin/vellum.js'
+      - 'meta/package.json'
+      - 'scripts/strip-bundled-field-from-tarball.mjs'
+      - 'scripts/test-cli-package-install.ts'
       - '.github/workflows/pr-cli.yaml'
 
 concurrency:
@@ -53,3 +58,44 @@ jobs:
 
       - name: Test
         run: bun run test
+
+  arm64-package-install:
+    name: Linux ARM64 Voice Package Install
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: cli
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter=@vellumai/cli
+
+      - name: Test live voice
+        run: >-
+          bun test
+          src/__tests__/guardian-session-auth.test.ts
+          src/__tests__/platform-client.test.ts
+          src/__tests__/live-voice-platform-auth.test.ts
+          src/__tests__/live-voice-pipewire-audio.test.ts
+          src/__tests__/live-voice-connection.test.ts
+          src/__tests__/live-voice-channel-client.test.ts
+          src/__tests__/live-voice-session.test.ts
+          src/__tests__/voice.test.ts
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Compile check
+        run: bun run compile:check
+
+      - name: Verify installed package
+        run: bun ../scripts/test-cli-package-install.ts

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -683,26 +683,62 @@ The conversation streaming path degrades gracefully to the existing batch STT pa
 
 **Live voice channel boundary:**
 
-The local live voice channel uses a single gateway-authenticated WebSocket at `/v1/live-voice`. Native clients connect to the gateway route, the gateway validates an actor token, mints a gateway service token, and opens an upstream WebSocket to the assistant runtime route. Both text control frames and binary audio frames are proxied opaquely by `gateway/src/http/routes/live-voice-websocket.ts`; `gateway/src/index.ts` dispatches `open`, `message`, and `close` callbacks to that handler before the generic runtime proxy fallback.
+Live voice uses a single gateway-authenticated WebSocket at `/v1/live-voice`.
+Web, native, and CLI clients all reach the same assistant-owned session:
 
-The assistant runtime route lives in `src/runtime/http-server.ts`. It mirrors the STT streaming security posture: direct access must come from private-network peers/origins, and authenticated deployments require the gateway service token. The runtime parses JSON frames with `parseLiveVoiceClientTextFrame()`, parses binary frames with `parseLiveVoiceBinaryAudioFrame()`, and routes accepted sessions through `LiveVoiceSessionManager`. The V1 manager owns a single-active-session lock and returns a `busy` frame for concurrent sessions.
+- A directly reachable gateway validates guardian authentication when enabled,
+  mints a gateway service token, and opens an upstream WebSocket to the
+  assistant runtime route. A local assistant can use platform-managed speech
+  providers without changing this direct transport.
+- A Vellum-managed CLI client uses its platform login to mint a short-lived,
+  assistant-scoped live-voice token. It connects through the
+  environment-matched Velay host, which forwards the same gateway route. The
+  long-lived platform session token is not placed in the WebSocket URL.
+- The Linux CLI owns host microphone capture and speaker playback through
+  PipeWire. It sends binary 16 kHz mono PCM and receives JSON `tts_audio`
+  frames. Audio devices and processes remain outside the assistant runtime.
+
+Both text control frames and binary audio frames are proxied opaquely by
+`gateway/src/http/routes/live-voice-websocket.ts`; `gateway/src/index.ts`
+dispatches `open`, `message`, and `close` callbacks to that handler before the
+generic runtime proxy fallback.
+
+The assistant runtime route lives in `src/runtime/http-server.ts`. It mirrors the STT streaming security posture: direct access must come from private-network peers/origins, and authenticated deployments require the gateway service token. Each runtime or plugin transport creates a `createLiveVoiceConnection({ send })` adapter, feeds it inbound JSON or PCM, and calls `release()` on close. The adapter resolves the process-wide `LiveVoiceSessionManager`, so the runtime WebSocket and in-process plugin transports share the same single-active-session lock. The manager returns a `busy` frame for concurrent sessions.
+
+The CLI runs out of process and does not import the plugin API. It speaks the
+same shared wire contract through the gateway WebSocket, which reaches the same
+`LiveVoiceSession` and lock as every other caller.
 
 The assistant-side live voice module is intentionally bounded under `src/live-voice/`:
 
 | File                            | Boundary                                                                                                                                                    |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `protocol.ts`                   | Provider-agnostic client/server frame types, validation, binary audio parsing, and monotonic server-frame sequencing                                        |
+| `protocol.ts`                   | Assistant-owned strict client validation, binary audio parsing, sequencing, and compatibility exports over `@vellumai/service-contracts/live-voice`         |
+| `live-voice-connection.ts`      | Transport-neutral adapter shared by the runtime WebSocket and in-process plugins                                                                            |
 | `live-voice-session-manager.ts` | Single-active-session lock, session factory context, and dispatch/release lifecycle                                                                         |
 | `live-voice-session.ts`         | Session orchestration: streaming STT, push-to-talk release, voice turn bridge callbacks, assistant text deltas, TTS, archive, metrics, interrupt, and close |
 | `live-voice-tts.ts`             | Streaming TTS helper that resolves `services.tts`, requires `TtsProvider.synthesizeStream()`, and forwards audio chunks as `tts_audio` frames               |
 | `live-voice-archive.ts`         | Audio artifact creation/linking for user utterance and assistant response message IDs                                                                       |
 | `live-voice-metrics.ts`         | Per-session and per-turn latency snapshots emitted as `metrics` frames                                                                                      |
 
+Client-neutral audio constants and live-voice frame unions are owned by
+`@vellumai/service-contracts/live-voice`. The assistant keeps strict inbound
+validation and session sequencing. Web and CLI clients use the shared tolerant
+server-frame parser so a future frame type can be ignored during version skew.
+
 Live voice STT uses the same `resolveStreamingTranscriber()` path as conversation streaming. For V1 latency-sensitive behavior, the selected `services.stt.provider` must resolve to a `daemon-streaming` transcriber whose catalog entry has `conversationStreamingMode: "realtime-ws"` and usable credentials. Providers that only support batch or incremental-batch transcription remain valid for other voice surfaces, but do not satisfy live voice's streaming STT requirement.
 
 Live voice TTS uses `streamLiveVoiceTtsAudio()` and the configured `services.tts.provider`. The selected provider must be registered, catalog-compatible, and expose `capabilities.supportsStreaming` plus `synthesizeStream()`. Providers whose catalog entry advertises `supportsStreaming` (currently all four catalog providers: ElevenLabs, Fish Audio, Deepgram, and xAI) satisfy this requirement; a buffered-only provider would remain available for buffered message playback or other supported surfaces, but live voice reports a TTS error instead of silently falling back to buffered playback.
 
-V1 is local/gateway-scoped. Managed/cloud WebSocket proxy support, cross-region routing, and p50/p95 latency guarantees are out of scope for this version. Metrics frames expose timing data for measurement, but the architecture does not promise a hard latency SLO.
+Managed speech providers, the `voiceFrontDoor` decision leg, main-agent
+handoff, persistence, streaming STT, and streaming TTS remain assistant-owned
+for every client topology. Clients never compose these provider calls
+themselves.
+
+Direct local gateways and Vellum-managed routing through Velay are implemented
+client paths. Docker and paired-remote CLI voice topologies, cross-region
+latency guarantees, and a hard p50/p95 SLO remain out of scope. Metrics frames
+expose timing data for measurement.
 
 **Client service-first boundary:**
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,9 +4,18 @@ CLI tools for provisioning and managing Vellum assistant instances.
 
 ## Installation
 
-This package is used internally by the `vel` CLI. You typically don't need to install it directly.
+Install the complete `vellum` command with Bun:
 
-To run it standalone with [Bun](https://bun.sh):
+```bash
+bun install -g vellum
+```
+
+The published `vellum` package installs a Bun wrapper that imports this
+TypeScript package. The CLI's `compile:check` script validates that Bun can
+compile the entry point, but the compiled executable is not the published
+artifact.
+
+To run `@vellumai/cli` from a source checkout:
 
 ```bash
 bun run ./src/index.ts <command> [options]
@@ -36,6 +45,45 @@ vellum sleep
 ```
 
 > **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically.
+
+### `voice`
+
+Talk to a local or Vellum-managed assistant from a foreground Linux ARM64
+terminal:
+
+```bash
+vellum voice devices
+vellum voice doctor assistant-123
+vellum voice assistant-123
+```
+
+Push-to-talk is the default. Press Enter to start and release capture, `s` to
+interrupt, `c` to cycle captions, and `q` to quit. Open mic is available only
+when `voice doctor --mode open-mic` verifies the exact PipeWire echo-cancel
+source and sink:
+
+```bash
+vellum voice doctor assistant-123 --mode open-mic
+vellum voice assistant-123 --mode open-mic
+```
+
+An explicit `--url` always selects a directly reachable gateway, including for
+a manually provisioned local assistant that uses platform-managed providers:
+
+```bash
+vellum voice doctor \
+  --url http://127.0.0.1:7821 \
+  --assistant-id assistant-123
+```
+
+A Vellum-managed assistant uses the session created by `vellum login`, mints a
+short-lived live-voice credential, and connects through Velay. Docker,
+paired-remote, and non-interactive service topologies are not supported by
+this command.
+
+See [Raspberry Pi live voice](../docs/raspberry-pi-voice.md) for installation,
+headless PipeWire setup, device selection, echo cancellation, recovery, and the
+current hardware-validation status.
 
 ### `hatch`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -72,7 +72,7 @@ a manually provisioned local assistant that uses platform-managed providers:
 
 ```bash
 vellum voice doctor \
-  --url http://127.0.0.1:7821 \
+  --url http://127.0.0.1:7830 \
   --assistant-id assistant-123
 ```
 

--- a/cli/src/__tests__/live-voice-pipewire-audio.test.ts
+++ b/cli/src/__tests__/live-voice-pipewire-audio.test.ts
@@ -27,6 +27,7 @@ import type {
 interface FakeProcessOptions {
   holdWrites?: boolean;
   closeOnStdinEnd?: boolean;
+  ignoredSignals?: readonly NodeJS.Signals[];
 }
 
 class FakeProcess extends EventEmitter {
@@ -40,9 +41,11 @@ class FakeProcess extends EventEmitter {
   signalCode: NodeJS.Signals | null = null;
   killed = false;
   private processClosed = false;
+  private readonly ignoredSignals: ReadonlySet<NodeJS.Signals>;
 
   constructor(options: FakeProcessOptions = {}) {
     super();
+    this.ignoredSignals = new Set(options.ignoredSignals);
     this.stdin = new Writable({
       highWaterMark: options.holdWrites ? 1 : 64 * 1024,
       write: (chunk: Buffer, _encoding, callback) => {
@@ -73,6 +76,9 @@ class FakeProcess extends EventEmitter {
     }
     this.killed = true;
     this.killSignals.push(signal);
+    if (this.ignoredSignals.has(signal)) {
+      return true;
+    }
     queueMicrotask(() => {
       this.finish(null, signal);
     });
@@ -393,6 +399,41 @@ describe("PipeWire device discovery and capture", () => {
     );
   });
 
+  test("reports an unsolicited clean capture exit", async () => {
+    const factory = createProcessFactory();
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+    });
+    const capture = await audio.startCapture({ onFrame: () => {} });
+
+    factory.processes[0].finish(0);
+
+    await expect(capture.closed).rejects.toThrow(
+      "pw-record stopped unexpectedly with code 0",
+    );
+  });
+
+  test("bounds capture shutdown when the process ignores termination", async () => {
+    const factory = createProcessFactory([
+      { ignoredSignals: ["SIGTERM", "SIGKILL"] },
+    ]);
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      processTerminationGraceMs: 1,
+      processForceKillGraceMs: 1,
+    });
+    const capture = await audio.startCapture({ onFrame: () => {} });
+
+    const firstStop = capture.stop();
+    const secondStop = capture.stop();
+
+    expect(firstStop).toBe(secondStop);
+    expect(await firstStop).toBeNull();
+    expect(factory.processes[0].killSignals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
   test("builds the protocol capture cadence without an explicit target", () => {
     expect(buildPipeWirePcmArgs()).toEqual([
       "--raw",
@@ -505,6 +546,60 @@ describe("PipeWire playback", () => {
     await playback.close();
     await playback.close();
     expect(factory.processes[1].killSignals).toEqual(["SIGTERM"]);
+  });
+
+  test("escalates playback shutdown and bounds the final reap wait", async () => {
+    const factory = createProcessFactory([
+      { ignoredSignals: ["SIGTERM", "SIGKILL"] },
+    ]);
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      processTerminationGraceMs: 1,
+      processForceKillGraceMs: 1,
+    });
+    const playback = audio.createPlayback();
+    await playback.write({
+      audio: Buffer.from([1, 2]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+
+    const firstClose = playback.close();
+    const secondClose = playback.close();
+
+    expect(secondClose).toBe(firstClose);
+    await expect(firstClose).rejects.toThrow(
+      "pw-play did not exit after SIGKILL",
+    );
+    expect(factory.processes[0].killSignals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  test("bounds playback drain when stdin closure does not stop the process", async () => {
+    const factory = createProcessFactory([
+      {
+        closeOnStdinEnd: false,
+        ignoredSignals: ["SIGKILL"],
+      },
+    ]);
+    const audio = new PipeWireAudio({
+      spawnProcess: factory.spawn,
+      findExecutable: async (name) => `/usr/bin/${name}`,
+      processForceKillGraceMs: 1,
+      playbackDrainGraceMs: 1,
+    });
+    const playback = audio.createPlayback();
+    await playback.write({
+      audio: Buffer.from([1, 2]),
+      mimeType: "audio/pcm",
+      sampleRate: 16_000,
+    });
+
+    await expect(playback.drain()).rejects.toThrow(
+      "pw-play did not exit after SIGKILL",
+    );
+    expect(factory.processes[0].killSignals).toEqual(["SIGKILL"]);
+    await playback.close();
   });
 
   test("rejects unsupported provider output with format details", async () => {

--- a/cli/src/__tests__/live-voice-session.test.ts
+++ b/cli/src/__tests__/live-voice-session.test.ts
@@ -21,13 +21,24 @@ import {
 } from "../lib/live-voice/session.js";
 
 class FakeCaptureSession implements LiveVoicePcmCaptureSession {
-  readonly closed = new Promise<void>(() => {});
+  readonly closed: Promise<void>;
   readonly tail = Buffer.from([5, 6]);
   stopCount = 0;
   muted = false;
+  private rejectClosed: (error: Error) => void = () => {};
+
+  constructor() {
+    this.closed = new Promise<void>((_resolve, reject) => {
+      this.rejectClosed = reject;
+    });
+  }
 
   setMuted(muted: boolean): void {
     this.muted = muted;
+  }
+
+  fail(error: Error): void {
+    this.rejectClosed(error);
   }
 
   async stop(): Promise<Buffer | null> {
@@ -581,6 +592,34 @@ describe("LiveVoiceForegroundSession", () => {
     expect(harness.capture.sessions[0].stopCount).toBe(0);
     expect(harness.session.currentState).toBe("listening");
     await harness.session.shutdown();
+  });
+
+  test("fails instead of silently listening after capture exits", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-open",
+          conversationId: "conversation-open",
+          turnDetection: "server_vad",
+        },
+      ],
+      { mode: "open-mic" },
+    );
+    await harness.session.start();
+    expect(harness.session.currentState).toBe("listening");
+
+    harness.capture.sessions[0].fail(
+      new Error("pw-record stopped unexpectedly with code 0."),
+    );
+
+    await waitFor(() => harness.session.currentState === "failed");
+    await harness.session.waitUntilClosed();
+    expect(harness.errors).toEqual([
+      new Error("pw-record stopped unexpectedly with code 0."),
+    ]);
+    expect(harness.capture.sessions[0].stopCount).toBe(1);
+    expect(harness.channels[0].endCount).toBe(1);
   });
 
   test("mutes with equal-duration zeros while preserving capture during TTS", async () => {

--- a/cli/src/__tests__/live-voice-session.test.ts
+++ b/cli/src/__tests__/live-voice-session.test.ts
@@ -365,6 +365,43 @@ describe("LiveVoiceForegroundSession", () => {
     await harness.session.shutdown();
   });
 
+  test("keeps push-to-talk capture active when STT arrives before release", async () => {
+    const harness = makeHarness(
+      [
+        {
+          type: "ready",
+          sessionId: "session-1",
+          conversationId: "conversation-1",
+        },
+      ],
+      { captions: "user" },
+    );
+
+    await harness.session.start();
+    await harness.session.handleKey("enter");
+    harness.capture.emit(Buffer.from([1, 2]));
+    harness.channels[0].emit("frame", {
+      type: "stt_partial",
+      seq: 2,
+      text: "hello",
+    });
+    await waitFor(() => harness.captions.length === 1);
+
+    expect(harness.session.currentState).toBe("listening");
+    harness.capture.emit(Buffer.from([3, 4]));
+    await harness.session.handleKey("enter");
+
+    expect(harness.channels[0].audio.map((value) => [...value])).toEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+    expect(harness.capture.sessions[0].stopCount).toBe(1);
+    expect(harness.channels[0].pttReleaseCount).toBe(1);
+    expect(harness.session.currentState).toBe("transcribing");
+    await harness.session.shutdown();
+  });
+
   test("retries when a same-session busy frame is followed by the client's immediate close", async () => {
     const harness = makeHarness([
       {

--- a/cli/src/lib/live-voice/pipewire-audio.ts
+++ b/cli/src/lib/live-voice/pipewire-audio.ts
@@ -40,6 +40,9 @@ const REQUIRED_EXECUTABLES = [
 ] as const;
 const MINIMUM_PIPEWIRE_VERSION = "1.4.0";
 const AUDIO_COMMAND_TIMEOUT_MS = 5_000;
+const PROCESS_TERMINATION_GRACE_MS = 500;
+const PROCESS_FORCE_KILL_GRACE_MS = 500;
+const PLAYBACK_DRAIN_GRACE_MS = 10_000;
 export const LIVE_VOICE_ECHO_CANCEL_SOURCE = "vellum_echo_cancel_source";
 export const LIVE_VOICE_ECHO_CANCEL_SINK = "vellum_echo_cancel_sink";
 const PIPEWIRE_ECHO_CANCEL_MODULE = "libpipewire-module-echo-cancel";
@@ -96,6 +99,23 @@ export interface PipeWireAudioDependencies {
   username?: string;
   runtimeDirectory?: string;
   pathExists?: (path: string) => boolean;
+  processTerminationGraceMs?: number;
+  processForceKillGraceMs?: number;
+  playbackDrainGraceMs?: number;
+}
+
+interface AudioProcessTimeouts {
+  terminationGraceMs: number;
+  forceKillGraceMs: number;
+  drainGraceMs: number;
+}
+
+interface AudioProcessReapResult {
+  closed: boolean;
+  forced: boolean;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  error?: Error;
 }
 
 export interface PipeWireVersion {
@@ -128,6 +148,7 @@ export class PipeWireAudio {
   private readonly username: string;
   private readonly runtimeDirectory: string | undefined;
   private readonly pathExists: (path: string) => boolean;
+  private readonly processTimeouts: AudioProcessTimeouts;
 
   constructor(dependencies: PipeWireAudioDependencies = {}) {
     this.spawnProcess = dependencies.spawnProcess ?? defaultSpawnProcess;
@@ -143,6 +164,14 @@ export class PipeWireAudio {
     this.runtimeDirectory =
       dependencies.runtimeDirectory ?? process.env.XDG_RUNTIME_DIR;
     this.pathExists = dependencies.pathExists ?? existsSync;
+    this.processTimeouts = {
+      terminationGraceMs:
+        dependencies.processTerminationGraceMs ?? PROCESS_TERMINATION_GRACE_MS,
+      forceKillGraceMs:
+        dependencies.processForceKillGraceMs ?? PROCESS_FORCE_KILL_GRACE_MS,
+      drainGraceMs:
+        dependencies.playbackDrainGraceMs ?? PLAYBACK_DRAIN_GRACE_MS,
+    };
   }
 
   async discoverDevices(): Promise<LiveVoiceAudioDevices> {
@@ -168,11 +197,16 @@ export class PipeWireAudio {
       buildPipeWirePcmArgs(options.target),
       pipeProcessOptions(),
     );
-    return new PipeWireCaptureSession(child, options);
+    return new PipeWireCaptureSession(child, options, this.processTimeouts);
   }
 
   createPlayback(target?: string): LiveVoicePcmPlayback {
-    return new PipeWirePlayback(this.spawnProcess, this.findExecutable, target);
+    return new PipeWirePlayback(
+      this.spawnProcess,
+      this.findExecutable,
+      this.processTimeouts,
+      target,
+    );
   }
 
   async doctor(
@@ -697,6 +731,7 @@ class PipeWireCaptureSession implements LiveVoicePcmCaptureSession {
   constructor(
     private readonly child: ChildProcessWithoutNullStreams,
     private readonly options: LiveVoicePcmCaptureOptions,
+    private readonly processTimeouts: AudioProcessTimeouts,
   ) {
     this.closed = new Promise<void>((resolve, reject) => {
       let settled = false;
@@ -715,7 +750,7 @@ class PipeWireCaptureSession implements LiveVoicePcmCaptureSession {
         settle(error);
       });
       child.once("close", (code, signal) => {
-        if (this.stopping || code === 0) {
+        if (this.stopping) {
           settle();
         } else {
           settle(
@@ -750,11 +785,22 @@ class PipeWireCaptureSession implements LiveVoicePcmCaptureSession {
   }
 
   private async stopOnce(): Promise<Buffer | null> {
-    this.stopping = true;
-    if (this.child.exitCode === null && !this.child.killed) {
-      this.child.kill("SIGTERM");
+    if (this.child.exitCode !== null || this.child.signalCode !== null) {
+      await this.closed;
+      return this.framer.flush(this.muted);
     }
-    await this.closed;
+    this.stopping = true;
+    const result = await terminateAndReapProcess(
+      this.child,
+      () => {
+        this.child.kill("SIGTERM");
+      },
+      this.processTimeouts.terminationGraceMs,
+      this.processTimeouts.forceKillGraceMs,
+    );
+    if (result.closed) {
+      await this.closed;
+    }
     return this.framer.flush(this.muted);
   }
 }
@@ -765,10 +811,12 @@ class PipeWirePlayback implements LiveVoicePcmPlayback {
   private generation = 0;
   private operations: Promise<void> = Promise.resolve();
   private closed = false;
+  private closePromise: Promise<void> | null = null;
 
   constructor(
     private readonly spawnProcess: AudioProcessFactory,
     private readonly findExecutable: AudioExecutableLookup,
+    private readonly processTimeouts: AudioProcessTimeouts,
     private readonly target?: string,
   ) {}
 
@@ -826,8 +874,15 @@ class PipeWirePlayback implements LiveVoicePcmPlayback {
       }
       this.child = null;
       this.sampleRate = null;
-      child.stdin.end();
-      await waitForProcessClose(child, false);
+      const result = await terminateAndReapProcess(
+        child,
+        () => {
+          child.stdin.end();
+        },
+        this.processTimeouts.drainGraceMs,
+        this.processTimeouts.forceKillGraceMs,
+      );
+      requireCleanPlaybackExit(result);
     });
   }
 
@@ -836,22 +891,28 @@ class PipeWirePlayback implements LiveVoicePcmPlayback {
     const child = this.child;
     this.child = null;
     this.sampleRate = null;
-    if (child !== null && child.exitCode === null && !child.killed) {
-      child.kill("SIGTERM");
+    if (child === null) {
+      return this.operations;
     }
-    return this.enqueue(async () => {
-      if (child !== null) {
-        await waitForProcessClose(child, true);
-      }
-    });
+    const result = terminateAndReapProcess(
+      child,
+      () => {
+        child.kill("SIGTERM");
+      },
+      this.processTimeouts.terminationGraceMs,
+      this.processTimeouts.forceKillGraceMs,
+    ).then(requireTerminatedPlaybackProcess);
+    this.operations = result.catch(() => {});
+    return result;
   }
 
   close(): Promise<void> {
-    if (this.closed) {
-      return this.operations;
+    if (this.closePromise !== null) {
+      return this.closePromise;
     }
     this.closed = true;
-    return this.flush();
+    this.closePromise = this.flush();
+    return this.closePromise;
   }
 
   private enqueue(operation: () => Promise<void>): Promise<void> {
@@ -896,10 +957,15 @@ class PipeWirePlayback implements LiveVoicePcmPlayback {
     if (child === null) {
       return;
     }
-    if (child.exitCode === null && !child.killed) {
-      child.kill(signal);
-    }
-    await waitForProcessClose(child, true);
+    const result = await terminateAndReapProcess(
+      child,
+      () => {
+        child.kill(signal);
+      },
+      this.processTimeouts.terminationGraceMs,
+      this.processTimeouts.forceKillGraceMs,
+    );
+    requireTerminatedPlaybackProcess(result);
   }
 }
 
@@ -1137,40 +1203,113 @@ function createDefaultProcessProbe(
     });
 }
 
-function waitForProcessClose(
+function terminateAndReapProcess(
   child: ChildProcessWithoutNullStreams,
-  acceptTermination: boolean,
-): Promise<void> {
+  requestGracefulStop: () => void,
+  gracefulTimeoutMs: number,
+  forceKillTimeoutMs: number,
+): Promise<AudioProcessReapResult> {
   if (child.exitCode !== null || child.signalCode !== null) {
-    return acceptTermination ||
-      (child.exitCode === 0 && child.signalCode === null)
-      ? Promise.resolve()
-      : Promise.reject(playbackExitError(child.exitCode, child.signalCode));
+    return Promise.resolve({
+      closed: true,
+      forced: false,
+      code: child.exitCode,
+      signal: child.signalCode,
+    });
   }
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     let settled = false;
-    const finish = (error?: Error): void => {
+    let forced = false;
+    let processError: Error | undefined;
+    const timers: {
+      graceful?: ReturnType<typeof setTimeout>;
+      forceKill?: ReturnType<typeof setTimeout>;
+    } = {};
+    const cleanup = (): void => {
+      child.off("close", onClose);
+      child.off("error", onError);
+      if (timers.graceful !== undefined) {
+        clearTimeout(timers.graceful);
+      }
+      if (timers.forceKill !== undefined) {
+        clearTimeout(timers.forceKill);
+      }
+    };
+    const finish = (result: AudioProcessReapResult): void => {
       if (settled) {
         return;
       }
       settled = true;
-      if (error === undefined) {
-        resolve();
-      } else {
-        reject(error);
-      }
+      cleanup();
+      resolve(result);
     };
-    child.once("close", (code, signal) => {
-      if (acceptTermination || (code === 0 && signal === null)) {
-        finish();
-      } else {
-        finish(playbackExitError(code, signal));
+    const onClose = (
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ): void => {
+      finish({ closed: true, forced, code, signal, error: processError });
+    };
+    const onError = (error: Error): void => {
+      processError ??= error;
+    };
+    child.once("close", onClose);
+    child.on("error", onError);
+
+    const forceKill = (): void => {
+      if (settled) {
+        return;
       }
-    });
-    child.once("error", (error) => {
-      finish(error);
-    });
+      forced = true;
+      try {
+        child.kill("SIGKILL");
+      } catch (error) {
+        onError(error instanceof Error ? error : new Error(String(error)));
+      }
+      timers.forceKill = setTimeout(
+        () => {
+          finish({
+            closed: false,
+            forced: true,
+            code: child.exitCode,
+            signal: child.signalCode,
+            error: processError,
+          });
+        },
+        Math.max(0, forceKillTimeoutMs),
+      );
+    };
+
+    try {
+      requestGracefulStop();
+      timers.graceful = setTimeout(forceKill, Math.max(0, gracefulTimeoutMs));
+    } catch (error) {
+      onError(error instanceof Error ? error : new Error(String(error)));
+      forceKill();
+    }
   });
+}
+
+function requireCleanPlaybackExit(result: AudioProcessReapResult): void {
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (!result.closed) {
+    throw new Error("pw-play did not exit after SIGKILL.");
+  }
+  if (result.code !== 0 || result.signal !== null) {
+    throw playbackExitError(result.code, result.signal);
+  }
+}
+
+function requireTerminatedPlaybackProcess(
+  result: AudioProcessReapResult,
+): void {
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (!result.closed) {
+    throw new Error("pw-play did not exit after SIGKILL.");
+  }
 }
 
 function writeWithBackpressure(

--- a/cli/src/lib/live-voice/session.ts
+++ b/cli/src/lib/live-voice/session.ts
@@ -186,7 +186,7 @@ export class LiveVoiceForegroundSession {
       }
       if (this.state === "ready") {
         await this.beginCapture();
-      } else if (this.state === "listening") {
+      } else if (this.captureSession !== null) {
         await this.releaseCapture();
       }
     });
@@ -225,7 +225,9 @@ export class LiveVoiceForegroundSession {
         this.recordEchoSample(microphoneAmplitude);
         if (
           generation === this.captureGeneration &&
-          (this.mode === "open-mic" || this.state === "listening") &&
+          (this.mode === "open-mic" ||
+            this.captureSession !== null ||
+            this.state === "listening") &&
           this.channel === channel
         ) {
           channel.sendAudio(this.muted ? Buffer.alloc(frame.length) : frame);
@@ -498,7 +500,9 @@ export class LiveVoiceForegroundSession {
         return;
       case "stt_partial":
       case "stt_final":
-        this.setState("transcribing");
+        if (this.mode === "open-mic" || this.captureSession === null) {
+          this.setState("transcribing");
+        }
         if (this.captionMode === "user" || this.captionMode === "both") {
           this.options.onCaption?.("user", frame.text);
         }

--- a/docs/raspberry-pi-voice.md
+++ b/docs/raspberry-pi-voice.md
@@ -1,0 +1,333 @@
+# Raspberry Pi live voice
+
+`vellum voice` is a foreground PipeWire client for the assistant's existing
+live-voice session. The assistant still owns speech recognition, speech
+synthesis, the front-door model, the main agent loop, conversation persistence,
+and model/provider selection.
+
+## Validation status
+
+The initial transport spike ran on this exact configuration:
+
+| Component       | Tested value                                             |
+| --------------- | -------------------------------------------------------- |
+| Board           | Raspberry Pi 5 Model B Rev 1.1                           |
+| RAM             | 15 GiB                                                   |
+| OS              | Debian GNU/Linux 13 (Trixie)                             |
+| Architecture    | aarch64                                                  |
+| Bun             | 1.3.14                                                   |
+| PipeWire tools  | 1.4.2                                                    |
+| Assistant route | Direct local gateway                                     |
+| Provider mode   | `IS_PLATFORM=1` with platform-managed and BYOK providers |
+
+The spike proved the real `bun install -g vellum@latest` package path, assistant
+preflight, binary microphone upload, streamed PCM playback, the front-door call
+site, and main-agent handoff. It did not run PipeWire as the active audio server
+and did not test a Vellum-managed route through Velay. The final hardware gate
+at the end of this guide is pending. Do not treat this document as a support
+announcement until that table is completed and approved.
+
+The ten-turn server-VAD run completed 7 of 10 turns. All failures were the same
+late-STT discard race, not resource exhaustion. The implementation adds a
+bounded late-final grace, but the final open-mic gate must prove that fix on
+hardware. Successful turns met the initial ready and first-audio latency
+thresholds. The stack used about 469 MB RSS, had no swap growth, and showed no
+OOM, restart, or thermal throttling.
+
+No smaller board, RAM size, or older OS is claimed. Docker assistants,
+assistants paired from another machine, and non-interactive service operation
+are unsupported for this release.
+
+## Install
+
+Install Bun and then the published wrapper:
+
+```bash
+bun install -g vellum
+vellum --version
+vellum voice --help
+```
+
+The `vellum` package contains a Bun wrapper. That wrapper imports the published
+TypeScript `@vellumai/cli` package, which includes its workspace dependencies.
+`compile:check` is CI validation and is not the artifact installed on the Pi.
+
+## Install and start PipeWire
+
+Voice requires PipeWire 1.4 or newer, `pw-record`, `pw-play`, `pw-dump`, and
+WirePlumber. On a Debian 13 Lite-style image:
+
+```bash
+sudo apt update
+sudo apt install pipewire pipewire-audio pipewire-pulse pipewire-bin wireplumber
+systemctl --user enable --now pipewire.socket wireplumber.service
+systemctl --user enable --now pipewire-pulse.socket
+sudo loginctl enable-linger "$USER"
+```
+
+The initial Pi used PulseAudio 17.0 as its active server even though PipeWire
+tools were installed. Migrate the user session before running voice:
+
+```bash
+systemctl --user disable --now pulseaudio.service pulseaudio.socket
+systemctl --user enable --now pipewire.socket pipewire-pulse.socket
+systemctl --user enable --now wireplumber.service
+systemctl --user restart pipewire pipewire-pulse wireplumber
+```
+
+Log out and back in if the user bus still has stale PulseAudio state. Verify the
+session:
+
+```bash
+systemctl --user --no-pager status pipewire wireplumber pipewire-pulse
+loginctl show-user "$USER" -p Linger
+pw-dump >/dev/null
+```
+
+Bluetooth audio was not validated in the spike. Use wired, USB, or directly
+attached ALSA hardware for the final validation baseline. Headless Bluetooth pairing,
+profile selection, and reconnect behavior remain outside the current claim.
+
+## Headless and SSH sessions
+
+PipeWire and WirePlumber run in the login user's systemd user session. Linger
+keeps that user session available after an SSH boundary, but `vellum voice`
+itself remains a foreground interactive command.
+
+Use the same Unix user that owns the audio devices. Confirm this runtime path
+exists:
+
+```bash
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+test -S "$XDG_RUNTIME_DIR/pipewire-0"
+```
+
+Start `tmux` after the user audio session is active so it inherits the correct
+`XDG_RUNTIME_DIR` and user bus. A voice command inside `tmux` can survive an SSH
+disconnect. Outside `tmux`, SSH loss sends `SIGHUP`; the CLI stops capture,
+flushes playback, closes the socket, and exits.
+
+Non-interactive system services are unsupported. Do not run `vellum voice` as
+root or from a system unit.
+
+## Choose and diagnose devices
+
+List stable PipeWire node names and object serials:
+
+```bash
+vellum voice devices
+vellum voice devices --json
+```
+
+Run diagnostics before opening the microphone:
+
+```bash
+vellum voice doctor assistant-123
+vellum voice doctor assistant-123 --json
+```
+
+Choose explicit devices for push-to-talk:
+
+```bash
+vellum voice assistant-123 \
+  --input-device alsa_input.example_mic \
+  --output-device alsa_output.example_speakers
+```
+
+Node names are safer across process restarts than transient PipeWire object
+IDs. Rerun `voice devices` after unplugging USB hardware or changing an audio
+profile.
+
+## Direct local assistants
+
+A normal locally hatched assistant uses its directly reachable gateway:
+
+```bash
+vellum voice doctor assistant-123
+vellum voice assistant-123
+```
+
+For a manually provisioned assistant, provide the gateway and exact assistant
+ID:
+
+```bash
+vellum voice doctor \
+  --url http://127.0.0.1:7821 \
+  --assistant-id assistant-123
+
+vellum voice \
+  --url http://127.0.0.1:7821 \
+  --assistant-id assistant-123
+```
+
+`--url` always means direct gateway routing. This remains true when the local
+assistant has `IS_PLATFORM=1` and uses platform-managed STT, TTS, or LLM
+providers. Provider ownership does not change the network route.
+
+Remote direct gateways require TLS and guardian authentication. A guardian
+token is sent as a WebSocket header and never placed in the URL.
+
+## Vellum-managed assistants
+
+Authenticate with a user session, select the managed assistant, and run voice:
+
+```bash
+vellum login
+vellum ps
+vellum voice doctor assistant-123
+vellum voice assistant-123
+```
+
+The CLI uses the stored platform session to mint a short-lived,
+assistant-scoped live-voice token, then connects through the
+environment-matched Velay host. The platform session token is never put in the
+WebSocket URL. Vellum API keys cannot mint this user-session credential.
+
+## Push-to-talk
+
+Push-to-talk is the default and does not require acoustic echo cancellation:
+
+```bash
+vellum voice assistant-123
+```
+
+Press Enter to begin capture and Enter again to release the utterance. Keep the
+terminal focused. Use `s` to interrupt playback, `c` to cycle captions, and `q`
+to exit.
+
+## Configure echo-cancelled open mic
+
+Open mic is optional. It is allowed only when one
+`libpipewire-module-echo-cancel` instance owns both exact virtual nodes:
+
+- Capture source: `vellum_echo_cancel_source`
+- Playback sink: `vellum_echo_cancel_sink`
+
+Find the real microphone and speaker `node.name` values with `pw-dump` or
+`wpctl status`. Replace the two example targets below, then create
+`~/.config/pipewire/pipewire.conf.d/90-vellum-echo-cancel.conf`. The stream
+layout follows PipeWire's
+[echo-cancel module](https://docs.pipewire.org/page_module_echo_cancel.html):
+
+```ini
+context.modules = [
+  {
+    name = libpipewire-module-echo-cancel
+    args = {
+      library.name = aec/libspa-aec-webrtc
+      monitor.mode = false
+      audio.rate = 48000
+      audio.channels = 1
+      audio.position = [ MONO ]
+
+      capture.props = {
+        node.name = "vellum_echo_cancel_capture"
+        target.object = "alsa_input.example_real_microphone"
+      }
+      source.props = {
+        node.name = "vellum_echo_cancel_source"
+        node.description = "Vellum Echo-Cancelled Microphone"
+        media.class = "Audio/Source"
+      }
+      sink.props = {
+        node.name = "vellum_echo_cancel_sink"
+        node.description = "Vellum Echo-Cancel Playback"
+        media.class = "Audio/Sink"
+      }
+      playback.props = {
+        node.name = "vellum_echo_cancel_playback"
+        target.object = "alsa_output.example_real_speakers"
+      }
+    }
+  }
+]
+```
+
+Restart the graph and verify the pair:
+
+```bash
+systemctl --user restart pipewire pipewire-pulse wireplumber
+vellum voice doctor assistant-123 --mode open-mic
+vellum voice assistant-123 --mode open-mic
+```
+
+Open mic always captures from the virtual source and sends TTS to the paired
+virtual sink. That sink supplies the far-end playback reference to the echo
+canceller. The CLI does not accept an unsafe device override for open mic.
+Press `m` to mute, `s` to interrupt, `c` to cycle captions, and `q` to exit.
+
+## Privacy and diagnostics
+
+The CLI streams microphone PCM to the selected assistant and plays returned
+PCM. Audio probes stay in memory. The CLI does not write microphone or TTS PCM
+to disk. Echo diagnostics retain only scalar amplitude, floor, margin, peak,
+and correlation summaries. Transcript captions are off by default.
+
+Assistant-side conversation and audio persistence follows the assistant's
+live-voice storage policy. Use `VELLUM_DEBUG=1` only when collecting support
+evidence. Debug output redacts long-lived credentials and does not contain PCM
+or transcript text.
+
+## Failure recovery
+
+- If `voice doctor` reports no user session, check linger, the user bus, and
+  `XDG_RUNTIME_DIR` before checking hardware.
+- If a node disappears, reconnect the device, rerun `voice devices`, and rerun
+  doctor. Open mic must rediscover the complete echo-cancel pair.
+- A busy response means another live-voice client owns the assistant's single
+  session. End that session and retry. The CLI never steals it.
+- Service-restart and overload closes use bounded reconnects. A managed
+  reconnect mints a new short-lived token.
+- After network loss, rerun doctor before resuming if the audio graph also
+  restarted.
+- `Ctrl+C`, `SIGTERM`, and `SIGHUP` stop capture, flush playback, release the
+  session, and reap audio children. If a process remains, run `vellum clean`
+  and collect its details before retrying.
+
+## Final hardware gate
+
+Complete this matrix on a freshly imaged target before announcing support.
+Attach redacted command output, call-site telemetry, route identity, and scalar
+echo summaries to the implementation PR. Never attach credentials or PCM.
+
+Run the gate in this order:
+
+1. Record the board, RAM, OS, kernel architecture, Bun version, installed
+   package version, PipeWire version, disk, swap, and login-linger state.
+2. Install from the registry into a clean Bun prefix. Run installed-wrapper
+   help, device discovery, and doctor without a source checkout on `PATH`.
+3. Run direct local push-to-talk turns, including one front-door answer and one
+   tool-requiring handoff. Confirm both call sites in redacted telemetry.
+4. Run the same two turns against an authenticated Vellum-managed assistant.
+   Confirm token minting and the Velay route without recording query strings.
+5. Enable the exact AEC pair. Run loud speaker playback with no user speech,
+   then speak over playback. Record route IDs and scalar echo summaries.
+6. Exercise busy ownership, device unplug, network loss, `Ctrl+C`, `SIGTERM`,
+   `SIGHUP`, and SSH loss. Check for stale sessions and orphaned audio children
+   after every case.
+7. Run a 30-minute mixed-turn soak and complete the resource and latency
+   fields below.
+
+| Gate                                                     | Result  | Evidence |
+| -------------------------------------------------------- | ------- | -------- |
+| Fresh `bun install -g vellum`                            | Pending |          |
+| `voice doctor` on installed wrapper                      | Pending |          |
+| Direct local push-to-talk conversation                   | Pending |          |
+| Authenticated Vellum-managed conversation through Velay  | Pending |          |
+| AEC open-mic conversation                                | Pending |          |
+| Simple front-door answer confirmed by call site          | Pending |          |
+| Tool-requiring main-agent handoff confirmed by call site | Pending |          |
+| Another-session busy behavior                            | Pending |          |
+| Device unplug and recovery                               | Pending |          |
+| Network loss and reconnect                               | Pending |          |
+| `Ctrl+C`, `SIGTERM`, `SIGHUP`, and SSH loss              | Pending |          |
+| Loud-speaker playback causes no ghost turn               | Pending |          |
+| Real speech still barges in during playback              | Pending |          |
+| 30-minute soak                                           | Pending |          |
+
+For the soak, record turn attempts and successes, ready latency, end-of-input
+to first-audio latency, assistant and gateway RSS, swap growth, CPU load,
+temperature, throttling, and orphaned `pw-record` or `pw-play` processes.
+
+Support remains blocked until every claimed topology and interaction above has
+a passing result.

--- a/docs/raspberry-pi-voice.md
+++ b/docs/raspberry-pi-voice.md
@@ -152,11 +152,11 @@ ID:
 
 ```bash
 vellum voice doctor \
-  --url http://127.0.0.1:7821 \
+  --url http://127.0.0.1:7830 \
   --assistant-id assistant-123
 
 vellum voice \
-  --url http://127.0.0.1:7821 \
+  --url http://127.0.0.1:7830 \
   --assistant-id assistant-123
 ```
 

--- a/scripts/test-cli-package-install.ts
+++ b/scripts/test-cli-package-install.ts
@@ -1,0 +1,438 @@
+#!/usr/bin/env bun
+
+import {
+  chmod,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+
+interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+const repoRoot = resolve(import.meta.dir, "..");
+const cliDir = join(repoRoot, "cli");
+const metaDir = join(repoRoot, "meta");
+const workspaceRoot = await realpath(repoRoot);
+const tempRoot = await mkdtemp(join(tmpdir(), "vellum-cli-package-install-"));
+const distDir = join(tempRoot, "dist");
+const wrapperDir = join(tempRoot, "wrapper");
+const fakeBinDir = join(tempRoot, "fake-bin");
+const installPrefix = join(tempRoot, "bun-prefix");
+const executionDir = join(tempRoot, "execution");
+const runtimeDir = join(tempRoot, "runtime");
+const configDir = join(tempRoot, "config");
+
+try {
+  await Promise.all(
+    [distDir, wrapperDir, fakeBinDir, executionDir, runtimeDir, configDir].map(
+      async (directory) => await mkdir(directory, { recursive: true }),
+    ),
+  );
+
+  const packCli = await run(["bun", "pm", "pack", "--destination", distDir], {
+    cwd: cliDir,
+  });
+  requireSuccess(packCli, "pack @vellumai/cli");
+  const cliTarball = await findSingleTarball(distDir);
+
+  const rewriteBundleManifest = await run(
+    [
+      "bun",
+      join(repoRoot, "scripts", "strip-bundled-field-from-tarball.mjs"),
+      cliTarball,
+    ],
+    { cwd: repoRoot },
+  );
+  requireSuccess(
+    rewriteBundleManifest,
+    "rewrite bundled workspace dependency paths",
+  );
+  await verifyBundledWorkspacePackages(cliTarball);
+
+  await stageWrapper(cliTarball);
+  const packWrapper = await run(
+    ["bun", "pm", "pack", "--destination", distDir],
+    {
+      cwd: wrapperDir,
+    },
+  );
+  requireSuccess(packWrapper, "pack vellum wrapper");
+  const wrapperTarball = await findSingleTarball(distDir, cliTarball);
+
+  const bunBinDir = dirname(process.execPath);
+  const installEnv = {
+    ...process.env,
+    BUN_INSTALL: installPrefix,
+    PATH: [fakeBinDir, bunBinDir, "/usr/local/bin", "/usr/bin", "/bin"].join(
+      ":",
+    ),
+    XDG_CONFIG_HOME: configDir,
+    XDG_RUNTIME_DIR: runtimeDir,
+    NODE_PATH: "",
+  };
+  const install = await run(["bun", "install", "--global", wrapperTarball], {
+    cwd: executionDir,
+    env: installEnv,
+  });
+  requireSuccess(install, "install staged vellum wrapper");
+
+  const vellumBin = join(installPrefix, "bin", "vellum");
+  const installedWrapper = await realpath(vellumBin);
+  assertOutsideWorkspace(installedWrapper, "installed wrapper");
+  await verifyInstalledCli(installPrefix);
+  await installFakeAudioCommands();
+
+  const server = startFakeVoiceServer();
+  try {
+    const help = await run([vellumBin, "voice", "--help"], {
+      cwd: executionDir,
+      env: installEnv,
+    });
+    requireSuccess(help, "invoke installed voice help");
+    assertIncludes(help.stdout, "Usage: vellum voice", "voice help");
+    assertNoWorkspaceFallback(help, "voice help");
+
+    const devices = await run([vellumBin, "voice", "devices", "--json"], {
+      cwd: executionDir,
+      env: installEnv,
+    });
+    requireSuccess(devices, "invoke installed voice device discovery");
+    const devicesReport = parseJson(devices.stdout, "voice devices");
+    assertDeviceReport(devicesReport);
+    assertNoWorkspaceFallback(devices, "voice devices");
+
+    const doctor = await run(
+      [
+        vellumBin,
+        "voice",
+        "doctor",
+        "--url",
+        `http://127.0.0.1:${server.port}`,
+        "--assistant-id",
+        "assistant-123",
+        "--json",
+      ],
+      { cwd: executionDir, env: installEnv },
+    );
+    const doctorReport = parseJson(doctor.stdout, "voice doctor");
+    assertDoctorReport(doctorReport, doctor.exitCode);
+    assertNoWorkspaceFallback(doctor, "voice doctor");
+  } finally {
+    server.stop(true);
+  }
+
+  console.log(
+    `Installed wrapper verification passed on ${process.platform} ${process.arch}.`,
+  );
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+async function stageWrapper(cliTarball: string): Promise<void> {
+  const manifest = JSON.parse(
+    await readFile(join(metaDir, "package.json"), "utf8"),
+  ) as Record<string, unknown>;
+  await mkdir(join(wrapperDir, "bin"), { recursive: true });
+  await cp(
+    join(metaDir, "bin", "vellum.js"),
+    join(wrapperDir, "bin", "vellum.js"),
+  );
+  await chmod(join(wrapperDir, "bin", "vellum.js"), 0o755);
+  await writeFile(
+    join(wrapperDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: manifest.name,
+        version: manifest.version,
+        license: manifest.license,
+        description: manifest.description,
+        bin: { vellum: "./bin/vellum.js" },
+        files: ["bin"],
+        dependencies: {
+          "@vellumai/cli": `file:${cliTarball}`,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function verifyBundledWorkspacePackages(
+  cliTarball: string,
+): Promise<void> {
+  const listing = await run(["tar", "-tzf", cliTarball], { cwd: repoRoot });
+  requireSuccess(listing, "inspect @vellumai/cli tarball");
+  for (const packageName of [
+    "environments",
+    "local-mode",
+    "service-contracts",
+  ]) {
+    assertIncludes(
+      listing.stdout,
+      `package/node_modules/@vellumai/${packageName}/package.json`,
+      `bundled @vellumai/${packageName}`,
+    );
+  }
+}
+
+async function verifyInstalledCli(prefix: string): Promise<void> {
+  const matches: string[] = [];
+  const glob = new Bun.Glob("**/node_modules/@vellumai/cli/package.json");
+  for await (const match of glob.scan({
+    cwd: prefix,
+    absolute: true,
+    onlyFiles: true,
+  })) {
+    matches.push(await realpath(match));
+  }
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected one installed @vellumai/cli package, found ${matches.length}.`,
+    );
+  }
+  assertOutsideWorkspace(matches[0], "installed @vellumai/cli");
+  const cliPackageDir = dirname(matches[0]);
+  for (const packageName of [
+    "environments",
+    "local-mode",
+    "service-contracts",
+  ]) {
+    const manifest = await realpath(
+      join(
+        cliPackageDir,
+        "node_modules",
+        "@vellumai",
+        packageName,
+        "package.json",
+      ),
+    );
+    assertOutsideWorkspace(manifest, `installed @vellumai/${packageName}`);
+  }
+}
+
+async function installFakeAudioCommands(): Promise<void> {
+  const pipeWireDump = JSON.stringify([
+    {
+      id: 11,
+      type: "PipeWire:Interface:Node",
+      info: {
+        props: {
+          "node.name": "test_microphone",
+          "node.description": "Package install test microphone",
+          "media.class": "Audio/Source",
+          "object.serial": 101,
+        },
+      },
+    },
+    {
+      id: 12,
+      type: "PipeWire:Interface:Node",
+      info: {
+        props: {
+          "node.name": "test_speakers",
+          "node.description": "Package install test speakers",
+          "media.class": "Audio/Sink",
+          "object.serial": 102,
+        },
+      },
+    },
+  ]);
+  await writeExecutable(
+    "pw-dump",
+    `#!/usr/bin/env bun\nprocess.stdout.write(${JSON.stringify(pipeWireDump)} + "\\n");\n`,
+  );
+  await writeExecutable(
+    "pw-record",
+    `#!/usr/bin/env bun\nif (process.argv.includes("--version")) {\n  console.log("pw-record 1.4.2");\n  process.exit(0);\n}\nprocess.stdout.write(Buffer.alloc(320));\nsetInterval(() => {}, 1000);\n`,
+  );
+  await writeExecutable(
+    "pw-play",
+    "#!/usr/bin/env bun\nfor await (const _chunk of Bun.stdin.stream()) {\n}\n",
+  );
+  await writeExecutable(
+    "systemctl",
+    '#!/usr/bin/env bun\nconsole.log("active");\n',
+  );
+  await writeExecutable(
+    "loginctl",
+    '#!/usr/bin/env bun\nconsole.log("Linger=yes");\n',
+  );
+}
+
+async function writeExecutable(name: string, contents: string): Promise<void> {
+  const path = join(fakeBinDir, name);
+  await writeFile(path, contents);
+  await chmod(path, 0o755);
+}
+
+function startFakeVoiceServer(): ReturnType<typeof Bun.serve> {
+  let seq = 0;
+  return Bun.serve({
+    port: 0,
+    fetch(request, server) {
+      const url = new URL(request.url);
+      if (url.pathname === "/v1/live-voice/preflight") {
+        return Response.json({ status: "ready" });
+      }
+      if (url.pathname === "/v1/live-voice" && server.upgrade(request)) {
+        return;
+      }
+      return new Response("not found", { status: 404 });
+    },
+    websocket: {
+      message(socket, message) {
+        if (typeof message !== "string") {
+          return;
+        }
+        const frame = JSON.parse(message) as { type?: unknown };
+        if (frame.type === "start") {
+          socket.send(
+            JSON.stringify({
+              type: "ready",
+              seq: ++seq,
+              sessionId: "session-123",
+              conversationId: "conversation-123",
+              turnDetection: "manual",
+            }),
+          );
+        } else if (frame.type === "end") {
+          socket.send(
+            JSON.stringify({
+              type: "session_released",
+              seq: ++seq,
+              sessionId: "session-123",
+            }),
+          );
+        }
+      },
+    },
+  });
+}
+
+async function run(
+  command: readonly string[],
+  options: {
+    readonly cwd: string;
+    readonly env?: Readonly<Record<string, string | undefined>>;
+  },
+): Promise<CommandResult> {
+  const child = Bun.spawn([...command], {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+async function findSingleTarball(
+  directory: string,
+  excluded?: string,
+): Promise<string> {
+  const matches: string[] = [];
+  const glob = new Bun.Glob("*.tgz");
+  for await (const match of glob.scan({
+    cwd: directory,
+    absolute: true,
+    onlyFiles: true,
+  })) {
+    if (excluded === undefined || resolve(match) !== resolve(excluded)) {
+      matches.push(match);
+    }
+  }
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected one tarball in ${relative(repoRoot, directory)}, found ${matches.length}.`,
+    );
+  }
+  return matches[0];
+}
+
+function requireSuccess(result: CommandResult, operation: string): void {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${operation} failed with exit ${result.exitCode}.\n${result.stdout}${result.stderr}`,
+    );
+  }
+}
+
+function parseJson(output: string, operation: string): Record<string, unknown> {
+  let value: unknown;
+  try {
+    value = JSON.parse(output);
+  } catch {
+    throw new Error(`${operation} did not return a JSON object.`);
+  }
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  throw new Error(`${operation} did not return a JSON object.`);
+}
+
+function assertDeviceReport(report: Record<string, unknown>): void {
+  if (
+    !Array.isArray(report.inputs) ||
+    report.inputs.length !== 1 ||
+    !Array.isArray(report.outputs) ||
+    report.outputs.length !== 1
+  ) {
+    throw new Error("Installed voice device discovery returned bad fixtures.");
+  }
+}
+
+function assertDoctorReport(
+  report: Record<string, unknown>,
+  exitCode: number,
+): void {
+  const target = report.target as Record<string, unknown> | undefined;
+  const audio = report.audio as Record<string, unknown> | undefined;
+  if (target?.status !== "ready" || !Array.isArray(audio?.checks)) {
+    throw new Error("Installed voice doctor did not reach the fake assistant.");
+  }
+  const supportedHost =
+    process.platform === "linux" && process.arch === "arm64";
+  if (supportedHost && (exitCode !== 0 || report.ok !== true)) {
+    throw new Error("Installed voice doctor failed on native Linux ARM64.");
+  }
+  if (!supportedHost && exitCode === 0) {
+    throw new Error("Voice doctor unexpectedly accepted an unsupported host.");
+  }
+}
+
+function assertOutsideWorkspace(path: string, label: string): void {
+  if (path === workspaceRoot || path.startsWith(`${workspaceRoot}/`)) {
+    throw new Error(`${label} resolved into the repository workspace.`);
+  }
+}
+
+function assertNoWorkspaceFallback(
+  result: CommandResult,
+  operation: string,
+): void {
+  if (`${result.stdout}\n${result.stderr}`.includes(workspaceRoot)) {
+    throw new Error(`${operation} exposed a repository workspace fallback.`);
+  }
+}
+
+function assertIncludes(value: string, expected: string, label: string): void {
+  if (!value.includes(expected)) {
+    throw new Error(`${label} did not include '${expected}'.`);
+  }
+}


### PR DESCRIPTION
## Summary

- add native Linux ARM64 package-install verification for PR and main CLI workflows
- document direct local and Vellum-managed Raspberry Pi voice routing, headless PipeWire, device recovery, privacy, and exact AEC setup
- update live-voice architecture ownership across shared contracts, gateway transport, plugins, CLI audio, and assistant-managed providers

## Validation

- `bun scripts/test-cli-package-install.ts`
- 125 focused live-voice and authentication tests
- `bun run lint`
- `bun run lint:unused`
- `bun run typecheck`
- `bun run compile:check`
- workflow YAML parse and changed-file formatting checks

## Hardware gate

The physical Raspberry Pi gate is pending. This PR does not announce support. Final approval remains blocked on a fresh registry install, push-to-talk, AEC open mic, direct local routing, authenticated Vellum-managed routing through Velay, failure and signal handling, loud-speaker echo evidence, barge-in, and a 30-minute soak.