### PR TITLE
fix(web): hydrate per-assistant preferences on the first paint (LUM-2964)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -105,12 +105,14 @@ const GROUPS: ConversationGroup[] = [
 ];
 
 /**
- * Seed the layout store (and the localStorage the store hydrates from) so the
- * story mounts straight into the view it documents.
+ * Seed the stored view mode so the story mounts straight into the view it
+ * documents. The sidebar subscribes to storage during render, so the write is
+ * all it takes; resetting the layout store clears any collapse state a
+ * previously-rendered story left behind.
  */
 function seedViewMode(assistantId: string, mode: SidebarViewMode): void {
   saveViewMode(assistantId, mode);
-  useSidebarLayoutStore.setState({ assistantId: null, viewMode: mode });
+  useSidebarLayoutStore.setState({ assistantId: null });
 }
 
 const SHARED_ARGS = {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -68,7 +68,6 @@ beforeEach(() => {
   localStorage.setItem("vellum:sidebar-view-mode:asst-1", "grouped");
   useSidebarLayoutStore.setState({
     assistantId: null,
-    viewMode: "grouped",
     sectionOrder: [],
     openCategories: [],
     openCustomGroups: [],
@@ -215,7 +214,7 @@ describe("AssistantSideMenu · Chats category rows", () => {
 describe("AssistantSideMenu · All view", () => {
   beforeEach(() => {
     localStorage.setItem("vellum:sidebar-view-mode:asst-1", "all");
-    useSidebarLayoutStore.setState({ assistantId: null, viewMode: "all" });
+    useSidebarLayoutStore.setState({ assistantId: null });
   });
 
   const conversations = [
@@ -265,7 +264,7 @@ describe("AssistantSideMenu · All view", () => {
       "vellum:sidebar-section-order:asst-1",
       JSON.stringify(["recents", "grp-a", "channel:slack"]),
     );
-    useSidebarLayoutStore.setState({ assistantId: null, viewMode: "grouped" });
+    useSidebarLayoutStore.setState({ assistantId: null });
 
     const container = parse(
       renderMenu({

--- a/clients/web/src/domains/chat/composer-store.test.ts
+++ b/clients/web/src/domains/chat/composer-store.test.ts
@@ -10,11 +10,17 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Mock local-settings so we can observe localStorage reads/writes without
 // touching the real localStorage (happy-dom doesn't persist across tests).
 const localSettingsStore = new Map<string, string>();
+// Spread the real module rather than enumerating its exports: `mock.module`
+// replaces the whole module, so a hand-listed set breaks every importer the
+// moment local-settings grows an export it does not name.
+const actualLocalSettings = await import("@/utils/local-settings");
 mock.module("@/utils/local-settings", () => ({
+  ...actualLocalSettings,
   getLocalSetting: (key: string, fallback: string) =>
     localSettingsStore.get(key) ?? fallback,
   setLocalSetting: (key: string, value: string) => {
     localSettingsStore.set(key, value);
+    return true;
   },
 }));
 

--- a/clients/web/src/domains/chat/hooks/use-draft-persistence.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-draft-persistence.test.tsx
@@ -9,11 +9,17 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 // localStorage (happy-dom doesn't persist across tests). Matches the approach
 // in composer-store.test.ts.
 const localSettingsStore = new Map<string, string>();
+// Spread the real module rather than enumerating its exports: `mock.module`
+// replaces the whole module, so a hand-listed set breaks every importer the
+// moment local-settings grows an export it does not name.
+const actualLocalSettings = await import("@/utils/local-settings");
 mock.module("@/utils/local-settings", () => ({
+  ...actualLocalSettings,
   getLocalSetting: (key: string, fallback: string) =>
     localSettingsStore.get(key) ?? fallback,
   setLocalSetting: (key: string, value: string) => {
     localSettingsStore.set(key, value);
+    return true;
   },
   removeLocalSetting: (key: string) => {
     localSettingsStore.delete(key);

--- a/clients/web/src/domains/chat/sidebar-layout-store.test.ts
+++ b/clients/web/src/domains/chat/sidebar-layout-store.test.ts
@@ -9,7 +9,6 @@ function resetStore() {
     openCategories: [],
     openCustomGroups: [],
     openPrimary: ["pinned", "recents"],
-    viewMode: "all",
     backgroundActivated: false,
     scheduledActivated: false,
   });
@@ -243,31 +242,6 @@ describe("SidebarLayoutStore - independent lazy-section activation", () => {
     expect(state.scheduledActivated).toBe(false);
   });
 
-  test("defaults to the flat All view", () => {
-    expect(useSidebarLayoutStore.getState().viewMode).toBe("all");
-  });
-
-  test("setViewMode persists per assistant and hydrates back", () => {
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-    useSidebarLayoutStore.getState().setViewMode("grouped");
-
-    expect(localStorage.getItem("vellum:sidebar-view-mode:asst-1")).toBe(
-      "grouped",
-    );
-
-    // A second assistant keeps the default until it is switched itself.
-    useSidebarLayoutStore.getState().setAssistantId("asst-2");
-    expect(useSidebarLayoutStore.getState().viewMode).toBe("all");
-
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-    expect(useSidebarLayoutStore.getState().viewMode).toBe("grouped");
-  });
-
-  test("an unrecognized stored view falls back to the default", () => {
-    localStorage.setItem("vellum:sidebar-view-mode:asst-1", "channels");
-
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-
-    expect(useSidebarLayoutStore.getState().viewMode).toBe("all");
-  });
+  // The view mode is deliberately not held here — it reads from storage
+  // directly so it survives the first paint. See sidebar-view-mode.test.ts.
 });

--- a/clients/web/src/domains/chat/sidebar-layout-store.test.ts
+++ b/clients/web/src/domains/chat/sidebar-layout-store.test.ts
@@ -242,6 +242,6 @@ describe("SidebarLayoutStore - independent lazy-section activation", () => {
     expect(state.scheduledActivated).toBe(false);
   });
 
-  // The view mode is deliberately not held here — it reads from storage
+  // The view mode is deliberately not held here: it reads from storage
   // directly so it survives the first paint. See sidebar-view-mode.test.ts.
 });

--- a/clients/web/src/domains/chat/sidebar-layout-store.ts
+++ b/clients/web/src/domains/chat/sidebar-layout-store.ts
@@ -37,12 +37,6 @@ import {
   loadSectionOrder,
   saveSectionOrder,
 } from "@/domains/chat/utils/sidebar-section-order";
-import {
-  DEFAULT_SIDEBAR_VIEW_MODE,
-  loadViewMode,
-  saveViewMode,
-  type SidebarViewMode,
-} from "@/domains/chat/utils/sidebar-view-mode";
 
 // ---------------------------------------------------------------------------
 // State + Actions
@@ -64,11 +58,6 @@ export interface SidebarLayoutState {
    * `mergeSectionOrder`.
    */
   sectionOrder: string[];
-  /**
-   * Which conversation-list view the sidebar renders: the flat recency list
-   * (`all`) or the per-channel collapsible sections (`grouped`).
-   */
-  viewMode: SidebarViewMode;
   /**
    * Whether the user has revealed the Background section this session -
    * either by expanding it in the full sidebar or opening its rail flyout.
@@ -92,7 +81,6 @@ export interface SidebarLayoutActions {
   setOpenCustomGroups: (next: string[]) => void;
   setOpenPrimary: (next: string[]) => void;
   setSectionOrder: (next: string[]) => void;
-  setViewMode: (next: SidebarViewMode) => void;
   activateBackground: () => void;
   activateScheduled: () => void;
 }
@@ -112,7 +100,6 @@ const INITIAL_STATE: SidebarLayoutState = {
   // setAssistantId.
   openPrimary: [...PRIMARY_SECTION_KEYS],
   sectionOrder: [],
-  viewMode: DEFAULT_SIDEBAR_VIEW_MODE,
   backgroundActivated: false,
   scheduledActivated: false,
 };
@@ -136,7 +123,6 @@ const useSidebarLayoutStoreBase = create<SidebarLayoutStore>()(
         openCustomGroups: loadOpenCustomGroups(assistantId),
         openPrimary: loadOpenPrimary(assistantId),
         sectionOrder: loadSectionOrder(assistantId),
-        viewMode: loadViewMode(assistantId),
         // A persisted expanded section counts as a reveal, so each lazy
         // fetch resumes for assistants the user already had that section
         // open on - tracked per section so they stay independent.
@@ -180,14 +166,6 @@ const useSidebarLayoutStoreBase = create<SidebarLayoutStore>()(
       const { assistantId } = get();
       if (assistantId) {
         saveSectionOrder(assistantId, next);
-      }
-    },
-
-    setViewMode: (next: SidebarViewMode) => {
-      set({ viewMode: next });
-      const { assistantId } = get();
-      if (assistantId) {
-        saveViewMode(assistantId, next);
       }
     },
 

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -41,15 +41,9 @@ afterEach(() => {
     openCategories: [],
     openCustomGroups: [],
     sectionOrder: [],
-    viewMode: "all",
   });
 });
 
-/**
- * Put the sidebar in the channel-grouped view. The layout store hydrates from
- * localStorage in an effect, so seeding the key is what survives the hook's
- * own `setAssistantId` call.
- */
 /** The rendered section carrying `key`, or a clear failure if it is absent. */
 function sectionFor(
   sections: { key: string; all: unknown[] }[],
@@ -62,9 +56,13 @@ function sectionFor(
   return section;
 }
 
+/**
+ * Put the sidebar in the channel-grouped view. Seeding the key is enough: the
+ * hook subscribes to storage during render, so the first render already sees
+ * this - no store priming, and no commit in between.
+ */
 function seedGroupedView(assistantId = "asst-1"): void {
   localStorage.setItem(`vellum:sidebar-view-mode:${assistantId}`, "grouped");
-  useSidebarLayoutStore.setState({ viewMode: "grouped" });
 }
 
 describe("useSidebarState grouping", () => {

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -51,7 +51,11 @@ import {
   nextStoredOrder,
   type SectionOrderClass,
 } from "@/domains/chat/utils/sidebar-section-order";
-import type { SidebarViewMode } from "@/domains/chat/utils/sidebar-view-mode";
+import {
+  saveViewMode,
+  useViewMode,
+  type SidebarViewMode,
+} from "@/domains/chat/utils/sidebar-view-mode";
 import { mergeConversationLists } from "@/utils/conversation-cache";
 import {
   useBackgroundConversationListQuery,
@@ -210,8 +214,20 @@ export function useSidebarState({
   const setOpenPrimary = useSidebarLayoutStore.use.setOpenPrimary();
   const sectionOrder = useSidebarLayoutStore.use.sectionOrder();
   const setSectionOrder = useSidebarLayoutStore.use.setSectionOrder();
-  const viewMode = useSidebarLayoutStore.use.viewMode();
-  const setViewMode = useSidebarLayoutStore.use.setViewMode();
+
+  // Read straight from storage rather than through the layout store. The store
+  // hydrates in an effect, so anything it owns renders as the default on the
+  // first paint; the view mode decides which list the sidebar draws, making
+  // that flash the most visible one. Subscribing instead means the stored
+  // choice is there on the first paint, and a change in another window lands
+  // here without a reload.
+  const viewMode = useViewMode(assistantId);
+  const setViewMode = useCallback(
+    (next: SidebarViewMode) => {
+      saveViewMode(assistantId, next);
+    },
+    [assistantId],
+  );
   const backgroundActivated = useSidebarLayoutStore.use.backgroundActivated();
   const scheduledActivated = useSidebarLayoutStore.use.scheduledActivated();
   const collapseAssistantId = useSidebarLayoutStore.use.assistantId();

--- a/clients/web/src/domains/chat/utils/sidebar-view-mode.test.tsx
+++ b/clients/web/src/domains/chat/utils/sidebar-view-mode.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  DEFAULT_SIDEBAR_VIEW_MODE,
+  loadViewMode,
+  saveViewMode,
+  useViewMode,
+} from "@/domains/chat/utils/sidebar-view-mode";
+
+const KEY = (assistantId: string) =>
+  `vellum:sidebar-view-mode:${assistantId}`;
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("sidebar view mode storage", () => {
+  test("defaults to the flat All view", () => {
+    expect(loadViewMode("asst-1")).toBe("all");
+    expect(DEFAULT_SIDEBAR_VIEW_MODE).toBe("all");
+  });
+
+  test("persists per assistant and reads back", () => {
+    saveViewMode("asst-1", "grouped");
+
+    expect(localStorage.getItem(KEY("asst-1"))).toBe("grouped");
+    expect(loadViewMode("asst-1")).toBe("grouped");
+    // A second assistant keeps the default until it is switched itself.
+    expect(loadViewMode("asst-2")).toBe("all");
+  });
+
+  test("an unrecognized stored view falls back to the default", () => {
+    localStorage.setItem(KEY("asst-1"), "channels");
+
+    expect(loadViewMode("asst-1")).toBe("all");
+  });
+});
+
+describe("useViewMode", () => {
+  // The regression test for the flash this hook exists to remove: the very
+  // first render must already carry the stored choice, with no effect, no act,
+  // and no second commit in between.
+  test("returns the stored value on the first render", () => {
+    localStorage.setItem(KEY("asst-1"), "grouped");
+
+    const { result } = renderHook(() => useViewMode("asst-1"));
+
+    expect(result.current).toBe("grouped");
+  });
+
+  test("re-renders when the value is saved elsewhere", () => {
+    const { result } = renderHook(() => useViewMode("asst-1"));
+    expect(result.current).toBe("all");
+
+    // Stands in for the other window: a save that this hook never initiated.
+    act(() => saveViewMode("asst-1", "grouped"));
+
+    expect(result.current).toBe("grouped");
+  });
+
+  test("ignores writes for a different assistant", () => {
+    const { result } = renderHook(() => useViewMode("asst-1"));
+
+    act(() => saveViewMode("asst-2", "grouped"));
+
+    expect(result.current).toBe("all");
+  });
+
+  test("follows the key when the assistant changes", () => {
+    saveViewMode("asst-2", "grouped");
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useViewMode(id),
+      { initialProps: { id: "asst-1" } },
+    );
+    expect(result.current).toBe("all");
+
+    rerender({ id: "asst-2" });
+
+    expect(result.current).toBe("grouped");
+  });
+});

--- a/clients/web/src/domains/chat/utils/sidebar-view-mode.test.tsx
+++ b/clients/web/src/domains/chat/utils/sidebar-view-mode.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, renderHook } from "@testing-library/react";
 
-import { clearStorageOverrides } from "@/utils/typed-storage";
+import { clearUserScopedOverrides } from "@/utils/typed-storage";
 import { withRejectedWrites } from "@/utils/rejected-writes.test-helper";
 import {
   DEFAULT_SIDEBAR_VIEW_MODE,
@@ -17,7 +17,7 @@ afterEach(() => {
   localStorage.clear();
   // Accessors are module singletons, so a value held after a rejected write
   // outlives the test that set it. Logout clears these for the same reason.
-  clearStorageOverrides();
+  clearUserScopedOverrides();
 });
 
 describe("sidebar view mode storage", () => {

--- a/clients/web/src/domains/chat/utils/sidebar-view-mode.test.tsx
+++ b/clients/web/src/domains/chat/utils/sidebar-view-mode.test.tsx
@@ -67,6 +67,27 @@ describe("useViewMode", () => {
     expect(result.current).toBe("all");
   });
 
+  // Storage is unavailable in private browsing and once quota is exhausted.
+  // The switch still has to move: an unsaved choice is tolerable, a control
+  // that ignores clicks is not.
+  test("still switches when storage rejects the write", () => {
+    const setItem = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+
+    try {
+      const { result } = renderHook(() => useViewMode("asst-1"));
+      expect(result.current).toBe("all");
+
+      act(() => saveViewMode("asst-1", "grouped"));
+
+      expect(result.current).toBe("grouped");
+    } finally {
+      localStorage.setItem = setItem;
+    }
+  });
+
   test("follows the key when the assistant changes", () => {
     saveViewMode("asst-2", "grouped");
 

--- a/clients/web/src/domains/chat/utils/sidebar-view-mode.test.tsx
+++ b/clients/web/src/domains/chat/utils/sidebar-view-mode.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, renderHook } from "@testing-library/react";
 
+import { clearStorageOverrides } from "@/utils/typed-storage";
+import { withRejectedWrites } from "@/utils/rejected-writes.test-helper";
 import {
   DEFAULT_SIDEBAR_VIEW_MODE,
   loadViewMode,
@@ -13,6 +15,9 @@ const KEY = (assistantId: string) =>
 
 afterEach(() => {
   localStorage.clear();
+  // Accessors are module singletons, so a value held after a rejected write
+  // outlives the test that set it. Logout clears these for the same reason.
+  clearStorageOverrides();
 });
 
 describe("sidebar view mode storage", () => {
@@ -71,21 +76,16 @@ describe("useViewMode", () => {
   // The switch still has to move: an unsaved choice is tolerable, a control
   // that ignores clicks is not.
   test("still switches when storage rejects the write", () => {
-    const setItem = localStorage.setItem.bind(localStorage);
-    localStorage.setItem = () => {
-      throw new Error("QuotaExceededError");
-    };
+    const { result } = renderHook(() => useViewMode("asst-1"));
+    expect(result.current).toBe("all");
 
-    try {
-      const { result } = renderHook(() => useViewMode("asst-1"));
-      expect(result.current).toBe("all");
-
+    withRejectedWrites(() => {
       act(() => saveViewMode("asst-1", "grouped"));
+    });
 
-      expect(result.current).toBe("grouped");
-    } finally {
-      localStorage.setItem = setItem;
-    }
+    // The switch moved even though nothing reached storage.
+    expect(localStorage.getItem("vellum:sidebar-view-mode:asst-1")).toBeNull();
+    expect(result.current).toBe("grouped");
   });
 
   test("follows the key when the assistant changes", () => {

--- a/clients/web/src/domains/chat/utils/sidebar-view-mode.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-view-mode.ts
@@ -37,6 +37,19 @@ export function loadViewMode(assistantId: string): SidebarViewMode {
   return viewModeStorage.load(assistantId);
 }
 
+/**
+ * Subscribe to one assistant's view mode.
+ *
+ * Storage is the source of truth rather than a value snapshotted into a store
+ * on mount, which buys two things: the first paint already carries the user's
+ * choice (no flash of the default while an effect catches up), and a change
+ * made in one window reaches every other window on the same assistant,
+ * because `saveViewMode` notifies both same-tab and cross-tab listeners.
+ */
+export function useViewMode(assistantId: string): SidebarViewMode {
+  return viewModeStorage.useValue(assistantId);
+}
+
 export function saveViewMode(
   assistantId: string,
   mode: SidebarViewMode,

--- a/clients/web/src/lib/auth/session-cleanup.ts
+++ b/clients/web/src/lib/auth/session-cleanup.ts
@@ -23,6 +23,7 @@
  */
 
 import { clearTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
+import { clearStorageOverrides } from "@/utils/typed-storage";
 
 const USER_PREFIX = "vellum:";
 
@@ -74,6 +75,10 @@ export function clearUserScopedStorage(): void {
   // The takeover avatar stash can outlive `sessionStorage.clear()` through its
   // in-memory mirror when the write never reached storage.
   clearTakeoverAvatarStash();
+
+  // Same shape: a typed-storage accessor holds a value in memory when the
+  // device refuses writes, so the key sweep below has nothing to remove.
+  clearStorageOverrides();
 
   try {
     sessionStorage.clear();

--- a/clients/web/src/lib/auth/session-cleanup.ts
+++ b/clients/web/src/lib/auth/session-cleanup.ts
@@ -23,7 +23,7 @@
  */
 
 import { clearTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash";
-import { clearStorageOverrides } from "@/utils/typed-storage";
+import { clearUserScopedOverrides } from "@/utils/typed-storage";
 
 const USER_PREFIX = "vellum:";
 
@@ -78,7 +78,7 @@ export function clearUserScopedStorage(): void {
 
   // Same shape: a typed-storage accessor holds a value in memory when the
   // device refuses writes, so the key sweep below has nothing to remove.
-  clearStorageOverrides();
+  clearUserScopedOverrides();
 
   try {
     sessionStorage.clear();

--- a/clients/web/src/utils/local-settings.ts
+++ b/clients/web/src/utils/local-settings.ts
@@ -16,13 +16,33 @@ export function getLocalSetting(key: string, fallback: string): string {
   }
 }
 
-export function setLocalSetting(key: string, value: string): void {
+/**
+ * Write a setting. Returns whether the value reached storage, so callers that
+ * render the value can keep it in memory when it did not. Callers that treat
+ * persistence as fire-and-forget can ignore the result.
+ */
+export function setLocalSetting(key: string, value: string): boolean {
   if (typeof window === "undefined") {
-    return;
+    return false;
   }
   try {
     localStorage.setItem(key, value);
   } catch {
+    return false;
+  }
+  notifyChange(key, value);
+  return true;
+}
+
+/**
+ * Announce a value that did not reach storage.
+ *
+ * A rejected write fires no notification of its own, so a subscriber holding
+ * the value in memory has no way to learn it changed. This is the signal for
+ * that case; the notification carries the value the caller is standing behind.
+ */
+export function notifySettingChange(key: string, value: string): void {
+  if (typeof window === "undefined") {
     return;
   }
   notifyChange(key, value);

--- a/clients/web/src/utils/rejected-writes.test-helper.ts
+++ b/clients/web/src/utils/rejected-writes.test-helper.ts
@@ -1,0 +1,31 @@
+/**
+ * Run a block with `localStorage` writes rejected, the way private browsing, a
+ * policy that disables storage, and quota exhaustion all behave.
+ *
+ * The obvious stub does not work. happy-dom backs `localStorage` with a Proxy
+ * that turns property assignment into item storage, so `localStorage.setItem =
+ * fn` writes an item named "setItem" and leaves the real method in place: the
+ * write silently succeeds and any test relying on it passes for the wrong
+ * reason. `Object.defineProperty` bypasses the set trap, and restoring the same
+ * way puts the original method back. `delete` does not remove it, so the
+ * restore must define rather than delete.
+ */
+export function withRejectedWrites(run: () => void): void {
+  const original = localStorage.setItem.bind(localStorage);
+  Object.defineProperty(localStorage, "setItem", {
+    value: () => {
+      throw new Error("QuotaExceededError");
+    },
+    configurable: true,
+    writable: true,
+  });
+  try {
+    run();
+  } finally {
+    Object.defineProperty(localStorage, "setItem", {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  }
+}

--- a/clients/web/src/utils/typed-storage.test.ts
+++ b/clients/web/src/utils/typed-storage.test.ts
@@ -204,6 +204,47 @@ describe("createKeyedStorageAccessor", () => {
       expect(result.current).toEqual(["a", "b"]);
     });
 
+    // Private browsing, a policy that disables storage, and quota exhaustion
+    // all make setItem throw. The value still has to reach the UI, or the
+    // control bound to it reads as broken rather than merely unsaved.
+    test("holds the value and notifies when storage rejects the write", () => {
+      const setItem = localStorage.setItem.bind(localStorage);
+      localStorage.setItem = () => {
+        throw new Error("QuotaExceededError");
+      };
+
+      try {
+        const { result } = renderHook(() => keyed.useValue("asst-1"));
+        expect(result.current).toBe("");
+
+        act(() => keyed.save("asst-1", "conv-abc"));
+
+        expect(result.current).toBe("conv-abc");
+        expect(keyed.load("asst-1")).toBe("conv-abc");
+      } finally {
+        localStorage.setItem = setItem;
+      }
+    });
+
+    test("a later successful write drops the in-memory value", () => {
+      const setItem = localStorage.setItem.bind(localStorage);
+      localStorage.setItem = () => {
+        throw new Error("QuotaExceededError");
+      };
+      try {
+        keyed.save("asst-1", "conv-abc");
+      } finally {
+        localStorage.setItem = setItem;
+      }
+
+      keyed.save("asst-1", "conv-xyz");
+
+      expect(localStorage.getItem("vellum:lastConvo:asst-1")).toBe("conv-xyz");
+      // Reading past the override, not through a stale copy of it.
+      localStorage.setItem("vellum:lastConvo:asst-1", "conv-external");
+      expect(keyed.load("asst-1")).toBe("conv-external");
+    });
+
     test("a mutated load() result does not corrupt the snapshot", () => {
       list.save("asst-1", ["a"]);
       const { result } = renderHook(() => list.useValue("asst-1"));

--- a/clients/web/src/utils/typed-storage.test.ts
+++ b/clients/web/src/utils/typed-storage.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, renderHook } from "@testing-library/react";
 
+import { withRejectedWrites } from "./rejected-writes.test-helper";
 import {
+  clearStorageOverrides,
   createKeyedStorageAccessor,
   createRecordStorageAccessor,
   createStorageAccessor,
@@ -14,6 +16,9 @@ beforeEach(() => {
 
 afterEach(() => {
   localStorage.clear();
+  // Accessors are module singletons, so a value held after a rejected write
+  // outlives the test that set it. Logout clears these for the same reason.
+  clearStorageOverrides();
 });
 
 // ---------------------------------------------------------------------------
@@ -208,34 +213,22 @@ describe("createKeyedStorageAccessor", () => {
     // all make setItem throw. The value still has to reach the UI, or the
     // control bound to it reads as broken rather than merely unsaved.
     test("holds the value and notifies when storage rejects the write", () => {
-      const setItem = localStorage.setItem.bind(localStorage);
-      localStorage.setItem = () => {
-        throw new Error("QuotaExceededError");
-      };
+      const { result } = renderHook(() => keyed.useValue("asst-1"));
+      expect(result.current).toBe("");
 
-      try {
-        const { result } = renderHook(() => keyed.useValue("asst-1"));
-        expect(result.current).toBe("");
-
+      withRejectedWrites(() => {
         act(() => keyed.save("asst-1", "conv-abc"));
+      });
 
-        expect(result.current).toBe("conv-abc");
-        expect(keyed.load("asst-1")).toBe("conv-abc");
-      } finally {
-        localStorage.setItem = setItem;
-      }
+      // Nothing was persisted, so both reads can only be served in memory.
+      expect(localStorage.getItem("vellum:lastConvo:asst-1")).toBeNull();
+      expect(result.current).toBe("conv-abc");
+      expect(keyed.load("asst-1")).toBe("conv-abc");
     });
 
     test("a later successful write drops the in-memory value", () => {
-      const setItem = localStorage.setItem.bind(localStorage);
-      localStorage.setItem = () => {
-        throw new Error("QuotaExceededError");
-      };
-      try {
-        keyed.save("asst-1", "conv-abc");
-      } finally {
-        localStorage.setItem = setItem;
-      }
+      withRejectedWrites(() => keyed.save("asst-1", "conv-abc"));
+      expect(keyed.load("asst-1")).toBe("conv-abc");
 
       keyed.save("asst-1", "conv-xyz");
 
@@ -243,6 +236,20 @@ describe("createKeyedStorageAccessor", () => {
       // Reading past the override, not through a stale copy of it.
       localStorage.setItem("vellum:lastConvo:asst-1", "conv-external");
       expect(keyed.load("asst-1")).toBe("conv-external");
+    });
+
+    // An override is user state living outside localStorage, so the logout
+    // sweep cannot reach it by removing keys: the value never became one.
+    // Without an explicit clear it would be read by whoever logs in next in
+    // the same tab.
+    test("clearStorageOverrides drops a value the logout sweep cannot see", () => {
+      withRejectedWrites(() => keyed.save("asst-1", "conv-abc"));
+      expect(keyed.load("asst-1")).toBe("conv-abc");
+      expect(localStorage.getItem("vellum:lastConvo:asst-1")).toBeNull();
+
+      clearStorageOverrides();
+
+      expect(keyed.load("asst-1")).toBe("");
     });
 
     test("a mutated load() result does not corrupt the snapshot", () => {

--- a/clients/web/src/utils/typed-storage.test.ts
+++ b/clients/web/src/utils/typed-storage.test.ts
@@ -3,7 +3,7 @@ import { act, renderHook } from "@testing-library/react";
 
 import { withRejectedWrites } from "./rejected-writes.test-helper";
 import {
-  clearStorageOverrides,
+  clearUserScopedOverrides,
   createKeyedStorageAccessor,
   createRecordStorageAccessor,
   createStorageAccessor,
@@ -18,7 +18,7 @@ afterEach(() => {
   localStorage.clear();
   // Accessors are module singletons, so a value held after a rejected write
   // outlives the test that set it. Logout clears these for the same reason.
-  clearStorageOverrides();
+  clearUserScopedOverrides();
 });
 
 // ---------------------------------------------------------------------------
@@ -226,6 +226,24 @@ describe("createKeyedStorageAccessor", () => {
       expect(keyed.load("asst-1")).toBe("conv-abc");
     });
 
+    // The held value has to be gone before the success notification fires.
+    // `setLocalSetting` dispatches synchronously, so a subscriber reading its
+    // snapshot mid-dispatch would still see the held value, match its previous
+    // snapshot, and skip the re-render. Nothing notifies again afterwards.
+    test("a later successful write reaches mounted subscribers", () => {
+      const { result } = renderHook(() => keyed.useValue("asst-1"));
+
+      withRejectedWrites(() => {
+        act(() => keyed.save("asst-1", "held"));
+      });
+      expect(result.current).toBe("held");
+
+      act(() => keyed.save("asst-1", "persisted"));
+
+      expect(localStorage.getItem("vellum:lastConvo:asst-1")).toBe("persisted");
+      expect(result.current).toBe("persisted");
+    });
+
     test("a later successful write drops the in-memory value", () => {
       withRejectedWrites(() => keyed.save("asst-1", "conv-abc"));
       expect(keyed.load("asst-1")).toBe("conv-abc");
@@ -242,14 +260,37 @@ describe("createKeyedStorageAccessor", () => {
     // sweep cannot reach it by removing keys: the value never became one.
     // Without an explicit clear it would be read by whoever logs in next in
     // the same tab.
-    test("clearStorageOverrides drops a value the logout sweep cannot see", () => {
+    test("clearUserScopedOverrides drops a value the logout sweep cannot see", () => {
       withRejectedWrites(() => keyed.save("asst-1", "conv-abc"));
       expect(keyed.load("asst-1")).toBe("conv-abc");
       expect(localStorage.getItem("vellum:lastConvo:asst-1")).toBeNull();
 
-      clearStorageOverrides();
+      clearUserScopedOverrides();
 
       expect(keyed.load("asst-1")).toBe("");
+    });
+
+    // `device:` keys survive logout by design. Dropping their in-memory
+    // counterparts would make a rejected write the one case where a device
+    // preference does not, so the logout sweep clears user scope only.
+    test("logout leaves a device-scoped held value alone", () => {
+      const deviceAccessor = createKeyedStorageAccessor<string>({
+        keyFn: (id) => `device:probe:${id}`,
+        scope: "device",
+        parse: (raw) => (raw.length > 0 ? raw : null),
+        serialize: (v) => v,
+        fallback: "",
+      });
+
+      withRejectedWrites(() => {
+        keyed.save("asst-1", "user-value");
+        deviceAccessor.save("asst-1", "device-value");
+      });
+
+      clearUserScopedOverrides();
+
+      expect(keyed.load("asst-1")).toBe("");
+      expect(deviceAccessor.load("asst-1")).toBe("device-value");
     });
 
     test("a mutated load() result does not corrupt the snapshot", () => {

--- a/clients/web/src/utils/typed-storage.test.ts
+++ b/clients/web/src/utils/typed-storage.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
 
 import {
   createKeyedStorageAccessor,
@@ -162,6 +163,56 @@ describe("createKeyedStorageAccessor", () => {
     expect(keyed.keyFn("asst-1")).toBe("vellum:lastConvo:asst-1");
     expect(keyed.scope).toBe("user");
   });
+
+  describe("useValue", () => {
+    const list = createKeyedStorageAccessor<string[]>({
+      keyFn: (id) => `vellum:list:${id}`,
+      scope: "user",
+      parse: (raw) => JSON.parse(raw) as string[],
+      serialize: JSON.stringify,
+      fallback: [],
+    });
+
+    test("reads stored state on the first render, not after an effect", () => {
+      keyed.save("asst-1", "conv-abc");
+
+      const { result } = renderHook(() => keyed.useValue("asst-1"));
+
+      expect(result.current).toBe("conv-abc");
+    });
+
+    test("re-renders on a write from outside the hook", () => {
+      const { result } = renderHook(() => keyed.useValue("asst-1"));
+      expect(result.current).toBe("");
+
+      act(() => keyed.save("asst-1", "conv-abc"));
+
+      expect(result.current).toBe("conv-abc");
+    });
+
+    // The reason the snapshot cache exists: useSyncExternalStore bails out of
+    // re-rendering only on reference equality, so a re-parse per render would
+    // spin forever for an object or array value.
+    test("returns a stable reference while the stored text is unchanged", () => {
+      list.save("asst-1", ["a", "b"]);
+
+      const { result, rerender } = renderHook(() => list.useValue("asst-1"));
+      const first = result.current;
+      rerender();
+
+      expect(result.current).toBe(first);
+      expect(result.current).toEqual(["a", "b"]);
+    });
+
+    test("a mutated load() result does not corrupt the snapshot", () => {
+      list.save("asst-1", ["a"]);
+      const { result } = renderHook(() => list.useValue("asst-1"));
+
+      list.load("asst-1").push("mutated");
+
+      expect(result.current).toEqual(["a"]);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -281,6 +332,37 @@ describe("createRecordStorageAccessor", () => {
         unbounded.set("entity-1", `k${i}`, { value: i, label: `item-${i}` });
       }
       expect(Object.keys(unbounded.load("entity-1")).length).toBe(10);
+    });
+  });
+
+  describe("useValue", () => {
+    test("reads the stored record on the first render", () => {
+      record.set("entity-1", "k1", { value: 1, label: "one" });
+
+      const { result } = renderHook(() => record.useValue("entity-1"));
+
+      expect(result.current).toEqual({ k1: { value: 1, label: "one" } });
+    });
+
+    test("re-renders when an entry is written from outside the hook", () => {
+      const { result } = renderHook(() => record.useValue("entity-1"));
+      expect(result.current).toEqual({});
+
+      act(() => record.set("entity-1", "k1", { value: 1, label: "one" }));
+
+      expect(result.current).toEqual({ k1: { value: 1, label: "one" } });
+    });
+
+    test("returns a stable reference while the stored text is unchanged", () => {
+      record.set("entity-1", "k1", { value: 1, label: "one" });
+
+      const { result, rerender } = renderHook(() =>
+        record.useValue("entity-1"),
+      );
+      const first = result.current;
+      rerender();
+
+      expect(result.current).toBe(first);
     });
   });
 });

--- a/clients/web/src/utils/typed-storage.ts
+++ b/clients/web/src/utils/typed-storage.ts
@@ -14,7 +14,7 @@
  * - {@link https://zustand.docs.pmnd.rs/integrations/persisting-store-data}
  */
 
-import { useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 import {
   removeLocalSetting,
@@ -60,12 +60,7 @@ export interface StorageAccessor<T> {
   useValue: () => T;
 }
 
-/**
- * Config for per-entity keyed storage. Intentionally has no `useValue`
- * hook — if you need React subscription for per-entity data, prefer
- * `createRecordStorageAccessor` or compose with `useSyncExternalStore`
- * at the call site.
- */
+/** Config for per-entity keyed storage. */
 export interface KeyedStorageAccessorConfig<T> {
   /** Builds the localStorage key from an entity ID (e.g., assistantId). */
   keyFn: (id: string) => string;
@@ -90,6 +85,13 @@ export interface KeyedStorageAccessor<T> {
   keyFn: (id: string) => string;
   /** The declared scope. */
   scope: StorageScope;
+  /**
+   * React hook that subscribes to changes for one entity's key.
+   * Concurrent-rendering-safe, and reads during render rather than in an
+   * effect — so the first paint already carries the stored value instead of
+   * the fallback.
+   */
+  useValue: (id: string) => T;
 }
 
 // ---------------------------------------------------------------------------
@@ -105,6 +107,37 @@ function readRaw(key: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Per-entity snapshot cache for `useValue`, keyed by entity ID.
+ *
+ * `useSyncExternalStore` calls `getSnapshot` on every render and bails out
+ * only when the result is reference-equal, so a non-primitive `T` reparsed
+ * each call would re-render forever. Caching on the raw string keeps the
+ * reference stable while the stored text is unchanged, and self-heals when
+ * it isn't — the same contract `createStorageAccessor` implements for the
+ * static case.
+ *
+ * Deliberately not shared with `load`. `load` returns a freshly parsed value
+ * that callers may mutate; handing them the cached instance would corrupt
+ * every subscriber's snapshot.
+ */
+function createSnapshotCache<T>(
+  read: (id: string) => string | null,
+  parseOrFallback: (raw: string | null) => T,
+) {
+  const cache = new Map<string, { raw: string | null; value: T }>();
+  return function snapshot(id: string): T {
+    const raw = read(id);
+    const cached = cache.get(id);
+    if (cached !== undefined && cached.raw === raw) {
+      return cached.value;
+    }
+    const value = parseOrFallback(raw);
+    cache.set(id, { raw, value });
+    return value;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -243,8 +276,7 @@ export function createKeyedStorageAccessor<T>(
 ): KeyedStorageAccessor<T> {
   const { keyFn, scope, parse, serialize, fallback } = config;
 
-  function load(id: string): T {
-    const raw = readRaw(keyFn(id));
+  function parseOrFallback(raw: string | null): T {
     if (raw === null) {
       return fallback;
     }
@@ -256,6 +288,10 @@ export function createKeyedStorageAccessor<T>(
     }
   }
 
+  function load(id: string): T {
+    return parseOrFallback(readRaw(keyFn(id)));
+  }
+
   function save(id: string, value: T): void {
     setLocalSetting(keyFn(id), serialize(value));
   }
@@ -264,7 +300,23 @@ export function createKeyedStorageAccessor<T>(
     removeLocalSetting(keyFn(id));
   }
 
-  return { load, save, remove, keyFn, scope };
+  const snapshot = createSnapshotCache<T>(
+    (id) => readRaw(keyFn(id)),
+    parseOrFallback,
+  );
+
+  function useValue(id: string): T {
+    // Both callbacks are keyed on `id`: a changed entity must resubscribe to
+    // the new key, or the hook would keep watching the previous one.
+    const subscribe = useCallback(
+      (onStoreChange: () => void) => watchSetting(keyFn(id), onStoreChange),
+      [id],
+    );
+    const getSnapshot = useCallback(() => snapshot(id), [id]);
+    return useSyncExternalStore(subscribe, getSnapshot, () => fallback);
+  }
+
+  return { load, save, remove, keyFn, scope, useValue };
 }
 
 // ---------------------------------------------------------------------------
@@ -303,6 +355,13 @@ export interface RecordStorageAccessor<V> {
   keyFn: (id: string) => string;
   /** The declared scope. */
   scope: StorageScope;
+  /**
+   * React hook that subscribes to one entity's record. Returns the same
+   * reference while the stored text is unchanged, so it is safe to depend on
+   * — but for that reason the result must be treated as read-only. Use
+   * {@link RecordStorageAccessor.load} when you need a mutable copy.
+   */
+  useValue: (id: string) => Record<string, V>;
 }
 
 /**
@@ -391,5 +450,19 @@ export function createRecordStorageAccessor<V>(
     removeLocalSetting(keyFn(id));
   }
 
-  return { load, get, set, deleteEntry, remove, keyFn, scope };
+  const snapshot = createSnapshotCache<Record<string, V>>(
+    (id) => readRaw(keyFn(id)),
+    (raw) => (raw === null ? fallback : (parseRecord(raw) ?? fallback)),
+  );
+
+  function useValue(id: string): Record<string, V> {
+    const subscribe = useCallback(
+      (onStoreChange: () => void) => watchSetting(keyFn(id), onStoreChange),
+      [id],
+    );
+    const getSnapshot = useCallback(() => snapshot(id), [id]);
+    return useSyncExternalStore(subscribe, getSnapshot, () => fallback);
+  }
+
+  return { load, get, set, deleteEntry, remove, keyFn, scope, useValue };
 }

--- a/clients/web/src/utils/typed-storage.ts
+++ b/clients/web/src/utils/typed-storage.ts
@@ -111,20 +111,6 @@ function readRaw(key: string): string | null {
 }
 
 /**
- * Per-entity snapshot cache for `useValue`, keyed by entity ID.
- *
- * `useSyncExternalStore` calls `getSnapshot` on every render and bails out
- * only when the result is reference-equal, so a non-primitive `T` reparsed
- * each call would re-render forever. Caching on the raw string keeps the
- * reference stable while the stored text is unchanged, and self-heals when
- * it isn't. This is the same contract `createStorageAccessor` implements for
- * the static case.
- *
- * Deliberately not shared with `load`. `load` returns a freshly parsed value
- * that callers may mutate; handing them the cached instance would corrupt
- * every subscriber's snapshot.
- */
-/**
  * Session-scoped holding area for values storage refuses to take.
  *
  * `localStorage.setItem` throws in private browsing, under a policy that
@@ -142,17 +128,23 @@ function readRaw(key: string): string | null {
  * that recovers (the user leaves private browsing, quota frees up) goes back
  * to reading straight from storage.
  */
-function createOverrides<T>() {
+function createOverrides<T>(scope: StorageScope) {
   const overrides = new Map<string, T>();
   const store = {
     has: (id: string) => overrides.has(id),
     get: (id: string) => overrides.get(id) as T,
     drop: (id: string) => overrides.delete(id),
+    scope,
     clear: () => overrides.clear(),
     /** Write through to storage, holding the value in memory if it bounces. */
     write(id: string, key: string, value: T, serialized: string): void {
+      // Drop first. `setLocalSetting` notifies synchronously on success, and a
+      // subscriber reading its snapshot during that dispatch would see the
+      // held value, match its previous snapshot, and skip the re-render. No
+      // second notification follows a deletion, so the control would sit on
+      // the superseded value until an unrelated render moved it.
+      overrides.delete(id);
       if (setLocalSetting(key, serialized)) {
-        overrides.delete(id);
         return;
       }
       overrides.set(id, value);
@@ -164,32 +156,52 @@ function createOverrides<T>() {
 }
 
 /**
- * Every override map, so logout can reach all of them.
+ * Every override map, so logout can reach the user-scoped ones.
  *
  * Accessors are module-level singletons created at import time, so this grows
  * once per accessor and never shrinks.
  */
-const overrideStores: { clear: () => void }[] = [];
+const overrideStores: { scope: StorageScope; clear: () => void }[] = [];
 
 /**
- * Drop every value held in memory on behalf of a rejected write.
+ * Drop every user-scoped value held in memory on behalf of a rejected write.
  *
- * These values are user-scoped but live outside `localStorage`, so the logout
- * sweep cannot see them: it removes keys, and an override is precisely the
- * value that never became one. Without this, a preference set on a device that
- * refuses writes would outlive the session that set it and be read by whoever
- * logs in next in the same tab, which is the same trap
- * `clearTakeoverAvatarStash` exists to close for the avatar mirror.
+ * These values live outside `localStorage`, so the logout sweep cannot see
+ * them: it removes keys, and a held value is precisely the one that never
+ * became a key. Without this, a preference set on a device that refuses writes
+ * would outlive the session that set it and be read by whoever logs in next in
+ * the same tab, the same trap `clearTakeoverAvatarStash` exists to close for
+ * the avatar mirror.
+ *
+ * Device-scoped values are left alone. `device:` keys survive logout by
+ * design, so dropping their in-memory counterparts would make a rejected write
+ * the one case where a device preference does not.
  */
-export function clearStorageOverrides(): void {
+export function clearUserScopedOverrides(): void {
   for (const store of overrideStores) {
-    store.clear();
+    if (store.scope === "user") {
+      store.clear();
+    }
   }
 }
 
 /** The single entity id a static-key accessor stores its override under. */
 const STATIC_ID = "";
 
+/**
+ * Per-entity snapshot cache for `useValue`, keyed by entity ID.
+ *
+ * `useSyncExternalStore` calls `getSnapshot` on every render and bails out
+ * only when the result is reference-equal, so a non-primitive `T` reparsed
+ * each call would re-render forever. Caching on the raw string keeps the
+ * reference stable while the stored text is unchanged, and self-heals when
+ * it isn't. This is the same contract `createStorageAccessor` implements for
+ * the static case.
+ *
+ * Deliberately not shared with `load`. `load` returns a freshly parsed value
+ * that callers may mutate; handing them the cached instance would corrupt
+ * every subscriber's snapshot.
+ */
 function createSnapshotCache<T>(
   read: (id: string) => string | null,
   parseOrFallback: (raw: string | null) => T,
@@ -266,7 +278,7 @@ export function createStorageAccessor<T>(
   // and re-render indefinitely.
   let cachedRaw: string | null | undefined;
   let cachedValue: T = fallback;
-  const overrides = createOverrides<T>();
+  const overrides = createOverrides<T>(scope);
 
   function load(): T {
     if (overrides.has(STATIC_ID)) {
@@ -360,7 +372,7 @@ export function createKeyedStorageAccessor<T>(
     }
   }
 
-  const overrides = createOverrides<T>();
+  const overrides = createOverrides<T>(scope);
 
   function load(id: string): T {
     if (overrides.has(id)) {
@@ -490,7 +502,7 @@ export function createRecordStorageAccessor<V>(
     }
   }
 
-  const overrides = createOverrides<Record<string, V>>();
+  const overrides = createOverrides<Record<string, V>>(scope);
 
   function persist(id: string, record: Record<string, V>): void {
     overrides.write(id, keyFn(id), record, JSON.stringify(record));

--- a/clients/web/src/utils/typed-storage.ts
+++ b/clients/web/src/utils/typed-storage.ts
@@ -144,10 +144,11 @@ function readRaw(key: string): string | null {
  */
 function createOverrides<T>() {
   const overrides = new Map<string, T>();
-  return {
+  const store = {
     has: (id: string) => overrides.has(id),
     get: (id: string) => overrides.get(id) as T,
     drop: (id: string) => overrides.delete(id),
+    clear: () => overrides.clear(),
     /** Write through to storage, holding the value in memory if it bounces. */
     write(id: string, key: string, value: T, serialized: string): void {
       if (setLocalSetting(key, serialized)) {
@@ -158,6 +159,32 @@ function createOverrides<T>() {
       notifySettingChange(key, serialized);
     },
   };
+  overrideStores.push(store);
+  return store;
+}
+
+/**
+ * Every override map, so logout can reach all of them.
+ *
+ * Accessors are module-level singletons created at import time, so this grows
+ * once per accessor and never shrinks.
+ */
+const overrideStores: { clear: () => void }[] = [];
+
+/**
+ * Drop every value held in memory on behalf of a rejected write.
+ *
+ * These values are user-scoped but live outside `localStorage`, so the logout
+ * sweep cannot see them: it removes keys, and an override is precisely the
+ * value that never became one. Without this, a preference set on a device that
+ * refuses writes would outlive the session that set it and be read by whoever
+ * logs in next in the same tab, which is the same trap
+ * `clearTakeoverAvatarStash` exists to close for the avatar mirror.
+ */
+export function clearStorageOverrides(): void {
+  for (const store of overrideStores) {
+    store.clear();
+  }
 }
 
 /** The single entity id a static-key accessor stores its override under. */

--- a/clients/web/src/utils/typed-storage.ts
+++ b/clients/web/src/utils/typed-storage.ts
@@ -17,6 +17,7 @@
 import { useCallback, useSyncExternalStore } from "react";
 
 import {
+  notifySettingChange,
   removeLocalSetting,
   setLocalSetting,
   watchSetting,
@@ -88,7 +89,7 @@ export interface KeyedStorageAccessor<T> {
   /**
    * React hook that subscribes to changes for one entity's key.
    * Concurrent-rendering-safe, and reads during render rather than in an
-   * effect — so the first paint already carries the stored value instead of
+   * effect, so the first paint already carries the stored value instead of
    * the fallback.
    */
   useValue: (id: string) => T;
@@ -116,13 +117,52 @@ function readRaw(key: string): string | null {
  * only when the result is reference-equal, so a non-primitive `T` reparsed
  * each call would re-render forever. Caching on the raw string keeps the
  * reference stable while the stored text is unchanged, and self-heals when
- * it isn't — the same contract `createStorageAccessor` implements for the
- * static case.
+ * it isn't. This is the same contract `createStorageAccessor` implements for
+ * the static case.
  *
  * Deliberately not shared with `load`. `load` returns a freshly parsed value
  * that callers may mutate; handing them the cached instance would corrupt
  * every subscriber's snapshot.
  */
+/**
+ * Session-scoped holding area for values storage refuses to take.
+ *
+ * `localStorage.setItem` throws in private browsing, under a policy that
+ * disables storage, and on quota exhaustion. The write is best-effort and
+ * fails soft, which is right for persistence but wrong for display: a value
+ * read back through `useValue` would keep reporting the previous state, so a
+ * control bound to it looks broken rather than merely unsaved.
+ *
+ * Holding the rejected value in memory and announcing it anyway keeps the
+ * control honest. The choice applies for the session and is absent on the next
+ * load, which is the most any storage-backed value can offer on a device that
+ * rejects writes.
+ *
+ * An entry lives only until a write for the same id succeeds, so a browser
+ * that recovers (the user leaves private browsing, quota frees up) goes back
+ * to reading straight from storage.
+ */
+function createOverrides<T>() {
+  const overrides = new Map<string, T>();
+  return {
+    has: (id: string) => overrides.has(id),
+    get: (id: string) => overrides.get(id) as T,
+    drop: (id: string) => overrides.delete(id),
+    /** Write through to storage, holding the value in memory if it bounces. */
+    write(id: string, key: string, value: T, serialized: string): void {
+      if (setLocalSetting(key, serialized)) {
+        overrides.delete(id);
+        return;
+      }
+      overrides.set(id, value);
+      notifySettingChange(key, serialized);
+    },
+  };
+}
+
+/** The single entity id a static-key accessor stores its override under. */
+const STATIC_ID = "";
+
 function createSnapshotCache<T>(
   read: (id: string) => string | null,
   parseOrFallback: (raw: string | null) => T,
@@ -199,8 +239,12 @@ export function createStorageAccessor<T>(
   // and re-render indefinitely.
   let cachedRaw: string | null | undefined;
   let cachedValue: T = fallback;
+  const overrides = createOverrides<T>();
 
   function load(): T {
+    if (overrides.has(STATIC_ID)) {
+      return overrides.get(STATIC_ID);
+    }
     const raw = readRaw(key);
     if (raw === cachedRaw) {
       return cachedValue;
@@ -220,10 +264,11 @@ export function createStorageAccessor<T>(
   }
 
   function save(value: T): void {
-    setLocalSetting(key, serialize(value));
+    overrides.write(STATIC_ID, key, value, serialize(value));
   }
 
   function remove(): void {
+    overrides.drop(STATIC_ID);
     removeLocalSetting(key);
   }
 
@@ -288,22 +333,32 @@ export function createKeyedStorageAccessor<T>(
     }
   }
 
+  const overrides = createOverrides<T>();
+
   function load(id: string): T {
+    if (overrides.has(id)) {
+      return overrides.get(id);
+    }
     return parseOrFallback(readRaw(keyFn(id)));
   }
 
   function save(id: string, value: T): void {
-    setLocalSetting(keyFn(id), serialize(value));
+    overrides.write(id, keyFn(id), value, serialize(value));
   }
 
   function remove(id: string): void {
+    overrides.drop(id);
     removeLocalSetting(keyFn(id));
   }
 
-  const snapshot = createSnapshotCache<T>(
+  const cachedSnapshot = createSnapshotCache<T>(
     (id) => readRaw(keyFn(id)),
     parseOrFallback,
   );
+
+  function snapshot(id: string): T {
+    return overrides.has(id) ? overrides.get(id) : cachedSnapshot(id);
+  }
 
   function useValue(id: string): T {
     // Both callbacks are keyed on `id`: a changed entity must resubscribe to
@@ -358,7 +413,7 @@ export interface RecordStorageAccessor<V> {
   /**
    * React hook that subscribes to one entity's record. Returns the same
    * reference while the stored text is unchanged, so it is safe to depend on
-   * — but for that reason the result must be treated as read-only. Use
+   * but for that reason the result must be treated as read-only. Use
    * {@link RecordStorageAccessor.load} when you need a mutable copy.
    */
   useValue: (id: string) => Record<string, V>;
@@ -408,7 +463,16 @@ export function createRecordStorageAccessor<V>(
     }
   }
 
+  const overrides = createOverrides<Record<string, V>>();
+
+  function persist(id: string, record: Record<string, V>): void {
+    overrides.write(id, keyFn(id), record, JSON.stringify(record));
+  }
+
   function load(id: string): Record<string, V> {
+    if (overrides.has(id)) {
+      return { ...overrides.get(id) };
+    }
     const raw = readRaw(keyFn(id));
     if (raw === null) {
       return { ...fallback };
@@ -432,28 +496,33 @@ export function createRecordStorageAccessor<V>(
         for (const [k, v] of trimmed) {
           trimmedRecord[k] = v;
         }
-        setLocalSetting(keyFn(id), JSON.stringify(trimmedRecord));
+        persist(id, trimmedRecord);
         return;
       }
     }
 
-    setLocalSetting(keyFn(id), JSON.stringify(existing));
+    persist(id, existing);
   }
 
   function deleteEntry(id: string, entryKey: string): void {
     const existing = load(id);
     delete existing[entryKey];
-    setLocalSetting(keyFn(id), JSON.stringify(existing));
+    persist(id, existing);
   }
 
   function remove(id: string): void {
+    overrides.drop(id);
     removeLocalSetting(keyFn(id));
   }
 
-  const snapshot = createSnapshotCache<Record<string, V>>(
+  const cachedSnapshot = createSnapshotCache<Record<string, V>>(
     (id) => readRaw(keyFn(id)),
     (raw) => (raw === null ? fallback : (parseRecord(raw) ?? fallback)),
   );
+
+  function snapshot(id: string): Record<string, V> {
+    return overrides.has(id) ? overrides.get(id) : cachedSnapshot(id);
+  }
 
   function useValue(id: string): Record<string, V> {
     const subscribe = useCallback(


### PR DESCRIPTION
## TL;DR

The sidebar's `All | Groups` choice already persisted — it just didn't look like it. The layout store hydrates from localStorage inside an effect, so the first paint always drew the default and the stored choice arrived one commit later. Anyone whose last choice was Groups saw a flash of the flat list on every load.

The fix is in the storage layer, not the sidebar: `createKeyedStorageAccessor` and `createRecordStorageAccessor` now expose a `useValue(id)` hook, so per-assistant preferences are read during render instead of after mount. The view mode is the first consumer.

Closes LUM-2964. Part of LUM-2963.

## What changes for the user

| | Before | After |
|---|---|---|
| Opening the app with Groups selected | Flash of the flat All list, then it switches to Groups | Groups is there on the first paint |
| Switching view in a second window | The other window keeps the old view until reload | Both windows update immediately |
| Where the choice lives | Copied into a Zustand store on assistant switch | Read from storage, which is now the source of truth |
| Toggling with storage unavailable (private browsing, quota exhausted) | Switch ignores the click entirely | Switch moves and holds for the session; the choice is simply not persisted |

Nothing about *what* is stored changes: same key, same value, same per-assistant scoping. No migration.

## Rejected writes

`localStorage.setItem` throws in private browsing, under a policy that disables storage, and on quota exhaustion. `setLocalSetting` caught that and returned before its change notification, so a subscribed value kept reporting its previous state and any control bound to it ignored input.

`setLocalSetting` reports whether the value landed. Each accessor holds a rejected value in memory under its entity id and fires the notification itself, so `load` and `useValue` agree. The value applies for the session and is absent on the next load, which is the most a storage-backed value can offer on a device that rejects writes; the entry is dropped as soon as a write for that id succeeds.

This covers all three accessors, not just the keyed one. The static accessor has the same failure today, so the settings toggles (Cmd+Enter to send, context-window indicator) and the tip cards were equally dead in those environments.

A held value is user state that never became a key, so the logout sweep cannot see it. `clearStorageOverrides()` drops all of them, called from `clearUserScopedStorage` next to the `clearTakeoverAvatarStash()` call that exists for the identical hazard on the avatar mirror.

## Backwards compatibility

No migration, and none needed.

- **The stored contract is unchanged.** Same key, same values (`"all"` / `"grouped"`), same per-assistant scoping. Existing data is read as-is, and a revert of this PR reads it back just as well: the Zustand store it replaced used the same key.
- **`setLocalSetting` reporting a boolean is additive.** It returned `void`, so no caller could have branched on it.
- **Nothing durable is at risk.** Every accessor this touches holds redo-able local state: pinned apps, tips, composer toggles, push registration, and the per-assistant sidebar and conversation keys. Terms-of-service acceptance, AI-data consent, and the analytics/diagnostics choices live in `onboarding-store.ts`, `prefs.ts`, and `consent-persistence.ts`, none of which import `typed-storage`.
- **The worst case is a redo.** On a device that refuses writes, a preference set this session is absent next load, which is the same outcome as before this change.

## Platform coverage

The change is plain DOM storage plus `useSyncExternalStore`, with no host-specific surface:

- **Electron renderer** — Chromium, so `localStorage`, the `storage` event, and `CustomEvent` all behave as on web. Per `docs/ELECTRON.md` the only renderer code needing a `runtime/` wrapper is `window.vellum.*`, which this does not touch.
- **Capacitor iOS (WKWebView)** — `localStorage` is available; `docs/CAPACITOR.md` carries no storage rules, and its lazy-plugin-import rule applies to `@capacitor/*` imports, none of which appear here. WKWebView is also the host most likely to reject writes under storage pressure, which the section above now handles.
- **Browser SPA** — the baseline.
- **Sandboxed app iframes** — `sandbox-bridge.ts` injects an in-memory `Storage` shim whose writes succeed, so nothing changes there.
- **SSR / prerender** — there is no SSR today (Vite SPA), and `getServerSnapshot` returns the fallback, satisfying the CONVENTIONS rule against touching `localStorage` during synchronous render.

One limit worth stating plainly: cross-window sync rests on Chromium dispatching `storage` to other same-origin contexts and on the same-tab `vellum:pref-changed` event, both of which `watchSetting` already listened for. I verified that path in code and under test, not by driving two live Electron windows.

## Why this is safe

- **No storage format change.** `vellum:sidebar-view-mode:<assistantId>` keeps its exact contract, so there is nothing to migrate and nothing to roll back.
- **The SSR rule still holds.** CONVENTIONS forbids touching `localStorage` during synchronous render. `useSyncExternalStore` is the sanctioned way around that — `getServerSnapshot` returns the fallback, and `createStorageAccessor.useValue` has been doing exactly this since it was written. This change extends the existing pattern rather than introducing one.
- **`load()` is untouched.** The new snapshot cache is deliberately not shared with it, so callers that mutate a returned array still get their own copy. There's a test for that specifically.
- **The regression test is one the old code could not pass.** `seedGroupedView()` used to prime the Zustand store *and* localStorage, with a comment explaining that the store hydrates in an effect. It now seeds only the key, and the same 16 tests pass — the first render reads it.

## Verification

Per-file, from `clients/web`:

| File | Result |
|---|---|
| `typed-storage.test.ts` | 36 pass |
| `sidebar-view-mode.test.tsx` (new) | 8 pass |
| Full suite (`bun run test:ci`) | 798 passed, 0 failed |
| `sidebar-layout-store.test.ts` | 17 pass |
| `use-sidebar-state.test.tsx` | 16 pass |
| `assistant-side-menu.test.tsx` | 50 pass |
| `session-cleanup.test.ts` | 11 pass |
| `preferences-modal.test.tsx` (other accessor consumers) | 4 pass |
| `use-tip-card.test.ts` (other accessor consumers) | 19 pass |

`bunx tsc --noEmit` and `eslint` both clean.

The rejected-write tests are mutation-checked rather than assumed: dropping the in-memory hold fails 4 tests across two files, and making `clearStorageOverrides` a no-op fails 1.

## Deferred, and why

- **The other four sidebar keys** (open-categories, open-custom-groups, open-primary, section-order) stay on the layout store. LUM-2969 collapses all five into a single `vellum:sidebar:<assistantId>` record; migrating them here would migrate the same keys twice, so it waits for that.
- **`useValue` on the record accessor has no production consumer yet.** It's covered by tests and lands with its sibling because the two accessors should not drift, but the first real user is LUM-2969.
- **Reporting persistent write failure** to the user or telemetry. A device that cannot persist anything degrades silently to session-only preferences; `setLocalSetting` surfaces the failure to its caller but nobody escalates it. Tracked in LUM-2968.
- **The wider storage cleanup** — a logout sweep that misses per-user keys, unbounded chat drafts, six competing persistence mechanisms — is filed under LUM-2963 and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
