### PR TITLE
fix: daemon cleanup and historical copy from plan re-review

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2262,7 +2262,7 @@ describe("session-agent-loop", () => {
         text: string;
       }>;
       expect(persistedBlocks[0]?.text).toBe(
-        "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+        "I couldn't reply because you ran out of credits. Add credits in Settings → Billing and we can pick up where we left off.",
       );
       expect(addCall[3]?.metadata).toMatchObject({
         messageKind: "provider_error",

--- a/assistant/src/__tests__/list-messages-provider-error.test.ts
+++ b/assistant/src/__tests__/list-messages-provider-error.test.ts
@@ -60,7 +60,7 @@ describe("handleListMessages provider-error projection", () => {
       JSON.stringify([
         {
           type: "text",
-          text: "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.",
+          text: "I couldn't reply because you ran out of credits. Add credits in Settings → Billing and we can pick up where we left off.",
         },
       ]),
       {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -139,10 +139,12 @@ const DISK_PRESSURE_ERROR_CATEGORY = "disk_pressure";
  * (`managedBalanceClassification` in conversation-error.ts) keeps its
  * `userMessage` context-neutral because it also feeds the non-terminal
  * memory-v3 degraded notice, where a normal reply still follows; here the
- * turn truly ends with no reply, so first-person copy is accurate.
+ * turn truly ends with no reply, so first-person copy is accurate. Phrased
+ * about the past failure, not the current balance, because the row stays in
+ * the transcript (and renders as a plain bubble) after the balance recovers.
  */
 const OUT_OF_CREDITS_ASSISTANT_REPLY =
-  "You're out of credits, so I can't reply right now. Add credits in Settings → Billing and we can pick up where we left off.";
+  "I couldn't reply because you ran out of credits. Add credits in Settings → Billing and we can pick up where we left off.";
 
 /** Title-cased friendly labels for tool names, used in confirmation chips. */
 const TOOL_FRIENDLY_LABEL: Record<string, string> = {

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -418,65 +418,25 @@ export function isProviderErrorMetadata(
 }
 
 /**
- * Parse an assistant row's raw persisted `metadata` JSON and apply a
- * metadata-level predicate to it. The single place the assistant-role guard
- * and malformed-JSON fallback live, so the row-level message-kind checks
- * cannot diverge.
- */
-function assistantRowMetadataMatches(
-  role: string,
-  metadata: string | null,
-  predicate: (parsed: Record<string, unknown>) => boolean,
-): boolean {
-  if (role !== "assistant" || !metadata) {
-    return false;
-  }
-  try {
-    return predicate(JSON.parse(metadata) as Record<string, unknown>);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Row-level variant of {@link isSystemCardMetadata} for callers holding the
- * raw persisted `metadata` JSON string, so display merging and turn grouping
- * agree on what a card is.
- */
-export function isSystemCardMessage(
-  role: string,
-  metadata: string | null,
-): boolean {
-  return assistantRowMetadataMatches(role, metadata, isSystemCardMetadata);
-}
-
-/**
- * Row-level variant of {@link isProviderErrorMetadata} for callers holding
- * the raw persisted `metadata` JSON string, so display merging and wire
- * projection agree on which rows carry the provider-error marker.
- */
-export function isProviderErrorMessage(
-  role: string,
-  metadata: string | null,
-): boolean {
-  return assistantRowMetadataMatches(role, metadata, isProviderErrorMetadata);
-}
-
-/**
  * True when an assistant row is a standalone display turn: a system card or
  * a provider-error notice. Standalone rows never merge with adjacent
  * assistant rows, and turn grouping closes on them, so display merging and
- * the turn resolver agree on boundaries.
+ * the turn resolver agree on boundaries. Takes the raw persisted `metadata`
+ * JSON string; malformed JSON and non-assistant roles are never standalone.
  */
 export function isStandaloneAssistantMessage(
   role: string,
   metadata: string | null,
 ): boolean {
-  return assistantRowMetadataMatches(
-    role,
-    metadata,
-    (parsed) => isSystemCardMetadata(parsed) || isProviderErrorMetadata(parsed),
-  );
+  if (role !== "assistant" || !metadata) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(metadata) as Record<string, unknown>;
+    return isSystemCardMetadata(parsed) || isProviderErrorMetadata(parsed);
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan re-review for credits-ux.md.

**Gap:** dead isSystemCardMessage/isProviderErrorMessage exports; present-tense persisted copy shown post-top-up
**What was expected:** module surface matches use; copy reads correctly live and as history
**What was found:** zero-caller exports with stale docs; 'I can't reply right now' rendered to funded users
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->