### PR TITLE
Restore optional Firebase config in Android releases

### DIFF
--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -83,6 +83,30 @@ jobs:
           VELLUM_ENVIRONMENT: ${{ inputs.environment }}
         run: bun run android:sync
 
+      - name: Restore optional Firebase configuration
+        env:
+          ANDROID_FIREBASE_CONFIG_B64: ${{ secrets.ANDROID_FIREBASE_CONFIG_B64 }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          EXPECTED_PACKAGE_ID: ${{ steps.config.outputs.package_id }}
+        run: |
+          if [ -z "$ANDROID_FIREBASE_CONFIG_B64" ]; then
+            echo "::warning::ANDROID_FIREBASE_CONFIG_B64 is not configured for $ENVIRONMENT; native Android push will be unavailable in this AAB"
+            exit 0
+          fi
+
+          umask 077
+          if ! printf '%s' "$ANDROID_FIREBASE_CONFIG_B64" \
+            | base64 --decode > clients/android/app/google-services.json; then
+            echo "::error::ANDROID_FIREBASE_CONFIG_B64 is not valid base64"
+            exit 1
+          fi
+          if ! jq -e --arg package_id "$EXPECTED_PACKAGE_ID" \
+            'any(.client[]?; .client_info.android_client_info.package_name == $package_id)' \
+            clients/android/app/google-services.json >/dev/null; then
+            echo "::error::Firebase configuration does not contain $EXPECTED_PACKAGE_ID"
+            exit 1
+          fi
+
       - name: Restore upload key
         env:
           ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
@@ -122,6 +146,8 @@ jobs:
           track: internal
           status: completed
 
-      - name: Remove signing material
+      - name: Remove sensitive build material
         if: ${{ always() }}
-        run: rm -f /tmp/vellum-android-upload.jks
+        run: |
+          rm -f /tmp/vellum-android-upload.jks
+          rm -f clients/android/app/google-services.json

--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -102,7 +102,7 @@ jobs:
           fi
           if ! jq -e --arg package_id "$EXPECTED_PACKAGE_ID" \
             'any(.client[]?; .client_info.android_client_info.package_name == $package_id)' \
-            clients/android/app/google-services.json >/dev/null; then
+            clients/android/app/google-services.json >/dev/null 2>&1; then
             echo "::error::Firebase configuration does not contain $EXPECTED_PACKAGE_ID"
             exit 1
           fi

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -194,20 +194,28 @@ annotations and methods are retained by `app/proguard-rules.pro`.
 `.github/workflows/release-android.yaml` is the reusable Android release
 workflow. It builds a signed AAB, retains it as an artifact, and uploads it to
 the matching Play internal track. Production-track promotion remains manual.
+When Firebase configuration is available, the workflow validates that it
+matches the selected flavor before including it in the build.
 
 Configure these environment-scoped GitHub secrets independently for `dev`,
 `staging`, and `production`:
 
 | Secret | Format |
 |--------|--------|
+| `ANDROID_FIREBASE_CONFIG_B64` | Optional base64-encoded `google-services.json` for the environment's package |
 | `ANDROID_UPLOAD_KEYSTORE_B64` | Base64-encoded Play upload keystore |
 | `ANDROID_UPLOAD_KEYSTORE_PASSWORD` | Upload keystore password |
 | `ANDROID_UPLOAD_KEY_ALIAS` | Upload key alias |
 | `ANDROID_UPLOAD_KEY_PASSWORD` | Upload key password |
 | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Raw Play service account JSON |
 
-Never commit the keystore, credentials, or decoded secret material. The
-workflow removes restored signing files even when a build fails.
+Never commit Firebase configuration, the keystore, credentials, or decoded
+secret material. The workflow removes restored files even when a build fails.
+
+`ANDROID_FIREBASE_CONFIG_B64` remains optional so signing and internal
+distribution do not depend on push setup. When it is absent, the workflow emits
+a warning and the resulting AAB has no native push support. When it is present,
+malformed base64, invalid JSON, or a package mismatch fails the build.
 
 After all prerequisites and environment secrets are ready, set the repository
 variable `ANDROID_RELEASE_ENABLED` to `true`. Until then, both orchestrators
@@ -231,3 +239,25 @@ Complete the following setup before enabling internal-track uploads:
 
 Before wider rollout, test the internal-track AAB on a physical device and
 verify its identity, web origin, authentication, keyboard, and file sharing.
+
+### Manual Firebase Prerequisites
+
+Create a separate Firebase Android app in each matching Firebase project:
+
+| GitHub environment | Android package ID |
+|--------------------|--------------------|
+| `production` | `ai.vellum.assistant` |
+| `staging` | `ai.vellum.assistant.staging` |
+| `dev` | `ai.vellum.assistant.dev` |
+
+For each app, download its `google-services.json`, encode it without line
+breaks, and save the result as the `ANDROID_FIREBASE_CONFIG_B64` secret on the
+matching GitHub Environment:
+
+```bash
+base64 < google-services.json | tr -d '\n'
+```
+
+Do not reuse a Firebase file across environments. After configuring the
+secret, verify push registration and notification delivery from an
+internal-track install on a physical device.


### PR DESCRIPTION
## Summary
- restore an optional environment-scoped ANDROID_FIREBASE_CONFIG_B64 secret during Android release builds
- validate supplied Firebase JSON against the selected production, staging, or dev package before Gradle runs
- warn and continue without native push when the secret is absent, preserving the existing release and signing behavior
- remove decoded Firebase configuration in the always-run sensitive-material cleanup step
- document the three Firebase package registrations and GitHub Environment setup

## Rationale and security
Android release builds currently omit google-services.json, so Gradle skips the Google Services plugin and the resulting AAB cannot use native push. Firebase remains optional because PR #39674 intentionally decoupled Play distribution from push-account setup. A missing secret produces a visible warning and a no-push AAB. A supplied secret fails closed on invalid base64, malformed JSON, or the wrong package ID. The workflow never prints the secret, creates the decoded file under a restrictive umask, and removes it even after failure.

ANDROID_RELEASE_ENABLED remains unchanged, so Android distribution stays disabled until account setup is ready. No iOS runtime or release behavior is changed.

## Validation
- parsed release-android.yaml locally
- exercised valid, wrong-package, and malformed Firebase config validation fixtures
- ran VELLUM_ENVIRONMENT=dev bun run android:sync
- ran ./gradlew :app:bundleDevRelease without Firebase credentials
- ran git diff --check
- completed the simplify review pass

## Manual setup still required
Register ai.vellum.assistant, ai.vellum.assistant.staging, and ai.vellum.assistant.dev in their matching Firebase projects, then save each base64-encoded google-services.json as the environment-scoped ANDROID_FIREBASE_CONFIG_B64 secret.

## Original prompt
Add the missing Android Firebase release configuration as a separate Wave parity PR while preserving credential-free builds and the existing Android release gate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->