### PR TITLE
fix: prime the platform probe cache at startup; single-flight the probe

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -28,6 +28,7 @@ import { initializeDb } from "../persistence/db-init.js";
 import { startEmbeddingRuntimeManager } from "../persistence/embeddings/embedding-backend.js";
 import { maybeEnqueueLexicalBackfillOnUpgrade } from "../persistence/job-handlers/message-lexical-backfill.js";
 import { clearLifecycleQuiesce } from "../persistence/lifecycle-quiesce.js";
+import { isPlatformClientConfigured } from "../platform/client.js";
 import { startConsentRefresh } from "../platform/consent-cache.js";
 import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
@@ -468,6 +469,12 @@ export async function runDaemon(): Promise<void> {
       log.warn({ err }, "Periodic managed connection cache refresh failed"),
     );
   }, MANAGED_CONNECTION_REFRESH_INTERVAL_MS);
+
+  // Warms the configured-probe cache (credential reads only, no DB) so the
+  // first urgent signal after a restart is not decided on an empty cache.
+  void isPlatformClientConfigured().catch((err) =>
+    log.warn({ err }, "Platform configured-probe warmup failed"),
+  );
 
   // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
   // into the workspace config file before profile seeding and the first

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -173,6 +173,60 @@ describe("VellumPlatformClient", () => {
       mockResolveManagedProxyContext = () => new Promise(() => {});
       expect(await isPlatformClientConfigured()).toBe(true);
     });
+
+    test("concurrent calls share a single in-flight resolution", async () => {
+      let resolutionCount = 0;
+      mockResolveManagedProxyContext = async () => {
+        resolutionCount += 1;
+        await Bun.sleep(5);
+        return mockManagedProxyCtx;
+      };
+
+      const [first, second] = await Promise.all([
+        isPlatformClientConfigured(),
+        isPlatformClientConfigured(),
+      ]);
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(resolutionCount).toBe(1);
+    });
+
+    test("a settled flight clears, so the next call starts a fresh resolution", async () => {
+      let resolutionCount = 0;
+      mockResolveManagedProxyContext = async () => {
+        resolutionCount += 1;
+        return mockManagedProxyCtx;
+      };
+
+      expect(await isPlatformClientConfigured()).toBe(true);
+      expect(await isPlatformClientConfigured()).toBe(true);
+      expect(resolutionCount).toBe(2);
+    });
+
+    test("a late caller joins the slow flight instead of racing a second resolution that could settle out of order", async () => {
+      let resolutionCount = 0;
+      let releaseHang = () => {};
+      const hang = new Promise<void>((resolve) => {
+        releaseHang = resolve;
+      });
+      mockResolveManagedProxyContext = async () => {
+        resolutionCount += 1;
+        await hang;
+        return mockManagedProxyCtx;
+      };
+
+      // The first caller abandons the slow flight at the deadline.
+      expect(await isPlatformClientConfigured()).toBe(false);
+
+      // A later caller joins the same still-in-flight resolution, so no
+      // second resolution exists whose settle could clobber a newer cache
+      // value.
+      const joined = isPlatformClientConfigured();
+      releaseHang();
+      expect(await joined).toBe(true);
+      expect(resolutionCount).toBe(1);
+    });
   });
 
   describe("fetch()", () => {

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -107,23 +107,21 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
 const CONFIGURED_PROBE_DEADLINE_MS = 500;
 
 let lastKnownConfigured: boolean | null = null;
+// Single-flight slot: concurrent probes share one resolution, so the cache is
+// written once per flight and an out-of-order settle cannot overwrite a newer
+// result.
+let inFlightConfiguredProbe: Promise<boolean> | null = null;
 
 export function _resetConfiguredProbeCacheForTests(): void {
   lastKnownConfigured = null;
+  inFlightConfiguredProbe = null;
 }
 
-/**
- * Whether the platform client can actually dispatch: auth prerequisites plus
- * a nonempty platform assistant id (`PlatformPushAdapter.send()` fails fast
- * without one). Constructs no client and makes no network requests.
- *
- * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
- * slower than the deadline, returns the last settled result (or `false` when
- * none exists yet). The abandoned resolution still settles in the background
- * and refreshes the cache for the next call.
- */
-export async function isPlatformClientConfigured(): Promise<boolean> {
-  const probe = resolvePlatformClientConfig()
+function startOrJoinConfiguredProbe(): Promise<boolean> {
+  if (inFlightConfiguredProbe) {
+    return inFlightConfiguredProbe;
+  }
+  const flight = resolvePlatformClientConfig()
     .then((config) => config !== null && config.assistantId.length > 0)
     .catch((err: unknown) => {
       log.debug(
@@ -133,9 +131,31 @@ export async function isPlatformClientConfigured(): Promise<boolean> {
       return false;
     })
     .then((value) => {
-      lastKnownConfigured = value;
+      // A cleared slot means a test reset invalidated this flight, so its
+      // result must not resurrect the cache.
+      if (inFlightConfiguredProbe === flight) {
+        lastKnownConfigured = value;
+        inFlightConfiguredProbe = null;
+      }
       return value;
     });
+  inFlightConfiguredProbe = flight;
+  return flight;
+}
+
+/**
+ * Whether the platform client can actually dispatch: auth prerequisites plus
+ * a nonempty platform assistant id (`PlatformPushAdapter.send()` fails fast
+ * without one). Constructs no client and makes no network requests.
+ *
+ * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
+ * slower than the deadline, returns the last settled result (or `false` when
+ * none exists yet). The probe is single-flight: concurrent calls share one
+ * resolution, and a resolution abandoned at the deadline still settles in
+ * the background and refreshes the cache for the next call.
+ */
+export async function isPlatformClientConfigured(): Promise<boolean> {
+  const probe = startOrJoinConfiguredProbe();
 
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<"deadline">((resolve) => {


### PR DESCRIPTION
## Summary
Closes the two round-3 review findings on the platform-configured probe:
- daemon startup primes the probe cache (fire-and-forget) so the first urgent signal after a restart is not decided on an empty cache
- the underlying config resolution is single-flight, so concurrent probes share one resolution and out-of-order settles cannot overwrite newer cache values