### PR TITLE
web: derive apns_environment from the build's signing, falling back to the bundle-suffix heuristic

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
+//
+// The default simulates an old shell without the plugin (bridge call rejects),
+// exercising the bundle-suffix heuristic fallback. Cases that exercise the
+// signing-derived path set `apnsEnvironmentRejects = false` and an explicit
+// `apnsEnvironmentResult`. Mirrors push-registration.test.ts, which covers the
+// resolver's own matrix; these tests pin the ActivityKit upsert to it.
+
+let apnsEnvironmentResult: string | undefined;
+let apnsEnvironmentRejects = true;
+const apnsEnvironmentGetMock = mock(
+  async (): Promise<{ environment?: string }> => {
+    if (apnsEnvironmentRejects) {
+      throw new Error("ApnsEnvironment.get() is not implemented on ios");
+    }
+    return { environment: apnsEnvironmentResult };
+  },
+);
+
+mock.module("@capacitor/core", () => ({
+  registerPlugin: (name: string) =>
+    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
+}));
+
+// ── @capacitor/app (lazy-imported plugin Proxy) ──────────────────────────────
+
+let bundleId = "ai.vocify-inc.vellum-assistant-ios";
+const getInfoMock = mock(async () => ({
+  id: bundleId,
+  name: "Vellum",
+  build: "1",
+  version: "1.0.0",
+}));
+mock.module("@capacitor/app", () => ({
+  App: { getInfo: getInfoMock },
+}));
+
+// ── generated platform SDK ───────────────────────────────────────────────────
+
+interface UpsertArg {
+  path: { assistant_id: string };
+  body: {
+    token: string;
+    bundle_id: string;
+    apns_environment: string;
+    conversation_id: string;
+    labels: Record<string, string>;
+  };
+  throwOnError: boolean;
+}
+
+let lastUpsertArg: UpsertArg | null = null;
+const upsertMock = mock(async (arg: UpsertArg) => {
+  lastUpsertArg = arg;
+  return { data: {}, error: undefined };
+});
+const deleteMock = mock(async () => ({ data: undefined, error: undefined }));
+mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsLiveActivityTokensUpsert: upsertMock,
+  assistantsLiveActivityTokensDelete: deleteMock,
+}));
+
+// ── Sentry capture-error ─────────────────────────────────────────────────────
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { registerLiveActivityPushToken } =
+  await import("@/domains/chat/voice/live-voice/live-activity-push-registration");
+
+beforeEach(() => {
+  bundleId = "ai.vocify-inc.vellum-assistant-ios";
+  apnsEnvironmentResult = undefined;
+  apnsEnvironmentRejects = true;
+  lastUpsertArg = null;
+  apnsEnvironmentGetMock.mockClear();
+  getInfoMock.mockClear();
+  upsertMock.mockClear();
+  deleteMock.mockClear();
+  captureErrorMock.mockClear();
+  localStorage.removeItem("vellum:live_activity_registration");
+});
+
+describe("registerLiveActivityPushToken APNs environment", () => {
+  test("tags the token with the signing-derived environment: production on a .dev bundle (TestFlight dev build)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "production";
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerLiveActivityPushToken(
+      "activity-token-tf",
+      "assistant-1",
+      "conv-1",
+    );
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg?.path).toEqual({ assistant_id: "assistant-1" });
+    expect(lastUpsertArg?.body.token).toBe("activity-token-tf");
+    expect(lastUpsertArg?.body.bundle_id).toBe(
+      "ai.vocify-inc.vellum-assistant-ios.dev",
+    );
+    expect(lastUpsertArg?.body.conversation_id).toBe("conv-1");
+    expect(lastUpsertArg?.body.apns_environment).toBe("production");
+  });
+
+  test("falls back to the bundle-suffix heuristic when the bridge rejects (old shell), without a Sentry capture", async () => {
+    apnsEnvironmentRejects = true;
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerLiveActivityPushToken(
+      "activity-token-old",
+      "assistant-1",
+      "conv-2",
+    );
+
+    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -33,7 +33,6 @@ import {
   assistantsLiveActivityTokensDelete,
   assistantsLiveActivityTokensUpsert,
 } from "@/generated/api/sdk.gen";
-import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
 import {
   isLiveVoiceSessionActive,
   LIVE_VOICE_STATE_LABELS,
@@ -41,20 +40,8 @@ import {
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { captureError } from "@/lib/sentry/capture-error";
+import { resolveSignedApnsEnvironment } from "@/runtime/apns-environment";
 import { createStorageAccessor } from "@/utils/typed-storage";
-
-/**
- * Bundle-id suffix that maps to the development APNs entitlement — the same
- * rule `runtime/push-registration.ts` applies to device tokens, and for the
- * same reason: APNs rejects a token minted under one environment when it is
- * addressed against the other, so the platform stores the environment
- * alongside the token.
- */
-const DEV_BUNDLE_SUFFIX = ".dev";
-
-function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
-  return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
-}
 
 /**
  * Every phase an activity can be pushed into, paired with its wording.
@@ -166,13 +153,17 @@ async function upsertToken(
     // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
     const { App } = await import("@capacitor/app");
     const { id: bundleId } = await App.getInfo();
+    // Shared with the device-token upsert so both registrations tag this
+    // build's tokens with the same APNs environment (signing-derived, with a
+    // bundle-suffix fallback).
+    const apnsEnvironment = await resolveSignedApnsEnvironment(bundleId);
 
     const result = await assistantsLiveActivityTokensUpsert({
       path: { assistant_id: assistantId },
       body: {
         token,
         bundle_id: bundleId,
-        apns_environment: resolveApnsEnvironment(bundleId),
+        apns_environment: apnsEnvironment,
         conversation_id: conversationId,
         labels: phaseLabels(),
       },

--- a/clients/web/src/runtime/apns-environment.ts
+++ b/clients/web/src/runtime/apns-environment.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared resolver for the APNs environment a push token must be tagged with.
+ *
+ * APNs rejects a token minted under one entitlement environment when it is
+ * dispatched against the other, so the platform stores the environment
+ * alongside every token and the value must match the running build. Two token
+ * upserts depend on that tag, and both resolve it here so they can never
+ * disagree: device push tokens (`runtime/push-registration.ts`) and
+ * ActivityKit Live Activity tokens
+ * (`domains/chat/voice/live-voice/live-activity-push-registration.ts`). A
+ * split resolution would let a TestFlight-signed dev build register device
+ * tokens as production while its Live Activity updates get rejected as
+ * sandbox-tagged.
+ *
+ * The primary source is the native `ApnsEnvironment` plugin
+ * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`), which reads the real
+ * `aps-environment` value from the embedded provisioning profile: TestFlight
+ * and App Store builds always carry production APNs tokens regardless of
+ * bundle id, which is exactly the case the bundle-suffix heuristic got wrong
+ * for TestFlight dev builds. Shells predating the plugin, and profiles it
+ * cannot parse, fall back to that heuristic.
+ *
+ * Per `docs/CAPACITOR.md`, only the plugin call's result may cross an `async`
+ * boundary, never the plugin Proxy itself: the Proxy's `.then` trap would hang
+ * the awaiting caller forever.
+ */
+
+import { registerPlugin } from "@capacitor/core";
+
+import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
+
+interface ApnsEnvironmentPlugin {
+  get(): Promise<{ environment?: string }>;
+}
+
+/**
+ * Native plugin reporting the build's real APNs entitlement environment, read
+ * from the embedded provisioning profile
+ * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`). Resolves
+ * `"development"`, `"production"`, or `"unknown"` on modern shells; on older
+ * shells that predate the plugin the bridge call rejects instead.
+ */
+const ApnsEnvironment =
+  registerPlugin<ApnsEnvironmentPlugin>("ApnsEnvironment");
+
+/**
+ * Bundle-id suffix that maps to the development APNs entitlement in the
+ * fallback heuristic, consulted only for shells predating the
+ * `ApnsEnvironment` plugin and for profiles it cannot parse (`"unknown"`).
+ * The dev Xcode config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs
+ * with `App-Dev.entitlements` (`aps-environment = development`) and ships the
+ * `.dev` bundle id; production and staging both sign with `App.entitlements`
+ * (`aps-environment = production`). The heuristic misreads TestFlight-signed
+ * dev builds (production tokens on a `.dev` bundle id), which is why the
+ * signing-derived plugin result wins when available.
+ */
+const DEV_BUNDLE_SUFFIX = ".dev";
+
+/**
+ * Fallback heuristic: map the running build's bundle id to its APNs
+ * entitlement environment. Only consulted when the `ApnsEnvironment` plugin
+ * is absent (older shell) or cannot read the entitlement (`"unknown"`).
+ */
+function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
+  return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
+}
+
+/**
+ * Resolve the environment to tag a push token with, preferring the build's
+ * real signing entitlement over the bundle-suffix heuristic.
+ */
+export async function resolveSignedApnsEnvironment(
+  bundleId: string,
+): Promise<ApnsEnvironmentEnum> {
+  try {
+    // Only the result crosses this `async` boundary, never the plugin Proxy
+    // itself (see CAPACITOR.md).
+    const { environment } = await ApnsEnvironment.get();
+    if (environment === "development" || environment === "production") {
+      return environment;
+    }
+    console.debug(
+      "[apns-environment] unreadable APNs entitlement, using bundle-id heuristic:",
+      environment,
+    );
+  } catch (err) {
+    // `console.debug`, not `captureError`, per the `native-voice.ts` skew
+    // convention: an older App Store/TestFlight shell without the plugin is
+    // an expected state on every web deploy, not a fault.
+    console.debug(
+      "[apns-environment] ApnsEnvironment bridge unavailable, using bundle-id heuristic:",
+      err,
+    );
+  }
+  return resolveApnsEnvironment(bundleId);
+}

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -10,6 +10,25 @@ import { subscribe } from "@/lib/event-bus";
 
 let isNative = true;
 let platform = "ios";
+
+// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
+//
+// The default simulates an old shell without the plugin (bridge call rejects),
+// so the pre-plugin tests below keep exercising the bundle-suffix heuristic
+// they were written against. Cases that exercise the signing-derived path set
+// `apnsEnvironmentRejects = false` and an explicit `apnsEnvironmentResult`.
+
+let apnsEnvironmentResult: string | undefined;
+let apnsEnvironmentRejects = true;
+const apnsEnvironmentGetMock = mock(
+  async (): Promise<{ environment?: string }> => {
+    if (apnsEnvironmentRejects) {
+      throw new Error("ApnsEnvironment.get() is not implemented on ios");
+    }
+    return { environment: apnsEnvironmentResult };
+  },
+);
+
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNative,
 }));
@@ -18,6 +37,8 @@ mock.module("@capacitor/core", () => ({
     isNativePlatform: () => isNative,
     getPlatform: () => platform,
   },
+  registerPlugin: (name: string) =>
+    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
 }));
 
 // ── @capacitor/push-notifications (lazy-imported plugin Proxy) ────────────────
@@ -164,6 +185,9 @@ beforeEach(() => {
   platform = "ios";
   permissionState = "granted";
   bundleId = "ai.vocify-inc.vellum-assistant-ios";
+  apnsEnvironmentResult = undefined;
+  apnsEnvironmentRejects = true;
+  apnsEnvironmentGetMock.mockClear();
   registrationHandler = null;
   registrationErrorHandler = null;
   actionPerformedHandler = null;
@@ -266,6 +290,56 @@ describe("registerForRemotePush", () => {
 
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
     expect(upsertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("signing-derived APNs environment", () => {
+  const registerToken = async (token: string) => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: token });
+    await flushMicrotasks();
+  };
+
+  test("prefers the signed entitlement: production on a .dev bundle (TestFlight dev build)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "production";
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerToken("apns-token-testflight");
+
+    expect(lastUpsertArg?.body.apns_environment).toBe("production");
+  });
+
+  test("registers development when the build is development-signed (Xcode install)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "development";
+
+    await registerToken("apns-token-xcode");
+
+    // The plugin result wins even though the non-.dev bundle id would map to
+    // production under the heuristic.
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+  });
+
+  test("falls back to the bundle-suffix heuristic when the entitlement is unreadable", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "unknown";
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerToken("apns-token-unknown");
+
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+  });
+
+  test("old shell without the plugin: heuristic fallback, no Sentry capture", async () => {
+    apnsEnvironmentRejects = true;
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerToken("apns-token-old-shell");
+
+    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -32,60 +32,27 @@
  * are reported to Sentry but never thrown into the app lifecycle.
  *
  * The upserted row tags the token with the build's APNs entitlement
- * environment. The primary source is the native `ApnsEnvironment` plugin
- * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`), which reads the real
- * `aps-environment` value from the embedded provisioning profile: TestFlight
- * and App Store builds always carry production APNs tokens regardless of
- * bundle id, which is exactly the case the bundle-suffix heuristic got wrong
- * for TestFlight dev builds. Shells predating the plugin, and profiles it
- * cannot parse, fall back to that heuristic ({@link resolveApnsEnvironment}).
+ * environment, resolved by `runtime/apns-environment.ts` (the native
+ * `ApnsEnvironment` plugin with a bundle-suffix heuristic fallback). The
+ * resolver is shared with the ActivityKit Live Activity token upsert so the
+ * two registrations can never tag the same build differently.
  *
  * Per `docs/CAPACITOR.md`, the `@capacitor/*` plugins are destructured inline
  * at each call site — never returned through an `async` boundary — because the
  * plugin Proxy's `.then` trap would hang the awaiting caller forever.
  */
 
-import { Capacitor, registerPlugin } from "@capacitor/core";
+import { Capacitor } from "@capacitor/core";
 
 import {
   assistantsPushTokensDelete,
   assistantsPushTokensUpsert,
 } from "@/generated/api/sdk.gen";
-import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
 import { publish } from "@/lib/event-bus";
 import { captureError } from "@/lib/sentry/capture-error";
+import { resolveSignedApnsEnvironment } from "@/runtime/apns-environment";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { createStorageAccessor } from "@/utils/typed-storage";
-
-interface ApnsEnvironmentPlugin {
-  get(): Promise<{ environment?: string }>;
-}
-
-/**
- * Native plugin reporting the build's real APNs entitlement environment, read
- * from the embedded provisioning profile
- * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`). Resolves
- * `"development"`, `"production"`, or `"unknown"` on modern shells; on older
- * shells that predate the plugin the bridge call rejects instead.
- */
-const ApnsEnvironment =
-  registerPlugin<ApnsEnvironmentPlugin>("ApnsEnvironment");
-
-/**
- * Bundle-id suffix that maps to the development APNs entitlement in the
- * fallback heuristic, consulted only for shells predating the
- * `ApnsEnvironment` plugin and for profiles it cannot parse (`"unknown"`).
- * The dev Xcode config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs
- * with `App-Dev.entitlements` (`aps-environment = development`) and ships the
- * `.dev` bundle id; production and staging both sign with `App.entitlements`
- * (`aps-environment = production`). APNs rejects a token minted under one
- * environment if dispatched against the other, so the platform stores the
- * environment alongside the token and the value must match the running build.
- * The heuristic misreads TestFlight-signed dev builds (production tokens on a
- * `.dev` bundle id), which is why the signing-derived plugin result wins when
- * available.
- */
-const DEV_BUNDLE_SUFFIX = ".dev";
 
 /** Token registration we last upserted, retained so logout can delete it. */
 interface RegisteredToken {
@@ -167,45 +134,6 @@ function trackUpsert(upsert: Promise<void>): void {
  */
 export function isRemotePushSupported(): boolean {
   return isNativePlatform() && Capacitor.getPlatform() === "ios";
-}
-
-/**
- * Fallback heuristic: map the running build's bundle id to its APNs
- * entitlement environment. Only consulted when the `ApnsEnvironment` plugin
- * is absent (older shell) or cannot read the entitlement (`"unknown"`).
- */
-function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
-  return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
-}
-
-/**
- * Resolve the environment to tag the token with, preferring the build's real
- * signing entitlement over the bundle-suffix heuristic.
- */
-async function resolveSignedApnsEnvironment(
-  bundleId: string,
-): Promise<ApnsEnvironmentEnum> {
-  try {
-    // Only the result crosses this `async` boundary, never the plugin Proxy
-    // itself (see CAPACITOR.md).
-    const { environment } = await ApnsEnvironment.get();
-    if (environment === "development" || environment === "production") {
-      return environment;
-    }
-    console.debug(
-      "[push-registration] unreadable APNs entitlement, using bundle-id heuristic:",
-      environment,
-    );
-  } catch (err) {
-    // `console.debug`, not `captureError`, per the `native-voice.ts` skew
-    // convention: an older App Store/TestFlight shell without the plugin is
-    // an expected state on every web deploy, not a fault.
-    console.debug(
-      "[push-registration] ApnsEnvironment bridge unavailable, using bundle-id heuristic:",
-      err,
-    );
-  }
-  return resolveApnsEnvironment(bundleId);
 }
 
 /**

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -31,12 +31,21 @@
  * (no native Capacitor Android shell ships today); registration/delete failures
  * are reported to Sentry but never thrown into the app lifecycle.
  *
+ * The upserted row tags the token with the build's APNs entitlement
+ * environment. The primary source is the native `ApnsEnvironment` plugin
+ * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`), which reads the real
+ * `aps-environment` value from the embedded provisioning profile: TestFlight
+ * and App Store builds always carry production APNs tokens regardless of
+ * bundle id, which is exactly the case the bundle-suffix heuristic got wrong
+ * for TestFlight dev builds. Shells predating the plugin, and profiles it
+ * cannot parse, fall back to that heuristic ({@link resolveApnsEnvironment}).
+ *
  * Per `docs/CAPACITOR.md`, the `@capacitor/*` plugins are destructured inline
  * at each call site — never returned through an `async` boundary — because the
  * plugin Proxy's `.then` trap would hang the awaiting caller forever.
  */
 
-import { Capacitor } from "@capacitor/core";
+import { Capacitor, registerPlugin } from "@capacitor/core";
 
 import {
   assistantsPushTokensDelete,
@@ -48,14 +57,33 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { createStorageAccessor } from "@/utils/typed-storage";
 
+interface ApnsEnvironmentPlugin {
+  get(): Promise<{ environment?: string }>;
+}
+
 /**
- * Bundle-id suffix that maps to the development APNs entitlement. The dev Xcode
- * config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs with
- * `App-Dev.entitlements` (`aps-environment = development`) and ships the `.dev`
- * bundle id; production and staging both sign with `App.entitlements`
+ * Native plugin reporting the build's real APNs entitlement environment, read
+ * from the embedded provisioning profile
+ * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`). Resolves
+ * `"development"`, `"production"`, or `"unknown"` on modern shells; on older
+ * shells that predate the plugin the bridge call rejects instead.
+ */
+const ApnsEnvironment =
+  registerPlugin<ApnsEnvironmentPlugin>("ApnsEnvironment");
+
+/**
+ * Bundle-id suffix that maps to the development APNs entitlement in the
+ * fallback heuristic, consulted only for shells predating the
+ * `ApnsEnvironment` plugin and for profiles it cannot parse (`"unknown"`).
+ * The dev Xcode config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs
+ * with `App-Dev.entitlements` (`aps-environment = development`) and ships the
+ * `.dev` bundle id; production and staging both sign with `App.entitlements`
  * (`aps-environment = production`). APNs rejects a token minted under one
  * environment if dispatched against the other, so the platform stores the
  * environment alongside the token and the value must match the running build.
+ * The heuristic misreads TestFlight-signed dev builds (production tokens on a
+ * `.dev` bundle id), which is why the signing-derived plugin result wins when
+ * available.
  */
 const DEV_BUNDLE_SUFFIX = ".dev";
 
@@ -141,9 +169,43 @@ export function isRemotePushSupported(): boolean {
   return isNativePlatform() && Capacitor.getPlatform() === "ios";
 }
 
-/** Map the running build's bundle id to its APNs entitlement environment. */
+/**
+ * Fallback heuristic: map the running build's bundle id to its APNs
+ * entitlement environment. Only consulted when the `ApnsEnvironment` plugin
+ * is absent (older shell) or cannot read the entitlement (`"unknown"`).
+ */
 function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
   return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
+}
+
+/**
+ * Resolve the environment to tag the token with, preferring the build's real
+ * signing entitlement over the bundle-suffix heuristic.
+ */
+async function resolveSignedApnsEnvironment(
+  bundleId: string,
+): Promise<ApnsEnvironmentEnum> {
+  try {
+    // Only the result crosses this `async` boundary, never the plugin Proxy
+    // itself (see CAPACITOR.md).
+    const { environment } = await ApnsEnvironment.get();
+    if (environment === "development" || environment === "production") {
+      return environment;
+    }
+    console.debug(
+      "[push-registration] unreadable APNs entitlement, using bundle-id heuristic:",
+      environment,
+    );
+  } catch (err) {
+    // `console.debug`, not `captureError`, per the `native-voice.ts` skew
+    // convention: an older App Store/TestFlight shell without the plugin is
+    // an expected state on every web deploy, not a fault.
+    console.debug(
+      "[push-registration] ApnsEnvironment bridge unavailable, using bundle-id heuristic:",
+      err,
+    );
+  }
+  return resolveApnsEnvironment(bundleId);
 }
 
 /**
@@ -155,6 +217,7 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
     // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
     const { App } = await import("@capacitor/app");
     const { id: bundleId } = await App.getInfo();
+    const apnsEnvironment = await resolveSignedApnsEnvironment(bundleId);
 
     const result = await assistantsPushTokensUpsert({
       path: { assistant_id: assistantId },
@@ -162,7 +225,7 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
         token,
         platform: "ios",
         bundle_id: bundleId,
-        apns_environment: resolveApnsEnvironment(bundleId),
+        apns_environment: apnsEnvironment,
       },
       throwOnError: false,
     });


### PR DESCRIPTION
## Summary
- Token registration now asks the native ApnsEnvironment plugin for the build's real APNs entitlement environment (TestFlight/App Store: production; Xcode installs: development).
- Falls back to the bundle-suffix heuristic for older shells and parse failures (console.debug, no Sentry: skew is an expected state).
- Fixes the TestFlight dev-build mismatch where production tokens were registered as sandbox tokens.

Part of plan: ios-push-lower-envs.md (PR 5 of 5)