### PR TITLE
fix: one reply-push eligibility predicate shared by batch selection and the producer

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -1799,55 +1799,62 @@ describe("Batched drain correctness fixes", () => {
     await new Promise((r) => setTimeout(r, 10));
   });
 
-  // The batch's shared reply answers the person's prompt; the hidden marker
-  // only rode along behind it. Pointing the producer at the last row would
-  // read the marker's metadata and suppress a push the user is waiting on.
-  test("drainBatch notifies about the genuine prompt, not a trailing hidden marker", async () => {
-    emitAssistantReplyNotificationMock.mockClear();
-    const conversation = makeConversation();
-    await conversation.loadFromDb();
+  // The batch's shared reply answers the person's prompt; the trailing row
+  // only rode along behind it. A channel send gets its reply delivered back to
+  // Slack and a hidden marker is nobody's prompt, so pointing the producer at
+  // either would suppress a push the user is waiting on.
+  const TRAILING_INELIGIBLE_ROW_CASES: Array<{
+    name: string;
+    metadata: Record<string, unknown>;
+  }> = [
+    { name: "hidden marker", metadata: { hidden: true } },
+    { name: "channel send", metadata: { userMessageChannel: "slack" } },
+  ];
 
-    const p1 = conversation.processMessage({
-      content: "msg-1",
-      attachments: [],
-      requestId: "req-1",
+  for (const { name, metadata } of TRAILING_INELIGIBLE_ROW_CASES) {
+    test(`drainBatch notifies about the genuine prompt, not a trailing ${name}`, async () => {
+      emitAssistantReplyNotificationMock.mockClear();
+      const conversation = makeConversation();
+      await conversation.loadFromDb();
+
+      const p1 = conversation.processMessage({
+        content: "msg-1",
+        attachments: [],
+        requestId: "req-1",
+      });
+      await waitForPendingRun(1);
+
+      conversation.enqueueMessage({
+        content: "batch-prompt-genuine",
+        requestId: "req-prompt",
+      });
+      conversation.enqueueMessage({
+        content: "batch-prompt-trailing",
+        requestId: "req-trailing",
+        metadata,
+      });
+
+      await resolveRun(0);
+      await p1;
+      await waitForPendingRun(2);
+      await resolveRun(1);
+      // Two turns finish here: msg-1's own run, then the batch's shared run.
+      await waitForCondition(
+        () => emitAssistantReplyNotificationMock.mock.calls.length >= 2,
+      );
+
+      const genuineRow = capturedAddMessages.find((m) =>
+        m.content.includes("batch-prompt-genuine"),
+      );
+      expect(genuineRow?.id).toBeDefined();
+
+      const notifyCalls = emitAssistantReplyNotificationMock.mock
+        .calls as unknown as Array<[{ userMessageId: string | undefined }]>;
+      expect(notifyCalls.at(-1)?.[0].userMessageId).toBe(genuineRow!.id);
+
+      await new Promise((r) => setTimeout(r, 10));
     });
-    await waitForPendingRun(1);
-
-    conversation.enqueueMessage({
-      content: "batch-prompt-genuine",
-      requestId: "req-prompt",
-    });
-    conversation.enqueueMessage({
-      content: "batch-prompt-hidden-marker",
-      requestId: "req-hidden",
-      metadata: { hidden: true },
-    });
-
-    await resolveRun(0);
-    await p1;
-    await waitForPendingRun(2);
-    await resolveRun(1);
-    // Two turns finish here: msg-1's own run, then the batch's shared run.
-    await waitForCondition(
-      () => emitAssistantReplyNotificationMock.mock.calls.length >= 2,
-    );
-
-    const genuineRow = capturedAddMessages.find((m) =>
-      m.content.includes("batch-prompt-genuine"),
-    );
-    const hiddenRow = capturedAddMessages.find((m) =>
-      m.content.includes("batch-prompt-hidden-marker"),
-    );
-    expect(genuineRow?.id).toBeDefined();
-    expect(hiddenRow?.metadata?.hidden).toBe(true);
-
-    const notifyCalls = emitAssistantReplyNotificationMock.mock
-      .calls as unknown as Array<[{ userMessageId: string | undefined }]>;
-    expect(notifyCalls.at(-1)?.[0].userMessageId).toBe(genuineRow!.id);
-
-    await new Promise((r) => setTimeout(r, 10));
-  });
+  }
 
   // Defensive recovery path: buildPassthroughBatch is designed to make
   // the invariant throw unreachable in practice, so neither the head

--- a/assistant/src/__tests__/conversation-retry-route.test.ts
+++ b/assistant/src/__tests__/conversation-retry-route.test.ts
@@ -17,6 +17,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { z } from "zod";
 
+// The route's hidden-prompt branch is exactly what these pure predicates
+// decide, so the crud mock below hands back the real ones rather than a
+// restatement that can drift. Imported from the `conversation-types` leaf so
+// naming them here pulls in no DB graph.
+import {
+  isBackgroundEventMetadata,
+  isEchoSuppressedUserMessage,
+} from "../persistence/conversation-types.js";
+
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   hasUngatedHttpAuthDisabled: () => false,
@@ -60,12 +69,6 @@ interface MessageRowLike {
 const getConversationMock = mock((id: string) =>
   id === "conv-retry-test" ? { id } : null,
 );
-
-// The metadata predicates are pure functions of the row's metadata record, and
-// the route's hidden-prompt branch is exactly what they decide, so the mock
-// hands back the real ones rather than a restatement that can drift.
-const { isBackgroundEventMetadata, isEchoSuppressedUserMessage } =
-  await import("../persistence/conversation-crud.js");
 
 mock.module("../persistence/conversation-crud.js", () => ({
   addMessage: async () => ({ id: "unused", deduplicated: false }),

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -628,7 +628,7 @@ export function createEventHandlerState(): EventHandlerState {
 async function chatRevealCandidates(
   state: EventHandlerState,
 ): Promise<readonly ResolvedRevealCandidate[] | undefined> {
-  if (!isAssistantFeatureFlagEnabled("chat-credential-reveal", getConfig())) {
+  if (!isAssistantFeatureFlagEnabled("chat-credential-reveal")) {
     return undefined;
   }
   return resolvedRevealCandidatesForState(state);

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -257,8 +257,9 @@ export async function runAgentLoopImpl(
     /**
      * Row the end-of-turn reply notification should treat as the prompt this
      * turn answers. Defaults to `userMessageId`; a coalesced batch overrides it
-     * with its last non-machine-signal member, whose reply the user is actually
-     * waiting on, rather than a hidden marker that merely landed last.
+     * with its last push-eligible member (see
+     * `isReplyPushIneligibleUserMessage`), whose reply the user is actually
+     * waiting on, rather than a suppressed row that merely landed last.
      */
     notifyUserMessageId?: string;
     /**

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -31,6 +31,7 @@ import {
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
 } from "../persistence/conversation-crud.js";
+import { isReplyPushIneligibleUserMessage } from "../persistence/conversation-types.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import {
@@ -1351,11 +1352,11 @@ async function drainBatch(
   let lastSuccessfulCurrentPage: string | undefined;
   let lastSuccessfulContent: string | undefined;
   let lastUserMessageId: string | undefined;
-  // `messages.id` of the last member that is a person's prompt rather than a
-  // machine signal. The reply-notification producer reads this row to decide
-  // whether the finished reply answers something a user is waiting on, so a
-  // trailing hidden marker must not stand in for the prompt ahead of it.
-  let lastVisibleUserMessageId: string | undefined;
+  // `messages.id` of the last member the reply-push producer would actually
+  // notify about. Selected with the producer's own eligibility predicate so a
+  // trailing row it suppresses (a hidden marker, a channel send) cannot stand
+  // in for the prompt ahead of it and swallow that prompt's push.
+  let lastPushEligibleUserMessageId: string | undefined;
   // Members whose persist succeeded. `fanOutOnEvent` below must only
   // broadcast agent-loop events to these — clients whose persist failed
   // already received an error event and must not also receive the
@@ -1521,10 +1522,13 @@ async function drainBatch(
       continue;
     }
 
+    if (!isReplyPushIneligibleUserMessage(qm.metadata)) {
+      lastPushEligibleUserMessageId = lastUserMessageId;
+    }
+
     // Broadcast the user message to all hub subscribers so passive devices
     // see each batched user turn before the assistant reply starts streaming.
     if (!isEchoSuppressedUserMessage(qm.metadata)) {
-      lastVisibleUserMessageId = lastUserMessageId;
       qm.onEvent({
         type: "user_message_echo",
         text: qmContent,
@@ -1661,10 +1665,10 @@ async function drainBatch(
     notifyUserMessageId?: string;
   } = {
     isUserMessage: true,
-    // A batch of only machine signals falls back to the last row, which the
-    // producer's own suppression gates then read and stay silent on.
-    notifyUserMessageId: lastVisibleUserMessageId ?? lastUserMessageId,
   };
+  if (lastPushEligibleUserMessageId !== undefined) {
+    drainLoopOptions.notifyUserMessageId = lastPushEligibleUserMessageId;
+  }
   // Source interactive flag from the last successfully-persisted sibling so
   // a trailing failed tail doesn't flip the agent loop's interactivity.
   const lastSuccessfulBatchEntry =

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -332,9 +332,9 @@ describe("emitAssistantReplyNotification", () => {
     expect(emitCalls).toHaveLength(0);
   });
 
-  // Hidden lifecycle rows persist with role "user" and are neither tool
-  // results nor `automated`, so only the shared echo-suppression classifier
-  // keeps a subagent or ACP completion turn from pushing a reply.
+  // Machine-signal rows persist with role "user" and are neither tool results
+  // nor `automated`, so only the shared echo-suppression classifier keeps a
+  // turn opened by one of them from pushing a reply.
   const LIFECYCLE_ROW_CASES: Array<{ name: string; metadata: unknown }> = [
     {
       name: "subagent notification",

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -10,7 +10,6 @@
 
 import type pino from "pino";
 
-import { parseChannelId } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   getAttentionStateByConversationIds,
@@ -20,11 +19,12 @@ import {
   type ConversationRow,
   getConversation,
   getMessageById,
-  isEchoSuppressedUserMessage,
-  isVoiceSessionUserMessage,
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
-import { resolveConversationKind } from "../persistence/conversation-types.js";
+import {
+  isReplyPushIneligibleUserMessage,
+  resolveConversationKind,
+} from "../persistence/conversation-types.js";
 import { stringifyMessageContent } from "../persistence/message-content.js";
 import { safeParseRecord } from "../util/json.js";
 import { emitNotificationSignal } from "./emit-signal.js";
@@ -34,30 +34,13 @@ import { sanitizeMessagePreview } from "./notification-utils.js";
 const ASSISTANT_REPLY_PUSH_FLAG = "assistant-reply-push" as const;
 
 /**
- * True when the row that opened the turn arrived over an external messaging
- * surface (Slack, Telegram, WhatsApp, email, a phone call, …) rather than the
- * native app.
- *
- * An absent (or unrecognized) channel counts as in-app: every external ingress
- * path stamps its channel via buildChannelMetadata, so the rows that omit the
- * field are daemon-internal persists on native-app conversations (for example
- * the deliberate omission in calls/call-pointer-messages.ts).
- */
-function isChannelOriginatedUserMessage(
-  metadata: Record<string, unknown> | undefined,
-): boolean {
-  const channel = parseChannelId(metadata?.userMessageChannel);
-  return channel != null && channel !== "vellum";
-}
-
-/**
- * Read the markers the gates below consult off a persisted message's metadata
- * column.
+ * Read the markers the eligibility gate below consults off a persisted
+ * message's metadata column.
  *
  * `parseMessageMetadata` validates the whole column and yields nothing when
  * any single field fails, so one unrecognized value would otherwise present
- * here as "no metadata" and open every gate at once. The gates are plain-record
- * predicates, so a permissive read of the same JSON keeps them answering over
+ * here as "no metadata" and open every gate at once. The gate is a plain-record
+ * predicate, so a permissive read of the same JSON keeps it answering over
  * whichever fields are intact.
  */
 function readSuppressionMarkers(
@@ -124,26 +107,7 @@ export async function emitAssistantReplyNotification(params: {
     const initiatingMetadata = readSuppressionMarkers(
       initiatingMessage.metadata,
     );
-    // Scheduled/background prompts injected into an ordinary user conversation
-    // are automated turns with their own producers (e.g. `schedule.notify`);
-    // notifying here too would double-notify.
-    if (initiatingMetadata?.automated === true) {
-      return;
-    }
-    // A turn opened by internal scaffolding is nobody's prompt awaiting a
-    // reply; see `isEchoSuppressedUserMessage`.
-    if (isEchoSuppressedUserMessage(initiatingMetadata)) {
-      return;
-    }
-    // A spoken reply is delivered over the still-open session; see
-    // `isVoiceSessionUserMessage`.
-    if (isVoiceSessionUserMessage(initiatingMetadata)) {
-      return;
-    }
-    // A turn started from a messaging channel has its finished reply delivered
-    // back to that channel (`finalizeEventDelivery`), so the sender already has
-    // it; pushing here would duplicate it on their phone.
-    if (isChannelOriginatedUserMessage(initiatingMetadata)) {
+    if (isReplyPushIneligibleUserMessage(initiatingMetadata)) {
       return;
     }
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -74,6 +74,7 @@ import { deleteConversationRowsInBatches } from "./conversation-row-batch-delete
 import {
   BACKGROUND_CONVERSATION_TYPES,
   type ConversationCreateType,
+  isHiddenMessageMetadata,
 } from "./conversation-types.js";
 import { runAsyncSqlite } from "./db-async-query.js";
 import {
@@ -354,78 +355,17 @@ export const messageMetadataSchema = z
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 
 /**
- * Shared predicate for the transcript-suppression flag on user-message
- * metadata (see the `hidden` field on {@link messageMetadataSchema}). One
- * definition so the sites that must agree — echo suppression, list-messages
- * filtering, queued-snapshot filtering, indexing exclusion, and downstream
- * consumers of message text — cannot drift.
+ * Pure predicates over the `metadata` record above. They live in the
+ * `conversation-types` leaf so a caller that only classifies a row does not
+ * pull in this module's DB graph, and are re-exported here alongside the
+ * schema they read.
  */
-export function isHiddenMessageMetadata(
-  metadata: Record<string, unknown> | null | undefined,
-): boolean {
-  return metadata?.hidden === true;
-}
-
-/**
- * True when the row is a persisted `<background_event source="...">` trigger.
- * Every wake, scheduled run, and backgrounded-tool completion stamps one (see
- * `persistWakeTriggerMessage`). The permission mode such a turn ran under
- * varies (most run interactive; clientless/headless wakes do not) and is
- * recorded separately in `backgroundEventInteractive`; this predicate only
- * identifies the row as a background event.
- */
-export function isBackgroundEventMetadata(
-  metadata: Record<string, unknown> | undefined,
-): boolean {
-  return typeof metadata?.backgroundEventSource === "string";
-}
-
-/**
- * True when a role-`"user"` row is internal scaffolding rather than a person's
- * prompt: a daemon-injected run lifecycle notification (subagent
- * `subagentNotification`, ACP run `acpNotification`, or any wake trigger, the
- * persisted `<background_event source="...">` row every wake reads), or a row
- * explicitly flagged `hidden` (e.g. a hidden `POST /messages` send that queued
- * behind an in-flight turn, like the channel-setup wizard-close marker).
- *
- * These rows are persisted so the orchestrator wakes and reads the trigger,
- * but the user sees the wake through its inline card ("Conversation Woke", or
- * a terminal card for a backgrounded bash run), not a chat turn. One
- * definition so the sites that must agree cannot drift: the
- * `user_message_echo` broadcast (never render a live user bubble), the retry
- * route's hidden-prompt re-run, and the assistant-reply notification producer
- * (a turn opened by one of these rows is not a user prompt awaiting a reply).
- */
-export function isEchoSuppressedUserMessage(
-  metadata: Record<string, unknown> | undefined,
-): boolean {
-  return (
-    isHiddenMessageMetadata(metadata) ||
-    metadata?.subagentNotification != null ||
-    metadata?.acpNotification != null ||
-    isBackgroundEventMetadata(metadata)
-  );
-}
-
-/**
- * True when a role-`"user"` row was persisted by the voice bridge for a live
- * phone call or in-app voice session (every row `startVoiceTurn` persists, see
- * `calls/voice-session-bridge.ts`).
- *
- * The reply to such a turn is spoken back over the still-open session, so any
- * consumer that treats a finished reply as something the user has yet to see
- * (the assistant-reply notification producer) must skip it rather than push a
- * notification for audio the user is hearing right now.
- *
- * This marker is the only durable signal for that: the channel/interface fields
- * cannot stand in, because an in-app live-voice turn persists as
- * `vellum`/`macos`, indistinguishable from a typed desktop send.
- */
-export function isVoiceSessionUserMessage(
-  metadata: Record<string, unknown> | undefined,
-): boolean {
-  return metadata?.voiceSessionTurn === true;
-}
+export {
+  isBackgroundEventMetadata,
+  isEchoSuppressedUserMessage,
+  isHiddenMessageMetadata,
+  isVoiceSessionUserMessage,
+} from "./conversation-types.js";
 
 /**
  * `messageKind` value marking a daemon-authored system card — a pre-composed

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -3,8 +3,11 @@
 // `conversation-crud.ts`, the notification pipeline, and read-side filters
 // share one declaration without importing the heavy CRUD module. Also provides
 // the shared "is this a non-interactive / background conversation?" predicate
-// used by notification-feed and memory filters, plus the source-aware
-// `resolveConversationKind` classifier.
+// used by notification-feed and memory filters, the source-aware
+// `resolveConversationKind` classifier, and the pure predicates over a
+// persisted message's `metadata` record.
+
+import { parseChannelId } from "../channels/types.js";
 
 /**
  * Canonical `conversations.source` string for background memory v2
@@ -69,4 +72,121 @@ export function resolveConversationKind(
     return "scheduled";
   }
   return "user";
+}
+
+/**
+ * Shared predicate for the transcript-suppression flag on user-message
+ * metadata (the `hidden` field of the persisted `metadata` column). One
+ * definition so the sites that must agree (echo suppression, list-messages
+ * filtering, queued-snapshot filtering, indexing exclusion, and downstream
+ * consumers of message text) cannot drift.
+ */
+export function isHiddenMessageMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  return metadata?.hidden === true;
+}
+
+/**
+ * True when the row is a persisted `<background_event source="...">` trigger.
+ * Every wake, scheduled run, and backgrounded-tool completion stamps one (see
+ * `persistWakeTriggerMessage`). The permission mode such a turn ran under
+ * varies (most run interactive; clientless/headless wakes do not) and is
+ * recorded separately in `backgroundEventInteractive`; this predicate only
+ * identifies the row as a background event.
+ */
+export function isBackgroundEventMetadata(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return typeof metadata?.backgroundEventSource === "string";
+}
+
+/**
+ * True when a role-`"user"` row is internal scaffolding rather than a person's
+ * prompt: a daemon-injected run lifecycle notification (subagent
+ * `subagentNotification`, ACP run `acpNotification`, or any wake trigger, the
+ * persisted `<background_event source="...">` row every wake reads), or a row
+ * explicitly flagged `hidden` (e.g. a hidden `POST /messages` send that queued
+ * behind an in-flight turn, like the channel-setup wizard-close marker).
+ *
+ * These rows are persisted so the orchestrator wakes and reads the trigger,
+ * but the user sees the wake through its inline card ("Conversation Woke", or
+ * a terminal card for a backgrounded bash run), not a chat turn. One
+ * definition so the sites that must agree cannot drift: the
+ * `user_message_echo` broadcast (never render a live user bubble), the retry
+ * route's hidden-prompt re-run, and {@link isReplyPushIneligibleUserMessage}
+ * (a turn opened by one of these rows is not a user prompt awaiting a reply).
+ */
+export function isEchoSuppressedUserMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return (
+    isHiddenMessageMetadata(metadata) ||
+    metadata?.subagentNotification != null ||
+    metadata?.acpNotification != null ||
+    isBackgroundEventMetadata(metadata)
+  );
+}
+
+/**
+ * True when a role-`"user"` row was persisted by the voice bridge for a live
+ * phone call or in-app voice session (every row `startVoiceTurn` persists, see
+ * `calls/voice-session-bridge.ts`).
+ *
+ * The reply to such a turn is spoken back over the still-open session, so any
+ * consumer that treats a finished reply as something the user has yet to see
+ * must skip it rather than push a notification for audio the user is hearing
+ * right now.
+ *
+ * This marker is the only durable signal for that: the channel/interface fields
+ * cannot stand in, because an in-app live-voice turn persists as
+ * `vellum`/`macos`, indistinguishable from a typed desktop send.
+ */
+export function isVoiceSessionUserMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return metadata?.voiceSessionTurn === true;
+}
+
+/**
+ * True when the row that opened the turn arrived over an external messaging
+ * surface (Slack, Telegram, WhatsApp, email, a phone call) rather than the
+ * native app.
+ *
+ * An absent (or unrecognized) channel counts as in-app: every external ingress
+ * path stamps its channel via buildChannelMetadata, so the rows that omit the
+ * field are daemon-internal persists on native-app conversations (for example
+ * the deliberate omission in calls/call-pointer-messages.ts).
+ */
+function isChannelOriginatedUserMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  const channel = parseChannelId(metadata?.userMessageChannel);
+  return channel != null && channel !== "vellum";
+}
+
+/**
+ * True when a finished reply to this row must not raise a
+ * `chat.assistant_reply` push. Four independent reasons, one predicate so the
+ * producer's own gating and the batch-drain selection of the row it reads
+ * cannot disagree: picking a row the producer then suppresses would swallow the
+ * push for a genuine prompt coalesced into the same batch.
+ *
+ * - `automated`: a scheduled or background prompt injected into an ordinary
+ *   user conversation, which has its own producer (e.g. `schedule.notify`).
+ * - Echo-suppressed: internal scaffolding, nobody's prompt awaiting a reply.
+ * - Voice-session: the reply is spoken back over the still-open session.
+ * - Channel-originated: the finished reply is delivered back to the
+ *   originating messaging surface (`finalizeEventDelivery`), so the sender
+ *   already has it and a push would duplicate it on their phone.
+ */
+export function isReplyPushIneligibleUserMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return (
+    metadata?.automated === true ||
+    isEchoSuppressedUserMessage(metadata) ||
+    isVoiceSessionUserMessage(metadata) ||
+    isChannelOriginatedUserMessage(metadata)
+  );
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1878,8 +1878,7 @@ export async function handleSendMessage(
   // real first response. Gated behind the `self-intro-greeting` flag (default
   // off); `undefined` (flag off or no names) falls back to the canned path.
   const selfIntroGreetingEnabled =
-    isWakeUp &&
-    isAssistantFeatureFlagEnabled(SELF_INTRO_GREETING_FLAG, getConfig());
+    isWakeUp && isAssistantFeatureFlagEnabled(SELF_INTRO_GREETING_FLAG);
   const selfIntro = selfIntroGreetingEnabled
     ? buildSelfIntroMessage(body.onboarding ?? undefined)
     : undefined;

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -22,7 +22,6 @@ import {
   assertAcpCredentialFormat,
 } from "../../acp/acp-credentials.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getConfig } from "../../config/loader.js";
 import {
   fetchManagedCatalog,
   type ManagedCredentialDescriptor,
@@ -319,10 +318,7 @@ async function handleCredentialsReveal({ body, headers }: RouteHandlerArgs) {
   }
 
   const forChat = (body as { forChat?: unknown }).forChat === true;
-  if (
-    forChat &&
-    !isAssistantFeatureFlagEnabled("chat-credential-reveal", getConfig())
-  ) {
+  if (forChat && !isAssistantFeatureFlagEnabled("chat-credential-reveal")) {
     throw new BadRequestError(
       "--for-chat requires the chat-credential-reveal feature flag",
     );

--- a/assistant/src/runtime/routes/playground/guard.ts
+++ b/assistant/src/runtime/routes/playground/guard.ts
@@ -1,5 +1,4 @@
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
-import { getConfig } from "../../../config/loader.js";
 import { RouteError } from "../errors.js";
 
 /**
@@ -16,7 +15,7 @@ import { RouteError } from "../errors.js";
 const PLAYGROUND_DISABLED_CODE = "playground_disabled";
 
 function isPlaygroundEnabled(): boolean {
-  return isAssistantFeatureFlagEnabled("compaction-playground", getConfig());
+  return isAssistantFeatureFlagEnabled("compaction-playground");
 }
 
 /**

--- a/clients/web/src/domains/onboarding/send-research-correction.test.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.test.ts
@@ -124,10 +124,6 @@ describe("sendResearchCorrection", () => {
     expect(postCalls[0]?.path).toEqual({ assistant_id: "a1" });
     expect(postCalls[0]?.body.conversationId).toBe("c1");
     expect(postCalls[0]?.throwOnError).toBe(false);
-    // The correction turn carries the transport interface + real OS so the
-    // assistant keeps platform context (mirrors the initial research send).
-    expect(postCalls[0]?.body.interface).toBe("web");
-    expect(postCalls[0]?.body.clientOs).toBe("web");
     // See `lib/side-conversation-message.ts` for why this posts hidden.
     expect(postCalls[0]?.body.hidden).toBe(true);
 

--- a/clients/web/src/lib/side-conversation-message.test.ts
+++ b/clients/web/src/lib/side-conversation-message.test.ts
@@ -17,9 +17,6 @@ describe("buildSideConversationMessageBody", () => {
     });
 
     expect(body.hidden).toBe(true);
-    expect(body.conversationId).toBe("conv-1");
-    expect(body.content).toBe("<system-message>rewrite</system-message>");
-    expect(body.sourceChannel).toBe("vellum");
     expect(body.interface).toBe("vellum");
     // `clientOs` is a web-transport concern only.
     expect(body.clientOs).toBeUndefined();
@@ -35,21 +32,5 @@ describe("buildSideConversationMessageBody", () => {
     expect(body.hidden).toBe(true);
     expect(body.interface).toBe("web");
     expect(body.clientOs).toBe("web");
-  });
-
-  test("mints a fresh idempotency nonce per send", () => {
-    const first = buildSideConversationMessageBody({
-      conversationId: "conv-3",
-      content: "a",
-      transport: "vellum",
-    });
-    const second = buildSideConversationMessageBody({
-      conversationId: "conv-3",
-      content: "a",
-      transport: "vellum",
-    });
-
-    expect(first.clientMessageId).toBeTruthy();
-    expect(second.clientMessageId).not.toBe(first.clientMessageId);
   });
 });


### PR DESCRIPTION
## Summary
Round-3 review fixes for unseen-reply-notify.md.

- Batch prompt selection and the reply-push producer now share one eligibility predicate, so coalesced channel/voice/automated rows cannot swallow a genuine prompt's push
- Pure metadata predicates moved to the zero-import conversation-types leaf (re-exported from crud); retry-route test no longer eagerly loads the crud graph
- Optional-config widening applied to its four intended call sites; small test hygiene