### PR TITLE
fix: modal lifecycle and touch inspect from plan re-review round 3

### DIFF
--- a/clients/web/src/domains/chat/components/credits-upsell-card.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.tsx
@@ -26,10 +26,11 @@ const ADD_CREDITS_COPY = {
 /**
  * Friendly credits upsell card: a single-CTA credit wall built on
  * {@link BillingErrorBanner}, rendered in the transcript in place of a
- * persisted credits-exhausted provider-error row. Self-contained (it resolves
- * its own CTA mode; the Add Credits CTA opens the shared modal mounted in
- * `ActiveChatView` via {@link useAddCreditsModalStore}), so it can also be
- * mounted outside the transcript with no transcript-specific props.
+ * persisted credits-exhausted provider-error row. Takes no
+ * transcript-specific props and resolves its own CTA mode, so it works
+ * anywhere under `ActiveChatView`, where the shared `LazyAddCreditsModal` the
+ * Add Credits CTA opens (via {@link useAddCreditsModalStore}) is mounted; a
+ * mount outside that tree would have a dead Add Credits CTA.
  */
 export function CreditsUpsellCard() {
   const navigate = useNavigate();

--- a/clients/web/src/domains/chat/components/lazy-add-credits-modal.test.tsx
+++ b/clients/web/src/domains/chat/components/lazy-add-credits-modal.test.tsx
@@ -65,6 +65,22 @@ describe("LazyAddCreditsModal", () => {
     expect(queryByTestId("add-credits-modal-stub")).toBeNull();
   });
 
+  test("unmounting the modal host resets the store so the checkout does not reopen", async () => {
+    // The modal's single stable mount lives in `ActiveChatView`, which
+    // unmounts on SPA navigation (settings/plans), the auto-greet overlay,
+    // and lifecycle transitions. A stale `open` would pop the checkout back
+    // up uninvoked on the next chat mount.
+    useAddCreditsModalStore.getState().setOpen(true);
+    const { findByTestId, unmount } = render(<LazyAddCreditsModal />);
+    expect(await findByTestId("add-credits-modal-stub")).toBeTruthy();
+
+    unmount();
+    expect(useAddCreditsModalStore.getState().open).toBe(false);
+
+    const { queryByTestId } = render(<LazyAddCreditsModal />);
+    expect(queryByTestId("add-credits-modal-stub")).toBeNull();
+  });
+
   test("an open checkout survives its CTA host unmounting", async () => {
     // Mirrors the production arrangement: the banner is a conditionally
     // rendered CTA host, the modal is mounted at a stable ancestor.
@@ -80,8 +96,16 @@ describe("LazyAddCreditsModal", () => {
     expect(await findByTestId("add-credits-modal-stub")).toBeTruthy();
 
     // Balance state flips (e.g. a concurrent turn ends and the warn band
-    // clears): the banner unmounts, the checkout must stay up.
-    rerender(<LazyAddCreditsModal />);
+    // clears): the banner unmounts, the checkout must stay up. The `{null}`
+    // placeholder keeps the modal at the same tree position, mirroring
+    // production where the CTA host unmounts elsewhere in the tree while the
+    // modal's own mount under `ActiveChatView` stays put.
+    rerender(
+      <>
+        {null}
+        <LazyAddCreditsModal />
+      </>,
+    );
 
     expect(queryByText("Your credits are running low")).toBeNull();
     expect(getByTestId("add-credits-modal-stub")).toBeTruthy();

--- a/clients/web/src/domains/chat/components/lazy-add-credits-modal.tsx
+++ b/clients/web/src/domains/chat/components/lazy-add-credits-modal.tsx
@@ -1,4 +1,4 @@
-import { lazy } from "react";
+import { lazy, useEffect } from "react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { useAddCreditsModalStore } from "@/stores/add-credits-modal-store";
@@ -20,6 +20,13 @@ const AddCreditsModal = lazy(() =>
 export function LazyAddCreditsModal() {
   const open = useAddCreditsModalStore.use.open();
   const setOpen = useAddCreditsModalStore.use.setOpen();
+  // The store outlives this stable mount, so an `open` left behind when the
+  // chat host unmounts (SPA navigation to settings/plans, the auto-greet
+  // overlay, an assistant-lifecycle transition) would pop the checkout back
+  // up uninvoked on the next chat mount. Closing on unmount scopes an open
+  // checkout to the life of its host while still letting it survive its CTA
+  // (banner/card) unmounting.
+  useEffect(() => () => useAddCreditsModalStore.getState().setOpen(false), []);
   if (!open) {
     return null;
   }

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -3,7 +3,6 @@ import {
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -42,6 +41,7 @@ import {
   isSubagentSpawnCall,
 } from "@/domains/chat/transcript/message-content";
 import { AcpConnectAffordance } from "@/domains/chat/transcript/acp-connect-affordance";
+import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
 import { AssistantContentDisclosure } from "@/domains/chat/transcript/assistant-content-disclosure";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
 import { useSmoothStreamText } from "@/domains/chat/hooks/use-smooth-stream-text";
@@ -208,8 +208,7 @@ export function TranscriptMessageBody({
       ? onRetryLatestTurn
       : undefined;
 
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const [revealed, setRevealed] = useState(false);
+  const { wrapperRef, revealed, toggleRevealed } = useCoarsePointerReveal();
   const slackMessageUrl = getExternalLinkUrl(message.slackMessage?.messageLink);
 
   const [longPressOpen, setLongPressOpen] = useState(false);
@@ -249,24 +248,6 @@ export function TranscriptMessageBody({
     }
   }, []);
 
-  useEffect(() => {
-    if (!revealed) {
-      return;
-    }
-    const onDocPointerDown = (e: PointerEvent) => {
-      const target = e.target as Node | null;
-      if (
-        target &&
-        wrapperRef.current &&
-        !wrapperRef.current.contains(target)
-      ) {
-        setRevealed(false);
-      }
-    };
-    document.addEventListener("pointerdown", onDocPointerDown);
-    return () => document.removeEventListener("pointerdown", onDocPointerDown);
-  }, [revealed]);
-
   const handleBubbleClick = useCallback(
     (e: ReactMouseEvent<HTMLDivElement>) => {
       // Suppress the click that follows a long-press activation so the
@@ -291,9 +272,9 @@ export function TranscriptMessageBody({
       if (!isPointerCoarse()) {
         return;
       }
-      setRevealed((v) => !v);
+      toggleRevealed();
     },
-    [slackMessageUrl],
+    [slackMessageUrl, toggleRevealed],
   );
 
   const linkedSubagentEntries = useSubagentStore((s) =>

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -114,4 +114,67 @@ describe("TranscriptRow creditsUpsell dispatch", () => {
 
     expect(container.querySelector('[title="Inspect"]')).toBeNull();
   });
+
+  test("a coarse-pointer tap reveals the actions; tapping outside dismisses", () => {
+    // Touch screens have no hover and no focus-visible path to the actions
+    // row, so the substituted card mirrors ordinary rows' tap-to-reveal:
+    // tapping the row stamps `data-revealed=true` on the `group/msg` wrapper
+    // (which the actions row's `group-data-[revealed=true]/msg:opacity-100`
+    // class keys off), and a press outside the row dismisses it.
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: mock((query: string) => ({
+        matches: query === "(pointer: coarse)",
+        media: query,
+        onchange: null,
+        addListener: mock(() => {}),
+        removeListener: mock(() => {}),
+        addEventListener: mock(() => {}),
+        removeEventListener: mock(() => {}),
+        dispatchEvent: mock(() => false),
+      })),
+    });
+
+    try {
+      const { container, getByTestId } = render(
+        <TranscriptRow
+          item={substitutedItem("m1")}
+          onSurfaceAction={() => {}}
+          onInspectMessage={() => {}}
+        />,
+      );
+      const wrapper = container.querySelector("#msg-m1")!;
+      expect(wrapper.getAttribute("data-revealed")).toBe("false");
+
+      fireEvent.click(getByTestId("credits-upsell-card-stub"));
+      expect(wrapper.getAttribute("data-revealed")).toBe("true");
+
+      fireEvent.pointerDown(document.body);
+      expect(wrapper.getAttribute("data-revealed")).toBe("false");
+    } finally {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
+  test("a fine-pointer click does not toggle the reveal state", () => {
+    // Desktop keeps hover/focus-visible as the only reveal paths; clicking
+    // the row must not latch the actions open.
+    const { container, getByTestId } = render(
+      <TranscriptRow
+        item={substitutedItem("m1")}
+        onSurfaceAction={() => {}}
+        onInspectMessage={() => {}}
+      />,
+    );
+    const wrapper = container.querySelector("#msg-m1")!;
+
+    fireEvent.click(getByTestId("credits-upsell-card-stub"));
+    expect(wrapper.getAttribute("data-revealed")).toBe("false");
+  });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -1,4 +1,8 @@
-import { memo, type ReactNode } from "react";
+import {
+  memo,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { CreditsUpsellCard } from "@/domains/chat/components/credits-upsell-card";
@@ -12,8 +16,12 @@ import { PendingContactRequestRow } from "@/domains/chat/transcript/pending-cont
 import { PendingSecretRow } from "@/domains/chat/transcript/pending-secret-row";
 import { SystemCardRow } from "@/domains/chat/transcript/system-card-row";
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
+import { isInteractiveClickTarget } from "@/domains/chat/transcript/transcript-message-body-shared";
+import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
+import { isPointerCoarse } from "@/utils/pointer";
 import type { ConfirmationDecision } from "@/types/event-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { DisplayMessage } from "@/domains/chat/types/types";
 
 /**
  * Thin dispatcher: render one `TranscriptItem` using the matching existing
@@ -84,6 +92,66 @@ export interface TranscriptRowProps {
    *  `TranscriptMessageBody` so the message directly above the parked avatar
    *  collapses its hover-actions row and animates it open on hover. */
   isLatestMessage?: boolean;
+}
+
+/**
+ * A credits upsell card substituted for a credits-exhausted provider-error
+ * row: a standalone card, outside the persona bubble/avatar machinery like
+ * `SystemCardRow`. It keeps the `msg-<id>` DOM anchor that
+ * `TranscriptHandle.scrollToMessage` and the `?message=<id>` deep link
+ * resolve via `getElementById`, and exposes the same Inspect affordance as
+ * ordinary rows: the daemon backfills the failed request's LLM logs onto
+ * this row's message id, and inspection is their only entry point while the
+ * bubble is substituted. The actions reveal on hover/focus-visible, and on
+ * coarse pointers via tap (dismissed by tapping outside), mirroring
+ * `TranscriptMessageBody`'s reveal behavior.
+ */
+function CreditsUpsellMessageRow({
+  message,
+  conversationId,
+  onInspectMessage,
+}: {
+  message: DisplayMessage;
+  conversationId?: string | null;
+  onInspectMessage?: (messageId: string) => void;
+}) {
+  const { wrapperRef, revealed, toggleRevealed } = useCoarsePointerReveal();
+  const handleClick = (e: ReactMouseEvent<HTMLDivElement>) => {
+    if (isInteractiveClickTarget(e.target as Element | null)) {
+      return;
+    }
+    if (!isPointerCoarse()) {
+      return;
+    }
+    toggleRevealed();
+  };
+
+  const messageId = message.id;
+  const inspectHandler =
+    onInspectMessage && messageId
+      ? () => onInspectMessage(messageId)
+      : undefined;
+  return (
+    <div
+      ref={wrapperRef}
+      id={messageId ? `msg-${messageId}` : undefined}
+      data-message-id={messageId || undefined}
+      data-revealed={revealed}
+      onClick={handleClick}
+      className="group/msg flex flex-col gap-2"
+    >
+      <CreditsUpsellCard />
+      {inspectHandler && (
+        <div className="h-6 overflow-hidden opacity-0 transition-opacity duration-200 ease-out group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100 motion-reduce:transition-none">
+          <MessageHoverActions
+            message={message}
+            conversationId={conversationId}
+            onInspect={inspectHandler}
+          />
+        </div>
+      )}
+    </div>
+  );
 }
 
 export const TranscriptRow = memo(function TranscriptRow({
@@ -211,39 +279,16 @@ export const TranscriptRow = memo(function TranscriptRow({
 
     case "creditsUpsell": {
       // Substituted in place of a credits-exhausted provider-error row by
-      // `buildTranscriptItems`: a standalone card, outside the persona
-      // bubble/avatar machinery like `SystemCardRow`. Substituted items carry
-      // the underlying row (`message`), so they keep the `msg-<id>` DOM
-      // anchor that `TranscriptHandle.scrollToMessage` and the `?message=<id>`
-      // deep link resolve via `getElementById`, and expose the same
-      // hover-revealed Inspect affordance as ordinary rows: the daemon
-      // backfills the failed request's LLM logs onto this row's message id,
-      // and inspection is their only entry point while the bubble is
-      // substituted. The proactive tail card has no backing message and needs
-      // neither.
+      // `buildTranscriptItems`. Substituted items carry the underlying row
+      // (`message`) and render through `CreditsUpsellMessageRow`; the
+      // proactive tail card has no backing message and renders the bare card.
       if (item.message) {
-        const messageId = item.message.id;
-        const inspectHandler =
-          onInspectMessage && messageId
-            ? () => onInspectMessage(messageId)
-            : undefined;
         return (
-          <div
-            id={messageId ? `msg-${messageId}` : undefined}
-            data-message-id={messageId || undefined}
-            className="group/msg flex flex-col gap-2"
-          >
-            <CreditsUpsellCard />
-            {inspectHandler && (
-              <div className="h-6 overflow-hidden opacity-0 transition-opacity duration-200 ease-out group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 motion-reduce:transition-none">
-                <MessageHoverActions
-                  message={item.message}
-                  conversationId={conversationId}
-                  onInspect={inspectHandler}
-                />
-              </div>
-            )}
-          </div>
+          <CreditsUpsellMessageRow
+            message={item.message}
+            conversationId={conversationId}
+            onInspectMessage={onInspectMessage}
+          />
         );
       }
       return <CreditsUpsellCard />;

--- a/clients/web/src/domains/chat/transcript/use-coarse-pointer-reveal.ts
+++ b/clients/web/src/domains/chat/transcript/use-coarse-pointer-reveal.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Tap-to-reveal state for a transcript row whose actions are hover-revealed.
+ * Hover and focus-visible cannot surface those actions on touch screens, so
+ * the row wrapper stamps `data-revealed={revealed}` (styled via
+ * `group-data-[revealed=true]/msg:*` classes) and calls `toggleRevealed()`
+ * from its coarse-pointer tap handler. While revealed, a document-level
+ * pointerdown listener dismisses the reveal on any press outside `wrapperRef`.
+ */
+export function useCoarsePointerReveal() {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    if (!revealed) {
+      return;
+    }
+    const onDocPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (
+        target &&
+        wrapperRef.current &&
+        !wrapperRef.current.contains(target)
+      ) {
+        setRevealed(false);
+      }
+    };
+    document.addEventListener("pointerdown", onDocPointerDown);
+    return () => document.removeEventListener("pointerdown", onDocPointerDown);
+  }, [revealed]);
+
+  const toggleRevealed = useCallback(() => setRevealed((v) => !v), []);
+
+  return { wrapperRef, revealed, toggleRevealed };
+}

--- a/clients/web/src/stores/add-credits-modal-store.ts
+++ b/clients/web/src/stores/add-credits-modal-store.ts
@@ -7,8 +7,10 @@ import { createSelectors } from "@/utils/create-selectors";
  * CTAs (the low-balance composer banner, the credits upsell card) only write
  * `open`; the modal is mounted once at a stable ancestor (`ActiveChatView`)
  * that outlives the CTAs, so an in-progress checkout survives its trigger
- * unmounting when live billing state changes mid-interaction. In-memory only:
- * a reload never resumes an open checkout.
+ * unmounting when live billing state changes mid-interaction. The modal mount
+ * resets `open` when it unmounts, so SPA-navigating away from chat also
+ * closes the checkout instead of leaving it to reopen on the next chat mount.
+ * In-memory only: a reload never resumes an open checkout.
  *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan re-review (round 3) for credits-ux.md.

**Gap:** stale checkout reopens after navigating away; inspect actions unreachable on touch; docstring overstates card mountability
**What was expected:** checkout closes with the chat host; tap reveals row actions on coarse pointers; docs match reality
**What was found:** no store reset on stable-mount unmount; hover/focus-only reveal; stale mount contract
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->