### PR TITLE
fix(web): post throwaway side-conversation prompts hidden so reply pushes skip them

### DIFF
--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Pins the shape of the identity-rewrite send. The prompt is a
+ * `<system-message>` the user never typed, so it posts hidden: the daemon's
+ * reply-notification producer skips hidden-initiated turns, which keeps the
+ * rewrite reply from pushing to a thread archived the moment it settles.
+ *
+ * NOTE: `bun mock.module` can leak across files. Run this file singly:
+ *   bun test src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+interface PostCall {
+  path: { assistant_id: string };
+  body: { conversationId: string; content: string; hidden?: boolean };
+}
+
+let postCalls: PostCall[] = [];
+let archiveCalls: Array<{ path: { assistant_id: string; id: string } }> = [];
+
+const ok = <T>(data: T) =>
+  Promise.resolve({ data, error: undefined, response: { ok: true } });
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  conversationsPost: () => ok({ id: "conv-1" }),
+  messagesPost: (opts: PostCall) => {
+    postCalls.push(opts);
+    return ok({});
+  },
+  messagesGet: () =>
+    ok({
+      processing: false,
+      messages: [
+        { role: "assistant", contentBlocks: [{ type: "text", text: "Done." }] },
+      ],
+    }),
+  conversationsByIdArchivePost: (opts: {
+    path: { assistant_id: string; id: string };
+  }) => {
+    archiveCalls.push(opts);
+    return ok({});
+  },
+}));
+mock.module("@/lib/sentry/capture-error", () => ({ captureError: () => {} }));
+
+const { runIdentityRewrite } = await import("./run-identity-rewrite");
+
+afterEach(() => {
+  postCalls = [];
+  archiveCalls = [];
+});
+
+describe("runIdentityRewrite", () => {
+  test("posts the rewrite prompt hidden and archives the side conversation", async () => {
+    await runIdentityRewrite({
+      assistantId: "ast-1",
+      content: "<system-message>rewrite</system-message>",
+      title: "Updating personality",
+      context: "test",
+    });
+
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0]?.path).toEqual({ assistant_id: "ast-1" });
+    expect(postCalls[0]?.body.conversationId).toBe("conv-1");
+    expect(postCalls[0]?.body.hidden).toBe(true);
+
+    expect(archiveCalls).toHaveLength(1);
+    expect(archiveCalls[0]?.path).toEqual({
+      assistant_id: "ast-1",
+      id: "conv-1",
+    });
+  });
+});

--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
@@ -66,6 +66,10 @@ export async function runIdentityRewrite({
       content,
       sourceChannel: "vellum",
       interface: "vellum",
+      // A machine signal the user never typed: hidden keeps the daemon from
+      // pushing this turn's reply to the user's phone, deep-linked into a
+      // thread archived a moment later.
+      hidden: true,
       clientMessageId: crypto.randomUUID(),
     };
     const posted = await messagesPost({

--- a/clients/web/src/domains/onboarding/apply-personality-save.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality-save.test.ts
@@ -5,6 +5,9 @@
  * left both empty after onboarding (the prose rewrite alone loses the
  * numbers). Kept separate from `apply-personality.test.ts` so the pure
  * message-builder tests stay free of module mocks.
+ *
+ * Also pins the shape of the rewrite send itself, which the daemon's
+ * reply-notification gating reads.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -13,7 +16,11 @@ const conversationsPostMock = mock(async () => ({
   data: { id: "conv-1" },
   response: { ok: true },
 }));
-const messagesPostMock = mock(async () => ({ response: { ok: true } }));
+const messagesPostMock = mock(
+  async (_opts: { body: { hidden?: boolean } }) => ({
+    response: { ok: true },
+  }),
+);
 const messagesGetMock = mock(async () => ({
   data: {
     processing: false,
@@ -51,6 +58,20 @@ beforeEach(() => {
   conversationsPostMock.mockClear();
   messagesPostMock.mockClear();
   saveSlidersMock.mockClear();
+});
+
+describe("applyPersonality rewrite prompt", () => {
+  test("posts the rewrite prompt as a hidden machine signal", async () => {
+    // The prompt is a `<system-message>` the user never typed. Hidden keeps
+    // the daemon's reply-notification producer from pushing the rewrite reply
+    // to the user's phone, deep-linked into a thread archived a moment later.
+    await applyPersonality({
+      awaitAssistantId: async () => "ast-1",
+      values: {},
+    });
+
+    expect(messagesPostMock.mock.calls[0]?.[0].body.hidden).toBe(true);
+  });
 });
 
 describe("applyPersonality slider persistence", () => {

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -96,6 +96,10 @@ export async function applyPersonality({
       content: buildPersonalityMessage(values, userName, assistantName),
       sourceChannel: "vellum",
       interface: "vellum",
+      // A machine signal the user never typed: hidden keeps the daemon from
+      // pushing this turn's reply to the user's phone, deep-linked into a
+      // thread archived a moment later.
+      hidden: true,
       clientMessageId: crypto.randomUUID(),
     };
     const posted = await messagesPost({

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for how the research runner opens its side conversation: the prompt is
+ * posted as a hidden machine signal, and a resumed run re-posts only when the
+ * turn never started.
+ *
+ * Hidden rows are filtered out of `/messages`, so "did the prompt land?" reads
+ * the turn's own state (still processing, or rows already produced) instead of
+ * looking for a user row.
+ *
+ * NOTE: `bun mock.module` can leak across files. Run this file singly:
+ *   bun test src/domains/onboarding/research-runner-send.test.ts
+ */
+
+import { createElement, type ReactNode } from "react";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { ResearchSubject } from "@/domains/onboarding/research-prompt";
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+
+interface PostCall {
+  path: { assistant_id: string };
+  body: { conversationId: string; hidden?: boolean };
+}
+
+let postCalls: PostCall[] = [];
+let getCalls = 0;
+let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
+
+const ok = <T>(data: T) =>
+  Promise.resolve({ data, error: undefined, response: { ok: true } });
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  pluginsSearchGet: () => ok({ matches: [] }),
+  pluginsInstallPost: () => ok({}),
+  telemetryIngestPost: () => ok({}),
+  conversationsPost: () => ok({ id: "conv-fresh" }),
+  conversationsByIdArchivePost: () => ok({}),
+  messagesGet: () => {
+    getCalls += 1;
+    return ok(listed);
+  },
+  messagesPost: (opts: PostCall) => {
+    postCalls.push(opts);
+    return ok({});
+  },
+}));
+mock.module("@/lib/sentry/capture-error", () => ({ captureError: () => {} }));
+
+const { useResearchRunner } =
+  await import("@/domains/onboarding/research-runner");
+
+const subject: ResearchSubject = {
+  firstName: "Alice",
+  lastName: "Example",
+  occupation: "Engineer",
+  hobbies: [],
+  timezone: "UTC",
+};
+
+function renderRunner() {
+  const queryClient = new QueryClient();
+  return renderHook(() => useResearchRunner(), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children),
+  });
+}
+
+afterEach(() => {
+  postCalls = [];
+  getCalls = 0;
+  listed = { messages: [] };
+});
+
+/**
+ * The resume branch reads `/messages` once and decides synchronously on the
+ * result, so observing that read is enough to assert on the decision. The poll
+ * loop's own reads are a poll interval away.
+ */
+async function whenResumeDecided(): Promise<void> {
+  await waitFor(() => {
+    expect(getCalls).toBeGreaterThan(0);
+  });
+}
+
+describe("research prompt send", () => {
+  test("posts the prompt as a hidden machine signal", async () => {
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+      });
+    });
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+    expect(postCalls[0]?.body.conversationId).toBe("conv-fresh");
+    // The daemon's reply-notification producer skips hidden-initiated turns,
+    // so the research reply never pushes to a thread the user cannot open.
+    expect(postCalls[0]?.body.hidden).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  test("re-posts on resume when the turn never started", async () => {
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+        resumeConversationId: "conv-resumed",
+      });
+    });
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+    expect(postCalls[0]?.body.conversationId).toBe("conv-resumed");
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  test("does not re-post on resume while the turn is still processing", async () => {
+    // The regression the hidden flag would otherwise cause: the prompt row is
+    // filtered from `/messages`, so a user-row check would read "never landed"
+    // and fire a second research turn on every refresh.
+    listed = { processing: true, messages: [] };
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+        resumeConversationId: "conv-resumed",
+      });
+    });
+
+    await whenResumeDecided();
+    expect(postCalls).toHaveLength(0);
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  test("does not re-post on resume when the turn already produced rows", async () => {
+    listed = {
+      processing: false,
+      messages: [{ role: "assistant", contentBlocks: [] }],
+    };
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+        resumeConversationId: "conv-resumed",
+      });
+    });
+
+    await whenResumeDecided();
+    expect(postCalls).toHaveLength(0);
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+});

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -605,6 +605,10 @@ export function useResearchRunner(): UseResearchRunner {
               // transport/host-proxy gating (mirrors `chat/api/messages.ts`).
               interface: "web",
               clientOs: detectClientOs(),
+              // A machine signal the user never typed: hidden keeps the daemon
+              // from pushing this turn's reply to the user's phone,
+              // deep-linked into a thread archived once the results settle.
+              hidden: true,
               clientMessageId: crypto.randomUUID(),
             };
             // Carry the browser timezone so any time-relative reasoning resolves
@@ -657,7 +661,7 @@ export function useResearchRunner(): UseResearchRunner {
             // Resume the prior session's research conversation rather than
             // running a second search. The turn keeps generating server-side
             // across the reload, so re-attach and poll it; only re-post the
-            // prompt if it never landed before the refresh (no user message).
+            // prompt if it never landed before the refresh.
             const existing = await messagesGet({
               path: { assistant_id: assistantId },
               query: { conversationId: resumeConversationId },
@@ -669,9 +673,12 @@ export function useResearchRunner(): UseResearchRunner {
             if (existing.response?.ok) {
               conversationId = resumeConversationId;
               createdConversationId = resumeConversationId;
-              const turnAlreadyStarted = (existing.data?.messages ?? []).some(
-                (m) => m.role === "user",
-              );
+              // The hidden prompt row is filtered out of `/messages`, so a
+              // started turn shows as the daemon still processing or as a row
+              // it has already produced, never as a user message.
+              const turnAlreadyStarted =
+                existing.data?.processing === true ||
+                (existing.data?.messages ?? []).length > 0;
               if (!turnAlreadyStarted) {
                 if (!(await postResearchPrompt(conversationId))) {
                   setState((s) => ({ ...s, status: "error" }));

--- a/clients/web/src/domains/onboarding/send-research-correction.test.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.test.ts
@@ -21,6 +21,7 @@ interface PostCall {
     content: string;
     interface?: string;
     clientOs?: string;
+    hidden?: boolean;
   };
   throwOnError: false;
 }
@@ -127,6 +128,10 @@ describe("sendResearchCorrection", () => {
     // assistant keeps platform context (mirrors the initial research send).
     expect(postCalls[0]?.body.interface).toBe("web");
     expect(postCalls[0]?.body.clientOs).toBe("web");
+    // The correction is a machine signal, not something the user typed: the
+    // daemon's reply-notification producer skips hidden-initiated turns, so
+    // acknowledging it never pushes to the user's phone.
+    expect(postCalls[0]?.body.hidden).toBe(true);
 
     expect(archiveCalls).toHaveLength(1);
     expect(archiveCalls[0]?.path).toEqual({ assistant_id: "a1", id: "c1" });

--- a/clients/web/src/domains/onboarding/send-research-correction.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.ts
@@ -103,6 +103,11 @@ export async function sendResearchCorrection({
       // matching the initial research send (`research-runner.ts`).
       interface: "web",
       clientOs: detectClientOs(),
+      // A machine signal the user never typed: hidden keeps the daemon from
+      // pushing this turn's reply to the user's phone, deep-linked into the
+      // thread re-archived below. The correction still reaches the assistant,
+      // since hidden rows stay in LLM-side history.
+      hidden: true,
       clientMessageId: crypto.randomUUID(),
     };
     await messagesPost({


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unseen-reply-notify.md.

**Gap:** personality/identity/onboarding side conversations look like user turns and would push their internal replies to the phone
**Fix:** their initiating messages/conversations now carry the marker the daemon reply producer already gates on

### Mechanism
The daemon's `emitAssistantReplyNotification` skips a turn whose initiating user row satisfies `isEchoSuppressedUserMessage`, which includes `hidden: true`. `hidden` is the only one of the candidate markers that is actually client-settable:

- **`automated: true`** (preferred on paper) is accepted by the daemon route (`conversation-routes.ts`) but is **not declared in `assistant/openapi.yaml`**, so the generated web SDK's `MessagesPostData["body"]` has no such field. Declaring it means editing the daemon's generated spec source, which is out of scope for this PR.
- **`conversationType: "background"`** is not reachable: `POST /v1/conversations` documents `const: standard` and its handler hardcodes `conversationType: "standard"`, never reading the body field.
- **`hidden: true`** is documented in the spec, exposed by the generated SDK, and semantically exact: "machine signals the user never typed". It keeps the row in LLM-side history and still drives the turn, so every flow's function is preserved.

### Flows fixed
- `domains/onboarding/apply-personality.ts`
- `domains/intelligence/identity-actions/run-identity-rewrite.ts`
- `domains/onboarding/research-runner.ts`
- `domains/onboarding/send-research-correction.ts` (**not in the original gap list** — same bug: it posts a user-looking correction into the same archived research thread, so its acknowledgement would push too)

### Compensating change
Hidden rows are filtered out of `GET /messages`, so the research runner's resume check can no longer look for a user row to decide whether the prompt already landed. It now reads the turn's own state (`processing === true`, or any row already produced), which is what "the turn started" actually means.

## Testing
- `bun test src/domains/onboarding/apply-personality-save.test.ts` (new hidden-flag assertion)
- `bun test src/domains/onboarding/research-runner-send.test.ts` (new file: hidden flag + all three resume branches)
- `bun test src/domains/onboarding/send-research-correction.test.ts` (new hidden-flag assertion)
- `bun test src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts` (new file)
- `bun test src/domains/onboarding/apply-personality.test.ts`, `research-runner.test.ts` (unchanged, still green)
- `bunx tsc --noEmit`: no errors in touched files. Pre-existing unrelated failures come from a stale `@vellumai/assistant-api` copy in the shared worktree `node_modules` (missing `MessageRequeuedEvent`) and `@vellumai/service-contracts/stripe-currency`.

## Notes
No backwards-compat gate added: hidden-send handling shipped in assistant 0.10.4 (current 0.11.0), and an older daemon that ignores the flag also predates the reply producer, so there is no push to suppress.