### PR TITLE
fix(docs): restore permanent redirects for legacy /docs URLs

### DIFF
--- a/clients/docs/next-config.test.ts
+++ b/clients/docs/next-config.test.ts
@@ -27,8 +27,15 @@ type RewriteResult =
       fallback?: RewriteRule[];
     };
 
+interface RedirectRule {
+  source: string;
+  destination: string;
+  permanent: boolean;
+}
+
 interface ConfigWithRewrites {
   rewrites?: () => Promise<RewriteResult>;
+  redirects?: () => Promise<RedirectRule[]>;
 }
 
 async function beforeFilesRewrites(): Promise<RewriteRule[]> {
@@ -173,6 +180,33 @@ describe("next config rewrite sources", () => {
     expect(() => docsPathForSource("/docs/:path*", "/docs/pricing")).toThrow(
       "Unsupported docs markdown rewrite source"
     );
+  });
+});
+
+describe("next config redirects", () => {
+  test("the redirect set is pinned exactly", async () => {
+    const redirects = (nextConfig as ConfigWithRewrites).redirects;
+    if (!redirects) {
+      throw new Error("nextConfig.redirects is missing");
+    }
+
+    await expect(redirects()).resolves.toEqual([
+      {
+        source: "/docs/data-sharing",
+        destination: "/docs/privacy-policy",
+        permanent: true,
+      },
+      {
+        source: "/docs/affiliate-program-rules",
+        destination: "/docs",
+        permanent: true,
+      },
+      {
+        source: "/docs/vellum-survey-giveaway-official-rules",
+        destination: "/docs",
+        permanent: true,
+      },
+    ]);
   });
 });
 

--- a/clients/docs/next.config.ts
+++ b/clients/docs/next.config.ts
@@ -30,6 +30,26 @@ const nextConfig: NextConfig = {
   // prefetches and every landing would emit a burst of phantom page_view
   // rows (see FLIGHT_HEADERS in next/dist/server/web/adapter.js).
   skipMiddlewareUrlNormalize: true,
+  async redirects() {
+    return [
+      // Legacy /docs URLs that permanently redirect to their successors.
+      {
+        source: "/docs/data-sharing",
+        destination: "/docs/privacy-policy",
+        permanent: true,
+      },
+      {
+        source: "/docs/affiliate-program-rules",
+        destination: "/docs",
+        permanent: true,
+      },
+      {
+        source: "/docs/vellum-survey-giveaway-official-rules",
+        destination: "/docs",
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     return {
       beforeFiles: [


### PR DESCRIPTION
## Summary
- Add `redirects()` to `clients/docs/next.config.ts` restoring the three legacy permanent redirects the platform app carried (`/docs/data-sharing` → `/docs/privacy-policy`, `/docs/affiliate-program-rules` → `/docs`, `/docs/vellum-survey-giveaway-official-rules` → `/docs`). Since the ingress cutover these paths terminate at this app and were 404ing in production.
- Pin the redirect set in `next-config.test.ts` alongside the existing rewrite-source pins.

## Rollout
After merge, the multi-env publish pushes the image to all registries; restart the docs deployments (dev/staging/prod) to pick it up.

Part of plan: docs-phase4-cleanup.md (vellum-assistant companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)