### PR TITLE
fix(ci): drop the disallowed Play-upload action that broke every dev releases

### DIFF
--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -113,14 +113,18 @@ jobs:
           path: clients/android/app/build/outputs/bundle/${{ inputs.environment }}Release/*.aab
           if-no-files-found: error
 
-      - name: Upload to Play internal track
-        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: ${{ steps.config.outputs.package_id }}
-          releaseFiles: clients/android/app/build/outputs/bundle/${{ inputs.environment }}Release/*.aab
-          track: internal
-          status: completed
+      # Play upload is temporarily manual: download the signed .aab artifact above
+      # and upload it to the internal track by hand.
+      #
+      # The automated step used r0adkll/upload-google-play, which our org's Actions
+      # allowlist does not permit. A disallowed `uses:` makes this whole reusable
+      # workflow file invalid, so every caller — dev-release.yaml and release.yml —
+      # failed at startup before running a single job. The `if:` gate on those call
+      # sites does not help: GitHub validates called workflows regardless of `if`.
+      #
+      # To restore automated publishing, allowlist the action (or switch to an
+      # already-permitted publisher) and re-add the step. The package id is still
+      # resolved above as steps.config.outputs.package_id for that purpose.
 
       - name: Remove signing material
         if: ${{ always() }}

--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -113,18 +113,12 @@ jobs:
           path: clients/android/app/build/outputs/bundle/${{ inputs.environment }}Release/*.aab
           if-no-files-found: error
 
-      # Play upload is temporarily manual: download the signed .aab artifact above
-      # and upload it to the internal track by hand.
-      #
-      # The automated step used r0adkll/upload-google-play, which our org's Actions
-      # allowlist does not permit. A disallowed `uses:` makes this whole reusable
-      # workflow file invalid, so every caller — dev-release.yaml and release.yml —
-      # failed at startup before running a single job. The `if:` gate on those call
-      # sites does not help: GitHub validates called workflows regardless of `if`.
-      #
-      # To restore automated publishing, allowlist the action (or switch to an
-      # already-permitted publisher) and re-add the step. The package id is still
-      # resolved above as steps.config.outputs.package_id for that purpose.
+      # Play publishing is manual: download the signed .aab artifact above and
+      # upload it to the internal track for steps.config.outputs.package_id.
+      # Automating it requires a Play publisher action permitted by the org
+      # Actions allowlist — a disallowed `uses:` makes this whole reusable
+      # workflow invalid, and every caller then fails at startup regardless of
+      # the `if:` gate on the call site.
 
       - name: Remove signing material
         if: ${{ always() }}


### PR DESCRIPTION
## Problem

Every scheduled **Dev Release** run has failed at startup since 18:35 UTC on Jul 31 — no jobs, just `startup_failure`. It's been down for ~6 hours.

`release-android.yaml` (added in #39674) references `r0adkll/upload-google-play`, which our org's Actions allowlist does not permit. A disallowed `uses:` makes the **entire reusable workflow file invalid**, so every caller dies before running a single job.

This is not limited to dev: **`release.yml` calls `release-android` too**, so the next staging or production release would have failed identically. It simply hasn't run since the merge.

Note that the `if: vars.ANDROID_RELEASE_ENABLED == 'true'` gate does not protect the call sites — GitHub validates called workflows regardless of `if`. And that variable isn't set, so the job would skip anyway: it was blocking all deploys for zero benefit.

## Why this wasn't caught pre-merge

`release-android.yaml` is only reachable through `dev-release.yaml` and `release.yml`, neither of which runs on PRs — so the invalid-workflow error could only surface on `main`.

## Fix

Drop the upload step. The job still resolves config, builds, signs, and publishes the `.aab` as a workflow artifact; uploading to the internal track is manual until the action is allowlisted. `steps.config.outputs.package_id` is retained so re-adding the step is a small diff, and a comment records the constraint.

## Verification

Diagnosed and verified empirically on throwaway branches, since GitHub doesn't expose startup-failure detail via the API for scheduled runs:

- A probe calling `release-android.yaml` at `main` → `startup_failure`.
- A probe using `vars.X` in `if` on a reusable-call job → valid, ruling out the gate.
- Step-by-step bisect: valid through step 9, invalid once the Play-upload step is included.
- The same file with **only** that one `uses:` swapped for an already-permitted action → valid.
- The action repo and pinned SHA both resolve, confirming policy rejection rather than a broken ref.
- **This branch's `release-android.yaml`, called by a probe → `skipped`, not `startup_failure`.**

All probe branches have been deleted.

## Follow-up

To restore automated publishing, allowlist `r0adkll/upload-google-play` in org Actions settings (or switch to an already-permitted publisher such as `google-github-actions`) and re-add the step.