### PR TITLE
fix(providers): route managed profiles to the platform when the vellum connection name is taken

### DIFF
--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -276,21 +276,28 @@ import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routin
 // Connection-aware resolver path: satisfy
 // `tryResolveProviderForConnectionName` lookups so resolveDefaultProvider
 // returns a usable provider for any connection name the winning profile
-// references. The managed connection must carry the provider the catalog
-// `balanced` default declares (fireworks) or resolution rejects the row as a
-// provider mismatch; other names behave as personal anthropic connections.
+// references. The managed connection must be the platform-auth sentinel row —
+// a managed profile routing through anything else is rejected as a
+// user-owned collision; other names behave as personal anthropic connections.
 mock.module("../providers/inference/connections.js", () => ({
-  getConnection: (_db: unknown, name: string) => ({
-    id: 1,
-    name,
-    provider:
-      name === VELLUM_MANAGED_CONNECTION_NAME ? "fireworks" : "anthropic",
-    auth_strategy: "user_managed_credential",
-    credential_alias: null,
-    metadata_json: null,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-  }),
+  getConnection: (_db: unknown, name: string) =>
+    name === VELLUM_MANAGED_CONNECTION_NAME
+      ? {
+          id: 1,
+          name,
+          provider: "vellum",
+          auth: { type: "platform" },
+        }
+      : {
+          id: 1,
+          name,
+          provider: "anthropic",
+          auth_strategy: "user_managed_credential",
+          credential_alias: null,
+          metadata_json: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
 }));
 
 /**

--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -276,9 +276,9 @@ import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routin
 // Connection-aware resolver path: satisfy
 // `tryResolveProviderForConnectionName` lookups so resolveDefaultProvider
 // returns a usable provider for any connection name the winning profile
-// references. The managed connection must be the platform-auth sentinel row —
-// a managed profile routing through anything else is rejected as a
-// user-owned collision; other names behave as personal anthropic connections.
+// references. The managed connection must be the platform-auth sentinel row:
+// a managed profile routing through anything else resolves to the platform
+// instead. Other names behave as personal anthropic connections.
 mock.module("../providers/inference/connections.js", () => ({
   getConnection: (_db: unknown, name: string) =>
     name === VELLUM_MANAGED_CONNECTION_NAME

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -148,6 +148,26 @@ describe("preflightResolvedConfig", () => {
     expect(err?.reason).toBe("platform_unauthenticated");
   });
 
+  test("a user-owned row claiming the vellum name throws provider_mismatch", async () => {
+    // Its provider equals the identity's derived upstream, so only the
+    // managed-row check rejects it.
+    connectionsByName["vellum"] = {
+      name: "vellum",
+      provider: "openai",
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
+    };
+    secureKeys["credential/openai/api_key"] = "sk-openai";
+    platformLoggedIn = true;
+    const err = await preflightError(
+      resolved({
+        provider: "vellum",
+        provider_connection: "",
+        model: "gpt-5.6-luna",
+      }),
+    );
+    expect(err?.reason).toBe("provider_mismatch");
+  });
+
   test("an unroutable vellum model throws unroutable_managed_model", async () => {
     const err = await preflightError(
       resolved({

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -148,26 +148,29 @@ describe("preflightResolvedConfig", () => {
     expect(err?.reason).toBe("platform_unauthenticated");
   });
 
-  test("a user-owned row claiming the vellum name is not a static failure", async () => {
-    // Dispatch self-heals (that row when it serves the upstream, platform auth
-    // otherwise), so preflight has no sound verdict — including the case where
-    // the row carries no credential at all.
+  test("a user-owned row claiming the vellum name preflights the platform", async () => {
+    // Dispatch ignores that row, so its credential is irrelevant to the
+    // verdict: signed in passes, signed out is the platform's own failure.
     connectionsByName["vellum"] = {
       name: "vellum",
       provider: "openai",
       auth: { type: "api_key", credential: "credential/openai/api_key" },
     };
-    platformLoggedIn = false;
+    secureKeys["credential/openai/api_key"] = "sk-openai";
+    const collided = resolved({
+      provider: "vellum",
+      provider_connection: "",
+      model: "gpt-5.6-luna",
+    });
+
+    platformLoggedIn = true;
     await expect(
-      preflightResolvedConfig(
-        resolved({
-          provider: "vellum",
-          provider_connection: "",
-          model: "gpt-5.6-luna",
-        }),
-        {},
-      ),
+      preflightResolvedConfig(collided, {}),
     ).resolves.toBeUndefined();
+
+    platformLoggedIn = false;
+    const err = await preflightError(collided);
+    expect(err?.reason).toBe("platform_unauthenticated");
   });
 
   test("an unroutable vellum model throws unroutable_managed_model", async () => {

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -148,24 +148,26 @@ describe("preflightResolvedConfig", () => {
     expect(err?.reason).toBe("platform_unauthenticated");
   });
 
-  test("a user-owned row claiming the vellum name throws provider_mismatch", async () => {
-    // Its provider equals the identity's derived upstream, so only the
-    // managed-row check rejects it.
+  test("a user-owned row claiming the vellum name is not a static failure", async () => {
+    // Dispatch self-heals (that row when it serves the upstream, platform auth
+    // otherwise), so preflight has no sound verdict — including the case where
+    // the row carries no credential at all.
     connectionsByName["vellum"] = {
       name: "vellum",
       provider: "openai",
       auth: { type: "api_key", credential: "credential/openai/api_key" },
     };
-    secureKeys["credential/openai/api_key"] = "sk-openai";
-    platformLoggedIn = true;
-    const err = await preflightError(
-      resolved({
-        provider: "vellum",
-        provider_connection: "",
-        model: "gpt-5.6-luna",
-      }),
-    );
-    expect(err?.reason).toBe("provider_mismatch");
+    platformLoggedIn = false;
+    await expect(
+      preflightResolvedConfig(
+        resolved({
+          provider: "vellum",
+          provider_connection: "",
+          model: "gpt-5.6-luna",
+        }),
+        {},
+      ),
+    ).resolves.toBeUndefined();
   });
 
   test("an unroutable vellum model throws unroutable_managed_model", async () => {

--- a/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
@@ -127,3 +127,53 @@ describe("vellum connection mismatch handling", () => {
     expect(resolveCalls[0].opts.providerOverride).toBeUndefined();
   });
 });
+
+/**
+ * Boot seeding leaves a user-owned row claiming the `vellum` name in place, so
+ * a managed profile whose model resolves to that row's provider would pass the
+ * plain provider-equality check and dispatch on the user's own credentials.
+ */
+describe("user-owned connection claiming the vellum name", () => {
+  beforeEach(reset);
+
+  const userOwnedVellum: Connection = {
+    name: "vellum",
+    provider: "openai",
+    auth: { type: "api_key", credential: "credential/openai/api_key" },
+  };
+
+  test("a managed profile never dispatches through it", async () => {
+    fakeConnections.set("vellum", userOwnedVellum);
+    // Recovery candidates exist and must not be used either: a managed
+    // profile is platform-billed, not reroutable onto a BYOK row.
+    listResult = [userOwnedVellum];
+    let caught: unknown;
+    try {
+      await tryResolveProviderForConnectionName(
+        "vellum",
+        config,
+        "vellum",
+        "gpt-5.6-luna",
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConnectionResolutionError);
+    expect((caught as ConnectionResolutionError).reason).toBe(
+      "provider_mismatch",
+    );
+    expect(resolveCalls).toHaveLength(0);
+  });
+
+  test("the canonical row still routes", async () => {
+    fakeConnections.set("vellum", vellumConn);
+    const provider = await tryResolveProviderForConnectionName(
+      "vellum",
+      config,
+      "vellum",
+      "gpt-5.6-luna",
+    );
+    expect(provider).not.toBeNull();
+    expect(resolveCalls[0].opts.providerOverride).toBe("openai");
+  });
+});

--- a/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
@@ -137,9 +137,9 @@ describe("vellum connection mismatch handling", () => {
 
 /**
  * Boot seeding leaves a user-owned row claiming the `vellum` name in place, so
- * an install can have no canonical row at all. A managed route must still
- * resolve: the user's own connection when it serves the upstream, platform
- * auth otherwise. It never errors on a collision the user did not author.
+ * an install can have no canonical row at all. A managed profile only resolves
+ * on a platform install, so its route is platform auth — never the credentials
+ * that row happens to carry, and never an error over the name collision.
  */
 describe("user-owned connection claiming the vellum name", () => {
   beforeEach(reset);
@@ -150,50 +150,10 @@ describe("user-owned connection claiming the vellum name", () => {
     auth: { type: "api_key", credential: "credential/openai/api_key" },
   };
 
-  test("the user's own connection serves a matching upstream", async () => {
+  test("routes through platform auth, not the claiming row", async () => {
+    // The row's provider equals the model's upstream, so plain provider
+    // equality would have accepted it and billed the user's own key.
     fakeConnections.set("vellum", userOwnedOpenai);
-    const provider = await tryResolveProviderForConnectionName(
-      "vellum",
-      config,
-      "vellum",
-      "gpt-5.6-luna",
-    );
-    expect(provider).not.toBeNull();
-    expect(resolveCalls).toHaveLength(1);
-    expect(resolveCalls[0].connection.provider).toBe("openai");
-    expect(resolveCalls[0].connection.auth.type).toBe("api_key");
-  });
-
-  test("another BYOK row serves an upstream the claiming row cannot", async () => {
-    fakeConnections.set("vellum", {
-      name: "vellum",
-      provider: "anthropic",
-      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
-    });
-    listResult = [
-      {
-        name: "openai-personal",
-        provider: "openai",
-        auth: { type: "api_key", credential: "credential/openai/api_key" },
-      },
-    ];
-    const provider = await tryResolveProviderForConnectionName(
-      "vellum",
-      config,
-      "vellum",
-      "gpt-5.6-luna",
-    );
-    expect(provider).not.toBeNull();
-    expect(resolveCalls[0].connection.name).toBe("openai-personal");
-  });
-
-  test("falls back to platform auth when no BYOK row serves the upstream", async () => {
-    fakeConnections.set("vellum", {
-      name: "vellum",
-      provider: "anthropic",
-      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
-    });
-    listResult = [];
     const provider = await tryResolveProviderForConnectionName(
       "vellum",
       config,
@@ -206,20 +166,54 @@ describe("user-owned connection claiming the vellum name", () => {
     expect(resolveCalls[0].opts.providerOverride).toBe("openai");
   });
 
-  test("falls back to platform auth when the claiming row has no usable credential", async () => {
+  test("does not reroute onto another BYOK row for the upstream", async () => {
+    fakeConnections.set("vellum", {
+      name: "vellum",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    listResult = [
+      {
+        name: "openai-personal",
+        provider: "openai",
+        auth: { type: "api_key", credential: "credential/openai/api_key" },
+      },
+    ];
+    await tryResolveProviderForConnectionName(
+      "vellum",
+      config,
+      "vellum",
+      "gpt-5.6-luna",
+    );
+    expect(resolveCalls).toHaveLength(1);
+    expect(resolveCalls[0].connection.auth.type).toBe("platform");
+  });
+
+  test("an unavailable platform is a soft miss, not a fall-through", async () => {
     fakeConnections.set("vellum", userOwnedOpenai);
-    resolveResult = null; // credential missing from the vault
+    resolveResult = null; // not signed in to the platform
     const provider = await tryResolveProviderForConnectionName(
       "vellum",
       config,
       "vellum",
       "gpt-5.6-luna",
     );
-    expect(resolveCalls).toHaveLength(2);
-    expect(resolveCalls[0].connection.auth.type).toBe("api_key");
-    expect(resolveCalls[1].connection.auth.type).toBe("platform");
-    // The stub returns null for every call here, including the fallback.
     expect(provider).toBeNull();
+    expect(resolveCalls).toHaveLength(1);
+    expect(resolveCalls[0].connection.auth.type).toBe("platform");
+  });
+
+  test("the row still serves a profile that names it directly", async () => {
+    fakeConnections.set("vellum", userOwnedOpenai);
+    const provider = await tryResolveProviderForConnectionName(
+      "vellum",
+      config,
+      "openai",
+      "gpt-5.6-luna",
+    );
+    expect(provider).not.toBeNull();
+    expect(resolveCalls).toHaveLength(1);
+    expect(resolveCalls[0].connection.auth.type).toBe("api_key");
   });
 
   test("the canonical row still routes", async () => {

--- a/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
@@ -138,7 +138,7 @@ describe("vellum connection mismatch handling", () => {
 /**
  * Boot seeding leaves a user-owned row claiming the `vellum` name in place, so
  * an install can have no canonical row at all. A managed profile only resolves
- * on a platform install, so its route is platform auth — never the credentials
+ * on a platform install, so its route is platform auth, never the credentials
  * that row happens to carry, and never an error over the name collision.
  */
 describe("user-owned connection claiming the vellum name", () => {

--- a/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
@@ -203,7 +203,11 @@ describe("user-owned connection claiming the vellum name", () => {
     expect(resolveCalls[0].connection.auth.type).toBe("platform");
   });
 
-  test("the row still serves a profile that names it directly", async () => {
+  test("a concrete provider over the canonical name is still platform-billed", async () => {
+    // The shape `resolveCallSiteConfig` produces when a call-site tweak pins a
+    // concrete upstream over a managed profile: provider is the upstream, the
+    // managed connection survives. The legacy config of the same shape (a BYOK
+    // profile pointing at a row named `vellum`) resolves the same way.
     fakeConnections.set("vellum", userOwnedOpenai);
     const provider = await tryResolveProviderForConnectionName(
       "vellum",
@@ -213,7 +217,8 @@ describe("user-owned connection claiming the vellum name", () => {
     );
     expect(provider).not.toBeNull();
     expect(resolveCalls).toHaveLength(1);
-    expect(resolveCalls[0].connection.auth.type).toBe("api_key");
+    expect(resolveCalls[0].connection.auth.type).toBe("platform");
+    expect(resolveCalls[0].opts.providerOverride).toBe("openai");
   });
 
   test("the canonical row still routes", async () => {

--- a/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
@@ -26,12 +26,14 @@ mock.module("../inference/connections.js", () => ({
     fakeConnections.get(name) ?? null,
   listConnections: (_db: unknown, _filter?: { provider?: string }) =>
     listResult,
+  canonicalVellumConnection: () => ({ ...vellumConn }),
 }));
 
 const resolveCalls: Array<{
   connection: Connection;
   opts: { model?: string; providerOverride?: string };
 }> = [];
+let resolveResult: unknown = undefined;
 mock.module("../registry.js", () => ({
   resolveProviderFromConnection: async (
     connection: Connection,
@@ -39,7 +41,11 @@ mock.module("../registry.js", () => ({
     opts: { model?: string; providerOverride?: string },
   ) => {
     resolveCalls.push({ connection, opts });
-    return { __provider: connection.name };
+    // `undefined` means "use the default stub"; an explicit null models a
+    // credential the vault cannot serve.
+    return resolveResult === undefined
+      ? { __provider: connection.name }
+      : resolveResult;
   },
 }));
 
@@ -65,6 +71,7 @@ function reset(): void {
   resolveCalls.length = 0;
   fakeConnections.clear();
   listResult = [];
+  resolveResult = undefined;
 }
 
 describe("vellum connection mismatch handling", () => {
@@ -130,39 +137,89 @@ describe("vellum connection mismatch handling", () => {
 
 /**
  * Boot seeding leaves a user-owned row claiming the `vellum` name in place, so
- * a managed profile whose model resolves to that row's provider would pass the
- * plain provider-equality check and dispatch on the user's own credentials.
+ * an install can have no canonical row at all. A managed route must still
+ * resolve: the user's own connection when it serves the upstream, platform
+ * auth otherwise. It never errors on a collision the user did not author.
  */
 describe("user-owned connection claiming the vellum name", () => {
   beforeEach(reset);
 
-  const userOwnedVellum: Connection = {
+  const userOwnedOpenai: Connection = {
     name: "vellum",
     provider: "openai",
     auth: { type: "api_key", credential: "credential/openai/api_key" },
   };
 
-  test("a managed profile never dispatches through it", async () => {
-    fakeConnections.set("vellum", userOwnedVellum);
-    // Recovery candidates exist and must not be used either: a managed
-    // profile is platform-billed, not reroutable onto a BYOK row.
-    listResult = [userOwnedVellum];
-    let caught: unknown;
-    try {
-      await tryResolveProviderForConnectionName(
-        "vellum",
-        config,
-        "vellum",
-        "gpt-5.6-luna",
-      );
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(ConnectionResolutionError);
-    expect((caught as ConnectionResolutionError).reason).toBe(
-      "provider_mismatch",
+  test("the user's own connection serves a matching upstream", async () => {
+    fakeConnections.set("vellum", userOwnedOpenai);
+    const provider = await tryResolveProviderForConnectionName(
+      "vellum",
+      config,
+      "vellum",
+      "gpt-5.6-luna",
     );
-    expect(resolveCalls).toHaveLength(0);
+    expect(provider).not.toBeNull();
+    expect(resolveCalls).toHaveLength(1);
+    expect(resolveCalls[0].connection.provider).toBe("openai");
+    expect(resolveCalls[0].connection.auth.type).toBe("api_key");
+  });
+
+  test("another BYOK row serves an upstream the claiming row cannot", async () => {
+    fakeConnections.set("vellum", {
+      name: "vellum",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    listResult = [
+      {
+        name: "openai-personal",
+        provider: "openai",
+        auth: { type: "api_key", credential: "credential/openai/api_key" },
+      },
+    ];
+    const provider = await tryResolveProviderForConnectionName(
+      "vellum",
+      config,
+      "vellum",
+      "gpt-5.6-luna",
+    );
+    expect(provider).not.toBeNull();
+    expect(resolveCalls[0].connection.name).toBe("openai-personal");
+  });
+
+  test("falls back to platform auth when no BYOK row serves the upstream", async () => {
+    fakeConnections.set("vellum", {
+      name: "vellum",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    listResult = [];
+    const provider = await tryResolveProviderForConnectionName(
+      "vellum",
+      config,
+      "vellum",
+      "gpt-5.6-luna",
+    );
+    expect(provider).not.toBeNull();
+    expect(resolveCalls).toHaveLength(1);
+    expect(resolveCalls[0].connection.auth.type).toBe("platform");
+    expect(resolveCalls[0].opts.providerOverride).toBe("openai");
+  });
+
+  test("falls back to platform auth when the claiming row has no usable credential", async () => {
+    fakeConnections.set("vellum", userOwnedOpenai);
+    resolveResult = null; // credential missing from the vault
+    const provider = await tryResolveProviderForConnectionName(
+      "vellum",
+      config,
+      "vellum",
+      "gpt-5.6-luna",
+    );
+    expect(resolveCalls).toHaveLength(2);
+    expect(resolveCalls[0].connection.auth.type).toBe("api_key");
+    expect(resolveCalls[1].connection.auth.type).toBe("platform");
+    // The stub returns null for every call here, including the fallback.
+    expect(provider).toBeNull();
   });
 
   test("the canonical row still routes", async () => {
@@ -174,6 +231,7 @@ describe("user-owned connection claiming the vellum name", () => {
       "gpt-5.6-luna",
     );
     expect(provider).not.toBeNull();
+    expect(resolveCalls).toHaveLength(1);
     expect(resolveCalls[0].opts.providerOverride).toBe("openai");
   });
 });

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -123,7 +123,7 @@ export async function tryResolveProviderForConnectionName(
   }
   // A `vellum`-identity route ignores a user-owned row claiming the canonical
   // name. Boot seeding refuses to overwrite such a row, so these installs have
-  // no canonical row at all — but they are platform installs (a managed
+  // no canonical row at all, but they are platform installs (a managed
   // profile only resolves when `llm.defaultProvider` is `vellum`), so the
   // route belongs on platform auth, not on whatever credentials that row
   // happens to carry. The row keeps serving any profile that names it.
@@ -244,7 +244,7 @@ async function resolveThroughPlatform(
   }
   log.info(
     { upstream, model },
-    "Vellum-managed route resolved through platform auth — a user-owned connection claims the canonical connection name",
+    "Vellum-managed route resolved through platform auth: a user-owned connection claims the canonical connection name",
   );
   try {
     return await resolveProviderFromConnection(

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -121,13 +121,18 @@ export async function tryResolveProviderForConnectionName(
       `provider_connection "${connectionName}" not found in DB — check your config or run the boot-time backfill`,
     );
   }
-  // A `vellum`-identity route whose row is user-owned (boot seeding leaves
-  // such a row in place, so the canonical row can be missing entirely) never
-  // errors: it uses that row when the row can serve the request, and falls
-  // back to platform auth when it cannot. See `resolveThroughPlatform` below.
-  const managedRouteOnUserRow =
+  // A `vellum`-identity route ignores a user-owned row claiming the canonical
+  // name. Boot seeding refuses to overwrite such a row, so these installs have
+  // no canonical row at all — but they are platform installs (a managed
+  // profile only resolves when `llm.defaultProvider` is `vellum`), so the
+  // route belongs on platform auth, not on whatever credentials that row
+  // happens to carry. The row keeps serving any profile that names it.
+  if (
     declaredProvider === VELLUM_MANAGED_PROVIDER &&
-    !isVellumManagedConnection(connection);
+    !isVellumManagedConnection(connection)
+  ) {
+    return resolveThroughPlatform(config, expectedProvider, model);
+  }
   // The provider-agnostic Vellum-managed connection carries only the `vellum`
   // sentinel, so the usual `connection.provider === expectedProvider` equality
   // never holds. It routes by the resolving profile's declared provider
@@ -185,11 +190,6 @@ export async function tryResolveProviderForConnectionName(
     } catch {
       // DB not available — fall through to the original error.
     }
-    if (!resolved && managedRouteOnUserRow) {
-      // No BYOK row serves this upstream, so the managed route falls back to
-      // the platform rather than failing on a name collision it did not cause.
-      return resolveThroughPlatform(config, expectedProvider, model);
-    }
     if (!resolved) {
       const incompatMsg = mismatchCandidates
         ? describeSubscriptionModelIncompatibility(mismatchCandidates, model)
@@ -216,22 +216,10 @@ export async function tryResolveProviderForConnectionName(
   // catch is specifically for in-flight failures that should not take
   // dispatch offline.
   try {
-    const provider = await resolveProviderFromConnection(connection, config, {
+    return await resolveProviderFromConnection(connection, config, {
       model,
       providerOverride: isVellumRoute ? expectedProvider : undefined,
     });
-    if (provider === null && managedRouteOnUserRow) {
-      // The user-owned row fits the upstream but has no usable credential —
-      // the managed route still has the platform.
-      return resolveThroughPlatform(config, expectedProvider, model);
-    }
-    if (provider !== null && managedRouteOnUserRow) {
-      log.warn(
-        { connectionName, resolvedConnection: connection.name },
-        "Vellum-managed route served by a user-owned connection — the request bills to that connection's own credentials, not the platform",
-      );
-    }
-    return provider;
   } catch (err) {
     log.warn(
       { err, connectionName },
@@ -243,8 +231,8 @@ export async function tryResolveProviderForConnectionName(
 
 /**
  * Resolve a managed route through platform auth without reading a connection
- * row. Used when the canonical `vellum` row is occupied by a user-owned
- * connection that cannot serve the request.
+ * row. Used when the canonical `vellum` row is claimed by a user-owned
+ * connection, so the row boot seeding would have written does not exist.
  */
 async function resolveThroughPlatform(
   config: ProvidersConfig,
@@ -256,7 +244,7 @@ async function resolveThroughPlatform(
   }
   log.info(
     { upstream, model },
-    "Vellum-managed route fell back to platform auth — the canonical connection row is claimed by a user-owned connection",
+    "Vellum-managed route resolved through platform auth — a user-owned connection claims the canonical connection name",
   );
   try {
     return await resolveProviderFromConnection(
@@ -417,14 +405,14 @@ export async function preflightResolvedConfig(
       errorOptions,
     );
   }
-  // A managed route landing on a user-owned row has two live paths at
-  // dispatch (that row, else platform auth), so no static verdict here is
-  // sound — a real failure still surfaces at dispatch with its own message.
+  // Dispatch routes a managed profile through platform auth when a user-owned
+  // row claims the canonical name, so preflight judges the platform rather
+  // than that row's credentials.
   if (
     resolved.provider === VELLUM_MANAGED_PROVIDER &&
     !isVellumManagedConnection(connection)
   ) {
-    return;
+    connection = canonicalVellumConnection();
   }
 
   if (isVellumManagedConnection(connection)) {

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -39,13 +39,16 @@ import {
   describeSubscriptionModelIncompatibility,
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
-import { getConnection, listConnections } from "./inference/connections.js";
+import {
+  canonicalVellumConnection,
+  getConnection,
+  listConnections,
+} from "./inference/connections.js";
 import { resolveManagedProxyContext } from "./platform-proxy/context.js";
 import { checkCredentialPresence } from "./provider-availability.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
 import {
-  assertVellumIdentityConnection,
   ConnectionResolutionError,
   resolveRoutingIdentity,
 } from "./routing-identity.js";
@@ -53,6 +56,7 @@ import type { Provider } from "./types.js";
 import {
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_PROVIDER,
 } from "./vellum-model-routing.js";
 
 export { ConnectionResolutionError, resolveRoutingIdentity };
@@ -117,9 +121,13 @@ export async function tryResolveProviderForConnectionName(
       `provider_connection "${connectionName}" not found in DB — check your config or run the boot-time backfill`,
     );
   }
-  assertVellumIdentityConnection(declaredProvider, connection, connectionName, {
-    ...(model !== undefined ? { model } : {}),
-  });
+  // A `vellum`-identity route whose row is user-owned (boot seeding leaves
+  // such a row in place, so the canonical row can be missing entirely) never
+  // errors: it uses that row when the row can serve the request, and falls
+  // back to platform auth when it cannot. See `resolveThroughPlatform` below.
+  const managedRouteOnUserRow =
+    declaredProvider === VELLUM_MANAGED_PROVIDER &&
+    !isVellumManagedConnection(connection);
   // The provider-agnostic Vellum-managed connection carries only the `vellum`
   // sentinel, so the usual `connection.provider === expectedProvider` equality
   // never holds. It routes by the resolving profile's declared provider
@@ -177,6 +185,11 @@ export async function tryResolveProviderForConnectionName(
     } catch {
       // DB not available — fall through to the original error.
     }
+    if (!resolved && managedRouteOnUserRow) {
+      // No BYOK row serves this upstream, so the managed route falls back to
+      // the platform rather than failing on a name collision it did not cause.
+      return resolveThroughPlatform(config, expectedProvider, model);
+    }
     if (!resolved) {
       const incompatMsg = mismatchCandidates
         ? describeSubscriptionModelIncompatibility(mismatchCandidates, model)
@@ -203,15 +216,56 @@ export async function tryResolveProviderForConnectionName(
   // catch is specifically for in-flight failures that should not take
   // dispatch offline.
   try {
-    return await resolveProviderFromConnection(connection, config, {
+    const provider = await resolveProviderFromConnection(connection, config, {
       model,
       providerOverride: isVellumRoute ? expectedProvider : undefined,
     });
+    if (provider === null && managedRouteOnUserRow) {
+      // The user-owned row fits the upstream but has no usable credential —
+      // the managed route still has the platform.
+      return resolveThroughPlatform(config, expectedProvider, model);
+    }
+    if (provider !== null && managedRouteOnUserRow) {
+      log.warn(
+        { connectionName, resolvedConnection: connection.name },
+        "Vellum-managed route served by a user-owned connection — the request bills to that connection's own credentials, not the platform",
+      );
+    }
+    return provider;
   } catch (err) {
     log.warn(
       { err, connectionName },
       "provider_connection auth resolution failed transiently — returning null",
     );
+    return null;
+  }
+}
+
+/**
+ * Resolve a managed route through platform auth without reading a connection
+ * row. Used when the canonical `vellum` row is occupied by a user-owned
+ * connection that cannot serve the request.
+ */
+async function resolveThroughPlatform(
+  config: ProvidersConfig,
+  upstream: string | undefined,
+  model: string | undefined,
+): Promise<Provider | null> {
+  if (!upstream || !MANAGED_ROUTABLE_PROVIDERS.has(upstream)) {
+    return null;
+  }
+  log.info(
+    { upstream, model },
+    "Vellum-managed route fell back to platform auth — the canonical connection row is claimed by a user-owned connection",
+  );
+  try {
+    return await resolveProviderFromConnection(
+      canonicalVellumConnection(),
+      config,
+      { model, providerOverride: upstream },
+    );
+  } catch (err) {
+    log.warn({ err }, "Platform fallback auth resolution failed transiently");
     return null;
   }
 }
@@ -363,12 +417,15 @@ export async function preflightResolvedConfig(
       errorOptions,
     );
   }
-  assertVellumIdentityConnection(
-    resolved.provider,
-    connection,
-    connectionName,
-    errorOptions,
-  );
+  // A managed route landing on a user-owned row has two live paths at
+  // dispatch (that row, else platform auth), so no static verdict here is
+  // sound — a real failure still surfaces at dispatch with its own message.
+  if (
+    resolved.provider === VELLUM_MANAGED_PROVIDER &&
+    !isVellumManagedConnection(connection)
+  ) {
+    return;
+  }
 
   if (isVellumManagedConnection(connection)) {
     if (!MANAGED_ROUTABLE_PROVIDERS.has(provider)) {

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -56,7 +56,7 @@ import type { Provider } from "./types.js";
 import {
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
-  VELLUM_MANAGED_PROVIDER,
+  VELLUM_MANAGED_CONNECTION_NAME,
 } from "./vellum-model-routing.js";
 
 export { ConnectionResolutionError, resolveRoutingIdentity };
@@ -121,17 +121,22 @@ export async function tryResolveProviderForConnectionName(
       `provider_connection "${connectionName}" not found in DB — check your config or run the boot-time backfill`,
     );
   }
-  // A `vellum`-identity route ignores a user-owned row claiming the canonical
-  // name. Boot seeding refuses to overwrite such a row, so these installs have
-  // no canonical row at all, but they are platform installs (a managed
-  // profile only resolves when `llm.defaultProvider` is `vellum`), so the
-  // route belongs on platform auth, not on whatever credentials that row
-  // happens to carry. The row keeps serving any profile that names it.
+  // Any route through the canonical connection name is platform-billed, so it
+  // resolves on platform auth and ignores a user-owned row claiming that name
+  // (boot seeding refuses to overwrite such a row, so these installs have no
+  // canonical row at all). Keyed on the name rather than the declared
+  // provider: a call-site tweak pinning a concrete upstream over a managed
+  // profile keeps the managed connection while replacing the provider
+  // (`llm-resolver.ts`), and that route is platform-billed just the same.
   if (
-    declaredProvider === VELLUM_MANAGED_PROVIDER &&
+    connectionName === VELLUM_MANAGED_CONNECTION_NAME &&
     !isVellumManagedConnection(connection)
   ) {
-    return resolveThroughPlatform(config, expectedProvider, model);
+    return resolveThroughPlatform(
+      config,
+      expectedProvider ?? declaredProvider,
+      model,
+    );
   }
   // The provider-agnostic Vellum-managed connection carries only the `vellum`
   // sentinel, so the usual `connection.provider === expectedProvider` equality
@@ -405,11 +410,10 @@ export async function preflightResolvedConfig(
       errorOptions,
     );
   }
-  // Dispatch routes a managed profile through platform auth when a user-owned
-  // row claims the canonical name, so preflight judges the platform rather
-  // than that row's credentials.
+  // Dispatch routes anything through the canonical name on platform auth, so
+  // preflight judges the platform rather than a claiming row's credentials.
   if (
-    resolved.provider === VELLUM_MANAGED_PROVIDER &&
+    connectionName === VELLUM_MANAGED_CONNECTION_NAME &&
     !isVellumManagedConnection(connection)
   ) {
     connection = canonicalVellumConnection();

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -45,6 +45,7 @@ import { checkCredentialPresence } from "./provider-availability.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
 import {
+  assertVellumIdentityConnection,
   ConnectionResolutionError,
   resolveRoutingIdentity,
 } from "./routing-identity.js";
@@ -92,6 +93,7 @@ export async function tryResolveProviderForConnectionName(
   // identity's canonical connection row and derived upstream before any
   // lookup. The stored connectionName is overridden — an identity has
   // exactly one authoritative row.
+  const declaredProvider = expectedProvider;
   const identity = resolveRoutingIdentity(expectedProvider, model);
   if (identity) {
     connectionName = identity.connectionName;
@@ -115,6 +117,9 @@ export async function tryResolveProviderForConnectionName(
       `provider_connection "${connectionName}" not found in DB — check your config or run the boot-time backfill`,
     );
   }
+  assertVellumIdentityConnection(declaredProvider, connection, connectionName, {
+    ...(model !== undefined ? { model } : {}),
+  });
   // The provider-agnostic Vellum-managed connection carries only the `vellum`
   // sentinel, so the usual `connection.provider === expectedProvider` equality
   // never holds. It routes by the resolving profile's declared provider
@@ -358,6 +363,12 @@ export async function preflightResolvedConfig(
       errorOptions,
     );
   }
+  assertVellumIdentityConnection(
+    resolved.provider,
+    connection,
+    connectionName,
+    errorOptions,
+  );
 
   if (isVellumManagedConnection(connection)) {
     if (!MANAGED_ROUTABLE_PROVIDERS.has(provider)) {

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -128,15 +128,6 @@ export async function computeConnectionAvailability(
     }
     return vellumManagedMismatch(resolvedConnectionName, provider);
   }
-  // Mirrors `assertVellumIdentityConnection`: a managed route judged against a
-  // user-owned row claiming the canonical name is a mismatch, even when that
-  // row's provider happens to equal the identity's derived upstream.
-  if (provider === VELLUM_MANAGED_PROVIDER) {
-    return {
-      status: "provider_mismatch",
-      message: `Connection "${resolvedConnectionName}" is a user-owned connection for provider "${connection.provider}", not the Vellum-managed connection. Rename or remove it ${SETTINGS_HINT} so the managed connection can be restored.`,
-    };
-  }
   if (connection.provider !== provider) {
     return {
       status: "provider_mismatch",

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -129,15 +129,11 @@ export async function computeConnectionAvailability(
     }
     return vellumManagedMismatch(resolvedConnectionName, provider);
   }
-  // A managed route whose canonical row is claimed by a user-owned connection
-  // dispatches through platform auth and never touches that row, so the
-  // platform's own status is the answer, not the row's. Scoped to the
-  // canonical name: a managed default explicitly pinned to some other row is a
-  // real misconfiguration and still reads as a mismatch below.
-  if (
-    provider === VELLUM_MANAGED_PROVIDER &&
-    resolvedConnectionName === VELLUM_MANAGED_CONNECTION_NAME
-  ) {
+  // Everything routed through the canonical name dispatches on platform auth,
+  // never on a claiming row's credentials, so the platform's own status is the
+  // answer. Scoped to that name: a managed default explicitly pinned to some
+  // other row is a real misconfiguration and still reads as a mismatch below.
+  if (resolvedConnectionName === VELLUM_MANAGED_CONNECTION_NAME) {
     return vellumConnectionAvailability();
   }
   if (connection.provider !== provider) {

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -18,6 +18,7 @@ import { resolveManagedProxyContext } from "../platform-proxy/context.js";
 import {
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_CONNECTION_NAME,
   VELLUM_MANAGED_PROVIDER,
 } from "../vellum-model-routing.js";
 import { getConnection } from "./connections.js";
@@ -127,6 +128,17 @@ export async function computeConnectionAvailability(
       return vellumConnectionAvailability();
     }
     return vellumManagedMismatch(resolvedConnectionName, provider);
+  }
+  // A managed route whose canonical row is claimed by a user-owned connection
+  // dispatches through platform auth and never touches that row, so the
+  // platform's own status is the answer — not the row's. Scoped to the
+  // canonical name: a managed default explicitly pinned to some other row is a
+  // real misconfiguration and still reads as a mismatch below.
+  if (
+    provider === VELLUM_MANAGED_PROVIDER &&
+    resolvedConnectionName === VELLUM_MANAGED_CONNECTION_NAME
+  ) {
+    return vellumConnectionAvailability();
   }
   if (connection.provider !== provider) {
     return {

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -131,7 +131,7 @@ export async function computeConnectionAvailability(
   }
   // A managed route whose canonical row is claimed by a user-owned connection
   // dispatches through platform auth and never touches that row, so the
-  // platform's own status is the answer — not the row's. Scoped to the
+  // platform's own status is the answer, not the row's. Scoped to the
   // canonical name: a managed default explicitly pinned to some other row is a
   // real misconfiguration and still reads as a mismatch below.
   if (

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -18,6 +18,7 @@ import { resolveManagedProxyContext } from "../platform-proxy/context.js";
 import {
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_PROVIDER,
 } from "../vellum-model-routing.js";
 import { getConnection } from "./connections.js";
 
@@ -119,10 +120,22 @@ export async function computeConnectionAvailability(
   // providers via platform auth; any other provider mismatch fails there, so
   // usable credentials must not read as ok.
   if (isVellumManagedConnection(connection)) {
-    if (provider === "vellum" || MANAGED_ROUTABLE_PROVIDERS.has(provider)) {
+    if (
+      provider === VELLUM_MANAGED_PROVIDER ||
+      MANAGED_ROUTABLE_PROVIDERS.has(provider)
+    ) {
       return vellumConnectionAvailability();
     }
     return vellumManagedMismatch(resolvedConnectionName, provider);
+  }
+  // Mirrors `assertVellumIdentityConnection`: a managed route judged against a
+  // user-owned row claiming the canonical name is a mismatch, even when that
+  // row's provider happens to equal the identity's derived upstream.
+  if (provider === VELLUM_MANAGED_PROVIDER) {
+    return {
+      status: "provider_mismatch",
+      message: `Connection "${resolvedConnectionName}" is a user-owned connection for provider "${connection.provider}", not the Vellum-managed connection. Rename or remove it ${SETTINGS_HINT} so the managed connection can be restored.`,
+    };
   }
   if (connection.provider !== provider) {
     return {

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -391,6 +391,29 @@ const CANONICAL_CONNECTIONS: Array<{
 ];
 
 /**
+ * The Vellum-managed connection as boot seeding defines it, built without a DB
+ * read. Dispatch uses this when the `vellum` name is occupied by a user-owned
+ * row: seeding refuses to overwrite such a row, so the canonical row can be
+ * absent from the DB while managed routing still has to work. Platform auth
+ * needs no row of its own — only this shape.
+ */
+export function canonicalVellumConnection(): ProviderConnection {
+  const now = Date.now();
+  const canonical = CANONICAL_CONNECTIONS[0];
+  return {
+    name: canonical.name,
+    provider: canonical.provider,
+    auth: canonical.auth,
+    label: canonical.label,
+    baseUrl: null,
+    models: null,
+    createdAt: now,
+    updatedAt: now,
+    isManaged: true,
+  };
+}
+
+/**
  * Names of the canonical Vellum-managed connections. Seeded on every daemon
  * boot via `seedCanonicalConnections` and representing the platform-managed
  * inference route. They are write-protected at the route layer:

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -7,6 +7,7 @@ import { normalizeCredentialRef } from "../../security/credential-key.js";
 import { getLogger } from "../../util/logger.js";
 import { clearConnectionProviderCache } from "../registry.js";
 import {
+  isVellumManagedConnection,
   VELLUM_MANAGED_CONNECTION_NAME,
   VELLUM_MANAGED_PROVIDER,
 } from "../vellum-model-routing.js";
@@ -25,6 +26,23 @@ import {
 } from "./auth.js";
 
 const log = getLogger("providers/inference/connections");
+
+/**
+ * Whether a row is one of the managed connections, judged by the row and not
+ * by its name alone. Boot seeding leaves a user-owned row claiming a canonical
+ * name in place, and that row is an ordinary connection: routing ignores it,
+ * the route layer lets it be edited and deleted, and clients must render it
+ * that way or the collision becomes unrecoverable from the UI.
+ */
+function isManagedRow(row: {
+  name: string;
+  provider: string;
+  auth: { type: string };
+}): boolean {
+  return (
+    MANAGED_CONNECTION_NAMES.has(row.name) && isVellumManagedConnection(row)
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -92,7 +110,7 @@ export function listConnections(
         label: row.label ?? null,
         baseUrl: row.baseUrl ?? null,
         models: parseModelsColumn(row.models),
-        isManaged: MANAGED_CONNECTION_NAMES.has(row.name),
+        isManaged: isManagedRow({ ...row, provider: provider.data, auth }),
       },
     ];
   });
@@ -126,7 +144,7 @@ export function getConnection(
     label: row.label ?? null,
     baseUrl: row.baseUrl ?? null,
     models: parseModelsColumn(row.models),
-    isManaged: MANAGED_CONNECTION_NAMES.has(row.name),
+    isManaged: isManagedRow({ ...row, provider: provider.data, auth }),
   };
 }
 
@@ -238,7 +256,7 @@ export function createConnection(
       models,
       createdAt: now,
       updatedAt: now,
-      isManaged: MANAGED_CONNECTION_NAMES.has(input.name),
+      isManaged: isManagedRow({ name: input.name, provider, auth }),
     },
   };
 }
@@ -395,7 +413,7 @@ const CANONICAL_CONNECTIONS: Array<{
  * read. Dispatch uses this when the `vellum` name is occupied by a user-owned
  * row: seeding refuses to overwrite such a row, so the canonical row can be
  * absent from the DB while managed routing still has to work. Platform auth
- * needs no row of its own — only this shape.
+ * needs no row of its own, only this shape.
  */
 export function canonicalVellumConnection(): ProviderConnection {
   const now = Date.now();

--- a/assistant/src/providers/routing-identity.ts
+++ b/assistant/src/providers/routing-identity.ts
@@ -14,7 +14,6 @@ import { CHATGPT_SUBSCRIPTION_CONNECTION_NAME } from "./inference/auth.js";
 import { isCodexSubscriptionModel } from "./openai/codex-models.js";
 import {
   getManagedUpstream,
-  isVellumManagedConnection,
   VELLUM_MANAGED_CONNECTION_NAME,
   VELLUM_MANAGED_PROVIDER,
 } from "./vellum-model-routing.js";
@@ -98,41 +97,4 @@ export function resolveRoutingIdentity(
     };
   }
   return null;
-}
-
-/**
- * Reject a `vellum`-identity route that lands on a row which is not the
- * canonical platform connection.
- *
- * Boot seeding deliberately leaves a user-owned connection claiming the
- * `vellum` name in place (`seedCanonicalConnections`), so an install can hold
- * a real BYOK row under that name. The identity's derived upstream is a real
- * provider id, so once a managed profile pins a model whose upstream matches
- * that row's provider (e.g. an `openai`-owned model against a user-owned
- * `vellum`/openai row), the ordinary `connection.provider === expectedProvider`
- * equality accepts it and the managed profile dispatches on the user's own
- * key — off platform billing, off platform usage attribution, and silent.
- * Managed routes must run on the platform row or fail loudly.
- *
- * No-ops unless `declaredProvider` is the managed sentinel: `chatgpt` rows
- * legitimately store their upstream (`openai`) as the row provider.
- */
-export function assertVellumIdentityConnection(
-  declaredProvider: string | undefined,
-  connection: { provider: string; auth: { type: string } },
-  connectionName: string,
-  options?: { model?: string; profileName?: string },
-): void {
-  if (declaredProvider !== VELLUM_MANAGED_PROVIDER) {
-    return;
-  }
-  if (isVellumManagedConnection(connection)) {
-    return;
-  }
-  throw new ConnectionResolutionError(
-    connectionName,
-    "provider_mismatch",
-    `provider_connection "${connectionName}" is a user-owned connection for provider "${connection.provider}", not the Vellum-managed connection — a Vellum-managed profile cannot route through your own credentials. Rename or remove that connection so the managed connection can be seeded on the next restart.`,
-    options,
-  );
 }

--- a/assistant/src/providers/routing-identity.ts
+++ b/assistant/src/providers/routing-identity.ts
@@ -14,7 +14,9 @@ import { CHATGPT_SUBSCRIPTION_CONNECTION_NAME } from "./inference/auth.js";
 import { isCodexSubscriptionModel } from "./openai/codex-models.js";
 import {
   getManagedUpstream,
+  isVellumManagedConnection,
   VELLUM_MANAGED_CONNECTION_NAME,
+  VELLUM_MANAGED_PROVIDER,
 } from "./vellum-model-routing.js";
 
 /**
@@ -63,7 +65,7 @@ export function resolveRoutingIdentity(
   provider: string | undefined,
   model: string | undefined,
 ): { connectionName: string; expectedProvider: string } | null {
-  if (provider === "vellum") {
+  if (provider === VELLUM_MANAGED_PROVIDER) {
     const upstream = model ? getManagedUpstream(model) : null;
     if (!upstream) {
       throw new ConnectionResolutionError(
@@ -96,4 +98,41 @@ export function resolveRoutingIdentity(
     };
   }
   return null;
+}
+
+/**
+ * Reject a `vellum`-identity route that lands on a row which is not the
+ * canonical platform connection.
+ *
+ * Boot seeding deliberately leaves a user-owned connection claiming the
+ * `vellum` name in place (`seedCanonicalConnections`), so an install can hold
+ * a real BYOK row under that name. The identity's derived upstream is a real
+ * provider id, so once a managed profile pins a model whose upstream matches
+ * that row's provider (e.g. an `openai`-owned model against a user-owned
+ * `vellum`/openai row), the ordinary `connection.provider === expectedProvider`
+ * equality accepts it and the managed profile dispatches on the user's own
+ * key — off platform billing, off platform usage attribution, and silent.
+ * Managed routes must run on the platform row or fail loudly.
+ *
+ * No-ops unless `declaredProvider` is the managed sentinel: `chatgpt` rows
+ * legitimately store their upstream (`openai`) as the row provider.
+ */
+export function assertVellumIdentityConnection(
+  declaredProvider: string | undefined,
+  connection: { provider: string; auth: { type: string } },
+  connectionName: string,
+  options?: { model?: string; profileName?: string },
+): void {
+  if (declaredProvider !== VELLUM_MANAGED_PROVIDER) {
+    return;
+  }
+  if (isVellumManagedConnection(connection)) {
+    return;
+  }
+  throw new ConnectionResolutionError(
+    connectionName,
+    "provider_mismatch",
+    `provider_connection "${connectionName}" is a user-owned connection for provider "${connection.provider}", not the Vellum-managed connection — a Vellum-managed profile cannot route through your own credentials. Rename or remove that connection so the managed connection can be seeded on the next restart.`,
+    options,
+  );
 }

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -159,10 +159,10 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result).status).toBe("missing_connection");
   });
 
-  test("user-owned connection claiming the vellum name → provider_mismatch, not ok", async () => {
+  test("user-owned connection claiming the vellum name → the platform's own status", async () => {
     // seedCanonicalConnections skips reseeding when a user row claims the
-    // name; dispatch then uses the user row, so signed-in Vellum must not
-    // read as ok.
+    // name. Dispatch ignores that row and routes through platform auth, so a
+    // signed-in platform is genuinely usable and reads as ok.
     seedConnection({
       name: "vellum",
       provider: "anthropic",
@@ -176,7 +176,7 @@ describe("GET config/llm/default-provider", () => {
     setConfig("llm", { defaultProvider: { provider: "vellum" } });
 
     const result = await get();
-    expect(availability(result).status).toBe("provider_mismatch");
+    expect(availability(result).status).toBe("ok");
   });
 
   test("platform-auth connection for a non-managed provider → unsupported_auth even when signed in", async () => {

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -460,6 +460,18 @@ describe("POST inference/provider-connections (create)", () => {
     });
   });
 
+  test("throws 400 on the reserved managed connection name", async () => {
+    await expect(
+      call(findHandler("inference_provider_connections_create"), {
+        body: {
+          name: "vellum",
+          provider: "openai",
+          credential: "credential/openai/api_key",
+        },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
   test("throws 400 when auth is omitted and a keyed provider has no credential", async () => {
     await expect(
       call(findHandler("inference_provider_connections_create"), {
@@ -935,7 +947,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
   test("managed-connection rejection still takes precedence over the defaultProvider guard", async () => {
     seedConnection({
       name: "vellum",
-      provider: "anthropic",
+      provider: "vellum",
       auth: { type: "platform" },
     });
     setConfig("llm", { defaultProvider: { provider: "vellum" } });
@@ -1069,7 +1081,7 @@ describe("Managed connection write protection", () => {
       // should be the managed-protection 400, not the references-409.
       seedConnection({
         name: "vellum",
-        provider: "anthropic",
+        provider: "vellum",
         auth: { type: "platform" },
       });
       setConfig("llm", {
@@ -1085,6 +1097,26 @@ describe("Managed connection write protection", () => {
 
       expect(err).toBeInstanceOf(BadRequestError);
       expect((err as BadRequestError).message).toContain("managed");
+    });
+
+    test("a user-owned row claiming the managed name stays deletable", async () => {
+      // Boot seeding refuses to overwrite it and managed routing refuses to
+      // use it, so deleting is the only way to restore the canonical row.
+      seedConnection({
+        name: "vellum",
+        provider: "openai",
+        auth: { type: "api_key", credential: "credential/openai/api_key" },
+      });
+
+      await call(findHandler("inference_provider_connections_delete"), {
+        pathParams: { name: "vellum" },
+      });
+
+      const remaining = (await call(
+        findHandler("inference_provider_connections_list"),
+        {},
+      )) as { connections: unknown[] };
+      expect(remaining.connections).toHaveLength(0);
     });
   });
 

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -1100,13 +1100,16 @@ describe("Managed connection write protection", () => {
     });
 
     test("a user-owned row claiming the managed name stays deletable", async () => {
-      // Boot seeding refuses to overwrite it and managed routing refuses to
-      // use it, so deleting is the only way to restore the canonical row.
+      // Boot seeding refuses to overwrite it and managed routing ignores it,
+      // so deleting is the only way to restore the canonical row. The vellum
+      // default resolves to this same name, and that guard must not block the
+      // delete either: the next boot re-seeds the row it points at.
       seedConnection({
         name: "vellum",
         provider: "openai",
         auth: { type: "api_key", credential: "credential/openai/api_key" },
       });
+      setConfig("llm", { defaultProvider: { provider: "vellum" } });
 
       await call(findHandler("inference_provider_connections_delete"), {
         pathParams: { name: "vellum" },
@@ -1287,7 +1290,7 @@ describe("isManaged flag on connection responses", () => {
     test("returns isManaged: true for a managed name", async () => {
       seedConnection({
         name: "vellum",
-        provider: "anthropic",
+        provider: "vellum",
         auth: { type: "platform" },
       });
 
@@ -1297,6 +1300,24 @@ describe("isManaged flag on connection responses", () => {
       )) as { name: string; isManaged: boolean };
 
       expect(result.isManaged).toBe(true);
+    });
+
+    test("returns isManaged: false for a user-owned row claiming a managed name", async () => {
+      // Clients gate edit and delete on this flag, so a claiming row must
+      // report as the ordinary connection it is or the collision cannot be
+      // cleared from the UI.
+      seedConnection({
+        name: "vellum",
+        provider: "openai",
+        auth: { type: "api_key", credential: "credential/openai/api_key" },
+      });
+
+      const result = (await call(
+        findHandler("inference_provider_connections_get"),
+        { pathParams: { name: "vellum" } },
+      )) as { name: string; isManaged: boolean };
+
+      expect(result.isManaged).toBe(false);
     });
 
     test("returns isManaged: false for a user-created name", async () => {
@@ -1336,7 +1357,7 @@ describe("isManaged flag on connection responses", () => {
     test("returns isManaged: true after relabeling a managed connection", async () => {
       seedConnection({
         name: "vellum",
-        provider: "anthropic",
+        provider: "vellum",
         auth: { type: "platform" },
       });
 

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -41,7 +41,6 @@ import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import { getConnection } from "../../providers/inference/connections.js";
 import { isModelInCatalog } from "../../providers/model-catalog.js";
-import { VELLUM_MANAGED_PROVIDER } from "../../providers/vellum-model-routing.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   commitConfigWrite,
@@ -225,14 +224,8 @@ async function profileAvailability(
       if (!identity) {
         return null;
       }
-      // The managed sentinel is judged as itself, not as the derived upstream:
-      // its route is platform auth whatever row holds the canonical name.
-      // `chatgpt` rows genuinely store the upstream as their provider, so they
-      // keep judging against it.
       return computeConnectionAvailability(
-        provider === VELLUM_MANAGED_PROVIDER
-          ? provider
-          : identity.expectedProvider,
+        identity.expectedProvider,
         identity.connectionName,
       );
     } catch (err) {

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -38,7 +38,10 @@ import {
   resolveRoutingIdentity,
 } from "../../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
-import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
+import {
+  computeConnectionAvailability,
+  vellumConnectionAvailability,
+} from "../../providers/inference/connection-availability.js";
 import { getConnection } from "../../providers/inference/connections.js";
 import { isModelInCatalog } from "../../providers/model-catalog.js";
 import { VELLUM_MANAGED_PROVIDER } from "../../providers/vellum-model-routing.js";
@@ -225,16 +228,22 @@ async function profileAvailability(
       if (!identity) {
         return null;
       }
-      // The managed sentinel is judged as itself, not as the derived
-      // upstream: availability must reject a user-owned row claiming the
-      // canonical name the same way dispatch does. `chatgpt` rows genuinely
-      // store the upstream as their provider, so they keep judging against it.
-      return computeConnectionAvailability(
-        provider === VELLUM_MANAGED_PROVIDER
-          ? provider
-          : identity.expectedProvider,
+      const availability = await computeConnectionAvailability(
+        identity.expectedProvider,
         identity.connectionName,
       );
+      // A managed route whose row cannot serve it falls back to platform auth
+      // at dispatch (the canonical row can be claimed by a user-owned
+      // connection), so the platform's own status is the honest answer. For
+      // the canonical row this is what `computeConnectionAvailability` just
+      // returned, so re-reporting it changes nothing.
+      if (
+        availability.status !== "ok" &&
+        provider === VELLUM_MANAGED_PROVIDER
+      ) {
+        return vellumConnectionAvailability();
+      }
+      return availability;
     } catch (err) {
       return {
         status: "provider_mismatch",

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -38,10 +38,7 @@ import {
   resolveRoutingIdentity,
 } from "../../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
-import {
-  computeConnectionAvailability,
-  vellumConnectionAvailability,
-} from "../../providers/inference/connection-availability.js";
+import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import { getConnection } from "../../providers/inference/connections.js";
 import { isModelInCatalog } from "../../providers/model-catalog.js";
 import { VELLUM_MANAGED_PROVIDER } from "../../providers/vellum-model-routing.js";
@@ -228,22 +225,16 @@ async function profileAvailability(
       if (!identity) {
         return null;
       }
-      const availability = await computeConnectionAvailability(
-        identity.expectedProvider,
+      // The managed sentinel is judged as itself, not as the derived upstream:
+      // its route is platform auth whatever row holds the canonical name.
+      // `chatgpt` rows genuinely store the upstream as their provider, so they
+      // keep judging against it.
+      return computeConnectionAvailability(
+        provider === VELLUM_MANAGED_PROVIDER
+          ? provider
+          : identity.expectedProvider,
         identity.connectionName,
       );
-      // A managed route whose row cannot serve it falls back to platform auth
-      // at dispatch (the canonical row can be claimed by a user-owned
-      // connection), so the platform's own status is the honest answer. For
-      // the canonical row this is what `computeConnectionAvailability` just
-      // returned, so re-reporting it changes nothing.
-      if (
-        availability.status !== "ok" &&
-        provider === VELLUM_MANAGED_PROVIDER
-      ) {
-        return vellumConnectionAvailability();
-      }
-      return availability;
     } catch (err) {
       return {
         status: "provider_mismatch",

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -41,6 +41,7 @@ import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import { getConnection } from "../../providers/inference/connections.js";
 import { isModelInCatalog } from "../../providers/model-catalog.js";
+import { VELLUM_MANAGED_PROVIDER } from "../../providers/vellum-model-routing.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   commitConfigWrite,
@@ -224,8 +225,14 @@ async function profileAvailability(
       if (!identity) {
         return null;
       }
+      // The managed sentinel is judged as itself, not as the derived
+      // upstream: availability must reject a user-owned row claiming the
+      // canonical name the same way dispatch does. `chatgpt` rows genuinely
+      // store the upstream as their provider, so they keep judging against it.
       return computeConnectionAvailability(
-        identity.expectedProvider,
+        provider === VELLUM_MANAGED_PROVIDER
+          ? provider
+          : identity.expectedProvider,
         identity.connectionName,
       );
     } catch (err) {

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -280,8 +280,8 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
   }
 
   // Canonical names belong to boot seeding, which skips a name already taken
-  // by a user-owned row — leaving the install with no managed connection and a
-  // BYOK row that managed routing must then reject. Refuse the name up front.
+  // by a user-owned row, leaving the install with no managed connection and a
+  // BYOK row that managed routing then ignores. Refuse the name up front.
   if (MANAGED_CONNECTION_NAMES.has(name)) {
     throw new BadRequestError(
       `Connection name "${name}" is reserved for the Vellum-managed connection. Pick another name.`,
@@ -485,12 +485,11 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   //
   // Gated on the row, not the name: an install predating the reserved name can
   // hold a user-owned row here, which boot seeding refuses to overwrite and
-  // managed routing refuses to use. That row must stay deletable — it is the
-  // only way out of the collision.
-  if (
-    MANAGED_CONNECTION_NAMES.has(name) &&
-    isVellumManagedConnection(existing)
-  ) {
+  // managed routing ignores. That row must stay deletable, since deleting it
+  // is what lets boot seeding restore the real managed connection.
+  const claimsManagedName =
+    MANAGED_CONNECTION_NAMES.has(name) && !isVellumManagedConnection(existing);
+  if (MANAGED_CONNECTION_NAMES.has(name) && !claimsManagedName) {
     throw new BadRequestError(
       `Cannot delete managed connection "${name}". This is a Vellum-managed connection that is re-seeded on every startup.`,
     );
@@ -509,7 +508,11 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // managed rows are excluded from the count for the same reason the list
   // route hides them — they aren't user-manageable connections.
   const dp = getDefaultProviderFromConfig(config);
-  if (dp) {
+  // A `vellum` default resolves to the canonical name, so this guard would
+  // otherwise block deleting a row that merely claims that name. Deleting it
+  // does not orphan the default: boot seeding writes the real managed
+  // connection under the same name on the next restart.
+  if (dp && !claimsManagedName) {
     if (name === resolveDefaultConnectionName(dp)) {
       throw new ConflictError(
         `Connection "${name}" is referenced by llm.defaultProvider. Update llm.defaultProvider before deleting.`,

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -39,6 +39,7 @@ import {
   updateConnection,
 } from "../../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
+import { isVellumManagedConnection } from "../../providers/vellum-model-routing.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { deleteSecureKeyAsync } from "../../security/secure-keys.js";
 import {
@@ -278,6 +279,15 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
     throw new BadRequestError("name must be a non-empty string");
   }
 
+  // Canonical names belong to boot seeding, which skips a name already taken
+  // by a user-owned row — leaving the install with no managed connection and a
+  // BYOK row that managed routing must then reject. Refuse the name up front.
+  if (MANAGED_CONNECTION_NAMES.has(name)) {
+    throw new BadRequestError(
+      `Connection name "${name}" is reserved for the Vellum-managed connection. Pick another name.`,
+    );
+  }
+
   const providerResult = ConnectionProviderSchema.safeParse(provider);
   if (!providerResult.success) {
     throw new BadRequestError(
@@ -399,9 +409,12 @@ async function handleUpdateConnection({
   // Managed connections: lock auth to `{type:"platform"}`. The boot upsert in
   // `seedCanonicalConnections` would revert any other value on next restart;
   // reject the write here so the surprise loop never happens. Label remains
-  // user-editable (the boot upsert leaves it alone).
+  // user-editable (the boot upsert leaves it alone). Gated on the row for the
+  // same reason as deletion: a user-owned row under the canonical name is not
+  // re-upserted by boot seeding, so its own auth stays editable.
   if (
     MANAGED_CONNECTION_NAMES.has(name) &&
+    isVellumManagedConnection(existing) &&
     authResult.data.type !== "platform"
   ) {
     throw new BadRequestError(
@@ -469,7 +482,15 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // produces a confusing delete → reappear loop. Reject outright. Mirrors
   // `rejectManagedProfileDeletion` for managed profiles (which are similarly
   // re-overlaid by `seed-inference-profiles.ts` on boot).
-  if (MANAGED_CONNECTION_NAMES.has(name)) {
+  //
+  // Gated on the row, not the name: an install predating the reserved name can
+  // hold a user-owned row here, which boot seeding refuses to overwrite and
+  // managed routing refuses to use. That row must stay deletable — it is the
+  // only way out of the collision.
+  if (
+    MANAGED_CONNECTION_NAMES.has(name) &&
+    isVellumManagedConnection(existing)
+  ) {
     throw new BadRequestError(
       `Cannot delete managed connection "${name}". This is a Vellum-managed connection that is re-seeded on every startup.`,
     );


### PR DESCRIPTION
Fixes the misroute Codex flagged on #39685 ([discussion](https://github.com/vellum-ai/vellum-assistant/pull/39685#discussion_r3691609736)). The finding is real but **not introduced by that PR** — it already ships on `main`, so this stands on its own and unblocks the Balanced repoint.

## The bug

`seedCanonicalConnections` deliberately skips a user-owned `provider_connection` named `vellum` (the name was not reserved before connection consolidation, and overwriting would rewrite a real BYOK row into the platform sentinel). Those installs therefore have **no canonical managed row at all** — just a BYOK row sitting on the name. Dispatch then reads whatever holds it:

1. A `provider: "vellum"` profile resolves its routing identity → `{ connectionName: "vellum", expectedProvider: <model's upstream> }`.
2. The row is not the sentinel, so `isVellumManagedConnection` is false.
3. The generic `connection.provider === expectedProvider` equality passes whenever the managed model's upstream equals the row's provider — and the request goes out on the user's own key, off platform billing and off usage attribution, with nothing logged.

Reachable today: managed Quality pins `gpt-5.6-sol` and managed Latency pins `gpt-5.6-luna`, both `openai`-owned, against a user-owned `vellum`/openai row. #39685 widens it to Balanced, the default active profile.

Note the affected install is a **platform** install. Default profile keys resolve from the default provider's column of the intent × provider matrix (`resolveDefaultProfileForProvider`), so a `provider: "vellum"` body only reaches dispatch when `llm.defaultProvider` is `vellum` (or unset). Those users chose Vellum and are spending credits — the leftover credentials on that row are not what they asked for.

## The fix

Any route through the canonical connection name **resolves through platform auth and ignores a user-owned row claiming that name**. Keyed on the name rather than the declared provider, so it also covers the shape `resolveCallSiteConfig` produces when a call-site tweak pins a concrete upstream over a managed profile (`llm-resolver.ts:426`): the provider is replaced, the managed connection survives, and the route is platform-billed just the same. `canonicalVellumConnection()` builds the managed connection shape without a DB read, so this works precisely on the installs where the canonical row was never seeded. The user's connection is untouched and still serves any profile that names it directly.

- **Preflight** judges the platform rather than the claiming row's credential.
- **Availability** reports the platform's own status for the canonical name. Scoped to that name: a managed default explicitly pinned to some other connection is a real misconfiguration and still reads as a mismatch.
- **Connection-create** rejects the reserved canonical name, so no new collisions get authored (`assertValidCustomProviderIdentity` only covered `openai-compatible` identities).
- **The managed delete guard and PATCH auth lock** are gated on the row (`isVellumManagedConnection`) rather than the name, so a pre-existing user-owned row stays deletable and re-keyable — previously it was frozen in place, which would have left the collision with no exit.

## Behavior change

On an affected install, managed turns move from the user's own API key to platform credits — the billing the user signed up for, and the point of the fix. If the platform is unavailable (signed out, no credits) the route now reports that instead of silently succeeding on someone's personal key.

One existing test asserted the collision should read as `provider_mismatch` in the default-provider status; its stated premise was "dispatch then uses the user row", which is exactly what this removes. Updated to `ok` with a rewritten comment.

A legacy config of the shape `{ provider: "anthropic", provider_connection: "vellum" }` (a BYOK profile pointing at a row the user named `vellum`) now resolves on platform auth as well. That shape is indistinguishable from the resolver-stamped managed route, and treating it as legacy is the accepted trade for closing the gap.

## Verification

- `src/providers/__tests__/vellum-mismatch-routing.test.ts` — new: routes through platform auth rather than the claiming row (the row's provider matches the upstream, so plain equality would have taken it), does not reroute onto another BYOK row for the same upstream, an unavailable platform is a soft miss rather than a fall-through, and the row still serves a profile that names it directly. 8 pass.
- `src/providers/__tests__/preflight-resolved-config.test.ts` — collided route preflights the platform: signed in passes, signed out throws `platform_unauthenticated`. 18 pass.
- `src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts` — new create-reservation and deletable-collision cases; two existing fixtures that seeded the managed row as `provider: "anthropic"` corrected to the shape boot seeding actually writes. 74 pass.
- `src/runtime/routes/__tests__/default-provider-routes.test.ts` — 27 pass, including the updated collision case and the untouched explicit-pin mismatch.
- `agent-loop-override-profile.test.ts` mocked the managed row as a plain fireworks connection; updated to the platform sentinel. 9 pass.
- Also green: `dispatch-connection-routing`, `satellite-connection-routing`, `retry-callsite`, `inference-profiles-routes`, `managed-profile-guard`, `connection-availability-keyless`, `connection-routes-vs-cli-parity`, `credential-security-invariants`, `inference-no-mode-boot-e2e`, `cli/inference-providers`.
- `bun run typecheck:fast` and eslint clean.

Pre-existing, not from this branch: `bun test src/providers/__tests__/` has 10 failures from cross-file pollution — identical set on a stashed baseline, each passes when its file runs alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LERzCcvbM5QqzUYsjZ52Zn

