### PR TITLE
fix(voice): stop the VAD test mock from inventing transcripts it never heard

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -128,7 +128,17 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 
   flushStopEvents(): void {
-    for (const event of this.stopEvents) {
+    // A stream that was never sent audio has nothing to transcribe, so a real
+    // provider closes without a final. Scripting one anyway let a cycle that
+    // armed and tore down in the same breath — a client interrupt racing the
+    // post-cancel re-arm — hand the session a transcript it never heard, which
+    // launched a turn nothing would ever finalize and wedged the
+    // one-turn-at-a-time gate for every later utterance.
+    const events =
+      this.received.length > 0
+        ? this.stopEvents
+        : this.stopEvents.filter((event) => event.type !== "final");
+    for (const event of events) {
       this.onEvent?.(event);
     }
   }


### PR DESCRIPTION
Fixes the `ci-assistant` failure in [Release run #373](https://github.com/vellum-ai/vellum-assistant/actions/runs/30631015715): `src/live-voice/__tests__/live-voice-vad.test.ts` → "a client interrupt after a barge-in drops the pending merge context", where the `waitFor` on line 763 timed out after 4s waiting for a later turn to start.

## Prompt / plan

"fix the test failure from this: https://github.com/vellum-ai/vellum-assistant/actions/runs/30631015715"

The failure is a harness-fidelity race, not a product bug. `MockStreamingTranscriber` replayed its scripted `final` event on `stop()` even when it had been sent no audio at all. When the client interrupt lands in the narrow window around the barge-in utterance's turn launch, the interrupt's re-arm creates a cycle and tears it down in the same breath — and that zero-audio cycle handed the session a transcript it had never heard. The session launched a turn for that phantom transcript; the test's turn starter only returns a handle and never completes a turn, so the unfinalized turn held the session's one-turn-at-a-time gate shut and the utterance the test was actually waiting on could never start.

A real STT stream that receives no audio closes without a final, so the mock now filters `final` events out of its stop replay when nothing was ever sent to it, and only replays the close. The session then discards the empty cycle (`utterance_discarded`) and stays idle, which is the production behavior the test meant to exercise.

## Test plan

- Reproduced deterministically by sweeping the delay between the barge-in and the client interrupt from 0–300 ms: delays of 20–32 ms wedged the session (turn starter stuck at 2 calls, a never-finalized `live-turn-3` holding the gate, the waiting utterance sitting at `transcriber_closed` with its transcript ready). Instrumentation confirmed the phantom cycle's transcriber received 0 bytes yet produced a final.
- Same sweep after the change: no delay in 0–300 ms wedges.
- `bun test src/live-voice/__tests__/live-voice-vad.test.ts` — 86 pass, run 3× plus 6 concurrent runs on a 4-core box.
- `bun test src/live-voice/` — 375 pass across 21 files.
- `bunx tsgo --noEmit`, `eslint`, and `prettier --check` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4BjD1UbaGA3E1ZbqUdzQu)_