### PR TITLE
fix(design-library): stack Notice actions under the message

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -65,14 +65,24 @@ mock.module("@vellumai/design-library", () => ({
     children,
     actions,
     tone,
+    onDismiss,
   }: {
     children?: ReactNode;
     actions?: ReactNode;
     tone?: string;
+    onDismiss?: () => void;
   }) => (
     <div data-testid="notice" data-tone={tone}>
       {children}
       {actions ? <div data-testid="notice-actions">{actions}</div> : null}
+      {onDismiss ? (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          data-testid="notice-dismiss"
+          onClick={onDismiss}
+        />
+      ) : null}
     </div>
   ),
   Card: {
@@ -561,10 +571,10 @@ describe("ChatBody — channel footer slot", () => {
 
 describe("ChatBody — generic chat error Notice (dismiss UX)", () => {
   // The Notice is rendered as an inline error banner above the composer.
-  // The banner has a "Go to Doctor" action and a "Dismiss" button as a
-  // second action (so the user has a real way to close the banner).
+  // The banner carries its own action ("Go to Doctor") plus the notice's
+  // dismiss control, so the user has a real way to close the banner.
 
-  test("renders a Dismiss button when genericChatError + onDismissChatError are both provided", () => {
+  test("renders the dismiss control when genericChatError + onDismissChatError are both provided", () => {
     const html = renderToStaticMarkup(
       <ChatBody
         {...baseProps({
@@ -580,7 +590,7 @@ describe("ChatBody — generic chat error Notice (dismiss UX)", () => {
     );
 
     expect(html).toContain("Go to Doctor");
-    expect(html).toContain("Dismiss");
+    expect(html).toContain('data-testid="notice-dismiss"');
   });
 
   test("renders warning-tone generic notices as status banners", () => {
@@ -600,8 +610,8 @@ describe("ChatBody — generic chat error Notice (dismiss UX)", () => {
     expect(html).toContain('data-tone="warning"');
   });
 
-  test("does NOT render the Dismiss button when onDismissChatError is omitted", () => {
-    // Defensive: don't silently show a Dismiss button that does nothing.
+  test("does NOT render the dismiss control when onDismissChatError is omitted", () => {
+    // Defensive: don't silently show a dismiss control that does nothing.
     const html = renderToStaticMarkup(
       <ChatBody
         {...baseProps({
@@ -610,7 +620,7 @@ describe("ChatBody — generic chat error Notice (dismiss UX)", () => {
       />,
     );
 
-    expect(html).not.toContain("Dismiss");
+    expect(html).not.toContain("notice-dismiss");
   });
 
   test("does not render the error banner at all when genericChatError is null", () => {
@@ -618,6 +628,6 @@ describe("ChatBody — generic chat error Notice (dismiss UX)", () => {
       <ChatBody {...baseProps({ genericChatError: null })} />,
     );
 
-    expect(html).not.toContain(">Dismiss<");
+    expect(html).not.toContain('data-testid="notice"');
   });
 });

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -6,7 +6,7 @@ import {
   type ReactNode,
 } from "react";
 
-import { Paperclip, X } from "lucide-react";
+import { Paperclip } from "lucide-react";
 
 import { useKeyboardOpen } from "@/hooks/use-keyboard-open";
 import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
@@ -21,7 +21,7 @@ import {
   RefreshFeedbackPill,
   type RefreshFeedback,
 } from "@/domains/chat/refresh-feedback-pill";
-import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
+import { Notice, type NoticeTone } from "@vellumai/design-library";
 
 /**
  * Single composition of a chat panel: a scrollable messages/empty-state
@@ -114,9 +114,9 @@ export interface ChatBodyProps {
     tone?: NoticeTone;
   } | null;
   /**
-   * Dismiss handler for {@link genericChatError}. When provided, the
-   * banner renders a "Dismiss" button as a second action next to the
-   * existing actions (typically "Go to Doctor").
+   * Dismiss handler for {@link genericChatError}. When provided, the banner
+   * renders the notice's own dismiss control, leaving the actions row to the
+   * error's own actions (typically "Go to Doctor").
    */
   onDismissChatError?: () => void;
 
@@ -334,27 +334,8 @@ export function ChatBody({
           <div className="mb-2">
             <Notice
               tone={genericChatError.tone ?? "error"}
-              actions={
-                <>
-                  {genericChatError.actions}
-                  {onDismissChatError ? (
-                    <Button
-                      variant="outlined"
-                      size="compact"
-                      leftIcon={
-                        <X
-                          className="h-3.5 w-3.5"
-                          strokeWidth={2}
-                          aria-hidden="true"
-                        />
-                      }
-                      onClick={onDismissChatError}
-                    >
-                      Dismiss
-                    </Button>
-                  ) : null}
-                </>
-              }
+              onDismiss={onDismissChatError}
+              actions={genericChatError.actions}
             >
               {genericChatError.message}
             </Notice>

--- a/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
@@ -28,7 +28,7 @@ const match: DetectedSecret = {
   wholeMessage: false,
 };
 
-const BLOCKED_TITLE = "Message not sent — it looks like it contains an API key";
+const BLOCKED_TITLE = "Message not sent. It looks like it contains an API key.";
 
 function renderNotice(overrides: Partial<ComposerSecretNoticeProps> = {}) {
   // Default the composer input to one that CONTAINS the previewed secret, so
@@ -69,7 +69,7 @@ describe("ComposerSecretNotice (passive)", () => {
       maskSecretValue(SYNTHETIC_PROJECT_KEY),
     );
     expect(container.textContent).toContain(
-      "Credentials sent in chat are visible in the transcript — store it securely instead.",
+      "Credentials sent in chat are visible in the transcript. Store it securely instead.",
     );
     expect(container.innerHTML).not.toContain(SYNTHETIC_PROJECT_KEY);
     // The detection label (vendor) stays internal.

--- a/clients/web/src/domains/chat/components/composer-secret-notice.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.tsx
@@ -106,7 +106,7 @@ export function ComposerSecretNotice({
         tone="warning"
         title={
           sendBlocked
-            ? "Message not sent — it looks like it contains an API key"
+            ? "Message not sent. It looks like it contains an API key."
             : "This looks like an API key"
         }
         onDismiss={sendBlocked ? undefined : onDismiss}
@@ -128,7 +128,7 @@ export function ComposerSecretNotice({
       >
         <span className="font-mono">{maskSecretValue(first.value)}</span>
         <p>
-          Credentials sent in chat are visible in the transcript — store it
+          Credentials sent in chat are visible in the transcript. Store it
           securely instead.
         </p>
       </Notice>

--- a/packages/design-library/src/components/notice.stories.tsx
+++ b/packages/design-library/src/components/notice.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { Button } from "./button";
 import { Notice } from "./notice";
 
 const meta: Meta<typeof Notice> = {
@@ -84,6 +85,41 @@ export const WithActions: Story = {
         <button type="button">Renew</button>
         <button type="button">Sign out</button>
       </div>
+    ),
+  },
+};
+
+/**
+ * Several actions inside a narrow notice. The actions sit under the message so
+ * the text keeps the full width instead of collapsing into a one-word-per-line
+ * column. A notice that offers an explicit "Dismiss" action leaves `onDismiss`
+ * unset, so the corner control is not a second way to do the same thing.
+ */
+export const NarrowWithActions: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 340 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    onDismiss: undefined,
+    tone: "warning",
+    title: "Message not sent. It looks like it contains an API key.",
+    children: "Credentials sent in chat are visible in the transcript.",
+    actions: (
+      <>
+        <Button variant="primary" size="compact">
+          Store securely
+        </Button>
+        <Button variant="outlined" size="compact">
+          Send anyway
+        </Button>
+        <Button variant="ghost" size="compact">
+          Dismiss
+        </Button>
+      </>
     ),
   },
 };

--- a/packages/design-library/src/components/notice.test.tsx
+++ b/packages/design-library/src/components/notice.test.tsx
@@ -29,7 +29,7 @@ describe("Notice — error tone icon", () => {
   });
 });
 
-describe("Notice — actions layout", () => {
+describe("Notice: actions layout", () => {
   test("actions render inside the message column, after the message", () => {
     const html = renderToStaticMarkup(
       <Notice
@@ -59,8 +59,9 @@ describe("Notice — actions layout", () => {
     );
 
     // A corner-pinned control would need a root padding lane, which `cn()`
-    // drops as soon as the consumer passes its own `p-*` — the button would
-    // then overlap the message. Staying in the flow removes that coupling.
+    // drops as soon as the consumer passes its own `p-*`, and the button
+    // would then overlap the message. Staying in the flow removes that
+    // coupling.
     expect(html).toContain("shrink-0");
     expect(html).not.toContain("absolute");
   });

--- a/packages/design-library/src/components/notice.test.tsx
+++ b/packages/design-library/src/components/notice.test.tsx
@@ -51,16 +51,18 @@ describe("Notice — actions layout", () => {
     );
   });
 
-  test("the dismiss control is pinned to the corner, out of the wrapping flow", () => {
+  test("the dismiss control keeps its space in the flow under a consumer padding class", () => {
     const html = renderToStaticMarkup(
-      <Notice tone="info" title="Heads up" onDismiss={() => {}}>
+      <Notice tone="info" title="Heads up" onDismiss={() => {}} className="p-4">
         Something to know.
       </Notice>,
     );
 
-    expect(html).toContain("absolute right-2.5 top-2.5");
-    // Its lane is reserved so a wrapped actions row never runs under it.
-    expect(html).toContain("pr-9");
+    // A corner-pinned control would need a root padding lane, which `cn()`
+    // drops as soon as the consumer passes its own `p-*` — the button would
+    // then overlap the message. Staying in the flow removes that coupling.
+    expect(html).toContain("shrink-0");
+    expect(html).not.toContain("absolute");
   });
 });
 

--- a/packages/design-library/src/components/notice.test.tsx
+++ b/packages/design-library/src/components/notice.test.tsx
@@ -29,3 +29,38 @@ describe("Notice — error tone icon", () => {
   });
 });
 
+describe("Notice — actions layout", () => {
+  test("actions render inside the message column, after the message", () => {
+    const html = renderToStaticMarkup(
+      <Notice
+        tone="warning"
+        title="Message not sent."
+        actions={<button type="button">Store securely</button>}
+      >
+        Credentials sent in chat are visible in the transcript.
+      </Notice>,
+    );
+
+    // Actions never form a side column, which would compete with the message
+    // for width. They follow the body inside the same text column, so they
+    // start on the text's left edge rather than under the icon.
+    const column = html.slice(html.indexOf("min-w-0 flex-1 space-y-1"));
+    expect(column).toContain("Store securely");
+    expect(column.indexOf("Store securely")).toBeGreaterThan(
+      column.indexOf("visible in the transcript"),
+    );
+  });
+
+  test("the dismiss control is pinned to the corner, out of the wrapping flow", () => {
+    const html = renderToStaticMarkup(
+      <Notice tone="info" title="Heads up" onDismiss={() => {}}>
+        Something to know.
+      </Notice>,
+    );
+
+    expect(html).toContain("absolute right-2.5 top-2.5");
+    // Its lane is reserved so a wrapped actions row never runs under it.
+    expect(html).toContain("pr-9");
+  });
+});
+

--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -96,8 +96,6 @@ export function Notice({
       className={cn(
         "relative flex w-full gap-3 rounded-lg border p-3",
         alignTop ? "items-start" : "items-center",
-        // The dismiss control is pinned to the corner, so reserve its lane.
-        onDismiss && "pr-9",
         "text-[color:var(--content-default)]",
         toneClasses.container,
         className,
@@ -145,13 +143,20 @@ export function Notice({
         ) : null}
       </div>
 
+      {/*
+       * The dismiss control stays in the flow rather than being pinned to the
+       * corner: reserving a corner lane means a root padding class, and `cn()`
+       * merges the consumer's `className` last, so any caller passing its own
+       * `p-*` would silently drop the reservation and let the button overlap
+       * the message. At ~22px it costs the message almost nothing.
+       */}
       {onDismiss ? (
         <button
           type="button"
           onClick={onDismiss}
           aria-label="Dismiss"
           className={cn(
-            "absolute right-2.5 top-2.5 cursor-pointer rounded bg-transparent p-0.5",
+            "shrink-0 cursor-pointer rounded bg-transparent p-0.5",
             "text-[color:var(--content-secondary)] opacity-70 transition-opacity",
             "hover:opacity-100 keyboard-focus:outline-none keyboard-focus:ring-2",
             "keyboard-focus:ring-[var(--ring)]",

--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -82,6 +82,11 @@ export function Notice({
         : null
       : icon;
 
+  // Anything stacked under the icon (a title, or an actions row) reads as a
+  // block the icon labels, so the icon aligns to the first line rather than to
+  // the middle of the notice.
+  const alignTop = Boolean(title || actions);
+
   return (
     <div
       {...rest}
@@ -90,7 +95,9 @@ export function Notice({
       data-slot="notice"
       className={cn(
         "relative flex w-full gap-3 rounded-lg border p-3",
-        title ? "items-start" : "items-center",
+        alignTop ? "items-start" : "items-center",
+        // The dismiss control is pinned to the corner, so reserve its lane.
+        onDismiss && "pr-9",
         "text-[color:var(--content-default)]",
         toneClasses.container,
         className,
@@ -100,7 +107,7 @@ export function Notice({
         <span
           className={cn(
             "flex shrink-0 items-center justify-center",
-            title && "mt-0.5",
+            alignTop && "mt-0.5",
             toneClasses.icon,
           )}
         >
@@ -127,11 +134,16 @@ export function Notice({
             {children}
           </Typography>
         ) : null}
+        {/*
+         * Actions sit under the message rather than beside it: a side column
+         * competes with the text for width, which collapses the message to a
+         * one-word-per-line column in narrow notices and strands the buttons
+         * against dead space in wide ones.
+         */}
+        {actions ? (
+          <div className="flex flex-wrap items-center gap-2 pt-1">{actions}</div>
+        ) : null}
       </div>
-
-      {actions ? (
-        <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>
-      ) : null}
 
       {onDismiss ? (
         <button
@@ -139,7 +151,7 @@ export function Notice({
           onClick={onDismiss}
           aria-label="Dismiss"
           className={cn(
-            "shrink-0 cursor-pointer rounded bg-transparent p-0.5",
+            "absolute right-2.5 top-2.5 cursor-pointer rounded bg-transparent p-0.5",
             "text-[color:var(--content-secondary)] opacity-70 transition-opacity",
             "hover:opacity-100 keyboard-focus:outline-none keyboard-focus:ring-2",
             "keyboard-focus:ring-[var(--ring)]",


### PR DESCRIPTION
## Problem

The API-key warning above the chat composer rendered as a one-word-per-line column with the buttons overlapping the clipped title on a narrow viewport:

The cause is in the shared `Notice` component, not that banner. `Notice` laid out `[icon | message (flex-1 min-w-0) | actions (shrink-0)]` as one row. Because the actions column never shrinks, three buttons ("Store securely" / "Send anyway" / "Dismiss") kept their full width and the message column collapsed to roughly 90px. Every `Notice` with actions had this failure mode; the secret-notice banner just has the most buttons.

Widening the notice traded one problem for another: the buttons floated against dead space beside a two-line message, vertically misaligned with it.

## Change

Actions render inside the message column, after the body, at every width. One layout, no breakpoints:

- The message always gets the full width, so it never collapses.
- The actions align with the text rather than starting under the icon.
- The dismiss control stays in the normal flow. An earlier revision pinned it to the corner and reserved its lane with a root `pr-9`, but `cn()` merges the consumer `className` last, so a caller passing its own `p-*` (`DiskPressureBanner` uses `className="p-4"`) silently dropped the reservation and let the button overlap the message. Both review bots caught it. The reservation is gone rather than hardened: the control was never what collapsed the message column, since at roughly 22px it costs almost nothing next to the ~300px actions column this PR moved.

`chat-body.tsx` hand-rolled an X-icon "Dismiss" button inside `actions` while `Notice` already provides that affordance; it now passes `onDismiss` instead (`Button` and `X` imports dropped with it).

The secret-notice copy loses its two em dashes, which the repo forbids in user-facing strings.

Note on the two dismiss affordances: `ComposerSecretNotice` already makes them mutually exclusive (`onDismiss={sendBlocked ? undefined : onDismiss}`), so the corner X and the labeled "Dismiss" button never render together. The new Storybook story sets `onDismiss: undefined` to mirror that, because the meta-level `argTypes` otherwise injects a dismiss spy into every story and makes the story look like it shows both.

## Verification

Reproduced the original bug in Storybook, then confirmed the fix at 340px and 660px in the velvet theme.

- `packages/design-library`: `bun test src/components/notice.test.tsx` (5 pass), `bunx tsc --noEmit` clean
- `clients/web`: `chat-body.test.tsx` (32 pass), `composer-secret-notice.test.tsx` (15 pass), `bunx tsc --noEmit` clean, `bun run lint` 0 errors

Unrelated pre-existing issue found along the way: running `chat-body.test.tsx` and `composer-secret-notice.test.tsx` in the same `bun test` process fails (3 failures on `main`, 2 on this branch) because `chat-body.test.tsx`'s `mock.module("@vellumai/design-library")` leaks through bun's shared module registry. Each file passes on its own. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

