### PR TITLE
fix(web): paint the iOS shell canvas so the keyboard slide-in cannot flash white

### DIFF
--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -15,6 +15,14 @@ body {
   color: var(--content-default);
 }
 
+/* Capacitor iOS shell: the app shell shrinks ahead of the keyboard plugin's
+ * deferred web view resize, briefly exposing the canvas, which unpainted falls
+ * through (isOpaque = false) to the near-white native SurfaceOverlay backdrop.
+ * Gated because Electron's transparent floating windows need an unpainted canvas. */
+:root[data-native-platform="ios"] body {
+  background: var(--surface-base);
+}
+
 /* Electron prechat onboarding typography — mirror the lighter DM Sans (Swift
  * VFont) weights/sizes so the macOS Electron funnel matches the native Swift
  * client. Scoped via `.electron-prechat-type` (applied ONLY on Electron) so the


### PR DESCRIPTION
## Summary
- Adds an iOS-shell-gated `body` background so the strip the app shell exposes during the keyboard slide-in paints `--surface-base` instead of falling through to the native near-white SurfaceOverlay backdrop.
- Gated on `data-native-platform=ios`, which only the Capacitor shell stamps, so Electron's transparent floating windows, mobile Safari, and desktop cannot match.
- Also covers the dismiss sliver and the pre-first-paint boot window.