### PR TITLE
ci(docs): publish the docs image to all environment registries on merge

### DIFF
--- a/.github/workflows/publish-docs-image.yaml
+++ b/.github/workflows/publish-docs-image.yaml
@@ -1,10 +1,12 @@
 name: Publish Docs Image
 
-# Builds and publishes the docs-site image to the target environment's
-# Artifact Registry. Pushes to main publish to `dev`; `workflow_dispatch`
-# can target the staging or production environments, which publish once
-# their registry vars are configured. The image lives under the existing
-# `sandbox-images` AR repo.
+# Builds and publishes the docs-site image to each environment's Artifact
+# Registry. Pushes to main publish to dev, staging, and production so every
+# environment's registry always has the latest main build; `workflow_dispatch`
+# republishes to a single chosen environment. The image lives under the
+# existing `sandbox-images` AR repo. Publishing is inert until the platform
+# Helm chart enables the docs backend in that environment and helm-cd rolls
+# it out.
 
 on:
   push:
@@ -29,14 +31,6 @@ on:
           - staging
           - production
 
-# Cancel superseded publishes per environment: concurrency groups run in
-# arbitrary order, so cancelling older runs is what guarantees the newest
-# commit's build is the one that tags `latest`. A cancelled run skips its
-# SHA tag; only the newest image matters in this registry.
-concurrency:
-  group: publish-docs-image-${{ inputs.environment || 'dev' }}
-  cancel-in-progress: true
-
 env:
   DOCS_IMAGE_NAME: sandbox-images/docs-site
 
@@ -44,10 +38,23 @@ jobs:
   push-docs-image:
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 30
+    strategy:
+      # A failure in one environment (e.g. missing registry vars) must not
+      # cancel the others.
+      fail-fast: false
+      matrix:
+        environment: ${{ github.event_name == 'push' && fromJSON('["dev", "staging", "production"]') || fromJSON(format('["{0}"]', inputs.environment)) }}
     permissions:
       contents: read
       id-token: write
-    environment: ${{ inputs.environment || 'dev' }}
+    environment: ${{ matrix.environment }}
+    # Cancel superseded publishes per environment: concurrency groups run in
+    # arbitrary order, so cancelling older runs is what guarantees the newest
+    # commit's build is the one that tags `latest`. A cancelled run skips its
+    # SHA tag; only the newest image matters in this registry.
+    concurrency:
+      group: publish-docs-image-${{ matrix.environment }}
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -70,7 +77,8 @@ jobs:
           echo "gcp=${{ vars.GCP_REGISTRY_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ env.DOCS_IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
 
       # Single-arch: GKE nodes are amd64, so no multi-arch digest/manifest
-      # dance is needed.
+      # dance is needed. The gha cache scope is shared across environments,
+      # so one leg builds and the others reuse its layers.
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:


### PR DESCRIPTION
## Summary
- Convert `publish-docs-image.yaml` from a single dev-only publish into a **matrix over dev/staging/production**: every merge to main that touches the docs build inputs publishes the same commit's image (`:sha` + `:latest`) to all three environments' `sandbox-images/docs-site` registries. `workflow_dispatch` still targets a single environment.
- Job-level concurrency per environment (replaces the workflow-level group) preserves the newest-commit-wins `:latest` guarantee; `fail-fast: false` isolates a registry/vars problem in one environment from the others; the shared `docs-site` gha cache scope means one leg builds and the other two reuse its layers.
- Verified prerequisites: staging/production GitHub environments have `GCP_PROJECT_ID`/`GCP_SERVICE_ACCOUNT`/`GCP_WORKLOAD_IDENTITY_PROVIDER` configured, `GCP_REGISTRY_HOST` is repo-level, and no environment has required-reviewer protection, so all three legs run unattended.

## Rollout
Publishing is inert in staging/production: the platform Helm chart there has `docs.enabled: false`, and helm-cd preserves the deployed docs tag across unrelated deploys. This unblocks the staging/production cutover phases of the docs-site migration (platform repo flips `docs.enabled` + adds the `/docs` ingress path rule per env).

## Original prompt
The docs-site migration's Phase 2 left a gap: the docs image only published to the dev registry, while the staging/production Helm value blocks sit disabled waiting for images to exist in their registries. With the content re-sync (#39767) merged, extend the publish workflow to cover all environments so the Phase 3 per-environment cutovers are values-only changes in the platform repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)