### PR TITLE
Hand pairing pages off to the Android app

### DIFF
--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -44,6 +44,17 @@ function setUserAgent(userAgent: string): void {
   });
 }
 
+function androidIntentQuery(href: string): URLSearchParams {
+  return new URLSearchParams(
+    href.slice(href.indexOf("?") + 1, href.indexOf("#Intent;")),
+  );
+}
+
+function androidIntentFallback(href: string): string {
+  const encoded = /;S\.browser_fallback_url=([^;]+);end$/.exec(href)?.[1];
+  return decodeURIComponent(encoded ?? "");
+}
+
 const exchangeRemoteWebPairingTokenMock = mock(
   async (
     _deviceCode: string,
@@ -370,10 +381,15 @@ describe("RemoteWebPairingPage", () => {
       name: "Open in the Vellum app",
     });
     const href = link.getAttribute("href") ?? "";
-    expect(href.startsWith("vellum-assistant://connect?")).toBe(true);
-    const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
+    expect(href.startsWith("intent://connect?")).toBe(true);
+    const intentIndex = href.indexOf("#Intent;");
+    const query = androidIntentQuery(href);
     expect(query.get("url")).toBe(window.location.origin);
     expect(query.get("code")).toBe("android-device");
+    expect(href.slice(intentIndex)).toContain(
+      "#Intent;scheme=vellum-assistant;package=ai.vocify.vellumassistant;",
+    );
+    expect(androidIntentFallback(href)).toBe(window.location.href);
     expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();
   });
 
@@ -404,37 +420,29 @@ describe("RemoteWebPairingPage", () => {
     }
   });
 
-  test("the app handoff url preserves encoded server paths and codes", async () => {
+  test("the Android app handoff url preserves encoded codes", async () => {
     remoteGatewayMode = true;
     setUserAgent(ANDROID_USER_AGENT);
-    window.history.pushState(null, "", "/team%20one/assistant/pair");
     const deviceCode = "code & # / 🚀";
     const pairingQuery = new URLSearchParams({
       deviceCode,
       userCode: "ABCD",
     });
 
-    try {
-      render(
-        <MemoryRouter
-          initialEntries={[`/assistant/pair?${pairingQuery.toString()}`]}
-        >
-          <RemoteWebPairingPage />
-        </MemoryRouter>,
-      );
+    render(
+      <MemoryRouter
+        initialEntries={[`/assistant/pair?${pairingQuery.toString()}`]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
 
-      const link = await screen.findByRole("link", {
-        name: "Open in the Vellum app",
-      });
-      const href = link.getAttribute("href") ?? "";
-      const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
-      expect(query.get("url")).toBe(
-        `${window.location.origin}/team%20one`,
-      );
-      expect(query.get("code")).toBe(deviceCode);
-    } finally {
-      window.history.pushState(null, "", "/");
-    }
+    const link = await screen.findByRole("link", {
+      name: "Open in the Vellum app",
+    });
+    const href = link.getAttribute("href") ?? "";
+    const query = androidIntentQuery(href);
+    expect(query.get("code")).toBe(deviceCode);
   });
 
   test("exchanges immediately for a device code in a desktop browser", async () => {
@@ -462,38 +470,47 @@ describe("RemoteWebPairingPage", () => {
   test("keeps browser pairing available when an app handoff fails", async () => {
     remoteGatewayMode = true;
     setUserAgent(ANDROID_USER_AGENT);
-
-    render(
-      <MemoryRouter
-        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
-      >
-        <RemoteWebPairingPage />
-      </MemoryRouter>,
+    window.history.pushState(
+      null,
+      "",
+      "/assistant/pair?deviceCode=device-1&userCode=ABCD",
     );
 
-    const link = await screen.findByRole("link", {
-      name: "Open in the Vellum app",
-    });
-    link.addEventListener("click", (event) => event.preventDefault(), {
-      once: true,
-    });
-    fireEvent.click(link);
-
-    const continueButton = screen.getByRole("button", {
-      name: "Continue in this browser",
-    });
-    expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();
-
-    fireEvent.click(continueButton);
-
-    await waitFor(() => {
-      expect(exchangeRemoteWebPairingTokenMock.mock.calls[0]?.[0]).toBe(
-        "device-1",
+    try {
+      render(
+        <MemoryRouter
+          initialEntries={[
+            "/assistant/pair?deviceCode=device-1&userCode=ABCD",
+          ]}
+        >
+          <RemoteWebPairingPage />
+        </MemoryRouter>,
       );
-    });
-    expect(
-      screen.queryByRole("link", { name: "Open in the Vellum app" }),
-    ).toBeNull();
+
+      const link = await screen.findByRole("link", {
+        name: "Open in the Vellum app",
+      });
+      const href = link.getAttribute("href") ?? "";
+      expect(androidIntentFallback(href)).toBe(window.location.href);
+
+      const continueButton = screen.getByRole("button", {
+        name: "Continue in this browser",
+      });
+      expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();
+
+      fireEvent.click(continueButton);
+
+      await waitFor(() => {
+        expect(exchangeRemoteWebPairingTokenMock.mock.calls[0]?.[0]).toBe(
+          "device-1",
+        );
+      });
+      expect(
+        screen.queryByRole("link", { name: "Open in the Vellum app" }),
+      ).toBeNull();
+    } finally {
+      window.history.pushState(null, "", "/");
+    }
   });
 
   test.each([

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -12,6 +12,7 @@ import type { RemoteWebPairingTokenResult } from "@/lib/auth/remote-gateway-sess
 
 let remoteGatewayMode = false;
 let nativePlatform = false;
+let nativePlatformName: "ios" | "android" = "ios";
 
 mock.module("@/lib/local-mode", () => ({
   isRemoteGatewayMode: () => remoteGatewayMode,
@@ -24,7 +25,7 @@ mock.module("@/runtime/native-auth", () => ({
 mock.module("@capacitor/core", () => ({
   Capacitor: {
     isNativePlatform: () => nativePlatform,
-    getPlatform: () => (nativePlatform ? "ios" : "web"),
+    getPlatform: () => (nativePlatform ? nativePlatformName : "web"),
   },
 }));
 
@@ -32,6 +33,9 @@ const ORIGINAL_USER_AGENT = navigator.userAgent;
 const IPHONE_USER_AGENT =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) " +
   "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+const ANDROID_USER_AGENT =
+  "Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/138.0.0.0 Mobile Safari/537.36";
 
 function setUserAgent(userAgent: string): void {
   Object.defineProperty(navigator, "userAgent", {
@@ -111,6 +115,7 @@ afterEach(() => {
   cleanup();
   remoteGatewayMode = false;
   nativePlatform = false;
+  nativePlatformName = "ios";
   setUserAgent(ORIGINAL_USER_AGENT);
   exchangeRemoteWebPairingTokenMock.mockClear();
   createRemoteWebPairingChallengeMock.mockClear();
@@ -347,6 +352,31 @@ describe("RemoteWebPairingPage", () => {
     ).not.toBeNull();
   });
 
+  test("offers the same app handoff in an Android browser", async () => {
+    remoteGatewayMode = true;
+    setUserAgent(ANDROID_USER_AGENT);
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/assistant/pair?deviceCode=android-device&userCode=ABCD",
+        ]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    const link = await screen.findByRole("link", {
+      name: "Open in the Vellum app",
+    });
+    const href = link.getAttribute("href") ?? "";
+    expect(href.startsWith("vellum-assistant://connect?")).toBe(true);
+    const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
+    expect(query.get("url")).toBe(window.location.origin);
+    expect(query.get("code")).toBe("android-device");
+    expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();
+  });
+
   test("the app handoff url keeps a served path prefix", async () => {
     remoteGatewayMode = true;
     setUserAgent(IPHONE_USER_AGENT);
@@ -374,9 +404,42 @@ describe("RemoteWebPairingPage", () => {
     }
   });
 
-  test("exchanges immediately for a device code in a non-iOS browser", async () => {
+  test("the app handoff url preserves encoded server paths and codes", async () => {
     remoteGatewayMode = true;
-    // The default happy-dom user agent is a non-iOS browser.
+    setUserAgent(ANDROID_USER_AGENT);
+    window.history.pushState(null, "", "/team%20one/assistant/pair");
+    const deviceCode = "code & # / 🚀";
+    const pairingQuery = new URLSearchParams({
+      deviceCode,
+      userCode: "ABCD",
+    });
+
+    try {
+      render(
+        <MemoryRouter
+          initialEntries={[`/assistant/pair?${pairingQuery.toString()}`]}
+        >
+          <RemoteWebPairingPage />
+        </MemoryRouter>,
+      );
+
+      const link = await screen.findByRole("link", {
+        name: "Open in the Vellum app",
+      });
+      const href = link.getAttribute("href") ?? "";
+      const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
+      expect(query.get("url")).toBe(
+        `${window.location.origin}/team%20one`,
+      );
+      expect(query.get("code")).toBe(deviceCode);
+    } finally {
+      window.history.pushState(null, "", "/");
+    }
+  });
+
+  test("exchanges immediately for a device code in a desktop browser", async () => {
+    remoteGatewayMode = true;
+    // The default happy-dom user agent is a desktop browser.
 
     render(
       <MemoryRouter
@@ -396,9 +459,9 @@ describe("RemoteWebPairingPage", () => {
     ).toBeNull();
   });
 
-  test("starts the browser exchange when the user declines the app handoff", async () => {
+  test("keeps browser pairing available when an app handoff fails", async () => {
     remoteGatewayMode = true;
-    setUserAgent(IPHONE_USER_AGENT);
+    setUserAgent(ANDROID_USER_AGENT);
 
     render(
       <MemoryRouter
@@ -408,7 +471,15 @@ describe("RemoteWebPairingPage", () => {
       </MemoryRouter>,
     );
 
-    const continueButton = await screen.findByRole("button", {
+    const link = await screen.findByRole("link", {
+      name: "Open in the Vellum app",
+    });
+    link.addEventListener("click", (event) => event.preventDefault(), {
+      once: true,
+    });
+    fireEvent.click(link);
+
+    const continueButton = screen.getByRole("button", {
       name: "Continue in this browser",
     });
     expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();
@@ -425,26 +496,33 @@ describe("RemoteWebPairingPage", () => {
     ).toBeNull();
   });
 
-  test("skips the app handoff inside the native iOS app webview", async () => {
-    remoteGatewayMode = true;
-    setUserAgent(IPHONE_USER_AGENT);
-    nativePlatform = true;
+  test.each([
+    ["iOS", "ios", IPHONE_USER_AGENT],
+    ["Android", "android", ANDROID_USER_AGENT],
+  ] as const)(
+    "skips the app handoff inside the native %s shell",
+    async (_, platform, userAgent) => {
+      remoteGatewayMode = true;
+      setUserAgent(userAgent);
+      nativePlatform = true;
+      nativePlatformName = platform;
 
-    render(
-      <MemoryRouter
-        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
-      >
-        <RemoteWebPairingPage />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(exchangeRemoteWebPairingTokenMock.mock.calls[0]?.[0]).toBe(
-        "device-1",
+      render(
+        <MemoryRouter
+          initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+        >
+          <RemoteWebPairingPage />
+        </MemoryRouter>,
       );
-    });
-    expect(
-      screen.queryByRole("link", { name: "Open in the Vellum app" }),
-    ).toBeNull();
-  });
+
+      await waitFor(() => {
+        expect(exchangeRemoteWebPairingTokenMock.mock.calls[0]?.[0]).toBe(
+          "device-1",
+        );
+      });
+      expect(
+        screen.queryByRole("link", { name: "Open in the Vellum app" }),
+      ).toBeNull();
+    },
+  );
 });

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -126,6 +126,8 @@ function clearDeviceCodeFromUrl(): void {
  * a phone that scanned a pairing QR with its camera.
  */
 const VELLUM_APP_SCHEME = "vellum-assistant";
+const VELLUM_ANDROID_PACKAGE = "ai.vocify.vellumassistant";
+type AppHandoffPlatform = "ios" | "android";
 
 /**
  * Build the `vellum-assistant://connect?url=<base>&code=<device-code>` deep
@@ -134,12 +136,25 @@ const VELLUM_APP_SCHEME = "vellum-assistant";
  * so the app reconnects to the same self-hosted assistant this browser is
  * already on.
  */
-function buildAppHandoffUrl(deviceCode: string): string {
+function buildAppHandoffUrl(
+  deviceCode: string,
+  platform: AppHandoffPlatform,
+): string {
   const query = new URLSearchParams({
     url: remoteGatewayPublicBaseUrl(),
     code: deviceCode,
   });
-  return `${VELLUM_APP_SCHEME}://connect?${query.toString()}`;
+  if (platform === "ios") {
+    return `${VELLUM_APP_SCHEME}://connect?${query.toString()}`;
+  }
+
+  const fallbackUrl = encodeURIComponent(window.location.href);
+  return (
+    `intent://connect?${query.toString()}` +
+    `#Intent;scheme=${VELLUM_APP_SCHEME};` +
+    `package=${VELLUM_ANDROID_PACKAGE};` +
+    `S.browser_fallback_url=${fallbackUrl};end`
+  );
 }
 
 /**
@@ -150,12 +165,17 @@ function buildAppHandoffUrl(deviceCode: string): string {
  */
 function PairingHandoffActions({
   deviceCode,
+  platform,
   onContinueInBrowser,
 }: {
   deviceCode: string;
+  platform: AppHandoffPlatform;
   onContinueInBrowser: () => void;
 }) {
-  const appLink = useMemo(() => buildAppHandoffUrl(deviceCode), [deviceCode]);
+  const appLink = useMemo(
+    () => buildAppHandoffUrl(deviceCode, platform),
+    [deviceCode, platform],
+  );
 
   return (
     <div className="mt-6 flex flex-col gap-3">
@@ -195,11 +215,16 @@ export function RemoteWebPairingPage() {
   // A phone that scanned the pairing QR with its camera lands here in a browser.
   // If the Vellum app is installed we offer to hand the pairing to it before
   // burning the single-use code, never inside a native shell that pairs directly.
-  const mobileAppHandoff = useMemo(
-    () =>
-      Boolean(params.deviceCode) &&
-      (isIOSBrowser() || isAndroidBrowser()) &&
-      !isNativePlatform(),
+  const appHandoffPlatform = useMemo<AppHandoffPlatform | null>(
+    () => {
+      if (!params.deviceCode || isNativePlatform()) {
+        return null;
+      }
+      if (isAndroidBrowser()) {
+        return "android";
+      }
+      return isIOSBrowser() ? "ios" : null;
+    },
     [params.deviceCode],
   );
 
@@ -216,11 +241,11 @@ export function RemoteWebPairingPage() {
   // screen it waits until the user picks "Continue in this browser"; every
   // other surface starts it immediately.
   const [browserExchangeAllowed, setBrowserExchangeAllowed] = useState(
-    () => !mobileAppHandoff,
+    () => !appHandoffPlatform,
   );
 
   const [state, setState] = useState<PairingState>(() => {
-    if (mobileAppHandoff) {
+    if (appHandoffPlatform) {
       return { kind: "handoff_choice" };
     }
     return params.deviceCode ? { kind: "verifying" } : { kind: "starting" };
@@ -380,9 +405,10 @@ export function RemoteWebPairingPage() {
           {copy.body}
         </p>
 
-        {state.kind === "handoff_choice" && pairing ? (
+        {state.kind === "handoff_choice" && pairing && appHandoffPlatform ? (
           <PairingHandoffActions
             deviceCode={pairing.deviceCode}
+            platform={appHandoffPlatform}
             onContinueInBrowser={handleContinueInBrowser}
           />
         ) : null}

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -18,7 +18,10 @@ import {
 } from "@/lib/auth/remote-gateway-session";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
 import { isNativePlatform } from "@/runtime/native-auth";
-import { isIOSBrowser } from "@/runtime/platform-detection";
+import {
+  isAndroidBrowser,
+  isIOSBrowser,
+} from "@/runtime/platform-detection";
 import { sanitizeReturnTo } from "@/utils/return-to";
 import { routes } from "@/utils/routes";
 
@@ -117,7 +120,7 @@ function clearDeviceCodeFromUrl(): void {
 }
 
 /**
- * Custom URL scheme registered by the shipped iOS app. Dev and staging app
+ * Custom URL scheme registered by the shipped mobile apps. Dev and staging app
  * builds register suffixed schemes (e.g. `vellum-assistant-dev`), so this
  * handoff link intentionally targets the production app — the common case for
  * a phone that scanned a pairing QR with its camera.
@@ -126,7 +129,7 @@ const VELLUM_APP_SCHEME = "vellum-assistant";
 
 /**
  * Build the `vellum-assistant://connect?url=<base>&code=<device-code>` deep
- * link the iOS app consumes to persist this server and finish pairing inside
+ * link the mobile app consumes to persist this server and finish pairing inside
  * the app. `url` is the page's own public base (origin + served path prefix)
  * so the app reconnects to the same self-hosted assistant this browser is
  * already on.
@@ -140,9 +143,9 @@ function buildAppHandoffUrl(deviceCode: string): string {
 }
 
 /**
- * Pre-exchange choice shown to an iOS browser that arrived with a device code.
- * The primary action is a plain anchor so Safari performs the custom-scheme
- * navigation natively; tapping it does not burn the single-use code, so
+ * Pre-exchange choice shown to a mobile browser that arrived with a device
+ * code. The primary action is a plain anchor so the browser performs the
+ * custom-scheme navigation natively; tapping it does not burn the code, so
  * "Continue in this browser" stays available if the app is not installed.
  */
 function PairingHandoffActions({
@@ -189,12 +192,14 @@ export function RemoteWebPairingPage() {
     [location.pathname, location.search, location.hash],
   );
 
-  // A phone that scanned the pairing QR with its camera lands here in Safari.
+  // A phone that scanned the pairing QR with its camera lands here in a browser.
   // If the Vellum app is installed we offer to hand the pairing to it before
-  // burning the single-use code — but only in an iOS browser, never inside the
-  // app's own WKWebView (which pairs directly).
-  const iosAppHandoff = useMemo(
-    () => Boolean(params.deviceCode) && isIOSBrowser() && !isNativePlatform(),
+  // burning the single-use code, never inside a native shell that pairs directly.
+  const mobileAppHandoff = useMemo(
+    () =>
+      Boolean(params.deviceCode) &&
+      (isIOSBrowser() || isAndroidBrowser()) &&
+      !isNativePlatform(),
     [params.deviceCode],
   );
 
@@ -207,15 +212,15 @@ export function RemoteWebPairingPage() {
       : null,
   );
 
-  // The browser-side exchange burns the single-use code, so on the iOS handoff
+  // The browser-side exchange burns the single-use code, so on the app handoff
   // screen it waits until the user picks "Continue in this browser"; every
   // other surface starts it immediately.
   const [browserExchangeAllowed, setBrowserExchangeAllowed] = useState(
-    () => !iosAppHandoff,
+    () => !mobileAppHandoff,
   );
 
   const [state, setState] = useState<PairingState>(() => {
-    if (iosAppHandoff) {
+    if (mobileAppHandoff) {
       return { kind: "handoff_choice" };
     }
     return params.deviceCode ? { kind: "verifying" } : { kind: "starting" };
@@ -267,7 +272,7 @@ export function RemoteWebPairingPage() {
     if (!pairing?.deviceCode) {
       return;
     }
-    // Hold the code-burning exchange while the iOS handoff choice is pending.
+    // Hold the code-burning exchange while the app handoff choice is pending.
     if (!browserExchangeAllowed) {
       return;
     }

--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -239,10 +239,12 @@ On the device you're pairing:
 2. On a phone or tablet, open the **system camera** and point it at the QR
    code, then tap the notification to open the pairing page. On a device
    without a camera (another computer), open the URL printed under the QR in
-   its browser instead — same result. On iOS the page first offers
+   its browser instead. The result is the same. On iOS and Android the page
+   first offers
    **Open in the Vellum app** or **Continue in this browser**; tap
-   **Continue in this browser** to pair here (see
-   [Using the Vellum iOS app](#6-using-the-vellum-ios-app) for the app path).
+   **Open in the Vellum app** to finish pairing in the native app, or
+   **Continue in this browser** to pair here. See
+   [Using the Vellum iOS app](#6-using-the-vellum-ios-app) for iOS details.
 3. On phones and tablets, use the browser **Share → Add to Home Screen** to
    install the assistant as an app icon.
 


### PR DESCRIPTION
Wave 2 PR 5 of the Android and iOS feature parity plan. Generalizes browser pairing handoff for Android while preserving iOS, native-shell, desktop, and browser fallback behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->