### PR TITLE
ios: native plugin exposing the build's real APNs entitlement environment

### DIFF
--- a/clients/ios/App/App/ApnsEnvironmentPlugin.swift
+++ b/clients/ios/App/App/ApnsEnvironmentPlugin.swift
@@ -1,0 +1,67 @@
+import Capacitor
+import Foundation
+
+/// Capacitor plugin that reports which APNs environment this build's
+/// `aps-environment` entitlement actually points at, read from the embedded
+/// provisioning profile. The web side
+/// (`clients/web/src/runtime/push-registration.ts`) uses it to tag device
+/// tokens correctly: TestFlight signs every build, including dev-suffixed
+/// bundle IDs, with the production entitlement, so any heuristic based on the
+/// bundle ID misclassifies TestFlight dev builds and their pushes are
+/// rejected by Apple.
+///
+/// The single `get` method resolves `{ environment }` with one of:
+/// - `"development"`: an Xcode / development-signed install
+/// - `"production"`: a TestFlight or App Store install
+/// - `"unknown"`: the profile exists but could not be read or parsed
+///
+/// It never rejects. Per the skew rule in `clients/web/docs/CAPACITOR.md`, a
+/// plugin must not require a separate availability probe, so the one result
+/// encodes every state; an older shell without the plugin simply fails the
+/// bridge call and the web side falls back to its heuristic.
+@objc(ApnsEnvironmentPlugin)
+public class ApnsEnvironmentPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "ApnsEnvironmentPlugin"
+    public let jsName = "ApnsEnvironment"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "get", returnType: CAPPluginReturnPromise),
+    ]
+
+    @objc public func get(_ call: CAPPluginCall) {
+        call.resolve(["environment": Self.entitlementEnvironment()])
+    }
+
+    private static func entitlementEnvironment() -> String {
+        guard let profileURL = Bundle.main.url(
+            forResource: "embedded",
+            withExtension: "mobileprovision"
+        ) else {
+            // App Store installs ship no embedded profile and are always production.
+            return "production"
+        }
+        guard let profileData = try? Data(contentsOf: profileURL) else {
+            return "unknown"
+        }
+
+        // The profile is a CMS blob wrapping a plist, so it is scanned as text
+        // rather than decoded. `String(decoding:as:)` is lossy: the wrapper's
+        // binary segments become replacement characters while the ASCII plist
+        // entries stay intact.
+        let text = String(decoding: profileData, as: UTF8.self)
+        guard let key = text.range(of: "<key>aps-environment</key>"),
+              let open = text.range(of: "<string>", range: key.upperBound..<text.endIndex),
+              let close = text.range(of: "</string>", range: open.upperBound..<text.endIndex)
+        else {
+            return "unknown"
+        }
+
+        let value = text[open.upperBound..<close.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        switch value {
+        case "development", "production":
+            return value
+        default:
+            return "unknown"
+        }
+    }
+}

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -5,9 +5,10 @@ import WebKit
 /// Custom `CAPBridgeViewController` subclass that:
 ///
 /// 1. Registers `NativeAuthPlugin`, `NativeBiometricPlugin`,
-///    `VoiceAudioSessionPlugin`, and `VoiceLiveActivityPlugin` as local plugin
-///    instances at bridge init time. These plugins live inside the App target
-///    (no SPM module) so the bridge won't discover them automatically.
+///    `VoiceAudioSessionPlugin`, `VoiceLiveActivityPlugin`, and
+///    `ApnsEnvironmentPlugin` as local plugin instances at bridge init time.
+///    These plugins live inside the App target (no SPM module) so the bridge
+///    won't discover them automatically.
 ///
 /// 2. Injects `WKUserScript`s at `.atDocumentEnd` to:
 ///    a) Pin focusable fields to a minimum 16px font-size, preventing the
@@ -146,6 +147,7 @@ class MyViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(NativeBiometricPlugin())
         bridge?.registerPluginInstance(VoiceAudioSessionPlugin())
         bridge?.registerPluginInstance(VoiceLiveActivityPlugin())
+        bridge?.registerPluginInstance(ApnsEnvironmentPlugin())
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -43,9 +43,9 @@ which URL is baked into the build.
   process. With `server.url`, only native shell changes (Swift code,
   entitlements, Capacitor plugin updates) require a store submission.
 - **Thin native surface** — the IPC bridge between the WKWebView and
-  native code is minimal (four plugins: `NativeAuthPlugin`,
-  `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`, and
-  `VoiceLiveActivityPlugin`), so version
+  native code is minimal (five plugins: `NativeAuthPlugin`,
+  `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`,
+  `VoiceLiveActivityPlugin`, and `ApnsEnvironmentPlugin`), so version
   skew risk between the web app and native shell is low. Every plugin
   call from the web side must still be capability-probed, because a new
   web bundle always ships ahead of the shell that hosts it. Contrast
@@ -150,7 +150,7 @@ Apple's reference for the toolbar controls:
 
 The app has two layers — the **WKWebView contents** (the React app loaded
 from the configured server URL) and the **native Swift shell** (Capacitor
-bridge, `MyViewController`, the four native plugins). Each has its own
+bridge, `MyViewController`, the five native plugins). Each has its own
 debugger.
 
 ### Safari Web Inspector — for the web side (JS / CSS / network / `console.log`)
@@ -198,8 +198,8 @@ For a **physical iPhone**:
 ⌘R runs with `lldb` already attached. Click in the gutter next to any
 line in `AppDelegate.swift`, `MyViewController.swift`,
 `NativeAuthPlugin.swift`, `NativeBiometricPlugin.swift`,
-`VoiceAudioSessionPlugin.swift`, or `VoiceLiveActivityPlugin.swift` to set a
-breakpoint.
+`VoiceAudioSessionPlugin.swift`, `VoiceLiveActivityPlugin.swift`, or
+`ApnsEnvironmentPlugin.swift` to set a breakpoint.
 
 - **Console / log output**: View → Debug Area → Activate Console (⇧⌘Y),
   or click the bottom-right console toggle. `print()` and `NSLog()` from
@@ -218,7 +218,7 @@ breakpoint.
 ### Common debugging recipes
 
 - **A native plugin call (`NativeAuth`, `NativeBiometric`,
-  `VoiceAudioSession`, `VoiceLiveActivity`) seems broken**:
+  `VoiceAudioSession`, `VoiceLiveActivity`, `ApnsEnvironment`) seems broken**:
   set a Swift breakpoint in the relevant `@objc func` inside the plugin
   file and trigger the action from the web app. If the breakpoint never
   hits, the JS-side `Capacitor.Plugins.NativeAuth` lookup is wrong (check
@@ -698,6 +698,7 @@ clients/
     │   │   ├── NativeBiometricPlugin.swift # Face ID / Touch ID Keychain
     │   │   ├── VoiceAudioSessionPlugin.swift # AVAudioSession for live voice
     │   │   ├── VoiceLiveActivityPlugin.swift # Dynamic Island for live voice
+    │   │   ├── ApnsEnvironmentPlugin.swift # APNs entitlement environment
     │   │   ├── Intents/              # App Intents + AppShortcutsProvider
     │   │   ├── Shared/               # Compiled into app + widget extension
     │   │   └── Info.plist

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -145,7 +145,7 @@ References:
 
 Live voice is a web feature with native accessories. The session — mic capture, the velay socket, TTS playback, every user-facing string — lives entirely under `src/domains/chat/voice/live-voice/`. The iOS shell adds an `AVAudioSession`, a Dynamic Island / Lock Screen presence, and a set of App Intents on top of it.
 
-The shell registers **four** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) — count them there, not from prose:
+The shell registers **five** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose):
 
 | Plugin | Web module | What it does |
 | --- | --- | --- |
@@ -153,6 +153,7 @@ The shell registers **four** Capacitor plugins in [`MyViewController.capacitorDi
 | `NativeBiometric` | [`src/runtime/native-biometric.ts`](../src/runtime/native-biometric.ts) | Face ID / Touch ID Keychain |
 | `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | `.playAndRecord` / `.voiceChat` session + interruption events. **Unproven on hardware** — see the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | The one ActivityKit activity mirroring a session |
+| `ApnsEnvironment` | [`src/runtime/push-registration.ts`](../src/runtime/push-registration.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
 


### PR DESCRIPTION
## Summary
- New ApnsEnvironment Capacitor plugin reads aps-environment from the embedded provisioning profile: development (Xcode installs), production (TestFlight/App Store), unknown (parse failure).
- Registered in MyViewController.capacitorDidLoad alongside the existing four app-target plugins; docs updated to five.
- Local Xcode project regeneration required after checkout: run bun run ios:setup (the staleness guard only watches project.yml mtime).
- Manual verification expectation: Xcode dev install resolves development; TestFlight build resolves production.

Part of plan: ios-push-lower-envs.md (PR 4 of 5)