### PR TITLE
fix(web): portal Dropdown menus out of transformed ancestors (LUM-2955)

### DIFF
--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -57,9 +57,6 @@ body {
 
 @keyframes fadeInUp {
   0% { transform: translateY(16px); opacity: 0; }
-  /* End at `none` (not translateY(0)) so the filled-forwards transform does
-     not create a containing block — otherwise position:fixed descendants like
-     the Dropdown menu anchor to this element instead of the viewport. */
   100% { transform: none; opacity: 1; }
 }
 
@@ -76,8 +73,12 @@ body {
   animation: fadeIn 0.25s ease-out both;
 }
 
+/* `backwards`, not `both`: see the note on `.home-detail-drawer` below. A
+   forwards-filled transform stays applied as an identity matrix once the
+   animation ends, and that is enough to make this element the containing
+   block for any `position: fixed` descendant. */
 .plans-takeover-content-enter {
-  animation: fadeInUp 0.35s ease-out both;
+  animation: fadeInUp 0.35s ease-out backwards;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -95,15 +96,23 @@ body {
 }
 
 /* Home Activity detail drawer (schedule / heartbeat / notification) sliding
-   in from the right. Ends at `transform: none` for the same containing-block
-   reason as fadeInUp above (the panel hosts fixed Dropdown/tooltip layers). */
+   in from the right. The panel hosts fixed Dropdown/tooltip layers, so the
+   fill mode below matters: see the note on the rule. */
 @keyframes drawer-slide-in {
   0% { transform: translateX(16px); opacity: 0; }
   100% { transform: none; opacity: 1; }
 }
 
+/* `backwards`, not `both`. Forwards-fill would hold the final keyframe after
+   the animation ends, and the held value is the interpolated identity matrix,
+   not the `transform: none` written above. A transform of any kind, identity
+   included, makes this element the containing block for `position: fixed`
+   descendants, which silently defeats the intent the keyframe documents:
+   fixed layers inside the panel would resolve their viewport coordinates
+   against this box and land offscreen. Dropping forwards-fill costs nothing,
+   because the final keyframe is already the element's own resting style. */
 .home-detail-drawer {
-  animation: drawer-slide-in 0.2s ease-out both;
+  animation: drawer-slide-in 0.2s ease-out backwards;
   height: 100%;
 }
 

--- a/packages/design-library/src/components/dropdown.stories.tsx
+++ b/packages/design-library/src/components/dropdown.stories.tsx
@@ -227,7 +227,7 @@ export const Compact: Story = {
  *
  * A transformed ancestor becomes the containing block for `position: fixed`
  * descendants, so a menu rendered inline under one resolves its viewport
- * coordinates against that ancestor's box instead — shifting it by the
+ * coordinates against that ancestor's box instead, shifting it by the
  * ancestor's origin, usually far enough to leave the viewport entirely. The
  * trigger still reports `data-state="open"`, which is why the failure reads to
  * users as "the dropdown won't open" rather than "the menu is in the wrong
@@ -235,7 +235,7 @@ export const Compact: Story = {
  * viewport as its containing block.
  *
  * The web app hits this with its detail drawer, whose slide-in animation uses
- * `animation-fill-mode: both` — the final keyframe's identity matrix stays
+ * `animation-fill-mode: both`, so the final keyframe's identity matrix stays
  * applied for the life of the drawer.
  */
 export const InsideTransformedAncestor: Story = {

--- a/packages/design-library/src/components/dropdown.stories.tsx
+++ b/packages/design-library/src/components/dropdown.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { expect, userEvent, within } from "storybook/test";
 
 import { Dropdown, type DropdownOption, type DropdownProps } from "./dropdown";
+import { Modal } from "./modal";
 import { Tag } from "./tag";
 
 const fruits: DropdownOption<string>[] = [
@@ -285,6 +286,91 @@ export const InsideTransformedAncestor: Story = {
       await expect(Math.abs(menuRect.left - triggerRect.left)).toBeLessThan(1);
       await expect(menuRect.top).toBeGreaterThanOrEqual(triggerRect.bottom);
       await expect(menuRect.top - triggerRect.bottom).toBeLessThan(8);
+    });
+  },
+};
+
+/**
+ * Regression guard for the riskiest consequence of portaling the menu to
+ * `document.body`: inside a modal, the menu is no longer a DOM descendant of
+ * the dialog it belongs to.
+ *
+ * Two things could break as a result, and this story pins both.
+ *
+ * 1. Dismissal. Radix's `DismissableLayer` decides what counts as an outside
+ *    click from a React `onPointerDownCapture` on the layer. `createPortal`
+ *    preserves React-tree parentage even though DOM parentage moves, so an
+ *    option click still reads as inside the dialog. If that ever stopped
+ *    holding, selecting an option would close the modal out from under the
+ *    user.
+ * 2. Clickability. Radix marks `body` with `pointer-events: none` in modal
+ *    mode, so a menu parented to `body` inherits it. The menu carries
+ *    `pointer-events-auto` for exactly this reason, and losing that class
+ *    would make every option silently unclickable.
+ */
+export const InsideModal: Story = {
+  args: {
+    "aria-label": "Fruit",
+  },
+  render: function ModalDropdown(args) {
+    const [value, setValue] = useState("apple");
+    return (
+      <Modal.Root defaultOpen>
+        <Modal.Content>
+          <Modal.Header>
+            <Modal.Title>Pick a fruit</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div className="w-64">
+              <Dropdown
+                {...args}
+                options={fruits}
+                value={value}
+                onChange={setValue}
+              />
+            </div>
+          </Modal.Body>
+        </Modal.Content>
+      </Modal.Root>
+    );
+  },
+  play: async ({ step }) => {
+    // Scoped to the document rather than the canvas: both the dialog and the
+    // menu are portaled out of the story's subtree.
+    const dialog = document.querySelector('[data-slot="modal-content"]');
+    await expect(dialog).not.toBeNull();
+
+    const trigger = document.querySelector<HTMLElement>(
+      '[data-slot="dropdown-trigger"]',
+    );
+    await expect(trigger).not.toBeNull();
+
+    await step("menu opens and escapes the dialog in the DOM", async () => {
+      await userEvent.click(trigger!);
+      const menu = document.querySelector('[data-slot="dropdown-menu"]');
+      await expect(menu).not.toBeNull();
+      await expect(dialog!.contains(menu)).toBe(false);
+    });
+
+    await step("options stay clickable under modal pointer-events", async () => {
+      const menu = document.querySelector<HTMLElement>(
+        '[data-slot="dropdown-menu"]',
+      );
+      await expect(getComputedStyle(menu!).pointerEvents).toBe("auto");
+    });
+
+    await step("selecting an option does not dismiss the modal", async () => {
+      const options = document.querySelectorAll<HTMLElement>(
+        '[data-slot="dropdown-option"]',
+      );
+      const cherry = [...options].find((o) => o.textContent?.includes("Cherry"));
+      await expect(cherry).toBeDefined();
+      await userEvent.click(cherry!);
+
+      await expect(trigger!.textContent).toContain("Cherry");
+      await expect(
+        document.querySelector('[data-slot="modal-content"]'),
+      ).not.toBeNull();
     });
   },
 };

--- a/packages/design-library/src/components/dropdown.stories.tsx
+++ b/packages/design-library/src/components/dropdown.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Globe, Lock, Users } from "lucide-react";
 import { useState } from "react";
+import { expect, userEvent, within } from "storybook/test";
 
 import { Dropdown, type DropdownOption, type DropdownProps } from "./dropdown";
 import { Tag } from "./tag";
@@ -217,5 +218,73 @@ export const Compact: Story = {
         />
       </div>
     );
+  },
+};
+
+/**
+ * Regression guard: the menu must stay glued to its trigger even when an
+ * ancestor has a `transform`.
+ *
+ * A transformed ancestor becomes the containing block for `position: fixed`
+ * descendants, so a menu rendered inline under one resolves its viewport
+ * coordinates against that ancestor's box instead — shifting it by the
+ * ancestor's origin, usually far enough to leave the viewport entirely. The
+ * trigger still reports `data-state="open"`, which is why the failure reads to
+ * users as "the dropdown won't open" rather than "the menu is in the wrong
+ * place". Portaling the menu out of the transformed subtree is what keeps the
+ * viewport as its containing block.
+ *
+ * The web app hits this with its detail drawer, whose slide-in animation uses
+ * `animation-fill-mode: both` — the final keyframe's identity matrix stays
+ * applied for the life of the drawer.
+ */
+export const InsideTransformedAncestor: Story = {
+  args: {
+    "aria-label": "Fruit",
+  },
+  render: function TransformedAncestorDropdown(args) {
+    const [value, setValue] = useState("apple");
+    return (
+      // `translate(80px, 40px)` stands in for the drawer's leftover matrix. A
+      // non-zero offset is deliberate: an identity transform triggers the same
+      // containing-block switch but hides the resulting drift behind a zero
+      // delta, so the assertion below would pass even on the broken build.
+      <div style={{ transform: "translate(80px, 40px)" }}>
+        <div className="w-64">
+          <Dropdown
+            {...args}
+            options={fruits}
+            value={value}
+            onChange={setValue}
+          />
+        </div>
+      </div>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole("combobox", { name: "Fruit" });
+
+    await step("open the menu", async () => {
+      await userEvent.click(trigger);
+      await expect(trigger).toHaveAttribute("data-state", "open");
+    });
+
+    await step("menu is positioned against the viewport", async () => {
+      // Scoped to the document, not the canvas: the menu is portaled out of
+      // the story's subtree, which is the whole point of this story.
+      const menu = document.querySelector('[data-slot="dropdown-menu"]');
+      await expect(menu).not.toBeNull();
+
+      const triggerRect = trigger.getBoundingClientRect();
+      const menuRect = menu!.getBoundingClientRect();
+
+      // Left-aligned (the default) and directly below the trigger. Sub-pixel
+      // layout rounding is the only slack; the transformed-ancestor bug
+      // offsets these by the ancestor's translate (80px / 40px).
+      await expect(Math.abs(menuRect.left - triggerRect.left)).toBeLessThan(1);
+      await expect(menuRect.top).toBeGreaterThanOrEqual(triggerRect.bottom);
+      await expect(menuRect.top - triggerRect.bottom).toBeLessThan(8);
+    });
   },
 };

--- a/packages/design-library/src/components/dropdown.stories.tsx
+++ b/packages/design-library/src/components/dropdown.stories.tsx
@@ -227,7 +227,7 @@ export const Compact: Story = {
  *
  * A transformed ancestor becomes the containing block for `position: fixed`
  * descendants, so a menu rendered inline under one resolves its viewport
- * coordinates against that ancestor's box instead — shifting it by the
+ * coordinates against that ancestor's box instead, shifting it by the
  * ancestor's origin, usually far enough to leave the viewport entirely. The
  * trigger still reports `data-state="open"`, which is why the failure reads to
  * users as "the dropdown won't open" rather than "the menu is in the wrong
@@ -235,7 +235,7 @@ export const Compact: Story = {
  * viewport as its containing block.
  *
  * The web app hits this with its detail drawer, whose slide-in animation uses
- * `animation-fill-mode: both` — the final keyframe's identity matrix stays
+ * `animation-fill-mode: both`. The final keyframe's identity matrix stays
  * applied for the life of the drawer.
  */
 export const InsideTransformedAncestor: Story = {

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -87,7 +87,7 @@ export interface DropdownProps<T extends string> {
  * at viewport coordinates read off the trigger's `getBoundingClientRect()`,
  * which only lands correctly when the viewport is its containing block. Any
  * ancestor with a `transform`, `filter`, or `will-change` becomes that
- * containing block instead and shifts the menu by that ancestor's origin —
+ * containing block instead and shifts the menu by that ancestor's origin,
  * usually clear off-screen, which reads as "the dropdown won't open". The web
  * app's detail drawer does exactly this: its slide-in animation uses
  * `animation-fill-mode: both`, so the final keyframe's identity matrix stays

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -78,8 +78,20 @@ export interface DropdownProps<T extends string> {
  *
  * The menu is portaled into the element provided by the nearest
  * `<PortalContainerProvider>` so it escapes ancestor `overflow: hidden` and
- * design tokens resolve correctly. Falls back to inline rendering when no
- * provider is mounted.
+ * design tokens resolve correctly. Falls back to `document.body` when no
+ * provider is mounted, matching every other overlay in this package
+ * (`Popover`, `Tooltip`, `Menu`, `Modal`, `ContextMenu`, `BottomSheet`, which
+ * all hand `container ?? undefined` to a Radix `Portal`).
+ *
+ * Portaling is not optional. The menu positions itself with `position: fixed`
+ * at viewport coordinates read off the trigger's `getBoundingClientRect()`,
+ * which only lands correctly when the viewport is its containing block. Any
+ * ancestor with a `transform`, `filter`, or `will-change` becomes that
+ * containing block instead and shifts the menu by that ancestor's origin —
+ * usually clear off-screen, which reads as "the dropdown won't open". The web
+ * app's detail drawer does exactly this: its slide-in animation uses
+ * `animation-fill-mode: both`, so the final keyframe's identity matrix stays
+ * applied for the life of the drawer.
  */
 const TRIGGER_SIZE_CLASSES: Record<DropdownSize, string> = {
   regular: "h-9 px-3 text-body-medium-lighter",
@@ -474,9 +486,9 @@ export function Dropdown<T extends string>({
         />
       </button>
 
-      {menuNode && portalContainer
-        ? createPortal(menuNode, portalContainer)
-        : menuNode}
+      {menuNode
+        ? createPortal(menuNode, portalContainer ?? document.body)
+        : null}
     </div>
   );
 }


### PR DESCRIPTION
## TL;DR

Every profile dropdown inside the settings detail drawer looked broken: click the trigger, nothing appears. The menu was open the whole time, rendering ~389px off the right edge of the viewport. Two independent defects combined to put it there, and this PR fixes both.

Closes [LUM-2955](https://linear.app/vellum/issue/LUM-2955/dropdown-menus-render-off-screen-inside-the-detail-drawer-action).

## What the user sees

| | Before | After |
|---|---|---|
| Clicking a profile dropdown in Action Overrides | Trigger border lights up, no list ever appears, reads as "it closes instantly" | The list opens under the trigger |
| Picking a profile | Impossible; the options are off-screen | Works, Save enables |
| Profile and provider editors in the same drawer | Same dead dropdowns | Same fix, no per-call-site change |
| Dropdowns outside the drawer (Web Search provider, etc.) | Already fine | Unchanged |

## Why it broke, and when

Nothing in `Dropdown` changed recently. Two long-standing pieces met for the first time:

| date | change | effect |
|---|---|---|
| 2026-05-18 | #31095 adds `Dropdown` | `position: fixed` at viewport coordinates, portaled **only** when a `PortalContainerProvider` is mounted. Latent flaw from day one. |
| 2026-06-18 | #35273 adds `.home-detail-drawer` | Slide-in animation with `animation-fill-mode: both`, which leaves a permanent identity transform. No `Dropdown` lived in a drawer yet, so it was harmless. |
| **2026-07-29** | **e26688c42e (LUM-2881)** | **Action Overrides moves out of `call-site-overrides-modal.tsx` (a Radix Dialog portaled to `body`, untransformed, worked fine) and into the drawer. This is the regression.** |
| 2026-07-30 | #39681 | Adds the Advisor row. A new instance of an already-broken surface, not the cause. |

## Root cause 1: the drawer holds a transform it never wanted

`animation-fill-mode: both` holds the final keyframe after the animation ends, and the held value is the *interpolated identity matrix*, not the `transform: none` the keyframe declares. Any transform, identity included, makes the element the containing block for `position: fixed` descendants.

Both `drawer-slide-in` and `fadeInUp` already carried comments saying they end at `transform: none` **specifically** so they would not create a containing block, one of them naming the Dropdown menu as the thing that would break:

```css
/* End at `none` (not translateY(0)) so the filled-forwards transform does
   not create a containing block, otherwise position:fixed descendants like
   the Dropdown menu anchor to this element instead of the viewport. */
```

The intent was right; the fill mode silently defeated it. Switching to `backwards` drops the forwards half, which costs nothing because the final keyframe is already the element's own resting style.

Left `.plans-takeover-canvas-enter` on `both` (opacity-only) and the `provision-*` animations on `both` (they end on real non-identity transforms that must persist).

## Root cause 2: `Dropdown` is the only overlay that doesn't portal out

`Popover`, `Tooltip`, `Menu`, `Modal`, `ContextMenu` and `BottomSheet` all pass `container ?? undefined` to a Radix `Portal`, which defaults to `document.body`. `Dropdown` fell back to inline rendering, contradicting the contract documented in `utils/portal-container.tsx`.

## Measurement

At a 1280x800 viewport with the Advisor dropdown open, before the fix:

| | value |
|---|---|
| menu computed style | `left: 918px; top: 425px` |
| `.home-detail-drawer` box origin | `(751, 89)` |
| menu actual `getBoundingClientRect()` | `(1669, 518)` |

918 + 751 = 1669, and 425 + 89 + 4 (`mt-1`) = 518.

## Why this is safe

- The portal change moves in the direction six sibling components already take. Nothing gains a transform or changes layout.
- Design tokens still resolve: they are defined on `:root` (scoped by `data-theme` on `<html>`), so `document.body` has them. This is exactly the fallback `portal-container.tsx` documents.
- Callers that *do* mount a `PortalContainerProvider` (voice room, onboarding) are unaffected; `portalContainer` still wins.
- `document.body` is only touched when the menu is open, which cannot happen during SSR (`menuNode` is null until a click sets `menuPosition`). The existing `renderToStaticMarkup` tests still pass.
- Close-on-outside-click, close-on-blur and focus-return all key off explicit `containerRef`/`menuRef` `.contains()` checks, not DOM ancestry, so they work identically through the portal.
- The CSS change is verified to preserve the animation: the slide-in still runs (`matrix(1, 0, 0, 1, 16, 0)` mid-flight) and settles to `transform: none` with `opacity: 1`.

## Testing

- New `InsideTransformedAncestor` story with a play function asserting the menu tracks its trigger. **Verified it fails on the pre-fix build** with `expected 80 to be less than 1`, exactly the stand-in ancestor's 80px translate. Runs in CI via `pr-design-library.yaml` (vitest + Playwright chromium).
- `packages/design-library`: 162 tests across 33 files pass; `tsc --noEmit` clean.
- `clients/web`: `overrides-detail-panel.test.tsx` (8) and `profiles-section.test.tsx` (15) pass.
- Manual verification against the local daemon: menu parents to `BODY`, `rectLeft` 918 matches its `left: 918px`, fully on-screen. Selecting an option updates the trigger, closes the menu, returns focus to it, and marks the panel dirty. Closing the panel leaves no orphaned menu in `body`.

## Correction to an earlier version of this description

I originally claimed this also fixed the Home and Schedules drawers. It does not fix anything there today: neither `HomeDetailPanel`, `ScheduleDetailPanel` nor `SystemTaskDetailPanel` renders a `Dropdown`. The drawer's transform had been harmless until the AI settings page moved in. Those surfaces are now protected prospectively, not repaired.

## Follow-up

This is the minimal correct fix so the settings page works now. It does not address the underlying design problem: `Dropdown` is the only overlay in the library that hand-rolls positioning, keyboard navigation, outside-click and focus management (553 lines) instead of building on the Radix primitive the other six use. That is why it was uniquely vulnerable here, and it still cannot flip when there is no room below (`top` is always `trigger.bottom`, and only horizontal collision is handled). A follow-up PR rebuilds it on `@radix-ui/react-select`, deleting `resolveDropdownMenuPosition`, the scroll/resize listeners, `findEnabledIndex`, the `document.mousedown` handler and the manual portal.

Also deferred: the `Dropdown` docstring sits above `TRIGGER_SIZE_CLASSES` rather than the component, so editors do not surface it on hover. Left alone here; the rewrite resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
