### PR TITLE
fix(web): fade the empty-chat suggestions dock while the keyboard is open

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -114,6 +114,11 @@ mock.module("@/domains/chat/components/question-prompt-slot", () => ({
   QuestionPromptSlot: () => <div data-testid="question-prompt-slot" />,
 }));
 
+let keyboardOpen = false;
+mock.module("@/hooks/use-keyboard-open", () => ({
+  useKeyboardOpen: () => keyboardOpen,
+}));
+
 // Import after mocks are registered.
 const { ChatBody } = await import("@/domains/chat/components/chat-body");
 
@@ -368,6 +373,69 @@ describe("ChatBody — startersSlot rendering", () => {
   test("omits starters when startersSlot is undefined", () => {
     const html = renderToStaticMarkup(<ChatBody {...withEmptyState()} />);
     expect(html).not.toContain("STARTER_CHIPS");
+  });
+});
+
+describe("ChatBody - docked starters hide while the keyboard is open", () => {
+  // The docked (mobile empty-state) suggestions row fades out while the soft
+  // keyboard is up, staying mounted so the centered greeting + composer keep
+  // their layout. Class assertions here are regression pins on the markup,
+  // not proof of the rendered layout.
+  const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
+
+  const dockedProps = () =>
+    withEmptyState({ dockStartersToBottom: true, startersSlot });
+
+  const dockWrapper = (container: HTMLElement) =>
+    container.querySelector('[data-slot="docked-starters"]');
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
+  });
+
+  test("keyboard closed: the dock is visible, interactive, and not inert", () => {
+    keyboardOpen = false;
+    const { container } = render(<ChatBody {...dockedProps()} />);
+
+    const dock = dockWrapper(container);
+    expect(dock).not.toBeNull();
+    expect(dock?.className).not.toContain("opacity-0");
+    expect(dock?.className).not.toContain("pointer-events-none");
+    expect(dock?.hasAttribute("inert")).toBe(false);
+  });
+
+  test("keyboard open: the dock stays mounted but fades out and goes inert", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...dockedProps()} />);
+
+    const dock = dockWrapper(container);
+    expect(dock).not.toBeNull();
+    expect(container.innerHTML).toContain("STARTER_CHIPS");
+    expect(dock?.className).toContain("opacity-0");
+    expect(dock?.className).toContain("pointer-events-none");
+    expect(dock?.hasAttribute("inert")).toBe(true);
+  });
+
+  test("keyboard toggling flips the hidden treatment without unmounting", () => {
+    keyboardOpen = true;
+    const { container, rerender } = render(<ChatBody {...dockedProps()} />);
+    expect(dockWrapper(container)?.className).toContain("opacity-0");
+
+    keyboardOpen = false;
+    rerender(<ChatBody {...dockedProps()} />);
+    expect(dockWrapper(container)?.className).not.toContain("opacity-0");
+    expect(container.innerHTML).toContain("STARTER_CHIPS");
+  });
+
+  test("non-docked empty state keeps its starters untouched by keyboard state", () => {
+    keyboardOpen = true;
+    const { container } = render(
+      <ChatBody {...withEmptyState({ startersSlot })} />,
+    );
+
+    expect(container.innerHTML).toContain("STARTER_CHIPS");
+    expect(dockWrapper(container)).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Paperclip, X } from "lucide-react";
 
+import { useKeyboardOpen } from "@/hooks/use-keyboard-open";
 import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
 import { QuestionPromptSlot } from "@/domains/chat/components/question-prompt-slot";
 import { StagedQuotesStrip } from "@/domains/chat/components/staged-quotes-strip";
@@ -172,6 +173,8 @@ export interface ChatBodyProps {
    * that viewport, and {@link belowFoldSlot} is placed below the fold. Used by
    * the new-thread suggestions library. When false, the empty state keeps the
    * default layout where the starters sit directly below the composer.
+   * While the soft keyboard is open the dock fades out (kept mounted so the
+   * centered group does not jump).
    */
   dockStartersToBottom?: boolean;
 
@@ -211,6 +214,7 @@ export function ChatBody({
   activeProcessOverlaysSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
+  const keyboardOpen = useKeyboardOpen();
   const bottomBannerOverlayRef = useRef<HTMLDivElement | null>(null);
   const [bottomBannerOverlayHeight, setBottomBannerOverlayHeight] = useState(0);
 
@@ -401,7 +405,15 @@ export function ChatBody({
             {renderComposerStack(null)}
           </div>
           {startersSlot && (
-            <div className="px-3 pb-3 sm:px-6">
+            // Faded rather than unmounted while the keyboard is open:
+            // unmounting would recenter the greeting + composer and jump the
+            // layout. `inert` (not just opacity/pointer-events) so the hidden
+            // dock also leaves the tab order and accessibility tree.
+            <div
+              data-slot="docked-starters"
+              inert={keyboardOpen || undefined}
+              className={`px-3 pb-3 sm:px-6 transition-opacity duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`}
+            >
               <div className="mx-auto max-w-[var(--chat-max-width)]">
                 {startersSlot}
               </div>

--- a/clients/web/src/hooks/use-keyboard-open.test.tsx
+++ b/clients/web/src/hooks/use-keyboard-open.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Tests for `useKeyboardOpen`, the shared soft-keyboard-visibility boolean.
+ *
+ * The hook composes `useIsMobile` + `useVisibleViewport`; both are mocked so
+ * each test drives an explicit platform / viewport state.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import type { VisibleViewport } from "@/hooks/use-visible-viewport";
+
+let isMobile = false;
+let visibleViewport: VisibleViewport | null = null;
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => isMobile,
+}));
+mock.module("@/hooks/use-visible-viewport", () => ({
+  KEYBOARD_OPEN_THRESHOLD_PX: 100,
+  useVisibleViewport: () => visibleViewport,
+}));
+
+const { useKeyboardOpen } = await import("@/hooks/use-keyboard-open");
+
+function viewportWithKeyboard(keyboardHeight: number): VisibleViewport {
+  return {
+    height: 800 - keyboardHeight,
+    keyboardHeight,
+    offsetTop: 0,
+    offsetLeft: 0,
+  };
+}
+
+function captureKeyboardOpen(): boolean {
+  let captured = false;
+  function Probe() {
+    captured = useKeyboardOpen();
+    return null;
+  }
+  render(<Probe />);
+  return captured;
+}
+
+afterEach(cleanup);
+
+describe("useKeyboardOpen", () => {
+  test("false on desktop regardless of the reported keyboard height", () => {
+    isMobile = false;
+    visibleViewport = viewportWithKeyboard(300);
+
+    expect(captureKeyboardOpen()).toBe(false);
+  });
+
+  test("false on mobile while the viewport is unmeasured (null)", () => {
+    isMobile = true;
+    visibleViewport = null;
+
+    expect(captureKeyboardOpen()).toBe(false);
+  });
+
+  test("false on mobile at exactly the threshold height", () => {
+    isMobile = true;
+    visibleViewport = viewportWithKeyboard(100);
+
+    expect(captureKeyboardOpen()).toBe(false);
+  });
+
+  test("true on mobile above the threshold height", () => {
+    isMobile = true;
+    visibleViewport = viewportWithKeyboard(300);
+
+    expect(captureKeyboardOpen()).toBe(true);
+  });
+});

--- a/clients/web/src/hooks/use-keyboard-open.ts
+++ b/clients/web/src/hooks/use-keyboard-open.ts
@@ -1,0 +1,23 @@
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import {
+  KEYBOARD_OPEN_THRESHOLD_PX,
+  useVisibleViewport,
+} from "@/hooks/use-visible-viewport";
+
+/**
+ * Returns `true` while the soft keyboard is open on a mobile viewport.
+ *
+ * On the iOS shell the visible-viewport state reports the keyboard height
+ * announced at the leading edge of the show animation, so this flips true
+ * before the native frame resize lands; elsewhere it flips at the measured
+ * height. Always `false` on desktop widths.
+ */
+export function useKeyboardOpen(): boolean {
+  const isMobile = useIsMobile();
+  const visibleViewport = useVisibleViewport();
+  return (
+    isMobile &&
+    visibleViewport !== null &&
+    visibleViewport.keyboardHeight > KEYBOARD_OPEN_THRESHOLD_PX
+  );
+}

--- a/clients/web/src/hooks/use-mobile-overlay-viewport-style.ts
+++ b/clients/web/src/hooks/use-mobile-overlay-viewport-style.ts
@@ -1,10 +1,7 @@
 import { type CSSProperties } from "react";
 
-import { useIsMobile } from "@/hooks/use-is-mobile";
-import {
-  KEYBOARD_OPEN_THRESHOLD_PX,
-  useVisibleViewport,
-} from "@/hooks/use-visible-viewport";
+import { useKeyboardOpen } from "@/hooks/use-keyboard-open";
+import { useVisibleViewport } from "@/hooks/use-visible-viewport";
 
 const SAFE_AREA_TOP =
   "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))";
@@ -45,13 +42,8 @@ const SAFE_AREA_RIGHT =
  * @see https://bugs.webkit.org/show_bug.cgi?id=207049
  */
 export function useMobileOverlayViewportStyle(): CSSProperties {
-  const isMobile = useIsMobile();
+  const keyboardOpen = useKeyboardOpen();
   const visibleViewport = useVisibleViewport();
-
-  const keyboardOpen =
-    isMobile &&
-    visibleViewport !== null &&
-    visibleViewport.keyboardHeight > KEYBOARD_OPEN_THRESHOLD_PX;
 
   if (keyboardOpen && visibleViewport) {
     return {

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -6,11 +6,8 @@ import { useAppTheme } from "@/hooks/use-app-theme";
 import { useEventBusInit } from "@/hooks/use-event-bus-init";
 import { useOpenUrlDirectives } from "@/hooks/use-open-url-directives";
 import { useGlobalDeepLinkConsumer } from "@/hooks/use-global-deep-link-consumer";
-import { useIsMobile } from "@/hooks/use-is-mobile";
-import {
-  useVisibleViewport,
-  KEYBOARD_OPEN_THRESHOLD_PX,
-} from "@/hooks/use-visible-viewport";
+import { useKeyboardOpen } from "@/hooks/use-keyboard-open";
+import { useVisibleViewport } from "@/hooks/use-visible-viewport";
 import { useAssistantLifecycle } from "@/assistant/use-lifecycle";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useChannelSetupCloseNotify } from "@/domains/chat/hooks/use-channel-setup-close-notify";
@@ -96,7 +93,7 @@ const ShareFeedbackModal = lazy(() =>
  */
 export function RootLayout() {
   useAppTheme();
-  const isMobile = useIsMobile();
+  const keyboardOpen = useKeyboardOpen();
   const visibleViewport = useVisibleViewport();
 
   const location = useLocation();
@@ -156,7 +153,11 @@ export function RootLayout() {
   useAvatarAccentVar(avatar.components, avatar.traits, avatar.customImageUrl);
   // Publish the same avatar for the iOS Live Activity, which cannot fetch an
   // image at render time and needs the bytes to travel with the activity.
-  useIslandAvatarSource(avatar.customImageUrl, avatar.components, avatar.traits);
+  useIslandAvatarSource(
+    avatar.customImageUrl,
+    avatar.components,
+    avatar.traits,
+  );
 
   // Feed the same avatar to the Electron Dock + menu-bar icons, and publish
   // the live connection status to the menu-bar dot. Both no-op off Electron.
@@ -283,11 +284,6 @@ export function RootLayout() {
     setRetirePending(false);
     setRetireId(null);
   };
-
-  const keyboardOpen =
-    isMobile &&
-    visibleViewport !== null &&
-    visibleViewport.keyboardHeight > KEYBOARD_OPEN_THRESHOLD_PX;
 
   // When the iOS keyboard opens, the system scrolls the layout viewport
   // down by `offsetTop` to keep the focused input visible. Size the outer


### PR DESCRIPTION
## Summary
- The bottom-docked suggestions on the mobile empty-chat screen fade out while the soft keyboard is open, so the anticipated shell shrink on the iOS shell no longer yanks them up over the incoming keyboard.
- Adds a shared `useKeyboardOpen()` and replaces the duplicated derivations in the root layout and the mobile overlay hook.
- The dock stays mounted so the centered greeting and composer do not jump; hidden state is inert to pointer and assistive tech. On non-iOS mobile web the fade triggers at the measured keyboard height, slightly later, which keeps behavior consistent.