### PR TITLE
Make Android billing consumption-only

### DIFF
--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -6,14 +6,21 @@ import { MemoryRouter } from "react-router";
 
 import { routes } from "@/utils/routes";
 
+let nativeAndroid = false;
+
 mock.module("@/runtime/browser", () => ({
   openUrl: () => Promise.resolve(),
   openUrlFinishedListener: () => () => {},
 }));
 
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeAndroid: () => nativeAndroid,
+}));
+
 const { AddCreditsModal } = await import("@/components/add-credits-modal");
 
 afterEach(() => {
+  nativeAndroid = false;
   cleanup();
 });
 
@@ -29,6 +36,18 @@ function renderModal() {
 }
 
 describe("AddCreditsModal", () => {
+  test("native Android renders website guidance without checkout links", () => {
+    nativeAndroid = true;
+    renderModal();
+
+    expect(
+      screen.getByText("Manage your subscription on our website."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
+  });
+
   test("renders the updated copy and labels", () => {
     renderModal();
 

--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -45,7 +45,6 @@ describe("AddCreditsModal", () => {
     ).toBeTruthy();
     expect(screen.queryByRole("link")).toBeNull();
     expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
   });
 
   test("renders the updated copy and labels", () => {

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -8,7 +8,9 @@ import {
   organizationsBillingSummaryRetrieveOptions,
   organizationsBillingTopUpsCheckoutSessionCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
+import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
@@ -58,7 +60,10 @@ interface AddCreditsModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
-export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
+function AddCreditsModalContent({
+  open,
+  onOpenChange,
+}: AddCreditsModalProps) {
   const queryClient = useQueryClient();
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
@@ -192,6 +197,30 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
           >
             Continue
           </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+export function AddCreditsModal(props: AddCreditsModalProps) {
+  const isNativeAndroid = useIsNativeAndroid();
+
+  if (!isNativeAndroid) {
+    return <AddCreditsModalContent {...props} />;
+  }
+
+  return (
+    <Modal.Root open={props.open} onOpenChange={props.onOpenChange}>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.Title>Billing</Modal.Title>
+          <Modal.Description>{ANDROID_BILLING_MESSAGE}</Modal.Description>
+        </Modal.Header>
+        <Modal.Footer>
+          <Modal.Close asChild>
+            <Button variant="outlined">Close</Button>
+          </Modal.Close>
         </Modal.Footer>
       </Modal.Content>
     </Modal.Root>

--- a/clients/web/src/components/disk-pressure-banner.test.tsx
+++ b/clients/web/src/components/disk-pressure-banner.test.tsx
@@ -69,4 +69,20 @@ describe("DiskPressureBanner warning variant", () => {
 
     expect(onUpgradeStorage).toHaveBeenCalledTimes(1);
   });
+
+  test("omits purchase copy and action when storage upgrades are unavailable", () => {
+    render(
+      <DiskPressureBanner
+        status={warningStatus}
+        mode="warning"
+        onAcknowledge={() => {}}
+        onReviewWorkspaceData={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText("Free up space to avoid interruptions."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Upgrade" })).toBeNull();
+  });
 });

--- a/clients/web/src/components/disk-pressure-banner.tsx
+++ b/clients/web/src/components/disk-pressure-banner.tsx
@@ -70,7 +70,9 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
             </span>
           </div>
           <p className="m-0">
-            Free up space or add more storage to avoid interruptions.
+            {onUpgradeStorage
+              ? "Free up space or add more storage to avoid interruptions."
+              : "Free up space to avoid interruptions."}
           </p>
           <div className="flex flex-wrap items-center gap-2">
             {onReviewWorkspaceData && (

--- a/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
@@ -24,8 +24,7 @@ describe("BillingErrorBanner", () => {
         icon={<span data-testid="banner-icon">!</span>}
         title="Title"
         subtitle="Subtitle"
-        ctaLabel="Upgrade"
-        onAction={onAction}
+        action={{ label: "Upgrade", onClick: onAction }}
       />,
     );
 
@@ -46,8 +45,7 @@ describe("BillingErrorBanner", () => {
         ariaLabel="Billing notice"
         title="Title"
         subtitle="Subtitle"
-        ctaLabel="Upgrade"
-        onAction={() => {}}
+        action={{ label: "Upgrade", onClick: () => {} }}
       />,
     );
 
@@ -61,8 +59,7 @@ describe("BillingErrorBanner", () => {
         ariaLabel="Billing notice"
         title="Title"
         subtitle="Subtitle"
-        ctaLabel="Upgrade"
-        onAction={() => {}}
+        action={{ label: "Upgrade", onClick: () => {} }}
       />,
     );
 

--- a/clients/web/src/domains/chat/components/billing-error-banner.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.tsx
@@ -2,13 +2,17 @@ import type { ReactNode } from "react";
 
 import { Button } from "@vellumai/design-library";
 
+interface BillingErrorBannerAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface BillingErrorBannerProps {
   ariaLabel: string;
   icon?: ReactNode;
   title: string;
   subtitle: string;
-  ctaLabel: string;
-  onAction: () => void;
+  action?: BillingErrorBannerAction;
   /**
    * Render as a standalone, centered card ~24px narrower than the composer with
    * full rounding, instead of a full-width banner flush-mounted above the
@@ -22,8 +26,7 @@ export function BillingErrorBanner({
   icon,
   title,
   subtitle,
-  ctaLabel,
-  onAction,
+  action,
   detached = false,
 }: BillingErrorBannerProps) {
   return (
@@ -69,16 +72,18 @@ export function BillingErrorBanner({
           </p>
         </div>
 
-        <div className="flex items-center shrink-0">
-          <Button
-            variant="primary"
-            size="regular"
-            onClick={onAction}
-            aria-label={ctaLabel}
-          >
-            {ctaLabel}
-          </Button>
-        </div>
+        {action ? (
+          <div className="flex shrink-0 items-center">
+            <Button
+              variant="primary"
+              size="regular"
+              onClick={action.onClick}
+              aria-label={action.label}
+            >
+              {action.label}
+            </Button>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/components/credits-card.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-card.test.tsx
@@ -37,4 +37,11 @@ describe("CreditsCard", () => {
 
     expect(container.firstChild).toBeNull();
   });
+
+  test("renders the balance without a purchase action when no handler is provided", () => {
+    const { getByText, queryByRole } = render(<CreditsCard balance="60" />);
+
+    expect(getByText("60 c")).toBeTruthy();
+    expect(queryByRole("button", { name: /credits/i })).toBeNull();
+  });
 });

--- a/clients/web/src/domains/chat/components/credits-card.tsx
+++ b/clients/web/src/domains/chat/components/credits-card.tsx
@@ -4,15 +4,13 @@ import { Coins, Plus } from "lucide-react";
 interface CreditsCardProps {
   /** Formatted whole-credits string, or null when unavailable. */
   balance: string | null;
-  onAddCredits: () => void;
+  onAddCredits?: () => void;
 }
 
 /**
- * Presentational credits card matching the preferences-drawer mock: a single
- * slim flat container with the coins icon + balance on the left and a ghost
- * "Credits" button (plus icon) on the right. No nested background — the container
- * is the only surface. Purely presentational; callers supply the formatted
- * balance and handler.
+ * Presentational credits card with the balance on the left and an optional
+ * "Credits" action on the right. The container is the only surface. Callers
+ * supply the formatted balance and, where purchases are supported, a handler.
  *
  * Renders nothing when `balance` is null (unavailable / still loading) so the
  * container never shows up empty.
@@ -36,23 +34,17 @@ export function CreditsCard({ balance, onAddCredits }: CreditsCardProps) {
           {balance} c
         </span>
       </div>
-      {/*
-       * size="regular" gives the label `text-body-medium-default`, matching
-       * the balance's line-height so the two are optically centered (the
-       * compact token uses line-height:1, which floats the small label). We
-       * keep the slim height/padding via className, and tighten the
-       * icon↔label gap from the base `gap-1.5` to `gap-1` for this button only
-       * (overriding the shared Button default without affecting other buttons).
-       */}
-      <Button
-        variant="ghost"
-        size="regular"
-        onClick={onAddCredits}
-        className="h-6 gap-1 px-1.5 font-normal!"
-      >
-        <Plus className="h-3.5 w-3.5" aria-hidden />
-        Credits
-      </Button>
+      {onAddCredits ? (
+        <Button
+          variant="ghost"
+          size="regular"
+          onClick={onAddCredits}
+          className="h-6 gap-1 px-1.5 font-normal!"
+        >
+          <Plus className="h-3.5 w-3.5" aria-hidden />
+          Credits
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -9,13 +9,42 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import { CreditsExhaustedBanner } from "./credits-exhausted-banner";
+let nativeAndroid = false;
+
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeAndroid: () => nativeAndroid,
+}));
+
+const { CreditsExhaustedBanner } = await import(
+  "./credits-exhausted-banner"
+);
 
 afterEach(() => {
+  nativeAndroid = false;
   cleanup();
 });
 
 describe("CreditsExhaustedBanner", () => {
+  test("native Android shows website guidance without a purchase action", () => {
+    nativeAndroid = true;
+    const onAddCredits = mock(() => {});
+    const onUpgrade = mock(() => {});
+
+    const { getByText, queryByRole } = render(
+      <CreditsExhaustedBanner
+        mode="add-credits-paid"
+        onAddCredits={onAddCredits}
+        onUpgrade={onUpgrade}
+      />,
+    );
+
+    expect(getByText("Manage your subscription on our website.")).toBeTruthy();
+    expect(queryByRole("button")).toBeNull();
+    expect(queryByRole("link")).toBeNull();
+    expect(onAddCredits).not.toHaveBeenCalled();
+    expect(onUpgrade).not.toHaveBeenCalled();
+  });
+
   test("add-credits-free mode renders exactly one Add credits CTA and no View plans", () => {
     const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -1,5 +1,7 @@
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
 import type { CreditPaywallCtaMode } from "@/domains/chat/utils/credit-paywall-cta";
+import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 
 const COPY: Record<
   CreditPaywallCtaMode,
@@ -34,13 +36,21 @@ export function CreditsExhaustedBanner({
   onUpgrade,
 }: CreditsExhaustedBannerProps) {
   const copy = COPY[mode];
+  const isNativeAndroid = useIsNativeAndroid();
+  const action = isNativeAndroid
+    ? undefined
+    : {
+        label: copy.ctaLabel,
+        onClick: mode === "upgrade" ? onUpgrade : onAddCredits,
+      };
   return (
     <BillingErrorBanner
-      ariaLabel={`${copy.title}. ${copy.subtitle}`}
+      ariaLabel={`${copy.title}. ${
+        isNativeAndroid ? ANDROID_BILLING_MESSAGE : copy.subtitle
+      }`}
       title={`💰  ${copy.title}`}
-      subtitle={copy.subtitle}
-      ctaLabel={copy.ctaLabel}
-      onAction={mode === "upgrade" ? onUpgrade : onAddCredits}
+      subtitle={isNativeAndroid ? ANDROID_BILLING_MESSAGE : copy.subtitle}
+      action={action}
       detached={true}
     />
   );

--- a/clients/web/src/domains/chat/components/daily-limit-banner.tsx
+++ b/clients/web/src/domains/chat/components/daily-limit-banner.tsx
@@ -18,8 +18,7 @@ export function DailyLimitBanner({ onAdjustLimit }: DailyLimitBannerProps) {
       }
       title="Daily credit limit reached"
       subtitle="This limit applies to Vellum credit spend and resets at midnight UTC."
-      ctaLabel="Adjust Limit"
-      onAction={onAdjustLimit}
+      action={{ label: "Adjust Limit", onClick: onAdjustLimit }}
     />
   );
 }

--- a/clients/web/src/domains/chat/components/disk-pressure-banner-slot.test.tsx
+++ b/clients/web/src/domains/chat/components/disk-pressure-banner-slot.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import type { UseDiskPressureMonitorResult } from "@/assistant/use-disk-pressure-monitor";
+import type { DiskPressureStatus } from "@vellumai/assistant-api";
+
+let nativeAndroid = false;
+
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeAndroid: () => nativeAndroid,
+}));
+
+const { DiskPressureBannerSlot } = await import(
+  "@/domains/chat/components/disk-pressure-banner-slot"
+);
+
+const warningStatus: DiskPressureStatus = {
+  enabled: true,
+  state: "warning",
+  locked: false,
+  acknowledged: false,
+  overrideActive: false,
+  effectivelyLocked: false,
+  lockId: null,
+  usagePercent: 85,
+  thresholdPercent: 90,
+  path: "/workspace",
+  lastCheckedAt: null,
+  blockedCapabilities: [],
+  error: null,
+};
+
+const diskPressure: UseDiskPressureMonitorResult = {
+  status: warningStatus,
+  mode: "warning",
+  hasResolvedStatus: true,
+  isAcknowledging: false,
+  acknowledgeError: null,
+  acknowledge: async () => {},
+  applyStatusEvent: () => {},
+  refresh: async () => {},
+};
+
+function renderSlot() {
+  return render(
+    <MemoryRouter>
+      <DiskPressureBannerSlot
+        diskPressure={diskPressure}
+        assistantId="assistant-1"
+        assistantStateKind="active"
+      />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  nativeAndroid = false;
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DiskPressureBannerSlot", () => {
+  test("native Android keeps storage management but hides the upgrade action", () => {
+    nativeAndroid = true;
+    renderSlot();
+
+    expect(screen.getByRole("button", { name: "Manage Storage" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Upgrade" })).toBeNull();
+  });
+
+  test("web keeps the storage upgrade action", () => {
+    renderSlot();
+
+    expect(screen.getByRole("button", { name: "Upgrade" })).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
+++ b/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
@@ -22,6 +22,7 @@ import {
   removeLocalSetting,
   setLocalBool,
 } from "@/utils/local-settings";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 
 // ---------------------------------------------------------------------------
@@ -45,6 +46,7 @@ export function DiskPressureBannerSlot({
   assistantStateKind,
 }: DiskPressureBannerSlotProps) {
   const navigate = useNavigate();
+  const isNativeAndroid = useIsNativeAndroid();
 
   const dismissedKey = assistantId
     ? `vellum:diskPressureDismissed:${assistantId}`
@@ -121,7 +123,7 @@ export function DiskPressureBannerSlot({
         void navigate(`${routes.workspace}?sort=size`)
       }
       onUpgradeStorage={
-        assistantStateKind === "active"
+        assistantStateKind === "active" && !isNativeAndroid
           ? () => void navigate(routes.plans)
           : null
       }

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -8,17 +8,32 @@
  * React Testing Library.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import type { AuthUser } from "@/stores/auth-store";
 
 const isMobileRef = { value: false };
+const nativeAndroidRef = { value: false };
 
 mock.module("@/hooks/use-is-mobile", () => ({
   useIsMobile: () => isMobileRef.value,
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeAndroid: () => nativeAndroidRef.value,
+}));
+
+mock.module("@/hooks/use-platform-gate", () => ({
+  usePlatformGate: () => "full",
+  useActiveAssistantIsPlatformHosted: () => true,
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => true,
 }));
 
 const authRef: {
@@ -56,7 +71,7 @@ const flagsRef = {};
 
 mock.module("@/stores/client-feature-flag-store", () => {
   const store = () => null;
-  store.use = {};
+  store.use = { velvet: () => false };
   store.getState = () => flagsRef;
   return { useClientFeatureFlagStore: store };
 });
@@ -94,14 +109,24 @@ mock.module("@/components/share-feedback-modal", () => ({
 }));
 
 mock.module("@/domains/chat/components/credits-card", () => ({
-  CreditsCard: () =>
-    createElement("div", { "data-testid": "credits-card" }, "Credits"),
+  CreditsCard: ({ onAddCredits }: { onAddCredits?: () => void }) =>
+    createElement(
+      "div",
+      { "data-testid": "credits-card" },
+      "Credits",
+      onAddCredits
+        ? createElement("button", { onClick: onAddCredits }, "Add credits")
+        : null,
+    ),
 }));
 
-import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
+const { PreferencesMenu } = await import(
+  "@/domains/chat/components/preferences-menu"
+);
 
 beforeEach(() => {
   isMobileRef.value = false;
+  nativeAndroidRef.value = false;
   authRef.isAuthenticated = true;
   authRef.user = {
     kind: "platform",
@@ -113,6 +138,10 @@ beforeEach(() => {
     lastName: "",
   };
   billingRef.data = undefined;
+});
+
+afterEach(() => {
+  cleanup();
 });
 
 describe("PreferencesMenu", () => {
@@ -168,5 +197,20 @@ describe("PreferencesMenu", () => {
     isMobileRef.value = true;
     const html = renderToStaticMarkup(createElement(PreferencesMenu));
     expect(html).toContain("Preferences");
+  });
+
+  test("native Android shows the balance without an add-credits action", async () => {
+    nativeAndroidRef.value = true;
+    isMobileRef.value = true;
+    billingRef.data = { effective_balance: "60" };
+    render(<PreferencesMenu />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Preferences/i }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("credits-card")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add credits" })).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -30,6 +30,7 @@ import {
 import { isElectron } from "@/runtime/is-electron";
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
 import { openUrl } from "@/runtime/browser";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { adminUrl, routes } from "@/utils/routes";
 
 import { CreditsCard } from "./credits-card";
@@ -171,6 +172,7 @@ function PreferencesMenuContent({
   const billingPlatformGate = usePlatformGate({ platformHostedOnly: true });
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   const isOrgReady = useIsOrgReady();
+  const isNativeAndroid = useIsNativeAndroid();
   const showBillingRows =
     billingPlatformGate === "full" && isPlatformHosted && isOrgReady;
   const { data: billingSummary } = useQuery({
@@ -189,10 +191,14 @@ function PreferencesMenuContent({
         <div className="my-2">
           <CreditsCard
             balance={formatWholeCredits(effectiveBalance)}
-            onAddCredits={() => {
-              onClose();
-              navigate(routes.settings.usageBilling);
-            }}
+            onAddCredits={
+              isNativeAndroid
+                ? undefined
+                : () => {
+                    onClose();
+                    navigate(routes.settings.usageBilling);
+                  }
+            }
           />
         </div>
       ) : null}

--- a/clients/web/src/domains/chat/components/provider-billing-banner.tsx
+++ b/clients/web/src/domains/chat/components/provider-billing-banner.tsx
@@ -20,8 +20,7 @@ export function ProviderBillingBanner({
       }
       title="Your API key needs credits"
       subtitle="Add funds with your provider or lower the model token limit."
-      ctaLabel="Open Settings"
-      onAction={onOpenSettings}
+      action={{ label: "Open Settings", onClick: onOpenSettings }}
     />
   );
 }

--- a/clients/web/src/domains/settings/ai/ai-page.test.tsx
+++ b/clients/web/src/domains/settings/ai/ai-page.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
 
@@ -38,6 +38,12 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 // form renders and the entitlement logic is reachable.
 mock.module("@/hooks/use-platform-gate", () => ({
   usePlatformGate: () => "full",
+}));
+
+let nativeAndroid = false;
+
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeAndroid: () => nativeAndroid,
 }));
 
 const ASSISTANT_ID = "asst-1";
@@ -63,6 +69,10 @@ const { EmailServiceCard } =
   await import("@/domains/settings/ai/email-service-card");
 
 const ASSISTANT_HANDLE = "my-assistant";
+
+beforeEach(() => {
+  nativeAndroid = false;
+});
 
 function makeSubscription(
   managedEmail: boolean,
@@ -118,6 +128,15 @@ describe("EmailServiceCard managed-email gate", () => {
     // The domain registration form renders for entitled orgs.
     expect(html).toContain("Subdomain");
     expect(html).toContain("Register");
+  });
+
+  test("native Android shows website guidance without an upgrade action", () => {
+    nativeAndroid = true;
+    const html = renderCard(makeSubscription(false, "base"));
+
+    expect(html).toContain("Manage your subscription on our website.");
+    expect(html).not.toContain(">Upgrade<");
+    expect(html).not.toContain("/assistant/plans");
   });
 
   test("Successful payload WITHOUT entitlements is treated as unknown and fails open", () => {

--- a/clients/web/src/domains/settings/ai/email-managed-content.tsx
+++ b/clients/web/src/domains/settings/ai/email-managed-content.tsx
@@ -20,7 +20,9 @@ import {
   assistantsListQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
+import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
 import { captureError } from "@/lib/sentry/capture-error";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -43,6 +45,7 @@ export function EmailManagedContent({
 }: EmailManagedContentProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const isNativeAndroid = useIsNativeAndroid();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [subdomainDraft, setSubdomainDraft] = useState("");
@@ -291,13 +294,21 @@ export function EmailManagedContent({
         icon={<Mail className="h-4 w-4" aria-hidden />}
         title="Give your assistant its own email address"
         actions={
-          <Button size="compact" onClick={() => navigate(routes.plans)}>
-            Upgrade
-          </Button>
+          isNativeAndroid ? undefined : (
+            <Button size="compact" onClick={() => navigate(routes.plans)}>
+              Upgrade
+            </Button>
+          )
         }
       >
-        Upgrade to a plan that includes an email address for your assistant. No
-        provider setup required.
+        {isNativeAndroid ? (
+          ANDROID_BILLING_MESSAGE
+        ) : (
+          <>
+            Upgrade to a plan that includes an email address for your assistant.
+            No provider setup required.
+          </>
+        )}
       </Notice>
     );
   }

--- a/clients/web/src/domains/settings/billing/android-billing-gate.tsx
+++ b/clients/web/src/domains/settings/billing/android-billing-gate.tsx
@@ -1,0 +1,29 @@
+import { type ReactNode } from "react";
+import { Navigate } from "react-router";
+
+import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
+import { routes } from "@/utils/routes";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+interface AndroidBillingGateProps {
+  children: ReactNode;
+  redirectToBilling?: boolean;
+}
+
+export function AndroidBillingGate({
+  children,
+  redirectToBilling = false,
+}: AndroidBillingGateProps) {
+  const isNativeAndroid = useIsNativeAndroid();
+
+  if (!isNativeAndroid) {
+    return children;
+  }
+
+  if (redirectToBilling) {
+    return <Navigate replace to={routes.settings.usageBilling} />;
+  }
+
+  return <Notice tone="info">{ANDROID_BILLING_MESSAGE}</Notice>;
+}

--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -32,6 +32,7 @@ import type {
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import * as platformGate from "@/hooks/use-platform-gate";
+import * as platformDetection from "@/runtime/platform-detection";
 import * as authStore from "@/stores/auth-store";
 
 let subscriptionResponse: SubscriptionResponse;
@@ -44,6 +45,7 @@ let domainsListPaths: string[] = [];
 // so the existing cases behave as before; one case flips it to model a fresh
 // login where the org store hasn't hydrated yet.
 let orgReady = true;
+let nativeAndroid = false;
 
 const ACTIVE_ASSISTANT = { id: "assistant-1" } as unknown as Assistant;
 
@@ -97,6 +99,11 @@ mock.module("@/stores/auth-store", () => ({
 
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
+}));
+
+mock.module("@/runtime/platform-detection", () => ({
+  ...platformDetection,
+  useIsNativeAndroid: () => nativeAndroid,
 }));
 
 mock.module(
@@ -227,11 +234,24 @@ beforeEach(() => {
   domainsCalls = 0;
   domainsListPaths = [];
   orgReady = true;
+  nativeAndroid = false;
   activeAssistantIsPlatformHosted = true;
 });
 
 afterEach(() => {
   cleanup();
+});
+
+describe("BillingTab on native Android", () => {
+  test("shows website guidance without billing controls", () => {
+    nativeAndroid = true;
+    const { getByText, queryByRole, queryByTestId } = renderPage();
+
+    expect(getByText("Manage your subscription on our website.")).toBeTruthy();
+    expect(queryByRole("link")).toBeNull();
+    expect(queryByTestId("plan-card-tier-upgraded")).toBeNull();
+    expect(queryByTestId("onboarding-modal")).toBeNull();
+  });
 });
 
 describe("BillingTab ?pro_onboarding param", () => {

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -7,6 +7,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
+import { AndroidBillingGate } from "@/domains/settings/billing/android-billing-gate";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { shouldShowBillingTab } from "@/domains/settings/billing/billing-tab-visibility";
 import { proPackageDisplayName } from "@/domains/settings/billing/package-types";
@@ -132,7 +133,7 @@ function FinishProSetupNotice({
   );
 }
 
-function BillingTab() {
+function BillingTabContent() {
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const billingGate = usePlatformGate();
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
@@ -284,6 +285,14 @@ function BillingTab() {
         />
       )}
     </div>
+  );
+}
+
+function BillingTab() {
+  return (
+    <AndroidBillingGate>
+      <BillingTabContent />
+    </AndroidBillingGate>
   );
 }
 

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -238,6 +238,16 @@ afterEach(() => {
 describe("CheckoutPage", () => {
   test("redirects native Android to billing without creating checkout", async () => {
     nativeAndroid = true;
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: AVATAR_TRAITS,
+    });
     const { getByTestId } = renderCheckout(
       "/assistant/checkout?package=super",
     );
@@ -249,6 +259,31 @@ describe("CheckoutPage", () => {
     );
     expect(upgradeCalls.length).toBe(0);
     expect(openedUrl).toBeNull();
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+    expect(readTakeoverAvatarStash()).toBeNull();
+  });
+
+  test("native Android resumes onboarding without leaving checkout state", async () => {
+    nativeAndroid = true;
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    saveTakeoverAvatarStash({
+      assistantId: "a1",
+      components: BUNDLED_COMPONENTS,
+      traits: AVATAR_TRAITS,
+    });
+    const { getByTestId } = renderCheckout(ONBOARDING_ENTRY);
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(ONBOARDING_NEXT),
+    );
+    expect(upgradeCalls.length).toBe(0);
+    expect(openedUrl).toBeNull();
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+    expect(readTakeoverAvatarStash()).toBeNull();
   });
 
   test("valid package + full gate fires the upgrade, stashes intent and avatar, opens Stripe", async () => {

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -16,6 +16,7 @@ import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import * as capacitorCore from "@capacitor/core";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
+import * as platformDetection from "@/runtime/platform-detection";
 import * as orgReadyMod from "@/hooks/use-is-org-ready";
 import type { OrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import * as platformGateMod from "@/hooks/use-platform-gate";
@@ -50,6 +51,7 @@ let takeoverValue: MarketingPricingTakeoverState = "enabled";
 // Drives `Capacitor.isNativePlatform()`, which is what puts checkout in an
 // `SFSafariViewController` that leaves this route mounted underneath it.
 let nativePlatform = false;
+let nativeAndroid = false;
 // When true the upgrade rejects — drives the error path. Otherwise it resolves
 // with `upgradeData`.
 let upgradeRejects = false;
@@ -100,6 +102,11 @@ mock.module("@/runtime/browser", () => ({
     openedUrl = url;
     return Promise.resolve();
   },
+}));
+
+mock.module("@/runtime/platform-detection", () => ({
+  ...platformDetection,
+  useIsNativeAndroid: () => nativeAndroid,
 }));
 
 mock.module("@/hooks/use-platform-gate", () => ({
@@ -201,6 +208,7 @@ beforeEach(() => {
   orgReadinessValue = "ready";
   takeoverValue = "enabled";
   nativePlatform = false;
+  nativeAndroid = false;
   delete (window as { vellum?: unknown }).vellum;
   fetchOrganizationsCalls = 0;
   useOrganizationStore.setState({
@@ -228,6 +236,21 @@ afterEach(() => {
 });
 
 describe("CheckoutPage", () => {
+  test("redirects native Android to billing without creating checkout", async () => {
+    nativeAndroid = true;
+    const { getByTestId } = renderCheckout(
+      "/assistant/checkout?package=super",
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(
+        "/assistant/settings/usage?tab=billing",
+      ),
+    );
+    expect(upgradeCalls.length).toBe(0);
+    expect(openedUrl).toBeNull();
+  });
+
   test("valid package + full gate fires the upgrade, stashes intent and avatar, opens Stripe", async () => {
     const client = freshQueryClient();
     seedCachedAvatar(client, "a1");

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -4,7 +4,6 @@ import { Link, useNavigate, useSearchParams } from "react-router";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { AndroidBillingGate } from "@/domains/settings/billing/android-billing-gate";
 import {
   captureTakeoverAvatarStash,
   clearTakeoverAvatarStash,
@@ -21,6 +20,7 @@ import {
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
 import { parseCustomCheckoutSelection } from "@/lib/billing/custom-checkout-params";
 import { openUrl } from "@/runtime/browser";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { PACKAGE_PARAM, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -386,10 +386,28 @@ function CheckoutPageContent() {
   );
 }
 
+function AndroidCheckoutRedirect() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const target = checkoutContinuation(
+    searchParams,
+    routes.settings.usageBilling,
+  );
+
+  useEffect(() => {
+    abandonCheckout();
+    navigate(target, { replace: true });
+  }, [navigate, target]);
+
+  return null;
+}
+
 export function CheckoutPage() {
-  return (
-    <AndroidBillingGate redirectToBilling>
-      <CheckoutPageContent />
-    </AndroidBillingGate>
+  const isNativeAndroid = useIsNativeAndroid();
+
+  return isNativeAndroid ? (
+    <AndroidCheckoutRedirect />
+  ) : (
+    <CheckoutPageContent />
   );
 }

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useSearchParams } from "react-router";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { AndroidBillingGate } from "@/domains/settings/billing/android-billing-gate";
 import {
   captureTakeoverAvatarStash,
   clearTakeoverAvatarStash,
@@ -91,7 +92,7 @@ function abandonCheckout() {
  * without paying: the return never arrives, so nothing else is coming to move
  * them off this route.
  */
-export function CheckoutPage() {
+function CheckoutPageContent() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const packageKey = searchParams.get(PACKAGE_PARAM) ?? "";
@@ -382,5 +383,13 @@ export function CheckoutPage() {
         Preparing checkout&hellip;
       </p>
     </div>
+  );
+}
+
+export function CheckoutPage() {
+  return (
+    <AndroidBillingGate redirectToBilling>
+      <CheckoutPageContent />
+    </AndroidBillingGate>
   );
 }

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -34,6 +34,7 @@ import { MemoryRouter, useLocation } from "react-router";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
 import * as platformGateMod from "@/hooks/use-platform-gate";
+import * as platformDetection from "@/runtime/platform-detection";
 import * as toastMod from "@vellumai/design-library/components/toast";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -79,6 +80,7 @@ let machineTierCall: Captured | null = null;
 let storageTierCall: Captured | null = null;
 let creditTierCall: Captured | null = null;
 let openedUrl: string | null = null;
+let nativeAndroid = false;
 // When non-null, the change-machine-tier call rejects — drives the failure path.
 let machineTierError: unknown = null;
 // Success-toast messages captured from the mocked toast module, so a path can
@@ -196,6 +198,11 @@ mock.module("@/hooks/use-platform-gate", () => ({
   usePlatformGate: () => "full",
   useActiveAssistantIsPlatformHosted: () => true,
   useActiveAssistantLifecycleIsLoading: () => false,
+}));
+
+mock.module("@/runtime/platform-detection", () => ({
+  ...platformDetection,
+  useIsNativeAndroid: () => nativeAndroid,
 }));
 
 // Render avatar placeholders; skip the lazy compositor bundle in the DOM test.
@@ -602,6 +609,7 @@ beforeEach(() => {
   storageTierCall = null;
   creditTierCall = null;
   openedUrl = null;
+  nativeAndroid = false;
   machineTierError = null;
   changePackageAutoResolve = true;
   changePackageData = {
@@ -630,6 +638,24 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+});
+
+describe("PlansPage on native Android", () => {
+  test("redirects to billing without exposing plan actions", async () => {
+    nativeAndroid = true;
+    const { getByTestId, queryByRole } = renderInteractive(
+      freeSubscription(),
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(
+        "/assistant/settings/usage?tab=billing",
+      ),
+    );
+    expect(queryByRole("button")).toBeNull();
+    expect(upgradeCall).toBeNull();
+    expect(openedUrl).toBeNull();
+  });
 });
 
 describe("PlansPage — Pro package switch (change-package)", () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { AndroidBillingGate } from "@/domains/settings/billing/android-billing-gate";
 import {
   isCleanPin,
   PACKAGE_ORDER,
@@ -148,7 +149,7 @@ function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
  * `pro-packages` flag off the catalog is empty and the route bounces back to
  * the billing page.
  */
-export function PlansPage() {
+function PlansPageContent() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -909,5 +910,13 @@ export function PlansPage() {
         {body}
       </div>
     </div>
+  );
+}
+
+export function PlansPage() {
+  return (
+    <AndroidBillingGate redirectToBilling>
+      <PlansPageContent />
+    </AndroidBillingGate>
   );
 }

--- a/clients/web/src/domains/settings/components/resize-card.test.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import type { Assistant } from "@/assistant/api";
+import {
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type { SubscriptionResponse } from "@/generated/api/types.gen";
+
+let nativeAndroid = false;
+
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeAndroid: () => nativeAndroid,
+}));
+
+const { ResizeCard } = await import(
+  "@/domains/settings/components/resize-card"
+);
+
+const assistant = {
+  id: "assistant-1",
+  is_local: false,
+  machine_size: "small",
+} as Assistant;
+
+function subscription(planId: SubscriptionResponse["plan_id"]): SubscriptionResponse {
+  return {
+    plan_id: planId,
+    status: "active",
+    renewal_date: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+function renderCard(planId: SubscriptionResponse["plan_id"]) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingSubscriptionRetrieveQueryKey(),
+    subscription(planId),
+  );
+  if (planId === "pro") {
+    client.setQueryData(
+      organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+      {
+        max_machine_tier: "large",
+        selected_storage_tier: "s",
+        selected_storage_gib: 10,
+        pvc_ready: true,
+        domain_setup_available: false,
+        primary_assistant_id: assistant.id,
+      },
+    );
+  }
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <ResizeCard
+          assistant={assistant}
+          healthz={null}
+          healthzLoading={false}
+          healthzPolling={false}
+          refetch={() => {}}
+          refetchUntilResized={() => {}}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  nativeAndroid = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ResizeCard billing actions", () => {
+  test("native Android hides Base plan upgrade entry points", () => {
+    nativeAndroid = true;
+    renderCard("base");
+
+    expect(screen.queryByRole("button", { name: "Resize" })).toBeNull();
+    expect(screen.queryByText("Upgrade your plan")).toBeNull();
+  });
+
+  test("native Android can resize within Pro without an upgrade link", () => {
+    nativeAndroid = true;
+    renderCard("pro");
+
+    fireEvent.click(screen.getByRole("button", { name: "Increase Size" }));
+
+    expect(screen.getByText("Resize Assistant")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Upgrade plan" })).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -21,6 +21,7 @@ import {
   machineSizeRank,
   SIZE_LABEL,
 } from "@/lib/billing/machine-sizes";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
@@ -51,6 +52,7 @@ export function ResizeCard({
   refetchUntilResized,
 }: ResizeCardProps) {
   const navigate = useNavigate();
+  const isNativeAndroid = useIsNativeAndroid();
   const subscriptionQuery = useQuery(
     organizationsBillingSubscriptionRetrieveOptions(),
   );
@@ -196,6 +198,16 @@ export function ResizeCard({
       }
     : null;
 
+  const basePlanResizeAction = isNativeAndroid ? null : (
+    <Button
+      variant="ghost"
+      size="compact"
+      onClick={() => setUpgradeModalOpen(true)}
+    >
+      Resize
+    </Button>
+  );
+
   const diskAction = !isPlatform ? null : isPro ? (
     canGrowStorage ? (
       <button
@@ -217,15 +229,7 @@ export function ResizeCard({
         Resize
       </Button>
     )
-  ) : (
-    <Button
-      variant="ghost"
-      size="compact"
-      onClick={() => setUpgradeModalOpen(true)}
-    >
-      Resize
-    </Button>
-  );
+  ) : basePlanResizeAction;
 
   const machineAction = !isPlatform ? null : isPro ? (
     canUpsize ? (
@@ -248,15 +252,7 @@ export function ResizeCard({
         Resize
       </Button>
     )
-  ) : (
-    <Button
-      variant="ghost"
-      size="compact"
-      onClick={() => setUpgradeModalOpen(true)}
-    >
-      Resize
-    </Button>
-  );
+  ) : basePlanResizeAction;
 
   return (
     <>
@@ -470,17 +466,23 @@ export function ResizeCard({
               {resizeError && <Notice tone="error">{resizeError}</Notice>}
             </div>
           </Modal.Body>
-          <Modal.Footer className="items-center justify-between">
-            <span className="text-label-small-default text-[var(--content-tertiary)]">
-              Need more?{" "}
-              <Link
-                to={routes.plans}
-                className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 transition-colors hover:text-[var(--content-default)]"
-                onClick={() => setResizeModalOpen(false)}
-              >
-                Upgrade plan
-              </Link>
-            </span>
+          <Modal.Footer
+            className={
+              isNativeAndroid ? "justify-end" : "items-center justify-between"
+            }
+          >
+            {!isNativeAndroid ? (
+              <span className="text-label-small-default text-[var(--content-tertiary)]">
+                Need more?{" "}
+                <Link
+                  to={routes.plans}
+                  className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 transition-colors hover:text-[var(--content-default)]"
+                  onClick={() => setResizeModalOpen(false)}
+                >
+                  Upgrade plan
+                </Link>
+              </span>
+            ) : null}
             <div className="flex gap-2">
               <Button
                 variant="ghost"

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -43,6 +43,7 @@ import {
   isRemoteGatewayMode,
 } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useIsAuthenticated } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
@@ -72,6 +73,7 @@ export function GeneralPage() {
   const platformGate = usePlatformGate();
   const infraGate = usePlatformGate({ platformHostedOnly: true });
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
+  const isNativeAndroid = useIsNativeAndroid();
   const diskPressure = useDiskPressureMonitor({
     assistantId: assistant?.id ?? null,
     enabled: infraGate === "full" && isPlatformHosted,
@@ -145,7 +147,9 @@ export function GeneralPage() {
             void navigate(`${routes.workspace}?sort=size`)
           }
           onUpgradeStorage={
-            infraGate === "full" ? () => void navigate(routes.plans) : null
+            infraGate === "full" && !isNativeAndroid
+              ? () => void navigate(routes.plans)
+              : null
           }
         />
       )}

--- a/clients/web/src/lib/billing/android-consumption-only.ts
+++ b/clients/web/src/lib/billing/android-consumption-only.ts
@@ -1,0 +1,2 @@
+export const ANDROID_BILLING_MESSAGE =
+  "Manage your subscription on our website.";

--- a/clients/web/src/runtime/platform-detection.ts
+++ b/clients/web/src/runtime/platform-detection.ts
@@ -332,3 +332,8 @@ export function useIsMacOSWeb(): boolean {
 export function useIsNativeIOS(): boolean {
   return useSyncExternalStore(noop, isNativeIOS, () => false);
 }
+
+/** Hook form of `isNativeAndroid()`, safe to call from a render body. */
+export function useIsNativeAndroid(): boolean {
+  return useSyncExternalStore(noop, isNativeAndroid, () => false);
+}


### PR DESCRIPTION
## Summary
- replace the Android Billing tab with non-clickable website-management guidance
- redirect Android checkout and plan routes before payment logic mounts
- remove Android credit purchase actions and guard the top-up modal

## Original prompt
Google Play billing rules make the current external Stripe flow risky unless the Android app is consumption-only. The request was to show “Manage your subscription on our website” in Android billing with no link, while preserving billing flows on web and iOS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->