### PR TITLE
fix: transcript inspect and projection cleanup from plan re-review

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-transcript-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.test.ts
@@ -1,12 +1,11 @@
 /**
- * Tests for `useTranscriptData`'s proactive credits-upsell append: with the
- * balance exhausted, an open conversation gets the card at the transcript
- * tail, a fresh conversation does not (the empty state owns the card there),
- * an in-flight turn suppresses the card until it settles, and a just-failed
- * turn's substituted card is never doubled. The flag also gates the per-row
- * card substitution for tagged provider-error rows. The projection
- * itself (`buildTranscriptItems`) is real; only the two chat stores the hook
- * reads are stubbed inert.
+ * Integration test for `useTranscriptData`'s credits-upsell wiring: the hook
+ * passes its inputs through to the projection, which appends the proactive
+ * card once an exhausted-balance turn settles and never while one is in
+ * flight. The combination coverage (dedupe, empty conversations, substitution
+ * gating) lives with the projection in `build-items.test.ts`; here the
+ * projection is real and only the two chat stores the hook reads are stubbed
+ * inert.
  */
 import { describe, expect, mock, test } from "bun:test";
 import { renderHook } from "@testing-library/react";
@@ -40,61 +39,24 @@ function makeMessage(
   return { id, role, ...textBody(text) };
 }
 
-function setup(
-  messages: DisplayMessage[],
-  creditsExhausted: boolean,
-  turnActive = false,
-) {
-  return renderHook(
-    (props: { turnActive: boolean }) =>
-      useTranscriptData({
-        messages,
-        showThinking: false,
-        turnActive: props.turnActive,
-        thinkingLabel: null,
-        showOnboardingChoice: false,
-        creditsExhausted,
-      }),
-    { initialProps: { turnActive } },
-  );
-}
-
 describe("useTranscriptData proactive credits upsell", () => {
-  test("exhausted balance appends the card at the tail of an open conversation", () => {
-    const { result } = setup(
-      [
-        makeMessage("m1", "user", "Hello"),
-        makeMessage("m2", "assistant", "Hi"),
-      ],
-      true,
-    );
-
-    const items = result.current.transcriptItems;
-    expect(items).toHaveLength(3);
-    expect(items[2]).toEqual({
-      kind: "creditsUpsell",
-      key: "credits-upsell-proactive",
-    });
-  });
-
-  test("no card in a fresh conversation (the empty state renders its own)", () => {
-    const { result } = setup([], true);
-    expect(result.current.transcriptItems).toEqual([]);
-  });
-
-  test("no card while the balance is not exhausted", () => {
-    const { result } = setup([makeMessage("m1", "user", "Hello")], false);
-    expect(
-      result.current.transcriptItems.filter((i) => i.kind === "creditsUpsell"),
-    ).toHaveLength(0);
-  });
-
   test("no proactive card while a turn is in flight; it appears once the turn settles", () => {
     const messages = [
       makeMessage("m1", "user", "Hello"),
       makeMessage("m2", "assistant", "Hi"),
     ];
-    const { result, rerender } = setup(messages, true, true);
+    const { result, rerender } = renderHook(
+      (props: { turnActive: boolean }) =>
+        useTranscriptData({
+          messages,
+          showThinking: false,
+          turnActive: props.turnActive,
+          thinkingLabel: null,
+          showOnboardingChoice: false,
+          creditsExhausted: true,
+        }),
+      { initialProps: { turnActive: true } },
+    );
 
     // In flight: only the thinking slot trails the messages, no credit wall
     // under the live progress indicator.
@@ -110,49 +72,6 @@ describe("useTranscriptData proactive credits upsell", () => {
       "message",
       "message",
       "creditsUpsell",
-    ]);
-  });
-
-  test("a just-failed turn's substituted card is not doubled", () => {
-    const errorRow: DisplayMessage = {
-      ...makeMessage("m2", "assistant", "I hit a snag: your credits ran out."),
-      providerError: {
-        code: "PROVIDER_BILLING",
-        category: "credits_exhausted",
-      },
-    };
-    const { result } = setup(
-      [makeMessage("m1", "user", "Hello"), errorRow],
-      true,
-    );
-
-    const cards = result.current.transcriptItems.filter(
-      (i) => i.kind === "creditsUpsell",
-    );
-    expect(cards).toHaveLength(1);
-    expect(cards[0]!.key).toBe("credits-upsell-m2");
-  });
-
-  test("a tagged provider-error row renders as a plain message while the balance is not exhausted", () => {
-    // Gated/self-hosted contexts leave the billing hook inert and a top-up
-    // clears the flag; in both, the persisted row must keep its visible
-    // historical bubble instead of substituting a card that could render
-    // nothing.
-    const errorRow: DisplayMessage = {
-      ...makeMessage("m2", "assistant", "I hit a snag: your credits ran out."),
-      providerError: {
-        code: "PROVIDER_BILLING",
-        category: "credits_exhausted",
-      },
-    };
-    const { result } = setup(
-      [makeMessage("m1", "user", "Hello"), errorRow],
-      false,
-    );
-
-    expect(result.current.transcriptItems.map((i) => i.kind)).toEqual([
-      "message",
-      "message",
     ]);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -40,14 +40,8 @@ export interface UseTranscriptDataParams {
   showOnboardingChoice: boolean;
   /**
    * Whether the org's credit balance is exhausted (from the shared
-   * `useBillingBalanceStatus()` read in `chat-route-content`). While true, a
-   * proactive credits upsell card is appended at the transcript tail of open
-   * conversations; empty conversations surface the card through the
-   * empty-state slots instead. Suppressed while a turn is in flight
-   * (`turnActive`) so the card never sits under the live progress indicator.
-   * Also gates the substitution of credits-exhausted provider-error rows:
-   * tagged rows render as the card only while the balance is currently
-   * exhausted, and as plain historical bubbles otherwise.
+   * `useBillingBalanceStatus()` read in `chat-route-content`). Drives the
+   * projection's credits-upsell surfaces; see `BuildTranscriptItemsInput`.
    */
   creditsExhausted: boolean;
 }
@@ -126,13 +120,6 @@ export function useTranscriptData({
         ephemeralMetaResults,
         showOnboardingChoice,
         creditsExhausted,
-        // The proactive card is an open-conversation surface: with no
-        // messages the chat renders the empty state (which mounts its own
-        // card), not the transcript. In-flight turns suppress it so a credit
-        // wall never renders under the live progress indicator; the
-        // turn-settled billing refetch re-shows it as soon as the turn ends.
-        appendCreditsUpsell:
-          creditsExhausted && !turnActive && sanitizedMessages.length > 0,
       }),
     [
       creditsExhausted,

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -674,7 +674,7 @@ describe("buildTranscriptItems", () => {
     expect(items[1]).toEqual({
       kind: "creditsUpsell",
       key: "credits-upsell-m2",
-      messageId: "m2",
+      message: errorRow,
     });
     expectDistinctNonEmptyKeys(items);
   });
@@ -701,7 +701,7 @@ describe("buildTranscriptItems", () => {
     expect(items[0]).toEqual({
       kind: "creditsUpsell",
       key: "credits-upsell-m1",
-      messageId: "m1",
+      message: errorRow,
     });
   });
 
@@ -719,7 +719,9 @@ describe("buildTranscriptItems", () => {
       creditsExhausted: true,
     });
 
-    expect(items).toHaveLength(1);
+    // The row keeps its bubble; the exhausted balance still appends the
+    // proactive tail card after it.
+    expect(items.map((i) => i.kind)).toEqual(["message", "creditsUpsell"]);
     expect((items[0] as MessageItem).message).toBe(errorRow);
   });
 
@@ -760,7 +762,7 @@ describe("buildTranscriptItems", () => {
     expect(items[1]).toEqual({
       kind: "creditsUpsell",
       key: "credits-upsell-m2",
-      messageId: "m2",
+      message: errorRow,
     });
     expectDistinctNonEmptyKeys(items);
   });
@@ -779,7 +781,9 @@ describe("buildTranscriptItems", () => {
       creditsExhausted: true,
     });
 
-    expect(items).toHaveLength(1);
+    // The row keeps its bubble; the exhausted balance still appends the
+    // proactive tail card after it.
+    expect(items.map((i) => i.kind)).toEqual(["message", "creditsUpsell"]);
     expect(items[0]).toEqual({
       kind: "message",
       key: "m1",
@@ -856,10 +860,13 @@ describe("buildTranscriptItems", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Proactive exhausted-balance card (appendCreditsUpsell)
+  // Proactive exhausted-balance card
+  //
+  // Derived entirely from inputs the projection already has: appended while
+  // `creditsExhausted` with no turn in flight and at least one message.
   // ---------------------------------------------------------------------------
 
-  test("appendCreditsUpsell appends the proactive card after the messages", () => {
+  test("an exhausted balance appends the proactive card after the messages", () => {
     const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
     const assistant = makeMessage({
       id: "m2",
@@ -870,7 +877,7 @@ describe("buildTranscriptItems", () => {
     const items = buildTranscriptItems({
       ...emptyInput(),
       messages: [user, assistant],
-      appendCreditsUpsell: true,
+      creditsExhausted: true,
     });
 
     expect(items).toHaveLength(3);
@@ -881,6 +888,30 @@ describe("buildTranscriptItems", () => {
     expectDistinctNonEmptyKeys(items);
   });
 
+  test("no proactive card without messages (the empty state renders its own)", () => {
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      creditsExhausted: true,
+    });
+
+    expect(items).toEqual([]);
+  });
+
+  test("no proactive card while a turn is in flight", () => {
+    // A credit wall never renders under the live progress indicator; the
+    // turn-settled billing refetch re-shows it as soon as the turn ends.
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [user],
+      turnActive: true,
+      creditsExhausted: true,
+    });
+
+    expect(items.map((i) => i.kind)).toEqual(["message", "thinking"]);
+  });
+
   test("proactive card lands before trailers (thinking slot, onboarding choice)", () => {
     const user = makeMessage({ id: "m1", role: "user", ...textBody("Hello") });
 
@@ -889,7 +920,7 @@ describe("buildTranscriptItems", () => {
       messages: [user],
       isThinking: true,
       showOnboardingChoice: true,
-      appendCreditsUpsell: true,
+      creditsExhausted: true,
     });
 
     expect(items.map((i) => i.kind)).toEqual([
@@ -917,7 +948,6 @@ describe("buildTranscriptItems", () => {
       ...emptyInput(),
       messages: [user, errorRow],
       creditsExhausted: true,
-      appendCreditsUpsell: true,
     });
 
     // Exactly one card: the substituted one from the failed turn.
@@ -925,7 +955,7 @@ describe("buildTranscriptItems", () => {
     expect(items[items.length - 1]).toEqual({
       kind: "creditsUpsell",
       key: "credits-upsell-m2",
-      messageId: "m2",
+      message: errorRow,
     });
   });
 
@@ -949,7 +979,6 @@ describe("buildTranscriptItems", () => {
       messages: [user, errorRow],
       showOnboardingChoice: true,
       creditsExhausted: true,
-      appendCreditsUpsell: true,
     });
 
     expect(items.map((i) => i.kind)).toEqual([
@@ -960,7 +989,9 @@ describe("buildTranscriptItems", () => {
     expectDistinctNonEmptyKeys(items);
   });
 
-  test("the thinking slot of a still-busy failed turn does not defeat the dedupe", () => {
+  test("a still-busy failed turn shows only the substituted card", () => {
+    // `turnActive` suppresses the proactive tail card outright, so the
+    // substituted card and the thinking slot are all that render.
     const errorRow = makeMessage({
       id: "m1",
       role: "assistant",
@@ -976,7 +1007,6 @@ describe("buildTranscriptItems", () => {
       messages: [errorRow],
       turnActive: true,
       creditsExhausted: true,
-      appendCreditsUpsell: true,
     });
 
     expect(items.map((i) => i.kind)).toEqual(["creditsUpsell", "thinking"]);
@@ -1003,7 +1033,6 @@ describe("buildTranscriptItems", () => {
       ...emptyInput(),
       messages: [errorRow, later],
       creditsExhausted: true,
-      appendCreditsUpsell: true,
     });
 
     expect(items.map((i) => i.kind)).toEqual([
@@ -1020,12 +1049,12 @@ describe("buildTranscriptItems", () => {
     const first = buildTranscriptItems({
       ...emptyInput(),
       messages: [message],
-      appendCreditsUpsell: true,
+      creditsExhausted: true,
     });
     const second = buildTranscriptItems({
       ...emptyInput(),
       messages: [message],
-      appendCreditsUpsell: true,
+      creditsExhausted: true,
     });
 
     expect(second[1]).toBe(first[1]!);

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -46,22 +46,14 @@ export interface BuildTranscriptItemsInput {
   ephemeralMetaResults?: EphemeralMetaResult[];
   showOnboardingChoice?: boolean;
   /**
-   * When true (the org's credit balance is exhausted), append the proactive
-   * credits upsell card directly after the message-derived items, ahead of
-   * trailers (thinking slot, pending prompts, onboarding choice). Skipped
-   * when the last message row already substituted a `creditsUpsell` card for
-   * its provider-error row, so an open conversation never shows two cards.
-   */
-  appendCreditsUpsell?: boolean;
-  /**
-   * Whether the org's credit balance is currently exhausted (from the same
-   * `useBillingBalanceStatus().isExhausted` read that drives
-   * `appendCreditsUpsell`). Gates the per-row card substitution for
-   * credits-exhausted provider-error rows: only while true does a tagged row
-   * render as a `creditsUpsell` card. When false, tagged rows keep the normal
-   * message rendering, whose persisted assistant-voice text reads as
-   * historical context. That covers both a balance that has since been topped
-   * up and contexts where the billing hook is inert (self-hosted/gated
+   * Whether the org's credit balance is currently exhausted (from
+   * `useBillingBalanceStatus().isExhausted`). Drives both credits-upsell
+   * surfaces of the projection: the per-row card substitution for
+   * credits-exhausted provider-error rows and the proactive tail card
+   * appended after the message-derived items. When false, tagged rows keep
+   * the normal message rendering, whose persisted assistant-voice text reads
+   * as historical context. That covers both a balance that has since been
+   * topped up and contexts where the billing hook is inert (self-hosted/gated
    * assistants, no platform session), so the card, which renders nothing when
    * platform billing is unreachable, is never substituted for a visible
    * bubble it cannot replace.
@@ -110,16 +102,15 @@ function toCreditsUpsellItem(message: DisplayMessage): CreditsUpsellItem {
   const item: CreditsUpsellItem = {
     kind: "creditsUpsell",
     key: `credits-upsell-${message.clientMessageId ?? message.id}`,
-    messageId: message.id,
+    message,
   };
   creditsUpsellItemCache.set(message, item);
   return item;
 }
 
 /** Singleton for the proactive exhausted-balance card appended after the
- *  message-derived items (see `appendCreditsUpsell`). Not tied to any message row;
- *  the stable reference keeps `TranscriptRow`'s `memo()` effective across
- *  rebuilds. */
+ *  message-derived items. Not tied to any message row; the stable reference
+ *  keeps `TranscriptRow`'s `memo()` effective across rebuilds. */
 const PROACTIVE_CREDITS_UPSELL_ITEM: CreditsUpsellItem = {
   kind: "creditsUpsell",
   key: "credits-upsell-proactive",
@@ -199,12 +190,20 @@ export function buildTranscriptItems(
     items.push(toMessageItem(message));
   }
 
-  // The proactive exhausted-balance card lands directly after the message
-  // rows; deduping here means trailers pushed below (thinking slot, pending
-  // prompts, onboarding choice) can never mask a just-failed turn's
-  // substituted card and cause a doubled card.
+  // While the balance is exhausted, the proactive upsell card lands directly
+  // after the message rows of an open conversation, so the credit wall shows
+  // before the next send fails. Empty conversations render the chat empty
+  // state (which mounts its own card), not the transcript, so a message-less
+  // build appends nothing. In-flight turns suppress the card so it never
+  // sits under the live progress indicator; the turn-settled billing refetch
+  // re-shows it as soon as the turn ends. Deduping against a trailing
+  // substituted card here, before trailers are pushed below (thinking slot,
+  // pending prompts, onboarding choice), means a just-failed turn's card can
+  // never be doubled.
   if (
-    input.appendCreditsUpsell &&
+    input.creditsExhausted &&
+    !input.turnActive &&
+    messages.length > 0 &&
     items[items.length - 1]?.kind !== "creditsUpsell"
   ) {
     items.push(PROACTIVE_CREDITS_UPSELL_ITEM);

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -2,10 +2,12 @@
  * Dispatch tests for `TranscriptRow`'s `creditsUpsell` kind. The card itself
  * is stubbed (its CTA behavior is covered by `credits-upsell-card.test.tsx`);
  * these tests pin that the transcript renders the substituted item through the
- * card component rather than any message-body machinery.
+ * card component rather than any message-body machinery, keeps the replaced
+ * row's DOM anchor, and exposes the standard Inspect affordance for the
+ * backing message.
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 mock.module("@/domains/chat/components/credits-upsell-card", () => ({
   CreditsUpsellCard: () => <div data-testid="credits-upsell-card-stub" />,
@@ -13,21 +15,39 @@ mock.module("@/domains/chat/components/credits-upsell-card", () => ({
 
 import { TranscriptRow } from "@/domains/chat/transcript/transcript-row";
 import type { CreditsUpsellItem } from "@/domains/chat/transcript/types";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import { textBody } from "@/domains/chat/utils/message-test-helpers";
 
 afterEach(() => {
   cleanup();
 });
 
+function makeErrorRow(id: string): DisplayMessage {
+  return {
+    id,
+    role: "assistant",
+    ...textBody("I hit a snag: your credits ran out."),
+    providerError: { code: "PROVIDER_BILLING", category: "credits_exhausted" },
+  };
+}
+
+function substitutedItem(id: string): CreditsUpsellItem {
+  return {
+    kind: "creditsUpsell",
+    key: `credits-upsell-${id}`,
+    message: makeErrorRow(id),
+  };
+}
+
+const PROACTIVE_ITEM: CreditsUpsellItem = {
+  kind: "creditsUpsell",
+  key: "credits-upsell-proactive",
+};
+
 describe("TranscriptRow creditsUpsell dispatch", () => {
   test("renders a creditsUpsell item via CreditsUpsellCard", () => {
-    const item: CreditsUpsellItem = {
-      kind: "creditsUpsell",
-      key: "credits-upsell-m1",
-      messageId: "m1",
-    };
-
     const { getByTestId } = render(
-      <TranscriptRow item={item} onSurfaceAction={() => {}} />,
+      <TranscriptRow item={substitutedItem("m1")} onSurfaceAction={() => {}} />,
     );
 
     expect(getByTestId("credits-upsell-card-stub")).toBeTruthy();
@@ -37,14 +57,8 @@ describe("TranscriptRow creditsUpsell dispatch", () => {
     // `TranscriptHandle.scrollToMessage` and the `?message=<id>` deep link
     // resolve rows via `getElementById("msg-<id>")`, so the substitution must
     // not drop the anchor the underlying message row would have had.
-    const item: CreditsUpsellItem = {
-      kind: "creditsUpsell",
-      key: "credits-upsell-m1",
-      messageId: "m1",
-    };
-
     const { container } = render(
-      <TranscriptRow item={item} onSurfaceAction={() => {}} />,
+      <TranscriptRow item={substitutedItem("m1")} onSurfaceAction={() => {}} />,
     );
 
     const anchor = container.querySelector("#msg-m1");
@@ -53,17 +67,51 @@ describe("TranscriptRow creditsUpsell dispatch", () => {
       .toBeTruthy();
   });
 
-  test("the proactive card (no messageId) renders without a msg anchor", () => {
-    const item: CreditsUpsellItem = {
-      kind: "creditsUpsell",
-      key: "credits-upsell-proactive",
-    };
-
+  test("the proactive card (no backing message) renders without a msg anchor", () => {
     const { container, getByTestId } = render(
-      <TranscriptRow item={item} onSurfaceAction={() => {}} />,
+      <TranscriptRow item={PROACTIVE_ITEM} onSurfaceAction={() => {}} />,
     );
 
     expect(getByTestId("credits-upsell-card-stub")).toBeTruthy();
     expect(container.querySelector('[id^="msg-"]')).toBeNull();
+  });
+
+  test("substituted cards expose the Inspect affordance wired to the backing message", () => {
+    // The daemon backfills the failed request's LLM logs onto the
+    // provider-error row's message id; while the card substitutes the bubble,
+    // the hover Inspect action is the only path to those logs.
+    const inspected: string[] = [];
+    const { getByTitle } = render(
+      <TranscriptRow
+        item={substitutedItem("m1")}
+        onSurfaceAction={() => {}}
+        onInspectMessage={(id) => inspected.push(id)}
+      />,
+    );
+
+    fireEvent.click(getByTitle("Inspect"));
+    expect(inspected).toEqual(["m1"]);
+  });
+
+  test("no Inspect affordance without an onInspectMessage handler", () => {
+    // Mirrors ordinary rows: the inspector entry point only exists when the
+    // LLM inspector is enabled (the parent passes the handler).
+    const { container } = render(
+      <TranscriptRow item={substitutedItem("m1")} onSurfaceAction={() => {}} />,
+    );
+
+    expect(container.querySelector('[title="Inspect"]')).toBeNull();
+  });
+
+  test("the proactive card gets no Inspect affordance", () => {
+    const { container } = render(
+      <TranscriptRow
+        item={PROACTIVE_ITEM}
+        onSurfaceAction={() => {}}
+        onInspectMessage={() => {}}
+      />,
+    );
+
+    expect(container.querySelector('[title="Inspect"]')).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -2,6 +2,7 @@ import { memo, type ReactNode } from "react";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { CreditsUpsellCard } from "@/domains/chat/components/credits-upsell-card";
+import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
 import { StreamingShimmerText } from "@/domains/chat/components/streaming-shimmer-text";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
@@ -208,22 +209,45 @@ export const TranscriptRow = memo(function TranscriptRow({
       }
       return null;
 
-    case "creditsUpsell":
+    case "creditsUpsell": {
       // Substituted in place of a credits-exhausted provider-error row by
       // `buildTranscriptItems`: a standalone card, outside the persona
-      // bubble/avatar/hover-action machinery like `SystemCardRow`. Substituted
-      // items carry the underlying row's `messageId`, so they keep the
-      // `msg-<id>` DOM anchor that `TranscriptHandle.scrollToMessage` and the
-      // `?message=<id>` deep link resolve via `getElementById`; the proactive
-      // tail card has no backing message and needs no anchor.
-      if (item.messageId) {
+      // bubble/avatar machinery like `SystemCardRow`. Substituted items carry
+      // the underlying row (`message`), so they keep the `msg-<id>` DOM
+      // anchor that `TranscriptHandle.scrollToMessage` and the `?message=<id>`
+      // deep link resolve via `getElementById`, and expose the same
+      // hover-revealed Inspect affordance as ordinary rows: the daemon
+      // backfills the failed request's LLM logs onto this row's message id,
+      // and inspection is their only entry point while the bubble is
+      // substituted. The proactive tail card has no backing message and needs
+      // neither.
+      if (item.message) {
+        const messageId = item.message.id;
+        const inspectHandler =
+          onInspectMessage && messageId
+            ? () => onInspectMessage(messageId)
+            : undefined;
         return (
-          <div id={`msg-${item.messageId}`} data-message-id={item.messageId}>
+          <div
+            id={messageId ? `msg-${messageId}` : undefined}
+            data-message-id={messageId || undefined}
+            className="group/msg flex flex-col gap-2"
+          >
             <CreditsUpsellCard />
+            {inspectHandler && (
+              <div className="h-6 overflow-hidden opacity-0 transition-opacity duration-200 ease-out group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 motion-reduce:transition-none">
+                <MessageHoverActions
+                  message={item.message}
+                  conversationId={conversationId}
+                  onInspect={inspectHandler}
+                />
+              </div>
+            )}
           </div>
         );
       }
       return <CreditsUpsellCard />;
+    }
 
     default: {
       // Exhaustiveness guard — TypeScript narrows `item` to `never` here.

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -87,9 +87,11 @@ export interface OnboardingChoiceItem extends TranscriptItemBase {
  *  before the next send fails. */
 export interface CreditsUpsellItem extends TranscriptItemBase {
   kind: "creditsUpsell";
-  /** Id of the provider-error message row this card renders in place of.
+  /** The provider-error message row this card renders in place of. Carries
+   *  the full row so the render layer can keep its `msg-<id>` DOM anchor and
+   *  expose the standard message affordances (hover actions, inspect) for it.
    *  Absent on the proactive tail card, which has no backing message row. */
-  messageId?: string;
+  message?: DisplayMessage;
 }
 
 export interface EphemeralMetaItem extends TranscriptItemBase {

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -18,20 +18,15 @@ const MANAGED_CREDITS_EXHAUSTED_CATEGORY = "credits_exhausted";
 const PROVIDER_BILLING_CATEGORY = "provider_billing";
 const DAILY_LIMIT_REACHED_CATEGORY = "daily_limit_reached";
 
-/** Whether a classified error category denotes managed-credits exhaustion
- *  (suffix match, so namespaced categories like `billing.credits_exhausted`
- *  classify too). */
-function isCreditsExhaustedCategory(category: string | undefined): boolean {
-  return category?.endsWith(MANAGED_CREDITS_EXHAUSTED_CATEGORY) ?? false;
-}
-
 /**
  * Whether a provider-error marker denotes managed-credits exhaustion. The
- * category decides when present; a bare `PROVIDER_BILLING` code with no
- * category also classifies (the daemon builds `providerError` with each field
- * conditional on being a string, so persisted rows can carry a code alone).
- * Shared by the live error classification (`getChatBillingBannerDecision`)
- * and the transcript's persisted-row substitution so the two never disagree.
+ * category decides when present (suffix match, so namespaced categories like
+ * `billing.credits_exhausted` classify too); a bare `PROVIDER_BILLING` code
+ * with no category also classifies (the daemon builds `providerError` with
+ * each field conditional on being a string, so persisted rows can carry a
+ * code alone). Shared by the live error classification
+ * (`getChatBillingBannerDecision`) and the transcript's persisted-row
+ * substitution so the two never disagree.
  */
 export function isCreditsExhaustedProviderError(
   providerError: { code?: string; category?: string } | null | undefined,
@@ -42,7 +37,7 @@ export function isCreditsExhaustedProviderError(
   if (!providerError.category) {
     return providerError.code === PROVIDER_BILLING_CODE;
   }
-  return isCreditsExhaustedCategory(providerError.category);
+  return providerError.category.endsWith(MANAGED_CREDITS_EXHAUSTED_CATEGORY);
 }
 
 function isManagedCreditsExhausted(


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan re-review for credits-ux.md.

**Gap:** LLM logs unreachable from the substituted card row; appendCreditsUpsell parameter sprawl; single-use category helper
**What was expected:** card rows inspectable like other rows; single derivation site; no dead indirection
**What was found:** creditsUpsell row without inspect path; derivable flag passed alongside its sources; one-line wrapper with one caller
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->