### PR TITLE
fix: harden the assistant-reply push producer and its turn-tail wiring

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -379,6 +379,11 @@ mock.module("../runtime/sync/sync-publisher.js", () => ({
   publishSyncInvalidation: publishSyncInvalidationMock,
 }));
 
+const emitAssistantReplyNotificationMock = mock(async () => {});
+mock.module("../notifications/assistant-reply-producer.js", () => ({
+  emitAssistantReplyNotification: emitAssistantReplyNotificationMock,
+}));
+
 afterAll(() => {
   mock.module(
     "../persistence/conversation-crud.js",
@@ -895,6 +900,7 @@ beforeEach(() => {
   setAgentLoopExitReasonOnLatestLogMock.mockClear();
   syncMessageToDiskMock.mockClear();
   rebuildConversationDiskViewFromDbStateMock.mockClear();
+  emitAssistantReplyNotificationMock.mockClear();
   updateMessageMetadataMock.mockClear();
   updateMessageMetadataMock.mockImplementation(() => {});
   updateConversationSlackContextWatermarkMock.mockClear();
@@ -2268,6 +2274,53 @@ describe("session-agent-loop", () => {
         string,
       ];
       expect(deleteCall[0]).toBe("msg-reserve");
+    });
+
+    test("does not push the synthetic error row as a reply notification", async () => {
+      // The synthetic row carries the provider's error text. It reaches the
+      // `message_complete` branch like any other turn, so without the
+      // provider-error guard the tail would send that text to the lock screen
+      // as if it were the assistant's reply.
+      const ctx = makeCtx({
+        loopProvider: {
+          name: "mock-provider",
+          async sendMessage() {
+            throw new Error("upstream 500");
+          },
+        } as unknown as Provider,
+      });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(addMessageMock).toHaveBeenCalled();
+      expect(emitAssistantReplyNotificationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("assistant-reply notification wiring", () => {
+    test("a completed turn notifies with the row that opened it", async () => {
+      mockMessageById = {
+        id: "msg-reserve",
+        conversationId: "test-conv",
+        createdAt: 1234567,
+        role: "assistant",
+        content: "[]",
+        metadata: null,
+      };
+
+      const ctx = makeCtx({
+        providerResponses: [textResponse("here you go")],
+      });
+      await runAgentLoopImpl(ctx, "hi", "msg-user-7", () => {});
+
+      expect(emitAssistantReplyNotificationMock).toHaveBeenCalledTimes(1);
+      const notifyCall = emitAssistantReplyNotificationMock.mock
+        .calls[0] as unknown as [
+        { conversationId: string; userMessageId: string | undefined },
+      ];
+      expect(notifyCall[0]).toMatchObject({
+        conversationId: "test-conv",
+        userMessageId: "msg-user-7",
+      });
     });
   });
 

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -356,30 +356,6 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
   });
 });
 
-describe("startVoiceTurn voice-origin marker", () => {
-  // The reply to a voice turn is spoken back over the open session, so
-  // downstream consumers (the assistant-reply push producer) need a durable
-  // way to recognize the row. The channel fields cannot serve: live voice
-  // persists as `vellum`/`macos`, the same as a typed desktop send.
-  test("every persisted voice row carries voiceSessionTurn", async () => {
-    const fake = makeFakeConversation({ processing: false });
-    fakeConversation = fake.conversation;
-
-    await startVoiceTurn({
-      ...makeTurnOptions(),
-      content: "what's the weather",
-      userMessageChannel: "vellum",
-      userMessageInterface: "macos",
-    });
-
-    expect(
-      realConversationCrud.isVoiceSessionUserMessage(
-        fake.lastPersistOpts()?.metadata as Record<string, unknown>,
-      ),
-    ).toBe(true);
-  });
-});
-
 describe("startVoiceTurn hiddenSyntheticPrompt", () => {
   // A caller whose internal instruction is composed per call carries no
   // sentinel for the content comparisons to recognize, so it declares itself.

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -873,9 +873,8 @@ export async function startVoiceTurn(
       content: persistedContent,
       requestId,
       metadata: {
-        // Durable "this turn came from an open voice session" marker. The
-        // channel fields cannot carry it: live voice persists as
-        // `vellum`/`macos`, indistinguishable from a typed desktop send.
+        // Durable "this turn came from an open voice session" marker; see
+        // `isVoiceSessionUserMessage` for why the channel fields cannot carry it.
         voiceSessionTurn: true,
         ...(isHiddenSyntheticPrompt ? { hidden: true } : {}),
       },

--- a/assistant/src/daemon/__tests__/turn-tail-assistant-reply-notify.test.ts
+++ b/assistant/src/daemon/__tests__/turn-tail-assistant-reply-notify.test.ts
@@ -1,20 +1,13 @@
 /**
- * Wiring tests for the `chat.assistant_reply` emit in `runDeferredTurnTail`.
- *
- * Coverage matrix:
- *   - a `message_complete` turn emits exactly once, carrying the conversation
- *     id and the turn's last assistant row id;
- *   - handoff and cancellation outcomes never emit;
- *   - a completed turn that produced no assistant row never emits;
- *   - the emit runs after the deferred finalize effects, so the producer's
- *     unseen check reads the attention cursor this turn just projected;
- *   - the tail does not await the producer, and a producer failure cannot
- *     break turn finalization.
+ * Wiring tests for the `chat.assistant_reply` emit in `runDeferredTurnTail`:
+ * which turn outcomes reach the producer, what the tail hands it, and that the
+ * emit can neither block nor break turn finalization.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
 import { setConfig } from "../../__tests__/helpers/set-config.js";
+import type { MessageRow } from "../../persistence/conversation-crud.js";
 import type { InflightContentWriter } from "../inflight-message-content.js";
 
 // The finalize module's import graph reaches the memory indexer; keep it inert
@@ -23,10 +16,13 @@ setConfig("memory", { enabled: false, v2: { enabled: false } });
 
 const CONVERSATION_ID = "conv-tail-1";
 const ASSISTANT_MESSAGE_ID = "msg-assistant-1";
+const USER_MESSAGE_ID = "msg-user-1";
 
 interface EmitCall {
   conversationId: string;
   assistantMessageId: string;
+  userMessageId: string | undefined;
+  assistantMessage?: MessageRow | null;
 }
 
 const emitCalls: EmitCall[] = [];
@@ -39,6 +35,8 @@ mock.module("../../notifications/assistant-reply-producer.js", () => ({
     emitCalls.push({
       conversationId: params.conversationId,
       assistantMessageId: params.assistantMessageId,
+      userMessageId: params.userMessageId,
+      assistantMessage: params.assistantMessage,
     });
     trace.push("emit");
     if (producerBehavior === "reject") {
@@ -74,7 +72,8 @@ const rlog = makeMockLogger() as Parameters<
 async function runTail(overrides: {
   turnCompleted: boolean;
   lastAssistantMessageId?: string | undefined;
-  deferredFinalizeEffects?: ReadonlyArray<() => Promise<void>>;
+  deferredFinalizeEffects?: ReadonlyArray<() => Promise<MessageRow | null>>;
+  userMessageId?: string | undefined;
 }): Promise<void> {
   await runDeferredTurnTail({
     ctx: { conversationId: CONVERSATION_ID, messages: [] },
@@ -89,7 +88,22 @@ async function runTail(overrides: {
     rlog,
     generationCompletedAt: Date.now(),
     turnCompleted: overrides.turnCompleted,
+    userMessageId:
+      "userMessageId" in overrides ? overrides.userMessageId : USER_MESSAGE_ID,
   });
+}
+
+function makeFinalizedRow(id: string): MessageRow {
+  return {
+    id,
+    conversationId: CONVERSATION_ID,
+    role: "assistant",
+    content: [{ type: "text", text: "done" }],
+    createdAt: 1700000000200,
+    metadata: null,
+    clientMessageId: null,
+    finalized: 1,
+  };
 }
 
 beforeEach(() => {
@@ -106,6 +120,8 @@ describe("runDeferredTurnTail assistant-reply notification", () => {
       {
         conversationId: CONVERSATION_ID,
         assistantMessageId: ASSISTANT_MESSAGE_ID,
+        userMessageId: USER_MESSAGE_ID,
+        assistantMessage: null,
       },
     ]);
   });
@@ -128,14 +144,30 @@ describe("runDeferredTurnTail assistant-reply notification", () => {
       deferredFinalizeEffects: [
         async () => {
           trace.push("effect-1");
+          return null;
         },
         async () => {
           trace.push("effect-2");
+          return null;
         },
       ],
     });
 
     expect(trace).toEqual(["effect-1", "effect-2", "emit"]);
+  });
+
+  test("hands the producer the row the finalize effect already read", async () => {
+    const finalizedRow = makeFinalizedRow(ASSISTANT_MESSAGE_ID);
+
+    await runTail({
+      turnCompleted: true,
+      deferredFinalizeEffects: [
+        async () => makeFinalizedRow("msg-assistant-0"),
+        async () => finalizedRow,
+      ],
+    });
+
+    expect(emitCalls[0]?.assistantMessage).toBe(finalizedRow);
   });
 
   test("completes without awaiting the producer, even when it never settles", async () => {

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -36,6 +36,7 @@ import {
   getConversation,
   getMessageById,
   messageMetadataSchema,
+  type MessageRow,
   provenanceFromTrustContext,
   recordConversationPersistedSeq,
   reserveMessage,
@@ -400,7 +401,7 @@ export interface EventHandlerState {
    * individually best-effort. Accumulates across retries/multi-call turns so
    * every produced assistant row is indexed.
    */
-  readonly deferredFinalizeEffects: Array<() => Promise<void>>;
+  readonly deferredFinalizeEffects: Array<() => Promise<MessageRow | null>>;
   /**
    * Credential refs parsed from `credentials reveal` invocations in this
    * turn's shell-style tool commands (see `chat-credential-redaction.ts`).

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -620,9 +620,10 @@ export async function runAgentLoopImpl(
   // has been emitted. Guards the catch block: an error thrown afterwards
   // (deferred turn-tail bookkeeping) must not relabel a visibly-replied turn.
   let turnReplied = false;
-  // Narrower than `turnReplied`: true only for the `message_complete` branch.
-  // A handed-off generation continues the run, so the deferred tail must not
-  // treat its reply as final.
+  // Narrower than `turnReplied`: true only for a `message_complete` branch that
+  // produced a genuine reply. A handed-off generation continues the run, and a
+  // provider-error turn's only assistant row is the synthetic error text, so
+  // the deferred tail must not treat either as a final reply.
   let turnCompleted = false;
 
   const publishLoopMessagesChanged = (): void => {
@@ -1510,7 +1511,7 @@ export async function runAgentLoopImpl(
         publishLoopMessagesChanged();
       } else {
         turnReplied = true;
-        turnCompleted = true;
+        turnCompleted = !persistedErrorAssistantMessage;
         ctx.emitActivityState("idle", "message_complete", {
           anchor: "global",
           requestId: reqId,
@@ -1552,6 +1553,7 @@ export async function runAgentLoopImpl(
       rlog,
       generationCompletedAt,
       turnCompleted,
+      userMessageId,
     });
   } catch (err) {
     clearConversationNotices(ctx.conversationId);

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -25,8 +25,10 @@ import {
 import { emitAssistantReplyNotification } from "../notifications/assistant-reply-producer.js";
 import { projectAssistantMessage } from "../persistence/conversation-attention-store.js";
 import {
+  type ConversationRow,
   getConversation,
   getMessageById,
+  type MessageRow,
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { getResolvedConversationDirPath } from "../persistence/conversation-directories.js";
@@ -49,7 +51,9 @@ interface TurnTailContext {
 
 /** Minimal per-run handler state the deferred tail consumes. */
 interface TurnTailState {
-  readonly deferredFinalizeEffects: ReadonlyArray<() => Promise<void>>;
+  readonly deferredFinalizeEffects: ReadonlyArray<
+    () => Promise<MessageRow | null>
+  >;
   readonly lastAssistantMessageId: string | undefined;
   /** In-flight content writers the turn left behind (see EventHandlerState). */
   readonly inflightWriters: Map<string, InflightContentWriter>;
@@ -66,19 +70,20 @@ interface TurnTailState {
  * The returned closure captures the row id and its already-persisted content
  * JSON, and is drained by {@link runDeferredTurnTail} after the terminal SSE.
  * Each step is best-effort: a memory hiccup must not escalate a delivered reply
- * into a turn-level throw.
+ * into a turn-level throw. It returns the finalized row it read so the tail can
+ * hand it to the notification producer instead of re-reading it.
  */
 export function buildDeferredFinalizeEffect(params: {
   conversationId: string;
   assistantMessageId: string;
   contentJson: string;
   rlog: pino.Logger;
-}): () => Promise<void> {
+}): () => Promise<MessageRow | null> {
   const { conversationId, assistantMessageId, contentJson, rlog } = params;
   return async () => {
     const finalizedRow = getMessageById(assistantMessageId, conversationId);
     if (!finalizedRow) {
-      return;
+      return null;
     }
     // Provenance/automation flags for the memory write-gate come off the
     // persisted metadata via the shared `parseMessageMetadata` (the single
@@ -124,6 +129,7 @@ export function buildDeferredFinalizeEffect(params: {
         "Failed to project assistant message for attention tracking (non-fatal)",
       );
     }
+    return finalizedRow;
   };
 }
 
@@ -144,20 +150,48 @@ export async function runDeferredTurnTail(params: {
   rlog: pino.Logger;
   generationCompletedAt: number;
   /**
-   * True only for a `message_complete` turn. A handed-off generation is not
-   * the end of the run, and a cancelled one has no final reply.
+   * True only for a `message_complete` turn that produced a genuine reply. A
+   * handed-off generation is not the end of the run, a cancelled one has no
+   * final reply, and a provider-error turn's only assistant row is the
+   * synthetic error text.
    */
   turnCompleted: boolean;
+  /** Id of the row that opened this turn, for the notification producer. */
+  userMessageId: string | undefined;
 }): Promise<void> {
-  const { ctx, state, rlog, generationCompletedAt, turnCompleted } = params;
+  const {
+    ctx,
+    state,
+    rlog,
+    generationCompletedAt,
+    turnCompleted,
+    userMessageId,
+  } = params;
   const tailStartedAt = Date.now();
+
+  // One conversation read for the whole tail: the notification producer, the
+  // truncation step, and the disk mirror all want the same row. Guarded like
+  // every step below, because this runs after the terminal SSE and a SQLite
+  // hiccup must not escape into the loop's outer catch.
+  let conversation: ConversationRow | null = null;
+  try {
+    conversation = getConversation(ctx.conversationId);
+  } catch (err) {
+    rlog.warn({ err }, "Failed to read conversation for end-of-turn work");
+  }
 
   // Per-message memory/attention finalize side-effects deferred from
   // `handleMessageComplete` — one closure per assistant row produced this turn,
   // in production order.
+  // Effects accumulate across a multi-call turn, so keep only the row the
+  // notification below is about rather than whichever ran last.
+  let finalizedAssistantRow: MessageRow | null = null;
   for (const effect of state.deferredFinalizeEffects) {
     try {
-      await effect();
+      const finalizedRow = await effect();
+      if (finalizedRow && finalizedRow.id === state.lastAssistantMessageId) {
+        finalizedAssistantRow = finalizedRow;
+      }
     } catch (err) {
       rlog.warn({ err }, "Deferred finalize side-effect failed (non-fatal)");
     }
@@ -172,7 +206,10 @@ export async function runDeferredTurnTail(params: {
     void emitAssistantReplyNotification({
       conversationId: ctx.conversationId,
       assistantMessageId: state.lastAssistantMessageId,
+      userMessageId,
       rlog,
+      conversation,
+      assistantMessage: finalizedAssistantRow,
     });
   }
 
@@ -181,11 +218,10 @@ export async function runDeferredTurnTail(params: {
   // turn's context. Rewrites only the in-memory history, so it has no bearing on
   // the reply already delivered to the client.
   try {
-    const conv = getConversation(ctx.conversationId);
-    if (conv) {
+    if (conversation) {
       const convDir = getResolvedConversationDirPath(
         ctx.conversationId,
-        conv.createdAt,
+        conversation.createdAt,
       );
       const { messages: derefMessages, dereferencedCount } =
         derefToolResultReReads(ctx.messages);
@@ -218,20 +254,16 @@ export async function runDeferredTurnTail(params: {
   }
 
   // Mirror the final assistant row into the JSONL disk view. Guarded like the
-  // steps above: this runs AFTER the terminal SSE, so a throw here (e.g. a
-  // SQLite read failure in `getConversation`) must not escape into the loop's
-  // outer catch and emit a second, contradictory terminal event for a turn the
-  // client already saw complete.
+  // steps above: this runs AFTER the terminal SSE, so a throw here must not
+  // escape into the loop's outer catch and emit a second, contradictory
+  // terminal event for a turn the client already saw complete.
   try {
-    if (state.lastAssistantMessageId) {
-      const convForDisk = getConversation(ctx.conversationId);
-      if (convForDisk) {
-        syncMessageToDisk(
-          ctx.conversationId,
-          state.lastAssistantMessageId,
-          convForDisk.createdAt,
-        );
-      }
+    if (state.lastAssistantMessageId && conversation) {
+      syncMessageToDisk(
+        ctx.conversationId,
+        state.lastAssistantMessageId,
+        conversation.createdAt,
+      );
     }
   } catch (err) {
     rlog.warn({ err }, "Failed to sync assistant message to disk (non-fatal)");

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -1,23 +1,10 @@
 /**
- * Tests for `assistant-reply-producer.ts`.
- *
- * Coverage matrix:
- *   - Qualifying unseen reply in a user conversation emits exactly one signal,
- *     asserted on the full shape (dedupeKey, absent `requiresConversation`).
- *   - Every non-"user" kind of the shared `resolveConversationKind` classifier
- *     is silent.
- *   - An `automated: true` initiating user message is silent.
- *   - A hidden lifecycle row (subagent / ACP notification) opening the turn is
- *     silent.
- *   - A live phone / in-app voice utterance opening the turn is silent.
- *   - A turn opened from a messaging channel (Slack, Telegram, …) is silent,
- *     while the in-app `vellum` channel and an unstamped row still emit.
- *   - An already-seen reply is silent.
- *   - A tool-only reply (empty text preview) is silent.
- *   - A throwing dependency is swallowed, not propagated.
+ * Tests for `assistant-reply-producer.ts`: which finished replies earn a push,
+ * and the shape of the signal the qualifying ones emit.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import type { AttentionState } from "../../persistence/conversation-attention-store.js";
 import type {
   ConversationRow,
@@ -34,9 +21,10 @@ import type { ContentBlock } from "../../providers/types.js";
 // below and inspects the captured emit calls afterwards.
 
 const emitCalls: any[] = [];
+const messageLookups: string[] = [];
 let conversationRow: ConversationRow | null = null;
 let assistantRow: MessageRow | null = null;
-let userRows: MessageRow[] = [];
+let initiatingRow: MessageRow | null = null;
 let attentionState: AttentionState | null = null;
 let getConversationShouldThrow = false;
 
@@ -53,6 +41,10 @@ mock.module("../emit-signal.js", () => ({
   },
 }));
 
+const CONVERSATION_ID = "conv-1";
+const ASSISTANT_MESSAGE_ID = "msg-assistant-1";
+const USER_MESSAGE_ID = "msg-user-1";
+
 const realCrud = await import("../../persistence/conversation-crud.js");
 mock.module("../../persistence/conversation-crud.js", () => ({
   ...realCrud,
@@ -62,23 +54,16 @@ mock.module("../../persistence/conversation-crud.js", () => ({
     }
     return conversationRow;
   },
-  getMessageById: () => assistantRow,
-  getMessagesPaginated: (
-    _conversationId: string,
-    _limit: number | undefined,
-    beforeTimestamp: number | undefined,
-    filter?: (row: MessageRow) => boolean,
-  ) => {
-    const matches = userRows
-      .filter(
-        (row) => beforeTimestamp == null || row.createdAt < beforeTimestamp,
-      )
-      .filter((row) => !filter || filter(row));
-    return { messages: matches.slice(-1), hasMore: false };
+  getMessageById: (messageId: string) => {
+    messageLookups.push(messageId);
+    return messageId === ASSISTANT_MESSAGE_ID ? assistantRow : initiatingRow;
   },
 }));
 
+const realAttentionStore =
+  await import("../../persistence/conversation-attention-store.js");
 mock.module("../../persistence/conversation-attention-store.js", () => ({
+  ...realAttentionStore,
   getAttentionStateByConversationIds: (ids: string[]) => {
     const map = new Map<string, AttentionState>();
     if (attentionState) {
@@ -92,9 +77,6 @@ const { emitAssistantReplyNotification } =
   await import("../assistant-reply-producer.js");
 
 // ── Fixtures ───────────────────────────────────────────────────────────
-
-const CONVERSATION_ID = "conv-1";
-const ASSISTANT_MESSAGE_ID = "msg-assistant-1";
 
 function makeConversation(
   overrides: Partial<ConversationRow> = {},
@@ -136,7 +118,7 @@ function makeConversation(
 
 function makeMessage(overrides: Partial<MessageRow> = {}): MessageRow {
   return {
-    id: "msg-1",
+    id: USER_MESSAGE_ID,
     conversationId: CONVERSATION_ID,
     role: "user",
     content: [{ type: "text", text: "hello" }] as ContentBlock[],
@@ -197,24 +179,32 @@ const rlog = {
   },
 } as any;
 
-async function run(): Promise<void> {
+async function run(
+  overrides: Partial<Parameters<typeof emitAssistantReplyNotification>[0]> = {},
+): Promise<void> {
   await emitAssistantReplyNotification({
     conversationId: CONVERSATION_ID,
     assistantMessageId: ASSISTANT_MESSAGE_ID,
+    userMessageId: USER_MESSAGE_ID,
     rlog,
+    ...overrides,
   });
 }
 
 beforeEach(() => {
   emitCalls.length = 0;
   warnCalls.length = 0;
+  messageLookups.length = 0;
   getConversationShouldThrow = false;
   conversationRow = makeConversation();
   assistantRow = makeAssistantRow([
     { type: "text", text: "Sure, here is the plan." },
   ] as ContentBlock[]);
-  userRows = [makeMessage()];
+  initiatingRow = makeMessage();
   attentionState = makeAttentionState();
+  // Empty overrides = every flag resolves to its registry default, so the
+  // kill switch reads as enabled unless a case says otherwise.
+  setOverridesForTesting({});
 });
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -246,6 +236,14 @@ describe("emitAssistantReplyNotification", () => {
     expect("routingIntent" in emitCalls[0]).toBe(false);
   });
 
+  test("stays silent when the kill-switch flag is off", async () => {
+    setOverridesForTesting({ "assistant-reply-push": false });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
   test("omits requestedTitle when the conversation has no title", async () => {
     conversationRow = makeConversation({ title: "   " });
 
@@ -257,9 +255,9 @@ describe("emitAssistantReplyNotification", () => {
     });
   });
 
-  test("collapses whitespace and caps the preview at 200 chars", async () => {
+  test("caps the preview at 200 chars", async () => {
     assistantRow = makeAssistantRow([
-      { type: "text", text: `${"a".repeat(300)}\n\n  b` },
+      { type: "text", text: "a".repeat(300) },
     ] as ContentBlock[]);
 
     await run();
@@ -267,6 +265,17 @@ describe("emitAssistantReplyNotification", () => {
     const preview = emitCalls[0].contextPayload.requestedMessage as string;
     expect(preview).toHaveLength(200);
     expect(preview.endsWith("…")).toBe(true);
+  });
+
+  // Control characters would otherwise ride into the APNs payload verbatim.
+  test("strips control characters and newlines out of the preview", async () => {
+    assistantRow = makeAssistantRow([
+      { type: "text", text: "Hello\n\tthere" },
+    ] as ContentBlock[]);
+
+    await run();
+
+    expect(emitCalls[0].contextPayload.requestedMessage).toBe("Hello there");
   });
 
   // Each case asserts the shared classifier's verdict alongside the silence, so
@@ -298,7 +307,9 @@ describe("emitAssistantReplyNotification", () => {
   });
 
   test("stays silent when the initiating user message is automated", async () => {
-    userRows = [makeMessage({ metadata: JSON.stringify({ automated: true }) })];
+    initiatingRow = makeMessage({
+      metadata: JSON.stringify({ automated: true }),
+    });
 
     await run();
 
@@ -329,7 +340,7 @@ describe("emitAssistantReplyNotification", () => {
 
   for (const { name, metadata } of LIFECYCLE_ROW_CASES) {
     test(`stays silent when the turn was opened by a ${name} row`, async () => {
-      userRows = [makeMessage({ metadata: JSON.stringify(metadata) })];
+      initiatingRow = makeMessage({ metadata: JSON.stringify(metadata) });
 
       await run();
 
@@ -337,12 +348,9 @@ describe("emitAssistantReplyNotification", () => {
     });
   }
 
-  // A voice utterance persists as an ordinary visible user row on a standard
-  // conversation, so only the `voiceSessionTurn` marker the bridge stamps keeps
-  // every spoken reply from also pushing. The phone case carries a `phone`
-  // channel; the in-app live-voice case is `vellum`/`macos`, identical to a
-  // typed desktop send, which is why the channel field cannot stand in for the
-  // marker.
+  // The phone case carries a `phone` channel; the in-app live-voice case is
+  // `vellum`/`macos`, identical to a typed desktop send, which is why the
+  // channel field cannot stand in for the `voiceSessionTurn` marker.
   const VOICE_ROW_CASES: Array<{ name: string; metadata: unknown }> = [
     {
       name: "phone call",
@@ -364,7 +372,7 @@ describe("emitAssistantReplyNotification", () => {
 
   for (const { name, metadata } of VOICE_ROW_CASES) {
     test(`stays silent when the turn was opened by a ${name} utterance`, async () => {
-      userRows = [makeMessage({ metadata: JSON.stringify(metadata) })];
+      initiatingRow = makeMessage({ metadata: JSON.stringify(metadata) });
 
       await run();
 
@@ -373,14 +381,12 @@ describe("emitAssistantReplyNotification", () => {
   }
 
   test("still emits for a typed desktop send on the same channel", async () => {
-    userRows = [
-      makeMessage({
-        metadata: JSON.stringify({
-          userMessageChannel: "vellum",
-          userMessageInterface: "macos",
-        }),
+    initiatingRow = makeMessage({
+      metadata: JSON.stringify({
+        userMessageChannel: "vellum",
+        userMessageInterface: "macos",
       }),
-    ];
+    });
 
     await run();
 
@@ -391,14 +397,12 @@ describe("emitAssistantReplyNotification", () => {
   // sender already has it in Slack/Telegram; a push would be a second copy.
   for (const channel of ["slack", "telegram"] as const) {
     test(`stays silent for a turn opened from ${channel}`, async () => {
-      userRows = [
-        makeMessage({
-          metadata: JSON.stringify({
-            userMessageChannel: channel,
-            assistantMessageChannel: channel,
-          }),
+      initiatingRow = makeMessage({
+        metadata: JSON.stringify({
+          userMessageChannel: channel,
+          assistantMessageChannel: channel,
         }),
-      ];
+      });
 
       await run();
 
@@ -409,40 +413,62 @@ describe("emitAssistantReplyNotification", () => {
   // Rows predating the channel stamp (and the daemon paths that omit it) are
   // in-app turns, so an absent channel must not suppress the push.
   test("still emits when the initiating row carries no channel", async () => {
-    userRows = [
-      makeMessage({
-        metadata: JSON.stringify({ userMessageInterface: "web" }),
-      }),
-    ];
+    initiatingRow = makeMessage({
+      metadata: JSON.stringify({ userMessageInterface: "web" }),
+    });
 
     await run();
 
     expect(emitCalls).toHaveLength(1);
   });
 
-  test("stays silent when no real user message opened the turn", async () => {
-    userRows = [];
+  // Only a value the channel registry recognizes may suppress: a corrupt one
+  // must fail open to notifying rather than silently swallow every reply.
+  test("still emits when the initiating row carries an unrecognized channel", async () => {
+    initiatingRow = makeMessage({
+      metadata: JSON.stringify({ userMessageChannel: "not-a-channel" }),
+    });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+  });
+
+  test("reads the initiating row by the threaded id, not by scanning", async () => {
+    await run();
+
+    expect(messageLookups).toEqual([ASSISTANT_MESSAGE_ID, USER_MESSAGE_ID]);
+    expect(emitCalls).toHaveLength(1);
+  });
+
+  test("stays silent when no initiating user message id was threaded", async () => {
+    await run({ userMessageId: undefined });
+
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("stays silent when the initiating user message row is missing", async () => {
+    initiatingRow = null;
 
     await run();
 
     expect(emitCalls).toHaveLength(0);
   });
 
-  test("skips tool-result rows when locating the initiating user message", async () => {
-    userRows = [
-      makeMessage({ id: "msg-user-1", createdAt: 1700000000100 }),
-      makeMessage({
-        id: "msg-tool-result-1",
-        createdAt: 1700000000150,
-        content: [
-          { type: "tool_result", tool_use_id: "t1", content: "done" },
-        ] as ContentBlock[],
-      }),
-    ];
+  test("uses the caller-supplied rows instead of re-reading them", async () => {
+    conversationRow = null;
+    assistantRow = null;
 
-    await run();
+    await run({
+      conversation: makeConversation(),
+      assistantMessage: makeAssistantRow([
+        { type: "text", text: "Handed down." },
+      ] as ContentBlock[]),
+    });
 
     expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].contextPayload.requestedMessage).toBe("Handed down.");
+    expect(messageLookups).toEqual([USER_MESSAGE_ID]);
   });
 
   test("stays silent when the reply is already seen", async () => {

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -10,101 +10,82 @@
 
 import type pino from "pino";
 
-import { isToolResultMessage } from "../context/refusal-quarantine.js";
-import { getAttentionStateByConversationIds } from "../persistence/conversation-attention-store.js";
+import { parseChannelId } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfigReadOnly } from "../config/loader.js";
 import {
+  getAttentionStateByConversationIds,
+  hasUnseenLatestAssistantMessage,
+} from "../persistence/conversation-attention-store.js";
+import {
+  type ConversationRow,
   getConversation,
   getMessageById,
-  getMessagesPaginated,
   isEchoSuppressedUserMessage,
   isVoiceSessionUserMessage,
+  type MessageRow,
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { resolveConversationKind } from "../persistence/conversation-types.js";
 import { stringifyMessageContent } from "../persistence/message-content.js";
-import type { ContentBlock } from "../providers/types.js";
 import { emitNotificationSignal } from "./emit-signal.js";
-import { truncate } from "./notification-utils.js";
+import { sanitizeMessagePreview } from "./notification-utils.js";
 
-/** Roughly one notification body's worth of reply text. */
-const PREVIEW_MAX_CHARS = 200;
+const ASSISTANT_REPLY_PUSH_FLAG = "assistant-reply-push" as const;
 
 /**
- * The channel id a native-app send carries, and `resolveTurnChannel`'s default
- * when a caller supplies none (see `daemon/process-message.ts`).
+ * Kill switch for this producer, on by default. Read through the read-only
+ * config accessor: the resolver ignores the config argument, so the write-side
+ * `getConfig()` would only add disk I/O to a best-effort path.
  */
-const IN_APP_CHANNEL = "vellum";
+function isAssistantReplyPushEnabled(): boolean {
+  return isAssistantFeatureFlagEnabled(
+    ASSISTANT_REPLY_PUSH_FLAG,
+    getConfigReadOnly(),
+  );
+}
 
 /**
  * True when the row that opened the turn arrived over an external messaging
  * surface (Slack, Telegram, WhatsApp, email, a phone call, …) rather than the
  * native app.
  *
- * An absent channel counts as in-app: every external ingress path stamps its
- * channel via buildChannelMetadata, so the rows that omit the field are
- * daemon-internal persists on native-app conversations (for example the
- * deliberate omission in calls/call-pointer-messages.ts).
+ * An absent (or unrecognized) channel counts as in-app: every external ingress
+ * path stamps its channel via buildChannelMetadata, so the rows that omit the
+ * field are daemon-internal persists on native-app conversations (for example
+ * the deliberate omission in calls/call-pointer-messages.ts).
  */
 function isChannelOriginatedUserMessage(
   metadata: Record<string, unknown> | undefined,
 ): boolean {
-  const channel = metadata?.userMessageChannel;
-  return typeof channel === "string" && channel !== IN_APP_CHANNEL;
-}
-
-/**
- * Same unseen predicate the sidebar renders from (`buildAssistantAttention` in
- * `runtime/services/conversation-serializer.ts`): the latest assistant cursor
- * is ahead of the last-seen cursor. A missing state row reads as seen, matching
- * the serializer's no-attention-state default.
- */
-function isLatestReplyUnseen(conversationId: string): boolean {
-  const state = getAttentionStateByConversationIds([conversationId]).get(
-    conversationId,
-  );
-  if (!state || state.latestAssistantMessageAt == null) {
-    return false;
-  }
-  return (
-    state.lastSeenAssistantMessageAt == null ||
-    state.lastSeenAssistantMessageAt < state.latestAssistantMessageAt
-  );
-}
-
-/**
- * The user-role row that opened this turn, skipping the tool-result rows the
- * agent loop also persists with role `"user"`.
- */
-function findInitiatingUserMessage(
-  conversationId: string,
-  assistantMessageCreatedAt: number,
-) {
-  const { messages } = getMessagesPaginated(
-    conversationId,
-    1,
-    assistantMessageCreatedAt,
-    (row) =>
-      row.role === "user" &&
-      !isToolResultMessage({ role: "user", content: row.content }),
-  );
-  return messages[0];
-}
-
-function buildPreview(content: ContentBlock[]): string {
-  return truncate(
-    stringifyMessageContent(content).replace(/\s+/g, " ").trim(),
-    PREVIEW_MAX_CHARS,
-  );
+  const channel = parseChannelId(metadata?.userMessageChannel);
+  return channel != null && channel !== "vellum";
 }
 
 export async function emitAssistantReplyNotification(params: {
   conversationId: string;
   assistantMessageId: string;
+  /**
+   * The row that opened the turn, threaded from the agent loop. Reading it by
+   * id rather than scanning back from the assistant row keeps a hidden or
+   * queued user message that landed mid-turn from being mistaken for the
+   * prompt this reply answers.
+   */
+  userMessageId: string | undefined;
   rlog: pino.Logger;
+  /** Rows the caller already holds; re-read when omitted. */
+  conversation?: ConversationRow | null;
+  assistantMessage?: MessageRow | null;
 }): Promise<void> {
-  const { conversationId, assistantMessageId, rlog } = params;
+  const { conversationId, assistantMessageId, userMessageId, rlog } = params;
   try {
-    const conversation = getConversation(conversationId);
+    if (!isAssistantReplyPushEnabled()) {
+      return;
+    }
+    if (!userMessageId) {
+      return;
+    }
+    const conversation = params.conversation ?? getConversation(conversationId);
     if (!conversation) {
       return;
     }
@@ -117,51 +98,51 @@ export async function emitAssistantReplyNotification(params: {
     if (kind !== "user") {
       return;
     }
-    if (!isLatestReplyUnseen(conversationId)) {
+    const attention = getAttentionStateByConversationIds([conversationId]).get(
+      conversationId,
+    );
+    if (!hasUnseenLatestAssistantMessage(attention)) {
       return;
     }
 
-    const assistantRow = getMessageById(assistantMessageId, conversationId);
+    const assistantRow =
+      params.assistantMessage ??
+      getMessageById(assistantMessageId, conversationId);
     if (!assistantRow) {
       return;
     }
 
-    // Scheduled/background prompts injected into an ordinary user conversation
-    // are automated turns with their own producers (e.g. `schedule.notify`);
-    // notifying here too would double-notify.
-    const initiatingMessage = findInitiatingUserMessage(
-      conversationId,
-      assistantRow.createdAt,
-    );
+    const initiatingMessage = getMessageById(userMessageId, conversationId);
     if (!initiatingMessage) {
       return;
     }
     const initiatingMetadata = parseMessageMetadata(initiatingMessage.metadata);
+    // Scheduled/background prompts injected into an ordinary user conversation
+    // are automated turns with their own producers (e.g. `schedule.notify`);
+    // notifying here too would double-notify.
     if (initiatingMetadata?.automated === true) {
       return;
     }
-    // Hidden lifecycle rows (subagent/ACP completions, wake triggers, hidden
-    // sends) are persisted with role "user" but are internal scaffolding, so
-    // the turn they open is nobody's prompt awaiting a reply.
+    // A turn opened by internal scaffolding is nobody's prompt awaiting a
+    // reply; see `isEchoSuppressedUserMessage`.
     if (isEchoSuppressedUserMessage(initiatingMetadata)) {
       return;
     }
-    // A phone or in-app voice utterance is answered out loud over the session
-    // the user is still on, so the reply is never unseen in the sense this
-    // producer notifies about; pushing here would fire once per spoken turn.
+    // A spoken reply is delivered over the still-open session; see
+    // `isVoiceSessionUserMessage`.
     if (isVoiceSessionUserMessage(initiatingMetadata)) {
       return;
     }
     // A turn started from a messaging channel has its finished reply delivered
     // back to that channel (`finalizeEventDelivery`), so the sender already has
-    // it; pushing here would duplicate it on their phone. The voice gate above
-    // cannot stand in for this one: an in-app live-voice turn persists as
-    // `vellum`, exactly like a typed send.
+    // it; pushing here would duplicate it on their phone.
     if (isChannelOriginatedUserMessage(initiatingMetadata)) {
       return;
     }
 
-    const preview = buildPreview(assistantRow.content);
+    const preview = sanitizeMessagePreview(
+      stringifyMessageContent(assistantRow.content),
+    );
     if (!preview) {
       return;
     }

--- a/assistant/src/persistence/conversation-attention-store.ts
+++ b/assistant/src/persistence/conversation-attention-store.ts
@@ -61,6 +61,32 @@ export interface AttentionState {
   updatedAt: number;
 }
 
+/**
+ * True when the latest assistant cursor is ahead of the last-seen cursor.
+ *
+ * The single definition of "unseen" for the sidebar indicator
+ * (`buildAssistantAttention` in `runtime/services/conversation-serializer.ts`)
+ * and the assistant-reply push producer, so the badge and the notification
+ * cannot disagree. An absent state row reads as seen.
+ */
+export function hasUnseenLatestAssistantMessage(
+  state:
+    | Pick<
+        AttentionState,
+        "latestAssistantMessageAt" | "lastSeenAssistantMessageAt"
+      >
+    | null
+    | undefined,
+): boolean {
+  if (!state || state.latestAssistantMessageAt == null) {
+    return false;
+  }
+  return (
+    state.lastSeenAssistantMessageAt == null ||
+    state.lastSeenAssistantMessageAt < state.latestAssistantMessageAt
+  );
+}
+
 // ── Row mappers ──────────────────────────────────────────────────────
 
 function rowToEvent(

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -298,11 +298,9 @@ export const messageMetadataSchema = z
      */
     hidden: z.boolean().optional(),
     /**
-     * Marks a role-`"user"` row that opened a live phone or in-app voice turn
-     * (every row `startVoiceTurn` persists, see `calls/voice-session-bridge.ts`).
-     * The channel/interface fields cannot stand in for it: a live-voice turn
-     * persists as `vellum`/`macos`, exactly like a typed desktop send. Test with
-     * {@link isVoiceSessionUserMessage}.
+     * Marks a role-`"user"` row that opened a live phone or in-app voice turn.
+     * Test with {@link isVoiceSessionUserMessage}, which documents why the
+     * channel/interface fields cannot stand in for it.
      */
     voiceSessionTurn: z.boolean().optional(),
     /**
@@ -411,13 +409,17 @@ export function isEchoSuppressedUserMessage(
 
 /**
  * True when a role-`"user"` row was persisted by the voice bridge for a live
- * phone call or in-app voice session (see the `voiceSessionTurn` field on
- * {@link messageMetadataSchema}).
+ * phone call or in-app voice session (every row `startVoiceTurn` persists, see
+ * `calls/voice-session-bridge.ts`).
  *
  * The reply to such a turn is spoken back over the still-open session, so any
  * consumer that treats a finished reply as something the user has yet to see
  * (the assistant-reply notification producer) must skip it rather than push a
  * notification for audio the user is hearing right now.
+ *
+ * This marker is the only durable signal for that: the channel/interface fields
+ * cannot stand in, because an in-app live-voice turn persists as
+ * `vellum`/`macos`, indistinguishable from a typed desktop send.
  */
 export function isVoiceSessionUserMessage(
   metadata: Record<string, unknown> | undefined,

--- a/assistant/src/runtime/services/conversation-serializer.ts
+++ b/assistant/src/runtime/services/conversation-serializer.ts
@@ -13,6 +13,7 @@ import {
   type AttentionState,
   type Confidence,
   getAttentionStateByConversationIds,
+  hasUnseenLatestAssistantMessage,
   type SignalType,
 } from "../../persistence/conversation-attention-store.js";
 import {
@@ -43,10 +44,7 @@ function buildAssistantAttention(attentionState: AttentionState | undefined):
 
   return {
     hasUnseenLatestAssistantMessage:
-      attentionState.latestAssistantMessageAt != null &&
-      (attentionState.lastSeenAssistantMessageAt == null ||
-        attentionState.lastSeenAssistantMessageAt <
-          attentionState.latestAssistantMessageAt),
+      hasUnseenLatestAssistantMessage(attentionState),
     ...(attentionState.latestAssistantMessageAt != null
       ? {
           latestAssistantMessageAt: attentionState.latestAssistantMessageAt,

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -348,6 +348,14 @@
       "label": "Marketing Pricing Takeover",
       "description": "Gates the marketing pricing takeover page (www.vellum.ai/pricing) and the `/assistant/checkout?package=<slug>` deep link its package CTAs target. One flag covers both halves of the funnel so they can never be enabled independently and strand a CTA. When off, the checkout deep link redirects to the in-app plans takeover.",
       "defaultEnabled": false
+    },
+    {
+      "id": "assistant-reply-push",
+      "scope": "assistant",
+      "key": "assistant-reply-push",
+      "label": "Assistant Reply Push",
+      "description": "Gates the `chat.assistant_reply` push notification the daemon emits at the end of a user-initiated turn whose reply the user has not seen. On by default; turn it off to silence the push without disabling the rest of the notification pipeline.",
+      "defaultEnabled": true
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -348,6 +348,14 @@
       "label": "Marketing Pricing Takeover",
       "description": "Gates the marketing pricing takeover page (www.vellum.ai/pricing) and the `/assistant/checkout?package=<slug>` deep link its package CTAs target. One flag covers both halves of the funnel so they can never be enabled independently and strand a CTA. When off, the checkout deep link redirects to the in-app plans takeover.",
       "defaultEnabled": false
+    },
+    {
+      "id": "assistant-reply-push",
+      "scope": "assistant",
+      "key": "assistant-reply-push",
+      "label": "Assistant Reply Push",
+      "description": "Gates the `chat.assistant_reply` push notification the daemon emits at the end of a user-initiated turn whose reply the user has not seen. On by default; turn it off to silence the push without disabling the rest of the notification pipeline.",
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for unseen-reply-notify.md.

- Provider-error turns no longer push their error text as a reply
- The initiating user row is threaded from the agent loop instead of re-derived by timestamp scan; redundant tail DB reads removed
- Daemon-side kill switch flag; sanitized preview; channel gate validates via parseChannelId; shared unseen predicate; comment/test dedup