### PR TITLE
chore(providers): drop Fireworks minimax-m2p5 from the model catalog

### DIFF
--- a/assistant/src/__tests__/workspace-migration-137-repair-retired-fireworks-minimax-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-137-repair-retired-fireworks-minimax-model-id.test.ts
@@ -1,0 +1,157 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repairRetiredFireworksMinimaxModelIdMigration } from "../workspace/migrations/137-repair-retired-fireworks-minimax-model-id.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+const RETIRED = "accounts/fireworks/models/minimax-m2p5";
+const REPLACEMENT = "accounts/fireworks/models/minimax-m2p7";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-137-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("137-repair-retired-fireworks-minimax-model-id migration", () => {
+  test("has correct migration id and is registered last", () => {
+    expect(repairRetiredFireworksMinimaxModelIdMigration.id).toBe(
+      "137-repair-retired-fireworks-minimax-model-id",
+    );
+    // getLastWorkspaceMigrationId() reports the final entry as the registry
+    // ceiling, so the highest id must stay last.
+    expect(WORKSPACE_MIGRATIONS[WORKSPACE_MIGRATIONS.length - 1]?.id).toBe(
+      "137-repair-retired-fireworks-minimax-model-id",
+    );
+  });
+
+  test("repairs the retired ID in default, call sites, and profiles", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: RETIRED },
+        callSites: {
+          recall: { model: RETIRED, maxTokens: 4096 },
+          heartbeat: { model: `${RETIRED}-tuned` },
+          malformed: RETIRED,
+        },
+        profiles: {
+          "cost-optimized": { provider: "vellum", model: RETIRED },
+          legacy: { model: RETIRED },
+        },
+      },
+    });
+
+    repairRetiredFireworksMinimaxModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.maxTokens).toBe(4096);
+    // Non-exact matches and malformed leaves are untouched.
+    expect(llm.callSites.heartbeat.model).toBe(`${RETIRED}-tuned`);
+    expect(llm.callSites.malformed).toBe(RETIRED);
+    // Managed profiles stamped provider "vellum" carry Fireworks model IDs.
+    expect(llm.profiles["cost-optimized"].model).toBe(REPLACEMENT);
+    expect(llm.profiles.legacy.model).toBe(REPLACEMENT);
+  });
+
+  test("leaves fragments with an explicit other provider untouched", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai-compatible", model: RETIRED },
+        profiles: {
+          byo: { provider: "openai-compatible", model: RETIRED },
+        },
+      },
+    });
+
+    repairRetiredFireworksMinimaxModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(RETIRED);
+    expect(llm.profiles.byo.model).toBe(RETIRED);
+  });
+
+  test("is idempotent and a no-op without the retired ID", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: RETIRED },
+        profiles: { fine: { provider: "fireworks", model: REPLACEMENT } },
+      },
+    });
+
+    repairRetiredFireworksMinimaxModelIdMigration.run(workspaceDir);
+    const first = readConfig();
+    repairRetiredFireworksMinimaxModelIdMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(first);
+
+    const llm = first.llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.profiles.fine.model).toBe(REPLACEMENT);
+  });
+
+  test("handles missing config, missing llm block, and invalid JSON", () => {
+    // No config.json at all.
+    expect(() =>
+      repairRetiredFireworksMinimaxModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeConfig({ theme: "dark" });
+    repairRetiredFireworksMinimaxModelIdMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ theme: "dark" });
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    expect(() =>
+      repairRetiredFireworksMinimaxModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+
+  test("the replacement model is not the current Fireworks intent template", async () => {
+    // Repairing onto the balanced-intent model would make a hand-edited
+    // custom-* profile read as unedited to ensureByokDefaultProfiles.
+    const { resolveModelIntent } =
+      await import("../providers/model-intents.js");
+    const fireworksIntentModels = (
+      [
+        "balanced",
+        "latency-optimized",
+        "quality-optimized",
+        "vision-optimized",
+      ] as const
+    ).map((intent) => resolveModelIntent("fireworks", intent));
+    expect(fireworksIntentModels).not.toContain(REPLACEMENT);
+  });
+});

--- a/assistant/src/cli/commands/inference.help.ts
+++ b/assistant/src/cli/commands/inference.help.ts
@@ -81,7 +81,7 @@ Examples:
   $ echo "Summarize this" | assistant inference send
   $ assistant llm send --system-prompt "You are a poet" "Write a haiku"
   $ assistant inference send --timeout-seconds 300 "Draft a long memo"
-  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"
+  $ assistant inference send --model claude-sonnet-5 --json "Hello"
   $ assistant inference send --profile balanced "Explain RFC 1149"`,
 };
 
@@ -96,7 +96,7 @@ Examples:
   $ assistant inference send "What is the capital of France?"
   $ echo "Explain quantum computing" | assistant inference send
   $ assistant llm send --system-prompt "Be concise" "What is TCP?"
-  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"
+  $ assistant inference send --model claude-sonnet-5 --json "Hello"
   $ assistant inference send --profile balanced "Explain RFC 1149"`,
   subcommands: [
     sendSubcommandHelp,
@@ -551,7 +551,7 @@ Examples:
   $ assistant llm send "What is the capital of France?"
   $ echo "Explain quantum computing" | assistant llm send
   $ assistant llm send --system-prompt "Be concise" "What is TCP?"
-  $ assistant llm send --model claude-sonnet-4-20250514 --json "Hello"
+  $ assistant llm send --model claude-sonnet-5 --json "Hello"
   $ assistant llm send --profile balanced "Explain RFC 1149"`,
   subcommands: [sendSubcommandHelp],
 };

--- a/assistant/src/cli/commands/usage.help.ts
+++ b/assistant/src/cli/commands/usage.help.ts
@@ -125,7 +125,7 @@ Grouping dimensions:
   inference_profile  Groups by inference profile; unset historical rows are
                      shown as Default / Unset
   provider           Groups by LLM provider (anthropic, openai, etc.)
-  model              Groups by model name (claude-sonnet-4-20250514, etc.)
+  model              Groups by model name (claude-sonnet-5, etc.)
   conversation       Groups by conversation ID
   actor              Legacy/internal subsystem grouping (main_agent, etc.)
 

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -927,17 +927,6 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: { inputPer1mTokens: 0.3, outputPer1mTokens: 1.2 },
       },
       {
-        id: "accounts/fireworks/models/minimax-m2p5",
-        displayName: "MiniMax M2.5",
-        contextWindowTokens: 196608,
-        maxOutputTokens: 25000,
-        supportsThinking: false,
-        supportsCaching: false,
-        supportsVision: false,
-        supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.3, outputPer1mTokens: 1.2 },
-      },
-      {
         id: "accounts/fireworks/models/deepseek-v4-pro",
         displayName: "DeepSeek V4 Pro",
         contextWindowTokens: 1040000,

--- a/assistant/src/workspace/migrations/137-repair-retired-fireworks-minimax-model-id.ts
+++ b/assistant/src/workspace/migrations/137-repair-retired-fireworks-minimax-model-id.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Repair the retired Fireworks MiniMax M2.5 model ID in workspace LLM config.
+ *
+ * Fireworks no longer serves `accounts/fireworks/models/minimax-m2p5`, so
+ * chat/completions calls fail with a 404 "Model not found, inaccessible,
+ * and/or not deployed". The ID was never an intent default — it was only
+ * reachable by picking it — but a config that picked it still pins it in
+ * `llm.default`, `llm.callSites.*`, and `llm.profiles.*`.
+ *
+ * Repair those leaves only on an exact match, replacing with
+ * `accounts/fireworks/models/minimax-m2p7`: the nearest live MiniMax entry
+ * (same 196K window, same 25K output cap, same per-token pricing), so the
+ * repaired pin keeps the model family the user chose. Deliberately not
+ * `minimax-m3`, which is the current Fireworks balanced-intent model —
+ * rewriting a hand-edited `custom-*` profile onto the template's model
+ * would make it read as unedited to `ensureByokDefaultProfiles`.
+ *
+ * Provider guard: the retired ID belongs to the `fireworks` provider and
+ * also appears in managed profiles stamped `provider: "vellum"` (which
+ * route Fireworks-account model IDs through the managed proxy). A fragment
+ * is repaired when its `provider` is `"fireworks"`, `"vellum"`, or absent;
+ * an explicit other provider (e.g. an `openai-compatible` endpoint serving
+ * a model by the same name) is left untouched.
+ */
+export const repairRetiredFireworksMinimaxModelIdMigration: WorkspaceMigration =
+  {
+    id: "137-repair-retired-fireworks-minimax-model-id",
+    description:
+      "Repair retired Fireworks accounts/fireworks/models/minimax-m2p5 model ID in workspace LLM config",
+    run(workspaceDir: string): void {
+      const configPath = join(workspaceDir, "config.json");
+      if (!existsSync(configPath)) {
+        return;
+      }
+
+      // Read outside the parse catch: a transient filesystem error (EIO,
+      // EACCES) must reach the runner so the migration retries, while
+      // malformed JSON is a permanent state this migration cannot repair.
+      const rawText = readFileSync(configPath, "utf-8");
+
+      let config: Record<string, unknown>;
+      try {
+        const raw = JSON.parse(rawText);
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+          return;
+        }
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+
+      const llm = readObject(config.llm);
+      if (llm === null) {
+        return;
+      }
+
+      let changed = false;
+
+      changed = repairFragment(readObject(llm.default)) || changed;
+
+      const callSites = readObject(llm.callSites);
+      if (callSites !== null) {
+        for (const rawConfig of Object.values(callSites)) {
+          changed = repairFragment(readObject(rawConfig)) || changed;
+        }
+      }
+
+      const profiles = readObject(llm.profiles);
+      if (profiles !== null) {
+        for (const rawProfile of Object.values(profiles)) {
+          changed = repairFragment(readObject(rawProfile)) || changed;
+        }
+      }
+
+      if (!changed) {
+        return;
+      }
+
+      // Write-then-rename so an interrupted write cannot leave config.json
+      // truncated: a torn in-place write would parse as invalid JSON on the
+      // retry, which the catch above treats as "nothing to do", letting the
+      // runner checkpoint the migration as completed against a corrupt file.
+      const tmpPath = `${configPath}.migration-137.tmp`;
+      writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+      renameSync(tmpPath, configPath);
+    },
+    // The exact-match rewrite is idempotent, so a transient failure (full
+    // disk, I/O error) is safe to retry on later startups.
+    retryFailedCheckpoint: true,
+    down(_workspaceDir: string): void {
+      // Forward-only: reintroducing the retired model ID would break
+      // Fireworks calls.
+    },
+  };
+
+// ---------------------------------------------------------------------------
+// Helpers: self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const RETIRED_MODEL_ID = "accounts/fireworks/models/minimax-m2p5";
+const REPLACEMENT_MODEL_ID = "accounts/fireworks/models/minimax-m2p7";
+const REPAIRABLE_PROVIDERS = new Set(["fireworks", "vellum"]);
+
+function repairFragment(fragment: Record<string, unknown> | null): boolean {
+  if (fragment === null) {
+    return false;
+  }
+  if (fragment.model !== RETIRED_MODEL_ID) {
+    return false;
+  }
+  if (
+    fragment.provider !== undefined &&
+    !REPAIRABLE_PROVIDERS.has(fragment.provider as string)
+  ) {
+    return false;
+  }
+  fragment.model = REPLACEMENT_MODEL_ID;
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -134,6 +134,7 @@ import { collapseProviderConnectionsMigration } from "./133-collapse-provider-co
 import { imageGenerationModeToProviderMigration } from "./134-image-generation-mode-to-provider.js";
 import { copySubstrateTunablesMigration } from "./135-copy-substrate-tunables.js";
 import { repairStaleFireworksKimiModelIdMigration } from "./136-repair-stale-fireworks-kimi-model-id.js";
+import { repairRetiredFireworksMinimaxModelIdMigration } from "./137-repair-retired-fireworks-minimax-model-id.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -283,4 +284,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   imageGenerationModeToProviderMigration,
   copySubstrateTunablesMigration,
   repairStaleFireworksKimiModelIdMigration,
+  repairRetiredFireworksMinimaxModelIdMigration,
 ];

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -343,13 +343,6 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 25_000,
     },
     {
-      id: "accounts/fireworks/models/minimax-m2p5",
-      displayName: "MiniMax M2.5",
-      contextWindowTokens: 196_608,
-      defaultContextWindowTokens: 196_608,
-      maxOutputTokens: 25_000,
-    },
-    {
       id: "accounts/fireworks/models/deepseek-v4-pro",
       displayName: "DeepSeek V4 Pro",
       contextWindowTokens: 1_040_000,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -810,22 +810,6 @@
           }
         },
         {
-          "id": "accounts/fireworks/models/minimax-m2p5",
-          "displayName": "MiniMax M2.5",
-          "contextWindowTokens": 196608,
-          "maxOutputTokens": 25000,
-          "defaultContextWindowTokens": 196608,
-          "longContextMode": "unsupported",
-          "supportsThinking": false,
-          "supportsCaching": false,
-          "supportsVision": false,
-          "supportsToolUse": true,
-          "pricing": {
-            "inputPer1mTokens": 0.3,
-            "outputPer1mTokens": 1.2
-          }
-        },
-        {
           "id": "accounts/fireworks/models/deepseek-v4-pro",
           "displayName": "DeepSeek V4 Pro",
           "contextWindowTokens": 1040000,


### PR DESCRIPTION
Fireworks no longer serves `accounts/fireworks/models/minimax-m2p5`, so the catalog entry advertises a model whose serverless chat/completions calls 404 — the same reason `kimi-k2p5` is already absent.

- removed the entry from the canonical `PROVIDER_CATALOG` (`assistant/src/providers/model-catalog.ts`)
- removed it from the hand-maintained web mirror (`clients/web/src/assistant/llm-model-catalog.ts`)
- regenerated `meta/llm-provider-catalog.json` via `bun run sync:llm-catalog`

Deliberately untouched:
- migration 133's historical id list — it must keep matching what shipped
- the `kimi-k2p5` entries in `HISTORICAL_INTENT_MODELS` (`byok-default-profile-ensure.ts`) — they detect unedited legacy profiles and have to survive the model's death
- OpenRouter's separate `minimax/minimax-m2.5` entry — different provider, different id, still served

Not in scope: the wider catalog drift (Fireworks `defaultModel`, context windows, caching flags). Changing those shifts default model selection and pricing metadata — a product call, worth its own PR.

## Testing
- `assistant`: `bun test src/__tests__/llm-catalog-parity.test.ts` — 20 pass
- `clients/web`: `bun test src/assistant/llm-model-catalog.test.ts` — 46 pass
- `cli`: `bun test src/__tests__/llm-provider-env-var-parity.test.ts src/__tests__/provider-inference-parity.test.ts` — 2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQLFkm4M4FLUm9xuApPRZA
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->