### PR TITLE
iOS keyboard polish round 3: dock the empty-chat composer and paint the keyboard backdrop

### DIFF
--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -102,20 +102,32 @@ class MyViewController: CAPBridgeViewController {
         return QuoteReplyWebView(frame: frame, configuration: configuration)
     }
 
-    /// Paint the native root view (and the web view's own backgrounds) with the
-    /// design system's `--surface-overlay` token so the safe-area regions that
-    /// fall *outside* the web viewport — most visibly the home-indicator band
-    /// below the drawer — match the web surface instead of the system default.
+    /// Paint the web view's backgrounds with the design system's
+    /// `--surface-overlay` token so the safe-area regions that fall *outside*
+    /// the web layout viewport, most visibly the home-indicator band below
+    /// the drawer, match the web surface instead of the system default.
     ///
-    /// The WKWebView's content extends to `viewport-fit=cover`, but its layout
-    /// height stops at the safe-area edge; the strip beneath it is painted by
-    /// the view controller's root view, which otherwise falls back to
-    /// `systemBackground` (pure white / near-black) and reads as a seam against
-    /// `--surface-overlay` (`#FDFDFC` light / `#1C2024` dark). Making the web
-    /// view non-opaque with a matching background lets the token color show
-    /// through uniformly. The color lives in the `SurfaceOverlay` asset-catalog
-    /// color set (light + dark appearances) so it tracks the design token as a
-    /// single native source of truth rather than a hardcoded literal.
+    /// Capacitor's `CAPBridgeViewController.loadView()` assigns
+    /// `view = webView`, so there is no separate root view behind the web
+    /// view: the `view.backgroundColor` and `webView?.backgroundColor` writes
+    /// below alias the same layer, and all four background writes cooperate
+    /// on the one web view. The web content extends under
+    /// `viewport-fit=cover`, but the layout height stops at the safe-area
+    /// edge; with the keyboard closed, the home-indicator band is painted by
+    /// the web view's own background plus `underPageBackgroundColor` (see
+    /// below), which otherwise fall back to `systemBackground` (pure white /
+    /// near-black) and read as a seam against `--surface-overlay` (`#FDFDFC`
+    /// light / `#1C2024` dark). While the keyboard is shown, the Keyboard
+    /// plugin (`resize: native`) shrinks the web view frame, and the region
+    /// below it is backed only by the `UIWindow`, whose backdrop is painted
+    /// via the Keyboard plugin's `autoBackdropColor` config in
+    /// `capacitor.config.ts`.
+    ///
+    /// Making the web view non-opaque with a matching background lets the
+    /// token color show through uniformly. The color lives in the
+    /// `SurfaceOverlay` asset-catalog color set (light + dark appearances) so
+    /// it tracks the design token as a single native source of truth rather
+    /// than a hardcoded literal.
     override open func viewDidLoad() {
         super.viewDidLoad()
         let surfaceOverlay = UIColor(named: "SurfaceOverlay")

--- a/clients/web/capacitor.config.ts
+++ b/clients/web/capacitor.config.ts
@@ -113,6 +113,19 @@ const config: CapacitorConfig = {
       // No `style` value expresses "follow the in-app theme"; that needs a
       // runtime `Keyboard.setStyle()` call.
       style: KeyboardStyle.Default,
+      // The iOS 26 keyboard is a transparent inset panel with rounded
+      // corners. Under `resize: native` the shrunk web view is the view
+      // controller's root view, so the unpainted UIWindow composites black
+      // through the panel's margins and corners. `"dom"` paints the window
+      // from the body's computed background (`--surface-base` on the iOS
+      // shell, via the gated rule in `index.css`) at plugin load and on
+      // every `keyboardWillShow`.
+      // Caution: the plugin's DOM color parser handles `rgb()`/hex/
+      // `transparent` and falls back to white for anything else. Today's
+      // tokens compute to `rgb()`, but a token migration to `oklch()` or
+      // `color()` would flash white behind the keyboard and must revisit
+      // this setting.
+      autoBackdropColor: "dom",
     },
   },
 };

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -396,7 +396,7 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     cleanup();
   });
 
-  test("keyboard closed: the dock is expanded, interactive, and the group centers", () => {
+  test("keyboard closed: the dock is expanded, interactive, unclipped, and the group centers", () => {
     keyboardOpen = false;
     const { container } = render(<ChatBody {...dockedProps()} />);
 
@@ -406,11 +406,16 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     expect(dock?.className).not.toContain("pointer-events-none");
     expect(dock?.hasAttribute("inert")).toBe(false);
     expect(dock?.style.gridTemplateRows).toBe("1fr");
+    // Markup pin on the clip mechanism: at rest the inner div must not
+    // clip, so keyboard-focus rings (painted outside the border box of the
+    // cards and buttons inside) stay fully visible.
+    expect(dock?.firstElementChild?.className).toContain("min-h-0");
+    expect(dock?.firstElementChild?.className).not.toContain("overflow-hidden");
     expect(container.innerHTML).toContain("[justify-content:safe_center]");
     expect(container.innerHTML).not.toContain("justify-end");
   });
 
-  test("keyboard open: the dock collapses, fades, goes inert, and the group bottom-anchors", () => {
+  test("keyboard open: the dock collapses, fades, goes inert, clips, and the group bottom-anchors", () => {
     keyboardOpen = true;
     const { container } = render(<ChatBody {...dockedProps()} />);
 
@@ -421,6 +426,9 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     expect(dock?.className).toContain("pointer-events-none");
     expect(dock?.hasAttribute("inert")).toBe(true);
     expect(dock?.style.gridTemplateRows).toBe("0fr");
+    // Markup pin on the clip mechanism: the collapse animation clips the
+    // shrinking row's content.
+    expect(dock?.firstElementChild?.className).toContain("overflow-hidden");
     expect(container.innerHTML).toContain("justify-end");
     expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
   });
@@ -430,50 +438,89 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     const { container, rerender } = render(<ChatBody {...dockedProps()} />);
     expect(dockWrapper(container)?.className).toContain("opacity-0");
     expect(dockWrapper(container)?.style.gridTemplateRows).toBe("0fr");
+    const mounted = container.querySelector('[data-testid="starters"]');
+    expect(mounted).not.toBeNull();
 
     keyboardOpen = false;
     rerender(<ChatBody {...dockedProps()} />);
     expect(dockWrapper(container)?.className).not.toContain("opacity-0");
     expect(dockWrapper(container)?.style.gridTemplateRows).toBe("1fr");
-    expect(container.innerHTML).toContain("STARTER_CHIPS");
+    // Same DOM node across the toggle proves the dock never remounted.
+    expect(container.querySelector('[data-testid="starters"]')).toBe(
+      mounted as HTMLElement,
+    );
+  });
+});
+
+describe("ChatBody - plain empty state bottom-anchors while the keyboard is open", () => {
+  // Before conversation starters arrive, the plain empty state renders the
+  // NON-docked branch with no startersSlot (server-side starter generation
+  // can take a while on a brand-new assistant). While the soft keyboard is
+  // open that branch must bottom-anchor the greeting + composer group just
+  // like the docked branch, so the composer docks to the keyboard edge in
+  // the zero-starters window and the docked/non-docked flip when starters
+  // arrive never moves the composer mid-typing. The app-editing side panel
+  // is the one non-docked state WITH a startersSlot (its inline chips), and
+  // it keeps its centered layout regardless of keyboard state.
+  const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
   });
 
-  test("non-docked empty state keeps its starters untouched by keyboard state", () => {
+  test("keyboard open, zero starters: the group bottom-anchors instead of centering", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...withEmptyState()} />);
+
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
+  });
+
+  test("starters arriving under an open keyboard keep the bottom anchor across the branch flip", () => {
+    keyboardOpen = true;
+    const { container, rerender } = render(<ChatBody {...withEmptyState()} />);
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
+
+    rerender(
+      <ChatBody
+        {...withEmptyState({ dockStartersToBottom: true, startersSlot })}
+      />,
+    );
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
+  });
+
+  test("app-editing (non-docked with inline starters) stays centered with the keyboard open", () => {
+    // Discriminates the gate: same non-docked empty state and open
+    // keyboard, but with the inline startersSlot the app-editing branch
+    // renders. A gate that bottom-anchored every non-docked empty state
+    // would fail here by pushing the side panel's composer and chips to
+    // the bottom edge.
     keyboardOpen = true;
     const { container } = render(
-      <ChatBody {...withEmptyState({ startersSlot })} />,
+      <ChatBody {...withEmptyState({ variant: "side-panel", startersSlot })} />,
     );
 
     expect(container.innerHTML).toContain("STARTER_CHIPS");
     expect(container.innerHTML).toContain("[justify-content:safe_center]");
     expect(container.innerHTML).not.toContain("justify-end");
-    expect(dockWrapper(container)).toBeNull();
-  });
-
-  test("transcript branch ignores keyboard state (no dock, no bottom-anchoring)", () => {
-    keyboardOpen = true;
-    const { container } = render(<ChatBody {...baseProps()} />);
-
-    expect(dockWrapper(container)).toBeNull();
-    expect(container.innerHTML).not.toContain("justify-end");
+    expect(container.querySelector('[data-slot="docked-starters"]')).toBeNull();
   });
 });
 
 describe("ChatBody - plugin pills hide while the keyboard is open", () => {
   // The plugin controls rendered below the composer share the dock's
-  // treatment: while the soft keyboard is up they fade out, collapse their
-  // reserved height, and go inert so the composer (not the plugin row)
-  // docks to the keyboard edge. The slot stays mounted so dismissing the
-  // keyboard restores it without a remount.
+  // collapse treatment (both call sites render through the same helper):
+  // while the soft keyboard is up they fade out, collapse their reserved
+  // height, and go inert so the composer, not the plugin row, docks to the
+  // keyboard edge. The slot stays mounted so dismissing the keyboard
+  // restores it without a remount.
   const pluginPillsSlot = <div data-testid="plugins">PLUGIN_PILLS</div>;
-  const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
 
-  const dockedProps = () =>
-    withEmptyState({
-      dockStartersToBottom: true,
-      startersSlot,
-      pluginPillsSlot,
-    });
+  const pluginProps = () =>
+    withEmptyState({ dockStartersToBottom: true, pluginPillsSlot });
 
   const pluginsWrapper = (container: HTMLElement) =>
     container.querySelector<HTMLElement>('[data-slot="new-chat-plugins"]');
@@ -483,22 +530,9 @@ describe("ChatBody - plugin pills hide while the keyboard is open", () => {
     cleanup();
   });
 
-  test("keyboard closed: the plugin row is expanded and interactive", () => {
-    keyboardOpen = false;
-    const { container } = render(<ChatBody {...dockedProps()} />);
-
-    const wrapper = pluginsWrapper(container);
-    expect(wrapper).not.toBeNull();
-    expect(wrapper?.className).not.toContain("opacity-0");
-    expect(wrapper?.className).not.toContain("pointer-events-none");
-    expect(wrapper?.hasAttribute("inert")).toBe(false);
-    expect(wrapper?.style.gridTemplateRows).toBe("1fr");
-    expect(container.innerHTML).toContain("PLUGIN_PILLS");
-  });
-
-  test("keyboard open: the plugin row collapses, fades, goes inert, and the composer is the last expanded child of the bottom-anchored group", () => {
+  test("keyboard open: the row collapses, fades, goes inert; closing restores it without a remount", () => {
     keyboardOpen = true;
-    const { container } = render(<ChatBody {...dockedProps()} />);
+    const { container, rerender } = render(<ChatBody {...pluginProps()} />);
 
     const wrapper = pluginsWrapper(container);
     expect(wrapper).not.toBeNull();
@@ -507,26 +541,20 @@ describe("ChatBody - plugin pills hide while the keyboard is open", () => {
     expect(wrapper?.className).toContain("pointer-events-none");
     expect(wrapper?.hasAttribute("inert")).toBe(true);
     expect(wrapper?.style.gridTemplateRows).toBe("0fr");
-
-    // Bottom-anchored group: the only sibling after the composer is the
-    // collapsed plugin wrapper, so the composer reaches the keyboard edge.
-    expect(container.innerHTML).toContain("justify-end");
-    const composer = container.querySelector('[data-testid="composer"]');
-    expect(composer?.nextElementSibling).toBe(wrapper as HTMLElement);
-    expect(composer?.nextElementSibling?.nextElementSibling).toBeNull();
-  });
-
-  test("keyboard toggling flips the hidden treatment without unmounting the slot", () => {
-    keyboardOpen = true;
-    const { container, rerender } = render(<ChatBody {...dockedProps()} />);
-    expect(pluginsWrapper(container)?.style.gridTemplateRows).toBe("0fr");
+    expect(wrapper?.firstElementChild?.className).toContain("overflow-hidden");
     const mounted = container.querySelector('[data-testid="plugins"]');
     expect(mounted).not.toBeNull();
 
     keyboardOpen = false;
-    rerender(<ChatBody {...dockedProps()} />);
-    expect(pluginsWrapper(container)?.className).not.toContain("opacity-0");
-    expect(pluginsWrapper(container)?.style.gridTemplateRows).toBe("1fr");
+    rerender(<ChatBody {...pluginProps()} />);
+    const restored = pluginsWrapper(container);
+    expect(restored?.className).not.toContain("opacity-0");
+    expect(restored?.className).not.toContain("pointer-events-none");
+    expect(restored?.hasAttribute("inert")).toBe(false);
+    expect(restored?.style.gridTemplateRows).toBe("1fr");
+    expect(restored?.firstElementChild?.className).not.toContain(
+      "overflow-hidden",
+    );
     // Same DOM node across the toggle proves the slot never remounted.
     expect(container.querySelector('[data-testid="plugins"]')).toBe(
       mounted as HTMLElement,

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -510,6 +510,49 @@ describe("ChatBody - plain empty state bottom-anchors while the keyboard is open
   });
 });
 
+describe("ChatBody - the empty-state scroll container never carries alignment", () => {
+  // Pins the scrollability STRUCTURE, not rendered geometry (happy-dom
+  // performs no layout): with `justify-end` on the `overflow-y-auto`
+  // container itself, content taller than the viewport overflows past the
+  // START edge, which scrolling cannot reach, so the greeting becomes
+  // unreachable on short viewports while the keyboard is open. The
+  // conditional alignment must live on the inner `min-h-full` wrapper.
+
+  const outerOf = (container: HTMLElement) =>
+    container.firstElementChild as HTMLElement;
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
+  });
+
+  test("keyboard open, zero starters: justify-end sits on the inner min-h-full wrapper, not the scroll container", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...withEmptyState()} />);
+
+    const outer = outerOf(container);
+    expect(outer.className).toContain("overflow-y-auto");
+    expect(outer.className).not.toContain("justify-end");
+
+    const inner = outer.firstElementChild as HTMLElement;
+    expect(inner.className).toContain("min-h-full");
+    expect(inner.className).toContain("justify-end");
+  });
+
+  test("at rest: safe_center sits on the inner min-h-full wrapper, not the scroll container", () => {
+    keyboardOpen = false;
+    const { container } = render(<ChatBody {...withEmptyState()} />);
+
+    const outer = outerOf(container);
+    expect(outer.className).toContain("overflow-y-auto");
+    expect(outer.className).not.toContain("[justify-content:safe_center]");
+
+    const inner = outer.firstElementChild as HTMLElement;
+    expect(inner.className).toContain("min-h-full");
+    expect(inner.className).toContain("[justify-content:safe_center]");
+  });
+});
+
 describe("ChatBody - plugin pills hide while the keyboard is open", () => {
   // The plugin controls rendered below the composer share the dock's
   // collapse treatment (both call sites render through the same helper):

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -377,24 +377,26 @@ describe("ChatBody — startersSlot rendering", () => {
 });
 
 describe("ChatBody - docked starters hide while the keyboard is open", () => {
-  // The docked (mobile empty-state) suggestions row fades out while the soft
-  // keyboard is up, staying mounted so the centered greeting + composer keep
-  // their layout. Class assertions here are regression pins on the markup,
-  // not proof of the rendered layout.
+  // The docked (mobile empty-state) suggestions row fades out and collapses
+  // its reserved height while the soft keyboard is up, and the greeting +
+  // composer group anchors to the bottom edge instead of centering. The dock
+  // stays mounted so dismissing the keyboard restores it without a remount.
+  // Class assertions here are regression pins on the markup, not proof of
+  // the rendered layout.
   const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
 
   const dockedProps = () =>
     withEmptyState({ dockStartersToBottom: true, startersSlot });
 
   const dockWrapper = (container: HTMLElement) =>
-    container.querySelector('[data-slot="docked-starters"]');
+    container.querySelector<HTMLElement>('[data-slot="docked-starters"]');
 
   afterEach(() => {
     keyboardOpen = false;
     cleanup();
   });
 
-  test("keyboard closed: the dock is visible, interactive, and not inert", () => {
+  test("keyboard closed: the dock is expanded, interactive, and the group centers", () => {
     keyboardOpen = false;
     const { container } = render(<ChatBody {...dockedProps()} />);
 
@@ -403,9 +405,12 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     expect(dock?.className).not.toContain("opacity-0");
     expect(dock?.className).not.toContain("pointer-events-none");
     expect(dock?.hasAttribute("inert")).toBe(false);
+    expect(dock?.style.gridTemplateRows).toBe("1fr");
+    expect(container.innerHTML).toContain("[justify-content:safe_center]");
+    expect(container.innerHTML).not.toContain("justify-end");
   });
 
-  test("keyboard open: the dock stays mounted but fades out and goes inert", () => {
+  test("keyboard open: the dock collapses, fades, goes inert, and the group bottom-anchors", () => {
     keyboardOpen = true;
     const { container } = render(<ChatBody {...dockedProps()} />);
 
@@ -415,16 +420,21 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     expect(dock?.className).toContain("opacity-0");
     expect(dock?.className).toContain("pointer-events-none");
     expect(dock?.hasAttribute("inert")).toBe(true);
+    expect(dock?.style.gridTemplateRows).toBe("0fr");
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
   });
 
   test("keyboard toggling flips the hidden treatment without unmounting", () => {
     keyboardOpen = true;
     const { container, rerender } = render(<ChatBody {...dockedProps()} />);
     expect(dockWrapper(container)?.className).toContain("opacity-0");
+    expect(dockWrapper(container)?.style.gridTemplateRows).toBe("0fr");
 
     keyboardOpen = false;
     rerender(<ChatBody {...dockedProps()} />);
     expect(dockWrapper(container)?.className).not.toContain("opacity-0");
+    expect(dockWrapper(container)?.style.gridTemplateRows).toBe("1fr");
     expect(container.innerHTML).toContain("STARTER_CHIPS");
   });
 
@@ -435,7 +445,92 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
     );
 
     expect(container.innerHTML).toContain("STARTER_CHIPS");
+    expect(container.innerHTML).toContain("[justify-content:safe_center]");
+    expect(container.innerHTML).not.toContain("justify-end");
     expect(dockWrapper(container)).toBeNull();
+  });
+
+  test("transcript branch ignores keyboard state (no dock, no bottom-anchoring)", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...baseProps()} />);
+
+    expect(dockWrapper(container)).toBeNull();
+    expect(container.innerHTML).not.toContain("justify-end");
+  });
+});
+
+describe("ChatBody - plugin pills hide while the keyboard is open", () => {
+  // The plugin controls rendered below the composer share the dock's
+  // treatment: while the soft keyboard is up they fade out, collapse their
+  // reserved height, and go inert so the composer (not the plugin row)
+  // docks to the keyboard edge. The slot stays mounted so dismissing the
+  // keyboard restores it without a remount.
+  const pluginPillsSlot = <div data-testid="plugins">PLUGIN_PILLS</div>;
+  const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
+
+  const dockedProps = () =>
+    withEmptyState({
+      dockStartersToBottom: true,
+      startersSlot,
+      pluginPillsSlot,
+    });
+
+  const pluginsWrapper = (container: HTMLElement) =>
+    container.querySelector<HTMLElement>('[data-slot="new-chat-plugins"]');
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
+  });
+
+  test("keyboard closed: the plugin row is expanded and interactive", () => {
+    keyboardOpen = false;
+    const { container } = render(<ChatBody {...dockedProps()} />);
+
+    const wrapper = pluginsWrapper(container);
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).not.toContain("opacity-0");
+    expect(wrapper?.className).not.toContain("pointer-events-none");
+    expect(wrapper?.hasAttribute("inert")).toBe(false);
+    expect(wrapper?.style.gridTemplateRows).toBe("1fr");
+    expect(container.innerHTML).toContain("PLUGIN_PILLS");
+  });
+
+  test("keyboard open: the plugin row collapses, fades, goes inert, and the composer is the last expanded child of the bottom-anchored group", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...dockedProps()} />);
+
+    const wrapper = pluginsWrapper(container);
+    expect(wrapper).not.toBeNull();
+    expect(container.innerHTML).toContain("PLUGIN_PILLS");
+    expect(wrapper?.className).toContain("opacity-0");
+    expect(wrapper?.className).toContain("pointer-events-none");
+    expect(wrapper?.hasAttribute("inert")).toBe(true);
+    expect(wrapper?.style.gridTemplateRows).toBe("0fr");
+
+    // Bottom-anchored group: the only sibling after the composer is the
+    // collapsed plugin wrapper, so the composer reaches the keyboard edge.
+    expect(container.innerHTML).toContain("justify-end");
+    const composer = container.querySelector('[data-testid="composer"]');
+    expect(composer?.nextElementSibling).toBe(wrapper as HTMLElement);
+    expect(composer?.nextElementSibling?.nextElementSibling).toBeNull();
+  });
+
+  test("keyboard toggling flips the hidden treatment without unmounting the slot", () => {
+    keyboardOpen = true;
+    const { container, rerender } = render(<ChatBody {...dockedProps()} />);
+    expect(pluginsWrapper(container)?.style.gridTemplateRows).toBe("0fr");
+    const mounted = container.querySelector('[data-testid="plugins"]');
+    expect(mounted).not.toBeNull();
+
+    keyboardOpen = false;
+    rerender(<ChatBody {...dockedProps()} />);
+    expect(pluginsWrapper(container)?.className).not.toContain("opacity-0");
+    expect(pluginsWrapper(container)?.style.gridTemplateRows).toBe("1fr");
+    // Same DOM node across the toggle proves the slot never remounted.
+    expect(container.querySelector('[data-testid="plugins"]')).toBe(
+      mounted as HTMLElement,
+    );
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -35,7 +35,9 @@ import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
  * the composer **stays at the same position in the React tree** so its
  * state (focus, draft text, attachments) is preserved across the
  * empty→active transition. `safe center` falls back to start-alignment
- * when the group overflows (e.g. iOS with the soft keyboard open).
+ * when the group overflows; while the soft keyboard is open the empty
+ * state bottom-anchors the group instead so the composer docks to the
+ * keyboard edge.
  *
  * See [React — Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)
  * and [MDN — `justify-content: safe center`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
@@ -253,20 +255,33 @@ export function ChatBody({
 
   // When the empty state is visible, center greeting + composer + starters
   // as one group. `safe center` falls back to start-alignment when the
-  // content overflows the container (e.g. iOS soft keyboard open).
-  // `overflow-y-auto` enables scrolling in that overflow case.
+  // content overflows the container. `overflow-y-auto` enables scrolling
+  // in that overflow case.
   const baseClass =
     variant === "main"
       ? "relative flex min-h-0 flex-1 flex-col"
       : "relative flex h-full min-h-0 flex-col";
 
-  // The docked (suggestions-library) empty state owns its own vertical layout
-  // — a full-height first screen that centers the greeting + composer and
-  // pins the featured row to the bottom — so it does not use `safe center`.
+  // While the soft keyboard is open and nothing renders below the composer
+  // (`startersSlot` absent: starters have not arrived yet), the plain
+  // non-docked empty state bottom-anchors instead of centering so the
+  // composer docks to the keyboard edge, and the flip to the docked branch
+  // when starters arrive keeps that alignment instead of jumping
+  // mid-typing. The app-editing side panel always passes inline starters,
+  // so it keeps its centered layout regardless of keyboard state.
+  const nonDockedAlignmentClass =
+    keyboardOpen && startersSlot == null
+      ? "justify-end"
+      : "[justify-content:safe_center]";
+
+  // The docked (suggestions-library) empty state owns its own vertical
+  // layout (a full-height first screen that centers the greeting + composer
+  // and pins the featured row to the bottom), so it does not use
+  // `safe center`.
   const outerClass = isEmptyState
     ? dockStartersToBottom
       ? `${baseClass} overflow-y-auto`
-      : `${baseClass} overflow-y-auto [justify-content:safe_center]`
+      : `${baseClass} overflow-y-auto ${nonDockedAlignmentClass}`
     : baseClass;
 
   // Suppress the absolutely-positioned overlay on the empty state: its
@@ -305,12 +320,22 @@ export function ChatBody({
   // the reserved height so the bottom-anchored composer reaches the keyboard
   // edge. Each stays mounted so dismissing the keyboard restores it without
   // a remount, and `inert` removes it from the tab order and the
-  // accessibility tree.
-  const keyboardCollapseProps = {
-    inert: keyboardOpen || undefined,
-    className: `grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`,
-    style: { gridTemplateRows: keyboardOpen ? "0fr" : "1fr" },
-  };
+  // accessibility tree. The inner div clips only while the keyboard is
+  // open: the collapse needs the clip, but at rest it would shave the
+  // keyboard-focus rings that paint outside the cards and buttons inside
+  // the slot.
+  const renderKeyboardCollapse = (dataSlot: string, children: ReactNode) => (
+    <div
+      data-slot={dataSlot}
+      inert={keyboardOpen || undefined}
+      className={`grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`}
+      style={{ gridTemplateRows: keyboardOpen ? "0fr" : "1fr" }}
+    >
+      <div className={`min-h-0${keyboardOpen ? " overflow-hidden" : ""}`}>
+        {children}
+      </div>
+    </div>
+  );
 
   // Composer stack — stays at the same tree position across the empty→active
   // transition so React preserves its state (focus, draft text, attachments)
@@ -381,13 +406,11 @@ export function ChatBody({
         {channelFooterSlot}
         <StagedQuotesStrip />
         {composerSlot}
-        {pluginPillsSlot && (
-          <div data-slot="new-chat-plugins" {...keyboardCollapseProps}>
-            <div className="min-h-0 overflow-hidden">
-              <div className="mt-4">{pluginPillsSlot}</div>
-            </div>
-          </div>
-        )}
+        {pluginPillsSlot &&
+          renderKeyboardCollapse(
+            "new-chat-plugins",
+            <div className="mt-4">{pluginPillsSlot}</div>,
+          )}
         {trailingStarters}
       </div>
     </div>
@@ -431,17 +454,15 @@ export function ChatBody({
             />
             {renderComposerStack(null)}
           </div>
-          {startersSlot && (
-            <div data-slot="docked-starters" {...keyboardCollapseProps}>
-              <div className="min-h-0 overflow-hidden">
-                <div className="px-3 pb-3 sm:px-6">
-                  <div className="mx-auto max-w-[var(--chat-max-width)]">
-                    {startersSlot}
-                  </div>
+          {startersSlot &&
+            renderKeyboardCollapse(
+              "docked-starters",
+              <div className="px-3 pb-3 sm:px-6">
+                <div className="mx-auto max-w-[var(--chat-max-width)]">
+                  {startersSlot}
                 </div>
-              </div>
-            </div>
-          )}
+              </div>,
+            )}
         </div>
         {belowFoldSlot && (
           <div className="px-3 pt-2 pb-8 sm:px-6">

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -156,7 +156,10 @@ export interface ChatBodyProps {
    * wrapper directly below the composer and above {@link startersSlot}.
    * Visible only on the empty state; the parent passes `undefined` once
    * messages arrive. Rendered as a slot (like {@link startersSlot}) so
-   * `ChatBody` stays agnostic of the plugin data model.
+   * `ChatBody` stays agnostic of the plugin data model. While the soft
+   * keyboard is open the row fades out and collapses its reserved height
+   * (kept mounted) so the composer, not the plugin row, docks to the
+   * keyboard edge.
    */
   pluginPillsSlot?: ReactNode;
 
@@ -173,8 +176,9 @@ export interface ChatBodyProps {
    * that viewport, and {@link belowFoldSlot} is placed below the fold. Used by
    * the new-thread suggestions library. When false, the empty state keeps the
    * default layout where the starters sit directly below the composer.
-   * While the soft keyboard is open the dock fades out (kept mounted so the
-   * centered group does not jump).
+   * While the soft keyboard is open the greeting + composer anchor to the
+   * bottom edge and the dock fades out and collapses its reserved height
+   * (kept mounted so dismissing the keyboard restores it without a remount).
    */
   dockStartersToBottom?: boolean;
 
@@ -296,6 +300,18 @@ export function ChatBody({
     return unregisterVisibleBanner;
   }, [bannerRendered, registerVisibleBanner, unregisterVisibleBanner]);
 
+  // Shared treatment for the below-composer extras (the starters dock and
+  // the plugin pills) while the soft keyboard is open: fade out and collapse
+  // the reserved height so the bottom-anchored composer reaches the keyboard
+  // edge. Each stays mounted so dismissing the keyboard restores it without
+  // a remount, and `inert` removes it from the tab order and the
+  // accessibility tree.
+  const keyboardCollapseProps = {
+    inert: keyboardOpen || undefined,
+    className: `grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`,
+    style: { gridTemplateRows: keyboardOpen ? "0fr" : "1fr" },
+  };
+
   // Composer stack — stays at the same tree position across the empty→active
   // transition so React preserves its state (focus, draft text, attachments)
   // and iOS Safari does not blur the input on first send (LUM-1506 / LUM-1516).
@@ -365,7 +381,13 @@ export function ChatBody({
         {channelFooterSlot}
         <StagedQuotesStrip />
         {composerSlot}
-        {pluginPillsSlot && <div className="mt-4">{pluginPillsSlot}</div>}
+        {pluginPillsSlot && (
+          <div data-slot="new-chat-plugins" {...keyboardCollapseProps}>
+            <div className="min-h-0 overflow-hidden">
+              <div className="mt-4">{pluginPillsSlot}</div>
+            </div>
+          </div>
+        )}
         {trailingStarters}
       </div>
     </div>
@@ -397,7 +419,12 @@ export function ChatBody({
         onDrop={dragHandlers.onDrop}
       >
         <div className="flex min-h-full flex-col">
-          <div className="flex flex-1 flex-col [justify-content:safe_center]">
+          {/* While the keyboard is open the group anchors to the bottom edge
+              (the shell bottom is the keyboard top), matching the transcript
+              layout; otherwise it centers in the first screen. */}
+          <div
+            className={`flex flex-1 flex-col ${keyboardOpen ? "justify-end" : "[justify-content:safe_center]"}`}
+          >
             <ChatScrollArea
               {...scrollAreaProps}
               bottomOverlayReservePx={bottomOverlayReservePx}
@@ -405,17 +432,13 @@ export function ChatBody({
             {renderComposerStack(null)}
           </div>
           {startersSlot && (
-            // Faded rather than unmounted while the keyboard is open:
-            // unmounting would recenter the greeting + composer and jump the
-            // layout. `inert` (not just opacity/pointer-events) so the hidden
-            // dock also leaves the tab order and accessibility tree.
-            <div
-              data-slot="docked-starters"
-              inert={keyboardOpen || undefined}
-              className={`px-3 pb-3 sm:px-6 transition-opacity duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`}
-            >
-              <div className="mx-auto max-w-[var(--chat-max-width)]">
-                {startersSlot}
+            <div data-slot="docked-starters" {...keyboardCollapseProps}>
+              <div className="min-h-0 overflow-hidden">
+                <div className="px-3 pb-3 sm:px-6">
+                  <div className="mx-auto max-w-[var(--chat-max-width)]">
+                    {startersSlot}
+                  </div>
+                </div>
               </div>
             </div>
           )}

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -28,8 +28,9 @@ import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
  * area on top, and a composer stack underneath.
  *
  * **Empty‑state centering (LUM-1566):** When the empty state is visible,
- * the outer container switches to `justify-content: safe center` +
- * `overflow-y-auto` and the scroll area drops its `flex-1`. This lets
+ * the outer container becomes a plain `overflow-y-auto` scroll container,
+ * an inner `min-h-full` wrapper carries `justify-content: safe center`,
+ * and the scroll area drops its `flex-1`. This lets
  * the greeting, composer, and conversation-starter chips center as a
  * single visual group — matching the original centered layout — while
  * the composer **stays at the same position in the React tree** so its
@@ -274,15 +275,22 @@ export function ChatBody({
       ? "justify-end"
       : "[justify-content:safe_center]";
 
-  // The docked (suggestions-library) empty state owns its own vertical
-  // layout (a full-height first screen that centers the greeting + composer
-  // and pins the featured row to the bottom), so it does not use
-  // `safe center`.
-  const outerClass = isEmptyState
-    ? dockStartersToBottom
-      ? `${baseClass} overflow-y-auto`
-      : `${baseClass} overflow-y-auto ${nonDockedAlignmentClass}`
-    : baseClass;
+  // On the empty state the outer container is a plain scroll container.
+  // Group alignment lives on an inner `min-h-full` wrapper (the docked
+  // branch builds its own): alignment directly on the scroll container
+  // would make end-aligned content taller than the viewport overflow past
+  // the START edge, where scrolling cannot reach, leaving the greeting
+  // unreachable on short viewports while the keyboard is open.
+  const outerClass = isEmptyState ? `${baseClass} overflow-y-auto` : baseClass;
+
+  // Inner wrapper for the non-docked layout. On the empty state it fills
+  // the first viewport (`min-h-full`) and carries the group alignment; on
+  // the active state it is a plain fill wrapper (`min-h-0 flex-1`) so the
+  // transcript keeps its height chain. It exists in both states so the
+  // composer keeps its tree position across the empty→active transition.
+  const nonDockedInnerClass = isEmptyState
+    ? `flex min-h-full flex-col ${nonDockedAlignmentClass}`
+    : "flex min-h-0 flex-1 flex-col";
 
   // Suppress the absolutely-positioned overlay on the empty state: its
   // `bottom-full` positioning would overlap the greeting when the outer
@@ -485,21 +493,23 @@ export function ChatBody({
       onDragLeave={dragHandlers.onDragLeave}
       onDrop={dragHandlers.onDrop}
     >
-      <ChatScrollArea
-        {...scrollAreaProps}
-        bottomOverlayReservePx={bottomOverlayReservePx}
-      />
+      <div className={nonDockedInnerClass}>
+        <ChatScrollArea
+          {...scrollAreaProps}
+          bottomOverlayReservePx={bottomOverlayReservePx}
+        />
 
-      {!isEmptyState && activeProcessOverlaysSlot && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
-          {/* Registry-driven row of active background-process overlays. The
-              caller owns which kinds it covers and their order; each overlay
-              self-gates on its own active ids. */}
-          {activeProcessOverlaysSlot}
-        </div>
-      )}
+        {!isEmptyState && activeProcessOverlaysSlot && (
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
+            {/* Registry-driven row of active background-process overlays. The
+                caller owns which kinds it covers and their order; each overlay
+                self-gates on its own active ids. */}
+            {activeProcessOverlaysSlot}
+          </div>
+        )}
 
-      {renderComposerStack(startersSlot)}
+        {renderComposerStack(startersSlot)}
+      </div>
       {dragOverlay}
     </div>
   );

--- a/clients/web/src/domains/chat/components/chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/components/chat-empty-state.tsx
@@ -9,9 +9,10 @@ import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-c
  * rendered by the parent `ChatBody` in the same flex column so that
  * greeting → composer → starters appear as one vertically-centered group.
  *
- * Centering and overflow handling live on `ChatBody`'s outer container
- * (`justify-content: safe center` + `overflow-y-auto`), not here. This
- * component just renders its content at natural height.
+ * Centering and overflow handling live on `ChatBody` (`overflow-y-auto`
+ * on its outer scroll container, `justify-content: safe center` on an
+ * inner `min-h-full` wrapper), not here. This component just renders its
+ * content at natural height.
  *
  * See [React — Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)
  * for why the composer must stay at a fixed tree position rather than

--- a/clients/web/tsconfig.json
+++ b/clients/web/tsconfig.json
@@ -22,7 +22,8 @@
     "src/**/*.ts",
     "src/**/*.tsx",
     ".storybook/**/*.ts",
-    ".storybook/**/*.tsx"
+    ".storybook/**/*.tsx",
+    "capacitor.config.ts"
   ],
   "exclude": ["dist/**", "node_modules/**"]
 }


### PR DESCRIPTION
## Summary

Fixes the two remaining device-confirmed keyboard defects from TestFlight QA.

**The empty-chat composer floated ~230px above the open keyboard.** The shell height was already correct; the gap was internal to the empty-state layout: centered alignment put half the free space below the composer, and the faded suggestions dock still reserved its height in flow. With the keyboard open, the greeting+composer group now bottom-anchors, and the suggestions dock and new-chat plugin slot fade and collapse (one shared helper) so the composer is the last expanded element above the keyboard. This holds in the zero-starters window before conversation starters load, and starters arriving mid-typing no longer jump the layout. The app-editing side panel keeps its centered layout.

**Black band and corner notches at the top of the iOS keyboard.** The iOS 26 keyboard is a transparent inset panel, and Capacitor's view controller root view IS the web view, so under `resize: native` the unpainted UIWindow composited black through the panel's margins. `autoBackdropColor: "dom"` (the plugin's own iOS 26 fix, off by default) now paints the window from the body's computed `--surface-base`. **Takes effect in the next iOS build** (`cap sync` bakes the config); web deploys alone do not change it.

Also: the false "root view paints the strip" comment in `MyViewController.swift` corrected to the `view = webView` reality, and `capacitor.config.ts` joined the tsconfig program so config typos fail typecheck instead of silently reverting the backdrop to `off`.

## PRs merged into this branch

- #39753: paint the keyboard backdrop from the page background
- #39752: correct the MyViewController background comment
- #39754: dock the empty-chat composer above the open keyboard (+ plugin-slot collapse after Codex review)
- #39774: dock the zero-starters empty chat and unclip focus rings at rest (self-review round 1)
- #39779: keep the zero-starters empty chat scrollable while bottom-anchored (self-review round 2)

## Self-review result

GAPS FOUND round 1 (zero-starters branch never docked and gained a mid-typing jump; always-on overflow clipping shaved desktop focus rings; the claimed tsc gate on the config did not exist), all fixed in #39774. Round 2 verification PASSED with one low-severity finding (unsafe end-alignment on a scroll container could clip content unreachable on SE-class phones), fixed in #39779. Mutation coverage: every behavioral guard was deleted individually and confirmed to turn the suite red, independently re-verified by a fresh reviewer.

## Device QA

- Empty chat, keyboard open: composer immediately above the keyboard, greeting above it; suggestions and plugin controls fade/collapse; dismissal restores the centered layout.
- Fast path: open a brand-new chat and focus immediately (before starters load); composer should dock, and should NOT jump when starters arrive.
- Keyboard backdrop: after the NEXT TestFlight build, the band and corners at the keyboard top should read the app background (theme-aware; velvet reads `#121214` after a keyboard reopen). Until that build, the black band remains and is not a regression.
- Desktop: tab-focus a suggestion card and the Manage Plugins button; focus rings must be fully visible.
- App-editing side panel at mobile width: unchanged centered layout.

Part of plan: ios-keyboard-composer-dock-and-backdrop.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)