### PR TITLE
fix(platform): rotate the configured probe on an observed give-up, not a clock age

### DIFF
--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -204,7 +204,7 @@ describe("VellumPlatformClient", () => {
       expect(resolutionCount).toBe(2);
     });
 
-    test("a caller that finds a flight older than the deadline rotates in a fresh resolution", async () => {
+    test("a caller that finds an abandoned flight rotates in a fresh resolution", async () => {
       let resolutionCount = 0;
       // The first resolution hangs forever; only the rotated-in second one
       // settles.
@@ -221,11 +221,35 @@ describe("VellumPlatformClient", () => {
       // The first caller abandons the hung flight at the deadline.
       expect(await isPlatformClientConfigured()).toBe(false);
 
-      // The hung flight is now older than the deadline, so the next caller
-      // rotates in a fresh resolution instead of joining it; the fresh
-      // flight settles immediately and answers live.
+      // The hung flight is marked abandoned, so the next caller rotates in a
+      // fresh resolution instead of joining it; the fresh flight settles
+      // immediately and answers live.
       expect(await isPlatformClientConfigured()).toBe(true);
       expect(resolutionCount).toBe(2);
+    });
+
+    test("a later caller joins a flight nobody has abandoned", async () => {
+      let resolutionCount = 0;
+      let release = () => {};
+      // Gating the resolution keeps it in flight until the second caller has
+      // joined, so the assertion does not race a settle.
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      mockResolveManagedProxyContext = async () => {
+        resolutionCount += 1;
+        await gate;
+        return mockManagedProxyCtx;
+      };
+
+      const first = isPlatformClientConfigured();
+      await Bun.sleep(1);
+      const second = isPlatformClientConfigured();
+      release();
+
+      expect(await first).toBe(true);
+      expect(await second).toBe(true);
+      expect(resolutionCount).toBe(1);
     });
 
     test("a rotated-out flight's late settle cannot overwrite the newer flight's cached result", async () => {

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -107,16 +107,21 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
 const CONFIGURED_PROBE_DEADLINE_MS = 500;
 
 let lastKnownConfigured: boolean | null = null;
-// Single-flight slot with rotation: probes started inside the deadline window
-// share one resolution, while a flight older than the deadline is replaced so
-// a hung credential backend cannot pin the slot (and the cache) stale until a
-// 45s credential timeout finally settles it. Generation fencing keeps an
+// Single-flight slot with rotation: concurrent probes share one resolution,
+// while a flight some caller already gave up on is replaced so a hung
+// credential backend cannot pin the slot (and the cache) stale until a 45s
+// credential timeout finally settles it. Generation fencing keeps an
 // out-of-order settle from a rotated-out flight from overwriting the result a
 // newer flight already wrote.
 interface ConfiguredProbeFlight {
   promise: Promise<boolean>;
-  startedAt: number;
   generation: number;
+  // Set once a caller's deadline elapsed on this flight. Rotation keys off
+  // this observed give-up rather than a wall-clock age, so the decision never
+  // lands on the deadline boundary, where drift between the timer's clock and
+  // Date.now() would decide whether a caller rejoins the flight it just
+  // abandoned.
+  abandoned: boolean;
 }
 let inFlightConfiguredProbe: ConfiguredProbeFlight | null = null;
 let probeGeneration = 0;
@@ -131,13 +136,10 @@ export function _resetConfiguredProbeCacheForTests(): void {
   lastWrittenGeneration = probeGeneration;
 }
 
-function startOrJoinConfiguredProbe(): Promise<boolean> {
+function startOrJoinConfiguredProbe(): ConfiguredProbeFlight {
   const existing = inFlightConfiguredProbe;
-  if (
-    existing !== null &&
-    Date.now() - existing.startedAt < CONFIGURED_PROBE_DEADLINE_MS
-  ) {
-    return existing.promise;
+  if (existing !== null && !existing.abandoned) {
+    return existing;
   }
   probeGeneration += 1;
   const generation = probeGeneration;
@@ -160,8 +162,13 @@ function startOrJoinConfiguredProbe(): Promise<boolean> {
       }
       return value;
     });
-  inFlightConfiguredProbe = { promise, startedAt: Date.now(), generation };
-  return promise;
+  const flight: ConfiguredProbeFlight = {
+    promise,
+    generation,
+    abandoned: false,
+  };
+  inFlightConfiguredProbe = flight;
+  return flight;
 }
 
 /**
@@ -171,14 +178,13 @@ function startOrJoinConfiguredProbe(): Promise<boolean> {
  *
  * Bounded by {@link CONFIGURED_PROBE_DEADLINE_MS}: when config resolution is
  * slower than the deadline, returns the last settled result (or `false` when
- * none exists yet). Calls inside the deadline window share one in-flight
- * resolution; a call that finds a flight older than the deadline starts a
- * fresh one, so a hung backend never pins the cache stale, and generation
- * fencing keeps a rotated-out flight's late settle from overwriting a newer
- * result.
+ * none exists yet) and marks the flight abandoned. Concurrent calls share one
+ * in-flight resolution; the next call after an abandonment starts a fresh one,
+ * so a hung backend never pins the cache stale, and generation fencing keeps a
+ * rotated-out flight's late settle from overwriting a newer result.
  */
 export async function isPlatformClientConfigured(): Promise<boolean> {
-  const probe = startOrJoinConfiguredProbe();
+  const flight = startOrJoinConfiguredProbe();
 
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<"deadline">((resolve) => {
@@ -187,9 +193,10 @@ export async function isPlatformClientConfigured(): Promise<boolean> {
       CONFIGURED_PROBE_DEADLINE_MS,
     );
   });
-  const raced = await Promise.race([probe, deadline]);
+  const raced = await Promise.race([flight.promise, deadline]);
   clearTimeout(deadlineTimer);
   if (raced === "deadline") {
+    flight.abandoned = true;
     return lastKnownConfigured ?? false;
   }
   return raced;


### PR DESCRIPTION
## Summary
- `isPlatformClientConfigured()` decided whether to join or rotate an in-flight credential probe by comparing the flight's wall-clock age against `CONFIGURED_PROBE_DEADLINE_MS` — the same constant that arms the caller's deadline timer. A caller arriving right after its own timeout therefore sat exactly on `age === deadline`, so any drift between the timer's clock and `Date.now()` decided whether it rotated in a fresh resolution or rejoined the flight it had just abandoned.
- The flight now carries an `abandoned` flag, set by whichever caller's deadline elapsed on it. Rotation keys off that observed give-up, so the decision is causal rather than temporal and never lands on the boundary.
- Test coverage follows: the rotation case asserts the abandoned-flight path, and a new case pins the positive side (a later caller joins a flight nobody has abandoned) using a gated resolution so it cannot race a settle.

## Why
`client.test.ts` › "a caller that finds a flight older than the deadline rotates in a fresh resolution" failed on main in [run 30673082003](https://github.com/vellum-ai/vellum-assistant/actions/runs/30673082003): the second call returned `false` and the case took 1008ms, which is two full deadlines back to back. That is only reachable if the second caller rejoined the hung flight instead of rotating, i.e. the age check read 499 where it should have read 500.

Production impact of losing that race was bounded — an urgent notification skips the APNs channel for one message while the credential backend is hanging, with the local banner unaffected — but the rotation contract should not depend on clock behavior at all.

## Verification
- `bun test src/platform/client.test.ts` — 29 pass, 12 consecutive runs under eight busy CPU hogs, 0 failures
- `bun test src/__tests__/emit-signal-routing-intent.test.ts` (18 pass) and `src/notifications/__tests__/broadcaster.test.ts` (20 pass), the probe's downstream consumers
- eslint and prettier clean on both changed files

Follow-up to #39770.