### PR TITLE
fix: web push test consolidation and dedup-skip simplification

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
@@ -1,32 +1,21 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
+// ── APNs environment resolver ────────────────────────────────────────────────
 //
-// The default simulates an old shell without the plugin (bridge call rejects),
-// exercising the bundle-suffix heuristic fallback. Cases that exercise the
-// signing-derived path set `apnsEnvironmentRejects = false` and an explicit
-// `apnsEnvironmentResult`. Mirrors push-registration.test.ts, which covers the
-// resolver's own matrix; these tests pin the ActivityKit upsert to it.
+// Mocked directly; the resolver's own fallback matrix is covered by
+// runtime/apns-environment.test.ts. This file only pins the ActivityKit upsert
+// wiring to the shared resolver.
 
-let apnsEnvironmentResult: string | undefined;
-let apnsEnvironmentRejects = true;
-const apnsEnvironmentGetMock = mock(
-  async (): Promise<{ environment?: string }> => {
-    if (apnsEnvironmentRejects) {
-      throw new Error("ApnsEnvironment.get() is not implemented on ios");
-    }
-    return { environment: apnsEnvironmentResult };
-  },
+const resolveSignedApnsEnvironmentMock = mock(
+  async () => "production" as const,
 );
-
-mock.module("@capacitor/core", () => ({
-  registerPlugin: (name: string) =>
-    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
+mock.module("@/runtime/apns-environment", () => ({
+  resolveSignedApnsEnvironment: resolveSignedApnsEnvironmentMock,
 }));
 
 // ── @capacitor/app (lazy-imported plugin Proxy) ──────────────────────────────
 
-let bundleId = "ai.vocify-inc.vellum-assistant-ios";
+const bundleId = "ai.vocify-inc.vellum-assistant-ios";
 const getInfoMock = mock(async () => ({
   id: bundleId,
   name: "Vellum",
@@ -73,11 +62,8 @@ const { registerLiveActivityPushToken } =
   await import("@/domains/chat/voice/live-voice/live-activity-push-registration");
 
 beforeEach(() => {
-  bundleId = "ai.vocify-inc.vellum-assistant-ios";
-  apnsEnvironmentResult = undefined;
-  apnsEnvironmentRejects = true;
   lastUpsertArg = null;
-  apnsEnvironmentGetMock.mockClear();
+  resolveSignedApnsEnvironmentMock.mockClear();
   getInfoMock.mockClear();
   upsertMock.mockClear();
   deleteMock.mockClear();
@@ -86,39 +72,19 @@ beforeEach(() => {
 });
 
 describe("registerLiveActivityPushToken APNs environment", () => {
-  test("tags the token with the signing-derived environment: production on a .dev bundle (TestFlight dev build)", async () => {
-    apnsEnvironmentRejects = false;
-    apnsEnvironmentResult = "production";
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
+  test("tags the upsert with the shared resolver's environment", async () => {
     await registerLiveActivityPushToken(
-      "activity-token-tf",
+      "activity-token",
       "assistant-1",
       "conv-1",
     );
 
+    expect(resolveSignedApnsEnvironmentMock).toHaveBeenCalledWith(bundleId);
     expect(upsertMock).toHaveBeenCalledTimes(1);
     expect(lastUpsertArg?.path).toEqual({ assistant_id: "assistant-1" });
-    expect(lastUpsertArg?.body.token).toBe("activity-token-tf");
-    expect(lastUpsertArg?.body.bundle_id).toBe(
-      "ai.vocify-inc.vellum-assistant-ios.dev",
-    );
+    expect(lastUpsertArg?.body.token).toBe("activity-token");
+    expect(lastUpsertArg?.body.bundle_id).toBe(bundleId);
     expect(lastUpsertArg?.body.conversation_id).toBe("conv-1");
     expect(lastUpsertArg?.body.apns_environment).toBe("production");
-  });
-
-  test("falls back to the bundle-suffix heuristic when the bridge rejects (old shell), without a Sentry capture", async () => {
-    apnsEnvironmentRejects = true;
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
-    await registerLiveActivityPushToken(
-      "activity-token-old",
-      "assistant-1",
-      "conv-2",
-    );
-
-    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(1);
-    expect(lastUpsertArg?.body.apns_environment).toBe("development");
-    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/runtime/apns-environment.test.ts
+++ b/clients/web/src/runtime/apns-environment.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Fallback matrix for `resolveSignedApnsEnvironment`: the signing-derived
+ * plugin result wins when readable, the bundle-suffix heuristic covers
+ * `"unknown"` entitlements and pre-plugin shells whose bridge call rejects.
+ * Consumers (`push-registration.test.ts`,
+ * `live-activity-push-registration.test.ts`) mock this module and only pin
+ * their upsert wiring to it.
+ */
+
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
+//
+// The default simulates an old shell without the plugin (bridge call rejects).
+// Signing-derived cases set `apnsEnvironmentRejects = false` and an explicit
+// `apnsEnvironmentResult`.
+
+let apnsEnvironmentResult: string | undefined;
+let apnsEnvironmentRejects = true;
+const apnsEnvironmentGetMock = mock(
+  async (): Promise<{ environment?: string }> => {
+    if (apnsEnvironmentRejects) {
+      throw new Error("ApnsEnvironment.get() is not implemented on ios");
+    }
+    return { environment: apnsEnvironmentResult };
+  },
+);
+
+mock.module("@capacitor/core", () => ({
+  registerPlugin: (name: string) =>
+    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
+}));
+
+// ── Sentry capture-error ─────────────────────────────────────────────────────
+//
+// The module deliberately reports fallbacks via `console.debug` only (an old
+// shell is an expected state, not a fault); the mock makes the no-capture
+// assertion fail loudly if a future edit starts reporting them.
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { resolveSignedApnsEnvironment } =
+  await import("@/runtime/apns-environment");
+
+const consoleDebugSpy = spyOn(console, "debug").mockImplementation(() => {});
+
+const DEV_BUNDLE_ID = "ai.vocify-inc.vellum-assistant-ios.dev";
+const PROD_BUNDLE_ID = "ai.vocify-inc.vellum-assistant-ios";
+
+beforeEach(() => {
+  apnsEnvironmentResult = undefined;
+  apnsEnvironmentRejects = true;
+  apnsEnvironmentGetMock.mockClear();
+  captureErrorMock.mockClear();
+  consoleDebugSpy.mockClear();
+});
+
+describe("resolveSignedApnsEnvironment", () => {
+  test("plugin production wins over a .dev bundle (TestFlight dev build)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "production";
+
+    expect(await resolveSignedApnsEnvironment(DEV_BUNDLE_ID)).toBe(
+      "production",
+    );
+  });
+
+  test("plugin development wins over a production-mapping bundle (Xcode install)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "development";
+
+    expect(await resolveSignedApnsEnvironment(PROD_BUNDLE_ID)).toBe(
+      "development",
+    );
+  });
+
+  test("unknown entitlement falls back to the bundle-suffix heuristic", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "unknown";
+
+    expect(await resolveSignedApnsEnvironment(DEV_BUNDLE_ID)).toBe(
+      "development",
+    );
+    expect(await resolveSignedApnsEnvironment(PROD_BUNDLE_ID)).toBe(
+      "production",
+    );
+  });
+
+  test("bridge rejection (old shell) falls back to the heuristic: console.debug, no Sentry capture", async () => {
+    expect(await resolveSignedApnsEnvironment(DEV_BUNDLE_ID)).toBe(
+      "development",
+    );
+    expect(await resolveSignedApnsEnvironment(PROD_BUNDLE_ID)).toBe(
+      "production",
+    );
+
+    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(2);
+    expect(consoleDebugSpy).toHaveBeenCalledTimes(2);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/apns-environment.ts
+++ b/clients/web/src/runtime/apns-environment.ts
@@ -43,24 +43,10 @@ interface ApnsEnvironmentPlugin {
 const ApnsEnvironment =
   registerPlugin<ApnsEnvironmentPlugin>("ApnsEnvironment");
 
-/**
- * Bundle-id suffix that maps to the development APNs entitlement in the
- * fallback heuristic, consulted only for shells predating the
- * `ApnsEnvironment` plugin and for profiles it cannot parse (`"unknown"`).
- * The dev Xcode config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs
- * with `App-Dev.entitlements` (`aps-environment = development`) and ships the
- * `.dev` bundle id; production and staging both sign with `App.entitlements`
- * (`aps-environment = production`). The heuristic misreads TestFlight-signed
- * dev builds (production tokens on a `.dev` bundle id), which is why the
- * signing-derived plugin result wins when available.
- */
+/** Suffix dev-signed builds ship (`App-Dev.xcconfig`); see module docblock. */
 const DEV_BUNDLE_SUFFIX = ".dev";
 
-/**
- * Fallback heuristic: map the running build's bundle id to its APNs
- * entitlement environment. Only consulted when the `ApnsEnvironment` plugin
- * is absent (older shell) or cannot read the entitlement (`"unknown"`).
- */
+/** Suffix-heuristic fallback for absent or `"unknown"` plugin results. */
 function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
   return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
 }

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -27,10 +27,8 @@ mock.module("@/runtime/native-auth", () => ({
 // Mocked as pure flags; the helpers' own behavior is covered by
 // push-registration.test.ts.
 
-let remotePushSupported = true;
 let sessionConfirmedAssistantId: string | null = null;
 mock.module("@/runtime/push-registration", () => ({
-  isRemotePushSupported: () => remotePushSupported,
   hasSessionConfirmedRemotePushRegistration: (assistantId: string) =>
     sessionConfirmedAssistantId === assistantId,
 }));
@@ -84,7 +82,6 @@ const baseArgs = {
 };
 
 beforeEach(() => {
-  remotePushSupported = true;
   sessionConfirmedAssistantId = null;
   scheduleMock.mockClear();
   ackMock.mockClear();
@@ -160,39 +157,8 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
     expect(scheduleMock).toHaveBeenCalledTimes(1);
   });
 
-  test("dispatched with only a persisted registration from an earlier session: schedules", async () => {
-    // The mocked helper mirrors the real one in ignoring persisted storage:
-    // only a session-confirmed upsert counts. Seeding storage documents the
-    // reload scenario where a stored record survives but proves nothing
-    // about a live server-side token row, so the dedup skip must not fire.
-    localStorage.setItem(
-      "vellum:push_registration",
-      JSON.stringify({
-        token: "persisted-token",
-        bundleId: "ai.vocify-inc.vellum-assistant-ios",
-        assistantId: "assistant-1",
-      }),
-    );
-    setVisibility("hidden");
-
-    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
-
-    expect(scheduleMock).toHaveBeenCalledTimes(1);
-    localStorage.removeItem("vellum:push_registration");
-  });
-
   test("dispatched but registration belongs to a different assistant: schedules", async () => {
     sessionConfirmedAssistantId = "assistant-2";
-    setVisibility("hidden");
-
-    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
-
-    expect(scheduleMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("dispatched but remote push unsupported on this native platform: schedules", async () => {
-    remotePushSupported = false;
-    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("hidden");
 
     await postLocalNotification({ ...baseArgs, remotePushDispatched: true });

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -32,10 +32,7 @@ import { notificationintentresultPost } from "@/generated/daemon/sdk.gen";
 import type { NotificationintentresultPostData } from "@/generated/daemon/types.gen";
 import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
-import {
-  hasSessionConfirmedRemotePushRegistration,
-  isRemotePushSupported,
-} from "@/runtime/push-registration";
+import { hasSessionConfirmedRemotePushRegistration } from "@/runtime/push-registration";
 
 /**
  * Payload stored alongside each native notification so the tap handler can
@@ -409,7 +406,9 @@ export async function postLocalNotification(
     // at mount), and the app was hidden when the intent arrived; the
     // remote push banners on its own there, and scheduling the local one
     // too would double-notify during the SSE grace window after
-    // backgrounding.
+    // backgrounding. No separate support check: a session-confirmed
+    // registration is only reachable through `registerForRemotePush`,
+    // which requires remote-push support.
     //
     // Residual limitation: `remotePushDispatched` is an aggregate
     // account-level outcome (any device token accepted), so on a
@@ -419,7 +418,6 @@ export async function postLocalNotification(
     // dispatch endpoint.
     if (
       args.remotePushDispatched === true &&
-      isRemotePushSupported() &&
       args.assistantId !== undefined &&
       hasSessionConfirmedRemotePushRegistration(args.assistantId) &&
       visibilityAtIntent === "hidden"

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -11,24 +11,6 @@ import { subscribe } from "@/lib/event-bus";
 let isNative = true;
 let platform = "ios";
 
-// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
-//
-// The default simulates an old shell without the plugin (bridge call rejects),
-// so the pre-plugin tests below keep exercising the bundle-suffix heuristic
-// they were written against. Cases that exercise the signing-derived path set
-// `apnsEnvironmentRejects = false` and an explicit `apnsEnvironmentResult`.
-
-let apnsEnvironmentResult: string | undefined;
-let apnsEnvironmentRejects = true;
-const apnsEnvironmentGetMock = mock(
-  async (): Promise<{ environment?: string }> => {
-    if (apnsEnvironmentRejects) {
-      throw new Error("ApnsEnvironment.get() is not implemented on ios");
-    }
-    return { environment: apnsEnvironmentResult };
-  },
-);
-
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNative,
 }));
@@ -37,8 +19,20 @@ mock.module("@capacitor/core", () => ({
     isNativePlatform: () => isNative,
     getPlatform: () => platform,
   },
-  registerPlugin: (name: string) =>
-    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
+}));
+
+// ── APNs environment resolver ────────────────────────────────────────────────
+//
+// Mocked directly; the resolver's own fallback matrix is covered by
+// apns-environment.test.ts. These tests only pin the wiring: the upsert body
+// carries whatever the resolver returns.
+
+let resolvedApnsEnvironment: "development" | "production" = "production";
+const resolveSignedApnsEnvironmentMock = mock(
+  async () => resolvedApnsEnvironment,
+);
+mock.module("@/runtime/apns-environment", () => ({
+  resolveSignedApnsEnvironment: resolveSignedApnsEnvironmentMock,
 }));
 
 // ── @capacitor/push-notifications (lazy-imported plugin Proxy) ────────────────
@@ -83,7 +77,7 @@ mock.module("@capacitor/push-notifications", () => ({
 
 // ── @capacitor/app (lazy-imported plugin Proxy) ──────────────────────────────
 
-let bundleId = "ai.vocify-inc.vellum-assistant-ios";
+const bundleId = "ai.vocify-inc.vellum-assistant-ios";
 const getInfoMock = mock(async () => ({
   id: bundleId,
   name: "Vellum",
@@ -185,10 +179,8 @@ beforeEach(() => {
   isNative = true;
   platform = "ios";
   permissionState = "granted";
-  bundleId = "ai.vocify-inc.vellum-assistant-ios";
-  apnsEnvironmentResult = undefined;
-  apnsEnvironmentRejects = true;
-  apnsEnvironmentGetMock.mockClear();
+  resolvedApnsEnvironment = "production";
+  resolveSignedApnsEnvironmentMock.mockClear();
   registrationHandler = null;
   registrationErrorHandler = null;
   actionPerformedHandler = null;
@@ -257,15 +249,6 @@ describe("registerForRemotePush", () => {
     });
   });
 
-  test("derives the development APNs environment from a .dev bundle id", async () => {
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-    await registerForRemotePush("assistant-1");
-    registrationHandler?.({ value: "apns-token-dev" });
-    await flushMicrotasks();
-
-    expect(lastUpsertArg?.body.apns_environment).toBe("development");
-  });
-
   test("does not register when notification permission is denied", async () => {
     permissionState = "denied";
     await registerForRemotePush("assistant-1");
@@ -294,53 +277,16 @@ describe("registerForRemotePush", () => {
   });
 });
 
-describe("signing-derived APNs environment", () => {
-  const registerToken = async (token: string) => {
+describe("APNs environment wiring", () => {
+  test("upsert body carries the resolver's result for the build's bundle id", async () => {
+    resolvedApnsEnvironment = "development";
+
     await registerForRemotePush("assistant-1");
-    registrationHandler?.({ value: token });
+    registrationHandler?.({ value: "apns-token-dev" });
     await flushMicrotasks();
-  };
 
-  test("prefers the signed entitlement: production on a .dev bundle (TestFlight dev build)", async () => {
-    apnsEnvironmentRejects = false;
-    apnsEnvironmentResult = "production";
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
-    await registerToken("apns-token-testflight");
-
-    expect(lastUpsertArg?.body.apns_environment).toBe("production");
-  });
-
-  test("registers development when the build is development-signed (Xcode install)", async () => {
-    apnsEnvironmentRejects = false;
-    apnsEnvironmentResult = "development";
-
-    await registerToken("apns-token-xcode");
-
-    // The plugin result wins even though the non-.dev bundle id would map to
-    // production under the heuristic.
+    expect(resolveSignedApnsEnvironmentMock).toHaveBeenCalledWith(bundleId);
     expect(lastUpsertArg?.body.apns_environment).toBe("development");
-  });
-
-  test("falls back to the bundle-suffix heuristic when the entitlement is unreadable", async () => {
-    apnsEnvironmentRejects = false;
-    apnsEnvironmentResult = "unknown";
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
-    await registerToken("apns-token-unknown");
-
-    expect(lastUpsertArg?.body.apns_environment).toBe("development");
-  });
-
-  test("old shell without the plugin: heuristic fallback, no Sentry capture", async () => {
-    apnsEnvironmentRejects = true;
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
-    await registerToken("apns-token-old-shell");
-
-    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(1);
-    expect(lastUpsertArg?.body.apns_environment).toBe("development");
-    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -311,7 +311,9 @@ export async function unregisterFromRemotePush(): Promise<void> {
     await Promise.allSettled([...pendingUpserts]);
   }
 
-  const registered = loadCurrentRegistration();
+  // Module memory, falling back to persisted storage: a process reload wipes
+  // `lastRegistered` while the token stays registered server-side.
+  const registered = lastRegistered ?? persistedRegistration.load();
   lastRegistered = null;
   persistedRegistration.remove();
 
@@ -346,15 +348,6 @@ export async function unregisterFromRemotePush(): Promise<void> {
       bestEffort: true,
     });
   }
-}
-
-/**
- * The registration this device currently holds: module memory, falling
- * back to persisted storage (a process reload wipes `lastRegistered`
- * while the token stays registered server-side).
- */
-function loadCurrentRegistration(): RegisteredToken | null {
-  return lastRegistered ?? persistedRegistration.load();
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ios-push-lower-envs.md:
- apns-environment.test.ts owns the resolver fallback matrix; consumer tests slim to wiring cases without duplicated bridge-mock scaffolding
- dedup skip drops the redundant isRemotePushSupported() check (session-confirmed registration implies it) and its impossible-state test
- inlined the one-caller loadCurrentRegistration wrapper, removed a mock-theater test, deduplicated the TestFlight rationale comments