### PR TITLE
feat(web): drag the sidebar rule to resize the Pinned section

### DIFF
--- a/clients/web/src/components/sidebar-nav-geometry.ts
+++ b/clients/web/src/components/sidebar-nav-geometry.ts
@@ -48,3 +48,13 @@ export const SIDEBAR_SECTION_INDENT = 12;
  * neighbours.
  */
 export const SIDEBAR_SECTION_MAX_HEIGHT = 300;
+
+/**
+ * Bounds for the Pinned section's user-adjustable height (dragging the rule
+ * under the curated block). Min fits two desktop rows (30px each) plus their
+ * 4px gap. Max stays a fixed constant rather than viewport-derived: the
+ * sidebar body scrolls, so an oversized section degrades to body scrolling
+ * the same way a long section list does today.
+ */
+export const SIDEBAR_SECTION_RESIZE_MIN_HEIGHT = 64;
+export const SIDEBAR_SECTION_RESIZE_MAX_HEIGHT = 600;

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -1014,17 +1014,19 @@ describe("AssistantSideMenu · equal section treatment", () => {
     const indexOfText = (text: string) =>
       children.findIndex((el) => (el.textContent ?? "").includes(text));
     const ruleIndex = children.findIndex((el) =>
-      el.matches('[data-slot="side-menu-separator"]'),
+      el.matches('[data-slot="sidebar-section-resize-handle"]'),
     );
 
     expect(
-      root.querySelectorAll('[data-slot="side-menu-separator"]'),
+      root.querySelectorAll('[data-slot="sidebar-section-resize-handle"]'),
     ).toHaveLength(1);
     // Pinned and Alpha above it, Chats and Slack below.
     expect(indexOfText("Pinned")).toBeLessThan(ruleIndex);
     expect(indexOfText("Alpha")).toBeLessThan(ruleIndex);
     expect(indexOfText("Chats")).toBeGreaterThan(ruleIndex);
     expect(indexOfText("Slack")).toBeGreaterThan(ruleIndex);
+    // Pinned is present and open by default, so the rule drags.
+    expect(children[ruleIndex]?.hasAttribute("data-resizable")).toBe(true);
   });
 
   test("the rule is absent until something is curated", () => {
@@ -1043,8 +1045,35 @@ describe("AssistantSideMenu · equal section treatment", () => {
     }
 
     expect(
-      root.querySelectorAll('[data-slot="side-menu-separator"]'),
+      root.querySelectorAll('[data-slot="sidebar-section-resize-handle"]'),
     ).toHaveLength(0);
+  });
+
+  // The rule only drags while there is a Pinned section to resize; a custom
+  // group alone still earns the rule, but an inert one.
+  test("the rule is inert when groups are curated without pins", () => {
+    const container = parse(
+      renderMenu({
+        conversations: [
+          makeConversation({ conversationId: "r1" }),
+          makeConversation({
+            conversationId: "g1",
+            title: "Group one",
+            groupId: "grp-a",
+          }),
+        ],
+        conversationGroups: LAYOUT_GROUPS,
+      }),
+    );
+
+    const rule = container.querySelector<HTMLElement>(
+      '[data-slot="sidebar-section-resize-handle"]',
+    );
+    if (!rule) {
+      throw new Error("expected the curated block's rule");
+    }
+
+    expect(rule.hasAttribute("data-resizable")).toBe(false);
   });
 
   // The switch sits outside the section list, ahead of it: a sticky element

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -37,8 +37,14 @@ import {
   type SidebarSection,
   type UseSidebarStateParams,
 } from "@/domains/chat/use-sidebar-state";
+import { SidebarSectionResizeHandle } from "@/domains/chat/components/sidebar-section-resize-handle";
 import { copyIdToClipboard } from "@/domains/chat/utils/copy-id-to-clipboard";
 import { NATIVE_IOS_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-ios-button-constants";
+import {
+  resetPinnedSectionHeight,
+  savePinnedSectionHeight,
+  usePinnedSectionHeight,
+} from "@/domains/chat/utils/sidebar-pinned-height";
 import {
   RECENTS_SECTION_ICON,
   RECENTS_SECTION_LABEL,
@@ -154,7 +160,8 @@ function SearchButton() {
  *     • [ All | Grouped ] - the view switch, first and sticky
  *     • Pinned ▾       - when non-empty
  *     • Group ▾        - one collapsible section per custom group
- *     • ───────────────  - when anything is curated above it
+ *     • ───────────────  - when anything is curated above it; drags to
+ *       resize Pinned while that section is expanded
  *     • All view: every remaining conversation as one headerless,
  *       virtualized list, newest first
  *     • Grouped view: Chats ▾ then one collapsible section per origin
@@ -231,6 +238,18 @@ export function AssistantSideMenu({
   const pinnedApps = usePinnedAppsStore.use.pinnedApps();
 
   const isCollapsedRail = collapsed && variant === "rail";
+
+  // --- Pinned section resize ---
+  // The section list's one rule doubles as the Pinned section's resize
+  // handle. During a drag the handle drives the bounded row list through
+  // this ref (no per-frame React state); the released height persists per
+  // assistant. Radix unmounts closed accordion content, so the ref only
+  // reaches a node while Pinned is expanded.
+  const pinnedListRef = useRef<HTMLDivElement | null>(null);
+  const pinnedListMaxHeight = usePinnedSectionHeight(assistantId);
+  const pinnedResizable =
+    sidebar.sections.some((section) => section.type === "pinned") &&
+    sidebar.effectiveOpenSections.includes("pinned");
 
   // --- Overlay bottom reserve ---
   // The overlay's floating bottom column (tip card + action pills) covers the
@@ -404,6 +423,10 @@ export function AssistantSideMenu({
       groupMenu={sectionMenu(section)}
       drag={sectionDragFor(section)}
       collapsedIndicator={collapsedActivityDot(section.all)}
+      listRef={section.type === "pinned" ? pinnedListRef : undefined}
+      listMaxHeight={
+        section.type === "pinned" ? pinnedListMaxHeight : undefined
+      }
     />
   );
 
@@ -652,10 +675,18 @@ export function AssistantSideMenu({
                   .map(renderSection)}
                 {/* The list's one rule, marking where curation ends and the
                     conversations begin. Absent when nothing is curated yet, so
-                    a fresh sidebar never opens on a stray line. `my-0` keeps it
-                    on the root's own gap instead of adding to it. */}
+                    a fresh sidebar never opens on a stray line. It carries no
+                    margin, sitting on the root's own gap, and doubles as the
+                    Pinned section's resize handle while Pinned is expanded. */}
                 {sidebar.curatedSectionCount > 0 ? (
-                  <SideMenu.Separator className="my-0" />
+                  <SidebarSectionResizeHandle
+                    targetRef={pinnedListRef}
+                    resizable={pinnedResizable}
+                    onCommit={(height) =>
+                      savePinnedSectionHeight(assistantId, height)
+                    }
+                    onReset={() => resetPinnedSectionHeight(assistantId)}
+                  />
                 ) : null}
                 {sidebar.sections
                   .slice(sidebar.curatedSectionCount)

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -23,7 +23,7 @@
  * (via `ConversationRow`), so neither takes them as props.
  */
 
-import { type ReactNode } from "react";
+import { type ReactNode, type Ref } from "react";
 
 import { type LucideIcon } from "lucide-react";
 
@@ -66,6 +66,13 @@ export interface ConversationRowListProps {
    * of its own would put a second scrollbar in the rail.
    */
   scrollParent?: HTMLElement;
+  /**
+   * Reaches the bounded scroll div, for the Pinned resize handle to drive
+   * imperatively during a drag. Unused when `scrollParent` unbounds the list.
+   */
+  listRef?: Ref<HTMLDivElement>;
+  /** Caps the bounded list instead of {@link SIDEBAR_SECTION_MAX_HEIGHT}. */
+  listMaxHeight?: number;
 }
 
 export function ConversationRowList({
@@ -73,6 +80,8 @@ export function ConversationRowList({
   dragSection,
   dragSiblings,
   scrollParent,
+  listRef,
+  listMaxHeight,
 }: ConversationRowListProps) {
   const renderRow = (conversation: Conversation) => (
     <ConversationRow
@@ -98,8 +107,9 @@ export function ConversationRowList({
       rows
     ) : (
       <div
+        ref={listRef}
         className="overflow-y-auto"
-        style={{ maxHeight: SIDEBAR_SECTION_MAX_HEIGHT }}
+        style={{ maxHeight: listMaxHeight ?? SIDEBAR_SECTION_MAX_HEIGHT }}
       >
         {rows}
       </div>
@@ -124,7 +134,12 @@ export function ConversationRowList({
   return scrollParent ? (
     windowed
   ) : (
-    <div style={{ height: SIDEBAR_SECTION_MAX_HEIGHT }}>{windowed}</div>
+    <div
+      ref={listRef}
+      style={{ height: listMaxHeight ?? SIDEBAR_SECTION_MAX_HEIGHT }}
+    >
+      {windowed}
+    </div>
   );
 }
 export interface ConversationNavSectionProps extends ConversationRowListProps {

--- a/clients/web/src/domains/chat/components/sidebar-section-item.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.tsx
@@ -19,7 +19,7 @@
  * comes in already resolved.
  */
 
-import type { ReactNode } from "react";
+import type { ReactNode, Ref } from "react";
 
 import type { CollapsibleNavSectionDrag } from "@/components/collapsible-nav-section";
 import { ConversationNavSection } from "@/domains/chat/components/conversation-nav-section";
@@ -38,6 +38,10 @@ export interface SidebarSectionItemProps {
   drag?: CollapsibleNavSectionDrag;
   /** Activity dot shown in the header only while the section is collapsed. */
   collapsedIndicator?: ReactNode;
+  /** Reaches the row list's bounded scroll div (the sidebar wires Pinned's). */
+  listRef?: Ref<HTMLDivElement>;
+  /** Caps the row list instead of the shared section max height. */
+  listMaxHeight?: number;
 }
 
 /**
@@ -60,6 +64,8 @@ export function SidebarSectionItem({
   groupMenu,
   drag,
   collapsedIndicator,
+  listRef,
+  listMaxHeight,
 }: SidebarSectionItemProps) {
   return (
     <ConversationNavSection
@@ -76,6 +82,8 @@ export function SidebarSectionItem({
       groupMenu={groupMenu}
       collapsedIndicator={collapsedIndicator}
       drag={drag}
+      listRef={listRef}
+      listMaxHeight={listMaxHeight}
       {...rowListPropsFor(section)}
     />
   );

--- a/clients/web/src/domains/chat/components/sidebar-section-resize-handle.test.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-resize-handle.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Drag mechanics for the Pinned section's resize handle.
+ *
+ * happy-dom implements pointer capture but not layout, so every rect height
+ * reads 0: the expected values below are pure clamp math from a 0px start.
+ * Real divider tracking is covered by manual QA, matching the side-menu
+ * width handle.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { createRef, type RefObject } from "react";
+
+import {
+  SIDEBAR_SECTION_RESIZE_MAX_HEIGHT,
+  SIDEBAR_SECTION_RESIZE_MIN_HEIGHT,
+} from "@/components/sidebar-nav-geometry";
+import { SidebarSectionResizeHandle } from "@/domains/chat/components/sidebar-section-resize-handle";
+
+afterEach(() => {
+  cleanup();
+  document.body.style.cursor = "";
+  document.body.style.userSelect = "";
+});
+
+function Harness({
+  targetRef,
+  withTarget,
+  resizable,
+  onCommit,
+  onReset,
+}: {
+  targetRef: RefObject<HTMLDivElement | null>;
+  withTarget: boolean;
+  resizable: boolean;
+  onCommit: (height: number) => void;
+  onReset?: () => void;
+}) {
+  return (
+    <>
+      {withTarget ? <div data-testid="target" ref={targetRef} /> : null}
+      <SidebarSectionResizeHandle
+        targetRef={targetRef}
+        resizable={resizable}
+        onCommit={onCommit}
+        onReset={onReset}
+      />
+    </>
+  );
+}
+
+function renderHandle({ resizable = true }: { resizable?: boolean } = {}) {
+  const targetRef = createRef<HTMLDivElement>();
+  const onCommit = mock((_height: number) => {});
+  const onReset = mock(() => {});
+  const utils = render(
+    <Harness
+      targetRef={targetRef}
+      withTarget
+      resizable={resizable}
+      onCommit={onCommit}
+      onReset={onReset}
+    />,
+  );
+  const root = utils.container.querySelector<HTMLElement>(
+    '[data-slot="sidebar-section-resize-handle"]',
+  );
+  if (!root || !(root.firstElementChild instanceof HTMLElement)) {
+    throw new Error("expected the resize handle and its hit strip");
+  }
+  return {
+    ...utils,
+    targetRef,
+    onCommit,
+    onReset,
+    root,
+    hit: root.firstElementChild,
+  };
+}
+
+// The rect height reads 0, so the clamped drag-start height is the minimum.
+const START_HEIGHT = SIDEBAR_SECTION_RESIZE_MIN_HEIGHT;
+
+describe("SidebarSectionResizeHandle", () => {
+  test("drags the divider and commits the released height", () => {
+    const { hit, targetRef, onCommit } = renderHandle();
+
+    fireEvent.pointerDown(hit, { button: 0, pointerId: 1, clientY: 100 });
+    expect(document.body.style.cursor).toBe("row-resize");
+    expect(document.body.style.userSelect).toBe("none");
+
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: 400 });
+    expect(targetRef.current?.style.maxHeight).toBe("300px");
+
+    fireEvent.pointerUp(hit, { pointerId: 1, clientY: 400 });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith(300);
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+  });
+
+  test("clamps the drag to the resize bounds", () => {
+    const { hit, targetRef, onCommit } = renderHandle();
+
+    fireEvent.pointerDown(hit, { button: 0, pointerId: 1, clientY: 0 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: 1000 });
+    expect(targetRef.current?.style.maxHeight).toBe(
+      `${SIDEBAR_SECTION_RESIZE_MAX_HEIGHT}px`,
+    );
+
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: -500 });
+    expect(targetRef.current?.style.maxHeight).toBe(
+      `${SIDEBAR_SECTION_RESIZE_MIN_HEIGHT}px`,
+    );
+
+    // The commit carries the clamped value, not the raw pointer math.
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: 1000 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientY: 1000 });
+    expect(onCommit).toHaveBeenCalledWith(SIDEBAR_SECTION_RESIZE_MAX_HEIGHT);
+  });
+
+  // With a persisted height taller than the rendered content, a stray tap
+  // must not silently re-cap the section to its rendered height.
+  test("a press that never moves commits nothing", () => {
+    const { hit, onCommit } = renderHandle();
+
+    fireEvent.pointerDown(hit, { button: 0, pointerId: 1, clientY: 100 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientY: 100 });
+
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(document.body.style.cursor).toBe("");
+  });
+
+  // A move that lands back on the clamped start height also changes nothing.
+  test("a drag that returns to its start commits nothing", () => {
+    const { hit, targetRef, onCommit } = renderHandle();
+
+    fireEvent.pointerDown(hit, { button: 0, pointerId: 1, clientY: 100 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: 400 });
+    fireEvent.pointerMove(hit, {
+      pointerId: 1,
+      clientY: 100 + START_HEIGHT,
+    });
+    expect(targetRef.current?.style.maxHeight).toBe(`${START_HEIGHT}px`);
+
+    fireEvent.pointerUp(hit, { pointerId: 1, clientY: 100 + START_HEIGHT });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  test("inert when not resizable", () => {
+    const { hit, root, targetRef, onCommit } = renderHandle({
+      resizable: false,
+    });
+
+    expect(root.hasAttribute("data-resizable")).toBe(false);
+
+    fireEvent.pointerDown(hit, { button: 0, pointerId: 1, clientY: 100 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: 400 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientY: 400 });
+
+    expect(document.body.style.cursor).toBe("");
+    expect(targetRef.current?.style.maxHeight).toBe("");
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  test("keeps its footing when the target unmounts mid-drag", () => {
+    const { hit, targetRef, onCommit, onReset, rerender } = renderHandle();
+
+    fireEvent.pointerDown(hit, { button: 0, pointerId: 1, clientY: 100 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: 400 });
+
+    // The section collapses (or the last pin vanishes) under the pointer.
+    rerender(
+      <Harness
+        targetRef={targetRef}
+        withTarget={false}
+        resizable={false}
+        onCommit={onCommit}
+        onReset={onReset}
+      />,
+    );
+    expect(targetRef.current).toBeNull();
+
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: 500 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientY: 500 });
+
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+    expect(onCommit).toHaveBeenCalledWith(400);
+  });
+
+  test("pointercancel ends the drag like pointerup", () => {
+    const { hit, onCommit } = renderHandle();
+
+    fireEvent.pointerDown(hit, { button: 0, pointerId: 1, clientY: 100 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientY: 400 });
+    // The cancel coordinate is deliberately garbage: the commit must come
+    // from the last tracked move, not from this event.
+    fireEvent.pointerCancel(hit, { pointerId: 1, clientY: -9999 });
+
+    expect(onCommit).toHaveBeenCalledWith(300);
+    expect(document.body.style.cursor).toBe("");
+  });
+
+  test("double-click resets only while resizable", () => {
+    const active = renderHandle();
+    fireEvent.doubleClick(active.hit);
+    expect(active.onReset).toHaveBeenCalledTimes(1);
+    cleanup();
+
+    const inert = renderHandle({ resizable: false });
+    fireEvent.doubleClick(inert.hit);
+    expect(inert.onReset).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/components/sidebar-section-resize-handle.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-resize-handle.tsx
@@ -1,0 +1,147 @@
+/**
+ * The section list's one rule, doubling as the Pinned section's resize
+ * handle.
+ *
+ * Visually it stays the 1px divider between the curated block and the
+ * conversations below it. While the Pinned section is present and expanded,
+ * a taller invisible hit strip over the line drags with a `row-resize`
+ * cursor: each pointer move writes the tracked height straight to the
+ * section's bounded scroll div (no per-frame React state, matching the
+ * side-menu width handle), and release commits the final clamped height for
+ * persistence. Double-click returns the section to its default height.
+ *
+ * The element tree is identical in the inert and resizable states; only the
+ * handlers and cursor/touch affordances are gated. Swapping elements on that
+ * flag would drop pointer capture mid-drag if the last pin vanished (say,
+ * from another window) and strand the body-level cursor override.
+ */
+
+import {
+  useEffect,
+  useRef,
+  type PointerEvent,
+  type RefObject,
+} from "react";
+
+import { clampPinnedSectionHeight } from "@/domains/chat/utils/sidebar-pinned-height";
+import { cn } from "@/utils/misc";
+
+export interface SidebarSectionResizeHandleProps {
+  /** Bounded scroll div of the Pinned section; its maxHeight is driven during the drag. */
+  targetRef: RefObject<HTMLDivElement | null>;
+  /** False while Pinned is absent or collapsed: the rule stays, the drag affordance goes. */
+  resizable: boolean;
+  /** Final clamped height, fired on release only when it changed. */
+  onCommit: (height: number) => void;
+  /** Double-click: return the section to its default height. */
+  onReset?: () => void;
+}
+
+export function SidebarSectionResizeHandle({
+  targetRef,
+  resizable,
+  onCommit,
+  onReset,
+}: SidebarSectionResizeHandleProps) {
+  const dragRef = useRef<{
+    startY: number;
+    startHeight: number;
+    initialHeight: number;
+    lastHeight: number;
+  } | null>(null);
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    const target = targetRef.current;
+    if (!resizable || event.button !== 0 || !target) {
+      return;
+    }
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    // Start from the rendered height, not the configured cap, so shrinking a
+    // section shorter than its cap bites on the first pixel.
+    const startHeight = target.getBoundingClientRect().height;
+    const initialHeight = clampPinnedSectionHeight(startHeight);
+    dragRef.current = {
+      startY: event.clientY,
+      startHeight,
+      initialHeight,
+      lastHeight: initialHeight,
+    };
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    const next = clampPinnedSectionHeight(
+      drag.startHeight + (event.clientY - drag.startY),
+    );
+    drag.lastHeight = next;
+    // The section can unmount mid-drag (unpinned elsewhere, accordion
+    // collapsed). Capture lives on this element, so keep tracking and let
+    // release settle the bookkeeping.
+    const target = targetRef.current;
+    if (target) {
+      target.style.maxHeight = `${next}px`;
+    }
+  };
+
+  const handlePointerEnd = (event: PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    dragRef.current = null;
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    // Commit the move-tracked height rather than one recomputed from this
+    // event: pointercancel can carry a garbage coordinate. A press that
+    // never moved commits nothing, so a stray tap on the divider cannot
+    // quietly re-cap the section to its rendered height.
+    if (drag.lastHeight !== drag.initialHeight) {
+      onCommit(drag.lastHeight);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (dragRef.current) {
+        dragRef.current = null;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      data-slot="sidebar-section-resize-handle"
+      data-resizable={resizable ? "" : undefined}
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label={resizable ? "Pinned section height" : undefined}
+      className="group/resize relative h-px w-full bg-[var(--border-base)]"
+    >
+      {/* The hit strip overshoots the line into the section gaps (wider on
+          mobile, where there is no hover and fingers are blunt). */}
+      <div
+        className={cn(
+          "absolute inset-x-0 -top-1 -bottom-1 z-10",
+          resizable && "cursor-row-resize touch-none",
+        )}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        onDoubleClick={resizable ? onReset : undefined}
+      />
+      {resizable ? (
+        <div className="pointer-events-none absolute left-1/2 top-1/2 h-1 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--content-tertiary)] opacity-0 transition-opacity group-hover/resize:opacity-100 max-md:opacity-60" />
+      ) : null}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/utils/sidebar-pinned-height.test.tsx
+++ b/clients/web/src/domains/chat/utils/sidebar-pinned-height.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  SIDEBAR_SECTION_MAX_HEIGHT,
+  SIDEBAR_SECTION_RESIZE_MAX_HEIGHT,
+  SIDEBAR_SECTION_RESIZE_MIN_HEIGHT,
+} from "@/components/sidebar-nav-geometry";
+import { clearUserScopedOverrides } from "@/utils/typed-storage";
+import { withRejectedWrites } from "@/utils/rejected-writes.test-helper";
+import {
+  clampPinnedSectionHeight,
+  resetPinnedSectionHeight,
+  savePinnedSectionHeight,
+  usePinnedSectionHeight,
+} from "@/domains/chat/utils/sidebar-pinned-height";
+
+const KEY = (assistantId: string) =>
+  `vellum:sidebar-pinned-height:${assistantId}`;
+
+afterEach(() => {
+  localStorage.clear();
+  // Accessors are module singletons, so a value held after a rejected write
+  // outlives the test that set it. Logout clears these for the same reason.
+  clearUserScopedOverrides();
+});
+
+describe("clampPinnedSectionHeight", () => {
+  test("rounds and bounds to the resize range", () => {
+    expect(clampPinnedSectionHeight(123.6)).toBe(124);
+    expect(clampPinnedSectionHeight(-500)).toBe(
+      SIDEBAR_SECTION_RESIZE_MIN_HEIGHT,
+    );
+    expect(clampPinnedSectionHeight(5000)).toBe(
+      SIDEBAR_SECTION_RESIZE_MAX_HEIGHT,
+    );
+  });
+});
+
+describe("pinned section height storage", () => {
+  test("defaults to the shared section cap", () => {
+    const { result } = renderHook(() => usePinnedSectionHeight("asst-1"));
+
+    expect(result.current).toBe(SIDEBAR_SECTION_MAX_HEIGHT);
+  });
+
+  test("persists per assistant, clamped, and reads back", () => {
+    savePinnedSectionHeight("asst-1", 450);
+    savePinnedSectionHeight("asst-2", 5000);
+
+    expect(localStorage.getItem(KEY("asst-1"))).toBe("450");
+    expect(localStorage.getItem(KEY("asst-2"))).toBe(
+      String(SIDEBAR_SECTION_RESIZE_MAX_HEIGHT),
+    );
+
+    const first = renderHook(() => usePinnedSectionHeight("asst-1"));
+    const second = renderHook(() => usePinnedSectionHeight("asst-2"));
+    expect(first.result.current).toBe(450);
+    expect(second.result.current).toBe(SIDEBAR_SECTION_RESIZE_MAX_HEIGHT);
+  });
+
+  test("junk in storage falls back to the default", () => {
+    for (const raw of ["abc", "", "  ", "NaN"]) {
+      localStorage.setItem(KEY("asst-1"), raw);
+
+      const { result } = renderHook(() => usePinnedSectionHeight("asst-1"));
+      expect(result.current).toBe(SIDEBAR_SECTION_MAX_HEIGHT);
+      clearUserScopedOverrides();
+    }
+  });
+
+  test("a stored out-of-range height clamps rather than resets", () => {
+    localStorage.setItem(KEY("asst-1"), "9999");
+
+    const { result } = renderHook(() => usePinnedSectionHeight("asst-1"));
+
+    expect(result.current).toBe(SIDEBAR_SECTION_RESIZE_MAX_HEIGHT);
+  });
+
+  test("reset returns the section to the default", () => {
+    savePinnedSectionHeight("asst-1", 450);
+
+    const { result } = renderHook(() => usePinnedSectionHeight("asst-1"));
+    expect(result.current).toBe(450);
+
+    act(() => resetPinnedSectionHeight("asst-1"));
+
+    expect(localStorage.getItem(KEY("asst-1"))).toBeNull();
+    expect(result.current).toBe(SIDEBAR_SECTION_MAX_HEIGHT);
+  });
+});
+
+describe("usePinnedSectionHeight", () => {
+  // The first render must already carry the stored choice: a flash of the
+  // default cap would visibly snap the section on every sidebar mount.
+  test("returns the stored value on the first render", () => {
+    localStorage.setItem(KEY("asst-1"), "450");
+
+    const { result } = renderHook(() => usePinnedSectionHeight("asst-1"));
+
+    expect(result.current).toBe(450);
+  });
+
+  test("re-renders when the value is saved elsewhere", () => {
+    const { result } = renderHook(() => usePinnedSectionHeight("asst-1"));
+    expect(result.current).toBe(SIDEBAR_SECTION_MAX_HEIGHT);
+
+    // Stands in for the other window: a save this hook never initiated.
+    act(() => savePinnedSectionHeight("asst-1", 480));
+
+    expect(result.current).toBe(480);
+  });
+
+  test("ignores writes for a different assistant", () => {
+    const { result } = renderHook(() => usePinnedSectionHeight("asst-1"));
+
+    act(() => savePinnedSectionHeight("asst-2", 480));
+
+    expect(result.current).toBe(SIDEBAR_SECTION_MAX_HEIGHT);
+  });
+
+  // Storage is unavailable in private browsing and once quota is exhausted.
+  // The divider still has to move: an unsaved height is tolerable, a handle
+  // that snaps back on release is not.
+  test("still resizes when storage rejects the write", () => {
+    const { result } = renderHook(() => usePinnedSectionHeight("asst-1"));
+
+    withRejectedWrites(() => {
+      act(() => savePinnedSectionHeight("asst-1", 480));
+    });
+
+    expect(localStorage.getItem(KEY("asst-1"))).toBeNull();
+    expect(result.current).toBe(480);
+  });
+});

--- a/clients/web/src/domains/chat/utils/sidebar-pinned-height.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-pinned-height.ts
@@ -1,0 +1,73 @@
+/**
+ * Where the Pinned section's user-chosen height persists, per assistant.
+ *
+ * Every section's row list caps at {@link SIDEBAR_SECTION_MAX_HEIGHT} and
+ * scrolls within itself; dragging the rule under the curated block re-caps
+ * Pinned alone, bounded to
+ * [{@link SIDEBAR_SECTION_RESIZE_MIN_HEIGHT},
+ * {@link SIDEBAR_SECTION_RESIZE_MAX_HEIGHT}]. Stored per assistant in
+ * localStorage under the `user` scope, matching how the view mode, collapse
+ * state, and section order persist.
+ */
+
+import {
+  SIDEBAR_SECTION_MAX_HEIGHT,
+  SIDEBAR_SECTION_RESIZE_MAX_HEIGHT,
+  SIDEBAR_SECTION_RESIZE_MIN_HEIGHT,
+} from "@/components/sidebar-nav-geometry";
+import { createKeyedStorageAccessor } from "@/utils/typed-storage";
+
+/** Round and bound a candidate height to the resize range. */
+export function clampPinnedSectionHeight(height: number): number {
+  return Math.min(
+    SIDEBAR_SECTION_RESIZE_MAX_HEIGHT,
+    Math.max(SIDEBAR_SECTION_RESIZE_MIN_HEIGHT, Math.round(height)),
+  );
+}
+
+/**
+ * Strict parse: junk falls back to the default, while a finite value outside
+ * the current bounds clamps rather than resets, so a stored height keeps its
+ * intent if the bounds ever tighten.
+ */
+function parsePinnedSectionHeight(raw: string): number | null {
+  if (raw.trim() === "") {
+    return null; // Number("") is 0, not a stored choice.
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return clampPinnedSectionHeight(value);
+}
+
+const pinnedHeightStorage = createKeyedStorageAccessor<number>({
+  keyFn: (assistantId) => `vellum:sidebar-pinned-height:${assistantId}`,
+  scope: "user",
+  parse: parsePinnedSectionHeight,
+  serialize: (height) => String(height),
+  fallback: SIDEBAR_SECTION_MAX_HEIGHT,
+});
+
+/**
+ * Subscribe to one assistant's Pinned section height.
+ *
+ * Storage is the source of truth: the first render already carries the
+ * stored choice, and a height committed in one window reaches every other
+ * window on the same assistant.
+ */
+export function usePinnedSectionHeight(assistantId: string): number {
+  return pinnedHeightStorage.useValue(assistantId);
+}
+
+export function savePinnedSectionHeight(
+  assistantId: string,
+  height: number,
+): void {
+  pinnedHeightStorage.save(assistantId, clampPinnedSectionHeight(height));
+}
+
+/** Drop the stored height so the section returns to the shipped default. */
+export function resetPinnedSectionHeight(assistantId: string): void {
+  pinnedHeightStorage.remove(assistantId);
+}


### PR DESCRIPTION
## Summary
- The sidebar's curated/conversations divider now drags (`row-resize` cursor, hover pill) to re-cap the Pinned section's height, clamped to 64-600px; double-click resets to the 300px default.
- Height persists per assistant (`vellum:sidebar-pinned-height:<id>`) through `createKeyedStorageAccessor`, so the first paint carries the stored value and other windows on the same assistant pick up commits live. Note: LUM-2969's planned consolidation of per-assistant sidebar keys into one record would fold this key in too.
- The handle keeps one stable element tree in resizable and inert states (only handlers/cursor gate on the flag): swapping elements mid-drag would drop pointer capture and strand `document.body` cursor/user-select overrides. Drag writes go straight to the row list's scroll div via ref; React state only changes on commit, per the web conventions on per-frame values.

Deliberate choices, per the design-system-first rule: this is a domain component (single call site, app-side persistence) rather than a design-library primitive, and it ships without keyboard resize, matching the existing side-menu and ResizablePanel handles (a "Reset height" menu item is the follow-up path if requested).

## Original prompt
The user pointed at the divider under the sidebar's Pinned section and asked for it to be adjustable by clicking and dragging, so the Pinned section's size can be changed. Planned in-session: reuse the blessed pointer-capture drag pattern from the sidebar width handle, persist per assistant with the first-paint-safe storage accessor, keep the divider inert when Pinned is absent or collapsed, and cover the drag mechanics, clamping, and storage parsing with colocated bun tests.