### PR TITLE
daemon: emit chat.assistant_reply from the deferred turn tail on message_complete

### DIFF
--- a/assistant/src/__tests__/conversation-retry-route.test.ts
+++ b/assistant/src/__tests__/conversation-retry-route.test.ts
@@ -24,13 +24,6 @@ mock.module("../config/env.js", () => ({
 
 mock.module("../daemon/conversation-process.js", () => ({
   formatSummarizeUpToResult: () => "",
-  isEchoSuppressedUserMessage: (
-    metadata: Record<string, unknown> | undefined,
-  ) =>
-    metadata?.hidden === true ||
-    typeof metadata?.backgroundEventSource === "string",
-  isBackgroundEventMetadata: (metadata: Record<string, unknown> | undefined) =>
-    typeof metadata?.backgroundEventSource === "string",
 }));
 
 mock.module("../daemon/handlers/conversations.js", () => ({
@@ -77,6 +70,13 @@ mock.module("../persistence/conversation-crud.js", () => ({
   extractImageSourcePaths: () => undefined,
   forkConversation: () => ({ id: "forked" }),
   getConversation: getConversationMock,
+  isBackgroundEventMetadata: (metadata: Record<string, unknown> | undefined) =>
+    typeof metadata?.backgroundEventSource === "string",
+  isEchoSuppressedUserMessage: (
+    metadata: Record<string, unknown> | undefined,
+  ) =>
+    metadata?.hidden === true ||
+    typeof metadata?.backgroundEventSource === "string",
   provenanceFromTrustContext: () => ({ provenanceTrustClass: "unknown" }),
   setConversationSurfaced: () => null,
   unarchiveConversation: () => true,

--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -99,6 +99,10 @@ const BASELINE: Record<string, readonly string[]> = {
     "src/home/feed-source-enrichment.ts",
     "src/permissions/checker.ts",
     "src/persistence/conversation-crud.ts",
+    // `resolveConversationKind` compares a conversation's `source` against the
+    // memory-consolidation source. The reach is one frozen string constant with
+    // no dependencies of its own.
+    "src/persistence/conversation-types.ts",
     "src/persistence/steps.ts",
     "src/prompts/system-prompt.ts",
     "src/runtime/routes/consolidation-routes.ts",

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -338,7 +338,10 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
     expect(fake.lastPersistOpts()?.content).toBe(
       ESCALATION_CONTINUATION_CONTENT,
     );
-    expect(fake.lastPersistOpts()?.metadata).toEqual({ hidden: true });
+    expect(fake.lastPersistOpts()?.metadata).toEqual({
+      voiceSessionTurn: true,
+      hidden: true,
+    });
   });
 
   test("the opener prompt is persisted un-hidden (unchanged)", async () => {
@@ -347,7 +350,33 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
 
     await startVoiceTurn(makeTurnOptions()); // content: CALL_OPENING_MARKER
 
-    expect(fake.lastPersistOpts()?.metadata).toBeUndefined();
+    expect(fake.lastPersistOpts()?.metadata).toEqual({
+      voiceSessionTurn: true,
+    });
+  });
+});
+
+describe("startVoiceTurn voice-origin marker", () => {
+  // The reply to a voice turn is spoken back over the open session, so
+  // downstream consumers (the assistant-reply push producer) need a durable
+  // way to recognize the row. The channel fields cannot serve: live voice
+  // persists as `vellum`/`macos`, the same as a typed desktop send.
+  test("every persisted voice row carries voiceSessionTurn", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what's the weather",
+      userMessageChannel: "vellum",
+      userMessageInterface: "macos",
+    });
+
+    expect(
+      realConversationCrud.isVoiceSessionUserMessage(
+        fake.lastPersistOpts()?.metadata as Record<string, unknown>,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -390,7 +419,10 @@ describe("startVoiceTurn hiddenSyntheticPrompt", () => {
     );
 
     expect(fake.lastPersistOpts()?.content).toBe(SYNTHETIC_CONTENT);
-    expect(fake.lastPersistOpts()?.metadata).toEqual({ hidden: true });
+    expect(fake.lastPersistOpts()?.metadata).toEqual({
+      voiceSessionTurn: true,
+      hidden: true,
+    });
     expect(echoes).toHaveLength(0);
   });
 
@@ -405,7 +437,9 @@ describe("startVoiceTurn hiddenSyntheticPrompt", () => {
       }),
     );
 
-    expect(fake.lastPersistOpts()?.metadata).toBeUndefined();
+    expect(fake.lastPersistOpts()?.metadata).toEqual({
+      voiceSessionTurn: true,
+    });
     expect(echoes).toEqual([
       expect.objectContaining({ text: SYNTHETIC_CONTENT }),
     ]);

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -872,7 +872,13 @@ export async function startVoiceTurn(
     const persistResult = await conversation.persistUserMessage({
       content: persistedContent,
       requestId,
-      ...(isHiddenSyntheticPrompt ? { metadata: { hidden: true } } : {}),
+      metadata: {
+        // Durable "this turn came from an open voice session" marker. The
+        // channel fields cannot carry it: live voice persists as
+        // `vellum`/`macos`, indistinguishable from a typed desktop send.
+        voiceSessionTurn: true,
+        ...(isHiddenSyntheticPrompt ? { hidden: true } : {}),
+      },
     });
     return persistResult.id;
   };

--- a/assistant/src/daemon/__tests__/turn-tail-assistant-reply-notify.test.ts
+++ b/assistant/src/daemon/__tests__/turn-tail-assistant-reply-notify.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Wiring tests for the `chat.assistant_reply` emit in `runDeferredTurnTail`.
+ *
+ * Coverage matrix:
+ *   - a `message_complete` turn emits exactly once, carrying the conversation
+ *     id and the turn's last assistant row id;
+ *   - handoff and cancellation outcomes never emit;
+ *   - a completed turn that produced no assistant row never emits;
+ *   - the emit runs after the deferred finalize effects, so the producer's
+ *     unseen check reads the attention cursor this turn just projected;
+ *   - the tail does not await the producer, and a producer failure cannot
+ *     break turn finalization.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+import { setConfig } from "../../__tests__/helpers/set-config.js";
+import type { InflightContentWriter } from "../inflight-message-content.js";
+
+// The finalize module's import graph reaches the memory indexer; keep it inert
+// so no embedding backend is touched.
+setConfig("memory", { enabled: false, v2: { enabled: false } });
+
+const CONVERSATION_ID = "conv-tail-1";
+const ASSISTANT_MESSAGE_ID = "msg-assistant-1";
+
+interface EmitCall {
+  conversationId: string;
+  assistantMessageId: string;
+}
+
+const emitCalls: EmitCall[] = [];
+/** Ordered trace of the tail's deferred work, for the ordering assertion. */
+const trace: string[] = [];
+let producerBehavior: "resolve" | "reject" | "hang" = "resolve";
+
+mock.module("../../notifications/assistant-reply-producer.js", () => ({
+  emitAssistantReplyNotification: (params: EmitCall): Promise<void> => {
+    emitCalls.push({
+      conversationId: params.conversationId,
+      assistantMessageId: params.assistantMessageId,
+    });
+    trace.push("emit");
+    if (producerBehavior === "reject") {
+      const rejected = Promise.reject(new Error("simulated producer failure"));
+      // The call site fires the producer without awaiting it, so nothing in
+      // the tail observes this rejection. Settle it here so the failure stays
+      // a test fixture rather than a process-level unhandled rejection.
+      rejected.catch(() => {});
+      return rejected;
+    }
+    if (producerBehavior === "hang") {
+      return new Promise<void>(() => {});
+    }
+    return Promise.resolve();
+  },
+}));
+
+const realCrud = await import("../../persistence/conversation-crud.js");
+mock.module("../../persistence/conversation-crud.js", () => ({
+  ...realCrud,
+  // No conversation row: the tail's truncation and disk-sync steps
+  // short-circuit, keeping these tests on the notify wiring.
+  getConversation: () => null,
+}));
+
+const { runDeferredTurnTail } =
+  await import("../conversation-turn-finalize.js");
+
+const rlog = makeMockLogger() as Parameters<
+  typeof runDeferredTurnTail
+>[0]["rlog"];
+
+async function runTail(overrides: {
+  turnCompleted: boolean;
+  lastAssistantMessageId?: string | undefined;
+  deferredFinalizeEffects?: ReadonlyArray<() => Promise<void>>;
+}): Promise<void> {
+  await runDeferredTurnTail({
+    ctx: { conversationId: CONVERSATION_ID, messages: [] },
+    state: {
+      deferredFinalizeEffects: overrides.deferredFinalizeEffects ?? [],
+      lastAssistantMessageId:
+        "lastAssistantMessageId" in overrides
+          ? overrides.lastAssistantMessageId
+          : ASSISTANT_MESSAGE_ID,
+      inflightWriters: new Map<string, InflightContentWriter>(),
+    },
+    rlog,
+    generationCompletedAt: Date.now(),
+    turnCompleted: overrides.turnCompleted,
+  });
+}
+
+beforeEach(() => {
+  emitCalls.length = 0;
+  trace.length = 0;
+  producerBehavior = "resolve";
+});
+
+describe("runDeferredTurnTail assistant-reply notification", () => {
+  test("emits once for a completed turn", async () => {
+    await runTail({ turnCompleted: true });
+
+    expect(emitCalls).toEqual([
+      {
+        conversationId: CONVERSATION_ID,
+        assistantMessageId: ASSISTANT_MESSAGE_ID,
+      },
+    ]);
+  });
+
+  test("stays silent for a handed-off or cancelled turn", async () => {
+    await runTail({ turnCompleted: false });
+
+    expect(emitCalls).toEqual([]);
+  });
+
+  test("stays silent when the turn produced no assistant row", async () => {
+    await runTail({ turnCompleted: true, lastAssistantMessageId: undefined });
+
+    expect(emitCalls).toEqual([]);
+  });
+
+  test("emits after the deferred finalize effects have run", async () => {
+    await runTail({
+      turnCompleted: true,
+      deferredFinalizeEffects: [
+        async () => {
+          trace.push("effect-1");
+        },
+        async () => {
+          trace.push("effect-2");
+        },
+      ],
+    });
+
+    expect(trace).toEqual(["effect-1", "effect-2", "emit"]);
+  });
+
+  test("completes without awaiting the producer, even when it never settles", async () => {
+    producerBehavior = "hang";
+
+    await runTail({ turnCompleted: true });
+
+    expect(emitCalls).toHaveLength(1);
+  });
+
+  test("survives a failing producer", async () => {
+    producerBehavior = "reject";
+
+    await runTail({ turnCompleted: true });
+
+    expect(emitCalls).toHaveLength(1);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -620,6 +620,10 @@ export async function runAgentLoopImpl(
   // has been emitted. Guards the catch block: an error thrown afterwards
   // (deferred turn-tail bookkeeping) must not relabel a visibly-replied turn.
   let turnReplied = false;
+  // Narrower than `turnReplied`: true only for the `message_complete` branch.
+  // A handed-off generation continues the run, so the deferred tail must not
+  // treat its reply as final.
+  let turnCompleted = false;
 
   const publishLoopMessagesChanged = (): void => {
     if (
@@ -1506,6 +1510,7 @@ export async function runAgentLoopImpl(
         publishLoopMessagesChanged();
       } else {
         turnReplied = true;
+        turnCompleted = true;
         ctx.emitActivityState("idle", "message_complete", {
           anchor: "global",
           requestId: reqId,
@@ -1541,7 +1546,13 @@ export async function runAgentLoopImpl(
     // drain the deferred bookkeeping — after the SSE, before the `finally`
     // commits and drains the queue for the next turn.
     await settlePendingPartialFlush(state, deps);
-    await runDeferredTurnTail({ ctx, state, rlog, generationCompletedAt });
+    await runDeferredTurnTail({
+      ctx,
+      state,
+      rlog,
+      generationCompletedAt,
+      turnCompleted,
+    });
   } catch (err) {
     clearConversationNotices(ctx.conversationId);
     const errorCtx = {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -24,6 +24,7 @@ import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
 import {
   addMessage,
+  isEchoSuppressedUserMessage,
   isHiddenMessageMetadata,
   provenanceFromTrustContext,
   recordConversationPersistedSeq,
@@ -62,48 +63,6 @@ import { buildTransportHints } from "./transport-hints.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
 const log = getLogger("conversation-process");
-
-/**
- * Daemon-injected run lifecycle notifications — subagent (`subagentNotification`),
- * ACP run (`acpNotification`), and any wake trigger (the persisted
- * `<background_event source="...">` row every wake reads) — are persisted into
- * the parent conversation so the orchestrator wakes and reads the trigger, but
- * they are internal scaffolding: the user sees the wake through its inline card
- * ("Conversation Woke", or a terminal card for a backgrounded bash run), not a
- * chat turn. Skip the `user_message_echo` broadcast for these so they never
- * render as a live user bubble; the persisted row is filtered from the rendered
- * transcript on the client.
- *
- * Messages explicitly flagged `hidden` (a hidden `POST /messages` send that
- * queued behind an in-flight turn, e.g. the channel-setup wizard-close
- * marker) are suppressed the same way — the immediate route path already
- * skips their echo, and the persisted `hidden` metadata keeps them out of
- * the fetched transcript.
- */
-export function isEchoSuppressedUserMessage(
-  metadata: Record<string, unknown> | undefined,
-): boolean {
-  return (
-    isHiddenMessageMetadata(metadata) ||
-    metadata?.subagentNotification != null ||
-    metadata?.acpNotification != null ||
-    isBackgroundEventMetadata(metadata)
-  );
-}
-
-/**
- * True when the row is a persisted `<background_event source="...">` trigger —
- * every wake, scheduled run, and backgrounded-tool completion stamps one (see
- * {@link persistWakeTriggerMessage}). The permission mode such a turn ran under
- * varies (most run interactive; clientless/headless wakes do not) and is
- * recorded separately in `backgroundEventInteractive`; this predicate only
- * identifies the row as a background event.
- */
-export function isBackgroundEventMetadata(
-  metadata: Record<string, unknown> | undefined,
-): boolean {
-  return typeof metadata?.backgroundEventSource === "string";
-}
 
 /** Locale-formatted count for the user-facing context stats cards. */
 const fmt = (n: number | undefined) => (n ?? 0).toLocaleString("en-US");

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -22,6 +22,7 @@ import {
   derefToolResultReReads,
   postTurnTruncateToolResults,
 } from "../context/post-turn-tool-result-truncation.js";
+import { emitAssistantReplyNotification } from "../notifications/assistant-reply-producer.js";
 import { projectAssistantMessage } from "../persistence/conversation-attention-store.js";
 import {
   getConversation,
@@ -142,8 +143,13 @@ export async function runDeferredTurnTail(params: {
   state: TurnTailState;
   rlog: pino.Logger;
   generationCompletedAt: number;
+  /**
+   * True only for a `message_complete` turn. A handed-off generation is not
+   * the end of the run, and a cancelled one has no final reply.
+   */
+  turnCompleted: boolean;
 }): Promise<void> {
-  const { ctx, state, rlog, generationCompletedAt } = params;
+  const { ctx, state, rlog, generationCompletedAt, turnCompleted } = params;
   const tailStartedAt = Date.now();
 
   // Per-message memory/attention finalize side-effects deferred from
@@ -155,6 +161,19 @@ export async function runDeferredTurnTail(params: {
     } catch (err) {
       rlog.warn({ err }, "Deferred finalize side-effect failed (non-fatal)");
     }
+  }
+
+  // Notify about a finished reply the user is no longer looking at. Ordered
+  // after the loop above so the producer's unseen check reads the attention
+  // cursor this turn's last row just projected. Not awaited: the pipeline
+  // awaits the platform adapter's HTTP dispatch, which retries with backoff,
+  // and nothing below here depends on the emit. The producer never rejects.
+  if (turnCompleted && state.lastAssistantMessageId) {
+    void emitAssistantReplyNotification({
+      conversationId: ctx.conversationId,
+      assistantMessageId: state.lastAssistantMessageId,
+      rlog,
+    });
   }
 
   // Post-turn tool-result truncation: spool oversized results to disk and

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -9,6 +9,7 @@
  *   - An `automated: true` initiating user message is silent.
  *   - A hidden lifecycle row (subagent / ACP notification) opening the turn is
  *     silent.
+ *   - A live phone / in-app voice utterance opening the turn is silent.
  *   - An already-seen reply is silent.
  *   - A tool-only reply (empty text preview) is silent.
  *   - A throwing dependency is swallowed, not propagated.
@@ -333,6 +334,55 @@ describe("emitAssistantReplyNotification", () => {
       expect(emitCalls).toHaveLength(0);
     });
   }
+
+  // A voice utterance persists as an ordinary visible user row on a standard
+  // conversation, so only the `voiceSessionTurn` marker the bridge stamps keeps
+  // every spoken reply from also pushing. The phone case carries a `phone`
+  // channel; the in-app live-voice case is `vellum`/`macos`, identical to a
+  // typed desktop send, which is why the channel fields cannot be the gate.
+  const VOICE_ROW_CASES: Array<{ name: string; metadata: unknown }> = [
+    {
+      name: "phone call",
+      metadata: {
+        voiceSessionTurn: true,
+        userMessageChannel: "phone",
+        userMessageInterface: "phone",
+      },
+    },
+    {
+      name: "in-app live voice",
+      metadata: {
+        voiceSessionTurn: true,
+        userMessageChannel: "vellum",
+        userMessageInterface: "macos",
+      },
+    },
+  ];
+
+  for (const { name, metadata } of VOICE_ROW_CASES) {
+    test(`stays silent when the turn was opened by a ${name} utterance`, async () => {
+      userRows = [makeMessage({ metadata: JSON.stringify(metadata) })];
+
+      await run();
+
+      expect(emitCalls).toHaveLength(0);
+    });
+  }
+
+  test("still emits for a typed desktop send on the same channel", async () => {
+    userRows = [
+      makeMessage({
+        metadata: JSON.stringify({
+          userMessageChannel: "vellum",
+          userMessageInterface: "macos",
+        }),
+      }),
+    ];
+
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+  });
 
   test("stays silent when no real user message opened the turn", async () => {
     userRows = [];

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -7,6 +7,8 @@
  *   - Every non-"user" kind of the shared `resolveConversationKind` classifier
  *     is silent.
  *   - An `automated: true` initiating user message is silent.
+ *   - A hidden lifecycle row (subagent / ACP notification) opening the turn is
+ *     silent.
  *   - An already-seen reply is silent.
  *   - A tool-only reply (empty text preview) is silent.
  *   - A throwing dependency is swallowed, not propagated.
@@ -299,6 +301,38 @@ describe("emitAssistantReplyNotification", () => {
 
     expect(emitCalls).toHaveLength(0);
   });
+
+  // Hidden lifecycle rows persist with role "user" and are neither tool
+  // results nor `automated`, so only the shared echo-suppression classifier
+  // keeps a subagent or ACP completion turn from pushing a reply.
+  const LIFECYCLE_ROW_CASES: Array<{ name: string; metadata: unknown }> = [
+    {
+      name: "subagent notification",
+      metadata: {
+        subagentNotification: {
+          subagentId: "sub-1",
+          label: "researcher",
+          status: "running",
+          conversationId: "conv-child-1",
+          objective: "look something up",
+        },
+      },
+    },
+    {
+      name: "ACP notification",
+      metadata: { acpNotification: { acpSessionId: "acp-1", agent: "codex" } },
+    },
+  ];
+
+  for (const { name, metadata } of LIFECYCLE_ROW_CASES) {
+    test(`stays silent when the turn was opened by a ${name} row`, async () => {
+      userRows = [makeMessage({ metadata: JSON.stringify(metadata) })];
+
+      await run();
+
+      expect(emitCalls).toHaveLength(0);
+    });
+  }
 
   test("stays silent when no real user message opened the turn", async () => {
     userRows = [];

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -10,6 +10,8 @@
  *   - A hidden lifecycle row (subagent / ACP notification) opening the turn is
  *     silent.
  *   - A live phone / in-app voice utterance opening the turn is silent.
+ *   - A turn opened from a messaging channel (Slack, Telegram, …) is silent,
+ *     while the in-app `vellum` channel and an unstamped row still emit.
  *   - An already-seen reply is silent.
  *   - A tool-only reply (empty text preview) is silent.
  *   - A throwing dependency is swallowed, not propagated.
@@ -339,7 +341,8 @@ describe("emitAssistantReplyNotification", () => {
   // conversation, so only the `voiceSessionTurn` marker the bridge stamps keeps
   // every spoken reply from also pushing. The phone case carries a `phone`
   // channel; the in-app live-voice case is `vellum`/`macos`, identical to a
-  // typed desktop send, which is why the channel fields cannot be the gate.
+  // typed desktop send, which is why the channel field cannot stand in for the
+  // marker.
   const VOICE_ROW_CASES: Array<{ name: string; metadata: unknown }> = [
     {
       name: "phone call",
@@ -376,6 +379,39 @@ describe("emitAssistantReplyNotification", () => {
           userMessageChannel: "vellum",
           userMessageInterface: "macos",
         }),
+      }),
+    ];
+
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+  });
+
+  // A channel turn's reply is delivered back to the originating surface, so the
+  // sender already has it in Slack/Telegram; a push would be a second copy.
+  for (const channel of ["slack", "telegram"] as const) {
+    test(`stays silent for a turn opened from ${channel}`, async () => {
+      userRows = [
+        makeMessage({
+          metadata: JSON.stringify({
+            userMessageChannel: channel,
+            assistantMessageChannel: channel,
+          }),
+        }),
+      ];
+
+      await run();
+
+      expect(emitCalls).toHaveLength(0);
+    });
+  }
+
+  // Rows predating the channel stamp (and the daemon paths that omit it) are
+  // in-app turns, so an absent channel must not suppress the push.
+  test("still emits when the initiating row carries no channel", async () => {
+    userRows = [
+      makeMessage({
+        metadata: JSON.stringify({ userMessageInterface: "web" }),
       }),
     ];
 

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -16,6 +16,7 @@ import {
   getConversation,
   getMessageById,
   getMessagesPaginated,
+  isEchoSuppressedUserMessage,
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { resolveConversationKind } from "../persistence/conversation-types.js";
@@ -111,7 +112,14 @@ export async function emitAssistantReplyNotification(params: {
     if (!initiatingMessage) {
       return;
     }
-    if (parseMessageMetadata(initiatingMessage.metadata)?.automated === true) {
+    const initiatingMetadata = parseMessageMetadata(initiatingMessage.metadata);
+    if (initiatingMetadata?.automated === true) {
+      return;
+    }
+    // Hidden lifecycle rows (subagent/ACP completions, wake triggers, hidden
+    // sends) are persisted with role "user" but are internal scaffolding, so
+    // the turn they open is nobody's prompt awaiting a reply.
+    if (isEchoSuppressedUserMessage(initiatingMetadata)) {
       return;
     }
 

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -17,6 +17,7 @@ import {
   getMessageById,
   getMessagesPaginated,
   isEchoSuppressedUserMessage,
+  isVoiceSessionUserMessage,
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { resolveConversationKind } from "../persistence/conversation-types.js";
@@ -120,6 +121,12 @@ export async function emitAssistantReplyNotification(params: {
     // sends) are persisted with role "user" but are internal scaffolding, so
     // the turn they open is nobody's prompt awaiting a reply.
     if (isEchoSuppressedUserMessage(initiatingMetadata)) {
+      return;
+    }
+    // A phone or in-app voice utterance is answered out loud over the session
+    // the user is still on, so the reply is never unseen in the sense this
+    // producer notifies about; pushing here would fire once per spoken turn.
+    if (isVoiceSessionUserMessage(initiatingMetadata)) {
       return;
     }
 

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -30,6 +30,27 @@ import { truncate } from "./notification-utils.js";
 const PREVIEW_MAX_CHARS = 200;
 
 /**
+ * The channel id a native-app send carries, and `resolveTurnChannel`'s default
+ * when a caller supplies none (see `daemon/process-message.ts`).
+ */
+const IN_APP_CHANNEL = "vellum";
+
+/**
+ * True when the row that opened the turn arrived over an external messaging
+ * surface (Slack, Telegram, WhatsApp, email, a phone call, …) rather than the
+ * native app.
+ *
+ * An absent channel counts as in-app: rows persisted before the stamp existed,
+ * and the daemon-side paths that omit it, are all native-app turns.
+ */
+function isChannelOriginatedUserMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  const channel = metadata?.userMessageChannel;
+  return typeof channel === "string" && channel !== IN_APP_CHANNEL;
+}
+
+/**
  * Same unseen predicate the sidebar renders from (`buildAssistantAttention` in
  * `runtime/services/conversation-serializer.ts`): the latest assistant cursor
  * is ahead of the last-seen cursor. A missing state row reads as seen, matching
@@ -127,6 +148,14 @@ export async function emitAssistantReplyNotification(params: {
     // the user is still on, so the reply is never unseen in the sense this
     // producer notifies about; pushing here would fire once per spoken turn.
     if (isVoiceSessionUserMessage(initiatingMetadata)) {
+      return;
+    }
+    // A turn started from a messaging channel has its finished reply delivered
+    // back to that channel (`finalizeEventDelivery`), so the sender already has
+    // it; pushing here would duplicate it on their phone. The voice gate above
+    // cannot stand in for this one: an in-app live-voice turn persists as
+    // `vellum`, exactly like a typed send.
+    if (isChannelOriginatedUserMessage(initiatingMetadata)) {
       return;
     }
 

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -40,8 +40,10 @@ const IN_APP_CHANNEL = "vellum";
  * surface (Slack, Telegram, WhatsApp, email, a phone call, …) rather than the
  * native app.
  *
- * An absent channel counts as in-app: rows persisted before the stamp existed,
- * and the daemon-side paths that omit it, are all native-app turns.
+ * An absent channel counts as in-app: every external ingress path stamps its
+ * channel via buildChannelMetadata, so the rows that omit the field are
+ * daemon-internal persists on native-app conversations (for example the
+ * deliberate omission in calls/call-pointer-messages.ts).
  */
 function isChannelOriginatedUserMessage(
   metadata: Record<string, unknown> | undefined,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -361,6 +361,47 @@ export function isHiddenMessageMetadata(
 }
 
 /**
+ * True when the row is a persisted `<background_event source="...">` trigger.
+ * Every wake, scheduled run, and backgrounded-tool completion stamps one (see
+ * `persistWakeTriggerMessage`). The permission mode such a turn ran under
+ * varies (most run interactive; clientless/headless wakes do not) and is
+ * recorded separately in `backgroundEventInteractive`; this predicate only
+ * identifies the row as a background event.
+ */
+export function isBackgroundEventMetadata(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return typeof metadata?.backgroundEventSource === "string";
+}
+
+/**
+ * True when a role-`"user"` row is internal scaffolding rather than a person's
+ * prompt: a daemon-injected run lifecycle notification (subagent
+ * `subagentNotification`, ACP run `acpNotification`, or any wake trigger, the
+ * persisted `<background_event source="...">` row every wake reads), or a row
+ * explicitly flagged `hidden` (e.g. a hidden `POST /messages` send that queued
+ * behind an in-flight turn, like the channel-setup wizard-close marker).
+ *
+ * These rows are persisted so the orchestrator wakes and reads the trigger,
+ * but the user sees the wake through its inline card ("Conversation Woke", or
+ * a terminal card for a backgrounded bash run), not a chat turn. One
+ * definition so the sites that must agree cannot drift: the
+ * `user_message_echo` broadcast (never render a live user bubble), the retry
+ * route's hidden-prompt re-run, and the assistant-reply notification producer
+ * (a turn opened by one of these rows is not a user prompt awaiting a reply).
+ */
+export function isEchoSuppressedUserMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return (
+    isHiddenMessageMetadata(metadata) ||
+    metadata?.subagentNotification != null ||
+    metadata?.acpNotification != null ||
+    isBackgroundEventMetadata(metadata)
+  );
+}
+
+/**
  * `messageKind` value marking a daemon-authored system card — a pre-composed
  * status reply (the /compact, /clean, and summarize-up-to result cards) that
  * bypasses the agent loop. Cards render as standalone system notices, never

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -298,6 +298,14 @@ export const messageMetadataSchema = z
      */
     hidden: z.boolean().optional(),
     /**
+     * Marks a role-`"user"` row that opened a live phone or in-app voice turn
+     * (every row `startVoiceTurn` persists, see `calls/voice-session-bridge.ts`).
+     * The channel/interface fields cannot stand in for it: a live-voice turn
+     * persists as `vellum`/`macos`, exactly like a typed desktop send. Test with
+     * {@link isVoiceSessionUserMessage}.
+     */
+    voiceSessionTurn: z.boolean().optional(),
+    /**
      * Discriminates daemon-authored rows from ordinary turns.
      * `"system_card"` marks pre-composed status cards (the /compact, /clean,
      * and summarize-up-to results); see {@link SYSTEM_CARD_MESSAGE_KIND}.
@@ -399,6 +407,22 @@ export function isEchoSuppressedUserMessage(
     metadata?.acpNotification != null ||
     isBackgroundEventMetadata(metadata)
   );
+}
+
+/**
+ * True when a role-`"user"` row was persisted by the voice bridge for a live
+ * phone call or in-app voice session (see the `voiceSessionTurn` field on
+ * {@link messageMetadataSchema}).
+ *
+ * The reply to such a turn is spoken back over the still-open session, so any
+ * consumer that treats a finished reply as something the user has yet to see
+ * (the assistant-reply notification producer) must skip it rather than push a
+ * notification for audio the user is hearing right now.
+ */
+export function isVoiceSessionUserMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return metadata?.voiceSessionTurn === true;
 }
 
 /**

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -29,11 +29,7 @@ import {
   discardLastAssistantDisplayTurn,
   extractUserPromptText,
 } from "../../daemon/conversation-history.js";
-import {
-  formatSummarizeUpToResult,
-  isBackgroundEventMetadata,
-  isEchoSuppressedUserMessage,
-} from "../../daemon/conversation-process.js";
+import { formatSummarizeUpToResult } from "../../daemon/conversation-process.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
   destroyActiveConversation,
@@ -55,6 +51,8 @@ import {
   deleteConversation,
   forkConversation as forkConversationInStore,
   getConversation,
+  isBackgroundEventMetadata,
+  isEchoSuppressedUserMessage,
   setConversationEnabledPlugins,
   setConversationSurfaced,
   unarchiveConversation,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -53,7 +53,6 @@ import {
   buildModelInfoEvent,
   formatCleanResult,
   formatCompactResult,
-  isBackgroundEventMetadata,
   isModelSlashCommand,
 } from "../../daemon/conversation-process.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
@@ -113,6 +112,7 @@ import {
   getMessages,
   getMessagesPaginated,
   hasMessages,
+  isBackgroundEventMetadata,
   isConversationProcessing,
   isHiddenMessageMetadata,
   isSystemCardMetadata,


### PR DESCRIPTION
## Summary
- Threads the turn's terminal outcome into runDeferredTurnTail; only message_complete turns qualify
- Fire-and-forget call to emitAssistantReplyNotification after attention projection, so a slow platform dispatch cannot delay the next turn
- Completes the LUM-2952 wiring: producer (PR 2) now has its call site

## Drive-by fix
PR #39741 (already merged into this feature branch) added a `plugins/defaults/memory` import to `persistence/conversation-types.ts` for the shared `resolveConversationKind` classifier without updating the host-to-plugin import baseline, leaving `plugin-import-boundary-reverse-guard.test.ts` red on the branch. This PR adds the baseline entry. Justification: the reach is a single frozen string constant with no dependencies of its own.

Part of plan: unseen-reply-notify.md (PR 3 of 3)