### PR TITLE
fix(voice): the mobile room stops swallowing what the header opens (JARVIS-1393)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -1016,15 +1016,15 @@ export function ChatLayout({
           >
             {chatContent}
             {/* A popout narrowed below the mobile breakpoint lands in this
-                branch — still headerless, so it still needs the floating
+                branch, still headerless, so it still needs the floating
                 session surface (see the desktop popout branch below). */}
             {isPopout ? <VoiceSessionPillHost variant="standalone" /> : null}
           </main>
           {/* The drawer is a sibling of `<main>`, not a child of it, even
               though it is the chat body's own navigation. `mainRoomClass`
               puts a `filter` + `opacity` on `<main>` while the voice room is
-              up, and both make it a stacking context AND — for the filter —
-              the containing block for `position: fixed` descendants. Nested,
+              up, and both make it a stacking context AND (for the filter) the
+              containing block for `position: fixed` descendants. Nested,
               the drawer would come up blurred at 40% opacity, offset to
               `<main>`'s box instead of the viewport, and sealed below the
               room by its parent's tier: the menu button read as dead. Out

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -1010,14 +1010,25 @@ export function ChatLayout({
       ) : null}
 
       {isMobile ? (
-        <main
-          className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
-        >
-          {chatContent}
-          {/* A popout narrowed below the mobile breakpoint lands in this
-              branch — still headerless, so it still needs the floating
-              session surface (see the desktop popout branch below). */}
-          {isPopout ? <VoiceSessionPillHost variant="standalone" /> : null}
+        <>
+          <main
+            className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
+          >
+            {chatContent}
+            {/* A popout narrowed below the mobile breakpoint lands in this
+                branch — still headerless, so it still needs the floating
+                session surface (see the desktop popout branch below). */}
+            {isPopout ? <VoiceSessionPillHost variant="standalone" /> : null}
+          </main>
+          {/* The drawer is a sibling of `<main>`, not a child of it, even
+              though it is the chat body's own navigation. `mainRoomClass`
+              puts a `filter` + `opacity` on `<main>` while the voice room is
+              up, and both make it a stacking context AND — for the filter —
+              the containing block for `position: fixed` descendants. Nested,
+              the drawer would come up blurred at 40% opacity, offset to
+              `<main>`'s box instead of the viewport, and sealed below the
+              room by its parent's tier: the menu button read as dead. Out
+              here its z-40 sorts against the room directly. */}
           {drawerVisible || drawerDragging ? (
             <div
               ref={drawerRef}
@@ -1065,7 +1076,7 @@ export function ChatLayout({
               </aside>
             </div>
           ) : null}
-        </main>
+        </>
       ) : isPopout ? (
         <main
           className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4 ${mainRoomClass}`}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -647,7 +647,7 @@ describe("VoiceRoom: mobile sheet", () => {
   // Leaving the header usable is only half the promise: what the header OPENS
   // has to land in front of the room too. `root-layout.tsx` isolates the whole
   // app shell, so a sheet portaled to the body sits outside that stacking
-  // context and outranks every surface inside it regardless of z-index — the
+  // context and outranks every surface inside it regardless of z-index: the
   // navigation drawer opened invisibly behind the room and search opened behind
   // it. The room belongs inside the shell, under both.
   describe("stacking against the surfaces the header opens", () => {
@@ -668,6 +668,57 @@ describe("VoiceRoom: mobile sheet", () => {
 
       const sheet = screen.getByRole("dialog", { name: "Voice session" });
       expect(overlays.host.contains(sheet)).toBe(true);
+      removeHeader();
+      overlays.remove();
+    });
+
+    // The drawer and the palette close themselves on Escape and do not stop
+    // propagation, so an unconditional window handler dismissed both them and
+    // the room behind them on one keypress.
+    test("Escape belongs to a dialog layered over the room", () => {
+      const overlays = mountOverlayHost();
+      const removeHeader = mountHeader();
+      mockIsMobile = true;
+      startOwnedSession("listening");
+      render(<VoiceRoom variant="sheet" />);
+
+      // Stand in for the navigation drawer: a dialog over the room, holding
+      // focus, that is not the room's own.
+      const drawer = document.createElement("div");
+      drawer.setAttribute("role", "dialog");
+      drawer.setAttribute("tabindex", "-1");
+      document.body.appendChild(drawer);
+      drawer.focus();
+
+      act(() => {
+        fireEvent.keyDown(window, { key: "Escape" });
+      });
+
+      expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
+      drawer.remove();
+      removeHeader();
+      overlays.remove();
+    });
+
+    test("Escape still minimizes from outside any dialog", () => {
+      // The composer textarea can still hold focus as the room opens, and it
+      // sits inside no dialog at all, so the key has to reach the room there.
+      const overlays = mountOverlayHost();
+      const removeHeader = mountHeader();
+      mockIsMobile = true;
+      startOwnedSession("listening");
+      render(<VoiceRoom variant="sheet" />);
+
+      const composer = document.createElement("textarea");
+      document.body.appendChild(composer);
+      composer.focus();
+
+      act(() => {
+        fireEvent.keyDown(window, { key: "Escape" });
+      });
+
+      expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+      composer.remove();
       removeHeader();
       overlays.remove();
     });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -644,6 +644,54 @@ describe("VoiceRoom: mobile sheet", () => {
     removeHeader();
   });
 
+  // Leaving the header usable is only half the promise: what the header OPENS
+  // has to land in front of the room too. `root-layout.tsx` isolates the whole
+  // app shell, so a sheet portaled to the body sits outside that stacking
+  // context and outranks every surface inside it regardless of z-index — the
+  // navigation drawer opened invisibly behind the room and search opened behind
+  // it. The room belongs inside the shell, under both.
+  describe("stacking against the surfaces the header opens", () => {
+    /** Stand in for `root-layout.tsx`'s portal container. */
+    function mountOverlayHost() {
+      const host = document.createElement("div");
+      host.id = "viewport-overlays";
+      document.body.appendChild(host);
+      return { host, remove: () => host.remove() };
+    }
+
+    test("portals into the app shell's overlay host, not the body", () => {
+      const overlays = mountOverlayHost();
+      const removeHeader = mountHeader();
+      mockIsMobile = true;
+      startOwnedSession("listening");
+      render(<VoiceRoom variant="sheet" />);
+
+      const sheet = screen.getByRole("dialog", { name: "Voice session" });
+      expect(overlays.host.contains(sheet)).toBe(true);
+      removeHeader();
+      overlays.remove();
+    });
+
+    test("sits below the navigation drawer and the search palette", () => {
+      const overlays = mountOverlayHost();
+      const removeHeader = mountHeader();
+      mockIsMobile = true;
+      startOwnedSession("listening");
+      render(<VoiceRoom variant="sheet" />);
+
+      // The drawer is z-40 (`chat-layout.tsx`) and the palette z-50
+      // (`command-palette.tsx`, which also has to clear the drawer it opens
+      // over), so the room takes the tier below both.
+      const sheet = screen.getByRole("dialog", { name: "Voice session" });
+      expect(sheet.className).toContain("z-30");
+      // The primitive's own z-50 must not survive the merge, or the tier is a
+      // coin flip on class order.
+      expect(sheet.className).not.toContain("z-50");
+      removeHeader();
+      overlays.remove();
+    });
+  });
+
   // The sheet slides up, so anything inside it that also animates in is a
   // second, competing arrival: the sheet lands and only then does its content
   // assemble itself. The room rides up already painted instead. See

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -30,8 +30,10 @@
  *   ends ({@link useChatHeaderBottom}) rather than inheriting that edge from
  *   the DOM. Non-modal, so the header it rests below stays lit and usable,
  *   which takes suppressing several of Radix's modal reflexes: see
- *   {@link VoiceRoomSheet}. Because the slide IS its entrance, the look inside
- *   is painted rather than grown. See `voice-room-entrance.ts`.
+ *   {@link VoiceRoomSheet}. It portals into `RootLayout`'s `#viewport-overlays`
+ *   rather than the body, which is what keeps the surfaces the header opens
+ *   ON TOP of it: see {@link VoiceRoom}. Because the slide IS its entrance, the
+ *   look inside is painted rather than grown. See `voice-room-entrance.ts`.
  * - `"fullscreen"`: `fixed inset-0` over the whole viewport, modal, with
  *   safe-area padding for notched iOS shells. No longer mounted by the chat
  *   layout; kept as the variant a surface with no chrome to sit under would
@@ -78,7 +80,14 @@ import {
 } from "motion/react";
 import { Captions, Mic, MicOff, Volume2, VolumeX, X } from "lucide-react";
 
-import { BottomSheet, Tooltip, cn } from "@vellumai/design-library";
+import {
+  BottomSheet,
+  PortalContainerProvider,
+  Tooltip,
+  cn,
+} from "@vellumai/design-library";
+
+import { useMobileOverlayTarget } from "@/domains/chat/hooks/use-mobile-overlay-target";
 
 import {
   endLiveVoiceSession,
@@ -153,6 +162,24 @@ const SESSION_CONTROL_NEUTRAL_CLASS =
 export type VoiceRoomVariant = "fullscreen" | "content" | "sheet";
 
 /**
+ * The mobile sheet's tier inside the app shell's stacking context, overriding
+ * the primitive's own `z-50`.
+ *
+ * The room rests below the thread header and leaves it usable, so everything
+ * that header opens has to land in front of the room: the navigation drawer
+ * (`z-40` in `chat-layout.tsx`) and, above that, the search palette (`z-50` in
+ * `command-palette.tsx`, which also has to clear the drawer it opens over).
+ * `z-30` is the shared tier for mobile surfaces that sit under the header —
+ * the same one `mobile-app-overlay.tsx` and `mobile-document-overlay.tsx` use.
+ *
+ * This only orders the sheet against the app's own chrome. Menus and sheets
+ * opened FROM the header (the conversation actions menu, the notifications
+ * bell) portal to the body, outside the shell's stacking context, so they clear
+ * the room by construction.
+ */
+const SHEET_LAYER = "z-30";
+
+/**
  * `BottomSheet.Content` with Motion attached, so `AnimatePresence` can play the
  * sheet's exit on the element Radix positions. The primitive forwards its ref
  * and spreads the rest onto Radix's content element, which is what
@@ -169,10 +196,33 @@ export function VoiceRoom({
 }) {
   const visible = useIsVoiceRoomVisible();
 
-  return (
+  // Where the mobile sheet portals to. `root-layout.tsx` wraps the whole app
+  // shell in `isolation: isolate`, so a sheet portaled to the body lands
+  // OUTSIDE that stacking context and paints above everything in it no matter
+  // what z-index the app uses — including the two surfaces the header opens
+  // (the navigation drawer and the search palette), which is why tapping the
+  // menu looked dead and search opened behind the room. Portaling into
+  // `#viewport-overlays` puts the room back inside the shell's stacking
+  // context, where {@link SHEET_LAYER} orders it under both.
+  //
+  // Resolved here rather than in the sheet: this component is mounted for the
+  // chat layout's whole life, so the container is settled long before a session
+  // opens the room and the portal never changes under a mounted sheet (which
+  // would remount it and restart the slide-up).
+  const overlayTarget = useMobileOverlayTarget();
+
+  const room = (
     <AnimatePresence>
       {visible ? <VoiceRoomOverlay key="voice-room" variant={variant} /> : null}
     </AnimatePresence>
+  );
+
+  return variant === "sheet" ? (
+    <PortalContainerProvider container={overlayTarget}>
+      {room}
+    </PortalContainerProvider>
+  ) : (
+    room
   );
 }
 
@@ -226,7 +276,10 @@ function VoiceRoomSheet({
         // Override the primitive's default height band. The room is not a
         // menu sized to its rows; it fills everything between the header and
         // the bottom edge.
-        className="top-[var(--voice-sheet-top)] max-h-none min-h-0 overflow-hidden border-t-0 bg-transparent p-0"
+        className={cn(
+          "top-[var(--voice-sheet-top)] max-h-none min-h-0 overflow-hidden border-t-0 bg-transparent p-0",
+          SHEET_LAYER,
+        )}
         onEscapeKeyDown={(event) => event.preventDefault()}
         onInteractOutside={(event) => event.preventDefault()}
         // Radix focuses the first focusable child on open, which here is the
@@ -375,10 +428,12 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       ref={roomRef}
       className={cn(
         "z-50 flex items-center justify-center overflow-hidden",
-        // Every variant sits at z-50, the highest tier used inside the chat
-        // layout. `overflow-hidden` above is what clips the full-bleed
-        // color/wave layers to whatever radius the variant carries: the panel's
-        // corners on desktop, the sheet's top corners on mobile.
+        // z-50 orders the room's own box against the chat layout for the
+        // fullscreen and panel variants; under the sheet it is scoped to the
+        // sheet's stacking context, whose tier is {@link SHEET_LAYER}.
+        // `overflow-hidden` above is what clips the full-bleed color/wave
+        // layers to whatever radius the variant carries: the panel's corners on
+        // desktop, the sheet's top corners on mobile.
         fullscreen && "fixed inset-0",
         variant === "content" && "absolute inset-0 rounded-xl",
         // The sheet's own box is the Radix content element, which is already

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -87,8 +87,6 @@ import {
   cn,
 } from "@vellumai/design-library";
 
-import { useMobileOverlayTarget } from "@/domains/chat/hooks/use-mobile-overlay-target";
-
 import {
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
@@ -169,8 +167,8 @@ export type VoiceRoomVariant = "fullscreen" | "content" | "sheet";
  * that header opens has to land in front of the room: the navigation drawer
  * (`z-40` in `chat-layout.tsx`) and, above that, the search palette (`z-50` in
  * `command-palette.tsx`, which also has to clear the drawer it opens over).
- * `z-30` is the shared tier for mobile surfaces that sit under the header —
- * the same one `mobile-app-overlay.tsx` and `mobile-document-overlay.tsx` use.
+ * `z-30` is the shared tier for mobile surfaces that sit under the header, the
+ * same one `mobile-app-overlay.tsx` and `mobile-document-overlay.tsx` use.
  *
  * This only orders the sheet against the app's own chrome. Menus and sheets
  * opened FROM the header (the conversation actions menu, the notifications
@@ -178,6 +176,14 @@ export type VoiceRoomVariant = "fullscreen" | "content" | "sheet";
  * the room by construction.
  */
 const SHEET_LAYER = "z-30";
+
+/**
+ * Marks a `role="dialog"` element as belonging to the room, so the global
+ * Escape handler can tell the room's own dialog apart from one layered over it.
+ * Carried by whichever element is the dialog for the variant: the room's box
+ * under `fullscreen` / `content`, the sheet's Radix content under `sheet`.
+ */
+const ROOM_DIALOG_ATTR = "data-voice-room";
 
 /**
  * `BottomSheet.Content` with Motion attached, so `AnimatePresence` can play the
@@ -188,6 +194,46 @@ const SHEET_LAYER = "z-30";
  */
 const MotionBottomSheetContent = motion.create(BottomSheet.Content);
 
+/** `RootLayout`'s portal container, inside the app shell's isolation. */
+const OVERLAY_HOST_ID = "viewport-overlays";
+
+/**
+ * The element the mobile sheet portals into.
+ *
+ * `root-layout.tsx` wraps the whole app shell in `isolation: isolate`, so a
+ * sheet portaled to the body lands OUTSIDE that stacking context and paints
+ * above everything in it whatever z-index the app uses, including the two
+ * surfaces the header opens (the navigation drawer and the search palette).
+ * `#viewport-overlays` puts the room back inside the shell, where
+ * {@link SHEET_LAYER} orders it under both.
+ *
+ * Read synchronously on first render rather than only from an effect. The sheet
+ * mounts fresh whenever the layout crosses into mobile, and a live session can
+ * already be running at that moment (a desktop window narrowing mid-call): a
+ * null first value would open the room against the `document.body` fallback,
+ * reviving the stacking path this avoids, and then remount it into the host,
+ * restarting the slide-up. The effect covers the one case the synchronous read
+ * misses, the app's very first commit, where `RootLayout` mounts the container
+ * in the same pass. No session can be live that early, so the room never opens
+ * against the null.
+ */
+function useVoiceRoomPortalTarget(): HTMLElement | null {
+  const [target, setTarget] = useState<HTMLElement | null>(() =>
+    typeof document === "undefined"
+      ? null
+      : document.getElementById(OVERLAY_HOST_ID),
+  );
+
+  useEffect(() => {
+    if (target) {
+      return;
+    }
+    setTarget(document.getElementById(OVERLAY_HOST_ID));
+  }, [target]);
+
+  return target;
+}
+
 export function VoiceRoom({
   variant = "fullscreen",
 }: {
@@ -195,21 +241,7 @@ export function VoiceRoom({
   variant?: VoiceRoomVariant;
 }) {
   const visible = useIsVoiceRoomVisible();
-
-  // Where the mobile sheet portals to. `root-layout.tsx` wraps the whole app
-  // shell in `isolation: isolate`, so a sheet portaled to the body lands
-  // OUTSIDE that stacking context and paints above everything in it no matter
-  // what z-index the app uses — including the two surfaces the header opens
-  // (the navigation drawer and the search palette), which is why tapping the
-  // menu looked dead and search opened behind the room. Portaling into
-  // `#viewport-overlays` puts the room back inside the shell's stacking
-  // context, where {@link SHEET_LAYER} orders it under both.
-  //
-  // Resolved here rather than in the sheet: this component is mounted for the
-  // chat layout's whole life, so the container is settled long before a session
-  // opens the room and the portal never changes under a mounted sheet (which
-  // would remount it and restart the slide-up).
-  const overlayTarget = useMobileOverlayTarget();
+  const overlayTarget = useVoiceRoomPortalTarget();
 
   const room = (
     <AnimatePresence>
@@ -280,6 +312,8 @@ function VoiceRoomSheet({
           "top-[var(--voice-sheet-top)] max-h-none min-h-0 overflow-hidden border-t-0 bg-transparent p-0",
           SHEET_LAYER,
         )}
+        // Marks the sheet as the room's own dialog. See {@link ROOM_DIALOG_ATTR}.
+        {...{ [ROOM_DIALOG_ATTR]: "" }}
         onEscapeKeyDown={(event) => event.preventDefault()}
         onInteractOutside={(event) => event.preventDefault()}
         // Radix focuses the first focusable child on open, which here is the
@@ -412,10 +446,29 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const choreography = resolveVoiceRoomChoreography(variant, reduce === true);
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        minimizeVoiceRoom();
+      if (event.key !== "Escape") {
+        return;
       }
+      // A dialog layered over the room owns the key while it holds focus. The
+      // navigation drawer and the search palette both sit above the room and
+      // close themselves on Escape without stopping propagation, so an
+      // unconditional minimize here dismisses two surfaces at once: the drawer
+      // closes and the room vanishes behind it.
+      //
+      // Keyed on the focused dialog rather than the event target, which is what
+      // keeps the unguarded behavior the room needs: the key still reaches us
+      // when the composer textarea holds focus as the room opens, since that is
+      // inside no dialog at all. The room's own dialog carries
+      // {@link ROOM_DIALOG_ATTR} in every variant, including the sheet, whose
+      // Radix content is the dialog and takes focus on open.
+      const active = document.activeElement;
+      const owner =
+        active instanceof Element ? active.closest(`[role="dialog"]`) : null;
+      if (owner && !owner.hasAttribute(ROOM_DIALOG_ATTR)) {
+        return;
+      }
+      event.preventDefault();
+      minimizeVoiceRoom();
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
@@ -447,6 +500,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       // The sheet's Radix content element is the dialog; a second `role` and
       // label nested inside it would announce the room twice.
       role={sheet ? undefined : "dialog"}
+      // Marks this box as the room's own dialog for the variants where it is
+      // one. See {@link ROOM_DIALOG_ATTR}; the sheet carries it on its content.
+      {...{ [ROOM_DIALOG_ATTR]: "" }}
       // Only the fullscreen room is modal by its own declaration. The content
       // variant deliberately leaves the header and sidenav usable, so claiming
       // the rest of the app is inert would be a lie to assistive tech; the


### PR DESCRIPTION
Fixes JARVIS-1393.

The mobile voice room rests below the thread header specifically so that header stays usable, but on iOS nothing the header *opens* landed in front of it. Tapping the menu button read as dead, and search opened its palette behind the room.

## Why

Two causes, one per symptom.

**The stacking context.** `root-layout.tsx` wraps the whole app shell in `isolation: isolate`. The room is a Radix `BottomSheet` portaled to `document.body`, i.e. *outside* that context, so it painted above everything inside it regardless of z-index, including the two surfaces the header opens that live inside the shell: the navigation drawer (`fixed z-40`) and the mobile search palette (`fixed inset-0 z-50`, rendered inline rather than portaled).

**The blur.** While the room is up, `<main>` gets `blur-sm opacity-40`, and the drawer was rendered inside it. `filter` makes `<main>` both a stacking context *and* the containing block for its `position: fixed` descendants, so the drawer *did* open: blurred to 40%, offset to `<main>`'s box instead of the viewport, and sealed under the room by its parent's tier.

## What changed

- The sheet portals into `RootLayout`'s `#viewport-overlays`, inside the shell, at `z-30`, the tier `mobile-app-overlay` / `mobile-document-overlay` already use for surfaces that sit under the header. Order is now room 30 < drawer 40 < palette 50 (the palette already had to clear the drawer it opens over). The container is read synchronously on first render, not only from an effect: the sheet mounts fresh whenever the layout crosses into mobile and a session can already be live then, where a null first value would open the room against the `document.body` fallback and then remount it.
- The drawer moves out of `<main>` to a sibling, where its z-40 sorts against the room directly.

Menus opened *from* the header, the conversation actions menu and the notifications bell, portal to the body and so clear the room by construction. That is noted where the tier is declared, since it is the reason they need no change.

## Escape

Making those surfaces actually appear over the room exposed a second bug, pre-existing on desktop where the palette has always portaled above the `content` variant. The drawer and the palette each close themselves on Escape without stopping propagation, and the room's handler is on `window` and fired unconditionally, so one keypress dismissed both: the drawer closed and the room vanished behind it.

Escape now yields to whichever dialog holds focus unless it is the room's own, marked with `data-voice-room`. Keyed on the focused dialog rather than the event target, which preserves the behavior the room needs: the key still reaches it when the composer textarea holds focus as the room opens, since that sits inside no dialog at all.

## Testing

Verified by hand on iOS: open the room, tap the menu, tap search. Both now open in front of the room.

Four tests in `voice-room.test.tsx`: the sheet portals into the shell's overlay host; it carries `z-30` with the primitive's own `z-50` merged away (otherwise the tier is a coin flip on class order); Escape from a foreign dialog leaves the room up; Escape from outside any dialog still minimizes. The Escape pair was mutation-checked, removing the guard fails exactly the first of them.

`bun test voice-room.test.tsx` (79 pass), plus `use-is-voice-room-visible`, `chat-layout-header`, `tsc --noEmit`, and eslint.

## CI

Merged with `--admin` over a red `Test` job that is inherited from main, not produced by this branch. `a417d4b141` ("polish: minor chat UI touch-ups", #39722) changed the nudge banner's background to `color-mix(...)` without updating `nudge-chat-banner.test.tsx`, which still asserts the old literal, and `CI Main Web` has been failing since. 792 of 793 web test files pass here, and the one failure is in a file this branch does not touch. `Lint`, `Type Check` and `Build` all pass; "Lint, Type Check & Build" is the aggregate gate reporting that single failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)