### PR TITLE
test(subagent): warm the tool registry so the advisor context test is not a race

### DIFF
--- a/assistant/src/subagent/__tests__/consult-context.test.ts
+++ b/assistant/src/subagent/__tests__/consult-context.test.ts
@@ -5,6 +5,12 @@ import { describe, expect, test } from "bun:test";
 
 import { buildAdvisorContext, buildWorkspaceTree } from "../consult-context.js";
 
+// `buildToolsSection` reaches the registry through a dynamic import, and that
+// module graph costs a few hundred milliseconds to evaluate cold. Paying it
+// here, outside the section's timeout, keeps a loaded runner's import speed
+// from deciding whether the section beats its budget.
+import "../../tools/registry.js";
+
 describe("buildWorkspaceTree", () => {
   test("lists files and directories, skipping dotfiles and dependency dirs", async () => {
     const root = mkdtempSync(join(tmpdir(), "consult-tree-"));


### PR DESCRIPTION
## Summary
- `consult-context.test.ts` › "lists the agent's available tools" has been failing intermittently on main. `buildAdvisorContext` races each section against `SECTION_TIMEOUT_MS` (2s) and silently drops any that lose, and `buildToolsSection` reaches the registry through `await import("../tools/registry.js")` — a module graph that costs a few hundred milliseconds to evaluate cold.
- Every observed failure lands just over the budget (2034ms, 2063ms, 2091ms, 2331ms), and the reported context is skills-only: the tools section lost its race, so the assertion measured the runner's import speed rather than the assembly logic.
- Paying that import at file load, outside the timed region, removes the cost from the section. Measured locally: the first `buildAdvisorContext` call spends 488ms of the 2s budget on a cold registry versus 10ms warm.

The production budget stays at 2s and the test still exercises it, so this pins the behavior rather than papering over it by widening the deadline.

## Note for the owner of #39750
The same cold import can drop the tools section in production: on a busy daemon, the first consult of a process can exceed the 2s section budget and hand the advisor a context with no tool list, silently. Worth deciding whether the section should warm the registry itself (or whether losing it is acceptable) — out of scope here.

## Verification
- `bun test src/subagent/__tests__/consult-context.test.ts` — 5 pass, 22 consecutive runs under eight busy CPU hogs (12 pre-autofix, 10 post), 0 failures
- eslint and prettier clean

Fixes the remaining red on main after #39802.