### PR TITLE
web: skip the Capacitor local banner when a remote push covers a backgrounded iOS app

### DIFF
--- a/clients/web/src/hooks/use-notification-intent-sync.test.tsx
+++ b/clients/web/src/hooks/use-notification-intent-sync.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * `useNotificationIntentSync` forwards `notification_intent` SSE events to
+ * `postLocalNotification`, including the optional `remotePushDispatched`
+ * flag the dedup skip in `runtime/notifications.ts` keys on.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { __resetForTesting, publish } from "@/lib/event-bus";
+import { useConversationStore } from "@/stores/conversation-store";
+import type { PostLocalNotificationArgs } from "@/runtime/notifications";
+
+const postedArgs: PostLocalNotificationArgs[] = [];
+const postLocalNotificationMock = mock(
+  async (args: PostLocalNotificationArgs) => {
+    postedArgs.push(args);
+  },
+);
+const sendAckMock = mock(async () => {});
+mock.module("@/runtime/notifications", () => ({
+  postLocalNotification: postLocalNotificationMock,
+  sendNotificationIntentAck: sendAckMock,
+  extractConversationId: (metadata?: Record<string, unknown>) =>
+    typeof metadata?.conversationId === "string"
+      ? metadata.conversationId
+      : undefined,
+}));
+
+mock.module("@/lib/sounds/sound-manager", () => ({
+  getSoundManager: () => ({ play: async () => {} }),
+}));
+
+const { useNotificationIntentSync } = await import(
+  "@/hooks/use-notification-intent-sync"
+);
+
+function publishNotificationIntent(overrides: {
+  remotePushDispatched?: boolean;
+}) {
+  act(() => {
+    publish("sse.event", {
+      id: "evt-1",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "notification_intent",
+        sourceEventName: "reminder.fired",
+        title: "Reminder",
+        body: "Stand up",
+        deliveryId: "delivery-1",
+        ...overrides,
+      },
+    });
+  });
+}
+
+beforeEach(() => {
+  __resetForTesting();
+  useConversationStore.getState().reset();
+  postedArgs.length = 0;
+  postLocalNotificationMock.mockClear();
+  sendAckMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+});
+
+describe("useNotificationIntentSync", () => {
+  test("passes remotePushDispatched through to postLocalNotification", () => {
+    renderHook(() => useNotificationIntentSync("assistant-1"));
+
+    publishNotificationIntent({ remotePushDispatched: true });
+
+    expect(postedArgs).toEqual([
+      {
+        title: "Reminder",
+        body: "Stand up",
+        sourceEventName: "reminder.fired",
+        deliveryId: "delivery-1",
+        deepLinkMetadata: undefined,
+        assistantId: "assistant-1",
+        remotePushDispatched: true,
+      },
+    ]);
+  });
+
+  test("leaves remotePushDispatched undefined when the daemon omits it", () => {
+    renderHook(() => useNotificationIntentSync("assistant-1"));
+
+    publishNotificationIntent({});
+
+    expect(postedArgs).toHaveLength(1);
+    expect(postedArgs[0]?.remotePushDispatched).toBeUndefined();
+  });
+});

--- a/clients/web/src/hooks/use-notification-intent-sync.ts
+++ b/clients/web/src/hooks/use-notification-intent-sync.ts
@@ -75,6 +75,7 @@ export function useNotificationIntentSync(assistantId: string | null): void {
       deliveryId: event.deliveryId,
       deepLinkMetadata: event.deepLinkMetadata,
       assistantId: assistantId ?? undefined,
+      remotePushDispatched: event.remotePushDispatched,
     });
   });
 }

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -1,0 +1,190 @@
+/**
+ * `postLocalNotification` native-branch behavior, focused on the
+ * remote-push dedup skip: a hidden Capacitor iOS app with an active APNs
+ * registration and a daemon-confirmed accepted remote push must not also
+ * schedule the local banner (the APNs banner covers it), while foreground
+ * and old-daemon paths keep scheduling as before.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── host platform guards ─────────────────────────────────────────────────────
+//
+// Force the native (Capacitor) branch: `isNativePlatform` reports false
+// under happy-dom, and the Electron branch would return before reaching
+// the code under test.
+
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => false,
+}));
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => true,
+}));
+
+// ── push-registration read-only helpers ──────────────────────────────────────
+//
+// Mocked as pure flags; the helpers' own behavior is covered by
+// push-registration.test.ts.
+
+let remotePushSupported = true;
+let activeRegistrationAssistantId: string | null = null;
+mock.module("@/runtime/push-registration", () => ({
+  isRemotePushSupported: () => remotePushSupported,
+  hasActiveRemotePushRegistration: (assistantId: string) =>
+    activeRegistrationAssistantId === assistantId,
+}));
+
+// ── @capacitor/local-notifications ───────────────────────────────────────────
+
+interface ScheduleArg {
+  notifications: Array<{ id: number; title: string; body: string }>;
+}
+const scheduleMock = mock(async (_arg: ScheduleArg) => {});
+mock.module("@capacitor/local-notifications", () => ({
+  LocalNotifications: {
+    checkPermissions: async () => ({ display: "granted" }),
+    requestPermissions: async () => ({ display: "granted" }),
+    schedule: scheduleMock,
+    addListener: async () => ({ remove: async () => {} }),
+  },
+}));
+
+// ── daemon ack SDK ───────────────────────────────────────────────────────────
+
+interface AckArg {
+  path: { assistant_id: string };
+  body: { deliveryId: string; success: boolean; errorMessage?: string };
+  throwOnError: boolean;
+}
+const ackArgs: AckArg[] = [];
+const ackMock = mock(async (arg: AckArg) => {
+  ackArgs.push(arg);
+  return { data: undefined, error: undefined };
+});
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  notificationintentresultPost: ackMock,
+}));
+
+const { postLocalNotification } = await import("@/runtime/notifications");
+
+const setVisibility = (state: "visible" | "hidden") => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+};
+
+const baseArgs = {
+  title: "Reminder",
+  body: "Stand up",
+  sourceEventName: "reminder.fired",
+  deliveryId: "delivery-1",
+  assistantId: "assistant-1",
+};
+
+beforeEach(() => {
+  remotePushSupported = true;
+  activeRegistrationAssistantId = null;
+  scheduleMock.mockClear();
+  ackMock.mockClear();
+  ackArgs.length = 0;
+  setVisibility("visible");
+});
+
+describe("postLocalNotification remote-push dedup (native branch)", () => {
+  test("hidden + dispatched + registered: skips the local banner and acks success", async () => {
+    activeRegistrationAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).not.toHaveBeenCalled();
+    expect(ackArgs).toEqual([
+      {
+        path: { assistant_id: "assistant-1" },
+        body: { deliveryId: "delivery-1", success: true },
+        throwOnError: false,
+      },
+    ]);
+  });
+
+  test("visible app schedules the local banner (the only foreground surface)", async () => {
+    activeRegistrationAssistantId = "assistant-1";
+    setVisibility("visible");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    expect(ackArgs).toEqual([
+      {
+        path: { assistant_id: "assistant-1" },
+        body: { deliveryId: "delivery-1", success: true },
+        throwOnError: false,
+      },
+    ]);
+  });
+
+  test("field absent (older daemon): schedules as before even when hidden", async () => {
+    activeRegistrationAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispatched but no active registration (e.g. permission denied): schedules", async () => {
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispatched but registration belongs to a different assistant: schedules", async () => {
+    activeRegistrationAssistantId = "assistant-2";
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispatched but remote push unsupported on this native platform: schedules", async () => {
+    remotePushSupported = false;
+    activeRegistrationAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("no assistantId: schedules even when hidden and dispatched, no ack", async () => {
+    activeRegistrationAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({
+      ...baseArgs,
+      assistantId: undefined,
+      remotePushDispatched: true,
+    });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    expect(ackMock).not.toHaveBeenCalled();
+  });
+
+  test("skip without a deliveryId still skips but sends no ack", async () => {
+    activeRegistrationAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({
+      ...baseArgs,
+      deliveryId: undefined,
+      remotePushDispatched: true,
+    });
+
+    expect(scheduleMock).not.toHaveBeenCalled();
+    expect(ackMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -2,9 +2,9 @@
  * `postLocalNotification` native-branch behavior, focused on the
  * remote-push dedup skip: the local banner is scheduled whenever
  * `remotePushDispatched` is absent or false; it is skipped only when the
- * daemon confirmed an accepted remote push, this device holds an active
- * APNs registration, and the app was hidden when the intent arrived (the
- * APNs banner covers that case).
+ * daemon confirmed an accepted remote push, this device holds a
+ * session-confirmed APNs registration, and the app was hidden when the
+ * intent arrived (the APNs banner covers that case).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -28,11 +28,11 @@ mock.module("@/runtime/native-auth", () => ({
 // push-registration.test.ts.
 
 let remotePushSupported = true;
-let activeRegistrationAssistantId: string | null = null;
+let sessionConfirmedAssistantId: string | null = null;
 mock.module("@/runtime/push-registration", () => ({
   isRemotePushSupported: () => remotePushSupported,
-  hasActiveRemotePushRegistration: (assistantId: string) =>
-    activeRegistrationAssistantId === assistantId,
+  hasSessionConfirmedRemotePushRegistration: (assistantId: string) =>
+    sessionConfirmedAssistantId === assistantId,
 }));
 
 // ── @capacitor/local-notifications ───────────────────────────────────────────
@@ -85,7 +85,7 @@ const baseArgs = {
 
 beforeEach(() => {
   remotePushSupported = true;
-  activeRegistrationAssistantId = null;
+  sessionConfirmedAssistantId = null;
   scheduleMock.mockClear();
   ackMock.mockClear();
   ackArgs.length = 0;
@@ -94,7 +94,7 @@ beforeEach(() => {
 
 describe("postLocalNotification remote-push dedup (native branch)", () => {
   test("hidden + dispatched + registered: skips the local banner and acks success", async () => {
-    activeRegistrationAssistantId = "assistant-1";
+    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("hidden");
 
     await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
@@ -110,7 +110,7 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
   });
 
   test("visible app schedules the local banner (the only foreground surface)", async () => {
-    activeRegistrationAssistantId = "assistant-1";
+    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("visible");
 
     await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
@@ -126,7 +126,7 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
   });
 
   test("visible at intent arrival, hidden after the permission await: schedules", async () => {
-    activeRegistrationAssistantId = "assistant-1";
+    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("visible");
 
     // The call's synchronous prefix snapshots visibility, then suspends on
@@ -144,7 +144,7 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
   });
 
   test("field absent (older daemon): schedules even when hidden", async () => {
-    activeRegistrationAssistantId = "assistant-1";
+    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("hidden");
 
     await postLocalNotification({ ...baseArgs });
@@ -160,8 +160,29 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
     expect(scheduleMock).toHaveBeenCalledTimes(1);
   });
 
+  test("dispatched with only a persisted registration from an earlier session: schedules", async () => {
+    // The mocked helper mirrors the real one in ignoring persisted storage:
+    // only a session-confirmed upsert counts. Seeding storage documents the
+    // reload scenario where a stored record survives but proves nothing
+    // about a live server-side token row, so the dedup skip must not fire.
+    localStorage.setItem(
+      "vellum:push_registration",
+      JSON.stringify({
+        token: "persisted-token",
+        bundleId: "ai.vocify-inc.vellum-assistant-ios",
+        assistantId: "assistant-1",
+      }),
+    );
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    localStorage.removeItem("vellum:push_registration");
+  });
+
   test("dispatched but registration belongs to a different assistant: schedules", async () => {
-    activeRegistrationAssistantId = "assistant-2";
+    sessionConfirmedAssistantId = "assistant-2";
     setVisibility("hidden");
 
     await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
@@ -171,7 +192,7 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
 
   test("dispatched but remote push unsupported on this native platform: schedules", async () => {
     remotePushSupported = false;
-    activeRegistrationAssistantId = "assistant-1";
+    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("hidden");
 
     await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
@@ -180,7 +201,7 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
   });
 
   test("no assistantId: schedules even when hidden and dispatched, no ack", async () => {
-    activeRegistrationAssistantId = "assistant-1";
+    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("hidden");
 
     await postLocalNotification({
@@ -194,7 +215,7 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
   });
 
   test("skip without a deliveryId still skips but sends no ack", async () => {
-    activeRegistrationAssistantId = "assistant-1";
+    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("hidden");
 
     await postLocalNotification({

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -1,9 +1,10 @@
 /**
  * `postLocalNotification` native-branch behavior, focused on the
- * remote-push dedup skip: a hidden Capacitor iOS app with an active APNs
- * registration and a daemon-confirmed accepted remote push must not also
- * schedule the local banner (the APNs banner covers it), while foreground
- * and old-daemon paths keep scheduling as before.
+ * remote-push dedup skip: the local banner is scheduled whenever
+ * `remotePushDispatched` is absent or false; it is skipped only when the
+ * daemon confirmed an accepted remote push, this device holds an active
+ * APNs registration, and the app was hidden when the intent arrived (the
+ * APNs banner covers that case).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -124,7 +125,25 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
     ]);
   });
 
-  test("field absent (older daemon): schedules as before even when hidden", async () => {
+  test("visible at intent arrival, hidden after the permission await: schedules", async () => {
+    activeRegistrationAssistantId = "assistant-1";
+    setVisibility("visible");
+
+    // The call's synchronous prefix snapshots visibility, then suspends on
+    // the permission await; flipping to hidden while it is pending mimics
+    // the user backgrounding the app mid-await. The entry-time snapshot
+    // must win, so the local banner is still scheduled.
+    const pending = postLocalNotification({
+      ...baseArgs,
+      remotePushDispatched: true,
+    });
+    setVisibility("hidden");
+    await pending;
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("field absent (older daemon): schedules even when hidden", async () => {
     activeRegistrationAssistantId = "assistant-1";
     setVisibility("hidden");
 

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -278,8 +278,9 @@ export interface PostLocalNotificationArgs {
   assistantId?: string;
   /**
    * True when the daemon confirmed the platform (APNs) channel accepted a
-   * remote push for this delivery. A hidden native app with an active push
-   * registration skips the local banner so the remote push is the only one.
+   * remote push for this delivery. A native app that is hidden at intent
+   * arrival with an active push registration skips the local banner so the
+   * remote push is the only one.
    */
   remotePushDispatched?: boolean;
 }
@@ -371,6 +372,10 @@ export async function postLocalNotification(
     return;
   }
 
+  // Snapshot before the awaits below: the remote-push dedup skip must see
+  // visibility at intent arrival, not after an async native-bridge gap.
+  const visibilityAtIntent = document.visibilityState;
+
   const permission = await ensureNotificationPermission();
   if (permission !== "granted") {
     if (args.assistantId && args.deliveryId) {
@@ -397,16 +402,18 @@ export async function postLocalNotification(
   if (isNativePlatform()) {
     // iOS suppresses remote pushes while the app is foregrounded (no
     // presentationOptions configured), so the local banner is the only
-    // foreground surface and must stay. When the app is hidden with an
-    // active APNs registration and a daemon-confirmed accepted push, the
-    // remote push will banner on its own; scheduling the local one too
-    // would double-notify during the SSE grace window after backgrounding.
+    // foreground surface. The banner is skipped only when the daemon
+    // confirmed an accepted remote push, this device holds an active APNs
+    // registration, and the app was hidden when the intent arrived; the
+    // remote push banners on its own there, and scheduling the local one
+    // too would double-notify during the SSE grace window after
+    // backgrounding.
     if (
       args.remotePushDispatched === true &&
       isRemotePushSupported() &&
       args.assistantId !== undefined &&
       hasActiveRemotePushRegistration(args.assistantId) &&
-      document.visibilityState === "hidden"
+      visibilityAtIntent === "hidden"
     ) {
       if (args.deliveryId) {
         await sendNotificationIntentAck(

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -416,7 +416,7 @@ export async function postLocalNotification(
     // multi-device account a token pruned mid-session can still suppress
     // this banner while only another device received the push. Closing
     // that gap requires per-token dispatch results from the platform's
-    // dispatch endpoint, deferred as a cross-repo follow-up.
+    // dispatch endpoint.
     if (
       args.remotePushDispatched === true &&
       isRemotePushSupported() &&

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -32,6 +32,10 @@ import { notificationintentresultPost } from "@/generated/daemon/sdk.gen";
 import type { NotificationintentresultPostData } from "@/generated/daemon/types.gen";
 import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
+import {
+  hasActiveRemotePushRegistration,
+  isRemotePushSupported,
+} from "@/runtime/push-registration";
 
 /**
  * Payload stored alongside each native notification so the tap handler can
@@ -272,6 +276,12 @@ export interface PostLocalNotificationArgs {
    * directly with `success=true`.
    */
   assistantId?: string;
+  /**
+   * True when the daemon confirmed the platform (APNs) channel accepted a
+   * remote push for this delivery. A hidden native app with an active push
+   * registration skips the local banner so the remote push is the only one.
+   */
+  remotePushDispatched?: boolean;
 }
 
 /**
@@ -385,6 +395,29 @@ export async function postLocalNotification(
   let errorMessage: string | undefined;
 
   if (isNativePlatform()) {
+    // iOS suppresses remote pushes while the app is foregrounded (no
+    // presentationOptions configured), so the local banner is the only
+    // foreground surface and must stay. When the app is hidden with an
+    // active APNs registration and a daemon-confirmed accepted push, the
+    // remote push will banner on its own; scheduling the local one too
+    // would double-notify during the SSE grace window after backgrounding.
+    if (
+      args.remotePushDispatched === true &&
+      isRemotePushSupported() &&
+      args.assistantId !== undefined &&
+      hasActiveRemotePushRegistration(args.assistantId) &&
+      document.visibilityState === "hidden"
+    ) {
+      if (args.deliveryId) {
+        await sendNotificationIntentAck(
+          args.assistantId,
+          args.deliveryId,
+          true,
+        );
+      }
+      return;
+    }
+
     const seed =
       args.deliveryId ?? `${args.sourceEventName}:${args.title}:${args.body}`;
     const notification: LocalNotificationSchema = {

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -33,7 +33,7 @@ import type { NotificationintentresultPostData } from "@/generated/daemon/types.
 import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
 import {
-  hasActiveRemotePushRegistration,
+  hasSessionConfirmedRemotePushRegistration,
   isRemotePushSupported,
 } from "@/runtime/push-registration";
 
@@ -279,8 +279,8 @@ export interface PostLocalNotificationArgs {
   /**
    * True when the daemon confirmed the platform (APNs) channel accepted a
    * remote push for this delivery. A native app that is hidden at intent
-   * arrival with an active push registration skips the local banner so the
-   * remote push is the only one.
+   * arrival with a session-confirmed push registration skips the local
+   * banner so the remote push is the only one.
    */
   remotePushDispatched?: boolean;
 }
@@ -403,16 +403,25 @@ export async function postLocalNotification(
     // iOS suppresses remote pushes while the app is foregrounded (no
     // presentationOptions configured), so the local banner is the only
     // foreground surface. The banner is skipped only when the daemon
-    // confirmed an accepted remote push, this device holds an active APNs
-    // registration, and the app was hidden when the intent arrived; the
+    // confirmed an accepted remote push, this device holds a
+    // session-confirmed APNs registration (an upsert succeeded in this JS
+    // session, proving the platform held a live token row for this device
+    // at mount), and the app was hidden when the intent arrived; the
     // remote push banners on its own there, and scheduling the local one
     // too would double-notify during the SSE grace window after
     // backgrounding.
+    //
+    // Residual limitation: `remotePushDispatched` is an aggregate
+    // account-level outcome (any device token accepted), so on a
+    // multi-device account a token pruned mid-session can still suppress
+    // this banner while only another device received the push. Closing
+    // that gap requires per-token dispatch results from the platform's
+    // dispatch endpoint, deferred as a cross-repo follow-up.
     if (
       args.remotePushDispatched === true &&
       isRemotePushSupported() &&
       args.assistantId !== undefined &&
-      hasActiveRemotePushRegistration(args.assistantId) &&
+      hasSessionConfirmedRemotePushRegistration(args.assistantId) &&
       visibilityAtIntent === "hidden"
     ) {
       if (args.deliveryId) {

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -128,7 +128,7 @@ mock.module("@/lib/sentry/capture-error", () => ({
 
 const {
   extractPushConversationId,
-  hasActiveRemotePushRegistration,
+  hasSessionConfirmedRemotePushRegistration,
   isRemotePushSupported,
   registerForRemotePush,
   unregisterFromRemotePush,
@@ -356,9 +356,11 @@ describe("extractPushConversationId", () => {
   });
 });
 
-describe("hasActiveRemotePushRegistration", () => {
+describe("hasSessionConfirmedRemotePushRegistration", () => {
   test("false when nothing has been registered", () => {
-    expect(hasActiveRemotePushRegistration("assistant-1")).toBe(false);
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-1")).toBe(
+      false,
+    );
   });
 
   test("true after a successful upsert for the same assistant", async () => {
@@ -366,7 +368,7 @@ describe("hasActiveRemotePushRegistration", () => {
     registrationHandler?.({ value: "apns-token-abc" });
     await flushMicrotasks();
 
-    expect(hasActiveRemotePushRegistration("assistant-1")).toBe(true);
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-1")).toBe(true);
   });
 
   test("false for a different assistant than the registered one", async () => {
@@ -374,10 +376,15 @@ describe("hasActiveRemotePushRegistration", () => {
     registrationHandler?.({ value: "apns-token-abc" });
     await flushMicrotasks();
 
-    expect(hasActiveRemotePushRegistration("assistant-2")).toBe(false);
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-2")).toBe(
+      false,
+    );
   });
 
-  test("falls back to the persisted registration after a process reload", () => {
+  test("ignores a persisted-only registration (reload before any re-upsert)", () => {
+    // A record surviving from an earlier session proves nothing about
+    // whether the platform still holds the token row (the server prunes
+    // rows on APNs BadDeviceToken), so it must not count as confirmed.
     localStorage.setItem(
       "vellum:push_registration",
       JSON.stringify({
@@ -387,8 +394,9 @@ describe("hasActiveRemotePushRegistration", () => {
       }),
     );
 
-    expect(hasActiveRemotePushRegistration("assistant-9")).toBe(true);
-    expect(hasActiveRemotePushRegistration("assistant-1")).toBe(false);
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-9")).toBe(
+      false,
+    );
   });
 
   test("false again after unregister clears the registration", async () => {
@@ -398,7 +406,9 @@ describe("hasActiveRemotePushRegistration", () => {
 
     await unregisterFromRemotePush();
 
-    expect(hasActiveRemotePushRegistration("assistant-1")).toBe(false);
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-1")).toBe(
+      false,
+    );
   });
 });
 

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -128,6 +128,7 @@ mock.module("@/lib/sentry/capture-error", () => ({
 
 const {
   extractPushConversationId,
+  hasActiveRemotePushRegistration,
   isRemotePushSupported,
   registerForRemotePush,
   unregisterFromRemotePush,
@@ -352,6 +353,52 @@ describe("extractPushConversationId", () => {
     expect(extractPushConversationId({ deep_link: null })).toBeUndefined();
     expect(extractPushConversationId({ deep_link: {} })).toBeUndefined();
     expect(extractPushConversationId({ conversationId: 42 })).toBeUndefined();
+  });
+});
+
+describe("hasActiveRemotePushRegistration", () => {
+  test("false when nothing has been registered", () => {
+    expect(hasActiveRemotePushRegistration("assistant-1")).toBe(false);
+  });
+
+  test("true after a successful upsert for the same assistant", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    expect(hasActiveRemotePushRegistration("assistant-1")).toBe(true);
+  });
+
+  test("false for a different assistant than the registered one", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    expect(hasActiveRemotePushRegistration("assistant-2")).toBe(false);
+  });
+
+  test("falls back to the persisted registration after a process reload", () => {
+    localStorage.setItem(
+      "vellum:push_registration",
+      JSON.stringify({
+        token: "persisted-token",
+        bundleId: "ai.vocify-inc.vellum-assistant-ios",
+        assistantId: "assistant-9",
+      }),
+    );
+
+    expect(hasActiveRemotePushRegistration("assistant-9")).toBe(true);
+    expect(hasActiveRemotePushRegistration("assistant-1")).toBe(false);
+  });
+
+  test("false again after unregister clears the registration", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    await unregisterFromRemotePush();
+
+    expect(hasActiveRemotePushRegistration("assistant-1")).toBe(false);
   });
 });
 

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -320,9 +320,7 @@ export async function unregisterFromRemotePush(): Promise<void> {
     await Promise.allSettled([...pendingUpserts]);
   }
 
-  // Fall back to persisted storage: a process reload before re-registration
-  // leaves `lastRegistered` null even though a token is still registered.
-  const registered = lastRegistered ?? persistedRegistration.load();
+  const registered = loadCurrentRegistration();
   lastRegistered = null;
   persistedRegistration.remove();
 
@@ -357,6 +355,24 @@ export async function unregisterFromRemotePush(): Promise<void> {
       bestEffort: true,
     });
   }
+}
+
+/**
+ * The registration this device currently holds: module memory, falling
+ * back to persisted storage (a process reload wipes `lastRegistered`
+ * while the token stays registered server-side).
+ */
+function loadCurrentRegistration(): RegisteredToken | null {
+  return lastRegistered ?? persistedRegistration.load();
+}
+
+/**
+ * True when this device holds a platform push registration for
+ * `assistantId`. Pure state read, never touches Capacitor plugins, so it
+ * is safe to call synchronously on any platform.
+ */
+export function hasActiveRemotePushRegistration(assistantId: string): boolean {
+  return loadCurrentRegistration()?.assistantId === assistantId;
 }
 
 /** Test-only: reset module + persisted state between cases. */

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -367,12 +367,27 @@ function loadCurrentRegistration(): RegisteredToken | null {
 }
 
 /**
- * True when this device holds a platform push registration for
- * `assistantId`. Pure state read, never touches Capacitor plugins, so it
- * is safe to call synchronously on any platform.
+ * True when this device holds a push registration for `assistantId` that was
+ * confirmed in the current JS session (module-memory `lastRegistered`, set
+ * only when an upsert succeeded after this process started).
+ *
+ * Deliberately ignores the persisted-storage registration: a record from an
+ * earlier session only proves an upsert once succeeded, not that the platform
+ * still holds a token row for this device (APNs BadDeviceToken responses
+ * prune rows server-side). A session-confirmed upsert proves the platform
+ * held a live token row for this device at mount time, which is the evidence
+ * the remote-push banner dedup in `runtime/notifications.ts` needs before
+ * suppressing a local banner. The logout path is different: deleting a
+ * possibly-stale token is harmless, so `unregisterFromRemotePush` falls back
+ * to the persisted registration.
+ *
+ * Pure state read, never touches Capacitor plugins, so it is safe to call
+ * synchronously on any platform.
  */
-export function hasActiveRemotePushRegistration(assistantId: string): boolean {
-  return loadCurrentRegistration()?.assistantId === assistantId;
+export function hasSessionConfirmedRemotePushRegistration(
+  assistantId: string,
+): boolean {
+  return lastRegistered?.assistantId === assistantId;
 }
 
 /** Test-only: reset module + persisted state between cases. */


### PR DESCRIPTION
## Summary
- On native iOS, when the daemon confirms an accepted remote push (remotePushDispatched), the app is hidden, and this device has a session-confirmed APNs registration (the token upsert succeeded in this JS session), the local Capacitor banner is skipped (the APNs banner covers it) and the intent is acked as handled.
- Foreground, Electron, desktop-browser, and old-daemon behavior unchanged.

Part of plan: ios-push-lower-envs.md (PR 3 of 5)

## Follow-up
Per-device push-delivery confirmation requires the platform dispatch endpoint to return per-token outcomes; until then the banner dedup uses session-confirmed registration as the closest available evidence.
