### PR TITLE
fix: comment hygiene and speculative test mock from re-review

### DIFF
--- a/clients/ios/App/App/ApnsEnvironmentPlugin.swift
+++ b/clients/ios/App/App/ApnsEnvironmentPlugin.swift
@@ -33,8 +33,6 @@ public class ApnsEnvironmentPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc public func get(_ call: CAPPluginCall) {
         #if targetEnvironment(simulator)
-            // Simulator builds ship no embedded profile, and APNs simulator
-            // push always uses the development environment.
             call.resolve(["environment": "development"])
             return
         #endif

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -153,9 +153,7 @@ async function upsertToken(
     // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
     const { App } = await import("@capacitor/app");
     const { id: bundleId } = await App.getInfo();
-    // Shared with the device-token upsert so both registrations tag this
-    // build's tokens with the same APNs environment (signing-derived, with a
-    // bundle-suffix fallback).
+    // See `runtime/apns-environment.ts` for the shared-resolver rationale.
     const apnsEnvironment = await resolveSignedApnsEnvironment(bundleId);
 
     const result = await assistantsLiveActivityTokensUpsert({

--- a/clients/web/src/runtime/apns-environment.test.ts
+++ b/clients/web/src/runtime/apns-environment.test.ts
@@ -31,17 +31,6 @@ mock.module("@capacitor/core", () => ({
     name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
 }));
 
-// ── Sentry capture-error ─────────────────────────────────────────────────────
-//
-// The module deliberately reports fallbacks via `console.debug` only (an old
-// shell is an expected state, not a fault); the mock makes the no-capture
-// assertion fail loudly if a future edit starts reporting them.
-
-const captureErrorMock = mock(() => {});
-mock.module("@/lib/sentry/capture-error", () => ({
-  captureError: captureErrorMock,
-}));
-
 const { resolveSignedApnsEnvironment } =
   await import("@/runtime/apns-environment");
 
@@ -54,7 +43,6 @@ beforeEach(() => {
   apnsEnvironmentResult = undefined;
   apnsEnvironmentRejects = true;
   apnsEnvironmentGetMock.mockClear();
-  captureErrorMock.mockClear();
   consoleDebugSpy.mockClear();
 });
 
@@ -89,7 +77,7 @@ describe("resolveSignedApnsEnvironment", () => {
     );
   });
 
-  test("bridge rejection (old shell) falls back to the heuristic: console.debug, no Sentry capture", async () => {
+  test("bridge rejection (old shell) falls back to the heuristic via console.debug", async () => {
     expect(await resolveSignedApnsEnvironment(DEV_BUNDLE_ID)).toBe(
       "development",
     );
@@ -99,6 +87,5 @@ describe("resolveSignedApnsEnvironment", () => {
 
     expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(2);
     expect(consoleDebugSpy).toHaveBeenCalledTimes(2);
-    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/runtime/apns-environment.ts
+++ b/clients/web/src/runtime/apns-environment.ts
@@ -19,10 +19,6 @@
  * bundle id, which is exactly the case the bundle-suffix heuristic got wrong
  * for TestFlight dev builds. Shells predating the plugin, and profiles it
  * cannot parse, fall back to that heuristic.
- *
- * Per `docs/CAPACITOR.md`, only the plugin call's result may cross an `async`
- * boundary, never the plugin Proxy itself: the Proxy's `.then` trap would hang
- * the awaiting caller forever.
  */
 
 import { registerPlugin } from "@capacitor/core";
@@ -33,13 +29,7 @@ interface ApnsEnvironmentPlugin {
   get(): Promise<{ environment?: string }>;
 }
 
-/**
- * Native plugin reporting the build's real APNs entitlement environment, read
- * from the embedded provisioning profile
- * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`). Resolves
- * `"development"`, `"production"`, or `"unknown"` on modern shells; on older
- * shells that predate the plugin the bridge call rejects instead.
- */
+/** Native entitlement-environment plugin; see the module docblock. */
 const ApnsEnvironment =
   registerPlugin<ApnsEnvironmentPlugin>("ApnsEnvironment");
 

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -406,16 +406,14 @@ export async function postLocalNotification(
     // at mount), and the app was hidden when the intent arrived; the
     // remote push banners on its own there, and scheduling the local one
     // too would double-notify during the SSE grace window after
-    // backgrounding. No separate support check: a session-confirmed
-    // registration is only reachable through `registerForRemotePush`,
-    // which requires remote-push support.
+    // backgrounding. A session-confirmed registration implies remote-push
+    // support: it is recorded only by `registerForRemotePush`, which is
+    // gated on that support.
     //
     // Residual limitation: `remotePushDispatched` is an aggregate
     // account-level outcome (any device token accepted), so on a
     // multi-device account a token pruned mid-session can still suppress
-    // this banner while only another device received the push. Closing
-    // that gap requires per-token dispatch results from the platform's
-    // dispatch endpoint.
+    // this banner while only another device received the push.
     if (
       args.remotePushDispatched === true &&
       args.assistantId !== undefined &&

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -31,11 +31,8 @@
  * (no native Capacitor Android shell ships today); registration/delete failures
  * are reported to Sentry but never thrown into the app lifecycle.
  *
- * The upserted row tags the token with the build's APNs entitlement
- * environment, resolved by `runtime/apns-environment.ts` (the native
- * `ApnsEnvironment` plugin with a bundle-suffix heuristic fallback). The
- * resolver is shared with the ActivityKit Live Activity token upsert so the
- * two registrations can never tag the same build differently.
+ * The upserted row's `apns_environment` tag is resolved by
+ * `runtime/apns-environment.ts`; see its docblock for the rationale.
  *
  * Per `docs/CAPACITOR.md`, the `@capacitor/*` plugins are destructured inline
  * at each call site — never returned through an `async` boundary — because the


### PR DESCRIPTION
## Summary
Round-2 review hygiene for ios-push-lower-envs.md: present-tense invariant comments in the dedup skip, single-home rationale for the shared APNs resolver (module docblock), removed a speculative Sentry mock guarding unimported code, and deduplicated the Swift simulator rationale. Zero behavior change.