### PR TITLE
fix: rotate stale probe flights; start the cache warmup before request admission

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -199,6 +199,14 @@ export async function runDaemon(): Promise<void> {
   // failure is non-fatal — the daemon falls back to IPC-only operation.
   await startRuntimeHttpServer();
 
+  // Warms the configured-probe cache (credential reads only, no DB). Fired
+  // immediately after the transport binds, ahead of DB init and readiness,
+  // so an urgent signal arriving the moment requests are admitted is not
+  // decided on an empty cache.
+  void isPlatformClientConfigured().catch((err) =>
+    log.warn({ err }, "Platform configured-probe warmup failed"),
+  );
+
   // Pre-populate feature flag overrides so subsequent sync
   // isAssistantFeatureFlagEnabled() calls have data. Fired non-blocking
   // so a slow or unreachable gateway doesn't delay daemon startup (the
@@ -469,12 +477,6 @@ export async function runDaemon(): Promise<void> {
       log.warn({ err }, "Periodic managed connection cache refresh failed"),
     );
   }, MANAGED_CONNECTION_REFRESH_INTERVAL_MS);
-
-  // Warms the configured-probe cache (credential reads only, no DB) so the
-  // first urgent signal after a restart is not decided on an empty cache.
-  void isPlatformClientConfigured().catch((err) =>
-    log.warn({ err }, "Platform configured-probe warmup failed"),
-  );
 
   // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
   // into the workspace config file before profile seeding and the first

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -204,28 +204,64 @@ describe("VellumPlatformClient", () => {
       expect(resolutionCount).toBe(2);
     });
 
-    test("a late caller joins the slow flight instead of racing a second resolution that could settle out of order", async () => {
+    test("a caller that finds a flight older than the deadline rotates in a fresh resolution", async () => {
       let resolutionCount = 0;
-      let releaseHang = () => {};
-      const hang = new Promise<void>((resolve) => {
-        releaseHang = resolve;
-      });
+      // The first resolution hangs forever; only the rotated-in second one
+      // settles.
+      const pendingHangs = [new Promise<void>(() => {})];
       mockResolveManagedProxyContext = async () => {
         resolutionCount += 1;
-        await hang;
+        const hang = pendingHangs.shift();
+        if (hang) {
+          await hang;
+        }
         return mockManagedProxyCtx;
       };
 
-      // The first caller abandons the slow flight at the deadline.
+      // The first caller abandons the hung flight at the deadline.
       expect(await isPlatformClientConfigured()).toBe(false);
 
-      // A later caller joins the same still-in-flight resolution, so no
-      // second resolution exists whose settle could clobber a newer cache
-      // value.
-      const joined = isPlatformClientConfigured();
-      releaseHang();
-      expect(await joined).toBe(true);
-      expect(resolutionCount).toBe(1);
+      // The hung flight is now older than the deadline, so the next caller
+      // rotates in a fresh resolution instead of joining it; the fresh
+      // flight settles immediately and answers live.
+      expect(await isPlatformClientConfigured()).toBe(true);
+      expect(resolutionCount).toBe(2);
+    });
+
+    test("a rotated-out flight's late settle cannot overwrite the newer flight's cached result", async () => {
+      let releaseFirstHang = () => {};
+      const firstHang = new Promise<void>((resolve) => {
+        releaseFirstHang = resolve;
+      });
+      const pendingHangs = [firstHang];
+      mockResolveManagedProxyContext = async () => {
+        const hang = pendingHangs.shift();
+        if (hang) {
+          await hang;
+        }
+        return mockManagedProxyCtx;
+      };
+
+      // First caller abandons the hung flight; second caller rotates in a
+      // fresh flight that settles true and writes the cache.
+      expect(await isPlatformClientConfigured()).toBe(false);
+      expect(await isPlatformClientConfigured()).toBe(true);
+
+      // The rotated-out flight now settles resolving an unconfigured
+      // context. Generation fencing must keep it from clobbering the newer
+      // flight's cached `true`.
+      mockManagedProxyCtx = {
+        enabled: false,
+        platformBaseUrl: "",
+        assistantApiKey: "",
+      };
+      releaseFirstHang();
+      await Bun.sleep(10);
+
+      // Resolution hangs forever, so this answer can only come from the
+      // cache, which must still hold the newer flight's `true`.
+      mockResolveManagedProxyContext = () => new Promise(() => {});
+      expect(await isPlatformClientConfigured()).toBe(true);
     });
   });
 

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -107,21 +107,41 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
 const CONFIGURED_PROBE_DEADLINE_MS = 500;
 
 let lastKnownConfigured: boolean | null = null;
-// Single-flight slot: concurrent probes share one resolution, so the cache is
-// written once per flight and an out-of-order settle cannot overwrite a newer
-// result.
-let inFlightConfiguredProbe: Promise<boolean> | null = null;
+// Single-flight slot with rotation: probes started inside the deadline window
+// share one resolution, while a flight older than the deadline is replaced so
+// a hung credential backend cannot pin the slot (and the cache) stale until a
+// 45s credential timeout finally settles it. Generation fencing keeps an
+// out-of-order settle from a rotated-out flight from overwriting the result a
+// newer flight already wrote.
+interface ConfiguredProbeFlight {
+  promise: Promise<boolean>;
+  startedAt: number;
+  generation: number;
+}
+let inFlightConfiguredProbe: ConfiguredProbeFlight | null = null;
+let probeGeneration = 0;
+let lastWrittenGeneration = 0;
 
 export function _resetConfiguredProbeCacheForTests(): void {
   lastKnownConfigured = null;
   inFlightConfiguredProbe = null;
+  // Outstanding flights all carry generations at or below the current
+  // counter; raising the written floor to it blocks their settles from
+  // resurrecting the cache after a reset.
+  lastWrittenGeneration = probeGeneration;
 }
 
 function startOrJoinConfiguredProbe(): Promise<boolean> {
-  if (inFlightConfiguredProbe) {
-    return inFlightConfiguredProbe;
+  const existing = inFlightConfiguredProbe;
+  if (
+    existing !== null &&
+    Date.now() - existing.startedAt < CONFIGURED_PROBE_DEADLINE_MS
+  ) {
+    return existing.promise;
   }
-  const flight = resolvePlatformClientConfig()
+  probeGeneration += 1;
+  const generation = probeGeneration;
+  const promise = resolvePlatformClientConfig()
     .then((config) => config !== null && config.assistantId.length > 0)
     .catch((err: unknown) => {
       log.debug(
@@ -131,16 +151,17 @@ function startOrJoinConfiguredProbe(): Promise<boolean> {
       return false;
     })
     .then((value) => {
-      // A cleared slot means a test reset invalidated this flight, so its
-      // result must not resurrect the cache.
-      if (inFlightConfiguredProbe === flight) {
+      if (generation > lastWrittenGeneration) {
         lastKnownConfigured = value;
+        lastWrittenGeneration = generation;
+      }
+      if (inFlightConfiguredProbe?.generation === generation) {
         inFlightConfiguredProbe = null;
       }
       return value;
     });
-  inFlightConfiguredProbe = flight;
-  return flight;
+  inFlightConfiguredProbe = { promise, startedAt: Date.now(), generation };
+  return promise;
 }
 
 /**
@@ -150,9 +171,11 @@ function startOrJoinConfiguredProbe(): Promise<boolean> {
  *
  * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
  * slower than the deadline, returns the last settled result (or `false` when
- * none exists yet). The probe is single-flight: concurrent calls share one
- * resolution, and a resolution abandoned at the deadline still settles in
- * the background and refreshes the cache for the next call.
+ * none exists yet). Calls inside the deadline window share one in-flight
+ * resolution; a call that finds a flight older than the deadline starts a
+ * fresh one, so a hung backend never pins the cache stale, and generation
+ * fencing keeps a rotated-out flight's late settle from overwriting a newer
+ * result.
  */
 export async function isPlatformClientConfigured(): Promise<boolean> {
   const probe = startOrJoinConfiguredProbe();


### PR DESCRIPTION
## Summary
Closes the two round-4 review findings on the platform-configured probe:
- a probe that finds an in-flight resolution older than the 500ms deadline rotates in a fresh one instead of joining, so a hung credential backend cannot pin the slot and cache stale until a 45s timeout settles it; generation fencing keeps a rotated-out flight's late settle from overwriting a newer result
- the startup cache warmup now fires immediately after the HTTP transport binds, ahead of DB init and readiness, so an urgent signal arriving the moment requests are admitted is not decided on an empty cache