### PR TITLE
notifications: deterministic decision path for chat.assistant_reply signals

### DIFF
--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -148,6 +148,7 @@ describe("assistant_tool pass-through in notification decision engine", () => {
     expect(decision.renderedCopy.vellum?.title).toBe("Custom Title");
     expect(decision.conversationActions?.vellum?.action).toBe("start_new");
     expect(decision.reasoningSummary).toBe("assistant_tool pass-through");
+    expect(decision.verbatimCopy).toBe(true);
     expect(decision.fallbackUsed).toBe(false);
     expect(decision.confidence).toBe(1.0);
     expect(decision.dedupeKey).toBe(signal.signalId);
@@ -337,6 +338,7 @@ describe("chat.assistant_reply pass-through in notification decision engine", ()
     expect(decision.renderedCopy.platform?.body).toBe("Here is your answer.");
     expect(decision.renderedCopy.platform?.title).toBe("Assistant");
     expect(decision.reasoningSummary).toBe("assistant_reply pass-through");
+    expect(decision.verbatimCopy).toBe(true);
     expect(decision.fallbackUsed).toBe(false);
     expect(decision.confidence).toBe(1.0);
   });

--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -1,20 +1,24 @@
 /**
- * Tests for the assistant_tool pass-through path in the notification
- * decision engine. When a producer hands us a verbatim message via
- * contextPayload.requestedMessage, the engine must skip the LLM call
- * entirely and use the producer-supplied copy as-is.
+ * Tests for the pass-through paths in the notification decision engine
+ * (assistant_tool signals and chat.assistant_reply signals). When a producer
+ * hands us a verbatim message via contextPayload.requestedMessage, the engine
+ * must skip the LLM call entirely and use the producer-supplied copy as-is.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Mocks (must precede imports from mocked modules) ──────────────────
 
 mock.module("../../channels/config.js", () => ({
-  getDeliverableChannels: () => ["vellum", "telegram"],
+  getDeliverableChannels: () => ["vellum", "telegram", "platform"],
 }));
 
+let persistedDecisions: Array<Record<string, unknown>> = [];
+
 mock.module("../decisions-store.js", () => ({
-  createDecision: () => {},
+  createDecision: (row: Record<string, unknown>) => {
+    persistedDecisions.push(row);
+  },
 }));
 
 mock.module("../preference-summary.js", () => ({
@@ -49,15 +53,15 @@ mock.module("../../contacts/contact-store.js", () => ({
     contactInfoFixture[contactId] ?? null,
 }));
 
-// Provider mock. By default `sendMessage` throws so the assistant_tool
-// pass-through path (which must skip the LLM) fails loudly if it reaches the
-// provider. LLM-path tests override `providerSendMessage` to capture inputs.
+// Provider mock. By default `sendMessage` throws so the pass-through paths
+// (which must skip the LLM) fail loudly if they reach the provider. LLM-path
+// tests override `providerSendMessage` to capture inputs.
 let providerSendMessage: (
   messages: unknown[],
   opts: { systemPrompt?: string },
 ) => Promise<unknown> = () => {
   throw new Error(
-    "provider.sendMessage should NOT be invoked for assistant_tool pass-through",
+    "provider.sendMessage should NOT be invoked for pass-through decisions",
   );
 };
 
@@ -98,6 +102,29 @@ function makeAssistantToolSignal(
     attentionHints: {
       requiresAction: false,
       urgency: "low",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeAssistantReplySignal(
+  overrides?: Partial<NotificationSignal>,
+): NotificationSignal {
+  return {
+    signalId: "sig-assistant-reply-test-1",
+    createdAt: Date.now(),
+    sourceChannel: "vellum",
+    sourceContextId: "conv-1",
+    sourceEventName: "chat.assistant_reply",
+    contextPayload: {
+      requestedMessage: "Here is your answer.",
+      requestedTitle: "Assistant",
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
       isAsyncBackground: false,
       visibleInSourceNow: false,
     },
@@ -291,6 +318,129 @@ describe("assistant_tool pass-through in notification decision engine", () => {
 
     expect(decision.selectedChannels).toEqual(["vellum"]);
     expect(decision.renderedCopy.vellum?.body).toBe("fyi");
+  });
+});
+
+describe("chat.assistant_reply pass-through in notification decision engine", () => {
+  beforeEach(() => {
+    persistedDecisions = [];
+  });
+
+  test("uses producer-supplied title and body verbatim, no LLM call", async () => {
+    const signal = makeAssistantReplySignal();
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+      "platform",
+    ] as NotificationChannel[]);
+
+    expect(decision.shouldNotify).toBe(true);
+    expect(decision.renderedCopy.platform?.body).toBe("Here is your answer.");
+    expect(decision.renderedCopy.platform?.title).toBe("Assistant");
+    expect(decision.reasoningSummary).toBe("assistant_reply pass-through");
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.confidence).toBe(1.0);
+  });
+
+  test("selects exactly the platform channel when platform is available", async () => {
+    const decision = await evaluateSignal(makeAssistantReplySignal(), [
+      "vellum",
+      "telegram",
+      "platform",
+    ] as NotificationChannel[]);
+
+    expect(decision.selectedChannels).toEqual(["platform"]);
+    expect(decision.shouldNotify).toBe(true);
+  });
+
+  test("selects nothing and suppresses when platform is unavailable", async () => {
+    const decision = await evaluateSignal(makeAssistantReplySignal(), [
+      "vellum",
+      "telegram",
+    ] as NotificationChannel[]);
+
+    expect(decision.selectedChannels).toEqual([]);
+    expect(decision.shouldNotify).toBe(false);
+  });
+
+  test("seeds rendered copy for every available channel, not just the selected one", async () => {
+    // A future channel added to ASSISTANT_REPLY_CHANNELS (or appended by a
+    // downstream guard) inherits the verbatim copy instead of falling back.
+    const available = [
+      "vellum",
+      "telegram",
+      "platform",
+    ] as NotificationChannel[];
+    const decision = await evaluateSignal(
+      makeAssistantReplySignal(),
+      available,
+    );
+
+    for (const ch of available) {
+      expect(decision.renderedCopy[ch]?.body).toBe("Here is your answer.");
+      expect(decision.renderedCopy[ch]?.title).toBe("Assistant");
+      expect(decision.conversationActions?.[ch]?.action).toBe("start_new");
+    }
+  });
+
+  test("derives the title from the body when requestedTitle is not supplied", async () => {
+    const signal = makeAssistantReplySignal({
+      contextPayload: {
+        requestedMessage: "First sentence. Second sentence follows here.",
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "platform",
+    ] as NotificationChannel[]);
+
+    expect(decision.renderedCopy.platform?.title).toBe("First sentence.");
+  });
+
+  test("uses the producer-supplied dedupeKey", async () => {
+    const signal = makeAssistantReplySignal({
+      dedupeKey: "chat.assistant_reply:conv-1:msg-1",
+    });
+    const decision = await evaluateSignal(signal, [
+      "platform",
+    ] as NotificationChannel[]);
+
+    expect(decision.dedupeKey).toBe("chat.assistant_reply:conv-1:msg-1");
+  });
+
+  test("falls back to the signal id when the producer supplies no dedupeKey", async () => {
+    const signal = makeAssistantReplySignal();
+    const decision = await evaluateSignal(signal, [
+      "platform",
+    ] as NotificationChannel[]);
+
+    expect(decision.dedupeKey).toBe(signal.signalId);
+  });
+
+  test("threads contextPayload.deepLinkMetadata through to decision.deepLinkTarget", async () => {
+    const signal = makeAssistantReplySignal({
+      contextPayload: {
+        requestedMessage: "Here is your answer.",
+        deepLinkMetadata: { conversationId: "conv-1" },
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "platform",
+    ] as NotificationChannel[]);
+
+    expect(decision.deepLinkTarget).toEqual({ conversationId: "conv-1" });
+  });
+
+  test("persists the decision", async () => {
+    const signal = makeAssistantReplySignal();
+    const decision = await evaluateSignal(signal, [
+      "platform",
+    ] as NotificationChannel[]);
+
+    expect(decision.persistedDecisionId).toBeDefined();
+    expect(persistedDecisions.length).toBe(1);
+    expect(persistedDecisions[0]?.notificationEventId).toBe(signal.signalId);
+    expect(persistedDecisions[0]?.reasoningSummary).toBe(
+      "assistant_reply pass-through",
+    );
   });
 });
 

--- a/assistant/src/notifications/__tests__/deterministic-checks.test.ts
+++ b/assistant/src/notifications/__tests__/deterministic-checks.test.ts
@@ -241,6 +241,7 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     });
     const decision = makeDecision({
       reasoningSummary: "assistant_tool pass-through",
+      verbatimCopy: true,
       renderedCopy: {
         vellum: { title: "Assistant share", body: "assistant share" },
       },
@@ -253,6 +254,7 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     const signal = makeSignal({ sourceChannel: "assistant_tool" });
     const decision = makeDecision({
       reasoningSummary: "assistant_tool pass-through",
+      verbatimCopy: true,
       renderedCopy: {
         vellum: { title: "Reminder", body: "" },
       },
@@ -269,6 +271,26 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     });
     const decision = makeDecision({
       reasoningSummary: "assistant_reply pass-through",
+      verbatimCopy: true,
+      renderedCopy: {
+        vellum: { title: "Assistant", body: "chat assistant reply" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(true);
+  });
+
+  test("passes assistant_reply pass-through after downstream suffixes mutate the reasoning summary", async () => {
+    // `emit-signal` and routing-intent enforcement append suffixes to
+    // `reasoningSummary`, so the exemption must key off `verbatimCopy`.
+    const signal = makeSignal({
+      sourceChannel: "vellum",
+      sourceEventName: "chat.assistant_reply",
+    });
+    const decision = makeDecision({
+      reasoningSummary:
+        "assistant_reply pass-through (vellum forced: high urgency)",
+      verbatimCopy: true,
       renderedCopy: {
         vellum: { title: "Assistant", body: "chat assistant reply" },
       },
@@ -284,6 +306,7 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     });
     const decision = makeDecision({
       reasoningSummary: "assistant_reply pass-through",
+      verbatimCopy: true,
       renderedCopy: {
         vellum: { title: "Assistant", body: "" },
       },

--- a/assistant/src/notifications/__tests__/deterministic-checks.test.ts
+++ b/assistant/src/notifications/__tests__/deterministic-checks.test.ts
@@ -262,6 +262,53 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     expect(result.reason).toContain("empty");
   });
 
+  test("passes assistant_reply pass-through even when body matches normalized event name", async () => {
+    const signal = makeSignal({
+      sourceChannel: "vellum",
+      sourceEventName: "chat.assistant_reply",
+    });
+    const decision = makeDecision({
+      reasoningSummary: "assistant_reply pass-through",
+      renderedCopy: {
+        vellum: { title: "Assistant", body: "chat assistant reply" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(true);
+  });
+
+  test("fails assistant_reply pass-through with empty body (empty-body branch still fires)", async () => {
+    const signal = makeSignal({
+      sourceChannel: "vellum",
+      sourceEventName: "chat.assistant_reply",
+    });
+    const decision = makeDecision({
+      reasoningSummary: "assistant_reply pass-through",
+      renderedCopy: {
+        vellum: { title: "Assistant", body: "" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("empty");
+  });
+
+  test("still fails a non-pass-through decision on a chat.assistant_reply event-name body", async () => {
+    const signal = makeSignal({
+      sourceChannel: "vellum",
+      sourceEventName: "chat.assistant_reply",
+    });
+    const decision = makeDecision({
+      reasoningSummary: "llm classification",
+      renderedCopy: {
+        vellum: { title: "Assistant", body: "chat.assistant_reply" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("fallback leak");
+  });
+
   test("still fails non-pass-through decision when body matches event name", async () => {
     // Regression guard: the pass-through short-circuit must not weaken
     // the check for LLM/fallback paths.

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -916,6 +916,7 @@ function buildPassThroughDecision(params: {
     dedupeKey: params.dedupeKey,
     confidence: 1.0,
     fallbackUsed: false,
+    verbatimCopy: true,
     ...(deepLinkTarget ? { deepLinkTarget } : {}),
   };
   decision = enforceGuardianRequestCode(decision, signal);

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -78,6 +78,16 @@ const PROMPT_VERSION = "v4";
  */
 const MAX_IDENTITY_CONTEXT_CHARS = 2000;
 
+/**
+ * Delivery scope for `chat.assistant_reply` signals.
+ *
+ * v1 (LUM-2952) is iOS push only: `platform` is a push_only relay, so it
+ * delivers an APNs push and never materializes a conversation. Adding
+ * `"vellum"` to this array is the entire switch for in-app banners on
+ * macOS, web, and foregrounded iOS.
+ */
+const ASSISTANT_REPLY_CHANNELS: NotificationChannel[] = ["platform"];
+
 // ── System prompt ──────────────────────────────────────────────────────
 
 function buildSystemPrompt(
@@ -855,6 +865,71 @@ function ensureInviteFlowDirectiveInCopy(
   };
 }
 
+// ── Producer pass-through decisions ────────────────────────────────────
+
+/** Deep-link metadata is only honored when the producer supplies a plain object. */
+function readDeepLinkTarget(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return payload.deepLinkMetadata != null &&
+    typeof payload.deepLinkMetadata === "object" &&
+    !Array.isArray(payload.deepLinkMetadata)
+    ? (payload.deepLinkMetadata as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Build, guard, and persist a decision whose copy came verbatim from the
+ * producer, bypassing the LLM classifier.
+ *
+ * `renderedCopy` and `conversationActions` are populated for every available
+ * channel, not just `selectedChannels`: downstream guards (routing-intent
+ * expansion in `enforceRoutingIntent`, urgency-forced vellum prepending in
+ * `emit-signal`) may widen `selectedChannels` afterwards, and pre-seeding
+ * keeps the verbatim message from degrading to an empty
+ * `composeFallbackCopy` body.
+ */
+function buildPassThroughDecision(params: {
+  signal: NotificationSignal;
+  availableChannels: NotificationChannel[];
+  selectedChannels: NotificationChannel[];
+  title: string;
+  body: string;
+  reasoningSummary: string;
+  dedupeKey: string;
+  deepLinkTarget?: Record<string, unknown>;
+}): NotificationDecision {
+  const { availableChannels, body, deepLinkTarget, signal, title } = params;
+  let decision: NotificationDecision = {
+    shouldNotify: params.selectedChannels.length > 0,
+    selectedChannels: params.selectedChannels,
+    reasoningSummary: params.reasoningSummary,
+    renderedCopy: Object.fromEntries(
+      availableChannels.map((ch) => [
+        ch,
+        { title, body, conversationSeedMessage: body },
+      ]),
+    ) as NotificationDecision["renderedCopy"],
+    conversationActions: Object.fromEntries(
+      availableChannels.map((ch) => [ch, { action: "start_new" as const }]),
+    ) as NotificationDecision["conversationActions"],
+    dedupeKey: params.dedupeKey,
+    confidence: 1.0,
+    fallbackUsed: false,
+    ...(deepLinkTarget ? { deepLinkTarget } : {}),
+  };
+  decision = enforceGuardianRequestCode(decision, signal);
+  decision = enforceToolApprovalSeedBlocks(decision, signal);
+  decision = enforceAccessRequestInstructions(decision, signal);
+  decision = enforceGuardianRequestConversationAffinity(decision, signal);
+  decision = enforceConversationAffinity(
+    decision,
+    signal.conversationAffinityHint,
+  );
+  decision.persistedDecisionId = persistDecision(signal, decision);
+  return decision;
+}
+
 // ── Core evaluation function ───────────────────────────────────────────
 
 export async function evaluateSignal(
@@ -939,48 +1014,43 @@ export async function evaluateSignal(
         );
       }
     }
-    // Thread `--deep-link-metadata` through when supplied as a plain object.
-    const deepLinkTarget =
-      payload.deepLinkMetadata != null &&
-      typeof payload.deepLinkMetadata === "object" &&
-      !Array.isArray(payload.deepLinkMetadata)
-        ? (payload.deepLinkMetadata as Record<string, unknown>)
-        : undefined;
-    // Populate renderedCopy and conversationActions for every available
-    // channel — not just `selectedChannels`. Downstream guards
-    // (routing-intent expansion in `enforceRoutingIntent`, urgency-forced
-    // vellum prepending in `emit-signal`) may widen `selectedChannels`
-    // beyond what we picked here. Pre-seeding copy for all channels ensures
-    // the verbatim message survives those expansions rather than falling
-    // back to an empty `composeFallbackCopy` body.
-    let decision: NotificationDecision = {
-      shouldNotify: selectedChannels.length > 0,
+    return buildPassThroughDecision({
+      signal,
+      availableChannels,
       selectedChannels,
+      title,
+      body,
       reasoningSummary: "assistant_tool pass-through",
-      renderedCopy: Object.fromEntries(
-        availableChannels.map((ch) => [
-          ch,
-          { title, body, conversationSeedMessage: body },
-        ]),
-      ) as NotificationDecision["renderedCopy"],
-      conversationActions: Object.fromEntries(
-        availableChannels.map((ch) => [ch, { action: "start_new" as const }]),
-      ) as NotificationDecision["conversationActions"],
       dedupeKey: signal.signalId,
-      confidence: 1.0,
-      fallbackUsed: false,
-      ...(deepLinkTarget ? { deepLinkTarget } : {}),
-    };
-    decision = enforceGuardianRequestCode(decision, signal);
-    decision = enforceToolApprovalSeedBlocks(decision, signal);
-    decision = enforceAccessRequestInstructions(decision, signal);
-    decision = enforceGuardianRequestConversationAffinity(decision, signal);
-    decision = enforceConversationAffinity(
-      decision,
-      signal.conversationAffinityHint,
-    );
-    decision.persistedDecisionId = persistDecision(signal, decision);
-    return decision;
+      // Thread `--deep-link-metadata` through when supplied as a plain object.
+      deepLinkTarget: readDeepLinkTarget(payload),
+    });
+  }
+
+  // Assistant-reply pass-through: the producer supplies the copy and the
+  // delivery scope is fixed (ASSISTANT_REPLY_CHANNELS), so the LLM
+  // classifier has nothing to decide. Deterministic: no urgency
+  // dependence, no preferredChannels handling. The seeded conversation
+  // actions are inert because the producer never sets
+  // `requiresConversation`.
+  if (signal.sourceEventName === "chat.assistant_reply") {
+    const body = requestedBody ?? "";
+    return buildPassThroughDecision({
+      signal,
+      availableChannels,
+      selectedChannels: ASSISTANT_REPLY_CHANNELS.filter((ch) =>
+        availableChannels.includes(ch),
+      ),
+      title:
+        nonEmpty(readPayloadString(signal.contextPayload, "requestedTitle")) ??
+        deriveTitle(body),
+      body,
+      reasoningSummary: "assistant_reply pass-through",
+      dedupeKey: signal.dedupeKey ?? signal.signalId,
+      deepLinkTarget: readDeepLinkTarget(
+        signal.contextPayload as Record<string, unknown>,
+      ),
+    });
   }
 
   const provider = await getConfiguredProvider("notificationDecision");

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -38,16 +38,6 @@ export interface DeterministicCheckContext {
 const DEFAULT_DEDUPE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
 /**
- * Decision reasoning summaries whose copy came verbatim from the producer.
- * These are exempt from the event-name-collision branch of the rendered-copy
- * quality check.
- */
-const PASS_THROUGH_REASONING_SUMMARIES = new Set<string>([
-  "assistant_tool pass-through",
-  "assistant_reply pass-through",
-]);
-
-/**
  * Run all deterministic pre-send checks against a decision.
  * Returns passed=false if any check fails, with a reason describing
  * which check blocked the notification.
@@ -279,10 +269,10 @@ function checkDedupe(
  * case, require `composeFallbackCopy` to yield a non-empty body for
  * at least one selected channel; otherwise fail-closed.
  *
- * The event-name-match branch is skipped for pass-through decisions
- * (see `PASS_THROUGH_REASONING_SUMMARIES`) because the producer supplied
- * the body verbatim, so a coincidental match with the event name is the
- * producer's intent, not a fallback leak.
+ * The event-name-match branch is skipped for decisions flagged
+ * `verbatimCopy` because the producer supplied the body verbatim, so a
+ * coincidental match with the event name is the producer's intent, not a
+ * fallback leak.
  */
 function checkRenderedCopyQuality(
   signal: NotificationSignal,
@@ -292,9 +282,7 @@ function checkRenderedCopyQuality(
     return { passed: true };
   }
 
-  const isPassthrough = PASS_THROUGH_REASONING_SUMMARIES.has(
-    decision.reasoningSummary,
-  );
+  const isPassthrough = decision.verbatimCopy === true;
   const normalizedEventName = signal.sourceEventName
     .replace(/[._]/g, " ")
     .toLowerCase()

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -38,6 +38,16 @@ export interface DeterministicCheckContext {
 const DEFAULT_DEDUPE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
 /**
+ * Decision reasoning summaries whose copy came verbatim from the producer.
+ * These are exempt from the event-name-collision branch of the rendered-copy
+ * quality check.
+ */
+const PASS_THROUGH_REASONING_SUMMARIES = new Set<string>([
+  "assistant_tool pass-through",
+  "assistant_reply pass-through",
+]);
+
+/**
  * Run all deterministic pre-send checks against a decision.
  * Returns passed=false if any check fails, with a reason describing
  * which check blocked the notification.
@@ -269,10 +279,10 @@ function checkDedupe(
  * case, require `composeFallbackCopy` to yield a non-empty body for
  * at least one selected channel; otherwise fail-closed.
  *
- * The event-name-match branch is skipped for `assistant_tool`
- * pass-through decisions because the producer supplied the body
- * verbatim — a coincidental match with the event name is the user's
- * intent, not a fallback leak.
+ * The event-name-match branch is skipped for pass-through decisions
+ * (see `PASS_THROUGH_REASONING_SUMMARIES`) because the producer supplied
+ * the body verbatim, so a coincidental match with the event name is the
+ * producer's intent, not a fallback leak.
  */
 function checkRenderedCopyQuality(
   signal: NotificationSignal,
@@ -282,8 +292,9 @@ function checkRenderedCopyQuality(
     return { passed: true };
   }
 
-  const isAssistantToolPassthrough =
-    decision.reasoningSummary === "assistant_tool pass-through";
+  const isPassthrough = PASS_THROUGH_REASONING_SUMMARIES.has(
+    decision.reasoningSummary,
+  );
   const normalizedEventName = signal.sourceEventName
     .replace(/[._]/g, " ")
     .toLowerCase()
@@ -304,7 +315,7 @@ function checkRenderedCopyQuality(
         reason: "rendered copy body is empty",
       };
     }
-    if (isAssistantToolPassthrough) {
+    if (isPassthrough) {
       continue;
     }
     const normalizedBody = trimmedBody.toLowerCase();

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -253,6 +253,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     contextPayload: (params.contextPayload ??
       {}) as NotificationContextPayload<TEventName>,
     attentionHints: params.attentionHints,
+    dedupeKey: params.dedupeKey,
     routingIntent: params.routingIntent,
     routingHints: params.routingHints,
     conversationAffinityHint: params.conversationAffinityHint,

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -123,6 +123,11 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
       "OAuth credential health issue detected (expired, revoked, missing scopes)",
   },
   {
+    id: "chat.assistant_reply",
+    description:
+      "Assistant finished replying to a user-initiated turn the user is no longer watching",
+  },
+  {
     id: "telegram.webhook_health_alert",
     description:
       "Telegram webhook is not delivering (unregistered, or failing per getWebhookInfo)",
@@ -231,6 +236,11 @@ export interface NotificationSignal<TEventName extends string = string> {
   sourceEventName: TEventName; // free-form: 'reminder_fired', 'guardian_question', etc.
   contextPayload: NotificationContextPayload<TEventName>;
   attentionHints: AttentionHints;
+  /**
+   * Producer-supplied deduplication key. Deterministic decision paths reuse it
+   * as the decision's dedupeKey so the decision row matches the event row.
+   */
+  dedupeKey?: string;
   /** Routing intent from the source (e.g. reminder). Controls post-decision channel enforcement. */
   routingIntent?: RoutingIntent;
   /** Free-form hints from the source for the decision engine (e.g. preferred channels). */

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -162,6 +162,7 @@ export const NotificationDecisionSchema = z.object({
   dedupeKey: z.string(),
   confidence: z.number(),
   fallbackUsed: z.boolean(),
+  verbatimCopy: z.boolean().optional(),
   persistedDecisionId: z.string().optional(),
 });
 
@@ -183,5 +184,7 @@ export interface NotificationDecision {
   dedupeKey: string;
   confidence: number;
   fallbackUsed: boolean;
+  /** Set by deterministic pass-through branches whose copy is producer-supplied verbatim; exempts the copy from the event-name-collision quality check. */
+  verbatimCopy?: boolean;
   persistedDecisionId?: string;
 }


### PR DESCRIPTION
## Summary
- Deterministic decision-engine bypass for chat.assistant_reply: no LLM call, selects the platform (APNs) channel from the ASSISTANT_REPLY_CHANNELS constant
- Widens the deterministic-checks pass-through predicate to a set so producer-verbatim copy passes for the new reason string
- Registers chat.assistant_reply in NOTIFICATION_SOURCE_EVENT_NAMES

Part of plan: unseen-reply-notify.md (PR 1 of 3)