### PR TITLE
fix(web): keep the zero-starters empty chat scrollable while bottom-anchored

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -510,6 +510,49 @@ describe("ChatBody - plain empty state bottom-anchors while the keyboard is open
   });
 });
 
+describe("ChatBody - the empty-state scroll container never carries alignment", () => {
+  // Pins the scrollability STRUCTURE, not rendered geometry (happy-dom
+  // performs no layout): with `justify-end` on the `overflow-y-auto`
+  // container itself, content taller than the viewport overflows past the
+  // START edge, which scrolling cannot reach, so the greeting becomes
+  // unreachable on short viewports while the keyboard is open. The
+  // conditional alignment must live on the inner `min-h-full` wrapper.
+
+  const outerOf = (container: HTMLElement) =>
+    container.firstElementChild as HTMLElement;
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
+  });
+
+  test("keyboard open, zero starters: justify-end sits on the inner min-h-full wrapper, not the scroll container", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...withEmptyState()} />);
+
+    const outer = outerOf(container);
+    expect(outer.className).toContain("overflow-y-auto");
+    expect(outer.className).not.toContain("justify-end");
+
+    const inner = outer.firstElementChild as HTMLElement;
+    expect(inner.className).toContain("min-h-full");
+    expect(inner.className).toContain("justify-end");
+  });
+
+  test("at rest: safe_center sits on the inner min-h-full wrapper, not the scroll container", () => {
+    keyboardOpen = false;
+    const { container } = render(<ChatBody {...withEmptyState()} />);
+
+    const outer = outerOf(container);
+    expect(outer.className).toContain("overflow-y-auto");
+    expect(outer.className).not.toContain("[justify-content:safe_center]");
+
+    const inner = outer.firstElementChild as HTMLElement;
+    expect(inner.className).toContain("min-h-full");
+    expect(inner.className).toContain("[justify-content:safe_center]");
+  });
+});
+
 describe("ChatBody - plugin pills hide while the keyboard is open", () => {
   // The plugin controls rendered below the composer share the dock's
   // collapse treatment (both call sites render through the same helper):

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -28,8 +28,9 @@ import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
  * area on top, and a composer stack underneath.
  *
  * **Empty‑state centering (LUM-1566):** When the empty state is visible,
- * the outer container switches to `justify-content: safe center` +
- * `overflow-y-auto` and the scroll area drops its `flex-1`. This lets
+ * the outer container becomes a plain `overflow-y-auto` scroll container,
+ * an inner `min-h-full` wrapper carries `justify-content: safe center`,
+ * and the scroll area drops its `flex-1`. This lets
  * the greeting, composer, and conversation-starter chips center as a
  * single visual group — matching the original centered layout — while
  * the composer **stays at the same position in the React tree** so its
@@ -274,15 +275,22 @@ export function ChatBody({
       ? "justify-end"
       : "[justify-content:safe_center]";
 
-  // The docked (suggestions-library) empty state owns its own vertical
-  // layout (a full-height first screen that centers the greeting + composer
-  // and pins the featured row to the bottom), so it does not use
-  // `safe center`.
-  const outerClass = isEmptyState
-    ? dockStartersToBottom
-      ? `${baseClass} overflow-y-auto`
-      : `${baseClass} overflow-y-auto ${nonDockedAlignmentClass}`
-    : baseClass;
+  // On the empty state the outer container is a plain scroll container.
+  // Group alignment lives on an inner `min-h-full` wrapper (the docked
+  // branch builds its own): alignment directly on the scroll container
+  // would make end-aligned content taller than the viewport overflow past
+  // the START edge, where scrolling cannot reach, leaving the greeting
+  // unreachable on short viewports while the keyboard is open.
+  const outerClass = isEmptyState ? `${baseClass} overflow-y-auto` : baseClass;
+
+  // Inner wrapper for the non-docked layout. On the empty state it fills
+  // the first viewport (`min-h-full`) and carries the group alignment; on
+  // the active state it is a plain fill wrapper (`min-h-0 flex-1`) so the
+  // transcript keeps its height chain. It exists in both states so the
+  // composer keeps its tree position across the empty→active transition.
+  const nonDockedInnerClass = isEmptyState
+    ? `flex min-h-full flex-col ${nonDockedAlignmentClass}`
+    : "flex min-h-0 flex-1 flex-col";
 
   // Suppress the absolutely-positioned overlay on the empty state: its
   // `bottom-full` positioning would overlap the greeting when the outer
@@ -485,21 +493,23 @@ export function ChatBody({
       onDragLeave={dragHandlers.onDragLeave}
       onDrop={dragHandlers.onDrop}
     >
-      <ChatScrollArea
-        {...scrollAreaProps}
-        bottomOverlayReservePx={bottomOverlayReservePx}
-      />
+      <div className={nonDockedInnerClass}>
+        <ChatScrollArea
+          {...scrollAreaProps}
+          bottomOverlayReservePx={bottomOverlayReservePx}
+        />
 
-      {!isEmptyState && activeProcessOverlaysSlot && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
-          {/* Registry-driven row of active background-process overlays. The
-              caller owns which kinds it covers and their order; each overlay
-              self-gates on its own active ids. */}
-          {activeProcessOverlaysSlot}
-        </div>
-      )}
+        {!isEmptyState && activeProcessOverlaysSlot && (
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
+            {/* Registry-driven row of active background-process overlays. The
+                caller owns which kinds it covers and their order; each overlay
+                self-gates on its own active ids. */}
+            {activeProcessOverlaysSlot}
+          </div>
+        )}
 
-      {renderComposerStack(startersSlot)}
+        {renderComposerStack(startersSlot)}
+      </div>
       {dragOverlay}
     </div>
   );

--- a/clients/web/src/domains/chat/components/chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/components/chat-empty-state.tsx
@@ -9,9 +9,10 @@ import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-c
  * rendered by the parent `ChatBody` in the same flex column so that
  * greeting → composer → starters appear as one vertically-centered group.
  *
- * Centering and overflow handling live on `ChatBody`'s outer container
- * (`justify-content: safe center` + `overflow-y-auto`), not here. This
- * component just renders its content at natural height.
+ * Centering and overflow handling live on `ChatBody` (`overflow-y-auto`
+ * on its outer scroll container, `justify-content: safe center` on an
+ * inner `min-h-full` wrapper), not here. This component just renders its
+ * content at natural height.
  *
  * See [React — Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)
  * for why the composer must stay at a fixed tree position rather than


### PR DESCRIPTION
## Summary
- Moves the keyboard-open bottom-anchoring in the non-docked empty state off the scroll container onto an inner min-h-full wrapper, mirroring the docked branch, so content taller than the visible area overflows downward and stays scrollable instead of clipping unreachable at the top edge.
- Structure pinned by a test; at-rest rendering unchanged.

Fixes a gap identified during plan self-review for ios-keyboard-composer-dock-and-backdrop.md