### PR TITLE
Add native Android voice contracts and audio focus

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -109,9 +109,10 @@ are disabled, and token values are never written to logs or crash metadata.
 
 The `VoiceAudioSession` plugin requests transient voice-communication audio
 focus while a live voice session is active. Calls and competing media produce
-the same interruption payload used by iOS. Duckable audio and device-route
-changes do not end the voice session. Focus is released when voice ends or the
-activity closes so interrupted media can resume.
+the same interruption payload used by iOS. Wired and Bluetooth changes emit a
+nonfatal route-change payload, and duckable audio does not end the voice
+session. Focus is released when voice ends or the activity closes so
+interrupted media can resume.
 
 Microphone capture and the voice socket remain in the foreground WebView. No
 microphone foreground service is used. Physical-device background validation

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -105,6 +105,19 @@ ciphertext.
 Stored preferences contain only an encrypted payload and IV. Android backups
 are disabled, and token values are never written to logs or crash metadata.
 
+## Voice Audio Focus
+
+The `VoiceAudioSession` plugin requests transient voice-communication audio
+focus while a live voice session is active. Calls and competing media produce
+the same interruption payload used by iOS, while Bluetooth and wired-device
+changes produce a route-change interruption. Focus is released when voice ends
+or the activity closes so interrupted media can resume.
+
+Microphone capture and the voice socket remain in the foreground WebView. No
+microphone foreground service is used. Physical-device background validation
+has not been completed: app switching and screen locking can suspend WebView
+capture or networking and are not supported as background voice behavior.
+
 ## Structure
 
 ```
@@ -125,6 +138,7 @@ clients/
     │       │   ├── NativeBiometricPlugin.java
     │       │   ├── BiometricTokenStore.java
     │       │   ├── SelfHostedServer.java
+    │       │   ├── VoiceAudioSessionPlugin.java
     │       │   └── WorkOSAuth.java
     │       └── res/              # Vellum icon, splash, colors, file paths
     ├── build.gradle

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -107,17 +107,11 @@ are disabled, and token values are never written to logs or crash metadata.
 
 ## Voice Audio Focus
 
-The `VoiceAudioSession` plugin requests transient voice-communication audio
-focus while a live voice session is active. Calls and competing media produce
-the same interruption payload used by iOS. Wired and Bluetooth changes emit a
-nonfatal route-change payload, and duckable audio does not end the voice
-session. Focus is released when voice ends or the activity closes so
-interrupted media can resume.
+The `VoiceAudioSession` plugin requests transient voice-communication audio focus while a live voice session is active. Calls and competing media produce the same interruption payload used by iOS.
+Wired and Bluetooth changes are nonfatal, duckable audio does not end voice, and focus is released when voice ends or the activity closes so interrupted media can resume.
 
-Microphone capture and the voice socket remain in the foreground WebView. No
-microphone foreground service is used. Physical-device background validation
-has not been completed: app switching and screen locking can suspend WebView
-capture or networking and are not supported as background voice behavior.
+Microphone capture and the voice socket remain in the foreground WebView. No microphone foreground service is used.
+Physical-device background validation has not been completed, so app switching and screen locking are not supported as background voice behavior.
 
 ## Structure
 

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -109,9 +109,9 @@ are disabled, and token values are never written to logs or crash metadata.
 
 The `VoiceAudioSession` plugin requests transient voice-communication audio
 focus while a live voice session is active. Calls and competing media produce
-the same interruption payload used by iOS, while Bluetooth and wired-device
-changes produce a route-change interruption. Focus is released when voice ends
-or the activity closes so interrupted media can resume.
+the same interruption payload used by iOS. Duckable audio and device-route
+changes do not end the voice session. Focus is released when voice ends or the
+activity closes so interrupted media can resume.
 
 Microphone capture and the voice socket remain in the foreground WebView. No
 microphone foreground service is used. Physical-device background validation

--- a/clients/android/app/src/main/java/ai/vocify/vellumassistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vocify/vellumassistant/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends BridgeActivity {
         configureServer(pendingConnect == null ? SelfHostedServer.configured(this) : pendingConnect.server());
         registerPlugin(NativeAuthPlugin.class);
         registerPlugin(NativeBiometricPlugin.class);
+        registerPlugin(VoiceAudioSessionPlugin.class);
         super.onCreate(savedInstanceState);
         if (bridge != null) {
             bridge.setWebViewClient(new SelfHostedWebViewClient(bridge, this));

--- a/clients/android/app/src/main/java/ai/vocify/vellumassistant/VoiceAudioSessionPlugin.java
+++ b/clients/android/app/src/main/java/ai/vocify/vellumassistant/VoiceAudioSessionPlugin.java
@@ -2,6 +2,8 @@ package ai.vocify.vellumassistant;
 
 import android.content.Context;
 import android.media.AudioAttributes;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.os.Build;
@@ -19,9 +21,22 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
     private static final String FAILURE_CODE = "AUDIO_SESSION_FAILED";
 
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final AudioDeviceCallback deviceCallback = new AudioDeviceCallback() {
+        @Override
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
+            emitRouteChange(addedDevices);
+        }
+
+        @Override
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
+            emitRouteChange(removedDevices);
+        }
+    };
     private AudioFocusRequest focusRequest;
     private AudioManager audioManager;
     private boolean active;
+    private boolean deviceCallbackRegistered;
+    private boolean routeCallbacksReady;
 
     @Override
     public void load() {
@@ -79,6 +94,9 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
                 return;
             }
             active = true;
+            audioManager.registerAudioDeviceCallback(deviceCallback, mainHandler);
+            deviceCallbackRegistered = true;
+            mainHandler.post(() -> routeCallbacksReady = active && deviceCallbackRegistered);
             call.resolve(activationResult(true));
         } catch (RuntimeException exception) {
             releaseAudioFocus();
@@ -100,6 +118,7 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
 
     @SuppressWarnings("deprecation")
     private void releaseAudioFocus() {
+        stopRouteMonitoring();
         if (audioManager == null) {
             active = false;
             return;
@@ -124,8 +143,38 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
         }
         if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
             active = false;
+            stopRouteMonitoring();
         }
         notifyListeners(EVENT_NAME, event.toJSObject());
+    }
+
+    private void emitRouteChange(AudioDeviceInfo[] devices) {
+        if (!active || !routeCallbacksReady) {
+            return;
+        }
+        for (AudioDeviceInfo device : devices) {
+            if (isCommunicationRoute(device.getType())) {
+                notifyListeners(EVENT_NAME, FocusEvent.routeChange().toJSObject());
+                return;
+            }
+        }
+    }
+
+    private static boolean isCommunicationRoute(int type) {
+        return type == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
+            type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES ||
+            type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO ||
+            type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+            type == AudioDeviceInfo.TYPE_USB_HEADSET ||
+            type == AudioDeviceInfo.TYPE_HEARING_AID;
+    }
+
+    private void stopRouteMonitoring() {
+        if (audioManager != null && deviceCallbackRegistered) {
+            audioManager.unregisterAudioDeviceCallback(deviceCallback);
+        }
+        deviceCallbackRegistered = false;
+        routeCallbacksReady = false;
     }
 
     private void runOnMainThread(Runnable action) {
@@ -149,6 +198,10 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
         private FocusEvent(String type, String reason) {
             this.type = type;
             this.reason = reason;
+        }
+
+        static FocusEvent routeChange() {
+            return new FocusEvent("began", "route-change");
         }
 
         static FocusEvent fromFocusChange(int focusChange) {

--- a/clients/android/app/src/main/java/ai/vocify/vellumassistant/VoiceAudioSessionPlugin.java
+++ b/clients/android/app/src/main/java/ai/vocify/vellumassistant/VoiceAudioSessionPlugin.java
@@ -1,0 +1,259 @@
+package ai.vocify.vellumassistant;
+
+import android.content.Context;
+import android.media.AudioAttributes;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+import android.media.AudioFocusRequest;
+import android.media.AudioManager;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.util.HashSet;
+import java.util.Set;
+
+@CapacitorPlugin(name = "VoiceAudioSession")
+public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAudioFocusChangeListener {
+    static final String EVENT_NAME = "voiceAudioInterruption";
+    private static final String FAILURE_CODE = "AUDIO_SESSION_FAILED";
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final AudioDeviceCallback deviceCallback = new AudioDeviceCallback() {
+        @Override
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
+            emitRouteChange();
+        }
+
+        @Override
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
+            emitRouteChange();
+        }
+    };
+
+    private AudioFocusRequest focusRequest;
+    private AudioManager audioManager;
+    private boolean active;
+    private boolean deviceCallbackRegistered;
+    private boolean modeChanged;
+    private int previousMode = AudioManager.MODE_NORMAL;
+    private Set<Integer> routeDeviceIds = new HashSet<>();
+
+    @Override
+    public void load() {
+        audioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            AudioAttributes attributes = new AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                .build();
+            focusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+                .setAudioAttributes(attributes)
+                .setAcceptsDelayedFocusGain(false)
+                .setOnAudioFocusChangeListener(this, mainHandler)
+                .setWillPauseWhenDucked(true)
+                .build();
+        }
+    }
+
+    @PluginMethod
+    public void activate(PluginCall call) {
+        runOnMainThread(() -> activateOnMain(call));
+    }
+
+    @PluginMethod
+    public void deactivate(PluginCall call) {
+        runOnMainThread(() -> {
+            releaseAudioFocus();
+            call.resolve();
+        });
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        runOnMainThread(this::releaseAudioFocus);
+    }
+
+    @Override
+    public void onAudioFocusChange(int focusChange) {
+        mainHandler.post(() -> handleFocusChange(focusChange));
+    }
+
+    private void activateOnMain(PluginCall call) {
+        if (audioManager == null) {
+            call.reject("Android audio services are unavailable", FAILURE_CODE);
+            return;
+        }
+        if (active) {
+            call.resolve(activationResult(true));
+            return;
+        }
+
+        previousMode = audioManager.getMode();
+        try {
+            audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+            modeChanged = true;
+            int result = requestAudioFocus();
+            if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+                restoreAudioMode();
+                call.resolve(activationResult(false));
+                return;
+            }
+            active = true;
+            routeDeviceIds = currentCommunicationRouteIds();
+            audioManager.registerAudioDeviceCallback(deviceCallback, mainHandler);
+            deviceCallbackRegistered = true;
+            call.resolve(activationResult(true));
+        } catch (RuntimeException exception) {
+            releaseAudioFocus();
+            call.reject("Failed to activate Android voice audio focus", FAILURE_CODE, exception);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private int requestAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return audioManager.requestAudioFocus(focusRequest);
+        }
+        return audioManager.requestAudioFocus(
+            this,
+            AudioManager.STREAM_VOICE_CALL,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
+        );
+    }
+
+    @SuppressWarnings("deprecation")
+    private void releaseAudioFocus() {
+        if (audioManager == null) {
+            active = false;
+            return;
+        }
+        if (deviceCallbackRegistered) {
+            audioManager.unregisterAudioDeviceCallback(deviceCallback);
+            deviceCallbackRegistered = false;
+            routeDeviceIds.clear();
+        }
+        if (active) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                audioManager.abandonAudioFocusRequest(focusRequest);
+            } else {
+                audioManager.abandonAudioFocus(this);
+            }
+        }
+        active = false;
+        restoreAudioMode();
+    }
+
+    private void restoreAudioMode() {
+        if (audioManager != null && modeChanged) {
+            audioManager.setMode(previousMode);
+            modeChanged = false;
+        }
+    }
+
+    private void handleFocusChange(int focusChange) {
+        if (!active) {
+            return;
+        }
+        FocusEvent event = FocusEvent.fromFocusChange(focusChange);
+        if (event == null) {
+            return;
+        }
+        if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+            active = false;
+        }
+        notifyListeners(EVENT_NAME, event.toJSObject());
+    }
+
+    private void emitRouteChange() {
+        if (!active) {
+            return;
+        }
+        Set<Integer> nextRouteDeviceIds = currentCommunicationRouteIds();
+        if (routeDeviceIds.equals(nextRouteDeviceIds)) {
+            return;
+        }
+        routeDeviceIds = nextRouteDeviceIds;
+        JSObject event = new JSObject();
+        event.put("type", "began");
+        event.put("reason", "route-change");
+        notifyListeners(EVENT_NAME, event);
+    }
+
+    private Set<Integer> currentCommunicationRouteIds() {
+        Set<Integer> ids = new HashSet<>();
+        for (
+            AudioDeviceInfo device : audioManager.getDevices(
+                AudioManager.GET_DEVICES_INPUTS | AudioManager.GET_DEVICES_OUTPUTS
+            )
+        ) {
+            if (isCommunicationRouteType(device.getType())) {
+                ids.add(device.getId());
+            }
+        }
+        return ids;
+    }
+
+    private static boolean isCommunicationRouteType(int type) {
+        switch (type) {
+            case AudioDeviceInfo.TYPE_WIRED_HEADSET:
+            case AudioDeviceInfo.TYPE_WIRED_HEADPHONES:
+            case AudioDeviceInfo.TYPE_BLUETOOTH_SCO:
+            case AudioDeviceInfo.TYPE_BLUETOOTH_A2DP:
+            case AudioDeviceInfo.TYPE_USB_HEADSET:
+            case AudioDeviceInfo.TYPE_HEARING_AID:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void runOnMainThread(Runnable action) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            action.run();
+        } else {
+            mainHandler.post(action);
+        }
+    }
+
+    private static JSObject activationResult(boolean activated) {
+        JSObject result = new JSObject();
+        result.put("activated", activated);
+        return result;
+    }
+
+    static final class FocusEvent {
+        final String type;
+        final String reason;
+
+        private FocusEvent(String type, String reason) {
+            this.type = type;
+            this.reason = reason;
+        }
+
+        static FocusEvent fromFocusChange(int focusChange) {
+            switch (focusChange) {
+                case AudioManager.AUDIOFOCUS_GAIN:
+                    return new FocusEvent("ended", "resume");
+                case AudioManager.AUDIOFOCUS_LOSS:
+                    return new FocusEvent("began", "focus-loss");
+                case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+                    return new FocusEvent("began", "interruption");
+                default:
+                    return null;
+            }
+        }
+
+        JSObject toJSObject() {
+            JSObject result = new JSObject();
+            result.put("type", type);
+            result.put("reason", reason);
+            return result;
+        }
+    }
+}

--- a/clients/android/app/src/main/java/ai/vocify/vellumassistant/VoiceAudioSessionPlugin.java
+++ b/clients/android/app/src/main/java/ai/vocify/vellumassistant/VoiceAudioSessionPlugin.java
@@ -2,8 +2,6 @@ package ai.vocify.vellumassistant;
 
 import android.content.Context;
 import android.media.AudioAttributes;
-import android.media.AudioDeviceCallback;
-import android.media.AudioDeviceInfo;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.os.Build;
@@ -14,8 +12,6 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-import java.util.HashSet;
-import java.util.Set;
 
 @CapacitorPlugin(name = "VoiceAudioSession")
 public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAudioFocusChangeListener {
@@ -23,25 +19,9 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
     private static final String FAILURE_CODE = "AUDIO_SESSION_FAILED";
 
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
-    private final AudioDeviceCallback deviceCallback = new AudioDeviceCallback() {
-        @Override
-        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
-            emitRouteChange();
-        }
-
-        @Override
-        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
-            emitRouteChange();
-        }
-    };
-
     private AudioFocusRequest focusRequest;
     private AudioManager audioManager;
     private boolean active;
-    private boolean deviceCallbackRegistered;
-    private boolean modeChanged;
-    private int previousMode = AudioManager.MODE_NORMAL;
-    private Set<Integer> routeDeviceIds = new HashSet<>();
 
     @Override
     public void load() {
@@ -55,7 +35,6 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
                 .setAudioAttributes(attributes)
                 .setAcceptsDelayedFocusGain(false)
                 .setOnAudioFocusChangeListener(this, mainHandler)
-                .setWillPauseWhenDucked(true)
                 .build();
         }
     }
@@ -93,20 +72,13 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
             return;
         }
 
-        previousMode = audioManager.getMode();
         try {
-            audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
-            modeChanged = true;
             int result = requestAudioFocus();
             if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-                restoreAudioMode();
                 call.resolve(activationResult(false));
                 return;
             }
             active = true;
-            routeDeviceIds = currentCommunicationRouteIds();
-            audioManager.registerAudioDeviceCallback(deviceCallback, mainHandler);
-            deviceCallbackRegistered = true;
             call.resolve(activationResult(true));
         } catch (RuntimeException exception) {
             releaseAudioFocus();
@@ -132,11 +104,6 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
             active = false;
             return;
         }
-        if (deviceCallbackRegistered) {
-            audioManager.unregisterAudioDeviceCallback(deviceCallback);
-            deviceCallbackRegistered = false;
-            routeDeviceIds.clear();
-        }
         if (active) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 audioManager.abandonAudioFocusRequest(focusRequest);
@@ -145,14 +112,6 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
             }
         }
         active = false;
-        restoreAudioMode();
-    }
-
-    private void restoreAudioMode() {
-        if (audioManager != null && modeChanged) {
-            audioManager.setMode(previousMode);
-            modeChanged = false;
-        }
     }
 
     private void handleFocusChange(int focusChange) {
@@ -167,49 +126,6 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
             active = false;
         }
         notifyListeners(EVENT_NAME, event.toJSObject());
-    }
-
-    private void emitRouteChange() {
-        if (!active) {
-            return;
-        }
-        Set<Integer> nextRouteDeviceIds = currentCommunicationRouteIds();
-        if (routeDeviceIds.equals(nextRouteDeviceIds)) {
-            return;
-        }
-        routeDeviceIds = nextRouteDeviceIds;
-        JSObject event = new JSObject();
-        event.put("type", "began");
-        event.put("reason", "route-change");
-        notifyListeners(EVENT_NAME, event);
-    }
-
-    private Set<Integer> currentCommunicationRouteIds() {
-        Set<Integer> ids = new HashSet<>();
-        for (
-            AudioDeviceInfo device : audioManager.getDevices(
-                AudioManager.GET_DEVICES_INPUTS | AudioManager.GET_DEVICES_OUTPUTS
-            )
-        ) {
-            if (isCommunicationRouteType(device.getType())) {
-                ids.add(device.getId());
-            }
-        }
-        return ids;
-    }
-
-    private static boolean isCommunicationRouteType(int type) {
-        switch (type) {
-            case AudioDeviceInfo.TYPE_WIRED_HEADSET:
-            case AudioDeviceInfo.TYPE_WIRED_HEADPHONES:
-            case AudioDeviceInfo.TYPE_BLUETOOTH_SCO:
-            case AudioDeviceInfo.TYPE_BLUETOOTH_A2DP:
-            case AudioDeviceInfo.TYPE_USB_HEADSET:
-            case AudioDeviceInfo.TYPE_HEARING_AID:
-                return true;
-            default:
-                return false;
-        }
     }
 
     private void runOnMainThread(Runnable action) {
@@ -242,7 +158,6 @@ public class VoiceAudioSessionPlugin extends Plugin implements AudioManager.OnAu
                 case AudioManager.AUDIOFOCUS_LOSS:
                     return new FocusEvent("began", "focus-loss");
                 case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
                     return new FocusEvent("began", "interruption");
                 default:
                     return null;

--- a/clients/android/app/src/test/java/ai/vocify/vellumassistant/VoiceAudioSessionPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vocify/vellumassistant/VoiceAudioSessionPluginTest.java
@@ -11,7 +11,6 @@ public class VoiceAudioSessionPluginTest {
     public void permanentFocusLossBeginsFocusLossInterruption() {
         VoiceAudioSessionPlugin.FocusEvent event =
             VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(AudioManager.AUDIOFOCUS_LOSS);
-
         assertEquals("began", event.type);
         assertEquals("focus-loss", event.reason);
     }
@@ -26,7 +25,6 @@ public class VoiceAudioSessionPluginTest {
             VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK
             );
-
         assertEquals("began", transientEvent.type);
         assertEquals("interruption", transientEvent.reason);
         assertNull(duckingEvent);
@@ -36,13 +34,15 @@ public class VoiceAudioSessionPluginTest {
     public void focusGainEndsWithResumeReason() {
         VoiceAudioSessionPlugin.FocusEvent event =
             VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(AudioManager.AUDIOFOCUS_GAIN);
-
         assertEquals("ended", event.type);
         assertEquals("resume", event.reason);
     }
 
     @Test
-    public void unknownFocusChangesAreIgnored() {
-        assertNull(VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(42));
+    public void routeChangesUseTheSharedInterruptionPayload() {
+        VoiceAudioSessionPlugin.FocusEvent event =
+            VoiceAudioSessionPlugin.FocusEvent.routeChange();
+        assertEquals("began", event.type);
+        assertEquals("route-change", event.reason);
     }
 }

--- a/clients/android/app/src/test/java/ai/vocify/vellumassistant/VoiceAudioSessionPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vocify/vellumassistant/VoiceAudioSessionPluginTest.java
@@ -1,0 +1,49 @@
+package ai.vocify.vellumassistant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import android.media.AudioManager;
+import org.junit.Test;
+
+public class VoiceAudioSessionPluginTest {
+    @Test
+    public void permanentFocusLossBeginsFocusLossInterruption() {
+        VoiceAudioSessionPlugin.FocusEvent event =
+            VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(AudioManager.AUDIOFOCUS_LOSS);
+
+        assertEquals("began", event.type);
+        assertEquals("focus-loss", event.reason);
+    }
+
+    @Test
+    public void transientFocusLossAndDuckingBeginInterruption() {
+        VoiceAudioSessionPlugin.FocusEvent transientEvent =
+            VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(
+                AudioManager.AUDIOFOCUS_LOSS_TRANSIENT
+            );
+        VoiceAudioSessionPlugin.FocusEvent duckingEvent =
+            VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(
+                AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK
+            );
+
+        assertEquals("began", transientEvent.type);
+        assertEquals("interruption", transientEvent.reason);
+        assertEquals("began", duckingEvent.type);
+        assertEquals("interruption", duckingEvent.reason);
+    }
+
+    @Test
+    public void focusGainEndsWithResumeReason() {
+        VoiceAudioSessionPlugin.FocusEvent event =
+            VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(AudioManager.AUDIOFOCUS_GAIN);
+
+        assertEquals("ended", event.type);
+        assertEquals("resume", event.reason);
+    }
+
+    @Test
+    public void unknownFocusChangesAreIgnored() {
+        assertNull(VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(42));
+    }
+}

--- a/clients/android/app/src/test/java/ai/vocify/vellumassistant/VoiceAudioSessionPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vocify/vellumassistant/VoiceAudioSessionPluginTest.java
@@ -17,7 +17,7 @@ public class VoiceAudioSessionPluginTest {
     }
 
     @Test
-    public void transientFocusLossAndDuckingBeginInterruption() {
+    public void transientFocusLossBeginsInterruptionButDuckingIsIgnored() {
         VoiceAudioSessionPlugin.FocusEvent transientEvent =
             VoiceAudioSessionPlugin.FocusEvent.fromFocusChange(
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT
@@ -29,8 +29,7 @@ public class VoiceAudioSessionPluginTest {
 
         assertEquals("began", transientEvent.type);
         assertEquals("interruption", transientEvent.reason);
-        assertEquals("began", duckingEvent.type);
-        assertEquals("interruption", duckingEvent.reason);
+        assertNull(duckingEvent);
     }
 
     @Test

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -143,7 +143,7 @@ References:
 
 ## Native voice bridge
 
-Live voice is a web feature with native accessories. The session, including mic capture, the velay socket, TTS playback, and every user-facing string, lives entirely under `src/domains/chat/voice/live-voice/`. iOS adds interruption reporting, a Dynamic Island and Lock Screen presence, and App Intents. Android adds foreground audio focus and uses the same optional status contract.
+Live voice is a web feature with native accessories. The session, including mic capture, the velay socket, TTS playback, and every user-facing string, lives entirely under `src/domains/chat/voice/live-voice/`. iOS adds interruption reporting, a Dynamic Island and Lock Screen presence, and App Intents. Android adds foreground audio focus. Its status surface is not implemented, so `VoiceLiveActivity` remains iOS-only.
 
 The shell registers **four** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) — count them there, not from prose:
 
@@ -167,10 +167,10 @@ This is a rule, not a caveat. The iOS app is a `server.url` shell: it bundles no
 Three things follow from the rule:
 
 - **Pick a fallback the caller can proceed with.** `startVoiceLiveActivity()` resolves `false`, `endVoiceLiveActivity()` resolves `undefined`. There is no error branch to write, and no call site may treat a `false` as a reason not to start a session.
-- **Fire and forget at the call site.** A bare `void` is enough because every export resolves a safe fallback. A hung or failed bridge call must never delay a voice session.
+- **Fire and forget at the call site.** A bare `void` is enough: because every export in these modules goes through `callNativeVoice`, none of them can reject, so there is no rejection for a call site to handle. A hung or failed bridge call must never delay a voice session.
 - **Destructure the plugin inline inside `invoke`.** The lazy-import rule at the top of this document applies verbatim: only the *result* may cross the `async` boundary, never the plugin Proxy.
 
-**No capability probes.** Neither voice plugin exposes an `isAvailable`. `startVoiceLiveActivity()` resolving `false` covers every reason the status surface is absent: a browser, an older shell, or a disabled platform surface. A probe that can itself be absent only moves the problem.
+**No capability probes.** Neither voice plugin exposes an `isAvailable`, and neither web module wants one: `startVoiceLiveActivity()` resolving `false` already covers every reason there is no native side: off-iOS, an older shell, and the user having switched Live Activities off in Settings. A probe that can itself be absent just moves the problem, and it is the only answer a caller could act on anyway.
 
 ### The background-audio contract
 
@@ -184,7 +184,7 @@ That history is the reason this is device-only territory. A change here that loo
 
 Android's `useNativeAudioSessionLifecycle` calls `activateVoiceAudioSession()` to request transient audio focus for the foreground WebView. It does not move capture into native code or claim screen-lock or app-switching support.
 
-The iOS `VoiceAudioSession` plugin stays in the shell because its interruption reporting listens to `AVAudioSession.sharedInstance()`. It still hears a phone call or Siri taking the input from WebKit's session without activating the session itself.
+The `VoiceAudioSession` plugin stays in the shell: its interruption reporting listens to `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri taking the input from WebKit's session, which is unrelated to owning a session ourselves.
 
 What is genuinely still open on iOS is **background audio**. The list below describes what an active iOS session *would* buy. None of it is in effect today because iOS never activates one. `UIBackgroundModes: audio` in `clients/ios/App/App/Info.plist`, plus an active `.playAndRecord` / `.voiceChat` session, would buy:
 
@@ -248,10 +248,8 @@ session around microphone capture. Changing the active session underneath
 WebKit can leave its live capture unit detached from the microphone.
 
 The iOS `VoiceAudioSession` plugin can perform that reconfiguration, but its
-`activate` method has no production caller. Android implements the same bridge
-contract by requesting audio focus without changing the WebView's audio mode or
-capture path. See § "Native voice bridge" and "The background-audio contract"
-before changing either implementation.
+`activate` method has no production caller. Android only requests audio focus;
+it does not change the WebView audio mode or capture path.
 
 Direct `AudioContext.destination` playback is not supplied to WebKit's capture
 unit as far-end audio for acoustic echo cancellation. On Capacitor iOS, route

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -184,7 +184,7 @@ That history is the reason this is device-only territory. A change here that loo
 
 Android's `useNativeAudioSessionLifecycle` calls `activateVoiceAudioSession()` to request transient audio focus for the foreground WebView. It does not move capture into native code or claim screen-lock or app-switching support.
 
-The `VoiceAudioSession` plugin stays in the shell: its interruption reporting listens to `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri taking the input from WebKit's session, which is unrelated to owning a session ourselves.
+The iOS `VoiceAudioSession` plugin stays in the shell: its interruption reporting listens to `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri taking the input from WebKit's session, which is unrelated to owning a session ourselves.
 
 What is genuinely still open on iOS is **background audio**. The list below describes what an active iOS session *would* buy. None of it is in effect today because iOS never activates one. `UIBackgroundModes: audio` in `clients/ios/App/App/Info.plist`, plus an active `.playAndRecord` / `.voiceChat` session, would buy:
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -143,7 +143,7 @@ References:
 
 ## Native voice bridge
 
-Live voice is a web feature with native accessories. The session — mic capture, the velay socket, TTS playback, every user-facing string — lives entirely under `src/domains/chat/voice/live-voice/`. The iOS shell adds an `AVAudioSession`, a Dynamic Island / Lock Screen presence, and a set of App Intents on top of it.
+Live voice is a web feature with native accessories. The session, including mic capture, the velay socket, TTS playback, and every user-facing string, lives entirely under `src/domains/chat/voice/live-voice/`. iOS adds interruption reporting, a Dynamic Island and Lock Screen presence, and App Intents. Android adds foreground audio focus and uses the same optional status contract.
 
 The shell registers **four** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) — count them there, not from prose:
 
@@ -151,7 +151,7 @@ The shell registers **four** Capacitor plugins in [`MyViewController.capacitorDi
 | --- | --- | --- |
 | `NativeAuth` | [`src/runtime/native-auth.ts`](../src/runtime/native-auth.ts) | `ASWebAuthenticationSession` OIDC flow |
 | `NativeBiometric` | [`src/runtime/native-biometric.ts`](../src/runtime/native-biometric.ts) | Face ID / Touch ID Keychain |
-| `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | `.playAndRecord` / `.voiceChat` session + interruption events. **Unproven on hardware** — see the background-audio contract below |
+| `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | iOS interruption events and Android foreground audio focus. See the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | The one ActivityKit activity mirroring a session |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
@@ -162,7 +162,7 @@ The two voice plugins are consumed only through `use-live-voice-session-controll
 
 This is a rule, not a caveat. The iOS app is a `server.url` shell: it bundles no web assets and navigates `WKWebView` straight at the deployed origin at launch (see [`clients/ios/README.md` § Web content delivery](../../../clients/ios/README.md#web-content-delivery)). So this bundle is live for every iOS user on their next app load, while the shell hosting it only changes after an App Store review cycle. At any moment an arbitrarily old shell can be running an arbitrarily new bundle. There is no build flag that tells you which.
 
-**Route every JS → native voice call through `callNativeVoice`** ([`src/runtime/native-voice.ts`](../src/runtime/native-voice.ts) — read it there, it is twenty lines). It short-circuits off-iOS, swallows any bridge failure into the caller's fallback, and never throws or rejects.
+**Route every JS to native voice call through `callNativeVoice`** ([`src/runtime/native-voice.ts`](../src/runtime/native-voice.ts)). It short-circuits outside the native mobile shells, swallows any bridge failure into the caller's fallback, and never throws or rejects.
 
 Three things follow from the rule:
 
@@ -170,7 +170,7 @@ Three things follow from the rule:
 - **Fire and forget at the call site.** A bare `void` is enough: because every export in these modules goes through `callNativeVoice`, none of them can reject, so there is no rejection for a call site to handle. A hung or failed bridge call must never delay a voice session.
 - **Destructure the plugin inline inside `invoke`.** The lazy-import rule at the top of this document applies verbatim: only the *result* may cross the `async` boundary, never the plugin Proxy.
 
-**No capability probes.** Neither voice plugin exposes an `isAvailable`, and neither web module wants one: `startVoiceLiveActivity()` resolving `false` already covers every reason there is no native side: off-iOS, an older shell, and the user having switched Live Activities off in Settings. A probe that can itself be absent just moves the problem, and it is the only answer a caller could act on anyway.
+**No capability probes.** Neither voice plugin exposes an `isAvailable`. `startVoiceLiveActivity()` resolving `false` covers every reason the status surface is absent: a browser, an older shell, or a disabled platform surface. A probe that can itself be absent only moves the problem.
 
 ### The background-audio contract
 
@@ -180,7 +180,9 @@ That history is the reason this is device-only territory. A change here that loo
 
 **Echo cancellation does not depend on this.** It used to be the argument for `.voiceChat`; since #39347 it comes from WebKit's own voice-processing unit, reached by routing TTS through a `MediaStreamAudioDestinationNode`. So if this plugin ever has to go, AEC does not go with it.
 
-**The rule: the web layer does not activate an audio session.** Settled the hard way, because the pattern broke live voice on a handset twice. First as #39331 (no capture at all, reverted in #39345), then again when it returned in #39306, where a session died roughly 60ms after its WebSocket opened while the Simulator sustained one normally against the same backend. The second failure went unattributed for a day because every #39306 upload was rejected by App Store Connect until #39556, so the plugin had never actually run on a device. `useNativeAudioSessionLifecycle` now only subscribes to interruptions; it never calls `activate`. Do not reintroduce the activation without a device test, and note that a green Simulator run is not one.
+**The iOS rule: the web layer does not activate an audio session.** Settled the hard way, because the pattern broke live voice on a handset twice. First as #39331 (no capture at all, reverted in #39345), then again when it returned in #39306, where a session died roughly 60ms after its WebSocket opened while the Simulator sustained one normally against the same backend. The second failure went unattributed for a day because every #39306 upload was rejected by App Store Connect until #39556, so the plugin had never actually run on a device. `useNativeAudioSessionLifecycle` subscribes to iOS interruptions but never calls iOS `activate`. Do not reintroduce iOS activation without a device test, and note that a green Simulator run is not one.
+
+Android uses the same optional bridge contract to request transient audio focus for the foreground WebView. It does not move capture into native code or claim screen-lock or app-switching support.
 
 The `VoiceAudioSession` plugin stays in the shell: its interruption reporting listens to `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri taking the input from WebKit's session, which is unrelated to owning a session ourselves.
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -167,14 +167,14 @@ This is a rule, not a caveat. The iOS app is a `server.url` shell: it bundles no
 Three things follow from the rule:
 
 - **Pick a fallback the caller can proceed with.** `startVoiceLiveActivity()` resolves `false`, `endVoiceLiveActivity()` resolves `undefined`. There is no error branch to write, and no call site may treat a `false` as a reason not to start a session.
-- **Fire and forget at the call site.** A bare `void` is enough: because every export in these modules goes through `callNativeVoice`, none of them can reject, so there is no rejection for a call site to handle. A hung or failed bridge call must never delay a voice session.
+- **Fire and forget at the call site.** A bare `void` is enough because every export resolves a safe fallback. A hung or failed bridge call must never delay a voice session.
 - **Destructure the plugin inline inside `invoke`.** The lazy-import rule at the top of this document applies verbatim: only the *result* may cross the `async` boundary, never the plugin Proxy.
 
 **No capability probes.** Neither voice plugin exposes an `isAvailable`. `startVoiceLiveActivity()` resolving `false` covers every reason the status surface is absent: a browser, an older shell, or a disabled platform surface. A probe that can itself be absent only moves the problem.
 
 ### The background-audio contract
 
-**Read § "Full-duplex TTS must render through a MediaStream track" before you touch any of this.** That section warns against reconfiguring the shared `AVAudioSession` around microphone capture. `VoiceAudioSession` is the one plugin in the tree that can do it, and **nothing calls it any more**: `activateVoiceAudioSession()` has no production caller, by the decision recorded below. The bridge function and the native plugin both remain, so reintroducing activation is one line away and must not be taken casually.
+**Read § "Full-duplex TTS must render through a MediaStream track" before you touch the iOS implementation.** That section warns against reconfiguring the shared `AVAudioSession` around microphone capture. The iOS `activate` method has no production caller by the decision recorded below. Android's `useNativeAudioSessionLifecycle` caller uses the same bridge method only to request audio focus, without reconfiguring WebView capture.
 
 That history is the reason this is device-only territory. A change here that looks obviously correct and passes in the Simulator is precisely the failure mode that has now shipped twice.
 
@@ -182,11 +182,11 @@ That history is the reason this is device-only territory. A change here that loo
 
 **The iOS rule: the web layer does not activate an audio session.** Settled the hard way, because the pattern broke live voice on a handset twice. First as #39331 (no capture at all, reverted in #39345), then again when it returned in #39306, where a session died roughly 60ms after its WebSocket opened while the Simulator sustained one normally against the same backend. The second failure went unattributed for a day because every #39306 upload was rejected by App Store Connect until #39556, so the plugin had never actually run on a device. `useNativeAudioSessionLifecycle` subscribes to iOS interruptions but never calls iOS `activate`. Do not reintroduce iOS activation without a device test, and note that a green Simulator run is not one.
 
-Android uses the same optional bridge contract to request transient audio focus for the foreground WebView. It does not move capture into native code or claim screen-lock or app-switching support.
+Android's `useNativeAudioSessionLifecycle` calls `activateVoiceAudioSession()` to request transient audio focus for the foreground WebView. It does not move capture into native code or claim screen-lock or app-switching support.
 
-The `VoiceAudioSession` plugin stays in the shell: its interruption reporting listens to `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri taking the input from WebKit's session, which is unrelated to owning a session ourselves.
+The iOS `VoiceAudioSession` plugin stays in the shell because its interruption reporting listens to `AVAudioSession.sharedInstance()`. It still hears a phone call or Siri taking the input from WebKit's session without activating the session itself.
 
-What is genuinely still open is **background audio**, and note that the list below describes what an active session *would* buy. None of it is in effect today, because nothing activates one. `UIBackgroundModes: audio` in `clients/ios/App/App/Info.plist`, plus an active `.playAndRecord` / `.voiceChat` session, would buy:
+What is genuinely still open on iOS is **background audio**. The list below describes what an active iOS session *would* buy. None of it is in effect today because iOS never activates one. `UIBackgroundModes: audio` in `clients/ios/App/App/Info.plist`, plus an active `.playAndRecord` / `.voiceChat` session, would buy:
 
 - audio keeps playing while the app is backgrounded or the screen is locked;
 - the mic route survives backgrounding;
@@ -247,13 +247,11 @@ requested. Do not add a Capacitor plugin that reconfigures or reactivates that
 session around microphone capture. Changing the active session underneath
 WebKit can leave its live capture unit detached from the microphone.
 
-One such plugin exists — `VoiceAudioSession`, for background/lock-screen audio,
-which echo cancellation no longer needs. It activates once at a session's
-leading edge and never re-asserts mid-session, which is the narrowest form of
-the thing this section warns about rather than an exemption from it. It is
-unproven on hardware; see § "Native voice bridge" → "The background-audio
-contract" for what has to be measured before trusting it. Treat it as the single
-exception under measurement, not as a precedent.
+The iOS `VoiceAudioSession` plugin can perform that reconfiguration, but its
+`activate` method has no production caller. Android implements the same bridge
+contract by requesting audio focus without changing the WebView's audio mode or
+capture path. See § "Native voice bridge" and "The background-audio contract"
+before changing either implementation.
 
 Direct `AudioContext.destination` playback is not supplied to WebKit's capture
 unit as far-end audio for acoustic echo cancellation. On Capacitor iOS, route

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -15,6 +15,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
+import type { VoiceAudioInterruptionEvent } from "@/runtime/native-audio-session";
 
 // The default client factory in use-live-voice statically imports the real
 // LiveVoiceChannelClient, which pulls in connection.ts -> the generated SDK.
@@ -30,10 +31,7 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
 // faking `isNativeIOS`) so the controller's lifecycle wiring is asserted
 // directly; the bridge's own off-native/skew behavior is pinned by
 // `runtime/native-audio-session.test.ts`.
-type InterruptionEvent = {
-  type: "began" | "ended";
-  reason?: "interruption" | "focus-loss" | "route-change" | "resume";
-};
+type InterruptionEvent = VoiceAudioInterruptionEvent;
 let onNativeAndroid = false;
 let onNativeIOS = false;
 const activateVoiceAudioSession = mock(async () => true);
@@ -400,47 +398,50 @@ describe("native audio session", () => {
     onNativeAndroid = true;
     const h = renderPersistentController();
     await startListeningViaStarter(h);
-
     expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
-
     await act(async () => {
       useLiveVoiceStore.getState().controls?.stop();
       await Promise.resolve();
       await Promise.resolve();
     });
-
     expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
   });
 
-  test("Android retries denied focus on a later active phase", async () => {
+  test("Android caps denied focus retries per session", async () => {
     onNativeAndroid = true;
-    activateVoiceAudioSession
-      .mockImplementationOnce(async () => false)
-      .mockImplementation(async () => true);
+    const outcomes = [false, false, false, true];
+    activateVoiceAudioSession.mockImplementation(
+      async () => outcomes.shift() ?? true,
+    );
     renderPersistentController();
-
     await act(async () => {
       useLiveVoiceStore.getState().starter?.start("assistant-1", "conv-1");
       await Promise.resolve();
     });
     expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      useLiveVoiceStore.getState().setState("listening");
-      await Promise.resolve();
-    });
+    for (const phase of ["listening", "thinking", "speaking"] as const) {
+      await act(async () => {
+        useLiveVoiceStore.getState().setState(phase);
+        await Promise.resolve();
+      });
+    }
     expect(activateVoiceAudioSession).toHaveBeenCalledTimes(2);
+    for (const phase of ["idle", "connecting", "listening"] as const) {
+      await act(async () => {
+        useLiveVoiceStore.getState().setState(phase);
+        await Promise.resolve();
+      });
+    }
+    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(4);
   });
 
   test("Android route changes do not end the session", async () => {
     onNativeAndroid = true;
     const h = renderPersistentController();
     await startListeningViaStarter(h);
-
     act(() => {
       emitInterruption({ type: "began", reason: "route-change" });
     });
-
     expect(useLiveVoiceStore.getState().state).toBe("listening");
     expect(h.lastClient().closed).toBe(false);
   });
@@ -449,13 +450,11 @@ describe("native audio session", () => {
     onNativeAndroid = true;
     const h = renderPersistentController();
     await startListeningViaStarter(h);
-
     await act(async () => {
       emitInterruption({ type: "began" });
       await Promise.resolve();
       await Promise.resolve();
     });
-
     expect(h.lastClient().ended).toBe(true);
     expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
   });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -30,7 +30,10 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
 // faking `isNativeIOS`) so the controller's lifecycle wiring is asserted
 // directly; the bridge's own off-native/skew behavior is pinned by
 // `runtime/native-audio-session.test.ts`.
-type InterruptionEvent = { type: "began" | "ended" };
+type InterruptionEvent = {
+  type: "began" | "ended";
+  reason?: "interruption" | "focus-loss" | "route-change" | "resume";
+};
 let onNativeAndroid = false;
 let onNativeIOS = false;
 const activateVoiceAudioSession = mock(async () => true);
@@ -407,6 +410,39 @@ describe("native audio session", () => {
     });
 
     expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("Android retries denied focus on a later active phase", async () => {
+    onNativeAndroid = true;
+    activateVoiceAudioSession
+      .mockImplementationOnce(async () => false)
+      .mockImplementation(async () => true);
+    renderPersistentController();
+
+    await act(async () => {
+      useLiveVoiceStore.getState().starter?.start("assistant-1", "conv-1");
+      await Promise.resolve();
+    });
+    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      useLiveVoiceStore.getState().setState("listening");
+      await Promise.resolve();
+    });
+    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("Android route changes do not end the session", async () => {
+    onNativeAndroid = true;
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    act(() => {
+      emitInterruption({ type: "began", reason: "route-change" });
+    });
+
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(h.lastClient().closed).toBe(false);
   });
 
   test("Android releases focus after a native interruption ends voice", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -31,6 +31,8 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
 // directly; the bridge's own off-native/skew behavior is pinned by
 // `runtime/native-audio-session.test.ts`.
 type InterruptionEvent = { type: "began" | "ended" };
+let onNativeAndroid = false;
+let onNativeIOS = false;
 const activateVoiceAudioSession = mock(async () => true);
 const deactivateVoiceAudioSession = mock(async () => undefined);
 const unsubscribeInterruptions = mock(() => undefined);
@@ -50,6 +52,12 @@ mock.module("@/runtime/native-audio-session", () => ({
       interruptionHandlers = interruptionHandlers.filter((h) => h !== handler);
     };
   },
+}));
+
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeAndroid: () => onNativeAndroid,
+  isNativeIOS: () => onNativeIOS,
+  isNativeMobile: () => onNativeAndroid || onNativeIOS,
 }));
 
 /** Deliver a native `AVAudioSession` interruption to every live subscriber. */
@@ -161,6 +169,8 @@ beforeEach(() => {
   useAssistantIdentityStore.setState({ assistantId: null, version: null });
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
   interruptionHandlers = [];
+  onNativeAndroid = false;
+  onNativeIOS = false;
   activateVoiceAudioSession.mockClear();
   activateVoiceAudioSession.mockImplementation(async () => true);
   deactivateVoiceAudioSession.mockClear();
@@ -341,7 +351,8 @@ describe("native audio session", () => {
   // #39331 (no capture at all, reverted in #39345) and again in #39306, where
   // a session died ~60ms after its socket opened. Nothing may reintroduce it
   // without a device test, and the Simulator cannot provide one.
-  test("never activates an audio session of its own", async () => {
+  test("iOS never activates an audio session of its own", async () => {
+    onNativeIOS = true;
     const h = renderPersistentController();
     await startListeningViaStarter(h);
 
@@ -362,7 +373,8 @@ describe("native audio session", () => {
     expect(deactivateVoiceAudioSession).not.toHaveBeenCalled();
   });
 
-  test("never deactivates one either, through idle, failure or unmount", async () => {
+  test("iOS never deactivates one through idle, failure, or unmount", async () => {
+    onNativeIOS = true;
     const h = renderPersistentController();
     await startListeningViaStarter(h);
 
@@ -379,6 +391,37 @@ describe("native audio session", () => {
     });
 
     expect(deactivateVoiceAudioSession).not.toHaveBeenCalled();
+  });
+
+  test("Android holds audio focus for exactly the active session", async () => {
+    onNativeAndroid = true;
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    expect(activateVoiceAudioSession).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      useLiveVoiceStore.getState().controls?.stop();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("Android releases focus after a native interruption ends voice", async () => {
+    onNativeAndroid = true;
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    await act(async () => {
+      emitInterruption({ type: "began" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(h.lastClient().ended).toBe(true);
+    expect(deactivateVoiceAudioSession).toHaveBeenCalledTimes(1);
   });
 
   test("drops the interruption listener on unmount", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -71,6 +71,7 @@ function useNativeAudioSessionLifecycle(): void {
     let hasAudioFocus = false;
     let reconcilingAudioFocus = false;
     let reconcileRequested = false;
+    let activationAttempts = 0;
     let lastSettledState = useLiveVoiceStore.getState().state;
 
     const reconcileAudioFocus = async (): Promise<void> => {
@@ -83,6 +84,10 @@ function useNativeAudioSessionLifecycle(): void {
       try {
         while (wantsAudioFocus !== hasAudioFocus) {
           if (wantsAudioFocus) {
+            if (activationAttempts >= 2) {
+              return;
+            }
+            activationAttempts += 1;
             hasAudioFocus = await activateVoiceAudioSession();
             if (!hasAudioFocus) {
               return;
@@ -107,6 +112,7 @@ function useNativeAudioSessionLifecycle(): void {
       const nextWantsAudioFocus = isLiveVoiceSessionActive(
         settledState,
       );
+      activationAttempts = nextWantsAudioFocus ? activationAttempts : 0;
       if (
         nextWantsAudioFocus === wantsAudioFocus &&
         (!stateChanged || hasAudioFocus)

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -25,10 +25,9 @@
  *   {@link useLiveVoice} itself.
  * - `state`/`error`/transcripts/amplitude — observable session state.
  *
- * It is also where the iOS-native mirrors of the session are bound to its
- * lifecycle — the audio session ({@link useNativeAudioSessionLifecycle}) and
- * the Live Activity ({@link useLiveActivityMirror}). Both are inert off the
- * iOS shell.
+ * It is also where optional native voice accessories are bound to the session:
+ * audio focus ({@link useNativeAudioSessionLifecycle}) and the platform status
+ * surface ({@link useLiveActivityMirror}).
  */
 
 import { useEffect } from "react";
@@ -40,13 +39,17 @@ import {
 import {
   endLiveVoiceSession,
   isLiveVoiceSessionActive,
+  subscribeSettledLiveVoiceState,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { drainPendingVoiceStartDeepLink } from "@/domains/chat/voice/live-voice/start-voice-deep-link";
 import { useLiveActivityMirror } from "@/domains/chat/voice/live-voice/use-live-activity-mirror";
 import {
+  activateVoiceAudioSession,
+  deactivateVoiceAudioSession,
   subscribeVoiceAudioInterruptions,
 } from "@/runtime/native-audio-session";
+import { isNativeAndroid } from "@/runtime/platform-detection";
 
 /** Injectable primitive factories, for tests. */
 export type UseLiveVoiceSessionControllerOptions = Pick<
@@ -55,43 +58,65 @@ export type UseLiveVoiceSessionControllerOptions = Pick<
 >;
 
 /**
- * Report native `AVAudioSession` interruptions into the live-voice session.
+ * Own Android audio focus and report native audio interruptions into voice.
  *
- * **This deliberately no longer activates an audio session of its own.**
- * WebKit owns the shared `AVAudioSession` backing `getUserMedia` in a
- * `WKWebView`, and activating ours alongside it is what `docs/CAPACITOR.md`
- * § "Full-duplex TTS must render through a MediaStream track" warns about. That
- * pattern has now broken live voice on a handset twice: first as #39331, which
- * produced no capture at all and was reverted in #39345, and again when it
- * returned in #39306, where a session died roughly 60ms after its socket
- * opened. The second failure took a while to attribute because #39306's uploads
- * were all rejected by App Store Connect until #39556, so the plugin had never
- * actually run on a device before.
- *
- * Nothing else depended on it. Echo cancellation moved to WebKit's own
- * voice-processing unit in #39347 via a `MediaStreamAudioDestinationNode`, and
- * background/lock-screen audio is claimed by `UIBackgroundModes: audio` in
- * `Info.plist`, which is independent of this call. Whether the plist entry
- * alone actually sustains a backgrounded session is still unmeasured (see the
- * background-audio contract in `docs/CAPACITOR.md`), but a session that dies
- * immediately in the foreground is strictly worse than one that may not survive
- * backgrounding.
- *
- * The interruption subscription stays. It listens to
- * `AVAudioSession.sharedInstance()`, so it still hears a phone call or Siri
- * taking the input from WebKit's session, and ending on that is unrelated to
- * owning a session ourselves.
- *
- * Off the iOS shell this is a no-op (see `runtime/native-audio-session`), so it
- * is inert in the browser and on Electron.
- *
- * **The Simulator cannot evaluate any of this.** Its mock audio device has no
- * acoustic path, so it passes whether or not a real handset would go silent.
- * Every Simulator run passed during #39331, and the Simulator sustained a
- * session normally throughout the #39306 failure too.
+ * Android focus follows settled session state and is serialized so a delayed
+ * activation cannot outlive the session that requested it. iOS still never
+ * calls `activate()`: WebKit owns its shared `AVAudioSession`, and activating a
+ * second owner has broken foreground capture on physical handsets.
  */
 function useNativeAudioSessionLifecycle(): void {
   useEffect(() => {
+    let wantsAudioFocus = false;
+    let hasAudioFocus = false;
+    let reconcilingAudioFocus = false;
+
+    const reconcileAudioFocus = async (): Promise<void> => {
+      if (reconcilingAudioFocus) {
+        return;
+      }
+      reconcilingAudioFocus = true;
+      let activationFailed = false;
+      try {
+        while (wantsAudioFocus !== hasAudioFocus) {
+          if (wantsAudioFocus) {
+            hasAudioFocus = await activateVoiceAudioSession();
+            if (!hasAudioFocus) {
+              activationFailed = true;
+              return;
+            }
+          } else {
+            await deactivateVoiceAudioSession();
+            hasAudioFocus = false;
+          }
+        }
+      } finally {
+        reconcilingAudioFocus = false;
+        if (!activationFailed && wantsAudioFocus !== hasAudioFocus) {
+          void reconcileAudioFocus();
+        }
+      }
+    };
+
+    const syncAudioFocus = (): void => {
+      const nextWantsAudioFocus = isLiveVoiceSessionActive(
+        useLiveVoiceStore.getState().state,
+      );
+      if (nextWantsAudioFocus === wantsAudioFocus) {
+        return;
+      }
+      wantsAudioFocus = nextWantsAudioFocus;
+      void reconcileAudioFocus();
+    };
+
+    const managesAudioFocus = isNativeAndroid();
+    const unsubscribeAudioFocus = managesAudioFocus
+      ? subscribeSettledLiveVoiceState(syncAudioFocus)
+      : () => undefined;
+    if (managesAudioFocus) {
+      syncAudioFocus();
+    }
+
     const unsubscribeInterruptions = subscribeVoiceAudioInterruptions(
       (event) => {
         // A phone call or Siri has taken the mic. End the session rather than
@@ -107,7 +132,12 @@ function useNativeAudioSessionLifecycle(): void {
       },
     );
 
-    return unsubscribeInterruptions;
+    return () => {
+      unsubscribeAudioFocus();
+      unsubscribeInterruptions();
+      wantsAudioFocus = false;
+      void reconcileAudioFocus();
+    };
   }, []);
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -70,19 +70,21 @@ function useNativeAudioSessionLifecycle(): void {
     let wantsAudioFocus = false;
     let hasAudioFocus = false;
     let reconcilingAudioFocus = false;
+    let reconcileRequested = false;
+    let lastSettledState = useLiveVoiceStore.getState().state;
 
     const reconcileAudioFocus = async (): Promise<void> => {
       if (reconcilingAudioFocus) {
+        reconcileRequested = true;
         return;
       }
       reconcilingAudioFocus = true;
-      let activationFailed = false;
+      reconcileRequested = false;
       try {
         while (wantsAudioFocus !== hasAudioFocus) {
           if (wantsAudioFocus) {
             hasAudioFocus = await activateVoiceAudioSession();
             if (!hasAudioFocus) {
-              activationFailed = true;
               return;
             }
           } else {
@@ -92,17 +94,23 @@ function useNativeAudioSessionLifecycle(): void {
         }
       } finally {
         reconcilingAudioFocus = false;
-        if (!activationFailed && wantsAudioFocus !== hasAudioFocus) {
+        if (reconcileRequested && wantsAudioFocus !== hasAudioFocus) {
           void reconcileAudioFocus();
         }
       }
     };
 
     const syncAudioFocus = (): void => {
+      const settledState = useLiveVoiceStore.getState().state;
+      const stateChanged = settledState !== lastSettledState;
+      lastSettledState = settledState;
       const nextWantsAudioFocus = isLiveVoiceSessionActive(
-        useLiveVoiceStore.getState().state,
+        settledState,
       );
-      if (nextWantsAudioFocus === wantsAudioFocus) {
+      if (
+        nextWantsAudioFocus === wantsAudioFocus &&
+        (!stateChanged || hasAudioFocus)
+      ) {
         return;
       }
       wantsAudioFocus = nextWantsAudioFocus;
@@ -122,7 +130,7 @@ function useNativeAudioSessionLifecycle(): void {
         // A phone call or Siri has taken the mic. End the session rather than
         // leave it "listening" into a dead input. No auto-resume on `ended`:
         // the user restarts explicitly.
-        if (event.type !== "began") {
+        if (event.type !== "began" || event.reason === "route-change") {
           return;
         }
         if (!isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {

--- a/clients/web/src/runtime/native-audio-session.test.ts
+++ b/clients/web/src/runtime/native-audio-session.test.ts
@@ -13,10 +13,12 @@ import type { PluginListenerHandle } from "@capacitor/core";
 
 import type { VoiceAudioInterruptionEvent } from "@/runtime/native-audio-session";
 
-let onNativeIOS = false;
+let onNativeMobile = false;
 
 mock.module("@/runtime/platform-detection", () => ({
-  isNativeIOS: () => onNativeIOS,
+  isNativeAndroid: () => false,
+  isNativeIOS: () => onNativeMobile,
+  isNativeMobile: () => onNativeMobile,
 }));
 
 type Handler = (event: VoiceAudioInterruptionEvent) => void;
@@ -54,7 +56,7 @@ const {
 } = await import("@/runtime/native-audio-session");
 
 beforeEach(() => {
-  onNativeIOS = true;
+  onNativeMobile = true;
   handlers = [];
   activate.mockClear();
   activate.mockImplementation(async () => ({ activated: true }));
@@ -69,9 +71,9 @@ beforeEach(() => {
 // Off-native — the browser and Electron paths
 // ---------------------------------------------------------------------------
 
-describe("off the iOS shell", () => {
+describe("outside a native mobile shell", () => {
   beforeEach(() => {
-    onNativeIOS = false;
+    onNativeMobile = false;
   });
 
   test("activate resolves false without touching the bridge", async () => {
@@ -117,8 +119,11 @@ describe("with the plugin present", () => {
       expect.any(Function),
     );
 
-    handlers[0]?.({ type: "began" });
-    expect(handler).toHaveBeenCalledWith({ type: "began" });
+    handlers[0]?.({ type: "began", reason: "route-change" });
+    expect(handler).toHaveBeenCalledWith({
+      type: "began",
+      reason: "route-change",
+    });
 
     // Let the registration settle so the handle is held, then release it.
     await Promise.resolve();

--- a/clients/web/src/runtime/native-audio-session.test.ts
+++ b/clients/web/src/runtime/native-audio-session.test.ts
@@ -1,11 +1,8 @@
 /**
  * Tests for the `VoiceAudioSession` bridge.
  *
- * The contract under test is skew-safety: the iOS shell ships through App Store
- * review while this bundle deploys continuously, so an arbitrarily old shell
- * can host it with no such plugin compiled in. Every exported function must
- * therefore resolve — never reject, never hang — whether the plugin answers,
- * rejects, or does not exist, and must not touch the bridge at all off iOS.
+ * Both mobile shells may lag behind the web bundle. Exports fall back outside
+ * native mobile and whenever the optional plugin is missing.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -68,7 +65,7 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Off-native — the browser and Electron paths
+// Outside native mobile: browser and Electron paths
 // ---------------------------------------------------------------------------
 
 describe("outside a native mobile shell", () => {
@@ -94,7 +91,7 @@ describe("outside a native mobile shell", () => {
 });
 
 // ---------------------------------------------------------------------------
-// On the iOS shell, plugin present
+// Native mobile shell with the plugin present
 // ---------------------------------------------------------------------------
 
 describe("with the plugin present", () => {
@@ -119,10 +116,10 @@ describe("with the plugin present", () => {
       expect.any(Function),
     );
 
-    handlers[0]?.({ type: "began", reason: "interruption" });
+    handlers[0]?.({ type: "began", reason: "route-change" });
     expect(handler).toHaveBeenCalledWith({
       type: "began",
-      reason: "interruption",
+      reason: "route-change",
     });
 
     // Let the registration settle so the handle is held, then release it.
@@ -143,7 +140,7 @@ describe("with the plugin present", () => {
 });
 
 // ---------------------------------------------------------------------------
-// On the iOS shell, older shell without the plugin — the skew case
+// Native mobile shell without the plugin
 // ---------------------------------------------------------------------------
 
 describe("with an older shell that has no plugin", () => {

--- a/clients/web/src/runtime/native-audio-session.test.ts
+++ b/clients/web/src/runtime/native-audio-session.test.ts
@@ -119,10 +119,10 @@ describe("with the plugin present", () => {
       expect.any(Function),
     );
 
-    handlers[0]?.({ type: "began", reason: "route-change" });
+    handlers[0]?.({ type: "began", reason: "interruption" });
     expect(handler).toHaveBeenCalledWith({
       type: "began",
-      reason: "route-change",
+      reason: "interruption",
     });
 
     // Let the registration settle so the handle is held, then release it.

--- a/clients/web/src/runtime/native-audio-session.ts
+++ b/clients/web/src/runtime/native-audio-session.ts
@@ -31,7 +31,7 @@ import {
  */
 export interface VoiceAudioInterruptionEvent {
   type: "began" | "ended";
-  reason?: "interruption" | "focus-loss" | "route-change" | "resume";
+  reason?: "interruption" | "focus-loss" | "resume";
 }
 
 interface VoiceAudioSessionPlugin {
@@ -78,7 +78,7 @@ export async function deactivateVoiceAudioSession(): Promise<void> {
 }
 
 /**
- * Subscribe to native interruption, focus, route, and resume events.
+ * Subscribe to native interruption, focus, and resume events.
  *
  * Consumers should end the voice session on `type: "began"` — the mic is gone,
  * and a session that silently keeps "listening" into a dead input is worse than

--- a/clients/web/src/runtime/native-audio-session.ts
+++ b/clients/web/src/runtime/native-audio-session.ts
@@ -31,7 +31,7 @@ import {
  */
 export interface VoiceAudioInterruptionEvent {
   type: "began" | "ended";
-  reason?: "interruption" | "focus-loss" | "resume";
+  reason?: "interruption" | "focus-loss" | "route-change" | "resume";
 }
 
 interface VoiceAudioSessionPlugin {
@@ -80,9 +80,9 @@ export async function deactivateVoiceAudioSession(): Promise<void> {
 /**
  * Subscribe to native interruption, focus, and resume events.
  *
- * Consumers should end the voice session on `type: "began"` — the mic is gone,
- * and a session that silently keeps "listening" into a dead input is worse than
- * one that ends. Do NOT auto-resume on `ended`: the user restarts explicitly.
+ * Consumers should end the voice session on `type: "began"` unless the reason
+ * is `route-change`. Route changes preserve the live media tracks. Do not
+ * auto-resume on `ended`; the user restarts explicitly.
  *
  * Registration is asynchronous, so an unsubscribe that beats it removes the
  * handle on arrival rather than leaking it.

--- a/clients/web/src/runtime/native-audio-session.ts
+++ b/clients/web/src/runtime/native-audio-session.ts
@@ -1,23 +1,13 @@
 /**
- * JS ↔ native bridge for the `VoiceAudioSession` Capacitor plugin registered by
- * `clients/ios/App/App/MyViewController.swift` +
- * `clients/ios/App/App/VoiceAudioSessionPlugin.swift`.
+ * JS to native bridge for the optional `VoiceAudioSession` Capacitor plugin.
  *
- * The plugin owns the app's `AVAudioSession` for the duration of a live-voice
- * session: `.playAndRecord` / `.voiceChat` (hardware echo cancellation, AGC,
- * correct AirPods/Bluetooth-HFP routing) plus the `audio` background mode, so
- * TTS keeps playing and the mic keeps its route while the app is backgrounded
- * or the screen is locked. Deactivating passes `.notifyOthersOnDeactivation`
- * so whatever the user was listening to before resumes.
+ * Android uses it to hold interactive voice audio focus while the foreground
+ * WebView owns capture and playback. The shipped iOS methods and payloads stay
+ * unchanged, but iOS activation remains disabled at its production caller due
+ * to the handset regression documented in `docs/CAPACITOR.md`.
  *
- * **Skew contract.** The iOS shell ships through App Store review while this
- * bundle deploys continuously (`clients/ios/README.md` § "Web content
- * delivery"), so an arbitrarily old shell may host this bundle with no such
- * plugin compiled in. Every call therefore goes through
- * {@link callNativeVoice}, which returns the fallback off-iOS and on any bridge
- * failure: without the plugin a voice session behaves exactly as it does today,
- * losing only the background/route niceties. Nothing here may throw, and
- * nothing here may block a session.
+ * Every call goes through {@link callNativeVoice}. Browsers and older native
+ * shells keep the existing no-op behavior.
  *
  * There is no separate `isAvailable` probe: {@link activateVoiceAudioSession}
  * resolving `false` *is* the probe, and it is the only answer a caller can act
@@ -29,23 +19,19 @@
  */
 
 import { registerPlugin } from "@capacitor/core";
-import type { PluginListenerHandle } from "@capacitor/core";
 
-import { callNativeVoice } from "@/runtime/native-voice";
-import { isNativeIOS } from "@/runtime/platform-detection";
+import {
+  callNativeVoice,
+  subscribeNativeVoiceListener,
+} from "@/runtime/native-voice";
 
 /**
- * An `AVAudioSession` interruption — something else took the audio hardware.
- *
- * - `began` — a phone call, a Siri invocation, or another app grabbed the mic.
- * - `ended` — the interrupting activity finished.
- *
- * Apple's `.shouldResume` option is deliberately not carried: the session is
- * over by the time `ended` arrives and the user restarts explicitly, so there
- * is nothing to resume (see {@link subscribeVoiceAudioInterruptions}).
+ * Shared audio event payload. `reason` is optional so existing iOS shells that
+ * emit only `{ type }` remain compatible.
  */
 export interface VoiceAudioInterruptionEvent {
   type: "began" | "ended";
+  reason?: "interruption" | "focus-loss" | "route-change" | "resume";
 }
 
 interface VoiceAudioSessionPlugin {
@@ -54,7 +40,7 @@ interface VoiceAudioSessionPlugin {
   addListener(
     eventName: "voiceAudioInterruption",
     handler: (event: VoiceAudioInterruptionEvent) => void,
-  ): Promise<PluginListenerHandle>;
+  ): Promise<{ remove(): Promise<void> }>;
 }
 
 const VoiceAudioSession =
@@ -62,8 +48,8 @@ const VoiceAudioSession =
 
 /**
  * Configure and activate the audio session for a live-voice session. Resolves
- * `true` when the native side took over, `false` on every other platform and
- * on any bridge failure (an older shell without the plugin).
+ * `true` when the native side took over, `false` outside a supported native
+ * shell or on any bridge failure.
  *
  * Call it when a session becomes active, and pair every call with
  * {@link deactivateVoiceAudioSession} — an audio session that outlives its
@@ -83,8 +69,7 @@ export async function activateVoiceAudioSession(): Promise<boolean> {
 }
 
 /**
- * Release the audio session at the end of a live-voice session. No-op off-iOS
- * and on an older shell. Never throws.
+ * Release native audio ownership. No-op in browsers and older shells.
  */
 export async function deactivateVoiceAudioSession(): Promise<void> {
   return callNativeVoice(async () => {
@@ -93,53 +78,20 @@ export async function deactivateVoiceAudioSession(): Promise<void> {
 }
 
 /**
- * Subscribe to `AVAudioSession` interruptions, returning an unsubscribe.
+ * Subscribe to native interruption, focus, route, and resume events.
  *
  * Consumers should end the voice session on `type: "began"` — the mic is gone,
  * and a session that silently keeps "listening" into a dead input is worse than
  * one that ends. Do NOT auto-resume on `ended`: the user restarts explicitly.
  *
- * `addListener` is one of the few property names the Capacitor plugin Proxy
- * does *not* trap into a fabricated native method, so calling it on a plugin
- * the shell never registered is safe — it simply never fires. The
- * `isNativeIOS()` guard still short-circuits everywhere else for the same
- * reason as {@link callNativeVoice}: off the iOS shell there is no native side
- * to listen to.
- *
  * Registration is asynchronous, so an unsubscribe that beats it removes the
- * handle on arrival rather than leaking it. This deliberately does not reuse
- * `subscribeCapacitorListener`: that scaffold reports failures through
- * `captureError`, and a missing plugin on a skewed shell is an expected state
- * on every web deploy, not a fault worth a Sentry event.
+ * handle on arrival rather than leaking it.
  */
 export function subscribeVoiceAudioInterruptions(
   handler: (event: VoiceAudioInterruptionEvent) => void,
 ): () => void {
-  if (!isNativeIOS()) {
-    return () => undefined;
-  }
-
-  let handle: PluginListenerHandle | null = null;
-  let cancelled = false;
-
-  VoiceAudioSession.addListener("voiceAudioInterruption", handler)
-    .then((registered) => {
-      if (cancelled) {
-        void registered.remove();
-        return;
-      }
-      handle = registered;
-    })
-    .catch((err: unknown) => {
-      console.debug(
-        "[native-audio-session] interruption listener failed:",
-        err,
-      );
-    });
-
-  return () => {
-    cancelled = true;
-    void handle?.remove();
-    handle = null;
-  };
+  return subscribeNativeVoiceListener(
+    () => VoiceAudioSession.addListener("voiceAudioInterruption", handler),
+    "native-audio-session",
+  );
 }

--- a/clients/web/src/runtime/native-live-activity.test.ts
+++ b/clients/web/src/runtime/native-live-activity.test.ts
@@ -15,18 +15,23 @@ import type {
   VoiceLiveActivityStart,
 } from "@/runtime/native-live-activity";
 
-let onNativeIOS = false;
+let onNativeMobile = false;
 
 mock.module("@/runtime/platform-detection", () => ({
-  isNativeIOS: () => onNativeIOS,
+  isNativeAndroid: () => false,
+  isNativeIOS: () => onNativeMobile,
+  isNativeMobile: () => onNativeMobile,
 }));
 
 const start = mock(async () => ({ started: true }));
 const update = mock(async () => undefined);
 const end = mock(async () => undefined);
+const addListener = mock(async () => ({
+  remove: async () => undefined,
+}));
 
 mock.module("@capacitor/core", () => ({
-  registerPlugin: () => ({ start, update, end }),
+  registerPlugin: () => ({ start, update, end, addListener }),
 }));
 
 const {
@@ -49,7 +54,7 @@ const startOptions: VoiceLiveActivityStart = {
 };
 
 beforeEach(() => {
-  onNativeIOS = true;
+  onNativeMobile = true;
   start.mockClear();
   start.mockImplementation(async () => ({ started: true }));
   update.mockClear();
@@ -62,9 +67,9 @@ beforeEach(() => {
 // Off-native — the browser and Electron paths
 // ---------------------------------------------------------------------------
 
-describe("off the iOS shell", () => {
+describe("outside a native mobile shell", () => {
   beforeEach(() => {
-    onNativeIOS = false;
+    onNativeMobile = false;
   });
 
   test("start resolves false without touching the bridge", async () => {

--- a/clients/web/src/runtime/native-live-activity.test.ts
+++ b/clients/web/src/runtime/native-live-activity.test.ts
@@ -15,12 +15,13 @@ import type {
   VoiceLiveActivityStart,
 } from "@/runtime/native-live-activity";
 
-let onNativeMobile = false;
+let onNativeAndroid = false;
+let onNativeIOS = false;
 
 mock.module("@/runtime/platform-detection", () => ({
-  isNativeAndroid: () => false,
-  isNativeIOS: () => onNativeMobile,
-  isNativeMobile: () => onNativeMobile,
+  isNativeAndroid: () => onNativeAndroid,
+  isNativeIOS: () => onNativeIOS,
+  isNativeMobile: () => onNativeAndroid || onNativeIOS,
 }));
 
 const start = mock(async () => ({ started: true }));
@@ -38,6 +39,7 @@ const {
   startVoiceLiveActivity,
   updateVoiceLiveActivity,
   endVoiceLiveActivity,
+  subscribeVoiceLiveActivityPushToken,
 } = await import("@/runtime/native-live-activity");
 
 const content: VoiceLiveActivityContent = {
@@ -54,13 +56,15 @@ const startOptions: VoiceLiveActivityStart = {
 };
 
 beforeEach(() => {
-  onNativeMobile = true;
+  onNativeAndroid = false;
+  onNativeIOS = true;
   start.mockClear();
   start.mockImplementation(async () => ({ started: true }));
   update.mockClear();
   update.mockImplementation(async () => undefined);
   end.mockClear();
   end.mockImplementation(async () => undefined);
+  addListener.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -69,7 +73,7 @@ beforeEach(() => {
 
 describe("outside a native mobile shell", () => {
   beforeEach(() => {
-    onNativeMobile = false;
+    onNativeIOS = false;
   });
 
   test("start resolves false without touching the bridge", async () => {
@@ -86,6 +90,17 @@ describe("outside a native mobile shell", () => {
     expect(await endVoiceLiveActivity()).toBeUndefined();
     expect(end).not.toHaveBeenCalled();
   });
+});
+
+test("Android does not dispatch to the ActivityKit bridge", async () => {
+  onNativeAndroid = true;
+  onNativeIOS = false;
+
+  expect(await startVoiceLiveActivity(startOptions)).toBe(false);
+  expect(start).not.toHaveBeenCalled();
+  const unsubscribe = subscribeVoiceLiveActivityPushToken(() => undefined);
+  expect(addListener).not.toHaveBeenCalled();
+  unsubscribe();
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/runtime/native-live-activity.ts
+++ b/clients/web/src/runtime/native-live-activity.ts
@@ -10,9 +10,9 @@
  * of stacking a second island.
  *
  * **Skew contract.** An installed mobile shell may not include this plugin.
- * Every call therefore goes through {@link callNativeVoice}, which returns the
- * fallback outside native mobile or on any bridge failure. The status surface
- * is optional and must never block or end a voice session.
+ * Every call therefore returns its fallback off iOS and goes through
+ * {@link callNativeVoice} on iOS. The status surface is optional and must never
+ * block or end a voice session.
  *
  * That fallback also covers the case where the user has turned Live Activities
  * off for the app in iOS Settings — the plugin reports that as
@@ -31,6 +31,7 @@ import {
   callNativeVoice,
   subscribeNativeVoiceListener,
 } from "@/runtime/native-voice";
+import { isNativeIOS } from "@/runtime/platform-detection";
 
 /** The mutable half of the activity — everything that can change mid-session. */
 export interface VoiceLiveActivityContent {
@@ -95,9 +96,19 @@ interface VoiceLiveActivityPlugin {
 const VoiceLiveActivity =
   registerPlugin<VoiceLiveActivityPlugin>("VoiceLiveActivity");
 
+async function callVoiceLiveActivity<T>(
+  invoke: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  if (!isNativeIOS()) {
+    return fallback;
+  }
+  return callNativeVoice(invoke, fallback);
+}
+
 /**
  * Show a Live Activity for a session that just became active. Resolves whether
- * one is now running. Returns `false` outside native mobile, on a shell without
+ * one is now running. Returns `false` off iOS, on a shell without
  * the plugin, and when the user has disabled the platform status surface.
  *
  * Safe to call when one is already running: the plugin updates it rather than
@@ -108,7 +119,7 @@ const VoiceLiveActivity =
 export async function startVoiceLiveActivity(
   options: VoiceLiveActivityStart,
 ): Promise<boolean> {
-  return callNativeVoice(async () => {
+  return callVoiceLiveActivity(async () => {
     // Only the result crosses this `async` boundary, never `VoiceLiveActivity`
     // itself: per `docs/CAPACITOR.md` § "Capacitor plugins must be destructured
     // inline", a plugin Proxy in a Promise-resolution context dispatches a
@@ -122,7 +133,7 @@ export async function startVoiceLiveActivity(
 
 /**
  * Push new content to the running activity. A no-op when none is running,
- * outside native mobile, and on an older shell. Never throws.
+ * off iOS, and on an older shell. Never throws.
  *
  * ActivityKit rate-limits updates, so callers must push only on an actual
  * {@link VoiceLiveActivityContent} change — never on high-frequency store
@@ -131,17 +142,17 @@ export async function startVoiceLiveActivity(
 export async function updateVoiceLiveActivity(
   content: VoiceLiveActivityContent,
 ): Promise<void> {
-  return callNativeVoice(async () => {
+  return callVoiceLiveActivity(async () => {
     await VoiceLiveActivity.update(content);
   }, undefined);
 }
 
 /**
  * Dismiss the Live Activity at the end of a session. A no-op when none is
- * running, outside native mobile, and on an older shell. Never throws.
+ * running, off iOS, and on an older shell. Never throws.
  */
 export async function endVoiceLiveActivity(): Promise<void> {
-  return callNativeVoice(async () => {
+  return callVoiceLiveActivity(async () => {
     await VoiceLiveActivity.end();
   }, undefined);
 }
@@ -168,6 +179,9 @@ export async function endVoiceLiveActivity(): Promise<void> {
 export function subscribeVoiceLiveActivityPushToken(
   handler: (event: VoiceLiveActivityPushToken) => void,
 ): () => void {
+  if (!isNativeIOS()) {
+    return () => undefined;
+  }
   return subscribeNativeVoiceListener(
     () => VoiceLiveActivity.addListener("liveActivityPushToken", handler),
     "native-live-activity",

--- a/clients/web/src/runtime/native-live-activity.ts
+++ b/clients/web/src/runtime/native-live-activity.ts
@@ -9,13 +9,10 @@
  * calling {@link startVoiceLiveActivity} twice updates the running one instead
  * of stacking a second island.
  *
- * **Skew contract.** The iOS shell ships through App Store review while this
- * bundle deploys continuously (`clients/ios/README.md` § "Web content
- * delivery"), so an arbitrarily old shell may host this bundle with no such
- * plugin compiled in. Every call therefore goes through {@link callNativeVoice},
- * which returns the fallback off-iOS and on any bridge failure. A Live Activity
- * is a flourish: nothing here may throw, block, or otherwise reach a voice
- * session.
+ * **Skew contract.** An installed mobile shell may not include this plugin.
+ * Every call therefore goes through {@link callNativeVoice}, which returns the
+ * fallback outside native mobile or on any bridge failure. The status surface
+ * is optional and must never block or end a voice session.
  *
  * That fallback also covers the case where the user has turned Live Activities
  * off for the app in iOS Settings — the plugin reports that as
@@ -27,11 +24,13 @@
  * Reference: https://developer.apple.com/documentation/activitykit/activity
  */
 
-import { registerPlugin, type PluginListenerHandle } from "@capacitor/core";
+import { registerPlugin } from "@capacitor/core";
 
 import type { ActiveLiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { callNativeVoice } from "@/runtime/native-voice";
-import { isNativeIOS } from "@/runtime/platform-detection";
+import {
+  callNativeVoice,
+  subscribeNativeVoiceListener,
+} from "@/runtime/native-voice";
 
 /** The mutable half of the activity — everything that can change mid-session. */
 export interface VoiceLiveActivityContent {
@@ -90,7 +89,7 @@ interface VoiceLiveActivityPlugin {
   addListener(
     eventName: "liveActivityPushToken",
     handler: (event: VoiceLiveActivityPushToken) => void,
-  ): Promise<PluginListenerHandle>;
+  ): Promise<{ remove(): Promise<void> }>;
 }
 
 const VoiceLiveActivity =
@@ -98,8 +97,8 @@ const VoiceLiveActivity =
 
 /**
  * Show a Live Activity for a session that just became active. Resolves whether
- * one is now running — `false` off-iOS, on a shell without the plugin, and when
- * the user has disabled Live Activities for the app in Settings.
+ * one is now running. Returns `false` outside native mobile, on a shell without
+ * the plugin, and when the user has disabled the platform status surface.
  *
  * Safe to call when one is already running: the plugin updates it rather than
  * requesting a second island. Pair every call with {@link endVoiceLiveActivity}
@@ -122,8 +121,8 @@ export async function startVoiceLiveActivity(
 }
 
 /**
- * Push new content to the running activity. A no-op when none is running, and
- * off-iOS, and on an older shell. Never throws.
+ * Push new content to the running activity. A no-op when none is running,
+ * outside native mobile, and on an older shell. Never throws.
  *
  * ActivityKit rate-limits updates, so callers must push only on an actual
  * {@link VoiceLiveActivityContent} change — never on high-frequency store
@@ -139,7 +138,7 @@ export async function updateVoiceLiveActivity(
 
 /**
  * Dismiss the Live Activity at the end of a session. A no-op when none is
- * running, and off-iOS, and on an older shell. Never throws.
+ * running, outside native mobile, and on an older shell. Never throws.
  */
 export async function endVoiceLiveActivity(): Promise<void> {
   return callNativeVoice(async () => {
@@ -169,30 +168,8 @@ export async function endVoiceLiveActivity(): Promise<void> {
 export function subscribeVoiceLiveActivityPushToken(
   handler: (event: VoiceLiveActivityPushToken) => void,
 ): () => void {
-  if (!isNativeIOS()) {
-    return () => undefined;
-  }
-
-  let handle: PluginListenerHandle | null = null;
-  let cancelled = false;
-
-  VoiceLiveActivity.addListener("liveActivityPushToken", handler)
-    .then((registered) => {
-      if (cancelled) {
-        void registered.remove();
-        return;
-      }
-      handle = registered;
-    })
-    .catch((err: unknown) => {
-      // `console.debug`, not `captureError`, for the same reason
-      // `callNativeVoice` swallows: a shell without this plugin is an expected
-      // state on every web deploy, not a fault.
-      console.debug("[native-live-activity] push token listener failed:", err);
-    });
-
-  return () => {
-    cancelled = true;
-    void handle?.remove();
-  };
+  return subscribeNativeVoiceListener(
+    () => VoiceLiveActivity.addListener("liveActivityPushToken", handler),
+    "native-live-activity",
+  );
 }

--- a/clients/web/src/runtime/native-voice.test.ts
+++ b/clients/web/src/runtime/native-voice.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
 
-let onNativeIOS = false;
+let onNativeMobile = false;
 
 mock.module("@/runtime/platform-detection", () => ({
-  isNativeIOS: () => onNativeIOS,
+  isNativeAndroid: () => false,
+  isNativeIOS: () => onNativeMobile,
+  isNativeMobile: () => onNativeMobile,
 }));
 
 import { callNativeVoice } from "@/runtime/native-voice";
@@ -19,15 +21,15 @@ import { callNativeVoice } from "@/runtime/native-voice";
 
 describe("callNativeVoice", () => {
   test("returns the fallback off-native without invoking the bridge", async () => {
-    onNativeIOS = false;
+    onNativeMobile = false;
     const invoke = mock(async () => "native");
 
     expect(await callNativeVoice(invoke, "fallback")).toBe("fallback");
     expect(invoke).not.toHaveBeenCalled();
   });
 
-  test("returns the invoke result on native iOS", async () => {
-    onNativeIOS = true;
+  test("returns the invoke result in a native mobile shell", async () => {
+    onNativeMobile = true;
     const invoke = mock(async () => "native");
 
     expect(await callNativeVoice(invoke, "fallback")).toBe("native");
@@ -35,7 +37,7 @@ describe("callNativeVoice", () => {
   });
 
   test("returns the fallback when the bridge call rejects", async () => {
-    onNativeIOS = true;
+    onNativeMobile = true;
     // The shape of an older shell missing the plugin entirely.
     const invoke = mock(async () => {
       throw new Error("VoiceAudioSession does not have web implementation.");
@@ -46,7 +48,7 @@ describe("callNativeVoice", () => {
   });
 
   test("never rethrows, for a synchronous throw or a non-Error rejection", async () => {
-    onNativeIOS = true;
+    onNativeMobile = true;
 
     expect(
       await callNativeVoice(() => {
@@ -67,10 +69,10 @@ describe("callNativeVoice", () => {
       throw new Error("bridge failure");
     };
 
-    onNativeIOS = false;
+    onNativeMobile = false;
     expect(await callNativeVoice(failing, false)).toBe(false);
 
-    onNativeIOS = true;
+    onNativeMobile = true;
     expect(await callNativeVoice(failing, false)).toBe(false);
   });
 });

--- a/clients/web/src/runtime/native-voice.test.ts
+++ b/clients/web/src/runtime/native-voice.test.ts
@@ -10,15 +10,6 @@ mock.module("@/runtime/platform-detection", () => ({
 
 import { callNativeVoice } from "@/runtime/native-voice";
 
-// ---------------------------------------------------------------------------
-// `callNativeVoice` is the skew-safe seam every native voice bridge call goes
-// through. The iOS shell ships through App Store review while this bundle
-// deploys continuously (`clients/ios/README.md` § "Web content delivery"), so
-// an arbitrarily old shell can host this bundle and the plugin may simply not
-// be there. The contract these tests pin: the helper never throws and never
-// rejects, so a missing bridge degrades to a working voice session.
-// ---------------------------------------------------------------------------
-
 describe("callNativeVoice", () => {
   test("returns the fallback off-native without invoking the bridge", async () => {
     onNativeMobile = false;

--- a/clients/web/src/runtime/native-voice.ts
+++ b/clients/web/src/runtime/native-voice.ts
@@ -38,9 +38,7 @@ export async function callNativeVoice<T>(
   }
 }
 
-interface NativeVoiceListenerHandle {
-  remove(): Promise<void>;
-}
+type NativeVoiceListenerHandle = { remove(): Promise<void> };
 
 export function subscribeNativeVoiceListener(
   register: () => Promise<NativeVoiceListenerHandle>,
@@ -53,29 +51,26 @@ export function subscribeNativeVoiceListener(
   let handle: NativeVoiceListenerHandle | null = null;
   let cancelled = false;
 
-  let registration: Promise<NativeVoiceListenerHandle>;
   try {
-    registration = register();
+    void register().then(
+      (registered) => {
+        if (cancelled) {
+          void registered.remove();
+        } else {
+          handle = registered;
+        }
+      },
+      (err: unknown) => {
+        console.debug(`[${failureContext}] listener unavailable:`, err);
+      },
+    );
   } catch (err) {
     console.debug(`[${failureContext}] listener unavailable:`, err);
     return () => undefined;
   }
 
-  registration
-    .then((registered) => {
-      if (cancelled) {
-        void registered.remove();
-        return;
-      }
-      handle = registered;
-    })
-    .catch((err: unknown) => {
-      console.debug(`[${failureContext}] listener unavailable:`, err);
-    });
-
   return () => {
     cancelled = true;
     void handle?.remove();
-    handle = null;
   };
 }

--- a/clients/web/src/runtime/native-voice.ts
+++ b/clients/web/src/runtime/native-voice.ts
@@ -1,18 +1,11 @@
-import { isNativeIOS } from "@/runtime/platform-detection";
+import { isNativeMobile } from "@/runtime/platform-detection";
 
 /**
- * Skew-safe seam for every JS → native call that supports iOS voice mode.
+ * Skew-safe seam for optional native voice calls in either mobile shell.
  *
- * **The skew contract.** The iOS app is a Capacitor `server.url` shell: it
- * bundles no web assets and navigates `WKWebView` straight at the deployed web
- * origin at launch (`clients/ios/README.md` § "Web content delivery"). So this
- * bundle deploys continuously and is live for every iOS user on their next app
- * load, while the shell that hosts it only changes after an App Store review
- * cycle. At any moment an arbitrarily old shell can be running an arbitrarily
- * new bundle. Every call site must therefore assume the native plugin it wants
- * does not exist, and must degrade to a working voice session without it —
- * a missing bridge may cost a native flourish (a Live Activity, an audio
- * session hint) but must never fail, block, or end the session itself.
+ * The web bundle can be newer than the installed iOS or Android shell. Every
+ * call therefore assumes the requested plugin may be absent and falls back
+ * without blocking or ending voice.
  *
  * Route every native voice call through {@link callNativeVoice}. This module
  * stays deliberately plugin-agnostic: it neither calls `registerPlugin` nor
@@ -27,33 +20,62 @@ import { isNativeIOS } from "@/runtime/platform-detection";
  *
  * @param invoke Performs the bridge call. Destructure the plugin inline here —
  *   never let a plugin Proxy cross an `async` return.
- * @param fallback Returned off-iOS and on any bridge failure. Must be a value
- *   the caller can proceed with.
+ * @param fallback Returned outside a native mobile shell and on bridge failure.
  */
 export async function callNativeVoice<T>(
   invoke: () => Promise<T>,
   fallback: T,
 ): Promise<T> {
-  // Platform short-circuit, cited per `docs/CAPACITOR.md` § "Platform
-  // short-circuits in capability detection". The constraint here is not a
-  // broken web API but the absence of a host: these bridges are custom
-  // Capacitor plugins compiled into the iOS shell (`clients/ios/README.md`
-  // § "Web content delivery"), so in a browser, in Electron, or in a
-  // Capacitor Android runtime there is no native side to call and no feature
-  // probe that could find one. Invalidated if an equivalent plugin ever ships
-  // in another shell — widen the gate then.
-  if (!isNativeIOS()) {
+  if (!isNativeMobile()) {
     return fallback;
   }
   try {
     return await invoke();
   } catch (err) {
-    // Deliberately `console.debug`, not the `captureError` that
-    // `docs/CONVENTIONS.md` § "Manual error reporting from imperative code"
-    // otherwise prescribes: an older App Store shell without the plugin is an
-    // expected state on every web deploy, not a fault, and reporting it would
-    // spam Sentry once per skewed install.
+    // Missing plugins are expected while installed shells catch up to the web.
     console.debug("[native-voice] bridge call unavailable:", err);
     return fallback;
   }
+}
+
+interface NativeVoiceListenerHandle {
+  remove(): Promise<void>;
+}
+
+export function subscribeNativeVoiceListener(
+  register: () => Promise<NativeVoiceListenerHandle>,
+  failureContext: string,
+): () => void {
+  if (!isNativeMobile()) {
+    return () => undefined;
+  }
+
+  let handle: NativeVoiceListenerHandle | null = null;
+  let cancelled = false;
+
+  let registration: Promise<NativeVoiceListenerHandle>;
+  try {
+    registration = register();
+  } catch (err) {
+    console.debug(`[${failureContext}] listener unavailable:`, err);
+    return () => undefined;
+  }
+
+  registration
+    .then((registered) => {
+      if (cancelled) {
+        void registered.remove();
+        return;
+      }
+      handle = registered;
+    })
+    .catch((err: unknown) => {
+      console.debug(`[${failureContext}] listener unavailable:`, err);
+    });
+
+  return () => {
+    cancelled = true;
+    void handle?.remove();
+    handle = null;
+  };
 }


### PR DESCRIPTION
Wave 2 PR 7 of the Android and iOS feature parity plan. Adds Android audio-focus handling behind the existing optional native voice contracts while preserving iOS and browser behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->