### PR TITLE
feat(web): fire Meta Pixel CompleteRegistration on privacy screen

### DIFF
--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -61,11 +61,11 @@ export function PrivacyScreen() {
   }, []);
 
   useEffect(() => {
-    if (!isNative) {
+    if (!isNative && !electron) {
       initMetaPixel();
       trackCompleteRegistration();
     }
-  }, [isNative]);
+  }, [isNative, electron]);
 
   const isPreview = searchParams.get("preview") === "true";
   const noop = useCallback((_next: boolean) => {}, []);

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -23,6 +23,10 @@ import {
 } from "@/lib/billing/checkout-intent";
 import { buildCustomCheckoutSearch } from "@/lib/billing/custom-checkout-params";
 import { isLocalClient } from "@/lib/local-mode";
+import {
+  initMetaPixel,
+  trackCompleteRegistration,
+} from "@/lib/meta-pixel/meta-pixel";
 import { postCheckoutHatchReturnTo } from "@/lib/navigation/navigation-resolver";
 import {
   usePrivacyConsent,
@@ -55,6 +59,13 @@ export function PrivacyScreen() {
   useEffect(() => {
     getOnboardingFunnelSessionId();
   }, []);
+
+  useEffect(() => {
+    if (!isNative) {
+      initMetaPixel();
+      trackCompleteRegistration();
+    }
+  }, [isNative]);
 
   const isPreview = searchParams.get("preview") === "true";
   const noop = useCallback((_next: boolean) => {}, []);

--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -87,4 +87,6 @@ interface Window {
    * the data endpoint has an init option but the beacon does not.
    */
   __SDKCONFIG__?: { statsURL?: string; serverURL?: string };
+  /** Meta Pixel queue function, injected by `lib/meta-pixel/meta-pixel.ts`. */
+  fbq?: (...args: unknown[]) => void;
 }

--- a/clients/web/src/lib/meta-pixel/meta-pixel.ts
+++ b/clients/web/src/lib/meta-pixel/meta-pixel.ts
@@ -1,0 +1,55 @@
+const PIXEL_ID = "917410754724056";
+
+interface FbqPixel {
+  (...args: unknown[]): void;
+  callMethod?: (...args: unknown[]) => void;
+  queue: unknown[][];
+  push: FbqPixel;
+  loaded: boolean;
+  version: string;
+}
+
+let initialized = false;
+
+/**
+ * Injects the Meta Pixel base script and initializes the pixel.
+ * Only runs on vellum.ai (no dev, staging, or Electron).
+ */
+export function initMetaPixel(): void {
+  if (initialized) {
+    return;
+  }
+
+  const host = window.location.hostname;
+  if (host !== "vellum.ai" && host !== "www.vellum.ai") {
+    return;
+  }
+
+  initialized = true;
+
+  const n = (window.fbq = function (...args: unknown[]) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    n.callMethod
+      ? n.callMethod(...args)
+      : n.queue.push(args);
+  } as FbqPixel);
+  n.push = n;
+  n.loaded = true;
+  n.version = "2.0";
+  n.queue = [] as unknown[][];
+
+  const s = document.createElement("script");
+  s.async = true;
+  s.src = "https://connect.facebook.net/en_US/fbevents.js";
+  document.head.appendChild(s);
+
+  window.fbq("init", PIXEL_ID);
+}
+
+/** Fires a CompleteRegistration standard event if the pixel is initialized. */
+export function trackCompleteRegistration(): void {
+  if (!initialized) {
+    return;
+  }
+  window.fbq!("track", "CompleteRegistration");
+}

--- a/clients/web/src/lib/meta-pixel/meta-pixel.ts
+++ b/clients/web/src/lib/meta-pixel/meta-pixel.ts
@@ -46,10 +46,21 @@ export function initMetaPixel(): void {
   window.fbq("init", PIXEL_ID);
 }
 
-/** Fires a CompleteRegistration standard event if the pixel is initialized. */
+const REGISTRATION_FIRED_KEY = "meta_pixel_complete_registration";
+
+/** Fires a CompleteRegistration standard event once per session. */
 export function trackCompleteRegistration(): void {
   if (!initialized) {
     return;
+  }
+  try {
+    if (sessionStorage.getItem(REGISTRATION_FIRED_KEY)) {
+      return;
+    }
+    sessionStorage.setItem(REGISTRATION_FIRED_KEY, "1");
+  } catch {
+    // Private browsing or storage full — fire anyway, accept the small
+    // duplicate risk over silently dropping the conversion.
   }
   window.fbq!("track", "CompleteRegistration");
 }


### PR DESCRIPTION
## Summary
- Adds a `meta-pixel` utility module that injects the Meta Pixel base script (ID `917410754724056`) and exposes `initMetaPixel()` + `trackCompleteRegistration()`
- Fires `CompleteRegistration` on the privacy screen mount — the first page every new signup lands on in the SPA
- Hostname-gated to `vellum.ai` / `www.vellum.ai` only (no dev, staging, or Electron); idempotent init guard prevents duplicate script injection

## Context
An earlier attempt in the platform repo failed because the callback/signup pages immediately `window.location.replace()` away, causing the beacon to be cancelled before Meta receives it. The privacy screen is an SPA page that stays mounted, so the event reliably reaches Meta. Returning users with stale consent see `ReviewTermsScreen` instead, so there is no double-counting risk.

## Test plan
- [x] `bunx tsc --noEmit` — no new type errors
- [x] `bun test src/domains/onboarding/pages/privacy-screen` — all 8 tests pass
- [ ] Manual: open the privacy screen on `vellum.ai`, confirm `fbevents.js` loads and a `CompleteRegistration` request fires to `facebook.com/tr/` in the Network tab
- [ ] Manual: confirm no pixel loads on `localhost` or staging domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)