### PR TITLE
fix(docs): restore permanent redirects for legacy /docs URLs

### DIFF
--- a/clients/docs/next-config.test.ts
+++ b/clients/docs/next-config.test.ts
@@ -27,12 +27,19 @@ type RewriteResult =
       fallback?: RewriteRule[];
     };
 
-interface ConfigWithRewrites {
+interface RedirectRule {
+  source: string;
+  destination: string;
+  permanent: boolean;
+}
+
+interface ConfigWithRoutes {
   rewrites?: () => Promise<RewriteResult>;
+  redirects?: () => Promise<RedirectRule[]>;
 }
 
 async function beforeFilesRewrites(): Promise<RewriteRule[]> {
-  const rewrites = (nextConfig as ConfigWithRewrites).rewrites;
+  const rewrites = (nextConfig as ConfigWithRoutes).rewrites;
   if (!rewrites) {
     throw new Error("nextConfig.rewrites is missing");
   }
@@ -173,6 +180,33 @@ describe("next config rewrite sources", () => {
     expect(() => docsPathForSource("/docs/:path*", "/docs/pricing")).toThrow(
       "Unsupported docs markdown rewrite source"
     );
+  });
+});
+
+describe("next config legacy redirects", () => {
+  test("pins the exact redirect set", async () => {
+    const redirects = (nextConfig as ConfigWithRoutes).redirects;
+    if (!redirects) {
+      throw new Error("nextConfig.redirects is missing");
+    }
+
+    await expect(redirects()).resolves.toEqual([
+      {
+        source: "/docs/data-sharing",
+        destination: "/docs/privacy-policy",
+        permanent: true,
+      },
+      {
+        source: "/docs/affiliate-program-rules",
+        destination: "/docs",
+        permanent: true,
+      },
+      {
+        source: "/docs/vellum-survey-giveaway-official-rules",
+        destination: "/docs",
+        permanent: true,
+      },
+    ]);
   });
 });
 

--- a/clients/docs/next.config.ts
+++ b/clients/docs/next.config.ts
@@ -30,6 +30,28 @@ const nextConfig: NextConfig = {
   // prefetches and every landing would emit a burst of phantom page_view
   // rows (see FLIGHT_HEADERS in next/dist/server/web/adapter.js).
   skipMiddlewareUrlNormalize: true,
+  // Legacy /docs URLs that predate the docs migration. These lived in the
+  // platform next.config until the ingress cutover moved the paths here;
+  // external links to them must keep resolving.
+  async redirects() {
+    return [
+      {
+        source: "/docs/data-sharing",
+        destination: "/docs/privacy-policy",
+        permanent: true,
+      },
+      {
+        source: "/docs/affiliate-program-rules",
+        destination: "/docs",
+        permanent: true,
+      },
+      {
+        source: "/docs/vellum-survey-giveaway-official-rules",
+        destination: "/docs",
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     return {
       beforeFiles: [


### PR DESCRIPTION
## Summary
- Adds a `redirects()` function to `clients/docs/next.config.ts` restoring the three legacy `/docs` redirects that lived in the platform `next.config.ts` before the ingress cutover: `/docs/data-sharing` → `/docs/privacy-policy`, `/docs/affiliate-program-rules` → `/docs`, and `/docs/vellum-survey-giveaway-official-rules` → `/docs` (all 308 permanent).
- Extends `next-config.test.ts` with a pinning test asserting the exact source/destination/permanent triples, matching the existing rewrite-source pinning pattern.
- Fixes a live production bug: `https://www.vellum.ai/docs/data-sharing` and `https://www.vellum.ai/docs/affiliate-program-rules` currently return 404 (verified 2026-07-31) because those paths now terminate in this app.

Verified locally: lint, `tsc --noEmit`, `bun test src next-config.test.ts` (116 pass), `bun run build`, and booting the standalone build — all three URLs return 308 with the correct `Location`.

**Rollout note:** after merge, the multi-env publish pushes the image everywhere; restart the docs deployments (dev/staging/prod) to pick it up — same procedure as the asset-prefix fix.

## Original prompt
Executed from `.private/plans/docs-phase4-cleanup.md`, the vellum-assistant companion to the platform repo's docs-migration Phase 4 cleanup plan. During Phase 4 planning we found that the platform `next.config.ts` still declared three permanent redirects for legacy `/docs/*` URLs, but since the ingress cutover those paths route to this repo's docs app, which never ported them, leaving live 404s in production. This PR restores the redirects in the docs app where the paths now terminate; it is independent of the platform plan's PRs and can merge as soon as it is green.