### PR TITLE
fix(test): deflake db-integrity-sample timeouts

### DIFF
--- a/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
+++ b/assistant/src/monitoring/__tests__/db-integrity-sample.test.ts
@@ -8,7 +8,13 @@ import { closeSync, mkdtempSync, openSync, rmSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 
 import { assertNotLiveDb } from "../../__tests__/assert-not-live-db.js";
 import {
@@ -16,6 +22,10 @@ import {
   type IntegritySampleResult,
   runIntegrityCheck,
 } from "../db-integrity-check.js";
+
+// quick_check and the cold `bun run` subprocess are disk-bound; loaded CI
+// runners blow past the 5s default.
+setDefaultTimeout(30_000);
 
 let dir: string;
 let dbPath: string;
@@ -36,9 +46,13 @@ function seedDb(walMode: boolean): void {
     db.exec(`PRAGMA journal_mode=${walMode ? "WAL" : "DELETE"}`);
     db.exec("CREATE TABLE t (id TEXT PRIMARY KEY, v TEXT)");
     const ins = db.prepare("INSERT INTO t (id, v) VALUES (?, ?)");
-    for (let i = 0; i < 200; i++) {
-      ins.run(`k-${i}`, `v-${i}`);
-    }
+    // One transaction: 200 per-insert commits are fsync-bound and take
+    // seconds on loaded CI runners.
+    db.transaction(() => {
+      for (let i = 0; i < 200; i++) {
+        ins.run(`k-${i}`, `v-${i}`);
+      }
+    })();
   } finally {
     db.close();
   }


### PR DESCRIPTION
## Summary
- Seed the test database in a single transaction: the 200 per-insert commits were each fsync-bound in DELETE journal mode, taking 7+ seconds on loaded CI runners and blowing past bun's 5s default test timeout (locally the whole file now runs in ~65ms, down from ~16s).
- Set `setDefaultTimeout(30_000)` for the file (same convention as `app-compiler.test.ts`) as headroom for the remaining disk-bound `quick_check` and cold `bun run` subprocess work.

## Original prompt
CI run 30661330557 failed on `src/monitoring/__tests__/db-integrity-sample.test.ts` — "reports corruption instead of throwing" (7.7s) and "subprocess entry prints the JSON verdict" (5.0s) both timed out at bun's 5s default, then passed on re-run. Noa asked to fix the flake.