### PR TITLE
docs(ios): correct the MyViewController background comment to the view == webView reality

### DIFF
--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -102,20 +102,32 @@ class MyViewController: CAPBridgeViewController {
         return QuoteReplyWebView(frame: frame, configuration: configuration)
     }
 
-    /// Paint the native root view (and the web view's own backgrounds) with the
-    /// design system's `--surface-overlay` token so the safe-area regions that
-    /// fall *outside* the web viewport — most visibly the home-indicator band
-    /// below the drawer — match the web surface instead of the system default.
+    /// Paint the web view's backgrounds with the design system's
+    /// `--surface-overlay` token so the safe-area regions that fall *outside*
+    /// the web layout viewport, most visibly the home-indicator band below
+    /// the drawer, match the web surface instead of the system default.
     ///
-    /// The WKWebView's content extends to `viewport-fit=cover`, but its layout
-    /// height stops at the safe-area edge; the strip beneath it is painted by
-    /// the view controller's root view, which otherwise falls back to
-    /// `systemBackground` (pure white / near-black) and reads as a seam against
-    /// `--surface-overlay` (`#FDFDFC` light / `#1C2024` dark). Making the web
-    /// view non-opaque with a matching background lets the token color show
-    /// through uniformly. The color lives in the `SurfaceOverlay` asset-catalog
-    /// color set (light + dark appearances) so it tracks the design token as a
-    /// single native source of truth rather than a hardcoded literal.
+    /// Capacitor's `CAPBridgeViewController.loadView()` assigns
+    /// `view = webView`, so there is no separate root view behind the web
+    /// view: the `view.backgroundColor` and `webView?.backgroundColor` writes
+    /// below alias the same layer, and all four background writes cooperate
+    /// on the one web view. The web content extends under
+    /// `viewport-fit=cover`, but the layout height stops at the safe-area
+    /// edge; with the keyboard closed, the home-indicator band is painted by
+    /// the web view's own background plus `underPageBackgroundColor` (see
+    /// below), which otherwise fall back to `systemBackground` (pure white /
+    /// near-black) and read as a seam against `--surface-overlay` (`#FDFDFC`
+    /// light / `#1C2024` dark). While the keyboard is shown, the Keyboard
+    /// plugin (`resize: native`) shrinks the web view frame, and the region
+    /// below it is backed only by the `UIWindow`, whose backdrop is painted
+    /// via the Keyboard plugin's `autoBackdropColor` config in
+    /// `capacitor.config.ts`.
+    ///
+    /// Making the web view non-opaque with a matching background lets the
+    /// token color show through uniformly. The color lives in the
+    /// `SurfaceOverlay` asset-catalog color set (light + dark appearances) so
+    /// it tracks the design token as a single native source of truth rather
+    /// than a hardcoded literal.
     override open func viewDidLoad() {
         super.viewDidLoad()
         let surfaceOverlay = UIColor(named: "SurfaceOverlay")


### PR DESCRIPTION
## Summary
- Corrects the background rationale comment: Capacitor's `loadView` assigns `view = webView`, so no separate root view exists; the at-rest home-indicator band is painted by the web view background plus `underPageBackgroundColor`.
- Documents that the region below the web view's shrunk frame during keyboard display is backed only by the UIWindow, painted via the Keyboard plugin's `autoBackdropColor`.
- Comment text only, no behavior change.

Part of plan: ios-keyboard-composer-dock-and-backdrop.md (PR 3 of 3)