### PR TITLE
iOS push notifications on lower-env TestFlight builds (assistant half)

### DIFF
--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -467,3 +467,199 @@ describe("access-request vellum floor", () => {
     expect(dispatched.reasoningSummary).not.toContain("vellum forced");
   });
 });
+
+describe("high/critical urgency channel force", () => {
+  beforeEach(() => {
+    evaluateSignalMock.mockReset();
+    enforceRoutingIntentMock.mockReset();
+    updateDecisionMock.mockReset();
+    runDeterministicChecksMock.mockReset();
+    createEventMock.mockReset();
+    updateEventDedupeKeyMock.mockReset();
+    dispatchDecisionMock.mockReset();
+    createEventMock.mockReturnValue({ id: "evt-1" });
+    runDeterministicChecksMock.mockResolvedValue({ passed: true });
+    dispatchDecisionMock.mockResolvedValue({
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    });
+    enforceRoutingIntentMock.mockImplementation(
+      (decision: unknown) => decision,
+    );
+  });
+
+  function makeDecision(overrides: Record<string, unknown>) {
+    return {
+      shouldNotify: true,
+      selectedChannels: ["telegram"],
+      reasoningSummary: "LLM selected telegram only",
+      renderedCopy: {},
+      dedupeKey: "dedupe-urg-1",
+      confidence: 0.9,
+      fallbackUsed: false,
+      persistedDecisionId: "dec-urg-1",
+      ...overrides,
+    };
+  }
+
+  function emitWithUrgency(urgency: "low" | "medium" | "high" | "critical") {
+    return emitNotificationSignal({
+      sourceEventName: "schedule.notify",
+      sourceChannel: "scheduler",
+      sourceContextId: "rem-urg-1",
+      attentionHints: {
+        requiresAction: true,
+        urgency,
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: { reminderId: "rem-urg-1" },
+    });
+  }
+
+  test("forces vellum and platform onto a high-urgency decision missing both", async () => {
+    evaluateSignalMock.mockResolvedValue(makeDecision({}));
+
+    const result = await emitWithUrgency("high");
+
+    expect(result.dispatched).toBe(true);
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.selectedChannels).toContain("vellum");
+    expect(dispatched.selectedChannels).toContain("platform");
+    expect(dispatched.selectedChannels).toContain("telegram");
+    expect(dispatched.reasoningSummary).toContain(
+      "(vellum, platform forced: high urgency)",
+    );
+  });
+
+  test("re-persists the stored decision with the force-added channels when routing enforcement is a no-op", async () => {
+    evaluateSignalMock.mockResolvedValue(makeDecision({}));
+
+    await emitWithUrgency("high");
+
+    // The identity enforcement mock leaves the decision unchanged, so only
+    // the urgency force-add differs from the evaluated decision. The stored
+    // row must still be synced to the dispatched channels.
+    expect(updateDecisionMock).toHaveBeenCalledTimes(1);
+    expect(updateDecisionMock).toHaveBeenCalledWith("dec-urg-1", {
+      selectedChannels: ["vellum", "platform", "telegram"],
+      reasoningSummary:
+        "LLM selected telegram only (vellum, platform forced: high urgency)",
+      validationResults: {
+        dedupeKey: "dedupe-urg-1",
+        channelCount: 3,
+        hasCopy: false,
+      },
+    });
+  });
+
+  test("forces only the missing channel when the other is already selected", async () => {
+    evaluateSignalMock.mockResolvedValue(
+      makeDecision({ selectedChannels: ["vellum"] }),
+    );
+
+    await emitWithUrgency("critical");
+
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.selectedChannels).toEqual(["platform", "vellum"]);
+    expect(dispatched.reasoningSummary).toContain(
+      "(platform forced: critical urgency)",
+    );
+  });
+
+  test("leaves a high-urgency decision untouched when both channels are already selected", async () => {
+    evaluateSignalMock.mockResolvedValue(
+      makeDecision({ selectedChannels: ["vellum", "platform"] }),
+    );
+
+    await emitWithUrgency("high");
+
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.selectedChannels).toEqual(["vellum", "platform"]);
+    expect(dispatched.reasoningSummary).not.toContain("forced");
+    expect(updateDecisionMock).not.toHaveBeenCalled();
+  });
+
+  test("leaves medium and low urgency selections untouched", async () => {
+    for (const urgency of ["medium", "low"] as const) {
+      dispatchDecisionMock.mockClear();
+      evaluateSignalMock.mockResolvedValue(makeDecision({}));
+
+      await emitWithUrgency(urgency);
+
+      const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+        selectedChannels: string[];
+        reasoningSummary: string;
+      };
+      expect(dispatched.selectedChannels).toEqual(["telegram"]);
+      expect(dispatched.reasoningSummary).not.toContain("forced");
+    }
+  });
+
+  test("does not force channels when the decision suppresses the notification", async () => {
+    evaluateSignalMock.mockResolvedValue(
+      makeDecision({ shouldNotify: false, selectedChannels: [] }),
+    );
+
+    await emitWithUrgency("high");
+
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      shouldNotify: boolean;
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.shouldNotify).toBe(false);
+    expect(dispatched.selectedChannels).toEqual([]);
+    expect(dispatched.reasoningSummary).not.toContain("forced");
+  });
+
+  test("routing-intent enforcement runs after the force-add and can cap channels", async () => {
+    evaluateSignalMock.mockResolvedValue(makeDecision({}));
+    // single_channel enforcement caps the selection to the source channel.
+    enforceRoutingIntentMock.mockImplementation(
+      (decision: { selectedChannels: string[] }) => ({
+        ...decision,
+        selectedChannels: ["telegram"],
+      }),
+    );
+
+    await emitNotificationSignal({
+      sourceEventName: "schedule.notify",
+      sourceChannel: "scheduler",
+      sourceContextId: "rem-urg-2",
+      routingIntent: "single_channel",
+      attentionHints: {
+        requiresAction: true,
+        urgency: "high",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: { reminderId: "rem-urg-2" },
+    });
+
+    // Enforcement sees the force-added channels...
+    const enforcedInput = enforceRoutingIntentMock.mock.calls[0][0] as {
+      selectedChannels: string[];
+    };
+    expect(enforcedInput.selectedChannels).toEqual([
+      "vellum",
+      "platform",
+      "telegram",
+    ]);
+    // ...and its cap wins over the force-add.
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+    };
+    expect(dispatched.selectedChannels).toEqual(["telegram"]);
+  });
+});

--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -7,6 +7,7 @@ const runDeterministicChecksMock = mock();
 const createEventMock = mock();
 const updateEventDedupeKeyMock = mock();
 const dispatchDecisionMock = mock();
+const isPlatformClientConfiguredMock = mock();
 
 mock.module("../channels/config.js", () => ({
   getDeliverableChannels: () => ["vellum", "telegram"],
@@ -37,6 +38,12 @@ mock.module("../notifications/broadcaster.js", () => ({
     setOnConversationCreated(_fn: unknown) {}
   },
 }));
+
+// Capture the real enforcement before the module mock below replaces it:
+// the single_channel interplay tests exercise the genuine cap logic against
+// the urgency force-add's channel ordering.
+const { enforceRoutingIntent: realEnforceRoutingIntent } =
+  await import("../notifications/decision-engine.js");
 
 mock.module("../notifications/decision-engine.js", () => ({
   evaluateSignal: (...args: unknown[]) => evaluateSignalMock(...args),
@@ -78,27 +85,41 @@ mock.module("../notifications/runtime-dispatch.js", () => ({
   dispatchDecision: (...args: unknown[]) => dispatchDecisionMock(...args),
 }));
 
+mock.module("../platform/client.js", () => ({
+  // The adapter import graph needs the class symbol; nothing in these tests
+  // dispatches through it.
+  VellumPlatformClient: class {
+    static async create(): Promise<null> {
+      return null;
+    }
+  },
+  isPlatformClientConfigured: () => isPlatformClientConfiguredMock(),
+}));
+
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 
-describe("emitNotificationSignal routing intent re-persistence", () => {
-  beforeEach(() => {
-    evaluateSignalMock.mockReset();
-    enforceRoutingIntentMock.mockReset();
-    updateDecisionMock.mockReset();
-    runDeterministicChecksMock.mockReset();
-    createEventMock.mockReset();
-    updateEventDedupeKeyMock.mockReset();
-    dispatchDecisionMock.mockReset();
+beforeEach(() => {
+  evaluateSignalMock.mockReset();
+  enforceRoutingIntentMock.mockReset();
+  updateDecisionMock.mockReset();
+  runDeterministicChecksMock.mockReset();
+  createEventMock.mockReset();
+  updateEventDedupeKeyMock.mockReset();
+  dispatchDecisionMock.mockReset();
+  isPlatformClientConfiguredMock.mockReset();
 
-    createEventMock.mockReturnValue({ id: "evt-1" });
-    runDeterministicChecksMock.mockResolvedValue({ passed: true });
-    dispatchDecisionMock.mockResolvedValue({
-      dispatched: true,
-      reason: "ok",
-      deliveryResults: [],
-    });
+  createEventMock.mockReturnValue({ id: "evt-1" });
+  runDeterministicChecksMock.mockResolvedValue({ passed: true });
+  dispatchDecisionMock.mockResolvedValue({
+    dispatched: true,
+    reason: "ok",
+    deliveryResults: [],
   });
+  isPlatformClientConfiguredMock.mockResolvedValue(true);
+  enforceRoutingIntentMock.mockImplementation((decision: unknown) => decision);
+});
 
+describe("emitNotificationSignal routing intent re-persistence", () => {
   test("re-persists selectedChannels/reasoningSummary when enforcement changes the decision", async () => {
     const preDecision = {
       shouldNotify: true,
@@ -226,21 +247,6 @@ describe("emitNotificationSignal routing intent re-persistence", () => {
 });
 
 describe("emitNotificationSignal source-active pre-gate", () => {
-  beforeEach(() => {
-    evaluateSignalMock.mockReset();
-    runDeterministicChecksMock.mockReset();
-    createEventMock.mockReset();
-    dispatchDecisionMock.mockReset();
-
-    createEventMock.mockReturnValue({ id: "evt-src-active" });
-    runDeterministicChecksMock.mockResolvedValue({ passed: true });
-    dispatchDecisionMock.mockResolvedValue({
-      dispatched: true,
-      reason: "ok",
-      deliveryResults: [],
-    });
-  });
-
   test("suppresses visibleInSourceNow signals before the decision engine runs", async () => {
     const result = await emitNotificationSignal({
       sourceEventName: "ingress.trusted_contact.verification_sent",
@@ -294,23 +300,6 @@ describe("emitNotificationSignal source-active pre-gate", () => {
 });
 
 describe("access-request vellum floor", () => {
-  beforeEach(() => {
-    evaluateSignalMock.mockReset();
-    enforceRoutingIntentMock.mockReset();
-    updateDecisionMock.mockReset();
-    runDeterministicChecksMock.mockReset();
-    createEventMock.mockReset();
-    updateEventDedupeKeyMock.mockReset();
-    dispatchDecisionMock.mockReset();
-    createEventMock.mockReturnValue({ id: "evt-1" });
-    runDeterministicChecksMock.mockResolvedValue({ passed: true });
-    dispatchDecisionMock.mockResolvedValue({
-      dispatched: true,
-      reason: "ok",
-      deliveryResults: [],
-    });
-  });
-
   test("rescues a suppressed access-request decision onto the vellum channel", async () => {
     evaluateSignalMock.mockResolvedValue({
       shouldNotify: false,
@@ -469,26 +458,6 @@ describe("access-request vellum floor", () => {
 });
 
 describe("high/critical urgency channel force", () => {
-  beforeEach(() => {
-    evaluateSignalMock.mockReset();
-    enforceRoutingIntentMock.mockReset();
-    updateDecisionMock.mockReset();
-    runDeterministicChecksMock.mockReset();
-    createEventMock.mockReset();
-    updateEventDedupeKeyMock.mockReset();
-    dispatchDecisionMock.mockReset();
-    createEventMock.mockReturnValue({ id: "evt-1" });
-    runDeterministicChecksMock.mockResolvedValue({ passed: true });
-    dispatchDecisionMock.mockResolvedValue({
-      dispatched: true,
-      reason: "ok",
-      deliveryResults: [],
-    });
-    enforceRoutingIntentMock.mockImplementation(
-      (decision: unknown) => decision,
-    );
-  });
-
   function makeDecision(overrides: Record<string, unknown>) {
     return {
       shouldNotify: true,
@@ -546,7 +515,7 @@ describe("high/critical urgency channel force", () => {
     // row must still be synced to the dispatched channels.
     expect(updateDecisionMock).toHaveBeenCalledTimes(1);
     expect(updateDecisionMock).toHaveBeenCalledWith("dec-urg-1", {
-      selectedChannels: ["vellum", "platform", "telegram"],
+      selectedChannels: ["vellum", "telegram", "platform"],
       reasoningSummary:
         "LLM selected telegram only (vellum, platform forced: high urgency)",
       validationResults: {
@@ -568,7 +537,7 @@ describe("high/critical urgency channel force", () => {
       selectedChannels: string[];
       reasoningSummary: string;
     };
-    expect(dispatched.selectedChannels).toEqual(["platform", "vellum"]);
+    expect(dispatched.selectedChannels).toEqual(["vellum", "platform"]);
     expect(dispatched.reasoningSummary).toContain(
       "(platform forced: critical urgency)",
     );
@@ -653,13 +622,89 @@ describe("high/critical urgency channel force", () => {
     };
     expect(enforcedInput.selectedChannels).toEqual([
       "vellum",
-      "platform",
       "telegram",
+      "platform",
     ]);
     // ...and its cap wins over the force-add.
     const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
       selectedChannels: string[];
     };
     expect(dispatched.selectedChannels).toEqual(["telegram"]);
+  });
+
+  test("forces only vellum when the platform client is not configured", async () => {
+    isPlatformClientConfiguredMock.mockResolvedValue(false);
+    evaluateSignalMock.mockResolvedValue(makeDecision({}));
+
+    await emitWithUrgency("high");
+
+    const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+      selectedChannels: string[];
+      reasoningSummary: string;
+    };
+    expect(dispatched.selectedChannels).toEqual(["vellum", "telegram"]);
+    expect(dispatched.reasoningSummary).toContain(
+      "(vellum forced: high urgency)",
+    );
+  });
+
+  // Real single_channel enforcement caps to the source channel when it is
+  // connected, else to the FIRST selected channel. The force-add prepends
+  // vellum precisely so that fallback keeps the in-app banner; these tests
+  // run the genuine enforcement to pin the interplay.
+  describe("interplay with real single_channel enforcement", () => {
+    beforeEach(() => {
+      enforceRoutingIntentMock.mockImplementation(
+        realEnforceRoutingIntent as (...args: unknown[]) => unknown,
+      );
+    });
+
+    function emitHighUrgencySingleChannel(
+      sourceChannel: "watcher" | "assistant_tool",
+    ) {
+      return emitNotificationSignal({
+        sourceEventName: "watcher.escalation",
+        sourceChannel,
+        sourceContextId: "watch-1",
+        routingIntent: "single_channel",
+        attentionHints: {
+          requiresAction: true,
+          urgency: "high",
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+        contextPayload: {},
+      });
+    }
+
+    test("vellum survives the cap when the decision selected only vellum", async () => {
+      evaluateSignalMock.mockResolvedValue(
+        makeDecision({ selectedChannels: ["vellum"] }),
+      );
+
+      await emitHighUrgencySingleChannel("watcher");
+
+      // Force-add appends platform: ["vellum", "platform"]. The source
+      // channel is not connected, so the cap falls back to index 0.
+      const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+        selectedChannels: string[];
+      };
+      expect(dispatched.selectedChannels).toEqual(["vellum"]);
+    });
+
+    test("the cap picks the prepended vellum when the decision selected another channel", async () => {
+      evaluateSignalMock.mockResolvedValue(
+        makeDecision({ selectedChannels: ["telegram"] }),
+      );
+
+      await emitHighUrgencySingleChannel("assistant_tool");
+
+      // Force-add yields ["vellum", "telegram", "platform"]; the
+      // non-connected source channel makes the cap take index 0.
+      const dispatched = dispatchDecisionMock.mock.calls[0][1] as {
+        selectedChannels: string[];
+      };
+      expect(dispatched.selectedChannels).toEqual(["vellum"]);
+    });
   });
 });

--- a/assistant/src/__tests__/notification-platform-adapter.test.ts
+++ b/assistant/src/__tests__/notification-platform-adapter.test.ts
@@ -33,11 +33,13 @@ interface FetchCall {
   path: string;
   method: string;
   body: Record<string, unknown>;
+  hasAbortSignal: boolean;
 }
 
 const fetchCalls: FetchCall[] = [];
 const fetchResponses: Array<{ ok: boolean; status: number; body?: string }> =
   [];
+const fetchErrors: Error[] = [];
 let clientAvailable = true;
 
 mock.module("../platform/client.js", () => ({
@@ -52,7 +54,16 @@ mock.module("../platform/client.js", () => ({
           const body = init?.body
             ? (JSON.parse(init.body as string) as Record<string, unknown>)
             : {};
-          fetchCalls.push({ path, method: init?.method ?? "GET", body });
+          fetchCalls.push({
+            path,
+            method: init?.method ?? "GET",
+            body,
+            hasAbortSignal: init?.signal instanceof AbortSignal,
+          });
+          const error = fetchErrors.shift();
+          if (error) {
+            throw error;
+          }
           const response = fetchResponses.shift() ?? {
             ok: true,
             status: 200,
@@ -107,6 +118,7 @@ describe("PlatformPushAdapter", () => {
   beforeEach(() => {
     fetchCalls.length = 0;
     fetchResponses.length = 0;
+    fetchErrors.length = 0;
     clientAvailable = true;
   });
 
@@ -201,6 +213,28 @@ describe("PlatformPushAdapter", () => {
     expect(result.error).toContain("500");
     // 1 initial + 3 retries = 4 attempts
     expect(fetchCalls).toHaveLength(4);
+  });
+
+  test("bounds every attempt with an abort signal", async () => {
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(fetchCalls[0]?.hasAbortSignal).toBe(true);
+  });
+
+  test("retries attempts that abort on the per-attempt timeout", async () => {
+    fetchErrors.push(
+      new DOMException("The operation timed out.", "TimeoutError"),
+    );
+    fetchResponses.push({ ok: true, status: 200, body: '{"tokens_sent": 1}' });
+
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
   });
 
   test("does not retry on 4xx responses", async () => {

--- a/assistant/src/__tests__/notification-platform-adapter.test.ts
+++ b/assistant/src/__tests__/notification-platform-adapter.test.ts
@@ -62,6 +62,7 @@ mock.module("../platform/client.js", () => ({
             ok: response.ok,
             status: response.status,
             text: async () => response.body ?? "",
+            json: async () => JSON.parse(response.body ?? "") as unknown,
           };
         },
       };
@@ -210,6 +211,72 @@ describe("PlatformPushAdapter", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("400");
     expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("reports remotePushAccepted: true on 200 with tokens_sent > 0", async () => {
+    fetchResponses.push({
+      ok: true,
+      status: 200,
+      body: '{"idempotent": false, "tokens_sent": 2}',
+    });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(true);
+  });
+
+  test("reports remotePushAccepted: false on 202 skipped (flag off)", async () => {
+    fetchResponses.push({
+      ok: true,
+      status: 202,
+      body: '{"skipped": "flag_off"}',
+    });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(false);
+  });
+
+  test("reports remotePushAccepted: false on 200 with tokens_sent 0", async () => {
+    fetchResponses.push({
+      ok: true,
+      status: 200,
+      body: '{"idempotent": true, "tokens_sent": 0}',
+    });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(false);
+  });
+
+  test("reports remotePushAccepted: false when the success body is unparseable", async () => {
+    fetchResponses.push({ ok: true, status: 200, body: "not json" });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(result.remotePushAccepted).toBe(false);
+  });
+
+  test("leaves remotePushAccepted unset on non-2xx failure", async () => {
+    fetchResponses.push({ ok: false, status: 400, body: "bad request" });
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(false);
+    expect(result.remotePushAccepted).toBeUndefined();
+  });
+
+  test("leaves remotePushAccepted unset when the platform client is unavailable", async () => {
+    clientAvailable = false;
+    const adapter = new PlatformPushAdapter();
+    const result = await adapter.send(makePayload(), makeDestination());
+
+    expect(result.success).toBe(false);
+    expect(result.remotePushAccepted).toBeUndefined();
   });
 
   test("omits optional fields when absent from payload", async () => {

--- a/assistant/src/__tests__/notification-vellum-adapter.test.ts
+++ b/assistant/src/__tests__/notification-vellum-adapter.test.ts
@@ -111,3 +111,44 @@ describe("VellumAdapter silent flag", () => {
     expect(intent.silent).toBe(false);
   });
 });
+
+describe("VellumAdapter remotePushDispatched pass-through", () => {
+  test("broadcasts remotePushDispatched: true verbatim", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(
+      makePayload({ remotePushDispatched: true }),
+      makeDestination(),
+    );
+
+    const intent = sent[0] as Extract<
+      AssistantEvent,
+      { type: "notification_intent" }
+    >;
+    expect(intent.remotePushDispatched).toBe(true);
+  });
+
+  test("broadcasts remotePushDispatched: false verbatim", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(
+      makePayload({ remotePushDispatched: false }),
+      makeDestination(),
+    );
+
+    const intent = sent[0] as Extract<
+      AssistantEvent,
+      { type: "notification_intent" }
+    >;
+    expect(intent.remotePushDispatched).toBe(false);
+  });
+
+  test("leaves remotePushDispatched undefined when absent from the payload", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(makePayload(), makeDestination());
+
+    const intent = sent[0] as Extract<
+      AssistantEvent,
+      { type: "notification_intent" }
+    >;
+    expect(intent.remotePushDispatched).toBeUndefined();
+  });
+});

--- a/assistant/src/api/events/notification-intent.ts
+++ b/assistant/src/api/events/notification-intent.ts
@@ -26,6 +26,11 @@ export const NotificationIntentEventSchema = z.object({
   deepLinkMetadata: z.record(z.string(), z.unknown()).optional(),
   targetGuardianPrincipalId: z.string().optional(),
   silent: z.boolean().optional(),
+  /**
+   * True when the platform (APNs) channel accepted a remote push for
+   * this delivery, so native clients can avoid double-bannering.
+   */
+  remotePushDispatched: z.boolean().optional(),
 });
 
 export type NotificationIntentEvent = z.infer<

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -199,6 +199,14 @@ export async function runDaemon(): Promise<void> {
   // failure is non-fatal — the daemon falls back to IPC-only operation.
   await startRuntimeHttpServer();
 
+  // Warms the configured-probe cache (credential reads only, no DB). Fired
+  // immediately after the transport binds, ahead of DB init and readiness,
+  // so an urgent signal arriving the moment requests are admitted is not
+  // decided on an empty cache.
+  void isPlatformClientConfigured().catch((err) =>
+    log.warn({ err }, "Platform configured-probe warmup failed"),
+  );
+
   // Pre-populate feature flag overrides so subsequent sync
   // isAssistantFeatureFlagEnabled() calls have data. Fired non-blocking
   // so a slow or unreachable gateway doesn't delay daemon startup (the
@@ -469,12 +477,6 @@ export async function runDaemon(): Promise<void> {
       log.warn({ err }, "Periodic managed connection cache refresh failed"),
     );
   }, MANAGED_CONNECTION_REFRESH_INTERVAL_MS);
-
-  // Warms the configured-probe cache (credential reads only, no DB) so the
-  // first urgent signal after a restart is not decided on an empty cache.
-  void isPlatformClientConfigured().catch((err) =>
-    log.warn({ err }, "Platform configured-probe warmup failed"),
-  );
 
   // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
   // into the workspace config file before profile seeding and the first

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -28,6 +28,7 @@ import { initializeDb } from "../persistence/db-init.js";
 import { startEmbeddingRuntimeManager } from "../persistence/embeddings/embedding-backend.js";
 import { maybeEnqueueLexicalBackfillOnUpgrade } from "../persistence/job-handlers/message-lexical-backfill.js";
 import { clearLifecycleQuiesce } from "../persistence/lifecycle-quiesce.js";
+import { isPlatformClientConfigured } from "../platform/client.js";
 import { startConsentRefresh } from "../platform/consent-cache.js";
 import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
@@ -468,6 +469,12 @@ export async function runDaemon(): Promise<void> {
       log.warn({ err }, "Periodic managed connection cache refresh failed"),
     );
   }, MANAGED_CONNECTION_REFRESH_INTERVAL_MS);
+
+  // Warms the configured-probe cache (credential reads only, no DB) so the
+  // first urgent signal after a restart is not decided on an empty cache.
+  void isPlatformClientConfigured().catch((err) =>
+    log.warn({ err }, "Platform configured-probe warmup failed"),
+  );
 
   // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
   // into the workspace config file before profile seeding and the first

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -7,6 +7,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { PairingResult } from "../conversation-pairing.js";
 import type { NotificationSignal } from "../signal.js";
 import type {
   ChannelAdapter,
@@ -36,15 +37,7 @@ mock.module("../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => null,
 }));
 
-interface MockPairing {
-  conversationId: string | null;
-  messageId: string | null;
-  strategy: string;
-  createdNewConversation: boolean;
-  conversationFallbackUsed: boolean;
-}
-
-function defaultPairing(): MockPairing {
+function defaultPairing(): PairingResult {
   return {
     conversationId: null,
     messageId: null,
@@ -54,11 +47,17 @@ function defaultPairing(): MockPairing {
   };
 }
 
-let pairingByChannel: Record<string, MockPairing> = {};
+let pairingByChannel: Record<string, PairingResult> = {};
+let pairingErrorByChannel: Record<string, Error> = {};
 
 mock.module("../conversation-pairing.js", () => ({
-  pairDeliveryWithConversation: async (_signal: unknown, channel: string) =>
-    pairingByChannel[channel] ?? defaultPairing(),
+  pairDeliveryWithConversation: async (_signal: unknown, channel: string) => {
+    const error = pairingErrorByChannel[channel];
+    if (error) {
+      throw error;
+    }
+    return pairingByChannel[channel] ?? defaultPairing();
+  },
 }));
 
 mock.module("../deliveries-store.js", () => ({
@@ -161,6 +160,7 @@ beforeEach(() => {
   composeFallbackReturn = {};
   knownConversations = new Set();
   pairingByChannel = {};
+  pairingErrorByChannel = {};
 });
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -426,21 +426,93 @@ describe("NotificationBroadcaster remotePushDispatched flag", () => {
     expect(results.find((r) => r.channel === "vellum")?.status).toBe("sent");
   });
 
-  test("vellum payload carries false when platform is not selected", async () => {
-    composeFallbackReturn = {
-      vellum: { title: "Reminder", body: "Hello" },
+  test("vellum intent still flushes with false when the platform channel's prep throws", async () => {
+    bothChannelsCopy();
+    pairingErrorByChannel = { platform: new Error("pairing exploded") };
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: true,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await expect(
+      broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision()),
+    ).rejects.toThrow("pairing exploded");
+
+    // The platform adapter never ran, but the deferred vellum send must not
+    // be lost -- its pending delivery row would block retries forever.
+    expect(platform.sends.length).toBe(0);
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("deadline expiry flushes vellum with false while the platform dispatch finishes in the background", async () => {
+    bothChannelsCopy();
+
+    let resolvePlatform: ((result: DeliveryResult) => void) | undefined;
+    const platformSends: CapturedSend[] = [];
+    const platform: ChannelAdapter = {
+      channel: "platform",
+      send(
+        payload: ChannelDeliveryPayload,
+        destination: ChannelDestination,
+      ): Promise<DeliveryResult> {
+        platformSends.push({ payload, destination });
+        return new Promise<DeliveryResult>((resolve) => {
+          resolvePlatform = resolve;
+        });
+      },
     };
+    const vellum = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([vellum.adapter, platform]);
 
-    const { adapter, sends } = makeCapturingAdapter("vellum");
-    const broadcaster = new NotificationBroadcaster([adapter]);
-
-    await broadcaster.broadcastDecision(
+    const results = await broadcaster.broadcastDecision(
       makeSignal(),
-      makeDecision({ selectedChannels: ["vellum"], renderedCopy: {} }),
+      bothChannelsDecision(),
+      { platformOutcomeDeadlineMs: 20 },
     );
 
-    expect(sends.length).toBe(1);
-    expect(sends[0]?.payload.remotePushDispatched).toBe(false);
+    expect(platformSends.length).toBe(1);
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+    expect(results.find((r) => r.channel === "platform")?.status).toBe(
+      "pending",
+    );
+
+    // The dispatch settling after the deadline must not re-send vellum.
+    resolvePlatform?.({ success: true, remotePushAccepted: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("platform completing before the deadline sets the real outcome on the vellum payload", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform: ChannelAdapter = {
+      channel: "platform",
+      async send(): Promise<DeliveryResult> {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return { success: true, remotePushAccepted: true };
+      },
+    };
+    const broadcaster = new NotificationBroadcaster([vellum.adapter, platform]);
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal(),
+      bothChannelsDecision(),
+      { platformOutcomeDeadlineMs: 1_000 },
+    );
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(true);
+    expect(results.find((r) => r.channel === "platform")?.status).toBe("sent");
   });
 
   test("dispatches the platform adapter before the vellum intent when both are selected", async () => {
@@ -498,6 +570,40 @@ describe("NotificationBroadcaster remotePushDispatched flag", () => {
       conversationId: "conv-vellum-1",
       messageId: "msg-1",
     });
+  });
+});
+
+describe("NotificationBroadcaster forced-platform copy reuse", () => {
+  test("platform payload reuses the vellum rendered copy instead of template fallback", async () => {
+    // A urgency-forced platform channel has no rendered copy of its own; the
+    // template fallback must lose to the vellum channel's rendered copy.
+    composeFallbackReturn = {
+      platform: { title: "Template title", body: "Template body" },
+    };
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: true,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(
+      makeSignal(),
+      makeDecision({
+        selectedChannels: ["vellum", "platform"],
+        renderedCopy: {
+          vellum: { title: "Rendered title", body: "Rendered body" },
+        },
+      }),
+    );
+
+    expect(platform.sends.length).toBe(1);
+    expect(platform.sends[0]?.payload.copy.title).toBe("Rendered title");
+    expect(platform.sends[0]?.payload.copy.body).toBe("Rendered body");
   });
 });
 

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -36,14 +36,29 @@ mock.module("../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: async () => null,
 }));
 
-mock.module("../conversation-pairing.js", () => ({
-  pairDeliveryWithConversation: async () => ({
-    conversationId: undefined,
-    messageId: undefined,
+interface MockPairing {
+  conversationId: string | null;
+  messageId: string | null;
+  strategy: string;
+  createdNewConversation: boolean;
+  conversationFallbackUsed: boolean;
+}
+
+function defaultPairing(): MockPairing {
+  return {
+    conversationId: null,
+    messageId: null,
     strategy: "start_new_conversation",
     createdNewConversation: false,
     conversationFallbackUsed: false,
-  }),
+  };
+}
+
+let pairingByChannel: Record<string, MockPairing> = {};
+
+mock.module("../conversation-pairing.js", () => ({
+  pairDeliveryWithConversation: async (_signal: unknown, channel: string) =>
+    pairingByChannel[channel] ?? defaultPairing(),
 }));
 
 mock.module("../deliveries-store.js", () => ({
@@ -121,7 +136,10 @@ interface CapturedSend {
   destination: ChannelDestination;
 }
 
-function makeCapturingAdapter(channel: "vellum" | "platform"): {
+function makeCapturingAdapter(
+  channel: "vellum" | "platform",
+  result: DeliveryResult = { success: true },
+): {
   adapter: ChannelAdapter;
   sends: CapturedSend[];
 } {
@@ -133,7 +151,7 @@ function makeCapturingAdapter(channel: "vellum" | "platform"): {
       destination: ChannelDestination,
     ): Promise<DeliveryResult> {
       sends.push({ payload, destination });
-      return { success: true };
+      return result;
     },
   };
   return { adapter, sends };
@@ -142,6 +160,7 @@ function makeCapturingAdapter(channel: "vellum" | "platform"): {
 beforeEach(() => {
   composeFallbackReturn = {};
   knownConversations = new Set();
+  pairingByChannel = {};
 });
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -290,6 +309,195 @@ describe("NotificationBroadcaster platform deep-link from contextPayload", () =>
 
     expect(sends.length).toBe(1);
     expect(sends[0]?.payload.deepLinkTarget).toBeUndefined();
+  });
+});
+
+describe("NotificationBroadcaster remotePushDispatched flag", () => {
+  const bothChannelsCopy = () => {
+    composeFallbackReturn = {
+      vellum: { title: "Reminder", body: "Hello" },
+      platform: { title: "Reminder", body: "Hello" },
+    };
+  };
+
+  const bothChannelsDecision = () =>
+    makeDecision({
+      selectedChannels: ["vellum", "platform"],
+      renderedCopy: {},
+    });
+
+  test("vellum payload carries true when the platform adapter reports an accepted push; platform payload omits it", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: true,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(true);
+    expect(platform.sends.length).toBe(1);
+    expect(platform.sends[0]?.payload.remotePushDispatched).toBeUndefined();
+  });
+
+  test("vellum payload carries false when the platform dispatch fails", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: false,
+      error: "HTTP 503",
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("vellum payload carries false when the platform reports no accepted push (skipped or zero tokens)", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: false,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("vellum payload carries false when the platform result omits remotePushAccepted", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", { success: true });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("vellum payload carries false when the platform adapter throws", async () => {
+    bothChannelsCopy();
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform: ChannelAdapter = {
+      channel: "platform",
+      async send(): Promise<DeliveryResult> {
+        throw new Error("boom");
+      },
+    };
+    const broadcaster = new NotificationBroadcaster([vellum.adapter, platform]);
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal(),
+      bothChannelsDecision(),
+    );
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.remotePushDispatched).toBe(false);
+    expect(results.find((r) => r.channel === "platform")?.status).toBe(
+      "failed",
+    );
+    expect(results.find((r) => r.channel === "vellum")?.status).toBe("sent");
+  });
+
+  test("vellum payload carries false when platform is not selected", async () => {
+    composeFallbackReturn = {
+      vellum: { title: "Reminder", body: "Hello" },
+    };
+
+    const { adapter, sends } = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    await broadcaster.broadcastDecision(
+      makeSignal(),
+      makeDecision({ selectedChannels: ["vellum"], renderedCopy: {} }),
+    );
+
+    expect(sends.length).toBe(1);
+    expect(sends[0]?.payload.remotePushDispatched).toBe(false);
+  });
+
+  test("dispatches the platform adapter before the vellum intent when both are selected", async () => {
+    bothChannelsCopy();
+
+    const callOrder: string[] = [];
+    const vellum: ChannelAdapter = {
+      channel: "vellum",
+      async send(): Promise<DeliveryResult> {
+        callOrder.push("vellum");
+        return { success: true };
+      },
+    };
+    const platform: ChannelAdapter = {
+      channel: "platform",
+      async send(): Promise<DeliveryResult> {
+        callOrder.push("platform");
+        return { success: true, remotePushAccepted: true };
+      },
+    };
+    const broadcaster = new NotificationBroadcaster([vellum, platform]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(callOrder).toEqual(["platform", "vellum"]);
+  });
+
+  test("platform deep link still carries the vellum pairing when the vellum send is deferred", async () => {
+    bothChannelsCopy();
+
+    pairingByChannel = {
+      vellum: {
+        conversationId: "conv-vellum-1",
+        messageId: "msg-1",
+        strategy: "start_new_conversation",
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      },
+    };
+
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform", {
+      success: true,
+      remotePushAccepted: true,
+    });
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(makeSignal(), bothChannelsDecision());
+
+    expect(platform.sends.length).toBe(1);
+    expect(platform.sends[0]?.payload.deepLinkTarget).toEqual({
+      conversationId: "conv-vellum-1",
+      messageId: "msg-1",
+    });
   });
 });
 

--- a/assistant/src/notifications/__tests__/guardian-delivery-recorder.test.ts
+++ b/assistant/src/notifications/__tests__/guardian-delivery-recorder.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const createGuardianRequestDeliveryMock = mock();
+const updateGuardianRequestDeliveryMock = mock();
+
+mock.module("../../channels/gateway-guardian-requests.js", () => ({
+  createGuardianRequestDelivery: (...args: unknown[]) =>
+    createGuardianRequestDeliveryMock(...args),
+  updateGuardianRequestDelivery: (...args: unknown[]) =>
+    updateGuardianRequestDeliveryMock(...args),
+}));
+
+import { recordGuardianRequestDeliveries } from "../guardian-delivery-recorder.js";
+import type { NotificationDeliveryResult } from "../types.js";
+
+beforeEach(() => {
+  createGuardianRequestDeliveryMock.mockReset();
+  updateGuardianRequestDeliveryMock.mockReset();
+  createGuardianRequestDeliveryMock.mockImplementation(async () => ({
+    id: `row-${createGuardianRequestDeliveryMock.mock.calls.length}`,
+  }));
+  updateGuardianRequestDeliveryMock.mockResolvedValue(undefined);
+});
+
+describe("recordGuardianRequestDeliveries", () => {
+  test("records rows only for addressable channels, skipping platform", async () => {
+    const deliveryResults: NotificationDeliveryResult[] = [
+      {
+        channel: "vellum",
+        destination: "vellum",
+        status: "sent",
+        conversationId: "conv-1",
+      },
+      {
+        // A forced platform push has no endpoint, so the broadcaster falls
+        // back to the channel name as the destination -- it must never be
+        // persisted as a destinationChatId.
+        channel: "platform",
+        destination: "platform",
+        status: "pending",
+      },
+      {
+        channel: "telegram",
+        destination: "12345",
+        status: "sent",
+        conversationId: "conv-1",
+        messageId: "tg-77",
+      },
+    ];
+
+    await recordGuardianRequestDeliveries({
+      requestId: "req-1",
+      deliveryResults,
+    });
+
+    const channels = createGuardianRequestDeliveryMock.mock.calls.map(
+      (call) => (call[0] as { destinationChannel: string }).destinationChannel,
+    );
+    expect(channels).toEqual(["vellum", "telegram"]);
+
+    const telegramRow = createGuardianRequestDeliveryMock.mock.calls[1]![0] as {
+      destinationChatId?: string;
+      destinationMessageId?: string;
+    };
+    expect(telegramRow.destinationChatId).toBe("12345");
+    expect(telegramRow.destinationMessageId).toBe("tg-77");
+
+    // Status patches apply only to the rows that were created.
+    expect(updateGuardianRequestDeliveryMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -107,6 +107,7 @@ export class VellumAdapter implements ChannelAdapter {
         deepLinkMetadata: payload.deepLinkTarget,
         targetGuardianPrincipalId,
         silent,
+        remotePushDispatched: payload.remotePushDispatched,
       } as AssistantEvent);
 
       log.info(

--- a/assistant/src/notifications/adapters/platform.ts
+++ b/assistant/src/notifications/adapters/platform.ts
@@ -121,16 +121,33 @@ export class PlatformPushAdapter implements ChannelAdapter {
       }
 
       if (response.ok) {
+        // A 2xx does not mean a push went out: the server returns
+        // 202 {"skipped": ...} when the feature flag is off or no tokens
+        // are registered, and 200 with tokens_sent: 0 on idempotent
+        // replays. Only report acceptance when the body confirms at least
+        // one device push was dispatched; an unparseable or ambiguous body
+        // counts as not accepted (a duplicate client banner beats a lost
+        // notification).
+        const responseBody = (await response.json().catch(() => null)) as {
+          skipped?: unknown;
+          tokens_sent?: unknown;
+        } | null;
+        const remotePushAccepted =
+          responseBody != null &&
+          !responseBody.skipped &&
+          typeof responseBody.tokens_sent === "number" &&
+          responseBody.tokens_sent > 0;
         log.info(
           {
             sourceEventName: payload.sourceEventName,
             title: payload.copy.title,
             guardianScoped: targetGuardianPrincipalId != null,
             status: response.status,
+            remotePushAccepted,
           },
           "Platform push dispatched",
         );
-        return { success: true };
+        return { success: true, remotePushAccepted };
       }
 
       if (

--- a/assistant/src/notifications/adapters/platform.ts
+++ b/assistant/src/notifications/adapters/platform.ts
@@ -35,6 +35,17 @@ const log = getLogger("notif-adapter-platform");
 // Exponential backoff delays for 5xx/timeout retries: 250ms → 1s → 4s
 const RETRY_DELAYS_MS = [250, 1_000, 4_000] as const;
 
+// Per-attempt abort timeout. The underlying platform fetch has no timeout of
+// its own, and the broadcaster defers the urgent local banner on this
+// dispatch's outcome -- a hung platform must fail the attempt, not stall it.
+const ATTEMPT_TIMEOUT_MS = 5_000;
+
+/** Whether a fetch error is the per-attempt abort timeout firing. */
+function isAttemptTimeout(err: unknown): boolean {
+  const name = (err as { name?: unknown } | null)?.name;
+  return name === "TimeoutError" || name === "AbortError";
+}
+
 interface DispatchBody {
   delivery_id?: string;
   source_event_name: string;
@@ -98,9 +109,13 @@ export class PlatformPushAdapter implements ChannelAdapter {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
+          signal: AbortSignal.timeout(ATTEMPT_TIMEOUT_MS),
         });
       } catch (err) {
-        if (attempt < RETRY_DELAYS_MS.length && isRetryableNetworkError(err)) {
+        if (
+          attempt < RETRY_DELAYS_MS.length &&
+          (isAttemptTimeout(err) || isRetryableNetworkError(err))
+        ) {
           log.warn(
             {
               attempt,

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -21,7 +21,10 @@ import {
   parseAccessRequestPayload,
 } from "./access-request-copy.js";
 import { isGuardianSensitiveEvent } from "./adapters/macos.js";
-import { pairDeliveryWithConversation } from "./conversation-pairing.js";
+import {
+  pairDeliveryWithConversation,
+  type PairingResult,
+} from "./conversation-pairing.js";
 import { composeFallbackCopy } from "./copy-composer.js";
 import {
   createDelivery,
@@ -43,7 +46,9 @@ import type { NotificationSignal } from "./signal.js";
 import type {
   ChannelAdapter,
   ChannelDeliveryPayload,
+  ChannelDestination,
   ConversationAction,
+  DeliveryResult,
   NotificationChannel,
   NotificationDecision,
   NotificationDeliveryResult,
@@ -223,6 +228,23 @@ export interface BroadcastDecisionOptions {
   onConversationCreated?: OnConversationCreatedFn;
 }
 
+/**
+ * A channel dispatch that is fully prepared (destination resolved, copy
+ * rendered, conversation paired, pending delivery row created) but whose
+ * adapter send has not yet run. Used to defer the vellum send until the
+ * platform dispatch outcome is known.
+ */
+interface PendingChannelDispatch {
+  adapter: ChannelAdapter;
+  channel: NotificationChannel;
+  destination: ChannelDestination;
+  payload: ChannelDeliveryPayload;
+  deliveryId: string;
+  destinationLabel: string;
+  pairing: PairingResult;
+  hasPersistedDecision: boolean;
+}
+
 export class NotificationBroadcaster {
   private adapters: Map<NotificationChannel, ChannelAdapter>;
   private onConversationCreated: OnConversationCreatedFn | null = null;
@@ -268,16 +290,22 @@ export class NotificationBroadcaster {
 
     // Ensure vellum is processed first so the notification_conversation_created
     // event fires immediately, before slower channel sends (e.g. Telegram 30s
-    // timeout) can delay it past the macOS deep-link retry window.
-    const orderedChannels = [...decision.selectedChannels].sort((a, b) => {
-      if (a === "vellum") {
-        return -1;
+    // timeout) can delay it past the macOS deep-link retry window. Platform
+    // sorts second: the vellum intent carries remotePushDispatched, so its
+    // deferred send (below) flushes right after the platform outcome is known
+    // instead of waiting behind slower channels.
+    const dispatchRank = (channel: NotificationChannel): number => {
+      if (channel === "vellum") {
+        return 0;
       }
-      if (b === "vellum") {
+      if (channel === "platform") {
         return 1;
       }
-      return 0;
-    });
+      return 2;
+    };
+    const orderedChannels = [...decision.selectedChannels].sort(
+      (a, b) => dispatchRank(a) - dispatchRank(b),
+    );
 
     // Pre-compute fallback copy in case any channel is missing rendered copy
     let fallbackCopy: Partial<
@@ -301,7 +329,34 @@ export class NotificationBroadcaster {
       messageId: string | null;
     } | null = null;
 
+    // The vellum intent's remotePushDispatched flag must reflect the ACTUAL
+    // platform dispatch outcome, not channel selection: when both channels
+    // are selected, the vellum channel is still prepared first (pairing, the
+    // conversation-created emission, and the pending delivery row all run
+    // eagerly, so the platform deep link keeps the vellum pairing carry), but
+    // its adapter send is deferred until the platform adapter reports whether
+    // the platform accepted a device push. Typical cost: one fast HTTP
+    // round-trip before the local banner goes out.
+    let deferredVellumSend: PendingChannelDispatch | null = null;
+    let platformRemotePushAccepted = false;
+    const flushDeferredVellumSend = async (): Promise<void> => {
+      if (!deferredVellumSend) {
+        return;
+      }
+      const pending = deferredVellumSend;
+      deferredVellumSend = null;
+      pending.payload.remotePushDispatched = platformRemotePushAccepted;
+      await this.sendAndRecord(pending, signal, results);
+    };
+
     for (const channel of orderedChannels) {
+      // Platform sorts immediately after vellum, so once any other channel is
+      // reached the platform outcome is settled: flush the deferred vellum
+      // send now so the local banner is not held behind slower sends.
+      if (channel !== "vellum" && channel !== "platform") {
+        await flushDeferredVellumSend();
+      }
+
       const adapter = this.adapters.get(channel);
       if (!adapter) {
         log.warn(
@@ -555,6 +610,9 @@ export class NotificationBroadcaster {
         approvalContext,
         accessRequestContext,
         toolApprovalSource,
+        // Starts false for vellum; the deferred-send flush overwrites it
+        // with the actual platform outcome when platform is also selected.
+        ...(channel === "vellum" ? { remotePushDispatched: false } : {}),
       };
 
       // Compute conversation decision audit fields for the delivery record
@@ -589,68 +647,12 @@ export class NotificationBroadcaster {
             "No persisted decision ID -- skipping delivery record creation",
           );
         }
-
-        const adapterResult = await adapter.send(payload, destination);
-
-        if (adapterResult.success) {
-          // Prefer the channel-native id the adapter just captured (e.g.
-          // Slack `ts`) so later edits can target the same message; fall
-          // back to the pairing-supplied id for channels that surface it
-          // through conversation pairing instead.
-          const resolvedMessageId =
-            adapterResult.messageId ?? pairing.messageId ?? undefined;
-          if (hasPersistedDecision) {
-            updateDeliveryStatus(
-              deliveryId,
-              "sent",
-              undefined,
-              adapterResult.messageId
-                ? { messageId: adapterResult.messageId }
-                : undefined,
-            );
-          }
-          results.push({
-            channel,
-            destination: destinationLabel,
-            status: "sent",
-            sentAt: Date.now(),
-            conversationId: pairing.conversationId ?? undefined,
-            messageId: resolvedMessageId,
-            conversationStrategy: pairing.strategy,
-          });
-        } else {
-          if (hasPersistedDecision) {
-            updateDeliveryStatus(deliveryId, "failed", {
-              message: adapterResult.error,
-            });
-          }
-          results.push({
-            channel,
-            destination: destinationLabel,
-            status: "failed",
-            errorMessage: adapterResult.error,
-            conversationId: pairing.conversationId ?? undefined,
-            messageId: pairing.messageId ?? undefined,
-            conversationStrategy: pairing.strategy,
-          });
-        }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
         log.error(
           { err, channel, signalId: signal.signalId },
-          "Unexpected error during channel delivery",
+          "Failed to create delivery record",
         );
-
-        if (hasPersistedDecision) {
-          try {
-            updateDeliveryStatus(deliveryId, "failed", {
-              message: errorMessage,
-            });
-          } catch {
-            // Swallow -- the delivery record may not exist if createDelivery failed
-          }
-        }
-
         results.push({
           channel,
           destination: destinationLabel,
@@ -660,10 +662,135 @@ export class NotificationBroadcaster {
           messageId: pairing.messageId ?? undefined,
           conversationStrategy: pairing.strategy,
         });
+        continue;
+      }
+
+      const dispatch: PendingChannelDispatch = {
+        adapter,
+        channel,
+        destination,
+        payload,
+        deliveryId,
+        destinationLabel,
+        pairing,
+        hasPersistedDecision,
+      };
+
+      if (channel === "vellum" && orderedChannels.includes("platform")) {
+        // The vellum intent carries remotePushDispatched, so its send waits
+        // for the platform outcome; everything else (pairing, events, the
+        // pending delivery row) already ran above.
+        deferredVellumSend = dispatch;
+        continue;
+      }
+
+      const adapterResult = await this.sendAndRecord(dispatch, signal, results);
+      if (channel === "platform") {
+        platformRemotePushAccepted = adapterResult?.remotePushAccepted === true;
       }
     }
 
+    // Covers the common [vellum, platform] selection where no later channel
+    // triggered the flush.
+    await flushDeferredVellumSend();
+
     return results;
+  }
+
+  /**
+   * Dispatch a prepared payload through its channel adapter and record the
+   * outcome (delivery row status + results entry). Returns the adapter's
+   * result, or null when the send threw.
+   */
+  private async sendAndRecord(
+    dispatch: PendingChannelDispatch,
+    signal: NotificationSignal,
+    results: NotificationDeliveryResult[],
+  ): Promise<DeliveryResult | null> {
+    const {
+      adapter,
+      channel,
+      destination,
+      payload,
+      deliveryId,
+      destinationLabel,
+      pairing,
+      hasPersistedDecision,
+    } = dispatch;
+    try {
+      const adapterResult = await adapter.send(payload, destination);
+
+      if (adapterResult.success) {
+        // Prefer the channel-native id the adapter just captured (e.g.
+        // Slack `ts`) so later edits can target the same message; fall
+        // back to the pairing-supplied id for channels that surface it
+        // through conversation pairing instead.
+        const resolvedMessageId =
+          adapterResult.messageId ?? pairing.messageId ?? undefined;
+        if (hasPersistedDecision) {
+          updateDeliveryStatus(
+            deliveryId,
+            "sent",
+            undefined,
+            adapterResult.messageId
+              ? { messageId: adapterResult.messageId }
+              : undefined,
+          );
+        }
+        results.push({
+          channel,
+          destination: destinationLabel,
+          status: "sent",
+          sentAt: Date.now(),
+          conversationId: pairing.conversationId ?? undefined,
+          messageId: resolvedMessageId,
+          conversationStrategy: pairing.strategy,
+        });
+      } else {
+        if (hasPersistedDecision) {
+          updateDeliveryStatus(deliveryId, "failed", {
+            message: adapterResult.error,
+          });
+        }
+        results.push({
+          channel,
+          destination: destinationLabel,
+          status: "failed",
+          errorMessage: adapterResult.error,
+          conversationId: pairing.conversationId ?? undefined,
+          messageId: pairing.messageId ?? undefined,
+          conversationStrategy: pairing.strategy,
+        });
+      }
+      return adapterResult;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, channel, signalId: signal.signalId },
+        "Unexpected error during channel delivery",
+      );
+
+      if (hasPersistedDecision) {
+        try {
+          updateDeliveryStatus(deliveryId, "failed", {
+            message: errorMessage,
+          });
+        } catch {
+          // Swallow -- best-effort failure-status update
+        }
+      }
+
+      results.push({
+        channel,
+        destination: destinationLabel,
+        status: "failed",
+        errorMessage,
+        conversationId: pairing.conversationId ?? undefined,
+        messageId: pairing.messageId ?? undefined,
+        conversationStrategy: pairing.strategy,
+      });
+      return null;
+    }
   }
 }
 

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -226,7 +226,13 @@ export type OnConversationCreatedFn = (
 ) => void | Promise<void>;
 export interface BroadcastDecisionOptions {
   onConversationCreated?: OnConversationCreatedFn;
+  /** Deadline override for tests; defaults to PLATFORM_OUTCOME_DEADLINE_MS. */
+  platformOutcomeDeadlineMs?: number;
 }
+
+// Cap on how long the deferred vellum send waits for the platform dispatch
+// outcome: a duplicate banner beats a late one.
+const PLATFORM_OUTCOME_DEADLINE_MS = 2_500;
 
 /**
  * A channel dispatch that is fully prepared (destination resolved, copy
@@ -336,7 +342,8 @@ export class NotificationBroadcaster {
     // eagerly, so the platform deep link keeps the vellum pairing carry), but
     // its adapter send is deferred until the platform adapter reports whether
     // the platform accepted a device push. Typical cost: one fast HTTP
-    // round-trip before the local banner goes out.
+    // round-trip before the local banner goes out, capped at
+    // PLATFORM_OUTCOME_DEADLINE_MS.
     let deferredVellumSend: PendingChannelDispatch | null = null;
     let platformRemotePushAccepted = false;
     const flushDeferredVellumSend = async (): Promise<void> => {
@@ -349,350 +356,427 @@ export class NotificationBroadcaster {
       await this.sendAndRecord(pending, signal, results);
     };
 
-    for (const channel of orderedChannels) {
-      // Platform sorts immediately after vellum, so once any other channel is
-      // reached the platform outcome is settled: flush the deferred vellum
-      // send now so the local banner is not held behind slower sends.
-      if (channel !== "vellum" && channel !== "platform") {
-        await flushDeferredVellumSend();
-      }
+    try {
+      for (const channel of orderedChannels) {
+        // Platform sorts immediately after vellum, so reaching any later
+        // channel means the platform outcome is settled (or the platform
+        // channel was skipped): flush the deferred vellum send now so the
+        // local banner is not held behind slower sends. On the vellum
+        // iteration itself this is a no-op -- vellum appears at most once in
+        // the decision's channels and sorts first, so nothing is deferred yet.
+        if (channel !== "platform") {
+          await flushDeferredVellumSend();
+        }
 
-      const adapter = this.adapters.get(channel);
-      if (!adapter) {
-        log.warn(
-          { channel, signalId: signal.signalId },
-          "No adapter registered for channel -- skipping",
-        );
-        results.push({
-          channel,
-          destination: "",
-          status: "skipped",
-          errorMessage: `No adapter for channel: ${channel}`,
-        });
-        continue;
-      }
-
-      const destination = destinations.get(channel);
-      if (!destination) {
-        log.warn(
-          { channel, signalId: signal.signalId },
-          "Could not resolve destination -- skipping",
-        );
-        results.push({
-          channel,
-          destination: "",
-          status: "skipped",
-          errorMessage: `Destination not resolved for channel: ${channel}`,
-        });
-        continue;
-      }
-
-      // Pull rendered copy from the decision; fall back to copy-composer if
-      // missing or effectively blank. The decision engine's LLM occasionally
-      // returns empty title/body strings that pass type-only validation, so
-      // treat copy with no usable content the same as missing copy.
-      let copy = decision.renderedCopy[channel];
-      if (!copy || (!copy.title?.trim() && !copy.body?.trim())) {
-        if (copy) {
+        const adapter = this.adapters.get(channel);
+        if (!adapter) {
           log.warn(
             { channel, signalId: signal.signalId },
-            "Decision copy has empty title and body — using fallback",
+            "No adapter registered for channel -- skipping",
           );
+          results.push({
+            channel,
+            destination: "",
+            status: "skipped",
+            errorMessage: `No adapter for channel: ${channel}`,
+          });
+          continue;
         }
-        if (!fallbackCopy) {
-          fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
+
+        const destination = destinations.get(channel);
+        if (!destination) {
+          log.warn(
+            { channel, signalId: signal.signalId },
+            "Could not resolve destination -- skipping",
+          );
+          results.push({
+            channel,
+            destination: "",
+            status: "skipped",
+            errorMessage: `Destination not resolved for channel: ${channel}`,
+          });
+          continue;
         }
-        copy = fallbackCopy[channel];
-      }
 
-      // Fail closed: if neither the decision nor the fallback composer produced
-      // a usable body, skip the channel rather than leaking the raw event name
-      // as placeholder text. The pre-send `checkRenderedCopyQuality` only sees
-      // `decision.renderedCopy`, so this is the last guard before delivery.
-      if (!copy || !copy.body?.trim()) {
-        log.warn(
-          { channel, signalId: signal.signalId },
-          "No usable rendered copy available -- skipping channel to avoid leaking event name",
-        );
-        results.push({
-          channel,
-          destination: destination.endpoint ?? channel,
-          status: "skipped",
-          errorMessage: `No usable rendered copy for channel: ${channel}`,
-        });
-        continue;
-      }
-
-      // For tool_grant_request signals, prefer the deterministic template seed
-      // over LLM-generated prose. The enriched questionText is already concise
-      // and informative — LLM rewording just adds noise.
-      if (signal.contextPayload?.requestKind === "tool_grant_request") {
-        if (!fallbackCopy) {
-          fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
-        }
-        const templateSeed = fallbackCopy[channel]?.conversationSeedMessage;
-        if (templateSeed) {
-          copy = { ...copy, conversationSeedMessage: templateSeed };
-        }
-      }
-
-      // Resolve the per-channel conversation action from the decision (default: start_new)
-      const conversationAction: ConversationAction | undefined =
-        decision.conversationActions?.[channel];
-
-      // Check for duplicate delivery BEFORE pairing to avoid side effects
-      // (e.g. appending seed messages to existing conversations) on retry paths
-      // where a delivery row already exists.
-      const persistedDecisionId = decision.persistedDecisionId;
-      const hasPersistedDecision = typeof persistedDecisionId === "string";
-      if (hasPersistedDecision) {
-        const existingDelivery = findDeliveryByDecisionAndChannel(
-          persistedDecisionId,
-          channel,
-        );
-        if (existingDelivery) {
-          // On retry paths the vellum row already exists, so the fresh-pairing
-          // carry below never runs — seed the platform deep-link carry from
-          // the duplicate row's conversation instead.
-          if (channel === "vellum" && existingDelivery.conversationId) {
-            vellumPairing = {
-              conversationId: existingDelivery.conversationId,
-              messageId: existingDelivery.messageId,
-            };
+        // Pull rendered copy from the decision; fall back to copy-composer if
+        // missing or effectively blank. The decision engine's LLM occasionally
+        // returns empty title/body strings that pass type-only validation, so
+        // treat copy with no usable content the same as missing copy.
+        let copy = decision.renderedCopy[channel];
+        if (!copy || (!copy.title?.trim() && !copy.body?.trim())) {
+          if (copy) {
+            log.warn(
+              { channel, signalId: signal.signalId },
+              "Decision copy has empty title and body -- using fallback",
+            );
           }
-          log.info(
-            {
-              channel,
-              signalId: signal.signalId,
-              existingDeliveryId: existingDelivery.id,
-            },
-            "Delivery already exists for this decision+channel — skipping duplicate",
+          // A policy-forced platform channel has no rendered copy of its own
+          // (the decision engine renders only the channels it selected). The
+          // push mirrors the in-app banner -- and the iOS dedup suppresses the
+          // vellum banner in its favor -- so reuse the vellum channel's
+          // rendered copy before falling back to deterministic templates.
+          const vellumCopy =
+            channel === "platform" ? decision.renderedCopy.vellum : undefined;
+          if (vellumCopy?.body?.trim()) {
+            copy = vellumCopy;
+          } else {
+            if (!fallbackCopy) {
+              fallbackCopy = composeFallbackCopy(
+                signal,
+                decision.selectedChannels,
+              );
+            }
+            copy = fallbackCopy[channel];
+          }
+        }
+
+        // Fail closed: if neither the decision nor the fallback composer produced
+        // a usable body, skip the channel rather than leaking the raw event name
+        // as placeholder text. The pre-send `checkRenderedCopyQuality` only sees
+        // `decision.renderedCopy`, so this is the last guard before delivery.
+        if (!copy || !copy.body?.trim()) {
+          log.warn(
+            { channel, signalId: signal.signalId },
+            "No usable rendered copy available -- skipping channel to avoid leaking event name",
           );
           results.push({
             channel,
             destination: destination.endpoint ?? channel,
             status: "skipped",
-            errorMessage: "Duplicate delivery skipped",
-            conversationId: existingDelivery.conversationId ?? undefined,
-            messageId: existingDelivery.messageId ?? undefined,
-            conversationStrategy:
-              existingDelivery.conversationStrategy ?? undefined,
+            errorMessage: `No usable rendered copy for channel: ${channel}`,
           });
           continue;
         }
-      }
 
-      // Pair the delivery with a conversation before sending, passing the conversation action
-      // and destination binding context for channel-scoped continuation
-      const pairing = await pairDeliveryWithConversation(
-        signal,
-        channel,
-        copy,
-        { conversationAction, bindingContext: destination.bindingContext },
-      );
-
-      if (channel === "vellum" && pairing.conversationId) {
-        vellumPairing = {
-          conversationId: pairing.conversationId,
-          messageId: pairing.messageId,
-        };
-      }
-
-      // For the vellum and platform channels, merge the conversationId into
-      // deep-link metadata so notification taps can navigate to the
-      // conversation. Prefer the channel's own pairing; platform (push_only,
-      // pairs nothing) takes this broadcast's vellum pairing; otherwise fall
-      // back to sourceContextId when it resolves to a real row. Sentinel
-      // context ids (job IDs, call session IDs, access-req-* strings) leave
-      // the deep link without a conversation, and the client opens the app to
-      // its default landing.
-      let deepLinkTarget = decision.deepLinkTarget;
-      if (channel === "vellum" || channel === "platform") {
-        const deepLinkPairing =
-          channel === "platform" && !pairing.conversationId
-            ? (vellumPairing ?? pairing)
-            : pairing;
-        const deepLinkConversationId =
-          deepLinkPairing.conversationId ??
-          resolveSourceConversationId(signal.sourceContextId) ??
-          resolveDeepLinkConversationId(signal.contextPayload);
-        if (deepLinkConversationId) {
-          deepLinkTarget = {
-            ...deepLinkTarget,
-            conversationId: deepLinkConversationId,
-          };
-          if (deepLinkPairing.messageId) {
-            deepLinkTarget = {
-              ...deepLinkTarget,
-              messageId: deepLinkPairing.messageId,
-            };
-          }
-        }
-      }
-
-      if (channel === "vellum" && pairing.conversationId) {
-        // Resolve guardian scoping for conversation-created events so clients
-        // can filter guardian-sensitive conversations the same way they filter
-        // guardian-sensitive notification intents.
-        const guardianPrincipalId =
-          typeof destination.metadata?.guardianPrincipalId === "string"
-            ? destination.metadata.guardianPrincipalId
-            : undefined;
-        const targetGuardianPrincipalId =
-          guardianPrincipalId &&
-          isGuardianSensitiveEvent(signal.sourceEventName)
-            ? guardianPrincipalId
-            : undefined;
-
-        const conversationTitle =
-          copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
-        const conversationSilent =
-          signal.attentionHints.urgency !== "high" &&
-          signal.attentionHints.urgency !== "critical";
-        const info: ConversationCreatedInfo = {
-          conversationId: pairing.conversationId,
-          title: conversationTitle,
-          sourceEventName: signal.sourceEventName,
-          targetGuardianPrincipalId,
-          groupId: signal.conversationMetadata?.groupId,
-          source: signal.conversationMetadata?.source,
-          silent: conversationSilent,
-        };
-
-        // The per-dispatch onConversationCreated callback fires whenever a vellum
-        // conversation is paired (new or reused) because callers like
-        // dispatchGuardianQuestion rely on it to create delivery bookkeeping
-        // rows before emitNotificationSignal() returns. A returned promise is
-        // awaited so those rows are durable before the client can learn of
-        // the conversation and act on its approval card.
-        if (options?.onConversationCreated) {
-          try {
-            await options.onConversationCreated(info);
-          } catch (err) {
-            log.error(
-              { err, signalId: signal.signalId },
-              "per-dispatch onConversationCreated callback failed — continuing broadcast",
+        // For tool_grant_request signals, prefer the deterministic template seed
+        // over LLM-generated prose. The enriched questionText is already concise
+        // and informative -- LLM rewording just adds noise.
+        if (signal.contextPayload?.requestKind === "tool_grant_request") {
+          if (!fallbackCopy) {
+            fallbackCopy = composeFallbackCopy(
+              signal,
+              decision.selectedChannels,
             );
           }
+          const templateSeed = fallbackCopy[channel]?.conversationSeedMessage;
+          if (templateSeed) {
+            copy = { ...copy, conversationSeedMessage: templateSeed };
+          }
         }
 
-        // Emit notification_conversation_created event only when a NEW
-        // conversation was actually created. Reusing an existing conversation
-        // should not fire the event — the client already knows about the
-        // conversation.
-        if (
-          pairing.createdNewConversation &&
-          pairing.strategy === "start_new_conversation"
-        ) {
-          if (this.onConversationCreated) {
-            try {
-              await this.onConversationCreated(info);
-            } catch (err) {
-              log.error(
-                { err, signalId: signal.signalId },
-                "onConversationCreated callback failed — continuing broadcast",
-              );
+        // Resolve the per-channel conversation action from the decision (default: start_new)
+        const conversationAction: ConversationAction | undefined =
+          decision.conversationActions?.[channel];
+
+        // Check for duplicate delivery BEFORE pairing to avoid side effects
+        // (e.g. appending seed messages to existing conversations) on retry paths
+        // where a delivery row already exists.
+        const persistedDecisionId = decision.persistedDecisionId;
+        const hasPersistedDecision = typeof persistedDecisionId === "string";
+        if (hasPersistedDecision) {
+          const existingDelivery = findDeliveryByDecisionAndChannel(
+            persistedDecisionId,
+            channel,
+          );
+          if (existingDelivery) {
+            // On retry paths the vellum row already exists, so the fresh-pairing
+            // carry below never runs -- seed the platform deep-link carry from
+            // the duplicate row's conversation instead.
+            if (channel === "vellum" && existingDelivery.conversationId) {
+              vellumPairing = {
+                conversationId: existingDelivery.conversationId,
+                messageId: existingDelivery.messageId,
+              };
+            }
+            log.info(
+              {
+                channel,
+                signalId: signal.signalId,
+                existingDeliveryId: existingDelivery.id,
+              },
+              "Delivery already exists for this decision+channel -- skipping duplicate",
+            );
+            results.push({
+              channel,
+              destination: destination.endpoint ?? channel,
+              status: "skipped",
+              errorMessage: "Duplicate delivery skipped",
+              conversationId: existingDelivery.conversationId ?? undefined,
+              messageId: existingDelivery.messageId ?? undefined,
+              conversationStrategy:
+                existingDelivery.conversationStrategy ?? undefined,
+            });
+            continue;
+          }
+        }
+
+        // Pair the delivery with a conversation before sending, passing the conversation action
+        // and destination binding context for channel-scoped continuation
+        const pairing = await pairDeliveryWithConversation(
+          signal,
+          channel,
+          copy,
+          { conversationAction, bindingContext: destination.bindingContext },
+        );
+
+        if (channel === "vellum" && pairing.conversationId) {
+          vellumPairing = {
+            conversationId: pairing.conversationId,
+            messageId: pairing.messageId,
+          };
+        }
+
+        // For the vellum and platform channels, merge the conversationId into
+        // deep-link metadata so notification taps can navigate to the
+        // conversation. Prefer the channel's own pairing; platform (push_only,
+        // pairs nothing) takes this broadcast's vellum pairing; otherwise fall
+        // back to sourceContextId when it resolves to a real row. Sentinel
+        // context ids (job IDs, call session IDs, access-req-* strings) leave
+        // the deep link without a conversation, and the client opens the app to
+        // its default landing.
+        let deepLinkTarget = decision.deepLinkTarget;
+        if (channel === "vellum" || channel === "platform") {
+          const deepLinkPairing =
+            channel === "platform" && !pairing.conversationId
+              ? (vellumPairing ?? pairing)
+              : pairing;
+          const deepLinkConversationId =
+            deepLinkPairing.conversationId ??
+            resolveSourceConversationId(signal.sourceContextId) ??
+            resolveDeepLinkConversationId(signal.contextPayload);
+          if (deepLinkConversationId) {
+            deepLinkTarget = {
+              ...deepLinkTarget,
+              conversationId: deepLinkConversationId,
+            };
+            if (deepLinkPairing.messageId) {
+              deepLinkTarget = {
+                ...deepLinkTarget,
+                messageId: deepLinkPairing.messageId,
+              };
             }
           }
         }
-      }
 
-      const deliveryId = uuid();
-      const destinationLabel = destination.endpoint ?? channel;
+        if (channel === "vellum" && pairing.conversationId) {
+          // Resolve guardian scoping for conversation-created events so clients
+          // can filter guardian-sensitive conversations the same way they filter
+          // guardian-sensitive notification intents.
+          const guardianPrincipalId =
+            typeof destination.metadata?.guardianPrincipalId === "string"
+              ? destination.metadata.guardianPrincipalId
+              : undefined;
+          const targetGuardianPrincipalId =
+            guardianPrincipalId &&
+            isGuardianSensitiveEvent(signal.sourceEventName)
+              ? guardianPrincipalId
+              : undefined;
 
-      const payload: ChannelDeliveryPayload = {
-        deliveryId,
-        sourceEventName: signal.sourceEventName,
-        copy,
-        deepLinkTarget,
-        contextPayload: signal.contextPayload,
-        urgency: signal.attentionHints.urgency,
-        approvalContext,
-        accessRequestContext,
-        toolApprovalSource,
-        // Starts false for vellum; the deferred-send flush overwrites it
-        // with the actual platform outcome when platform is also selected.
-        ...(channel === "vellum" ? { remotePushDispatched: false } : {}),
-      };
+          const conversationTitle =
+            copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
+          const conversationSilent =
+            signal.attentionHints.urgency !== "high" &&
+            signal.attentionHints.urgency !== "critical";
+          const info: ConversationCreatedInfo = {
+            conversationId: pairing.conversationId,
+            title: conversationTitle,
+            sourceEventName: signal.sourceEventName,
+            targetGuardianPrincipalId,
+            groupId: signal.conversationMetadata?.groupId,
+            source: signal.conversationMetadata?.source,
+            silent: conversationSilent,
+          };
 
-      // Compute conversation decision audit fields for the delivery record
-      const conversationAudit = {
-        conversationAction: conversationAction?.action ?? "start_new",
-        conversationTargetId:
-          conversationAction?.action === "reuse_existing"
-            ? conversationAction.conversationId
-            : undefined,
-        conversationFallbackUsed: pairing.conversationFallbackUsed,
-      };
+          // The per-dispatch onConversationCreated callback fires whenever a vellum
+          // conversation is paired (new or reused) because callers like
+          // dispatchGuardianQuestion rely on it to create delivery bookkeeping
+          // rows before emitNotificationSignal() returns. A returned promise is
+          // awaited so those rows are durable before the client can learn of
+          // the conversation and act on its approval card.
+          if (options?.onConversationCreated) {
+            try {
+              await options.onConversationCreated(info);
+            } catch (err) {
+              log.error(
+                { err, signalId: signal.signalId },
+                "per-dispatch onConversationCreated callback failed -- continuing broadcast",
+              );
+            }
+          }
 
-      try {
-        if (hasPersistedDecision) {
-          createDelivery({
-            id: deliveryId,
-            notificationDecisionId: persistedDecisionId,
+          // Emit notification_conversation_created event only when a NEW
+          // conversation was actually created. Reusing an existing conversation
+          // should not fire the event -- the client already knows about the
+          // conversation.
+          if (
+            pairing.createdNewConversation &&
+            pairing.strategy === "start_new_conversation"
+          ) {
+            if (this.onConversationCreated) {
+              try {
+                await this.onConversationCreated(info);
+              } catch (err) {
+                log.error(
+                  { err, signalId: signal.signalId },
+                  "onConversationCreated callback failed -- continuing broadcast",
+                );
+              }
+            }
+          }
+        }
+
+        const deliveryId = uuid();
+        const destinationLabel = destination.endpoint ?? channel;
+
+        const payload: ChannelDeliveryPayload = {
+          deliveryId,
+          sourceEventName: signal.sourceEventName,
+          copy,
+          deepLinkTarget,
+          contextPayload: signal.contextPayload,
+          urgency: signal.attentionHints.urgency,
+          approvalContext,
+          accessRequestContext,
+          toolApprovalSource,
+        };
+
+        // Compute conversation decision audit fields for the delivery record
+        const conversationAudit = {
+          conversationAction: conversationAction?.action ?? "start_new",
+          conversationTargetId:
+            conversationAction?.action === "reuse_existing"
+              ? conversationAction.conversationId
+              : undefined,
+          conversationFallbackUsed: pairing.conversationFallbackUsed,
+        };
+
+        try {
+          if (hasPersistedDecision) {
+            createDelivery({
+              id: deliveryId,
+              notificationDecisionId: persistedDecisionId,
+              channel,
+              destination: destinationLabel,
+              status: "pending",
+              attempt: 1,
+              renderedTitle: copy.title,
+              renderedBody: copy.body,
+              conversationId: pairing.conversationId ?? undefined,
+              messageId: pairing.messageId ?? undefined,
+              conversationStrategy: pairing.strategy,
+              ...conversationAudit,
+            });
+          } else {
+            log.warn(
+              { channel, signalId: signal.signalId },
+              "No persisted decision ID -- skipping delivery record creation",
+            );
+          }
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          log.error(
+            { err, channel, signalId: signal.signalId },
+            "Failed to create delivery record",
+          );
+          results.push({
             channel,
             destination: destinationLabel,
-            status: "pending",
-            attempt: 1,
-            renderedTitle: copy.title,
-            renderedBody: copy.body,
+            status: "failed",
+            errorMessage,
             conversationId: pairing.conversationId ?? undefined,
             messageId: pairing.messageId ?? undefined,
             conversationStrategy: pairing.strategy,
-            ...conversationAudit,
           });
-        } else {
-          log.warn(
-            { channel, signalId: signal.signalId },
-            "No persisted decision ID -- skipping delivery record creation",
-          );
+          continue;
         }
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        log.error(
-          { err, channel, signalId: signal.signalId },
-          "Failed to create delivery record",
-        );
-        results.push({
+
+        const dispatch: PendingChannelDispatch = {
+          adapter,
           channel,
-          destination: destinationLabel,
-          status: "failed",
-          errorMessage,
-          conversationId: pairing.conversationId ?? undefined,
-          messageId: pairing.messageId ?? undefined,
-          conversationStrategy: pairing.strategy,
-        });
-        continue;
-      }
+          destination,
+          payload,
+          deliveryId,
+          destinationLabel,
+          pairing,
+          hasPersistedDecision,
+        };
 
-      const dispatch: PendingChannelDispatch = {
-        adapter,
-        channel,
-        destination,
-        payload,
-        deliveryId,
-        destinationLabel,
-        pairing,
-        hasPersistedDecision,
-      };
+        if (channel === "vellum" && orderedChannels.includes("platform")) {
+          // The vellum intent carries remotePushDispatched, so its send waits
+          // for the platform outcome; everything else (pairing, events, the
+          // pending delivery row) already ran above.
+          deferredVellumSend = dispatch;
+          continue;
+        }
 
-      if (channel === "vellum" && orderedChannels.includes("platform")) {
-        // The vellum intent carries remotePushDispatched, so its send waits
-        // for the platform outcome; everything else (pairing, events, the
-        // pending delivery row) already ran above.
-        deferredVellumSend = dispatch;
-        continue;
-      }
+        if (channel === "platform" && deferredVellumSend) {
+          // The local banner is urgent: wait for the platform outcome only up
+          // to the deadline (a duplicate banner beats a late one). On expiry
+          // the vellum send flushes with remotePushDispatched=false while the
+          // dispatch keeps running, recording its delivery row when it
+          // settles; the late outcome cannot re-flush vellum.
+          const backgroundResults: NotificationDeliveryResult[] = [];
+          const platformSend = this.sendAndRecord(
+            dispatch,
+            signal,
+            backgroundResults,
+          ).then((adapterResult) => {
+            platformRemotePushAccepted =
+              adapterResult?.remotePushAccepted === true;
+          });
+          let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+          const deadline = new Promise<"deadline">((resolve) => {
+            deadlineTimer = setTimeout(
+              () => resolve("deadline"),
+              options?.platformOutcomeDeadlineMs ??
+                PLATFORM_OUTCOME_DEADLINE_MS,
+            );
+          });
+          const raced = await Promise.race([
+            platformSend.then(() => "settled" as const),
+            deadline,
+          ]);
+          clearTimeout(deadlineTimer);
+          if (raced === "deadline") {
+            log.warn(
+              { channel, signalId: signal.signalId },
+              "Platform dispatch outcome unknown at deadline -- sending the local banner without it",
+            );
+            // The in-flight dispatch's result lands in backgroundResults,
+            // which this call no longer reads; its delivery row still gets
+            // the real terminal status.
+            results.push({
+              channel,
+              destination: destinationLabel,
+              status: "pending",
+              conversationId: pairing.conversationId ?? undefined,
+              messageId: pairing.messageId ?? undefined,
+              conversationStrategy: pairing.strategy,
+            });
+          } else {
+            results.push(...backgroundResults);
+          }
+          await flushDeferredVellumSend();
+          continue;
+        }
 
-      const adapterResult = await this.sendAndRecord(dispatch, signal, results);
-      if (channel === "platform") {
-        platformRemotePushAccepted = adapterResult?.remotePushAccepted === true;
+        const adapterResult = await this.sendAndRecord(
+          dispatch,
+          signal,
+          results,
+        );
+        if (channel === "platform") {
+          platformRemotePushAccepted =
+            adapterResult?.remotePushAccepted === true;
+        }
       }
+    } finally {
+      // Guarantees the vellum intent is emitted (and its pending delivery
+      // row resolved) even when a later channel's prep throws; also covers
+      // the common [vellum, platform] selection where no later channel
+      // triggered the mid-loop flush.
+      await flushDeferredVellumSend();
     }
-
-    // Covers the common [vellum, platform] selection where no later channel
-    // triggered the flush.
-    await flushDeferredVellumSend();
 
     return results;
   }

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -251,6 +251,27 @@ interface PendingChannelDispatch {
   hasPersistedDecision: boolean;
 }
 
+/**
+ * Build a delivery result for a prepared dispatch. The single construction
+ * site for every post-preparation outcome branch, so a future field cannot
+ * be added to one branch and missed in another.
+ */
+function buildDeliveryResult(
+  dispatch: PendingChannelDispatch,
+  status: NotificationDeliveryResult["status"],
+  overrides?: Partial<NotificationDeliveryResult>,
+): NotificationDeliveryResult {
+  return {
+    channel: dispatch.channel,
+    destination: dispatch.destinationLabel,
+    status,
+    conversationId: dispatch.pairing.conversationId ?? undefined,
+    messageId: dispatch.pairing.messageId ?? undefined,
+    conversationStrategy: dispatch.pairing.strategy,
+    ...overrides,
+  };
+}
+
 export class NotificationBroadcaster {
   private adapters: Map<NotificationChannel, ChannelAdapter>;
   private onConversationCreated: OnConversationCreatedFn | null = null;
@@ -640,6 +661,17 @@ export class NotificationBroadcaster {
           toolApprovalSource,
         };
 
+        const dispatch: PendingChannelDispatch = {
+          adapter,
+          channel,
+          destination,
+          payload,
+          deliveryId,
+          destinationLabel,
+          pairing,
+          hasPersistedDecision,
+        };
+
         // Compute conversation decision audit fields for the delivery record
         const conversationAudit = {
           conversationAction: conversationAction?.action ?? "start_new",
@@ -678,28 +710,11 @@ export class NotificationBroadcaster {
             { err, channel, signalId: signal.signalId },
             "Failed to create delivery record",
           );
-          results.push({
-            channel,
-            destination: destinationLabel,
-            status: "failed",
-            errorMessage,
-            conversationId: pairing.conversationId ?? undefined,
-            messageId: pairing.messageId ?? undefined,
-            conversationStrategy: pairing.strategy,
-          });
+          results.push(
+            buildDeliveryResult(dispatch, "failed", { errorMessage }),
+          );
           continue;
         }
-
-        const dispatch: PendingChannelDispatch = {
-          adapter,
-          channel,
-          destination,
-          payload,
-          deliveryId,
-          destinationLabel,
-          pairing,
-          hasPersistedDecision,
-        };
 
         if (channel === "vellum" && orderedChannels.includes("platform")) {
           // The vellum intent carries remotePushDispatched, so its send waits
@@ -745,14 +760,7 @@ export class NotificationBroadcaster {
             // The in-flight dispatch's result lands in backgroundResults,
             // which this call no longer reads; its delivery row still gets
             // the real terminal status.
-            results.push({
-              channel,
-              destination: destinationLabel,
-              status: "pending",
-              conversationId: pairing.conversationId ?? undefined,
-              messageId: pairing.messageId ?? undefined,
-              conversationStrategy: pairing.strategy,
-            });
+            results.push(buildDeliveryResult(dispatch, "pending"));
           } else {
             results.push(...backgroundResults);
           }
@@ -760,15 +768,7 @@ export class NotificationBroadcaster {
           continue;
         }
 
-        const adapterResult = await this.sendAndRecord(
-          dispatch,
-          signal,
-          results,
-        );
-        if (channel === "platform") {
-          platformRemotePushAccepted =
-            adapterResult?.remotePushAccepted === true;
-        }
+        await this.sendAndRecord(dispatch, signal, results);
       }
     } finally {
       // Guarantees the vellum intent is emitted (and its pending delivery
@@ -797,7 +797,6 @@ export class NotificationBroadcaster {
       destination,
       payload,
       deliveryId,
-      destinationLabel,
       pairing,
       hasPersistedDecision,
     } = dispatch;
@@ -821,30 +820,23 @@ export class NotificationBroadcaster {
               : undefined,
           );
         }
-        results.push({
-          channel,
-          destination: destinationLabel,
-          status: "sent",
-          sentAt: Date.now(),
-          conversationId: pairing.conversationId ?? undefined,
-          messageId: resolvedMessageId,
-          conversationStrategy: pairing.strategy,
-        });
+        results.push(
+          buildDeliveryResult(dispatch, "sent", {
+            sentAt: Date.now(),
+            messageId: resolvedMessageId,
+          }),
+        );
       } else {
         if (hasPersistedDecision) {
           updateDeliveryStatus(deliveryId, "failed", {
             message: adapterResult.error,
           });
         }
-        results.push({
-          channel,
-          destination: destinationLabel,
-          status: "failed",
-          errorMessage: adapterResult.error,
-          conversationId: pairing.conversationId ?? undefined,
-          messageId: pairing.messageId ?? undefined,
-          conversationStrategy: pairing.strategy,
-        });
+        results.push(
+          buildDeliveryResult(dispatch, "failed", {
+            errorMessage: adapterResult.error,
+          }),
+        );
       }
       return adapterResult;
     } catch (err) {
@@ -864,15 +856,7 @@ export class NotificationBroadcaster {
         }
       }
 
-      results.push({
-        channel,
-        destination: destinationLabel,
-        status: "failed",
-        errorMessage,
-        conversationId: pairing.conversationId ?? undefined,
-        messageId: pairing.messageId ?? undefined,
-        conversationStrategy: pairing.strategy,
-      });
+      results.push(buildDeliveryResult(dispatch, "failed", { errorMessage }));
       return null;
     }
   }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -320,25 +320,34 @@ export async function emitNotificationSignal<TEventName extends string>(
 
     let decision = await evaluateSignal(signal, connectedChannels);
 
-    // Step 2.5a: High/critical urgency signals always get a system
-    // notification via the vellum channel, regardless of what the
-    // decision engine selected. This ensures macOS surfaces a banner
-    // even when the app is focused.
+    // Baseline for the re-persist check below. Captured before the policy
+    // steps (2.5a/2.5b/2.5c) so any of them replacing the decision triggers
+    // the re-persist and the stored row matches what is dispatched.
+    const prePolicyDecision = decision;
+
+    // Step 2.5a: High/critical urgency signals always get both the in-app
+    // system notification (vellum) and the remote push (platform),
+    // regardless of what the decision engine selected. macOS surfaces a
+    // banner even when the app is focused, and a suspended iOS device is
+    // only reachable via APNs.
     const urgency = signal.attentionHints.urgency;
     if (
       (urgency === "high" || urgency === "critical") &&
-      decision.shouldNotify &&
-      !decision.selectedChannels.includes("vellum")
+      decision.shouldNotify
     ) {
-      decision = {
-        ...decision,
-        selectedChannels: ["vellum", ...decision.selectedChannels],
-        reasoningSummary: `${decision.reasoningSummary} (vellum forced: ${urgency} urgency)`,
-      };
+      const forcedChannels: NotificationChannel[] = (
+        ["vellum", "platform"] as const
+      ).filter((channel) => !decision.selectedChannels.includes(channel));
+      if (forcedChannels.length > 0) {
+        decision = {
+          ...decision,
+          selectedChannels: [...forcedChannels, ...decision.selectedChannels],
+          reasoningSummary: `${decision.reasoningSummary} (${forcedChannels.join(", ")} forced: ${urgency} urgency)`,
+        };
+      }
     }
 
     // Step 2.5b: Enforce routing intent policy (fire-time guard)
-    const preEnforcementDecision = decision;
     decision = enforceRoutingIntent(
       decision,
       signal.routingIntent,
@@ -368,9 +377,10 @@ export async function emitNotificationSignal<TEventName extends string>(
       };
     }
 
-    // Re-persist the decision if routing intent enforcement changed it,
-    // so the stored decision row matches what is actually dispatched.
-    if (decision !== preEnforcementDecision && decision.persistedDecisionId) {
+    // Re-persist the decision if any policy step changed it (urgency channel
+    // forcing, routing intent enforcement, or the access-request vellum
+    // floor), so the stored decision row matches what is actually dispatched.
+    if (decision !== prePolicyDecision && decision.persistedDecisionId) {
       try {
         updateDecision(decision.persistedDecisionId, {
           selectedChannels: decision.selectedChannels,
@@ -384,7 +394,7 @@ export async function emitNotificationSignal<TEventName extends string>(
       } catch (err) {
         log.warn(
           { err, signalId },
-          "Failed to re-persist decision after routing intent enforcement",
+          "Failed to re-persist decision after policy enforcement",
         );
       }
     }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -331,8 +331,10 @@ export async function emitNotificationSignal<TEventName extends string>(
     // regardless of what the decision engine selected. macOS surfaces a
     // banner even when the app is focused, and a suspended iOS device is
     // only reachable via APNs. Platform is only forced when the daemon has
-    // platform credentials -- on unbound daemons the dispatch can never
-    // succeed and would write a failed delivery row per signal.
+    // platform credentials and an assistant id -- on unbound daemons the
+    // dispatch can never succeed and would write a failed delivery row per
+    // signal. The probe is deadline-bounded internally, so a slow credential
+    // backend cannot stall the urgent dispatch.
     //
     // Vellum PREPENDS and platform APPENDS: the broadcaster re-sorts by
     // dispatch rank, so selection order only matters to single_channel

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -18,6 +18,7 @@ import {
   guardianForChannel,
 } from "../contacts/guardian-delivery-reader.js";
 import type { ConversationCreateType } from "../persistence/conversation-types.js";
+import { isPlatformClientConfigured } from "../platform/client.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import { VellumAdapter } from "./adapters/macos.js";
@@ -329,19 +330,38 @@ export async function emitNotificationSignal<TEventName extends string>(
     // system notification (vellum) and the remote push (platform),
     // regardless of what the decision engine selected. macOS surfaces a
     // banner even when the app is focused, and a suspended iOS device is
-    // only reachable via APNs.
+    // only reachable via APNs. Platform is only forced when the daemon has
+    // platform credentials -- on unbound daemons the dispatch can never
+    // succeed and would write a failed delivery row per signal.
+    //
+    // Vellum PREPENDS and platform APPENDS: the broadcaster re-sorts by
+    // dispatch rank, so selection order only matters to single_channel
+    // enforcement's first-selected fallback (step 2.5b), which must keep
+    // the in-app banner rather than a push the server may skip.
     const urgency = signal.attentionHints.urgency;
     if (
       (urgency === "high" || urgency === "critical") &&
       decision.shouldNotify
     ) {
-      const forcedChannels: NotificationChannel[] = (
-        ["vellum", "platform"] as const
-      ).filter((channel) => !decision.selectedChannels.includes(channel));
+      const selectedChannels: NotificationChannel[] = [
+        ...decision.selectedChannels,
+      ];
+      const forcedChannels: NotificationChannel[] = [];
+      if (!selectedChannels.includes("vellum")) {
+        selectedChannels.unshift("vellum");
+        forcedChannels.push("vellum");
+      }
+      if (
+        !selectedChannels.includes("platform") &&
+        (await isPlatformClientConfigured())
+      ) {
+        selectedChannels.push("platform");
+        forcedChannels.push("platform");
+      }
       if (forcedChannels.length > 0) {
         decision = {
           ...decision,
-          selectedChannels: [...forcedChannels, ...decision.selectedChannels],
+          selectedChannels,
           reasoningSummary: `${decision.reasoningSummary} (${forcedChannels.join(", ")} forced: ${urgency} urgency)`,
         };
       }

--- a/assistant/src/notifications/guardian-delivery-recorder.ts
+++ b/assistant/src/notifications/guardian-delivery-recorder.ts
@@ -91,8 +91,10 @@ export async function recordApprovalCardDelivery(
  * that row's id as `vellumDeliveryId` and it is reused (only its status applied)
  * — otherwise the vellum row is created here from the result.
  *
- * Every result records the internal `conversationId` the card is shown in, so a
- * conversation's pending cards can be found uniformly regardless of channel.
+ * Every addressable result records the internal `conversationId` the card is
+ * shown in, so a conversation's pending cards can be found uniformly
+ * regardless of channel. Platform push results are skipped entirely: a push
+ * has no channel-native card surface to address back to.
  * Channel results additionally carry the chat (`destination`) and channel-native
  * id (`messageId`) used to match inbound replies/reactions; a blank `destination`
  * is recorded as unknown rather than persisting the literal channel name as a
@@ -112,6 +114,10 @@ export async function recordGuardianRequestDeliveries(params: {
   let vellumDeliveryId = params.vellumDeliveryId;
 
   for (const result of deliveryResults) {
+    if (result.channel === "platform") {
+      // A push is not an independently addressable card surface -- no row.
+      continue;
+    }
     let deliveryId: string | undefined;
     if (result.channel === "vellum") {
       if (!vellumDeliveryId) {

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -58,6 +58,9 @@ export const DeliveryResultSchema = z.object({
   success: z.boolean(),
   error: z.string().optional(),
   messageId: z.string().optional(),
+  /** Set only by the platform push adapter: true when the platform accepted
+   *  at least one device push for delivery (not proof of device receipt). */
+  remotePushAccepted: z.boolean().optional(),
 });
 export type DeliveryResult = z.infer<typeof DeliveryResultSchema>;
 
@@ -106,6 +109,10 @@ export const ChannelDeliveryPayloadSchema = z.object({
    *  broadcaster so channel adapters render it without re-parsing
    *  `contextPayload`. */
   toolApprovalSource: ToolApprovalSourceViewSchema.optional(),
+  /** True when the platform (APNs) channel accepted a remote push for this
+   *  delivery. Set only on the vellum channel's payload so clients can avoid
+   *  double-bannering. */
+  remotePushDispatched: z.boolean().optional(),
 });
 export type ChannelDeliveryPayload = z.infer<
   typeof ChannelDeliveryPayloadSchema

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -173,6 +173,60 @@ describe("VellumPlatformClient", () => {
       mockResolveManagedProxyContext = () => new Promise(() => {});
       expect(await isPlatformClientConfigured()).toBe(true);
     });
+
+    test("concurrent calls share a single in-flight resolution", async () => {
+      let resolutionCount = 0;
+      mockResolveManagedProxyContext = async () => {
+        resolutionCount += 1;
+        await Bun.sleep(5);
+        return mockManagedProxyCtx;
+      };
+
+      const [first, second] = await Promise.all([
+        isPlatformClientConfigured(),
+        isPlatformClientConfigured(),
+      ]);
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(resolutionCount).toBe(1);
+    });
+
+    test("a settled flight clears, so the next call starts a fresh resolution", async () => {
+      let resolutionCount = 0;
+      mockResolveManagedProxyContext = async () => {
+        resolutionCount += 1;
+        return mockManagedProxyCtx;
+      };
+
+      expect(await isPlatformClientConfigured()).toBe(true);
+      expect(await isPlatformClientConfigured()).toBe(true);
+      expect(resolutionCount).toBe(2);
+    });
+
+    test("a late caller joins the slow flight instead of racing a second resolution that could settle out of order", async () => {
+      let resolutionCount = 0;
+      let releaseHang = () => {};
+      const hang = new Promise<void>((resolve) => {
+        releaseHang = resolve;
+      });
+      mockResolveManagedProxyContext = async () => {
+        resolutionCount += 1;
+        await hang;
+        return mockManagedProxyCtx;
+      };
+
+      // The first caller abandons the slow flight at the deadline.
+      expect(await isPlatformClientConfigured()).toBe(false);
+
+      // A later caller joins the same still-in-flight resolution, so no
+      // second resolution exists whose settle could clobber a newer cache
+      // value.
+      const joined = isPlatformClientConfigured();
+      releaseHang();
+      expect(await joined).toBe(true);
+      expect(resolutionCount).toBe(1);
+    });
   });
 
   describe("fetch()", () => {

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -204,28 +204,64 @@ describe("VellumPlatformClient", () => {
       expect(resolutionCount).toBe(2);
     });
 
-    test("a late caller joins the slow flight instead of racing a second resolution that could settle out of order", async () => {
+    test("a caller that finds a flight older than the deadline rotates in a fresh resolution", async () => {
       let resolutionCount = 0;
-      let releaseHang = () => {};
-      const hang = new Promise<void>((resolve) => {
-        releaseHang = resolve;
-      });
+      // The first resolution hangs forever; only the rotated-in second one
+      // settles.
+      const pendingHangs = [new Promise<void>(() => {})];
       mockResolveManagedProxyContext = async () => {
         resolutionCount += 1;
-        await hang;
+        const hang = pendingHangs.shift();
+        if (hang) {
+          await hang;
+        }
         return mockManagedProxyCtx;
       };
 
-      // The first caller abandons the slow flight at the deadline.
+      // The first caller abandons the hung flight at the deadline.
       expect(await isPlatformClientConfigured()).toBe(false);
 
-      // A later caller joins the same still-in-flight resolution, so no
-      // second resolution exists whose settle could clobber a newer cache
-      // value.
-      const joined = isPlatformClientConfigured();
-      releaseHang();
-      expect(await joined).toBe(true);
-      expect(resolutionCount).toBe(1);
+      // The hung flight is now older than the deadline, so the next caller
+      // rotates in a fresh resolution instead of joining it; the fresh
+      // flight settles immediately and answers live.
+      expect(await isPlatformClientConfigured()).toBe(true);
+      expect(resolutionCount).toBe(2);
+    });
+
+    test("a rotated-out flight's late settle cannot overwrite the newer flight's cached result", async () => {
+      let releaseFirstHang = () => {};
+      const firstHang = new Promise<void>((resolve) => {
+        releaseFirstHang = resolve;
+      });
+      const pendingHangs = [firstHang];
+      mockResolveManagedProxyContext = async () => {
+        const hang = pendingHangs.shift();
+        if (hang) {
+          await hang;
+        }
+        return mockManagedProxyCtx;
+      };
+
+      // First caller abandons the hung flight; second caller rotates in a
+      // fresh flight that settles true and writes the cache.
+      expect(await isPlatformClientConfigured()).toBe(false);
+      expect(await isPlatformClientConfigured()).toBe(true);
+
+      // The rotated-out flight now settles resolving an unconfigured
+      // context. Generation fencing must keep it from clobbering the newer
+      // flight's cached `true`.
+      mockManagedProxyCtx = {
+        enabled: false,
+        platformBaseUrl: "",
+        assistantApiKey: "",
+      };
+      releaseFirstHang();
+      await Bun.sleep(10);
+
+      // Resolution hangs forever, so this answer can only come from the
+      // cache, which must still hold the newer flight's `true`.
+      mockResolveManagedProxyContext = () => new Promise(() => {});
+      expect(await isPlatformClientConfigured()).toBe(true);
     });
   });
 

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -11,13 +11,17 @@ let mockManagedProxyCtx = {
 };
 let mockAssistantId = "";
 let mockSecureKeys: Record<string, string | null | undefined> = {};
+// Re-pointable so the probe-deadline tests can hang context resolution.
+let mockResolveManagedProxyContext: () => Promise<
+  typeof mockManagedProxyCtx
+> = async () => mockManagedProxyCtx;
 
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
 
 mock.module("../providers/platform-proxy/context.js", () => ({
-  resolveManagedProxyContext: async () => mockManagedProxyCtx,
+  resolveManagedProxyContext: () => mockResolveManagedProxyContext(),
 }));
 
 mock.module("../config/env.js", () => ({
@@ -38,7 +42,11 @@ mock.module("../security/credential-key.js", () => ({
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------
 
-import { VellumPlatformClient } from "./client.js";
+import {
+  _resetConfiguredProbeCacheForTests,
+  isPlatformClientConfigured,
+  VellumPlatformClient,
+} from "./client.js";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -56,6 +64,8 @@ describe("VellumPlatformClient", () => {
     };
     mockAssistantId = "asst-123";
     mockSecureKeys = {};
+    mockResolveManagedProxyContext = async () => mockManagedProxyCtx;
+    _resetConfiguredProbeCacheForTests();
   });
 
   afterEach(() => {
@@ -116,6 +126,52 @@ describe("VellumPlatformClient", () => {
       expect(client!.baseUrl).toBe("https://stored-platform.example.com");
       expect(client!.assistantApiKey).toBe("stored-api-key");
       expect(client!.platformAssistantId).toBe("stored-assistant-id");
+    });
+  });
+
+  describe("isPlatformClientConfigured()", () => {
+    test("true when base url, api key, and assistant id are all present", async () => {
+      expect(await isPlatformClientConfigured()).toBe(true);
+    });
+
+    test("false when the platform assistant id is missing", async () => {
+      mockAssistantId = "";
+
+      expect(await isPlatformClientConfigured()).toBe(false);
+    });
+
+    test("false when auth prerequisites are missing", async () => {
+      mockManagedProxyCtx = {
+        enabled: false,
+        platformBaseUrl: "",
+        assistantApiKey: "",
+      };
+
+      expect(await isPlatformClientConfigured()).toBe(false);
+    });
+
+    test("hung resolution answers false at the deadline, then serves the late result from cache", async () => {
+      let releaseHang = () => {};
+      const hang = new Promise<void>((resolve) => {
+        releaseHang = resolve;
+      });
+      mockResolveManagedProxyContext = async () => {
+        await hang;
+        return mockManagedProxyCtx;
+      };
+
+      // Resolution is hung and no result has ever settled -- the deadline
+      // must answer false instead of stalling the caller.
+      expect(await isPlatformClientConfigured()).toBe(false);
+
+      // Release the abandoned resolution; it settles true in the background
+      // and refreshes the cache.
+      releaseHang();
+      await Bun.sleep(10);
+
+      // Resolution hangs forever this time, but the cache answers true.
+      mockResolveManagedProxyContext = () => new Promise(() => {});
+      expect(await isPlatformClientConfigured()).toBe(true);
     });
   });
 

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -107,21 +107,41 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
 const CONFIGURED_PROBE_DEADLINE_MS = 500;
 
 let lastKnownConfigured: boolean | null = null;
-// Single-flight slot: concurrent probes share one resolution, so the cache is
-// written once per flight and an out-of-order settle cannot overwrite a newer
-// result.
-let inFlightConfiguredProbe: Promise<boolean> | null = null;
+// Single-flight slot with rotation: probes started inside the deadline window
+// share one resolution, while a flight older than the deadline is replaced so
+// a hung credential backend cannot pin the slot (and the cache) stale until a
+// 45s credential timeout finally settles it. Generation fencing keeps an
+// out-of-order settle from a rotated-out flight from overwriting the result a
+// newer flight already wrote.
+interface ConfiguredProbeFlight {
+  promise: Promise<boolean>;
+  startedAt: number;
+  generation: number;
+}
+let inFlightConfiguredProbe: ConfiguredProbeFlight | null = null;
+let probeGeneration = 0;
+let lastWrittenGeneration = 0;
 
 export function _resetConfiguredProbeCacheForTests(): void {
   lastKnownConfigured = null;
   inFlightConfiguredProbe = null;
+  // Outstanding flights all carry generations at or below the current
+  // counter; raising the written floor to it blocks their settles from
+  // resurrecting the cache after a reset.
+  lastWrittenGeneration = probeGeneration;
 }
 
 function startOrJoinConfiguredProbe(): Promise<boolean> {
-  if (inFlightConfiguredProbe) {
-    return inFlightConfiguredProbe;
+  const existing = inFlightConfiguredProbe;
+  if (
+    existing !== null &&
+    Date.now() - existing.startedAt < CONFIGURED_PROBE_DEADLINE_MS
+  ) {
+    return existing.promise;
   }
-  const flight = resolvePlatformClientConfig()
+  probeGeneration += 1;
+  const generation = probeGeneration;
+  const promise = resolvePlatformClientConfig()
     .then((config) => config !== null && config.assistantId.length > 0)
     .catch((err: unknown) => {
       log.debug(
@@ -131,16 +151,17 @@ function startOrJoinConfiguredProbe(): Promise<boolean> {
       return false;
     })
     .then((value) => {
-      // A cleared slot means a test reset invalidated this flight, so its
-      // result must not resurrect the cache.
-      if (inFlightConfiguredProbe === flight) {
+      if (generation > lastWrittenGeneration) {
         lastKnownConfigured = value;
+        lastWrittenGeneration = generation;
+      }
+      if (inFlightConfiguredProbe?.generation === generation) {
         inFlightConfiguredProbe = null;
       }
       return value;
     });
-  inFlightConfiguredProbe = flight;
-  return flight;
+  inFlightConfiguredProbe = { promise, startedAt: Date.now(), generation };
+  return promise;
 }
 
 /**
@@ -150,9 +171,11 @@ function startOrJoinConfiguredProbe(): Promise<boolean> {
  *
  * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
  * slower than the deadline, returns the last settled result (or `false` when
- * none exists yet). The probe is single-flight: concurrent calls share one
- * resolution, and a resolution abandoned at the deadline still settles in
- * the background and refreshes the cache for the next call.
+ * none exists yet). Calls inside the deadline window share one in-flight
+ * resolution; a call that finds a flight older than the deadline starts a
+ * fresh one, so a hung backend never pins the cache stale, and generation
+ * fencing keeps a rotated-out flight's late settle from overwriting a newer
+ * result.
  */
 export async function isPlatformClientConfigured(): Promise<boolean> {
   const probe = startOrJoinConfiguredProbe();

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -34,6 +34,83 @@ export interface OwnerConsent {
   shareDiagnosticsAcceptedVersion: string;
 }
 
+interface PlatformClientConfig {
+  baseUrl: string;
+  apiKey: string;
+  assistantId: string;
+}
+
+/**
+ * Resolve the platform client's prerequisites.
+ *
+ * First tries the in-memory managed proxy context (available when the daemon
+ * has rehydrated env overrides). Falls back to reading platform credentials
+ * directly from the credential store so that standalone CLI invocations work
+ * without the daemon having run its rehydration step.
+ *
+ * Returns `null` when auth prerequisites are missing (not logged in, no API
+ * key). The assistant ID is resolved but not required.
+ */
+async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | null> {
+  if (!arePlatformFeaturesEnabled()) {
+    log.debug("platform features disabled -- returning null");
+    return null;
+  }
+
+  const ctx = await resolveManagedProxyContext();
+
+  let baseUrl = ctx.enabled ? ctx.platformBaseUrl : "";
+  let apiKey = ctx.enabled ? ctx.assistantApiKey : "";
+  let assistantId = getPlatformAssistantId();
+
+  // Fall back to credential store for values not yet rehydrated (standalone CLI).
+  if (!baseUrl) {
+    baseUrl =
+      (await getSecureKeyAsync(credentialKey("vellum", "platform_base_url"))) ??
+      "";
+  }
+  if (!apiKey) {
+    apiKey =
+      (await getSecureKeyAsync(credentialKey("vellum", "assistant_api_key"))) ??
+      "";
+  }
+  if (!assistantId) {
+    assistantId =
+      (
+        await getSecureKeyAsync(
+          credentialKey("vellum", "platform_assistant_id"),
+        )
+      )?.trim() ?? "";
+  }
+
+  if (!baseUrl || !apiKey) {
+    const level = _missingPrereqsWarned ? "debug" : "warn";
+    _missingPrereqsWarned = true;
+    log[level](
+      {
+        hasBaseUrl: !!baseUrl,
+        hasApiKey: !!apiKey,
+        hasAssistantId: !!assistantId,
+        managedProxyEnabled: ctx.enabled,
+      },
+      "Platform client prerequisites missing -- returning null",
+    );
+    return null;
+  }
+
+  return { baseUrl, apiKey, assistantId };
+}
+
+/**
+ * Whether the platform client's auth prerequisites are present. A cheap
+ * availability probe for callers that only need to know if platform calls
+ * can be attempted: reads config and the credential store, constructs no
+ * client, and makes no network requests.
+ */
+export async function isPlatformClientConfigured(): Promise<boolean> {
+  return (await resolvePlatformClientConfig()) !== null;
+}
+
 export class VellumPlatformClient {
   private readonly platformBaseUrl: string;
   private readonly apiKey: string;
@@ -50,67 +127,22 @@ export class VellumPlatformClient {
   }
 
   /**
-   * Create a platform client by resolving managed proxy context.
-   *
-   * First tries the in-memory managed proxy context (available when the daemon
-   * has rehydrated env overrides). Falls back to reading platform credentials
-   * directly from the credential store so that standalone CLI invocations work
-   * without the daemon having run its rehydration step.
+   * Create a platform client from {@link resolvePlatformClientConfig}.
    *
    * Returns `null` when auth prerequisites are missing (not logged in, no API
-   * key). The assistant ID is resolved but not required — callers that need it
-   * should check `platformAssistantId` themselves.
+   * key). The assistant ID is resolved but not required -- callers that need
+   * it should check `platformAssistantId` themselves.
    */
   static async create(): Promise<VellumPlatformClient | null> {
-    if (!arePlatformFeaturesEnabled()) {
-      log.debug("platform features disabled — returning null");
+    const config = await resolvePlatformClientConfig();
+    if (!config) {
       return null;
     }
-
-    const ctx = await resolveManagedProxyContext();
-
-    let baseUrl = ctx.enabled ? ctx.platformBaseUrl : "";
-    let apiKey = ctx.enabled ? ctx.assistantApiKey : "";
-    let assistantId = getPlatformAssistantId();
-
-    // Fall back to credential store for values not yet rehydrated (standalone CLI).
-    if (!baseUrl) {
-      baseUrl =
-        (await getSecureKeyAsync(
-          credentialKey("vellum", "platform_base_url"),
-        )) ?? "";
-    }
-    if (!apiKey) {
-      apiKey =
-        (await getSecureKeyAsync(
-          credentialKey("vellum", "assistant_api_key"),
-        )) ?? "";
-    }
-    if (!assistantId) {
-      assistantId =
-        (
-          await getSecureKeyAsync(
-            credentialKey("vellum", "platform_assistant_id"),
-          )
-        )?.trim() ?? "";
-    }
-
-    if (!baseUrl || !apiKey) {
-      const level = _missingPrereqsWarned ? "debug" : "warn";
-      _missingPrereqsWarned = true;
-      log[level](
-        {
-          hasBaseUrl: !!baseUrl,
-          hasApiKey: !!apiKey,
-          hasAssistantId: !!assistantId,
-          managedProxyEnabled: ctx.enabled,
-        },
-        "Platform client prerequisites missing — returning null",
-      );
-      return null;
-    }
-
-    return new VellumPlatformClient(baseUrl, apiKey, assistantId);
+    return new VellumPlatformClient(
+      config.baseUrl,
+      config.apiKey,
+      config.assistantId,
+    );
   }
 
   /**

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -107,23 +107,21 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
 const CONFIGURED_PROBE_DEADLINE_MS = 500;
 
 let lastKnownConfigured: boolean | null = null;
+// Single-flight slot: concurrent probes share one resolution, so the cache is
+// written once per flight and an out-of-order settle cannot overwrite a newer
+// result.
+let inFlightConfiguredProbe: Promise<boolean> | null = null;
 
 export function _resetConfiguredProbeCacheForTests(): void {
   lastKnownConfigured = null;
+  inFlightConfiguredProbe = null;
 }
 
-/**
- * Whether the platform client can actually dispatch: auth prerequisites plus
- * a nonempty platform assistant id (`PlatformPushAdapter.send()` fails fast
- * without one). Constructs no client and makes no network requests.
- *
- * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
- * slower than the deadline, returns the last settled result (or `false` when
- * none exists yet). The abandoned resolution still settles in the background
- * and refreshes the cache for the next call.
- */
-export async function isPlatformClientConfigured(): Promise<boolean> {
-  const probe = resolvePlatformClientConfig()
+function startOrJoinConfiguredProbe(): Promise<boolean> {
+  if (inFlightConfiguredProbe) {
+    return inFlightConfiguredProbe;
+  }
+  const flight = resolvePlatformClientConfig()
     .then((config) => config !== null && config.assistantId.length > 0)
     .catch((err: unknown) => {
       log.debug(
@@ -133,9 +131,31 @@ export async function isPlatformClientConfigured(): Promise<boolean> {
       return false;
     })
     .then((value) => {
-      lastKnownConfigured = value;
+      // A cleared slot means a test reset invalidated this flight, so its
+      // result must not resurrect the cache.
+      if (inFlightConfiguredProbe === flight) {
+        lastKnownConfigured = value;
+        inFlightConfiguredProbe = null;
+      }
       return value;
     });
+  inFlightConfiguredProbe = flight;
+  return flight;
+}
+
+/**
+ * Whether the platform client can actually dispatch: auth prerequisites plus
+ * a nonempty platform assistant id (`PlatformPushAdapter.send()` fails fast
+ * without one). Constructs no client and makes no network requests.
+ *
+ * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
+ * slower than the deadline, returns the last settled result (or `false` when
+ * none exists yet). The probe is single-flight: concurrent calls share one
+ * resolution, and a resolution abandoned at the deadline still settles in
+ * the background and refreshes the cache for the next call.
+ */
+export async function isPlatformClientConfigured(): Promise<boolean> {
+  const probe = startOrJoinConfiguredProbe();
 
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<"deadline">((resolve) => {

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -101,14 +101,55 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
   return { baseUrl, apiKey, assistantId };
 }
 
+// Bounds the configured probe: resolution can hit up to three credential-store
+// reads, and urgent-notification dispatch awaits this probe, so a slow
+// credential backend must answer from cache instead of stalling the banner.
+const CONFIGURED_PROBE_DEADLINE_MS = 500;
+
+let lastKnownConfigured: boolean | null = null;
+
+export function _resetConfiguredProbeCacheForTests(): void {
+  lastKnownConfigured = null;
+}
+
 /**
- * Whether the platform client's auth prerequisites are present. A cheap
- * availability probe for callers that only need to know if platform calls
- * can be attempted: reads config and the credential store, constructs no
- * client, and makes no network requests.
+ * Whether the platform client can actually dispatch: auth prerequisites plus
+ * a nonempty platform assistant id (`PlatformPushAdapter.send()` fails fast
+ * without one). Constructs no client and makes no network requests.
+ *
+ * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
+ * slower than the deadline, returns the last settled result (or `false` when
+ * none exists yet). The abandoned resolution still settles in the background
+ * and refreshes the cache for the next call.
  */
 export async function isPlatformClientConfigured(): Promise<boolean> {
-  return (await resolvePlatformClientConfig()) !== null;
+  const probe = resolvePlatformClientConfig()
+    .then((config) => config !== null && config.assistantId.length > 0)
+    .catch((err: unknown) => {
+      log.debug(
+        { err },
+        "Configured probe failed -- treating as not configured",
+      );
+      return false;
+    })
+    .then((value) => {
+      lastKnownConfigured = value;
+      return value;
+    });
+
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<"deadline">((resolve) => {
+    deadlineTimer = setTimeout(
+      () => resolve("deadline"),
+      CONFIGURED_PROBE_DEADLINE_MS,
+    );
+  });
+  const raced = await Promise.race([probe, deadline]);
+  clearTimeout(deadlineTimer);
+  if (raced === "deadline") {
+    return lastKnownConfigured ?? false;
+  }
+  return raced;
 }
 
 export class VellumPlatformClient {

--- a/clients/ios/App/App/ApnsEnvironmentPlugin.swift
+++ b/clients/ios/App/App/ApnsEnvironmentPlugin.swift
@@ -1,0 +1,67 @@
+import Capacitor
+import Foundation
+
+/// Capacitor plugin that reports which APNs environment this build's
+/// `aps-environment` entitlement actually points at, read from the embedded
+/// provisioning profile. The web side
+/// (`clients/web/src/runtime/push-registration.ts`) uses it to tag device
+/// tokens correctly: TestFlight signs every build, including dev-suffixed
+/// bundle IDs, with the production entitlement, so any heuristic based on the
+/// bundle ID misclassifies TestFlight dev builds and their pushes are
+/// rejected by Apple.
+///
+/// The single `get` method resolves `{ environment }` with one of:
+/// - `"development"`: an Xcode / development-signed install
+/// - `"production"`: a TestFlight or App Store install
+/// - `"unknown"`: the profile exists but could not be read or parsed
+///
+/// It never rejects. Per the skew rule in `clients/web/docs/CAPACITOR.md`, a
+/// plugin must not require a separate availability probe, so the one result
+/// encodes every state; an older shell without the plugin simply fails the
+/// bridge call and the web side falls back to its heuristic.
+@objc(ApnsEnvironmentPlugin)
+public class ApnsEnvironmentPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "ApnsEnvironmentPlugin"
+    public let jsName = "ApnsEnvironment"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "get", returnType: CAPPluginReturnPromise),
+    ]
+
+    @objc public func get(_ call: CAPPluginCall) {
+        call.resolve(["environment": Self.entitlementEnvironment()])
+    }
+
+    private static func entitlementEnvironment() -> String {
+        guard let profileURL = Bundle.main.url(
+            forResource: "embedded",
+            withExtension: "mobileprovision"
+        ) else {
+            // App Store installs ship no embedded profile and are always production.
+            return "production"
+        }
+        guard let profileData = try? Data(contentsOf: profileURL) else {
+            return "unknown"
+        }
+
+        // The profile is a CMS blob wrapping a plist, so it is scanned as text
+        // rather than decoded. `String(decoding:as:)` is lossy: the wrapper's
+        // binary segments become replacement characters while the ASCII plist
+        // entries stay intact.
+        let text = String(decoding: profileData, as: UTF8.self)
+        guard let key = text.range(of: "<key>aps-environment</key>"),
+              let open = text.range(of: "<string>", range: key.upperBound..<text.endIndex),
+              let close = text.range(of: "</string>", range: open.upperBound..<text.endIndex)
+        else {
+            return "unknown"
+        }
+
+        let value = text[open.upperBound..<close.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        switch value {
+        case "development", "production":
+            return value
+        default:
+            return "unknown"
+        }
+    }
+}

--- a/clients/ios/App/App/ApnsEnvironmentPlugin.swift
+++ b/clients/ios/App/App/ApnsEnvironmentPlugin.swift
@@ -33,8 +33,6 @@ public class ApnsEnvironmentPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc public func get(_ call: CAPPluginCall) {
         #if targetEnvironment(simulator)
-            // Simulator builds ship no embedded profile, and APNs simulator
-            // push always uses the development environment.
             call.resolve(["environment": "development"])
             return
         #endif

--- a/clients/ios/App/App/ApnsEnvironmentPlugin.swift
+++ b/clients/ios/App/App/ApnsEnvironmentPlugin.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Capacitor plugin that reports which APNs environment this build's
 /// `aps-environment` entitlement actually points at, read from the embedded
 /// provisioning profile. The web side
-/// (`clients/web/src/runtime/push-registration.ts`) uses it to tag device
+/// (`clients/web/src/runtime/apns-environment.ts`) uses it to tag device
 /// tokens correctly: TestFlight signs every build, including dev-suffixed
 /// bundle IDs, with the production entitlement, so any heuristic based on the
 /// bundle ID misclassifies TestFlight dev builds and their pushes are
@@ -14,6 +14,10 @@ import Foundation
 /// - `"development"`: an Xcode / development-signed install
 /// - `"production"`: a TestFlight or App Store install
 /// - `"unknown"`: the profile exists but could not be read or parsed
+///
+/// Simulator builds ship no embedded profile and always resolve
+/// `"development"`, because APNs simulator push only uses the development
+/// environment.
 ///
 /// It never rejects. Per the skew rule in `clients/web/docs/CAPACITOR.md`, a
 /// plugin must not require a separate availability probe, so the one result
@@ -28,6 +32,12 @@ public class ApnsEnvironmentPlugin: CAPPlugin, CAPBridgedPlugin {
     ]
 
     @objc public func get(_ call: CAPPluginCall) {
+        #if targetEnvironment(simulator)
+            // Simulator builds ship no embedded profile, and APNs simulator
+            // push always uses the development environment.
+            call.resolve(["environment": "development"])
+            return
+        #endif
         call.resolve(["environment": Self.entitlementEnvironment()])
     }
 

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -5,9 +5,10 @@ import WebKit
 /// Custom `CAPBridgeViewController` subclass that:
 ///
 /// 1. Registers `NativeAuthPlugin`, `NativeBiometricPlugin`,
-///    `VoiceAudioSessionPlugin`, and `VoiceLiveActivityPlugin` as local plugin
-///    instances at bridge init time. These plugins live inside the App target
-///    (no SPM module) so the bridge won't discover them automatically.
+///    `VoiceAudioSessionPlugin`, `VoiceLiveActivityPlugin`, and
+///    `ApnsEnvironmentPlugin` as local plugin instances at bridge init time.
+///    These plugins live inside the App target (no SPM module) so the bridge
+///    won't discover them automatically.
 ///
 /// 2. Injects `WKUserScript`s at `.atDocumentEnd` to:
 ///    a) Pin focusable fields to a minimum 16px font-size, preventing the
@@ -146,6 +147,7 @@ class MyViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(NativeBiometricPlugin())
         bridge?.registerPluginInstance(VoiceAudioSessionPlugin())
         bridge?.registerPluginInstance(VoiceLiveActivityPlugin())
+        bridge?.registerPluginInstance(ApnsEnvironmentPlugin())
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -43,9 +43,9 @@ which URL is baked into the build.
   process. With `server.url`, only native shell changes (Swift code,
   entitlements, Capacitor plugin updates) require a store submission.
 - **Thin native surface** — the IPC bridge between the WKWebView and
-  native code is minimal (four plugins: `NativeAuthPlugin`,
-  `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`, and
-  `VoiceLiveActivityPlugin`), so version
+  native code is minimal (five plugins: `NativeAuthPlugin`,
+  `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`,
+  `VoiceLiveActivityPlugin`, and `ApnsEnvironmentPlugin`), so version
   skew risk between the web app and native shell is low. Every plugin
   call from the web side must still be capability-probed, because a new
   web bundle always ships ahead of the shell that hosts it. Contrast
@@ -150,7 +150,7 @@ Apple's reference for the toolbar controls:
 
 The app has two layers — the **WKWebView contents** (the React app loaded
 from the configured server URL) and the **native Swift shell** (Capacitor
-bridge, `MyViewController`, the four native plugins). Each has its own
+bridge, `MyViewController`, the five native plugins). Each has its own
 debugger.
 
 ### Safari Web Inspector — for the web side (JS / CSS / network / `console.log`)
@@ -198,8 +198,8 @@ For a **physical iPhone**:
 ⌘R runs with `lldb` already attached. Click in the gutter next to any
 line in `AppDelegate.swift`, `MyViewController.swift`,
 `NativeAuthPlugin.swift`, `NativeBiometricPlugin.swift`,
-`VoiceAudioSessionPlugin.swift`, or `VoiceLiveActivityPlugin.swift` to set a
-breakpoint.
+`VoiceAudioSessionPlugin.swift`, `VoiceLiveActivityPlugin.swift`, or
+`ApnsEnvironmentPlugin.swift` to set a breakpoint.
 
 - **Console / log output**: View → Debug Area → Activate Console (⇧⌘Y),
   or click the bottom-right console toggle. `print()` and `NSLog()` from
@@ -218,7 +218,7 @@ breakpoint.
 ### Common debugging recipes
 
 - **A native plugin call (`NativeAuth`, `NativeBiometric`,
-  `VoiceAudioSession`, `VoiceLiveActivity`) seems broken**:
+  `VoiceAudioSession`, `VoiceLiveActivity`, `ApnsEnvironment`) seems broken**:
   set a Swift breakpoint in the relevant `@objc func` inside the plugin
   file and trigger the action from the web app. If the breakpoint never
   hits, the JS-side `Capacitor.Plugins.NativeAuth` lookup is wrong (check
@@ -698,6 +698,7 @@ clients/
     │   │   ├── NativeBiometricPlugin.swift # Face ID / Touch ID Keychain
     │   │   ├── VoiceAudioSessionPlugin.swift # AVAudioSession for live voice
     │   │   ├── VoiceLiveActivityPlugin.swift # Dynamic Island for live voice
+    │   │   ├── ApnsEnvironmentPlugin.swift # APNs entitlement environment
     │   │   ├── Intents/              # App Intents + AppShortcutsProvider
     │   │   ├── Shared/               # Compiled into app + widget extension
     │   │   └── Info.plist

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -145,7 +145,7 @@ References:
 
 Live voice is a web feature with native accessories. The session — mic capture, the velay socket, TTS playback, every user-facing string — lives entirely under `src/domains/chat/voice/live-voice/`. The iOS shell adds an `AVAudioSession`, a Dynamic Island / Lock Screen presence, and a set of App Intents on top of it.
 
-The shell registers **four** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) — count them there, not from prose:
+The shell registers **five** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose):
 
 | Plugin | Web module | What it does |
 | --- | --- | --- |
@@ -153,6 +153,7 @@ The shell registers **four** Capacitor plugins in [`MyViewController.capacitorDi
 | `NativeBiometric` | [`src/runtime/native-biometric.ts`](../src/runtime/native-biometric.ts) | Face ID / Touch ID Keychain |
 | `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | `.playAndRecord` / `.voiceChat` session + interruption events. **Unproven on hardware** — see the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | The one ActivityKit activity mirroring a session |
+| `ApnsEnvironment` | [`src/runtime/push-registration.ts`](../src/runtime/push-registration.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -153,7 +153,7 @@ The shell registers **five** Capacitor plugins in [`MyViewController.capacitorDi
 | `NativeBiometric` | [`src/runtime/native-biometric.ts`](../src/runtime/native-biometric.ts) | Face ID / Touch ID Keychain |
 | `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | `.playAndRecord` / `.voiceChat` session + interruption events. **Unproven on hardware** — see the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | The one ActivityKit activity mirroring a session |
-| `ApnsEnvironment` | [`src/runtime/push-registration.ts`](../src/runtime/push-registration.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
+| `ApnsEnvironment` | [`src/runtime/apns-environment.ts`](../src/runtime/apns-environment.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
+//
+// The default simulates an old shell without the plugin (bridge call rejects),
+// exercising the bundle-suffix heuristic fallback. Cases that exercise the
+// signing-derived path set `apnsEnvironmentRejects = false` and an explicit
+// `apnsEnvironmentResult`. Mirrors push-registration.test.ts, which covers the
+// resolver's own matrix; these tests pin the ActivityKit upsert to it.
+
+let apnsEnvironmentResult: string | undefined;
+let apnsEnvironmentRejects = true;
+const apnsEnvironmentGetMock = mock(
+  async (): Promise<{ environment?: string }> => {
+    if (apnsEnvironmentRejects) {
+      throw new Error("ApnsEnvironment.get() is not implemented on ios");
+    }
+    return { environment: apnsEnvironmentResult };
+  },
+);
+
+mock.module("@capacitor/core", () => ({
+  registerPlugin: (name: string) =>
+    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
+}));
+
+// ── @capacitor/app (lazy-imported plugin Proxy) ──────────────────────────────
+
+let bundleId = "ai.vocify-inc.vellum-assistant-ios";
+const getInfoMock = mock(async () => ({
+  id: bundleId,
+  name: "Vellum",
+  build: "1",
+  version: "1.0.0",
+}));
+mock.module("@capacitor/app", () => ({
+  App: { getInfo: getInfoMock },
+}));
+
+// ── generated platform SDK ───────────────────────────────────────────────────
+
+interface UpsertArg {
+  path: { assistant_id: string };
+  body: {
+    token: string;
+    bundle_id: string;
+    apns_environment: string;
+    conversation_id: string;
+    labels: Record<string, string>;
+  };
+  throwOnError: boolean;
+}
+
+let lastUpsertArg: UpsertArg | null = null;
+const upsertMock = mock(async (arg: UpsertArg) => {
+  lastUpsertArg = arg;
+  return { data: {}, error: undefined };
+});
+const deleteMock = mock(async () => ({ data: undefined, error: undefined }));
+mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsLiveActivityTokensUpsert: upsertMock,
+  assistantsLiveActivityTokensDelete: deleteMock,
+}));
+
+// ── Sentry capture-error ─────────────────────────────────────────────────────
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { registerLiveActivityPushToken } =
+  await import("@/domains/chat/voice/live-voice/live-activity-push-registration");
+
+beforeEach(() => {
+  bundleId = "ai.vocify-inc.vellum-assistant-ios";
+  apnsEnvironmentResult = undefined;
+  apnsEnvironmentRejects = true;
+  lastUpsertArg = null;
+  apnsEnvironmentGetMock.mockClear();
+  getInfoMock.mockClear();
+  upsertMock.mockClear();
+  deleteMock.mockClear();
+  captureErrorMock.mockClear();
+  localStorage.removeItem("vellum:live_activity_registration");
+});
+
+describe("registerLiveActivityPushToken APNs environment", () => {
+  test("tags the token with the signing-derived environment: production on a .dev bundle (TestFlight dev build)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "production";
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerLiveActivityPushToken(
+      "activity-token-tf",
+      "assistant-1",
+      "conv-1",
+    );
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg?.path).toEqual({ assistant_id: "assistant-1" });
+    expect(lastUpsertArg?.body.token).toBe("activity-token-tf");
+    expect(lastUpsertArg?.body.bundle_id).toBe(
+      "ai.vocify-inc.vellum-assistant-ios.dev",
+    );
+    expect(lastUpsertArg?.body.conversation_id).toBe("conv-1");
+    expect(lastUpsertArg?.body.apns_environment).toBe("production");
+  });
+
+  test("falls back to the bundle-suffix heuristic when the bridge rejects (old shell), without a Sentry capture", async () => {
+    apnsEnvironmentRejects = true;
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerLiveActivityPushToken(
+      "activity-token-old",
+      "assistant-1",
+      "conv-2",
+    );
+
+    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
@@ -1,32 +1,21 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
+// ── APNs environment resolver ────────────────────────────────────────────────
 //
-// The default simulates an old shell without the plugin (bridge call rejects),
-// exercising the bundle-suffix heuristic fallback. Cases that exercise the
-// signing-derived path set `apnsEnvironmentRejects = false` and an explicit
-// `apnsEnvironmentResult`. Mirrors push-registration.test.ts, which covers the
-// resolver's own matrix; these tests pin the ActivityKit upsert to it.
+// Mocked directly; the resolver's own fallback matrix is covered by
+// runtime/apns-environment.test.ts. This file only pins the ActivityKit upsert
+// wiring to the shared resolver.
 
-let apnsEnvironmentResult: string | undefined;
-let apnsEnvironmentRejects = true;
-const apnsEnvironmentGetMock = mock(
-  async (): Promise<{ environment?: string }> => {
-    if (apnsEnvironmentRejects) {
-      throw new Error("ApnsEnvironment.get() is not implemented on ios");
-    }
-    return { environment: apnsEnvironmentResult };
-  },
+const resolveSignedApnsEnvironmentMock = mock(
+  async () => "production" as const,
 );
-
-mock.module("@capacitor/core", () => ({
-  registerPlugin: (name: string) =>
-    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
+mock.module("@/runtime/apns-environment", () => ({
+  resolveSignedApnsEnvironment: resolveSignedApnsEnvironmentMock,
 }));
 
 // ── @capacitor/app (lazy-imported plugin Proxy) ──────────────────────────────
 
-let bundleId = "ai.vocify-inc.vellum-assistant-ios";
+const bundleId = "ai.vocify-inc.vellum-assistant-ios";
 const getInfoMock = mock(async () => ({
   id: bundleId,
   name: "Vellum",
@@ -73,11 +62,8 @@ const { registerLiveActivityPushToken } =
   await import("@/domains/chat/voice/live-voice/live-activity-push-registration");
 
 beforeEach(() => {
-  bundleId = "ai.vocify-inc.vellum-assistant-ios";
-  apnsEnvironmentResult = undefined;
-  apnsEnvironmentRejects = true;
   lastUpsertArg = null;
-  apnsEnvironmentGetMock.mockClear();
+  resolveSignedApnsEnvironmentMock.mockClear();
   getInfoMock.mockClear();
   upsertMock.mockClear();
   deleteMock.mockClear();
@@ -86,39 +72,19 @@ beforeEach(() => {
 });
 
 describe("registerLiveActivityPushToken APNs environment", () => {
-  test("tags the token with the signing-derived environment: production on a .dev bundle (TestFlight dev build)", async () => {
-    apnsEnvironmentRejects = false;
-    apnsEnvironmentResult = "production";
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
+  test("tags the upsert with the shared resolver's environment", async () => {
     await registerLiveActivityPushToken(
-      "activity-token-tf",
+      "activity-token",
       "assistant-1",
       "conv-1",
     );
 
+    expect(resolveSignedApnsEnvironmentMock).toHaveBeenCalledWith(bundleId);
     expect(upsertMock).toHaveBeenCalledTimes(1);
     expect(lastUpsertArg?.path).toEqual({ assistant_id: "assistant-1" });
-    expect(lastUpsertArg?.body.token).toBe("activity-token-tf");
-    expect(lastUpsertArg?.body.bundle_id).toBe(
-      "ai.vocify-inc.vellum-assistant-ios.dev",
-    );
+    expect(lastUpsertArg?.body.token).toBe("activity-token");
+    expect(lastUpsertArg?.body.bundle_id).toBe(bundleId);
     expect(lastUpsertArg?.body.conversation_id).toBe("conv-1");
     expect(lastUpsertArg?.body.apns_environment).toBe("production");
-  });
-
-  test("falls back to the bundle-suffix heuristic when the bridge rejects (old shell), without a Sentry capture", async () => {
-    apnsEnvironmentRejects = true;
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
-    await registerLiveActivityPushToken(
-      "activity-token-old",
-      "assistant-1",
-      "conv-2",
-    );
-
-    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(1);
-    expect(lastUpsertArg?.body.apns_environment).toBe("development");
-    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -153,9 +153,7 @@ async function upsertToken(
     // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
     const { App } = await import("@capacitor/app");
     const { id: bundleId } = await App.getInfo();
-    // Shared with the device-token upsert so both registrations tag this
-    // build's tokens with the same APNs environment (signing-derived, with a
-    // bundle-suffix fallback).
+    // See `runtime/apns-environment.ts` for the shared-resolver rationale.
     const apnsEnvironment = await resolveSignedApnsEnvironment(bundleId);
 
     const result = await assistantsLiveActivityTokensUpsert({

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -33,7 +33,6 @@ import {
   assistantsLiveActivityTokensDelete,
   assistantsLiveActivityTokensUpsert,
 } from "@/generated/api/sdk.gen";
-import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
 import {
   isLiveVoiceSessionActive,
   LIVE_VOICE_STATE_LABELS,
@@ -41,20 +40,8 @@ import {
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { captureError } from "@/lib/sentry/capture-error";
+import { resolveSignedApnsEnvironment } from "@/runtime/apns-environment";
 import { createStorageAccessor } from "@/utils/typed-storage";
-
-/**
- * Bundle-id suffix that maps to the development APNs entitlement — the same
- * rule `runtime/push-registration.ts` applies to device tokens, and for the
- * same reason: APNs rejects a token minted under one environment when it is
- * addressed against the other, so the platform stores the environment
- * alongside the token.
- */
-const DEV_BUNDLE_SUFFIX = ".dev";
-
-function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
-  return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
-}
 
 /**
  * Every phase an activity can be pushed into, paired with its wording.
@@ -166,13 +153,17 @@ async function upsertToken(
     // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
     const { App } = await import("@capacitor/app");
     const { id: bundleId } = await App.getInfo();
+    // Shared with the device-token upsert so both registrations tag this
+    // build's tokens with the same APNs environment (signing-derived, with a
+    // bundle-suffix fallback).
+    const apnsEnvironment = await resolveSignedApnsEnvironment(bundleId);
 
     const result = await assistantsLiveActivityTokensUpsert({
       path: { assistant_id: assistantId },
       body: {
         token,
         bundle_id: bundleId,
-        apns_environment: resolveApnsEnvironment(bundleId),
+        apns_environment: apnsEnvironment,
         conversation_id: conversationId,
         labels: phaseLabels(),
       },

--- a/clients/web/src/hooks/use-notification-intent-sync.test.tsx
+++ b/clients/web/src/hooks/use-notification-intent-sync.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * `useNotificationIntentSync` forwards `notification_intent` SSE events to
+ * `postLocalNotification`, including the optional `remotePushDispatched`
+ * flag the dedup skip in `runtime/notifications.ts` keys on.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { __resetForTesting, publish } from "@/lib/event-bus";
+import { useConversationStore } from "@/stores/conversation-store";
+import type { PostLocalNotificationArgs } from "@/runtime/notifications";
+
+const postedArgs: PostLocalNotificationArgs[] = [];
+const postLocalNotificationMock = mock(
+  async (args: PostLocalNotificationArgs) => {
+    postedArgs.push(args);
+  },
+);
+const sendAckMock = mock(async () => {});
+mock.module("@/runtime/notifications", () => ({
+  postLocalNotification: postLocalNotificationMock,
+  sendNotificationIntentAck: sendAckMock,
+  extractConversationId: (metadata?: Record<string, unknown>) =>
+    typeof metadata?.conversationId === "string"
+      ? metadata.conversationId
+      : undefined,
+}));
+
+mock.module("@/lib/sounds/sound-manager", () => ({
+  getSoundManager: () => ({ play: async () => {} }),
+}));
+
+const { useNotificationIntentSync } = await import(
+  "@/hooks/use-notification-intent-sync"
+);
+
+function publishNotificationIntent(overrides: {
+  remotePushDispatched?: boolean;
+}) {
+  act(() => {
+    publish("sse.event", {
+      id: "evt-1",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "notification_intent",
+        sourceEventName: "reminder.fired",
+        title: "Reminder",
+        body: "Stand up",
+        deliveryId: "delivery-1",
+        ...overrides,
+      },
+    });
+  });
+}
+
+beforeEach(() => {
+  __resetForTesting();
+  useConversationStore.getState().reset();
+  postedArgs.length = 0;
+  postLocalNotificationMock.mockClear();
+  sendAckMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+});
+
+describe("useNotificationIntentSync", () => {
+  test("passes remotePushDispatched through to postLocalNotification", () => {
+    renderHook(() => useNotificationIntentSync("assistant-1"));
+
+    publishNotificationIntent({ remotePushDispatched: true });
+
+    expect(postedArgs).toEqual([
+      {
+        title: "Reminder",
+        body: "Stand up",
+        sourceEventName: "reminder.fired",
+        deliveryId: "delivery-1",
+        deepLinkMetadata: undefined,
+        assistantId: "assistant-1",
+        remotePushDispatched: true,
+      },
+    ]);
+  });
+
+  test("leaves remotePushDispatched undefined when the daemon omits it", () => {
+    renderHook(() => useNotificationIntentSync("assistant-1"));
+
+    publishNotificationIntent({});
+
+    expect(postedArgs).toHaveLength(1);
+    expect(postedArgs[0]?.remotePushDispatched).toBeUndefined();
+  });
+});

--- a/clients/web/src/hooks/use-notification-intent-sync.ts
+++ b/clients/web/src/hooks/use-notification-intent-sync.ts
@@ -75,6 +75,7 @@ export function useNotificationIntentSync(assistantId: string | null): void {
       deliveryId: event.deliveryId,
       deepLinkMetadata: event.deepLinkMetadata,
       assistantId: assistantId ?? undefined,
+      remotePushDispatched: event.remotePushDispatched,
     });
   });
 }

--- a/clients/web/src/runtime/apns-environment.test.ts
+++ b/clients/web/src/runtime/apns-environment.test.ts
@@ -31,17 +31,6 @@ mock.module("@capacitor/core", () => ({
     name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
 }));
 
-// ── Sentry capture-error ─────────────────────────────────────────────────────
-//
-// The module deliberately reports fallbacks via `console.debug` only (an old
-// shell is an expected state, not a fault); the mock makes the no-capture
-// assertion fail loudly if a future edit starts reporting them.
-
-const captureErrorMock = mock(() => {});
-mock.module("@/lib/sentry/capture-error", () => ({
-  captureError: captureErrorMock,
-}));
-
 const { resolveSignedApnsEnvironment } =
   await import("@/runtime/apns-environment");
 
@@ -54,7 +43,6 @@ beforeEach(() => {
   apnsEnvironmentResult = undefined;
   apnsEnvironmentRejects = true;
   apnsEnvironmentGetMock.mockClear();
-  captureErrorMock.mockClear();
   consoleDebugSpy.mockClear();
 });
 
@@ -89,7 +77,7 @@ describe("resolveSignedApnsEnvironment", () => {
     );
   });
 
-  test("bridge rejection (old shell) falls back to the heuristic: console.debug, no Sentry capture", async () => {
+  test("bridge rejection (old shell) falls back to the heuristic via console.debug", async () => {
     expect(await resolveSignedApnsEnvironment(DEV_BUNDLE_ID)).toBe(
       "development",
     );
@@ -99,6 +87,5 @@ describe("resolveSignedApnsEnvironment", () => {
 
     expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(2);
     expect(consoleDebugSpy).toHaveBeenCalledTimes(2);
-    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/runtime/apns-environment.test.ts
+++ b/clients/web/src/runtime/apns-environment.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Fallback matrix for `resolveSignedApnsEnvironment`: the signing-derived
+ * plugin result wins when readable, the bundle-suffix heuristic covers
+ * `"unknown"` entitlements and pre-plugin shells whose bridge call rejects.
+ * Consumers (`push-registration.test.ts`,
+ * `live-activity-push-registration.test.ts`) mock this module and only pin
+ * their upsert wiring to it.
+ */
+
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
+//
+// The default simulates an old shell without the plugin (bridge call rejects).
+// Signing-derived cases set `apnsEnvironmentRejects = false` and an explicit
+// `apnsEnvironmentResult`.
+
+let apnsEnvironmentResult: string | undefined;
+let apnsEnvironmentRejects = true;
+const apnsEnvironmentGetMock = mock(
+  async (): Promise<{ environment?: string }> => {
+    if (apnsEnvironmentRejects) {
+      throw new Error("ApnsEnvironment.get() is not implemented on ios");
+    }
+    return { environment: apnsEnvironmentResult };
+  },
+);
+
+mock.module("@capacitor/core", () => ({
+  registerPlugin: (name: string) =>
+    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
+}));
+
+// ── Sentry capture-error ─────────────────────────────────────────────────────
+//
+// The module deliberately reports fallbacks via `console.debug` only (an old
+// shell is an expected state, not a fault); the mock makes the no-capture
+// assertion fail loudly if a future edit starts reporting them.
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { resolveSignedApnsEnvironment } =
+  await import("@/runtime/apns-environment");
+
+const consoleDebugSpy = spyOn(console, "debug").mockImplementation(() => {});
+
+const DEV_BUNDLE_ID = "ai.vocify-inc.vellum-assistant-ios.dev";
+const PROD_BUNDLE_ID = "ai.vocify-inc.vellum-assistant-ios";
+
+beforeEach(() => {
+  apnsEnvironmentResult = undefined;
+  apnsEnvironmentRejects = true;
+  apnsEnvironmentGetMock.mockClear();
+  captureErrorMock.mockClear();
+  consoleDebugSpy.mockClear();
+});
+
+describe("resolveSignedApnsEnvironment", () => {
+  test("plugin production wins over a .dev bundle (TestFlight dev build)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "production";
+
+    expect(await resolveSignedApnsEnvironment(DEV_BUNDLE_ID)).toBe(
+      "production",
+    );
+  });
+
+  test("plugin development wins over a production-mapping bundle (Xcode install)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "development";
+
+    expect(await resolveSignedApnsEnvironment(PROD_BUNDLE_ID)).toBe(
+      "development",
+    );
+  });
+
+  test("unknown entitlement falls back to the bundle-suffix heuristic", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "unknown";
+
+    expect(await resolveSignedApnsEnvironment(DEV_BUNDLE_ID)).toBe(
+      "development",
+    );
+    expect(await resolveSignedApnsEnvironment(PROD_BUNDLE_ID)).toBe(
+      "production",
+    );
+  });
+
+  test("bridge rejection (old shell) falls back to the heuristic: console.debug, no Sentry capture", async () => {
+    expect(await resolveSignedApnsEnvironment(DEV_BUNDLE_ID)).toBe(
+      "development",
+    );
+    expect(await resolveSignedApnsEnvironment(PROD_BUNDLE_ID)).toBe(
+      "production",
+    );
+
+    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(2);
+    expect(consoleDebugSpy).toHaveBeenCalledTimes(2);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/apns-environment.ts
+++ b/clients/web/src/runtime/apns-environment.ts
@@ -43,24 +43,10 @@ interface ApnsEnvironmentPlugin {
 const ApnsEnvironment =
   registerPlugin<ApnsEnvironmentPlugin>("ApnsEnvironment");
 
-/**
- * Bundle-id suffix that maps to the development APNs entitlement in the
- * fallback heuristic, consulted only for shells predating the
- * `ApnsEnvironment` plugin and for profiles it cannot parse (`"unknown"`).
- * The dev Xcode config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs
- * with `App-Dev.entitlements` (`aps-environment = development`) and ships the
- * `.dev` bundle id; production and staging both sign with `App.entitlements`
- * (`aps-environment = production`). The heuristic misreads TestFlight-signed
- * dev builds (production tokens on a `.dev` bundle id), which is why the
- * signing-derived plugin result wins when available.
- */
+/** Suffix dev-signed builds ship (`App-Dev.xcconfig`); see module docblock. */
 const DEV_BUNDLE_SUFFIX = ".dev";
 
-/**
- * Fallback heuristic: map the running build's bundle id to its APNs
- * entitlement environment. Only consulted when the `ApnsEnvironment` plugin
- * is absent (older shell) or cannot read the entitlement (`"unknown"`).
- */
+/** Suffix-heuristic fallback for absent or `"unknown"` plugin results. */
 function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
   return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
 }

--- a/clients/web/src/runtime/apns-environment.ts
+++ b/clients/web/src/runtime/apns-environment.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared resolver for the APNs environment a push token must be tagged with.
+ *
+ * APNs rejects a token minted under one entitlement environment when it is
+ * dispatched against the other, so the platform stores the environment
+ * alongside every token and the value must match the running build. Two token
+ * upserts depend on that tag, and both resolve it here so they can never
+ * disagree: device push tokens (`runtime/push-registration.ts`) and
+ * ActivityKit Live Activity tokens
+ * (`domains/chat/voice/live-voice/live-activity-push-registration.ts`). A
+ * split resolution would let a TestFlight-signed dev build register device
+ * tokens as production while its Live Activity updates get rejected as
+ * sandbox-tagged.
+ *
+ * The primary source is the native `ApnsEnvironment` plugin
+ * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`), which reads the real
+ * `aps-environment` value from the embedded provisioning profile: TestFlight
+ * and App Store builds always carry production APNs tokens regardless of
+ * bundle id, which is exactly the case the bundle-suffix heuristic got wrong
+ * for TestFlight dev builds. Shells predating the plugin, and profiles it
+ * cannot parse, fall back to that heuristic.
+ *
+ * Per `docs/CAPACITOR.md`, only the plugin call's result may cross an `async`
+ * boundary, never the plugin Proxy itself: the Proxy's `.then` trap would hang
+ * the awaiting caller forever.
+ */
+
+import { registerPlugin } from "@capacitor/core";
+
+import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
+
+interface ApnsEnvironmentPlugin {
+  get(): Promise<{ environment?: string }>;
+}
+
+/**
+ * Native plugin reporting the build's real APNs entitlement environment, read
+ * from the embedded provisioning profile
+ * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`). Resolves
+ * `"development"`, `"production"`, or `"unknown"` on modern shells; on older
+ * shells that predate the plugin the bridge call rejects instead.
+ */
+const ApnsEnvironment =
+  registerPlugin<ApnsEnvironmentPlugin>("ApnsEnvironment");
+
+/**
+ * Bundle-id suffix that maps to the development APNs entitlement in the
+ * fallback heuristic, consulted only for shells predating the
+ * `ApnsEnvironment` plugin and for profiles it cannot parse (`"unknown"`).
+ * The dev Xcode config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs
+ * with `App-Dev.entitlements` (`aps-environment = development`) and ships the
+ * `.dev` bundle id; production and staging both sign with `App.entitlements`
+ * (`aps-environment = production`). The heuristic misreads TestFlight-signed
+ * dev builds (production tokens on a `.dev` bundle id), which is why the
+ * signing-derived plugin result wins when available.
+ */
+const DEV_BUNDLE_SUFFIX = ".dev";
+
+/**
+ * Fallback heuristic: map the running build's bundle id to its APNs
+ * entitlement environment. Only consulted when the `ApnsEnvironment` plugin
+ * is absent (older shell) or cannot read the entitlement (`"unknown"`).
+ */
+function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
+  return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
+}
+
+/**
+ * Resolve the environment to tag a push token with, preferring the build's
+ * real signing entitlement over the bundle-suffix heuristic.
+ */
+export async function resolveSignedApnsEnvironment(
+  bundleId: string,
+): Promise<ApnsEnvironmentEnum> {
+  try {
+    // Only the result crosses this `async` boundary, never the plugin Proxy
+    // itself (see CAPACITOR.md).
+    const { environment } = await ApnsEnvironment.get();
+    if (environment === "development" || environment === "production") {
+      return environment;
+    }
+    console.debug(
+      "[apns-environment] unreadable APNs entitlement, using bundle-id heuristic:",
+      environment,
+    );
+  } catch (err) {
+    // `console.debug`, not `captureError`, per the `native-voice.ts` skew
+    // convention: an older App Store/TestFlight shell without the plugin is
+    // an expected state on every web deploy, not a fault.
+    console.debug(
+      "[apns-environment] ApnsEnvironment bridge unavailable, using bundle-id heuristic:",
+      err,
+    );
+  }
+  return resolveApnsEnvironment(bundleId);
+}

--- a/clients/web/src/runtime/apns-environment.ts
+++ b/clients/web/src/runtime/apns-environment.ts
@@ -19,10 +19,6 @@
  * bundle id, which is exactly the case the bundle-suffix heuristic got wrong
  * for TestFlight dev builds. Shells predating the plugin, and profiles it
  * cannot parse, fall back to that heuristic.
- *
- * Per `docs/CAPACITOR.md`, only the plugin call's result may cross an `async`
- * boundary, never the plugin Proxy itself: the Proxy's `.then` trap would hang
- * the awaiting caller forever.
  */
 
 import { registerPlugin } from "@capacitor/core";
@@ -33,13 +29,7 @@ interface ApnsEnvironmentPlugin {
   get(): Promise<{ environment?: string }>;
 }
 
-/**
- * Native plugin reporting the build's real APNs entitlement environment, read
- * from the embedded provisioning profile
- * (`clients/ios/App/App/ApnsEnvironmentPlugin.swift`). Resolves
- * `"development"`, `"production"`, or `"unknown"` on modern shells; on older
- * shells that predate the plugin the bridge call rejects instead.
- */
+/** Native entitlement-environment plugin; see the module docblock. */
 const ApnsEnvironment =
   registerPlugin<ApnsEnvironmentPlugin>("ApnsEnvironment");
 

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -27,10 +27,8 @@ mock.module("@/runtime/native-auth", () => ({
 // Mocked as pure flags; the helpers' own behavior is covered by
 // push-registration.test.ts.
 
-let remotePushSupported = true;
 let sessionConfirmedAssistantId: string | null = null;
 mock.module("@/runtime/push-registration", () => ({
-  isRemotePushSupported: () => remotePushSupported,
   hasSessionConfirmedRemotePushRegistration: (assistantId: string) =>
     sessionConfirmedAssistantId === assistantId,
 }));
@@ -84,7 +82,6 @@ const baseArgs = {
 };
 
 beforeEach(() => {
-  remotePushSupported = true;
   sessionConfirmedAssistantId = null;
   scheduleMock.mockClear();
   ackMock.mockClear();
@@ -160,39 +157,8 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
     expect(scheduleMock).toHaveBeenCalledTimes(1);
   });
 
-  test("dispatched with only a persisted registration from an earlier session: schedules", async () => {
-    // The mocked helper mirrors the real one in ignoring persisted storage:
-    // only a session-confirmed upsert counts. Seeding storage documents the
-    // reload scenario where a stored record survives but proves nothing
-    // about a live server-side token row, so the dedup skip must not fire.
-    localStorage.setItem(
-      "vellum:push_registration",
-      JSON.stringify({
-        token: "persisted-token",
-        bundleId: "ai.vocify-inc.vellum-assistant-ios",
-        assistantId: "assistant-1",
-      }),
-    );
-    setVisibility("hidden");
-
-    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
-
-    expect(scheduleMock).toHaveBeenCalledTimes(1);
-    localStorage.removeItem("vellum:push_registration");
-  });
-
   test("dispatched but registration belongs to a different assistant: schedules", async () => {
     sessionConfirmedAssistantId = "assistant-2";
-    setVisibility("hidden");
-
-    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
-
-    expect(scheduleMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("dispatched but remote push unsupported on this native platform: schedules", async () => {
-    remotePushSupported = false;
-    sessionConfirmedAssistantId = "assistant-1";
     setVisibility("hidden");
 
     await postLocalNotification({ ...baseArgs, remotePushDispatched: true });

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -1,0 +1,230 @@
+/**
+ * `postLocalNotification` native-branch behavior, focused on the
+ * remote-push dedup skip: the local banner is scheduled whenever
+ * `remotePushDispatched` is absent or false; it is skipped only when the
+ * daemon confirmed an accepted remote push, this device holds a
+ * session-confirmed APNs registration, and the app was hidden when the
+ * intent arrived (the APNs banner covers that case).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── host platform guards ─────────────────────────────────────────────────────
+//
+// Force the native (Capacitor) branch: `isNativePlatform` reports false
+// under happy-dom, and the Electron branch would return before reaching
+// the code under test.
+
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => false,
+}));
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => true,
+}));
+
+// ── push-registration read-only helpers ──────────────────────────────────────
+//
+// Mocked as pure flags; the helpers' own behavior is covered by
+// push-registration.test.ts.
+
+let remotePushSupported = true;
+let sessionConfirmedAssistantId: string | null = null;
+mock.module("@/runtime/push-registration", () => ({
+  isRemotePushSupported: () => remotePushSupported,
+  hasSessionConfirmedRemotePushRegistration: (assistantId: string) =>
+    sessionConfirmedAssistantId === assistantId,
+}));
+
+// ── @capacitor/local-notifications ───────────────────────────────────────────
+
+interface ScheduleArg {
+  notifications: Array<{ id: number; title: string; body: string }>;
+}
+const scheduleMock = mock(async (_arg: ScheduleArg) => {});
+mock.module("@capacitor/local-notifications", () => ({
+  LocalNotifications: {
+    checkPermissions: async () => ({ display: "granted" }),
+    requestPermissions: async () => ({ display: "granted" }),
+    schedule: scheduleMock,
+    addListener: async () => ({ remove: async () => {} }),
+  },
+}));
+
+// ── daemon ack SDK ───────────────────────────────────────────────────────────
+
+interface AckArg {
+  path: { assistant_id: string };
+  body: { deliveryId: string; success: boolean; errorMessage?: string };
+  throwOnError: boolean;
+}
+const ackArgs: AckArg[] = [];
+const ackMock = mock(async (arg: AckArg) => {
+  ackArgs.push(arg);
+  return { data: undefined, error: undefined };
+});
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  notificationintentresultPost: ackMock,
+}));
+
+const { postLocalNotification } = await import("@/runtime/notifications");
+
+const setVisibility = (state: "visible" | "hidden") => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+};
+
+const baseArgs = {
+  title: "Reminder",
+  body: "Stand up",
+  sourceEventName: "reminder.fired",
+  deliveryId: "delivery-1",
+  assistantId: "assistant-1",
+};
+
+beforeEach(() => {
+  remotePushSupported = true;
+  sessionConfirmedAssistantId = null;
+  scheduleMock.mockClear();
+  ackMock.mockClear();
+  ackArgs.length = 0;
+  setVisibility("visible");
+});
+
+describe("postLocalNotification remote-push dedup (native branch)", () => {
+  test("hidden + dispatched + registered: skips the local banner and acks success", async () => {
+    sessionConfirmedAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).not.toHaveBeenCalled();
+    expect(ackArgs).toEqual([
+      {
+        path: { assistant_id: "assistant-1" },
+        body: { deliveryId: "delivery-1", success: true },
+        throwOnError: false,
+      },
+    ]);
+  });
+
+  test("visible app schedules the local banner (the only foreground surface)", async () => {
+    sessionConfirmedAssistantId = "assistant-1";
+    setVisibility("visible");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    expect(ackArgs).toEqual([
+      {
+        path: { assistant_id: "assistant-1" },
+        body: { deliveryId: "delivery-1", success: true },
+        throwOnError: false,
+      },
+    ]);
+  });
+
+  test("visible at intent arrival, hidden after the permission await: schedules", async () => {
+    sessionConfirmedAssistantId = "assistant-1";
+    setVisibility("visible");
+
+    // The call's synchronous prefix snapshots visibility, then suspends on
+    // the permission await; flipping to hidden while it is pending mimics
+    // the user backgrounding the app mid-await. The entry-time snapshot
+    // must win, so the local banner is still scheduled.
+    const pending = postLocalNotification({
+      ...baseArgs,
+      remotePushDispatched: true,
+    });
+    setVisibility("hidden");
+    await pending;
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("field absent (older daemon): schedules even when hidden", async () => {
+    sessionConfirmedAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispatched but no active registration (e.g. permission denied): schedules", async () => {
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispatched with only a persisted registration from an earlier session: schedules", async () => {
+    // The mocked helper mirrors the real one in ignoring persisted storage:
+    // only a session-confirmed upsert counts. Seeding storage documents the
+    // reload scenario where a stored record survives but proves nothing
+    // about a live server-side token row, so the dedup skip must not fire.
+    localStorage.setItem(
+      "vellum:push_registration",
+      JSON.stringify({
+        token: "persisted-token",
+        bundleId: "ai.vocify-inc.vellum-assistant-ios",
+        assistantId: "assistant-1",
+      }),
+    );
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    localStorage.removeItem("vellum:push_registration");
+  });
+
+  test("dispatched but registration belongs to a different assistant: schedules", async () => {
+    sessionConfirmedAssistantId = "assistant-2";
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispatched but remote push unsupported on this native platform: schedules", async () => {
+    remotePushSupported = false;
+    sessionConfirmedAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({ ...baseArgs, remotePushDispatched: true });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("no assistantId: schedules even when hidden and dispatched, no ack", async () => {
+    sessionConfirmedAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({
+      ...baseArgs,
+      assistantId: undefined,
+      remotePushDispatched: true,
+    });
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    expect(ackMock).not.toHaveBeenCalled();
+  });
+
+  test("skip without a deliveryId still skips but sends no ack", async () => {
+    sessionConfirmedAssistantId = "assistant-1";
+    setVisibility("hidden");
+
+    await postLocalNotification({
+      ...baseArgs,
+      deliveryId: undefined,
+      remotePushDispatched: true,
+    });
+
+    expect(scheduleMock).not.toHaveBeenCalled();
+    expect(ackMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -406,16 +406,14 @@ export async function postLocalNotification(
     // at mount), and the app was hidden when the intent arrived; the
     // remote push banners on its own there, and scheduling the local one
     // too would double-notify during the SSE grace window after
-    // backgrounding. No separate support check: a session-confirmed
-    // registration is only reachable through `registerForRemotePush`,
-    // which requires remote-push support.
+    // backgrounding. A session-confirmed registration implies remote-push
+    // support: it is recorded only by `registerForRemotePush`, which is
+    // gated on that support.
     //
     // Residual limitation: `remotePushDispatched` is an aggregate
     // account-level outcome (any device token accepted), so on a
     // multi-device account a token pruned mid-session can still suppress
-    // this banner while only another device received the push. Closing
-    // that gap requires per-token dispatch results from the platform's
-    // dispatch endpoint.
+    // this banner while only another device received the push.
     if (
       args.remotePushDispatched === true &&
       args.assistantId !== undefined &&

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -32,6 +32,10 @@ import { notificationintentresultPost } from "@/generated/daemon/sdk.gen";
 import type { NotificationintentresultPostData } from "@/generated/daemon/types.gen";
 import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
+import {
+  hasSessionConfirmedRemotePushRegistration,
+  isRemotePushSupported,
+} from "@/runtime/push-registration";
 
 /**
  * Payload stored alongside each native notification so the tap handler can
@@ -272,6 +276,13 @@ export interface PostLocalNotificationArgs {
    * directly with `success=true`.
    */
   assistantId?: string;
+  /**
+   * True when the daemon confirmed the platform (APNs) channel accepted a
+   * remote push for this delivery. A native app that is hidden at intent
+   * arrival with a session-confirmed push registration skips the local
+   * banner so the remote push is the only one.
+   */
+  remotePushDispatched?: boolean;
 }
 
 /**
@@ -361,6 +372,10 @@ export async function postLocalNotification(
     return;
   }
 
+  // Snapshot before the awaits below: the remote-push dedup skip must see
+  // visibility at intent arrival, not after an async native-bridge gap.
+  const visibilityAtIntent = document.visibilityState;
+
   const permission = await ensureNotificationPermission();
   if (permission !== "granted") {
     if (args.assistantId && args.deliveryId) {
@@ -385,6 +400,40 @@ export async function postLocalNotification(
   let errorMessage: string | undefined;
 
   if (isNativePlatform()) {
+    // iOS suppresses remote pushes while the app is foregrounded (no
+    // presentationOptions configured), so the local banner is the only
+    // foreground surface. The banner is skipped only when the daemon
+    // confirmed an accepted remote push, this device holds a
+    // session-confirmed APNs registration (an upsert succeeded in this JS
+    // session, proving the platform held a live token row for this device
+    // at mount), and the app was hidden when the intent arrived; the
+    // remote push banners on its own there, and scheduling the local one
+    // too would double-notify during the SSE grace window after
+    // backgrounding.
+    //
+    // Residual limitation: `remotePushDispatched` is an aggregate
+    // account-level outcome (any device token accepted), so on a
+    // multi-device account a token pruned mid-session can still suppress
+    // this banner while only another device received the push. Closing
+    // that gap requires per-token dispatch results from the platform's
+    // dispatch endpoint.
+    if (
+      args.remotePushDispatched === true &&
+      isRemotePushSupported() &&
+      args.assistantId !== undefined &&
+      hasSessionConfirmedRemotePushRegistration(args.assistantId) &&
+      visibilityAtIntent === "hidden"
+    ) {
+      if (args.deliveryId) {
+        await sendNotificationIntentAck(
+          args.assistantId,
+          args.deliveryId,
+          true,
+        );
+      }
+      return;
+    }
+
     const seed =
       args.deliveryId ?? `${args.sourceEventName}:${args.title}:${args.body}`;
     const notification: LocalNotificationSchema = {

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -32,10 +32,7 @@ import { notificationintentresultPost } from "@/generated/daemon/sdk.gen";
 import type { NotificationintentresultPostData } from "@/generated/daemon/types.gen";
 import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
-import {
-  hasSessionConfirmedRemotePushRegistration,
-  isRemotePushSupported,
-} from "@/runtime/push-registration";
+import { hasSessionConfirmedRemotePushRegistration } from "@/runtime/push-registration";
 
 /**
  * Payload stored alongside each native notification so the tap handler can
@@ -409,7 +406,9 @@ export async function postLocalNotification(
     // at mount), and the app was hidden when the intent arrived; the
     // remote push banners on its own there, and scheduling the local one
     // too would double-notify during the SSE grace window after
-    // backgrounding.
+    // backgrounding. No separate support check: a session-confirmed
+    // registration is only reachable through `registerForRemotePush`,
+    // which requires remote-push support.
     //
     // Residual limitation: `remotePushDispatched` is an aggregate
     // account-level outcome (any device token accepted), so on a
@@ -419,7 +418,6 @@ export async function postLocalNotification(
     // dispatch endpoint.
     if (
       args.remotePushDispatched === true &&
-      isRemotePushSupported() &&
       args.assistantId !== undefined &&
       hasSessionConfirmedRemotePushRegistration(args.assistantId) &&
       visibilityAtIntent === "hidden"

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -149,6 +149,7 @@ mock.module("@/lib/sentry/capture-error", () => ({
 
 const {
   extractPushConversationId,
+  hasSessionConfirmedRemotePushRegistration,
   isRemotePushSupported,
   registerForRemotePush,
   unregisterFromRemotePush,
@@ -426,6 +427,62 @@ describe("extractPushConversationId", () => {
     expect(extractPushConversationId({ deep_link: null })).toBeUndefined();
     expect(extractPushConversationId({ deep_link: {} })).toBeUndefined();
     expect(extractPushConversationId({ conversationId: 42 })).toBeUndefined();
+  });
+});
+
+describe("hasSessionConfirmedRemotePushRegistration", () => {
+  test("false when nothing has been registered", () => {
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-1")).toBe(
+      false,
+    );
+  });
+
+  test("true after a successful upsert for the same assistant", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-1")).toBe(true);
+  });
+
+  test("false for a different assistant than the registered one", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-2")).toBe(
+      false,
+    );
+  });
+
+  test("ignores a persisted-only registration (reload before any re-upsert)", () => {
+    // A record surviving from an earlier session proves nothing about
+    // whether the platform still holds the token row (the server prunes
+    // rows on APNs BadDeviceToken), so it must not count as confirmed.
+    localStorage.setItem(
+      "vellum:push_registration",
+      JSON.stringify({
+        token: "persisted-token",
+        bundleId: "ai.vocify-inc.vellum-assistant-ios",
+        assistantId: "assistant-9",
+      }),
+    );
+
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-9")).toBe(
+      false,
+    );
+  });
+
+  test("false again after unregister clears the registration", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    await unregisterFromRemotePush();
+
+    expect(hasSessionConfirmedRemotePushRegistration("assistant-1")).toBe(
+      false,
+    );
   });
 });
 

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -11,24 +11,6 @@ import { subscribe } from "@/lib/event-bus";
 let isNative = true;
 let platform = "ios";
 
-// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
-//
-// The default simulates an old shell without the plugin (bridge call rejects),
-// so the pre-plugin tests below keep exercising the bundle-suffix heuristic
-// they were written against. Cases that exercise the signing-derived path set
-// `apnsEnvironmentRejects = false` and an explicit `apnsEnvironmentResult`.
-
-let apnsEnvironmentResult: string | undefined;
-let apnsEnvironmentRejects = true;
-const apnsEnvironmentGetMock = mock(
-  async (): Promise<{ environment?: string }> => {
-    if (apnsEnvironmentRejects) {
-      throw new Error("ApnsEnvironment.get() is not implemented on ios");
-    }
-    return { environment: apnsEnvironmentResult };
-  },
-);
-
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNative,
 }));
@@ -37,8 +19,20 @@ mock.module("@capacitor/core", () => ({
     isNativePlatform: () => isNative,
     getPlatform: () => platform,
   },
-  registerPlugin: (name: string) =>
-    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
+}));
+
+// ── APNs environment resolver ────────────────────────────────────────────────
+//
+// Mocked directly; the resolver's own fallback matrix is covered by
+// apns-environment.test.ts. These tests only pin the wiring: the upsert body
+// carries whatever the resolver returns.
+
+let resolvedApnsEnvironment: "development" | "production" = "production";
+const resolveSignedApnsEnvironmentMock = mock(
+  async () => resolvedApnsEnvironment,
+);
+mock.module("@/runtime/apns-environment", () => ({
+  resolveSignedApnsEnvironment: resolveSignedApnsEnvironmentMock,
 }));
 
 // ── @capacitor/push-notifications (lazy-imported plugin Proxy) ────────────────
@@ -83,7 +77,7 @@ mock.module("@capacitor/push-notifications", () => ({
 
 // ── @capacitor/app (lazy-imported plugin Proxy) ──────────────────────────────
 
-let bundleId = "ai.vocify-inc.vellum-assistant-ios";
+const bundleId = "ai.vocify-inc.vellum-assistant-ios";
 const getInfoMock = mock(async () => ({
   id: bundleId,
   name: "Vellum",
@@ -185,10 +179,8 @@ beforeEach(() => {
   isNative = true;
   platform = "ios";
   permissionState = "granted";
-  bundleId = "ai.vocify-inc.vellum-assistant-ios";
-  apnsEnvironmentResult = undefined;
-  apnsEnvironmentRejects = true;
-  apnsEnvironmentGetMock.mockClear();
+  resolvedApnsEnvironment = "production";
+  resolveSignedApnsEnvironmentMock.mockClear();
   registrationHandler = null;
   registrationErrorHandler = null;
   actionPerformedHandler = null;
@@ -257,15 +249,6 @@ describe("registerForRemotePush", () => {
     });
   });
 
-  test("derives the development APNs environment from a .dev bundle id", async () => {
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-    await registerForRemotePush("assistant-1");
-    registrationHandler?.({ value: "apns-token-dev" });
-    await flushMicrotasks();
-
-    expect(lastUpsertArg?.body.apns_environment).toBe("development");
-  });
-
   test("does not register when notification permission is denied", async () => {
     permissionState = "denied";
     await registerForRemotePush("assistant-1");
@@ -294,53 +277,16 @@ describe("registerForRemotePush", () => {
   });
 });
 
-describe("signing-derived APNs environment", () => {
-  const registerToken = async (token: string) => {
+describe("APNs environment wiring", () => {
+  test("upsert body carries the resolver's result for the build's bundle id", async () => {
+    resolvedApnsEnvironment = "development";
+
     await registerForRemotePush("assistant-1");
-    registrationHandler?.({ value: token });
+    registrationHandler?.({ value: "apns-token-dev" });
     await flushMicrotasks();
-  };
 
-  test("prefers the signed entitlement: production on a .dev bundle (TestFlight dev build)", async () => {
-    apnsEnvironmentRejects = false;
-    apnsEnvironmentResult = "production";
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
-    await registerToken("apns-token-testflight");
-
-    expect(lastUpsertArg?.body.apns_environment).toBe("production");
-  });
-
-  test("registers development when the build is development-signed (Xcode install)", async () => {
-    apnsEnvironmentRejects = false;
-    apnsEnvironmentResult = "development";
-
-    await registerToken("apns-token-xcode");
-
-    // The plugin result wins even though the non-.dev bundle id would map to
-    // production under the heuristic.
+    expect(resolveSignedApnsEnvironmentMock).toHaveBeenCalledWith(bundleId);
     expect(lastUpsertArg?.body.apns_environment).toBe("development");
-  });
-
-  test("falls back to the bundle-suffix heuristic when the entitlement is unreadable", async () => {
-    apnsEnvironmentRejects = false;
-    apnsEnvironmentResult = "unknown";
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
-    await registerToken("apns-token-unknown");
-
-    expect(lastUpsertArg?.body.apns_environment).toBe("development");
-  });
-
-  test("old shell without the plugin: heuristic fallback, no Sentry capture", async () => {
-    apnsEnvironmentRejects = true;
-    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
-
-    await registerToken("apns-token-old-shell");
-
-    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(1);
-    expect(lastUpsertArg?.body.apns_environment).toBe("development");
-    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -10,6 +10,25 @@ import { subscribe } from "@/lib/event-bus";
 
 let isNative = true;
 let platform = "ios";
+
+// ── ApnsEnvironment (module-scope registerPlugin bridge) ─────────────────────
+//
+// The default simulates an old shell without the plugin (bridge call rejects),
+// so the pre-plugin tests below keep exercising the bundle-suffix heuristic
+// they were written against. Cases that exercise the signing-derived path set
+// `apnsEnvironmentRejects = false` and an explicit `apnsEnvironmentResult`.
+
+let apnsEnvironmentResult: string | undefined;
+let apnsEnvironmentRejects = true;
+const apnsEnvironmentGetMock = mock(
+  async (): Promise<{ environment?: string }> => {
+    if (apnsEnvironmentRejects) {
+      throw new Error("ApnsEnvironment.get() is not implemented on ios");
+    }
+    return { environment: apnsEnvironmentResult };
+  },
+);
+
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNative,
 }));
@@ -18,6 +37,8 @@ mock.module("@capacitor/core", () => ({
     isNativePlatform: () => isNative,
     getPlatform: () => platform,
   },
+  registerPlugin: (name: string) =>
+    name === "ApnsEnvironment" ? { get: apnsEnvironmentGetMock } : {},
 }));
 
 // ── @capacitor/push-notifications (lazy-imported plugin Proxy) ────────────────
@@ -164,6 +185,9 @@ beforeEach(() => {
   platform = "ios";
   permissionState = "granted";
   bundleId = "ai.vocify-inc.vellum-assistant-ios";
+  apnsEnvironmentResult = undefined;
+  apnsEnvironmentRejects = true;
+  apnsEnvironmentGetMock.mockClear();
   registrationHandler = null;
   registrationErrorHandler = null;
   actionPerformedHandler = null;
@@ -266,6 +290,56 @@ describe("registerForRemotePush", () => {
 
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
     expect(upsertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("signing-derived APNs environment", () => {
+  const registerToken = async (token: string) => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: token });
+    await flushMicrotasks();
+  };
+
+  test("prefers the signed entitlement: production on a .dev bundle (TestFlight dev build)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "production";
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerToken("apns-token-testflight");
+
+    expect(lastUpsertArg?.body.apns_environment).toBe("production");
+  });
+
+  test("registers development when the build is development-signed (Xcode install)", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "development";
+
+    await registerToken("apns-token-xcode");
+
+    // The plugin result wins even though the non-.dev bundle id would map to
+    // production under the heuristic.
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+  });
+
+  test("falls back to the bundle-suffix heuristic when the entitlement is unreadable", async () => {
+    apnsEnvironmentRejects = false;
+    apnsEnvironmentResult = "unknown";
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerToken("apns-token-unknown");
+
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+  });
+
+  test("old shell without the plugin: heuristic fallback, no Sentry capture", async () => {
+    apnsEnvironmentRejects = true;
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+    await registerToken("apns-token-old-shell");
+
+    expect(apnsEnvironmentGetMock).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -31,11 +31,8 @@
  * (no native Capacitor Android shell ships today); registration/delete failures
  * are reported to Sentry but never thrown into the app lifecycle.
  *
- * The upserted row tags the token with the build's APNs entitlement
- * environment, resolved by `runtime/apns-environment.ts` (the native
- * `ApnsEnvironment` plugin with a bundle-suffix heuristic fallback). The
- * resolver is shared with the ActivityKit Live Activity token upsert so the
- * two registrations can never tag the same build differently.
+ * The upserted row's `apns_environment` tag is resolved by
+ * `runtime/apns-environment.ts`; see its docblock for the rationale.
  *
  * Per `docs/CAPACITOR.md`, the `@capacitor/*` plugins are destructured inline
  * at each call site — never returned through an `async` boundary — because the

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -31,6 +31,12 @@
  * (no native Capacitor Android shell ships today); registration/delete failures
  * are reported to Sentry but never thrown into the app lifecycle.
  *
+ * The upserted row tags the token with the build's APNs entitlement
+ * environment, resolved by `runtime/apns-environment.ts` (the native
+ * `ApnsEnvironment` plugin with a bundle-suffix heuristic fallback). The
+ * resolver is shared with the ActivityKit Live Activity token upsert so the
+ * two registrations can never tag the same build differently.
+ *
  * Per `docs/CAPACITOR.md`, the `@capacitor/*` plugins are destructured inline
  * at each call site — never returned through an `async` boundary — because the
  * plugin Proxy's `.then` trap would hang the awaiting caller forever.
@@ -42,22 +48,11 @@ import {
   assistantsPushTokensDelete,
   assistantsPushTokensUpsert,
 } from "@/generated/api/sdk.gen";
-import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
 import { publish } from "@/lib/event-bus";
 import { captureError } from "@/lib/sentry/capture-error";
+import { resolveSignedApnsEnvironment } from "@/runtime/apns-environment";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { createStorageAccessor } from "@/utils/typed-storage";
-
-/**
- * Bundle-id suffix that maps to the development APNs entitlement. The dev Xcode
- * config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs with
- * `App-Dev.entitlements` (`aps-environment = development`) and ships the `.dev`
- * bundle id; production and staging both sign with `App.entitlements`
- * (`aps-environment = production`). APNs rejects a token minted under one
- * environment if dispatched against the other, so the platform stores the
- * environment alongside the token and the value must match the running build.
- */
-const DEV_BUNDLE_SUFFIX = ".dev";
 
 /** Token registration we last upserted, retained so logout can delete it. */
 interface RegisteredToken {
@@ -141,11 +136,6 @@ export function isRemotePushSupported(): boolean {
   return isNativePlatform() && Capacitor.getPlatform() === "ios";
 }
 
-/** Map the running build's bundle id to its APNs entitlement environment. */
-function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
-  return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
-}
-
 /**
  * Upsert a freshly-minted APNs token to the platform for the given assistant.
  * Best-effort: a non-2xx response or thrown error is reported and swallowed.
@@ -155,6 +145,7 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
     // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
     const { App } = await import("@capacitor/app");
     const { id: bundleId } = await App.getInfo();
+    const apnsEnvironment = await resolveSignedApnsEnvironment(bundleId);
 
     const result = await assistantsPushTokensUpsert({
       path: { assistant_id: assistantId },
@@ -162,7 +153,7 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
         token,
         platform: "ios",
         bundle_id: bundleId,
-        apns_environment: resolveApnsEnvironment(bundleId),
+        apns_environment: apnsEnvironment,
       },
       throwOnError: false,
     });

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -311,9 +311,7 @@ export async function unregisterFromRemotePush(): Promise<void> {
     await Promise.allSettled([...pendingUpserts]);
   }
 
-  // Fall back to persisted storage: a process reload before re-registration
-  // leaves `lastRegistered` null even though a token is still registered.
-  const registered = lastRegistered ?? persistedRegistration.load();
+  const registered = loadCurrentRegistration();
   lastRegistered = null;
   persistedRegistration.remove();
 
@@ -348,6 +346,39 @@ export async function unregisterFromRemotePush(): Promise<void> {
       bestEffort: true,
     });
   }
+}
+
+/**
+ * The registration this device currently holds: module memory, falling
+ * back to persisted storage (a process reload wipes `lastRegistered`
+ * while the token stays registered server-side).
+ */
+function loadCurrentRegistration(): RegisteredToken | null {
+  return lastRegistered ?? persistedRegistration.load();
+}
+
+/**
+ * True when this device holds a push registration for `assistantId` that was
+ * confirmed in the current JS session (module-memory `lastRegistered`, set
+ * only when an upsert succeeded after this process started).
+ *
+ * Deliberately ignores the persisted-storage registration: a record from an
+ * earlier session only proves an upsert once succeeded, not that the platform
+ * still holds a token row for this device (APNs BadDeviceToken responses
+ * prune rows server-side). A session-confirmed upsert proves the platform
+ * held a live token row for this device at mount time, which is the evidence
+ * the remote-push banner dedup in `runtime/notifications.ts` needs before
+ * suppressing a local banner. The logout path is different: deleting a
+ * possibly-stale token is harmless, so `unregisterFromRemotePush` falls back
+ * to the persisted registration.
+ *
+ * Pure state read, never touches Capacitor plugins, so it is safe to call
+ * synchronously on any platform.
+ */
+export function hasSessionConfirmedRemotePushRegistration(
+  assistantId: string,
+): boolean {
+  return lastRegistered?.assistantId === assistantId;
 }
 
 /** Test-only: reset module + persisted state between cases. */

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -311,7 +311,9 @@ export async function unregisterFromRemotePush(): Promise<void> {
     await Promise.allSettled([...pendingUpserts]);
   }
 
-  const registered = loadCurrentRegistration();
+  // Module memory, falling back to persisted storage: a process reload wipes
+  // `lastRegistered` while the token stays registered server-side.
+  const registered = lastRegistered ?? persistedRegistration.load();
   lastRegistered = null;
   persistedRegistration.remove();
 
@@ -346,15 +348,6 @@ export async function unregisterFromRemotePush(): Promise<void> {
       bestEffort: true,
     });
   }
-}
-
-/**
- * The registration this device currently holds: module memory, falling
- * back to persisted storage (a process reload wipes `lastRegistered`
- * while the token stays registered server-side).
- */
-function loadCurrentRegistration(): RegisteredToken | null {
-  return lastRegistered ?? persistedRegistration.load();
 }
 
 /**


### PR DESCRIPTION
## Summary
Makes iOS push work correctly on TestFlight Vellum Dev/Staging builds and makes high-priority notifications reliably take the APNs path. Root cause: TestFlight always signs with the production APNs environment, but token tagging used a bundle-suffix heuristic and lower-env platforms force the sandbox gateway, so dev-build tokens were presented to the wrong Apple gateway and rejected. The client now derives the environment from the build's real signing (native ApnsEnvironment plugin with heuristic fallback for old shells), high/critical signals force the platform channel with an outcome-based flag, and iOS dedups the local banner against confirmed remote pushes. Companion platform-repo plan (sandbox un-forcing + bundle-id allowlist) ships separately.

## Self-review result
GAPS FOUND and fixed across 4 remediation rounds (7 fix PRs); final round verified clean with a Codex clean verdict on every terminal commit.

## PRs merged into feature branch
- #39737: notifications: force the platform (APNs) channel for high/critical urgency signals
- #39736: notifications: tell vellum-channel clients whether a remote push was also dispatched
- #39738: ios: native plugin exposing the build's real APNs entitlement environment
- #39746: web: derive apns_environment from the build's signing, falling back to the bundle-suffix heuristic
- #39747: web: skip the Capacitor local banner when a remote push covers a backgrounded iOS app

### Fix PRs
- #39755: fix: simulator APNs environment and stale plugin doc pointers
- #39756: fix: web push test consolidation and dedup-skip simplification
- #39758: fix: notification routing and deferral robustness gaps from plan review
- #39763: fix: comment hygiene and speculative test mock from re-review
- #39764: fix: platform probe bounds and guardian-registry addressing from re-review
- #39766: fix: prime the platform probe cache at startup; single-flight the probe
- #39769: fix: rotate stale probe flights; start the cache warmup before request admission

Part of plan: ios-push-lower-envs.md