### PR TITLE
fix: keep the persistence layer free of plugin imports for the conversation-kind classifier

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -125,6 +125,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../daemon/turn-latency-sub-spans.js",
     "../../../../notifications/emit-signal.js",
     "../../../../persistence/checkpoints.js",
+    "../../../../persistence/conversation-types.js",
     "../../../../persistence/db-connection.js",
     "../../../../persistence/embeddings/embed.js",
     "../../../../persistence/embeddings/embedding-backend.js",

--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -99,10 +99,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "src/home/feed-source-enrichment.ts",
     "src/permissions/checker.ts",
     "src/persistence/conversation-crud.ts",
-    // `resolveConversationKind` compares a conversation's `source` against the
-    // memory-consolidation source. The reach is one frozen string constant with
-    // no dependencies of its own.
-    "src/persistence/conversation-types.ts",
     "src/persistence/steps.ts",
     "src/prompts/system-prompt.ts",
     "src/runtime/routes/consolidation-routes.ts",

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -6,9 +6,14 @@
 // used by notification-feed and memory filters, plus the source-aware
 // `resolveConversationKind` classifier.
 
-// The only import here is a frozen string constant with no dependencies of its
-// own, which keeps this module cheap for every importer.
-import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../plugins/defaults/memory/substrate/constants.js";
+/**
+ * Canonical `conversations.source` string for background memory v2
+ * consolidation runs. A persisted column value, so it lives with the rest of
+ * the conversation vocabulary rather than inside the memory plugin that
+ * writes it (persistence must not depend on a plugin).
+ */
+// FROZEN: persisted `conversations.source` value. Never rename it.
+export const MEMORY_V2_CONSOLIDATION_SOURCE = "memory_v2_consolidation";
 
 /** How a conversation was created / its execution mode. */
 export type ConversationCreateType = "standard" | "background" | "scheduled";

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -156,7 +156,7 @@ const HOST_TIER_IMPORT_ALLOWLIST: readonly HostTierImportExemption[] = [
   { path: "src/runtime/routes/consolidation-routes.ts", tiers: ["substrate"] },
   {
     path: "src/runtime/routes/conversation-query-routes.ts",
-    tiers: ["substrate", "v2", "v3"],
+    tiers: ["v2", "v3"],
   },
   { path: "src/runtime/routes/global-search-routes.ts", tiers: ["v1"] },
   { path: "src/runtime/routes/secret-routes.ts", tiers: ["substrate"] },

--- a/assistant/src/plugins/defaults/memory/substrate/constants.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/constants.ts
@@ -1,8 +1,6 @@
 /**
  * Canonical `conversations.source` string for background memory v2
- * consolidation runs. Lives in a tiny constants module so the route layer can
- * recognize consolidation conversations without importing the consolidation
- * job (which pulls in agent-wake + bootstrap dependencies).
+ * consolidation runs. Owned by the persistence layer (it is a persisted
+ * column value) and re-exported here for the plugin's own call sites.
  */
-// FROZEN: persisted `conversations.source` value — never rename it.
-export const MEMORY_V2_CONSOLIDATION_SOURCE = "memory_v2_consolidation";
+export { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../../../persistence/conversation-types.js";


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unseen-reply-notify.md.

**Gap:** persistence -> memory-plugin import broke the frozen architecture guards (branch test job red)
**Fix:** MEMORY_V2_CONSOLIDATION_SOURCE now lives in persistence and the plugin re-exports it; guard baselines/exemptions cleaned instead of widened