### PR TITLE
notifications: tell vellum-channel clients whether a remote push was also dispatched

### DIFF
--- a/assistant/src/__tests__/notification-platform-adapter.test.ts
+++ b/assistant/src/__tests__/notification-platform-adapter.test.ts
@@ -62,6 +62,7 @@ mock.module("../platform/client.js", () => ({
             ok: response.ok,
             status: response.status,
             text: async () => response.body ?? "",
+            json: async () => JSON.parse(response.body ?? "") as unknown,
           };
         },
       };
@@ -210,6 +211,72 @@ describe("PlatformPushAdapter", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("400");
     expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("reports remotePushAccepted: true on 200 with tokens_sent > 0", async () => {
+    fetchResponses.push({
+      ok: true,
+      status: 200,
+      body: '{"idempotent": false, "tokens_sent": 2}',
+    });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(true);
+  });
+
+  test("reports remotePushAccepted: false on 202 skipped (flag off)", async () => {
+    fetchResponses.push({
+      ok: true,
+      status: 202,
+      body: '{"skipped": "flag_off"}',
+    });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(false);
+  });
+
+  test("reports remotePushAccepted: false on 200 with tokens_sent 0", async () => {
+    fetchResponses.push({
+      ok: true,
+      status: 200,
+      body: '{"idempotent": true, "tokens_sent": 0}',
+    });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(false);
+  });
+
+  test("reports remotePushAccepted: false when the success body is unparseable", async () => {
+    fetchResponses.push({ ok: true, status: 200, body: "not json" });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(false);
+  });
+
+  test("leaves remotePushAccepted unset on non-2xx failure", async () => {
+    fetchResponses.push({ ok: false, status: 400, body: "bad request" });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(false);
+    expect(result.remotePushAccepted).toBeUndefined();
+  });
+
+  test("leaves remotePushAccepted unset when the platform client is unavailable", async () => {
+    clientAvailable = false;
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(false);
+    expect(result.remotePushAccepted).toBeUndefined();
   });
 
   test("omits optional fields when absent from payload", async () => {

--- a/assistant/src/__tests__/notification-vellum-adapter.test.ts
+++ b/assistant/src/__tests__/notification-vellum-adapter.test.ts
@@ -111,3 +111,44 @@ describe("VellumAdapter silent flag", () => {
     expect(intent.silent).toBe(false);
   });
 });
+
+describe("VellumAdapter remotePushDispatched pass-through", () => {
+  test("broadcasts remotePushDispatched: true verbatim", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(
+      makePayload({ remotePushDispatched: true }),
+      makeDestination(),
+    );
+
+    const intent = sent[0] as Extract<
+      AssistantEvent,
+      { type: "notification_intent" }
+    >;
+    expect(intent.remotePushDispatched).toBe(true);
+  });
+
+  test("broadcasts remotePushDispatched: false verbatim", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(
+      makePayload({ remotePushDispatched: false }),
+      makeDestination(),
+    );
+
+    const intent = sent[0] as Extract<
+      AssistantEvent,
+      { type: "notification_intent" }
+    >;
+    expect(intent.remotePushDispatched).toBe(false);
+  });
+
+  test("leaves remotePushDispatched undefined when absent from the payload", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(makePayload(), makeDestination());
+
+    const intent = sent[0] as Extract<
+      AssistantEvent,
+      { type: "notification_intent" }
+    >;
+    expect(intent.remotePushDispatched).toBeUndefined();
+  });
+});

--- a/assistant/src/api/events/notification-intent.ts
+++ b/assistant/src/api/events/notification-intent.ts
@@ -26,6 +26,11 @@ export const NotificationIntentEventSchema = z.object({
   deepLinkMetadata: z.record(z.string(), z.unknown()).optional(),
   targetGuardianPrincipalId: z.string().optional(),
   silent: z.boolean().optional(),
+  /**
+   * True when the same decision also dispatched the platform (APNs)
+   * channel, so native clients can avoid double-bannering.
+   */
+  remotePushDispatched: z.boolean().optional(),
 });
 
 export type NotificationIntentEvent = z.infer<

--- a/assistant/src/api/events/notification-intent.ts
+++ b/assistant/src/api/events/notification-intent.ts
@@ -27,8 +27,8 @@ export const NotificationIntentEventSchema = z.object({
   targetGuardianPrincipalId: z.string().optional(),
   silent: z.boolean().optional(),
   /**
-   * True when the same decision also dispatched the platform (APNs)
-   * channel, so native clients can avoid double-bannering.
+   * True when the platform (APNs) channel accepted a remote push for
+   * this delivery, so native clients can avoid double-bannering.
    */
   remotePushDispatched: z.boolean().optional(),
 });

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -293,6 +293,52 @@ describe("NotificationBroadcaster platform deep-link from contextPayload", () =>
   });
 });
 
+describe("NotificationBroadcaster remotePushDispatched flag", () => {
+  test("vellum payload carries true when platform is also selected; platform payload omits it", async () => {
+    composeFallbackReturn = {
+      vellum: { title: "Reminder", body: "Hello" },
+      platform: { title: "Reminder", body: "Hello" },
+    };
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform");
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(
+      makeSignal(),
+      makeDecision({
+        selectedChannels: ["vellum", "platform"],
+        renderedCopy: {},
+      }),
+    );
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(true);
+    expect(platform.sends.length).toBe(1);
+    expect(platform.sends[0]?.payload.remotePushDispatched).toBeUndefined();
+  });
+
+  test("vellum payload carries false when platform is not selected", async () => {
+    composeFallbackReturn = {
+      vellum: { title: "Reminder", body: "Hello" },
+    };
+
+    const { adapter, sends } = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    await broadcaster.broadcastDecision(
+      makeSignal(),
+      makeDecision({ selectedChannels: ["vellum"], renderedCopy: {} }),
+    );
+
+    expect(sends.length).toBe(1);
+    expect(sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+});
+
 // The card context is built once per broadcast (adapters render only); an
 // answer-mode pending_question with structured options renders them as
 // tappable card actions in the answer-token scheme the reply router

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -36,14 +36,29 @@ mock.module("../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => null,
 }));
 
-mock.module("../conversation-pairing.js", () => ({
-  pairDeliveryWithConversation: async () => ({
-    conversationId: undefined,
-    messageId: undefined,
+interface MockPairing {
+  conversationId: string | null;
+  messageId: string | null;
+  strategy: string;
+  createdNewConversation: boolean;
+  conversationFallbackUsed: boolean;
+}
+
+function defaultPairing(): MockPairing {
+  return {
+    conversationId: null,
+    messageId: null,
     strategy: "start_new_conversation",
     createdNewConversation: false,
     conversationFallbackUsed: false,
-  }),
+  };
+}
+
+let pairingByChannel: Record<string, MockPairing> = {};
+
+mock.module("../conversation-pairing.js", () => ({
+  pairDeliveryWithConversation: async (_signal: unknown, channel: string) =>
+    pairingByChannel[channel] ?? defaultPairing(),
 }));
 
 mock.module("../deliveries-store.js", () => ({
@@ -121,7 +136,10 @@ interface CapturedSend {
   destination: ChannelDestination;
 }
 
-function makeCapturingAdapter(channel: "vellum" | "platform"): {
+function makeCapturingAdapter(
+  channel: "vellum" | "platform",
+  result: DeliveryResult = { success: true },
+): {
   adapter: ChannelAdapter;
   sends: CapturedSend[];
 } {
@@ -133,7 +151,7 @@ function makeCapturingAdapter(channel: "vellum" | "platform"): {
       destination: ChannelDestination,
     ): Promise<DeliveryResult> {
       sends.push({ payload, destination });
-      return { success: true };
+      return result;
     },
   };
   return { adapter, sends };
@@ -142,6 +160,7 @@ function makeCapturingAdapter(channel: "vellum" | "platform"): {
 beforeEach(() => {
   composeFallbackReturn = {};
   knownConversations = new Set();
+  pairingByChannel = {};
 });
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -294,31 +313,117 @@ describe("NotificationBroadcaster platform deep-link from contextPayload", () =>
 });
 
 describe("NotificationBroadcaster remotePushDispatched flag", () => {
-  test("vellum payload carries true when platform is also selected; platform payload omits it", async () => {
+  const bothChannelsCopy = () => {
     composeFallbackReturn = {
       vellum: { title: "Reminder", body: "Hello" },
       platform: { title: "Reminder", body: "Hello" },
     };
+  };
+
+  const bothChannelsDecision = () =>
+    makeDecision({
+      selectedChannels: ["vellum", "platform"],
+      renderedCopy: {},
+    });
+
+  test("vellum payload carries true when the platform adapter reports an accepted push; platform payload omits it", async () => {
+    bothChannelsCopy();
 
     const vellum = makeCapturingAdapter("vellum");
-    const platform = makeCapturingAdapter("platform");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: true,
+    });
     const broadcaster = new NotificationBroadcaster([
       vellum.adapter,
       platform.adapter,
     ]);
 
-    await broadcaster.broadcastDecision(
-      makeSignal(),
-      makeDecision({
-        selectedChannels: ["vellum", "platform"],
-        renderedCopy: {},
-      }),
-    );
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
 
     expect(vellum.sends.length).toBe(1);
     expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(true);
     expect(platform.sends.length).toBe(1);
     expect(platform.sends[0]?.payload.remotePushDispatched).toBeUndefined();
+  });
+
+  test("vellum payload carries false when the platform dispatch fails", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: false,
+      error: "HTTP 503",
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("vellum payload carries false when the platform reports no accepted push (skipped or zero tokens)", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: false,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("vellum payload carries false when the platform result omits remotePushAccepted", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", { success: true });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("vellum payload carries false when the platform adapter throws", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform: ChannelAdapter = {
+      channel: "platform",
+      async send(): Promise<DeliveryResult> {
+        throw new Error("boom");
+      },
+    };
+    const broadcaster = new NotificationBroadcaster([vellum.adapter, platform]);
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal(),
+      bothChannelsDecision(),
+    );
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+    expect(results.find((r) => r.channel === "platform")?.status).toBe(
+      "failed",
+    );
+    expect(results.find((r) => r.channel === "vellum")?.status).toBe("sent");
   });
 
   test("vellum payload carries false when platform is not selected", async () => {
@@ -336,6 +441,63 @@ describe("NotificationBroadcaster remotePushDispatched flag", () => {
 
     expect(sends.length).toBe(1);
     expect(sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("dispatches the platform adapter before the vellum intent when both are selected", async () => {
+    bothChannelsCopy();
+
+    const callOrder: string[] = [];
+    const vellum: ChannelAdapter = {
+      channel: "vellum",
+      async send(): Promise<DeliveryResult> {
+        callOrder.push("vellum");
+        return { success: true };
+      },
+    };
+    const platform: ChannelAdapter = {
+      channel: "platform",
+      async send(): Promise<DeliveryResult> {
+        callOrder.push("platform");
+        return { success: true, remotePushAccepted: true };
+      },
+    };
+    const broadcaster = new NotificationBroadcaster([vellum, platform]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(callOrder).toEqual(["platform", "vellum"]);
+  });
+
+  test("platform deep link still carries the vellum pairing when the vellum send is deferred", async () => {
+    bothChannelsCopy();
+
+    pairingByChannel = {
+      vellum: {
+        conversationId: "conv-vellum-1",
+        messageId: "msg-1",
+        strategy: "start_new_conversation",
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      },
+    };
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: true,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(platform.sends.length).toBe(1);
+    expect(platform.sends[0]?.payload.deepLinkTarget).toEqual({
+      conversationId: "conv-vellum-1",
+      messageId: "msg-1",
+    });
   });
 });
 

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -107,6 +107,7 @@ export class VellumAdapter implements ChannelAdapter {
         deepLinkMetadata: payload.deepLinkTarget,
         targetGuardianPrincipalId,
         silent,
+        remotePushDispatched: payload.remotePushDispatched,
       } as AssistantEvent);
 
       log.info(

--- a/assistant/src/notifications/adapters/platform.ts
+++ b/assistant/src/notifications/adapters/platform.ts
@@ -121,16 +121,33 @@ export class PlatformPushAdapter implements ChannelAdapter {
       }
 
       if (response.ok) {
+        // A 2xx does not mean a push went out: the server returns
+        // 202 {"skipped": ...} when the feature flag is off or no tokens
+        // are registered, and 200 with tokens_sent: 0 on idempotent
+        // replays. Only report acceptance when the body confirms at least
+        // one device push was dispatched; an unparseable or ambiguous body
+        // counts as not accepted (a duplicate client banner beats a lost
+        // notification).
+        const responseBody = (await response.json().catch(() => null)) as {
+          skipped?: unknown;
+          tokens_sent?: unknown;
+        } | null;
+        const remotePushAccepted =
+          responseBody != null &&
+          !responseBody.skipped &&
+          typeof responseBody.tokens_sent === "number" &&
+          responseBody.tokens_sent > 0;
         log.info(
           {
             sourceEventName: payload.sourceEventName,
             title: payload.copy.title,
             guardianScoped: targetGuardianPrincipalId != null,
             status: response.status,
+            remotePushAccepted,
           },
           "Platform push dispatched",
         );
-        return { success: true };
+        return { success: true, remotePushAccepted };
       }
 
       if (

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -21,7 +21,10 @@ import {
   parseAccessRequestPayload,
 } from "./access-request-copy.js";
 import { isGuardianSensitiveEvent } from "./adapters/macos.js";
-import { pairDeliveryWithConversation } from "./conversation-pairing.js";
+import {
+  pairDeliveryWithConversation,
+  type PairingResult,
+} from "./conversation-pairing.js";
 import { composeFallbackCopy } from "./copy-composer.js";
 import {
   createDelivery,
@@ -43,7 +46,9 @@ import type { NotificationSignal } from "./signal.js";
 import type {
   ChannelAdapter,
   ChannelDeliveryPayload,
+  ChannelDestination,
   ConversationAction,
+  DeliveryResult,
   NotificationChannel,
   NotificationDecision,
   NotificationDeliveryResult,
@@ -223,6 +228,23 @@ export interface BroadcastDecisionOptions {
   onConversationCreated?: OnConversationCreatedFn;
 }
 
+/**
+ * A channel dispatch that is fully prepared (destination resolved, copy
+ * rendered, conversation paired, pending delivery row created) but whose
+ * adapter send has not yet run. Used to defer the vellum send until the
+ * platform dispatch outcome is known.
+ */
+interface PendingChannelDispatch {
+  adapter: ChannelAdapter;
+  channel: NotificationChannel;
+  destination: ChannelDestination;
+  payload: ChannelDeliveryPayload;
+  deliveryId: string;
+  destinationLabel: string;
+  pairing: PairingResult;
+  hasPersistedDecision: boolean;
+}
+
 export class NotificationBroadcaster {
   private adapters: Map<NotificationChannel, ChannelAdapter>;
   private onConversationCreated: OnConversationCreatedFn | null = null;
@@ -268,16 +290,22 @@ export class NotificationBroadcaster {
 
     // Ensure vellum is processed first so the notification_conversation_created
     // event fires immediately, before slower channel sends (e.g. Telegram 30s
-    // timeout) can delay it past the macOS deep-link retry window.
-    const orderedChannels = [...decision.selectedChannels].sort((a, b) => {
-      if (a === "vellum") {
-        return -1;
+    // timeout) can delay it past the macOS deep-link retry window. Platform
+    // sorts second: the vellum intent carries remotePushDispatched, so its
+    // deferred send (below) flushes right after the platform outcome is known
+    // instead of waiting behind slower channels.
+    const dispatchRank = (channel: NotificationChannel): number => {
+      if (channel === "vellum") {
+        return 0;
       }
-      if (b === "vellum") {
+      if (channel === "platform") {
         return 1;
       }
-      return 0;
-    });
+      return 2;
+    };
+    const orderedChannels = [...decision.selectedChannels].sort(
+      (a, b) => dispatchRank(a) - dispatchRank(b),
+    );
 
     // Pre-compute fallback copy in case any channel is missing rendered copy
     let fallbackCopy: Partial<
@@ -301,7 +329,34 @@ export class NotificationBroadcaster {
       messageId: string | null;
     } | null = null;
 
+    // The vellum intent's remotePushDispatched flag must reflect the ACTUAL
+    // platform dispatch outcome, not channel selection: when both channels
+    // are selected, the vellum channel is still prepared first (pairing, the
+    // conversation-created emission, and the pending delivery row all run
+    // eagerly, so the platform deep link keeps the vellum pairing carry), but
+    // its adapter send is deferred until the platform adapter reports whether
+    // the platform accepted a device push. Typical cost: one fast HTTP
+    // round-trip before the local banner goes out.
+    let deferredVellumSend: PendingChannelDispatch | null = null;
+    let platformRemotePushAccepted = false;
+    const flushDeferredVellumSend = async (): Promise<void> => {
+      if (!deferredVellumSend) {
+        return;
+      }
+      const pending = deferredVellumSend;
+      deferredVellumSend = null;
+      pending.payload.remotePushDispatched = platformRemotePushAccepted;
+      await this.sendAndRecord(pending, signal, results);
+    };
+
     for (const channel of orderedChannels) {
+      // Platform sorts immediately after vellum, so once any other channel is
+      // reached the platform outcome is settled: flush the deferred vellum
+      // send now so the local banner is not held behind slower sends.
+      if (channel !== "vellum" && channel !== "platform") {
+        await flushDeferredVellumSend();
+      }
+
       const adapter = this.adapters.get(channel);
       if (!adapter) {
         log.warn(
@@ -555,12 +610,9 @@ export class NotificationBroadcaster {
         approvalContext,
         accessRequestContext,
         toolApprovalSource,
-        ...(channel === "vellum"
-          ? {
-              remotePushDispatched:
-                decision.selectedChannels.includes("platform"),
-            }
-          : {}),
+        // Starts false for vellum; the deferred-send flush overwrites it
+        // with the actual platform outcome when platform is also selected.
+        ...(channel === "vellum" ? { remotePushDispatched: false } : {}),
       };
 
       // Compute conversation decision audit fields for the delivery record
@@ -595,68 +647,12 @@ export class NotificationBroadcaster {
             "No persisted decision ID -- skipping delivery record creation",
           );
         }
-
-        const adapterResult = await adapter.send(payload, destination);
-
-        if (adapterResult.success) {
-          // Prefer the channel-native id the adapter just captured (e.g.
-          // Slack `ts`) so later edits can target the same message; fall
-          // back to the pairing-supplied id for channels that surface it
-          // through conversation pairing instead.
-          const resolvedMessageId =
-            adapterResult.messageId ?? pairing.messageId ?? undefined;
-          if (hasPersistedDecision) {
-            updateDeliveryStatus(
-              deliveryId,
-              "sent",
-              undefined,
-              adapterResult.messageId
-                ? { messageId: adapterResult.messageId }
-                : undefined,
-            );
-          }
-          results.push({
-            channel,
-            destination: destinationLabel,
-            status: "sent",
-            sentAt: Date.now(),
-            conversationId: pairing.conversationId ?? undefined,
-            messageId: resolvedMessageId,
-            conversationStrategy: pairing.strategy,
-          });
-        } else {
-          if (hasPersistedDecision) {
-            updateDeliveryStatus(deliveryId, "failed", {
-              message: adapterResult.error,
-            });
-          }
-          results.push({
-            channel,
-            destination: destinationLabel,
-            status: "failed",
-            errorMessage: adapterResult.error,
-            conversationId: pairing.conversationId ?? undefined,
-            messageId: pairing.messageId ?? undefined,
-            conversationStrategy: pairing.strategy,
-          });
-        }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
         log.error(
           { err, channel, signalId: signal.signalId },
-          "Unexpected error during channel delivery",
+          "Failed to create delivery record",
         );
-
-        if (hasPersistedDecision) {
-          try {
-            updateDeliveryStatus(deliveryId, "failed", {
-              message: errorMessage,
-            });
-          } catch {
-            // Swallow -- the delivery record may not exist if createDelivery failed
-          }
-        }
-
         results.push({
           channel,
           destination: destinationLabel,
@@ -666,10 +662,135 @@ export class NotificationBroadcaster {
           messageId: pairing.messageId ?? undefined,
           conversationStrategy: pairing.strategy,
         });
+        continue;
+      }
+
+      const dispatch: PendingChannelDispatch = {
+        adapter,
+        channel,
+        destination,
+        payload,
+        deliveryId,
+        destinationLabel,
+        pairing,
+        hasPersistedDecision,
+      };
+
+      if (channel === "vellum" && orderedChannels.includes("platform")) {
+        // The vellum intent carries remotePushDispatched, so its send waits
+        // for the platform outcome; everything else (pairing, events, the
+        // pending delivery row) already ran above.
+        deferredVellumSend = dispatch;
+        continue;
+      }
+
+      const adapterResult = await this.sendAndRecord(dispatch, signal, results);
+      if (channel === "platform") {
+        platformRemotePushAccepted = adapterResult?.remotePushAccepted === true;
       }
     }
 
+    // Covers the common [vellum, platform] selection where no later channel
+    // triggered the flush.
+    await flushDeferredVellumSend();
+
     return results;
+  }
+
+  /**
+   * Dispatch a prepared payload through its channel adapter and record the
+   * outcome (delivery row status + results entry). Returns the adapter's
+   * result, or null when the send threw.
+   */
+  private async sendAndRecord(
+    dispatch: PendingChannelDispatch,
+    signal: NotificationSignal,
+    results: NotificationDeliveryResult[],
+  ): Promise<DeliveryResult | null> {
+    const {
+      adapter,
+      channel,
+      destination,
+      payload,
+      deliveryId,
+      destinationLabel,
+      pairing,
+      hasPersistedDecision,
+    } = dispatch;
+    try {
+      const adapterResult = await adapter.send(payload, destination);
+
+      if (adapterResult.success) {
+        // Prefer the channel-native id the adapter just captured (e.g.
+        // Slack `ts`) so later edits can target the same message; fall
+        // back to the pairing-supplied id for channels that surface it
+        // through conversation pairing instead.
+        const resolvedMessageId =
+          adapterResult.messageId ?? pairing.messageId ?? undefined;
+        if (hasPersistedDecision) {
+          updateDeliveryStatus(
+            deliveryId,
+            "sent",
+            undefined,
+            adapterResult.messageId
+              ? { messageId: adapterResult.messageId }
+              : undefined,
+          );
+        }
+        results.push({
+          channel,
+          destination: destinationLabel,
+          status: "sent",
+          sentAt: Date.now(),
+          conversationId: pairing.conversationId ?? undefined,
+          messageId: resolvedMessageId,
+          conversationStrategy: pairing.strategy,
+        });
+      } else {
+        if (hasPersistedDecision) {
+          updateDeliveryStatus(deliveryId, "failed", {
+            message: adapterResult.error,
+          });
+        }
+        results.push({
+          channel,
+          destination: destinationLabel,
+          status: "failed",
+          errorMessage: adapterResult.error,
+          conversationId: pairing.conversationId ?? undefined,
+          messageId: pairing.messageId ?? undefined,
+          conversationStrategy: pairing.strategy,
+        });
+      }
+      return adapterResult;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, channel, signalId: signal.signalId },
+        "Unexpected error during channel delivery",
+      );
+
+      if (hasPersistedDecision) {
+        try {
+          updateDeliveryStatus(deliveryId, "failed", {
+            message: errorMessage,
+          });
+        } catch {
+          // Swallow -- best-effort failure-status update
+        }
+      }
+
+      results.push({
+        channel,
+        destination: destinationLabel,
+        status: "failed",
+        errorMessage,
+        conversationId: pairing.conversationId ?? undefined,
+        messageId: pairing.messageId ?? undefined,
+        conversationStrategy: pairing.strategy,
+      });
+      return null;
+    }
   }
 }
 

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -555,6 +555,12 @@ export class NotificationBroadcaster {
         approvalContext,
         accessRequestContext,
         toolApprovalSource,
+        ...(channel === "vellum"
+          ? {
+              remotePushDispatched:
+                decision.selectedChannels.includes("platform"),
+            }
+          : {}),
       };
 
       // Compute conversation decision audit fields for the delivery record

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -106,6 +106,10 @@ export const ChannelDeliveryPayloadSchema = z.object({
    *  broadcaster so channel adapters render it without re-parsing
    *  `contextPayload`. */
   toolApprovalSource: ToolApprovalSourceViewSchema.optional(),
+  /** True when the decision also selected the platform (APNs) channel.
+   *  Set only on the vellum channel's payload so clients can avoid
+   *  double-bannering. */
+  remotePushDispatched: z.boolean().optional(),
 });
 export type ChannelDeliveryPayload = z.infer<
   typeof ChannelDeliveryPayloadSchema

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -58,6 +58,9 @@ export const DeliveryResultSchema = z.object({
   success: z.boolean(),
   error: z.string().optional(),
   messageId: z.string().optional(),
+  /** Set only by the platform push adapter: true when the platform accepted
+   *  at least one device push for delivery (not proof of device receipt). */
+  remotePushAccepted: z.boolean().optional(),
 });
 export type DeliveryResult = z.infer<typeof DeliveryResultSchema>;
 
@@ -106,8 +109,8 @@ export const ChannelDeliveryPayloadSchema = z.object({
    *  broadcaster so channel adapters render it without re-parsing
    *  `contextPayload`. */
   toolApprovalSource: ToolApprovalSourceViewSchema.optional(),
-  /** True when the decision also selected the platform (APNs) channel.
-   *  Set only on the vellum channel's payload so clients can avoid
+  /** True when the platform (APNs) channel accepted a remote push for this
+   *  delivery. Set only on the vellum channel's payload so clients can avoid
    *  double-bannering. */
   remotePushDispatched: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary
- Adds an optional remotePushDispatched flag to the notification_intent event, set when the decision also selected the platform (APNs) channel.
- Additive and optional: older clients ignore it; older daemons simply omit it.
- Enables clients (next PR) to skip the local banner when a remote push covers a backgrounded iOS app.

Part of plan: ios-push-lower-envs.md (PR 2 of 5)