### PR TITLE
feat(search): keep the match near the front of display excerpts

### DIFF
--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -902,16 +902,16 @@ function buildExcerptWithExternalContentMode(
 
   if (externalContentMode === "display") {
     text = unwrapExternalContentForDisplay(text);
-  } else {
-    const envelope = parseExternalContentEnvelope(text);
-    if (envelope) {
-      const innerExcerpt = buildExcerptFromText(envelope.content, query);
-      return wrapRecallEvidenceExcerpt(
-        innerExcerpt,
-        envelope.source,
-        envelope.origin,
-      );
-    }
+    return buildExcerptFromText(text, query, DISPLAY_EXCERPT_LEADING_CHARS);
+  }
+  const envelope = parseExternalContentEnvelope(text);
+  if (envelope) {
+    const innerExcerpt = buildExcerptFromText(envelope.content, query);
+    return wrapRecallEvidenceExcerpt(
+      innerExcerpt,
+      envelope.source,
+      envelope.origin,
+    );
   }
 
   return buildExcerptFromText(text, query);
@@ -985,19 +985,34 @@ function findEarliestMatch(
   return match ? { index: match.index, length: match[0].length } : null;
 }
 
-function buildExcerptFromText(text: string, query: string): string {
-  const WINDOW = 100;
+const EXCERPT_WINDOW = 100;
+
+/**
+ * Leading context for palette display excerpts. The result row truncates
+ * from the right, so a wide leading window can push the match past the
+ * visible cutoff; recall evidence keeps the full window.
+ */
+const DISPLAY_EXCERPT_LEADING_CHARS = 30;
+
+function buildExcerptFromText(
+  text: string,
+  query: string,
+  leadingChars: number = EXCERPT_WINDOW,
+): string {
   const match = findEarliestMatch(text, query);
   if (!match) {
     // Neither the query nor any of its tokens is present (e.g. the lexical
     // index matched JSON structure instead); fall back to the text start.
     return text
-      .slice(0, WINDOW * 2)
+      .slice(0, EXCERPT_WINDOW * 2)
       .replace(/\s+/g, " ")
       .trim();
   }
-  const start = Math.max(0, match.index - WINDOW);
-  const end = Math.min(text.length, match.index + match.length + WINDOW);
+  const start = Math.max(0, match.index - leadingChars);
+  const end = Math.min(
+    text.length,
+    match.index + match.length + EXCERPT_WINDOW,
+  );
   const excerpt =
     (start > 0 ? "\u2026" : "") +
     text.slice(start, end).replace(/\s+/g, " ").trim() +

--- a/assistant/src/plugins/defaults/memory/__tests__/conversation-queries.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/conversation-queries.test.ts
@@ -169,6 +169,18 @@ describe("buildExcerpt", () => {
     expect(excerpt.startsWith("…")).toBe(true);
   });
 
+  test("keeps the match near the front of the display excerpt", () => {
+    const prefix = "p".repeat(200);
+    const excerpt = buildExcerpt(
+      JSON.stringify([{ type: "text", text: `${prefix} alpha trailing text` }]),
+      "alpha",
+    );
+
+    const alphaIndex = excerpt.indexOf("alpha");
+    expect(alphaIndex).toBeGreaterThan(0);
+    expect(alphaIndex).toBeLessThanOrEqual(32);
+  });
+
   test("whole-query matches also respect tokenizer boundaries", () => {
     const filler = "party planning notes ".repeat(10);
     const excerpt = buildExcerpt(
@@ -335,6 +347,16 @@ describe("buildRecallEvidenceExcerpt", () => {
     expect(excerpt).toBe(
       '<external_content source="slack">\nSearchable Slack text\n</external_content>',
     );
+  });
+
+  test("keeps the wide leading window for recall evidence", () => {
+    const prefix = "p".repeat(200);
+    const excerpt = buildRecallEvidenceExcerpt(
+      JSON.stringify([{ type: "text", text: `${prefix} alpha trailing text` }]),
+      "alpha",
+    );
+
+    expect(excerpt.indexOf("alpha")).toBeGreaterThan(50);
   });
 
   test("keeps the raw fallback for messages with no legible text", () => {


### PR DESCRIPTION
Summary:
Follow-up to #39646: palette result rows truncate from the right, so up to 100 chars of leading excerpt context could push the actual match past the visible cutoff. Display excerpts now cap leading context at 30 characters while model-facing recall evidence keeps the full symmetric window.

Changes:
- Add a leading-chars parameter to the excerpt windower; display mode passes 30, recall evidence keeps 100
- Tests: display match sits within the first ~32 chars of the excerpt; recall evidence retains the wide window

🤖 Generated with [Claude Code](https://claude.com/claude-code)