### PR TITLE
fix(docker): copy all clients workspace manifests into image build contexts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,8 +10,10 @@
 # covers the clients/docs/package.json manifest the other images install from).
 !clients/docs/
 !clients/docs/**
-!clients/macos/package.json
-!clients/web/package.json
+# Every clients/* workspace member manifest must reach the context: bun's
+# frozen-lockfile install validates the full workspace set, so a member whose
+# package.json is missing fails every image build.
+!clients/*/package.json
 !cli/package.json
 # Although we have a `**` ignore that correctly excludes large build artifacts from the build context,
 # it seems the walker doesn't prune a directory when there are `!` exceptions that can include files

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -22,9 +22,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 # Note that we don't need source code to resolve cross-workspace dependencies.
 COPY package.json bun.lock ./
 COPY patches ./patches
-COPY clients/docs/package.json ./clients/docs/
-COPY clients/macos/package.json ./clients/macos/
-COPY clients/web/package.json ./clients/web/
+COPY --parents clients/*/package.json ./
 COPY cli/package.json ./cli/
 COPY gateway/package.json ./gateway/
 COPY credential-executor/package.json ./credential-executor/

--- a/clients/docs/Dockerfile
+++ b/clients/docs/Dockerfile
@@ -9,9 +9,7 @@ WORKDIR /app
 # Note that we don't need source code to resolve cross-workspace dependencies.
 COPY package.json bun.lock ./
 COPY patches ./patches
-COPY clients/docs/package.json ./clients/docs/
-COPY clients/macos/package.json ./clients/macos/
-COPY clients/web/package.json ./clients/web/
+COPY --parents clients/*/package.json ./
 COPY cli/package.json ./cli/
 COPY gateway/package.json ./gateway/
 COPY credential-executor/package.json ./credential-executor/

--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -19,9 +19,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 # Note that we don't need source code to resolve cross-workspace dependencies.
 COPY package.json bun.lock ./
 COPY patches ./patches
-COPY clients/docs/package.json ./clients/docs/
-COPY clients/macos/package.json ./clients/macos/
-COPY clients/web/package.json ./clients/web/
+COPY --parents clients/*/package.json ./
 COPY cli/package.json ./cli/
 COPY gateway/package.json ./gateway/
 COPY credential-executor/package.json ./credential-executor/

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -14,9 +14,7 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 # Note that we don't need source code to resolve cross-workspace dependencies.
 COPY package.json bun.lock ./
 COPY patches ./patches
-COPY clients/docs/package.json ./clients/docs/
-COPY clients/macos/package.json ./clients/macos/
-COPY clients/web/package.json ./clients/web/
+COPY --parents clients/*/package.json ./
 COPY cli/package.json ./cli/
 COPY gateway/package.json ./gateway/
 COPY credential-executor/package.json ./credential-executor/


### PR DESCRIPTION
## Summary
- `clients/windows` joined the root bun workspace (#34717) but the four Dockerfiles enumerate `clients/*/package.json` COPYs by hand — and `.dockerignore` re-includes those manifests by hand too — so `bun install --frozen-lockfile` inside every image build fails with `Workspace not found "clients/windows"`. **The hourly dev releases and all docs-image publishes have been failing since it merged** (including the publish for #39800, so the legacy-redirect fix hasn't reached any registry).
- Fix both hand-maintained lists with globs, matching the existing `packages/*` pattern: `COPY --parents clients/*/package.json ./` in all four Dockerfiles, and `!clients/*/package.json` in `.dockerignore` — a future clients member can't break image builds again.

## Verification
- `docker build -f clients/docs/Dockerfile .` — full image builds clean (exit 0).
- `docker build -f gateway/Dockerfile --target builder .` — the frozen-lockfile install stage passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)