### PR TITLE
feat(daemon): raise tool-result spool threshold from 8k to 25k chars

### DIFF
--- a/assistant/src/__tests__/tool-result-spool.test.ts
+++ b/assistant/src/__tests__/tool-result-spool.test.ts
@@ -293,10 +293,11 @@ describe("AgentLoop result-time spooling", () => {
 
   test("spools the raw output even when it exceeds the post-tool-use truncation budget", async () => {
     // maxInputTokens of 10k gives the default truncate plugin a 12k-char
-    // budget (0.3 share × 4 chars/token). The spool must run before that
-    // hook, so the file holds all 20k chars of raw output rather than the
-    // hook's tail-dropped copy — otherwise the omitted tail is unrecoverable.
-    const HUGE = "z".repeat(20_000);
+    // budget (0.3 share × 4 chars/token); HUGE exceeds both that budget and
+    // the spool threshold. The spool must run before that hook, so the file
+    // holds the full raw output rather than the hook's tail-dropped copy;
+    // otherwise the omitted tail is unrecoverable.
+    const HUGE = "z".repeat(THRESHOLD_CHARS + 5_000);
     const { provider } = createMockProvider([
       toolUseResponse("tu_1", "fetch_transcript", {}),
       textResponse("Done."),

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -14,8 +14,8 @@ import {
 } from "../security/untrusted-content.js";
 import { safeStringSlice } from "../util/unicode.js";
 
-/** Minimum content length (chars) before a tool result is eligible for truncation. ~2000 tokens at 4 chars/token. */
-export const THRESHOLD_CHARS = 8_000;
+/** Minimum content length (chars) before a tool result is eligible for truncation. ~6250 tokens at 4 chars/token. */
+export const THRESHOLD_CHARS = 25_000;
 
 /** Target size (chars) for the truncated stub. ~300 tokens at 4 chars/token. */
 export const TARGET_CHARS = 1_200;


### PR DESCRIPTION
## Summary
- Raise `THRESHOLD_CHARS` in the tool-result truncation/spool pipeline from 8,000 to 25,000 chars (roughly 2k to 6.25k tokens at 4 chars/token), so mid-size tool results stay inline in context instead of being stubbed to `.tool-results/` files. Both passes (result-time spool and post-turn truncation) share this constant, as does the re-read dedup path.
- Re-derive the spool-ordering test fixture in `tool-result-spool.test.ts` from `THRESHOLD_CHARS` instead of a hard-coded 20,000 chars, so a future threshold change cannot silently turn the test into a no-op (the fixture must exceed both the spool threshold and the truncate hook budget).

Interaction check: the `tool-result-truncate` post-tool-use hook tail-drops at `min(400k, contextWindow x 0.3 x 4)` chars, which stays far above 25k for any realistic context window, so the spool-before-hook recoverability invariant is unaffected. The theoretical gap (hook budget below the spool threshold, making tail-dropped content unrecoverable) only opens for context windows under about 21k tokens, which no shipped configuration uses; the old 8k threshold had the same gap below about 6.7k tokens.

## Original prompt
While tracing why a `file_read` result appeared in a later turn as a head/tail stub pointing at a `.tool-results/` file, we reviewed the truncation rules and confirmed the 8k-char threshold had been unchanged since the feature landed (#24203). The user asked to raise it to 25,000 chars on the grounds that a ~2k-token inline budget is aggressively low relative to modern context windows.