### PR TITLE
chore(android): rename application package

### DIFF
--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -33,15 +33,15 @@ jobs:
           case "$ENVIRONMENT" in
             production)
               echo "flavor=Production" >> "$GITHUB_OUTPUT"
-              echo "package_id=ai.vocify.vellumassistant" >> "$GITHUB_OUTPUT"
+              echo "package_id=ai.vellum.assistant" >> "$GITHUB_OUTPUT"
               ;;
             staging)
               echo "flavor=Staging" >> "$GITHUB_OUTPUT"
-              echo "package_id=ai.vocify.vellumassistant.staging" >> "$GITHUB_OUTPUT"
+              echo "package_id=ai.vellum.assistant.staging" >> "$GITHUB_OUTPUT"
               ;;
             dev)
               echo "flavor=Dev" >> "$GITHUB_OUTPUT"
-              echo "package_id=ai.vocify.vellumassistant.dev" >> "$GITHUB_OUTPUT"
+              echo "package_id=ai.vellum.assistant.dev" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Invalid Android environment: $ENVIRONMENT"

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -43,9 +43,9 @@ hosts.
 
 | Flavor | Application ID | Display Name | Auth Scheme | Auth Host |
 |--------|----------------|--------------|-------------|-----------|
-| `production` | `ai.vocify.vellumassistant` | Vellum | `vellum-assistant` | `www.vellum.ai` |
-| `staging` | `ai.vocify.vellumassistant.staging` | Vellum Staging | `vellum-assistant-staging` | `staging-assistant.vellum.ai` |
-| `dev` | `ai.vocify.vellumassistant.dev` | Vellum Dev | `vellum-assistant-dev` | `dev-assistant.vellum.ai` |
+| `production` | `ai.vellum.assistant` | Vellum | `vellum-assistant` | `www.vellum.ai` |
+| `staging` | `ai.vellum.assistant.staging` | Vellum Staging | `vellum-assistant-staging` | `staging-assistant.vellum.ai` |
+| `dev` | `ai.vellum.assistant.dev` | Vellum Dev | `vellum-assistant-dev` | `dev-assistant.vellum.ai` |
 
 For local development, pick the `devDebug` variant in Android Studio. If you
 sync a different `VELLUM_ENVIRONMENT`, build the matching flavor so the WebView
@@ -126,7 +126,7 @@ clients/
     │   ├── build.gradle          # Product flavors and Capacitor app module
     │   └── src/main/
     │       ├── AndroidManifest.xml
-    │       ├── java/ai/vocify/vellumassistant/
+    │       ├── java/ai/vellum/assistant/
     │       │   ├── ConnectDeepLink.java
     │       │   ├── MainActivity.java
     │       │   ├── NativeAuthPlugin.java
@@ -217,9 +217,9 @@ skip Android distribution so existing releases remain unaffected.
 
 Complete the following setup before enabling internal-track uploads:
 
-1. Create Play Console apps for `ai.vocify.vellumassistant`,
-   `ai.vocify.vellumassistant.staging`, and
-   `ai.vocify.vellumassistant.dev`.
+1. Create Play Console apps for `ai.vellum.assistant`,
+   `ai.vellum.assistant.staging`, and
+   `ai.vellum.assistant.dev`.
 2. Enable Play App Signing for each app and create one controlled upload key.
 3. Upload and roll out one signed AAB to each app's internal track manually.
    Google Play requires this initial release before the Publisher API can

--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -29,10 +29,10 @@ if (!signingConfigured && (requireSigning || signingValues.values().any { !it.is
 }
 
 android {
-    namespace = "ai.vocify.vellumassistant"
+    namespace = "ai.vellum.assistant"
     compileSdk = rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId "ai.vocify.vellumassistant"
+        applicationId "ai.vellum.assistant"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode versionCodeInput.toInteger()

--- a/clients/android/app/src/main/java/ai/vellum/assistant/BiometricTokenStore.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/BiometricTokenStore.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import android.content.Context;
 import android.content.SharedPreferences;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URI;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import android.app.AlertDialog;
 import android.content.Intent;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeAuthPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeAuthPlugin.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeBiometricPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeBiometricPlugin.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import android.app.Activity;
 import android.security.keystore.KeyPermanentlyInvalidatedException;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import android.content.Context;
 import android.content.SharedPreferences;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/VoiceAudioSessionPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/VoiceAudioSessionPlugin.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import android.content.Context;
 import android.media.AudioAttributes;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/WorkOSAuth.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/WorkOSAuth.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import android.net.Uri;
 import android.util.Base64;

--- a/clients/android/app/src/test/java/ai/vellum/assistant/BiometricTokenStoreTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/BiometricTokenStoreTest.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/clients/android/app/src/test/java/ai/vellum/assistant/ConnectDeepLinkTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/ConnectDeepLinkTest.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/clients/android/app/src/test/java/ai/vellum/assistant/VoiceAudioSessionPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/VoiceAudioSessionPluginTest.java
@@ -1,4 +1,4 @@
-package ai.vocify.vellumassistant;
+package ai.vellum.assistant;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -308,7 +308,7 @@ There's a deliberate mismatch:
 | Where                       | Value                                      |
 | --------------------------- | ------------------------------------------ |
 | Xcode `PRODUCT_BUNDLE_IDENTIFIER` | `ai.vocify-inc.vellum-assistant-ios` ← real one |
-| `capacitor.config.ts` `appId`     | `ai.vocify.vellumassistant`                     |
+| `capacitor.config.ts` `appId`     | `ai.vellum.assistant`                     |
 
 Capacitor requires `appId` to use Java package form because Android uses it as
 the application namespace. The iOS project is generated from `project.yml`

--- a/clients/web/capacitor.config.ts
+++ b/clients/web/capacitor.config.ts
@@ -59,7 +59,7 @@ const config: CapacitorConfig = {
   // NOTE: Capacitor's CLI requires Java-package form here because Android
   // uses this value as its application namespace. The real iOS bundle IDs are
   // set via `PRODUCT_BUNDLE_IDENTIFIER` in the Xcode project.
-  appId: "ai.vocify.vellumassistant",
+  appId: "ai.vellum.assistant",
   appName: "Vellum",
   webDir: "capacitor-shell",
   server: {

--- a/clients/web/scripts/run-android.ts
+++ b/clients/web/scripts/run-android.ts
@@ -535,7 +535,7 @@ async function main(): Promise<void> {
       "am",
       "start",
       "-n",
-      "ai.vocify.vellumassistant.dev/ai.vocify.vellumassistant.MainActivity",
+      "ai.vellum.assistant.dev/ai.vellum.assistant.MainActivity",
     ],
     env,
   );

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -387,7 +387,7 @@ describe("RemoteWebPairingPage", () => {
     expect(query.get("url")).toBe(window.location.origin);
     expect(query.get("code")).toBe("android-device");
     expect(href.slice(intentIndex)).toContain(
-      "#Intent;scheme=vellum-assistant;package=ai.vocify.vellumassistant;",
+      "#Intent;scheme=vellum-assistant;package=ai.vellum.assistant;",
     );
     expect(androidIntentFallback(href)).toBe(window.location.href);
     expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -126,7 +126,7 @@ function clearDeviceCodeFromUrl(): void {
  * a phone that scanned a pairing QR with its camera.
  */
 const VELLUM_APP_SCHEME = "vellum-assistant";
-const VELLUM_ANDROID_PACKAGE = "ai.vocify.vellumassistant";
+const VELLUM_ANDROID_PACKAGE = "ai.vellum.assistant";
 type AppHandoffPlatform = "ios" | "android";
 
 /**


### PR DESCRIPTION
## Summary

- rename the Android application ID and Java namespace to `ai.vellum.assistant`, preserving the `.staging` and `.dev` flavor suffixes
- update Capacitor, command-line launch, browser handoff, release automation, Java source paths, tests, and documentation to use the new identity
- treat this as a new Android install identity, requiring Play and Firebase registrations under the new package IDs

## Original prompt

The Android client was introduced with the legacy Vocify package identifier during the iOS parity work. Rename it to the Vellum-owned `ai.vellum.assistant` identity in a separate reviewable PR before distribution setup proceeds.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->