### PR TITLE
fix: platform probe bounds and guardian-registry addressing from re-review

### DIFF
--- a/assistant/src/notifications/__tests__/guardian-delivery-recorder.test.ts
+++ b/assistant/src/notifications/__tests__/guardian-delivery-recorder.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const createGuardianRequestDeliveryMock = mock();
+const updateGuardianRequestDeliveryMock = mock();
+
+mock.module("../../channels/gateway-guardian-requests.js", () => ({
+  createGuardianRequestDelivery: (...args: unknown[]) =>
+    createGuardianRequestDeliveryMock(...args),
+  updateGuardianRequestDelivery: (...args: unknown[]) =>
+    updateGuardianRequestDeliveryMock(...args),
+}));
+
+import { recordGuardianRequestDeliveries } from "../guardian-delivery-recorder.js";
+import type { NotificationDeliveryResult } from "../types.js";
+
+beforeEach(() => {
+  createGuardianRequestDeliveryMock.mockReset();
+  updateGuardianRequestDeliveryMock.mockReset();
+  createGuardianRequestDeliveryMock.mockImplementation(async () => ({
+    id: `row-${createGuardianRequestDeliveryMock.mock.calls.length}`,
+  }));
+  updateGuardianRequestDeliveryMock.mockResolvedValue(undefined);
+});
+
+describe("recordGuardianRequestDeliveries", () => {
+  test("records rows only for addressable channels, skipping platform", async () => {
+    const deliveryResults: NotificationDeliveryResult[] = [
+      {
+        channel: "vellum",
+        destination: "vellum",
+        status: "sent",
+        conversationId: "conv-1",
+      },
+      {
+        // A forced platform push has no endpoint, so the broadcaster falls
+        // back to the channel name as the destination -- it must never be
+        // persisted as a destinationChatId.
+        channel: "platform",
+        destination: "platform",
+        status: "pending",
+      },
+      {
+        channel: "telegram",
+        destination: "12345",
+        status: "sent",
+        conversationId: "conv-1",
+        messageId: "tg-77",
+      },
+    ];
+
+    await recordGuardianRequestDeliveries({
+      requestId: "req-1",
+      deliveryResults,
+    });
+
+    const channels = createGuardianRequestDeliveryMock.mock.calls.map(
+      (call) => (call[0] as { destinationChannel: string }).destinationChannel,
+    );
+    expect(channels).toEqual(["vellum", "telegram"]);
+
+    const telegramRow = createGuardianRequestDeliveryMock.mock.calls[1]![0] as {
+      destinationChatId?: string;
+      destinationMessageId?: string;
+    };
+    expect(telegramRow.destinationChatId).toBe("12345");
+    expect(telegramRow.destinationMessageId).toBe("tg-77");
+
+    // Status patches apply only to the rows that were created.
+    expect(updateGuardianRequestDeliveryMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -251,6 +251,27 @@ interface PendingChannelDispatch {
   hasPersistedDecision: boolean;
 }
 
+/**
+ * Build a delivery result for a prepared dispatch. The single construction
+ * site for every post-preparation outcome branch, so a future field cannot
+ * be added to one branch and missed in another.
+ */
+function buildDeliveryResult(
+  dispatch: PendingChannelDispatch,
+  status: NotificationDeliveryResult["status"],
+  overrides?: Partial<NotificationDeliveryResult>,
+): NotificationDeliveryResult {
+  return {
+    channel: dispatch.channel,
+    destination: dispatch.destinationLabel,
+    status,
+    conversationId: dispatch.pairing.conversationId ?? undefined,
+    messageId: dispatch.pairing.messageId ?? undefined,
+    conversationStrategy: dispatch.pairing.strategy,
+    ...overrides,
+  };
+}
+
 export class NotificationBroadcaster {
   private adapters: Map<NotificationChannel, ChannelAdapter>;
   private onConversationCreated: OnConversationCreatedFn | null = null;
@@ -640,6 +661,17 @@ export class NotificationBroadcaster {
           toolApprovalSource,
         };
 
+        const dispatch: PendingChannelDispatch = {
+          adapter,
+          channel,
+          destination,
+          payload,
+          deliveryId,
+          destinationLabel,
+          pairing,
+          hasPersistedDecision,
+        };
+
         // Compute conversation decision audit fields for the delivery record
         const conversationAudit = {
           conversationAction: conversationAction?.action ?? "start_new",
@@ -678,28 +710,11 @@ export class NotificationBroadcaster {
             { err, channel, signalId: signal.signalId },
             "Failed to create delivery record",
           );
-          results.push({
-            channel,
-            destination: destinationLabel,
-            status: "failed",
-            errorMessage,
-            conversationId: pairing.conversationId ?? undefined,
-            messageId: pairing.messageId ?? undefined,
-            conversationStrategy: pairing.strategy,
-          });
+          results.push(
+            buildDeliveryResult(dispatch, "failed", { errorMessage }),
+          );
           continue;
         }
-
-        const dispatch: PendingChannelDispatch = {
-          adapter,
-          channel,
-          destination,
-          payload,
-          deliveryId,
-          destinationLabel,
-          pairing,
-          hasPersistedDecision,
-        };
 
         if (channel === "vellum" && orderedChannels.includes("platform")) {
           // The vellum intent carries remotePushDispatched, so its send waits
@@ -745,14 +760,7 @@ export class NotificationBroadcaster {
             // The in-flight dispatch's result lands in backgroundResults,
             // which this call no longer reads; its delivery row still gets
             // the real terminal status.
-            results.push({
-              channel,
-              destination: destinationLabel,
-              status: "pending",
-              conversationId: pairing.conversationId ?? undefined,
-              messageId: pairing.messageId ?? undefined,
-              conversationStrategy: pairing.strategy,
-            });
+            results.push(buildDeliveryResult(dispatch, "pending"));
           } else {
             results.push(...backgroundResults);
           }
@@ -760,15 +768,7 @@ export class NotificationBroadcaster {
           continue;
         }
 
-        const adapterResult = await this.sendAndRecord(
-          dispatch,
-          signal,
-          results,
-        );
-        if (channel === "platform") {
-          platformRemotePushAccepted =
-            adapterResult?.remotePushAccepted === true;
-        }
+        await this.sendAndRecord(dispatch, signal, results);
       }
     } finally {
       // Guarantees the vellum intent is emitted (and its pending delivery
@@ -797,7 +797,6 @@ export class NotificationBroadcaster {
       destination,
       payload,
       deliveryId,
-      destinationLabel,
       pairing,
       hasPersistedDecision,
     } = dispatch;
@@ -821,30 +820,23 @@ export class NotificationBroadcaster {
               : undefined,
           );
         }
-        results.push({
-          channel,
-          destination: destinationLabel,
-          status: "sent",
-          sentAt: Date.now(),
-          conversationId: pairing.conversationId ?? undefined,
-          messageId: resolvedMessageId,
-          conversationStrategy: pairing.strategy,
-        });
+        results.push(
+          buildDeliveryResult(dispatch, "sent", {
+            sentAt: Date.now(),
+            messageId: resolvedMessageId,
+          }),
+        );
       } else {
         if (hasPersistedDecision) {
           updateDeliveryStatus(deliveryId, "failed", {
             message: adapterResult.error,
           });
         }
-        results.push({
-          channel,
-          destination: destinationLabel,
-          status: "failed",
-          errorMessage: adapterResult.error,
-          conversationId: pairing.conversationId ?? undefined,
-          messageId: pairing.messageId ?? undefined,
-          conversationStrategy: pairing.strategy,
-        });
+        results.push(
+          buildDeliveryResult(dispatch, "failed", {
+            errorMessage: adapterResult.error,
+          }),
+        );
       }
       return adapterResult;
     } catch (err) {
@@ -864,15 +856,7 @@ export class NotificationBroadcaster {
         }
       }
 
-      results.push({
-        channel,
-        destination: destinationLabel,
-        status: "failed",
-        errorMessage,
-        conversationId: pairing.conversationId ?? undefined,
-        messageId: pairing.messageId ?? undefined,
-        conversationStrategy: pairing.strategy,
-      });
+      results.push(buildDeliveryResult(dispatch, "failed", { errorMessage }));
       return null;
     }
   }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -331,8 +331,10 @@ export async function emitNotificationSignal<TEventName extends string>(
     // regardless of what the decision engine selected. macOS surfaces a
     // banner even when the app is focused, and a suspended iOS device is
     // only reachable via APNs. Platform is only forced when the daemon has
-    // platform credentials -- on unbound daemons the dispatch can never
-    // succeed and would write a failed delivery row per signal.
+    // platform credentials and an assistant id -- on unbound daemons the
+    // dispatch can never succeed and would write a failed delivery row per
+    // signal. The probe is deadline-bounded internally, so a slow credential
+    // backend cannot stall the urgent dispatch.
     //
     // Vellum PREPENDS and platform APPENDS: the broadcaster re-sorts by
     // dispatch rank, so selection order only matters to single_channel

--- a/assistant/src/notifications/guardian-delivery-recorder.ts
+++ b/assistant/src/notifications/guardian-delivery-recorder.ts
@@ -91,8 +91,10 @@ export async function recordApprovalCardDelivery(
  * that row's id as `vellumDeliveryId` and it is reused (only its status applied)
  * — otherwise the vellum row is created here from the result.
  *
- * Every result records the internal `conversationId` the card is shown in, so a
- * conversation's pending cards can be found uniformly regardless of channel.
+ * Every addressable result records the internal `conversationId` the card is
+ * shown in, so a conversation's pending cards can be found uniformly
+ * regardless of channel. Platform push results are skipped entirely: a push
+ * has no channel-native card surface to address back to.
  * Channel results additionally carry the chat (`destination`) and channel-native
  * id (`messageId`) used to match inbound replies/reactions; a blank `destination`
  * is recorded as unknown rather than persisting the literal channel name as a
@@ -112,6 +114,10 @@ export async function recordGuardianRequestDeliveries(params: {
   let vellumDeliveryId = params.vellumDeliveryId;
 
   for (const result of deliveryResults) {
+    if (result.channel === "platform") {
+      // A push is not an independently addressable card surface -- no row.
+      continue;
+    }
     let deliveryId: string | undefined;
     if (result.channel === "vellum") {
       if (!vellumDeliveryId) {

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -11,13 +11,17 @@ let mockManagedProxyCtx = {
 };
 let mockAssistantId = "";
 let mockSecureKeys: Record<string, string | null | undefined> = {};
+// Re-pointable so the probe-deadline tests can hang context resolution.
+let mockResolveManagedProxyContext: () => Promise<
+  typeof mockManagedProxyCtx
+> = async () => mockManagedProxyCtx;
 
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
 
 mock.module("../providers/platform-proxy/context.js", () => ({
-  resolveManagedProxyContext: async () => mockManagedProxyCtx,
+  resolveManagedProxyContext: () => mockResolveManagedProxyContext(),
 }));
 
 mock.module("../config/env.js", () => ({
@@ -38,7 +42,11 @@ mock.module("../security/credential-key.js", () => ({
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------
 
-import { VellumPlatformClient } from "./client.js";
+import {
+  _resetConfiguredProbeCacheForTests,
+  isPlatformClientConfigured,
+  VellumPlatformClient,
+} from "./client.js";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -56,6 +64,8 @@ describe("VellumPlatformClient", () => {
     };
     mockAssistantId = "asst-123";
     mockSecureKeys = {};
+    mockResolveManagedProxyContext = async () => mockManagedProxyCtx;
+    _resetConfiguredProbeCacheForTests();
   });
 
   afterEach(() => {
@@ -116,6 +126,52 @@ describe("VellumPlatformClient", () => {
       expect(client!.baseUrl).toBe("https://stored-platform.example.com");
       expect(client!.assistantApiKey).toBe("stored-api-key");
       expect(client!.platformAssistantId).toBe("stored-assistant-id");
+    });
+  });
+
+  describe("isPlatformClientConfigured()", () => {
+    test("true when base url, api key, and assistant id are all present", async () => {
+      expect(await isPlatformClientConfigured()).toBe(true);
+    });
+
+    test("false when the platform assistant id is missing", async () => {
+      mockAssistantId = "";
+
+      expect(await isPlatformClientConfigured()).toBe(false);
+    });
+
+    test("false when auth prerequisites are missing", async () => {
+      mockManagedProxyCtx = {
+        enabled: false,
+        platformBaseUrl: "",
+        assistantApiKey: "",
+      };
+
+      expect(await isPlatformClientConfigured()).toBe(false);
+    });
+
+    test("hung resolution answers false at the deadline, then serves the late result from cache", async () => {
+      let releaseHang = () => {};
+      const hang = new Promise<void>((resolve) => {
+        releaseHang = resolve;
+      });
+      mockResolveManagedProxyContext = async () => {
+        await hang;
+        return mockManagedProxyCtx;
+      };
+
+      // Resolution is hung and no result has ever settled -- the deadline
+      // must answer false instead of stalling the caller.
+      expect(await isPlatformClientConfigured()).toBe(false);
+
+      // Release the abandoned resolution; it settles true in the background
+      // and refreshes the cache.
+      releaseHang();
+      await Bun.sleep(10);
+
+      // Resolution hangs forever this time, but the cache answers true.
+      mockResolveManagedProxyContext = () => new Promise(() => {});
+      expect(await isPlatformClientConfigured()).toBe(true);
     });
   });
 

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -101,14 +101,55 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
   return { baseUrl, apiKey, assistantId };
 }
 
+// Bounds the configured probe: resolution can hit up to three credential-store
+// reads, and urgent-notification dispatch awaits this probe, so a slow
+// credential backend must answer from cache instead of stalling the banner.
+const CONFIGURED_PROBE_DEADLINE_MS = 500;
+
+let lastKnownConfigured: boolean | null = null;
+
+export function _resetConfiguredProbeCacheForTests(): void {
+  lastKnownConfigured = null;
+}
+
 /**
- * Whether the platform client's auth prerequisites are present. A cheap
- * availability probe for callers that only need to know if platform calls
- * can be attempted: reads config and the credential store, constructs no
- * client, and makes no network requests.
+ * Whether the platform client can actually dispatch: auth prerequisites plus
+ * a nonempty platform assistant id (`PlatformPushAdapter.send()` fails fast
+ * without one). Constructs no client and makes no network requests.
+ *
+ * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
+ * slower than the deadline, returns the last settled result (or `false` when
+ * none exists yet). The abandoned resolution still settles in the background
+ * and refreshes the cache for the next call.
  */
 export async function isPlatformClientConfigured(): Promise<boolean> {
-  return (await resolvePlatformClientConfig()) !== null;
+  const probe = resolvePlatformClientConfig()
+    .then((config) => config !== null && config.assistantId.length > 0)
+    .catch((err: unknown) => {
+      log.debug(
+        { err },
+        "Configured probe failed -- treating as not configured",
+      );
+      return false;
+    })
+    .then((value) => {
+      lastKnownConfigured = value;
+      return value;
+    });
+
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<"deadline">((resolve) => {
+    deadlineTimer = setTimeout(
+      () => resolve("deadline"),
+      CONFIGURED_PROBE_DEADLINE_MS,
+    );
+  });
+  const raced = await Promise.race([probe, deadline]);
+  clearTimeout(deadlineTimer);
+  if (raced === "deadline") {
+    return lastKnownConfigured ?? false;
+  }
+  return raced;
 }
 
 export class VellumPlatformClient {


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for ios-push-lower-envs.md:
- isPlatformClientConfigured also requires the platform assistant id (matching the adapter's fail-fast) and is bounded by a 500ms race with a last-known-result cache so slow credential reads cannot stall urgent banners
- recordGuardianRequestDeliveries skips the platform channel (a push is not an addressable card surface), ending junk destinationChatId rows
- removed a dead platform-outcome write in the broadcaster fall-through path; extracted a delivery-result builder to collapse five near-identical literals