### PR TITLE
fix(web): restore main-side code the v0.11.1 release merge reverted

### DIFF
--- a/clients/web/src/components/sidebar-nav-geometry.ts
+++ b/clients/web/src/components/sidebar-nav-geometry.ts
@@ -48,3 +48,13 @@ export const SIDEBAR_SECTION_INDENT = 12;
  * neighbours.
  */
 export const SIDEBAR_SECTION_MAX_HEIGHT = 300;
+
+/**
+ * Bounds for the Pinned section's user-adjustable height (dragging the rule
+ * under the curated block). Min fits two desktop rows (30px each) plus their
+ * 4px gap. Max stays a fixed constant rather than viewport-derived: the
+ * sidebar body scrolls, so an oversized section degrades to body scrolling
+ * the same way a long section list does today.
+ */
+export const SIDEBAR_SECTION_RESIZE_MIN_HEIGHT = 64;
+export const SIDEBAR_SECTION_RESIZE_MAX_HEIGHT = 600;

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -105,12 +105,14 @@ const GROUPS: ConversationGroup[] = [
 ];
 
 /**
- * Seed the layout store (and the localStorage the store hydrates from) so the
- * story mounts straight into the view it documents.
+ * Seed the stored view mode so the story mounts straight into the view it
+ * documents. The sidebar subscribes to storage during render, so the write is
+ * all it takes; resetting the layout store clears any collapse state a
+ * previously-rendered story left behind.
  */
 function seedViewMode(assistantId: string, mode: SidebarViewMode): void {
   saveViewMode(assistantId, mode);
-  useSidebarLayoutStore.setState({ assistantId: null, viewMode: mode });
+  useSidebarLayoutStore.setState({ assistantId: null });
 }
 
 const SHARED_ARGS = {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -68,7 +68,6 @@ beforeEach(() => {
   localStorage.setItem("vellum:sidebar-view-mode:asst-1", "grouped");
   useSidebarLayoutStore.setState({
     assistantId: null,
-    viewMode: "grouped",
     sectionOrder: [],
     openCategories: [],
     openCustomGroups: [],
@@ -215,7 +214,7 @@ describe("AssistantSideMenu · Chats category rows", () => {
 describe("AssistantSideMenu · All view", () => {
   beforeEach(() => {
     localStorage.setItem("vellum:sidebar-view-mode:asst-1", "all");
-    useSidebarLayoutStore.setState({ assistantId: null, viewMode: "all" });
+    useSidebarLayoutStore.setState({ assistantId: null });
   });
 
   const conversations = [
@@ -265,7 +264,7 @@ describe("AssistantSideMenu · All view", () => {
       "vellum:sidebar-section-order:asst-1",
       JSON.stringify(["recents", "grp-a", "channel:slack"]),
     );
-    useSidebarLayoutStore.setState({ assistantId: null, viewMode: "grouped" });
+    useSidebarLayoutStore.setState({ assistantId: null });
 
     const container = parse(
       renderMenu({
@@ -1015,17 +1014,19 @@ describe("AssistantSideMenu · equal section treatment", () => {
     const indexOfText = (text: string) =>
       children.findIndex((el) => (el.textContent ?? "").includes(text));
     const ruleIndex = children.findIndex((el) =>
-      el.matches('[data-slot="side-menu-separator"]'),
+      el.matches('[data-slot="sidebar-section-resize-handle"]'),
     );
 
     expect(
-      root.querySelectorAll('[data-slot="side-menu-separator"]'),
+      root.querySelectorAll('[data-slot="sidebar-section-resize-handle"]'),
     ).toHaveLength(1);
     // Pinned and Alpha above it, Chats and Slack below.
     expect(indexOfText("Pinned")).toBeLessThan(ruleIndex);
     expect(indexOfText("Alpha")).toBeLessThan(ruleIndex);
     expect(indexOfText("Chats")).toBeGreaterThan(ruleIndex);
     expect(indexOfText("Slack")).toBeGreaterThan(ruleIndex);
+    // Pinned is present and open by default, so the rule drags.
+    expect(children[ruleIndex]?.hasAttribute("data-resizable")).toBe(true);
   });
 
   test("the rule is absent until something is curated", () => {
@@ -1044,8 +1045,35 @@ describe("AssistantSideMenu · equal section treatment", () => {
     }
 
     expect(
-      root.querySelectorAll('[data-slot="side-menu-separator"]'),
+      root.querySelectorAll('[data-slot="sidebar-section-resize-handle"]'),
     ).toHaveLength(0);
+  });
+
+  // The rule only drags while there is a Pinned section to resize; a custom
+  // group alone still earns the rule, but an inert one.
+  test("the rule is inert when groups are curated without pins", () => {
+    const container = parse(
+      renderMenu({
+        conversations: [
+          makeConversation({ conversationId: "r1" }),
+          makeConversation({
+            conversationId: "g1",
+            title: "Group one",
+            groupId: "grp-a",
+          }),
+        ],
+        conversationGroups: LAYOUT_GROUPS,
+      }),
+    );
+
+    const rule = container.querySelector<HTMLElement>(
+      '[data-slot="sidebar-section-resize-handle"]',
+    );
+    if (!rule) {
+      throw new Error("expected the curated block's rule");
+    }
+
+    expect(rule.hasAttribute("data-resizable")).toBe(false);
   });
 
   // The switch sits outside the section list, ahead of it: a sticky element

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -41,6 +41,11 @@ import { SidebarSectionResizeHandle } from "@/domains/chat/components/sidebar-se
 import { copyIdToClipboard } from "@/domains/chat/utils/copy-id-to-clipboard";
 import { NATIVE_IOS_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-ios-button-constants";
 import {
+  resetPinnedSectionHeight,
+  savePinnedSectionHeight,
+  usePinnedSectionHeight,
+} from "@/domains/chat/utils/sidebar-pinned-height";
+import {
   RECENTS_SECTION_ICON,
   RECENTS_SECTION_LABEL,
   sectionIcon,
@@ -155,7 +160,8 @@ function SearchButton() {
  *     • [ All | Grouped ] - the view switch, first and sticky
  *     • Pinned ▾       - when non-empty
  *     • Group ▾        - one collapsible section per custom group
- *     • ───────────────  - when anything is curated above it
+ *     • ───────────────  - when anything is curated above it; drags to
+ *       resize Pinned while that section is expanded
  *     • All view: every remaining conversation as one headerless,
  *       virtualized list, newest first
  *     • Grouped view: Chats ▾ then one collapsible section per origin
@@ -417,6 +423,10 @@ export function AssistantSideMenu({
       groupMenu={sectionMenu(section)}
       drag={sectionDragFor(section)}
       collapsedIndicator={collapsedActivityDot(section.all)}
+      listRef={section.type === "pinned" ? pinnedListRef : undefined}
+      listMaxHeight={
+        section.type === "pinned" ? pinnedListMaxHeight : undefined
+      }
     />
   );
 
@@ -665,10 +675,18 @@ export function AssistantSideMenu({
                   .map(renderSection)}
                 {/* The list's one rule, marking where curation ends and the
                     conversations begin. Absent when nothing is curated yet, so
-                    a fresh sidebar never opens on a stray line. `my-0` keeps it
-                    on the root's own gap instead of adding to it. */}
+                    a fresh sidebar never opens on a stray line. It carries no
+                    margin, sitting on the root's own gap, and doubles as the
+                    Pinned section's resize handle while Pinned is expanded. */}
                 {sidebar.curatedSectionCount > 0 ? (
-                  <SideMenu.Separator className="my-0" />
+                  <SidebarSectionResizeHandle
+                    targetRef={pinnedListRef}
+                    resizable={pinnedResizable}
+                    onCommit={(height) =>
+                      savePinnedSectionHeight(assistantId, height)
+                    }
+                    onReset={() => resetPinnedSectionHeight(assistantId)}
+                  />
                 ) : null}
                 {sidebar.sections
                   .slice(sidebar.curatedSectionCount)

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -66,6 +66,13 @@ export interface ConversationRowListProps {
    * of its own would put a second scrollbar in the rail.
    */
   scrollParent?: HTMLElement;
+  /**
+   * Reaches the bounded scroll div, for the Pinned resize handle to drive
+   * imperatively during a drag. Unused when `scrollParent` unbounds the list.
+   */
+  listRef?: Ref<HTMLDivElement>;
+  /** Caps the bounded list instead of {@link SIDEBAR_SECTION_MAX_HEIGHT}. */
+  listMaxHeight?: number;
 }
 
 export function ConversationRowList({
@@ -73,6 +80,8 @@ export function ConversationRowList({
   dragSection,
   dragSiblings,
   scrollParent,
+  listRef,
+  listMaxHeight,
 }: ConversationRowListProps) {
   const renderRow = (conversation: Conversation) => (
     <ConversationRow
@@ -98,8 +107,9 @@ export function ConversationRowList({
       rows
     ) : (
       <div
+        ref={listRef}
         className="overflow-y-auto"
-        style={{ maxHeight: SIDEBAR_SECTION_MAX_HEIGHT }}
+        style={{ maxHeight: listMaxHeight ?? SIDEBAR_SECTION_MAX_HEIGHT }}
       >
         {rows}
       </div>
@@ -124,7 +134,12 @@ export function ConversationRowList({
   return scrollParent ? (
     windowed
   ) : (
-    <div style={{ height: SIDEBAR_SECTION_MAX_HEIGHT }}>{windowed}</div>
+    <div
+      ref={listRef}
+      style={{ height: listMaxHeight ?? SIDEBAR_SECTION_MAX_HEIGHT }}
+    >
+      {windowed}
+    </div>
   );
 }
 export interface ConversationNavSectionProps extends ConversationRowListProps {

--- a/clients/web/src/domains/chat/sidebar-layout-store.test.ts
+++ b/clients/web/src/domains/chat/sidebar-layout-store.test.ts
@@ -9,7 +9,6 @@ function resetStore() {
     openCategories: [],
     openCustomGroups: [],
     openPrimary: ["pinned", "recents"],
-    viewMode: "all",
     backgroundActivated: false,
     scheduledActivated: false,
   });
@@ -243,31 +242,6 @@ describe("SidebarLayoutStore - independent lazy-section activation", () => {
     expect(state.scheduledActivated).toBe(false);
   });
 
-  test("defaults to the flat All view", () => {
-    expect(useSidebarLayoutStore.getState().viewMode).toBe("all");
-  });
-
-  test("setViewMode persists per assistant and hydrates back", () => {
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-    useSidebarLayoutStore.getState().setViewMode("grouped");
-
-    expect(localStorage.getItem("vellum:sidebar-view-mode:asst-1")).toBe(
-      "grouped",
-    );
-
-    // A second assistant keeps the default until it is switched itself.
-    useSidebarLayoutStore.getState().setAssistantId("asst-2");
-    expect(useSidebarLayoutStore.getState().viewMode).toBe("all");
-
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-    expect(useSidebarLayoutStore.getState().viewMode).toBe("grouped");
-  });
-
-  test("an unrecognized stored view falls back to the default", () => {
-    localStorage.setItem("vellum:sidebar-view-mode:asst-1", "channels");
-
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-
-    expect(useSidebarLayoutStore.getState().viewMode).toBe("all");
-  });
+  // The view mode is deliberately not held here: it reads from storage
+  // directly so it survives the first paint. See sidebar-view-mode.test.ts.
 });

--- a/clients/web/src/domains/chat/sidebar-layout-store.ts
+++ b/clients/web/src/domains/chat/sidebar-layout-store.ts
@@ -37,12 +37,6 @@ import {
   loadSectionOrder,
   saveSectionOrder,
 } from "@/domains/chat/utils/sidebar-section-order";
-import {
-  DEFAULT_SIDEBAR_VIEW_MODE,
-  loadViewMode,
-  saveViewMode,
-  type SidebarViewMode,
-} from "@/domains/chat/utils/sidebar-view-mode";
 
 // ---------------------------------------------------------------------------
 // State + Actions
@@ -64,11 +58,6 @@ export interface SidebarLayoutState {
    * `mergeSectionOrder`.
    */
   sectionOrder: string[];
-  /**
-   * Which conversation-list view the sidebar renders: the flat recency list
-   * (`all`) or the per-channel collapsible sections (`grouped`).
-   */
-  viewMode: SidebarViewMode;
   /**
    * Whether the user has revealed the Background section this session -
    * either by expanding it in the full sidebar or opening its rail flyout.
@@ -92,7 +81,6 @@ export interface SidebarLayoutActions {
   setOpenCustomGroups: (next: string[]) => void;
   setOpenPrimary: (next: string[]) => void;
   setSectionOrder: (next: string[]) => void;
-  setViewMode: (next: SidebarViewMode) => void;
   activateBackground: () => void;
   activateScheduled: () => void;
 }
@@ -112,7 +100,6 @@ const INITIAL_STATE: SidebarLayoutState = {
   // setAssistantId.
   openPrimary: [...PRIMARY_SECTION_KEYS],
   sectionOrder: [],
-  viewMode: DEFAULT_SIDEBAR_VIEW_MODE,
   backgroundActivated: false,
   scheduledActivated: false,
 };
@@ -136,7 +123,6 @@ const useSidebarLayoutStoreBase = create<SidebarLayoutStore>()(
         openCustomGroups: loadOpenCustomGroups(assistantId),
         openPrimary: loadOpenPrimary(assistantId),
         sectionOrder: loadSectionOrder(assistantId),
-        viewMode: loadViewMode(assistantId),
         // A persisted expanded section counts as a reveal, so each lazy
         // fetch resumes for assistants the user already had that section
         // open on - tracked per section so they stay independent.
@@ -180,14 +166,6 @@ const useSidebarLayoutStoreBase = create<SidebarLayoutStore>()(
       const { assistantId } = get();
       if (assistantId) {
         saveSectionOrder(assistantId, next);
-      }
-    },
-
-    setViewMode: (next: SidebarViewMode) => {
-      set({ viewMode: next });
-      const { assistantId } = get();
-      if (assistantId) {
-        saveViewMode(assistantId, next);
       }
     },
 

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -41,15 +41,9 @@ afterEach(() => {
     openCategories: [],
     openCustomGroups: [],
     sectionOrder: [],
-    viewMode: "all",
   });
 });
 
-/**
- * Put the sidebar in the channel-grouped view. The layout store hydrates from
- * localStorage in an effect, so seeding the key is what survives the hook's
- * own `setAssistantId` call.
- */
 /** The rendered section carrying `key`, or a clear failure if it is absent. */
 function sectionFor(
   sections: { key: string; all: unknown[] }[],
@@ -62,9 +56,13 @@ function sectionFor(
   return section;
 }
 
+/**
+ * Put the sidebar in the channel-grouped view. Seeding the key is enough: the
+ * hook subscribes to storage during render, so the first render already sees
+ * this - no store priming, and no commit in between.
+ */
 function seedGroupedView(assistantId = "asst-1"): void {
   localStorage.setItem(`vellum:sidebar-view-mode:${assistantId}`, "grouped");
-  useSidebarLayoutStore.setState({ viewMode: "grouped" });
 }
 
 describe("useSidebarState grouping", () => {

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -51,7 +51,11 @@ import {
   nextStoredOrder,
   type SectionOrderClass,
 } from "@/domains/chat/utils/sidebar-section-order";
-import type { SidebarViewMode } from "@/domains/chat/utils/sidebar-view-mode";
+import {
+  saveViewMode,
+  useViewMode,
+  type SidebarViewMode,
+} from "@/domains/chat/utils/sidebar-view-mode";
 import { mergeConversationLists } from "@/utils/conversation-cache";
 import {
   useBackgroundConversationListQuery,
@@ -210,8 +214,20 @@ export function useSidebarState({
   const setOpenPrimary = useSidebarLayoutStore.use.setOpenPrimary();
   const sectionOrder = useSidebarLayoutStore.use.sectionOrder();
   const setSectionOrder = useSidebarLayoutStore.use.setSectionOrder();
-  const viewMode = useSidebarLayoutStore.use.viewMode();
-  const setViewMode = useSidebarLayoutStore.use.setViewMode();
+
+  // Read straight from storage rather than through the layout store. The store
+  // hydrates in an effect, so anything it owns renders as the default on the
+  // first paint; the view mode decides which list the sidebar draws, making
+  // that flash the most visible one. Subscribing instead means the stored
+  // choice is there on the first paint, and a change in another window lands
+  // here without a reload.
+  const viewMode = useViewMode(assistantId);
+  const setViewMode = useCallback(
+    (next: SidebarViewMode) => {
+      saveViewMode(assistantId, next);
+    },
+    [assistantId],
+  );
   const backgroundActivated = useSidebarLayoutStore.use.backgroundActivated();
   const scheduledActivated = useSidebarLayoutStore.use.scheduledActivated();
   const collapseAssistantId = useSidebarLayoutStore.use.assistantId();

--- a/clients/web/src/domains/chat/utils/sidebar-view-mode.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-view-mode.ts
@@ -37,6 +37,19 @@ export function loadViewMode(assistantId: string): SidebarViewMode {
   return viewModeStorage.load(assistantId);
 }
 
+/**
+ * Subscribe to one assistant's view mode.
+ *
+ * Storage is the source of truth rather than a value snapshotted into a store
+ * on mount, which buys two things: the first paint already carries the user's
+ * choice (no flash of the default while an effect catches up), and a change
+ * made in one window reaches every other window on the same assistant,
+ * because `saveViewMode` notifies both same-tab and cross-tab listeners.
+ */
+export function useViewMode(assistantId: string): SidebarViewMode {
+  return viewModeStorage.useValue(assistantId);
+}
+
 export function saveViewMode(
   assistantId: string,
   mode: SidebarViewMode,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -446,7 +446,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const choreography = resolveVoiceRoomChoreography(variant, reduce === true);
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key !== "Escape") {
+      if (event.key !== "Escape" || event.defaultPrevented) {
         return;
       }
       // A dialog layered over the room owns the key while it holds focus. The

--- a/clients/web/src/runtime/native-audio-session.ts
+++ b/clients/web/src/runtime/native-audio-session.ts
@@ -31,6 +31,7 @@ import {
  */
 export interface VoiceAudioInterruptionEvent {
   type: "began" | "ended";
+  reason?: "interruption" | "focus-loss" | "route-change" | "resume";
 }
 
 interface VoiceAudioSessionPlugin {
@@ -68,8 +69,7 @@ export async function activateVoiceAudioSession(): Promise<boolean> {
 }
 
 /**
- * Release the audio session at the end of a live-voice session. No-op off-iOS
- * and on an older shell. Never throws.
+ * Release native audio ownership. No-op in browsers and older shells.
  */
 export async function deactivateVoiceAudioSession(): Promise<void> {
   return callNativeVoice(async () => {

--- a/packages/design-library/src/components/dropdown.stories.tsx
+++ b/packages/design-library/src/components/dropdown.stories.tsx
@@ -3,7 +3,7 @@ import { Globe, Lock, Users } from "lucide-react";
 import { useState } from "react";
 import { expect, userEvent, within } from "storybook/test";
 
-import { Dropdown, type DropdownOption, type DropdownProps } from "./dropdown";
+import { Dropdown, type DropdownOption } from "./dropdown";
 import { Modal } from "./modal";
 import { Tag } from "./tag";
 
@@ -347,7 +347,14 @@ export const InsideModal: Story = {
   render: function ModalDropdown(args) {
     const [value, setValue] = useState("apple");
     return (
-      <Modal.Root defaultOpen>
+      // Opened by the play function rather than `defaultOpen`. An always-open
+      // modal renders over the whole autodocs page, hiding every other story.
+      <Modal.Root>
+        <Modal.Trigger asChild>
+          <button type="button" data-testid="open-modal">
+            Open modal
+          </button>
+        </Modal.Trigger>
         <Modal.Content>
           <Modal.Header>
             <Modal.Title>Pick a fruit</Modal.Title>
@@ -366,7 +373,9 @@ export const InsideModal: Story = {
       </Modal.Root>
     );
   },
-  play: async ({ step }) => {
+  play: async ({ canvasElement, step }) => {
+    await userEvent.click(within(canvasElement).getByTestId("open-modal"));
+
     // Scoped to the document rather than the canvas: both the dialog and the
     // menu are portaled out of the story's subtree.
     const dialog = document.querySelector('[data-slot="modal-content"]');

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -68,31 +68,6 @@ export interface DropdownProps<T extends string> {
   readonly "data-testid"?: string;
 }
 
-/**
- * Single-select dropdown for choosing a text item.
- *
- * Generic over `T extends string` so callers can narrow selection to a union
- * of literal values (e.g. `"managed" | "your-own"`) and get a typed
- * `onChange` callback. Visuals follow semantic tokens (`--surface-lift`,
- * `--border-base`, etc.) and mirror the desktop dropdown behavior.
- *
- * The menu is portaled into the element provided by the nearest
- * `<PortalContainerProvider>` so it escapes ancestor `overflow: hidden` and
- * design tokens resolve correctly. Falls back to `document.body` when no
- * provider is mounted, matching every other overlay in this package
- * (`Popover`, `Tooltip`, `Menu`, `Modal`, `ContextMenu`, `BottomSheet`, which
- * all hand `container ?? undefined` to a Radix `Portal`).
- *
- * Portaling is not optional. The menu positions itself with `position: fixed`
- * at viewport coordinates read off the trigger's `getBoundingClientRect()`,
- * which only lands correctly when the viewport is its containing block. Any
- * ancestor with a `transform`, `filter`, or `will-change` becomes that
- * containing block instead and shifts the menu by that ancestor's origin,
- * usually clear off-screen, which reads as "the dropdown won't open". The web
- * app's detail drawer does exactly this: its slide-in animation uses
- * `animation-fill-mode: both`, so the final keyframe's identity matrix stays
- * applied for the life of the drawer.
- */
 const TRIGGER_SIZE_CLASSES: Record<DropdownSize, string> = {
   regular: "h-9 px-3 text-body-medium-lighter",
   compact: "h-7 px-2.5 text-body-small-default",


### PR DESCRIPTION
## Summary
- The v0.11.1 release merge (#39797) mis-resolved conflicts and partially reverted several main PRs (#39795 pinned-section resize, #39733/#39760 sidebar internals, voice fixes, design-library Dropdown), leaving main red: 5 unused-var lint errors and multiple typecheck errors (dropped imports/props).
- Restores the 14 affected files byte-for-byte to their pre-merge main state (`c632e710f0^1`); release version bumps and lockfile changes are kept.
- Verified locally: web lint 0 errors, design-library typecheck + dropdown tests green, all 102 restored sidebar tests pass. Remaining local typecheck noise is the known stale worktree-symlink artifact; CI regenerates the API client.

## Original prompt
Fix the lint failures in the Dev Release run https://github.com/vellum-ai/vellum-assistant/actions/runs/30676387757/job/91304451959 (ci-web job, main branch). Investigation showed the lint errors were one symptom of the release merge accidentally reverting main-side code, so the fix restores everything the merge clobbered — matching the known pattern of release merges re-breaking main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)