### PR TITLE
chore(voice): drop the device bring-up token logging (JARVIS-1377)

### DIFF
--- a/clients/ios/App/App/VoiceLiveActivityPlugin.swift
+++ b/clients/ios/App/App/VoiceLiveActivityPlugin.swift
@@ -182,10 +182,6 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
                 )
                 self.activity = requested
                 self.observePushToken(of: requested)
-                // TEMPORARY (JARVIS-1377 device bring-up): pairs with the token
-                // log below, so a run that starts an activity but never mints a
-                // token is distinguishable from one that never started it.
-                NSLog("[VoiceLiveActivity] activity requested; awaiting push token")
                 call.resolve(["started": true])
             } catch {
                 call.reject(
@@ -260,14 +256,6 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
                 // APNs addresses devices by the hex string, not the bytes.
                 let token = tokenData.map { String(format: "%02x", $0) }.joined()
                 guard !Task.isCancelled else { return }
-                // TEMPORARY (JARVIS-1377 device bring-up): `WKWebView` console
-                // output never reaches the system log, so this is the only way
-                // to see whether ActivityKit issues a token on hardware at all
-                // — the one question the Simulator cannot answer. The token is
-                // a routing address, not a credential, and printing it lets a
-                // push be aimed at this activity by hand before the rest of the
-                // pipeline is deployed. Remove once verified.
-                NSLog("[VoiceLiveActivity] push token (%d chars): %@", token.count, token)
                 self?.notifyListeners(Self.pushTokenEvent, data: ["token": token])
             }
         }


### PR DESCRIPTION
Removes the two `NSLog` lines added last night for the JARVIS-1377 device bring-up. **Should land before today's production release.**

## Why they existed

The Simulator mints no ActivityKit push token at all, so whether one arrives on real hardware was unanswerable until a build reached a phone. `WKWebView` console output never reaches the system log, so native logging was the only way to see it.

They did their job. On device:

```
23:31:24  activity requested; awaiting push token
23:31:25  push token (160 chars): 407f31c2…
```

A token one second after the request, and again on rotation — so the server-driven update path is viable, and the Simulator's refusal was a Simulator limitation rather than a property of this app.

## Why they should go

The token line printed the **full token** into the unified log on every activity start and every rotation — about a dozen times in a 25-minute session. A Live Activity push token is a routing address, not a credential (sending anything still requires the signing key), so this is not a disclosure worth alarm. But it is durable data written to every user's device log with no ongoing purpose, and it exists only to answer a question that is now answered.

Nothing else changes. The token still reaches the web layer via the `liveActivityPushToken` event, which is the path that actually matters.

## Test plan

Deletion only — twelve lines, no behaviour change. The path it instrumented is covered by the mirror's registration tests (`use-live-activity-mirror.test.tsx`) and the reporter's frame-mapping tests, both unaffected.

If a future device session needs a token by hand, the middle ground is logging length plus the last 8 characters — enough to see that a token exists and that it rotated, without publishing it.

## Context for the release

Two things worth knowing if this is going out today, neither introduced by this PR:

- **Nonprod cannot deliver any push to a TestFlight build.** dev and staging set `APNS_USE_SANDBOX: "true"` and dev's key is sandbox-restricted, but every TestFlight build is signed Apple Distribution and mints **production** tokens. Sandbox gateway + production token = `BadDeviceToken`, which the sender treats as "device is gone" and deletes the row. Verified by hand: sandbox returned `BadDeviceToken`, production returned `BadEnvironmentKeyInToken` (the nonprod key cannot address production at all). This predates JARVIS-1377 and affects ordinary notifications too.
- Consequently **a green staging bake says nothing about whether pushes land** — production is the first environment where this pipeline can actually work, and where it can be verified from the server side (registration rows, dispatch outcomes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
