### PR TITLE
fix(chat): label the sidebar footer "Preferences", not the user's name (LUM-2950)

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -122,8 +122,8 @@ describe("PreferencesMenu", () => {
     expect(html).toBe("");
   });
 
-  // The trigger names the menu it opens, not the person signed in. A fully
-  // populated platform account is the case that used to render "Jane Doe".
+  // A platform account with every identity field populated is the case most
+  // able to leak one into the trigger, so it is the one asserted against.
   test("labels the trigger 'Preferences', never the account identity", () => {
     authRef.user = {
       kind: "platform",

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -122,7 +122,9 @@ describe("PreferencesMenu", () => {
     expect(html).toBe("");
   });
 
-  test("labels the trigger with the account's full name when present", () => {
+  // The trigger names the menu it opens, not the person signed in. A fully
+  // populated platform account is the case that used to render "Jane Doe".
+  test("labels the trigger 'Preferences', never the account identity", () => {
     authRef.user = {
       kind: "platform",
       id: "u1",
@@ -133,54 +135,13 @@ describe("PreferencesMenu", () => {
       lastName: "Doe",
     };
     const html = renderToStaticMarkup(createElement(PreferencesMenu));
-    expect(html).toContain("Jane Doe");
+    expect(html).toContain("Preferences");
+    expect(html).not.toContain("Jane Doe");
+    expect(html).not.toContain("jdoe");
+    expect(html).not.toContain("user@example.com");
   });
 
-  test("falls back to username, then email, then the generic label", () => {
-    // username fallback (no name)
-    authRef.user = {
-      kind: "platform",
-      id: "u1",
-      email: "user@example.com",
-      isStaff: false,
-      username: "jdoe",
-      firstName: "",
-      lastName: "",
-    };
-    expect(renderToStaticMarkup(createElement(PreferencesMenu))).toContain(
-      "jdoe",
-    );
-
-    // email fallback (no name, no username)
-    authRef.user = {
-      kind: "platform",
-      id: "u1",
-      email: "user@example.com",
-      isStaff: false,
-      username: null,
-      firstName: "",
-      lastName: "",
-    };
-    expect(renderToStaticMarkup(createElement(PreferencesMenu))).toContain(
-      "user@example.com",
-    );
-
-    // generic label (nothing identifying)
-    authRef.user = {
-      kind: "platform",
-      id: "u1",
-      email: null,
-      isStaff: false,
-      username: null,
-      firstName: "",
-      lastName: "",
-    };
-    expect(renderToStaticMarkup(createElement(PreferencesMenu))).toContain(
-      "Preferences",
-    );
-  });
-
-  test("shows the generic label for the synthetic local gateway user", () => {
+  test("labels the trigger 'Preferences' for the local gateway user", () => {
     // Mirrors GATEWAY_LOCAL_USER: name fields are populated but identify no
     // real account, so they must not surface as a profile.
     authRef.user = {
@@ -200,12 +161,12 @@ describe("PreferencesMenu", () => {
   test("desktop renders trigger (Popover surface)", () => {
     isMobileRef.value = false;
     const html = renderToStaticMarkup(createElement(PreferencesMenu));
-    expect(html).toContain("user@example.com");
+    expect(html).toContain("Preferences");
   });
 
   test("mobile renders trigger (BottomSheet surface)", () => {
     isMobileRef.value = true;
     const html = renderToStaticMarkup(createElement(PreferencesMenu));
-    expect(html).toContain("user@example.com");
+    expect(html).toContain("Preferences");
   });
 });

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -44,10 +44,9 @@ const ShareFeedbackModal = lazy(() =>
 );
 
 /**
- * The trigger is a settings entry point, not a profile row: labelling it with
- * the signed-in account's name (as it did between #38187 and this change) read
- * as an identity affordance and left no visible way to name what the menu
- * actually opens. The account identity stays discoverable on the Settings page.
+ * The trigger names the menu it opens, never the signed-in account. This is a
+ * settings entry point rather than a profile row, and the account's identity
+ * belongs on the Settings page the menu links to.
  */
 const PREFERENCES_LABEL = "Preferences";
 

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -43,6 +43,14 @@ const ShareFeedbackModal = lazy(() =>
   })),
 );
 
+/**
+ * The trigger is a settings entry point, not a profile row: labelling it with
+ * the signed-in account's name (as it did between #38187 and this change) read
+ * as an identity affordance and left no visible way to name what the menu
+ * actually opens. The account identity stays discoverable on the Settings page.
+ */
+const PREFERENCES_LABEL = "Preferences";
+
 export interface PreferencesMenuProps {
   assistantId?: string | null;
   assistantVersion?: string | null;
@@ -62,7 +70,6 @@ export function PreferencesMenu({
 }: PreferencesMenuProps) {
   const isAuthenticated = useIsAuthenticated();
   const isMobile = useIsMobile();
-  const user = useAuthStore.use.user();
   const [isOpen, setIsOpen] = useState(false);
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
 
@@ -72,19 +79,6 @@ export function PreferencesMenu({
 
   const closeMenu = () => setIsOpen(false);
 
-  // Only a platform account carries a real identity; the local gateway user is
-  // a synthetic placeholder whose "Local"/"User" name fields would otherwise
-  // render as a profile.
-  const account = user?.kind === "platform" ? user : null;
-
-  // Prefer the account's real name; fall back to username, then email, then the
-  // generic label so the trigger is never blank.
-  const displayName =
-    [account?.firstName, account?.lastName].filter(Boolean).join(" ").trim() ||
-    account?.username ||
-    account?.email ||
-    "Preferences";
-
   const trigger =
     triggerVariant === "pill" ? (
       /* Solid surface + shadow: the pill floats over the scrolling
@@ -92,19 +86,17 @@ export function PreferencesMenu({
       <Button
         variant="ghost"
         leftIcon={<CircleUser />}
-        aria-label={displayName}
-        title={displayName}
         className="h-10 w-full min-w-0 rounded-full border border-[var(--border-base)] bg-[var(--surface-lift)] px-4 shadow-[var(--shadow-lg)]"
       >
-        {/* A long name/email must not force the pill wider and overlap the
-            sibling New Chat pill, so truncate the visible label; the full
-            value stays available via aria-label/title. */}
-        <span className="min-w-0 truncate">{displayName}</span>
+        {/* `truncate` is belt-and-braces: the label is a fixed short string,
+            but the pill shares its row with New Chat and must never grow
+            wide enough to overlap it at narrow viewports. */}
+        <span className="min-w-0 truncate">{PREFERENCES_LABEL}</span>
       </Button>
     ) : (
       <SideMenu.Item
         icon={CircleUser}
-        label={displayName}
+        label={PREFERENCES_LABEL}
         trailingIcon={isOpen ? ChevronDown : ChevronUp}
         active={isOpen}
         data-tour-id="settings"


### PR DESCRIPTION
## TL;DR

The sidebar footer trigger that opens the Preferences menu showed the signed-in user's name instead of the word "Preferences". It now always reads "Preferences". One string, both trigger variants.

Fixes [LUM-2950](https://linear.app/vellum/issue/LUM-2950/mobile-sidebar-footer-says-user-name-instead-of-preferences).

## What changed for the user

| | Before | After |
|---|---|---|
| Sidebar footer, named account | "Jane Doe" | "Preferences" |
| Sidebar footer, no name set | "jdoe" (username) | "Preferences" |
| Sidebar footer, no name or username | "jane@example.com" | "Preferences" |
| Sidebar footer, local gateway user | "Preferences" | "Preferences" (unchanged) |
| Icon | CircleUser | CircleUser (unchanged) |
| Menu contents | Theme, Credits, Share Feedback, Admin, Settings | unchanged |

## Why

Raised in the Jul 31 G1 standup while reviewing the iOS demo — the label names the person, not the thing it opens, so it reads as a profile row rather than the settings entry point. On mobile it also sits beside New Chat, where a long name or email crowds the pill.

This reverts the label half of #38187 ("personalize account menu with user name + generic icon"). The icon half of that change stays.

## Scope note: this covers desktop too, not just mobile

The ticket is filed as a mobile bug, but there is no mobile-specific code path — a single `displayName` fed both the mobile `pill` and the desktop rail `item`. The same reasoning applies to the rail, so branching on viewport would have added a fork with no behavioral justification. If the desktop rail is meant to keep the name, that's a deliberate divergence worth its own decision — say so and I'll add the branch.

## Why it's safe

- Pure presentational string change. No auth, routing, query, or menu-contents changes; the `data-tour-id="settings"` anchor is untouched, and the onboarding tour targets that attribute rather than the label text (its own copy already reads "Settings" / "Preferences and account stuff").
- Dropping the `displayName` derivation makes the outer component stop reading `useAuthStore.use.user()`. `PreferencesMenuContent` still reads it for the `isStaff` Admin row, so that behavior is unaffected.
- Accessibility: the pill previously set `aria-label`/`title` to the full name while visibly truncating it. With a fixed short label the visible text is the accessible name, so both were removed rather than left to duplicate it.
- No identity is lost — name, username, and email remain on the Settings page this menu links to.
- Tests: `preferences-menu.test.tsx` rewritten to assert the inverse of what it used to (the fully-populated account that rendered "Jane Doe" is now the case asserted *not* to leak an identity). 5/5 pass; `bun run lint` clean.

## Deferred

- **Tips card height on mobile** — Noa noted in the same standup that `SidebarTipCard` eats ~a quarter of the mobile viewport. Deferred because it's an independent layout question with a real design decision behind it (compress vs. hide on mobile), not a label fix, and bundling it would have made this diff two unrelated changes. Not yet filed — worth its own ticket if you want it pursued.
- **`CircleUser` icon** — a user glyph next to a "Preferences" label is arguably now mismatched (#38187 swapped out `SlidersHorizontal` as part of the same personalization). Left alone deliberately: the ticket asked for the label, and the icon is a design call rather than a bug.

## Verification

- [x] `bun test src/domains/chat/components/preferences-menu.test.tsx` — 5 pass, 0 fail
- [x] `bun run lint` — 0 errors
- [ ] Not visually verified in a running app — this is a static label swap with no layout branch, so the rendered-markup assertions cover it.

Note on typecheck: `bunx tsc --noEmit` reports 44 errors in this worktree, all pre-existing environment noise (bun-types resolution) in unrelated files — identical count with the change stashed, and none in the touched files. CI is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->