### PR TITLE
fix(web): dock the zero-starters empty chat and unclip focus rings at rest

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -396,7 +396,7 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     cleanup();
   });
 
-  test("keyboard closed: the dock is expanded, interactive, and the group centers", () => {
+  test("keyboard closed: the dock is expanded, interactive, unclipped, and the group centers", () => {
     keyboardOpen = false;
     const { container } = render(<ChatBody {...dockedProps()} />);
 
@@ -406,11 +406,16 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     expect(dock?.className).not.toContain("pointer-events-none");
     expect(dock?.hasAttribute("inert")).toBe(false);
     expect(dock?.style.gridTemplateRows).toBe("1fr");
+    // Markup pin on the clip mechanism: at rest the inner div must not
+    // clip, so keyboard-focus rings (painted outside the border box of the
+    // cards and buttons inside) stay fully visible.
+    expect(dock?.firstElementChild?.className).toContain("min-h-0");
+    expect(dock?.firstElementChild?.className).not.toContain("overflow-hidden");
     expect(container.innerHTML).toContain("[justify-content:safe_center]");
     expect(container.innerHTML).not.toContain("justify-end");
   });
 
-  test("keyboard open: the dock collapses, fades, goes inert, and the group bottom-anchors", () => {
+  test("keyboard open: the dock collapses, fades, goes inert, clips, and the group bottom-anchors", () => {
     keyboardOpen = true;
     const { container } = render(<ChatBody {...dockedProps()} />);
 
@@ -421,6 +426,9 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     expect(dock?.className).toContain("pointer-events-none");
     expect(dock?.hasAttribute("inert")).toBe(true);
     expect(dock?.style.gridTemplateRows).toBe("0fr");
+    // Markup pin on the clip mechanism: the collapse animation clips the
+    // shrinking row's content.
+    expect(dock?.firstElementChild?.className).toContain("overflow-hidden");
     expect(container.innerHTML).toContain("justify-end");
     expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
   });
@@ -430,50 +438,89 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     const { container, rerender } = render(<ChatBody {...dockedProps()} />);
     expect(dockWrapper(container)?.className).toContain("opacity-0");
     expect(dockWrapper(container)?.style.gridTemplateRows).toBe("0fr");
+    const mounted = container.querySelector('[data-testid="starters"]');
+    expect(mounted).not.toBeNull();
 
     keyboardOpen = false;
     rerender(<ChatBody {...dockedProps()} />);
     expect(dockWrapper(container)?.className).not.toContain("opacity-0");
     expect(dockWrapper(container)?.style.gridTemplateRows).toBe("1fr");
-    expect(container.innerHTML).toContain("STARTER_CHIPS");
+    // Same DOM node across the toggle proves the dock never remounted.
+    expect(container.querySelector('[data-testid="starters"]')).toBe(
+      mounted as HTMLElement,
+    );
+  });
+});
+
+describe("ChatBody - plain empty state bottom-anchors while the keyboard is open", () => {
+  // Before conversation starters arrive, the plain empty state renders the
+  // NON-docked branch with no startersSlot (server-side starter generation
+  // can take a while on a brand-new assistant). While the soft keyboard is
+  // open that branch must bottom-anchor the greeting + composer group just
+  // like the docked branch, so the composer docks to the keyboard edge in
+  // the zero-starters window and the docked/non-docked flip when starters
+  // arrive never moves the composer mid-typing. The app-editing side panel
+  // is the one non-docked state WITH a startersSlot (its inline chips), and
+  // it keeps its centered layout regardless of keyboard state.
+  const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
   });
 
-  test("non-docked empty state keeps its starters untouched by keyboard state", () => {
+  test("keyboard open, zero starters: the group bottom-anchors instead of centering", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...withEmptyState()} />);
+
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
+  });
+
+  test("starters arriving under an open keyboard keep the bottom anchor across the branch flip", () => {
+    keyboardOpen = true;
+    const { container, rerender } = render(<ChatBody {...withEmptyState()} />);
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
+
+    rerender(
+      <ChatBody
+        {...withEmptyState({ dockStartersToBottom: true, startersSlot })}
+      />,
+    );
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
+  });
+
+  test("app-editing (non-docked with inline starters) stays centered with the keyboard open", () => {
+    // Discriminates the gate: same non-docked empty state and open
+    // keyboard, but with the inline startersSlot the app-editing branch
+    // renders. A gate that bottom-anchored every non-docked empty state
+    // would fail here by pushing the side panel's composer and chips to
+    // the bottom edge.
     keyboardOpen = true;
     const { container } = render(
-      <ChatBody {...withEmptyState({ startersSlot })} />,
+      <ChatBody {...withEmptyState({ variant: "side-panel", startersSlot })} />,
     );
 
     expect(container.innerHTML).toContain("STARTER_CHIPS");
     expect(container.innerHTML).toContain("[justify-content:safe_center]");
     expect(container.innerHTML).not.toContain("justify-end");
-    expect(dockWrapper(container)).toBeNull();
-  });
-
-  test("transcript branch ignores keyboard state (no dock, no bottom-anchoring)", () => {
-    keyboardOpen = true;
-    const { container } = render(<ChatBody {...baseProps()} />);
-
-    expect(dockWrapper(container)).toBeNull();
-    expect(container.innerHTML).not.toContain("justify-end");
+    expect(container.querySelector('[data-slot="docked-starters"]')).toBeNull();
   });
 });
 
 describe("ChatBody - plugin pills hide while the keyboard is open", () => {
   // The plugin controls rendered below the composer share the dock's
-  // treatment: while the soft keyboard is up they fade out, collapse their
-  // reserved height, and go inert so the composer (not the plugin row)
-  // docks to the keyboard edge. The slot stays mounted so dismissing the
-  // keyboard restores it without a remount.
+  // collapse treatment (both call sites render through the same helper):
+  // while the soft keyboard is up they fade out, collapse their reserved
+  // height, and go inert so the composer, not the plugin row, docks to the
+  // keyboard edge. The slot stays mounted so dismissing the keyboard
+  // restores it without a remount.
   const pluginPillsSlot = <div data-testid="plugins">PLUGIN_PILLS</div>;
-  const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
 
-  const dockedProps = () =>
-    withEmptyState({
-      dockStartersToBottom: true,
-      startersSlot,
-      pluginPillsSlot,
-    });
+  const pluginProps = () =>
+    withEmptyState({ dockStartersToBottom: true, pluginPillsSlot });
 
   const pluginsWrapper = (container: HTMLElement) =>
     container.querySelector<HTMLElement>('[data-slot="new-chat-plugins"]');
@@ -483,22 +530,9 @@ describe("ChatBody - plugin pills hide while the keyboard is open", () => {
     cleanup();
   });
 
-  test("keyboard closed: the plugin row is expanded and interactive", () => {
-    keyboardOpen = false;
-    const { container } = render(<ChatBody {...dockedProps()} />);
-
-    const wrapper = pluginsWrapper(container);
-    expect(wrapper).not.toBeNull();
-    expect(wrapper?.className).not.toContain("opacity-0");
-    expect(wrapper?.className).not.toContain("pointer-events-none");
-    expect(wrapper?.hasAttribute("inert")).toBe(false);
-    expect(wrapper?.style.gridTemplateRows).toBe("1fr");
-    expect(container.innerHTML).toContain("PLUGIN_PILLS");
-  });
-
-  test("keyboard open: the plugin row collapses, fades, goes inert, and the composer is the last expanded child of the bottom-anchored group", () => {
+  test("keyboard open: the row collapses, fades, goes inert; closing restores it without a remount", () => {
     keyboardOpen = true;
-    const { container } = render(<ChatBody {...dockedProps()} />);
+    const { container, rerender } = render(<ChatBody {...pluginProps()} />);
 
     const wrapper = pluginsWrapper(container);
     expect(wrapper).not.toBeNull();
@@ -507,26 +541,20 @@ describe("ChatBody - plugin pills hide while the keyboard is open", () => {
     expect(wrapper?.className).toContain("pointer-events-none");
     expect(wrapper?.hasAttribute("inert")).toBe(true);
     expect(wrapper?.style.gridTemplateRows).toBe("0fr");
-
-    // Bottom-anchored group: the only sibling after the composer is the
-    // collapsed plugin wrapper, so the composer reaches the keyboard edge.
-    expect(container.innerHTML).toContain("justify-end");
-    const composer = container.querySelector('[data-testid="composer"]');
-    expect(composer?.nextElementSibling).toBe(wrapper as HTMLElement);
-    expect(composer?.nextElementSibling?.nextElementSibling).toBeNull();
-  });
-
-  test("keyboard toggling flips the hidden treatment without unmounting the slot", () => {
-    keyboardOpen = true;
-    const { container, rerender } = render(<ChatBody {...dockedProps()} />);
-    expect(pluginsWrapper(container)?.style.gridTemplateRows).toBe("0fr");
+    expect(wrapper?.firstElementChild?.className).toContain("overflow-hidden");
     const mounted = container.querySelector('[data-testid="plugins"]');
     expect(mounted).not.toBeNull();
 
     keyboardOpen = false;
-    rerender(<ChatBody {...dockedProps()} />);
-    expect(pluginsWrapper(container)?.className).not.toContain("opacity-0");
-    expect(pluginsWrapper(container)?.style.gridTemplateRows).toBe("1fr");
+    rerender(<ChatBody {...pluginProps()} />);
+    const restored = pluginsWrapper(container);
+    expect(restored?.className).not.toContain("opacity-0");
+    expect(restored?.className).not.toContain("pointer-events-none");
+    expect(restored?.hasAttribute("inert")).toBe(false);
+    expect(restored?.style.gridTemplateRows).toBe("1fr");
+    expect(restored?.firstElementChild?.className).not.toContain(
+      "overflow-hidden",
+    );
     // Same DOM node across the toggle proves the slot never remounted.
     expect(container.querySelector('[data-testid="plugins"]')).toBe(
       mounted as HTMLElement,

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -35,7 +35,9 @@ import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
  * the composer **stays at the same position in the React tree** so its
  * state (focus, draft text, attachments) is preserved across the
  * empty→active transition. `safe center` falls back to start-alignment
- * when the group overflows (e.g. iOS with the soft keyboard open).
+ * when the group overflows; while the soft keyboard is open the empty
+ * state bottom-anchors the group instead so the composer docks to the
+ * keyboard edge.
  *
  * See [React — Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)
  * and [MDN — `justify-content: safe center`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
@@ -253,20 +255,33 @@ export function ChatBody({
 
   // When the empty state is visible, center greeting + composer + starters
   // as one group. `safe center` falls back to start-alignment when the
-  // content overflows the container (e.g. iOS soft keyboard open).
-  // `overflow-y-auto` enables scrolling in that overflow case.
+  // content overflows the container. `overflow-y-auto` enables scrolling
+  // in that overflow case.
   const baseClass =
     variant === "main"
       ? "relative flex min-h-0 flex-1 flex-col"
       : "relative flex h-full min-h-0 flex-col";
 
-  // The docked (suggestions-library) empty state owns its own vertical layout
-  // — a full-height first screen that centers the greeting + composer and
-  // pins the featured row to the bottom — so it does not use `safe center`.
+  // While the soft keyboard is open and nothing renders below the composer
+  // (`startersSlot` absent: starters have not arrived yet), the plain
+  // non-docked empty state bottom-anchors instead of centering so the
+  // composer docks to the keyboard edge, and the flip to the docked branch
+  // when starters arrive keeps that alignment instead of jumping
+  // mid-typing. The app-editing side panel always passes inline starters,
+  // so it keeps its centered layout regardless of keyboard state.
+  const nonDockedAlignmentClass =
+    keyboardOpen && startersSlot == null
+      ? "justify-end"
+      : "[justify-content:safe_center]";
+
+  // The docked (suggestions-library) empty state owns its own vertical
+  // layout (a full-height first screen that centers the greeting + composer
+  // and pins the featured row to the bottom), so it does not use
+  // `safe center`.
   const outerClass = isEmptyState
     ? dockStartersToBottom
       ? `${baseClass} overflow-y-auto`
-      : `${baseClass} overflow-y-auto [justify-content:safe_center]`
+      : `${baseClass} overflow-y-auto ${nonDockedAlignmentClass}`
     : baseClass;
 
   // Suppress the absolutely-positioned overlay on the empty state: its
@@ -305,12 +320,22 @@ export function ChatBody({
   // the reserved height so the bottom-anchored composer reaches the keyboard
   // edge. Each stays mounted so dismissing the keyboard restores it without
   // a remount, and `inert` removes it from the tab order and the
-  // accessibility tree.
-  const keyboardCollapseProps = {
-    inert: keyboardOpen || undefined,
-    className: `grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`,
-    style: { gridTemplateRows: keyboardOpen ? "0fr" : "1fr" },
-  };
+  // accessibility tree. The inner div clips only while the keyboard is
+  // open: the collapse needs the clip, but at rest it would shave the
+  // keyboard-focus rings that paint outside the cards and buttons inside
+  // the slot.
+  const renderKeyboardCollapse = (dataSlot: string, children: ReactNode) => (
+    <div
+      data-slot={dataSlot}
+      inert={keyboardOpen || undefined}
+      className={`grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`}
+      style={{ gridTemplateRows: keyboardOpen ? "0fr" : "1fr" }}
+    >
+      <div className={`min-h-0${keyboardOpen ? " overflow-hidden" : ""}`}>
+        {children}
+      </div>
+    </div>
+  );
 
   // Composer stack — stays at the same tree position across the empty→active
   // transition so React preserves its state (focus, draft text, attachments)
@@ -381,13 +406,11 @@ export function ChatBody({
         {channelFooterSlot}
         <StagedQuotesStrip />
         {composerSlot}
-        {pluginPillsSlot && (
-          <div data-slot="new-chat-plugins" {...keyboardCollapseProps}>
-            <div className="min-h-0 overflow-hidden">
-              <div className="mt-4">{pluginPillsSlot}</div>
-            </div>
-          </div>
-        )}
+        {pluginPillsSlot &&
+          renderKeyboardCollapse(
+            "new-chat-plugins",
+            <div className="mt-4">{pluginPillsSlot}</div>,
+          )}
         {trailingStarters}
       </div>
     </div>
@@ -431,17 +454,15 @@ export function ChatBody({
             />
             {renderComposerStack(null)}
           </div>
-          {startersSlot && (
-            <div data-slot="docked-starters" {...keyboardCollapseProps}>
-              <div className="min-h-0 overflow-hidden">
-                <div className="px-3 pb-3 sm:px-6">
-                  <div className="mx-auto max-w-[var(--chat-max-width)]">
-                    {startersSlot}
-                  </div>
+          {startersSlot &&
+            renderKeyboardCollapse(
+              "docked-starters",
+              <div className="px-3 pb-3 sm:px-6">
+                <div className="mx-auto max-w-[var(--chat-max-width)]">
+                  {startersSlot}
                 </div>
-              </div>
-            </div>
-          )}
+              </div>,
+            )}
         </div>
         {belowFoldSlot && (
           <div className="px-3 pt-2 pb-8 sm:px-6">

--- a/clients/web/tsconfig.json
+++ b/clients/web/tsconfig.json
@@ -22,7 +22,8 @@
     "src/**/*.ts",
     "src/**/*.tsx",
     ".storybook/**/*.ts",
-    ".storybook/**/*.tsx"
+    ".storybook/**/*.tsx",
+    "capacitor.config.ts"
   ],
   "exclude": ["dist/**", "node_modules/**"]
 }


### PR DESCRIPTION
## Summary
- The plain empty chat now bottom-anchors while the keyboard is open even before conversation starters load, so the composer docks in the zero-starters window and no longer jumps when starters arrive mid-typing. The app-editing side panel keeps its layout.
- The collapse wrappers only clip while the keyboard is open, so keyboard-focus rings on suggestion cards and buttons are no longer shaved at rest on desktop.
- `capacitor.config.ts` joins the tsconfig program so config typos fail typecheck instead of silently reverting the keyboard backdrop to off.
- Consolidates the collapse wrapper into one helper, strengthens the dock no-remount test to node identity, and removes non-discriminating tests.

Fixes gaps identified during plan self-review for ios-keyboard-composer-dock-and-backdrop.md