### PR TITLE
fix(embeddings): do not read a container's PID 1 daemon as a dead owner (JARVIS-1125)

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -79,18 +79,19 @@ afterEach(() => {
 
 describe("worker ownership classification", () => {
   const alive = () => true;
-  const ON_HOST = false;
-  const IN_CONTAINER = true;
+  // Whether PID 1 is an assistant daemon (exec'd as PID 1) or an init process.
+  const PID1_IS_INIT = false;
+  const PID1_IS_DAEMON = true;
 
   test("a worker parented to us is ours to reclaim", () => {
     expect(
-      classifyWorkerOwnership({ pid: 100, ppid: 42 }, 42, alive, ON_HOST),
+      classifyWorkerOwnership({ pid: 100, ppid: 42 }, 42, alive, PID1_IS_INIT),
     ).toBe("reclaim");
   });
 
   test("a worker reparented to init is an orphan", () => {
     expect(
-      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 42, alive, ON_HOST),
+      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 42, alive, PID1_IS_INIT),
     ).toBe("orphan");
   });
 
@@ -100,28 +101,38 @@ describe("worker ownership classification", () => {
         { pid: 100, ppid: 999 },
         42,
         () => false,
-        ON_HOST,
+        PID1_IS_INIT,
       ),
     ).toBe("orphan");
   });
 
   /**
-   * `docker-entrypoint.sh` execs the daemon, so in a container PID 1 IS the
-   * daemon. The memory-worker process sweeping alongside it must not read the
-   * daemon's healthy child as an orphan and signal it, which would recreate the
-   * cross-owner interference this change removes, in the shipped topology.
+   * Where `docker-entrypoint.sh` execs the daemon, PID 1 is that daemon and a
+   * worker parented to it belongs to a live sibling. A memory-worker process
+   * sweeping alongside must leave it running.
    */
-  test("in a container, a worker parented to the PID 1 daemon is left alone", () => {
+  test("a worker parented to a PID 1 daemon belongs to that daemon", () => {
     expect(
-      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 42, alive, IN_CONTAINER),
+      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 42, alive, PID1_IS_DAEMON),
     ).toBe("foreign");
   });
 
-  test("the containerized daemon still reclaims its own workers", () => {
-    // The daemon is PID 1, so its own children match selfPid first.
+  test("a daemon running as PID 1 still reclaims its own workers", () => {
+    // Its children match selfPid, which is checked before the PID 1 branch.
     expect(
-      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 1, alive, IN_CONTAINER),
+      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 1, alive, PID1_IS_DAEMON),
     ).toBe("reclaim");
+  });
+
+  /**
+   * Under `docker run --init` the container is still containerized but PID 1 is
+   * docker-init, so a worker reparented there was abandoned and must stay
+   * reclaimable. Deployment shape alone cannot answer this; what PID 1 is can.
+   */
+  test("a worker reparented to an init PID 1 stays reclaimable", () => {
+    expect(
+      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 42, alive, PID1_IS_INIT),
+    ).toBe("orphan");
   });
 
   /**
@@ -132,7 +143,7 @@ describe("worker ownership classification", () => {
    */
   test("a worker owned by another live process is left alone", () => {
     expect(
-      classifyWorkerOwnership({ pid: 100, ppid: 999 }, 42, alive, ON_HOST),
+      classifyWorkerOwnership({ pid: 100, ppid: 999 }, 42, alive, PID1_IS_INIT),
     ).toBe("foreign");
   });
 });
@@ -717,5 +728,28 @@ describe("audit regressions", () => {
 
     expect(backend.stdoutReaderActive).toBe(false);
     expect(backend.initGuard.active).toBe(false);
+  });
+});
+
+describe("model matching", () => {
+  test("a worker for a longer model name is not matched by a shorter one", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "embed-worker-model-"));
+    const scriptPath = join(dir, "embed-worker.mjs");
+    writeFileSync(scriptPath, "setTimeout(() => {}, 60_000);\n");
+
+    const proc = Bun.spawn({
+      cmd: [process.execPath, scriptPath, "foo/bar-small-v2", "cache-dir"],
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    spawned.push(proc);
+    await Bun.sleep(400);
+
+    // The worker script path is shared by every local model, so only the model
+    // argv token separates one backend's worker from another's in one process.
+    expect(listWorkerProcesses(scriptPath, "foo/bar-small")).toEqual([]);
+    expect(
+      listWorkerProcesses(scriptPath, "foo/bar-small-v2").map((w) => w.pid),
+    ).toEqual([proc.pid]);
   });
 });

--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -79,23 +79,49 @@ afterEach(() => {
 
 describe("worker ownership classification", () => {
   const alive = () => true;
+  const ON_HOST = false;
+  const IN_CONTAINER = true;
 
   test("a worker parented to us is ours to reclaim", () => {
-    expect(classifyWorkerOwnership({ pid: 100, ppid: 42 }, 42, alive)).toBe(
-      "reclaim",
-    );
+    expect(
+      classifyWorkerOwnership({ pid: 100, ppid: 42 }, 42, alive, ON_HOST),
+    ).toBe("reclaim");
   });
 
   test("a worker reparented to init is an orphan", () => {
-    expect(classifyWorkerOwnership({ pid: 100, ppid: 1 }, 42, alive)).toBe(
-      "orphan",
-    );
+    expect(
+      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 42, alive, ON_HOST),
+    ).toBe("orphan");
   });
 
   test("a worker whose owner is gone is an orphan", () => {
     expect(
-      classifyWorkerOwnership({ pid: 100, ppid: 999 }, 42, () => false),
+      classifyWorkerOwnership(
+        { pid: 100, ppid: 999 },
+        42,
+        () => false,
+        ON_HOST,
+      ),
     ).toBe("orphan");
+  });
+
+  /**
+   * `docker-entrypoint.sh` execs the daemon, so in a container PID 1 IS the
+   * daemon. The memory-worker process sweeping alongside it must not read the
+   * daemon's healthy child as an orphan and signal it, which would recreate the
+   * cross-owner interference this change removes, in the shipped topology.
+   */
+  test("in a container, a worker parented to the PID 1 daemon is left alone", () => {
+    expect(
+      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 42, alive, IN_CONTAINER),
+    ).toBe("foreign");
+  });
+
+  test("the containerized daemon still reclaims its own workers", () => {
+    // The daemon is PID 1, so its own children match selfPid first.
+    expect(
+      classifyWorkerOwnership({ pid: 100, ppid: 1 }, 1, alive, IN_CONTAINER),
+    ).toBe("reclaim");
   });
 
   /**
@@ -105,9 +131,9 @@ describe("worker ownership classification", () => {
    * spawn, which is the ping-pong in the incident timeline.
    */
   test("a worker owned by another live process is left alone", () => {
-    expect(classifyWorkerOwnership({ pid: 100, ppid: 999 }, 42, alive)).toBe(
-      "foreign",
-    );
+    expect(
+      classifyWorkerOwnership({ pid: 100, ppid: 999 }, 42, alive, ON_HOST),
+    ).toBe("foreign");
   });
 });
 
@@ -118,7 +144,7 @@ describe("worker process enumeration", () => {
     writeFileSync(scriptPath, "setTimeout(() => {}, 60_000);\n");
 
     const proc = Bun.spawn({
-      cmd: [process.execPath, scriptPath],
+      cmd: [process.execPath, scriptPath, "test-model", "cache-dir"],
       stdout: "ignore",
       stderr: "ignore",
     });
@@ -133,9 +159,9 @@ describe("worker process enumeration", () => {
 
     // Ownership of a child of ours must resolve to "reclaim", which is what
     // lets a spawn reap a worker the instance had lost track of.
-    expect(classifyWorkerOwnership(match!, process.pid, () => true)).toBe(
-      "reclaim",
-    );
+    expect(
+      classifyWorkerOwnership(match!, process.pid, () => true, false),
+    ).toBe("reclaim");
   });
 
   test("does not match another workspace's worker path", () => {
@@ -356,7 +382,7 @@ describe("termination that cannot be confirmed", () => {
     writeFileSync(scriptPath, "setTimeout(() => {}, 60_000);\n");
 
     const proc = Bun.spawn({
-      cmd: [process.execPath, scriptPath],
+      cmd: [process.execPath, scriptPath, "test-model", "cache-dir"],
       stdout: "ignore",
       stderr: "ignore",
     });
@@ -393,7 +419,7 @@ describe("reclaiming before spawning a replacement", () => {
     writeFileSync(scriptPath, "setTimeout(() => {}, 60_000);\n");
 
     const proc = Bun.spawn({
-      cmd: [process.execPath, scriptPath],
+      cmd: [process.execPath, scriptPath, "test-model", "cache-dir"],
       stdout: "ignore",
       stderr: "ignore",
     });
@@ -418,7 +444,7 @@ describe("reclaiming before spawning a replacement", () => {
     );
 
     const proc = Bun.spawn({
-      cmd: [process.execPath, scriptPath],
+      cmd: [process.execPath, scriptPath, "test-model", "cache-dir"],
       stdout: "ignore",
       stderr: "ignore",
     });
@@ -443,7 +469,7 @@ describe("reclaiming before spawning a replacement", () => {
     writeFileSync(
       launcher,
       `import { spawn } from "node:child_process";
-spawn(process.execPath, [${JSON.stringify(scriptPath)}], { stdio: "ignore" });
+spawn(process.execPath, [${JSON.stringify(scriptPath)}, "test-model", "cache-dir"], { stdio: "ignore" });
 setTimeout(() => {}, 60_000);\n`,
     );
     const parent = Bun.spawn({
@@ -661,7 +687,7 @@ describe("audit regressions", () => {
     writeFileSync(scriptPath, "setTimeout(() => {}, 60_000);\n");
 
     const proc = Bun.spawn({
-      cmd: [process.execPath, scriptPath],
+      cmd: [process.execPath, scriptPath, "test-model", "cache-dir"],
       stdout: "ignore",
       stderr: "ignore",
     });

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -67,14 +67,6 @@ function clearModelCache(): void {
 /** How long a worker gets to exit after each signal before we escalate. */
 const WORKER_TERMINATE_GRACE_MS = 2_000;
 
-/**
- * Worst-case time to tear down one worker: the SIGTERM wait plus the SIGKILL
- * wait. Exported so a caller that bounds its own shutdown (the standalone
- * memory-worker process) can budget above this instead of guessing, which
- * would otherwise exit before disposal could finish on the slow path.
- */
-export const WORKER_TEARDOWN_BUDGET_MS = WORKER_TERMINATE_GRACE_MS * 2;
-
 /** Poll interval while waiting for a worker we hold no handle for to exit. */
 const WORKER_EXIT_POLL_MS = 50;
 
@@ -117,6 +109,15 @@ interface WorkerProcess {
  * - `foreign`: owned by another live process. The memory-worker process runs
  *   its own backend against this same workspace and is entitled to its own
  *   worker; signalling it is what made the two replace each other in a loop.
+ *
+ * PID 1 means different things in different deployments, and getting it wrong
+ * reintroduces exactly the cross-owner interference this exists to remove. In a
+ * container `docker-entrypoint.sh` execs the daemon, so PID 1 IS the daemon and
+ * a worker parented to it is a healthy sibling's. On a host PID 1 is init, so
+ * the same parentage means the owner died. Containerized workers therefore
+ * resolve to `foreign`: the daemon still reclaims its own (they match
+ * `selfPid`), and declining to signal costs at most a delayed reap, where
+ * guessing wrong kills a live worker.
  */
 export type WorkerOwnership = "reclaim" | "orphan" | "foreign";
 
@@ -124,11 +125,15 @@ export function classifyWorkerOwnership(
   worker: WorkerProcess,
   selfPid: number,
   isOwnerAlive: (pid: number) => boolean,
+  isContainerized: boolean,
 ): WorkerOwnership {
   if (worker.ppid === selfPid) {
     return "reclaim";
   }
-  if (worker.ppid <= 1 || !isOwnerAlive(worker.ppid)) {
+  if (worker.ppid <= 1) {
+    return isContainerized ? "foreign" : "orphan";
+  }
+  if (!isOwnerAlive(worker.ppid)) {
     return "orphan";
   }
   return "foreign";
@@ -206,7 +211,10 @@ function listProcessRowsFromPs(): { pid: number; ppid: number; cmd: string }[] {
  * read for matching only, never stored or logged: process arguments can carry
  * secrets (see the redaction note in `util/process-tree.ts`).
  */
-export function listWorkerProcesses(workerPath: string): WorkerProcess[] {
+export function listWorkerProcesses(
+  workerPath: string,
+  model?: string,
+): WorkerProcess[] {
   let rows: { pid: number; ppid: number; cmd: string }[];
   try {
     rows = listProcessRowsFromProc();
@@ -214,7 +222,10 @@ export function listWorkerProcesses(workerPath: string): WorkerProcess[] {
     rows = listProcessRowsFromPs();
   }
   return rows
-    .filter((r) => r.cmd.includes(workerPath))
+    .filter(
+      (r) =>
+        r.cmd.includes(workerPath) && (model == null || r.cmd.includes(model)),
+    )
     .map((r) => ({ pid: r.pid, ppid: r.ppid }));
 }
 
@@ -327,9 +338,8 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       // an escaping EPIPE reaches the daemon's `unhandledRejection` handler,
       // which tears down the whole process (JARVIS-1125).
       //
-      // The guard covers `write`, not just `flush`. Both are synchronous on
-      // Bun's FileSink, and `write` is the call that actually raises the broken
-      // pipe, so wrapping `flush` alone (as this did) never caught it.
+      // The guard covers `write` as well as `flush`: both are synchronous on
+      // Bun's FileSink, and `write` is the call that raises the broken pipe.
       try {
         proc.stdin.write(JSON.stringify({ id, texts }) + "\n");
         proc.stdin.flush();
@@ -481,10 +491,9 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       await this.waitForReady();
     } catch (err) {
       // Startup failed. Release ownership through the same bounded path every
-      // other teardown uses: a worker wedged in native ONNX ignores SIGTERM,
-      // and the bare `await proc.exited` this used to do would hang here
-      // forever, leaving the init guard holding a promise that never settles
-      // and every later embed waiting on it.
+      // other teardown uses: a worker wedged in native ONNX ignores SIGTERM, so
+      // an unbounded wait here would leave the init guard holding a promise
+      // that never settles and every later embed queued behind it.
       this.workerProc = null;
       this.stdoutReaderActive = false;
       // A partial line from the dead worker would otherwise be prepended to the
@@ -686,7 +695,9 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       return false;
     }
     const stillListed = this.workerPath
-      ? listWorkerProcesses(this.workerPath).some((w) => w.pid === pid)
+      ? listWorkerProcesses(this.workerPath, this.model).some(
+          (w) => w.pid === pid,
+        )
       : isProcessAlive(pid);
     if (!stillListed) {
       log.info(
@@ -714,12 +725,16 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   ): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-      if (!listWorkerProcesses(workerPath).some((w) => w.pid === pid)) {
+      if (
+        !listWorkerProcesses(workerPath, this.model).some((w) => w.pid === pid)
+      ) {
         return true;
       }
       await Bun.sleep(WORKER_EXIT_POLL_MS);
     }
-    return !listWorkerProcesses(workerPath).some((w) => w.pid === pid);
+    return !listWorkerProcesses(workerPath, this.model).some(
+      (w) => w.pid === pid,
+    );
   }
 
   private readyResolve: (() => void) | null = null;
@@ -882,7 +897,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
    * generations, not just the single entry a PID file can hold.
    */
   private async reclaimOwnedWorkers(workerPath: string): Promise<void> {
-    for (const worker of listWorkerProcesses(workerPath)) {
+    for (const worker of listWorkerProcesses(workerPath, this.model)) {
       // Never signal ourselves. This should not happen, since the worker is a
       // child process, but guard against logic bugs that would deadlock us.
       if (worker.pid === process.pid) {
@@ -893,6 +908,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         worker,
         process.pid,
         isProcessAlive,
+        getIsContainerized(),
       );
       if (ownership === "foreign") {
         continue;
@@ -1030,7 +1046,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     if (!this.workerPath) {
       return;
     }
-    for (const worker of listWorkerProcesses(this.workerPath)) {
+    for (const worker of listWorkerProcesses(this.workerPath, this.model)) {
       if (worker.ppid !== process.pid || worker.pid === proc?.pid) {
         continue;
       }

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -110,14 +110,13 @@ interface WorkerProcess {
  *   its own backend against this same workspace and is entitled to its own
  *   worker; signalling it is what made the two replace each other in a loop.
  *
- * PID 1 means different things in different deployments, and getting it wrong
- * reintroduces exactly the cross-owner interference this exists to remove. In a
- * container `docker-entrypoint.sh` execs the daemon, so PID 1 IS the daemon and
- * a worker parented to it is a healthy sibling's. On a host PID 1 is init, so
- * the same parentage means the owner died. Containerized workers therefore
- * resolve to `foreign`: the daemon still reclaims its own (they match
- * `selfPid`), and declining to signal costs at most a delayed reap, where
- * guessing wrong kills a live worker.
+ * A parent of PID 1 is ambiguous, and resolving it wrongly in either direction
+ * costs something real. `docker-entrypoint.sh` execs the daemon, so PID 1 can
+ * BE the daemon and its child a healthy sibling's worker. Under `docker run
+ * --init`, and on any host, PID 1 is an init process instead, so the same
+ * parentage means the owner died and the worker needs reclaiming. Callers
+ * therefore pass what PID 1 actually is rather than inferring it from whether
+ * the deployment is containerized, which is true in both container shapes.
  */
 export type WorkerOwnership = "reclaim" | "orphan" | "foreign";
 
@@ -125,18 +124,51 @@ export function classifyWorkerOwnership(
   worker: WorkerProcess,
   selfPid: number,
   isOwnerAlive: (pid: number) => boolean,
-  isContainerized: boolean,
+  pid1OwnsWorkers: boolean,
 ): WorkerOwnership {
   if (worker.ppid === selfPid) {
     return "reclaim";
   }
   if (worker.ppid <= 1) {
-    return isContainerized ? "foreign" : "orphan";
+    return pid1OwnsWorkers ? "foreign" : "orphan";
   }
   if (!isOwnerAlive(worker.ppid)) {
     return "orphan";
   }
   return "foreign";
+}
+
+/** Entrypoint the daemon is exec'd with, including inside a container. */
+const DAEMON_ENTRYPOINT_MARKER = "daemon/main";
+
+/**
+ * Whether PID 1 is an assistant daemon rather than an init process.
+ *
+ * True only where the daemon was exec'd as PID 1 (`docker-entrypoint.sh`),
+ * which is what makes a worker parented to 1 a live sibling's rather than an
+ * orphan. Under `docker run --init` PID 1 is docker-init and under launchd or
+ * systemd it is the system init, so both answer false and PID-1 orphans stay
+ * reclaimable. Unreadable means false, which keeps the reclaiming behaviour.
+ */
+function pid1OwnsEmbedWorkers(): boolean {
+  if (process.pid === 1) {
+    return true;
+  }
+  let cmd: string;
+  try {
+    cmd = readFileSync("/proc/1/cmdline", "utf8").split("\0").join(" ");
+  } catch {
+    const result = Bun.spawnSync({
+      cmd: ["ps", "-ww", "-p", "1", "-o", "command="],
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    if (result.exitCode !== 0) {
+      return false;
+    }
+    cmd = new TextDecoder().decode(result.stdout);
+  }
+  return cmd.includes(DAEMON_ENTRYPOINT_MARKER);
 }
 
 /** Enumerate `(pid, ppid, rawCommand)` rows from Linux `/proc`. */
@@ -224,7 +256,11 @@ export function listWorkerProcesses(
   return rows
     .filter(
       (r) =>
-        r.cmd.includes(workerPath) && (model == null || r.cmd.includes(model)),
+        r.cmd.includes(workerPath) &&
+        // An argv token, not a substring: `foo/bar-small` must not match a
+        // `foo/bar-small-v2` worker, or a backend for the shorter name would
+        // reclaim the longer one's live worker. Model names carry no spaces.
+        (!model || r.cmd.split(/\s+/).includes(model)),
     )
     .map((r) => ({ pid: r.pid, ppid: r.ppid }));
 }
@@ -908,7 +944,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         worker,
         process.pid,
         isProcessAlive,
-        getIsContainerized(),
+        pid1OwnsEmbedWorkers(),
       );
       if (ownership === "foreign") {
         continue;


### PR DESCRIPTION
## TL;DR

Follow-up to [#39731](https://github.com/vellum-ai/vellum-assistant/pull/39731), which merged with a confirmed defect in the ownership rule.

`assistant/docker-entrypoint.sh` ends in `exec bun ... src/daemon/main.ts`, so **in a container the daemon is PID 1** and its healthy embedding worker has `ppid === 1`. The merged rule classifies any `ppid <= 1` as orphaned, so the memory-worker process sweeping alongside the daemon reads that healthy child as abandoned and SIGTERMs it. That recreates, in the shipped container topology, precisely the cross-owner interference #39731 exists to remove.

Caught by both Devin and Vex on the final review round, after the branch had already merged.

## Before / after

| Situation | On main today | After |
|---|---|---|
| Docker: memory worker starts while daemon (PID 1) has a healthy worker | Sweep reads `ppid === 1` as orphaned and kills the daemon's live worker | Left alone as another owner's |
| Docker: daemon reclaims a worker it lost track of | Works (matches its own pid first) | Unchanged |
| Host: worker reparented to init after its owner died | Reclaimed as an orphan | Unchanged |
| Two local backends for different models in one process | Each reclaims the other's worker | Each only matches its own |

## Why this shape

The classifier reads PID 1's command line to distinguish the two supported container topologies instead of treating `IS_CONTAINERIZED` as sufficient. Direct Docker execs the daemon as PID 1, so a sibling sweep preserves that daemon's healthy worker. CLI-managed Docker uses `docker run --init`, so PID 1 is an init process and a genuinely reparented worker remains reclaimable as an orphan. If PID 1 cannot be read, the check fails closed toward reclamation rather than silently protecting a leak.

The model is now part of worker matching because `getWorkerPath()` is model-independent while `backendCache` is keyed by `local:<model>`, so two backends would otherwise share a path and a parent and reclaim each other. The real worker already carries the model in argv, so this is matching what is there; test fixtures were spawning without it and are corrected.

## Why this is safe

- **Strictly narrows what gets signalled.** The only behaviour change is `foreign` where the merged code said `orphan`, plus a tighter match. Nothing is killed that main spares today.
- **Host and `docker run --init` orphan behavior stays intact.** When PID 1 is not the assistant daemon, a reparented worker remains reclaimable.
- **No interface, config, file-format, or CLI change.** The PID file's path, format, and write points are untouched, so `vellum ps` and orphan detection are unaffected.
- **Backwards compatible** with workers already running from an older daemon: matching is on the worker script path plus the model, both of which older workers already carry in argv.

## Verification

37 lifecycle tests pin both PID-1 meanings: a direct-Docker daemon-owned worker is left alone by a sibling sweep, the daemon still reclaims its own child, and a worker reparented to `docker-init` remains reclaimable. The broader focused audit passed 57 tests across lifecycle, embedding backend, and memory-worker control suites. Fast and full typechecks pass, and all GitHub CI checks are green.

The ownership matcher was previously verified on both platforms (macOS `ps -ww`, and real Linux `/proc/<pid>/cmdline` in Docker, confirming `process.title` does not clobber argv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->