### PR TITLE
fix(web): dock the empty-chat composer above the open keyboard

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -459,6 +459,81 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
   });
 });
 
+describe("ChatBody - plugin pills hide while the keyboard is open", () => {
+  // The plugin controls rendered below the composer share the dock's
+  // treatment: while the soft keyboard is up they fade out, collapse their
+  // reserved height, and go inert so the composer (not the plugin row)
+  // docks to the keyboard edge. The slot stays mounted so dismissing the
+  // keyboard restores it without a remount.
+  const pluginPillsSlot = <div data-testid="plugins">PLUGIN_PILLS</div>;
+  const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
+
+  const dockedProps = () =>
+    withEmptyState({
+      dockStartersToBottom: true,
+      startersSlot,
+      pluginPillsSlot,
+    });
+
+  const pluginsWrapper = (container: HTMLElement) =>
+    container.querySelector<HTMLElement>('[data-slot="new-chat-plugins"]');
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
+  });
+
+  test("keyboard closed: the plugin row is expanded and interactive", () => {
+    keyboardOpen = false;
+    const { container } = render(<ChatBody {...dockedProps()} />);
+
+    const wrapper = pluginsWrapper(container);
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).not.toContain("opacity-0");
+    expect(wrapper?.className).not.toContain("pointer-events-none");
+    expect(wrapper?.hasAttribute("inert")).toBe(false);
+    expect(wrapper?.style.gridTemplateRows).toBe("1fr");
+    expect(container.innerHTML).toContain("PLUGIN_PILLS");
+  });
+
+  test("keyboard open: the plugin row collapses, fades, goes inert, and the composer is the last expanded child of the bottom-anchored group", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...dockedProps()} />);
+
+    const wrapper = pluginsWrapper(container);
+    expect(wrapper).not.toBeNull();
+    expect(container.innerHTML).toContain("PLUGIN_PILLS");
+    expect(wrapper?.className).toContain("opacity-0");
+    expect(wrapper?.className).toContain("pointer-events-none");
+    expect(wrapper?.hasAttribute("inert")).toBe(true);
+    expect(wrapper?.style.gridTemplateRows).toBe("0fr");
+
+    // Bottom-anchored group: the only sibling after the composer is the
+    // collapsed plugin wrapper, so the composer reaches the keyboard edge.
+    expect(container.innerHTML).toContain("justify-end");
+    const composer = container.querySelector('[data-testid="composer"]');
+    expect(composer?.nextElementSibling).toBe(wrapper as HTMLElement);
+    expect(composer?.nextElementSibling?.nextElementSibling).toBeNull();
+  });
+
+  test("keyboard toggling flips the hidden treatment without unmounting the slot", () => {
+    keyboardOpen = true;
+    const { container, rerender } = render(<ChatBody {...dockedProps()} />);
+    expect(pluginsWrapper(container)?.style.gridTemplateRows).toBe("0fr");
+    const mounted = container.querySelector('[data-testid="plugins"]');
+    expect(mounted).not.toBeNull();
+
+    keyboardOpen = false;
+    rerender(<ChatBody {...dockedProps()} />);
+    expect(pluginsWrapper(container)?.className).not.toContain("opacity-0");
+    expect(pluginsWrapper(container)?.style.gridTemplateRows).toBe("1fr");
+    // Same DOM node across the toggle proves the slot never remounted.
+    expect(container.querySelector('[data-testid="plugins"]')).toBe(
+      mounted as HTMLElement,
+    );
+  });
+});
+
 describe("ChatBody — pluginPillsSlot rendering", () => {
   test("renders pluginPillsSlot between the composer and the starters", () => {
     const html = renderToStaticMarkup(

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -377,24 +377,26 @@ describe("ChatBody — startersSlot rendering", () => {
 });
 
 describe("ChatBody - docked starters hide while the keyboard is open", () => {
-  // The docked (mobile empty-state) suggestions row fades out while the soft
-  // keyboard is up, staying mounted so the centered greeting + composer keep
-  // their layout. Class assertions here are regression pins on the markup,
-  // not proof of the rendered layout.
+  // The docked (mobile empty-state) suggestions row fades out and collapses
+  // its reserved height while the soft keyboard is up, and the greeting +
+  // composer group anchors to the bottom edge instead of centering. The dock
+  // stays mounted so dismissing the keyboard restores it without a remount.
+  // Class assertions here are regression pins on the markup, not proof of
+  // the rendered layout.
   const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
 
   const dockedProps = () =>
     withEmptyState({ dockStartersToBottom: true, startersSlot });
 
   const dockWrapper = (container: HTMLElement) =>
-    container.querySelector('[data-slot="docked-starters"]');
+    container.querySelector<HTMLElement>('[data-slot="docked-starters"]');
 
   afterEach(() => {
     keyboardOpen = false;
     cleanup();
   });
 
-  test("keyboard closed: the dock is visible, interactive, and not inert", () => {
+  test("keyboard closed: the dock is expanded, interactive, and the group centers", () => {
     keyboardOpen = false;
     const { container } = render(<ChatBody {...dockedProps()} />);
 
@@ -403,9 +405,12 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     expect(dock?.className).not.toContain("opacity-0");
     expect(dock?.className).not.toContain("pointer-events-none");
     expect(dock?.hasAttribute("inert")).toBe(false);
+    expect(dock?.style.gridTemplateRows).toBe("1fr");
+    expect(container.innerHTML).toContain("[justify-content:safe_center]");
+    expect(container.innerHTML).not.toContain("justify-end");
   });
 
-  test("keyboard open: the dock stays mounted but fades out and goes inert", () => {
+  test("keyboard open: the dock collapses, fades, goes inert, and the group bottom-anchors", () => {
     keyboardOpen = true;
     const { container } = render(<ChatBody {...dockedProps()} />);
 
@@ -415,16 +420,21 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     expect(dock?.className).toContain("opacity-0");
     expect(dock?.className).toContain("pointer-events-none");
     expect(dock?.hasAttribute("inert")).toBe(true);
+    expect(dock?.style.gridTemplateRows).toBe("0fr");
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
   });
 
   test("keyboard toggling flips the hidden treatment without unmounting", () => {
     keyboardOpen = true;
     const { container, rerender } = render(<ChatBody {...dockedProps()} />);
     expect(dockWrapper(container)?.className).toContain("opacity-0");
+    expect(dockWrapper(container)?.style.gridTemplateRows).toBe("0fr");
 
     keyboardOpen = false;
     rerender(<ChatBody {...dockedProps()} />);
     expect(dockWrapper(container)?.className).not.toContain("opacity-0");
+    expect(dockWrapper(container)?.style.gridTemplateRows).toBe("1fr");
     expect(container.innerHTML).toContain("STARTER_CHIPS");
   });
 
@@ -435,7 +445,17 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     );
 
     expect(container.innerHTML).toContain("STARTER_CHIPS");
+    expect(container.innerHTML).toContain("[justify-content:safe_center]");
+    expect(container.innerHTML).not.toContain("justify-end");
     expect(dockWrapper(container)).toBeNull();
+  });
+
+  test("transcript branch ignores keyboard state (no dock, no bottom-anchoring)", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...baseProps()} />);
+
+    expect(dockWrapper(container)).toBeNull();
+    expect(container.innerHTML).not.toContain("justify-end");
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -173,8 +173,9 @@ export interface ChatBodyProps {
    * that viewport, and {@link belowFoldSlot} is placed below the fold. Used by
    * the new-thread suggestions library. When false, the empty state keeps the
    * default layout where the starters sit directly below the composer.
-   * While the soft keyboard is open the dock fades out (kept mounted so the
-   * centered group does not jump).
+   * While the soft keyboard is open the greeting + composer anchor to the
+   * bottom edge and the dock fades out and collapses its reserved height
+   * (kept mounted so dismissing the keyboard restores it without a remount).
    */
   dockStartersToBottom?: boolean;
 
@@ -397,7 +398,12 @@ export function ChatBody({
         onDrop={dragHandlers.onDrop}
       >
         <div className="flex min-h-full flex-col">
-          <div className="flex flex-1 flex-col [justify-content:safe_center]">
+          {/* While the keyboard is open the group anchors to the bottom edge
+              (the shell bottom is the keyboard top), matching the transcript
+              layout; otherwise it centers in the first screen. */}
+          <div
+            className={`flex flex-1 flex-col ${keyboardOpen ? "justify-end" : "[justify-content:safe_center]"}`}
+          >
             <ChatScrollArea
               {...scrollAreaProps}
               bottomOverlayReservePx={bottomOverlayReservePx}
@@ -405,17 +411,23 @@ export function ChatBody({
             {renderComposerStack(null)}
           </div>
           {startersSlot && (
-            // Faded rather than unmounted while the keyboard is open:
-            // unmounting would recenter the greeting + composer and jump the
-            // layout. `inert` (not just opacity/pointer-events) so the hidden
-            // dock also leaves the tab order and accessibility tree.
+            // While the keyboard is open the dock fades and collapses its
+            // reserved height so the bottom-anchored composer reaches the
+            // keyboard edge. It stays mounted so it restores without a
+            // remount, and `inert` removes it from the tab order and the
+            // accessibility tree.
             <div
               data-slot="docked-starters"
               inert={keyboardOpen || undefined}
-              className={`px-3 pb-3 sm:px-6 transition-opacity duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`}
+              className={`grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`}
+              style={{ gridTemplateRows: keyboardOpen ? "0fr" : "1fr" }}
             >
-              <div className="mx-auto max-w-[var(--chat-max-width)]">
-                {startersSlot}
+              <div className="min-h-0 overflow-hidden">
+                <div className="px-3 pb-3 sm:px-6">
+                  <div className="mx-auto max-w-[var(--chat-max-width)]">
+                    {startersSlot}
+                  </div>
+                </div>
               </div>
             </div>
           )}

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -156,7 +156,10 @@ export interface ChatBodyProps {
    * wrapper directly below the composer and above {@link startersSlot}.
    * Visible only on the empty state; the parent passes `undefined` once
    * messages arrive. Rendered as a slot (like {@link startersSlot}) so
-   * `ChatBody` stays agnostic of the plugin data model.
+   * `ChatBody` stays agnostic of the plugin data model. While the soft
+   * keyboard is open the row fades out and collapses its reserved height
+   * (kept mounted) so the composer, not the plugin row, docks to the
+   * keyboard edge.
    */
   pluginPillsSlot?: ReactNode;
 
@@ -297,6 +300,18 @@ export function ChatBody({
     return unregisterVisibleBanner;
   }, [bannerRendered, registerVisibleBanner, unregisterVisibleBanner]);
 
+  // Shared treatment for the below-composer extras (the starters dock and
+  // the plugin pills) while the soft keyboard is open: fade out and collapse
+  // the reserved height so the bottom-anchored composer reaches the keyboard
+  // edge. Each stays mounted so dismissing the keyboard restores it without
+  // a remount, and `inert` removes it from the tab order and the
+  // accessibility tree.
+  const keyboardCollapseProps = {
+    inert: keyboardOpen || undefined,
+    className: `grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`,
+    style: { gridTemplateRows: keyboardOpen ? "0fr" : "1fr" },
+  };
+
   // Composer stack — stays at the same tree position across the empty→active
   // transition so React preserves its state (focus, draft text, attachments)
   // and iOS Safari does not blur the input on first send (LUM-1506 / LUM-1516).
@@ -366,7 +381,13 @@ export function ChatBody({
         {channelFooterSlot}
         <StagedQuotesStrip />
         {composerSlot}
-        {pluginPillsSlot && <div className="mt-4">{pluginPillsSlot}</div>}
+        {pluginPillsSlot && (
+          <div data-slot="new-chat-plugins" {...keyboardCollapseProps}>
+            <div className="min-h-0 overflow-hidden">
+              <div className="mt-4">{pluginPillsSlot}</div>
+            </div>
+          </div>
+        )}
         {trailingStarters}
       </div>
     </div>
@@ -411,17 +432,7 @@ export function ChatBody({
             {renderComposerStack(null)}
           </div>
           {startersSlot && (
-            // While the keyboard is open the dock fades and collapses its
-            // reserved height so the bottom-anchored composer reaches the
-            // keyboard edge. It stays mounted so it restores without a
-            // remount, and `inert` removes it from the tab order and the
-            // accessibility tree.
-            <div
-              data-slot="docked-starters"
-              inert={keyboardOpen || undefined}
-              className={`grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`}
-              style={{ gridTemplateRows: keyboardOpen ? "0fr" : "1fr" }}
-            >
+            <div data-slot="docked-starters" {...keyboardCollapseProps}>
               <div className="min-h-0 overflow-hidden">
                 <div className="px-3 pb-3 sm:px-6">
                   <div className="mx-auto max-w-[var(--chat-max-width)]">


### PR DESCRIPTION
## Summary
- While the soft keyboard is open, the empty-chat greeting and composer anchor to the bottom of the shell instead of centering, so the composer sits immediately above the keyboard like the transcript layout.
- The faded suggestions dock also collapses its reserved height (grid-rows 1fr to 0fr, existing repo pattern), which is what lets the composer reach the keyboard edge; it stays mounted and inert so dismissal restores it without a remount.
- At rest and on desktop/iPad the layout is unchanged.

Part of plan: ios-keyboard-composer-dock-and-backdrop.md (PR 1 of 3)