### PR TITLE
fix: notification routing and deferral robustness gaps from plan review

### DIFF
--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -7,6 +7,7 @@ const runDeterministicChecksMock = mock();
 const createEventMock = mock();
 const updateEventDedupeKeyMock = mock();
 const dispatchDecisionMock = mock();
+const isPlatformClientConfiguredMock = mock();
 
 mock.module("../channels/config.js", () => ({
   getDeliverableChannels: () => ["vellum", "telegram"],
@@ -37,6 +38,12 @@ mock.module("../notifications/broadcaster.js", () => ({
     setOnConversationCreated(_fn: unknown) {}
   },
 }));
+
+// Capture the real enforcement before the module mock below replaces it:
+// the single_channel interplay tests exercise the genuine cap logic against
+// the urgency force-add's channel ordering.
+const { enforceRoutingIntent: realEnforceRoutingIntent } =
+  await import("../notifications/decision-engine.js");
 
 mock.module("../notifications/decision-engine.js", () => ({
   evaluateSignal: (...args: unknown[]) => evaluateSignalMock(...args),
@@ -78,27 +85,41 @@ mock.module("../notifications/runtime-dispatch.js", () => ({
   dispatchDecision: (...args: unknown[]) => dispatchDecisionMock(...args),
 }));
 
+mock.module("../platform/client.js", () => ({
+  // The adapter import graph needs the class symbol; nothing in these tests
+  // dispatches through it.
+  VellumPlatformClient: class {
+    static async create(): Promise<null> {
+      return null;
+    }
+  },
+  isPlatformClientConfigured: () => isPlatformClientConfiguredMock(),
+}));
+
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 
-describe("emitNotificationSignal routing intent re-persistence", () => {
-  beforeEach(() => {
-    evaluateSignalMock.mockReset();
-    enforceRoutingIntentMock.mockReset();
-    updateDecisionMock.mockReset();
-    runDeterministicChecksMock.mockReset();
-    createEventMock.mockReset();
-    updateEventDedupeKeyMock.mockReset();
-    dispatchDecisionMock.mockReset();
+beforeEach(() => {
+  evaluateSignalMock.mockReset();
+  enforceRoutingIntentMock.mockReset();
+  updateDecisionMock.mockReset();
+  runDeterministicChecksMock.mockReset();
+  createEventMock.mockReset();
+  updateEventDedupeKeyMock.mockReset();
+  dispatchDecisionMock.mockReset();
+  isPlatformClientConfiguredMock.mockReset();
 
-    createEventMock.mockReturnValue({ id: "evt-1" });
-    runDeterministicChecksMock.mockResolvedValue({ passed: true });
-    dispatchDecisionMock.mockResolvedValue({
-      dispatched: true,
-      reason: "ok",
-      deliveryResults: [],
-    });
+  createEventMock.mockReturnValue({ id: "evt-1" });
+  runDeterministicChecksMock.mockResolvedValue({ passed: true });
+  dispatchDecisionMock.mockResolvedValue({
+    dispatched: true,
+    reason: "ok",
+    deliveryResults: [],
   });
+  isPlatformClientConfiguredMock.mockResolvedValue(true);
+  enforceRoutingIntentMock.mockImplementation((decision: unknown) => decision);
+});
 
+describe("emitNotificationSignal routing intent re-persistence", () => {
   test("re-persists selectedChannels/reasoningSummary when enforcement changes the decision", async () => {
     const preDecision = {
       shouldNotify: true,
@@ -226,21 +247,6 @@ describe("emitNotificationSignal routing intent re-persistence", () => {
 });
 
 describe("emitNotificationSignal source-active pre-gate", () => {
-  beforeEach(() => {
-    evaluateSignalMock.mockReset();
-    runDeterministicChecksMock.mockReset();
-    createEventMock.mockReset();
-    dispatchDecisionMock.mockReset();
-
-    createEventMock.mockReturnValue({ id: "evt-src-active" });
-    runDeterministicChecksMock.mockResolvedValue({ passed: true });
-    dispatchDecisionMock.mockResolvedValue({
-      dispatched: true,
-      reason: "ok",
-      deliveryResults: [],
-    });
-  });
-
   test("suppresses visibleInSourceNow signals before the decision engine runs", async () => {
     const result = await emitNotificationSignal({
       sourceEventName: "ingress.trusted_contact.verification_sent",
@@ -294,23 +300,6 @@ describe("emitNotificationSignal source-active pre-gate", () => {
 });
 
 describe("access-request vellum floor", () => {
-  beforeEach(() => {
-    evaluateSignalMock.mockReset();
-    enforceRoutingIntentMock.mockReset();
-    updateDecisionMock.mockReset();
-    runDeterministicChecksMock.mockReset();
-    createEventMock.mockReset();
-    updateEventDedupeKeyMock.mockReset();
-    dispatchDecisionMock.mockReset();
-    createEventMock.mockReturnValue({ id: "evt-1" });
-    runDeterministicChecksMock.mockResolvedValue({ passed: true });
-    dispatchDecisionMock.mockResolvedValue({
-      dispatched: true,
-      reason: "ok",
-      deliveryResults: [],
-    });
-  });
-
   test("rescues a suppressed access-request decision onto the vellum channel", async () => {
     evaluateSignalMock.mockResolvedValue({
       shouldNotify: false,
@@ -469,26 +458,6 @@ describe("access-request vellum floor", () => {
 });
 
 describe("high/critical urgency channel force", () => {
-  beforeEach(() => {
-    evaluateSignalMock.mockReset();
-    enforceRoutingIntentMock.mockReset();
-    updateDecisionMock.mockReset();
-    runDeterministicChecksMock.mockReset();
-    createEventMock.mockReset();
-    updateEventDedupeKeyMock.mockReset();
-    dispatchDecisionMock.mockReset();
-    createEventMock.mockReturnValue({ id: "evt-1" });
-    runDeterministicChecksMock.mockResolvedValue({ passed: true });
-    dispatchDecisionMock.mockResolvedValue({
-      dispatched: true,
-      reason: "ok",
-      deliveryResults: [],
-    });
-    enforceRoutingIntentMock.mockImplementation(
-      (decision: unknown) => decision,
-    );
-  });
-
   function makeDecision(overrides: Record<string, unknown>) {
     return {
       shouldNotify: true,
@@ -546,7 +515,7 @@ describe("high/critical urgency channel force", () => {
     // row must still be synced to the dispatched channels.
     expect(updateDecisionMock).toHaveBeenCalledTimes(1);
     expect(updateDecisionMock).toHaveBeenCalledWith("dec-urg-1", {
-      selectedChannels: ["vellum", "platform", "telegram"],
+      selectedChannels: ["vellum", "telegram", "platform"],
       reasoningSummary:
         "LLM selected telegram only (vellum, platform forced: high urgency)",
       validationResults: {
@@ -568,7 +537,7 @@ describe("high/critical urgency channel force", () => {
       selectedChannels: string[];
       reasoningSummary: string;
     };
-    expect(dispatched.selectedChannels).toEqual(["platform", "vellum"]);
+    expect(dispatched.selectedChannels).toEqual(["vellum", "platform"]);
     expect(dispatched.reasoningSummary).toContain(
       "(platform forced: critical urgency)",
     );
@@ -653,13 +622,89 @@ describe("high/critical urgency channel force", () => {
     };
     expect(enforcedInput.selectedChannels).toEqual([
       "vellum",
-      "platform",
       "telegram",
+      "platform",
     ]);
     // ...and its cap wins over the force-add.
     const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
       selectedChannels: string[];
     };
     expect(dispatched.selectedChannels).toEqual(["telegram"]);
+  });
+
+  test("forces only vellum when the platform client is not configured", async () => {
+    isPlatformClientConfiguredMock.mockResolvedValue(false);
+    evaluateSignalMock.mockResolvedValue(makeDecision({}));
+
+    await emitWithUrgency("high");
+
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.selectedChannels).toEqual(["vellum", "telegram"]);
+    expect(dispatched.reasoningSummary).toContain(
+      "(vellum forced: high urgency)",
+    );
+  });
+
+  // Real single_channel enforcement caps to the source channel when it is
+  // connected, else to the FIRST selected channel. The force-add prepends
+  // vellum precisely so that fallback keeps the in-app banner; these tests
+  // run the genuine enforcement to pin the interplay.
+  describe("interplay with real single_channel enforcement", () => {
+    beforeEach(() => {
+      enforceRoutingIntentMock.mockImplementation(
+        realEnforceRoutingIntent as (...args: unknown[]) => unknown,
+      );
+    });
+
+    function emitHighUrgencySingleChannel(
+      sourceChannel: "watcher" | "assistant_tool",
+    ) {
+      return emitNotificationSignal({
+        sourceEventName: "watcher.escalation",
+        sourceChannel,
+        sourceContextId: "watch-1",
+        routingIntent: "single_channel",
+        attentionHints: {
+          requiresAction: true,
+          urgency: "high",
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+        contextPayload: {},
+      });
+    }
+
+    test("vellum survives the cap when the decision selected only vellum", async () => {
+      evaluateSignalMock.mockResolvedValue(
+        makeDecision({ selectedChannels: ["vellum"] }),
+      );
+
+      await emitHighUrgencySingleChannel("watcher");
+
+      // Force-add appends platform: ["vellum", "platform"]. The source
+      // channel is not connected, so the cap falls back to index 0.
+      const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+        selectedChannels: string[];
+      };
+      expect(dispatched.selectedChannels).toEqual(["vellum"]);
+    });
+
+    test("the cap picks the prepended vellum when the decision selected another channel", async () => {
+      evaluateSignalMock.mockResolvedValue(
+        makeDecision({ selectedChannels: ["telegram"] }),
+      );
+
+      await emitHighUrgencySingleChannel("assistant_tool");
+
+      // Force-add yields ["vellum", "telegram", "platform"]; the
+      // non-connected source channel makes the cap take index 0.
+      const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+        selectedChannels: string[];
+      };
+      expect(dispatched.selectedChannels).toEqual(["vellum"]);
+    });
   });
 });

--- a/assistant/src/__tests__/notification-platform-adapter.test.ts
+++ b/assistant/src/__tests__/notification-platform-adapter.test.ts
@@ -33,11 +33,13 @@ interface FetchCall {
   path: string;
   method: string;
   body: Record<string, unknown>;
+  hasAbortSignal: boolean;
 }
 
 const fetchCalls: FetchCall[] = [];
 const fetchResponses: Array<{ ok: boolean; status: number; body?: string }> =
   [];
+const fetchErrors: Error[] = [];
 let clientAvailable = true;
 
 mock.module("../platform/client.js", () => ({
@@ -52,7 +54,16 @@ mock.module("../platform/client.js", () => ({
           const body = init?.body
             ? (JSON.parse(init.body as string) as Record<string, unknown>)
             : {};
-          fetchCalls.push({ path, method: init?.method ?? "GET", body });
+          fetchCalls.push({
+            path,
+            method: init?.method ?? "GET",
+            body,
+            hasAbortSignal: init?.signal instanceof AbortSignal,
+          });
+          const error = fetchErrors.shift();
+          if (error) {
+            throw error;
+          }
           const response = fetchResponses.shift() ?? {
             ok: true,
             status: 200,
@@ -107,6 +118,7 @@ describe("PlatformPushAdapter", () => {
   beforeEach(() => {
     fetchCalls.length = 0;
     fetchResponses.length = 0;
+    fetchErrors.length = 0;
     clientAvailable = true;
   });
 
@@ -201,6 +213,28 @@ describe("PlatformPushAdapter", () => {
     expect(result.error).toContain("500");
     // 1 initial + 3 retries = 4 attempts
     expect(fetchCalls).toHaveLength(4);
+  });
+
+  test("bounds every attempt with an abort signal", async () => {
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(fetchCalls[0]?.hasAbortSignal).toBe(true);
+  });
+
+  test("retries attempts that abort on the per-attempt timeout", async () => {
+    fetchErrors.push(
+      new DOMException("The operation timed out.", "TimeoutError"),
+    );
+    fetchResponses.push({ ok: true, status: 200, body: '{"tokens_sent": 1}' });
+
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
   });
 
   test("does not retry on 4xx responses", async () => {

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -7,6 +7,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { PairingResult } from "../conversation-pairing.js";
 import type { NotificationSignal } from "../signal.js";
 import type {
   ChannelAdapter,
@@ -36,15 +37,7 @@ mock.module("../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => null,
 }));
 
-interface MockPairing {
-  conversationId: string | null;
-  messageId: string | null;
-  strategy: string;
-  createdNewConversation: boolean;
-  conversationFallbackUsed: boolean;
-}
-
-function defaultPairing(): MockPairing {
+function defaultPairing(): PairingResult {
   return {
     conversationId: null,
     messageId: null,
@@ -54,11 +47,17 @@ function defaultPairing(): MockPairing {
   };
 }
 
-let pairingByChannel: Record<string, MockPairing> = {};
+let pairingByChannel: Record<string, PairingResult> = {};
+let pairingErrorByChannel: Record<string, Error> = {};
 
 mock.module("../conversation-pairing.js", () => ({
-  pairDeliveryWithConversation: async (_signal: unknown, channel: string) =>
-    pairingByChannel[channel] ?? defaultPairing(),
+  pairDeliveryWithConversation: async (_signal: unknown, channel: string) => {
+    const error = pairingErrorByChannel[channel];
+    if (error) {
+      throw error;
+    }
+    return pairingByChannel[channel] ?? defaultPairing();
+  },
 }));
 
 mock.module("../deliveries-store.js", () => ({
@@ -161,6 +160,7 @@ beforeEach(() => {
   composeFallbackReturn = {};
   knownConversations = new Set();
   pairingByChannel = {};
+  pairingErrorByChannel = {};
 });
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -426,21 +426,93 @@ describe("NotificationBroadcaster remotePushDispatched flag", () => {
     expect(results.find((r) => r.channel === "vellum")?.status).toBe("sent");
   });
 
-  test("vellum payload carries false when platform is not selected", async () => {
-    composeFallbackReturn = {
-      vellum: { title: "Reminder", body: "Hello" },
+  test("vellum intent still flushes with false when the platform channel's prep throws", async () => {
+    bothChannelsCopy();
+    pairingErrorByChannel = { platform: new Error("pairing exploded") };
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: true,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await expect(
+      broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision()),
+    ).rejects.toThrow("pairing exploded");
+
+    // The platform adapter never ran, but the deferred vellum send must not
+    // be lost -- its pending delivery row would block retries forever.
+    expect(platform.sends.length).toBe(0);
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("deadline expiry flushes vellum with false while the platform dispatch finishes in the background", async () => {
+    bothChannelsCopy();
+
+    let resolvePlatform: ((result: DeliveryResult) => void) | undefined;
+    const platformSends: CapturedSend[] = [];
+    const platform: ChannelAdapter = {
+      channel: "platform",
+      send(
+        payload: ChannelDeliveryPayload,
+        destination: ChannelDestination,
+      ): Promise<DeliveryResult> {
+        platformSends.push({ payload, destination });
+        return new Promise<DeliveryResult>((resolve) => {
+          resolvePlatform = resolve;
+        });
+      },
     };
+    const vellum = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([vellum.adapter, platform]);
 
-    const { adapter, sends } = makeCapturingAdapter("vellum");
-    const broadcaster = new NotificationBroadcaster([adapter]);
-
-    await broadcaster.broadcastDecision(
+    const results = await broadcaster.broadcastDecision(
       makeSignal(),
-      makeDecision({ selectedChannels: ["vellum"], renderedCopy: {} }),
+      bothChannelsDecision(),
+      { platformOutcomeDeadlineMs: 20 },
     );
 
-    expect(sends.length).toBe(1);
-    expect(sends[0]?.payload.remotePushDispatched).toBe(false);
+    expect(platformSends.length).toBe(1);
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+    expect(results.find((r) => r.channel === "platform")?.status).toBe(
+      "pending",
+    );
+
+    // The dispatch settling after the deadline must not re-send vellum.
+    resolvePlatform?.({ success: true, remotePushAccepted: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("platform completing before the deadline sets the real outcome on the vellum payload", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform: ChannelAdapter = {
+      channel: "platform",
+      async send(): Promise<DeliveryResult> {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return { success: true, remotePushAccepted: true };
+      },
+    };
+    const broadcaster = new NotificationBroadcaster([vellum.adapter, platform]);
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal(),
+      bothChannelsDecision(),
+      { platformOutcomeDeadlineMs: 1_000 },
+    );
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(true);
+    expect(results.find((r) => r.channel === "platform")?.status).toBe("sent");
   });
 
   test("dispatches the platform adapter before the vellum intent when both are selected", async () => {
@@ -498,6 +570,40 @@ describe("NotificationBroadcaster remotePushDispatched flag", () => {
       conversationId: "conv-vellum-1",
       messageId: "msg-1",
     });
+  });
+});
+
+describe("NotificationBroadcaster forced-platform copy reuse", () => {
+  test("platform payload reuses the vellum rendered copy instead of template fallback", async () => {
+    // A urgency-forced platform channel has no rendered copy of its own; the
+    // template fallback must lose to the vellum channel's rendered copy.
+    composeFallbackReturn = {
+      platform: { title: "Template title", body: "Template body" },
+    };
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: true,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(
+      makeSignal(),
+      makeDecision({
+        selectedChannels: ["vellum", "platform"],
+        renderedCopy: {
+          vellum: { title: "Rendered title", body: "Rendered body" },
+        },
+      }),
+    );
+
+    expect(platform.sends.length).toBe(1);
+    expect(platform.sends[0]?.payload.copy.title).toBe("Rendered title");
+    expect(platform.sends[0]?.payload.copy.body).toBe("Rendered body");
   });
 });
 

--- a/assistant/src/notifications/adapters/platform.ts
+++ b/assistant/src/notifications/adapters/platform.ts
@@ -35,6 +35,17 @@ const log = getLogger("notif-adapter-platform");
 // Exponential backoff delays for 5xx/timeout retries: 250ms → 1s → 4s
 const RETRY_DELAYS_MS = [250, 1_000, 4_000] as const;
 
+// Per-attempt abort timeout. The underlying platform fetch has no timeout of
+// its own, and the broadcaster defers the urgent local banner on this
+// dispatch's outcome -- a hung platform must fail the attempt, not stall it.
+const ATTEMPT_TIMEOUT_MS = 5_000;
+
+/** Whether a fetch error is the per-attempt abort timeout firing. */
+function isAttemptTimeout(err: unknown): boolean {
+  const name = (err as { name?: unknown } | null)?.name;
+  return name === "TimeoutError" || name === "AbortError";
+}
+
 interface DispatchBody {
   delivery_id?: string;
   source_event_name: string;
@@ -98,9 +109,13 @@ export class PlatformPushAdapter implements ChannelAdapter {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
+          signal: AbortSignal.timeout(ATTEMPT_TIMEOUT_MS),
         });
       } catch (err) {
-        if (attempt < RETRY_DELAYS_MS.length && isRetryableNetworkError(err)) {
+        if (
+          attempt < RETRY_DELAYS_MS.length &&
+          (isAttemptTimeout(err) || isRetryableNetworkError(err))
+        ) {
           log.warn(
             {
               attempt,

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -226,7 +226,13 @@ export type OnConversationCreatedFn = (
 ) => void | Promise<void>;
 export interface BroadcastDecisionOptions {
   onConversationCreated?: OnConversationCreatedFn;
+  /** Deadline override for tests; defaults to PLATFORM_OUTCOME_DEADLINE_MS. */
+  platformOutcomeDeadlineMs?: number;
 }
+
+// Cap on how long the deferred vellum send waits for the platform dispatch
+// outcome: a duplicate banner beats a late one.
+const PLATFORM_OUTCOME_DEADLINE_MS = 2_500;
 
 /**
  * A channel dispatch that is fully prepared (destination resolved, copy
@@ -336,7 +342,8 @@ export class NotificationBroadcaster {
     // eagerly, so the platform deep link keeps the vellum pairing carry), but
     // its adapter send is deferred until the platform adapter reports whether
     // the platform accepted a device push. Typical cost: one fast HTTP
-    // round-trip before the local banner goes out.
+    // round-trip before the local banner goes out, capped at
+    // PLATFORM_OUTCOME_DEADLINE_MS.
     let deferredVellumSend: PendingChannelDispatch | null = null;
     let platformRemotePushAccepted = false;
     const flushDeferredVellumSend = async (): Promise<void> => {
@@ -349,350 +356,427 @@ export class NotificationBroadcaster {
       await this.sendAndRecord(pending, signal, results);
     };
 
-    for (const channel of orderedChannels) {
-      // Platform sorts immediately after vellum, so once any other channel is
-      // reached the platform outcome is settled: flush the deferred vellum
-      // send now so the local banner is not held behind slower sends.
-      if (channel !== "vellum" && channel !== "platform") {
-        await flushDeferredVellumSend();
-      }
+    try {
+      for (const channel of orderedChannels) {
+        // Platform sorts immediately after vellum, so reaching any later
+        // channel means the platform outcome is settled (or the platform
+        // channel was skipped): flush the deferred vellum send now so the
+        // local banner is not held behind slower sends. On the vellum
+        // iteration itself this is a no-op -- vellum appears at most once in
+        // the decision's channels and sorts first, so nothing is deferred yet.
+        if (channel !== "platform") {
+          await flushDeferredVellumSend();
+        }
 
-      const adapter = this.adapters.get(channel);
-      if (!adapter) {
-        log.warn(
-          { channel, signalId: signal.signalId },
-          "No adapter registered for channel -- skipping",
-        );
-        results.push({
-          channel,
-          destination: "",
-          status: "skipped",
-          errorMessage: `No adapter for channel: ${channel}`,
-        });
-        continue;
-      }
-
-      const destination = destinations.get(channel);
-      if (!destination) {
-        log.warn(
-          { channel, signalId: signal.signalId },
-          "Could not resolve destination -- skipping",
-        );
-        results.push({
-          channel,
-          destination: "",
-          status: "skipped",
-          errorMessage: `Destination not resolved for channel: ${channel}`,
-        });
-        continue;
-      }
-
-      // Pull rendered copy from the decision; fall back to copy-composer if
-      // missing or effectively blank. The decision engine's LLM occasionally
-      // returns empty title/body strings that pass type-only validation, so
-      // treat copy with no usable content the same as missing copy.
-      let copy = decision.renderedCopy[channel];
-      if (!copy || (!copy.title?.trim() && !copy.body?.trim())) {
-        if (copy) {
+        const adapter = this.adapters.get(channel);
+        if (!adapter) {
           log.warn(
             { channel, signalId: signal.signalId },
-            "Decision copy has empty title and body — using fallback",
+            "No adapter registered for channel -- skipping",
           );
+          results.push({
+            channel,
+            destination: "",
+            status: "skipped",
+            errorMessage: `No adapter for channel: ${channel}`,
+          });
+          continue;
         }
-        if (!fallbackCopy) {
-          fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
+
+        const destination = destinations.get(channel);
+        if (!destination) {
+          log.warn(
+            { channel, signalId: signal.signalId },
+            "Could not resolve destination -- skipping",
+          );
+          results.push({
+            channel,
+            destination: "",
+            status: "skipped",
+            errorMessage: `Destination not resolved for channel: ${channel}`,
+          });
+          continue;
         }
-        copy = fallbackCopy[channel];
-      }
 
-      // Fail closed: if neither the decision nor the fallback composer produced
-      // a usable body, skip the channel rather than leaking the raw event name
-      // as placeholder text. The pre-send `checkRenderedCopyQuality` only sees
-      // `decision.renderedCopy`, so this is the last guard before delivery.
-      if (!copy || !copy.body?.trim()) {
-        log.warn(
-          { channel, signalId: signal.signalId },
-          "No usable rendered copy available -- skipping channel to avoid leaking event name",
-        );
-        results.push({
-          channel,
-          destination: destination.endpoint ?? channel,
-          status: "skipped",
-          errorMessage: `No usable rendered copy for channel: ${channel}`,
-        });
-        continue;
-      }
-
-      // For tool_grant_request signals, prefer the deterministic template seed
-      // over LLM-generated prose. The enriched questionText is already concise
-      // and informative — LLM rewording just adds noise.
-      if (signal.contextPayload?.requestKind === "tool_grant_request") {
-        if (!fallbackCopy) {
-          fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
-        }
-        const templateSeed = fallbackCopy[channel]?.conversationSeedMessage;
-        if (templateSeed) {
-          copy = { ...copy, conversationSeedMessage: templateSeed };
-        }
-      }
-
-      // Resolve the per-channel conversation action from the decision (default: start_new)
-      const conversationAction: ConversationAction | undefined =
-        decision.conversationActions?.[channel];
-
-      // Check for duplicate delivery BEFORE pairing to avoid side effects
-      // (e.g. appending seed messages to existing conversations) on retry paths
-      // where a delivery row already exists.
-      const persistedDecisionId = decision.persistedDecisionId;
-      const hasPersistedDecision = typeof persistedDecisionId === "string";
-      if (hasPersistedDecision) {
-        const existingDelivery = findDeliveryByDecisionAndChannel(
-          persistedDecisionId,
-          channel,
-        );
-        if (existingDelivery) {
-          // On retry paths the vellum row already exists, so the fresh-pairing
-          // carry below never runs — seed the platform deep-link carry from
-          // the duplicate row's conversation instead.
-          if (channel === "vellum" && existingDelivery.conversationId) {
-            vellumPairing = {
-              conversationId: existingDelivery.conversationId,
-              messageId: existingDelivery.messageId,
-            };
+        // Pull rendered copy from the decision; fall back to copy-composer if
+        // missing or effectively blank. The decision engine's LLM occasionally
+        // returns empty title/body strings that pass type-only validation, so
+        // treat copy with no usable content the same as missing copy.
+        let copy = decision.renderedCopy[channel];
+        if (!copy || (!copy.title?.trim() && !copy.body?.trim())) {
+          if (copy) {
+            log.warn(
+              { channel, signalId: signal.signalId },
+              "Decision copy has empty title and body -- using fallback",
+            );
           }
-          log.info(
-            {
-              channel,
-              signalId: signal.signalId,
-              existingDeliveryId: existingDelivery.id,
-            },
-            "Delivery already exists for this decision+channel — skipping duplicate",
+          // A policy-forced platform channel has no rendered copy of its own
+          // (the decision engine renders only the channels it selected). The
+          // push mirrors the in-app banner -- and the iOS dedup suppresses the
+          // vellum banner in its favor -- so reuse the vellum channel's
+          // rendered copy before falling back to deterministic templates.
+          const vellumCopy =
+            channel === "platform" ? decision.renderedCopy.vellum : undefined;
+          if (vellumCopy?.body?.trim()) {
+            copy = vellumCopy;
+          } else {
+            if (!fallbackCopy) {
+              fallbackCopy = composeFallbackCopy(
+                signal,
+                decision.selectedChannels,
+              );
+            }
+            copy = fallbackCopy[channel];
+          }
+        }
+
+        // Fail closed: if neither the decision nor the fallback composer produced
+        // a usable body, skip the channel rather than leaking the raw event name
+        // as placeholder text. The pre-send `checkRenderedCopyQuality` only sees
+        // `decision.renderedCopy`, so this is the last guard before delivery.
+        if (!copy || !copy.body?.trim()) {
+          log.warn(
+            { channel, signalId: signal.signalId },
+            "No usable rendered copy available -- skipping channel to avoid leaking event name",
           );
           results.push({
             channel,
             destination: destination.endpoint ?? channel,
             status: "skipped",
-            errorMessage: "Duplicate delivery skipped",
-            conversationId: existingDelivery.conversationId ?? undefined,
-            messageId: existingDelivery.messageId ?? undefined,
-            conversationStrategy:
-              existingDelivery.conversationStrategy ?? undefined,
+            errorMessage: `No usable rendered copy for channel: ${channel}`,
           });
           continue;
         }
-      }
 
-      // Pair the delivery with a conversation before sending, passing the conversation action
-      // and destination binding context for channel-scoped continuation
-      const pairing = await pairDeliveryWithConversation(
-        signal,
-        channel,
-        copy,
-        { conversationAction, bindingContext: destination.bindingContext },
-      );
-
-      if (channel === "vellum" && pairing.conversationId) {
-        vellumPairing = {
-          conversationId: pairing.conversationId,
-          messageId: pairing.messageId,
-        };
-      }
-
-      // For the vellum and platform channels, merge the conversationId into
-      // deep-link metadata so notification taps can navigate to the
-      // conversation. Prefer the channel's own pairing; platform (push_only,
-      // pairs nothing) takes this broadcast's vellum pairing; otherwise fall
-      // back to sourceContextId when it resolves to a real row. Sentinel
-      // context ids (job IDs, call session IDs, access-req-* strings) leave
-      // the deep link without a conversation, and the client opens the app to
-      // its default landing.
-      let deepLinkTarget = decision.deepLinkTarget;
-      if (channel === "vellum" || channel === "platform") {
-        const deepLinkPairing =
-          channel === "platform" && !pairing.conversationId
-            ? (vellumPairing ?? pairing)
-            : pairing;
-        const deepLinkConversationId =
-          deepLinkPairing.conversationId ??
-          resolveSourceConversationId(signal.sourceContextId) ??
-          resolveDeepLinkConversationId(signal.contextPayload);
-        if (deepLinkConversationId) {
-          deepLinkTarget = {
-            ...deepLinkTarget,
-            conversationId: deepLinkConversationId,
-          };
-          if (deepLinkPairing.messageId) {
-            deepLinkTarget = {
-              ...deepLinkTarget,
-              messageId: deepLinkPairing.messageId,
-            };
-          }
-        }
-      }
-
-      if (channel === "vellum" && pairing.conversationId) {
-        // Resolve guardian scoping for conversation-created events so clients
-        // can filter guardian-sensitive conversations the same way they filter
-        // guardian-sensitive notification intents.
-        const guardianPrincipalId =
-          typeof destination.metadata?.guardianPrincipalId === "string"
-            ? destination.metadata.guardianPrincipalId
-            : undefined;
-        const targetGuardianPrincipalId =
-          guardianPrincipalId &&
-          isGuardianSensitiveEvent(signal.sourceEventName)
-            ? guardianPrincipalId
-            : undefined;
-
-        const conversationTitle =
-          copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
-        const conversationSilent =
-          signal.attentionHints.urgency !== "high" &&
-          signal.attentionHints.urgency !== "critical";
-        const info: ConversationCreatedInfo = {
-          conversationId: pairing.conversationId,
-          title: conversationTitle,
-          sourceEventName: signal.sourceEventName,
-          targetGuardianPrincipalId,
-          groupId: signal.conversationMetadata?.groupId,
-          source: signal.conversationMetadata?.source,
-          silent: conversationSilent,
-        };
-
-        // The per-dispatch onConversationCreated callback fires whenever a vellum
-        // conversation is paired (new or reused) because callers like
-        // dispatchGuardianQuestion rely on it to create delivery bookkeeping
-        // rows before emitNotificationSignal() returns. A returned promise is
-        // awaited so those rows are durable before the client can learn of
-        // the conversation and act on its approval card.
-        if (options?.onConversationCreated) {
-          try {
-            await options.onConversationCreated(info);
-          } catch (err) {
-            log.error(
-              { err, signalId: signal.signalId },
-              "per-dispatch onConversationCreated callback failed — continuing broadcast",
+        // For tool_grant_request signals, prefer the deterministic template seed
+        // over LLM-generated prose. The enriched questionText is already concise
+        // and informative -- LLM rewording just adds noise.
+        if (signal.contextPayload?.requestKind === "tool_grant_request") {
+          if (!fallbackCopy) {
+            fallbackCopy = composeFallbackCopy(
+              signal,
+              decision.selectedChannels,
             );
           }
+          const templateSeed = fallbackCopy[channel]?.conversationSeedMessage;
+          if (templateSeed) {
+            copy = { ...copy, conversationSeedMessage: templateSeed };
+          }
         }
 
-        // Emit notification_conversation_created event only when a NEW
-        // conversation was actually created. Reusing an existing conversation
-        // should not fire the event — the client already knows about the
-        // conversation.
-        if (
-          pairing.createdNewConversation &&
-          pairing.strategy === "start_new_conversation"
-        ) {
-          if (this.onConversationCreated) {
-            try {
-              await this.onConversationCreated(info);
-            } catch (err) {
-              log.error(
-                { err, signalId: signal.signalId },
-                "onConversationCreated callback failed — continuing broadcast",
-              );
+        // Resolve the per-channel conversation action from the decision (default: start_new)
+        const conversationAction: ConversationAction | undefined =
+          decision.conversationActions?.[channel];
+
+        // Check for duplicate delivery BEFORE pairing to avoid side effects
+        // (e.g. appending seed messages to existing conversations) on retry paths
+        // where a delivery row already exists.
+        const persistedDecisionId = decision.persistedDecisionId;
+        const hasPersistedDecision = typeof persistedDecisionId === "string";
+        if (hasPersistedDecision) {
+          const existingDelivery = findDeliveryByDecisionAndChannel(
+            persistedDecisionId,
+            channel,
+          );
+          if (existingDelivery) {
+            // On retry paths the vellum row already exists, so the fresh-pairing
+            // carry below never runs -- seed the platform deep-link carry from
+            // the duplicate row's conversation instead.
+            if (channel === "vellum" && existingDelivery.conversationId) {
+              vellumPairing = {
+                conversationId: existingDelivery.conversationId,
+                messageId: existingDelivery.messageId,
+              };
+            }
+            log.info(
+              {
+                channel,
+                signalId: signal.signalId,
+                existingDeliveryId: existingDelivery.id,
+              },
+              "Delivery already exists for this decision+channel -- skipping duplicate",
+            );
+            results.push({
+              channel,
+              destination: destination.endpoint ?? channel,
+              status: "skipped",
+              errorMessage: "Duplicate delivery skipped",
+              conversationId: existingDelivery.conversationId ?? undefined,
+              messageId: existingDelivery.messageId ?? undefined,
+              conversationStrategy:
+                existingDelivery.conversationStrategy ?? undefined,
+            });
+            continue;
+          }
+        }
+
+        // Pair the delivery with a conversation before sending, passing the conversation action
+        // and destination binding context for channel-scoped continuation
+        const pairing = await pairDeliveryWithConversation(
+          signal,
+          channel,
+          copy,
+          { conversationAction, bindingContext: destination.bindingContext },
+        );
+
+        if (channel === "vellum" && pairing.conversationId) {
+          vellumPairing = {
+            conversationId: pairing.conversationId,
+            messageId: pairing.messageId,
+          };
+        }
+
+        // For the vellum and platform channels, merge the conversationId into
+        // deep-link metadata so notification taps can navigate to the
+        // conversation. Prefer the channel's own pairing; platform (push_only,
+        // pairs nothing) takes this broadcast's vellum pairing; otherwise fall
+        // back to sourceContextId when it resolves to a real row. Sentinel
+        // context ids (job IDs, call session IDs, access-req-* strings) leave
+        // the deep link without a conversation, and the client opens the app to
+        // its default landing.
+        let deepLinkTarget = decision.deepLinkTarget;
+        if (channel === "vellum" || channel === "platform") {
+          const deepLinkPairing =
+            channel === "platform" && !pairing.conversationId
+              ? (vellumPairing ?? pairing)
+              : pairing;
+          const deepLinkConversationId =
+            deepLinkPairing.conversationId ??
+            resolveSourceConversationId(signal.sourceContextId) ??
+            resolveDeepLinkConversationId(signal.contextPayload);
+          if (deepLinkConversationId) {
+            deepLinkTarget = {
+              ...deepLinkTarget,
+              conversationId: deepLinkConversationId,
+            };
+            if (deepLinkPairing.messageId) {
+              deepLinkTarget = {
+                ...deepLinkTarget,
+                messageId: deepLinkPairing.messageId,
+              };
             }
           }
         }
-      }
 
-      const deliveryId = uuid();
-      const destinationLabel = destination.endpoint ?? channel;
+        if (channel === "vellum" && pairing.conversationId) {
+          // Resolve guardian scoping for conversation-created events so clients
+          // can filter guardian-sensitive conversations the same way they filter
+          // guardian-sensitive notification intents.
+          const guardianPrincipalId =
+            typeof destination.metadata?.guardianPrincipalId === "string"
+              ? destination.metadata.guardianPrincipalId
+              : undefined;
+          const targetGuardianPrincipalId =
+            guardianPrincipalId &&
+            isGuardianSensitiveEvent(signal.sourceEventName)
+              ? guardianPrincipalId
+              : undefined;
 
-      const payload: ChannelDeliveryPayload = {
-        deliveryId,
-        sourceEventName: signal.sourceEventName,
-        copy,
-        deepLinkTarget,
-        contextPayload: signal.contextPayload,
-        urgency: signal.attentionHints.urgency,
-        approvalContext,
-        accessRequestContext,
-        toolApprovalSource,
-        // Starts false for vellum; the deferred-send flush overwrites it
-        // with the actual platform outcome when platform is also selected.
-        ...(channel === "vellum" ? { remotePushDispatched: false } : {}),
-      };
+          const conversationTitle =
+            copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
+          const conversationSilent =
+            signal.attentionHints.urgency !== "high" &&
+            signal.attentionHints.urgency !== "critical";
+          const info: ConversationCreatedInfo = {
+            conversationId: pairing.conversationId,
+            title: conversationTitle,
+            sourceEventName: signal.sourceEventName,
+            targetGuardianPrincipalId,
+            groupId: signal.conversationMetadata?.groupId,
+            source: signal.conversationMetadata?.source,
+            silent: conversationSilent,
+          };
 
-      // Compute conversation decision audit fields for the delivery record
-      const conversationAudit = {
-        conversationAction: conversationAction?.action ?? "start_new",
-        conversationTargetId:
-          conversationAction?.action === "reuse_existing"
-            ? conversationAction.conversationId
-            : undefined,
-        conversationFallbackUsed: pairing.conversationFallbackUsed,
-      };
+          // The per-dispatch onConversationCreated callback fires whenever a vellum
+          // conversation is paired (new or reused) because callers like
+          // dispatchGuardianQuestion rely on it to create delivery bookkeeping
+          // rows before emitNotificationSignal() returns. A returned promise is
+          // awaited so those rows are durable before the client can learn of
+          // the conversation and act on its approval card.
+          if (options?.onConversationCreated) {
+            try {
+              await options.onConversationCreated(info);
+            } catch (err) {
+              log.error(
+                { err, signalId: signal.signalId },
+                "per-dispatch onConversationCreated callback failed -- continuing broadcast",
+              );
+            }
+          }
 
-      try {
-        if (hasPersistedDecision) {
-          createDelivery({
-            id: deliveryId,
-            notificationDecisionId: persistedDecisionId,
+          // Emit notification_conversation_created event only when a NEW
+          // conversation was actually created. Reusing an existing conversation
+          // should not fire the event -- the client already knows about the
+          // conversation.
+          if (
+            pairing.createdNewConversation &&
+            pairing.strategy === "start_new_conversation"
+          ) {
+            if (this.onConversationCreated) {
+              try {
+                await this.onConversationCreated(info);
+              } catch (err) {
+                log.error(
+                  { err, signalId: signal.signalId },
+                  "onConversationCreated callback failed -- continuing broadcast",
+                );
+              }
+            }
+          }
+        }
+
+        const deliveryId = uuid();
+        const destinationLabel = destination.endpoint ?? channel;
+
+        const payload: ChannelDeliveryPayload = {
+          deliveryId,
+          sourceEventName: signal.sourceEventName,
+          copy,
+          deepLinkTarget,
+          contextPayload: signal.contextPayload,
+          urgency: signal.attentionHints.urgency,
+          approvalContext,
+          accessRequestContext,
+          toolApprovalSource,
+        };
+
+        // Compute conversation decision audit fields for the delivery record
+        const conversationAudit = {
+          conversationAction: conversationAction?.action ?? "start_new",
+          conversationTargetId:
+            conversationAction?.action === "reuse_existing"
+              ? conversationAction.conversationId
+              : undefined,
+          conversationFallbackUsed: pairing.conversationFallbackUsed,
+        };
+
+        try {
+          if (hasPersistedDecision) {
+            createDelivery({
+              id: deliveryId,
+              notificationDecisionId: persistedDecisionId,
+              channel,
+              destination: destinationLabel,
+              status: "pending",
+              attempt: 1,
+              renderedTitle: copy.title,
+              renderedBody: copy.body,
+              conversationId: pairing.conversationId ?? undefined,
+              messageId: pairing.messageId ?? undefined,
+              conversationStrategy: pairing.strategy,
+              ...conversationAudit,
+            });
+          } else {
+            log.warn(
+              { channel, signalId: signal.signalId },
+              "No persisted decision ID -- skipping delivery record creation",
+            );
+          }
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          log.error(
+            { err, channel, signalId: signal.signalId },
+            "Failed to create delivery record",
+          );
+          results.push({
             channel,
             destination: destinationLabel,
-            status: "pending",
-            attempt: 1,
-            renderedTitle: copy.title,
-            renderedBody: copy.body,
+            status: "failed",
+            errorMessage,
             conversationId: pairing.conversationId ?? undefined,
             messageId: pairing.messageId ?? undefined,
             conversationStrategy: pairing.strategy,
-            ...conversationAudit,
           });
-        } else {
-          log.warn(
-            { channel, signalId: signal.signalId },
-            "No persisted decision ID -- skipping delivery record creation",
-          );
+          continue;
         }
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        log.error(
-          { err, channel, signalId: signal.signalId },
-          "Failed to create delivery record",
-        );
-        results.push({
+
+        const dispatch: PendingChannelDispatch = {
+          adapter,
           channel,
-          destination: destinationLabel,
-          status: "failed",
-          errorMessage,
-          conversationId: pairing.conversationId ?? undefined,
-          messageId: pairing.messageId ?? undefined,
-          conversationStrategy: pairing.strategy,
-        });
-        continue;
-      }
+          destination,
+          payload,
+          deliveryId,
+          destinationLabel,
+          pairing,
+          hasPersistedDecision,
+        };
 
-      const dispatch: PendingChannelDispatch = {
-        adapter,
-        channel,
-        destination,
-        payload,
-        deliveryId,
-        destinationLabel,
-        pairing,
-        hasPersistedDecision,
-      };
+        if (channel === "vellum" && orderedChannels.includes("platform")) {
+          // The vellum intent carries remotePushDispatched, so its send waits
+          // for the platform outcome; everything else (pairing, events, the
+          // pending delivery row) already ran above.
+          deferredVellumSend = dispatch;
+          continue;
+        }
 
-      if (channel === "vellum" && orderedChannels.includes("platform")) {
-        // The vellum intent carries remotePushDispatched, so its send waits
-        // for the platform outcome; everything else (pairing, events, the
-        // pending delivery row) already ran above.
-        deferredVellumSend = dispatch;
-        continue;
-      }
+        if (channel === "platform" && deferredVellumSend) {
+          // The local banner is urgent: wait for the platform outcome only up
+          // to the deadline (a duplicate banner beats a late one). On expiry
+          // the vellum send flushes with remotePushDispatched=false while the
+          // dispatch keeps running, recording its delivery row when it
+          // settles; the late outcome cannot re-flush vellum.
+          const backgroundResults: NotificationDeliveryResult[] = [];
+          const platformSend = this.sendAndRecord(
+            dispatch,
+            signal,
+            backgroundResults,
+          ).then((adapterResult) => {
+            platformRemotePushAccepted =
+              adapterResult?.remotePushAccepted === true;
+          });
+          let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+          const deadline = new Promise<"deadline">((resolve) => {
+            deadlineTimer = setTimeout(
+              () => resolve("deadline"),
+              options?.platformOutcomeDeadlineMs ??
+                PLATFORM_OUTCOME_DEADLINE_MS,
+            );
+          });
+          const raced = await Promise.race([
+            platformSend.then(() => "settled" as const),
+            deadline,
+          ]);
+          clearTimeout(deadlineTimer);
+          if (raced === "deadline") {
+            log.warn(
+              { channel, signalId: signal.signalId },
+              "Platform dispatch outcome unknown at deadline -- sending the local banner without it",
+            );
+            // The in-flight dispatch's result lands in backgroundResults,
+            // which this call no longer reads; its delivery row still gets
+            // the real terminal status.
+            results.push({
+              channel,
+              destination: destinationLabel,
+              status: "pending",
+              conversationId: pairing.conversationId ?? undefined,
+              messageId: pairing.messageId ?? undefined,
+              conversationStrategy: pairing.strategy,
+            });
+          } else {
+            results.push(...backgroundResults);
+          }
+          await flushDeferredVellumSend();
+          continue;
+        }
 
-      const adapterResult = await this.sendAndRecord(dispatch, signal, results);
-      if (channel === "platform") {
-        platformRemotePushAccepted = adapterResult?.remotePushAccepted === true;
+        const adapterResult = await this.sendAndRecord(
+          dispatch,
+          signal,
+          results,
+        );
+        if (channel === "platform") {
+          platformRemotePushAccepted =
+            adapterResult?.remotePushAccepted === true;
+        }
       }
+    } finally {
+      // Guarantees the vellum intent is emitted (and its pending delivery
+      // row resolved) even when a later channel's prep throws; also covers
+      // the common [vellum, platform] selection where no later channel
+      // triggered the mid-loop flush.
+      await flushDeferredVellumSend();
     }
-
-    // Covers the common [vellum, platform] selection where no later channel
-    // triggered the flush.
-    await flushDeferredVellumSend();
 
     return results;
   }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -18,6 +18,7 @@ import {
   guardianForChannel,
 } from "../contacts/guardian-delivery-reader.js";
 import type { ConversationCreateType } from "../persistence/conversation-types.js";
+import { isPlatformClientConfigured } from "../platform/client.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import { VellumAdapter } from "./adapters/macos.js";
@@ -329,19 +330,38 @@ export async function emitNotificationSignal<TEventName extends string>(
     // system notification (vellum) and the remote push (platform),
     // regardless of what the decision engine selected. macOS surfaces a
     // banner even when the app is focused, and a suspended iOS device is
-    // only reachable via APNs.
+    // only reachable via APNs. Platform is only forced when the daemon has
+    // platform credentials -- on unbound daemons the dispatch can never
+    // succeed and would write a failed delivery row per signal.
+    //
+    // Vellum PREPENDS and platform APPENDS: the broadcaster re-sorts by
+    // dispatch rank, so selection order only matters to single_channel
+    // enforcement's first-selected fallback (step 2.5b), which must keep
+    // the in-app banner rather than a push the server may skip.
     const urgency = signal.attentionHints.urgency;
     if (
       (urgency === "high" || urgency === "critical") &&
       decision.shouldNotify
     ) {
-      const forcedChannels: NotificationChannel[] = (
-        ["vellum", "platform"] as const
-      ).filter((channel) => !decision.selectedChannels.includes(channel));
+      const selectedChannels: NotificationChannel[] = [
+        ...decision.selectedChannels,
+      ];
+      const forcedChannels: NotificationChannel[] = [];
+      if (!selectedChannels.includes("vellum")) {
+        selectedChannels.unshift("vellum");
+        forcedChannels.push("vellum");
+      }
+      if (
+        !selectedChannels.includes("platform") &&
+        (await isPlatformClientConfigured())
+      ) {
+        selectedChannels.push("platform");
+        forcedChannels.push("platform");
+      }
       if (forcedChannels.length > 0) {
         decision = {
           ...decision,
-          selectedChannels: [...forcedChannels, ...decision.selectedChannels],
+          selectedChannels,
           reasoningSummary: `${decision.reasoningSummary} (${forcedChannels.join(", ")} forced: ${urgency} urgency)`,
         };
       }

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -34,6 +34,83 @@ export interface OwnerConsent {
   shareDiagnosticsAcceptedVersion: string;
 }
 
+interface PlatformClientConfig {
+  baseUrl: string;
+  apiKey: string;
+  assistantId: string;
+}
+
+/**
+ * Resolve the platform client's prerequisites.
+ *
+ * First tries the in-memory managed proxy context (available when the daemon
+ * has rehydrated env overrides). Falls back to reading platform credentials
+ * directly from the credential store so that standalone CLI invocations work
+ * without the daemon having run its rehydration step.
+ *
+ * Returns `null` when auth prerequisites are missing (not logged in, no API
+ * key). The assistant ID is resolved but not required.
+ */
+async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | null> {
+  if (!arePlatformFeaturesEnabled()) {
+    log.debug("platform features disabled -- returning null");
+    return null;
+  }
+
+  const ctx = await resolveManagedProxyContext();
+
+  let baseUrl = ctx.enabled ? ctx.platformBaseUrl : "";
+  let apiKey = ctx.enabled ? ctx.assistantApiKey : "";
+  let assistantId = getPlatformAssistantId();
+
+  // Fall back to credential store for values not yet rehydrated (standalone CLI).
+  if (!baseUrl) {
+    baseUrl =
+      (await getSecureKeyAsync(credentialKey("vellum", "platform_base_url"))) ??
+      "";
+  }
+  if (!apiKey) {
+    apiKey =
+      (await getSecureKeyAsync(credentialKey("vellum", "assistant_api_key"))) ??
+      "";
+  }
+  if (!assistantId) {
+    assistantId =
+      (
+        await getSecureKeyAsync(
+          credentialKey("vellum", "platform_assistant_id"),
+        )
+      )?.trim() ?? "";
+  }
+
+  if (!baseUrl || !apiKey) {
+    const level = _missingPrereqsWarned ? "debug" : "warn";
+    _missingPrereqsWarned = true;
+    log[level](
+      {
+        hasBaseUrl: !!baseUrl,
+        hasApiKey: !!apiKey,
+        hasAssistantId: !!assistantId,
+        managedProxyEnabled: ctx.enabled,
+      },
+      "Platform client prerequisites missing -- returning null",
+    );
+    return null;
+  }
+
+  return { baseUrl, apiKey, assistantId };
+}
+
+/**
+ * Whether the platform client's auth prerequisites are present. A cheap
+ * availability probe for callers that only need to know if platform calls
+ * can be attempted: reads config and the credential store, constructs no
+ * client, and makes no network requests.
+ */
+export async function isPlatformClientConfigured(): Promise<boolean> {
+  return (await resolvePlatformClientConfig()) !== null;
+}
+
 export class VellumPlatformClient {
   private readonly platformBaseUrl: string;
   private readonly apiKey: string;
@@ -50,67 +127,22 @@ export class VellumPlatformClient {
   }
 
   /**
-   * Create a platform client by resolving managed proxy context.
-   *
-   * First tries the in-memory managed proxy context (available when the daemon
-   * has rehydrated env overrides). Falls back to reading platform credentials
-   * directly from the credential store so that standalone CLI invocations work
-   * without the daemon having run its rehydration step.
+   * Create a platform client from {@link resolvePlatformClientConfig}.
    *
    * Returns `null` when auth prerequisites are missing (not logged in, no API
-   * key). The assistant ID is resolved but not required — callers that need it
-   * should check `platformAssistantId` themselves.
+   * key). The assistant ID is resolved but not required -- callers that need
+   * it should check `platformAssistantId` themselves.
    */
   static async create(): Promise<VellumPlatformClient | null> {
-    if (!arePlatformFeaturesEnabled()) {
-      log.debug("platform features disabled — returning null");
+    const config = await resolvePlatformClientConfig();
+    if (!config) {
       return null;
     }
-
-    const ctx = await resolveManagedProxyContext();
-
-    let baseUrl = ctx.enabled ? ctx.platformBaseUrl : "";
-    let apiKey = ctx.enabled ? ctx.assistantApiKey : "";
-    let assistantId = getPlatformAssistantId();
-
-    // Fall back to credential store for values not yet rehydrated (standalone CLI).
-    if (!baseUrl) {
-      baseUrl =
-        (await getSecureKeyAsync(
-          credentialKey("vellum", "platform_base_url"),
-        )) ?? "";
-    }
-    if (!apiKey) {
-      apiKey =
-        (await getSecureKeyAsync(
-          credentialKey("vellum", "assistant_api_key"),
-        )) ?? "";
-    }
-    if (!assistantId) {
-      assistantId =
-        (
-          await getSecureKeyAsync(
-            credentialKey("vellum", "platform_assistant_id"),
-          )
-        )?.trim() ?? "";
-    }
-
-    if (!baseUrl || !apiKey) {
-      const level = _missingPrereqsWarned ? "debug" : "warn";
-      _missingPrereqsWarned = true;
-      log[level](
-        {
-          hasBaseUrl: !!baseUrl,
-          hasApiKey: !!apiKey,
-          hasAssistantId: !!assistantId,
-          managedProxyEnabled: ctx.enabled,
-        },
-        "Platform client prerequisites missing — returning null",
-      );
-      return null;
-    }
-
-    return new VellumPlatformClient(baseUrl, apiKey, assistantId);
+    return new VellumPlatformClient(
+      config.baseUrl,
+      config.apiKey,
+      config.assistantId,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ios-push-lower-envs.md:
- single_channel enforcement no longer strips vellum after the urgency force-add (vellum prepends, platform appends)
- deferred vellum send is exception-safe (try/finally flush) and deadline-capped (~2.5s; duplicate banner beats a late one), with an abort timeout on platform dispatch fetches
- force-added platform channel reuses vellum rendered copy instead of template fallback
- platform force-add skips daemons with no platform credentials
- test slop: hoisted beforeEach resets, PairingResult import, dropped dead guard half and unread false-vs-absent spread