### PR TITLE
fix: simulator APNs environment and stale plugin doc pointers

### DIFF
--- a/clients/ios/App/App/ApnsEnvironmentPlugin.swift
+++ b/clients/ios/App/App/ApnsEnvironmentPlugin.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Capacitor plugin that reports which APNs environment this build's
 /// `aps-environment` entitlement actually points at, read from the embedded
 /// provisioning profile. The web side
-/// (`clients/web/src/runtime/push-registration.ts`) uses it to tag device
+/// (`clients/web/src/runtime/apns-environment.ts`) uses it to tag device
 /// tokens correctly: TestFlight signs every build, including dev-suffixed
 /// bundle IDs, with the production entitlement, so any heuristic based on the
 /// bundle ID misclassifies TestFlight dev builds and their pushes are
@@ -14,6 +14,10 @@ import Foundation
 /// - `"development"`: an Xcode / development-signed install
 /// - `"production"`: a TestFlight or App Store install
 /// - `"unknown"`: the profile exists but could not be read or parsed
+///
+/// Simulator builds ship no embedded profile and always resolve
+/// `"development"`, because APNs simulator push only uses the development
+/// environment.
 ///
 /// It never rejects. Per the skew rule in `clients/web/docs/CAPACITOR.md`, a
 /// plugin must not require a separate availability probe, so the one result
@@ -28,6 +32,12 @@ public class ApnsEnvironmentPlugin: CAPPlugin, CAPBridgedPlugin {
     ]
 
     @objc public func get(_ call: CAPPluginCall) {
+        #if targetEnvironment(simulator)
+            // Simulator builds ship no embedded profile, and APNs simulator
+            // push always uses the development environment.
+            call.resolve(["environment": "development"])
+            return
+        #endif
         call.resolve(["environment": Self.entitlementEnvironment()])
     }
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -153,7 +153,7 @@ The shell registers **five** Capacitor plugins in [`MyViewController.capacitorDi
 | `NativeBiometric` | [`src/runtime/native-biometric.ts`](../src/runtime/native-biometric.ts) | Face ID / Touch ID Keychain |
 | `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | `.playAndRecord` / `.voiceChat` session + interruption events. **Unproven on hardware** — see the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | The one ActivityKit activity mirroring a session |
-| `ApnsEnvironment` | [`src/runtime/push-registration.ts`](../src/runtime/push-registration.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
+| `ApnsEnvironment` | [`src/runtime/apns-environment.ts`](../src/runtime/apns-environment.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ios-push-lower-envs.md:
- Simulator builds resolve the development APNs environment instead of production (no embedded profile exists on simulators, which previously hit the App Store branch)
- CAPACITOR.md plugin table and the Swift doc header point at src/runtime/apns-environment.ts, the module that owns the registerPlugin call