### PR TITLE
fix(docs): serve Next static assets under the /docs ingress prefix

### DIFF
--- a/clients/docs/AGENTS.md
+++ b/clients/docs/AGENTS.md
@@ -10,6 +10,7 @@ Ingress only routes `/docs/*` to this app. Every URL the app emits publicly MUST
 
 - Pages are authored under `src/app/docs/` with no `basePath`.
 - The search API is `/docs/api/search`, markdown mirrors are `/docs/<path>.md` (index: `/docs/index.md`), the agent index is `/docs/llms.txt`, the sitemap is `/docs/sitemap.xml`, and assets are served from `public/docs/`.
+- Next's build assets are served under the prefix too: `assetPrefix: "/docs"` in `next.config.ts` plus the first `beforeFiles` rewrite (`/docs/_next/*` → `/_next/*`). Without both halves, stylesheets and scripts resolve to `/_next/*`, which ingress routes to a different backend. `verify-parity.ts` asserts asset subresources load.
 - The only exception is `/api/health`: GKE BackendConfig health checks hit the pod directly and bypass ingress path rules.
 - Canonical URLs are absolute `https://www.vellum.ai<path>` via `createMetadata` (`src/lib/metadata.ts`). Never change a page's `path:` value; URLs did not change in the migration, and native clients link the legal paths (`/docs/privacy-policy`, `/docs/vellum-terms-of-use`, `/docs/prohibited-use`) directly.
 - Links to non-docs Vellum surfaces (signup, login, the assistant app) are cross-app now: absolute URLs from `src/lib/routes.ts`.

--- a/clients/docs/next-config.test.ts
+++ b/clients/docs/next-config.test.ts
@@ -154,11 +154,19 @@ describe("next config rewrite sources", () => {
   test("every beforeFiles rewrite source is a known pattern", async () => {
     const sources = (await beforeFilesRewrites()).map((rule) => rule.source);
     expect(sources).toEqual([
+      "/docs/_next/:path*",
       "/docs/index.md",
       "/docs/:path*.md",
       "/docs",
       "/docs/:path((?!llms\\.txt$)(?!api(?:\\/|$))(?!_md(?:\\/|$)).*)",
     ]);
+  });
+
+  test("the asset rewrite is first and maps the assetPrefix back to /_next", async () => {
+    const [assetRule] = await beforeFilesRewrites();
+    expect(assetRule.source).toBe("/docs/_next/:path*");
+    expect(assetRule.destination).toBe("/_next/:path*");
+    expect(hasMarkdownAcceptCondition(assetRule)).toBe(false);
   });
 
   test("docsPathForSource rejects unrecognized sources", () => {

--- a/clients/docs/next.config.ts
+++ b/clients/docs/next.config.ts
@@ -16,6 +16,14 @@ const MARKDOWN_ACCEPT_HEADER = {
 const nextConfig: NextConfig = {
   output: "standalone",
   typedRoutes: true,
+  // Ingress only routes /docs/* to this app, so the build's static assets
+  // must be referenced under that prefix; the /docs/_next rewrite below maps
+  // them back to Next's real /_next filesystem route.
+  assetPrefix: "/docs",
+  // The /_next/image optimizer endpoint is NOT covered by assetPrefix and
+  // would resolve outside the /docs ingress prefix. Assets are pre-sized
+  // WebP, so serve them as-is.
+  images: { unoptimized: true },
   // Without this, Next's middleware adapter strips the router prefetch
   // headers (Next-Router-Prefetch, Next-Router-Segment-Prefetch, RSC) before
   // src/proxy.ts runs, so isPrefetch() could never suppress segment-cache
@@ -25,6 +33,13 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return {
       beforeFiles: [
+        {
+          // Counterpart of assetPrefix: serve the prefixed asset URLs from
+          // Next's real static route. Ordered first so no other rule can
+          // capture an asset path.
+          source: "/docs/_next/:path*",
+          destination: "/_next/:path*",
+        },
         //
         // The `.md` URL-suffix rules are ordered BEFORE the Accept rules
         // because the permissive `/docs/:path` Accept rule would otherwise

--- a/clients/docs/scripts/verify-parity.ts
+++ b/clients/docs/scripts/verify-parity.ts
@@ -247,6 +247,39 @@ async function verifyLegalPaths(): Promise<void> {
   }
 }
 
+/** Static assets must be /docs-prefixed (ingress only routes /docs/*) and
+ *  must load through the same base URL the HTML came from. */
+async function verifyAssetSubresources(): Promise<void> {
+  const res = await fetchWithTimeout(`${baseUrl}/docs`);
+  const html = await res.text();
+
+  const unprefixed = html.match(/(?:href|src)="\/_next\/[^"]+"/g) ?? [];
+  check(
+    unprefixed.length === 0,
+    `/docs HTML references ${unprefixed.length} unprefixed /_next asset(s) ` +
+      `(would 404 through ingress): ${unprefixed[0] ?? ""}`,
+  );
+
+  const assetUrls = [
+    ...new Set(
+      [...html.matchAll(/(?:href|src)="(\/docs\/_next\/[^"]+)"/g)].map(
+        (m) => m[1],
+      ),
+    ),
+  ].slice(0, 8);
+  check(
+    assetUrls.length > 0,
+    "/docs HTML references no /docs/_next assets (expected stylesheets/scripts)",
+  );
+  for (const url of assetUrls) {
+    const assetRes = await fetchWithTimeout(`${baseUrl}${url}`);
+    check(
+      assetRes.status === 200,
+      `asset ${url}: expected 200, got ${assetRes.status}`,
+    );
+  }
+}
+
 async function main(): Promise<void> {
   console.log(`Verifying docs parity against ${baseUrl}`);
   console.log(`Snapshot routes: ${snapshotRoutes.length}`);
@@ -258,6 +291,7 @@ async function main(): Promise<void> {
   await verifySitemap();
   await verifySearch();
   await verifyLegalPaths();
+  await verifyAssetSubresources();
 
   if (failures.length > 0) {
     console.error(`\nFAIL: ${failures.length} of ${checksRun} checks failed:`);

--- a/clients/docs/src/proxy.ts
+++ b/clients/docs/src/proxy.ts
@@ -324,6 +324,9 @@ function isPagePath(pathname: string): boolean {
   if (pathname === "/docs/_md" || pathname.startsWith("/docs/_md/")) {
     return false;
   }
+  if (pathname.startsWith("/docs/_next/")) {
+    return false;
+  }
   const lastSegment = pathname.split("/").at(-1) ?? "";
   return !lastSegment.includes(".");
 }


### PR DESCRIPTION
## Summary
- **Fixes the unstyled pages on the dev cutover** (dev-assistant.vellum.ai/docs): the app emitted asset URLs at `/_next/static/*`, which is outside the `/docs` ingress prefix — those requests hit the platform nextjs catch-all and 404'd, killing all CSS and hydration. Root cause was a design gap in the Phase 1 URL rules: "everything public lives under /docs" missed Next's own asset paths.
- Fix: `assetPrefix: "/docs"` + a first-position `beforeFiles` rewrite (`/docs/_next/*` → `/_next/*`), plus global `images.unoptimized` because the `/_next/image` optimizer endpoint is not covered by assetPrefix (one component was silently using it). `/docs/_next/` is also excluded from page_view attribution, and AGENTS.md documents the two-halves contract.
- **Hardens verification**: `verify-parity.ts` now extracts asset subresources from the rendered HTML, asserts they're `/docs`-prefixed, and fetches each through the base URL — the check that would have caught this before cutover (it caught the second, image-optimizer instance immediately when added).

## Verification
typecheck/lint/115 tests/build green; built server passes **723 checks across 88 routes** including the new asset checks; CSS confirmed serving through the prefixed URL.

## Rollout
Merge → the multi-env publish puts the fixed image in all three registries → restart the dev docs deployment (`kubectl rollout restart`) to restore styling on dev. Staging's cutover (platform #9674, deploying) will pick the fixed image automatically at its next pod start; verify staging only after this image lands there.

## Original prompt
User reported CSS not loading on https://dev-assistant.vellum.ai/docs after the otherwise-verified dev cutover; browser inspection confirmed fully unstyled HTML and curl confirmed `/_next/static` chunk 404s through the load balancer. Fix the asset routing under the /docs prefix and add automated verification so the staging/production cutovers can't ship this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)