### PR TITLE
refactor(web): remove the sidebar's padding coupling, gate windowing once

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -228,16 +228,19 @@ describe("AssistantSideMenu · All view", () => {
     }),
   ];
 
-  // The flat list is virtualized, and virtuoso renders no rows without real
-  // layout, so these assert the composition around it. What lands *in* the
-  // list is covered by `use-sidebar-state.test.tsx` (`flatList`).
+  // Short lists mount their rows directly, so this can assert what actually
+  // renders. The windowed path is covered below, where virtuoso emits no rows
+  // without real layout and only its presence can be asserted.
   test("drops the Chats and channel headers in favour of one flat list", () => {
     const html = renderMenu({ conversations });
 
     expect(html).not.toContain(">Chats<");
     expect(html).not.toContain(">Slack<");
     expect(html).toContain(">Pinned<");
-    expect(html).toContain('data-slot="virtual-list"');
+    expect(html).not.toContain('data-slot="virtual-list"');
+    // The channel conversation is in the flat list, not a channel section.
+    expect(html).toContain("Slack one");
+    expect(html).toContain("Recent one");
   });
 
   test("carries no 'Show more' affordance", () => {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -312,6 +312,52 @@ describe("AssistantSideMenu · All view", () => {
   });
 });
 
+describe("AssistantSideMenu · scrollport top inset", () => {
+  // The sticky view switch sticks to the scrollport's *content* box, so the
+  // body carries no top padding: any there would park the switch that far
+  // down and open a strip above it for rows to scroll through. The overlay
+  // still needs the inset though, because its first body child is the
+  // assistant cluster rather than the switch, and without it the cluster
+  // collides with the floating close and search glyphs. So the inset moves
+  // onto the cluster rather than disappearing.
+  test("the rail's scrollport carries no top inset", () => {
+    const container = parse(
+      renderMenu({ conversations: [makeConversation({ conversationId: "r1" })] }),
+    );
+    const body = container.querySelector<HTMLElement>(
+      '[data-slot="side-menu-body"]',
+    );
+    if (!body) {
+      throw new Error("expected the side menu body");
+    }
+
+    expect(body.className).not.toContain("pt-3");
+    expect(body.className).not.toContain("pt-4");
+  });
+
+  test("the overlay's assistant cluster keeps its inset off the glyph row", () => {
+    const container = parse(
+      renderMenu({
+        conversations: [makeConversation({ conversationId: "r1" })],
+        variant: "overlay",
+      }),
+    );
+    const body = container.querySelector<HTMLElement>(
+      '[data-slot="side-menu-body"]',
+    );
+    if (!body) {
+      throw new Error("expected the side menu body");
+    }
+
+    // Not on the scrollport itself.
+    expect(body.className).not.toContain(" pt-3");
+    // On its first child, the assistant cluster.
+    const cluster = body.firstElementChild;
+    expect(cluster?.className).toContain("pt-3");
+    expect(cluster?.textContent).toContain("Your Assistant");
+  });
+});
+
 describe("AssistantSideMenu · section scrolling", () => {
   // Every section behaves like the flat list: no "Show more", the rows just
   // keep going inside a bounded, scrollable area. Without the cap one busy

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -548,7 +548,19 @@ export function AssistantSideMenu({
               : undefined
           }
         >
-          {variant === "overlay" ? builtInNav : null}
+          {/* The overlay puts the assistant cluster at the top of the
+              scrollport rather than in a fixed header, so it owns the inset
+              that keeps it clear of the floating close and search glyphs. It
+              lives here rather than on the scrollport because the sticky view
+              switch sticks to the scrollport's content box: any padding there
+              would park the switch that far down and open a strip above it
+              for rows to scroll through. `gap-4` restates the body's own gap,
+              which wrapping these into one flex item would otherwise drop. */}
+          {variant === "overlay" ? (
+            <div className="flex flex-col gap-4 pt-3 max-md:pt-4">
+              {builtInNav}
+            </div>
+          ) : null}
           {isCollapsedRail ? (
             /* The rail shows the same sections in the same order, as icons.
                Nothing here is type-aware - order and labels come straight

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -521,7 +521,7 @@ export function AssistantSideMenu({
                  inline padding below is applied. pt-14 on iOS clears the 40px
                  the floating icon row covers plus a 16px gap, so the first
                  row starts below the glyphs at rest. */
-                `-mx-4 gap-4 px-4 pt-3 pb-24 native-ios:pt-14 max-md:pt-4 ${NATIVE_IOS_LIST_TOP_FADE}`
+                `-mx-4 gap-4 px-4 pb-24 native-ios:pt-14 ${NATIVE_IOS_LIST_TOP_FADE}`
               : /* The collapsed rail tucks the group icons up under the
                  cluster separator (~12px to the first icon tile) so they
                  read as the next section, not a distant island. */
@@ -530,8 +530,10 @@ export function AssistantSideMenu({
                 : /* The scrollport spans the full rail so its scrollbar rides
                      the outer edge instead of cutting through the content, and
                      takes over the horizontal inset the root would have given
-                     it, so rows sit exactly where they did. */
-                  "-mx-4 gap-4 px-4 pt-3 max-md:pt-4"
+                     it, so rows sit exactly where they did. No top inset: the
+                     sticky view switch sits flush against the header, and any
+                     padding here would be a gap it has to cancel. */
+                  "-mx-4 gap-4 px-4"
           }
           style={
             variant === "overlay" && overlayBottomColumnHeight > 0

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -13,9 +13,11 @@
  * screen. The flat list instead scrolls against the sidebar body it already
  * fills (`scrollParent`), which keeps the rail to a single scrollbar.
  *
- * Either way a long list windows rather than mounting every row, because an
- * assistant accumulates conversations indefinitely and they all arrive in one
- * query - there is no page to fetch, only rows to render.
+ * Either way a list past {@link CONVERSATION_LIST_VIRTUALIZE_THRESHOLD} rows
+ * windows rather than mounting every one, because an assistant accumulates
+ * conversations indefinitely and they all arrive in one query: there is no
+ * page to fetch, only rows to render. Shorter lists mount directly and skip
+ * virtuoso's measuring pass.
  *
  * Row callbacks and state come from {@link useConversationListContext}
  * (via `ConversationRow`), so neither takes them as props.
@@ -81,6 +83,29 @@ export function ConversationRowList({
     />
   );
 
+  const rows = <SideMenu.SubList>{items.map(renderRow)}</SideMenu.SubList>;
+
+  // Reorderable sections (Pinned, custom groups) always mount every row: the
+  // drag controller resolves a drop target from the rows themselves, so a
+  // windowed list would have nothing to drop onto past the viewport. They
+  // stay bounded and scrollable either way, and they are the curated
+  // sections, so they are the least likely to run long.
+  const windows =
+    !dragSection && items.length > CONVERSATION_LIST_VIRTUALIZE_THRESHOLD;
+
+  if (!windows) {
+    return scrollParent ? (
+      rows
+    ) : (
+      <div
+        className="overflow-y-auto"
+        style={{ maxHeight: SIDEBAR_SECTION_MAX_HEIGHT }}
+      >
+        {rows}
+      </div>
+    );
+  }
+
   /* The primitive paints `--surface-base` for a list that owns its surface;
      every list here sits on a sidebar that has already painted its own. */
   const windowed = (
@@ -93,28 +118,13 @@ export function ConversationRowList({
     />
   );
 
-  if (scrollParent) {
-    return windowed;
-  }
-
-  // Reorderable sections (Pinned, custom groups) always mount every row: the
-  // drag controller resolves a drop target from the rows themselves, so a
-  // windowed list would have nothing to drop onto past the viewport. They
-  // stay bounded and scrollable either way, and they are the curated
-  // sections, so they are the least likely to run long.
-  if (!dragSection && items.length > CONVERSATION_LIST_VIRTUALIZE_THRESHOLD) {
-    /* Virtuoso's scroller sizes to 100%, so this branch commits to the full
-       height, which is honest here, since the list is past the cap. */
-    return <div style={{ height: SIDEBAR_SECTION_MAX_HEIGHT }}>{windowed}</div>;
-  }
-
-  return (
-    <div
-      className="overflow-y-auto"
-      style={{ maxHeight: SIDEBAR_SECTION_MAX_HEIGHT }}
-    >
-      <SideMenu.SubList>{items.map(renderRow)}</SideMenu.SubList>
-    </div>
+  /* Scrolling against an ancestor means no height of our own. Otherwise
+     virtuoso's scroller sizes to 100%, so the wrapper commits to the full
+     height, which is honest here since the list is past the cap. */
+  return scrollParent ? (
+    windowed
+  ) : (
+    <div style={{ height: SIDEBAR_SECTION_MAX_HEIGHT }}>{windowed}</div>
   );
 }
 export interface ConversationNavSectionProps extends ConversationRowListProps {

--- a/clients/web/src/domains/chat/components/sidebar-view-mode-toggle.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-view-mode-toggle.tsx
@@ -28,11 +28,10 @@ export function SidebarViewModeToggle({
     /* Sticky, so the view switch is reachable from anywhere in a list that
        can run tens of thousands of pixels tall. It needs the sidebar's own
        surface behind it and a z-index, or rows would scroll through it, and
-       A sticky offset is measured from the scrollport's *content* box, so a
-       plain `top-0` parks this the full height of the body's top inset below
-       the edge and rows slide through the strip above it. The negative `top`
-       cancels that inset so it sits flush against the header, and the
-       matching negative margin keeps it flush at rest too.
+       A sticky offset is measured from the scrollport's *content* box, so
+       this only lands flush against the header because the body carries no
+       top inset for it to sit below. Adding one back there would open a strip
+       above this that rows scroll through.
 
        It spans the full scrollport width and carries no padding of its own,
        so the list runs right up under it. Size and width are the primitive's
@@ -41,7 +40,7 @@ export function SidebarViewModeToggle({
        splits evenly between the segments - so the halves stay equal whatever
        the labels say, and "Groups" gets no bigger a target than "All". */
     <div
-      className="sticky -top-3 z-20 -mt-3 bg-[var(--surface-overlay)] max-md:-top-4 max-md:-mt-4"
+      className="sticky top-0 z-20 bg-[var(--surface-overlay)]"
     >
       <SegmentControl<SidebarViewMode>
         items={VIEW_MODE_ITEMS}


### PR DESCRIPTION
## TL;DR

Two simplifications to the sidebar that shipped in #39733. No behavior change, verified in the running app.

**Deliberately not labelled `cherry-pick-to-release`.** This is cleanup, not a fix, and the release branch already has the feature.

## 1. The sticky view switch no longer cancels a padding it does not own

A sticky offset is measured from the scrollport's *content* box. The switch is meant to sit flush against the header, so it was cancelling the body's top inset with a matching negative `top` and margin, in responsive pairs:

```
body:   -mx-4 gap-4 px-4 pt-3 max-md:pt-4
switch: sticky -top-3 -mt-3 max-md:-top-4 max-md:-mt-4
```

Three files had to agree on one number, with nothing linking them. Change the body's `pt-3` and the switch silently parks that far down, opening a strip above it that conversation rows scroll through. That exact bug happened twice during #39733.

The body carries no top inset now, which is what the layout wanted anyway, so the switch is a plain `sticky top-0` and there is nothing to keep in sync. The overlay keeps its `native-ios:pt-14`, which clears the floating iOS glyph row and is genuinely its own concern.

## 2. One threshold governs windowing

`ConversationRowList` virtualized unconditionally when given a `scrollParent`, while every other path waited for `CONVERSATION_LIST_VIRTUALIZE_THRESHOLD` (30) rows. So a flat list of three conversations paid for virtuoso's measuring pass to window three rows.

Both paths share the threshold now. A pleasant side effect: short lists render real rows, so the component test can assert what is in the flat list rather than only that a virtual list exists.

## Considered and not done

`CollapsedGroupFlyout` still renders its own rows rather than reusing `ConversationRowList`, which looks like duplication. It is not worth unifying: the flyout's rows are deliberately lighter (no context menu, no marquee, its own `onSelect`), and more decisively, `ConversationRowList` wraps rows in `SideMenu.SubList`, which returns `null` on the collapsed rail. The flyout only ever renders on the collapsed rail, so reusing that component would render an empty popover. The shared piece is about ten lines of `VirtualList` wiring; the threshold constant is already shared.

## Testing

172 tests across the touched files. Verified in the running app that the switch stays flush at the scrollport top at rest and while scrolled, the body's computed `padding-top` is `0px`, and the scrollbar still rides the outer edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->