### PR TITLE
fix(web): share one side-conversation message builder across throwaway flows

### DIFF
--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
@@ -1,8 +1,6 @@
 /**
- * Pins the shape of the identity-rewrite send. The prompt is a
- * `<system-message>` the user never typed, so it posts hidden: the daemon's
- * reply-notification producer skips hidden-initiated turns, which keeps the
- * rewrite reply from pushing to a thread archived the moment it settles.
+ * Pins the shape of the identity-rewrite send: it goes out hidden (see
+ * `lib/side-conversation-message.ts`) and the side conversation is archived.
  *
  * NOTE: `bun mock.module` can leak across files. Run this file singly:
  *   bun test src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts

--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
@@ -20,9 +20,9 @@ import {
   messagesGet,
   messagesPost,
 } from "@/generated/daemon/sdk.gen";
-import type { MessagesPostData } from "@/generated/daemon/types.gen";
 import { shouldSettlePersonalityPoll } from "@/assistant/personality-rewrite";
 import { captureError } from "@/lib/sentry/capture-error";
+import { buildSideConversationMessageBody } from "@/lib/side-conversation-message";
 import { latestAssistantText } from "@/utils/latest-assistant-text";
 
 /** Poll cadence + ceiling while waiting for the rewrite turn to land. */
@@ -61,17 +61,11 @@ export async function runIdentityRewrite({
       return false;
     }
 
-    const body: MessagesPostData["body"] = {
+    const body = buildSideConversationMessageBody({
       conversationId,
       content,
-      sourceChannel: "vellum",
-      interface: "vellum",
-      // A machine signal the user never typed: hidden keeps the daemon from
-      // pushing this turn's reply to the user's phone, deep-linked into a
-      // thread archived a moment later.
-      hidden: true,
-      clientMessageId: crypto.randomUUID(),
-    };
+      transport: "vellum",
+    });
     const posted = await messagesPost({
       path: { assistant_id: assistantId },
       body,

--- a/clients/web/src/domains/onboarding/apply-personality-save.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality-save.test.ts
@@ -6,8 +6,8 @@
  * numbers). Kept separate from `apply-personality.test.ts` so the pure
  * message-builder tests stay free of module mocks.
  *
- * Also pins the shape of the rewrite send itself, which the daemon's
- * reply-notification gating reads.
+ * Also pins that the rewrite send goes out hidden (see
+ * `lib/side-conversation-message.ts`).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -62,9 +62,7 @@ beforeEach(() => {
 
 describe("applyPersonality rewrite prompt", () => {
   test("posts the rewrite prompt as a hidden machine signal", async () => {
-    // The prompt is a `<system-message>` the user never typed. Hidden keeps
-    // the daemon's reply-notification producer from pushing the rewrite reply
-    // to the user's phone, deep-linked into a thread archived a moment later.
+    // See `lib/side-conversation-message.ts` for why this posts hidden.
     await applyPersonality({
       awaitAssistantId: async () => "ast-1",
       values: {},

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -35,8 +35,8 @@ import {
   messagesGet,
   messagesPost,
 } from "@/generated/daemon/sdk.gen";
-import type { MessagesPostData } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
+import { buildSideConversationMessageBody } from "@/lib/side-conversation-message";
 import { latestAssistantText } from "@/utils/latest-assistant-text";
 
 export {
@@ -91,17 +91,11 @@ export async function applyPersonality({
       return;
     }
 
-    const body: MessagesPostData["body"] = {
+    const body = buildSideConversationMessageBody({
       conversationId,
       content: buildPersonalityMessage(values, userName, assistantName),
-      sourceChannel: "vellum",
-      interface: "vellum",
-      // A machine signal the user never typed: hidden keeps the daemon from
-      // pushing this turn's reply to the user's phone, deep-linked into a
-      // thread archived a moment later.
-      hidden: true,
-      clientMessageId: crypto.randomUUID(),
-    };
+      transport: "vellum",
+    });
     const posted = await messagesPost({
       path: { assistant_id: assistantId },
       body,

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for how the research runner opens its side conversation: the prompt is
- * posted as a hidden machine signal, and a resumed run re-posts only when the
- * turn never started.
+ * posted hidden (see `lib/side-conversation-message.ts`), and a resumed run
+ * re-posts only when the turn never started.
  *
  * Hidden rows are filtered out of `/messages`, so "did the prompt land?" reads
  * the turn's own state (still processing, or rows already produced) instead of
@@ -101,8 +101,6 @@ describe("research prompt send", () => {
       expect(postCalls).toHaveLength(1);
     });
     expect(postCalls[0]?.body.conversationId).toBe("conv-fresh");
-    // The daemon's reply-notification producer skips hidden-initiated turns,
-    // so the research reply never pushes to a thread the user cannot open.
     expect(postCalls[0]?.body.hidden).toBe(true);
 
     act(() => {

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -33,13 +33,10 @@ import {
 } from "@/generated/daemon/sdk.gen";
 import { archiveResearchConversation } from "@/domains/onboarding/archive-research-conversation";
 import { invalidateConversationQueries } from "@/utils/conversation-cache";
-import type {
-  MessagesPostData,
-  PluginsSearchGetResponses,
-} from "@/generated/daemon/types.gen";
+import type { PluginsSearchGetResponses } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
+import { buildSideConversationMessageBody } from "@/lib/side-conversation-message";
 import { latestAssistantText } from "@/utils/latest-assistant-text";
-import { detectClientOs } from "@/runtime/platform-detection";
 import {
   buildResearchPrompt,
   type AvailableCapability,
@@ -593,24 +590,13 @@ export function useResearchRunner(): UseResearchRunner {
           // Post the research prompt onto a conversation. Returns false on a
           // failed POST so the caller can settle "error".
           const postResearchPrompt = async (cid: string): Promise<boolean> => {
-            const body: MessagesPostData["body"] = {
+            const body = buildSideConversationMessageBody({
               conversationId: cid,
               content: buildResearchPrompt(subject, capabilities, {
                 includeSuggestions,
               }),
-              sourceChannel: "vellum",
-              // `interface` is the transport ("web"); the real OS travels in
-              // `clientOs` so the assistant's `client_os` context is correct
-              // for this onboarding side conversation too, without affecting
-              // transport/host-proxy gating (mirrors `chat/api/messages.ts`).
-              interface: "web",
-              clientOs: detectClientOs(),
-              // A machine signal the user never typed: hidden keeps the daemon
-              // from pushing this turn's reply to the user's phone,
-              // deep-linked into a thread archived once the results settle.
-              hidden: true,
-              clientMessageId: crypto.randomUUID(),
-            };
+              transport: "web",
+            });
             // Carry the browser timezone so any time-relative reasoning resolves
             // to the user's local clock. Mirrors `checkin-scheduler.ts`.
             try {

--- a/clients/web/src/domains/onboarding/send-research-correction.test.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.test.ts
@@ -128,9 +128,7 @@ describe("sendResearchCorrection", () => {
     // assistant keeps platform context (mirrors the initial research send).
     expect(postCalls[0]?.body.interface).toBe("web");
     expect(postCalls[0]?.body.clientOs).toBe("web");
-    // The correction is a machine signal, not something the user typed: the
-    // daemon's reply-notification producer skips hidden-initiated turns, so
-    // acknowledging it never pushes to the user's phone.
+    // See `lib/side-conversation-message.ts` for why this posts hidden.
     expect(postCalls[0]?.body.hidden).toBe(true);
 
     expect(archiveCalls).toHaveLength(1);

--- a/clients/web/src/domains/onboarding/send-research-correction.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.ts
@@ -27,9 +27,8 @@
  */
 
 import { messagesPost } from "@/generated/daemon/sdk.gen";
-import type { MessagesPostData } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
-import { detectClientOs } from "@/runtime/platform-detection";
+import { buildSideConversationMessageBody } from "@/lib/side-conversation-message";
 import { archiveResearchConversation } from "@/domains/onboarding/archive-research-conversation";
 
 export interface ResearchCorrection {
@@ -94,22 +93,13 @@ export async function sendResearchCorrection({
     return;
   }
   try {
-    const body: MessagesPostData["body"] = {
+    // Hidden rows stay in LLM-side history, so the correction still reaches
+    // the assistant.
+    const body = buildSideConversationMessageBody({
       conversationId,
       content,
-      sourceChannel: "vellum",
-      // `interface` is the transport ("web"); the real OS travels in `clientOs`
-      // so the correction turn keeps the assistant's `client_os` context too,
-      // matching the initial research send (`research-runner.ts`).
-      interface: "web",
-      clientOs: detectClientOs(),
-      // A machine signal the user never typed: hidden keeps the daemon from
-      // pushing this turn's reply to the user's phone, deep-linked into the
-      // thread re-archived below. The correction still reaches the assistant,
-      // since hidden rows stay in LLM-side history.
-      hidden: true,
-      clientMessageId: crypto.randomUUID(),
-    };
+      transport: "web",
+    });
     await messagesPost({
       path: { assistant_id: assistantId },
       body,

--- a/clients/web/src/lib/side-conversation-message.test.ts
+++ b/clients/web/src/lib/side-conversation-message.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Pins the marker every throwaway side-conversation send depends on: the body
+ * always carries `hidden: true`, which is what the daemon's assistant-reply
+ * push producer gates on.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildSideConversationMessageBody } from "@/lib/side-conversation-message";
+
+describe("buildSideConversationMessageBody", () => {
+  test("marks the send hidden on the vellum transport", () => {
+    const body = buildSideConversationMessageBody({
+      conversationId: "conv-1",
+      content: "<system-message>rewrite</system-message>",
+      transport: "vellum",
+    });
+
+    expect(body.hidden).toBe(true);
+    expect(body.conversationId).toBe("conv-1");
+    expect(body.content).toBe("<system-message>rewrite</system-message>");
+    expect(body.sourceChannel).toBe("vellum");
+    expect(body.interface).toBe("vellum");
+    // `clientOs` is a web-transport concern only.
+    expect(body.clientOs).toBeUndefined();
+  });
+
+  test("marks the send hidden on the web transport and carries the OS", () => {
+    const body = buildSideConversationMessageBody({
+      conversationId: "conv-2",
+      content: "research this",
+      transport: "web",
+    });
+
+    expect(body.hidden).toBe(true);
+    expect(body.interface).toBe("web");
+    expect(body.clientOs).toBe("web");
+  });
+
+  test("mints a fresh idempotency nonce per send", () => {
+    const first = buildSideConversationMessageBody({
+      conversationId: "conv-3",
+      content: "a",
+      transport: "vellum",
+    });
+    const second = buildSideConversationMessageBody({
+      conversationId: "conv-3",
+      content: "a",
+      transport: "vellum",
+    });
+
+    expect(first.clientMessageId).toBeTruthy();
+    expect(second.clientMessageId).not.toBe(first.clientMessageId);
+  });
+});

--- a/clients/web/src/lib/side-conversation-message.ts
+++ b/clients/web/src/lib/side-conversation-message.ts
@@ -1,0 +1,47 @@
+/**
+ * Builds the `POST /messages` body for a throwaway side conversation.
+ *
+ * Onboarding research, the research correction, the personality apply, and the
+ * identity rewrite each mint a conversation the user never opens, post one
+ * prompt, wait for the turn, then archive it. Those prompts are machine
+ * signals the user never typed, so they all post `hidden: true`. Hidden keeps
+ * the prompt out of the visible transcript and is the marker the daemon's
+ * assistant-reply push producer gates on, so the reply never notifies the user
+ * with a deep link into an archived thread.
+ *
+ * Every such flow builds its body here, so a new one cannot drop the marker.
+ */
+
+import type { MessagesPostData } from "@/generated/daemon/types.gen";
+import { detectClientOs } from "@/runtime/platform-detection";
+
+export interface SideConversationMessageOptions {
+  conversationId: string;
+  content: string;
+  /**
+   * Wire transport. `"web"` additionally carries the real OS in `clientOs`, so
+   * the assistant's per-turn `client_os` context stays correct without
+   * affecting transport/host-proxy gating (mirrors
+   * `domains/chat/api/messages.ts`).
+   */
+  transport: "vellum" | "web";
+}
+
+export function buildSideConversationMessageBody({
+  conversationId,
+  content,
+  transport,
+}: SideConversationMessageOptions): MessagesPostData["body"] {
+  const body: MessagesPostData["body"] = {
+    conversationId,
+    content,
+    sourceChannel: "vellum",
+    interface: transport,
+    hidden: true,
+    clientMessageId: crypto.randomUUID(),
+  };
+  if (transport === "web") {
+    body.clientOs = detectClientOs();
+  }
+  return body;
+}


### PR DESCRIPTION
## Summary
Fixes the round-2 review gap for unseen-reply-notify.md: the hidden side-conversation marker now lives in one lib/ builder consumed by all four flows, so future throwaway flows cannot silently omit it.