### PR TITLE
test(web): match the nudge banner assertion to its color-mix background

### DIFF
--- a/clients/web/src/components/nudges/nudge-chat-banner.test.tsx
+++ b/clients/web/src/components/nudges/nudge-chat-banner.test.tsx
@@ -79,7 +79,9 @@ describe("NudgeChatBanner", () => {
       />,
     );
 
-    expect(html).toContain("background:var(--surface-base)");
+    expect(html).toContain(
+      "background:color-mix(in srgb, var(--surface-base) 92%, white)",
+    );
     expect(html).not.toContain("background:var(--surface-overlay)");
   });
 


### PR DESCRIPTION
## Summary
- The opaque-surface test still asserts the banner's old `background:var(--surface-base)` inline style; the component now paints `color-mix(in srgb, var(--surface-base) 92%, white)`, so the test fails on main and on every PR whose merge-ref CI includes it.
- Updates the assertion to the current serialization. The surface-overlay negative assertion is still valid and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)