### PR TITLE
notifications: assistant-reply producer with unseen/user-initiated gating

### DIFF
--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for `assistant-reply-producer.ts`.
+ *
+ * Coverage matrix:
+ *   - Qualifying unseen reply in a user conversation emits exactly one signal,
+ *     asserted on the full shape (dedupeKey, absent `requiresConversation`).
+ *   - Background / scheduled / memory-consolidation conversations are silent.
+ *   - An `automated: true` initiating user message is silent.
+ *   - An already-seen reply is silent.
+ *   - A tool-only reply (empty text preview) is silent.
+ *   - A throwing dependency is swallowed, not propagated.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AttentionState } from "../../persistence/conversation-attention-store.js";
+import type {
+  ConversationRow,
+  MessageRow,
+} from "../../persistence/conversation-crud.js";
+import type { ContentBlock } from "../../providers/types.js";
+
+// ── Module mocks ───────────────────────────────────────────────────────
+//
+// `mock.module` is hoisted, so these intercepts apply before the module under
+// test resolves its imports. Each test rewrites the module-scoped fixtures
+// below and inspects the captured emit calls afterwards.
+
+const emitCalls: any[] = [];
+let conversationRow: ConversationRow | null = null;
+let assistantRow: MessageRow | null = null;
+let userRows: MessageRow[] = [];
+let attentionState: AttentionState | null = null;
+let getConversationShouldThrow = false;
+
+mock.module("../emit-signal.js", () => ({
+  emitNotificationSignal: async (params: any) => {
+    emitCalls.push(params);
+    return {
+      signalId: "sig-1",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    };
+  },
+}));
+
+const realCrud = await import("../../persistence/conversation-crud.js");
+mock.module("../../persistence/conversation-crud.js", () => ({
+  ...realCrud,
+  getConversation: () => {
+    if (getConversationShouldThrow) {
+      throw new Error("simulated conversation lookup failure");
+    }
+    return conversationRow;
+  },
+  getMessageById: () => assistantRow,
+  getMessagesPaginated: (
+    _conversationId: string,
+    _limit: number | undefined,
+    beforeTimestamp: number | undefined,
+    filter?: (row: MessageRow) => boolean,
+  ) => {
+    const matches = userRows
+      .filter(
+        (row) => beforeTimestamp == null || row.createdAt < beforeTimestamp,
+      )
+      .filter((row) => !filter || filter(row));
+    return { messages: matches.slice(-1), hasMore: false };
+  },
+}));
+
+mock.module("../../persistence/conversation-attention-store.js", () => ({
+  getAttentionStateByConversationIds: (ids: string[]) => {
+    const map = new Map<string, AttentionState>();
+    if (attentionState) {
+      map.set(ids[0], attentionState);
+    }
+    return map;
+  },
+}));
+
+const { emitAssistantReplyNotification } =
+  await import("../assistant-reply-producer.js");
+
+// ── Fixtures ───────────────────────────────────────────────────────────
+
+const CONVERSATION_ID = "conv-1";
+const ASSISTANT_MESSAGE_ID = "msg-assistant-1";
+
+function makeConversation(
+  overrides: Partial<ConversationRow> = {},
+): ConversationRow {
+  return {
+    id: CONVERSATION_ID,
+    title: "Weekend plans",
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    contextCompactedAt: null,
+    historyStrippedAt: null,
+    slackContextCompactionWatermarkTs: null,
+    slackContextCompactionWatermarkAt: null,
+    conversationType: "chat",
+    source: "user",
+    originChannel: null,
+    originInterface: null,
+    forkParentConversationId: null,
+    forkParentMessageId: null,
+    isAutoTitle: 0,
+    scheduleJobId: null,
+    lastMessageAt: null,
+    archivedAt: null,
+    surfacedAt: null,
+    inferenceProfile: null,
+    enabledPlugins: null,
+    inferenceProfileSessionId: null,
+    inferenceProfileExpiresAt: null,
+    lastNotifiedInferenceProfile: null,
+    processingStartedAt: null,
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<MessageRow> = {}): MessageRow {
+  return {
+    id: "msg-1",
+    conversationId: CONVERSATION_ID,
+    role: "user",
+    content: [{ type: "text", text: "hello" }] as ContentBlock[],
+    createdAt: 1700000000100,
+    metadata: null,
+    clientMessageId: null,
+    finalized: 1,
+    ...overrides,
+  };
+}
+
+function makeAssistantRow(content: ContentBlock[]): MessageRow {
+  return makeMessage({
+    id: ASSISTANT_MESSAGE_ID,
+    role: "assistant",
+    content,
+    createdAt: 1700000000200,
+  });
+}
+
+function makeAttentionState(
+  overrides: Partial<AttentionState> = {},
+): AttentionState {
+  return {
+    conversationId: CONVERSATION_ID,
+    latestAssistantMessageId: ASSISTANT_MESSAGE_ID,
+    latestAssistantMessageAt: 1700000000200,
+    lastSeenAssistantMessageId: null,
+    lastSeenAssistantMessageAt: null,
+    lastSeenEventAt: null,
+    lastSeenConfidence: null,
+    lastSeenSignalType: null,
+    lastSeenSourceChannel: null,
+    lastSeenSource: null,
+    lastSeenEvidenceText: null,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000200,
+    ...overrides,
+  };
+}
+
+const warnCalls: unknown[] = [];
+const rlog = {
+  warn: (...args: unknown[]) => {
+    warnCalls.push(args);
+  },
+} as any;
+
+async function run(): Promise<void> {
+  await emitAssistantReplyNotification({
+    conversationId: CONVERSATION_ID,
+    assistantMessageId: ASSISTANT_MESSAGE_ID,
+    rlog,
+  });
+}
+
+beforeEach(() => {
+  emitCalls.length = 0;
+  warnCalls.length = 0;
+  getConversationShouldThrow = false;
+  conversationRow = makeConversation();
+  assistantRow = makeAssistantRow([
+    { type: "text", text: "Sure, here is the plan." },
+  ] as ContentBlock[]);
+  userRows = [makeMessage()];
+  attentionState = makeAttentionState();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("emitAssistantReplyNotification", () => {
+  test("emits one well-formed signal for an unseen user-conversation reply", async () => {
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0]).toEqual({
+      sourceEventName: "chat.assistant_reply",
+      sourceChannel: "vellum",
+      sourceContextId: CONVERSATION_ID,
+      attentionHints: {
+        requiresAction: false,
+        urgency: "medium",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: {
+        requestedTitle: "Weekend plans",
+        requestedMessage: "Sure, here is the plan.",
+      },
+      dedupeKey: `chat.assistant_reply:${CONVERSATION_ID}:${ASSISTANT_MESSAGE_ID}`,
+    });
+    // No conversation-creation fields: the platform channel is push-only.
+    expect("requiresConversation" in emitCalls[0]).toBe(false);
+    expect("conversationAffinityHint" in emitCalls[0]).toBe(false);
+    expect("routingIntent" in emitCalls[0]).toBe(false);
+  });
+
+  test("omits requestedTitle when the conversation has no title", async () => {
+    conversationRow = makeConversation({ title: "   " });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].contextPayload).toEqual({
+      requestedMessage: "Sure, here is the plan.",
+    });
+  });
+
+  test("collapses whitespace and caps the preview at 200 chars", async () => {
+    assistantRow = makeAssistantRow([
+      { type: "text", text: `${"a".repeat(300)}\n\n  b` },
+    ] as ContentBlock[]);
+
+    await run();
+
+    const preview = emitCalls[0].contextPayload.requestedMessage as string;
+    expect(preview).toHaveLength(200);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  test("stays silent for a background conversation", async () => {
+    conversationRow = makeConversation({ conversationType: "background" });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent for a scheduled conversation", async () => {
+    conversationRow = makeConversation({ conversationType: "scheduled" });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent for a memory-consolidation conversation", async () => {
+    const { MEMORY_V2_CONSOLIDATION_SOURCE } =
+      await import("../../plugins/defaults/memory/substrate/constants.js");
+    conversationRow = makeConversation({
+      source: MEMORY_V2_CONSOLIDATION_SOURCE,
+    });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent when the conversation is missing", async () => {
+    conversationRow = null;
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent when the initiating user message is automated", async () => {
+    userRows = [makeMessage({ metadata: JSON.stringify({ automated: true }) })];
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent when no real user message opened the turn", async () => {
+    userRows = [];
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("skips tool-result rows when locating the initiating user message", async () => {
+    userRows = [
+      makeMessage({ id: "msg-user-1", createdAt: 1700000000100 }),
+      makeMessage({
+        id: "msg-tool-result-1",
+        createdAt: 1700000000150,
+        content: [
+          { type: "tool_result", tool_use_id: "t1", content: "done" },
+        ] as ContentBlock[],
+      }),
+    ];
+
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+  });
+
+  test("stays silent when the reply is already seen", async () => {
+    attentionState = makeAttentionState({
+      lastSeenAssistantMessageId: ASSISTANT_MESSAGE_ID,
+      lastSeenAssistantMessageAt: 1700000000200,
+    });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent when there is no attention state row", async () => {
+    attentionState = null;
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent when the reply has no user-visible text", async () => {
+    assistantRow = makeAssistantRow([
+      { type: "tool_use", id: "t1", name: "bash", input: {} },
+    ] as ContentBlock[]);
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent when the assistant row is missing", async () => {
+    assistantRow = null;
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("never throws when a dependency throws", async () => {
+    getConversationShouldThrow = true;
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+    expect(warnCalls).toHaveLength(1);
+  });
+});

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -4,7 +4,8 @@
  * Coverage matrix:
  *   - Qualifying unseen reply in a user conversation emits exactly one signal,
  *     asserted on the full shape (dedupeKey, absent `requiresConversation`).
- *   - Background / scheduled / memory-consolidation conversations are silent.
+ *   - Every non-"user" kind of the shared `resolveConversationKind` classifier
+ *     is silent.
  *   - An `automated: true` initiating user message is silent.
  *   - An already-seen reply is silent.
  *   - A tool-only reply (empty text preview) is silent.
@@ -17,6 +18,8 @@ import type {
   ConversationRow,
   MessageRow,
 } from "../../persistence/conversation-crud.js";
+import { resolveConversationKind } from "../../persistence/conversation-types.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../plugins/defaults/memory/substrate/constants.js";
 import type { ContentBlock } from "../../providers/types.js";
 
 // ── Module mocks ───────────────────────────────────────────────────────
@@ -170,6 +173,18 @@ function makeAttentionState(
   };
 }
 
+const NON_USER_KIND_CASES: Array<{
+  name: string;
+  overrides: Partial<ConversationRow>;
+}> = [
+  { name: "background", overrides: { conversationType: "background" } },
+  { name: "scheduled", overrides: { conversationType: "scheduled" } },
+  {
+    name: "memory-consolidation",
+    overrides: { source: MEMORY_V2_CONSOLIDATION_SOURCE },
+  },
+];
+
 const warnCalls: unknown[] = [];
 const rlog = {
   warn: (...args: unknown[]) => {
@@ -249,33 +264,25 @@ describe("emitAssistantReplyNotification", () => {
     expect(preview.endsWith("…")).toBe(true);
   });
 
-  test("stays silent for a background conversation", async () => {
-    conversationRow = makeConversation({ conversationType: "background" });
+  // Each case asserts the shared classifier's verdict alongside the silence, so
+  // the gate is exercised through `resolveConversationKind` rather than through
+  // a restatement of its branches.
+  for (const { name, overrides } of NON_USER_KIND_CASES) {
+    test(`stays silent for a ${name} conversation`, async () => {
+      conversationRow = makeConversation(overrides);
 
-    await run();
+      expect(
+        resolveConversationKind(
+          conversationRow.source,
+          conversationRow.conversationType,
+        ),
+      ).not.toBe("user");
 
-    expect(emitCalls).toHaveLength(0);
-  });
+      await run();
 
-  test("stays silent for a scheduled conversation", async () => {
-    conversationRow = makeConversation({ conversationType: "scheduled" });
-
-    await run();
-
-    expect(emitCalls).toHaveLength(0);
-  });
-
-  test("stays silent for a memory-consolidation conversation", async () => {
-    const { MEMORY_V2_CONSOLIDATION_SOURCE } =
-      await import("../../plugins/defaults/memory/substrate/constants.js");
-    conversationRow = makeConversation({
-      source: MEMORY_V2_CONSOLIDATION_SOURCE,
+      expect(emitCalls).toHaveLength(0);
     });
-
-    await run();
-
-    expect(emitCalls).toHaveLength(0);
-  });
+  }
 
   test("stays silent when the conversation is missing", async () => {
     conversationRow = null;

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -13,35 +13,19 @@ import type pino from "pino";
 import { isToolResultMessage } from "../context/refusal-quarantine.js";
 import { getAttentionStateByConversationIds } from "../persistence/conversation-attention-store.js";
 import {
-  type ConversationRow,
   getConversation,
   getMessageById,
   getMessagesPaginated,
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
+import { resolveConversationKind } from "../persistence/conversation-types.js";
 import { stringifyMessageContent } from "../persistence/message-content.js";
-import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../plugins/defaults/memory/substrate/constants.js";
 import type { ContentBlock } from "../providers/types.js";
 import { emitNotificationSignal } from "./emit-signal.js";
 import { truncate } from "./notification-utils.js";
 
 /** Roughly one notification body's worth of reply text. */
 const PREVIEW_MAX_CHARS = 200;
-
-/**
- * True only for the `"user"` kind of `resolveConversationKind`
- * (`runtime/routes/conversation-query-routes.ts`). Replicated rather than
- * imported because producers must not depend on `runtime/routes`; the three
- * excluded kinds (memory consolidation, background, scheduled) are the ones
- * that already have their own notification producers.
- */
-function isUserInitiatedConversation(conversation: ConversationRow): boolean {
-  return (
-    conversation.source !== MEMORY_V2_CONSOLIDATION_SOURCE &&
-    conversation.conversationType !== "background" &&
-    conversation.conversationType !== "scheduled"
-  );
-}
 
 /**
  * Same unseen predicate the sidebar renders from (`buildAssistantAttention` in
@@ -99,7 +83,13 @@ export async function emitAssistantReplyNotification(params: {
     if (!conversation) {
       return;
     }
-    if (!isUserInitiatedConversation(conversation)) {
+    // The other three kinds (memory consolidation, background, scheduled) each
+    // already have their own notification producer.
+    const kind = resolveConversationKind(
+      conversation.source,
+      conversation.conversationType,
+    );
+    if (kind !== "user") {
       return;
     }
     if (!isLatestReplyUnseen(conversationId)) {

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -1,0 +1,171 @@
+/**
+ * `chat.assistant_reply` producer: an APNs push for a finished reply the user
+ * is no longer looking at.
+ *
+ * Called at the end of a user-initiated turn (see
+ * `daemon/conversation-turn-finalize.ts`) and best-effort throughout: every
+ * failure is logged and swallowed, because a notification hiccup must never
+ * escalate a reply the client already received into a turn-level throw.
+ */
+
+import type pino from "pino";
+
+import { isToolResultMessage } from "../context/refusal-quarantine.js";
+import { getAttentionStateByConversationIds } from "../persistence/conversation-attention-store.js";
+import {
+  type ConversationRow,
+  getConversation,
+  getMessageById,
+  getMessagesPaginated,
+  parseMessageMetadata,
+} from "../persistence/conversation-crud.js";
+import { stringifyMessageContent } from "../persistence/message-content.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../plugins/defaults/memory/substrate/constants.js";
+import type { ContentBlock } from "../providers/types.js";
+import { emitNotificationSignal } from "./emit-signal.js";
+import { truncate } from "./notification-utils.js";
+
+/** Roughly one notification body's worth of reply text. */
+const PREVIEW_MAX_CHARS = 200;
+
+/**
+ * True only for the `"user"` kind of `resolveConversationKind`
+ * (`runtime/routes/conversation-query-routes.ts`). Replicated rather than
+ * imported because producers must not depend on `runtime/routes`; the three
+ * excluded kinds (memory consolidation, background, scheduled) are the ones
+ * that already have their own notification producers.
+ */
+function isUserInitiatedConversation(conversation: ConversationRow): boolean {
+  return (
+    conversation.source !== MEMORY_V2_CONSOLIDATION_SOURCE &&
+    conversation.conversationType !== "background" &&
+    conversation.conversationType !== "scheduled"
+  );
+}
+
+/**
+ * Same unseen predicate the sidebar renders from (`buildAssistantAttention` in
+ * `runtime/services/conversation-serializer.ts`): the latest assistant cursor
+ * is ahead of the last-seen cursor. A missing state row reads as seen, matching
+ * the serializer's no-attention-state default.
+ */
+function isLatestReplyUnseen(conversationId: string): boolean {
+  const state = getAttentionStateByConversationIds([conversationId]).get(
+    conversationId,
+  );
+  if (!state || state.latestAssistantMessageAt == null) {
+    return false;
+  }
+  return (
+    state.lastSeenAssistantMessageAt == null ||
+    state.lastSeenAssistantMessageAt < state.latestAssistantMessageAt
+  );
+}
+
+/**
+ * The user-role row that opened this turn, skipping the tool-result rows the
+ * agent loop also persists with role `"user"`.
+ */
+function findInitiatingUserMessage(
+  conversationId: string,
+  assistantMessageCreatedAt: number,
+) {
+  const { messages } = getMessagesPaginated(
+    conversationId,
+    1,
+    assistantMessageCreatedAt,
+    (row) =>
+      row.role === "user" &&
+      !isToolResultMessage({ role: "user", content: row.content }),
+  );
+  return messages[0];
+}
+
+function buildPreview(content: ContentBlock[]): string {
+  return truncate(
+    stringifyMessageContent(content).replace(/\s+/g, " ").trim(),
+    PREVIEW_MAX_CHARS,
+  );
+}
+
+export async function emitAssistantReplyNotification(params: {
+  conversationId: string;
+  assistantMessageId: string;
+  rlog: pino.Logger;
+}): Promise<void> {
+  const { conversationId, assistantMessageId, rlog } = params;
+  try {
+    const conversation = getConversation(conversationId);
+    if (!conversation) {
+      return;
+    }
+    if (!isUserInitiatedConversation(conversation)) {
+      return;
+    }
+    if (!isLatestReplyUnseen(conversationId)) {
+      return;
+    }
+
+    const assistantRow = getMessageById(assistantMessageId, conversationId);
+    if (!assistantRow) {
+      return;
+    }
+
+    // Scheduled/background prompts injected into an ordinary user conversation
+    // are automated turns with their own producers (e.g. `schedule.notify`);
+    // notifying here too would double-notify.
+    const initiatingMessage = findInitiatingUserMessage(
+      conversationId,
+      assistantRow.createdAt,
+    );
+    if (!initiatingMessage) {
+      return;
+    }
+    if (parseMessageMetadata(initiatingMessage.metadata)?.automated === true) {
+      return;
+    }
+
+    const preview = buildPreview(assistantRow.content);
+    if (!preview) {
+      return;
+    }
+
+    // Absent `requestedTitle` lets the decision branch derive a title from the
+    // body, which reads better than an empty or placeholder conversation title.
+    const requestedTitle = conversation.title?.trim();
+
+    await emitNotificationSignal({
+      sourceEventName: "chat.assistant_reply",
+      sourceChannel: "vellum",
+      // Deep-link target; the broadcaster validates it and merges it into
+      // `deepLinkTarget.conversationId`.
+      sourceContextId: conversationId,
+      attentionHints: {
+        requiresAction: false,
+        // Load-bearing for the iOS-only scope: `emit-signal.ts` force-adds the
+        // vellum channel for high/critical signals, which would widen this into
+        // an in-app banner on every client. Raising the urgency is the same as
+        // opting into v2.
+        urgency: "medium",
+        isAsyncBackground: false,
+        // The daemon cannot tell "still viewing" from "just left" at turn end.
+        // The viewing-on-iPhone case is covered by iOS suppressing remote
+        // pushes while the app is foregrounded.
+        visibleInSourceNow: false,
+      },
+      contextPayload: {
+        ...(requestedTitle ? { requestedTitle } : {}),
+        requestedMessage: preview,
+      },
+      // The pipeline dedupe window is a flat hour keyed on this alone, so it
+      // has to carry the message id or a second reply within the hour is
+      // silently dropped.
+      dedupeKey: `chat.assistant_reply:${conversationId}:${assistantMessageId}`,
+    });
+  } catch (err) {
+    rlog.warn(
+      { err, conversationId, messageId: assistantMessageId },
+      "Failed to emit assistant reply notification (non-fatal)",
+    );
+  }
+}

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -3,7 +3,12 @@
 // `conversation-crud.ts`, the notification pipeline, and read-side filters
 // share one declaration without importing the heavy CRUD module. Also provides
 // the shared "is this a non-interactive / background conversation?" predicate
-// used by notification-feed and memory filters.
+// used by notification-feed and memory filters, plus the source-aware
+// `resolveConversationKind` classifier.
+
+// The only import here is a frozen string constant with no dependencies of its
+// own, which keeps this module cheap for every importer.
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../plugins/defaults/memory/substrate/constants.js";
 
 /** How a conversation was created / its execution mode. */
 export type ConversationCreateType = "standard" | "background" | "scheduled";
@@ -28,4 +33,35 @@ export function isBackgroundConversationType(
   t: ConversationType | string | null | undefined,
 ): boolean {
   return (BACKGROUND_CONVERSATION_TYPES as readonly string[]).includes(t ?? "");
+}
+
+/**
+ * Who or what drove a conversation, folding the `source` and `conversationType`
+ * columns into one label.
+ */
+export type ConversationKind =
+  | "user"
+  | "background"
+  | "background_memory_consolidation"
+  | "scheduled";
+
+/**
+ * Single classifier shared by the LLM-context routes and the notification
+ * producers, so a new background source or conversation type lands in every
+ * consumer at once.
+ */
+export function resolveConversationKind(
+  source: string,
+  conversationType: string,
+): ConversationKind {
+  if (source === MEMORY_V2_CONSOLIDATION_SOURCE) {
+    return "background_memory_consolidation";
+  }
+  if (conversationType === "background") {
+    return "background";
+  }
+  if (conversationType === "scheduled") {
+    return "scheduled";
+  }
+  return "user";
 }

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -87,12 +87,15 @@ import {
   getMessageById,
 } from "../../persistence/conversation-crud.js";
 import { getConversationByKey } from "../../persistence/conversation-key-store.js";
+import {
+  type ConversationKind,
+  resolveConversationKind,
+} from "../../persistence/conversation-types.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { clearEmbeddingBackendCache } from "../../persistence/embeddings/embedding-backend.js";
 import { getLlmRequestLogSource } from "../../persistence/llm-request-log-source.js";
 import { type LogRow } from "../../persistence/llm-request-log-store.js";
 import { getMemoryRecallLogByMessageIds } from "../../plugins/defaults/memory/memory-recall-log-store.js";
-import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../plugins/defaults/memory/substrate/constants.js";
 import { getMemoryV2ActivationLogByMessageIds } from "../../plugins/defaults/memory/v2/activation-log-store.js";
 import { getMemoryV3SelectionForInspectorByMessageIds } from "../../plugins/defaults/memory/v3/selection-log-store.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
@@ -1964,28 +1967,6 @@ function handleGetMessageContent({
     throw new NotFoundError(`Message ${pathParams.id} not found`);
   }
   return result;
-}
-
-type ConversationKind =
-  | "user"
-  | "background"
-  | "background_memory_consolidation"
-  | "scheduled";
-
-function resolveConversationKind(
-  source: string,
-  conversationType: string,
-): ConversationKind {
-  if (source === MEMORY_V2_CONSOLIDATION_SOURCE) {
-    return "background_memory_consolidation";
-  }
-  if (conversationType === "background") {
-    return "background";
-  }
-  if (conversationType === "scheduled") {
-    return "scheduled";
-  }
-  return "user";
 }
 
 async function handleGetLlmContext({


### PR DESCRIPTION
## Summary
- New chat.assistant_reply producer: emits via emitNotificationSignal at most once per qualifying reply
- Gates on user-initiated conversation, unseen attention state, non-automated initiating message, and non-empty text preview
- Per-message dedupeKey; sourceContextId deep-links to the source conversation with no conversation creation

Part of plan: unseen-reply-notify.md (PR 2 of 3)