### PR TITLE
notifications: force the platform (APNs) channel for high/critical urgency signals

### DIFF
--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -467,3 +467,177 @@ describe("access-request vellum floor", () => {
     expect(dispatched.reasoningSummary).not.toContain("vellum forced");
   });
 });
+
+describe("high/critical urgency channel force", () => {
+  beforeEach(() => {
+    evaluateSignalMock.mockReset();
+    enforceRoutingIntentMock.mockReset();
+    updateDecisionMock.mockReset();
+    runDeterministicChecksMock.mockReset();
+    createEventMock.mockReset();
+    updateEventDedupeKeyMock.mockReset();
+    dispatchDecisionMock.mockReset();
+    createEventMock.mockReturnValue({ id: "evt-1" });
+    runDeterministicChecksMock.mockResolvedValue({ passed: true });
+    dispatchDecisionMock.mockResolvedValue({
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    });
+    enforceRoutingIntentMock.mockImplementation(
+      (decision: unknown) => decision,
+    );
+  });
+
+  function makeDecision(overrides: Record<string, unknown>) {
+    return {
+      shouldNotify: true,
+      selectedChannels: ["telegram"],
+      reasoningSummary: "LLM selected telegram only",
+      renderedCopy: {},
+      dedupeKey: "dedupe-urg-1",
+      confidence: 0.9,
+      fallbackUsed: false,
+      persistedDecisionId: "dec-urg-1",
+      ...overrides,
+    };
+  }
+
+  function emitWithUrgency(urgency: "low" | "medium" | "high" | "critical") {
+    return emitNotificationSignal({
+      sourceEventName: "schedule.notify",
+      sourceChannel: "scheduler",
+      sourceContextId: "rem-urg-1",
+      attentionHints: {
+        requiresAction: true,
+        urgency,
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: { reminderId: "rem-urg-1" },
+    });
+  }
+
+  test("forces vellum and platform onto a high-urgency decision missing both", async () => {
+    evaluateSignalMock.mockResolvedValue(makeDecision({}));
+
+    const result = await emitWithUrgency("high");
+
+    expect(result.dispatched).toBe(true);
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.selectedChannels).toContain("vellum");
+    expect(dispatched.selectedChannels).toContain("platform");
+    expect(dispatched.selectedChannels).toContain("telegram");
+    expect(dispatched.reasoningSummary).toContain(
+      "(vellum, platform forced: high urgency)",
+    );
+  });
+
+  test("forces only the missing channel when the other is already selected", async () => {
+    evaluateSignalMock.mockResolvedValue(
+      makeDecision({ selectedChannels: ["vellum"] }),
+    );
+
+    await emitWithUrgency("critical");
+
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.selectedChannels).toEqual(["platform", "vellum"]);
+    expect(dispatched.reasoningSummary).toContain(
+      "(platform forced: critical urgency)",
+    );
+  });
+
+  test("leaves a high-urgency decision untouched when both channels are already selected", async () => {
+    evaluateSignalMock.mockResolvedValue(
+      makeDecision({ selectedChannels: ["vellum", "platform"] }),
+    );
+
+    await emitWithUrgency("high");
+
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.selectedChannels).toEqual(["vellum", "platform"]);
+    expect(dispatched.reasoningSummary).not.toContain("forced");
+  });
+
+  test("leaves medium and low urgency selections untouched", async () => {
+    for (const urgency of ["medium", "low"] as const) {
+      dispatchDecisionMock.mockClear();
+      evaluateSignalMock.mockResolvedValue(makeDecision({}));
+
+      await emitWithUrgency(urgency);
+
+      const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+        selectedChannels: string[];
+        reasoningSummary: string;
+      };
+      expect(dispatched.selectedChannels).toEqual(["telegram"]);
+      expect(dispatched.reasoningSummary).not.toContain("forced");
+    }
+  });
+
+  test("does not force channels when the decision suppresses the notification", async () => {
+    evaluateSignalMock.mockResolvedValue(
+      makeDecision({ shouldNotify: false, selectedChannels: [] }),
+    );
+
+    await emitWithUrgency("high");
+
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      shouldNotify: boolean;
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.shouldNotify).toBe(false);
+    expect(dispatched.selectedChannels).toEqual([]);
+    expect(dispatched.reasoningSummary).not.toContain("forced");
+  });
+
+  test("routing-intent enforcement runs after the force-add and can cap channels", async () => {
+    evaluateSignalMock.mockResolvedValue(makeDecision({}));
+    // single_channel enforcement caps the selection to the source channel.
+    enforceRoutingIntentMock.mockImplementation(
+      (decision: { selectedChannels: string[] }) => ({
+        ...decision,
+        selectedChannels: ["telegram"],
+      }),
+    );
+
+    await emitNotificationSignal({
+      sourceEventName: "schedule.notify",
+      sourceChannel: "scheduler",
+      sourceContextId: "rem-urg-2",
+      routingIntent: "single_channel",
+      attentionHints: {
+        requiresAction: true,
+        urgency: "high",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: { reminderId: "rem-urg-2" },
+    });
+
+    // Enforcement sees the force-added channels...
+    const enforcedInput = enforceRoutingIntentMock.mock.calls[0][0] as {
+      selectedChannels: string[];
+    };
+    expect(enforcedInput.selectedChannels).toEqual([
+      "vellum",
+      "platform",
+      "telegram",
+    ]);
+    // ...and its cap wins over the force-add.
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+    };
+    expect(dispatched.selectedChannels).toEqual(["telegram"]);
+  });
+});

--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -536,6 +536,27 @@ describe("high/critical urgency channel force", () => {
     );
   });
 
+  test("re-persists the stored decision with the force-added channels when routing enforcement is a no-op", async () => {
+    evaluateSignalMock.mockResolvedValue(makeDecision({}));
+
+    await emitWithUrgency("high");
+
+    // The identity enforcement mock leaves the decision unchanged, so only
+    // the urgency force-add differs from the evaluated decision. The stored
+    // row must still be synced to the dispatched channels.
+    expect(updateDecisionMock).toHaveBeenCalledTimes(1);
+    expect(updateDecisionMock).toHaveBeenCalledWith("dec-urg-1", {
+      selectedChannels: ["vellum", "platform", "telegram"],
+      reasoningSummary:
+        "LLM selected telegram only (vellum, platform forced: high urgency)",
+      validationResults: {
+        dedupeKey: "dedupe-urg-1",
+        channelCount: 3,
+        hasCopy: false,
+      },
+    });
+  });
+
   test("forces only the missing channel when the other is already selected", async () => {
     evaluateSignalMock.mockResolvedValue(
       makeDecision({ selectedChannels: ["vellum"] }),
@@ -566,6 +587,7 @@ describe("high/critical urgency channel force", () => {
     };
     expect(dispatched.selectedChannels).toEqual(["vellum", "platform"]);
     expect(dispatched.reasoningSummary).not.toContain("forced");
+    expect(updateDecisionMock).not.toHaveBeenCalled();
   });
 
   test("leaves medium and low urgency selections untouched", async () => {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -320,6 +320,11 @@ export async function emitNotificationSignal<TEventName extends string>(
 
     let decision = await evaluateSignal(signal, connectedChannels);
 
+    // Baseline for the re-persist check below. Captured before the policy
+    // steps (2.5a/2.5b/2.5c) so any of them replacing the decision triggers
+    // the re-persist and the stored row matches what is dispatched.
+    const prePolicyDecision = decision;
+
     // Step 2.5a: High/critical urgency signals always get both the in-app
     // system notification (vellum) and the remote push (platform),
     // regardless of what the decision engine selected. macOS surfaces a
@@ -343,7 +348,6 @@ export async function emitNotificationSignal<TEventName extends string>(
     }
 
     // Step 2.5b: Enforce routing intent policy (fire-time guard)
-    const preEnforcementDecision = decision;
     decision = enforceRoutingIntent(
       decision,
       signal.routingIntent,
@@ -373,9 +377,10 @@ export async function emitNotificationSignal<TEventName extends string>(
       };
     }
 
-    // Re-persist the decision if routing intent enforcement changed it,
-    // so the stored decision row matches what is actually dispatched.
-    if (decision !== preEnforcementDecision && decision.persistedDecisionId) {
+    // Re-persist the decision if any policy step changed it (urgency channel
+    // forcing, routing intent enforcement, or the access-request vellum
+    // floor), so the stored decision row matches what is actually dispatched.
+    if (decision !== prePolicyDecision && decision.persistedDecisionId) {
       try {
         updateDecision(decision.persistedDecisionId, {
           selectedChannels: decision.selectedChannels,
@@ -389,7 +394,7 @@ export async function emitNotificationSignal<TEventName extends string>(
       } catch (err) {
         log.warn(
           { err, signalId },
-          "Failed to re-persist decision after routing intent enforcement",
+          "Failed to re-persist decision after policy enforcement",
         );
       }
     }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -320,21 +320,26 @@ export async function emitNotificationSignal<TEventName extends string>(
 
     let decision = await evaluateSignal(signal, connectedChannels);
 
-    // Step 2.5a: High/critical urgency signals always get a system
-    // notification via the vellum channel, regardless of what the
-    // decision engine selected. This ensures macOS surfaces a banner
-    // even when the app is focused.
+    // Step 2.5a: High/critical urgency signals always get both the in-app
+    // system notification (vellum) and the remote push (platform),
+    // regardless of what the decision engine selected. macOS surfaces a
+    // banner even when the app is focused, and a suspended iOS device is
+    // only reachable via APNs.
     const urgency = signal.attentionHints.urgency;
     if (
       (urgency === "high" || urgency === "critical") &&
-      decision.shouldNotify &&
-      !decision.selectedChannels.includes("vellum")
+      decision.shouldNotify
     ) {
-      decision = {
-        ...decision,
-        selectedChannels: ["vellum", ...decision.selectedChannels],
-        reasoningSummary: `${decision.reasoningSummary} (vellum forced: ${urgency} urgency)`,
-      };
+      const forcedChannels: NotificationChannel[] = (
+        ["vellum", "platform"] as const
+      ).filter((channel) => !decision.selectedChannels.includes(channel));
+      if (forcedChannels.length > 0) {
+        decision = {
+          ...decision,
+          selectedChannels: [...forcedChannels, ...decision.selectedChannels],
+          reasoningSummary: `${decision.reasoningSummary} (${forcedChannels.join(", ")} forced: ${urgency} urgency)`,
+        };
+      }
     }
 
     // Step 2.5b: Enforce routing intent policy (fire-time guard)


### PR DESCRIPTION
## Summary
- High/critical urgency notification signals now force-add the platform (APNs) channel alongside vellum, so urgent notifications always attempt remote push delivery to iOS.
- Routing-intent enforcement still runs after the force-add and can cap channels as before.

Part of plan: ios-push-lower-envs.md (PR 1 of 5)